### PR TITLE
docker-compose: fix image names

### DIFF
--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   cilium:
-    image: cilium:cilium-ubuntu-16-04
+    image: cilium/cilium:cilium-ubuntu-16-04
     command: cilium -D daemon run -d eth1 --ui
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -15,7 +15,7 @@ services:
       - consul
 
   cilium_docker:
-    image: cilium:cilium-ubuntu-16-04
+    image: cilium/cilium:cilium-ubuntu-16-04
     command: cilium-docker -D
     volumes:
       - /var/run/cilium:/var/run/cilium


### PR DESCRIPTION
Symptoms:

```
$ sudo docker-compose up
Error: image library/cilium not found
ERROR: Error: image library/cilium not found
```

The images are located on
https://hub.docker.com/r/cilium/cilium/
