### PR TITLE
policy: Use StringID() consistently and check BPF map for consumer

### DIFF
--- a/bpf/policymap/policymap.go
+++ b/bpf/policymap/policymap.go
@@ -75,6 +75,11 @@ func (m *PolicyMap) AllowConsumer(id uint32) error {
 	return bpf.UpdateElement(m.Fd, unsafe.Pointer(&id), unsafe.Pointer(&entry), 0)
 }
 
+func (m *PolicyMap) ConsumerExists(id uint32) bool {
+	var entry PolicyEntry
+	return bpf.LookupElement(m.Fd, unsafe.Pointer(&id), unsafe.Pointer(&entry)) == nil
+}
+
 func (m *PolicyMap) DeleteConsumer(id uint32) error {
 	return bpf.DeleteElement(m.Fd, unsafe.Pointer(&id))
 }


### PR DESCRIPTION
This resolves an issue when String() on a consumer identity translates
to the human readabe form for reserved values while StringID() always
returns the numeric form. Due to mixed use, the cache was inconsistent.

Also adds a ConsumerExists() method to the policy BPF map to ensure
we never leave it in a inconsistent state if the cache became invalid
for some reason.

Signed-off-by: Thomas Graf <thomas@cilium.io>