### PR TITLE
go: bumped go version to 1.7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ make install && \
 
 cd /tmp && \
 curl -Sslk -o go.linux-amd64.tar.gz \
-https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz && \
+https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz && \
 tar -C /usr/local -xzf go.linux-amd64.tar.gz && \
 cd /tmp/cilium-net-build/src/github.com/cilium/cilium && \
 export GOROOT=/usr/local/go && \

--- a/contrib/packaging/deb/cfg/Dockerfile
+++ b/contrib/packaging/deb/cfg/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update && \
 apt-get install -y --no-install-recommends dh-golang devscripts fakeroot dh-make \
     build-essential curl gcc make libc6-dev.i386
 RUN cd /tmp && \
-curl -Sslk -o go1.7.1.linux-amd64.tar.gz \
-https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz && \
-tar -C /usr/local -xzf go1.7.1.linux-amd64.tar.gz && \
-rm -f go1.7.1.linux-amd64.tar.gz
+curl -Sslk -o go1.7.4.linux-amd64.tar.gz \
+https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz && \
+tar -C /usr/local -xzf go1.7.4.linux-amd64.tar.gz && \
+rm -f go1.7.4.linux-amd64.tar.gz
 
 ADD . /tmp/cilium-net-build/src/github.com/cilium/cilium
 

--- a/contrib/packaging/rpm/cfg/Dockerfile
+++ b/contrib/packaging/rpm/cfg/Dockerfile
@@ -4,10 +4,10 @@ MAINTAINER "Andre Martins <andre@cilium.io>"
 
 RUN dnf install -y gettext curl gcc fedora-packager fedora-review && \
 cd /tmp && \
-curl -Sslk -o go1.7.1.linux-amd64.tar.gz \
-https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz && \
-tar -C /usr/local -xzf go1.7.1.linux-amd64.tar.gz && \
-rm -f go1.7.1.linux-amd64.tar.gz
+curl -Sslk -o go1.7.4.linux-amd64.tar.gz \
+https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz && \
+tar -C /usr/local -xzf go1.7.4.linux-amd64.tar.gz && \
+rm -f go1.7.4.linux-amd64.tar.gz
 
 ADD . /tmp/cilium-net-build/src/github.com/cilium/cilium
 

--- a/contrib/packer-scripts/ubuntu-14.04/scripts/go.sh
+++ b/contrib/packer-scripts/ubuntu-14.04/scripts/go.sh
@@ -9,10 +9,10 @@ CLANG_FILE="${CLANG_DIR}.tar.xz"
 CLANG_URL="http://llvm.org/releases/3.8.1/$CLANG_FILE"
 CLANGROOT=/usr/local/clang
 
-wget --quiet https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz
+wget --quiet https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz
 mkdir -p /usr/local
-tar -C /usr/local -xzf go1.6.linux-amd64.tar.gz
-rm go1.6.linux-amd64.tar.gz
+tar -C /usr/local -xzf go1.7.4.linux-amd64.tar.gz
+rm go1.7.4.linux-amd64.tar.gz
 
 wget --quiet $CLANG_URL
 mkdir -p /usr/local


### PR DESCRIPTION
Go1.7.4 includes 2 security fixes.
More info:
https://github.com/golang/go/issues?q=milestone%3AGo1.7.4

Signed-off-by: André Martins <andre@cilium.io>