### PR TITLE
types: omitting Protocol in json for L4Addr.

### DIFF
--- a/common/types/loadbalancer.go
+++ b/common/types/loadbalancer.go
@@ -116,7 +116,8 @@ func NewK8sServiceEndpoint() *K8sServiceEndpoint {
 // L4Addr is an abstraction for the backend port with a L4Type, usually tcp or udp, and
 // the Port number.
 type L4Addr struct {
-	Protocol L4Type
+	// TODO: Remove json's omission once we care about protocols.
+	Protocol L4Type `json:"-"`
 	Port     uint16
 }
 


### PR DESCRIPTION
By caring about which protocol was in the L4Addr we were creating a new ID
for the same service with different protocols. Since we are not
accounting for different types of protocols, this variable should be
omitted.

Signed-off-by: André Martins <andre@cilium.io>