### PR TITLE
daemon: fixed wrong ID assignment when synced

### DIFF
--- a/daemon/daemon/k8s_watcher.go
+++ b/daemon/daemon/k8s_watcher.go
@@ -350,7 +350,7 @@ func (d *Daemon) addK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 				log.Errorf("Error while creating a new L3n4Addr: %s. Ignoring service...", err)
 				continue
 			}
-			feAddrID, err := d.PutL3n4Addr(*feAddr)
+			feAddrID, err := d.PutL3n4Addr(*feAddr, 0)
 			if err != nil {
 				log.Errorf("Error while getting a new service ID: %s. Ignoring service %v...", err, feAddr)
 				continue
@@ -389,7 +389,7 @@ func (d *Daemon) addK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 			log.Errorf("Error while creating a New L3n4AddrID: %s. Ignoring service %v...", err, svcInfo)
 			continue
 		}
-		if err := d.SVCAdd(*fe, besValues, isServerPresent); err != nil {
+		if err := d.svcAdd(*fe, besValues, isServerPresent); err != nil {
 			log.Errorf("Error while inserting service in LB map: %s", err)
 		}
 	}

--- a/daemon/daemon/services_test.go
+++ b/daemon/daemon/services_test.go
@@ -48,15 +48,15 @@ func (ds *DaemonSuite) TestServices(c *C) {
 
 	ffsIDu16 := types.ServiceID(uint16(common.FirstFreeServiceID))
 
-	l3n4AddrID, err := ds.d.PutL3n4Addr(l3n4Addr1)
+	l3n4AddrID, err := ds.d.PutL3n4Addr(l3n4Addr1, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(l3n4AddrID.ID, Equals, ffsIDu16)
 
-	l3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr1)
+	l3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr1, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(l3n4AddrID.ID, Equals, ffsIDu16)
 
-	l3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr2)
+	l3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr2, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(l3n4AddrID.ID, Equals, ffsIDu16+1)
 
@@ -90,7 +90,7 @@ func (ds *DaemonSuite) TestServices(c *C) {
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID, Equals, nilL3n4AddrID)
 
-	gotL3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr2)
+	gotL3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr2, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID.ID, Equals, types.ServiceID(common.FirstFreeServiceID+1))
 
@@ -108,13 +108,24 @@ func (ds *DaemonSuite) TestServices(c *C) {
 	err = ds.d.DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID + 1)
 	c.Assert(err, Equals, nil)
 
-	gotL3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr2)
+	gotL3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr2, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID.ID, Equals, ffsIDu16)
 
