### PR TITLE
daemon: implemented a endpoint status

### DIFF
--- a/cilium/endpoint/endpoint.go
+++ b/cilium/endpoint/endpoint.go
@@ -287,7 +287,11 @@ func dumpLXCInfo(ctx *cli.Context) {
 		return
 	}
 
+	es := ep.Status.DeepCopy()
+	// We will omit the endpoints status so we don't duplicate them
+	ep.Status = nil
 	fmt.Printf("Endpoint %d\n%s\n", ep.ID, ep)
+	fmt.Printf("Endpoint status: \n%s\n", es.DumpLog())
 }
 
 func listEndpointOptions() {
@@ -479,7 +483,7 @@ func removePolicyKey(ctx *cli.Context) {
 }
 
 func dumpFirstEndpoint(w *tabwriter.Writer, ep *types.Endpoint, seclabel string, label string) {
-	fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t\n", ep.ID, seclabel, label, ep.IPv6.String(), ep.IPv4.String())
+	fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t\n", ep.ID, seclabel, label, ep.IPv6.String(), ep.IPv4.String(), ep.Status.String())
 }
 
 func dumpEndpoints(ctx *cli.Context) {
@@ -503,10 +507,11 @@ func dumpEndpoints(ctx *cli.Context) {
 		ipv6Title      = "IPv6"
 		ipv4Title      = "IPv4"
 		endpointTitle  = "ENDPOINT ID"
+		statusTitle    = "STATUS"
 	)
 
-	fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t\n",
-		endpointTitle, labelsIDTitle, labelsDesTitle, ipv6Title, ipv4Title)
+	fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t\n",
+		endpointTitle, labelsIDTitle, labelsDesTitle, ipv6Title, ipv4Title, statusTitle)
 
 	for _, ep := range eps {
 		if ep.SecLabel == nil {
@@ -523,7 +528,7 @@ func dumpEndpoints(ctx *cli.Context) {
 						dumpFirstEndpoint(w, &ep, seclabel, lbl.String())
 						first = false
 					} else {
-						fmt.Fprintf(w, "\t\t%s\t\t\t\n", lbl)
+						fmt.Fprintf(w, "\t\t%s\t\t\t\t\n", lbl)
 					}
 				}
 			}

--- a/common/types/endpoint_test.go
+++ b/common/types/endpoint_test.go
@@ -85,6 +85,7 @@ func (s *EndpointSuite) TestDeepCopy(c *C) {
 		NodeIP:           net.ParseIP("192.168.0.1"),
 		PortMap:          make([]EPPortMap, 2),
 		Opts:             NewBoolOptions(&EndpointOptionLibrary),
+		Status:           &EndpointStatus{},
 	}
 	cpy := epWant.DeepCopy()
 	c.Assert(*cpy, DeepEquals, *epWant)

--- a/common/types/status.go
+++ b/common/types/status.go
@@ -31,11 +31,7 @@ const (
 )
 
 func NewStatusOK(info string) Status {
-	if info == "" {
-		return Status{Code: OK, Msg: "OK"}
-	} else {
-		return Status{Code: OK, Msg: info}
-	}
+	return Status{Code: OK, Msg: info}
 }
 
 type Status struct {
@@ -43,23 +39,28 @@ type Status struct {
 	Msg  string     `json:"msg"`
 }
 
-func (s Status) String() string {
+func (sc StatusCode) String() string {
 	var text string
-	switch s.Code {
+	switch sc {
 	case OK:
 		text = common.Green("OK")
-		return fmt.Sprintf("%s", text)
 	case Warning:
 		text = common.Yellow("Warning")
-		return fmt.Sprintf("%s - %s", text, s.Msg)
 	case Failure:
 		text = common.Red("Failure")
-		return fmt.Sprintf("%s - %s", text, s.Msg)
 	case Disabled:
 		text = common.Yellow("Disabled")
-		return fmt.Sprintf("%s - %s", text, s.Msg)
+	default:
+		text = "Unknown code"
 	}
-	return "Unknown code"
+	return fmt.Sprintf("%s", text)
+}
+
+func (s Status) String() string {
+	if s.Msg == "" {
+		return fmt.Sprintf("%s", s.Code)
+	}
+	return fmt.Sprintf("%s - %s", s.Code, s.Msg)
 }
 
 type StatusResponse struct {

--- a/daemon/daemon/ct.go
+++ b/daemon/daemon/ct.go
@@ -16,6 +16,7 @@
 package daemon
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"time"
@@ -35,6 +36,7 @@ func runGC(e *types.Endpoint, prefix string, ctType ctmap.CtType) {
 	fd, err := bpf.ObjGet(file)
 	if err != nil {
 		log.Warningf("Unable to open CT map %s: %s\n", file, err)
+		e.LogStatus(types.Warning, fmt.Sprintf("Unable to open CT map %s: %s", file, err))
 		return
 	}
 

--- a/daemon/daemon/policy.go
+++ b/daemon/daemon/policy.go
@@ -245,6 +245,7 @@ func (d *Daemon) regenerateEndpointPolicy(e *types.Endpoint, regenerateEndpoint 
 			if err != nil {
 				log.Warningf("Error while updating endpoint: %s\n", err)
 			}
+			return err
 		}
 	}
 
@@ -265,7 +266,12 @@ func (d *Daemon) triggerPolicyUpdates(added []uint32) {
 	}
 
 	for _, ep := range d.endpoints {
-		d.regenerateEndpointPolicy(ep, true)
+		err := d.regenerateEndpointPolicy(ep, true)
+		if err != nil {
+			ep.LogStatus(types.Failure, err.Error())
+		} else {
+			ep.LogStatusOK("Policy regenerated")
+		}
 	}
 }
 


### PR DESCRIPTION
```
$ cilium endpoint inspect endpoint 35542
Endpoint status: 
2016-09-19T21:01:58-07:00 - OK - Policy regenerated
2016-09-19T21:01:58-07:00 - OK - Regenerated BPF code
2016-09-19T21:01:58-07:00 - OK - Policy regenerated
2016-09-19T21:01:58-07:00 - OK - Successfully regenerated program for endpoint
2016-09-19T21:00:58-07:00 - OK - Policy regenerated
2016-09-19T21:00:58-07:00 - OK - Successfully regenerated program for endpoint
2016-09-19T20:58:47-07:00 - OK - Policy regenerated
$ cilium endpoint list
ENDPOINT ID   LABEL ID   LABELS (source:key[=value])   IPv6                     IPv4          STATUS                                                         
35542         259        cilium:io.cilium.client       f00d::c0a8:210b:0:8ad6   10.1.28.238   2016-09-19T21:01:58-07:00 - OK - Policy regenerated
```

With the cilium endpoint status the user will be able to see the last
256 log messages for a particular endpoint when it's being inspected.

Fixes #128 
Signed-off-by: André Martins andre@cilium.io
