### PR TITLE
bpf: disable -Waddress-of-packed-member in scripts as well

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -59,7 +59,7 @@ function bpf_compile()
 
 # This directory was created by the daemon and contains the per container header file
 DIR="$PWD/globals"
-CLANG_OPTS="-D__NR_CPUS__=$(nproc) -O2 -target bpf -I$DIR -I. -I$LIB/include -DENABLE_ARP_RESPONDER -DHANDLE_NS"
+CLANG_OPTS="-D__NR_CPUS__=$(nproc) -O2 -target bpf -I$DIR -I. -I$LIB/include -DENABLE_ARP_RESPONDER -DHANDLE_NS -Wno-address-of-packed-member -Wno-unknown-warning-option"
 
 HOST_DEV1="cilium_host"
 HOST_DEV2="cilium_net"

--- a/bpf/join_ep.sh
+++ b/bpf/join_ep.sh
@@ -25,7 +25,7 @@ echo "Join EP id=$ID ifname=$IFNAME"
 
 # This directory was created by the daemon and contains the per container header file
 DIR="$PWD/$ID"
-CLANG_OPTS="-D__NR_CPUS__=$(nproc) -O2 -target bpf -I$RUNDIR/globals -I$DIR -I$LIB/include"
+CLANG_OPTS="-D__NR_CPUS__=$(nproc) -O2 -target bpf -I$RUNDIR/globals -I$DIR -I$LIB/include -Wno-address-of-packed-member -Wno-unknown-warning-option"
 
 clang $CLANG_OPTS -c $LIB/bpf_lxc.c -S -o $DIR/bpf_lxc.asm
 clang $CLANG_OPTS -c $LIB/bpf_lxc.c -o $DIR/bpf_lxc.o

--- a/bpf/run_probes.sh
+++ b/bpf/run_probes.sh
@@ -43,7 +43,7 @@ function probe_run()
 	FEATURE=$2
 	tc qdisc del dev $DEV clsact 2> /dev/null
 
-	PROBE_OPTS="-D__NR_CPUS__=$(nproc) -O2 -target bpf -I$DIR -I. -I$LIB/include"
+	PROBE_OPTS="-D__NR_CPUS__=$(nproc) -O2 -target bpf -I$DIR -I. -I$LIB/include -Wno-address-of-packed-member -Wno-unknown-warning-option"
 
 	clang $PROBE_OPTS -c $PROBE -o $OUT &&
 	tc qdisc add dev $DEV clsact &&

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -298,7 +298,7 @@ RUN=/var/run/cilium
 NH_IFINDEX=$(cat /sys/class/net/cilium_host/ifindex)
 NH_MAC=$(ip link show cilium_host | grep ether | awk '{print $2}')
 NH_MAC="{.addr=$(mac2array $NH_MAC)}"
-CLANG_OPTS="-D__NR_CPUS__=$(nproc) -DLB_L3 -DLB_REDIRECT=$NH_IFINDEX -DLB_DSTMAC=$NH_MAC -O2 -target bpf -I. -I$LIB/include -I$RUN/globals -DDEBUG"
+CLANG_OPTS="-D__NR_CPUS__=$(nproc) -DLB_L3 -DLB_REDIRECT=$NH_IFINDEX -DLB_DSTMAC=$NH_MAC -O2 -target bpf -I. -I$LIB/include -I$RUN/globals -DDEBUG -Wno-address-of-packed-member -Wno-unknown-warning-option"
 touch netdev_config.h
 clang $CLANG_OPTS -c $LIB/bpf_lb.c -o tmp_lb.o
 


