### PR TITLE
daemon: list reserved IPAM addresses in debug

### DIFF
--- a/common/types/status.go
+++ b/common/types/status.go
@@ -64,9 +64,10 @@ func (s Status) String() string {
 }
 
 type StatusResponse struct {
-	KVStore    Status `json:"kvstore"`
-	Docker     Status `json:"docker"`
-	Kubernetes Status `json:"kubernetes"`
-	Logstash   Status `json:"logstash"`
-	Cilium     Status `json:"cilium"`
+	KVStore    Status              `json:"kvstore"`
+	Docker     Status              `json:"docker"`
+	Kubernetes Status              `json:"kubernetes"`
+	Logstash   Status              `json:"logstash"`
+	Cilium     Status              `json:"cilium"`
+	IPAMStatus map[string][]string `json:",omitempty"`
 }

--- a/daemon/daemon/status.go
+++ b/daemon/daemon/status.go
@@ -59,5 +59,7 @@ func (d *Daemon) GlobalStatus() (*types.StatusResponse, error) {
 	// TODO Create a logstash status in its runnable function
 	//Logstash   Status `json:"logstash"`
 
+	sr.IPAMStatus = d.DumpIPAM()
+
 	return &sr, nil
 }

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -263,8 +263,23 @@ func statusDaemon(ctx *cli.Context) {
 		fmt.Fprintf(w, "Kubernetes:\t%s\n", sr.Kubernetes)
 		fmt.Fprintf(w, "Cilium:\t%s\n", sr.Cilium)
 		w.Flush()
+
+		if sr.IPAMStatus != nil {
+			fmt.Printf("V4 addresses reserved:\n")
+			for _, ipv4 := range sr.IPAMStatus["4"] {
+				fmt.Printf(" %s\n", ipv4)
+
+			}
+			fmt.Printf("V6 addresses reserved:\n")
+			for _, ipv6 := range sr.IPAMStatus["6"] {
+				fmt.Printf(" %s\n", ipv6)
+			}
+			w.Flush()
+		}
+
 		os.Exit(int(sr.Cilium.Code))
 	}
+
 }
 
 func configDaemon(ctx *cli.Context) {

--- a/tests/07-ipam.sh
+++ b/tests/07-ipam.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+source "./helpers.bash"
+
+set -e
+
+# Set debug mode on so that we can retrieve the list of IPs allocated
+cilium daemon config Debug=true
+
+# Check the list of IPs allocated. The IPv4 IP used on the IPv4 range should be allocated.
+if [[ "$(cilium daemon status | tail -n 3)" != \
+      "$(echo -e "V4 addresses reserved:\n 10.1.0.1\nV6 addresses reserved:")" ]]; then
+     abort "IPs were not properly released"
+fi


### PR DESCRIPTION
Now we will know which IPs are being properly clean and reserved. Will be useful to develop some tests on following PR.
- [x] add cleaner to clean up unused IP addresses
- [x] add unit-tests to detect if IPs are being cleared
- [X] add function to return list of reserved IP addresses

Signed-off-by: André Martins andre@cilium.io