-	gotL3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr1)
+	gotL3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr1, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID.ID, Equals, types.ServiceID(common.FirstFreeServiceID+1))
+
+	gotL3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr1, 99)
+	c.Assert(err, Equals, nil)
+	c.Assert(gotL3n4AddrID.ID, Equals, types.ServiceID(common.FirstFreeServiceID+1))
+
+	err = ds.d.DeleteL3n4AddrIDByUUID(uint32(common.FirstFreeServiceID + 1))
+	c.Assert(err, Equals, nil)
+
+	gotL3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr1, 99)
+	c.Assert(err, Equals, nil)
+	c.Assert(gotL3n4AddrID.ID, Equals, types.ServiceID(99))
 }
 
 func (ds *DaemonSuite) TestGetMaxServiceID(c *C) {

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -332,8 +332,8 @@ if [ -n "${IPV4}" ]; then
 		abort "Services map should be clean"
 	fi
 
-	# Add a service with ID 1
-	sudo cilium lb --no-daemon update-service --frontend 127.0.0.1:80 --backend 127.0.0.2:90 --backend 127.0.0.3:90 --id 1 --rev 2> /dev/null || {
+	# Add a service with ID 10
+	sudo cilium lb --no-daemon update-service --frontend 127.0.0.1:80 --backend 127.0.0.2:90 --backend 127.0.0.3:90 --id 10 --rev 2> /dev/null || {
 		abort "Service should have been added"
 	}
 
@@ -344,25 +344,25 @@ if [ -n "${IPV4}" ]; then
 
 	# Check if it's the only service present
 	if [[ "$(sudo cilium lb --no-daemon dump-service)" != \
-	      "$(echo -e "127.0.0.1:80 =>\n\t\t1 => 127.0.0.2:90 (1)\n\t\t2 => 127.0.0.3:90 (1)")" ]]; then
+	      "$(echo -e "127.0.0.1:80 =>\n\t\t1 => 127.0.0.2:90 (10)\n\t\t2 => 127.0.0.3:90 (10)")" ]]; then
 	     abort "Service was not properly added"
 	fi
 
 	# Check if we can get the service by it's ID
 	if [[ "$(sudo cilium lb --no-daemon get-service 127.0.0.1:80)" != \
-	      "$(echo -e "127.0.0.1:80 =>\n\t\t1 => 127.0.0.2:90 (1)\n\t\t2 => 127.0.0.3:90 (1)")" ]]; then
+	      "$(echo -e "127.0.0.1:80 =>\n\t\t1 => 127.0.0.2:90 (10)\n\t\t2 => 127.0.0.3:90 (10)")" ]]; then
 	     abort "Service was not properly added"
 	fi
 
 	# Check if it's the only RevNAT present
 	if [[ "$(sudo cilium lb --no-daemon dump-rev-nat)" != \
-	      "$(echo -e "IPv4:\n1 => 127.0.0.1:80")" ]]; then
+	      "$(echo -e "IPv4:\n10 => 127.0.0.1:80")" ]]; then
 	     abort "RevNAT's service was not properly added"
 	fi
 
 	# Check if we can get the RevNAT by it's ID
-	if [[ "$(sudo cilium lb --no-daemon get-rev-nat 1)" != \
-	      "$(echo -e "1 => 127.0.0.1:80")" ]]; then
+	if [[ "$(sudo cilium lb --no-daemon get-rev-nat 10)" != \
+	      "$(echo -e "10 => 127.0.0.1:80")" ]]; then
 	     abort "RevNAT's service was not properly added"
 	fi
 
@@ -378,78 +378,78 @@ if [ -n "${IPV4}" ]; then
 
 	# BPF's map should be unmodified
 	if [[ "$(sudo cilium lb --no-daemon dump-service)" != \
-	      "$(echo -e "127.0.0.1:80 =>\n\t\t1 => 127.0.0.2:90 (1)\n\t\t2 => 127.0.0.3:90 (1)")" ]]; then
+	      "$(echo -e "127.0.0.1:80 =>\n\t\t1 => 127.0.0.2:90 (10)\n\t\t2 => 127.0.0.3:90 (10)")" ]]; then
 	     abort "Service was not properly added"
 	fi
 
