### PR TITLE
ipam: fixing invalid CIDR address

### DIFF
--- a/common/ipam/ipam.go
+++ b/common/ipam/ipam.go
@@ -37,6 +37,10 @@ const (
 	LibnetworkDefaultPoolV4 = "CiliumPoolv4"
 	// LibnetworkDefaultPoolV6 is the IPv6 pool name for libnetwork.
 	LibnetworkDefaultPoolV6 = "CiliumPoolv6"
+	// LibnetworkDummyV4AllocPool is never exposed, makes libnetwork happy.
+	LibnetworkDummyV4AllocPool = "0.0.0.0/0"
+	// LibnetworkDummyV4Gateway is never exposed, makes libnetwork happy.
+	LibnetworkDummyV4Gateway = "1.1.1.1/32"
 )
 
 // IPAMConfig is the IPAM configuration used for a particular IPAM type.

--- a/daemon/daemon/ipam.go
+++ b/daemon/daemon/ipam.go
@@ -183,10 +183,13 @@ func (d *Daemon) getIPAMConfLibnetwork(ln ipam.IPAMReq) (*ipam.IPAMConfigRep, er
 		var poolID, pool, gw string
 
 		if ln.RequestPoolRequest.V6 == false {
+			poolID = ipam.LibnetworkDefaultPoolV4
 			if d.conf.IPv4Enabled {
-				poolID = ipam.LibnetworkDefaultPoolV4
 				pool = d.conf.NodeAddress.IPv4AllocRange().String()
 				gw = d.conf.NodeAddress.IPv4Address.IP().String() + "/32"
+			} else {
+				pool = ipam.LibnetworkDummyV4AllocPool
+				gw = ipam.LibnetworkDummyV4Gateway
 			}
 		} else {
 			subnetGo := net.IPNet(d.ipamConf.IPAMConfig.Subnet)


### PR DESCRIPTION
This commit fixes the 'invalid CIDR address' error when the user tried
to create a docker network when cilium daemon was started with the flag
--ipv4=false

Fixes: a736c076f5d7f54cc0a3c51336638da084dbae8c
Signed-off-by: André Martins andre@cilium.io

with `--ipv4=true`

```
$ docker network inspect cilium 
[
    {
        "Name": "cilium",
        "Id": "00a9dcc77f6541fd7e393f703fc340c01432ee31687d8b109494e25062dff94c",
        "Scope": "local",
        "Driver": "cilium",
        "IPAM": {
            "Driver": "cilium",
            "Options": {},
            "Config": [
                {
                    "Subnet": "10.15.0.0/16",
                    "Gateway": "10.15.0.1/32"
                },
                {
                    "Subnet": "f00d::c0a8:210b:0:0/112",
                    "Gateway": "f00d::c0a8:210b:0:0/128"
                }
            ]
        },
        "Containers": {},
        "Options": {}
    }
]
```

with `--ipv4=false`

```
$ docker network inspect cilium 
[
    {
        "Name": "cilium",
        "Id": "a4114828a65850b323ff7113e315b786ae96bdd4147b958b690b042f74db722b",
        "Scope": "local",
        "Driver": "cilium",
        "IPAM": {
            "Driver": "cilium",
            "Options": {},
            "Config": [
                {
                    "Subnet": "0.0.0.0/0",
                    "Gateway": "1.1.1.1/32"
                },
                {
                    "Subnet": "f00d::c0a8:210b:0:0/112",
                    "Gateway": "f00d::c0a8:210b:0:0/128"
                }
            ]
        },
        "Containers": {},
        "Options": {}
    }
]
```
