### PR TITLE
k8s: adding kubernetes DaemonSet

### DIFF
--- a/contrib/packaging/k8s/daemon-set.yaml
+++ b/contrib/packaging/k8s/daemon-set.yaml
@@ -1,0 +1,80 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: cilium-net-controller
+spec:
+  template:
+    metadata:
+      labels:
+        name: cilium-net-controller
+    spec:
+      # nodeSelector:
+      #   with-network-plugin: cilium
+      containers:
+      - image: cilium/cilium:cilium-ubuntu-16-04
+        imagePullPolicy: Always
+        name: cilium-net-daemon
+        command: [ "/home/with-cni.sh", "-D", "daemon", "run" ]
+        args:
+          - "--ipv4"
+          - "-t"
+          - "vxlan"
+          - "--etcd-config-path"
+          - "/var/lib/cilium/etcd-config.yml"
+          - "--k8s-kubeconfig-path"
+          - "/var/lib/kubelet/kubeconfig"
+        env:
+          # If you want to specify the interface uncomment the following 2 lines
+          #- name: "IFACE"
+          #  value: "ens4"
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+        volumeMounts:
+          - name: cilium-run
+            mountPath: /var/run/cilium
+          - name: cni-path
+            mountPath: /tmp/cni/bin
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: docker-socket
+            mountPath: /var/run/docker.sock
+            readOnly: true
+          - name: etcd-config
+            mountPath: /var/lib/cilium/etcd-config.yml
+            readOnly: true
+          - name: kubeconfig-path
+            mountPath: /var/lib/kubelet/kubeconfig
+            readOnly: true
+          - name: kubeconfig-cert
+            mountPath: /var/lib/kubernetes/ca.pem
+            readOnly: true
+        securityContext:
+          capabilities:
+            add:
+              - "NET_ADMIN"
+          privileged: true
+      hostNetwork: true
+      volumes:
+        - name: cilium-run
+          hostPath:
+              path: /var/run/cilium
+        - name: cni-path
+          hostPath:
+              path: /opt/cni/bin
+        - name: bpf-maps
+          hostPath:
+              path: /sys/fs/bpf
+        - name: docker-socket
+          hostPath:
+              path: /var/run/docker.sock
+        - name: etcd-config
+          hostPath:
+              path: /var/lib/cilium/etcd-config.yml
+        - name: kubeconfig-path
+          hostPath:
+              path: /var/lib/kubelet/kubeconfig
+        - name: kubeconfig-cert
+          hostPath:
+              path: /var/lib/kubernetes/ca.pem


### PR DESCRIPTION
Fixes #156 

