### PR TITLE
bpf: simplify Makefile rules

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -10,14 +10,8 @@ ifeq ("$(PKG_BUILD)","")
 
 all: $(BPF)
 
-bpf_lxc.o:
-	clang ${CLANG_FLAGS} -c bpf_lxc.c -o $@
-
-bpf_netdev.o:
-	clang ${CLANG_FLAGS} -c bpf_netdev.c -o $@
-
-bpf_overlay.o:
-	clang ${CLANG_FLAGS} -c bpf_overlay.c -o $@
+%.o: %.c
+	clang ${CLANG_FLAGS} -c $< -o $@
 
 LB_OPTIONS = \
 	 \


### PR DESCRIPTION
The targets for bpf_lxc.o, bpf_netdev.o, bpf_overlay.o (and possible
future additions) can be merged and handled by a pattern rule.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>