### PR TITLE
loadbalancer: improvements and refactored some variables

### DIFF
--- a/bpf/lbmap/ipv4.go
+++ b/bpf/lbmap/ipv4.go
@@ -167,6 +167,7 @@ func (k *RevNat4Key) Map() *bpf.Map             { return RevNat4Map }
 func (k *RevNat4Key) NewValue() bpf.MapValue    { return &RevNat4Value{} }
 func (k *RevNat4Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 func (k *RevNat4Key) String() string            { return fmt.Sprintf("%d", k.Key) }
+func (k *RevNat4Key) GetKey() uint16            { return k.Key }
 
 func (k *RevNat4Key) Convert() RevNatKey {
 	n := *k

--- a/bpf/lbmap/ipv6.go
+++ b/bpf/lbmap/ipv6.go
@@ -161,6 +161,7 @@ func (k *RevNat6Key) Map() *bpf.Map             { return RevNat6Map }
 func (k *RevNat6Key) NewValue() bpf.MapValue    { return &RevNat6Value{} }
 func (k *RevNat6Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 func (k *RevNat6Key) String() string            { return fmt.Sprintf("%d", k.Key) }
+func (k *RevNat6Key) GetKey() uint16            { return k.Key }
 
 func (k *RevNat6Key) Convert() RevNatKey {
 	n := *k

--- a/bpf/lbmap/lbmap.go
+++ b/bpf/lbmap/lbmap.go
@@ -337,3 +337,23 @@ func RevNatValue2L3n4AddrID(revNATKey RevNatKey, revNATValue RevNatValue) (*type
 
 	return &types.L3n4AddrID{L3n4Addr: *be, ID: svcID}, nil
 }
+
+// ServiceValue2L3n4Addr converts the svcValue to a L3n4Addr. The svcKey is necessary to
+// determine which IP version svcValue is.
+func ServiceValue2L3n4Addr(svcKey ServiceKey, svcValue ServiceValue) (*types.L3n4Addr, error) {
+	var (
+		feIP   net.IP
+		fePort uint16
+	)
+	if svcKey.IsIPv6() {
+		svc6Value := svcValue.(*Service6Value)
+		feIP = svc6Value.Address.IP()
+		fePort = svc6Value.Port
+	} else {
+		svc4Value := svcValue.(*Service4Value)
+		feIP = svc4Value.Address.IP()
+		fePort = svc4Value.Port
+	}
+
+	return types.NewL3n4Addr(types.TCP, feIP, fePort)
+}

--- a/bpf/lbmap/lbmap.go
+++ b/bpf/lbmap/lbmap.go
@@ -87,6 +87,9 @@ type ServiceValue interface {
 }
 
 func UpdateService(key ServiceKey, value ServiceValue) error {
+	if key.GetBackend() != 0 && value.RevNatKey().GetKey() == 0 {
+		return fmt.Errorf("invalid RevNat ID (0) in the Service Value")
+	}
 	if _, err := key.Map().OpenOrCreate(); err != nil {
 		return err
 	}
@@ -126,6 +129,9 @@ type RevNatKey interface {
 
 	// Convert between host byte order and map byte order
 	Convert() RevNatKey
+
+	// Returns the key value
+	GetKey() uint16
 }
 
 type RevNatValue interface {
@@ -136,6 +142,9 @@ type RevNatValue interface {
 }
 
 func UpdateRevNat(key RevNatKey, value RevNatValue) error {
+	if key.GetKey() == 0 {
+		return fmt.Errorf("invalid RevNat ID (0)")
+	}
 	if _, err := key.Map().OpenOrCreate(); err != nil {
 		return err
 	}

--- a/bpf/lbmap/lbmap.go
+++ b/bpf/lbmap/lbmap.go
@@ -16,9 +16,11 @@
 package lbmap
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/cilium/cilium/common/bpf"
+	"github.com/cilium/cilium/common/types"
 )
 
 const (
@@ -160,4 +162,178 @@ func LookupRevNat(key RevNatKey) (RevNatValue, error) {
 	}
 
 	return revnat.Convert(), nil
+}
+
+// AddSVC2BPFMap adds the given bpf service to the bpf maps.
+func AddSVC2BPFMap(fe ServiceKey, besValues []ServiceValue, addRevNAT bool, revNATID int) error {
+	var err error
+	// Put all the backend services first
+	nSvcs := 1
+	for _, be := range besValues {
+		fe.SetBackend(nSvcs)
+		if err := UpdateService(fe, be); err != nil {
+			return fmt.Errorf("unable to update service %+v with the value %+v: %s", fe, be, err)
+		}
+		nSvcs++
+	}
+
+	if addRevNAT {
+		zeroValue := fe.NewValue().(ServiceValue)
+		zeroValue.SetRevNat(revNATID)
+		revNATKey := zeroValue.RevNatKey()
+		revNATValue := fe.RevNatValue()
+		if err := UpdateRevNat(revNATKey, revNATValue); err != nil {
+			return fmt.Errorf("unable to update reverse NAT %+v with value %+v, %s", revNATKey, revNATValue, err)
+		}
+		defer func() {
+			if err != nil {
+				DeleteRevNat(revNATKey)
+			}
+		}()
+	}
+
+	fe.SetBackend(0)
+	zeroValue := fe.NewValue().(ServiceValue)
+	zeroValue.SetCount(nSvcs - 1)
+
+	err = UpdateService(fe, zeroValue)
+	if err != nil {
+		return fmt.Errorf("unable to update service %+v with the value %+v: %s", fe, zeroValue, err)
+	}
+	return nil
+}
+
+// L3n4Addr2ServiceKey converts the given l3n4Addr to a ServiceKey with the slave ID
+// set to 0.
+func L3n4Addr2ServiceKey(l3n4Addr types.L3n4Addr) ServiceKey {
+	if l3n4Addr.IsIPv6() {
+		return NewService6Key(l3n4Addr.IP, l3n4Addr.Port, 0)
+	} else {
+		return NewService4Key(l3n4Addr.IP, l3n4Addr.Port, 0)
+	}
+}
+
+// LBSVC2ServiceKeynValue transforms the SVC cilium type into a bpf SVC type.
+func LBSVC2ServiceKeynValue(svc types.LBSVC) (ServiceKey, []ServiceValue, error) {
+
+	fe := L3n4Addr2ServiceKey(svc.FE.L3n4Addr)
+
+	// Create a list of ServiceValues so we know everything is safe to put in the lb
+	// map
+	besValues := []ServiceValue{}
+	for _, be := range svc.BES {
+		beValue := fe.NewValue().(ServiceValue)
+		if err := beValue.SetAddress(be.IP); err != nil {
+			return nil, nil, err
+		}
+		beValue.SetPort(uint16(be.Port))
+		beValue.SetRevNat(int(svc.FE.ID))
+
+		besValues = append(besValues, beValue)
+	}
+
+	return fe, besValues, nil
+}
+
+// L3n4Addr2RevNatKeynValue converts the given L3n4Addr to a RevNatKey and RevNatValue.
+func L3n4Addr2RevNatKeynValue(svcID types.ServiceID, feL3n4Addr types.L3n4Addr) (RevNatKey, RevNatValue) {
+	if feL3n4Addr.IsIPv6() {
+		return NewRevNat6Key(uint16(svcID)), NewRevNat6Value(feL3n4Addr.IP, feL3n4Addr.Port)
+	} else {
+		return NewRevNat4Key(uint16(svcID)), NewRevNat4Value(feL3n4Addr.IP, feL3n4Addr.Port)
+	}
+}
+
+// ServiceKey2L3n4Addr converts the given svcKey to a L3n4Addr.
+func ServiceKey2L3n4Addr(svcKey ServiceKey) (*types.L3n4Addr, error) {
+	var (
+		feIP   net.IP
+		fePort uint16
+	)
+	if svcKey.IsIPv6() {
+		svc6Key := svcKey.(*Service6Key)
+		feIP = svc6Key.Address.IP()
+		fePort = svc6Key.Port
+	} else {
+		svc4Key := svcKey.(*Service4Key)
+		feIP = svc4Key.Address.IP()
+		fePort = svc4Key.Port
+	}
+
+	return types.NewL3n4Addr(types.TCP, feIP, fePort)
+}
+
+// ServiceKeynValue2FEnBE converts the given svcKey and svcValue to a frontend int the
+// form of L3n4AddrID and backend int he form of L3n4Addr.
+func ServiceKeynValue2FEnBE(svcKey ServiceKey, svcValue ServiceValue) (*types.L3n4AddrID, *types.L3n4Addr, error) {
+	var (
+		beIP   net.IP
+		svcID  types.ServiceID
+		bePort uint16
+	)
+	if svcKey.IsIPv6() {
+		svc6Val := svcValue.(*Service6Value)
+		svcID = types.ServiceID(svc6Val.RevNat)
+		beIP = svc6Val.Address.IP()
+		bePort = svc6Val.Port
+	} else {
+		svc4Val := svcValue.(*Service4Value)
+		svcID = types.ServiceID(svc4Val.RevNat)
+		beIP = svc4Val.Address.IP()
+		bePort = svc4Val.Port
+	}
+
+	feL3n4Addr, err := ServiceKey2L3n4Addr(svcKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to create a new FE for service key %s: %s", svcKey, err)
+	}
+
+	beL3n4Addr, err := types.NewL3n4Addr(types.TCP, beIP, bePort)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to create a new BE for IP: %s Port: %d: %s", beIP, bePort, err)
+	}
+
+	feL3n4AddrID := &types.L3n4AddrID{
+		L3n4Addr: *feL3n4Addr,
+		ID:       svcID,
+	}
+
+	return feL3n4AddrID, beL3n4Addr, nil
+}
+
+// RevNat6Value2L3n4Addr converts the given RevNat6Value to a L3n4Addr.
+func RevNat6Value2L3n4Addr(revNATV *RevNat6Value) (*types.L3n4Addr, error) {
+	return types.NewL3n4Addr(types.TCP, revNATV.Address.IP(), revNATV.Port)
+}
+
+// RevNat4Value2L3n4Addr converts the given RevNat4Value to a L3n4Addr.
+func RevNat4Value2L3n4Addr(revNATV *RevNat4Value) (*types.L3n4Addr, error) {
+	return types.NewL3n4Addr(types.TCP, revNATV.Address.IP(), revNATV.Port)
+}
+
+// RevNatValue2L3n4AddrID converts the given RevNatKey and RevNatValue to a L3n4AddrID.
+func RevNatValue2L3n4AddrID(revNATKey RevNatKey, revNATValue RevNatValue) (*types.L3n4AddrID, error) {
+	var (
+		svcID types.ServiceID
+		be    *types.L3n4Addr
+		err   error
+	)
+	if revNATKey.IsIPv6() {
+		revNat6Key := revNATKey.(*RevNat6Key)
+		svcID = types.ServiceID(revNat6Key.Key)
+
+		revNat6Value := revNATValue.(*RevNat6Value)
+		be, err = RevNat6Value2L3n4Addr(revNat6Value)
+	} else {
+		revNat4Key := revNATKey.(*RevNat4Key)
+		svcID = types.ServiceID(revNat4Key.Key)
+
+		revNat4Value := revNATValue.(*RevNat4Value)
+		be, err = RevNat4Value2L3n4Addr(revNat4Value)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.L3n4AddrID{L3n4Addr: *be, ID: svcID}, nil
 }

--- a/cilium/Makefile
+++ b/cilium/Makefile
@@ -11,7 +11,7 @@ clean:
 	go clean
 	rm -f $(TARGET)
 
-SOURCES := $(shell find monitor/ policy/ endpoint/ ../daemon ../common ../pkg . -name '*.go')
+SOURCES := $(shell find monitor/ policy/ endpoint/ ../bpf ../daemon ../common ../pkg . -name '*.go')
 
 $(TARGET): $(SOURCES)
 	go build -ldflags "-X "github.com/cilium/cilium/common".Version=$(VERSION)" -o $(TARGET) ./main.go

--- a/cilium/lb/bpflbclient.go
+++ b/cilium/lb/bpflbclient.go
@@ -215,3 +215,7 @@ func (cli *LBClient) RevNATDump() ([]types.L3n4AddrID, error) {
 	}
 	return dump, nil
 }
+
+func (cli *LBClient) SyncLBMap() error {
+	return NonAvailable
+}

--- a/cilium/lb/bpflbclient.go
+++ b/cilium/lb/bpflbclient.go
@@ -1,0 +1,214 @@
+//
+// Copyright 2016 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package lb
+
+import (
+	"errors"
+
+	"github.com/cilium/cilium/bpf/lbmap"
+	"github.com/cilium/cilium/common/bpf"
+	"github.com/cilium/cilium/common/types"
+)
+
+var (
+	NonAvailable = errors.New("Method not available")
+)
+
+type LBClient struct{}
+
+func NewLBClient() *LBClient {
+	return &LBClient{}
+}
+
+func (cli *LBClient) SVCAdd(fe types.L3n4AddrID, be []types.L3n4Addr, addRevNAT bool) error {
+	svc := types.LBSVC{
+		FE:  fe,
+		BES: be,
+	}
+	svcKey, svcValues, err := lbmap.LBSVC2ServiceKeynValue(svc)
+	if err != nil {
+		return err
+	}
+	return lbmap.AddSVC2BPFMap(svcKey, svcValues, addRevNAT, int(fe.ID))
+}
+
+func (cli *LBClient) SVCDelete(feL3n4 types.L3n4Addr) error {
+	return lbmap.DeleteService(lbmap.L3n4Addr2ServiceKey(feL3n4))
+}
+
+func (cli *LBClient) SVCDeleteBySHA256Sum(_ string) error {
+	return NonAvailable
+}
+
+func (cli *LBClient) SVCDeleteAll() error {
+	if err := lbmap.Service6Map.DeleteAll(); err != nil {
+		log.Warningf("%s", err)
+	}
+	if err := lbmap.Service4Map.DeleteAll(); err != nil {
+		log.Warningf("%s", err)
+	}
+	return nil
+}
+
+func (cli *LBClient) SVCGet(feL3n4 types.L3n4Addr) (*types.LBSVC, error) {
+	key := lbmap.L3n4Addr2ServiceKey(feL3n4)
+	svc, err := lbmap.LookupService(key)
+	if err != nil {
+		return nil, err
+	}
+	besLen := 0
+	if key.IsIPv6() {
+		besLen = int(svc.(*lbmap.Service6Value).Count)
+	} else {
+		besLen = int(svc.(*lbmap.Service4Value).Count)
+	}
+	bes := []types.L3n4Addr{}
+	svcID := 0
+	for i := 1; i <= besLen; i++ {
+		key.SetBackend(i)
+		svc, err := lbmap.LookupService(key)
+		if err != nil {
+			return nil, err
+		}
+		sv, err := lbmap.ServiceValue2L3n4Addr(key, svc)
+		if err != nil {
+			return nil, err
+		}
+		bes = append(bes, *sv)
+	}
+	return &types.LBSVC{
+		FE: types.L3n4AddrID{
+			ID:       types.ServiceID(svcID),
+			L3n4Addr: feL3n4,
+		},
+		BES: bes,
+	}, nil
+}
+
+func (cli *LBClient) SVCGetBySHA256Sum(_ string) (*types.LBSVC, error) {
+	return nil, NonAvailable
+}
+
+func (cli *LBClient) SVCDump() ([]types.LBSVC, error) {
+	svcs := types.SVCMap{}
+
+	parseSVCEntries := func(key bpf.MapKey, value bpf.MapValue) {
+		svcKey := key.(lbmap.ServiceKey)
+		//It's the frontend service so we don't add this one
+		if svcKey.GetBackend() == 0 {
+			return
+		}
+		svcValue := value.(lbmap.ServiceValue)
+		fe, be, err := lbmap.ServiceKeynValue2FEnBE(svcKey, svcValue)
+		if err != nil {
+			log.Errorf("%s", err)
+			return
+		}
+		if err := svcs.AddFEnBE(fe, be, svcKey.GetBackend()); err != nil {
+			log.Errorf("%s", err)
+			return
+		}
+	}
+	if err := lbmap.Service4Map.Dump(lbmap.Service4DumpParser, parseSVCEntries); err != nil {
+		return nil, err
+	}
+	if err := lbmap.Service6Map.Dump(lbmap.Service6DumpParser, parseSVCEntries); err != nil {
+		return nil, err
+	}
+
+	dump := []types.LBSVC{}
+	for _, v := range svcs {
+		dump = append(dump, v)
+	}
+	return dump, nil
+}
+
+func (cli *LBClient) RevNATAdd(id types.ServiceID, revNAT types.L3n4Addr) error {
+	return lbmap.UpdateRevNat(lbmap.L3n4Addr2RevNatKeynValue(id, revNAT))
+}
+
+func (cli *LBClient) RevNATDelete(id types.ServiceID) error {
+	// TODO Since we don't know if the ID belongs to IPv6 map or IPv4 map we try to
+	// delete it first on IPv6. In case of success the deletion stops, in case of
+	// failure tries to delete on the IPv4 map.
+	revNATK6 := lbmap.NewRevNat6Key(uint16(id))
+	err1 := lbmap.DeleteRevNat(revNATK6)
+	if err1 == nil {
+		return nil
+	}
+
+	revNATK4 := lbmap.NewRevNat4Key(uint16(id))
+	if err := lbmap.DeleteRevNat(revNATK4); err != nil {
+		return err1
+	}
+	return nil
+}
+
+func (cli *LBClient) RevNATDeleteAll() error {
+	if err := lbmap.RevNat6Map.DeleteAll(); err != nil {
+		log.Warningf("%s", err)
+	}
+	if err := lbmap.RevNat4Map.DeleteAll(); err != nil {
+		log.Warningf("%s", err)
+	}
+	return nil
+}
+
+func (cli *LBClient) RevNATGet(id types.ServiceID) (*types.L3n4Addr, error) {
+	revNATK6 := lbmap.NewRevNat6Key(uint16(id))
+	revNat6V, err1 := lbmap.LookupRevNat(revNATK6)
+	if err1 == nil {
+		return lbmap.RevNat6Value2L3n4Addr(revNat6V.(*lbmap.RevNat6Value))
+	}
+
+	revNATK4 := lbmap.NewRevNat4Key(uint16(id))
+	revNat4V, err := lbmap.LookupRevNat(revNATK4)
+	if err != nil {
+		return nil, err1
+	}
+	return lbmap.RevNat4Value2L3n4Addr(revNat4V.(*lbmap.RevNat4Value))
+}
+
+func (cli *LBClient) RevNATDump() ([]types.L3n4AddrID, error) {
+	revNATs := types.RevNATMap{}
+
+	parseRevNATEntries := func(key bpf.MapKey, value bpf.MapValue) {
+		revNatK := key.(lbmap.RevNatKey)
+		revNatV := value.(lbmap.RevNatValue)
+		fe, err := lbmap.RevNatValue2L3n4AddrID(revNatK, revNatV)
+		if err != nil {
+			log.Errorf("%s", err)
+			return
+		}
+		revNATs[fe.ID] = fe.L3n4Addr
+	}
+
+	if err := lbmap.RevNat4Map.Dump(lbmap.RevNat4DumpParser, parseRevNATEntries); err != nil {
+		return nil, err
+	}
+	if err := lbmap.RevNat6Map.Dump(lbmap.RevNat6DumpParser, parseRevNATEntries); err != nil {
+		return nil, err
+	}
+
+	dump := []types.L3n4AddrID{}
+	for k, v := range revNATs {
+		dump = append(dump, types.L3n4AddrID{
+			ID:       k,
+			L3n4Addr: v,
+		})
+	}
+	return dump, nil
+}

--- a/cilium/lb/bpflbclient.go
+++ b/cilium/lb/bpflbclient.go
@@ -76,7 +76,7 @@ func (cli *LBClient) SVCGet(feL3n4 types.L3n4Addr) (*types.LBSVC, error) {
 		besLen = int(svc.(*lbmap.Service4Value).Count)
 	}
 	bes := []types.L3n4Addr{}
-	svcID := 0
+	svcID := types.ServiceID(0)
 	for i := 1; i <= besLen; i++ {
 		key.SetBackend(i)
 		svc, err := lbmap.LookupService(key)
@@ -88,10 +88,13 @@ func (cli *LBClient) SVCGet(feL3n4 types.L3n4Addr) (*types.LBSVC, error) {
 			return nil, err
 		}
 		bes = append(bes, *sv)
+		if i == 1 {
+			svcID = types.ServiceID(svc.RevNatKey().GetKey())
+		}
 	}
 	return &types.LBSVC{
 		FE: types.L3n4AddrID{
-			ID:       types.ServiceID(svcID),
+			ID:       svcID,
 			L3n4Addr: feL3n4,
 		},
 		BES: bes,

--- a/cilium/lb/main.go
+++ b/cilium/lb/main.go
@@ -23,7 +23,6 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/cilium/cilium/bpf/lbmap"
 	"github.com/cilium/cilium/common"
 	cnc "github.com/cilium/cilium/common/client"
 	"github.com/cilium/cilium/common/types"
@@ -380,12 +379,7 @@ func cliDeleteService(ctx *cli.Context) {
 	var err error
 
 	if ctx.Bool("all") {
-		//TODO add all flag to daemon
-		if err := lbmap.Service6Map.DeleteAll(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
-		}
-
-		if err := lbmap.Service4Map.DeleteAll(); err != nil {
+		if err := client.SVCDeleteAll(); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
 		}
 	} else {
@@ -403,13 +397,7 @@ func cliDeleteService(ctx *cli.Context) {
 
 func cliDeleteRevNat(ctx *cli.Context) {
 	if ctx.Bool("all") {
-		//TODO add all flag to daemon
-		if err := lbmap.RevNat6Map.DeleteAll(); err != nil {
-			fmt.Fprintf(os.Stderr, "%s", err)
-			os.Exit(1)
-		}
-
-		if err := lbmap.RevNat4Map.DeleteAll(); err != nil {
+		if err := client.RevNATDeleteAll(); err != nil {
 			fmt.Fprintf(os.Stderr, "%s", err)
 			os.Exit(1)
 		}

--- a/cilium/lb/main.go
+++ b/cilium/lb/main.go
@@ -24,14 +24,20 @@ import (
 	"strconv"
 
 	"github.com/cilium/cilium/bpf/lbmap"
-	"github.com/cilium/cilium/common/bpf"
+	"github.com/cilium/cilium/common"
+	cnc "github.com/cilium/cilium/common/client"
+	"github.com/cilium/cilium/common/types"
 
 	"github.com/codegangsta/cli"
+	l "github.com/op/go-logging"
 )
 
 var (
 	ipv4   bool
 	addRev bool
+
+	client *cnc.Client
+	log    = l.MustGetLogger("cilium-cli")
 
 	// CliCommand is the command that will be used in cilium-net main program.
 	CliCommand cli.Command
@@ -53,23 +59,27 @@ func init() {
 				Name:   "dump-service",
 				Usage:  "dumps map present on the given <map file>",
 				Action: cliDumpServices,
+				Before: initEnv,
 			},
 			{
 				Name:   "dump-rev-nat",
 				Usage:  "dumps map present on the given <map file>",
 				Action: cliDumpRevNat,
+				Before: initEnv,
 			},
 			{
 				Name:      "get-service",
 				Usage:     "Lookup LB service",
 				ArgsUsage: "<address>:<port>",
 				Action:    cliLookupService,
+				Before:    initEnv,
 			},
 			{
 				Name:      "get-rev-nat",
 				Usage:     "gets key's value of the given <map file>",
 				ArgsUsage: "<reverse NAT key>",
 				Action:    cliLookupRevNat,
+				Before:    initEnv,
 			},
 			{
 				Name:  "update-service",
@@ -94,6 +104,7 @@ func init() {
 					},
 				},
 				Action: cliUpdateService,
+				Before: initEnv,
 			},
 			{
 				Name:  "update-rev-nat",
@@ -109,6 +120,7 @@ func init() {
 					},
 				},
 				Action: cliUpdateRevNat,
+				Before: initEnv,
 			},
 			{
 				Name:   "delete-service",
@@ -120,6 +132,7 @@ func init() {
 					},
 				},
 				ArgsUsage: "--all | <address>:<port>",
+				Before:    initEnv,
 			},
 			{
 				Name:   "delete-rev-nat",
@@ -131,142 +144,170 @@ func init() {
 					},
 				},
 				ArgsUsage: "--all | <reverse NAT key>",
+				Before:    initEnv,
 			},
 		},
 	}
 }
 
-type ServiceDump struct {
-	Keys     []int
-	Backends map[int]lbmap.ServiceValue
-}
-
-var dumpTable map[string]*ServiceDump
-
-func addToDumpTable(keyStr string, key lbmap.ServiceKey, value lbmap.ServiceValue) {
-	var sd *ServiceDump
-
-	sd, _ = dumpTable[keyStr]
-	if sd == nil {
-		sd = &ServiceDump{Backends: map[int]lbmap.ServiceValue{}}
-		dumpTable[keyStr] = sd
+func initEnv(ctx *cli.Context) error {
+	if ctx.GlobalBool("debug") {
+		common.SetupLOG(log, "DEBUG")
+	} else {
+		common.SetupLOG(log, "INFO")
 	}
 
-	if backend := key.GetBackend(); backend != 0 {
-		sd.Backends[backend] = value
-		sd.Keys = append(sd.Keys, backend)
+	var (
+		c   *cnc.Client
+		err error
+	)
+	if host := ctx.GlobalString("host"); host == "" {
+		c, err = cnc.NewDefaultClient()
+	} else {
+		c, err = cnc.NewClient(host, nil)
 	}
-}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error while creating cilium-client: %s\n", err)
+		return fmt.Errorf("Error while creating cilium-client: %s", err)
+	}
+	client = c
 
-func dumpService4(key bpf.MapKey, value bpf.MapValue) {
-	svcKey := key.(*lbmap.Service4Key)
-	svcVal := value.(*lbmap.Service4Value)
-	addToDumpTable(svcKey.String(), svcKey, svcVal)
-}
-
-func dumpService6(key bpf.MapKey, value bpf.MapValue) {
-	svcKey := key.(*lbmap.Service6Key)
-	svcVal := value.(*lbmap.Service6Value)
-	addToDumpTable(svcKey.String(), svcKey, svcVal)
+	return nil
 }
 
 func cliDumpServices(ctx *cli.Context) {
-	dumpTable = map[string]*ServiceDump{}
-
-	if err := lbmap.Service4Map.Dump(lbmap.Service4DumpParser, dumpService4); err != nil {
+	dump, err := client.SVCDump()
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: Unable to dump map: %s\n", err)
 	}
 
-	if err := lbmap.Service6Map.Dump(lbmap.Service6DumpParser, dumpService6); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: Unable to dump map: %s\n", err)
+	svcs := map[string][]string{}
+	for _, v := range dump {
+		besWithID := []string{}
+		for i, be := range v.BES {
+			str := fmt.Sprintf("%d => %s (%d)", i+1, be.String(), v.FE.ID)
+			besWithID = append(besWithID, str)
+		}
+		svcs[v.FE.L3n4Addr.String()] = besWithID
 	}
 
-	var keys []string
-	for k := range dumpTable {
-		keys = append(keys, k)
+	var svcsKeys []string
+	for k := range svcs {
+		svcsKeys = append(svcsKeys, k)
 	}
-	sort.Strings(keys)
-	for _, k1 := range keys {
-		fmt.Printf("%s =>\n", k1)
-		sort.Ints(dumpTable[k1].Keys)
-		for _, k2 := range dumpTable[k1].Keys {
-			fmt.Printf("\t\t%d => %s\n", k2, dumpTable[k1].Backends[k2])
+	sort.Strings(svcsKeys)
+
+	for _, svcKey := range svcsKeys {
+		fmt.Printf("%s =>\n", svcKey)
+		for _, be := range svcs[svcKey] {
+			fmt.Printf("\t\t%s\n", be)
 		}
 	}
 }
 
-func dumpRevNat4(key bpf.MapKey, value bpf.MapValue) {
-	k := key.(*lbmap.RevNat4Key)
-	v := value.(*lbmap.RevNat4Value)
-	fmt.Printf("  %d => %s\n", k.Key, v)
-}
-
-func dumpRevNat6(key bpf.MapKey, value bpf.MapValue) {
-	k := key.(*lbmap.RevNat6Key)
-	v := value.(*lbmap.RevNat6Value)
-	fmt.Printf("  %d => %s\n", k.Key, v)
-}
-
 func cliDumpRevNat(ctx *cli.Context) {
+	dump, err := client.RevNATDump()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: Unable to dump map: %s\n", err)
+	}
+
+	revNatFormat := map[int]string{}
+	revNatFormatKeysV4 := []int{}
+	revNatFormatKeysV6 := []int{}
+	for _, revNat := range dump {
+		revNatFormat[int(revNat.ID)] = revNat.String()
+		if revNat.IsIPv6() {
+			revNatFormatKeysV6 = append(revNatFormatKeysV6, int(revNat.ID))
+		} else {
+			revNatFormatKeysV4 = append(revNatFormatKeysV4, int(revNat.ID))
+		}
+	}
+	sort.Ints(revNatFormatKeysV6)
+	sort.Ints(revNatFormatKeysV4)
+
 	fmt.Printf("IPv6:\n")
-	if err := lbmap.RevNat6Map.Dump(lbmap.RevNat6DumpParser, dumpRevNat6); err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to dump map: %s\n", err)
+	for _, revNATID := range revNatFormatKeysV6 {
+		fmt.Printf("%d => %s\n", revNATID, revNatFormat[revNATID])
 	}
 
 	fmt.Printf("IPv4:\n")
-	if err := lbmap.RevNat4Map.Dump(lbmap.RevNat4DumpParser, dumpRevNat4); err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to dump map: %s\n", err)
+	for _, revNATID := range revNatFormatKeysV4 {
+		fmt.Printf("%d => %s\n", revNATID, revNatFormat[revNATID])
 	}
 }
 
-func parseServiceKey(address string) lbmap.ServiceKey {
+func parseServiceKey(address string) *types.L3n4Addr {
 	frontend, err := net.ResolveTCPAddr("tcp", address)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Unable to parse frontend address: %s\n", err)
 		os.Exit(1)
 	}
 
-	if frontend.IP.To4() != nil {
-		return lbmap.NewService4Key(frontend.IP, uint16(frontend.Port), 0)
-	} else {
-		return lbmap.NewService6Key(frontend.IP, uint16(frontend.Port), 0)
+	l3n4Addr, err := types.NewL3n4Addr(types.TCP, frontend.IP, uint16(frontend.Port))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to parse frontend address: %s\n", err)
+		os.Exit(1)
 	}
+	return l3n4Addr
 }
 
 func cliLookupService(ctx *cli.Context) {
 	key := parseServiceKey(ctx.Args().Get(0))
 
-	svc, err := lbmap.LookupService(key)
+	lbSVC, err := client.SVCGet(*key)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
+		fmt.Fprintf(os.Stderr, "Unable to receive service from daemon: %s\n", err)
+		os.Exit(1)
+	}
+	if lbSVC == nil {
+		fmt.Fprintf(os.Stderr, "Entry not found \n")
 		os.Exit(1)
 	}
 
-	fmt.Printf("%s = %s\n", key, svc)
+	besSlice := []string{}
+	for _, revNat := range lbSVC.BES {
+		besSlice = append(besSlice, revNat.String())
+	}
+	sort.Strings(besSlice)
+
+	fmt.Printf("%s\n", key.String())
+	for _, svcBackend := range besSlice {
+		fmt.Printf("\t\t=> %s\n", svcBackend)
+	}
+}
+
+func parseRevNatKey(key string) types.ServiceID {
+	k, err := strconv.ParseUint(key, 0, 16)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s", err)
+		os.Exit(1)
+	}
+	return types.ServiceID(k)
 }
 
 func cliLookupRevNat(ctx *cli.Context) {
 	key := parseRevNatKey(ctx.Args().Get(0))
-	val, err := lbmap.LookupRevNat(key)
+
+	val, err := client.RevNATGet(key)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
+	if val == nil {
+		fmt.Fprintf(os.Stderr, "Entry not found \n")
+		os.Exit(1)
+	}
 
-	fmt.Printf("%v = %v\n", key, val)
+	fmt.Printf("%d = %v\n", key, val)
 }
 
 func cliUpdateService(ctx *cli.Context) {
-	key := parseServiceKey(ctx.String("frontend"))
-	svc := key.NewValue().(lbmap.ServiceValue)
-	backends := []*net.TCPAddr{}
-
-	proto := "tcp4"
-	if key.IsIPv6() {
-		proto = "tcp6"
+	feL3n4Addr := parseServiceKey(ctx.String("frontend"))
+	backends := []types.L3n4Addr{}
+	fe := types.L3n4AddrID{
+		ID:       types.ServiceID(ctx.Int("id")),
+		L3n4Addr: *feL3n4Addr,
 	}
-
-	revNat := ctx.Int("id")
 
 	backendList := ctx.StringSlice("backend")
 	if len(backendList) == 0 {
@@ -279,100 +320,57 @@ func cliUpdateService(ctx *cli.Context) {
 		}
 	}
 
-	for k := range backendList {
-		tcpAddr, err := net.ResolveTCPAddr(proto, backendList[k])
+	for _, backend := range backendList {
+		beAddr, err := net.ResolveTCPAddr("tcp", backend)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s\n", err)
 			os.Exit(1)
 		}
 
-		if tcpAddr.IP.To4() != nil && key.IsIPv6() {
+		be, err := types.NewL3n4Addr(types.TCP, beAddr.IP, uint16(beAddr.Port))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to create a new L3n4Addr for backend %s: %s\n", backend, err)
+			os.Exit(1)
+		}
+
+		if !be.IsIPv6() && fe.IsIPv6() {
 			fmt.Fprintf(os.Stderr, "Address mismatch between frontend and backend %s\n",
-				backendList[k])
+				backend)
 			os.Exit(1)
 		}
 
-		if key.GetPort() == 0 && tcpAddr.Port != 0 {
-			fmt.Fprintf(os.Stderr, "L4 backend found (%v) with L3 frontend\n", tcpAddr)
+		if fe.Port == 0 && beAddr.Port != 0 {
+			fmt.Fprintf(os.Stderr, "L4 backend found (%v) with L3 frontend\n", beAddr)
 			os.Exit(1)
 		}
 
-		backends = append(backends, tcpAddr)
+		backends = append(backends, *be)
 	}
 
-	idx := 1
-	for k := range backends {
-		key.SetBackend(idx)
-		if err := svc.SetAddress(backends[k].IP); err != nil {
-			// FIXME: Undo the damage that is already done
-			fmt.Fprintf(os.Stderr, "%s\n", err)
-			os.Exit(1)
-		}
-
-		svc.SetPort(uint16(backends[k].Port))
-		svc.SetRevNat(revNat)
-
-		fmt.Printf("Adding %+v %+v\n", key, svc)
-
-		if err := lbmap.UpdateService(key, svc); err != nil {
-			// FIXME: Undo the damage that is already done
-			fmt.Fprintf(os.Stderr, "%s\n", err)
-			os.Exit(1)
-		}
-
-		idx++
-	}
-
-	if addRev {
-		revKey := svc.RevNatKey()
-		revVal := key.RevNatValue()
-
-		fmt.Printf("Adding %+v %+v\n", revKey, revVal)
-		if err := lbmap.UpdateRevNat(revKey, revVal); err != nil {
-			fmt.Fprintf(os.Stderr, "%s\n", err)
-			os.Exit(1)
-		}
-
-		fmt.Printf("Added reverse NAT entry\n")
-	}
-
-	// Create master service last to avoid hitting backends all of
-	// them have been inserted into the map
-	key.SetBackend(0)
-	svc.SetCount(len(backends))
-	svc.SetPort(uint16(0))
-	svc.SetRevNat(0)
-
-	fmt.Printf("Adding %+v %+v\n", key, svc)
-	if err := lbmap.UpdateService(key, svc); err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
+	if err := client.SVCAdd(fe, backends, addRev); err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to add the service: %s", err)
 		os.Exit(1)
 	}
 
-	fmt.Printf("Added %d backends\n", idx-1)
+	fmt.Printf("Added %d backends\n", len(backends))
 }
 
 func cliUpdateRevNat(ctx *cli.Context) {
-	var key lbmap.RevNatKey
-	var val lbmap.RevNatValue
-
 	tcpAddr, err := net.ResolveTCPAddr("tcp", ctx.String("address"))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
 
-	k := uint16(ctx.Int("id"))
-
-	if tcpAddr.IP.To4() != nil {
-		key = lbmap.NewRevNat4Key(k)
-		val = lbmap.NewRevNat4Value(tcpAddr.IP, uint16(tcpAddr.Port))
-	} else {
-		key = lbmap.NewRevNat6Key(k)
-		val = lbmap.NewRevNat6Value(tcpAddr.IP, uint16(tcpAddr.Port))
+	val, err := types.NewL3n4Addr(types.TCP, tcpAddr.IP, uint16(tcpAddr.Port))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to create a new L3n4Addr: %s\n", err)
+		os.Exit(1)
 	}
 
-	if err := lbmap.UpdateRevNat(key, val); err != nil {
+	id := types.ServiceID(ctx.Int("id"))
+
+	if err := client.RevNATAdd(id, *val); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
@@ -382,6 +380,7 @@ func cliDeleteService(ctx *cli.Context) {
 	var err error
 
 	if ctx.Bool("all") {
+		//TODO add all flag to daemon
 		if err := lbmap.Service6Map.DeleteAll(); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
 		}
@@ -390,50 +389,21 @@ func cliDeleteService(ctx *cli.Context) {
 			fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
 		}
 	} else {
-		key := parseServiceKey(ctx.Args().Get(0))
-		val, err := lbmap.LookupService(key)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s\n", err)
-			os.Exit(1)
-		}
-
-		svc := val.(lbmap.ServiceValue)
-		fmt.Printf("Deleting %d backends...\n", svc.GetCount())
-		for i := 1; i <= svc.GetCount(); i++ {
-			key.SetBackend(i)
-			if err := lbmap.DeleteService(key); err != nil {
-				fmt.Fprintf(os.Stderr, "%s", err)
-				os.Exit(1)
-			}
-		}
-
-		key.SetBackend(0)
-		fmt.Printf("Deleting master entry %v\n", key)
-		err = lbmap.DeleteService(key)
+		fe := parseServiceKey(ctx.Args().Get(0))
+		err = client.SVCDelete(*fe)
 	}
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s", err)
 		os.Exit(1)
 	}
-}
 
-func parseRevNatKey(key string) lbmap.RevNatKey {
-	k, err := strconv.ParseUint(key, 0, 16)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s", err)
-		os.Exit(1)
-	}
-
-	if ipv4 {
-		return lbmap.NewRevNat4Key(uint16(k))
-	} else {
-		return lbmap.NewRevNat6Key(uint16(k))
-	}
+	fmt.Printf("Successfully deleted\n")
 }
 
 func cliDeleteRevNat(ctx *cli.Context) {
 	if ctx.Bool("all") {
+		//TODO add all flag to daemon
 		if err := lbmap.RevNat6Map.DeleteAll(); err != nil {
 			fmt.Fprintf(os.Stderr, "%s", err)
 			os.Exit(1)
@@ -444,9 +414,12 @@ func cliDeleteRevNat(ctx *cli.Context) {
 			os.Exit(1)
 		}
 	} else {
-		if err := lbmap.DeleteRevNat(parseRevNatKey(ctx.Args().Get(0))); err != nil {
-			fmt.Fprintf(os.Stderr, "%s", err)
+		id := types.ServiceID(ctx.Int("id"))
+
+		if err := client.RevNATDelete(id); err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err)
 			os.Exit(1)
 		}
 	}
+	fmt.Printf("Successfully deleted\n")
 }

--- a/cilium/lb/main.go
+++ b/cilium/lb/main.go
@@ -148,6 +148,12 @@ func init() {
 				ArgsUsage: "--all | <reverse NAT key>",
 				Before:    initEnv,
 			},
+			{
+				Name:   "sync-lb-maps",
+				Usage:  "Syncs bpf LB maps with the running daemon",
+				Action: cliSyncLBMaps,
+				Before: initEnv,
+			},
 		},
 	}
 }
@@ -441,4 +447,12 @@ func cliDeleteRevNat(ctx *cli.Context) {
 		}
 	}
 	fmt.Printf("Successfully deleted\n")
+}
+
+func cliSyncLBMaps(_ *cli.Context) {
+	if err := client.SyncLBMap(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Maps successfully synced\n")
 }

--- a/cilium/lb/main.go
+++ b/cilium/lb/main.go
@@ -32,7 +32,6 @@ import (
 )
 
 var (
-	ipv4   bool
 	addRev bool
 
 	client *cnc.Client
@@ -45,37 +44,30 @@ var (
 func init() {
 	CliCommand = cli.Command{
 		Name:  "lb",
-		Usage: "configure load balancer",
-		Flags: []cli.Flag{
-			cli.BoolFlag{
-				Destination: &ipv4,
-				Name:        "ipv4, 4",
-				Usage:       "Apply setting to IPv4 LB",
-			},
-		},
+		Usage: "Configure daemon's load balancer",
 		Subcommands: []cli.Command{
 			{
 				Name:   "dump-service",
-				Usage:  "dumps map present on the given <map file>",
+				Usage:  "Dumps the Service map present on the daemon",
 				Action: cliDumpServices,
 				Before: initEnv,
 			},
 			{
 				Name:   "dump-rev-nat",
-				Usage:  "dumps map present on the given <map file>",
+				Usage:  "Dumps the RevNAT map present on the daemon",
 				Action: cliDumpRevNat,
 				Before: initEnv,
 			},
 			{
 				Name:      "get-service",
-				Usage:     "Lookup LB service",
-				ArgsUsage: "<address>:<port>",
+				Usage:     "Lookup LB Service from the daemon",
+				ArgsUsage: "(<IPv4Address>:<port> | [<IPv6Address>]:<port>)",
 				Action:    cliLookupService,
 				Before:    initEnv,
 			},
 			{
 				Name:      "get-rev-nat",
-				Usage:     "gets key's value of the given <map file>",
+				Usage:     "Lookup Reverse NAT's value from the daemon",
 				ArgsUsage: "<reverse NAT key>",
 				Action:    cliLookupRevNat,
 				Before:    initEnv,
@@ -107,7 +99,7 @@ func init() {
 			},
 			{
 				Name:  "update-rev-nat",
-				Usage: "update LB reverse NAT table",
+				Usage: "Update LB Reverse NAT table",
 				Flags: []cli.Flag{
 					cli.StringFlag{
 						Name:  "address",
@@ -123,6 +115,7 @@ func init() {
 			},
 			{
 				Name:   "delete-service",
+				Usage:  "Deletes the service and respective backends",
 				Action: cliDeleteService,
 				Flags: []cli.Flag{
 					cli.BoolFlag{
@@ -130,11 +123,12 @@ func init() {
 						Usage: "Delete all entries",
 					},
 				},
-				ArgsUsage: "--all | <address>:<port>",
+				ArgsUsage: "--all | (<IPv4Address>:<port> | [<IPv6Address>]:<port>)",
 				Before:    initEnv,
 			},
 			{
 				Name:   "delete-rev-nat",
+				Usage:  "Deletes the Reverse NAT from the daemon",
 				Action: cliDeleteRevNat,
 				Flags: []cli.Flag{
 					cli.BoolFlag{

--- a/common/backend/backend.go
+++ b/common/backend/backend.go
@@ -86,6 +86,7 @@ type LBBackend interface {
 	RevNATDeleteAll() error
 	RevNATGet(id types.ServiceID) (*types.L3n4Addr, error)
 	RevNATDump() ([]types.L3n4AddrID, error)
+	SyncLBMap() error
 }
 
 // CiliumBackend is the interface for both client and daemon.

--- a/common/backend/backend.go
+++ b/common/backend/backend.go
@@ -73,6 +73,19 @@ type ui interface {
 	RegisterUIListener(conn *websocket.Conn) (chan types.UIUpdateMsg, error)
 }
 
+type lbBackend interface {
+	SVCAdd(fe types.L3n4AddrID, be []types.L3n4Addr, addRevNAT bool) error
+	SVCDelete(feL3n4 types.L3n4Addr) error
+	SVCDeleteBySHA256Sum(feL3n4SHA256Sum string) error
+	SVCGet(feL3n4 types.L3n4Addr) (*types.LBSVC, error)
+	SVCGetBySHA256Sum(feL3n4SHA256Sum string) (*types.LBSVC, error)
+	SVCDump() ([]types.LBSVC, error)
+	RevNATAdd(id types.ServiceID, revNAT types.L3n4Addr) error
+	RevNATDelete(id types.ServiceID) error
+	RevNATGet(id types.ServiceID) (*types.L3n4Addr, error)
+	RevNATDump() ([]types.L3n4AddrID, error)
+}
+
 // CiliumBackend is the interface for both client and daemon.
 type CiliumBackend interface {
 	bpfBackend
@@ -80,6 +93,7 @@ type CiliumBackend interface {
 	ipamBackend
 	labelBackend
 	policyBackend
+	lbBackend
 }
 
 // CiliumDaemonBackend is the interface for daemon only.

--- a/common/backend/backend.go
+++ b/common/backend/backend.go
@@ -73,7 +73,7 @@ type ui interface {
 	RegisterUIListener(conn *websocket.Conn) (chan types.UIUpdateMsg, error)
 }
 
-type lbBackend interface {
+type LBBackend interface {
 	SVCAdd(fe types.L3n4AddrID, be []types.L3n4Addr, addRevNAT bool) error
 	SVCDelete(feL3n4 types.L3n4Addr) error
 	SVCDeleteBySHA256Sum(feL3n4SHA256Sum string) error
@@ -95,7 +95,7 @@ type CiliumBackend interface {
 	ipamBackend
 	labelBackend
 	policyBackend
-	lbBackend
+	LBBackend
 }
 
 // CiliumDaemonBackend is the interface for daemon only.

--- a/common/backend/backend.go
+++ b/common/backend/backend.go
@@ -77,11 +77,13 @@ type lbBackend interface {
 	SVCAdd(fe types.L3n4AddrID, be []types.L3n4Addr, addRevNAT bool) error
 	SVCDelete(feL3n4 types.L3n4Addr) error
 	SVCDeleteBySHA256Sum(feL3n4SHA256Sum string) error
+	SVCDeleteAll() error
 	SVCGet(feL3n4 types.L3n4Addr) (*types.LBSVC, error)
 	SVCGetBySHA256Sum(feL3n4SHA256Sum string) (*types.LBSVC, error)
 	SVCDump() ([]types.LBSVC, error)
 	RevNATAdd(id types.ServiceID, revNAT types.L3n4Addr) error
 	RevNATDelete(id types.ServiceID) error
+	RevNATDeleteAll() error
 	RevNATGet(id types.ServiceID) (*types.L3n4Addr, error)
 	RevNATDump() ([]types.L3n4AddrID, error)
 }

--- a/common/client/endpoint_test.go
+++ b/common/client/endpoint_test.go
@@ -163,7 +163,6 @@ func (s *CiliumNetClientSuite) TestEndpointLeaveFail(c *C) {
 
 	err := cli.EndpointLeave(ep.ID)
 
-	c.Log(err.Error())
 	c.Assert(strings.Contains(err.Error(), "daemon didn't complete your request"), Equals, true)
 }
 

--- a/common/client/loadbalancer.go
+++ b/common/client/loadbalancer.go
@@ -238,3 +238,17 @@ func (cli Client) RevNATDump() ([]types.L3n4AddrID, error) {
 
 	return dump, nil
 }
+
+// SyncLBMap sends a POST request to the daemon to sync all LB maps.
+func (cli Client) SyncLBMap() error {
+	serverResp, err := cli.R().Post("/lb/synclbmap")
+	if err != nil {
+		return fmt.Errorf("error while connecting to daemon: %s", err)
+	}
+
+	if serverResp.StatusCode() != http.StatusOK {
+		return processErrorBody(serverResp.Body(), nil)
+	}
+
+	return nil
+}

--- a/common/client/loadbalancer.go
+++ b/common/client/loadbalancer.go
@@ -70,6 +70,20 @@ func (cli Client) SVCDeleteBySHA256Sum(feSHA256Sum string) error {
 	return nil
 }
 
+// SVCDeleteAll sends a DELETE request to the daemon to delete all services in the daemon.
+func (cli Client) SVCDeleteAll() error {
+	serverResp, err := cli.R().Delete("/lb/services")
+	if err != nil {
+		return fmt.Errorf("error while connecting to daemon: %s", err)
+	}
+
+	if serverResp.StatusCode() != http.StatusNoContent {
+		return processErrorBody(serverResp.Body(), nil)
+	}
+
+	return nil
+}
+
 // SVCGet calculates the SHA256Sum from the given frontend and sends a GET request with
 // the calculated SHA256Sum to the daemon.
 func (cli Client) SVCGet(fe types.L3n4Addr) (*types.LBSVC, error) {
@@ -151,6 +165,20 @@ func (cli Client) RevNATAdd(id types.ServiceID, revNATValue types.L3n4Addr) erro
 // RevNATDelete sends a DELETE request with the id to the daemon.
 func (cli Client) RevNATDelete(id types.ServiceID) error {
 	serverResp, err := cli.R().Delete("/lb/revnat/" + strconv.FormatUint(uint64(id), 10))
+	if err != nil {
+		return fmt.Errorf("error while connecting to daemon: %s", err)
+	}
+
+	if serverResp.StatusCode() != http.StatusNoContent {
+		return processErrorBody(serverResp.Body(), nil)
+	}
+
+	return nil
+}
+
+// RevNATDeleteAll sends a DELETE request to delete all RevNAT on the daemon.
+func (cli Client) RevNATDeleteAll() error {
+	serverResp, err := cli.R().Delete("/lb/revnats")
 	if err != nil {
 		return fmt.Errorf("error while connecting to daemon: %s", err)
 	}

--- a/common/client/loadbalancer.go
+++ b/common/client/loadbalancer.go
@@ -1,0 +1,212 @@
+//
+// Copyright 2016 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/cilium/cilium/common/types"
+)
+
+// SVCAdd sends a POST request with the given frontend and respective backends to the
+// daemon. The addRevNAT will be sent as an URL query value.
+func (cli Client) SVCAdd(fe types.L3n4AddrID, bes []types.L3n4Addr, addRevNAT bool) error {
+	svcRest := types.LBSVC{
+		FE:  fe,
+		BES: bes,
+	}
+	serverResp, err := cli.R().SetQueryParam("rev-nat", strconv.FormatBool(addRevNAT)).
+		SetBody(svcRest).Post("/lb/service")
+
+	if err != nil {
+		return fmt.Errorf("error while connecting to daemon: %s", err)
+	}
+
+	if serverResp.StatusCode() != http.StatusCreated {
+		return processErrorBody(serverResp.Body(), nil)
+	}
+
+	return nil
+}
+
+// SVCDelete calculates the SHA256Sum from the given frontend and sends a DELETE request
+// to the daemon.
+func (cli Client) SVCDelete(fe types.L3n4Addr) error {
+	feSHA256Sum, err := fe.SHA256Sum()
+	if err != nil {
+		return fmt.Errorf("invalid SHA256Sum for front end %+v: %s", fe, err)
+	}
+	return cli.SVCDeleteBySHA256Sum(feSHA256Sum)
+}
+
+// SVCDeleteBySHA256Sum sends a DELETE request with the given feSHA256Sum to delete the
+// frontend, and respective backends, on the daemon.
+func (cli Client) SVCDeleteBySHA256Sum(feSHA256Sum string) error {
+	serverResp, err := cli.R().Delete("/lb/service/" + feSHA256Sum)
+	if err != nil {
+		return fmt.Errorf("error while connecting to daemon: %s", err)
+	}
+
+	if serverResp.StatusCode() != http.StatusNoContent {
+		return processErrorBody(serverResp.Body(), nil)
+	}
+
+	return nil
+}
+
+// SVCGet calculates the SHA256Sum from the given frontend and sends a GET request with
+// the calculated SHA256Sum to the daemon.
+func (cli Client) SVCGet(fe types.L3n4Addr) (*types.LBSVC, error) {
+	feSHA256Sum, err := fe.SHA256Sum()
+	if err != nil {
+		return nil, fmt.Errorf("invalid SHA256Sum for front end %+v: %s", fe, err)
+	}
+	return cli.SVCGetBySHA256Sum(feSHA256Sum)
+}
+
+// SVCGetBySHA256Sum sends a GET request with the given feSHA256Sum to the daemon.
+func (cli Client) SVCGetBySHA256Sum(feSHA256Sum string) (*types.LBSVC, error) {
+	serverResp, err := cli.R().Get("/lb/service/" + feSHA256Sum)
+	if err != nil {
+		return nil, fmt.Errorf("error while connecting to daemon: %s", err)
+	}
+
+	if serverResp.StatusCode() != http.StatusNoContent &&
+		serverResp.StatusCode() != http.StatusOK {
+		return nil, processErrorBody(serverResp.Body(), nil)
+	}
+
+	if serverResp.StatusCode() == http.StatusNoContent {
+		return nil, nil
+	}
+
+	var lbSvc types.LBSVC
+	if err := json.Unmarshal(serverResp.Body(), &lbSvc); err != nil {
+		return nil, err
+	}
+
+	return &lbSvc, nil
+}
+
+// SVCDump sends a GET request to receive all services (frontend with respective backends)
+// stored in the daemon.
+func (cli Client) SVCDump() ([]types.LBSVC, error) {
+	serverResp, err := cli.R().Get("/lb/services")
+	if err != nil {
+		return nil, fmt.Errorf("error while connecting to daemon: %s", err)
+	}
+
+	if serverResp.StatusCode() != http.StatusNoContent &&
+		serverResp.StatusCode() != http.StatusOK {
+		return nil, processErrorBody(serverResp.Body(), nil)
+	}
+
+	if serverResp.StatusCode() == http.StatusNoContent {
+		return nil, nil
+	}
+
+	dump := []types.LBSVC{}
+	if err := json.Unmarshal(serverResp.Body(), &dump); err != nil {
+		return nil, err
+	}
+
+	return dump, nil
+}
+
+// RevNATAdd sends a POST request with the RevNAT to the daemon.
+func (cli Client) RevNATAdd(id types.ServiceID, revNATValue types.L3n4Addr) error {
+	revNAT := types.L3n4AddrID{
+		ID:       id,
+		L3n4Addr: revNATValue,
+	}
+	serverResp, err := cli.R().SetBody(revNAT).Post("/lb/revnat")
+
+	if err != nil {
+		return fmt.Errorf("error while connecting to daemon: %s", err)
+	}
+
+	if serverResp.StatusCode() != http.StatusCreated {
+		return processErrorBody(serverResp.Body(), nil)
+	}
+
+	return nil
+}
+
+// RevNATDelete sends a DELETE request with the id to the daemon.
+func (cli Client) RevNATDelete(id types.ServiceID) error {
+	serverResp, err := cli.R().Delete("/lb/revnat/" + strconv.FormatUint(uint64(id), 10))
+	if err != nil {
+		return fmt.Errorf("error while connecting to daemon: %s", err)
+	}
+
+	if serverResp.StatusCode() != http.StatusNoContent {
+		return processErrorBody(serverResp.Body(), nil)
+	}
+
+	return nil
+}
+
+// RevNATGet sends a GET request with the revNATID to receive the revNAT that belongs to
+// the given revNATID.
+func (cli Client) RevNATGet(revNATID types.ServiceID) (*types.L3n4Addr, error) {
+	serverResp, err := cli.R().Get("/lb/revnat/" + strconv.FormatUint(uint64(revNATID), 10))
+	if err != nil {
+		return nil, fmt.Errorf("error while connecting to daemon: %s", err)
+	}
+
+	if serverResp.StatusCode() != http.StatusNoContent &&
+		serverResp.StatusCode() != http.StatusOK {
+		return nil, processErrorBody(serverResp.Body(), nil)
+	}
+
+	if serverResp.StatusCode() == http.StatusNoContent {
+		return nil, nil
+	}
+
+	var revNAT types.L3n4Addr
+	if err := json.Unmarshal(serverResp.Body(), &revNAT); err != nil {
+		return nil, err
+	}
+
+	return &revNAT, nil
+}
+
+// RevNATDump sends a GET request to receive all revnats stored, from the daemon.
+func (cli Client) RevNATDump() ([]types.L3n4AddrID, error) {
+	serverResp, err := cli.R().Get("/lb/revnats")
+	if err != nil {
+		return nil, fmt.Errorf("error while connecting to daemon: %s", err)
+	}
+
+	if serverResp.StatusCode() != http.StatusNoContent &&
+		serverResp.StatusCode() != http.StatusOK {
+		return nil, processErrorBody(serverResp.Body(), nil)
+	}
+
+	if serverResp.StatusCode() == http.StatusNoContent {
+		return nil, nil
+	}
+
+	var dump []types.L3n4AddrID
+	if err := json.Unmarshal(serverResp.Body(), &dump); err != nil {
+		return nil, err
+	}
+
+	return dump, nil
+}

--- a/common/client/loadbalancer_test.go
+++ b/common/client/loadbalancer_test.go
@@ -157,6 +157,40 @@ func (s *CiliumNetClientSuite) TestSVCDeleteFail(c *C) {
 	c.Assert(strings.Contains(err.Error(), "daemon didn't complete your request"), Equals, true)
 }
 
+func (s *CiliumNetClientSuite) TestSVCDeleteAllOK(c *C) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "DELETE")
+		c.Assert(r.URL.Path, Equals, "/lb/services")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	err := cli.SVCDeleteAll()
+
+	c.Assert(err, Equals, nil)
+}
+
+func (s *CiliumNetClientSuite) TestSVCDeleteAllFail(c *C) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "DELETE")
+		c.Assert(r.URL.Path, Equals, "/lb/services")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		e := json.NewEncoder(w)
+		err := e.Encode(types.ServerError{Code: -1, Text: "daemon didn't complete your request"})
+		c.Assert(err, Equals, nil)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	err := cli.SVCDeleteAll()
+
+	c.Assert(strings.Contains(err.Error(), "daemon didn't complete your request"), Equals, true)
+}
+
 func (s *CiliumNetClientSuite) TestSVCGetOK(c *C) {
 	fe, err := types.NewL3n4AddrID(types.TCP, randomAddr1, 1984, 2016)
 	c.Assert(err, IsNil)
@@ -355,6 +389,38 @@ func (s *CiliumNetClientSuite) TestRevNATDeleteFail(c *C) {
 	cli := NewTestClient(server.URL, c)
 
 	err := cli.RevNATDelete(id)
+	c.Assert(strings.Contains(err.Error(), "daemon didn't complete your request"), Equals, true)
+}
+
+func (s *CiliumNetClientSuite) TestRevNATDeleteAllOK(c *C) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "DELETE")
+		c.Assert(r.URL.Path, Equals, "/lb/revnats")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	err := cli.RevNATDeleteAll()
+	c.Assert(err, Equals, nil)
+}
+
+func (s *CiliumNetClientSuite) TestRevNATDeleteAllFail(c *C) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "DELETE")
+		c.Assert(r.URL.Path, Equals, "/lb/revnats")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		e := json.NewEncoder(w)
+		err := e.Encode(types.ServerError{Code: -1, Text: "daemon didn't complete your request"})
+		c.Assert(err, Equals, nil)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	err := cli.RevNATDeleteAll()
 	c.Assert(strings.Contains(err.Error(), "daemon didn't complete your request"), Equals, true)
 }
 

--- a/common/client/loadbalancer_test.go
+++ b/common/client/loadbalancer_test.go
@@ -1,0 +1,458 @@
+//
+// Copyright 2016 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package client
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/cilium/cilium/common/types"
+
+	. "gopkg.in/check.v1"
+	"strconv"
+)
+
+var (
+	randomAddr1 = net.ParseIP("beef:beef:beef:beef:aaaa:aaaa:1111:0:1")
+	randomAddr2 = net.ParseIP("beef:beef:beef:beef:aaaa:aaaa:1111:0:2")
+	revNat1     = types.L3n4Addr{
+		IP: randomAddr1,
+		L4Addr: types.L4Addr{
+			Protocol: types.TCP,
+			Port:     1984,
+		},
+	}
+	revNat2 = types.L3n4Addr{
+		IP: randomAddr2,
+		L4Addr: types.L4Addr{
+			Protocol: types.TCP,
+			Port:     1911,
+		},
+	}
+)
+
+func (s *CiliumNetClientSuite) TestSVCAddOK(c *C) {
+
+	fe, err := types.NewL3n4AddrID(types.TCP, randomAddr1, 1984, 2016)
+	c.Assert(err, IsNil)
+	wantLBSVC := types.LBSVC{
+		FE: *fe,
+		BES: []types.L3n4Addr{
+			revNat1,
+			revNat2,
+		},
+	}
+	addRevNAT := true
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "POST")
+		c.Assert(r.URL.Path, Equals, "/lb/service")
+		var receivedLBSVC types.LBSVC
+		err := json.NewDecoder(r.Body).Decode(&receivedLBSVC)
+		c.Assert(err, Equals, nil)
+		c.Assert(receivedLBSVC, DeepEquals, wantLBSVC)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	err = cli.SVCAdd(wantLBSVC.FE, wantLBSVC.BES, addRevNAT)
+
+	c.Assert(err, Equals, nil)
+}
+
+func (s *CiliumNetClientSuite) TestSVCAddFail(c *C) {
+
+	fe, err := types.NewL3n4AddrID(types.TCP, randomAddr1, 1984, 2016)
+	c.Assert(err, IsNil)
+	wantLBSVC := types.LBSVC{
+		FE: *fe,
+		BES: []types.L3n4Addr{
+			revNat1,
+			revNat2,
+		},
+	}
+	addRevNAT := true
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "POST")
+		c.Assert(r.URL.Path, Equals, "/lb/service")
+		var receivedLBSVC types.LBSVC
+		err := json.NewDecoder(r.Body).Decode(&receivedLBSVC)
+		c.Assert(err, Equals, nil)
+		c.Assert(receivedLBSVC, DeepEquals, wantLBSVC)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		e := json.NewEncoder(w)
+		err = e.Encode(types.ServerError{Code: -1, Text: "daemon didn't complete your request"})
+		c.Assert(err, Equals, nil)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	err = cli.SVCAdd(wantLBSVC.FE, wantLBSVC.BES, addRevNAT)
+
+	c.Assert(strings.Contains(err.Error(), "daemon didn't complete your request"), Equals, true)
+}
+
+func (s *CiliumNetClientSuite) TestSVCDeleteOK(c *C) {
+	fe, err := types.NewL3n4Addr(types.TCP, randomAddr1, 1984)
+	c.Assert(err, IsNil)
+	feSHA256Sum, err := fe.SHA256Sum()
+	c.Assert(err, IsNil)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "DELETE")
+		c.Assert(r.URL.Path, Equals, "/lb/service/"+feSHA256Sum)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	err = cli.SVCDelete(*fe)
+
+	c.Assert(err, Equals, nil)
+}
+
+func (s *CiliumNetClientSuite) TestSVCDeleteFail(c *C) {
+	fe, err := types.NewL3n4Addr(types.TCP, randomAddr1, 1984)
+	c.Assert(err, IsNil)
+	feSHA256Sum, err := fe.SHA256Sum()
+	c.Assert(err, IsNil)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "DELETE")
+		c.Assert(r.URL.Path, Equals, "/lb/service/"+feSHA256Sum)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		e := json.NewEncoder(w)
+		err := e.Encode(types.ServerError{Code: -1, Text: "daemon didn't complete your request"})
+		c.Assert(err, Equals, nil)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	err = cli.SVCDelete(*fe)
+
+	c.Assert(strings.Contains(err.Error(), "daemon didn't complete your request"), Equals, true)
+}
+
+func (s *CiliumNetClientSuite) TestSVCGetOK(c *C) {
+	fe, err := types.NewL3n4AddrID(types.TCP, randomAddr1, 1984, 2016)
+	c.Assert(err, IsNil)
+	wantLBSVC := types.LBSVC{
+		FE: *fe,
+		BES: []types.L3n4Addr{
+			revNat1,
+			revNat2,
+		},
+	}
+	feSHA256Sum, err := fe.SHA256Sum()
+	c.Assert(err, IsNil)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "GET")
+		c.Assert(r.URL.Path, Equals, "/lb/service/"+feSHA256Sum)
+		w.WriteHeader(http.StatusOK)
+		err := json.NewEncoder(w).Encode(wantLBSVC)
+		c.Assert(err, Equals, nil)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	lbSvcReceived, err := cli.SVCGet(fe.L3n4Addr)
+
+	c.Assert(err, IsNil)
+	c.Assert(*lbSvcReceived, DeepEquals, wantLBSVC)
+}
+
+func (s *CiliumNetClientSuite) TestSVCGetFail(c *C) {
+	fe, err := types.NewL3n4AddrID(types.TCP, randomAddr1, 1984, 2016)
+	c.Assert(err, IsNil)
+	feSHA256Sum, err := fe.SHA256Sum()
+	c.Assert(err, IsNil)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "GET")
+		c.Assert(r.URL.Path, Equals, "/lb/service/"+feSHA256Sum)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		e := json.NewEncoder(w)
+		err := e.Encode(types.ServerError{Code: -1, Text: "daemon didn't complete your request"})
+		c.Assert(err, Equals, nil)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	lbSvcReceived, err := cli.SVCGet(fe.L3n4Addr)
+
+	c.Assert(strings.Contains(err.Error(), "daemon didn't complete your request"), Equals, true)
+	var nilFe *types.LBSVC
+	c.Assert(lbSvcReceived, DeepEquals, nilFe)
+}
+
+func (s *CiliumNetClientSuite) TestSVCDumpOK(c *C) {
+	fe, err := types.NewL3n4AddrID(types.TCP, randomAddr1, 1984, 2016)
+	c.Assert(err, IsNil)
+	wantLBSVC := []types.LBSVC{
+		{
+			FE: *fe,
+			BES: []types.L3n4Addr{
+				revNat1,
+				revNat2,
+			},
+		},
+		{
+			FE: *fe,
+			BES: []types.L3n4Addr{
+				revNat1,
+				revNat2,
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "GET")
+		c.Assert(r.URL.Path, Equals, "/lb/services")
+		w.WriteHeader(http.StatusOK)
+		err := json.NewEncoder(w).Encode(wantLBSVC)
+		c.Assert(err, Equals, nil)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	lbSVCReceived, err := cli.SVCDump()
+
+	c.Assert(err, IsNil)
+	c.Assert(lbSVCReceived, DeepEquals, wantLBSVC)
+}
+
+func (s *CiliumNetClientSuite) TestSVCDumpFail(c *C) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "GET")
+		c.Assert(r.URL.Path, Equals, "/lb/services")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		e := json.NewEncoder(w)
+		err := e.Encode(types.ServerError{Code: -1, Text: "daemon didn't complete your request"})
+		c.Assert(err, Equals, nil)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	lbSVCReceived, err := cli.SVCDump()
+
+	c.Assert(strings.Contains(err.Error(), "daemon didn't complete your request"), Equals, true)
+	var nilFe []types.LBSVC
+	c.Assert(lbSVCReceived, DeepEquals, nilFe)
+}
+
+func (s *CiliumNetClientSuite) TestRevNATAddOK(c *C) {
+	wantRevNATID := types.L3n4AddrID{
+		ID:       2016,
+		L3n4Addr: revNat1,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "POST")
+		c.Assert(r.URL.Path, Equals, "/lb/revnat")
+		var receivedRevNATID types.L3n4AddrID
+		err := json.NewDecoder(r.Body).Decode(&receivedRevNATID)
+		c.Assert(err, Equals, nil)
+		c.Assert(receivedRevNATID, DeepEquals, wantRevNATID)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	err := cli.RevNATAdd(wantRevNATID.ID, wantRevNATID.L3n4Addr)
+	c.Assert(err, Equals, nil)
+}
+
+func (s *CiliumNetClientSuite) TestRevNATAddFail(c *C) {
+	wantRevNATID := types.L3n4AddrID{
+		ID:       2016,
+		L3n4Addr: revNat1,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "POST")
+		c.Assert(r.URL.Path, Equals, "/lb/revnat")
+		var receivedRevNATID types.L3n4AddrID
+		err := json.NewDecoder(r.Body).Decode(&receivedRevNATID)
+		c.Assert(err, Equals, nil)
+		c.Assert(receivedRevNATID, DeepEquals, wantRevNATID)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		e := json.NewEncoder(w)
+		err = e.Encode(types.ServerError{Code: -1, Text: "daemon didn't complete your request"})
+		c.Assert(err, Equals, nil)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	err := cli.RevNATAdd(wantRevNATID.ID, wantRevNATID.L3n4Addr)
+
+	c.Assert(strings.Contains(err.Error(), "daemon didn't complete your request"), Equals, true)
+}
+
+func (s *CiliumNetClientSuite) TestRevNATDeleteOK(c *C) {
+	id := types.ServiceID(2016)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "DELETE")
+		c.Assert(r.URL.Path, Equals, "/lb/revnat/"+strconv.FormatUint(uint64(id), 10))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	err := cli.RevNATDelete(id)
+	c.Assert(err, Equals, nil)
+}
+
+func (s *CiliumNetClientSuite) TestRevNATDeleteFail(c *C) {
+	id := types.ServiceID(2016)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "DELETE")
+		c.Assert(r.URL.Path, Equals, "/lb/revnat/"+strconv.FormatUint(uint64(id), 10))
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		e := json.NewEncoder(w)
+		err := e.Encode(types.ServerError{Code: -1, Text: "daemon didn't complete your request"})
+		c.Assert(err, Equals, nil)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	err := cli.RevNATDelete(id)
+	c.Assert(strings.Contains(err.Error(), "daemon didn't complete your request"), Equals, true)
+}
+
+func (s *CiliumNetClientSuite) TestRevNATGetOK(c *C) {
+	wantRevNATID := types.L3n4AddrID{
+		ID:       2016,
+		L3n4Addr: revNat1,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "GET")
+		c.Assert(r.URL.Path, Equals, "/lb/revnat/"+strconv.FormatUint(uint64(wantRevNATID.ID), 10))
+		w.WriteHeader(http.StatusOK)
+		err := json.NewEncoder(w).Encode(wantRevNATID.L3n4Addr)
+		c.Assert(err, Equals, nil)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	revNATReceived, err := cli.RevNATGet(wantRevNATID.ID)
+
+	c.Assert(err, IsNil)
+	c.Assert(*revNATReceived, DeepEquals, wantRevNATID.L3n4Addr)
+}
+
+func (s *CiliumNetClientSuite) TestRevNATGetFail(c *C) {
+	wantRevNATID := types.L3n4AddrID{
+		ID:       2016,
+		L3n4Addr: revNat1,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "GET")
+		c.Assert(r.URL.Path, Equals, "/lb/revnat/"+strconv.FormatUint(uint64(wantRevNATID.ID), 10))
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		e := json.NewEncoder(w)
+		err := e.Encode(types.ServerError{Code: -1, Text: "daemon didn't complete your request"})
+		c.Assert(err, Equals, nil)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	revNATReceived, err := cli.RevNATGet(wantRevNATID.ID)
+
+	c.Assert(strings.Contains(err.Error(), "daemon didn't complete your request"), Equals, true)
+	var nilFe *types.L3n4Addr
+	c.Assert(revNATReceived, Equals, nilFe)
+}
+
+func (s *CiliumNetClientSuite) TestRevNATDumpOK(c *C) {
+	wantRevNATs := []types.L3n4AddrID{
+		{
+			ID:       1984,
+			L3n4Addr: revNat1,
+		},
+		{
+			ID:       1911,
+			L3n4Addr: revNat2,
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "GET")
+		c.Assert(r.URL.Path, Equals, "/lb/revnats")
+		w.WriteHeader(http.StatusOK)
+		err := json.NewEncoder(w).Encode(wantRevNATs)
+		c.Assert(err, Equals, nil)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	revNATsReceived, err := cli.RevNATDump()
+
+	c.Assert(err, IsNil)
+	c.Assert(revNATsReceived, DeepEquals, wantRevNATs)
+}
+
+func (s *CiliumNetClientSuite) TestRevNATDumpFail(c *C) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "GET")
+		c.Assert(r.URL.Path, Equals, "/lb/revnats")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		e := json.NewEncoder(w)
+		err := e.Encode(types.ServerError{Code: -1, Text: "daemon didn't complete your request"})
+		c.Assert(err, Equals, nil)
+	}))
+	defer server.Close()
+
+	cli := NewTestClient(server.URL, c)
+
+	lbSVCReceived, err := cli.RevNATDump()
+
+	c.Assert(strings.Contains(err.Error(), "daemon didn't complete your request"), Equals, true)
+	var nilRevNATDump []types.L3n4AddrID
+	c.Assert(lbSVCReceived, DeepEquals, nilRevNATDump)
+}

