### PR TITLE
bpf: rebase to net-next kernel

### DIFF
--- a/bpf/include/bpf/api.h
+++ b/bpf/include/bpf/api.h
@@ -210,7 +210,7 @@ static uint32_t BPF_FUNC(get_cgroup_classid, struct __sk_buff *skb);
 static uint32_t BPF_FUNC(get_route_realm, struct __sk_buff *skb);
 static uint32_t BPF_FUNC(get_hash_recalc, struct __sk_buff *skb);
 
-static int BPF_FUNC(skb_in_cgroup, void *map, uint32_t index);
+static int BPF_FUNC(skb_under_cgroup, void *map, uint32_t index);
 
 /* Packet redirection */
 static int BPF_FUNC(redirect, int ifindex, uint32_t flags);
@@ -233,7 +233,8 @@ static int BPF_FUNC(csum_diff, void *from, uint32_t from_size, void *to,
 static int BPF_FUNC(skb_change_type, struct __sk_buff *skb, uint32_t type);
 static int BPF_FUNC(skb_change_proto, struct __sk_buff *skb, uint32_t proto,
 		    uint32_t flags);
-static int BPF_FUNC(skb_change_tail, struct __sk_buff *skb, uint32_t nlen);
+static int BPF_FUNC(skb_change_tail, struct __sk_buff *skb, uint32_t nlen,
+		    uint32_t flags);
 
 /* Packet vlan encap/decap */
 static int BPF_FUNC(skb_vlan_push, struct __sk_buff *skb, uint16_t proto,

--- a/bpf/include/linux/bpf.h
+++ b/bpf/include/linux/bpf.h
@@ -339,7 +339,7 @@ enum bpf_func_id {
 	BPF_FUNC_skb_change_type,
 
 	/**
-	 * bpf_skb_in_cgroup(skb, map, index) - Check cgroup2 membership of skb
+	 * bpf_skb_under_cgroup(skb, map, index) - Check cgroup2 membership of skb
 	 * @skb: pointer to skb
 	 * @map: pointer to bpf_map in BPF_MAP_TYPE_CGROUP_ARRAY type
 	 * @index: index of the cgroup in the bpf_map
@@ -348,7 +348,7 @@ enum bpf_func_id {
 	 *   == 1 skb succeeded the cgroup2 descendant test
 	 *    < 0 error
 	 */
-	BPF_FUNC_skb_in_cgroup,
+	BPF_FUNC_skb_under_cgroup,
 
 	/**
 	 * bpf_get_hash_recalc(skb)
@@ -375,6 +375,26 @@ enum bpf_func_id {
 	 */
 	BPF_FUNC_probe_write_user,
 
+	/**
+	 * bpf_current_task_under_cgroup(map, index) - Check cgroup2 membership of current task
+	 * @map: pointer to bpf_map in BPF_MAP_TYPE_CGROUP_ARRAY type
+	 * @index: index of the cgroup in the bpf_map
+	 * Return:
+	 *   == 0 current failed the cgroup2 descendant test
+	 *   == 1 current succeeded the cgroup2 descendant test
+	 *    < 0 error
+	 */
+	BPF_FUNC_current_task_under_cgroup,
+
+	/**
+	 * bpf_skb_change_tail(skb, len, flags)
+	 * The helper will resize the skb to the given new size,
+	 * to be used f.e. with control messages.
+	 * @skb: pointer to skb
+	 * @len: new skb length
+	 * @flags: reserved
+	 * Return: 0 on success or negative error
+	 */
 	BPF_FUNC_skb_change_tail,
 
 	__BPF_FUNC_MAX_ID,

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -257,7 +257,7 @@ static inline int __icmp6_send_time_exceeded(struct __sk_buff *skb, int nh_off)
 		sum = compute_icmp6_csum(data, 56, ipv6hdr);
 		payload_len = htons(56);
 		trimlen = 56 - ntohs(ipv6hdr->payload_len);
-		if (skb_change_tail(skb, skb->len + trimlen) < 0)
+		if (skb_change_tail(skb, skb->len + trimlen, 0) < 0)
 			return DROP_WRITE_ERROR;
 		/* trim or expand buffer and copy data buffer after ipv6 header */
 		if (skb_store_bytes(skb, nh_off + sizeof(struct ipv6hdr),
@@ -276,7 +276,7 @@ static inline int __icmp6_send_time_exceeded(struct __sk_buff *skb, int nh_off)
 		payload_len = htons(68);
 		/* trim or expand buffer and copy data buffer after ipv6 header */
 		trimlen = 68 - ntohs(ipv6hdr->payload_len);
-		if (skb_change_tail(skb, skb->len + trimlen) < 0)
+		if (skb_change_tail(skb, skb->len + trimlen, 0) < 0)
 			return DROP_WRITE_ERROR;
 		if (skb_store_bytes(skb, nh_off + sizeof(struct ipv6hdr),
 				    data, 68, 0) < 0)

--- a/bpf/probes/skb_change_tail.c
+++ b/bpf/probes/skb_change_tail.c
@@ -21,7 +21,7 @@ __section("probe")
 int probe_skb_change_tail(struct __sk_buff *skb)
 {
 	if (skb->cb[0] != 0)
-		skb_change_tail(skb, 0);
+		skb_change_tail(skb, 0, 0);
 
 	return TC_ACT_SHOT;
 }


### PR DESCRIPTION
Rebase to upstream to import the recently merged skb_change_tail()
helper, and changes from the cgroup v2 bits. This requires to carry
no extra out-of-tree patches around anymore.

Signed-off-by: Daniel Borkmann daniel@cilium.io
