### PR TITLE
k8s-policy: setting io.cilium.k8s as default parent prefix for K8S NP

### DIFF
--- a/common/const.go
+++ b/common/const.go
@@ -68,6 +68,9 @@ const (
 	// K8sLabelPrefix is the default prefix used when parsing labels that don't have
 	// the GlobalLabelPrefix in kubernetes.
 	K8sLabelPrefix = "io.cilium.k8s."
+	// K8sDefaultParent is the default prefix for network policies received from
+	// kubernetes.
+	K8sDefaultParent = "io.cilium.k8s"
 	// K8sPodNamespaceLabel is the label used in kubernetes containers to specify
 	// which namespace they belong to.
 	K8sPodNamespaceLabel = "io.kubernetes.pod.namespace"

--- a/common/types/network_policy.go
+++ b/common/types/network_policy.go
@@ -26,7 +26,7 @@ import (
 func K8sNP2CP(np *v1beta1.NetworkPolicy) (string, *policy.Node, error) {
 	var parentNodeName, policyName string
 	if np.Annotations[common.K8sAnnotationParentName] == "" {
-		parentNodeName = common.GlobalLabelPrefix
+		parentNodeName = common.K8sDefaultParent
 	} else {
 		parentNodeName = np.Annotations[common.K8sAnnotationParentName]
 	}

--- a/examples/kubernetes/network-policy/guestbook-policy-redis.json
+++ b/examples/kubernetes/network-policy/guestbook-policy-redis.json
@@ -3,8 +3,7 @@
   "kind": "NetworkPolicy",
   "metadata": {
     "annotations": {
-      "io.cilium.name": "k8s-app",
-      "io.cilium.parent": "io.cilium.k8s"
+      "io.cilium.name": "k8s-app"
     },
     "name": "guestbook-redis"
   },

--- a/examples/kubernetes/network-policy/guestbook-policy-web.json
+++ b/examples/kubernetes/network-policy/guestbook-policy-web.json
@@ -3,8 +3,7 @@
   "kind": "NetworkPolicy",
   "metadata": {
     "annotations": {
-      "io.cilium.name": "k8s-app",
-      "io.cilium.parent": "io.cilium.k8s"
+      "io.cilium.name": "k8s-app"
     },
     "name": "guestbook-web"
   },


### PR DESCRIPTION
Since all the policies coming from kubernetes are being set in the path `io.cilium.k8s` I changed the default parent path to be that one removing the need to specify the parent on the network policy annotation.

Signed-off-by: André Martins <andre@cilium.io>