### PR TITLE
Fix loadbalancer tests

### DIFF
--- a/daemon/daemon/endpoint.go
+++ b/daemon/daemon/endpoint.go
@@ -275,7 +275,7 @@ func (d *Daemon) writeBPFHeader(lxcDir string, ep *endpoint.Endpoint, geneveOpts
 	fmt.Fprintf(fw, "#define SECLABEL_NB %#x\n", common.Swab32(ep.SecLabel.ID))
 	fmt.Fprintf(fw, "#define SECLABEL %#x\n", ep.SecLabel.ID)
 	fmt.Fprintf(fw, "#define POLICY_MAP %s\n", path.Base(ep.PolicyMapPath()))
-	fmt.Fprintf(fw, "#define CT_MAP_SIZE 4096\n")
+	fmt.Fprintf(fw, "#define CT_MAP_SIZE 512000\n")
 	fmt.Fprintf(fw, "#define CT_MAP6 %s\n", path.Base(common.BPFMapCT6+strconv.Itoa(int(ep.ID))))
 	fmt.Fprintf(fw, "#define CT_MAP4 %s\n", path.Base(common.BPFMapCT4+strconv.Itoa(int(ep.ID))))
 


### PR DESCRIPTION
Increasing the conntrack table limit is a temporary fix until we have a dynamic sizable bpf map type.