### PR TITLE
Increased cilium-docker connection timeout with daemon

### DIFF
--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -45,14 +45,14 @@ func NewDriver(ctx *cli.Context) (Driver, error) {
 		log.Fatalf("Error while starting cilium-client: %s", err)
 	}
 
-	for tries := 10; tries > 0; tries-- {
+	for tries := 0; tries < 10; tries++ {
 		if res, err := c.Ping(); err != nil {
-			if tries == 1 {
+			if tries == 9 {
 				log.Fatalf("Unable to reach cilium daemon: %s", err)
 			} else {
 				log.Warningf("Waiting for cilium daemon to come up...")
 			}
-			time.Sleep(time.Second)
+			time.Sleep(time.Duration(tries) * time.Second)
 		} else {
 			nodeAddress = res.NodeAddress
 			log.Infof("Received node address from daemon: %s", nodeAddress)


### PR DESCRIPTION
The daemon can take more than 10 seconds when resuming state for a large
number of containers. When cilium-net-daemon service is restarted,
cilium-docker expects an immediate connection with the daemon, this
commit increases that time expectancy.

Signed-off-by: André Martins andre@cilium.io
