### PR TITLE
Add success/failure msg to vagrant start.sh

### DIFF
--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -306,13 +306,22 @@ fi
 
 service cilium restart
 
+cilium_started=false
+
 for ((i = 0 ; i < 24; i++)); do
     if cilium status > /dev/null 2>&1; then
+        cilium_started=true
         break
     fi
     sleep 5s
     echo "Waiting for Cilium daemon to come up..."
 done
+
+if [ "\$cilium_started" = true ] ; then
+    echo 'Cilium successfully started!'
+else
+    >&2 echo 'Timeout waiting for Cilium to start...'
+fi
 EOF
 }
 


### PR DESCRIPTION
Hi folks,

When testing with Vagrant, I saw that the start.sh script would end with the following line regardless of whether Cilium successfully came up or not.  

==> cilium-master: Waiting for Cilium daemon to come up...

Here's a small tweak to make the script print a success or error message. 

Note: you can't tell from the diff, but this chunk of code is actually part of a larger block that writes this out as a file (cilium-master.sh), and then executes it.  This is why the $cilium_started needs to be escaped.   See http://stackoverflow.com/questions/2953646/how-to-declare-and-use-boolean-variables-in-shell-script for why that needs to be double-quoted in the first place.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/317%23issuecomment-286942047%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/317%23issuecomment-286942047%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hey%20%40danwent%20the%20PR%20looks%20great%2C%20however%20we%20can%27t%20accept%20it%20unless%20the%20commit%20is%20signed%20%28%60git%20commit%20-s%60%20or%20since%20you%20want%20to%20sign%20this%20commit%20%60git%20commit%20--amend%20-s%60%29.%5Cr%5Cn%5Cr%5CnMore%20info%3A%20https%3A//github.com/cilium/cilium/blob/master/doc/contributing.md%23developers-certificate-of-origin%22%2C%20%22created_at%22%3A%20%222017-03-16T02%3A45%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/317#issuecomment-286942047'>General Comment</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> Hey @danwent the PR looks great, however we can't accept it unless the commit is signed (`git commit -s` or since you want to sign this commit `git commit --amend -s`).
More info: https://github.com/cilium/cilium/blob/master/doc/contributing.md#developers-certificate-of-origin


<a href='https://www.codereviewhub.com/cilium/cilium/pull/317?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/317?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/317'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>