### PR TITLE
bpf: disable -Waddress-of-packed-member on newer clang versions

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -1,6 +1,10 @@
 include ../Makefile.defs
 
-CLANG_FLAGS := -Iinclude -D__NR_CPUS__=$(shell nproc) -O2 -target bpf -I. -Wall -Werror
+CLANG_FLAGS := -Iinclude -D__NR_CPUS__=$(shell nproc) -O2 -target bpf -I.
+
+# eBPF verifier enforces unaligned access checks where necessary, so don't
+# let clang complain too early.
+CLANG_FLAGS += -Wall -Werror -Wno-address-of-packed-member -Wno-unknown-warning-option
 
 BPF = bpf_lxc.o bpf_netdev.o bpf_overlay.o bpf_lb.o
 SCRIPTS = init.sh join_ep.sh run_probes.sh


### PR DESCRIPTION
clang 4.0 and higher bails out when compiling cilium's eBPF programs
with the following error:

  [...]
  In file included from bpf_lxc.c:41:
  ./lib/lb.h:167:33: error: taking address of packed member 'address'
  of class or structure 'lb6_reverse_nat' may result in an unaligned
  pointer value [-Werror,-Waddress-of-packed-member]
      ipv6_addr_copy(&tuple->addr, &nat->address);
                                   ^~~~~~~~~~~~
  [...]

Disable the new -Waddress-of-packed-member warning as the verifier
will eventually make the call whether a given access is fine or not.
F.e., context, stack, (regs) can never be accessed unaligned, direct
packet access and dynamic map value access may be accessed unaligned
if the underlying architecture supports it, f.e. x86/arm64. Thus,
just disable -Waddress-of-packed-member and make sure that earlier
clang versions don't bail out on not supporting the warning by adding
-Wno-unknown-warning-option to the flags.

Closes #310

Reported-by: André Martins <andre@cilium.io>
Signed-off-by: Daniel Borkmann <daniel@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/315?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/315'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>