### PR TITLE
daemon: Remove stale socket on startup

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/common/ipam"
 	"github.com/cilium/cilium/common/types"
+	"github.com/cilium/cilium/daemon/defaults"
 	"github.com/cilium/cilium/daemon/options"
 	"github.com/cilium/cilium/pkg/apierror"
 	"github.com/cilium/cilium/pkg/bpf"
@@ -223,7 +224,7 @@ func (d *Daemon) useK8sNodeCIDR(nodeName string) error {
 
 func (d *Daemon) init() error {
 	globalsDir := filepath.Join(d.conf.RunDir, "globals")
-	if err := os.MkdirAll(globalsDir, 0755); err != nil {
+	if err := os.MkdirAll(globalsDir, defaults.RuntimePathRights); err != nil {
 		log.Fatalf("Could not create runtime directory %s: %s", globalsDir, err)
 	}
 

--- a/daemon/defaults/defaults.go
+++ b/daemon/defaults/defaults.go
@@ -15,15 +15,18 @@
 package defaults
 
 const (
-	// Default path to runtime files
+	// RuntimePath is the default path to the runtime directory
 	RuntimePath = "/var/run/cilium"
 
-	// Default path to static library files
+	// RuntimePathRights are the default access rights of the RuntimePath directory
+	RuntimePathRights = 0770
+
+	// LibDir is the default path to static library files
 	LibDir = "/usr/lib/cilium"
 
-	// Path to UNIX domain socket exposing the API to clients
+	// SockPath is the path to the UNIX domain socket exposing the API to clients locally
 	SockPath = RuntimePath + "/cilium.sock"
 
-	// Environment variable for UNIX domain socket
+	// SockPathEnv is the environment variable to overwrite SockPath
 	SockPathEnv = "CILIUM_SOCK"
 )

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path"
 	"strings"
 	"sync"
 	"time"
@@ -146,6 +147,15 @@ func initConfig() {
 }
 
 func initEnv() {
+	socketDir := path.Dir(socketPath)
+	if err := os.MkdirAll(socketDir, 0700); err != nil {
+		log.Fatalf("Cannot mkdir directory \"%s\" for cilium socket: %s", socketDir, err)
+	}
+
+	if err := os.Remove(socketPath); !os.IsNotExist(err) && err != nil {
+		log.Fatalf("Cannot remove existing Cilium sock \"%s\": %s", socketPath, err)
+	}
+
 	// The standard operation is to mount the BPF filesystem to the
 	// standard location (/sys/fs/bpf). The user may chose to specify
 	// the path to an already mounted filesystem instead. This is

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -148,7 +148,7 @@ func initConfig() {
 
 func initEnv() {
 	socketDir := path.Dir(socketPath)
-	if err := os.MkdirAll(socketDir, 0700); err != nil {
+	if err := os.MkdirAll(socketDir, defaults.RuntimePathRights); err != nil {
 		log.Fatalf("Cannot mkdir directory \"%s\" for cilium socket: %s", socketDir, err)
 	}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -73,19 +73,17 @@ func NewClient(host string) (*Client, error) {
 		return nil, fmt.Errorf("invalid host format '%s'", host)
 	}
 
-	proto, addr := tmp[0], tmp[1]
-
-	switch proto {
+	switch tmp[0] {
 	case "tcp":
-		if _, err := url.Parse("tcp://" + addr); err != nil {
+		if _, err := url.Parse("tcp://" + tmp[1]); err != nil {
 			return nil, err
 		}
-		addr = "http://" + addr
-	case "http":
-		addr = "http://" + addr
+		host = "http://" + tmp[1]
+	case "unix":
+		host = tmp[1]
 	}
 
-	transport := configureTransport(nil, proto, addr)
+	transport := configureTransport(nil, tmp[0], host)
 	httpClient := &http.Client{Transport: transport}
 	clientTrans := runtime_client.NewWithClient(host, clientapi.DefaultBasePath,
 		clientapi.DefaultSchemes, httpClient)


### PR DESCRIPTION
This was existing behaviour and got lost in the API code generation
transition.

Signed-off-by:  <thomas@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/305%23discussion_r105208655%22%2C%20%22https%3A//github.com/cilium/cilium/pull/305%23discussion_r105227649%22%2C%20%22https%3A//github.com/cilium/cilium/pull/305%23discussion_r105228088%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20ced36eaff2352c76b902d2d14402cfac3ba2bc1a%20daemon/main.go%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/305%23discussion_r105208655%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22No%20%60770%60%20or%20%60775%60%20in%20case%20we%20have%20the%20socket%20running%20with%20group%20%60cilium%60%3F%22%2C%20%22created_at%22%3A%20%222017-03-09T16%3A34%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60700%60%20was%20the%20mode%20we%20had%20before.%20I%20just%20restored%20the%20code.%20I%27m%20fine%20with%20%60750%60%20though.%22%2C%20%22created_at%22%3A%20%222017-03-09T17%3A52%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%2C%20%7B%22body%22%3A%20%22Looking%20further%20into%20this.%20In%20most%20cases%2C%20the%20directory%20is%20created%20by%20the%20daemon%20but%20I%20notice%20the%20mode%20is%20set%20to%20%60755%60%20which%20we%20definitely%20don%27t%20want.%20I%20will%20fix%20this%20up%20separately.%22%2C%20%22created_at%22%3A%20%222017-03-09T17%3A54%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20daemon/main.go%3AL147-162%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull ced36eaff2352c76b902d2d14402cfac3ba2bc1a daemon/main.go 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/305#discussion_r105208655'>File: daemon/main.go:L147-162</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> No `770` or `775` in case we have the socket running with group `cilium`?
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> `700` was the mode we had before. I just restored the code. I'm fine with `750` though.
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> Looking further into this. In most cases, the directory is created by the daemon but I notice the mode is set to `755` which we definitely don't want. I will fix this up separately.


<a href='https://www.codereviewhub.com/cilium/cilium/pull/305?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/305?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/305'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>