-	# Add a service with ID 2
-	cilium lb update-service --frontend 127.0.0.1:80 --backend 127.0.0.2:90 --backend 127.0.0.3:90 --id 2 --rev 2> /dev/null || {
+	# Add a service with ID 20
+	cilium lb update-service --frontend 127.0.0.1:80 --backend 127.0.0.2:90 --backend 127.0.0.3:90 --id 20 --rev 2> /dev/null || {
 		abort "Service should have been added"
 	}
 
 	# Check if it's the only service present
 	if [[ "$(cilium lb dump-service)" != \
-	      "$(echo -e "127.0.0.1:80 =>\n\t\t1 => 127.0.0.2:90 (2)\n\t\t2 => 127.0.0.3:90 (2)")" ]]; then
+	      "$(echo -e "127.0.0.1:80 =>\n\t\t1 => 127.0.0.2:90 (20)\n\t\t2 => 127.0.0.3:90 (20)")" ]]; then
 	     abort "Service was not properly added"
 	fi
 
 	# Check if we can get the service by it's ID
 	if [[ "$(cilium lb get-service 127.0.0.1:80)" != \
-	      "$(echo -e "127.0.0.1:80 =>\n\t\t1 => 127.0.0.2:90 (2)\n\t\t2 => 127.0.0.3:90 (2)")" ]]; then
+	      "$(echo -e "127.0.0.1:80 =>\n\t\t1 => 127.0.0.2:90 (20)\n\t\t2 => 127.0.0.3:90 (20)")" ]]; then
 	     abort "Service was not properly added"
 	fi
 
 	# BPF's map should contain service with a different RevNAT ID
 	if [[ "$(sudo cilium lb --no-daemon dump-service)" != \
-	      "$(echo -e "127.0.0.1:80 =>\n\t\t1 => 127.0.0.2:90 (2)\n\t\t2 => 127.0.0.3:90 (2)\n")" ]]; then
+	      "$(echo -e "127.0.0.1:80 =>\n\t\t1 => 127.0.0.2:90 (20)\n\t\t2 => 127.0.0.3:90 (20)\n")" ]]; then
 	     abort "Service was not properly added"
 	fi
 
 	# Check if it's the only RevNAT present
 	if [[ "$(cilium lb dump-rev-nat)" != \
-	      "$(echo -e "IPv4:\n2 => 127.0.0.1:80")" ]]; then
+	      "$(echo -e "IPv4:\n20 => 127.0.0.1:80")" ]]; then
 	     abort "RevNAT's service was not properly added"
 	fi
 
 	# Check if we can get the RevNAT by it's ID
-	if [[ "$(cilium lb get-rev-nat 2)" != \
-	      "$(echo -e "2 => 127.0.0.1:80")" ]]; then
+	if [[ "$(cilium lb get-rev-nat 20)" != \
+	      "$(echo -e "20 => 127.0.0.1:80")" ]]; then
 	     abort "RevNAT's service was not properly added"
 	fi
 
 	# BPF's RevNAT map's should contain both RevNATs
 	if [[ "$(sudo cilium lb --no-daemon dump-rev-nat)" != \
-	      "$(echo -e "IPv4:\n1 => 127.0.0.1:80\n2 => 127.0.0.1:80")" ]]; then
+	      "$(echo -e "IPv4:\n10 => 127.0.0.1:80\n20 => 127.0.0.1:80")" ]]; then
 	     abort "RevNAT's service was not properly added"
 	fi
 
 	# Let's try delete RevNAT 1
-	if [[ "$(cilium lb delete-rev-nat 1)" != \
+	if [[ "$(cilium lb delete-rev-nat 10)" != \
 	      "$(echo -e "Successfully deleted")" ]]; then
 	     abort "RevNAT's was not deleted"
 	fi
 
 	# BPF's RevNAT map's should contain both RevNATs
 	if [[ "$(sudo cilium lb --no-daemon dump-rev-nat)" != \
-	      "$(echo -e "IPv4:\n1 => 127.0.0.1:80\n2 => 127.0.0.1:80")" ]]; then
+	      "$(echo -e "IPv4:\n10 => 127.0.0.1:80\n20 => 127.0.0.1:80")" ]]; then
 	     abort "RevNAT's service was wrongly deleted"
 	fi
 
-	# Let's try delete RevNAT 2
-	if [[ "$(cilium lb delete-rev-nat 2)" != \
+	# Let's try delete RevNAT 20
+	if [[ "$(cilium lb delete-rev-nat 20)" != \
 	      "$(echo -e "Successfully deleted")" ]]; then
 	     abort "RevNAT's was not deleted"
 	fi
 
-	# Let's try delete RevNAT 2
+	# Let's try delete RevNAT 20
 	if [[ "$(cilium lb dump-rev-nat)" != \
 	      "$(echo -e "")" ]]; then
 	     abort "RevNAT's was not deleted"
 	fi
 
-	# BPF's RevNAT map's should contain RevNAT with ID 1
+	# BPF's RevNAT map's should contain RevNAT with ID 10
 	if [[ "$(sudo cilium lb --no-daemon dump-rev-nat)" != \
-	      "$(echo -e "IPv4:\n1 => 127.0.0.1:80")" ]]; then
+	      "$(echo -e "IPv4:\n10 => 127.0.0.1:80")" ]]; then
 	     abort "RevNAT's service was not properly deleted"
 	fi
 
