### PR TITLE
policy: fixing missing consumers map

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -287,6 +287,11 @@ func (e *Endpoint) SetIdentity(owner Owner, id *policy.Identity) {
 	cache := owner.GetConsumableCache()
 
 	if e.Consumable != nil {
+		if e.SecLabel != nil && id.ID == e.Consumable.ID {
+			e.SecLabel = id
+			e.Consumable.Labels = id
+			return
+		}
 		cache.Remove(e.Consumable)
 	}
 	e.SecLabel = id


### PR DESCRIPTION
Fixes missing consumers map on `cilium endpoint inspect`
Signed-off-by: André Martins <andre@cilium.io>

@tgraf can I do that? won't the cache get corrupted?