### PR TITLE
policy: Ignore empty search context when evaluating policy

### DIFF
--- a/daemon/daemon/policy.go
+++ b/daemon/daemon/policy.go
@@ -97,6 +97,11 @@ func (d *Daemon) evaluateConsumerSource(e *types.Endpoint, ctx *types.SearchCont
 		return err
 	}
 
+	// Skip currently unused IDs
+	if ctx.From == nil || len(ctx.From) == 0 {
+		return nil
+	}
+
 	log.Debugf("Evaluating policy for %+v", ctx)
 
 	decision := d.policyCanConsume(ctx)


### PR DESCRIPTION
Fixes: #81
