### PR TITLE
nat46 changes.

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -177,7 +177,8 @@ struct ct_entry {
 	__u16 lifetime;
 	__u16 rx_closing:1,
 	      tx_closing:1,
-	      reserve:14;
+              nat46:1,
+	      reserve:13;
 	__u16 rev_nat_index;
 };
 

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -59,6 +59,8 @@ static inline int __inline__ __ct_lookup(void *map, struct __sk_buff *skb,
 		entry->lifetime = CT_DEFAULT_LIFEIME;
 		if (rev_nat_index)
 			*rev_nat_index = entry->rev_nat_index;;
+		if (entry->nat46)
+			skb->tc_index = 1;
 
 #ifdef CONNTRACK_ACCOUNTING
 		/* FIXME: This is slow, per-cpu counters? */
@@ -393,6 +395,9 @@ static inline int __inline__ ct_create6(void *map, struct ipv6_ct_tuple *tuple,
 		entry.tx_packets = 1;
 		entry.tx_bytes = skb->len;
 	}
+
+	if (skb->tc_index)
+		entry.nat46 = 1;
 
 	cilium_trace(skb, DBG_CT_CREATED, (ntohs(tuple->sport) << 16) | ntohs(tuple->dport),
 		     (tuple->nexthdr << 8) | tuple->flags);

--- a/common/addressing/defaults.go
+++ b/common/addressing/defaults.go
@@ -32,7 +32,7 @@ const (
 	// Default IPv4 prefix length of entire cluster
 	DefaultIPv4ClusterPrefixLen = 8
 	// Default IPv6 prefix to represent NATed IPv4 addresses
-	DefaultNAT46Prefix = "aa46::/48"
+	DefaultNAT46Prefix = "f00d::/48"
 )
 
 var (

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -330,7 +330,7 @@ func initEnv(ctx *cli.Context) error {
 	}
 
 	config.Opts.Set(types.OptionDropNotify, true)
-	config.Opts.Set(types.OptionNAT46, false)
+	config.Opts.Set(types.OptionNAT46, true)
 	config.Opts.Set(daemon.OptionPolicyTracing, enableTracing)
 	config.Opts.Set(types.OptionConntrack, !disableConntrack)
 	config.Opts.Set(types.OptionConntrackAccounting, !disableConntrack)

--- a/tests/07-nat46.sh
+++ b/tests/07-nat46.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+source "./helpers.bash"
+
+set -e
+
+TEST_NET="cilium"
+
+function cleanup {
+        docker rm -f server client 2> /dev/null || true
+        monitor_stop
+}
+
+trap cleanup EXIT
+
+SERVER_LABEL="io.cilium.server"
+CLIENT_LABEL="io.cilium.client"
+NETPERF_IMAGE="noironetworks/netperf"
+
+monitor_start
+
+docker network inspect $TEST_NET 2> /dev/null || {
+        docker network create --ipv6 --subnet ::1/112 --ipam-driver cilium --driver cilium $TEST_NET
+}
+
+docker run -dt --net=$TEST_NET --name server -l $SERVER_LABEL $NETPERF_IMAGE
+docker run -dt --net=$TEST_NET --name client -l $CLIENT_LABEL $NETPERF_IMAGE
+
+CLIENT_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' client)
+CLIENT_IP4=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' client)
+CLIENT_ID=$(cilium endpoint list | grep $CLIENT_IP | awk '{ print $1}')
+SERVER_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server)
+SERVER_IP4=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' server)
+SERVER_ID=$(cilium endpoint list | grep $SERVER_IP | awk '{ print $1}')
+
+echo CLIENT_IP=$CLIENT_IP
+echo CLIENT_IP4=$CLIENT_IP4
+echo CLIENT_ID=$CLIENT_ID
+echo SERVER_IP=$SERVER_IP
+echo SERVER_IP4=$SERVER_IP4
+echo SERVER_ID=$SERVER_ID
+
+function int_to_ip4 {
+echo -n $(($(($(($((${1}/256))/256))/256))%256)).
+echo -n $(($(($((${1}/256))/256))%256)).
+echo -n $(($((${1}/256))%256)).
+echo $((${1}%256))
+}
+
+# 10.1 prefix 10 * 256*256*256 + 1 *  256*256
+IP64_PREFIX=167837696
+CLIENT_IP64=$(int_to_ip4 $((IP64_PREFIX+CLIENT_ID)))
+SERVER_IP64=$(int_to_ip4 $((IP64_PREFIX+SERVER_ID)))
+
+# FIXME IPv6 DAD period
+sleep 5
+set -x
+
+cat <<EOF | cilium -D policy import -
+{
+        "name": "io.cilium",
+        "children": {
+                "client": {
+                        "rules": [{
+                                "allow": ["reserved:host"]
+                        }]
+                },
+                "server": {
+                        "rules": [{
+                                "allow": ["reserved:host", "../client"]
+                        }]
+                }
+
+        }
+}
+EOF
+
+function connectivity_test() {
+        # ICMPv6 echo request client => server should succeed
+        monitor_clear
+        docker exec -i client ping6 -c 5 $SERVER_IP || {
+                abort "Error: Could not ping server container from client"
+        }
+
+        if [ $SERVER_IP4 ]; then
+                # ICMPv4 echo request client => server should succeed
+                monitor_clear
+                docker exec -i client ping -c 5 $SERVER_IP4 || {
+                        abort "Error: Could not ping server container from client"
+                }
+        fi
+
+        # ICMPv6 echo request host => client should succeed
+        monitor_clear
+        ping6 -c 5 $CLIENT_IP || {
+                abort "Error: Could not ping server container from host"
+        }
+
+        if [ $CLIENT_IP4 ]; then
+                # ICMPv4 echo request host => client should succeed
+                monitor_clear
+                ping -c 5 $CLIENT_IP4 || {
+                        abort "Error: Could not ping server container from host"
+                }
+        fi
+
+        # ICMPv6 echo request host => server should succeed
+        monitor_clear
+        ping6 -c 5 $SERVER_IP || {
+                abort "Error: Could not ping server container from host"
+        }
+
+        if [ $SERVER_IP4 ]; then
+                # ICMPv4 echo request host => server should succeed
+                monitor_clear
+                ping -c 5 $SERVER_IP4 || {
+                        abort "Error: Could not ping server container from host"
+                }
+        fi
+
+}
+
+function connectivity_test64() {
+        # ICMPv4 echo request host => client64 should succeed
+        monitor_clear
+        ping -c 5 $CLIENT_IP64 || {
+                abort "Error: Could not ping nat64 address of client from host"
+        }
+
+        # ICMPv4 echo request host => server64 should succeed
+        monitor_clear
+        ping -c 5 $SERVER_IP64 || {
+                abort "Error: Could not ping nat64 address of server from host"
+        }
+}
+
+connectivity_test
+connectivity_test64
+
+cilium -D policy delete io.cilium


### PR DESCRIPTION
By default use single ipv6 prefix f00d:: for nat46 and ipv6.
Support for nat46 with ipv4 needs connection tracking.
nat46 is turned on by default.
A new test case for nat46 is added that runs connection tests as well
to ensure nat46 does not break ipv6 -> ipv6 connectivity.
# nat46 packet path
1. ipv4 packet from external world to lxc processed by ipv4 code.
2. container not found packet send to nat46 conversion.
3. lookup container based on ipv6 packet
4. if container found deliver to container else pass it to stack.
5. add a conntrack entry for ipv6 connection indicating needs nat64.
# nat64 packet path
1. ipv6 packet from container to external world.
2. lookup conntrack and check if needs nat64.
3. if needs nat64, do nat64.
4. redirect packet to host.

Signed-off-by: Madhu Challa madhu@cilium.io
