### PR TITLE
Various policy improvements

### DIFF
--- a/common/const.go
+++ b/common/const.go
@@ -50,8 +50,6 @@ const (
 
 	// Miscellaneous dedicated constants
 
-	// GlobalLabelPrefix is the default root path for the policy.
-	GlobalLabelPrefix = "io.cilium"
 	// CiliumLabelSource is the default label source for the labels read from containers.
 	CiliumLabelSource = "cilium"
 	// K8sLabelSource is the default label source for the labels read from kubernetes.
@@ -59,8 +57,7 @@ const (
 	// K8sAnnotationName is the annotation name used for the cilium policy name in the
 	// kubernetes network policy.
 	K8sAnnotationName = "io.cilium.name"
-	// K8sLabelPrefix is the default prefix used when parsing labels that don't have
-	// the GlobalLabelPrefix in kubernetes.
+	// K8sLabelPrefix is the default prefix used to represent kubernetes labels
 	K8sLabelPrefix = "io.cilium.k8s."
 	// K8sDefaultParent is the default prefix for network policies received from
 	// kubernetes.
@@ -76,7 +73,7 @@ const (
 	// Label source for reserved types
 	ReservedLabelSource = "reserved"
 	// Label used to represent the reserved source
-	ReservedLabelKey = GlobalLabelPrefix + "." + ReservedLabelSource
+	ReservedLabelKey = "io.cilium." + ReservedLabelSource
 	// EndpointsPerHost is the maximum number of endpoints allowed per host. It should
 	// represent the same number of IPv6 addresses supported on each node.
 	EndpointsPerHost = 0xFFFF

--- a/common/types/network_policy.go
+++ b/common/types/network_policy.go
@@ -68,7 +68,7 @@ func K8sNP2CP(np *v1beta1.NetworkPolicy) (string, *policy.Node, error) {
 	coverageLbls := labels.Map2Labels(np.Spec.PodSelector.MatchLabels, common.K8sLabelSource)
 	pn := policy.NewNode(policyName, nil)
 	pn.Rules = []policy.PolicyRule{
-		&policy.PolicyRuleConsumers{
+		&policy.RuleConsumers{
 			Coverage: coverageLbls.ToSlice(),
 			Allow:    allowRules,
 		},

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -471,10 +471,9 @@ func NewDaemon(c *Config) (*Daemon, error) {
 		events:            make(chan events.Event, 512),
 		loadBalancer:      lb,
 		consumableCache:   policy.NewConsumableCache(),
-		policy:            policy.Tree{Root: policy.NewNode(common.GlobalLabelPrefix, nil)},
+		policy:            policy.Tree{},
 		ignoredContainers: make(map[string]int),
 	}
-	d.policy.Root.Path()
 
 	d.listenForCiliumEvents()
 

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -54,6 +54,7 @@ var (
 	enableLogstash     bool
 	etcdAddr           []string
 	k8sLabels          []string
+	validLabels        []string
 	labelPrefixFile    string
 	logstashAddr       string
 	logstashProbeTimer uint32
@@ -106,6 +107,8 @@ func init() {
 	flags.BoolVar(&config.KeepConfig, "keep-config", false,
 		"When restoring state, keeps containers' configuration in place")
 	flags.StringVar(&labelPrefixFile, "label-prefix-file", "", "File with valid label prefixes")
+	flags.StringSliceVar(&validLabels, "labels", []string{},
+		"List of label prefixes used to determine identity of an endpoint")
 	flags.StringVar(&config.LibDir, "libdir", defaults.LibDir, "Path to directory with program templates")
 	flags.BoolVar(&enableLogstash, "logstash", false, "Enable logstash integration")
 	flags.StringVar(&logstashAddr, "logstash-agent", "127.0.0.1:8080", "Logstash agent address")
@@ -201,6 +204,11 @@ func initEnv() {
 			)
 		}
 	}
+
+	for _, label := range validLabels {
+		config.ValidLabelPrefixes.Append(labels.ParseLabelPrefix(label))
+	}
+
 	config.ValidLabelPrefixesMU.Unlock()
 
 	_, r, err := net.ParseCIDR(nat46prefix)

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -102,7 +102,7 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 	rootNode := policy.Node{
 		Name: common.GlobalLabelPrefix,
 		Rules: []policy.PolicyRule{
-			&policy.PolicyRuleConsumers{
+			&policy.RuleConsumers{
 				Coverage: []labels.Label{*lblBar},
 				Allow: []policy.AllowRule{
 					// always-allow: user=joe
@@ -111,11 +111,11 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 					{Action: policy.ACCEPT, Label: *lblPete},
 				},
 			},
-			&policy.PolicyRuleRequires{ // coverage qa, requires qa
+			&policy.RuleRequires{ // coverage qa, requires qa
 				Coverage: []labels.Label{*lblQA},
 				Requires: []labels.Label{*lblQA},
 			},
-			&policy.PolicyRuleRequires{ // coverage prod, requires: prod
+			&policy.RuleRequires{ // coverage prod, requires: prod
 				Coverage: []labels.Label{*lblProd},
 				Requires: []labels.Label{*lblProd},
 			},
@@ -124,7 +124,7 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 			"foo": {},
 			"bar": {
 				Rules: []policy.PolicyRule{
-					&policy.PolicyRuleConsumers{
+					&policy.RuleConsumers{
 						Allow: []policy.AllowRule{
 							{ // allow: foo
 								Action: policy.ACCEPT,

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -54,7 +54,7 @@ ip -6 route add default via beef::1
 The following tests connectivity from a container to the outside world:
 
 ```
-$ sudo docker run --rm -ti --net cilium -l io.cilium noironetworks/nettools ping6 www.google.com
+$ sudo docker run --rm -ti --net cilium -l client noironetworks/nettools ping6 www.google.com
 PING www.google.com(zrh04s07-in-x04.1e100.net) 56 data bytes
 64 bytes from zrh04s07-in-x04.1e100.net: icmp_seq=1 ttl=56 time=7.84 ms
 64 bytes from zrh04s07-in-x04.1e100.net: icmp_seq=2 ttl=56 time=8.63 ms

--- a/examples/demo/demo1.sh
+++ b/examples/demo/demo1.sh
@@ -3,7 +3,7 @@
 . $(dirname ${BASH_SOURCE})/../../contrib/shell/util.sh
 
 NETWORK="cilium"
-CLIENT_LABEL="io.cilium.client"
+CLIENT_LABEL="client"
 
 function cleanup {
 	docker rm -f demo1 2> /dev/null || true

--- a/examples/demo/demo2.sh
+++ b/examples/demo/demo2.sh
@@ -3,8 +3,8 @@
 . $(dirname ${BASH_SOURCE})/../../contrib/shell/util.sh
 
 NETWORK="cilium"
-CLIENT_LABEL="io.cilium.client"
-SERVER_LABEL="io.cilium.server"
+CLIENT_LABEL="client"
+SERVER_LABEL="server"
 
 function cleanup {
 	docker rm -f server client 2> /dev/null || true
@@ -22,7 +22,7 @@ desc "This step is only required once, all containers can be attached to the sam
 desc "thus creating a single flat network. Isolation can then be defined based on labels."
 run "docker network create --ipv6 --subnet ::1/112 --driver cilium --ipam-driver cilium $NETWORK"
 
-cilium policy delete io.cilium
+cilium policy delete .
 
 desc "Start a container with label $SERVER_LABEL"
 run "docker run -d --net cilium --name server -l $SERVER_LABEL noironetworks/netperf"

--- a/examples/demo/demo3.sh
+++ b/examples/demo/demo3.sh
@@ -3,8 +3,8 @@
 . $(dirname ${BASH_SOURCE})/../../contrib/shell/util.sh
 
 NETWORK="cilium"
-CLIENT_LABEL="io.cilium.client"
-SERVER_LABEL="io.cilium.server"
+CLIENT_LABEL="client"
+SERVER_LABEL="server"
 
 function cleanup {
 	tmux kill-session -t my-session >/dev/null 2>&1
@@ -15,7 +15,7 @@ trap cleanup EXIT
 
 docker network rm $NETWORK > /dev/null 2>&1
 docker network create --ipv6 --subnet ::1/112 --driver cilium --ipam-driver cilium $NETWORK > /dev/null
-cilium policy delete io.cilium
+cilium policy delete .
 
 desc "How to debug a connectivity issue?"
 desc "Start client and server containers"

--- a/examples/demo/demo5.sh
+++ b/examples/demo/demo5.sh
@@ -14,14 +14,14 @@ function cleanup {
     sudo killall -9 kube-proxy 2> /dev/null || true
     sudo killall -9 kube-apiserver 2> /dev/null || true
     docker rm -f `docker ps -aq --filter=name=k8s` 2> /dev/null || true
-    cilium policy delete io.cilium
+    cilium policy delete .
 }
 
 trap cleanup EXIT
 
 docker network rm $NETWORK > /dev/null 2>&1
 docker network create --ipv6 --subnet ::1/112 --driver cilium --ipam-driver cilium $NETWORK > /dev/null
-cilium policy delete io.cilium
+cilium policy delete .
 #Clean old kubernetes certificates
 sudo rm -fr /run/kubernetes
 

--- a/examples/policy/default/default.policy
+++ b/examples/policy/default/default.policy
@@ -1,5 +1,5 @@
 {
-        "name": "io.cilium",
+	"name": "root",
 	"rules": [{
 		"coverage": ["public"],
 		"allow": ["$world"]
@@ -8,21 +8,15 @@
 		"allow": ["$all"]
 	},{
 		"coverage": ["$world"],
-		"allow": ["client"]
+		"allow": ["id.client"]
 	},{
 		"coverage": ["$host"],
 		"allow": ["$all"]
 	},{
 		"coverage": ["$all"],
 		"allow": ["$host"]
-	}],
-        "children": {
-		"client": { },
-		"server": {
-			"rules": [{
-				"allow": ["../client"]
-			}]
-		}
-
-	}
+	},{
+		"coverage": ["id.server"],
+		"allow": ["id.client"]
+	}]
 }

--- a/examples/valid-labels.lpc
+++ b/examples/valid-labels.lpc
@@ -3,11 +3,11 @@
     "valid-prefixes": [
         {
             "prefix": "io.cilium",
-            "source": "cilium"
+            "source": ""
         },
         {
-            "prefix": "io.cilium",
-            "source": "k8s"
+            "prefix": "id.",
+            "source": ""
         }
     ]
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -136,7 +136,7 @@ func (e *Endpoint) regenerateConsumable(owner Owner) (bool, error) {
 		if err := e.evaluateConsumerSource(owner, &ctx, id.ID); err != nil {
 			// This should never really happen
 			// FIXME: clear policy because it is inconsistent
-			break
+			log.Debugf("Received error while evaluating policy: %s", err)
 		}
 	}
 
@@ -146,7 +146,7 @@ func (e *Endpoint) regenerateConsumable(owner Owner) (bool, error) {
 	for idx < maxID {
 		if err := e.evaluateConsumerSource(owner, &ctx, idx); err != nil {
 			// FIXME: clear policy because it is inconsistent
-			break
+			log.Debugf("Received error while evaluating policy: %s", err)
 		}
 		idx++
 	}

--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -69,16 +69,10 @@ func DefaultLabelPrefixCfg() *LabelPrefixCfg {
 		Version: LPCfgFileVersion,
 		LabelPrefixes: []*LabelPrefix{
 			{
-				Prefix: common.GlobalLabelPrefix,
-				Source: common.ReservedLabelSource,
+				Prefix: "id.",
 			},
 			{
-				Prefix: common.GlobalLabelPrefix,
-				Source: common.CiliumLabelSource,
-			},
-			{
-				Prefix: common.GlobalLabelPrefix,
-				Source: common.K8sLabelSource,
+				Prefix: "io.cilium.",
 			},
 			{
 				Prefix: common.K8sPodNamespaceLabel,

--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -60,10 +60,7 @@ func (cfg *LabelPrefixCfg) Append(l *LabelPrefix) {
 }
 
 // DefaultLabelPrefixCfg returns a default LabelPrefixCfg using the latest
-// LPCfgFileVersion and the following label prefixes: Key: common.GlobalLabelPrefix,
-// Source: common.CiliumLabelSource, Key: common.GlobalLabelPrefix, Source:
-// common.CiliumLabelSource, Key: common.GlobalLabelPrefix, Source: common.K8sLabelSource
-// and Key: common.K8sPodNamespaceLabel, Source: common.K8sLabelSource.
+// LPCfgFileVersion
 func DefaultLabelPrefixCfg() *LabelPrefixCfg {
 	return &LabelPrefixCfg{
 		Version: LPCfgFileVersion,

--- a/pkg/labels/filter_test.go
+++ b/pkg/labels/filter_test.go
@@ -27,8 +27,8 @@ var _ = Suite(&LabelsPrefCfgSuite{})
 
 func (s *LabelsPrefCfgSuite) TestFilterLabels(c *C) {
 	wanted := Labels{
-		"io.cilium.lizards":     NewLabel("io.cilium.lizards", "web", common.CiliumLabelSource),
-		"io.cilium.lizards.k8s": NewLabel("io.cilium.lizards.k8s", "web", common.K8sLabelSource),
+		"id.lizards":     NewLabel("id.lizards", "web", common.CiliumLabelSource),
+		"id.lizards.k8s": NewLabel("id.lizards.k8s", "web", common.K8sLabelSource),
 	}
 
 	dlpcfg := DefaultLabelPrefixCfg()
@@ -45,13 +45,13 @@ func (s *LabelsPrefCfgSuite) TestFilterLabels(c *C) {
 	allLabels := Map2Labels(allNormalLabels, common.CiliumLabelSource)
 	filtered := dlpcfg.FilterLabels(allLabels)
 	c.Assert(len(filtered), Equals, 0)
-	allLabels["io.cilium.lizards"] = NewLabel("io.cilium.lizards", "web", common.CiliumLabelSource)
-	allLabels["io.cilium.lizards.k8s"] = NewLabel("io.cilium.lizards.k8s", "web", common.K8sLabelSource)
+	allLabels["id.lizards"] = NewLabel("id.lizards", "web", common.CiliumLabelSource)
+	allLabels["id.lizards.k8s"] = NewLabel("id.lizards.k8s", "web", common.K8sLabelSource)
 	filtered = dlpcfg.FilterLabels(allLabels)
 	c.Assert(len(filtered), Equals, 2)
 	c.Assert(filtered, DeepEquals, wanted)
 
 	// Making sure we are deep copying the labels
-	allLabels["io.cilium.lizards"].Source = "I can change this and doesn't affect any one"
+	allLabels["id.lizards"].Source = "I can change this and doesn't affect any one"
 	c.Assert(filtered, DeepEquals, wanted)
 }

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -95,8 +95,8 @@ func (s *LabelsSuite) TestSliceToMap(c *C) {
 	}
 
 	lbls := LabelSlice2LabelsMap([]Label{
-		{"key1", "value3", "source4", "", false},
-		{"key2", "value5", "source7", "", false},
+		{"key1", "value3", "source4", "", false, nil},
+		{"key2", "value5", "source7", "", false, nil},
 	})
 	c.Assert(len(lbls), Equals, 2)
 	c.Assert(lbls, DeepEquals, want)
@@ -157,4 +157,19 @@ func (s *LabelsSuite) TestLabel(c *C) {
 	label = Label{}
 	err = json.Unmarshal([]byte(""), &label)
 	c.Assert(err, Not(Equals), nil)
+}
+
+func (s *LabelsSuite) TestLabelCompare(c *C) {
+	a1 := NewLabel(".", "", "")
+	a2 := NewLabel(".", "", "")
+	b1 := NewLabel("bar", "", common.CiliumLabelSource)
+	c1 := NewLabel("bar", "", "kubernetes")
+	d1 := NewLabel("", "", "")
+
+	c.Assert(a1.Equals(a2), Equals, true)
+	c.Assert(a2.Equals(a1), Equals, true)
+	c.Assert(a1.Equals(b1), Equals, false)
+	c.Assert(a1.Equals(c1), Equals, false)
+	c.Assert(a1.Equals(d1), Equals, false)
+	c.Assert(b1.Equals(c1), Equals, false)
 }

--- a/pkg/policy/defaults.go
+++ b/pkg/policy/defaults.go
@@ -14,18 +14,8 @@
 
 package policy
 
-import (
-	"path/filepath"
+const (
+	RootNodeName      = "root"
+	NodePathDelimiter = "."
+	RootPrefix        = RootNodeName + NodePathDelimiter
 )
-
-func SplitNodePath(fullPath string) (string, string) {
-	var extension = filepath.Ext(fullPath)
-	if len(extension) > 0 {
-		return fullPath[0 : len(fullPath)-len(extension)], extension[1:]
-	}
-	return fullPath[0 : len(fullPath)-len(extension)], extension
-}
-
-func JoinPath(a, b string) string {
-	return a + NodePathDelimiter + b
-}

--- a/pkg/policy/node.go
+++ b/pkg/policy/node.go
@@ -78,12 +78,12 @@ func (p *Node) Allows(ctx *SearchContext) ConsumableDecision {
 		sub_decision := UNDECIDED
 
 		switch rule.(type) {
-		case *PolicyRuleConsumers:
-			r := rule.(*PolicyRuleConsumers)
+		case *RuleConsumers:
+			r := rule.(*RuleConsumers)
 			sub_decision = r.Allows(ctx)
 
-		case *PolicyRuleRequires:
-			r := rule.(*PolicyRuleRequires)
+		case *RuleRequires:
+			r := rule.(*RuleRequires)
 			sub_decision = r.Allows(ctx)
 		}
 
@@ -222,7 +222,7 @@ func (pn *Node) UnmarshalJSON(data []byte) error {
 		}
 
 		if _, ok := om[privEnc[ALLOW]]; ok {
-			var pr_c PolicyRuleConsumers
+			var pr_c RuleConsumers
 
 			if err := json.Unmarshal(*rawMsg, &pr_c); err != nil {
 				return err
@@ -234,7 +234,7 @@ func (pn *Node) UnmarshalJSON(data []byte) error {
 				pn.Rules = append(pn.Rules, &pr_c)
 			}
 		} else if _, ok := om[privEnc[ALWAYS_ALLOW]]; ok {
-			var pr_c PolicyRuleConsumers
+			var pr_c RuleConsumers
 
 			if err := json.Unmarshal(*rawMsg, &pr_c); err != nil {
 				return err
@@ -253,7 +253,7 @@ func (pn *Node) UnmarshalJSON(data []byte) error {
 				pn.Rules = append(pn.Rules, &pr_c)
 			}
 		} else if _, ok := om[privEnc[REQUIRES]]; ok {
-			var pr_r PolicyRuleRequires
+			var pr_r RuleRequires
 
 			if err := json.Unmarshal(*rawMsg, &pr_r); err != nil {
 				return err

--- a/pkg/policy/node_test.go
+++ b/pkg/policy/node_test.go
@@ -1,0 +1,71 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+func (ds *PolicyTestSuite) TestNormalizeNames(c *C) {
+	n := Node{}
+	path, err := n.NormalizeNames(RootNodeName)
+	c.Assert(err, IsNil)
+	c.Assert(path, Equals, RootNodeName)
+	c.Assert(n.Name, Equals, RootNodeName)
+
+	n = Node{Name: "foo"}
+	path, err = n.NormalizeNames(RootNodeName)
+	c.Assert(err, IsNil)
+	c.Assert(path, Equals, RootNodeName)
+	c.Assert(n.Name, Equals, "foo")
+
+	n = Node{}
+	path, err = n.NormalizeNames("root.foo.bar")
+	c.Assert(err, IsNil)
+	c.Assert(path, Equals, "root.foo")
+	c.Assert(n.Name, Equals, "bar")
+
+	// absolute name foo.bar does not match path .bar.foo
+	n = Node{Name: "foo.bar"}
+	path, err = n.NormalizeNames("root.bar.foo")
+	c.Assert(err, Not(IsNil))
+	c.Assert(path, Equals, "")
+
+	// absolute name root.foo.bar matches path .bar.foo
+	n = Node{Name: "root.foo.bar"}
+	path, err = n.NormalizeNames("root.foo")
+	c.Assert(err, IsNil)
+	c.Assert(path, Equals, "root.foo")
+	c.Assert(n.Name, Equals, "bar")
+
+	// absolute name foo.bar2 does not match path baz
+	n = Node{
+		Children: map[string]*Node{
+			"bar": {Name: "foo.bar2"},
+		},
+	}
+	path, err = n.NormalizeNames("baz")
+	c.Assert(err, Not(IsNil))
+	c.Assert(path, Equals, "")
+
+	n = Node{
+		Children: map[string]*Node{
+			"bar": {Name: "bar2"},
+		},
+	}
+	path, err = n.NormalizeNames(".")
+	c.Assert(err, Not(IsNil))
+	c.Assert(path, Equals, "")
+}

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -213,7 +213,7 @@ func (s *PolicyTestSuite) TestAllowConsumer(c *C) {
 	alwaysAllowFoo := AllowRule{Action: ALWAYS_ACCEPT, Label: *lblFoo}
 
 	// Allow: foo, !foo
-	consumers := PolicyRuleConsumers{
+	consumers := RuleConsumers{
 		Coverage: []labels.Label{*lblBar},
 		Allow:    []AllowRule{allowFoo, dontAllowFoo},
 	}
@@ -227,7 +227,7 @@ func (s *PolicyTestSuite) TestAllowConsumer(c *C) {
 	c.Assert(consumers.Allows(&bBazToBar), Equals, UNDECIDED)
 
 	// Always-Allow: foo, !foo
-	consumers = PolicyRuleConsumers{
+	consumers = RuleConsumers{
 		Coverage: []labels.Label{*lblBar},
 		Allow:    []AllowRule{alwaysAllowFoo, dontAllowFoo},
 	}
@@ -238,7 +238,7 @@ func (s *PolicyTestSuite) TestAllowConsumer(c *C) {
 	c.Assert(consumers.Allows(&bBazToBar), Equals, UNDECIDED)
 
 	// Allow: TeamA, !baz
-	consumers = PolicyRuleConsumers{
+	consumers = RuleConsumers{
 		Coverage: []labels.Label{*lblBar},
 		Allow:    []AllowRule{allowTeamA, dontAllowBaz},
 	}
@@ -249,7 +249,7 @@ func (s *PolicyTestSuite) TestAllowConsumer(c *C) {
 	c.Assert(consumers.Allows(&bBazToBar), Equals, DENY)
 
 	// Allow: TeamA, !baz
-	consumers = PolicyRuleConsumers{
+	consumers = RuleConsumers{
 		Coverage: []labels.Label{*lblFoo},
 		Allow:    []AllowRule{allowTeamA, dontAllowBaz},
 	}
@@ -293,18 +293,18 @@ func (s *PolicyTestSuite) TestValidateCoverage(c *C) {
 	}
 
 	lblBar := labels.NewLabel("io.cilium.bar", "", common.CiliumLabelSource)
-	consumer := PolicyRuleConsumers{Coverage: []labels.Label{*lblBar}}
+	consumer := RuleConsumers{Coverage: []labels.Label{*lblBar}}
 	c.Assert(consumer.Resolve(&node), Not(Equals), nil)
 
-	consumer2 := PolicyRuleRequires{Coverage: []labels.Label{*lblBar}}
+	consumer2 := RuleRequires{Coverage: []labels.Label{*lblBar}}
 	c.Assert(consumer2.Resolve(&node), Not(Equals), nil)
 
 	lblFoo := labels.NewLabel("io.cilium.foo", "", common.CiliumLabelSource)
-	consumer = PolicyRuleConsumers{Coverage: []labels.Label{*lblFoo}}
+	consumer = RuleConsumers{Coverage: []labels.Label{*lblFoo}}
 	c.Assert(consumer.Resolve(&node), Equals, nil)
 
 	lblFoo = labels.NewLabel("foo", "", common.CiliumLabelSource)
-	consumer = PolicyRuleConsumers{Coverage: []labels.Label{*lblFoo}}
+	consumer = RuleConsumers{Coverage: []labels.Label{*lblFoo}}
 	c.Assert(consumer.Resolve(&node), Equals, nil)
 }
 
@@ -333,7 +333,7 @@ func (s *PolicyTestSuite) TestRequires(c *C) {
 
 	// coverage: bar
 	// Require: foo
-	requires := PolicyRuleRequires{
+	requires := RuleRequires{
 		Coverage: []labels.Label{*lblBar},
 		Requires: []labels.Label{*lblFoo},
 	}
@@ -391,7 +391,7 @@ func (s *PolicyTestSuite) TestNodeAllows(c *C) {
 	rootNode := Node{
 		Name: common.GlobalLabelPrefix,
 		Rules: []PolicyRule{
-			&PolicyRuleConsumers{
+			&RuleConsumers{
 				Coverage: []labels.Label{*lblBar},
 				Allow: []AllowRule{
 					{ // always-allow:  user=joe
@@ -404,15 +404,15 @@ func (s *PolicyTestSuite) TestNodeAllows(c *C) {
 					},
 				},
 			},
-			&PolicyRuleRequires{ // coverage qa, requires qa
+			&RuleRequires{ // coverage qa, requires qa
 				Coverage: []labels.Label{*lblQA},
 				Requires: []labels.Label{*lblQA},
 			},
-			&PolicyRuleRequires{ // coverage prod, requires: prod
+			&RuleRequires{ // coverage prod, requires: prod
 				Coverage: []labels.Label{*lblProd},
 				Requires: []labels.Label{*lblProd},
 			},
-			&PolicyRuleConsumers{
+			&RuleConsumers{
 				Coverage: []labels.Label{*lblBar},
 				Allow: []AllowRule{
 					{ // allow: foo
@@ -438,7 +438,7 @@ func (s *PolicyTestSuite) TestResolveTree(c *C) {
 	rootNode := Node{
 		Name: common.GlobalLabelPrefix,
 		Children: map[string]*Node{
-			"foo": {Rules: []PolicyRule{&PolicyRuleConsumers{}}},
+			"foo": {Rules: []PolicyRule{&RuleConsumers{}}},
 		},
 	}
 
@@ -494,7 +494,7 @@ func (s *PolicyTestSuite) TestpolicyAllows(c *C) {
 	rootNode := Node{
 		Name: common.GlobalLabelPrefix,
 		Rules: []PolicyRule{
-			&PolicyRuleConsumers{
+			&RuleConsumers{
 				Coverage: []labels.Label{*lblBar},
 				Allow: []AllowRule{
 					// always-allow: user=joe
@@ -503,11 +503,11 @@ func (s *PolicyTestSuite) TestpolicyAllows(c *C) {
 					{Action: ACCEPT, Label: *lblPete},
 				},
 			},
-			&PolicyRuleRequires{ // coverage qa, requires qa
+			&RuleRequires{ // coverage qa, requires qa
 				Coverage: []labels.Label{*lblQA},
 				Requires: []labels.Label{*lblQA},
 			},
-			&PolicyRuleRequires{ // coverage prod, requires: prod
+			&RuleRequires{ // coverage prod, requires: prod
 				Coverage: []labels.Label{*lblProd},
 				Requires: []labels.Label{*lblProd},
 			},
@@ -516,7 +516,7 @@ func (s *PolicyTestSuite) TestpolicyAllows(c *C) {
 			"foo": {},
 			"bar": {
 				Rules: []PolicyRule{
-					&PolicyRuleConsumers{
+					&RuleConsumers{
 						Allow: []AllowRule{
 							{ // allow: foo
 								Action: ACCEPT,
@@ -571,7 +571,7 @@ func (s *PolicyTestSuite) TestNodeMerge(c *C) {
 	aNode = Node{
 		Name: common.GlobalLabelPrefix,
 		Rules: []PolicyRule{
-			&PolicyRuleRequires{ // coverage qa, requires qa
+			&RuleRequires{ // coverage qa, requires qa
 				Coverage: []labels.Label{*lblQA},
 				Requires: []labels.Label{*lblQA},
 			},
@@ -581,7 +581,7 @@ func (s *PolicyTestSuite) TestNodeMerge(c *C) {
 				Name: "bar",
 				path: common.GlobalLabelPrefix + ".bar",
 				Rules: []PolicyRule{
-					&PolicyRuleConsumers{
+					&RuleConsumers{
 						Allow: []AllowRule{
 							{Action: ACCEPT, Label: *lblJoe},
 							{Action: ACCEPT, Label: *lblPete},
@@ -595,7 +595,7 @@ func (s *PolicyTestSuite) TestNodeMerge(c *C) {
 	bNode = Node{
 		Name: common.GlobalLabelPrefix,
 		Rules: []PolicyRule{
-			&PolicyRuleRequires{ // coverage prod, requires: prod
+			&RuleRequires{ // coverage prod, requires: prod
 				Coverage: []labels.Label{*lblProd},
 				Requires: []labels.Label{*lblProd},
 			},
@@ -609,7 +609,7 @@ func (s *PolicyTestSuite) TestNodeMerge(c *C) {
 				Name: "bar",
 				path: common.GlobalLabelPrefix + ".bar",
 				Rules: []PolicyRule{
-					&PolicyRuleConsumers{
+					&RuleConsumers{
 						Allow: []AllowRule{
 							{ // allow: foo
 								Action: ACCEPT,
@@ -632,7 +632,7 @@ func (s *PolicyTestSuite) TestNodeMerge(c *C) {
 	unmergeableNode := Node{
 		Name: common.GlobalLabelPrefix,
 		Rules: []PolicyRule{
-			&PolicyRuleConsumers{
+			&RuleConsumers{
 				Allow: []AllowRule{
 					{ // deny: foo
 						Action: DENY,
@@ -682,6 +682,6 @@ func (s *PolicyTestSuite) TestRuleMergeable(c *C) {
 	always_allow := AllowRule{Action: ALWAYS_ACCEPT}
 	c.Assert(always_allow.IsMergeable(), Equals, true)
 
-	req := PolicyRuleRequires{}
+	req := RuleRequires{}
 	c.Assert(req.IsMergeable(), Equals, true)
 }

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -18,4 +18,9 @@ type PolicyRule interface {
 	Resolve(node *Node) error
 	SHA256Sum() (string, error)
 	CoverageSHA256Sum() (string, error)
+
+	// Must return true if a rule allows merging with other rules within a node.
+	// Certain rules are not additive and require strict ordering, such rules
+	// may never be merged in a node as merging may occur in undefined order.
+	IsMergeable() bool
 }

--- a/pkg/policy/rule_consumers.go
+++ b/pkg/policy/rule_consumers.go
@@ -111,12 +111,12 @@ func (a *AllowRule) Allows(ctx *SearchContext) ConsumableDecision {
 }
 
 // Allow the following consumers
-type PolicyRuleConsumers struct {
+type RuleConsumers struct {
 	Coverage []labels.Label `json:"coverage,omitempty"`
 	Allow    []AllowRule    `json:"allow"`
 }
 
-func (prc *PolicyRuleConsumers) IsMergeable() bool {
+func (prc *RuleConsumers) IsMergeable() bool {
 	for _, r := range prc.Allow {
 		if !r.IsMergeable() {
 			return false
@@ -126,11 +126,11 @@ func (prc *PolicyRuleConsumers) IsMergeable() bool {
 	return true
 }
 
-func (prc *PolicyRuleConsumers) String() string {
+func (prc *RuleConsumers) String() string {
 	return fmt.Sprintf("Coverage: %s Allowing: %s", prc.Coverage, prc.Allow)
 }
 
-func (c *PolicyRuleConsumers) Allows(ctx *SearchContext) ConsumableDecision {
+func (c *RuleConsumers) Allows(ctx *SearchContext) ConsumableDecision {
 	// A decision is undecided until we encoutner a DENY or ACCEPT.
 	// An ACCEPT can still be overwritten by a DENY inside the same rule.
 	decision := UNDECIDED
@@ -158,7 +158,7 @@ func (c *PolicyRuleConsumers) Allows(ctx *SearchContext) ConsumableDecision {
 	return decision
 }
 
-func (c *PolicyRuleConsumers) Resolve(node *Node) error {
+func (c *RuleConsumers) Resolve(node *Node) error {
 	log.Debugf("Resolving consumer rule %+v\n", c)
 	for k := range c.Coverage {
 		l := &c.Coverage[k]
@@ -179,7 +179,7 @@ func (c *PolicyRuleConsumers) Resolve(node *Node) error {
 	return nil
 }
 
-func (c *PolicyRuleConsumers) SHA256Sum() (string, error) {
+func (c *RuleConsumers) SHA256Sum() (string, error) {
 	sha := sha512.New512_256()
 	if err := json.NewEncoder(sha).Encode(c); err != nil {
 		return "", err
@@ -187,6 +187,6 @@ func (c *PolicyRuleConsumers) SHA256Sum() (string, error) {
 	return fmt.Sprintf("%x", sha.Sum(nil)), nil
 }
 
-func (c *PolicyRuleConsumers) CoverageSHA256Sum() (string, error) {
+func (c *RuleConsumers) CoverageSHA256Sum() (string, error) {
 	return labels.LabelSliceSHA256Sum(c.Coverage)
 }

--- a/pkg/policy/rule_l4.go
+++ b/pkg/policy/rule_l4.go
@@ -112,6 +112,10 @@ type RuleL4 struct {
 	Allow    []AllowL4      `json:"l4"`
 }
 
+func (l4 *RuleL4) IsMergeable() bool {
+	return true
+}
+
 func (l4 *RuleL4) GetL4Policy(ctx *SearchContext, result *L4Policy) *L4Policy {
 	if len(l4.Coverage) > 0 && !ctx.TargetCoveredBy(l4.Coverage) {
 		policyTrace(ctx, "L4 Rule %v has no coverage\n", l4)

--- a/pkg/policy/rule_l4_test.go
+++ b/pkg/policy/rule_l4_test.go
@@ -22,9 +22,9 @@ import (
 )
 
 func (s *PolicyTestSuite) TestGetL4Policy(c *C) {
-	lblFoo := labels.NewLabel("io.cilium.foo", "", common.CiliumLabelSource)
-	lblBar := labels.NewLabel("io.cilium.bar", "", common.CiliumLabelSource)
-	lblBaz := labels.NewLabel("io.cilium.baz", "", common.CiliumLabelSource)
+	lblFoo := labels.NewLabel("root.foo", "", common.CiliumLabelSource)
+	lblBar := labels.NewLabel("root.bar", "", common.CiliumLabelSource)
+	lblBaz := labels.NewLabel("root.baz", "", common.CiliumLabelSource)
 
 	// -> [Foo]
 	toFoo := SearchContext{To: []labels.Label{*lblFoo}}
@@ -69,7 +69,7 @@ func (s *PolicyTestSuite) TestGetL4Policy(c *C) {
 	}
 
 	rootNode := Node{
-		Name:  common.GlobalLabelPrefix,
+		Name:  RootNodeName,
 		Rules: []PolicyRule{&rule1},
 		Children: map[string]*Node{
 			"foo": {},

--- a/pkg/policy/rule_requires.go
+++ b/pkg/policy/rule_requires.go
@@ -25,16 +25,16 @@ import (
 
 // Any further consumer requires the specified list of
 // labels in order to consume
-type PolicyRuleRequires struct {
+type RuleRequires struct {
 	Coverage []labels.Label `json:"coverage,omitempty"`
 	Requires []labels.Label `json:"requires"`
 }
 
-func (prr *PolicyRuleRequires) IsMergeable() bool {
+func (prr *RuleRequires) IsMergeable() bool {
 	return true
 }
 
-func (prr *PolicyRuleRequires) String() string {
+func (prr *RuleRequires) String() string {
 	return fmt.Sprintf("Coverage: %s, Requires: %s", prr.Coverage, prr.Requires)
 }
 
@@ -43,7 +43,7 @@ func (prr *PolicyRuleRequires) String() string {
 // access can be denied but fullfillment of the requirement only leads to
 // the decision being UNDECIDED waiting on an explicit allow rule further
 // down the tree
-func (r *PolicyRuleRequires) Allows(ctx *SearchContext) ConsumableDecision {
+func (r *RuleRequires) Allows(ctx *SearchContext) ConsumableDecision {
 	if len(r.Coverage) > 0 && ctx.TargetCoveredBy(r.Coverage) {
 		policyTrace(ctx, "Found coverage rule: %s\n", r.String())
 		for k := range r.Requires {
@@ -71,7 +71,7 @@ func (r *PolicyRuleRequires) Allows(ctx *SearchContext) ConsumableDecision {
 	return UNDECIDED
 }
 
-func (c *PolicyRuleRequires) Resolve(node *Node) error {
+func (c *RuleRequires) Resolve(node *Node) error {
 	log.Debugf("Resolving requires rule %+v\n", c)
 	for k := range c.Coverage {
 		l := &c.Coverage[k]
@@ -91,7 +91,7 @@ func (c *PolicyRuleRequires) Resolve(node *Node) error {
 	return nil
 }
 
-func (c *PolicyRuleRequires) SHA256Sum() (string, error) {
+func (c *RuleRequires) SHA256Sum() (string, error) {
 	sha := sha512.New512_256()
 	if err := json.NewEncoder(sha).Encode(c); err != nil {
 		return "", err
@@ -99,7 +99,7 @@ func (c *PolicyRuleRequires) SHA256Sum() (string, error) {
 	return fmt.Sprintf("%x", sha.Sum(nil)), nil
 }
 
-func (c *PolicyRuleRequires) CoverageSHA256Sum() (string, error) {
+func (c *RuleRequires) CoverageSHA256Sum() (string, error) {
 	sha := sha512.New512_256()
 	if err := json.NewEncoder(sha).Encode(c.Coverage); err != nil {
 		return "", err

--- a/pkg/policy/rule_requires.go
+++ b/pkg/policy/rule_requires.go
@@ -30,6 +30,10 @@ type PolicyRuleRequires struct {
 	Requires []labels.Label `json:"requires"`
 }
 
+func (prr *PolicyRuleRequires) IsMergeable() bool {
+	return true
+}
+
 func (prr *PolicyRuleRequires) String() string {
 	return fmt.Sprintf("Coverage: %s, Requires: %s", prr.Coverage, prr.Requires)
 }

--- a/pkg/policy/tree_test.go
+++ b/pkg/policy/tree_test.go
@@ -1,0 +1,109 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+func (ds *PolicyTestSuite) TestAddDelete(c *C) {
+	//var nullPtr *Node
+
+	tree := Tree{}
+
+	// Empty tree should return empty result
+	n, p := tree.Lookup("")
+	c.Assert(n, IsNil)
+	c.Assert(p, IsNil)
+
+	root := Node{}
+
+	// adding a root node should succeed
+	added, err := tree.Add(RootNodeName, &root)
+	c.Assert(added, Equals, true)
+	c.Assert(err, IsNil)
+
+	// lookup of root node should succeed now
+	n, p = tree.Lookup(RootNodeName)
+	c.Assert(n, Equals, &root)
+	c.Assert(n.Name, Equals, RootNodeName)
+	c.Assert(p, IsNil)
+
+	// lookup of empty path should return root node
+	n, p = tree.Lookup("")
+	c.Assert(n, Equals, &root)
+	c.Assert(n.Name, Equals, RootNodeName)
+	c.Assert(p, IsNil)
+
+	deleted := tree.Delete(RootNodeName, "")
+	c.Assert(deleted, Equals, true)
+
+	n, p = tree.Lookup(RootNodeName)
+	c.Assert(n, IsNil)
+	c.Assert(p, IsNil)
+
+	// Added a child if no root node exist must fail
+	added, err = tree.Add(RootNodeName, &Node{Name: "foo"})
+	c.Assert(added, Equals, false)
+	c.Assert(err, Not(IsNil))
+
+	// The node should not exist afterwards
+	n, p = tree.Lookup("root.foo")
+	c.Assert(n, IsNil)
+	c.Assert(p, IsNil)
+
+	// No root node should have been added
+	n, p = tree.Lookup(RootNodeName)
+	c.Assert(n, IsNil)
+	c.Assert(p, IsNil)
+
+	fooNode := Node{}
+	root = Node{
+		Children: map[string]*Node{
+			"foo": &fooNode,
+			"bar": {},
+		},
+	}
+
+	// Add root ndoe with children, should succeed
+	added, err = tree.Add(RootNodeName, &root)
+	c.Assert(added, Equals, true)
+	c.Assert(err, IsNil)
+
+	// lookup of root node should succeed now
+	n, p = tree.Lookup(RootNodeName)
+	c.Assert(n, Equals, &root)
+	c.Assert(n.Name, Equals, RootNodeName)
+	c.Assert(p, IsNil)
+
+	// lookup of child foo should succeed
+	n, p = tree.Lookup("root.foo")
+	c.Assert(n, Equals, &fooNode)
+	c.Assert(p, Equals, &root)
+
+	// delete root node
+	deleted = tree.Delete("root", "")
+	c.Assert(deleted, Equals, true)
+
+	// lookup of root node should fail now
+	n, p = tree.Lookup(RootNodeName)
+	c.Assert(n, IsNil)
+	c.Assert(p, IsNil)
+
+	// lookup of child foo should fail now
+	n, p = tree.Lookup("root.foo")
+	c.Assert(n, IsNil)
+	c.Assert(p, IsNil)
+}

--- a/tests/02-perf.sh
+++ b/tests/02-perf.sh
@@ -21,8 +21,8 @@ function cleanup {
 
 trap cleanup EXIT
 
-SERVER_LABEL="io.cilium.server"
-CLIENT_LABEL="io.cilium.client"
+SERVER_LABEL="id.server"
+CLIENT_LABEL="id.client"
 
 docker network inspect $TEST_NET || {
 	docker network create --ipv6 --subnet ::1/112 --ipam-driver cilium --driver cilium $TEST_NET
@@ -49,16 +49,11 @@ set -x
 
 cat <<EOF | cilium -D policy import -
 {
-        "name": "io.cilium",
-        "children": {
-            "client": { },
-            "server": {
-                "rules": [{
-                    "allow": ["reserved:host", "../client"]
-                }]
-            }
-
-	    }
+        "name": "root",
+	"rules": [{
+		"coverage": ["${SERVER_LABEL}"],
+		"allow": ["reserved:host", "${CLIENT_LABEL}"]
+	}]
 }
 EOF
 
@@ -168,4 +163,4 @@ cilium endpoint config $SERVER_ID Policy=false
 cilium endpoint config $CLIENT_ID Policy=false
 perf_test
 
-cilium -D policy delete io.cilium
+cilium -D policy delete root

--- a/tests/03-docker.sh
+++ b/tests/03-docker.sh
@@ -14,8 +14,8 @@ function cleanup {
 
 trap cleanup EXIT
 
-SERVER_LABEL="io.cilium.test.server"
-CLIENT_LABEL="io.cilium.test.client"
+SERVER_LABEL="id.server"
+CLIENT_LABEL="id.client"
 
 sudo cilium -D policy import ./policy
 
@@ -61,4 +61,4 @@ ping6 -c 5 "$SERVER_IP" || {
 	abort "Error: Could not ping server container from host"
 }
 
-sudo cilium -D policy delete io.cilium
+sudo cilium -D policy delete root

--- a/tests/05-cni.sh
+++ b/tests/05-cni.sh
@@ -75,16 +75,11 @@ monitor_start
 
 cat <<EOF | cilium -D policy import -
 {
-        "name": "io.cilium",
-        "children": {
-		"client": { },
-		"server": {
-			"rules": [{
-				"allow": ["reserved:host", "../client"]
-			}]
-		}
-
-	}
+        "name": "root",
+	"rules": [{
+		"coverage": ["id.server"],
+		"allow": ["reserved:host", "id.client"]
+	}]
 }
 EOF
 
@@ -105,8 +100,8 @@ export CNI_PATH=`pwd`/bin
 cp "${dir}/../plugins/cilium-cni/cilium-cni" "${CNI_PATH}"
 cd scripts
 
-server_id=$(run_cni_container -d -l io.cilium.server --name cni-server noironetworks/netperf)
-client_id=$(run_cni_container -d -l io.cilium.client --name cni-client noironetworks/netperf)
+server_id=$(run_cni_container -d -l id.server --name cni-server noironetworks/netperf)
+client_id=$(run_cni_container -d -l id.client --name cni-client noironetworks/netperf)
 
 server_ip=$(extract_ip6 $server_id)
 server_ip4=$(extract_ip4 $server_id)

--- a/tests/07-ipam.sh
+++ b/tests/07-ipam.sh
@@ -5,7 +5,7 @@ source "./helpers.bash"
 set -e
 
 # Set debug mode on so that we can retrieve the list of IPs allocated
-cilium daemon config Debug=true
+cilium config Debug=true
 
 # Check the list of IPs allocated. The IPv4 IP used on the IPv4 range should be allocated.
 if [[ "$(cilium status | tail -n 3)" != \

--- a/tests/08-nat46.sh
+++ b/tests/08-nat46.sh
@@ -13,8 +13,8 @@ function cleanup {
 
 trap cleanup EXIT
 
-SERVER_LABEL="io.cilium.server"
-CLIENT_LABEL="io.cilium.client"
+SERVER_LABEL="id.server"
+CLIENT_LABEL="id.client"
 NETPERF_IMAGE="noironetworks/netperf"
 
 monitor_start
@@ -46,16 +46,11 @@ set -x
 
 cat <<EOF | cilium -D policy import -
 {
-        "name": "io.cilium",
-        "children": {
-                "client": { },
-                "server": {
-                        "rules": [{
-                                "allow": ["../client"]
-                        }]
-                }
-
-        }
+        "name": "root",
+	"rules": [{
+		"coverage": ["$SERVER_LABEL"],
+		"allow": ["$CLIENT_LABEL"]
+	}]
 }
 EOF
 
@@ -68,4 +63,4 @@ function connectivity_test64() {
 }
 
 connectivity_test64
-cilium -D policy delete io.cilium
+cilium -D policy delete root

--- a/tests/09-perf-gce.sh
+++ b/tests/09-perf-gce.sh
@@ -7,8 +7,8 @@ set -e
 TEST_NET="cilium"
 NETPERF_IMAGE="tgraf/nettools"
 TEST_TIME=30
-SERVER_LABEL="io.cilium.server"
-CLIENT_LABEL="io.cilium.client"
+SERVER_LABEL="id.server"
+CLIENT_LABEL="id.client"
 SERVER_NAME="server"
 CLIENT_NAME="client"
 HEADERS=${HEADERS_OFF:+"-P 0"}
@@ -93,26 +93,26 @@ set -x
 
 cat <<EOF | kubectl exec -i "${server_cilium}" -- cilium -D policy import -
 {
-    "name": "io.cilium",
-            "rules": [
-                {
-                    "coverage": [
-                        {
-                            "key": "server",
-                            "source": "k8s"
-                        }
-                    ],
-                    "allow": [
-                        {
-                            "action": "always-accept",
-                            "label": {
-                                "key": "client",
-                                "source": "k8s"
-                            }
-                        }
-                    ]
-                }
-            ]
+    "name": "root",
+    "rules": [
+	{
+	    "coverage": [
+		{
+		    "key": "${SERVER_LABEL}",
+		    "source": "k8s"
+		}
+	    ],
+	    "allow": [
+		{
+		    "action": "always-accept",
+		    "label": {
+			"key": "${CLIENT_LABEL}",
+			"source": "k8s"
+		    }
+		}
+	    ]
+	}
+    ]
 }
 EOF
 

--- a/tests/manual-multi-node.bash
+++ b/tests/manual-multi-node.bash
@@ -37,8 +37,8 @@ function init {
 }
 
 function test_run {
-	SERVER=$(node_run_quiet cilium-master 'docker run -d --net cilium -l io.cilium.server --name server noironetworks/netperf')
-	CLIENT=$(node_run_quiet cilium-node-2 'docker run -d --net cilium -l io.cilium.client --name client noironetworks/netperf')
+	SERVER=$(node_run_quiet cilium-master 'docker run -d --net cilium -l id.server --name server noironetworks/netperf')
+	CLIENT=$(node_run_quiet cilium-node-2 'docker run -d --net cilium -l id.client --name client noironetworks/netperf')
 	sleep 5s
 
 	SERVER_IP=$(node_run_quiet cilium-master "docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server" | tr -d '\r')

--- a/tests/policy/test.policy
+++ b/tests/policy/test.policy
@@ -1,17 +1,13 @@
 {
-        "name": "io.cilium",
-        "children": {
-		"test": {
-			"rules": [{
-				"coverage": ["qa"],
-				"requires": ["qa"]
-			},{
-				"coverage": ["prod"],
-				"requires": ["prod"]
-			},{
-				"coverage": ["server"],
-				"allow": ["client", "$host"]
-			}]
-		}
-	}
+        "name": "root",
+	"rules": [{
+		"coverage": ["id.qa"],
+		"requires": ["id.qa"]
+	},{
+		"coverage": ["id.prod"],
+		"requires": ["id.prod"]
+	},{
+		"coverage": ["id.server"],
+		"allow": ["id.client", "$host"]
+	}]
 }


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/306%23discussion_r105389426%22%2C%20%22https%3A//github.com/cilium/cilium/pull/306%23discussion_r105389676%22%2C%20%22https%3A//github.com/cilium/cilium/pull/306%23discussion_r105390049%22%2C%20%22https%3A//github.com/cilium/cilium/pull/306%23discussion_r105390326%22%2C%20%22https%3A//github.com/cilium/cilium/pull/306%23discussion_r105390588%22%2C%20%22https%3A//github.com/cilium/cilium/pull/306%23discussion_r105397531%22%2C%20%22https%3A//github.com/cilium/cilium/pull/306%23discussion_r105397786%22%2C%20%22https%3A//github.com/cilium/cilium/pull/306%23discussion_r105397890%22%2C%20%22https%3A//github.com/cilium/cilium/pull/306%23discussion_r105398304%22%2C%20%22https%3A//github.com/cilium/cilium/pull/306%23discussion_r105398613%22%2C%20%22https%3A//github.com/cilium/cilium/pull/306%23discussion_r105398919%22%2C%20%22https%3A//github.com/cilium/cilium/pull/306%23discussion_r105401578%22%2C%20%22https%3A//github.com/cilium/cilium/pull/306%23discussion_r105599364%22%2C%20%22https%3A//github.com/cilium/cilium/pull/306%23discussion_r105660321%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%206927602d2b73c89de878c5a23486231c8ac2ead2%20pkg/labels/labels.go%2099%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/306%23discussion_r105390588%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Maybe%20we%20should%20pass%20an%20argument%20to%20%60AbsoluteKey%60%20with%20the%20list%20of%20valid%20prefixes%3F%20Depends%20if%20the%20caller%20is%20always%20the%20daemon.%22%2C%20%22created_at%22%3A%20%222017-03-10T12%3A53%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22With%20this%20change.%20Only%20the%20%60root.%60%20prefix%20is%20a%20valid%20prefix.%20I%20will%20remove%20this%20FIXME.%5Cr%5Cn%5Cr%5CnWhat%20we%20can%20talk%20about%20though%20is%20validating%20absolute%20label%20names%20as%20they%20are%20loaded%20as%20policy%20and%20then%20reject%20them.%20This%20way%20it%20will%20become%20trivial%20to%20notice%20if%20a%20policy%20contains%20elements%20which%20are%20not%20covered%20by%20the%20configured%20prefix.%22%2C%20%22created_at%22%3A%20%222017-03-10T13%3A44%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pkg/labels/labels.go%3AL203-237%22%7D%2C%20%22Pull%206927602d2b73c89de878c5a23486231c8ac2ead2%20daemon/policy_test.go%2066%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/306%23discussion_r105390326%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Shouldn%27t%20we%20add%20%60root%60%20has%20valid%20label%20prefixes%3F%22%2C%20%22created_at%22%3A%20%222017-03-10T12%3A51%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22Not%20sure%20I%20understand.%20These%20tests%20validate%20proper%20label%20resolving.%20%60root.%60%20is%20the%20absolute%20name%20of%20these%20labels.%20The%20user%20will%20never%20see%20it%20this%20way.%22%2C%20%22created_at%22%3A%20%222017-03-10T13%3A42%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20so%20the%20user%20type%20%60docker%20--label%20%5C%22Prod%5C%22%60%20and%20the%20label%20will%20actually%20be%20%60root.Prod%60%3F%22%2C%20%22created_at%22%3A%20%222017-03-10T13%3A47%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%22%2C%20%22created_at%22%3A%20%222017-03-10T14%3A02%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20daemon/policy_test.go%3AL36-52%22%7D%2C%20%22Pull%2068f0f99617222fd0d6b9b77a874231ca45ed51b1%20daemon/main.go%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/306%23discussion_r105389676%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Should%20we%20also%20add%20this%20options%20on%20%60cilium%20client%60%3F%22%2C%20%22created_at%22%3A%20%222017-03-10T12%3A46%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22Why%20do%20we%20need%20it%20for%20the%20client%3F%20I%20would%20rather%20not%20complicate%20this%20unless%20required.%20Restarting%20the%20daemon%20is%20possible%20without%20losing%20state%20so%20unless%20we%20get%20a%20direct%20request%20for%20making%20this%20changeable%20at%20runtime%20I%20don%27t%20see%20a%20need%20for%20it.%22%2C%20%22created_at%22%3A%20%222017-03-10T13%3A40%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40aanm%20Ping%20on%20this%20comment.%20Please%20clarify%20whether%20you%20still.%22%2C%20%22created_at%22%3A%20%222017-03-13T07%3A06%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20was%20just%20a%20thought%2C%20let%27s%20keep%20as%20is%20and%20change%20it%20in%20the%20future%20if%20needed.%22%2C%20%22created_at%22%3A%20%222017-03-13T13%3A35%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20daemon/main.go%3AL107-115%22%7D%2C%20%22Pull%2068f0f99617222fd0d6b9b77a874231ca45ed51b1%20pkg/labels/filter.go%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/306%23discussion_r105389426%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Should%20we%20validate%20the%20source%3F%20What%20happens%20if%20user%20misspells%20%60cilium%60%20for%20example%3F%22%2C%20%22created_at%22%3A%20%222017-03-10T12%3A44%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22Then%20the%20label%20will%20not%20match.%20How%20do%20you%20know%20the%20valid%20label%20sources%20at%20this%20point.%20It%20could%20be%20anything.%20As%20we%20make%20the%20label%20retrieving%20more%20modular%2C%20we%20will%20have%20no%20idea%20about%20all%20possible%20sources%20of%20labels.%22%2C%20%22created_at%22%3A%20%222017-03-10T13%3A46%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pkg/labels/filter.go%3AL34-65%22%7D%2C%20%22Pull%2057ef910e2cb2dd9e8564b4b771cde664884c99d5%20pkg/labels/filter.go%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/306%23discussion_r105390049%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20ID%3F%22%2C%20%22created_at%22%3A%20%222017-03-10T12%3A49%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60id.%60%20is%20a%20short%20prefix%20that%20we%20can%20use%20in%20examples.%20%60id.frontend%60%20talks%20to%20%60id.backend%60%22%2C%20%22created_at%22%3A%20%222017-03-10T13%3A41%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pkg/labels/filter.go%3AL69-79%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 68f0f99617222fd0d6b9b77a874231ca45ed51b1 pkg/labels/filter.go 8'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/306#discussion_r105389426'>File: pkg/labels/filter.go:L34-65</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> Should we validate the source? What happens if user misspells `cilium` for example?
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> Then the label will not match. How do you know the valid label sources at this point. It could be anything. As we make the label retrieving more modular, we will have no idea about all possible sources of labels.
- [x] <a href='#crh-comment-Pull 68f0f99617222fd0d6b9b77a874231ca45ed51b1 daemon/main.go 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/306#discussion_r105389676'>File: daemon/main.go:L107-115</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> Should we also add this options on `cilium client`?
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> Why do we need it for the client? I would rather not complicate this unless required. Restarting the daemon is possible without losing state so unless we get a direct request for making this changeable at runtime I don't see a need for it.
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> @aanm Ping on this comment. Please clarify whether you still.
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> It was just a thought, let's keep as is and change it in the future if needed.
- [x] <a href='#crh-comment-Pull 57ef910e2cb2dd9e8564b4b771cde664884c99d5 pkg/labels/filter.go 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/306#discussion_r105390049'>File: pkg/labels/filter.go:L69-79</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> Why ID?
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> `id.` is a short prefix that we can use in examples. `id.frontend` talks to `id.backend`
- [x] <a href='#crh-comment-Pull 6927602d2b73c89de878c5a23486231c8ac2ead2 daemon/policy_test.go 66'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/306#discussion_r105390326'>File: daemon/policy_test.go:L36-52</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> Shouldn't we add `root` has valid label prefixes?
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> Not sure I understand. These tests validate proper label resolving. `root.` is the absolute name of these labels. The user will never see it this way.
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> Ah, so the user type `docker --label "Prod"` and the label will actually be `root.Prod`?
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> Yes
- [x] <a href='#crh-comment-Pull 6927602d2b73c89de878c5a23486231c8ac2ead2 pkg/labels/labels.go 99'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/306#discussion_r105390588'>File: pkg/labels/labels.go:L203-237</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> Maybe we should pass an argument to `AbsoluteKey` with the list of valid prefixes? Depends if the caller is always the daemon.
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> With this change. Only the `root.` prefix is a valid prefix. I will remove this FIXME.
What we can talk about though is validating absolute label names as they are loaded as policy and then reject them. This way it will become trivial to notice if a policy contains elements which are not covered by the configured prefix.


<a href='https://www.codereviewhub.com/cilium/cilium/pull/306?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/306?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/306'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>