### PR TITLE
policy: improved policy allowed cli usability

### DIFF
--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -18,6 +18,7 @@ package policy
 import (
 	"crypto/sha512"
 	"fmt"
+	"strconv"
 
 	"github.com/cilium/cilium/pkg/labels"
 
@@ -116,6 +117,8 @@ func policyTrace(ctx *SearchContext, format string, a ...interface{}) {
 	case TRACE_ENABLED, TRACE_VERBOSE:
 		log.Debugf(format, a...)
 		if ctx.Logging != nil {
+			format = "%-" + ctx.CallDepth() + "s" + format
+			a = append([]interface{}{""}, a...)
 			ctx.Logging.Logger.Printf(format, a...)
 		}
 	}
@@ -159,6 +162,7 @@ func (d ConsumableDecision) MarshalJSON() ([]byte, error) {
 
 type SearchContext struct {
 	Trace   Tracing
+	Depth   int
 	Logging *logging.LogBackend
 	// TODO: Put this as []*Label?
 	From []labels.Label
@@ -168,6 +172,14 @@ type SearchContext struct {
 type SearchContextReply struct {
 	Logging  []byte
 	Decision ConsumableDecision
+}
+
+func (s *SearchContext) String() string {
+	return fmt.Sprintf("From: %s => To: %s", s.From, s.To)
+}
+
+func (s *SearchContext) CallDepth() string {
+	return strconv.Itoa(s.Depth * 2)
 }
 
 func (s *SearchContext) TargetCoveredBy(coverage []labels.Label) bool {


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

Some examples:
```
$ cilium policy allowed -d io.cilium.test.qa -s io.cilium.test.qa 
Resolving policy: From: [cilium:io.cilium.test.qa] => To: [cilium:io.cilium.test.qa]
Root's [io.cilium] rules verdict: [undecided]
Searching in [io.cilium]'s children that have the coverage for: [[cilium:io.cilium.test.qa]]
  Coverage found in [io.cilium.test], processing rules...
    Found coverage rule: Coverage: [cilium:qa], Requires: [cilium:qa]
    Rule has no coverage: Coverage: [cilium:prod], Requires: [cilium:prod]
    Rule has no coverage: [Coverage: [cilium:server] Allowing: [{accept cilium:client} {accept reserved:host}]]
  No conclusion in [io.cilium.test] rules, current verdict: [undecided]
  No matching children in [io.cilium.test]
Root's [io.cilium] children verdict: [undecided]
Final verdict: [DENY]
```
```
$ cilium policy allowed -s 260 -d 261
Resolving policy: From: [k8s:io.cilium.k8s.k8s-app.guestbook=web k8s:io.kubernetes.pod.namespace=default] => To: [k8s:io.cilium.k8s.k8s-app.guestbook=redis k8s:io.kubernetes.pod.namespace=default]
Root's [io.cilium] rules verdict: [undecided]
Searching in [io.cilium]'s children that have the coverage for: [[k8s:io.cilium.k8s.k8s-app.guestbook=redis k8s:io.kubernetes.pod.namespace=default]]
  Coverage found in [io.cilium.k8s], processing rules...
    Rule has no coverage: [Coverage: [k8s:k8s-app=kubernetes-dashboard] Allowing: [{always-accept reserved:host}]]
    Rule has no coverage: [Coverage: [k8s:k8s-app=kube-dns] Allowing: [{always-accept k8s:io.kubernetes.pod.namespace=kube-system} {always-accept k8s:io.kubernetes.pod.namespace=default} {always-accept reserved:host}]]
  No conclusion in [io.cilium.k8s] rules, current verdict: [undecided]
    Coverage found in [io.cilium.k8s.k8s-app], processing rules...
      Found coverage rule: [Coverage: [k8s:guestbook=redis] Allowing: [{always-accept k8s:guestbook=redis} {always-accept k8s:guestbook=web}]]
        No matching labels in allow rule: [{label: k8s:guestbook=redis, action: always-accept}]
        Found label matching [k8s:io.cilium.k8s.k8s-app.guestbook=web] in rule: [{label: k8s:guestbook=web, action: always-accept}]
Root's [io.cilium] children verdict: [always-accept]
Final verdict: [ACCEPT]
```

TODO:
- [ ] L4 policy