### PR TITLE
Fix race when receiving docker die event

### DIFF
--- a/daemon/daemon/state.go
+++ b/daemon/daemon/state.go
@@ -259,15 +259,6 @@ func (d *Daemon) cleanUpDockerDandlingEndpoints() {
 	cleanUp := func(ep endpoint.Endpoint) {
 		log.Infof("Endpoint %d not found in docker, cleaning it up...", ep.ID)
 		d.EndpointLeave(ep.ID)
-		// FIXME: IPV4
-		if ep.IPv6 != nil {
-			if ep.IsCNI() {
-				d.ReleaseIP(ipam.CNIIPAMType, ep.IPv6.IPAMReq())
-			} else if ep.IsLibnetwork() {
-				d.ReleaseIP(ipam.LibnetworkIPAMType, ep.IPv6.IPAMReq())
-			}
-		}
-
 	}
 
 	for _, ep := range eps {


### PR DESCRIPTION
The IPAM unregistration is currently bound to the docker die event.
This leaves IPAM addresses registered if the endpoint deletion
occurs through the API instead of the docker event.
