### PR TITLE
repoint git locations to official upstream kernel ones

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,8 @@ ls -d /usr/local/clang+llvm/bin/* | grep -vE "clang$|clang-3.8$|llc$" | xargs rm
 #
 # iproute2-begin
 cd /tmp && \
-git clone git://git.breakpoint.cc/dborkman/iproute2.git && \
+git clone -b v4.9.0 git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git && \
 cd /tmp/iproute2 && \
-git checkout bpf-wip && \
 ./configure && \
 make -j `getconf _NPROCESSORS_ONLN` && \
 make install && \

--- a/README.md
+++ b/README.md
@@ -97,11 +97,17 @@ buffer.
 ## Prerequisites
 
 Cilium requires a recent version of the Linux kernel, iproute2 and clang+LLVM.
-All required changes have been merged upstream but may have not been included
-in an official release yet.
-  * https://git.kernel.org/cgit/linux/kernel/git/davem/net-next.git
-  * https://git.kernel.org/cgit/linux/kernel/git/shemminger/iproute2.git/log/?h=net-next
-  * clang+LLVM >=3.7.1: http://llvm.org/releases
+All required changes have been merged upstream and are available in official
+releases:
+ * Linux >= 4.8.0: http://www.kernel.org/
+ * iproute2 >= 4.8.0: https://www.kernel.org/pub/linux/utils/net/iproute2/
+ * clang+LLVM >=3.7.1: http://llvm.org/releases
+
+Cilium can make use of additional functionality available in >= 4.9 kernels. It
+will probe for the availability upon startup and enable it automatically.
+Development snapshots of the Linux kernel and iproute2 tree can be found here:
+ * https://git.kernel.org/cgit/linux/kernel/git/davem/net-next.git
+ * https://git.kernel.org/cgit/linux/kernel/git/shemminger/iproute2.git
 
 Alternatively, the vagrant box `noironetworks/net-next` is built regularly
 and provides the above branches compiled and pre-installed. See the

--- a/contrib/ansible/roles/iproute2/tasks/iproute2_fetch.yml
+++ b/contrib/ansible/roles/iproute2/tasks/iproute2_fetch.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Fetch bpf-wip iproute2 package
-  git: repo=git://git.breakpoint.cc/dborkman/iproute2.git
+  git: repo=git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git
        dest={{ iproute2_home }}/iproute2
-       version=bpf-wip
+       version=master
   register: iproute2_fetch

--- a/contrib/ansible/roles/kernel/tasks/kernel_fetch.yml
+++ b/contrib/ansible/roles/kernel/tasks/kernel_fetch.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Fetch bpf-wip kernel package
-  git: repo=git://git.breakpoint.cc/dborkman/net-next.git
+  git: repo=git://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git
        dest={{ kernel_home }}/net-next
-       version=bpf-wip
+       version=master
   register: kernel_fetch

--- a/contrib/packer-scripts/ubuntu-14.04/scripts/net-next.sh
+++ b/contrib/packer-scripts/ubuntu-14.04/scripts/net-next.sh
@@ -14,7 +14,7 @@ apt-get -y install pkg-config bison flex
 
 cd $HOME
 rm -Rf net-next
-git clone -b bpf-wip git://git.breakpoint.cc/dborkman/net-next.git
+git clone git://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git
 cd net-next
 rm -Rf .git
 cp /boot/config-`uname -r` .config
@@ -81,9 +81,8 @@ apt-get -y install pkg-config bison flex
 apt-get -y install gcc-multilib
 
 cd $HOME
-git clone git://git.breakpoint.cc/dborkman/iproute2.git
+git clone -b net-next git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git
 cd iproute2/
-git checkout bpf-wip
 ./configure
 make -j `getconf _NPROCESSORS_ONLN`
 make install

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -10,9 +10,9 @@ install docker-compose >=1.7.1 in it.
 
 If you want to install the dependencies manually, you need:
  - docker-compose (>=1.7.1)
- - Linux kernel and iproute2 from this tree:
-    - https://git.breakpoint.cc/cgit/dborkman/iproute2.git/log/?h=bpf-wip
-    - https://git.breakpoint.cc/cgit/dborkman/net-next.git/log/?h=bpf-wip
+ - Linux kernel and iproute2 version >= 4.8.0 or from this tree:
+    - https://git.kernel.org/cgit/linux/kernel/git/davem/net-next.git
+    - https://git.kernel.org/cgit/linux/kernel/git/shemminger/iproute2.git/log/?h=net-next
 
 ### Download docker-compose.yml
 


### PR DESCRIPTION
Dockerfile will be kept with version 4.9.0 so we have the same base
image every time we build it.

Signed-off-by: André Martins <andre@cilium.io>