--- a/common/types/loadbalancer.go
+++ b/common/types/loadbalancer.go
@@ -158,6 +158,16 @@ func NewL3n4Addr(protocol L4Type, ip net.IP, portNumber uint16) (*L3n4Addr, erro
 	return &L3n4Addr{IP: ip, L4Addr: *lbport}, nil
 }
 
+// String returns the L3n4Addr in the "IPv4:Port" format for IPv4 and "[IPv6]:Port" format
+// for IPv6.
+func (l *L3n4Addr) String() string {
+	if l.IsIPv6() {
+		return fmt.Sprintf("[%s]:%d", l.IP.String(), l.Port)
+	} else {
+		return fmt.Sprintf("%s:%d", l.IP.String(), l.Port)
+	}
+}
+
 // DeepCopy returns a DeepCopy of the given L3n4Addr.
 func (l *L3n4Addr) DeepCopy() *L3n4Addr {
 	copyIP := make(net.IP, len(l.IP))

--- a/daemon/daemon/daemon.go
+++ b/daemon/daemon/daemon.go
@@ -347,10 +347,7 @@ func NewDaemon(c *Config) (*Daemon, error) {
 
 	rootNode.Root.Path()
 
-	lb := &types.LoadBalancer{
-		K8sServices:  map[types.K8sServiceNamespace]*types.K8sServiceInfo{},
-		K8sEndpoints: map[types.K8sServiceNamespace]*types.K8sServiceEndpoint{},
-	}
+	lb := types.NewLoadBalancer()
 
 	d := Daemon{
 		conf:                      c,

--- a/daemon/daemon/daemon.go
+++ b/daemon/daemon/daemon.go
@@ -236,15 +236,6 @@ func (d *Daemon) init() error {
 		if _, err := lbmap.RevNat6Map.OpenOrCreate(); err != nil {
 			return err
 		}
-		// Clean all lb entries
-		if !d.conf.RestoreState {
-			if err := lbmap.Service6Map.DeleteAll(); err != nil {
-				return err
-			}
-			if err := lbmap.RevNat6Map.DeleteAll(); err != nil {
-				return err
-			}
-		}
 		if d.conf.IPv4Enabled {
 			if _, err := lbmap.Service4Map.OpenOrCreate(); err != nil {
 				return err
@@ -252,14 +243,11 @@ func (d *Daemon) init() error {
 			if _, err := lbmap.RevNat4Map.OpenOrCreate(); err != nil {
 				return err
 			}
-			// Clean all lb entries
-			if !d.conf.RestoreState {
-				if err := lbmap.Service4Map.DeleteAll(); err != nil {
-					return err
-				}
-				if err := lbmap.RevNat4Map.DeleteAll(); err != nil {
-					return err
-				}
+		}
+		// Clean all lb entries
+		if !d.conf.RestoreState {
+			if err := d.SVCDeleteAll(); err != nil {
+				return err
 			}
 		}
 	}

--- a/daemon/daemon/daemon.go
+++ b/daemon/daemon/daemon.go
@@ -376,6 +376,9 @@ func NewDaemon(c *Config) (*Daemon, error) {
 		if err := d.SyncState(common.CiliumPath, true); err != nil {
 			log.Warningf("Error while recovering endpoints: %s\n", err)
 		}
+		if err := d.SyncLBMap(); err != nil {
+			log.Warningf("Error while recovering endpoints: %s\n", err)
+		}
 	}
 
 	d.endpointsMU.Lock()

--- a/daemon/daemon/daemon.go
+++ b/daemon/daemon/daemon.go
@@ -348,8 +348,8 @@ func NewDaemon(c *Config) (*Daemon, error) {
 	rootNode.Root.Path()
 
 	lb := &types.LoadBalancer{
-		Services:  map[types.ServiceNamespace]*types.ServiceInfo{},
-		Endpoints: map[types.ServiceNamespace]*types.ServiceEndpoint{},
+		K8sServices:  map[types.K8sServiceNamespace]*types.K8sServiceInfo{},
+		K8sEndpoints: map[types.K8sServiceNamespace]*types.K8sServiceEndpoint{},
 	}
 
 	d := Daemon{

--- a/daemon/daemon/k8s_watcher.go
+++ b/daemon/daemon/k8s_watcher.go
@@ -304,7 +304,7 @@ func (d *Daemon) delK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 		repPorts[svcPort.Port] = false
 
 		if svcPort.ID != 0 {
-			if err := d.DeleteServiceL4IDByUUID(uint32(svcPort.ID)); err != nil {
+			if err := d.DeleteL3n4AddrIDByUUID(uint32(svcPort.ID)); err != nil {
 				log.Warningf("Error while cleaning service ID: %s", err)
 			}
 		}
@@ -356,7 +356,7 @@ func (d *Daemon) addK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 				log.Errorf("Error while creating a new L3n4Addr: %s. Ignoring service...", err)
 				continue
 			}
-			feAddrID, err := d.PutServiceL4(*feAddr)
+			feAddrID, err := d.PutL3n4Addr(*feAddr)
 			if err != nil {
 				log.Errorf("Error while getting a new service ID: %s. Ignoring service %v...", err, feAddr)
 				continue

--- a/daemon/daemon/loadbalancer.go
+++ b/daemon/daemon/loadbalancer.go
@@ -22,29 +22,53 @@ import (
 	"github.com/cilium/cilium/common/types"
 )
 
-// SVCAdd adds a service from the given fe (frontend) and bes (backends) with the given
-// id. If addRevNAT is set, the RevNAT entry is also created for this particular service.
+// SVCAdd adds a service from the given feL3n4Addr (frontend) and beL3n4Addr (backends).
+// If addRevNAT is set, the RevNAT entry is also created for this particular service.
 // If any of the backend addresses set in bes have a different L3 address type than the
 // one set in fe, it returns an error without modifying the bpf LB map. If any backend
-// entry fails while updating the LB map, the frontend won't be inserted in the LB map and
+// entry fails while updating the LB map, the frontend won't be inserted in the LB map
 // therefore there won't be any traffic going to the given backends.
-func (d *Daemon) SVCAdd(id types.ServiceID, fe lbmap.ServiceKey, bes []types.L3n4Addr, addRevNAT bool) error {
-	d.loadBalancer.BPFMapMU.Lock()
-	defer d.loadBalancer.BPFMapMU.Unlock()
+// All of the backends added will be DeepCopied to the internal load balancer map.
+func (d *Daemon) SVCAdd(feL3n4Addr types.L3n4AddrID, beL3n4Addr []types.L3n4Addr, addRevNAT bool) error {
+	if feL3n4Addr.ID == 0 {
+		return fmt.Errorf("invalid ID (%d)", feL3n4Addr.ID)
+	}
+
+	// We will move the slice to the loadbalancer map which have a mutex. If we don't
+	// copy the slice we might risk changing memory that should be locked.
+	beL3n4AddrCpy := []types.L3n4Addr{}
+	for _, v := range beL3n4Addr {
+		beL3n4AddrCpy = append(beL3n4AddrCpy, v)
+	}
+
+	var fe lbmap.ServiceKey
+	if !feL3n4Addr.IsIPv6() {
+		fe = lbmap.NewService4Key(feL3n4Addr.IP, feL3n4Addr.Port, 0)
+	} else {
+		fe = lbmap.NewService6Key(feL3n4Addr.IP, feL3n4Addr.Port, 0)
+	}
 
 	// Create a list of ServiceValues so we know everything is safe to put in the lb
 	// map
 	besValues := []lbmap.ServiceValue{}
-	for _, be := range bes {
+	for _, be := range beL3n4AddrCpy {
 		beValue := fe.NewValue().(lbmap.ServiceValue)
 		if err := beValue.SetAddress(be.IP); err != nil {
 			return err
 		}
 		beValue.SetPort(uint16(be.Port))
-		beValue.SetRevNat(int(id))
+		beValue.SetRevNat(int(feL3n4Addr.ID))
 
 		besValues = append(besValues, beValue)
 	}
+
+	feL3n4Uniq, err := feL3n4Addr.L3n4Addr.SHA256Sum()
+	if err != nil {
+		return err
+	}
+
+	d.loadBalancer.BPFMapMU.Lock()
+	defer d.loadBalancer.BPFMapMU.Unlock()
 
 	// Put all the backend services first
 	nSvcs := 1
@@ -56,10 +80,9 @@ func (d *Daemon) SVCAdd(id types.ServiceID, fe lbmap.ServiceKey, bes []types.L3n
 		nSvcs++
 	}
 
-	var err error
 	if addRevNAT {
 		zeroValue := fe.NewValue().(lbmap.ServiceValue)
-		zeroValue.SetRevNat(int(id))
+		zeroValue.SetRevNat(int(feL3n4Addr.ID))
 		revNATKey := zeroValue.RevNatKey()
 		revNATValue := fe.RevNatValue()
 		if err := lbmap.UpdateRevNat(revNATKey, revNATValue); err != nil {
@@ -68,8 +91,10 @@ func (d *Daemon) SVCAdd(id types.ServiceID, fe lbmap.ServiceKey, bes []types.L3n
 		defer func() {
 			if err != nil {
 				lbmap.DeleteRevNat(revNATKey)
+				delete(d.loadBalancer.RevNATMap, feL3n4Addr.ID)
 			}
 		}()
+		d.loadBalancer.RevNATMap[feL3n4Addr.ID] = *feL3n4Addr.L3n4Addr.DeepCopy()
 	}
 
 	fe.SetBackend(0)
@@ -81,20 +106,196 @@ func (d *Daemon) SVCAdd(id types.ServiceID, fe lbmap.ServiceKey, bes []types.L3n
 		return fmt.Errorf("unable to update service %+v with the value %+v: %s", fe, zeroValue, err)
 	}
 
+	d.loadBalancer.SVCMap[feL3n4Uniq] = types.LBSVC{
+		FE:  feL3n4Addr,
+		BES: beL3n4AddrCpy,
+	}
+
 	return nil
 }
 
-// SVCDelete deletes the svcKey from the local bpf map.
-func (d *Daemon) SVCDelete(svcKey lbmap.ServiceKey) error {
+// SVCDelete deletes the frontend from the local bpf map.
+func (d *Daemon) SVCDelete(feL3n4 types.L3n4Addr) error {
+	feL3n4Uniq, err := feL3n4.SHA256Sum()
+	if err != nil {
+		return err
+	}
+
+	var svcKey lbmap.ServiceKey
+	if !feL3n4.IsIPv6() {
+		svcKey = lbmap.NewService4Key(feL3n4.IP, feL3n4.Port, 0)
+	} else {
+		svcKey = lbmap.NewService6Key(feL3n4.IP, feL3n4.Port, 0)
+	}
+
+	svcKey.SetBackend(0)
+
 	d.loadBalancer.BPFMapMU.Lock()
 	defer d.loadBalancer.BPFMapMU.Unlock()
+	err = lbmap.DeleteService(svcKey)
+	// TODO should we delete even if err is != nil?
+	if err == nil {
+		delete(d.loadBalancer.SVCMap, feL3n4Uniq)
+	}
+	return err
+}
+
+// SVCDeleteBySHA256Sum deletes the frontend from the local bpf map by its SHA256Sum.
+func (d *Daemon) SVCDeleteBySHA256Sum(feL3n4SHA256Sum string) error {
+	d.loadBalancer.BPFMapMU.Lock()
+	defer d.loadBalancer.BPFMapMU.Unlock()
+
+	svc, ok := d.loadBalancer.SVCMap[feL3n4SHA256Sum]
+	if !ok {
+		return nil
+	}
+	feL3n4 := svc.FE
+
+	var svcKey lbmap.ServiceKey
+	if !feL3n4.IsIPv6() {
+		svcKey = lbmap.NewService4Key(feL3n4.IP, feL3n4.Port, 0)
+	} else {
+		svcKey = lbmap.NewService6Key(feL3n4.IP, feL3n4.Port, 0)
+	}
+
 	svcKey.SetBackend(0)
-	return lbmap.DeleteService(svcKey)
+
+	err := lbmap.DeleteService(svcKey)
+	// TODO should we delete even if err is != nil?
+	if err == nil {
+		delete(d.loadBalancer.SVCMap, feL3n4SHA256Sum)
+	}
+	return err
+}
+
+// SVCGet returns a DeepCopied frontend with its backends.
+func (d *Daemon) SVCGet(feL3n4 types.L3n4Addr) (*types.LBSVC, error) {
+	feL3n4Uniq, err := feL3n4.SHA256Sum()
+	if err != nil {
+		return nil, err
+	}
+	return d.SVCGetBySHA256Sum(feL3n4Uniq)
+}
+
+// SVCGetBySHA256Sum returns a DeepCopied frontend with its backends.
+func (d *Daemon) SVCGetBySHA256Sum(feL3n4SHA256Sum string) (*types.LBSVC, error) {
+	d.loadBalancer.BPFMapMU.RLock()
+	defer d.loadBalancer.BPFMapMU.RUnlock()
+
+	if v, ok := d.loadBalancer.SVCMap[feL3n4SHA256Sum]; !ok {
+		return nil, nil
+	} else {
+		// We will move the slice from the loadbalancer map which have a mutex. If
+		// we don't copy the slice we might risk changing memory that should be
+		// locked.
+		beL3n4AddrCpy := []types.L3n4Addr{}
+		for _, v := range v.BES {
+			beL3n4AddrCpy = append(beL3n4AddrCpy, v)
+		}
+		return &types.LBSVC{
+			FE:  *v.FE.DeepCopy(),
+			BES: beL3n4AddrCpy,
+		}, nil
+	}
+}
+
+// SVCDump dumps a DeepCopy of the cilium's loadbalancer.
+func (d *Daemon) SVCDump() ([]types.LBSVC, error) {
+	dump := []types.LBSVC{}
+
+	d.loadBalancer.BPFMapMU.RLock()
+	defer d.loadBalancer.BPFMapMU.RUnlock()
+
+	for _, v := range d.loadBalancer.SVCMap {
+		beL3n4AddrCpy := []types.L3n4Addr{}
+		for _, v := range v.BES {
+			beL3n4AddrCpy = append(beL3n4AddrCpy, v)
+		}
+		dump = append(dump, types.LBSVC{FE: *v.FE.DeepCopy(), BES: beL3n4AddrCpy})
+	}
+
+	return dump, nil
+}
+
+// RevNATAdd deep copies the given revNAT address to the cilium lbmap with the given id.
+func (d *Daemon) RevNATAdd(id types.ServiceID, revNAT types.L3n4Addr) error {
+	if id == 0 {
+		return fmt.Errorf("invalid ID (%d)", id)
+	}
+	var (
+		revNATK lbmap.RevNatKey
+		revNATV lbmap.RevNatValue
+	)
+	if !revNAT.IsIPv6() {
+		revNATK = lbmap.NewRevNat4Key(uint16(id))
+		revNATV = lbmap.NewRevNat4Value(revNAT.IP, revNAT.Port)
+	} else {
+		revNATK = lbmap.NewRevNat6Key(uint16(id))
+		revNATV = lbmap.NewRevNat6Value(revNAT.IP, revNAT.Port)
+	}
+
+	d.loadBalancer.BPFMapMU.Lock()
+	defer d.loadBalancer.BPFMapMU.Unlock()
+
+	err := lbmap.UpdateRevNat(revNATK, revNATV)
+	if err != nil {
+		return err
+	}
+
+	d.loadBalancer.RevNATMap[id] = *revNAT.DeepCopy()
+	return nil
 }
 
 // RevNATDelete deletes the revNatKey from the local bpf map.
-func (d *Daemon) RevNATDelete(revNatKey lbmap.RevNatKey) error {
+func (d *Daemon) RevNATDelete(id types.ServiceID) error {
 	d.loadBalancer.BPFMapMU.Lock()
 	defer d.loadBalancer.BPFMapMU.Unlock()
-	return lbmap.DeleteRevNat(revNatKey)
+
+	revNAT, ok := d.loadBalancer.RevNATMap[id]
+	if !ok {
+		return nil
+	}
+
+	var revNATK lbmap.RevNatKey
+	if !revNAT.IsIPv6() {
+		revNATK = lbmap.NewRevNat4Key(uint16(id))
+	} else {
+		revNATK = lbmap.NewRevNat6Key(uint16(id))
+	}
+
+	err := lbmap.DeleteRevNat(revNATK)
+	// TODO should we delete even if err is != nil?
+	if err == nil {
+		delete(d.loadBalancer.RevNATMap, id)
+	}
+	return err
+}
+
+// RevNATGet returns a DeepCopy of the revNAT found with the given ID or nil if not found.
+func (d *Daemon) RevNATGet(id types.ServiceID) (*types.L3n4Addr, error) {
+	d.loadBalancer.BPFMapMU.RLock()
+	defer d.loadBalancer.BPFMapMU.RUnlock()
+
+	revNAT, ok := d.loadBalancer.RevNATMap[id]
+	if !ok {
+		return nil, nil
+	}
+	return revNAT.DeepCopy(), nil
+}
+
+// RevNATDump dumps a DeepCopy of the cilium's loadbalancer.
+func (d *Daemon) RevNATDump() ([]types.L3n4AddrID, error) {
+	dump := []types.L3n4AddrID{}
+
+	d.loadBalancer.BPFMapMU.RLock()
+	defer d.loadBalancer.BPFMapMU.RUnlock()
+
+	for k, v := range d.loadBalancer.RevNATMap {
+		dump = append(dump, types.L3n4AddrID{
+			ID:       k,
+			L3n4Addr: *v.DeepCopy(),
+		})
+	}
+
+	return dump, nil
 }

--- a/daemon/daemon/loadbalancer.go
+++ b/daemon/daemon/loadbalancer.go
@@ -1,0 +1,100 @@
+//
+// Copyright 2016 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package daemon
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/bpf/lbmap"
+	"github.com/cilium/cilium/common/types"
+)
+
+// SVCAdd adds a service from the given fe (frontend) and bes (backends) with the given
+// id. If addRevNAT is set, the RevNAT entry is also created for this particular service.
+// If any of the backend addresses set in bes have a different L3 address type than the
+// one set in fe, it returns an error without modifying the bpf LB map. If any backend
+// entry fails while updating the LB map, the frontend won't be inserted in the LB map and
+// therefore there won't be any traffic going to the given backends.
+func (d *Daemon) SVCAdd(id types.ServiceID, fe lbmap.ServiceKey, bes []types.L3n4Addr, addRevNAT bool) error {
+	d.loadBalancer.BPFMapMU.Lock()
+	defer d.loadBalancer.BPFMapMU.Unlock()
+
+	// Create a list of ServiceValues so we know everything is safe to put in the lb
+	// map
+	besValues := []lbmap.ServiceValue{}
+	for _, be := range bes {
+		beValue := fe.NewValue().(lbmap.ServiceValue)
+		if err := beValue.SetAddress(be.IP); err != nil {
+			return err
+		}
+		beValue.SetPort(uint16(be.Port))
+		beValue.SetRevNat(int(id))
+
+		besValues = append(besValues, beValue)
+	}
+
+	// Put all the backend services first
+	nSvcs := 1
+	for _, be := range besValues {
+		fe.SetBackend(nSvcs)
+		if err := lbmap.UpdateService(fe, be); err != nil {
+			return fmt.Errorf("unable to update service %+v with the value %+v: %s", fe, be, err)
+		}
+		nSvcs++
+	}
+
+	var err error
+	if addRevNAT {
+		zeroValue := fe.NewValue().(lbmap.ServiceValue)
+		zeroValue.SetRevNat(int(id))
+		revNATKey := zeroValue.RevNatKey()
+		revNATValue := fe.RevNatValue()
+		if err := lbmap.UpdateRevNat(revNATKey, revNATValue); err != nil {
+			return fmt.Errorf("unable to update reverse NAT %+v with value %+v, %s", revNATKey, revNATValue, err)
+		}
+		defer func() {
+			if err != nil {
+				lbmap.DeleteRevNat(revNATKey)
+			}
+		}()
+	}
+
+	fe.SetBackend(0)
+	zeroValue := fe.NewValue().(lbmap.ServiceValue)
+	zeroValue.SetCount(nSvcs - 1)
+
+	err = lbmap.UpdateService(fe, zeroValue)
+	if err != nil {
+		return fmt.Errorf("unable to update service %+v with the value %+v: %s", fe, zeroValue, err)
+	}
+
+	return nil
+}
+
+// SVCDelete deletes the svcKey from the local bpf map.
+func (d *Daemon) SVCDelete(svcKey lbmap.ServiceKey) error {
+	d.loadBalancer.BPFMapMU.Lock()
+	defer d.loadBalancer.BPFMapMU.Unlock()
+	svcKey.SetBackend(0)
+	return lbmap.DeleteService(svcKey)
+}
+
+// RevNATDelete deletes the revNatKey from the local bpf map.
+func (d *Daemon) RevNATDelete(revNatKey lbmap.RevNatKey) error {
+	d.loadBalancer.BPFMapMU.Lock()
+	defer d.loadBalancer.BPFMapMU.Unlock()
+	return lbmap.DeleteRevNat(revNatKey)
+}

--- a/daemon/daemon/services_test.go
+++ b/daemon/daemon/services_test.go
@@ -25,22 +25,22 @@ import (
 )
 
 var (
-	svc1 = types.ServiceL4{
-		IP:   net.IPv6loopback,
-		Port: 0,
+	svc1 = types.L3n4Addr{
+		IP:     net.IPv6loopback,
+		L4Addr: types.L4Addr{Port: 0},
 	}
-	svc2 = types.ServiceL4{
-		IP:   net.IPv6loopback,
-		Port: 1,
+	svc2 = types.L3n4Addr{
+		IP:     net.IPv6loopback,
+		L4Addr: types.L4Addr{Port: 1},
 	}
-	wantSvcL4ID = &types.ServiceL4ID{
-		ServiceID: 123,
-		ServiceL4: svc2,
+	wantSvcL4ID = &types.L3n4AddrID{
+		ID:       123,
+		L3n4Addr: svc2,
 	}
 )
 
 func (ds *DaemonSuite) TestServices(c *C) {
-	var nilSvcL4ID *types.ServiceL4ID
+	var nilSvcL4ID *types.L3n4AddrID
 	// Set up last free ID with zero
 	id, err := ds.d.GetMaxServiceID()
 	c.Assert(err, Equals, nil)
@@ -50,20 +50,20 @@ func (ds *DaemonSuite) TestServices(c *C) {
 
 	svcL4ID, err := ds.d.PutServiceL4(svc1)
 	c.Assert(err, Equals, nil)
-	c.Assert(svcL4ID.ServiceID, Equals, ffsIDu16)
+	c.Assert(svcL4ID.ID, Equals, ffsIDu16)
 
 	svcL4ID, err = ds.d.PutServiceL4(svc1)
 	c.Assert(err, Equals, nil)
-	c.Assert(svcL4ID.ServiceID, Equals, ffsIDu16)
+	c.Assert(svcL4ID.ID, Equals, ffsIDu16)
 
 	svcL4ID, err = ds.d.PutServiceL4(svc2)
 	c.Assert(err, Equals, nil)
-	c.Assert(svcL4ID.ServiceID, Equals, ffsIDu16+1)
+	c.Assert(svcL4ID.ID, Equals, ffsIDu16+1)
 
 	gotSvcL4ID, err := ds.d.GetServiceL4ID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
-	wantSvcL4ID.ServiceID = ffsIDu16
-	wantSvcL4ID.ServiceL4 = svc1
+	wantSvcL4ID.ID = ffsIDu16
+	wantSvcL4ID.L3n4Addr = svc1
 	c.Assert(gotSvcL4ID, DeepEquals, wantSvcL4ID)
 
 	err = ds.d.DeleteServiceL4IDByUUID(common.FirstFreeServiceID)
@@ -74,8 +74,8 @@ func (ds *DaemonSuite) TestServices(c *C) {
 
 	gotSvcL4ID, err = ds.d.GetServiceL4ID(common.FirstFreeServiceID + 1)
 	c.Assert(err, Equals, nil)
-	wantSvcL4ID.ServiceID = types.ServiceID(common.FirstFreeServiceID + 1)
-	wantSvcL4ID.ServiceL4 = svc2
+	wantSvcL4ID.ID = types.ServiceID(common.FirstFreeServiceID + 1)
+	wantSvcL4ID.L3n4Addr = svc2
 	c.Assert(gotSvcL4ID, DeepEquals, wantSvcL4ID)
 
 	err = ds.d.DeleteServiceL4IDByUUID(common.FirstFreeServiceID)
@@ -92,7 +92,7 @@ func (ds *DaemonSuite) TestServices(c *C) {
 
 	gotSvcL4ID, err = ds.d.PutServiceL4(svc2)
 	c.Assert(err, Equals, nil)
-	c.Assert(gotSvcL4ID.ServiceID, Equals, types.ServiceID(common.FirstFreeServiceID+1))
+	c.Assert(gotSvcL4ID.ID, Equals, types.ServiceID(common.FirstFreeServiceID+1))
 
 	sha256sum, err := svc2.SHA256Sum()
 	c.Assert(err, Equals, nil)
@@ -110,11 +110,11 @@ func (ds *DaemonSuite) TestServices(c *C) {
 
 	gotSvcL4ID, err = ds.d.PutServiceL4(svc2)
 	c.Assert(err, Equals, nil)
-	c.Assert(gotSvcL4ID.ServiceID, Equals, ffsIDu16)
+	c.Assert(gotSvcL4ID.ID, Equals, ffsIDu16)
 
 	gotSvcL4ID, err = ds.d.PutServiceL4(svc1)
 	c.Assert(err, Equals, nil)
-	c.Assert(gotSvcL4ID.ServiceID, Equals, types.ServiceID(common.FirstFreeServiceID+1))
+	c.Assert(gotSvcL4ID.ID, Equals, types.ServiceID(common.FirstFreeServiceID+1))
 }
 
 func (ds *DaemonSuite) TestGetMaxServiceID(c *C) {

--- a/daemon/daemon/services_test.go
+++ b/daemon/daemon/services_test.go
@@ -25,22 +25,22 @@ import (
 )
 
 var (
-	svc1 = types.L3n4Addr{
+	l3n4Addr1 = types.L3n4Addr{
 		IP:     net.IPv6loopback,
 		L4Addr: types.L4Addr{Port: 0},
 	}
-	svc2 = types.L3n4Addr{
+	l3n4Addr2 = types.L3n4Addr{
 		IP:     net.IPv6loopback,
 		L4Addr: types.L4Addr{Port: 1},
 	}
-	wantSvcL4ID = &types.L3n4AddrID{
+	wantL3n4AddrID = &types.L3n4AddrID{
 		ID:       123,
-		L3n4Addr: svc2,
+		L3n4Addr: l3n4Addr2,
 	}
 )
 
 func (ds *DaemonSuite) TestServices(c *C) {
-	var nilSvcL4ID *types.L3n4AddrID
+	var nilL3n4AddrID *types.L3n4AddrID
 	// Set up last free ID with zero
 	id, err := ds.d.GetMaxServiceID()
 	c.Assert(err, Equals, nil)
@@ -48,73 +48,73 @@ func (ds *DaemonSuite) TestServices(c *C) {
 
 	ffsIDu16 := types.ServiceID(uint16(common.FirstFreeServiceID))
 
-	svcL4ID, err := ds.d.PutServiceL4(svc1)
+	l3n4AddrID, err := ds.d.PutL3n4Addr(l3n4Addr1)
 	c.Assert(err, Equals, nil)
-	c.Assert(svcL4ID.ID, Equals, ffsIDu16)
+	c.Assert(l3n4AddrID.ID, Equals, ffsIDu16)
 
-	svcL4ID, err = ds.d.PutServiceL4(svc1)
+	l3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr1)
 	c.Assert(err, Equals, nil)
-	c.Assert(svcL4ID.ID, Equals, ffsIDu16)
+	c.Assert(l3n4AddrID.ID, Equals, ffsIDu16)
 
-	svcL4ID, err = ds.d.PutServiceL4(svc2)
+	l3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr2)
 	c.Assert(err, Equals, nil)
-	c.Assert(svcL4ID.ID, Equals, ffsIDu16+1)
+	c.Assert(l3n4AddrID.ID, Equals, ffsIDu16+1)
 
-	gotSvcL4ID, err := ds.d.GetServiceL4ID(common.FirstFreeServiceID)
+	gotL3n4AddrID, err := ds.d.GetL3n4AddrID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
-	wantSvcL4ID.ID = ffsIDu16
-	wantSvcL4ID.L3n4Addr = svc1
-	c.Assert(gotSvcL4ID, DeepEquals, wantSvcL4ID)
+	wantL3n4AddrID.ID = ffsIDu16
+	wantL3n4AddrID.L3n4Addr = l3n4Addr1
+	c.Assert(gotL3n4AddrID, DeepEquals, wantL3n4AddrID)
 
-	err = ds.d.DeleteServiceL4IDByUUID(common.FirstFreeServiceID)
+	err = ds.d.DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
-	gotSvcL4ID, err = ds.d.GetServiceL4ID(common.FirstFreeServiceID)
+	gotL3n4AddrID, err = ds.d.GetL3n4AddrID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
-	c.Assert(gotSvcL4ID, Equals, nilSvcL4ID)
+	c.Assert(gotL3n4AddrID, Equals, nilL3n4AddrID)
 
-	gotSvcL4ID, err = ds.d.GetServiceL4ID(common.FirstFreeServiceID + 1)
+	gotL3n4AddrID, err = ds.d.GetL3n4AddrID(common.FirstFreeServiceID + 1)
 	c.Assert(err, Equals, nil)
-	wantSvcL4ID.ID = types.ServiceID(common.FirstFreeServiceID + 1)
-	wantSvcL4ID.L3n4Addr = svc2
-	c.Assert(gotSvcL4ID, DeepEquals, wantSvcL4ID)
+	wantL3n4AddrID.ID = types.ServiceID(common.FirstFreeServiceID + 1)
+	wantL3n4AddrID.L3n4Addr = l3n4Addr2
+	c.Assert(gotL3n4AddrID, DeepEquals, wantL3n4AddrID)
 
-	err = ds.d.DeleteServiceL4IDByUUID(common.FirstFreeServiceID)
+	err = ds.d.DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
 
 	err = ds.d.kvClient.SetMaxID(common.LastFreeServiceIDKeyPath, common.FirstFreeServiceID, common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
 
-	err = ds.d.DeleteServiceL4IDByUUID(common.FirstFreeServiceID)
+	err = ds.d.DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
-	gotSvcL4ID, err = ds.d.GetServiceL4ID(common.FirstFreeServiceID)
+	gotL3n4AddrID, err = ds.d.GetL3n4AddrID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
-	c.Assert(gotSvcL4ID, Equals, nilSvcL4ID)
+	c.Assert(gotL3n4AddrID, Equals, nilL3n4AddrID)
 
-	gotSvcL4ID, err = ds.d.PutServiceL4(svc2)
+	gotL3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr2)
 	c.Assert(err, Equals, nil)
-	c.Assert(gotSvcL4ID.ID, Equals, types.ServiceID(common.FirstFreeServiceID+1))
+	c.Assert(gotL3n4AddrID.ID, Equals, types.ServiceID(common.FirstFreeServiceID+1))
 
-	sha256sum, err := svc2.SHA256Sum()
-	c.Assert(err, Equals, nil)
-
-	gotSvcL4ID, err = ds.d.GetServiceL4IDBySHA256(sha256sum)
-	c.Assert(err, Equals, nil)
-	c.Assert(gotSvcL4ID, DeepEquals, wantSvcL4ID)
-
-	err = ds.d.DeleteServiceL4IDBySHA256(sha256sum)
-	c.Assert(err, Equals, nil)
-	err = ds.d.DeleteServiceL4IDByUUID(common.FirstFreeServiceID + 1)
-	c.Assert(err, Equals, nil)
-	err = ds.d.DeleteServiceL4IDByUUID(common.FirstFreeServiceID + 1)
+	sha256sum, err := l3n4Addr2.SHA256Sum()
 	c.Assert(err, Equals, nil)
 
-	gotSvcL4ID, err = ds.d.PutServiceL4(svc2)
+	gotL3n4AddrID, err = ds.d.GetL3n4AddrIDBySHA256(sha256sum)
 	c.Assert(err, Equals, nil)
-	c.Assert(gotSvcL4ID.ID, Equals, ffsIDu16)
+	c.Assert(gotL3n4AddrID, DeepEquals, wantL3n4AddrID)
 
-	gotSvcL4ID, err = ds.d.PutServiceL4(svc1)
+	err = ds.d.DeleteL3n4AddrIDBySHA256(sha256sum)
 	c.Assert(err, Equals, nil)
-	c.Assert(gotSvcL4ID.ID, Equals, types.ServiceID(common.FirstFreeServiceID+1))
+	err = ds.d.DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID + 1)
+	c.Assert(err, Equals, nil)
+	err = ds.d.DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID + 1)
+	c.Assert(err, Equals, nil)
+
+	gotL3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr2)
+	c.Assert(err, Equals, nil)
+	c.Assert(gotL3n4AddrID.ID, Equals, ffsIDu16)
+
+	gotL3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr1)
+	c.Assert(err, Equals, nil)
+	c.Assert(gotL3n4AddrID.ID, Equals, types.ServiceID(common.FirstFreeServiceID+1))
 }
 
 func (ds *DaemonSuite) TestGetMaxServiceID(c *C) {

--- a/daemon/server/daemon_mock_test.go
+++ b/daemon/server/daemon_mock_test.go
@@ -57,11 +57,13 @@ type TestDaemon struct {
 	OnSVCAdd                    func(fe types.L3n4AddrID, be []types.L3n4Addr, addRevNAT bool) error
 	OnSVCDelete                 func(feL3n4 types.L3n4Addr) error
 	OnSVCDeleteBySHA256Sum      func(feL3n4SHA256Sum string) error
+	OnSVCDeleteAll              func() error
 	OnSVCGet                    func(feL3n4 types.L3n4Addr) (*types.LBSVC, error)
 	OnSVCGetBySHA256Sum         func(feL3n4SHA256Sum string) (*types.LBSVC, error)
 	OnSVCDump                   func() ([]types.LBSVC, error)
 	OnRevNATAdd                 func(id types.ServiceID, revNAT types.L3n4Addr) error
 	OnRevNATDelete              func(id types.ServiceID) error
+	OnRevNATDeleteAll           func() error
 	OnRevNATGet                 func(id types.ServiceID) (*types.L3n4Addr, error)
 	OnRevNATDump                func() ([]types.L3n4AddrID, error)
 	OnGetUIIP                   func() (*net.TCPAddr, error)
@@ -290,6 +292,13 @@ func (d TestDaemon) SVCDeleteBySHA256Sum(feL3n4SHA256Sum string) error {
 	return errors.New("SVCDeleteBySHA256Sum should not have been called")
 }
 
+func (d TestDaemon) SVCDeleteAll() error {
+	if d.OnSVCDeleteAll != nil {
+		return d.OnSVCDeleteAll()
+	}
+	return errors.New("SVCDeleteAll should not have been called")
+}
+
 func (d TestDaemon) SVCGet(feL3n4 types.L3n4Addr) (*types.LBSVC, error) {
 	if d.OnSVCGet != nil {
 		return d.OnSVCGet(feL3n4)
@@ -323,6 +332,13 @@ func (d TestDaemon) RevNATDelete(id types.ServiceID) error {
 		return d.OnRevNATDelete(id)
 	}
 	return errors.New("RevNATDelete should not have been called")
+}
+
+func (d TestDaemon) RevNATDeleteAll() error {
+	if d.OnRevNATDeleteAll != nil {
+		return d.OnRevNATDeleteAll()
+	}
+	return errors.New("RevNATDeleteAll should not have been called")
 }
 
 func (d TestDaemon) RevNATGet(id types.ServiceID) (*types.L3n4Addr, error) {

--- a/daemon/server/daemon_mock_test.go
+++ b/daemon/server/daemon_mock_test.go
@@ -66,6 +66,7 @@ type TestDaemon struct {
 	OnRevNATDeleteAll           func() error
 	OnRevNATGet                 func(id types.ServiceID) (*types.L3n4Addr, error)
 	OnRevNATDump                func() ([]types.L3n4AddrID, error)
+	OnSyncLBMap                 func() error
 	OnGetUIIP                   func() (*net.TCPAddr, error)
 	OnGetUIPath                 func() (string, error)
 	OnRegisterUIListener        func(conn *websocket.Conn) (chan types.UIUpdateMsg, error)
@@ -353,6 +354,13 @@ func (d TestDaemon) RevNATDump() ([]types.L3n4AddrID, error) {
 		return d.OnRevNATDump()
 	}
 	return nil, errors.New("RevNATDump should not have been called")
+}
+
+func (d TestDaemon) SyncLBMap() error {
+	if d.OnSyncLBMap != nil {
+		return d.OnSyncLBMap()
+	}
+	return errors.New("SyncLBMap should not have been called")
 }
 
 func (d TestDaemon) GetUIIP() (*net.TCPAddr, error) {

--- a/daemon/server/daemon_mock_test.go
+++ b/daemon/server/daemon_mock_test.go
@@ -54,6 +54,16 @@ type TestDaemon struct {
 	OnPolicyDelete              func(path string) error
 	OnPolicyGet                 func(path string) (*types.PolicyNode, error)
 	OnPolicyCanConsume          func(sc *types.SearchContext) (*types.SearchContextReply, error)
+	OnSVCAdd                    func(fe types.L3n4AddrID, be []types.L3n4Addr, addRevNAT bool) error
+	OnSVCDelete                 func(feL3n4 types.L3n4Addr) error
+	OnSVCDeleteBySHA256Sum      func(feL3n4SHA256Sum string) error
+	OnSVCGet                    func(feL3n4 types.L3n4Addr) (*types.LBSVC, error)
+	OnSVCGetBySHA256Sum         func(feL3n4SHA256Sum string) (*types.LBSVC, error)
+	OnSVCDump                   func() ([]types.LBSVC, error)
+	OnRevNATAdd                 func(id types.ServiceID, revNAT types.L3n4Addr) error
+	OnRevNATDelete              func(id types.ServiceID) error
+	OnRevNATGet                 func(id types.ServiceID) (*types.L3n4Addr, error)
+	OnRevNATDump                func() ([]types.L3n4AddrID, error)
 	OnGetUIIP                   func() (*net.TCPAddr, error)
 	OnGetUIPath                 func() (string, error)
 	OnRegisterUIListener        func(conn *websocket.Conn) (chan types.UIUpdateMsg, error)
@@ -257,6 +267,76 @@ func (d TestDaemon) PolicyCanConsume(sc *types.SearchContext) (*types.SearchCont
 		return d.OnPolicyCanConsume(sc)
 	}
 	return nil, errors.New("PolicyCanConsume should not have been called")
+}
+
+func (d TestDaemon) SVCAdd(fe types.L3n4AddrID, be []types.L3n4Addr, addRevNAT bool) error {
+	if d.OnSVCAdd != nil {
+		return d.OnSVCAdd(fe, be, addRevNAT)
+	}
+	return errors.New("SVCAdd should not have been called")
+}
+
+func (d TestDaemon) SVCDelete(feL3n4 types.L3n4Addr) error {
+	if d.OnSVCDelete != nil {
+		return d.OnSVCDelete(feL3n4)
+	}
+	return errors.New("SVCDelete should not have been called")
+}
+
+func (d TestDaemon) SVCDeleteBySHA256Sum(feL3n4SHA256Sum string) error {
+	if d.OnSVCDeleteBySHA256Sum != nil {
+		return d.OnSVCDeleteBySHA256Sum(feL3n4SHA256Sum)
+	}
+	return errors.New("SVCDeleteBySHA256Sum should not have been called")
+}
+
+func (d TestDaemon) SVCGet(feL3n4 types.L3n4Addr) (*types.LBSVC, error) {
+	if d.OnSVCGet != nil {
+		return d.OnSVCGet(feL3n4)
+	}
+	return nil, errors.New("SVCGet should not have been called")
+}
+
+func (d TestDaemon) SVCGetBySHA256Sum(feL3n4SHA256Sum string) (*types.LBSVC, error) {
+	if d.OnSVCGetBySHA256Sum != nil {
+		return d.OnSVCGetBySHA256Sum(feL3n4SHA256Sum)
+	}
+	return nil, errors.New("SVCGetBySHA256Sum should not have been called")
+}
+
+func (d TestDaemon) SVCDump() ([]types.LBSVC, error) {
+	if d.OnSVCDump != nil {
+		return d.OnSVCDump()
+	}
+	return nil, errors.New("SVCDump should not have been called")
+}
+
+func (d TestDaemon) RevNATAdd(id types.ServiceID, revNAT types.L3n4Addr) error {
+	if d.OnRevNATAdd != nil {
+		return d.OnRevNATAdd(id, revNAT)
+	}
+	return errors.New("RevNATAdd should not have been called")
+}
+
+func (d TestDaemon) RevNATDelete(id types.ServiceID) error {
+	if d.OnRevNATDelete != nil {
+		return d.OnRevNATDelete(id)
+	}
+	return errors.New("RevNATDelete should not have been called")
+}
+
+func (d TestDaemon) RevNATGet(id types.ServiceID) (*types.L3n4Addr, error) {
+	if d.OnRevNATGet != nil {
+		return d.OnRevNATGet(id)
+	}
+	return nil, errors.New("RevNATGet should not have been called")
+}
+
+func (d TestDaemon) RevNATDump() ([]types.L3n4AddrID, error) {
+	if d.OnRevNATDump != nil {
+		return d.OnRevNATDump()
+	}
+	return nil, errors.New("RevNATDump should not have been called")
 }
 
 func (d TestDaemon) GetUIIP() (*net.TCPAddr, error) {

--- a/daemon/server/handlers.go
+++ b/daemon/server/handlers.go
@@ -734,3 +734,12 @@ func (router *Router) revNATDump(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 }
+
+func (router *Router) syncLBMap(w http.ResponseWriter, r *http.Request) {
+	err := router.daemon.SyncLBMap()
+	if err != nil {
+		processServerError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/daemon/server/handlers.go
+++ b/daemon/server/handlers.go
@@ -606,6 +606,14 @@ func (router *Router) serviceDel(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+func (router *Router) serviceDelAll(w http.ResponseWriter, r *http.Request) {
+	if err := router.daemon.SVCDeleteAll(); err != nil {
+		processServerError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func (router *Router) serviceGet(w http.ResponseWriter, r *http.Request) {
 	feSHA256Sum, err := verifyFESHA256Sum(mux.Vars(r))
 	if err != nil {
@@ -674,6 +682,14 @@ func (router *Router) revNATDel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := router.daemon.RevNATDelete(revNATID); err != nil {
+		processServerError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (router *Router) revNATDelAll(w http.ResponseWriter, r *http.Request) {
+	if err := router.daemon.RevNATDeleteAll(); err != nil {
 		processServerError(w, r, err)
 		return
 	}

--- a/daemon/server/loadbalancer_test.go
+++ b/daemon/server/loadbalancer_test.go
@@ -386,3 +386,21 @@ func (s *DaemonSuite) TestRevNATDumpFail(c *C) {
 	c.Assert(err, ErrorMatches, ".*Unable to read lbmap.*")
 	c.Assert(lbSVCReceived, IsNil)
 }
+
+func (s *DaemonSuite) TestSyncLBMapOK(c *C) {
+	s.d.OnSyncLBMap = func() error {
+		return nil
+	}
+
+	err := s.c.SyncLBMap()
+	c.Assert(err, IsNil)
+}
+
+func (s *DaemonSuite) TestSyncLBMapFail(c *C) {
+	s.d.OnSyncLBMap = func() error {
+		return errors.New("Unable to read lbmap")
+	}
+
+	err := s.c.SyncLBMap()
+	c.Assert(err, ErrorMatches, ".*Unable to read lbmap.*")
+}

--- a/daemon/server/loadbalancer_test.go
+++ b/daemon/server/loadbalancer_test.go
@@ -138,6 +138,24 @@ func (s *DaemonSuite) TestSVCDeleteBySHA256SumFail(c *C) {
 	c.Assert(err, ErrorMatches, ".*Unable to read lbmap.*")
 }
 
+func (s *DaemonSuite) TestSVCDeleteAllOK(c *C) {
+	s.d.OnSVCDeleteAll = func() error {
+		return nil
+	}
+
+	err := s.c.SVCDeleteAll()
+	c.Assert(err, IsNil)
+}
+
+func (s *DaemonSuite) TestSVCDeleteAllFail(c *C) {
+	s.d.OnSVCDeleteAll = func() error {
+		return errors.New("Unable to read lbmap")
+	}
+
+	err := s.c.SVCDeleteAll()
+	c.Assert(err, ErrorMatches, ".*Unable to read lbmap.*")
+}
+
 func (s *DaemonSuite) TestSVCGetOK(c *C) {
 	feWant, err := types.NewL3n4AddrID(types.TCP, randomAddr1, 1984, 2016)
 	c.Assert(err, IsNil)
@@ -291,6 +309,24 @@ func (s *DaemonSuite) TestRevNATDeleteFail(c *C) {
 	}
 
 	err := s.c.RevNATDelete(idWant)
+	c.Assert(err, ErrorMatches, ".*ID 0 is reserved.*")
+}
+
+func (s *DaemonSuite) TestRevNATDeleteAllOK(c *C) {
+	s.d.OnRevNATDeleteAll = func() error {
+		return nil
+	}
+
+	err := s.c.RevNATDeleteAll()
+	c.Assert(err, IsNil)
+}
+
+func (s *DaemonSuite) TestRevNATDeleteAllFail(c *C) {
+	s.d.OnRevNATDeleteAll = func() error {
+		return errors.New("ID 0 is reserved")
+	}
+
+	err := s.c.RevNATDeleteAll()
 	c.Assert(err, ErrorMatches, ".*ID 0 is reserved.*")
 }
 

--- a/daemon/server/loadbalancer_test.go
+++ b/daemon/server/loadbalancer_test.go
@@ -1,0 +1,352 @@
+//
+// Copyright 2016 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package server
+
+import (
+	"errors"
+	"net"
+
+	"github.com/cilium/cilium/common/types"
+
+	. "gopkg.in/check.v1"
+)
+
+var (
+	randomAddr1 = net.ParseIP("beef:beef:beef:beef:aaaa:aaaa:1111:0:1")
+	randomAddr2 = net.ParseIP("beef:beef:beef:beef:aaaa:aaaa:1111:0:2")
+	revNat1     = types.L3n4Addr{
+		IP: randomAddr1,
+		L4Addr: types.L4Addr{
+			Protocol: types.TCP,
+			Port:     1984,
+		},
+	}
+	revNat2 = types.L3n4Addr{
+		IP: randomAddr2,
+		L4Addr: types.L4Addr{
+			Protocol: types.TCP,
+			Port:     1911,
+		},
+	}
+
+	bes = []types.L3n4Addr{
+		revNat1,
+		revNat2,
+	}
+)
+
+func (s *DaemonSuite) TestSVCAddIDOK(c *C) {
+	feWant, err := types.NewL3n4AddrID(types.TCP, randomAddr1, 1984, 2016)
+	c.Assert(err, IsNil)
+
+	s.d.OnSVCAdd = func(fe types.L3n4AddrID, be []types.L3n4Addr, addRevNAT bool) error {
+		c.Assert(fe, DeepEquals, *feWant)
+		c.Assert(be, DeepEquals, bes)
+		c.Assert(addRevNAT, Equals, false)
+		return nil
+	}
+
+	err = s.c.SVCAdd(*feWant, bes, false)
+	c.Assert(err, IsNil)
+}
+
+func (s *DaemonSuite) TestSVCAddIDFail(c *C) {
+	feWant, err := types.NewL3n4AddrID(types.TCP, randomAddr1, 1984, 2016)
+	c.Assert(err, IsNil)
+
+	s.d.OnSVCAdd = func(fe types.L3n4AddrID, be []types.L3n4Addr, addRevNAT bool) error {
+		c.Assert(fe, DeepEquals, *feWant)
+		c.Assert(be, DeepEquals, bes)
+		c.Assert(addRevNAT, Equals, true)
+		return errors.New("Unable to read lbmap")
+	}
+
+	err = s.c.SVCAdd(*feWant, bes, true)
+	c.Assert(err, ErrorMatches, ".*Unable to read lbmap.*")
+}
+
+func (s *DaemonSuite) TestSVCDeleteOK(c *C) {
+	feWant, err := types.NewL3n4Addr(types.TCP, randomAddr1, 1984)
+	c.Assert(err, IsNil)
+	feL3n4SHA256Want, err := feWant.SHA256Sum()
+	c.Assert(err, IsNil)
+
+	s.d.OnSVCDeleteBySHA256Sum = func(feL3n4SHA256Sum string) error {
+		c.Assert(feL3n4SHA256Sum, Equals, feL3n4SHA256Want)
+		return nil
+	}
+
+	err = s.c.SVCDelete(*feWant)
+	c.Assert(err, IsNil)
+}
+
+func (s *DaemonSuite) TestSVCDeleteFail(c *C) {
+	feWant, err := types.NewL3n4Addr(types.TCP, randomAddr1, 1984)
+	c.Assert(err, IsNil)
+	feL3n4SHA256Want, err := feWant.SHA256Sum()
+	c.Assert(err, IsNil)
+
+	s.d.OnSVCDeleteBySHA256Sum = func(feL3n4SHA256Sum string) error {
+		c.Assert(feL3n4SHA256Sum, Equals, feL3n4SHA256Want)
+		return errors.New("Unable to read lbmap")
+	}
+
+	err = s.c.SVCDelete(*feWant)
+	c.Assert(err, ErrorMatches, ".*Unable to read lbmap.*")
+}
+
+func (s *DaemonSuite) TestSVCDeleteBySHA256SumOK(c *C) {
+	feWant, err := types.NewL3n4AddrID(types.TCP, randomAddr1, 1984, 2016)
+	c.Assert(err, IsNil)
+	feL3n4SHA256Want, err := feWant.SHA256Sum()
+	c.Assert(err, IsNil)
+
+	s.d.OnSVCDeleteBySHA256Sum = func(feL3n4SHA256Sum string) error {
+		c.Assert(feL3n4SHA256Sum, Equals, feL3n4SHA256Want)
+		return nil
+	}
+
+	err = s.c.SVCDeleteBySHA256Sum(feL3n4SHA256Want)
+	c.Assert(err, IsNil)
+}
+
+func (s *DaemonSuite) TestSVCDeleteBySHA256SumFail(c *C) {
+	feWant, err := types.NewL3n4AddrID(types.TCP, randomAddr1, 1984, 2016)
+	c.Assert(err, IsNil)
+	feL3n4SHA256Want, err := feWant.SHA256Sum()
+	c.Assert(err, IsNil)
+
+	s.d.OnSVCDeleteBySHA256Sum = func(feL3n4SHA256Sum string) error {
+		c.Assert(feL3n4SHA256Sum, Equals, feL3n4SHA256Want)
+		return errors.New("Unable to read lbmap")
+	}
+
+	err = s.c.SVCDeleteBySHA256Sum(feL3n4SHA256Want)
+	c.Assert(err, ErrorMatches, ".*Unable to read lbmap.*")
+}
+
+func (s *DaemonSuite) TestSVCGetOK(c *C) {
+	feWant, err := types.NewL3n4AddrID(types.TCP, randomAddr1, 1984, 2016)
+	c.Assert(err, IsNil)
+	feL3n4SHA256Want, err := feWant.SHA256Sum()
+	c.Assert(err, IsNil)
+
+	lbSVCWant := types.LBSVC{
+		FE:  *feWant,
+		BES: bes,
+	}
+
+	s.d.OnSVCGetBySHA256Sum = func(feL3n4SHA256Sum string) (*types.LBSVC, error) {
+		c.Assert(feL3n4SHA256Sum, Equals, feL3n4SHA256Want)
+		return &lbSVCWant, nil
+	}
+
+	lbSvcReceived, err := s.c.SVCGet(feWant.L3n4Addr)
+	c.Assert(err, IsNil)
+	c.Assert(*lbSvcReceived, DeepEquals, lbSVCWant)
+}
+
+func (s *DaemonSuite) TestSVCGetFail(c *C) {
+	feWant, err := types.NewL3n4AddrID(types.TCP, randomAddr1, 1984, 2016)
+	c.Assert(err, IsNil)
+	feL3n4SHA256Want, err := feWant.SHA256Sum()
+	c.Assert(err, IsNil)
+
+	s.d.OnSVCGetBySHA256Sum = func(feL3n4SHA256Sum string) (*types.LBSVC, error) {
+		c.Assert(feL3n4SHA256Sum, Equals, feL3n4SHA256Want)
+		return nil, errors.New("Unable to read lbmap")
+	}
+
+	lbSvcReceived, err := s.c.SVCGet(feWant.L3n4Addr)
+	c.Assert(err, ErrorMatches, ".*Unable to read lbmap.*")
+	c.Assert(lbSvcReceived, IsNil)
+}
+
+func (s *DaemonSuite) TestSVCGetBySHA256SumOK(c *C) {
+	feWant, err := types.NewL3n4AddrID(types.TCP, randomAddr1, 1984, 2016)
+	c.Assert(err, IsNil)
+	feL3n4SHA256Want, err := feWant.SHA256Sum()
+	c.Assert(err, IsNil)
+
+	lbSVCWant := types.LBSVC{
+		FE:  *feWant,
+		BES: bes,
+	}
+
+	s.d.OnSVCGetBySHA256Sum = func(feL3n4SHA256Sum string) (*types.LBSVC, error) {
+		c.Assert(feL3n4SHA256Sum, Equals, feL3n4SHA256Want)
+		return &lbSVCWant, nil
+	}
+
+	lbSvcReceived, err := s.c.SVCGetBySHA256Sum(feL3n4SHA256Want)
+	c.Assert(err, IsNil)
+	c.Assert(*lbSvcReceived, DeepEquals, lbSVCWant)
+}
+
+func (s *DaemonSuite) TestSVCGetBySHA256SumFail(c *C) {
+	feWant, err := types.NewL3n4Addr(types.TCP, randomAddr1, 1984)
+	c.Assert(err, IsNil)
+	feL3n4SHA256Want, err := feWant.SHA256Sum()
+	c.Assert(err, IsNil)
+
+	s.d.OnSVCGetBySHA256Sum = func(feL3n4SHA256Sum string) (*types.LBSVC, error) {
+		c.Assert(feL3n4SHA256Sum, Equals, feL3n4SHA256Want)
+		return nil, errors.New("Unable to read lbmap")
+	}
+
+	lbSvcReceived, err := s.c.SVCGetBySHA256Sum(feL3n4SHA256Want)
+	c.Assert(err, ErrorMatches, ".*Unable to read lbmap.*")
+	c.Assert(lbSvcReceived, IsNil)
+}
+
+func (s *DaemonSuite) TestSVCDumpOK(c *C) {
+	feWant, err := types.NewL3n4AddrID(types.TCP, randomAddr1, 1984, 2016)
+	c.Assert(err, IsNil)
+	wantLBSVC := []types.LBSVC{
+		{
+			FE:  *feWant,
+			BES: bes,
+		},
+		{
+			FE:  *feWant,
+			BES: bes,
+		},
+	}
+	s.d.OnSVCDump = func() ([]types.LBSVC, error) {
+		return wantLBSVC, nil
+	}
+
+	lbSVCReceived, err := s.c.SVCDump()
+	c.Assert(err, IsNil)
+	c.Assert(wantLBSVC, DeepEquals, lbSVCReceived)
+}
+
+func (s *DaemonSuite) TestSVCDumpFail(c *C) {
+	s.d.OnSVCDump = func() ([]types.LBSVC, error) {
+		return nil, errors.New("Unable to read lbmap")
+	}
+
+	lbSVCReceived, err := s.c.SVCDump()
+	c.Assert(err, ErrorMatches, ".*Unable to read lbmap.*")
+	c.Assert(lbSVCReceived, IsNil)
+}
+
+func (s *DaemonSuite) TestRevNATAddOK(c *C) {
+	idWant := types.ServiceID(1)
+
+	s.d.OnRevNATAdd = func(id types.ServiceID, revNAT types.L3n4Addr) error {
+		c.Assert(id, DeepEquals, idWant)
+		c.Assert(revNAT, DeepEquals, revNat1)
+		return nil
+	}
+
+	err := s.c.RevNATAdd(idWant, revNat1)
+	c.Assert(err, IsNil)
+}
+
+func (s *DaemonSuite) TestRevNATAddFail(c *C) {
+	idWant := types.ServiceID(0)
+
+	s.d.OnRevNATAdd = func(id types.ServiceID, revNAT types.L3n4Addr) error {
+		c.Assert(id, DeepEquals, idWant)
+		c.Assert(revNAT, DeepEquals, revNat1)
+		return errors.New("ID 0 is reserved")
+	}
+
+	err := s.c.RevNATAdd(idWant, revNat1)
+	c.Assert(err, ErrorMatches, ".*ID 0 is reserved.*")
+}
+
+func (s *DaemonSuite) TestRevNATDeleteOK(c *C) {
+	idWant := types.ServiceID(1)
+
+	s.d.OnRevNATDelete = func(id types.ServiceID) error {
+		c.Assert(id, DeepEquals, idWant)
+		return nil
+	}
+
+	err := s.c.RevNATDelete(idWant)
+	c.Assert(err, IsNil)
+}
+
+func (s *DaemonSuite) TestRevNATDeleteFail(c *C) {
+	idWant := types.ServiceID(0)
+
+	s.d.OnRevNATDelete = func(id types.ServiceID) error {
+		c.Assert(id, DeepEquals, idWant)
+		return errors.New("ID 0 is reserved")
+	}
+
+	err := s.c.RevNATDelete(idWant)
+	c.Assert(err, ErrorMatches, ".*ID 0 is reserved.*")
+}
+
+func (s *DaemonSuite) TestRevNATGetOK(c *C) {
+	idWant := types.ServiceID(1)
+
+	s.d.OnRevNATGet = func(id types.ServiceID) (*types.L3n4Addr, error) {
+		c.Assert(id, DeepEquals, idWant)
+		return &revNat1, nil
+	}
+
+	revNat1Received, err := s.c.RevNATGet(idWant)
+	c.Assert(err, IsNil)
+	c.Assert(*revNat1Received, DeepEquals, revNat1)
+}
+
+func (s *DaemonSuite) TestRevNATGetFail(c *C) {
+	idWant := types.ServiceID(0)
+
+	s.d.OnRevNATGet = func(id types.ServiceID) (*types.L3n4Addr, error) {
+		c.Assert(id, DeepEquals, idWant)
+		return nil, errors.New("ID 0 is reserved")
+	}
+
+	revNat1Received, err := s.c.RevNATGet(idWant)
+	c.Assert(err, ErrorMatches, ".*ID 0 is reserved.*")
+	c.Assert(revNat1Received, IsNil)
+}
+
+func (s *DaemonSuite) TestRevNATDumpOK(c *C) {
+	wantRevNATs := []types.L3n4AddrID{
+		{
+			ID:       1984,
+			L3n4Addr: revNat1,
+		},
+		{
+			ID:       1911,
+			L3n4Addr: revNat2,
+		},
+	}
+
+	s.d.OnRevNATDump = func() ([]types.L3n4AddrID, error) {
+		return wantRevNATs, nil
+	}
+
+	wantRevNATsReceived, err := s.c.RevNATDump()
+	c.Assert(err, IsNil)
+	c.Assert(wantRevNATsReceived, DeepEquals, wantRevNATs)
+}
+
+func (s *DaemonSuite) TestRevNATDumpFail(c *C) {
+	s.d.OnRevNATDump = func() ([]types.L3n4AddrID, error) {
+		return nil, errors.New("Unable to read lbmap")
+	}
+
+	lbSVCReceived, err := s.c.RevNATDump()
+	c.Assert(err, ErrorMatches, ".*Unable to read lbmap.*")
+	c.Assert(lbSVCReceived, IsNil)
+}

--- a/daemon/server/routes.go
+++ b/daemon/server/routes.go
@@ -141,6 +141,9 @@ func (r *Router) initBackendRoutes() {
 		route{
 			"RevNATDump", "GET", "/lb/revnats", r.revNATDump,
 		},
+		route{
+			"SyncLBMap", "POST", "/lb/synclbmap", r.syncLBMap,
+		},
 	}
 }
 

--- a/daemon/server/routes.go
+++ b/daemon/server/routes.go
@@ -118,6 +118,9 @@ func (r *Router) initBackendRoutes() {
 			"ServiceDel", "DELETE", "/lb/service/{feSHA256Sum}", r.serviceDel,
 		},
 		route{
+			"ServiceDelAll", "DELETE", "/lb/services", r.serviceDelAll,
+		},
+		route{
 			"ServiceGet", "GET", "/lb/service/{feSHA256Sum}", r.serviceGet,
 		},
 		route{
@@ -128,6 +131,9 @@ func (r *Router) initBackendRoutes() {
 		},
 		route{
 			"RevNATDel", "DELETE", "/lb/revnat/{revNATID}", r.revNATDel,
+		},
+		route{
+			"RevNATDelAll", "DELETE", "/lb/revnats", r.revNATDelAll,
 		},
 		route{
 			"RevNATGet", "GET", "/lb/revnat/{revNATID}", r.revNATGet,

--- a/daemon/server/routes.go
+++ b/daemon/server/routes.go
@@ -111,6 +111,30 @@ func (r *Router) initBackendRoutes() {
 		route{
 			"PolicyCanConsume", "POST", "/policy-consume-decision", r.policyCanConsume,
 		},
+		route{
+			"ServiceAdd", "POST", "/lb/service", r.serviceAdd,
+		},
+		route{
+			"ServiceDel", "DELETE", "/lb/service/{feSHA256Sum}", r.serviceDel,
+		},
+		route{
+			"ServiceGet", "GET", "/lb/service/{feSHA256Sum}", r.serviceGet,
+		},
+		route{
+			"ServiceDump", "GET", "/lb/services", r.serviceDump,
+		},
+		route{
+			"RevNATAdd", "POST", "/lb/revnat", r.revNATAdd,
+		},
+		route{
+			"RevNATDel", "DELETE", "/lb/revnat/{revNATID}", r.revNATDel,
+		},
+		route{
+			"RevNATGet", "GET", "/lb/revnat/{revNATID}", r.revNATGet,
+		},
+		route{
+			"RevNATDump", "GET", "/lb/revnats", r.revNATDump,
+		},
 	}
 }
 

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -274,20 +274,20 @@ func (c *ConsulClient) GASNewSecLabelID(basePath string, baseID uint32, secCtxLa
 	}
 }
 
-func (c *ConsulClient) setMaxServiceL4ID(maxID uint32) error {
+func (c *ConsulClient) setMaxL3n4AddrID(maxID uint32) error {
 	return c.SetMaxID(common.LastFreeServiceIDKeyPath, common.FirstFreeServiceID, maxID)
 }
 
-func (c *ConsulClient) GASNewServiceL4ID(basePath string, baseID uint32, sl4 *types.L3n4AddrID) error {
+func (c *ConsulClient) GASNewL3n4AddrID(basePath string, baseID uint32, lAddrID *types.L3n4AddrID) error {
 
-	setID2ServiceL4 := func(lockPair *consulAPI.KVPair) error {
+	setIDtoL3n4Addr := func(lockPair *consulAPI.KVPair) error {
 		defer c.KV().Release(lockPair, nil)
-		sl4.ID = types.ServiceID(baseID)
-		keyPath := path.Join(basePath, strconv.FormatUint(uint64(sl4.ID), 10))
-		if err := c.SetValue(keyPath, sl4); err != nil {
+		lAddrID.ID = types.ServiceID(baseID)
+		keyPath := path.Join(basePath, strconv.FormatUint(uint64(lAddrID.ID), 10))
+		if err := c.SetValue(keyPath, lAddrID); err != nil {
 			return err
 		}
-		return c.setMaxServiceL4ID(baseID + 1)
+		return c.setMaxL3n4AddrID(baseID + 1)
 	}
 
 	session, _, err := c.Session().CreateNoChecks(nil, nil)
@@ -313,16 +313,16 @@ func (c *ConsulClient) GASNewServiceL4ID(basePath string, baseID uint32, sl4 *ty
 				return err
 			}
 			if svcKey == nil {
-				return setID2ServiceL4(lockPair)
+				return setIDtoL3n4Addr(lockPair)
 			}
-			var consulServiceL4ID types.L3n4AddrID
-			if err := json.Unmarshal(svcKey.Value, &consulServiceL4ID); err != nil {
+			var consulL3n4AddrID types.L3n4AddrID
+			if err := json.Unmarshal(svcKey.Value, &consulL3n4AddrID); err != nil {
 				c.KV().Release(lockPair, nil)
 				return err
 			}
-			if consulServiceL4ID.ID == 0 {
+			if consulL3n4AddrID.ID == 0 {
 				log.Infof("Recycling Service ID %d", baseID)
-				return setID2ServiceL4(lockPair)
+				return setIDtoL3n4Addr(lockPair)
 			}
 			c.KV().Release(lockPair, nil)
 		}

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -278,12 +278,12 @@ func (c *ConsulClient) setMaxServiceL4ID(maxID uint32) error {
 	return c.SetMaxID(common.LastFreeServiceIDKeyPath, common.FirstFreeServiceID, maxID)
 }
 
-func (c *ConsulClient) GASNewServiceL4ID(basePath string, baseID uint32, sl4 *types.ServiceL4ID) error {
+func (c *ConsulClient) GASNewServiceL4ID(basePath string, baseID uint32, sl4 *types.L3n4AddrID) error {
 
 	setID2ServiceL4 := func(lockPair *consulAPI.KVPair) error {
 		defer c.KV().Release(lockPair, nil)
-		sl4.ServiceID = types.ServiceID(baseID)
-		keyPath := path.Join(basePath, strconv.FormatUint(uint64(sl4.ServiceID), 10))
+		sl4.ID = types.ServiceID(baseID)
+		keyPath := path.Join(basePath, strconv.FormatUint(uint64(sl4.ID), 10))
 		if err := c.SetValue(keyPath, sl4); err != nil {
 			return err
 		}
@@ -315,12 +315,12 @@ func (c *ConsulClient) GASNewServiceL4ID(basePath string, baseID uint32, sl4 *ty
 			if svcKey == nil {
 				return setID2ServiceL4(lockPair)
 			}
-			var consulServiceL4ID types.ServiceL4ID
+			var consulServiceL4ID types.L3n4AddrID
 			if err := json.Unmarshal(svcKey.Value, &consulServiceL4ID); err != nil {
 				c.KV().Release(lockPair, nil)
 				return err
 			}
-			if consulServiceL4ID.ServiceID == 0 {
+			if consulServiceL4ID.ID == 0 {
 				log.Infof("Recycling Service ID %d", baseID)
 				return setID2ServiceL4(lockPair)
 			}

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -298,10 +298,10 @@ func (e *EtcdClient) setMaxServiceL4ID(maxID uint32) error {
 
 // GASNewServiceL4ID gets the next available ServiceID and sets it in sl4. After assigning
 // the ServiceID to sl4 it sets the ServiceID + 1 in common.LastFreeServiceIDKeyPath path.
-func (e *EtcdClient) GASNewServiceL4ID(basePath string, baseID uint32, sl4 *types.ServiceL4ID) error {
+func (e *EtcdClient) GASNewServiceL4ID(basePath string, baseID uint32, sl4 *types.L3n4AddrID) error {
 	setID2ServiceL4 := func(id uint32) error {
-		sl4.ServiceID = types.ServiceID(id)
-		keyPath := path.Join(basePath, strconv.FormatUint(uint64(sl4.ServiceID), 10))
+		sl4.ID = types.ServiceID(id)
+		keyPath := path.Join(basePath, strconv.FormatUint(uint64(sl4.ID), 10))
 		if err := e.SetValue(keyPath, sl4); err != nil {
 			return err
 		}
@@ -325,11 +325,11 @@ func (e *EtcdClient) GASNewServiceL4ID(basePath string, baseID uint32, sl4 *type
 		if value == nil {
 			return setID2ServiceL4(*incID)
 		}
-		var consulServiceL4ID types.ServiceL4ID
+		var consulServiceL4ID types.L3n4AddrID
 		if err := json.Unmarshal(value, &consulServiceL4ID); err != nil {
 			return err
 		}
-		if consulServiceL4ID.ServiceID == 0 {
+		if consulServiceL4ID.ID == 0 {
 			log.Infof("Recycling Service ID %d", *incID)
 			return setID2ServiceL4(*incID)
 		}

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -37,7 +37,7 @@ type KVClient interface {
 	SetMaxID(key string, firstID, maxID uint32) error
 
 	GASNewSecLabelID(baseKeyPath string, baseID uint32, secCtxLabels *types.SecCtxLabel) error
-	GASNewServiceL4ID(basePath string, baseID uint32, sl4 *types.L3n4AddrID) error
+	GASNewL3n4AddrID(basePath string, baseID uint32, lAddrID *types.L3n4AddrID) error
 
 	DeleteTree(path string) error
 

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -37,7 +37,7 @@ type KVClient interface {
 	SetMaxID(key string, firstID, maxID uint32) error
 
 	GASNewSecLabelID(baseKeyPath string, baseID uint32, secCtxLabels *types.SecCtxLabel) error
-	GASNewServiceL4ID(basePath string, baseID uint32, sl4 *types.ServiceL4ID) error
+	GASNewServiceL4ID(basePath string, baseID uint32, sl4 *types.L3n4AddrID) error
 
 	DeleteTree(path string) error
 

--- a/tests/05-cni.sh
+++ b/tests/05-cni.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "./helpers.bash"
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 server_id=""
 client_id=""
@@ -99,6 +100,7 @@ git clone 'https://github.com/containernetworking/cni'
 cd cni
 ./build
 export CNI_PATH=`pwd`/bin
+cp "${dir}/../plugins/cilium-cni/cilium-cni" "${CNI_PATH}"
 cd scripts
 
 server_id=$(run_cni_container -d -l io.cilium.server --name cni-server noironetworks/netperf)

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -110,8 +110,8 @@ cat <<EOF | cilium -D policy import -
 EOF
 
 # Clear eventual old entries, this may fail if the maps have not been created
-sudo cilium lb delete-service --all || true
-sudo cilium lb delete-rev-nat --all || true
+cilium lb delete-service --all || true
+cilium lb delete-rev-nat --all || true
 
 # Create IPv4 L3 service without reverse entry
 cilium lb update-service --frontend 4.4.4.4:0 --id 1 --backend 5.5.5.5:0 || {

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -114,70 +114,65 @@ sudo cilium lb delete-service --all || true
 sudo cilium lb delete-rev-nat --all || true
 
 # Create IPv4 L3 service without reverse entry
-sudo cilium lb update-service --frontend 4.4.4.4:0 --id 1 --backend 5.5.5.5:0 || {
+cilium lb update-service --frontend 4.4.4.4:0 --id 1 --backend 5.5.5.5:0 || {
 	abort "Unable to add IPv4 service entry"
 }
 
-sudo cilium lb dump-service
+cilium lb dump-service
 
 # Check if reverse NAT entry was created anyway, should fail
-sudo cilium lb get-rev-nat 1 2> /dev/null && {
+cilium lb get-rev-nat 1 2> /dev/null && {
 	abort "Unexpected reverse NAT entry"
 }
 
-# Attempt deletion without providing a key, should fail
-sudo cilium lb delete-service 2> /dev/null && {
-	abort "Unexpected success in deleting service without a key"
-}
-
 # Delete IPv4 L3 entry
-sudo cilium lb delete-service 4.4.4.4:0 || {
+cilium lb delete-service 4.4.4.4:0 || {
 	abort "Unable to delete IPv4 service entry"
 }
 
 # Mixing L3/L4 in frontend and backend is not allowed
-sudo cilium lb update-service --frontend 4.4.4.4:0 --id 1 --backend 5.5.5.5:80 2> /dev/null && {
+cilium lb update-service --frontend 4.4.4.4:0 --id 1 --backend 5.5.5.5:80 2> /dev/null && {
 	abort "Unexpected success in creating mixed L3/L4 service"
 }
 
 # Add L4 IPv4 entry
-sudo cilium lb update-service --frontend 4.4.4.4:40 --rev --id 1 --backend 5.5.5.5:80 || {
+cilium lb update-service --frontend 4.4.4.4:40 --rev --id 1 --backend 5.5.5.5:80 || {
 	abort "Unable to add IPv4 service entry"
 }
 
-sudo cilium lb dump-service
+cilium lb dump-service
 
 # Check if requested reverse NAT entry exists
-sudo cilium lb --ipv4 get-rev-nat 1 || {
+cilium lb --ipv4 get-rev-nat 1 || {
 	abort "Unable to find reverse NAT entry that should have been created"
 }
 
 # Try an L3 lookup for the created L4 entry, should fail
-sudo cilium lb delete-service 4.4.4.4:0 2> /dev/null && {
+cilium lb delete-service 4.4.4.4:0 || {
 	abort "Unexpected success in looking up with L3 key of L4 entry"
 }
 
 # Delete L4 entry
-sudo cilium lb delete-service 4.4.4.4:40 || {
+cilium lb delete-service 4.4.4.4:40 || {
 	abort "Unable to delete IPv4 service entry"
 }
 
 SVC_IP6="f00d::1:1"
-sudo cilium lb update-service --rev --frontend "[$SVC_IP6]:0" --id 222 \
+cilium lb update-service --rev --frontend "[$SVC_IP6]:0" --id 222 \
                         --backend "[$SERVER1_IP]:0" \
                         --backend "[$SERVER2_IP]:0"
 
 SVC_IP4="2.2.2.2"
-sudo cilium lb update-service --rev --frontend "[$SVC_IP4]:$LB_PORT"  --id 222 \
-			--backend "$SERVER1_IP4:$LB_PORT" \
-			--backend "$SERVER2_IP4:$LB_PORT"
+cilium lb update-service --rev --frontend "$SVC_IP4:0"  --id 223 \
+			--backend "$SERVER1_IP4:0" \
+			--backend "$SERVER2_IP4:0"
 
 LB_HOST_IP6="f00d::1:2"
-sudo cilium lb update-service --rev --frontend "[$LB_HOST_IP6]:0" --id 223 \
+cilium lb update-service --rev --frontend "[$LB_HOST_IP6]:0" --id 224 \
 			--backend "[$(host_ip6)]:0"
 
 LB_HOST_IP4="3.3.3.3"
-sudo cilium lb update-service --rev --frontend "$LB_HOST_IP4:0" --id 223 \
+cilium lb update-service --rev --frontend "$LB_HOST_IP4:0" --id 225 \
 			--backend "$(host_ip4):0"
 
 ## Test 1: local host => bpf_lb => local container
@@ -217,7 +212,16 @@ docker exec -i client ping -c 4 $LB_HOST_IP4 || {
 
 monitor_stop
 
-## Test 4: Run wrk & ab from conainer => bpf_lxc (LB) => local container
+## Test 4: Run wrk & ab from container => bpf_lxc (LB) => local container
+
+cilium lb update-service --rev --frontend "[$SVC_IP6]:80" --id 222 \
+                        --backend "[$SERVER1_IP]:80" \
+                        --backend "[$SERVER2_IP]:80"
+cilium lb update-service --rev --frontend "$SVC_IP4:80" --id 223 \
+			--backend "$SERVER1_IP4:80" \
+			--backend "$SERVER2_IP4:80"
+
+
 cilium daemon config Debug=false DropNotification=false
 cilium endpoint config $SERVER1_ID Debug=false DropNotification=false
 cilium endpoint config $SERVER2_ID Debug=false DropNotification=false


### PR DESCRIPTION
- Split the k8s loadbalancer API from a general API to the loadbalancer
  bpf maps.
- Refactored some variables names to be less confusing.
- Add more documentation to the functions and variables.
- [x] add on the client side to add and remove service and nat keys into lb maps
- [x] add delete all option in daemon interface.
- [x] restore lbmap state to daemon.
- [x] add client to modify the lbmaps directly without contacting the daemon.
- [ ] ~~add lbmap path to the daemon so it won't be a global variable name.~~

Signed-off-by: André Martins andre@cilium.io
