### PR TITLE
scripts: add --ipv6 flag in docker setup

### DIFF
--- a/contrib/packer-scripts/ubuntu-14.04/scripts/install-docker.sh
+++ b/contrib/packer-scripts/ubuntu-14.04/scripts/install-docker.sh
@@ -15,7 +15,7 @@ for pkg in *.deb; do
 done
 
 usermod -aG docker vagrant
-echo 'DOCKER_OPTS="--storage-driver=overlay --iptables=false"' >> /etc/default/docker
+echo 'DOCKER_OPTS="--storage-driver=overlay --iptables=false --ipv6"' >> /etc/default/docker
 
 cd ..
 rm -rf $HOME/install


### PR DESCRIPTION
Signed-off-by: André Martins andre@cilium.io

This is odd, `docker` stopped asking for an IPv6 pool but we never had this option set before.
