### PR TITLE
cilium: update helpers to newer kernel

### DIFF
--- a/bpf/include/iproute2/bpf_elf.h
+++ b/bpf/include/iproute2/bpf_elf.h
@@ -32,6 +32,7 @@ struct bpf_elf_map {
 	__u32 size_key;
 	__u32 size_value;
 	__u32 max_elem;
+	__u32 flags;
 	__u32 id;
 	__u32 pinning;
 };

--- a/bpf/include/linux/bpf.h
+++ b/bpf/include/linux/bpf.h
@@ -84,6 +84,7 @@ enum bpf_map_type {
 	BPF_MAP_TYPE_PERCPU_HASH,
 	BPF_MAP_TYPE_PERCPU_ARRAY,
 	BPF_MAP_TYPE_STACK_TRACE,
+	BPF_MAP_TYPE_CGROUP_ARRAY,
 };
 
 enum bpf_prog_type {
@@ -314,9 +315,56 @@ enum bpf_func_id {
 	BPF_FUNC_skb_get_tunnel_opt,
 	BPF_FUNC_skb_set_tunnel_opt,
 
-	BPF_FUNC_l2_hdr_change,
-	BPF_FUNC_l3_hdr_change,
-	BPF_FUNC_l4_hdr_change,
+	/**
+	 * bpf_skb_change_proto(skb, proto, flags)
+	 * Change protocol of the skb. Currently supported is
+	 * v4 -> v6, v6 -> v4 transitions. The helper will also
+	 * resize the skb. eBPF program is expected to fill the
+	 * new headers via skb_store_bytes and lX_csum_replace.
+	 * @skb: pointer to skb
+	 * @proto: new skb->protocol type
+	 * @flags: reserved
+	 * Return: 0 on success or negative error
+	 */
+	BPF_FUNC_skb_change_proto,
+
+	/**
+	 * bpf_skb_change_type(skb, type)
+	 * Change packet type of skb.
+	 * @skb: pointer to skb
+	 * @type: new skb->pkt_type type
+	 * Return: 0 on success or negative error
+	 */
+	BPF_FUNC_skb_change_type,
+
+	/**
+	 * bpf_skb_in_cgroup(skb, map, index) - Check cgroup2 membership of skb
+	 * @skb: pointer to skb
+	 * @map: pointer to bpf_map in BPF_MAP_TYPE_CGROUP_ARRAY type
+	 * @index: index of the cgroup in the bpf_map
+	 * Return:
+	 *   == 0 skb failed the cgroup2 descendant test
+	 *   == 1 skb succeeded the cgroup2 descendant test
+	 *    < 0 error
+	 */
+	BPF_FUNC_skb_in_cgroup,
+
+	/**
+	 * bpf_get_hash_recalc(skb)
+	 * Retrieve and possibly recalculate skb->hash.
+	 * @skb: pointer to skb
+	 * Return: hash
+	 */
+	BPF_FUNC_get_hash_recalc,
+
+	/**
+	 * u64 bpf_get_current_task(void)
+	 * Returns current task_struct
+	 * Return: current
+	 */
+	BPF_FUNC_get_current_task,
+
+	BPF_FUNC_skb_change_tail,
 
 	__BPF_FUNC_MAX_ID,
 };
@@ -352,9 +400,11 @@ enum bpf_func_id {
 #define BPF_F_ZERO_CSUM_TX		(1ULL << 1)
 #define BPF_F_DONT_FRAGMENT		(1ULL << 2)
 
-/* BPF_FUNC_perf_event_output flags. */
+/* BPF_FUNC_perf_event_output and BPF_FUNC_perf_event_read flags. */
 #define BPF_F_INDEX_MASK		0xffffffffULL
 #define BPF_F_CURRENT_CPU		BPF_F_INDEX_MASK
+/* BPF_FUNC_perf_event_output for sk_buff input context. */
+#define BPF_F_CTXLEN_MASK		(0xfffffULL << 32)
 
 /* user accessible mirror of in-kernel sk_buff.
  * new fields can only be added to the end of this structure

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -59,8 +59,6 @@ struct policy_entry {
 	__u64		bytes;
 };
 
-#define DROP_SAMPLE_LEN 64
-
 enum {
 	CILIUM_NOTIFY_UNSPEC,
 	CILIUM_NOTIFY_DROP,
@@ -75,12 +73,12 @@ enum {
 
 struct drop_notify {
 	NOTIFY_COMMON_HDR
-	__u32		len;
+	__u32		len_orig;
+	__u32		len_cap;
 	__u32		src_label;
 	__u32		dst_label;
 	__u32		dst_id;
 	__u32		ifindex;
-	char		data[DROP_SAMPLE_LEN];
 };
 
 #ifndef BPF_F_PSEUDO_HDR

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -218,13 +218,8 @@ static inline int __icmp6_send_time_exceeded(struct __sk_buff *skb, int nh_off)
 		sum = compute_icmp6_csum(data, 56, ipv6hdr);
 		payload_len = htons(56);
 		trimlen = 56 - ntohs(ipv6hdr->payload_len);
-		if (trimlen < 0) {
-			if (l4_hdr_change(skb, skb->len + trimlen, trimlen) < 0)
-				return DROP_WRITE_ERROR;
-		} else if (trimlen > 0) {
-			if (l4_hdr_change(skb, skb->len, trimlen) < 0)
-				return DROP_WRITE_ERROR;
-		}
+		if (skb_change_tail(skb, skb->len + trimlen) < 0)
+			return DROP_WRITE_ERROR;
 		/* trim or expand buffer and copy data buffer after ipv6 header */
 		if (skb_store_bytes(skb, nh_off + sizeof(struct ipv6hdr),
 				    data, 56, 0) < 0)
@@ -242,13 +237,8 @@ static inline int __icmp6_send_time_exceeded(struct __sk_buff *skb, int nh_off)
 		payload_len = htons(68);
 		/* trim or expand buffer and copy data buffer after ipv6 header */
 		trimlen = 68 - ntohs(ipv6hdr->payload_len);
-		if (trimlen < 0) {
-			if (l4_hdr_change(skb, skb->len + trimlen, trimlen) < 0)
-				return DROP_WRITE_ERROR;
-		} else if (trimlen > 0) {
-			if (l4_hdr_change(skb, skb->len, trimlen) < 0)
-				return DROP_WRITE_ERROR;
-		}
+		if (skb_change_tail(skb, skb->len + trimlen) < 0)
+			return DROP_WRITE_ERROR;
 		if (skb_store_bytes(skb, nh_off + sizeof(struct ipv6hdr),
 				    data, 68, 0) < 0)
 			return DROP_WRITE_ERROR;

--- a/bpf/lib/utils.h
+++ b/bpf/lib/utils.h
@@ -1,0 +1,22 @@
+#ifndef __LIB_UTILS_H_
+#define __LIB_UTILS_H_
+
+#include <bpf/api.h>
+
+#define min(x, y)		\
+({				\
+	typeof(x) _x = (x);	\
+	typeof(y) _y = (y);	\
+	(void) (&_x == &_y);	\
+	_x < _y ? _x : _y;	\
+})
+
+#define max(x, y)		\
+({				\
+	typeof(x) _x = (x);	\
+	typeof(y) _y = (y);	\
+	(void) (&_x == &_y);	\
+	_x > _y ? _x : _y;	\
+})
+
+#endif

--- a/common/bpf/debug.go
+++ b/common/bpf/debug.go
@@ -88,6 +88,7 @@ type DebugCapture struct {
 	SubType uint8
 	Source  uint16
 	Len     uint32
+	OrigLen uint32
 	Arg1    uint32
 	// data
 }
@@ -106,5 +107,5 @@ func (n *DebugCapture) Dump(dissect bool, data []byte, prefix string) {
 	default:
 		fmt.Printf("Unknown message type=%d arg1=%d\n", n.SubType, n.Arg1)
 	}
-	Dissect(dissect, data[12:])
+	Dissect(dissect, data[16:])
 }

--- a/common/bpf/drop.go
+++ b/common/bpf/drop.go
@@ -8,7 +8,8 @@ type DropNotify struct {
 	Type     uint8
 	SubType  uint8
 	Source   uint16
-	Len      uint32
+	OrigLen  uint32
+	CapLen   uint32
 	SrcLabel uint32
 	DstLabel uint32
 	DstID    uint32
@@ -54,7 +55,7 @@ var errors = map[uint8]string{
 
 func (n *DropNotify) Dump(dissect bool, data []byte, prefix string) {
 	fmt.Printf("%s FROM %d Packet dropped %d (%s) %d bytes ifindex=%d",
-		prefix, n.Source, n.SubType, errors[n.SubType], n.Len, n.Ifindex)
+		prefix, n.Source, n.SubType, errors[n.SubType], n.OrigLen, n.Ifindex)
 
 	if n.SrcLabel != 0 || n.DstLabel != 0 {
 		fmt.Printf(" %d->%d", n.SrcLabel, n.DstLabel)
@@ -66,5 +67,5 @@ func (n *DropNotify) Dump(dissect bool, data []byte, prefix string) {
 		fmt.Printf("\n")
 	}
 
-	Dissect(dissect, data[24:])
+	Dissect(dissect, data[28:])
 }

--- a/common/bpf/perf.go
+++ b/common/bpf/perf.go
@@ -163,7 +163,7 @@ type PerfEventHeader struct {
 // Matching 'struct perf_event_sample in kernel sources
 type PerfEventSample struct {
 	PerfEventHeader
-	size uint32
+	Size uint32
 	data byte // Size bytes of data
 }
 
@@ -176,12 +176,12 @@ type PerfEventLost struct {
 
 func (e *PerfEventSample) DataDirect() []byte {
 	// http://stackoverflow.com/questions/27532523/how-to-convert-1024c-char-to-1024byte
-	size := e.size - 4
+	size := e.Size - 4
 	return (*[1 << 30]byte)(unsafe.Pointer(&e.data))[:int(size):int(size)]
 }
 
 func (e *PerfEventSample) DataCopy() []byte {
-	return C.GoBytes(unsafe.Pointer(&e.data), C.int(e.size))
+	return C.GoBytes(unsafe.Pointer(&e.data), C.int(e.Size))
 }
 
 type ReceiveFunc func(msg *PerfEventSample, cpu int)

--- a/contrib/packer-scripts/ubuntu-14.04/ubuntu-1404-atlas.json
+++ b/contrib/packer-scripts/ubuntu-14.04/ubuntu-1404-atlas.json
@@ -86,7 +86,7 @@
       "artifact_type": "vagrant.box",
       "metadata": {
           "provider": "libvirt",
-	  "version": "0.0.35",
+	  "version": "0.0.36",
 	  "description": "Snapshot of net-next kernel"
       }
   }]


### PR DESCRIPTION
After rebase, fix the related code wrt uapi changes. Note that
perf ring buffer formats will change and Go code needs to adapt
as we no longer zero pad the tail if skb length is < 64, and pass
original and captured length as meta data.

Signed-off-by: Daniel Borkmann daniel@cilium.io
