### PR TITLE
daemon: added function to check if kubernetes option is set

### DIFF
--- a/common/types/status.go
+++ b/common/types/status.go
@@ -24,9 +24,10 @@ import (
 type StatusCode int
 
 const (
-	OK      StatusCode = 0
-	Warning StatusCode = -1
-	Failure StatusCode = -2
+	OK       StatusCode = 0
+	Warning  StatusCode = -1
+	Failure  StatusCode = -2
+	Disabled StatusCode = -3
 )
 
 func NewStatusOK(info string) Status {
@@ -53,6 +54,9 @@ func (s Status) String() string {
 		return fmt.Sprintf("%s - %s", text, s.Msg)
 	case Failure:
 		text = common.Red("Failure")
+		return fmt.Sprintf("%s - %s", text, s.Msg)
+	case Disabled:
+		text = common.Yellow("Disabled")
 		return fmt.Sprintf("%s - %s", text, s.Msg)
 	}
 	return "Unknown code"

--- a/daemon/daemon/daemon.go
+++ b/daemon/daemon/daemon.go
@@ -286,11 +286,6 @@ func NewDaemon(c *Config) (*Daemon, error) {
 		return nil, err
 	}
 
-	k8sClient, err := createK8sClient(c.K8sEndpoint)
-	if err != nil {
-		return nil, err
-	}
-
 	rootNode := types.PolicyTree{
 		Root: types.NewPolicyNode(common.GlobalLabelPrefix, nil),
 	}
@@ -307,7 +302,6 @@ func NewDaemon(c *Config) (*Daemon, error) {
 		ipamConf:                  ipamConf,
 		kvClient:                  kvClient,
 		dockerClient:              dockerClient,
-		k8sClient:                 k8sClient,
 		containers:                make(map[string]*types.Container),
 		endpoints:                 make(map[uint16]*types.Endpoint),
 		endpointsDocker:           make(map[string]*types.Endpoint),
@@ -321,6 +315,13 @@ func NewDaemon(c *Config) (*Daemon, error) {
 		uiTopo:                    types.NewUITopo(),
 		uiListeners:               make(map[*Conn]bool),
 		registerUIListener:        make(chan *Conn, 1),
+	}
+
+	if c.IsK8sEnabled() {
+		d.k8sClient, err = createK8sClient(c.K8sEndpoint)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if err := d.init(); err != nil {

--- a/daemon/daemon/daemon_config.go
+++ b/daemon/daemon/daemon_config.go
@@ -82,3 +82,7 @@ func NewConfig() *Config {
 func (c *Config) IsUIEnabled() bool {
 	return c.UIEnabled
 }
+
+func (c *Config) IsK8sEnabled() bool {
+	return len(c.K8sEndpoint) != 0
+}

--- a/daemon/daemon/docker_watcher.go
+++ b/daemon/daemon/docker_watcher.go
@@ -114,6 +114,9 @@ func getCiliumEndpointID(cont dTypes.ContainerJSON, gwIP *addressing.NodeAddress
 }
 
 func (d *Daemon) fetchK8sLabels(dockerLbls map[string]string) (map[string]string, error) {
+	if !d.conf.IsK8sEnabled() {
+		return nil, nil
+	}
 	ns := k8sDockerLbls.GetPodNamespace(dockerLbls)
 	if ns == "" {
 		ns = "default"

--- a/daemon/daemon/k8s_watcher.go
+++ b/daemon/daemon/k8s_watcher.go
@@ -35,6 +35,10 @@ type networkPolicyWatchEvent struct {
 }
 
 func (d *Daemon) EnableK8sWatcher(maxSeconds time.Duration) error {
+	if !d.conf.IsK8sEnabled() {
+		return nil
+	}
+
 	curSeconds := 2 * time.Second
 	uNPs := d.k8sClient.Get().RequestURI("apis/extensions/v1beta1").
 		Resource("networkpolicies").URL().String()

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -113,8 +113,7 @@ func init() {
 					cli.StringFlag{
 						Destination: &config.K8sEndpoint,
 						Name:        "k",
-						Value:       "http://[node-ipv6]:8080",
-						Usage:       "Kubernetes endpoint to retrieve metadata information of new started containers",
+						Usage:       "Kubernetes master address server",
 					},
 					cli.StringFlag{
 						Destination: &labelPrefixFile,
@@ -365,8 +364,8 @@ func initEnv(ctx *cli.Context) error {
 		}
 	}
 
-	if config.K8sEndpoint == "http://[node-ipv6]:8080" {
-		config.K8sEndpoint = fmt.Sprintf("http://[%s:ffff]:8080", strings.TrimSuffix(nodeAddress.IPv6Address.String(), ":0"))
+	if config.IsK8sEnabled() && !strings.HasPrefix(config.K8sEndpoint, "http") {
+		config.K8sEndpoint = "http://" + config.K8sEndpoint
 	}
 
 	if uiServerAddr != "" {


### PR DESCRIPTION
By having this function allows cilium to detect if it should connect to
kubernetes and give the proper status report for the kubernetes side.

Signed-off-by: André Martins andre@cilium.io
