### PR TITLE
Fit better resource requirement for Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -118,8 +118,8 @@ Vagrant.configure(2) do |config|
 
     config.vm.provider "virtualbox" do |vb|
         config.vm.box = "noironetworks/net-next"
-        vb.memory = "5120"
-        vb.cpus = 8
+        vb.memory = "3072"
+        vb.cpus = 2
 
         if ENV["NFS"] then
             config.vm.synced_folder '.', '/home/vagrant/go/src/github.com/cilium/cilium', type: "nfs"


### PR DESCRIPTION
The current configuration requires 8 CPU and 5 GB RAM but usually
Vagrant is for local provisioning and I don't know if this values has
sense.
I tried with 2GB but the provisioning didn't work well. 3 GB was good.
/cc. @tgraf 
https://github.com/cilium/cilium/issues/174
