### PR TITLE
Vagrantfile: Wait for the Cilium daemon to come up

### DIFF
--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -133,7 +133,13 @@ else
     echo 'INITSYSTEM=SYSTEMD' >> /etc/sysconfig/cilium
     systemctl restart cilium-net-daemon.service
 fi
-sleep 10s
+for ((i = 0 ; i < 24; i++)); do
+    if cilium daemon status > /dev/null 2>&1; then
+        break
+    fi
+    sleep 5
+    echo "Waiting for Cilium daemon to come up..."
+done
 EOF
     else
 	    cat <<EOF >> "$filename"
@@ -148,7 +154,13 @@ else
     echo 'PATH=/usr/local/clang/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin' >> /etc/sysconfig/cilium
     systemctl restart cilium-net-daemon.service
 fi
-sleep 10s
+for ((i = 0 ; i < 24; i++)); do
+    if cilium daemon status > /dev/null 2>&1; then
+        break
+    fi
+    sleep 5
+    echo "Waiting for Cilium daemon to come up..."
+done
 EOF
     fi
 }


### PR DESCRIPTION
Gianluca Arbezzano reported that policy import fails in his environment.
The failure is due to the Cilium daemon not being ready when the policy
import script is being run as a provisioner.

The scripts previously contained a fixed 10 seconds wait period. This
replaces it with a script to wait up to 2 minutes for the Deamon to come
up.

Fixes: #265