### PR TITLE
daemon: added KeepConfig option

### DIFF
--- a/common/types/option.go
+++ b/common/types/option.go
@@ -113,7 +113,7 @@ func (o *BoolOptions) SetIfUnset(key string, value bool) {
 }
 
 func (o *BoolOptions) InheritDefault(parent *BoolOptions, key string) {
-	o.SetIfUnset(key, parent.IsEnabled(key))
+	o.Set(key, parent.IsEnabled(key))
 }
 
 func ParseOption(arg string, lib *OptionLibrary) (string, bool, error) {
@@ -221,7 +221,7 @@ func (o *BoolOptions) Apply(n OptionMap, changed ChangedFunc, data interface{}) 
 		} else {
 			/* Only disable if enabled already */
 			if ok && val {
-				delete(o.Opts, k)
+				o.Opts[k] = false
 				changes++
 				changed(k, v, data)
 			}

--- a/daemon/daemon/daemon_config.go
+++ b/daemon/daemon/daemon_config.go
@@ -36,15 +36,15 @@ var (
 	}
 
 	DaemonOptionLibrary = types.OptionLibrary{
-		types.OptionNAT46:               &types.OptionSpecNAT46,
-		types.OptionDropNotify:          &types.OptionSpecDropNotify,
-		types.OptionDebug:               &types.OptionSpecDebug,
-		types.OptionPolicy:              &types.OptionSpecPolicy,
-		types.OptionConntrack:           &types.OptionSpecConntrack,
-		types.OptionConntrackAccounting: &types.OptionSpecConntrackAccounting,
-		OptionPolicyTracing:             &OptionSpecPolicyTracing,
+		OptionPolicyTracing: &OptionSpecPolicyTracing,
 	}
 )
+
+func init() {
+	for k, v := range types.EndpointMutableOptionLibrary {
+		DaemonOptionLibrary[k] = v
+	}
+}
 
 // Config is the configuration used by Daemon.
 type Config struct {
@@ -67,6 +67,7 @@ type Config struct {
 
 	DryMode      bool // Do not create BPF maps, devices, ..
 	RestoreState bool // RestoreState restores the state from previous running daemons.
+	KeepConfig   bool // Keep configuration of existing endpoints when starting up.
 
 	// Options changeable at runtime
 	Opts   *types.BoolOptions

--- a/daemon/daemon/state.go
+++ b/daemon/daemon/state.go
@@ -63,9 +63,13 @@ func (d *Daemon) SyncState(dir string, clean bool) error {
 			continue
 		}
 
-		d.conf.OptsMU.RLock()
-		ep.SetDefaultOpts(d.conf.Opts)
-		d.conf.OptsMU.RUnlock()
+		if d.conf.KeepConfig {
+			ep.SetDefaultOpts(nil)
+		} else {
+			d.conf.OptsMU.RLock()
+			ep.SetDefaultOpts(d.conf.Opts)
+			d.conf.OptsMU.RUnlock()
+		}
 
 		if err := d.regenerateEndpoint(ep); err != nil {
 			log.Warningf("Unable to restore endpoint %d: %s", ep.ID, err)

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -115,6 +115,11 @@ func init() {
 						Name:        "k",
 						Usage:       "Kubernetes master address server",
 					},
+					cli.BoolTFlag{
+						Destination: &config.KeepConfig,
+						Name:        "keep-config",
+						Usage:       "When restoring state, keeps containers' configuration in place",
+					},
 					cli.StringFlag{
 						Destination: &labelPrefixFile,
 						Name:        "p",
@@ -152,8 +157,8 @@ func init() {
 					},
 					cli.BoolTFlag{
 						Destination: &config.RestoreState,
-						Name:        "restore-state",
-						Usage:       "Restore state from previous daemon",
+						Name:        "restore",
+						Usage:       "Restores state, if possible, from previous daemon",
 					},
 					cli.StringFlag{
 						Destination: &config.RunDir,


### PR DESCRIPTION
KeepConfig allows users to specify if they want to keep the container
configuration or not when the daemon is set to restore state. The option
is set by default. If user sepcify unsets it, the daemon configuration
will be used instead.

Fixes #48 

Signed-off-by: André Martins andre@cilium.io
