### PR TITLE
bpf: map: Add new map types introduced upstream

### DIFF
--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -47,6 +47,9 @@ const (
 	MapTypePerCPUArray
 	MapTypeStackTrace
 	MapTypeCgroupArray
+	MapTypeLRUHash
+	MapTypeLRUPerCPUHash
+	MapTypeLPMTrie
 )
 
 func (t MapType) String() string {
@@ -67,6 +70,12 @@ func (t MapType) String() string {
 		return "Stack trace"
 	case MapTypeCgroupArray:
 		return "Cgroup array"
+	case MapTypeLRUHash:
+		return "LRU hash"
+	case MapTypeLRUPerCPUHash:
+		return "LRU per-CPU hash"
+	case MapTypeLPMTrie:
+		return "Longest prefix match trie"
 	}
 
 	return "Unknown"


### PR DESCRIPTION
Add the map types MapTypeLRUHash, MapTypeLRUPerCPUHash and
MapTypeLPMTrie to match BPF_MAP_TYPE_LRU_HASH,
BPF_MAP_TYPE_LRU_PERCPU_HASH and BPF_MAP_TYPE_LPM_TRIE, respectively.

All are present in the current net-next tree.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>