@@ -459,8 +459,8 @@ if [ -n "${IPV4}" ]; then
 	     abort "RevNAT's was not deleted"
 	fi
 
-	# Let's delete the remaining RevNAT with ID 1
-	if [[ "$(sudo cilium lb --no-daemon delete-rev-nat 1)" != \
+	# Let's delete the remaining RevNAT with ID 10
+	if [[ "$(sudo cilium lb --no-daemon delete-rev-nat 10)" != \
 	      "$(echo -e "Successfully deleted")" ]]; then
 	     abort "RevNAT's service was not properly deleted"
 	fi
@@ -490,42 +490,42 @@ if [ -n "${IPV4}" ]; then
 	cilium lb delete-rev-nat --all
 	sudo cilium lb --no-daemon delete-rev-nat --all
 
-	# Add a service with ID 2
-	cilium lb update-service --frontend 127.0.0.1:80 --backend 127.0.0.2:90 --backend 127.0.0.3:90 --id 2 --rev 2> /dev/null || {
+	# Add a service with ID 32
+	cilium lb update-service --frontend 127.0.0.1:8080 --backend 127.0.0.2:90 --backend 127.0.0.3:90 --id 32 --rev 2> /dev/null || {
 		abort "Service should have been added"
 	}
 
-	# Add the same service with ID 1
-	sudo cilium lb --no-daemon update-service --frontend 127.0.0.1:80 --backend 127.0.0.2:90 --backend 127.0.0.3:90 --id 1 --rev 2> /dev/null || {
+	# Add the same service with ID 31
+	sudo cilium lb --no-daemon update-service --frontend 127.0.0.1:8080 --backend 127.0.0.2:90 --backend 127.0.0.3:90 --id 31 --rev 2> /dev/null || {
 		abort "Service should have been added"
 	}
 
-	# Add other service with ID 3
-	sudo cilium lb --no-daemon update-service --frontend 127.0.1.1:80 --backend 127.0.0.2:90 --backend 127.0.0.3:90 --id 3 --rev 2> /dev/null || {
+	# Add other service with ID 33
+	sudo cilium lb --no-daemon update-service --frontend 127.0.1.1:80 --backend 127.0.0.2:90 --backend 127.0.0.3:90 --id 33 --rev 2> /dev/null || {
 		abort "Service should have been added"
 	}
 
-	# BPF's map should contain service with RevNAT ID 1
+	# BPF's map should contain service with RevNAT ID 31
 	if [[ "$(sudo cilium lb --no-daemon dump-service)" != \
-	      "$(echo -e "127.0.0.1:80 =>\n\t\t1 => 127.0.0.2:90 (1)\n\t\t2 => 127.0.0.3:90 (1)\n127.0.1.1:80 =>\n\t\t1 => 127.0.0.2:90 (3)\n\t\t2 => 127.0.0.3:90 (3)\n")" ]]; then
+	      "$(echo -e "127.0.0.1:8080 =>\n\t\t1 => 127.0.0.2:90 (31)\n\t\t2 => 127.0.0.3:90 (31)\n127.0.1.1:80 =>\n\t\t1 => 127.0.0.2:90 (33)\n\t\t2 => 127.0.0.3:90 (33)\n")" ]]; then
 	     abort "Service was not properly added"
 	fi
 
-	# Daemon's map should contain service with RevNAT ID 2
+	# Daemon's map should contain service with RevNAT ID 32
 	if [[ "$(cilium lb dump-service)" != \
-	      "$(echo -e "127.0.0.1:80 =>\n\t\t1 => 127.0.0.2:90 (2)\n\t\t2 => 127.0.0.3:90 (2)\n")" ]]; then
+	      "$(echo -e "127.0.0.1:8080 =>\n\t\t1 => 127.0.0.2:90 (32)\n\t\t2 => 127.0.0.3:90 (32)\n")" ]]; then
 	     abort "Service was not properly added"
 	fi
 
 	# BPF's RevNAT map's should contain all RevNATs
 	if [[ "$(sudo cilium lb --no-daemon dump-rev-nat)" != \
-	      "$(echo -e "IPv4:\n1 => 127.0.0.1:80\n2 => 127.0.0.1:80\n3 => 127.0.1.1:80")" ]]; then
+	      "$(echo -e "IPv4:\n31 => 127.0.0.1:8080\n32 => 127.0.0.1:8080\n33 => 127.0.1.1:80")" ]]; then
 	     abort "RevNAT's service was not properly added"
 	fi
 
 	# Daemon's RevNAT map's should contain only 1 RevNATs
 	if [[ "$(cilium lb dump-rev-nat)" != \
-	      "$(echo -e "IPv4:\n2 => 127.0.0.1:80")" ]]; then
+	      "$(echo -e "IPv4:\n32 => 127.0.0.1:8080")" ]]; then
 	     abort "RevNAT's service was not properly added"
 	fi
 
