### PR TITLE
cilium-docker: provide real subnet if IPv4 is enabled

### DIFF
--- a/common/ipam/ipam.go
+++ b/common/ipam/ipam.go
@@ -37,10 +37,6 @@ const (
 	LibnetworkDefaultPoolV4 = "CiliumPoolv4"
 	// LibnetworkDefaultPoolV6 is the IPv6 pool name for libnetwork.
 	LibnetworkDefaultPoolV6 = "CiliumPoolv6"
-	// LibnetworkDummyV4AllocPool is never exposed, makes libnetwork happy.
-	LibnetworkDummyV4AllocPool = "0.0.0.0/0"
-	// LibnetworkDummyV4Gateway is never exposed, makes libnetwork happy.
-	LibnetworkDummyV4Gateway = "1.1.1.1/32"
 )
 
 // IPAMConfig is the IPAM configuration used for a particular IPAM type.


### PR DESCRIPTION
Fixes #129 

```
$ docker network inspect cilium 
[
    {
        "Name": "cilium",
        "Id": "4ee291bf52d742d18b5353f83d307ffc9429e1fff0b94a34215eea254ef13ca2",
        "Scope": "local",
        "Driver": "cilium",
        "IPAM": {
            "Driver": "cilium",
            "Options": {},
            "Config": [
                {
                    "Subnet": "10.1.0.0/16",
                    "Gateway": "10.1.0.1/32"
                },
                {
                    "Subnet": "f00d::c0a8:210b:0:0/112",
                    "Gateway": "f00d::c0a8:210b:0:0/128"
                }
            ]
        },
        "Containers": {},
        "Options": {}
    }
]
```

Signed-off-by: André Martins andre@cilium.io
