### PR TITLE
K8S: make k8s network policy annotation as optional

### DIFF
--- a/common/types/network_policy.go
+++ b/common/types/network_policy.go
@@ -16,21 +16,22 @@
 package types
 
 import (
-	"fmt"
-
 	"github.com/cilium/cilium/common"
 
 	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 )
 
 func K8sNP2CP(np v1beta1.NetworkPolicy) (string, *PolicyNode, error) {
-	parentNodeName := np.Annotations[common.K8sAnnotationParentName]
-	if parentNodeName == "" {
-		return "", nil, fmt.Errorf("%s not found in network policy annotations", common.K8sAnnotationParentName)
+	var parentNodeName, policyName string
+	if np.Annotations[common.K8sAnnotationParentName] == "" {
+		parentNodeName = common.GlobalLabelPrefix
+	} else {
+		parentNodeName = np.Annotations[common.K8sAnnotationParentName]
 	}
-	policyName := np.Annotations[common.K8sAnnotationName]
-	if policyName == "" {
-		return "", nil, fmt.Errorf("%s not found in network policy annotations", common.K8sAnnotationName)
+	if np.Annotations[common.K8sAnnotationName] == "" {
+		policyName = np.Name
+	} else {
+		policyName = np.Annotations[common.K8sAnnotationName]
 	}
 
 	allowRules := []AllowRule{}

--- a/examples/kubernetes/network-policy/admin-policy.json
+++ b/examples/kubernetes/network-policy/admin-policy.json
@@ -2,11 +2,7 @@
   "apiVersion": "extensions/v1beta1",
   "kind": "NetworkPolicy",
   "metadata": {
-    "annotations": {
-      "io.cilium.name": "admin",
-      "io.cilium.parent": "io.cilium"
-    },
-    "name": "admin-policy"
+    "name": "admin"
   },
   "spec": {
     "podSelector": {


### PR DESCRIPTION
By removing the obligation of the cilium policy metadata presence will
allow the network policies to be used on others implementations as well.

Fixes #105 

Signed-off-by: André Martins andre@cilium.io