Signed-off-by: André Martins <andre@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/197%23issuecomment-262678547%22%2C%20%22https%3A//github.com/cilium/cilium/pull/197%23issuecomment-263461173%22%2C%20%22https%3A//github.com/cilium/cilium/pull/197%23issuecomment-264083416%22%2C%20%22https%3A//github.com/cilium/cilium/pull/197%23issuecomment-266229583%22%2C%20%22https%3A//github.com/cilium/cilium/pull/197%23issuecomment-271882084%22%2C%20%22https%3A//github.com/cilium/cilium/pull/197%23discussion_r91834263%22%2C%20%22https%3A//github.com/cilium/cilium/pull/197%23issuecomment-284373543%22%2C%20%22https%3A//github.com/cilium/cilium/pull/197%23issuecomment-284475112%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/197%23issuecomment-262678547%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Some%20env%20variables%20are%20specific%20to%20the%20node%2C%20such%20as%20IPs%20and%20interfaces.%20Any%20ideias%20on%20how%20to%20fix%20that%3F%22%2C%20%22created_at%22%3A%20%222016-11-24T02%3A51%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20was%20discussed%20there%20will%20be%20implemented%20a%20mechanism%20that%20will%20automatically%20assign%20the%20%60ipv4-range%60%2C%20via%20a%20similar%20system%20has%20the%20DHCP%2C%20with%20the%20KVStore%20on%20each%20node%20of%20the%20cluster.%20We%27ll%20assume%20all%20the%20worker%20nodes%20will%20have%20the%20same%20configuration%20and%20values%2C%20like%20the%20interface%20name%2C%20and%20the%20DaemonSet%20will%20have%20set%20the%20same%20name%20for%20all%20the%20nodes%20on%20the%20same%20k8s-cluster.%20%60NODE_ADDRESS%60%20will%20be%20calculated%20via%20the%20IP%20of%20that%20interface%20and%20if%20the%20interface%20name%20is%20not%20provided%20the%20first%20IP%20with%20scope%20global.%20The%20etcd%20host%20and%20kubernetes%20master%20will%20use%20the%20%60k8s%60%20secrets%20or%20configmaps.%22%2C%20%22created_at%22%3A%20%222016-11-29T02%3A47%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22Waiting%20on%20https%3A//github.com/cilium/cilium/pull/204%22%2C%20%22created_at%22%3A%20%222016-12-01T05%3A36%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22todo%3A%5Cr%5Cn%5Cr%5Cn-%20%5Bx%5D%20Add%20argument%20to%20change%20bpf%20map%27s%20path%22%2C%20%22created_at%22%3A%20%222016-12-10T18%3A57%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22Postponed%20this%20until%20the%20bpf%20mounting%20issue%20is%20figure%20it%20out.%22%2C%20%22created_at%22%3A%20%222017-01-11T14%3A28%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%27s%20the%20status%20of%20this%3F%22%2C%20%22created_at%22%3A%20%222017-03-06T11%3A38%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%2C%20%7B%22body%22%3A%20%22TODO%3A%5Cr%5Cn%5B%20%5D%20rebase%20%28check%20which%20flags%20are%20still%20working%29%5Cr%5Cn%5B%20%5D%20check%20if%20bpf%20mounting%20problem%20still%20happens%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-03-06T17%3A49%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20bf164e8f20e9ab659856e614fe645eeb0b25e3f9%20contrib/packaging/k8s/daemon-set.yaml%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/197%23discussion_r91834263%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Yes%2C%20it%27s%20the%20version%20pointed%20to%20the%20master%20branch%20plus%20it%27s%20the%20base%20image%20we%20are%20using%20to%20build%20cilium%27s%20docker%20image.%20We%20don%27t%20have%20an%20%5C%22official%5C%22%20release%20version%20yet.%22%2C%20%22created_at%22%3A%20%222016-12-10T12%3A09%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20contrib/packaging/k8s/daemon-set.yaml%3AL1-75%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/197#issuecomment-262678547'>General Comment</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> Some env variables are specific to the node, such as IPs and interfaces. Any ideias on how to fix that?
- <a href='https://github.com/aanm'><img border=0 src='https://avatars.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> It was discussed there will be implemented a mechanism that will automatically assign the `ipv4-range`, via a similar system has the DHCP, with the KVStore on each node of the cluster. We'll assume all the worker nodes will have the same configuration and values, like the interface name, and the DaemonSet will have set the same name for all the nodes on the same k8s-cluster. `NODE_ADDRESS` will be calculated via the IP of that interface and if the interface name is not provided the first IP with scope global. The etcd host and kubernetes master will use the `k8s` secrets or configmaps.
- <a href='https://github.com/aanm'><img border=0 src='https://avatars.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> Waiting on https://github.com/cilium/cilium/pull/204
- <a href='https://github.com/aanm'><img border=0 src='https://avatars.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> todo:
- [x] Add argument to change bpf map's path
- <a href='https://github.com/aanm'><img border=0 src='https://avatars.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> Postponed this until the bpf mounting issue is figure it out.
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> What's the status of this?
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> TODO:
[ ] rebase (check which flags are still working)
[ ] check if bpf mounting problem still happens
- [ ] <a href='#crh-comment-Pull bf164e8f20e9ab659856e614fe645eeb0b25e3f9 contrib/packaging/k8s/daemon-set.yaml 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/197#discussion_r91834263'>File: contrib/packaging/k8s/daemon-set.yaml:L1-75</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> Yes, it's the version pointed to the master branch plus it's the base image we are using to build cilium's docker image. We don't have an "official" release version yet.


<a href='https://www.codereviewhub.com/cilium/cilium/pull/197?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/197?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/197'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>