@@ -534,31 +534,31 @@ if [ -n "${IPV4}" ]; then
 		abort "Unable to sync LB Maps"
 	}
 
-	# Daemon's map should contain service with RevNAT ID 4 because ID 3 was taken for IPv6 and not properly cleaned in kvstore #FIXME
+	# Daemon's map should contain service with RevNAT ID 32 because it was the ID first
+	# associated with this service. RevNAT ID 33 should be assigned to the second service
+	# because was the ID  associated with the service when was created "offline".
 	if [[ "$(cilium lb dump-service)" != \
-	      "$(echo -e "127.0.0.1:80 =>\n\t\t1 => 127.0.0.2:90 (1)\n\t\t2 => 127.0.0.3:90 (1)\n127.0.1.1:80 =>\n\t\t1 => 127.0.0.2:90 (4)\n\t\t2 => 127.0.0.3:90 (4)\n")" ]]; then
+	      "$(echo -e "127.0.0.1:8080 =>\n\t\t1 => 127.0.0.2:90 (32)\n\t\t2 => 127.0.0.3:90 (32)\n127.0.1.1:80 =>\n\t\t1 => 127.0.0.2:90 (33)\n\t\t2 => 127.0.0.3:90 (33)\n")" ]]; then
 	     abort "Service was not properly synced"
 	fi
 
-	# BPF's map should contain service with RevNAT ID 4
+	# BPF's map should be has same as daemon. The Service ID of 127.0.0.1:8080 synced
+	# from 31 to 32.
 	if [[ "$(sudo cilium lb --no-daemon dump-service)" != \
-	      "$(echo -e "127.0.0.1:80 =>\n\t\t1 => 127.0.0.2:90 (1)\n\t\t2 => 127.0.0.3:90 (1)\n127.0.1.1:80 =>\n\t\t1 => 127.0.0.2:90 (4)\n\t\t2 => 127.0.0.3:90 (4)\n")" ]]; then
+	      "$(echo -e "127.0.0.1:8080 =>\n\t\t1 => 127.0.0.2:90 (32)\n\t\t2 => 127.0.0.3:90 (32)\n127.0.1.1:80 =>\n\t\t1 => 127.0.0.2:90 (33)\n\t\t2 => 127.0.0.3:90 (33)\n")" ]]; then
 	     abort "Service was not properly synced"
 	fi
 
