### PR TITLE
Fix typo when parsing map data

### DIFF
--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -154,7 +154,7 @@ func GetMapInfo(pid int, fd int) (*MapInfo, error) {
 			info.ValueSize = uint32(value)
 		} else if n, err := fmt.Sscanf(line, "max_entries:\t%d", &value); n == 1 && err == nil {
 			info.MaxEntries = uint32(value)
-		} else if n, err := fmt.Sscanf(line, "map_flags:\t%i", &value); n == 1 && err == nil {
+		} else if n, err := fmt.Sscanf(line, "map_flags:\t%x", &value); n == 1 && err == nil {
 			info.Flags = uint32(value)
 		}
 	}

--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -154,7 +154,7 @@ func GetMapInfo(pid int, fd int) (*MapInfo, error) {
 			info.ValueSize = uint32(value)
 		} else if n, err := fmt.Sscanf(line, "max_entries:\t%d", &value); n == 1 && err == nil {
 			info.MaxEntries = uint32(value)
-		} else if n, err := fmt.Sscanf(line, "map_flas:\t%i", &value); n == 1 && err == nil {
+		} else if n, err := fmt.Sscanf(line, "map_flags:\t%i", &value); n == 1 && err == nil {
 			info.Flags = uint32(value)
 		}
 	}


### PR DESCRIPTION
Also I couldn't find anything about `%i` in Sscanf, is that correct? A quick test in the Go Playground failed (I'm not a Go programmer)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/295%23issuecomment-284311907%22%2C%20%22https%3A//github.com/cilium/cilium/pull/295%23issuecomment-284330861%22%2C%20%22https%3A//github.com/cilium/cilium/pull/295%23issuecomment-284337349%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/295%23issuecomment-284311907%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22LGTM%2C%20the%20%60%25i%60%20should%20definitely%20be%20%60%25x%60%20instead.%20Let%20me%20know%20if%20you%20want%20to%20fix%20this%20up%20in%20this%20commit%2C%20otherwise%20I%27ll%20take%20care%20of%20fixing%20it.%22%2C%20%22created_at%22%3A%20%222017-03-06T06%3A17%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20went%20ahead%20and%20replaced%20it%20with%20%25x%22%2C%20%22created_at%22%3A%20%222017-03-06T08%3A23%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/2129%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/badboy%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%21%22%2C%20%22created_at%22%3A%20%222017-03-06T08%3A56%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/295#issuecomment-284311907'>General Comment</a></b>
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> LGTM, the `%i` should definitely be `%x` instead. Let me know if you want to fix this up in this commit, otherwise I'll take care of fixing it.
- <a href='https://github.com/badboy'><img border=0 src='https://avatars1.githubusercontent.com/u/2129?v=3' height=16 width=16></a> I went ahead and replaced it with %x
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> Thanks!


<a href='https://www.codereviewhub.com/cilium/cilium/pull/295?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/295?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/295'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>