### PR TITLE
daemon: fix vet warning for docker_watcher

### DIFF
--- a/daemon/daemon/docker_watcher.go
+++ b/daemon/daemon/docker_watcher.go
@@ -66,10 +66,10 @@ func (d *Daemon) EnableDockerSync(once bool) {
 		}
 		for _, cont := range cList {
 			wg.Add(1)
-			go func(wg *sync.WaitGroup) {
-				d.createContainer(cont.ID)
+			go func(wg *sync.WaitGroup, id string) {
+				d.createContainer(id)
 				wg.Done()
-			}(&wg)
+			}(&wg, cont.ID)
 		}
 
 		if once {


### PR DESCRIPTION
go vet error: range variable cont captured by func literal

Signed-off-by: André Martins <andre@cilium.io>