### PR TITLE
lb: Better loadbalancer API and CLI

### DIFF
--- a/bpf/lbmap/ipv4.go
+++ b/bpf/lbmap/ipv4.go
@@ -35,7 +35,7 @@ var (
 		maxEntries)
 	RevNat4Map = bpf.NewMap(common.BPFCiliumMaps+"/cilium_lb4_reverse_nat",
 		bpf.MapTypeHash,
-		int(unsafe.Sizeof(RevNat4Key(0))),
+		int(unsafe.Sizeof(RevNat4Key{})),
 		int(unsafe.Sizeof(RevNat4Value{})),
 		maxEntries)
 )
@@ -47,21 +47,32 @@ type Service4Key struct {
 	Slave   uint16
 }
 
-func (k Service4Key) IsIPv6() bool           { return false }
-func (k Service4Key) Map() *bpf.Map          { return Service4Map }
-func (k Service4Key) NewValue() bpf.MapValue { return &Service4Value{} }
+func (k Service4Key) IsIPv6() bool               { return false }
+func (k Service4Key) Map() *bpf.Map              { return Service4Map }
+func (k Service4Key) NewValue() bpf.MapValue     { return &Service4Value{} }
+func (k *Service4Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
+func (k *Service4Key) GetPort() uint16           { return k.Port }
+func (k *Service4Key) SetPort(port uint16)       { k.Port = port }
+func (k *Service4Key) SetBackend(backend int)    { k.Slave = uint16(backend) }
+func (k *Service4Key) GetBackend() int           { return int(k.Slave) }
 
-func (k Service4Key) GetKeyPtr() unsafe.Pointer {
-	return unsafe.Pointer(&k)
+func (k *Service4Key) String() string {
+	return fmt.Sprintf("%s:%d", k.Address, k.Port)
 }
 
-func (k Service4Key) MapDelete() error {
+func (k *Service4Key) Convert() ServiceKey {
+	n := *k
+	n.Port = common.Swab16(n.Port)
+	return &n
+}
+
+func (k *Service4Key) MapDelete() error {
 	return k.Map().Delete(k)
 }
 
 func NewService4Key(ip net.IP, port uint16, slave uint16) *Service4Key {
 	key := Service4Key{
-		Port:  common.Swab16(port),
+		Port:  port,
 		Slave: slave,
 	}
 
@@ -82,14 +93,14 @@ type Service4Value struct {
 	Address types.IPv4
 	Port    uint16
 	Count   uint16
-	RevNAT  uint16
+	RevNat  uint16
 }
 
 func NewService4Value(count uint16, target net.IP, port uint16, revNat uint16) *Service4Value {
 	svc := Service4Value{
 		Count:  count,
-		RevNAT: common.Swab16(revNat),
-		Port:   common.Swab16(port),
+		RevNat: revNat,
+		Port:   port,
 	}
 
 	copy(svc.Address[:], target.To4())
@@ -97,12 +108,33 @@ func NewService4Value(count uint16, target net.IP, port uint16, revNat uint16) *
 	return &svc
 }
 
-func (s Service4Value) GetValuePtr() unsafe.Pointer {
-	return unsafe.Pointer(&s)
+func (s *Service4Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(s) }
+func (s *Service4Value) SetPort(port uint16)         { s.Port = port }
+func (s *Service4Value) SetCount(count int)          { s.Count = uint16(count) }
+func (s *Service4Value) GetCount() int               { return int(s.Count) }
+func (s *Service4Value) SetRevNat(id int)            { s.RevNat = uint16(id) }
+func (s *Service4Value) SetAddress(ip net.IP) error {
+	if ip4 := ip.To4(); ip4 == nil {
+		return fmt.Errorf("Not an IPv4 address")
+	} else {
+		copy(s.Address[:], ip4)
+		return nil
+	}
+}
+
+func (v *Service4Value) Convert() ServiceValue {
+	n := *v
+	n.RevNat = common.Swab16(n.RevNat)
+	n.Port = common.Swab16(n.Port)
+	return &n
 }
 
 func (v *Service4Value) RevNatKey() RevNatKey {
-	return RevNat4Key(v.RevNAT)
+	return &RevNat4Key{v.RevNat}
+}
+
+func (v *Service4Value) String() string {
+	return fmt.Sprintf("%s:%d (%d)", v.Address, v.Port, v.RevNat)
 }
 
 func Service4DumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue, error) {
@@ -115,29 +147,31 @@ func Service4DumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue, err
 		return nil, nil, fmt.Errorf("Unable to convert key: %s\n", err)
 	}
 
-	svcKey.Port = common.Swab16(svcKey.Port)
-
 	if err := binary.Read(valueBuf, binary.LittleEndian, &svcVal); err != nil {
 		return nil, nil, fmt.Errorf("Unable to convert key: %s\n", err)
 	}
 
-	svcVal.Port = common.Swab16(svcVal.Port)
-	svcVal.RevNAT = common.Swab16(svcVal.RevNAT)
-
-	return &svcKey, &svcVal, nil
+	return svcKey.Convert(), svcVal.Convert(), nil
 }
 
-type RevNat4Key uint16
-
-func NewRevNat4Key(value uint16) RevNat4Key {
-	return RevNat4Key(common.Swab16(value))
+type RevNat4Key struct {
+	Key uint16
 }
 
-func (k RevNat4Key) IsIPv6() bool           { return false }
-func (k RevNat4Key) Map() *bpf.Map          { return RevNat4Map }
-func (k RevNat4Key) NewValue() bpf.MapValue { return &RevNat4Value{} }
-func (k RevNat4Key) GetKeyPtr() unsafe.Pointer {
-	return unsafe.Pointer(&k)
+func NewRevNat4Key(value uint16) *RevNat4Key {
+	return &RevNat4Key{value}
+}
+
+func (k *RevNat4Key) IsIPv6() bool              { return false }
+func (k *RevNat4Key) Map() *bpf.Map             { return RevNat4Map }
+func (k *RevNat4Key) NewValue() bpf.MapValue    { return &RevNat4Value{} }
+func (k *RevNat4Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
+func (k *RevNat4Key) String() string            { return fmt.Sprintf("%d", k.Key) }
+
+func (k *RevNat4Key) Convert() RevNatKey {
+	n := *k
+	n.Key = common.Swab16(n.Key)
+	return &n
 }
 
 type RevNat4Value struct {
@@ -145,13 +179,21 @@ type RevNat4Value struct {
 	Port    uint16
 }
 
-func (k RevNat4Value) GetValuePtr() unsafe.Pointer {
-	return unsafe.Pointer(&k)
+func (v *RevNat4Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
+
+func (v *RevNat4Value) Convert() RevNatValue {
+	n := *v
+	n.Port = common.Swab16(n.Port)
+	return &n
+}
+
+func (v *RevNat4Value) String() string {
+	return fmt.Sprintf("%s:%d", v.Address, v.Port)
 }
 
 func NewRevNat4Value(ip net.IP, port uint16) *RevNat4Value {
 	revNat := RevNat4Value{
-		Port: common.Swab16(port),
+		Port: port,
 	}
 
 	copy(revNat.Address[:], ip.To4())
@@ -175,7 +217,5 @@ func RevNat4DumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue, erro
 		return nil, nil, fmt.Errorf("Unable to convert value: %s\n", err)
 	}
 
-	revNat.Port = common.Swab16(revNat.Port)
-
-	return &revKey, &revNat, nil
+	return revKey.Convert(), revNat.Convert(), nil
 }

--- a/bpf/lbmap/ipv6.go
+++ b/bpf/lbmap/ipv6.go
@@ -35,7 +35,7 @@ var (
 		maxEntries)
 	RevNat6Map = bpf.NewMap(common.BPFCiliumMaps+"/cilium_lb6_reverse_nat",
 		bpf.MapTypeHash,
-		int(unsafe.Sizeof(RevNat6Key(0))),
+		int(unsafe.Sizeof(RevNat6Key{})),
 		int(unsafe.Sizeof(RevNat6Value{})),
 		maxEntries)
 )
@@ -49,7 +49,7 @@ type Service6Key struct {
 
 func NewService6Key(ip net.IP, port uint16, slave uint16) *Service6Key {
 	key := Service6Key{
-		Port:  common.Swab16(port),
+		Port:  port,
 		Slave: slave,
 	}
 
@@ -58,12 +58,23 @@ func NewService6Key(ip net.IP, port uint16, slave uint16) *Service6Key {
 	return &key
 }
 
-func (k Service6Key) IsIPv6() bool           { return true }
-func (k Service6Key) Map() *bpf.Map          { return Service6Map }
-func (k Service6Key) NewValue() bpf.MapValue { return &Service6Value{} }
+func (k Service6Key) IsIPv6() bool               { return true }
+func (k Service6Key) Map() *bpf.Map              { return Service6Map }
+func (k Service6Key) NewValue() bpf.MapValue     { return &Service6Value{} }
+func (k *Service6Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
+func (k *Service6Key) GetPort() uint16           { return k.Port }
+func (k *Service6Key) SetPort(port uint16)       { k.Port = port }
+func (k *Service6Key) SetBackend(backend int)    { k.Slave = uint16(backend) }
+func (k *Service6Key) GetBackend() int           { return int(k.Slave) }
 
-func (k Service6Key) GetKeyPtr() unsafe.Pointer {
-	return unsafe.Pointer(&k)
+func (k *Service6Key) Convert() ServiceKey {
+	n := *k
+	n.Port = common.Swab16(n.Port)
+	return &n
+}
+
+func (k *Service6Key) String() string {
+	return fmt.Sprintf("%s:%d", k.Address, k.Port)
 }
 
 func (k *Service6Key) RevNatValue() RevNatValue {
@@ -84,8 +95,8 @@ type Service6Value struct {
 func NewService6Value(count uint16, target net.IP, port uint16, revNat uint16) *Service6Value {
 	svc := Service6Value{
 		Count:  count,
-		Port:   common.Swab16(port),
-		RevNat: common.Swab16(revNat),
+		Port:   port,
+		RevNat: revNat,
 	}
 
 	copy(svc.Address[:], target.To16())
@@ -93,12 +104,31 @@ func NewService6Value(count uint16, target net.IP, port uint16, revNat uint16) *
 	return &svc
 }
 
-func (s Service6Value) GetValuePtr() unsafe.Pointer {
-	return unsafe.Pointer(&s)
+func (s *Service6Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(s) }
+func (s *Service6Value) SetPort(port uint16)         { s.Port = port }
+func (s *Service6Value) SetCount(count int)          { s.Count = uint16(count) }
+func (s *Service6Value) GetCount() int               { return int(s.Count) }
+func (s *Service6Value) SetRevNat(id int)            { s.RevNat = uint16(id) }
+func (s *Service6Value) RevNatKey() RevNatKey        { return &RevNat6Key{s.RevNat} }
+
+func (s *Service6Value) SetAddress(ip net.IP) error {
+	if ip.To4() != nil {
+		return fmt.Errorf("Not an IPv6 address")
+	}
+
+	copy(s.Address[:], ip.To16())
+	return nil
 }
 
-func (v *Service6Value) RevNatKey() RevNatKey {
-	return RevNat6Key(v.RevNat)
+func (v *Service6Value) Convert() ServiceValue {
+	n := *v
+	n.RevNat = common.Swab16(n.RevNat)
+	n.Port = common.Swab16(n.Port)
+	return &n
+}
+
+func (v *Service6Value) String() string {
+	return fmt.Sprintf("%s:%d (%d)", v.Address, v.Port, v.RevNat)
 }
 
 func Service6DumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue, error) {
@@ -111,29 +141,31 @@ func Service6DumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue, err
 		return nil, nil, fmt.Errorf("Unable to convert key: %s\n", err)
 	}
 
-	svcKey.Port = common.Swab16(svcKey.Port)
-
 	if err := binary.Read(valueBuf, binary.LittleEndian, &svcVal); err != nil {
 		return nil, nil, fmt.Errorf("Unable to convert value: %s\n", err)
 	}
 
-	svcVal.Port = common.Swab16(svcVal.Port)
-	svcVal.RevNat = common.Swab16(svcVal.RevNat)
-
-	return &svcKey, &svcVal, nil
+	return svcKey.Convert(), svcVal.Convert(), nil
 }
 
-type RevNat6Key uint16
-
-func NewRevNat6Key(value uint16) RevNat6Key {
-	return RevNat6Key(common.Swab16(value))
+type RevNat6Key struct {
+	Key uint16
 }
 
-func (k RevNat6Key) IsIPv6() bool           { return true }
-func (k RevNat6Key) Map() *bpf.Map          { return RevNat6Map }
-func (k RevNat6Key) NewValue() bpf.MapValue { return &RevNat6Value{} }
-func (k RevNat6Key) GetKeyPtr() unsafe.Pointer {
-	return unsafe.Pointer(&k)
+func NewRevNat6Key(value uint16) *RevNat6Key {
+	return &RevNat6Key{value}
+}
+
+func (k *RevNat6Key) IsIPv6() bool              { return true }
+func (k *RevNat6Key) Map() *bpf.Map             { return RevNat6Map }
+func (k *RevNat6Key) NewValue() bpf.MapValue    { return &RevNat6Value{} }
+func (k *RevNat6Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
+func (k *RevNat6Key) String() string            { return fmt.Sprintf("%d", k.Key) }
+
+func (k *RevNat6Key) Convert() RevNatKey {
+	n := *k
+	n.Key = common.Swab16(n.Key)
+	return &n
 }
 
 type RevNat6Value struct {
@@ -143,7 +175,7 @@ type RevNat6Value struct {
 
 func NewRevNat6Value(ip net.IP, port uint16) *RevNat6Value {
 	revNat := RevNat6Value{
-		Port: common.Swab16(port),
+		Port: port,
 	}
 
 	copy(revNat.Address[:], ip.To16())
@@ -151,8 +183,13 @@ func NewRevNat6Value(ip net.IP, port uint16) *RevNat6Value {
 	return &revNat
 }
 
-func (k RevNat6Value) GetValuePtr() unsafe.Pointer {
-	return unsafe.Pointer(&k)
+func (k *RevNat6Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(k) }
+func (v *RevNat6Value) String() string              { return fmt.Sprintf("%s:%d", v.Address, v.Port) }
+
+func (v *RevNat6Value) Convert() RevNatValue {
+	n := *v
+	n.Port = common.Swab16(n.Port)
+	return &n
 }
 
 func RevNat6DumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue, error) {
@@ -171,7 +208,5 @@ func RevNat6DumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue, erro
 		return nil, nil, fmt.Errorf("Unable to convert value: %s\n", err)
 	}
 
-	revNat.Port = common.Swab16(revNat.Port)
-
-	return &revKey, &revNat, nil
+	return revKey.Convert(), revNat.Convert(), nil
 }

--- a/bpf/lbmap/lbmap.go
+++ b/bpf/lbmap/lbmap.go
@@ -16,6 +16,8 @@
 package lbmap
 
 import (
+	"net"
+
 	"github.com/cilium/cilium/common/bpf"
 )
 
@@ -28,6 +30,9 @@ const (
 type ServiceKey interface {
 	bpf.MapKey
 
+	// Returns human readable string representation
+	String() string
+
 	// Returns true if the key is of type IPv6
 	IsIPv6() bool
 
@@ -36,26 +41,76 @@ type ServiceKey interface {
 
 	// Returns a RevNatValue matching a ServiceKey
 	RevNatValue() RevNatValue
+
+	// Returns the port set in the key or 0
+	GetPort() uint16
+
+	// Set the backend index (master: 0, backend: nth backend)
+	SetBackend(int)
+
+	// Return backend index
+	GetBackend() int
+
+	// Convert between host byte order and map byte order
+	Convert() ServiceKey
 }
 
 // Interface describing protocol independent value for services map
 type ServiceValue interface {
 	bpf.MapValue
 
+	// Returns human readable string representation
+	String() string
+
 	// Returns a RevNatKey matching a ServiceValue
 	RevNatKey() RevNatKey
+
+	// Set the number of backends
+	SetCount(int)
+
+	// Get the number of backends
+	GetCount() int
+
+	// Set address to map to (left blank for master)
+	SetAddress(net.IP) error
+
+	// Set port to map to (left blank for master)
+	SetPort(uint16)
+
+	// Set reverse NAT identifier
+	SetRevNat(int)
+
+	// Convert between host byte order and map byte order
+	Convert() ServiceValue
 }
 
 func UpdateService(key ServiceKey, value ServiceValue) error {
-	return key.Map().Update(key, value)
+	if _, err := key.Map().OpenOrCreate(); err != nil {
+		return err
+	}
+
+	return key.Map().Update(key.Convert(), value.Convert())
 }
 
 func DeleteService(key ServiceKey) error {
-	return key.Map().Delete(key)
+	return key.Map().Delete(key.Convert())
 }
 
-func LookupService(key ServiceKey) (bpf.MapValue, error) {
-	return key.Map().Lookup(key)
+func LookupService(key ServiceKey) (ServiceValue, error) {
+	var svc ServiceValue
+
+	val, err := key.Map().Lookup(key.Convert())
+	if err != nil {
+		return nil, err
+	}
+
+	if key.IsIPv6() {
+		svc = val.(*Service6Value)
+	} else {
+		svc = val.(*Service4Value)
+	}
+
+	return svc.Convert(), nil
 }
 
 type RevNatKey interface {
@@ -66,20 +121,43 @@ type RevNatKey interface {
 
 	// Returns the BPF map matching the key type
 	Map() *bpf.Map
+
+	// Convert between host byte order and map byte order
+	Convert() RevNatKey
 }
 
 type RevNatValue interface {
 	bpf.MapValue
+
+	// Convert between host byte order and map byte order
+	Convert() RevNatValue
 }
 
 func UpdateRevNat(key RevNatKey, value RevNatValue) error {
-	return key.Map().Update(key, value)
+	if _, err := key.Map().OpenOrCreate(); err != nil {
+		return err
+	}
+
+	return key.Map().Update(key.Convert(), value.Convert())
 }
 
 func DeleteRevNat(key RevNatKey) error {
-	return key.Map().Delete(key)
+	return key.Map().Delete(key.Convert())
 }
 
 func LookupRevNat(key RevNatKey) (RevNatValue, error) {
-	return key.Map().Lookup(key)
+	var revnat RevNatValue
+
+	val, err := key.Map().Lookup(key.Convert())
+	if err != nil {
+		return nil, err
+	}
+
+	if key.IsIPv6() {
+		revnat = val.(*RevNat6Value)
+	} else {
+		revnat = val.(*RevNat4Value)
+	}
+
+	return revnat.Convert(), nil
 }

--- a/cilium/lb/main.go
+++ b/cilium/lb/main.go
@@ -191,13 +191,11 @@ func cliDumpServices(ctx *cli.Context) {
 	dumpTable = map[string]*ServiceDump{}
 
 	if err := lbmap.Service4Map.Dump(lbmap.Service4DumpParser, dumpService4); err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to dump map: %s\n", err)
-		os.Exit(1)
+		fmt.Fprintf(os.Stderr, "Warning: Unable to dump map: %s\n", err)
 	}
 
 	if err := lbmap.Service6Map.Dump(lbmap.Service6DumpParser, dumpService6); err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to dump map: %s\n", err)
-		os.Exit(1)
+		fmt.Fprintf(os.Stderr, "Warning: Unable to dump map: %s\n", err)
 	}
 
 	for k1 := range dumpTable {
@@ -397,13 +395,11 @@ func cliDeleteService(ctx *cli.Context) {
 
 	if ctx.Bool("all") {
 		if err := lbmap.Service6Map.DeleteAll(); err != nil {
-			fmt.Fprintf(os.Stderr, "%s\n", err)
-			os.Exit(1)
+			fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
 		}
 
 		if err := lbmap.Service4Map.DeleteAll(); err != nil {
-			fmt.Fprintf(os.Stderr, "%s\n", err)
-			os.Exit(1)
+			fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
 		}
 	} else {
 		key := parseServiceKey(ctx.Args().Get(0))


### PR DESCRIPTION
- Adds interfaces for service key/value and RevNat key/value
  to hide address family specific code
- Automatically create map files on first update/insert
- Keep structure in host byte order and convert before reading
  or writing from/to map
- Use ParseTCPAddr() to parse IP and port combination
- Allow reading backends from stdin
- Allow specifying multiple backends in update-service command
- Automatically count backends

Signed-off-by: Thomas Graf thomas@cilium.io
