### PR TITLE
demo: added k8s-cilium-proxy demo

### DIFF
--- a/contrib/shell/util.sh
+++ b/contrib/shell/util.sh
@@ -17,7 +17,8 @@ readonly  reset=$(tput sgr0)
 readonly  green=$(tput bold; tput setaf 2)
 readonly yellow=$(tput bold; tput setaf 3)
 readonly   blue=$(tput bold; tput setaf 6)
-readonly timeout=$(if [ "$(uname)" == "Darwin" ]; then echo "1"; else echo "0.1"; fi) 
+readonly timeout=$(if [ "$(uname)" == "Darwin" ]; then echo "1"; else echo "0.1"; fi)
+readonly ipv6regex='(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))'
 
 function desc() {
     maybe_first_prompt

--- a/examples/demo/demo5.sh
+++ b/examples/demo/demo5.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+. $(dirname ${BASH_SOURCE})/../../contrib/shell/util.sh
+
+NETWORK="cilium"
+
+function cleanup {
+	tmux kill-session -t my-session >/dev/null 2>&1
+    sudo killall -9 etcd 2> /dev/null || true
+    sudo killall -9 kubelet 2> /dev/null || true
+    sudo killall -9 hyperkube 2> /dev/null || true
+    sudo killall -9 kube-scheduler 2> /dev/null || true
+    sudo killall -9 kube-controller-manager 2> /dev/null || true
+    sudo killall -9 kube-proxy 2> /dev/null || true
+    sudo killall -9 kube-apiserver 2> /dev/null || true
+    docker rm -f `docker ps -aq --filter=name=k8s` 2> /dev/null || true
+    cilium policy delete io.cilium
+}
+
+trap cleanup EXIT
+
+docker network rm $NETWORK > /dev/null 2>&1
+docker network create --driver cilium --ipam-driver cilium $NETWORK > /dev/null
+cilium policy delete io.cilium
+#Clean old kubernetes certificates
+sudo rm -fr /run/kubernetes
+
+desc "Demo: Start kubernetes, import k8s network policy, test connections"
+run ""
+
+tmux new -d -s my-session \
+    "$(dirname ${BASH_SOURCE})/demo5_top.sh" \; \
+    split-window -v -d "$(dirname $BASH_SOURCE)/demo5_bottom.sh" \; \
+    attach \;
+
+desc "Clean up"

--- a/examples/demo/demo5_bottom.sh
+++ b/examples/demo/demo5_bottom.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+. $(dirname ${BASH_SOURCE})/../../contrib/shell/util.sh
+
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+source "${dir}/../../examples/kubernetes/env-kube.sh"
+
+K8S_PATH="/home/vagrant/kubernetes"
+
+desc "Run kubernetes and wait until it's ready"
+run "cd ${K8S_PATH} && ./hack/local-up-cluster.sh"

--- a/examples/demo/demo5_top.sh
+++ b/examples/demo/demo5_top.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+. $(dirname ${BASH_SOURCE})/../../contrib/shell/util.sh
+
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+run ""
+
+desc "Import kubernetes' network policy when kubernetes is ready"
+run "${dir}/../../examples/kubernetes/0-policy.sh 300"
+desc "Import guestbook's replication controller and service to kubernetes"
+run "${dir}/../../examples/kubernetes/1-guestbook.sh 300"
+desc "Success!"
+desc "Wait until the guestbook's service is ready"
+run "${dir}/../../tests/wait-for-docker.bash k8s_guestbook 100"
+desc "Success!"
+desc "Wait until the redis-slave's service is ready"
+run "${dir}/../../tests/wait-for-docker.bash k8s_redis-slave 100"
+desc "Success!"
+desc "Wait until the redis-master's service is ready"
+run "${dir}/../../tests/wait-for-docker.bash k8s_redis-master 100"
+desc "Success!"
+desc ""
+desc "LB and rev-nat maps were automatically created and updated"
+desc "Services"
+run "sudo cilium lb dump-service"
+desc "Reverse NAT"
+run "sudo cilium lb dump-rev-nat"
+
+containerID=$(docker ps -aq --filter=name=k8s_guestbook)
+desc "Ping will not work because we are not load balancing ICMP messages for the redis-master service"
+run "docker exec -ti ${containerID} ping6 -c 2 redis-master"
+
+run "cilium endpoint list"
+redis_master_IP_dirty=$(docker exec -ti `docker ps -aq --filter=name=k8s_redis-master` sh -c "ip -6 a s | grep global | grep -oE \"${ipv6regex}\" ")
+redis_master_IP=$(echo ${redis_master_IP_dirty}|tr -d '\r')
+desc "Although it will work if we directly ping the redis-master container's IP"
+run "docker exec -ti ${containerID} ping6 -c 2 ${redis_master_IP}"
+
+desc "We are load balancing services, so we will \"ping\" the redis service on port 6379"
+run "docker exec -ti ${containerID} sh -c 'nc redis-master 6379 <<EOF
+PING
+EOF'"


### PR DESCRIPTION
The demo is finished and works but there's a step that fails and I can't find out why.

Signed-off-by: André Martins andre@cilium.io

On `demo5_top.sh` we have this

``` bash
run "cilium endpoint list"
redis_master_IP=$(docker exec -ti `docker ps -aq --filter=name=k8s_redis-master` sh -c "ip -6 a s | grep global | grep -oE \"${ipv6regex}\" ")
desc "But it will work if we directly ping the redis-master container's IP"

run "docker exec -ti `docker ps -aq --filter=name=k8s_guestbook` ping6 -c 2 ${redis_master_IP}"
```

Which results in this:

``` bash
But it will work if we directly ping the redis-master container's IP
$ docker exec -ti b415e5707893 ping6 -c 2 f00d::c0a8:210b:0:81db
'ing6: bad address 'f00d::c0a8:210b:0:81db
```

any ideas?
