### PR TITLE
Increase test coverage of the IP module and small cleanup fix

### DIFF
--- a/common/addressing/ip.go
+++ b/common/addressing/ip.go
@@ -43,10 +43,13 @@ func NewCiliumIPv6(address string) (CiliumIPv6, error) {
 		return nil, fmt.Errorf("Unable to parse IPv6 address: %s", address)
 	}
 
-	if ip16 := ip.To16(); ip16 == nil {
-		return nil, fmt.Errorf("Not an IPv6 address")
+	// As result of ParseIP, ip is either a valid IPv6 or IPv4 address. net.IP
+	// represents both versions on 16 bytes, so a more reliable way to tell
+	// IPv4 and IPv6 apart is to see if it fits 4 bytes
+	if ip4 := ip.To4(); ip4 != nil {
+		return nil, fmt.Errorf("Not an IPv6 address: %s", address)
 	} else {
-		return DeriveCiliumIPv6(ip16), nil
+		return DeriveCiliumIPv6(ip.To16()), nil
 	}
 }
 

--- a/doc/vagrant.md
+++ b/doc/vagrant.md
@@ -10,7 +10,7 @@ $ contrib/vagrant/start.sh
 ```
 
 This will bring up a master node plus the configured  number of additional slave
-nodes. The master node will run a consult agent with the slaves configured to
+nodes. The master node will run a consul agent with the slaves configured to
 point to it.
 
 ### Options

--- a/plugins/cilium-docker/main.go
+++ b/plugins/cilium-docker/main.go
@@ -18,7 +18,7 @@ package main
 import (
 	"os"
 
-	common "github.com/cilium/cilium/common"
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/plugins/cilium-docker/driver"
 
 	"github.com/codegangsta/cli"

--- a/tests/02-perf.sh
+++ b/tests/02-perf.sh
@@ -51,14 +51,14 @@ cat <<EOF | cilium -D policy import -
 {
         "name": "io.cilium",
         "children": {
-		"client": { },
-		"server": {
-			"rules": [{
-				"allow": ["reserved:host", "../client"]
-			}]
-		}
+            "client": { },
+            "server": {
+                "rules": [{
+                    "allow": ["reserved:host", "../client"]
+                }]
+            }
 
-	}
+	    }
 }
 EOF
 


### PR DESCRIPTION
- Adding unit tests to cover more functionalities and corner cases of the ip module.
- Corrected typo in doc/vagrant.md
- Removed redundant alias in plugins/cilium-docker/main.go
- Fixed indentation level of the policy imported on tests/02-perf.sh