-	# BPF's RevNAT map's should contain RevNATs 1, 2 and 4. Number 3 was removed since the
-	# new service ID is 4. Number 2 was not removed because the new assigned ID to service
-	# 127.0.0.1:80 was the same ID of the bpf map.
+	# BPF's RevNAT map's should contain RevNATs 32 and 33. Number 31 was removed since the
+	# new service ID is 32.
 	if [[ "$(sudo cilium lb --no-daemon dump-rev-nat)" != \
-	      "$(echo -e "IPv4:\n1 => 127.0.0.1:80\n2 => 127.0.0.1:80\n4 => 127.0.1.1:80")" ]]; then
+	      "$(echo -e "IPv4:\n32 => 127.0.0.1:8080\n33 => 127.0.1.1:80")" ]]; then
 	     abort "RevNAT's service was not properly synced"
 	fi
 
-	# Daemon's RevNAT map's should contain RevNATs 1 and 4. Number 3 was removed since the
-	# new service ID is 4.Number 2 was not removed because the new assigned ID to service
-	# 127.0.0.1:80 was the same ID of the bpf map.
+	# Daemon's RevNAT map's should be the same ID as the bpf map RevNAT.
 	if [[ "$(cilium lb dump-rev-nat)" != \
-	      "$(echo -e "IPv4:\n1 => 127.0.0.1:80\n2 => 127.0.0.1:80\n4 => 127.0.1.1:80")" ]]; then
+	      "$(echo -e "IPv4:\n32 => 127.0.0.1:8080\n33 => 127.0.1.1:80")" ]]; then
 	     abort "RevNAT's service was not properly synced"
 	fi
 fi
@@ -663,14 +663,14 @@ cilium lb update-service --frontend 4.4.4.4:0 --id 1 --backend 5.5.5.5:80 2> /de
 }
 
 # Add L4 IPv4 entry
-cilium lb update-service --frontend 4.4.4.4:40 --rev --id 1 --backend 5.5.5.5:80 || {
+cilium lb update-service --frontend 4.4.4.4:40 --rev --id 5 --backend 5.5.5.5:80 || {
 	abort "Unable to add IPv4 service entry"
 }
 
 cilium lb dump-service
 
 # Check if requested reverse NAT entry exists
-cilium lb get-rev-nat 1 || {
+cilium lb get-rev-nat 5 || {
 	abort "Unable to find reverse NAT entry that should have been created"
 }
 
@@ -741,10 +741,10 @@ monitor_stop
 
 ## Test 4: Run wrk & ab from container => bpf_lxc (LB) => local container
 
-cilium lb update-service --rev --frontend "[$SVC_IP6]:80" --id 222 \
+cilium lb update-service --rev --frontend "[$SVC_IP6]:80" --id 2223 \
                         --backend "[$SERVER1_IP]:80" \
                         --backend "[$SERVER2_IP]:80"
-cilium lb update-service --rev --frontend "$SVC_IP4:80" --id 223 \
+cilium lb update-service --rev --frontend "$SVC_IP4:80" --id 2233 \
 			--backend "$SERVER1_IP4:80" \
 			--backend "$SERVER2_IP4:80"
 


### PR DESCRIPTION
If the user tries to add the same ID to 2 different services, on the
second try it gets an error.

$ cilium lb update-service --frontend [::]:80 --backend [::2]:91 --id 1 --rev
$ cilium lb update-service --frontend [::]:99 --backend [::2]:91 --id 1 --rev
$ ... service ID 1 is already registered to service [::]:99, please choose a different ID

If the user decides to perform the operation offline and then sync the
lb maps, a new service ID will be assigned to the conflicted service.

$ sudo cilium lb --no-daemon update-service --frontend [::]:99 --backend [::2]:91 --id 1 --rev
$ cilium lb sync-lb-maps
$ cilium lb dump-service
$ [::]:80 =>
                  1 => [::2]:91 (1)
  [::]:99 =>
                  1 => [::2]:91 (2)

Signed-off-by: André Martins <andre@cilium.io>