### PR TITLE
Refactor NUM_NODES to N_WORKERS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.require_version ">= 1.7.4"
 if ARGV.first == "up" && ENV['CILIUM_SCRIPT'] != 'true'
     raise Vagrant::Errors::VagrantError.new, <<END
 Calling 'vagrant up' directly is not supported.  Instead, please run the following:
-  export NUM_NODES=n
+  export NWORKERS=n
   ./contrib/vagrant/start.sh
 END
 end
@@ -99,7 +99,7 @@ SCRIPT
 
 $node_ip_base = ENV['NODE_IP_BASE'] || ""
 $master_ip = $node_ip_base + "#{ENV['FIRST_IP_SUFFIX']}"
-$num_node = (ENV['NUM_NODES'] || 0).to_i
+$num_node = (ENV['NWORKERS'] || 0).to_i
 $node_ips = $num_node.times.collect { |n| $node_ip_base + "#{n+(ENV['FIRST_IP_SUFFIX']).to_i+1}" }
 $node_nfs_base_ip = ENV['NODE_NFS_IP_BASE']
 

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -62,7 +62,7 @@ function write_nodes_routes(){
 EOF
     local i
     local index=1
-    for i in `seq $(( FIRST_IP_SUFFIX + 1 )) $(( FIRST_IP_SUFFIX + NUM_NODES ))`; do
+    for i in `seq $(( FIRST_IP_SUFFIX + 1 )) $(( FIRST_IP_SUFFIX + NWORKERS ))`; do
         index=$(( index + 1 ))
         if [ "${node_index}" -eq "${index}" ]; then
             eval "${1}=$(printf '%02X' ${i})"
@@ -155,7 +155,7 @@ EOF
 function create_master(){
     write_header 1 "${dir}/cilium-master.sh"
 
-    if [ -n "${NUM_NODES}" ]; then
+    if [ -n "${NWORKERS}" ]; then
         write_nodes_routes hexNodeIPv4 1 "${dir}/cilium-master.sh"
     fi
 
@@ -164,8 +164,8 @@ function create_master(){
 }
 
 function create_nodes(){
-    if [ -n "${NUM_NODES}" ]; then
-        for i in `seq 2 $(( NUM_NODES + 1 ))`; do
+    if [ -n "${NWORKERS}" ]; then
+        for i in `seq 2 $(( NWORKERS + 1 ))`; do
             write_header "${i}" "${dir}/node-start-${i}.sh"
 
             cat <<EOF >> "${dir}/node-start-${i}.sh"
@@ -179,7 +179,7 @@ fi
 echo "2001:DB8:AAAA::$(printf "%04X" "${i}") cilium${K8STAG}-node-${i}" >> /etc/hosts
 
 EOF
-            if [ -n "${NUM_NODES}" ]; then
+            if [ -n "${NWORKERS}" ]; then
                 write_nodes_routes hexNodeIPv4 "${i}" "${dir}/node-start-${i}.sh"
             fi
 

--- a/doc/vagrant.md
+++ b/doc/vagrant.md
@@ -9,7 +9,7 @@ dependencies installed, run:
 $ contrib/vagrant/start.sh
 ```
 
-This will bring up a master node plus the configured  number of additional slave
+This will bring up a master node plus the configured number of additional worker
 nodes. The master node will run a consul agent with the slaves configured to
 point to it.
 
@@ -17,17 +17,18 @@ point to it.
 
 The following environment variables can be set to customize the VMs brought up
 by vagrant:
- * NUM_NODES=n: Number of child nodes you want to start
- * RELOAD=1: Issue a `vagrant reload` instead of `vagrant up`
- * NFS=1: Use NFS for vagrant shared directories instead of rsync
- * K8S=1: Build & install kubernetes on the nodes
- * IPV4=1: Run Cilium with IPv4 enabled
+ * `NWORKERS=n`: Number of child nodes you want to start with the master, default 0.
+ * `RELOAD=1`: Issue a `vagrant reload` instead of `vagrant up`
+ * `NFS=1`: Use NFS for vagrant shared directories instead of rsync
+ * `K8S=1`: Build & install kubernetes on the nodes
+ * `IPV4=1`: Run Cilium with IPv4 enabled
  * VAGRANT_DEFAULT_PROVIDER={virtualbox | libvirt | ...}
 
-Example:
+If you want to start the VM with cilium enabled with IPv4, with kubernetes installed
+ and plus a worker, run:
 
  ```
- $ IPV4=1 K8S=1 NUM_NODES=3 contrib/vagrant/start.sh
+ $ IPV4=1 K8S=1 NWORKERS=1 contrib/vagrant/start.sh
  ```
 
 If you have any issue with the provided vagrant box `noironetworks/net-next`
@@ -35,7 +36,7 @@ if your need a different box format, you may build the box yourself using
 packer:
 
 ```
-$ cd contrib/packer-scripts/ubuntu-14.04/
+$ cd contrib/packer-scripts/ubuntu-16.10/
 $ make build-vbox [See Makefile for other targets]
 $ vagrant box add --name noironetworks/net-next [...]
 ```
@@ -62,7 +63,7 @@ and manually install Cilium:
 To manually build the vagrant boxes using packer:
 
 ```
-$ cd contrib/packer-scripts/ubuntu-14.04/
+$ cd contrib/packer-scripts/ubuntu-16.10/
 $ make build-vbox
 $ make build-libvirt
 $ make build-...

--- a/tests/manual-multi-node.bash
+++ b/tests/manual-multi-node.bash
@@ -3,7 +3,7 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 set -e
 
-export NUM_NODES=1
+export NWORKERS=1
 
 function node_run {
 	NODE=$1


### PR DESCRIPTION
`NUM_NODES` can cause some confusion so I've refactored the variable to `N_WORKERS`
Signed-off-by: André Martins <andre@cilium.io>