### PR TITLE
Adding IPv4Registration mode capability

### DIFF
--- a/common/addressing/ipv4_prefix.go
+++ b/common/addressing/ipv4_prefix.go
@@ -1,0 +1,54 @@
+//
+// Copyright 2016 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package addressing
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	ipv4PrefixTimeout = time.Duration(2 * time.Hour)
+)
+
+type NodeIPv4Prefix struct {
+	NodeAddr     string    `json:"node-address"`
+	IPv4         string    `json:"ipv4"`
+	ID           uint8     `json:"id"`
+	LastTimeSeen time.Time `json:"last-time-seen"`
+}
+
+func (n *NodeIPv4Prefix) IsValid() bool {
+	return n.LastTimeSeen.Add(ipv4PrefixTimeout).After(time.Now())
+}
+
+func (n *NodeIPv4Prefix) SetInvalid() {
+	n.LastTimeSeen = time.Unix(0, 0)
+}
+
+func (n NodeIPv4Prefix) String() string {
+	return n.IPv4 + " => " + n.LastTimeSeen.String()
+}
+
+func (n *NodeIPv4Prefix) SetID(id uint8) {
+	n.ID = id
+	n.IPv4 = fmt.Sprintf(DefaultIPv4Prefix, id)
+	n.RefreshLastTimeSeen()
+}
+
+func (n *NodeIPv4Prefix) RefreshLastTimeSeen() {
+	n.LastTimeSeen = time.Now()
+}

--- a/common/addressing/ipv4_prefix_test.go
+++ b/common/addressing/ipv4_prefix_test.go
@@ -1,0 +1,34 @@
+//
+// Copyright 2016 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package addressing
+
+import (
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *AddressingSuite) TestIsValidNode(c *C) {
+	n := NodeIPv4Prefix{
+		IPv4:         "",
+		LastTimeSeen: time.Now(),
+	}
+	c.Assert(n.IsValid(), Equals, true)
+	n.LastTimeSeen = time.Now().Add(ipv4PrefixTimeout)
+	c.Assert(n.IsValid(), Equals, true)
+	n.LastTimeSeen = time.Now().Add(-ipv4PrefixTimeout)
+	c.Assert(n.IsValid(), Equals, false)
+}

