### PR TITLE
Bug fix when SecCtxLabel is nil

### DIFF
--- a/cilium-net-daemon/daemon/policy.go
+++ b/cilium-net-daemon/daemon/policy.go
@@ -64,6 +64,9 @@ func (d *Daemon) RegenerateConsumerMap(e *types.Endpoint) error {
 	if err != nil {
 		return err
 	}
+	if secCtxLabels == nil {
+		return nil
+	}
 
 	ctx := types.SearchContext{To: make([]types.Label, len(secCtxLabels.Labels))}
 


### PR DESCRIPTION
`GetLabels` can return a nil error and a nil `SecCtxLabel` if it's not found in consul. I _think_ there isn't other place where this can cause any troubles.

Ping @tgraf to see if I forgot something besides this one.

Signed-off-by: André Martins aanm90@gmail.com
