### PR TITLE
policy: optimized policy triggering updates

### DIFF
--- a/cilium/policy/main.go
+++ b/cilium/policy/main.go
@@ -318,7 +318,7 @@ func loadPolicy(name string) (*policy.Node, error) {
 			return nil, err
 		} else {
 			if node != nil {
-				if err := node.Merge(p); err != nil {
+				if _, err := node.Merge(p); err != nil {
 					return nil, fmt.Errorf("Error: %s: %s", f.Name(), err)
 				}
 			} else {

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -550,14 +550,14 @@ func (s *PolicyTestSuite) TestNodeMerge(c *C) {
 	// Name mismatch
 	aNode := Node{Name: "a"}
 	bNode := Node{Name: "b"}
-	err := aNode.Merge(&bNode)
+	_, err := aNode.Merge(&bNode)
 	c.Assert(err, Not(Equals), nil)
 
 	// Empty nodes
 	aOrig := Node{Name: "a"}
 	aNode = Node{Name: "a"}
 	bNode = Node{Name: "a"}
-	err = aNode.Merge(&bNode)
+	_, err = aNode.Merge(&bNode)
 	c.Assert(err, Equals, nil)
 	c.Assert(aNode, DeepEquals, aOrig)
 
@@ -624,7 +624,7 @@ func (s *PolicyTestSuite) TestNodeMerge(c *C) {
 	aNode.Path()
 	bNode.Path()
 
-	err = aNode.Merge(&bNode)
+	_, err = aNode.Merge(&bNode)
 	c.Assert(err, Equals, nil)
 }
 


### PR DESCRIPTION
Due to external inputs from probes, such as kubernetes, we are pooling
the external policies every 5 minutes to keep the state synced as
possible with the kubernetes api-server. Unfortunately, this is also
causing a full triggering policy update for every endpoint even if the
policy was not locally changed.

This commit optimizes the policy addition and checks if the new policy
modified the existing one, if that was the case, the policy update is
triggered for every endpoint present.

TODO: Trigger the policy update only for the necessary endpoints.

Signed-off-by: André Martins <andre@cilium.io>