--- a/common/const.go
+++ b/common/const.go
@@ -55,6 +55,17 @@ const (
 	// FirstFreeServiceID is the first ID for which the services should be assigned.
 	FirstFreeServiceID = uint32(1)
 
+	// LastFreeIPv4PrefixKeyPath is the path where the Last free IPv4 prefix is stored in KVStore.
+	LastFreeIPv4PrefixKeyPath = OperationalPath + "/NodeIPv4Prefixes/LastIPv4Prefix"
+	// NodeAddrKeyPath is the base path where the Node Addresses are stored in the KVStore.
+	NodeAddrKeyPath = OperationalPath + "/NodeIPv4Prefixes/NodeAddrs"
+	// IPv4PrefixKeyPath is the base path where IPv4 prefix is stored in the KVStore.
+	IPv4PrefixKeyPath = OperationalPath + "/NodeIPv4Prefixes/IPv4Prefixes"
+	// MaxSetOfIPv4Prefix is maximum number of set of service IDs that can be stored in consul.
+	MaxSetOfIPv4Prefix = uint32(0xFF)
+	// FirstFreeServiceID is the first ID for which the services should be assigned.
+	FirstFreeIPv4Prefix = uint32(0)
+
 	// Miscellaneous dedicated constants
 
 	// GlobalLabelPrefix is the default root path for the policy.

--- a/daemon/daemon/daemon_config.go
+++ b/daemon/daemon/daemon_config.go
@@ -53,26 +53,27 @@ func init() {
 
 // Config is the configuration used by Daemon.
 type Config struct {
-	LibDir                string                  // Cilium library directory
-	RunDir                string                  // Cilium runtime directory
-	LXCMap                *lxcmap.LXCMap          // LXCMap where all LXCs are stored
-	NodeAddress           *addressing.NodeAddress // Node IPv6 Address
-	NAT46Prefix           *net.IPNet              // NAT46 IPv6 Prefix
-	Device                string                  // Receive device
-	ConsulConfig          *consulAPI.Config       // Consul configuration
-	EtcdConfig            *etcdAPI.Config         // Etcd Configuration
-	EtcdCfgPath           string                  // Etcd Configuration path
-	DockerEndpoint        string                  // Docker endpoint
-	IPv4Enabled           bool                    // Gives IPv4 addresses to containers
-	K8sEndpoint           string                  // Kubernetes endpoint
-	K8sCfgPath            string                  // Kubeconfig path
-	ValidLabelPrefixes    *labels.LabelPrefixCfg  // Label prefixes used to filter from all labels
-	ValidK8sLabelPrefixes *labels.LabelPrefixCfg  // Label prefixes used to filter from all labels
-	ValidLabelPrefixesMU  sync.RWMutex
-	UIServerAddr          string // TCP address for UI server
-	UIEnabled             bool
-	LBMode                bool   // Set to true on load balancer node
-	Tunnel                string // Tunnel mode
+	LibDir                  string                  // Cilium library directory
+	RunDir                  string                  // Cilium runtime directory
+	LXCMap                  *lxcmap.LXCMap          // LXCMap where all LXCs are stored
+	NodeAddress             *addressing.NodeAddress // Node IPv6 Address
+	NAT46Prefix             *net.IPNet              // NAT46 IPv6 Prefix
+	Device                  string                  // Receive device
+	ConsulConfig            *consulAPI.Config       // Consul configuration
+	EtcdConfig              *etcdAPI.Config         // Etcd Configuration
+	EtcdCfgPath             string                  // Etcd Configuration path
+	DockerEndpoint          string                  // Docker endpoint
+	IPv4Enabled             bool                    // Gives IPv4 addresses to containers
+	K8sEndpoint             string                  // Kubernetes endpoint
+	K8sCfgPath              string                  // Kubeconfig path
+	ValidLabelPrefixes      *labels.LabelPrefixCfg  // Label prefixes used to filter from all labels
+	ValidK8sLabelPrefixes   *labels.LabelPrefixCfg  // Label prefixes used to filter from all labels
+	ValidLabelPrefixesMU    sync.RWMutex
+	UIServerAddr            string // TCP address for UI server
+	UIEnabled               bool
+	LBMode                  bool   // Set to true on load balancer node
+	Tunnel                  string // Tunnel mode
+	KVStoreIPv4Registration bool   // Registers the NodeAddress in the KVStore.
 
 	DryMode      bool // Do not create BPF maps, devices, ..
 	RestoreState bool // RestoreState restores the state from previous running daemons.

--- a/daemon/daemon/ipv4_prefix.go
+++ b/daemon/daemon/ipv4_prefix.go
@@ -1,0 +1,188 @@
+//
+// Copyright 2016 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package daemon
+
+import (
+	"encoding/json"
+	"path"
+	"strconv"
+
+	"github.com/cilium/cilium/common"
+	"github.com/cilium/cilium/common/addressing"
+)
+
+func (d *Daemon) updateIPv4Prefix(nodeIPv4 *addressing.NodeIPv4Prefix) error {
+	key := path.Join(common.IPv4PrefixKeyPath, strconv.FormatUint(uint64(nodeIPv4.ID), 10))
+	return d.kvClient.SetValue(key, nodeIPv4)
+}
+
+// gasNewSecLabelID gets and sets a New SecLabel ID.
+func (d *Daemon) gasNewIPv4Prefix(nodeIPv4 *addressing.NodeIPv4Prefix) error {
+	baseIPv4Prefix, err := d.GetMaxIPv4Prefix()
+	if err != nil {
+		return err
+	}
+
+	return d.kvClient.GASNewIPv4Prefix(common.IPv4PrefixKeyPath, baseIPv4Prefix, nodeIPv4)
+}
+
+// PutNodeAddr stores the given nodeAddr in the KVStore and returns the NodeIPv4Prefix
+// created for the given nodeAddr.
+func (d *Daemon) PutNodeAddr(nodeAddr string) (*addressing.NodeIPv4Prefix, bool, error) {
+	isNew := false
+
+	nodeAddrPath := path.Join(common.NodeAddrKeyPath, nodeAddr)
+
+	// Lock that sha256Sum
+	lockKey, err := d.kvClient.LockPath(nodeAddrPath)
+	if err != nil {
+		return nil, false, err
+	}
+	defer lockKey.Unlock()
+
+	// After lock complete, get label's path
+	ipv4PrefixRaw, err := d.kvClient.GetValue(nodeAddrPath)
+	if err != nil {
+		return nil, false, err
+	}
+
+	ipv4Prefix := addressing.NodeIPv4Prefix{NodeAddr: nodeAddr}
+
+	if ipv4PrefixRaw != nil {
+		if err := json.Unmarshal(ipv4PrefixRaw, &ipv4Prefix); err != nil {
+			return nil, false, err
+		}
+		if !ipv4Prefix.IsValid() {
+			isNew = true
+		}
+	} else {
+		isNew = true
+	}
+
+	if isNew {
+		if err := d.gasNewIPv4Prefix(&ipv4Prefix); err != nil {
+			return nil, false, err
+		}
+	} else {
+		ipv4Prefix.RefreshLastTimeSeen()
+		if err := d.updateIPv4Prefix(&ipv4Prefix); err != nil {
+			return nil, false, err
+		}
+	}
+
+	log.Debugf("Setting NodeIPv4Prefix for %s: %s\n", nodeAddrPath, ipv4Prefix)
+
+	err = d.kvClient.SetValue(nodeAddrPath, ipv4Prefix)
+
+	return &ipv4Prefix, isNew, err
+}
+
+// GetNodeIPv4Prefix returns the NodeIPv4Prefix that belongs to the IPv4 prefix ID.
+func (d *Daemon) GetNodeIPv4Prefix(id uint32) (*addressing.NodeIPv4Prefix, error) {
+	strID := strconv.FormatUint(uint64(id), 10)
+	rmsg, err := d.kvClient.GetValue(path.Join(common.IPv4PrefixKeyPath, strID))
+	if err != nil {
+		return nil, err
+	}
+	if rmsg == nil {
+		return nil, nil
+	}
+
+	var nodeIPv4Prefix addressing.NodeIPv4Prefix
+	if err := json.Unmarshal(rmsg, &nodeIPv4Prefix); err != nil {
+		return nil, err
+	}
+	if !nodeIPv4Prefix.IsValid() {
+		return nil, nil
+	}
+	return &nodeIPv4Prefix, nil
+}
+
+// GetNodeIPv4PrefixByNodeAddr returns the NodeIPv4Prefix that have the given nodeAddr.
+func (d *Daemon) GetNodeIPv4PrefixByNodeAddr(nodeAddr string) (*addressing.NodeIPv4Prefix, error) {
+	path := path.Join(common.NodeAddrKeyPath, nodeAddr)
+	rmsg, err := d.kvClient.GetValue(path)
+	if err != nil {
+		return nil, err
+	}
+	if rmsg == nil {
+		return nil, nil
+	}
+
+	var nodeIPv4Prefix addressing.NodeIPv4Prefix
+	if err := json.Unmarshal(rmsg, &nodeIPv4Prefix); err != nil {
+		return nil, err
+	}
+	if !nodeIPv4Prefix.IsValid() {
+		return nil, nil
+	}
+	return &nodeIPv4Prefix, nil
+}
+
+// DeleteNodeIPv4PrefixByUUID deletes the NodeIPv4Prefix belonging to the given id.
+func (d *Daemon) DeleteNodeIPv4PrefixByUUID(id uint32) error {
+	nodeIPv4Prefix, err := d.GetNodeIPv4Prefix(id)
+	if err != nil {
+		return err
+	}
+	if nodeIPv4Prefix == nil {
+		return nil
+	}
+	return d.DeleteNodeIPv4PrefixByNodeAddr(nodeIPv4Prefix.NodeAddr)
+}
+
+// DeleteNodeIPv4PrefixByNodeAddr deletes the NodeIPv4Prefix that belong to the nodeAddr.
+func (d *Daemon) DeleteNodeIPv4PrefixByNodeAddr(nodeAddr string) error {
+	if nodeAddr == "" {
+		return nil
+	}
+	nodeAddrPath := path.Join(common.NodeAddrKeyPath, nodeAddr)
+	// Lock that sha256Sum
+	lockKey, err := d.kvClient.LockPath(nodeAddrPath)
+	if err != nil {
+		return err
+	}
+	defer lockKey.Unlock()
+
+	// After lock complete, get nodeAddr's value
+	rmsg, err := d.kvClient.GetValue(nodeAddrPath)
+	if err != nil {
+		return err
+	}
+	if rmsg == nil {
+		return nil
+	}
+
+	var nodeIPv4Prefix addressing.NodeIPv4Prefix
+	if err := json.Unmarshal(rmsg, &nodeIPv4Prefix); err != nil {
+		return err
+	}
+
+	nodeIPv4Prefix.SetInvalid()
+
+	log.Debugf("Deleting node addr %s\n", nodeAddr)
+
+	if err := d.updateIPv4Prefix(&nodeIPv4Prefix); err != nil {
+		return err
+	}
+
+	return d.kvClient.SetValue(nodeAddrPath, nodeIPv4Prefix)
+}
+
+// GetMaxIPv4Prefix returns the maximum possible free IPv4Prefix stored in the KVStore.
+func (d *Daemon) GetMaxIPv4Prefix() (uint32, error) {
+	return d.kvClient.GetMaxID(common.LastFreeIPv4PrefixKeyPath, common.FirstFreeIPv4Prefix)
+}

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -145,6 +145,11 @@ func init() {
 						Name:        "keep-config",
 						Usage:       "When restoring state, keeps containers' configuration in place",
 					},
+					cli.BoolFlag{
+						Destination: &config.KVStoreIPv4Registration,
+						Name:        "kvstore-ipv4-registration",
+						Usage:       "Registers the node address in KVStore so it can receive an IPv4 range automatically",
+					},
 					cli.StringFlag{
 						Destination: &labelPrefixFile,
 						Name:        "p",
@@ -360,7 +365,18 @@ func configDaemon(ctx *cli.Context) {
 	}
 }
 
+func validateFlags(ctx *cli.Context) error {
+	if config.KVStoreIPv4Registration && v4Prefix != "" {
+		return fmt.Errorf("invalid settings: Either use kvstore-ipv4-registration or ipv4-range option but not both")
+	}
+	return nil
+}
+
 func initEnv(ctx *cli.Context) error {
+	if err := validateFlags(ctx); err != nil {
+		return err
+	}
+
 	// The standard operation is to mount the BPF filesystem to the
 	// standard location (/sys/fs/bpf). The user may chose to specify
 	// the path to an already mounted filesystem instead. This is

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/common/types"
 	"github.com/cilium/cilium/pkg/policy"
 
@@ -39,6 +40,7 @@ type KVClient interface {
 
 	GASNewSecLabelID(baseKeyPath string, baseID uint32, secCtxLabels *policy.Identity) error
 	GASNewL3n4AddrID(basePath string, baseID uint32, lAddrID *types.L3n4AddrID) error
+	GASNewIPv4Prefix(basePath string, baseIPv4Prefix uint32, nodeIPv4Prefix *addressing.NodeIPv4Prefix) error
 
 	DeleteTree(path string) error
 


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/204%23discussion_r91457510%22%2C%20%22https%3A//github.com/cilium/cilium/pull/204%23discussion_r91458130%22%2C%20%22https%3A//github.com/cilium/cilium/pull/204%23discussion_r91458269%22%2C%20%22https%3A//github.com/cilium/cilium/pull/204%23discussion_r91522447%22%2C%20%22https%3A//github.com/cilium/cilium/pull/204%23discussion_r91523513%22%2C%20%22https%3A//github.com/cilium/cilium/pull/204%23discussion_r91525901%22%2C%20%22https%3A//github.com/cilium/cilium/pull/204%23discussion_r91844127%22%2C%20%22https%3A//github.com/cilium/cilium/pull/204%23discussion_r91844169%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20d65a90cd72748287b57fc22f71b1eb7da0aa74a6%20daemon/daemon/ipv4_prefix.go%2034%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/204%23discussion_r91458269%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%27ll%20need%20the%20same%20for%20IPv6%20as%20well.%20It%27s%20less%20urgent%20but%20the%20current%20method%20of%20deriving%20it%20from%20the%20IPv4%20address%20will%20not%20always%20work%20as%20it%27s%20perfectly%20valid%20to%20have%20overlapping%20IPv4%20addresses%20for%20the%20host%20itself.%5Cr%5Cn%5Cr%5CnAt%20the%20very%20least%2C%20we%20should%20verify%20that%20the%20IPv6%20node%20address%20is%20not%20conflicting.%22%2C%20%22created_at%22%3A%20%222016-12-08T07%3A30%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20daemon/daemon/ipv4_prefix.go%3AL1-189%22%7D%2C%20%22Pull%20d65a90cd72748287b57fc22f71b1eb7da0aa74a6%20daemon/main.go%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/204%23discussion_r91457510%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20we%20should%20push%20the%20address%20unconditionally%20if%20the%20KVStore%20is%20available.%20We%20can%20think%20about%20a%20mode%20which%20does%20not%20require%20a%20KVStore%20in%20which%20forwarding%20is%20performed%20without%20policy%20enforcement.%22%2C%20%22created_at%22%3A%20%222016-12-08T07%3A21%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%2C%20%7B%22body%22%3A%20%22But%20how%20can%20we%20make%20sure%20the%20address%20is%20available%3F%22%2C%20%22created_at%22%3A%20%222016-12-08T14%3A23%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20sure%20the%20KV%20store%20supports%20an%20atomic%20lookup-or-add%20operation%20which%20allows%20to%20uniquely%20register%20the%20address%20or%20receive%20the%20information%20that%20somebody%20else%20is%20using%20it.%22%2C%20%22created_at%22%3A%20%222016-12-08T14%3A29%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%20and%20that%27s%20sort%20of%20what%27s%20doing%20right%20now%2C%20the%20problem%20is%2C%20how%20can%20we%20know%20the%20that%20the%20node%20that%20is%20registering%20is%20not%20the%20same%20node%20that%20registered%20before%3F%20For%20example%3A%20something%20crashes%20and%20cilium%20has%20to%20be%20restarted%20again.%22%2C%20%22created_at%22%3A%20%222016-12-08T14%3A42%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20don%27t%20have%20to%20do%20this%20in%20this%20PR%20but%20we%20can%20add%20an%20identity%20to%20each%20node%20using%20a%20key%20or%20certificate%20and%20associate%20the%20lookup%20with%20the%20identity%20so%20a%20node%20can%20reclaim%20its%20own%20node%20address.%22%2C%20%22created_at%22%3A%20%222016-12-10T23%3A03%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%2C%20%7B%22body%22%3A%20%22For%20now%2C%20this%20could%20be%20done%20by%20the%20node%20itself%20by%20storing%20some%20metadata%20such%20as%20the%20hostid%20or%20the%20UUID%20of%20the%20fstab%20together%20with%20the%20registered%20prefix%20and%20verify%20that%20this%20is%20the%20same%22%2C%20%22created_at%22%3A%20%222016-12-10T23%3A06%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20daemon/main.go%3AL138-149%22%7D%2C%20%22Pull%20d65a90cd72748287b57fc22f71b1eb7da0aa74a6%20daemon/daemon/ipv4_prefix.go%2044%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/204%23discussion_r91458130%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20would%20be%20great%20to%20store%20both%20the%20IPv4%20prefix%20and%20the%20IPv6%20node%20address%20here%20to%20correlate%20the%20two.%22%2C%20%22created_at%22%3A%20%222016-12-08T07%3A28%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20daemon/daemon/ipv4_prefix.go%3AL1-189%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull d65a90cd72748287b57fc22f71b1eb7da0aa74a6 daemon/main.go 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/204#discussion_r91457510'>File: daemon/main.go:L138-149</a></b>
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> I think we should push the address unconditionally if the KVStore is available. We can think about a mode which does not require a KVStore in which forwarding is performed without policy enforcement.
- <a href='https://github.com/aanm'><img border=0 src='https://avatars.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> But how can we make sure the address is available?
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> I'm sure the KV store supports an atomic lookup-or-add operation which allows to uniquely register the address or receive the information that somebody else is using it.
- <a href='https://github.com/aanm'><img border=0 src='https://avatars.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> Yes and that's sort of what's doing right now, the problem is, how can we know the that the node that is registering is not the same node that registered before? For example: something crashes and cilium has to be restarted again.
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> We don't have to do this in this PR but we can add an identity to each node using a key or certificate and associate the lookup with the identity so a node can reclaim its own node address.
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> For now, this could be done by the node itself by storing some metadata such as the hostid or the UUID of the fstab together with the registered prefix and verify that this is the same
- [ ] <a href='#crh-comment-Pull d65a90cd72748287b57fc22f71b1eb7da0aa74a6 daemon/daemon/ipv4_prefix.go 44'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/204#discussion_r91458130'>File: daemon/daemon/ipv4_prefix.go:L1-189</a></b>
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> It would be great to store both the IPv4 prefix and the IPv6 node address here to correlate the two.
- [ ] <a href='#crh-comment-Pull d65a90cd72748287b57fc22f71b1eb7da0aa74a6 daemon/daemon/ipv4_prefix.go 34'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/204#discussion_r91458269'>File: daemon/daemon/ipv4_prefix.go:L1-189</a></b>
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> We'll need the same for IPv6 as well. It's less urgent but the current method of deriving it from the IPv4 address will not always work as it's perfectly valid to have overlapping IPv4 addresses for the host itself.
At the very least, we should verify that the IPv6 node address is not conflicting.


<a href='https://www.codereviewhub.com/cilium/cilium/pull/204?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/204?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/204'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>