### PR DESCRIPTION
Do the same as in the recent commit ca0038e32909 ("bpf: disable
-Waddress-of-packed-member on newer clang versions") also for
various scripts where we have BPF compilation targets.

Signed-off-by: Daniel Borkmann <daniel@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/318%23issuecomment-286909276%22%2C%20%22https%3A//github.com/cilium/cilium/pull/318%23issuecomment-286926903%22%2C%20%22https%3A//github.com/cilium/cilium/pull/318%23issuecomment-286942538%22%2C%20%22https%3A//github.com/cilium/cilium/pull/318%23issuecomment-287003700%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/318%23issuecomment-286909276%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Note%20that%20for%20GCE%20kernel%2C%20we%20likely%20need%20...%5Cr%5Cn%5Cr%5Cnhttps%3A//git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/%3Fid%3Da08dd0da5307ba01295c8383923e51e7997c3576%5Cr%5Cnhttps%3A//git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/%3Fid%3D6760bf2ddde8ad64f8205a651223a93de3a35494%5Cr%5Cn%5Cr%5Cn...%20as%20new%20clang%20fetches%20spilled%20map_value_or_null%20register%20from%20stack%20%28r0%29%2C%20then%20compares%20r0%20against%20NULL%2C%20marks%20it%20to%20map_value%2C%20and%20later%20on%20fetches%20the%20same%20spilled%20map_value_or_null%20register%20from%20stack%20again%20into%20r2%20and%20performs%20some%20work%20on%20r2.%20On%20GCE%20verifier%20seems%20to%20complain%20that%20r2%20is%20still%20map_value_or_null.%20Explanation%20is%20that%20in%20kernel%20in%20mark_map_regs%28%29%2C%20the%20reg%20id%20was%20not%20cached.%20So%20the%20buggy%20kernel%20would%20mark%20the%20register%20first%20%28due%20to%20being%20traversed%20first%29%2C%20and%20then%20override%20the%20regs%5Bregno%5D.id%2C%20which%20will%20have%20the%20side%20effect%20that%20no%20marking%20will%20be%20performed%20on%20spilled%20regs%20%28due%20to%20id%20mismatches%29.%22%2C%20%22created_at%22%3A%20%222017-03-15T23%3A15%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/677393%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/borkmann%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20...%20as%20new%20clang%20fetches%20spilled%20map_value_or_null%20register%20from%20stack%20%28r0%29%2C%20then%20compares%20r0%20against%20NULL%2C%20marks%20it%20to%20map_value%2C%20and%20later%20on%20fetches%20the%20same%20spilled%20map_value_or_null%20register%20from%20stack%20again%20into%20r2%20and%20performs%20some%20work%20on%20r2.%20On%20GCE%20verifier%20seems%20to%20complain%20that%20r2%20is%20still%20map_value_or_null.%20Explanation%20is%20that%20in%20kernel%20in%20mark_map_regs%28%29%2C%20the%20reg%20id%20was%20not%20cached.%20So%20the%20buggy%20kernel%20would%20mark%20the%20register%20first%20%28due%20to%20being%20traversed%20first%29%2C%20and%20then%20override%20the%20regs%5Bregno%5D.id%2C%20which%20will%20have%20the%20side%20effect%20that%20no%20marking%20will%20be%20performed%20on%20spilled%20regs%20%28due%20to%20id%20mismatches%29.%5Cr%5Cn%5Cr%5CnWhat%20does%20this%20mean%20for%20actual%20kernel%20versions%20what%20is%20the%20behaviour%20a%20user%20would%20observe%3F%20Rejection%20of%20produced%20bytecode%3F%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-03-16T01%3A03%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20What%20does%20this%20mean%20for%20actual%20kernel%20versions%20what%20is%20the%20behaviour%20a%20user%20would%20observe%3F%20Rejection%20of%20produced%20bytecode%3F%5Cr%5Cn%5Cr%5CnFor%20the%204.8%20kernel%20%28the%20one%20running%20on%20gce%29%3A%5Cr%5Cn%60%60%60%5Cr%5CnProg%20section%20%27from-container%27%20rejected%3A%20Permission%20denied%20%2813%29%21%5Cr%5Cn%20-%20Type%3A%20%20%20%20%20%20%20%20%203%5Cr%5Cn%20-%20Instructions%3A%203243%20%280%20over%20limit%29%5Cr%5Cn%20-%20License%3A%20%20%20%20%20%20GPL%5Cr%5CnVerifier%20analysis%3A%5Cr%5CnSkipped%2019922%20bytes%2C%20use%20%27verb%27%20option%20for%20the%20full%20verbose%20log.%5Cr%5Cn%5B...%5D%5Cr%5Cn8%29%5Cr%5Cn1610%3A%20%2815%29%20if%20r8%20%3D%3D%200x160010ac%20goto%20pc%2B162%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnThis%20only%20happens%20if%20the%20clang%20version%20used%20is%20the%20%604.0.0%60.%20Should%20we%20keep%20the%20Dockerfile%20version%20with%20%603.7.1%60%20or%20increment%20it%20to%20%604.0.0%60%20at%20the%20cost%20of%20bumping%20the%20kernel%20minimal%20required%20version%3F%22%2C%20%22created_at%22%3A%20%222017-03-16T02%3A48%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20interesting%20piece%20of%20the%20log%20is%20this%20one%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%5B...%5D%5Cr%5Cn1817%3A%20%2885%29%20call%201%5Cr%5Cn1818%3A%20%2818%29%20r8%20%3D%200xffffff68%5Cr%5Cn1820%3A%20%287b%29%20%2A%28u64%20%2A%29%28r10%20-152%29%20%3D%20r0%5Cr%5Cn1821%3A%20%2815%29%20if%20r0%20%3D%3D%200x0%20goto%20pc-1718%5Cr%5Cn%20R0%3Dmap_value%28ks%3D4%2Cvs%3D104%29%20R6%3Dctx%20R7%3Dimm2%20R8%3Dinv%20R9%3Dinv%20R10%3Dfp%20fp-152%3Dmap_value_or_null%5Cr%5Cn1822%3A%20%2879%29%20r2%20%3D%20%2A%28u64%20%2A%29%28r10%20-152%29%5Cr%5Cn1823%3A%20%2879%29%20r1%20%3D%20%2A%28u64%20%2A%29%28r2%20%2B8%29%5Cr%5CnR2%20invalid%20mem%20access%20%27map_value_or_null%27%5Cr%5CnError%20fetching%20program/map%21%5Cr%5Cn%60%60%60%5Cr%5CnI%20wrote%20a%20similar%20test%20case%20yesterday%20to%20reproduce%20and%20it%20passed%20on%20my%20-net%20kernel%2C%20realizing%20that%20the%20one%20on%20GCE%20was%20older%2C%20not%20having%20these%20fixes%20against%20clang%20code%20generation%20we%20once%20did%20already.%5Cr%5Cn%5Cr%5CnIssue%20is%20that%204.8%20kernel%20is%20EOL%20since%20some%20months%2C%20the%20current%20stable%20kernels%20are%204.9%20and%204.10%20maintained%20by%20Greg.%20I%20went%20back%20to%20the%20list%20I%20once%20did%20with%20commits%20for%20cilium%2C%20and%20saw%20that%20the%20original%20map%20value%20marking%20commit%20is%20not%20even%20part%20of%204.8%20and%204.9.%5Cr%5Cn%5Cr%5CnSo%20we%20would%20need%20the%20original%20fix%20from%2057a09bf%20plus%20all%20follow-ups%3A%5Cr%5Cn%60%60%60%5Cr%5Cn57a09bf%20bpf%3A%20Detect%20identical%20PTR_TO_MAP_VALUE_OR_NULL%20registers%5Cr%5Cnd2a4dd3%20bpf%3A%20fix%20state%20equivalence%5Cr%5Cna08dd0d%20bpf%3A%20fix%20regression%20on%20verifier%20pruning%20wrt%20map%20lookups%5Cr%5Cn6760bf2%20bpf%3A%20fix%20mark_reg_unknown_value%20for%20spilled%20regs%20on%20map%20value%20marking%5Cr%5Cn%60%60%60%5Cr%5CnI%20could%20ask%20Dave%20today%20to%20queue%20these%20to%20stable%2C%20and%20once%20they%27re%20in%20we%20could%20open%20a%20ticket%20either%20at%20GCE%20support%20or%20Canonical%20to%20get%20this%20into%20their%204.8%20kernels%3F%20Given%20that%20these%20are%20part%20of%20stable%20kernel%20would%20make%20the%20argument%20simple%20hopefully.%5Cr%5Cn%5Cr%5CnMeanwhile%20going%20back%20to%20clang%20%603.7.1%60%20seems%20probably%20reasonable%20as%20a%20quick%20fix.%5Cr%5Cn%5Cr%5CnThe%20cilium%20commit%20from%20here%20can%20go%20in%20independent%20of%20it%2C%20though%2C%20so%20that%20for%20clang%20%604.0%60%20and%20latest%20kernels%20we%20don%27t%20throw%20this%20useless%20%28for%20eBPF%20context%29%20warning%20anymore.%22%2C%20%22created_at%22%3A%20%222017-03-16T09%3A35%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/677393%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/borkmann%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/318#issuecomment-286909276'>General Comment</a></b>
- <a href='https://github.com/borkmann'><img border=0 src='https://avatars2.githubusercontent.com/u/677393?v=3' height=16 width=16></a> Note that for GCE kernel, we likely need ...
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a08dd0da5307ba01295c8383923e51e7997c3576
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=6760bf2ddde8ad64f8205a651223a93de3a35494
... as new clang fetches spilled map_value_or_null register from stack (r0), then compares r0 against NULL, marks it to map_value, and later on fetches the same spilled map_value_or_null register from stack again into r2 and performs some work on r2. On GCE verifier seems to complain that r2 is still map_value_or_null. Explanation is that in kernel in mark_map_regs(), the reg id was not cached. So the buggy kernel would mark the register first (due to being traversed first), and then override the regs[regno].id, which will have the side effect that no marking will be performed on spilled regs (due to id mismatches).
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> > ... as new clang fetches spilled map_value_or_null register from stack (r0), then compares r0 against NULL, marks it to map_value, and later on fetches the same spilled map_value_or_null register from stack again into r2 and performs some work on r2. On GCE verifier seems to complain that r2 is still map_value_or_null. Explanation is that in kernel in mark_map_regs(), the reg id was not cached. So the buggy kernel would mark the register first (due to being traversed first), and then override the regs[regno].id, which will have the side effect that no marking will be performed on spilled regs (due to id mismatches).
What does this mean for actual kernel versions what is the behaviour a user would observe? Rejection of produced bytecode?
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> > What does this mean for actual kernel versions what is the behaviour a user would observe? Rejection of produced bytecode?
For the 4.8 kernel (the one running on gce):
```
Prog section 'from-container' rejected: Permission denied (13)!
- Type:         3
- Instructions: 3243 (0 over limit)
- License:      GPL
Verifier analysis:
Skipped 19922 bytes, use 'verb' option for the full verbose log.
[...]
8)
1610: (15) if r8 == 0x160010ac goto pc+162
```
This only happens if the clang version used is the `4.0.0`. Should we keep the Dockerfile version with `3.7.1` or increment it to `4.0.0` at the cost of bumping the kernel minimal required version?
- <a href='https://github.com/borkmann'><img border=0 src='https://avatars2.githubusercontent.com/u/677393?v=3' height=16 width=16></a> The interesting piece of the log is this one:
```
[...]
1817: (85) call 1
1818: (18) r8 = 0xffffff68
1820: (7b) *(u64 *)(r10 -152) = r0
1821: (15) if r0 == 0x0 goto pc-1718
R0=map_value(ks=4,vs=104) R6=ctx R7=imm2 R8=inv R9=inv R10=fp fp-152=map_value_or_null
1822: (79) r2 = *(u64 *)(r10 -152)
1823: (79) r1 = *(u64 *)(r2 +8)
R2 invalid mem access 'map_value_or_null'
Error fetching program/map!
```
I wrote a similar test case yesterday to reproduce and it passed on my -net kernel, realizing that the one on GCE was older, not having these fixes against clang code generation we once did already.
Issue is that 4.8 kernel is EOL since some months, the current stable kernels are 4.9 and 4.10 maintained by Greg. I went back to the list I once did with commits for cilium, and saw that the original map value marking commit is not even part of 4.8 and 4.9.
So we would need the original fix from 57a09bf plus all follow-ups:
```
57a09bf bpf: Detect identical PTR_TO_MAP_VALUE_OR_NULL registers
d2a4dd3 bpf: fix state equivalence
a08dd0d bpf: fix regression on verifier pruning wrt map lookups
6760bf2 bpf: fix mark_reg_unknown_value for spilled regs on map value marking
```
I could ask Dave today to queue these to stable, and once they're in we could open a ticket either at GCE support or Canonical to get this into their 4.8 kernels? Given that these are part of stable kernel would make the argument simple hopefully.
Meanwhile going back to clang `3.7.1` seems probably reasonable as a quick fix.
The cilium commit from here can go in independent of it, though, so that for clang `4.0` and latest kernels we don't throw this useless (for eBPF context) warning anymore.


<a href='https://www.codereviewhub.com/cilium/cilium/pull/318?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/318?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/318'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>