### PR TITLE
Make Vagrant memory and #CPUs more dynamic on each use case

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -111,15 +111,15 @@ Vagrant.configure(2) do |config|
 
     config.vm.provider :libvirt do |libvirt|
         config.vm.box = "noironetworks/net-next"
-        libvirt.memory = 5120
-        libvirt.cpus = 8
+        libvirt.memory = ENV['VM_MEMORY']
+        libvirt.cpus = ENV['VM_CPUS']
         config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/cilium/cilium", disabled: false
     end
 
     config.vm.provider "virtualbox" do |vb|
         config.vm.box = "noironetworks/net-next"
-        vb.memory = "3072"
-        vb.cpus = 2
+        vb.memory = ENV['VM_MEMORY']
+        vb.cpus = ENV['VM_CPUS']
 
         if ENV["NFS"] then
             config.vm.synced_folder '.', '/home/vagrant/go/src/github.com/cilium/cilium', type: "nfs"

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -4,6 +4,8 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 #If you change this IPv4 you'll have to change the following IPv6 base address as well
 export 'NODE_IP_BASE'="192.168.33."
 export 'FIRST_IP_SUFFIX'="11"
+export 'VM_MEMORY'=3072
+export 'VM_CPUS'=2
 ipv6_base_addr="F00D::C0A8:210B"
 
 # FIXME: Always enable IPv4 for now until it can be enabled at runtime
@@ -18,6 +20,11 @@ fi
 
 if [ -n "${K8S}" ]; then
     export 'K8STAG'="-k8s"
+    export 'VM_MEMORY'=5120
+    export 'VM_CPUS'=8
+    echo "Warning: In K8S mode, the VM memory and number of CPUs had to be"
+    echo "increased to ${VM_MEMORY} and ${VM_CPUS} respectively."
+    sleep 2s
 fi
 
 if [ -z "${VAGRANT_DEFAULT_PROVIDER}" ]; then


### PR DESCRIPTION
Values need to be as they were. It's the kubernetes build minimal requirement. I'll change the values once our PRs are merged (https://github.com/kubernetes/kubernetes/pull/35472) and then we will be able to use the kubernetes binaries directly (with no need to build it).

Ping @gianarb

Reverts cilium/cilium#180
