### PR TITLE
Improving label update

### DIFF
--- a/cilium/endpoint/endpoint.go
+++ b/cilium/endpoint/endpoint.go
@@ -225,29 +225,23 @@ func configLabels(ctx *cli.Context) {
 	disableLabels := types.ParseStringLabels(ctx.StringSlice("disable"))
 	deleteLabels := types.ParseStringLabels(ctx.StringSlice("delete"))
 
+	lo := types.LabelOp{}
+
 	if len(addLabels) != 0 {
-		err := client.EndpointLabelsUpdate(epID, types.AddLabelsOp, addLabels)
-		if err != nil {
-			log.Errorf("Error while adding labels %s", err)
-		}
+		lo[types.AddLabelsOp] = addLabels
 	}
 	if len(enableLabels) != 0 {
-		err := client.EndpointLabelsUpdate(epID, types.EnableLabelsOp, enableLabels)
-		if err != nil {
-			log.Errorf("Error while enabling labels %s", err)
-		}
+		lo[types.EnableLabelsOp] = enableLabels
 	}
 	if len(disableLabels) != 0 {
-		err := client.EndpointLabelsUpdate(epID, types.DisableLabelsOp, disableLabels)
-		if err != nil {
-			log.Errorf("Error while disabling labels %s", err)
-		}
+		lo[types.DisableLabelsOp] = disableLabels
 	}
 	if len(deleteLabels) != 0 {
-		err := client.EndpointLabelsUpdate(epID, types.DelLabelsOp, deleteLabels)
-		if err != nil {
-			log.Errorf("Error while deleting labels %s", err)
-		}
+		lo[types.DelLabelsOp] = deleteLabels
+	}
+
+	if err := client.EndpointLabelsUpdate(epID, lo); err != nil {
+		log.Errorf("Error while deleting labels %s", err)
 	}
 
 	if lbls, err := client.EndpointLabelsGet(epID); err != nil {
@@ -537,7 +531,7 @@ func recompileBPF(ctx *cli.Context) {
 		return
 	}
 
-	fmt.Printf("Endpoint %s's successfully recompiled\n", epID)
+	fmt.Printf("Endpoint %d's successfully recompiled\n", epID)
 }
 
 func detachBPF(ctx *cli.Context) {
@@ -553,7 +547,7 @@ func detachBPF(ctx *cli.Context) {
 		return
 	}
 
-	fmt.Printf("Endpoint %s's successfully detached\n", epID)
+	fmt.Printf("Endpoint %d's successfully detached\n", epID)
 }
 
 func listEndpointsBash(ctx *cli.Context) {

--- a/common/backend/backend.go
+++ b/common/backend/backend.go
@@ -19,7 +19,7 @@ type bpfBackend interface {
 	EndpointUpdate(epID uint16, opts types.OptionMap) error
 	EndpointSave(ep types.Endpoint) error
 	EndpointLabelsGet(epID uint16) (*types.OpLabels, error)
-	EndpointLabelsUpdate(epID uint16, op types.LabelOP, labels types.Labels) error
+	EndpointLabelsUpdate(epID uint16, labelOp types.LabelOp) error
 }
 
 type ipamBackend interface {

--- a/common/client/endpoint.go
+++ b/common/client/endpoint.go
@@ -190,9 +190,8 @@ func (cli Client) EndpointLabelsGet(epID uint16) (*types.OpLabels, error) {
 	return &opLbls, nil
 }
 
-func (cli Client) EndpointLabelsUpdate(epID uint16, op types.LabelOP, labels types.Labels) error {
-
-	serverResp, err := cli.R().SetBody(labels).Post(fmt.Sprintf("/endpoint/labels/%s/%d", op, epID))
+func (cli Client) EndpointLabelsUpdate(epID uint16, labelOp types.LabelOp) error {
+	serverResp, err := cli.R().SetBody(labelOp).Post(fmt.Sprintf("/endpoint/labels/%d", epID))
 	if err != nil {
 		return fmt.Errorf("error while connecting to daemon: %s", err)
 	}

--- a/common/types/labels.go
+++ b/common/types/labels.go
@@ -12,15 +12,17 @@ import (
 	"github.com/noironetworks/cilium-net/common"
 )
 
-type LabelOP string
+type LabelOpType string
 
 const (
-	secLabelTimeout         = time.Duration(120 * time.Second)
-	AddLabelsOp     LabelOP = "AddLabelsOp"
-	DelLabelsOp     LabelOP = "DelLabelsOp"
-	EnableLabelsOp  LabelOP = "EnableLabelsOp"
-	DisableLabelsOp LabelOP = "DisableLabelsOp"
+	secLabelTimeout             = time.Duration(120 * time.Second)
+	AddLabelsOp     LabelOpType = "AddLabelsOp"
+	DelLabelsOp     LabelOpType = "DelLabelsOp"
+	EnableLabelsOp  LabelOpType = "EnableLabelsOp"
+	DisableLabelsOp LabelOpType = "DisableLabelsOp"
 )
+
+type LabelOp map[LabelOpType]Labels
 
 type OpLabels struct {
 	// All labels

--- a/daemon/daemon/monitor.go
+++ b/daemon/daemon/monitor.go
@@ -36,7 +36,7 @@ func (d *Daemon) receiveEvent(msg *bpf.PerfEventSample, cpu int) {
 						log.Warningf("Endpoint %d is receiving traffic from an unknown label ID %d", epID, lblID)
 						return
 					}
-					if err := d.EndpointLabelsUpdate(epID, types.AddLabelsOp, sec.Labels); err != nil {
+					if err := d.EndpointLabelsUpdate(epID, types.LabelOp{types.AddLabelsOp: sec.Labels}); err != nil {
 						log.Warningf("Error while add learned labels into the daemon %s", err)
 					}
 				}(v.EndpointID, dn.SrcLabel)

--- a/daemon/server/daemon_mock_test.go
+++ b/daemon/server/daemon_mock_test.go
@@ -20,7 +20,7 @@ type TestDaemon struct {
 	OnEndpointUpdate            func(epID uint16, opts types.OptionMap) error
 	OnEndpointSave              func(ep types.Endpoint) error
 	OnEndpointLabelsGet         func(epID uint16) (*types.OpLabels, error)
-	OnEndpointLabelsUpdate      func(epID uint16, op types.LabelOP, labels types.Labels) error
+	OnEndpointLabelsUpdate      func(epID uint16, labelOp types.LabelOp) error
 	OnGetIPAMConf               func(ipamType ipam.IPAMType, options ipam.IPAMReq) (*ipam.IPAMConfigRep, error)
 	OnAllocateIP                func(ipamType ipam.IPAMType, opts ipam.IPAMReq) (*ipam.IPAMRep, error)
 	OnReleaseIP                 func(ipamType ipam.IPAMType, opts ipam.IPAMReq) error
@@ -109,9 +109,9 @@ func (d TestDaemon) EndpointLabelsGet(epID uint16) (*types.OpLabels, error) {
 	return nil, errors.New("EndpointLabelsGet should not have been called")
 }
 
-func (d TestDaemon) EndpointLabelsUpdate(epID uint16, op types.LabelOP, labels types.Labels) error {
+func (d TestDaemon) EndpointLabelsUpdate(epID uint16, labelOp types.LabelOp) error {
 	if d.OnEndpointLabelsUpdate != nil {
-		return d.OnEndpointLabelsUpdate(epID, op, labels)
+		return d.OnEndpointLabelsUpdate(epID, labelOp)
 	}
 	return errors.New("EndpointLabelsUpdate should not have been called")
 }

--- a/daemon/server/endpoint_test.go
+++ b/daemon/server/endpoint_test.go
@@ -443,18 +443,19 @@ func (s *DaemonSuite) TestEndpointLabelsAddOK(c *C) {
 	}
 	ep.SetID()
 
-	wantedLabels := types.Labels{
-		"foo": types.NewLabel("foo", "bar", "cilium"),
+	wantedLabels := types.LabelOp{
+		types.AddLabelsOp: types.Labels{
+			"foo": types.NewLabel("foo", "bar", "cilium"),
+		},
 	}
 
-	s.d.OnEndpointLabelsUpdate = func(epID uint16, op types.LabelOP, lbls types.Labels) error {
+	s.d.OnEndpointLabelsUpdate = func(epID uint16, lbls types.LabelOp) error {
 		c.Assert(ep.ID, DeepEquals, epID)
-		c.Assert(op, Equals, types.AddLabelsOp)
 		c.Assert(wantedLabels, DeepEquals, lbls)
 		return nil
 	}
 
-	err := s.c.EndpointLabelsUpdate(ep.ID, types.AddLabelsOp, wantedLabels)
+	err := s.c.EndpointLabelsUpdate(ep.ID, wantedLabels)
 	c.Assert(err, IsNil)
 }
 
@@ -471,17 +472,18 @@ func (s *DaemonSuite) TestEndpointLabelsAddFail(c *C) {
 	}
 	ep.SetID()
 
-	wantedLabels := types.Labels{
-		"foo": types.NewLabel("foo", "bar", "cilium"),
+	wantedLabels := types.LabelOp{
+		types.AddLabelsOp: types.Labels{
+			"foo": types.NewLabel("foo", "bar", "cilium"),
+		},
 	}
 
-	s.d.OnEndpointLabelsUpdate = func(epID uint16, op types.LabelOP, lbls types.Labels) error {
+	s.d.OnEndpointLabelsUpdate = func(epID uint16, labelOp types.LabelOp) error {
 		c.Assert(ep.ID, DeepEquals, epID)
-		c.Assert(op, Equals, types.AddLabelsOp)
-		c.Assert(wantedLabels, DeepEquals, lbls)
+		c.Assert(labelOp, DeepEquals, wantedLabels)
 		return errors.New("invalid endpoint")
 	}
 
-	err := s.c.EndpointLabelsUpdate(ep.ID, types.AddLabelsOp, wantedLabels)
+	err := s.c.EndpointLabelsUpdate(ep.ID, wantedLabels)
 	c.Assert(strings.Contains(err.Error(), "invalid endpoint"), Equals, true)
 }

--- a/daemon/server/handlers.go
+++ b/daemon/server/handlers.go
@@ -141,17 +141,12 @@ func (router *Router) endpointLabelsUpdate(w http.ResponseWriter, r *http.Reques
 		processServerError(w, r, err)
 		return
 	}
-	labelOp, exists := vars["labelOp"]
-	if !exists {
-		processServerError(w, r, errors.New("server received empty label operation id"))
-		return
-	}
-	var lbls types.Labels
-	if err := json.NewDecoder(r.Body).Decode(&lbls); err != nil {
+	var labelOp types.LabelOp
+	if err := json.NewDecoder(r.Body).Decode(&labelOp); err != nil {
 		processServerError(w, r, err)
 		return
 	}
-	if err := router.daemon.EndpointLabelsUpdate(epID, types.LabelOP(labelOp), lbls); err != nil {
+	if err := router.daemon.EndpointLabelsUpdate(epID, labelOp); err != nil {
 		processServerError(w, r, err)
 		return
 	}

--- a/daemon/server/routes.go
+++ b/daemon/server/routes.go
@@ -49,7 +49,7 @@ func (r *Router) initBackendRoutes() {
 			"EndpointLabelsGet", "GET", "/endpoint/labels/{endpointID}", r.endpointLabelsGet,
 		},
 		route{
-			"EndpointLabelsUpdate", "POST", "/endpoint/labels/{labelOp}/{endpointID}", r.endpointLabelsUpdate,
+			"EndpointLabelsUpdate", "POST", "/endpoint/labels/{endpointID}", r.endpointLabelsUpdate,
 		},
 		route{
 			"IPAMConfiguration", "POST", "/allocator/ipam-configuration/{ipam-type}", r.ipamConfig,
@@ -120,7 +120,7 @@ func (r *Router) initUIRoutes() {
 			"EndpointLabelsGet", "GET", "/endpoint/labels/{endpointID}", r.endpointLabelsGet,
 		},
 		route{
-			"EndpointLabelsUpdate", "POST", "/endpoint/labels/{labelOp}/{endpointID}", r.endpointLabelsUpdate,
+			"EndpointLabelsUpdate", "POST", "/endpoint/labels/{endpointID}", r.endpointLabelsUpdate,
 		},
 	}
 }

--- a/daemon/ui/index.html
+++ b/daemon/ui/index.html
@@ -238,14 +238,14 @@
 				updateDaemonOption(e.target.id, $(this).is(":checked"));
 			});
 
-			function sendLabelChanges(lbls, operation, endpointID, calb) {
+			function sendLabelChanges(lbls, endpointID, calb) {
 				var xmlHttp = new XMLHttpRequest();
 				xmlHttp.onreadystatechange = function() {
 					if (xmlHttp.readyState == 4 && xmlHttp.status == 202) {
 						calb();
 					}
 				};
-				xmlHttp.open("POST", "endpoint/labels/" + operation + "/" + endpointID, true);
+				xmlHttp.open("POST", "endpoint/labels/" + endpointID, true);
 				xmlHttp.setRequestHeader("Content-type", "application/json");
 				xmlHttp.send(JSON.stringify(lbls));
 			}
@@ -301,20 +301,15 @@
 					}
 				}
 
-				function sendEnabledLabels() {
-					sendLabelChanges(enabledLabels, "EnableLabelsOp", endpointID, function() {
-						closeModal();
-						refreshApplyChangesButton(endpointID);
-					});
-				}
+				var opLabels = {
+					"DisableLabelsOp" : disabledLabels,
+					"EnableLabelsOp" : enabledLabels
+				};
 
-				if (Object.keys(disabledLabels).length != 0) {
-					sendLabelChanges(disabledLabels, "DisableLabelsOp", endpointID, function() {
-						sendEnabledLabels();
-					});
-				} else {
-					sendEnabledLabels();
-				}
+				sendLabelChanges(opLabels, endpointID, function() {
+					closeModal();
+					refreshApplyChangesButton(endpointID);
+				});
 
 			}
 		</script>


### PR DESCRIPTION
This commit provides in a atomic operation to update the endpoint labels
without wasting Security Label IDs by adding a label and getting an ID,
then removing a label and getting an ID.
Now the operations are performed a single time and the new ID is gotten
afterwards.
