### PR TITLE
Vagrantfile: removing cilium binaries from go path

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,7 @@ SCRIPT
 
 $build = <<SCRIPT
 ~/go/src/github.com/cilium/cilium/common/build.sh
+rm -fr ~/go/bin/cilium*
 SCRIPT
 
 $install = <<SCRIPT


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>