### PR TITLE
Add code coverage statistics for GO tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ _testmain.go
 
 *.swp
 .vagrant
+coverage.out
+coverage-all.out
+coverage-all.html

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,16 @@ tests-etcd:
         -listen-client-urls http://0.0.0.0:4001 \
         -initial-cluster-token etcd-cluster-1 \
         -initial-cluster-state new
+	echo "mode: count" > coverage-all.out
+	echo "mode: count" > coverage.out
+	$(foreach pkg,$(GOFILES),\
 	go test \
-	    -ldflags "-X "github.com/cilium/cilium/daemon/daemon".kvBackend=etcd" \
-	    -timeout 30s $(GOFILES)
+            -ldflags "-X "github.com/cilium/cilium/daemon/daemon".kvBackend=etcd" \
+            -timeout 30s -coverprofile=coverage.out -covermode=count $(pkg);\
+            tail -n +2 coverage.out >> coverage-all.out;)
+	go tool cover -html=coverage-all.out -o=coverage-all.html
+	rm coverage-all.out
+	rm coverage.out
 	@rmdir ./daemon/1 ./daemon/1_backup 2> /dev/null || true
 	docker rm -f "cilium-etcd-test-container"
 
@@ -40,9 +47,16 @@ tests-consul:
            -e 'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true}' \
            consul:v0.6.4 \
            agent -client=0.0.0.0 -server -bootstrap-expect 1
+	echo "mode: count" > coverage-all.out
+	echo "mode: count" > coverage.out
+	$(foreach pkg,$(GOFILES),\
 	go test \
-	    -ldflags "-X "github.com/cilium/cilium/daemon/daemon".kvBackend=consul" \
-	    -timeout 30s $(GOFILES)
+            -ldflags "-X "github.com/cilium/cilium/daemon/daemon".kvBackend=consul" \
+            -timeout 30s -coverprofile=coverage.out -covermode=count $(pkg);\
+            tail -n +2 coverage.out >> coverage-all.out;)
+	go tool cover -html=coverage-all.out -o=coverage-all.html
+	rm coverage-all.out
+	rm coverage.out
 	@rmdir ./daemon/1 ./daemon/1_backup 2> /dev/null || true
 	docker rm -f "cilium-consul-test-container"
 


### PR DESCRIPTION
To keep track of GO code coverage, targets "tests-etcd" and
"tests-consul" will now generate a coverage-all.html file
that contains the aggregate branch coverage statistics for
all the GO files under test. This file can be consumed in a
browser. coverage-all.html is also added to .gitignore to
avoid pushing it into the repo by mistake.

A step forward could be to load such result to a coverage
service when generated from Travis, in order to simplify the
reviewer job in figuring out the level of test coverage of
a specific patch. This can prove to be a useful metrics in some
cases.

Note that packages with no test file will not generate a cover
profile, so their files will be excluded from the statistics
instead of showing 0% coverage.