### PR TITLE
k8s special labels: add optional filter

### DIFF
--- a/common/const.go
+++ b/common/const.go
@@ -69,6 +69,9 @@ const (
 	// K8sAnnotationName is the annotation name used for the cilium policy name in the
 	// kubernetes network policy.
 	K8sAnnotationName = "io.cilium.name"
+	// K8sLabelPrefix is the default prefix used when parsing labels that don't have
+	// the GlobalLabelPrefix in kubernetes.
+	K8sLabelPrefix = "io.cilium.k8s."
 	// K8sPodNamespaceLabel is the label used in kubernetes containers to specify
 	// which namespace they belong to.
 	K8sPodNamespaceLabel = "io.kubernetes.pod.namespace"

--- a/daemon/daemon/daemon_config.go
+++ b/daemon/daemon/daemon_config.go
@@ -53,25 +53,26 @@ func init() {
 
 // Config is the configuration used by Daemon.
 type Config struct {
-	LibDir               string                  // Cilium library directory
-	RunDir               string                  // Cilium runtime directory
-	LXCMap               *lxcmap.LXCMap          // LXCMap where all LXCs are stored
-	NodeAddress          *addressing.NodeAddress // Node IPv6 Address
-	NAT46Prefix          *net.IPNet              // NAT46 IPv6 Prefix
-	Device               string                  // Receive device
-	ConsulConfig         *consulAPI.Config       // Consul configuration
-	EtcdConfig           *etcdAPI.Config         // Etcd Configuration
-	EtcdCfgPath          string                  // Etcd Configuration path
-	DockerEndpoint       string                  // Docker endpoint
-	IPv4Enabled          bool                    // Gives IPv4 addresses to containers
-	K8sEndpoint          string                  // Kubernetes endpoint
-	K8sCfgPath           string                  // Kubeconfig path
-	ValidLabelPrefixes   *labels.LabelPrefixCfg  // Label prefixes used to filter from all labels
-	ValidLabelPrefixesMU sync.RWMutex
-	UIServerAddr         string // TCP address for UI server
-	UIEnabled            bool
-	LBMode               bool   // Set to true on load balancer node
-	Tunnel               string // Tunnel mode
+	LibDir                string                  // Cilium library directory
+	RunDir                string                  // Cilium runtime directory
+	LXCMap                *lxcmap.LXCMap          // LXCMap where all LXCs are stored
+	NodeAddress           *addressing.NodeAddress // Node IPv6 Address
+	NAT46Prefix           *net.IPNet              // NAT46 IPv6 Prefix
+	Device                string                  // Receive device
+	ConsulConfig          *consulAPI.Config       // Consul configuration
+	EtcdConfig            *etcdAPI.Config         // Etcd Configuration
+	EtcdCfgPath           string                  // Etcd Configuration path
+	DockerEndpoint        string                  // Docker endpoint
+	IPv4Enabled           bool                    // Gives IPv4 addresses to containers
+	K8sEndpoint           string                  // Kubernetes endpoint
+	K8sCfgPath            string                  // Kubeconfig path
+	ValidLabelPrefixes    *labels.LabelPrefixCfg  // Label prefixes used to filter from all labels
+	ValidK8sLabelPrefixes *labels.LabelPrefixCfg  // Label prefixes used to filter from all labels
+	ValidLabelPrefixesMU  sync.RWMutex
+	UIServerAddr          string // TCP address for UI server
+	UIEnabled             bool
+	LBMode                bool   // Set to true on load balancer node
+	Tunnel                string // Tunnel mode
 
 	DryMode      bool // Do not create BPF maps, devices, ..
 	RestoreState bool // RestoreState restores the state from previous running daemons.

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -49,6 +49,7 @@ var (
 	enableTracing      bool
 	enableLogstash     bool
 	etcdAddr           cli.StringSlice
+	k8sLabels          cli.StringSlice
 	labelPrefixFile    string
 	logstashAddr       string
 	logstashProbeTimer int
@@ -133,6 +134,11 @@ func init() {
 						Destination: &config.K8sCfgPath,
 						Name:        "k8s-kubeconfig-path",
 						Usage:       "Absolute path to the kubeconfig file",
+					},
+					cli.StringSliceFlag{
+						Value: &k8sLabels,
+						Name:  "k8s-prefix",
+						Usage: "Key values that will be read from kubernetes. (Default: k8s-app, version)",
 					},
 					cli.BoolTFlag{
 						Destination: &config.KeepConfig,
@@ -391,6 +397,17 @@ func initEnv(ctx *cli.Context) error {
 		}
 	} else {
 		config.ValidLabelPrefixes = labels.DefaultLabelPrefixCfg()
+	}
+
+	if len(k8sLabels) == 0 {
+		config.ValidK8sLabelPrefixes = labels.DefaultK8sLabelPrefixCfg()
+	} else {
+		for _, prefix := range k8sLabels {
+			config.ValidK8sLabelPrefixes.LabelPrefixes = append(
+				config.ValidK8sLabelPrefixes.LabelPrefixes,
+				&labels.LabelPrefix{Prefix: prefix, Source: common.K8sLabelSource},
+			)
+		}
 	}
 	config.ValidLabelPrefixesMU.Unlock()
 

--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -44,8 +44,9 @@ type LabelPrefixCfg struct {
 
 // DefaultLabelPrefixCfg returns a default LabelPrefixCfg using the latest
 // LPCfgFileVersion and the following label prefixes: Key: common.GlobalLabelPrefix,
-// Source: common.CiliumLabelSource and Key: common.GlobalLabelPrefix, Source:
-// common.K8sLabelSource.
+// Source: common.CiliumLabelSource, Key: common.GlobalLabelPrefix, Source:
+// common.CiliumLabelSource, Key: common.GlobalLabelPrefix, Source: common.K8sLabelSource
+// and Key: common.K8sPodNamespaceLabel, Source: common.K8sLabelSource.
 func DefaultLabelPrefixCfg() *LabelPrefixCfg {
 	return &LabelPrefixCfg{
 		Version: LPCfgFileVersion,
@@ -64,6 +65,25 @@ func DefaultLabelPrefixCfg() *LabelPrefixCfg {
 			},
 			{
 				Prefix: common.K8sPodNamespaceLabel,
+				Source: common.K8sLabelSource,
+			},
+		},
+	}
+}
+
+// DefaultK8sLabelPrefixCfg returns a default LabelPrefixCfg using the latest
+// LPCfgFileVersion and the following label prefixes: Key: "k8s-app", Source:
+// common.K8sLabelSource and Key: "version", Source: common.K8sLabelSource.
+func DefaultK8sLabelPrefixCfg() *LabelPrefixCfg {
+	return &LabelPrefixCfg{
+		Version: LPCfgFileVersion,
+		LabelPrefixes: []*LabelPrefix{
+			{
+				Prefix: "k8s-app",
+				Source: common.K8sLabelSource,
+			},
+			{
+				Prefix: "version",
 				Source: common.K8sLabelSource,
 			},
 		},

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -98,6 +98,21 @@ type Label struct {
 // Labels is a map of labels where the map's key is the same as the label's key.
 type Labels map[string]*Label
 
+// AppendPrefixInKey appends the given prefix to all the Key's of the map and the
+// respective Labels' Key.
+func (l Labels) AppendPrefixInKey(prefix string) Labels {
+	newLabels := Labels{}
+	for k, v := range l {
+		newLabels[prefix+k] = &Label{
+			prefix + v.Key,
+			v.Value,
+			v.Source,
+			v.absKey,
+		}
+	}
+	return newLabels
+}
+
 // SecCtxLabel is the representation of the security context for a particular set of
 // labels.
 type SecCtxLabel struct {


### PR DESCRIPTION
With --k8s-prefix the user will have the ability to add his own labels
to cilium without the need to specify io.cilium on legacy pods.
By default we will use the k8s labels: k8s-app and version.

Signed-off-by: André Martins <andre@cilium.io>