### PR TITLE
Misspellings correction

### DIFF
--- a/api/v1/client/endpoint/endpoint_client.go
+++ b/api/v1/client/endpoint/endpoint_client.go
@@ -27,7 +27,7 @@ DeleteEndpointID deletes endpoint
 
 Deletes the endpoint specified by the ID. Deletion is imminent and
 atomic, if the deletion request is valid and the endpoint exists,
-deletion will occur even if errors are encounted in the process. If
+deletion will occur even if errors are encountered in the process. If
 errors have been encountered, the code 202 will be returned, otherwise
 200 on success.
 

--- a/api/v1/models/endpoint_status_change.go
+++ b/api/v1/models/endpoint_status_change.go
@@ -23,7 +23,7 @@ type EndpointStatusChange struct {
 	// Status message
 	Message string `json:"message,omitempty"`
 
-	// Timestamp when status change occured
+	// Timestamp when status change occurred
 	Timestamp string `json:"timestamp,omitempty"`
 }
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -141,7 +141,7 @@ paths:
       description: |
         Deletes the endpoint specified by the ID. Deletion is imminent and
         atomic, if the deletion request is valid and the endpoint exists,
-        deletion will occur even if errors are encounted in the process. If
+        deletion will occur even if errors are encountered in the process. If
         errors have been encountered, the code 202 will be returned, otherwise
         200 on success.
 
@@ -732,7 +732,7 @@ definitions:
     type: object
     properties:
       timestamp:
-        description: Timestamp when status change occured
+        description: Timestamp when status change occurred
         type: string
       code:
         description: Code indicate type of status change
@@ -894,7 +894,7 @@ definitions:
           type: string
   DaemonConfigurationResponse:
     description: |
-      Response to a daemon configuration request. Contains the adddresing
+      Response to a daemon configuration request. Contains the addressing
       information and configuration settings.
     type: object
     properties:
@@ -953,7 +953,7 @@ definitions:
       log:
         type: string
   IdentityContext:
-    description: Context describing a pair of source and destination identies
+    description: Context describing a pair of source and destination identity
     type: object
     properties:
       from:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -169,7 +169,7 @@ func init() {
         }
       },
       "delete": {
-        "description": "Deletes the endpoint specified by the ID. Deletion is imminent and\natomic, if the deletion request is valid and the endpoint exists,\ndeletion will occur even if errors are encounted in the process. If\nerrors have been encountered, the code 202 will be returned, otherwise\n200 on success.\n\nAll resources associated with the endpoint will be freed and the\nworkload represented by the endpoint will be disconnected.It will no\nlonger be able to initiate or receive communications of any sort.\n",
+        "description": "Deletes the endpoint specified by the ID. Deletion is imminent and\natomic, if the deletion request is valid and the endpoint exists,\ndeletion will occur even if errors are encountered in the process. If\nerrors have been encountered, the code 202 will be returned, otherwise\n200 on success.\n\nAll resources associated with the endpoint will be freed and the\nworkload represented by the endpoint will be disconnected.It will no\nlonger be able to initiate or receive communications of any sort.\n",
         "tags": [
           "endpoint"
         ],
@@ -1061,7 +1061,7 @@ func init() {
           "type": "string"
         },
         "timestamp": {
-          "description": "Timestamp when status change occured",
+          "description": "Timestamp when status change occurred",
           "type": "string"
         }
       }

--- a/api/v1/server/restapi/endpoint/delete_endpoint_id.go
+++ b/api/v1/server/restapi/endpoint/delete_endpoint_id.go
@@ -33,7 +33,7 @@ Delete endpoint
 
 Deletes the endpoint specified by the ID. Deletion is imminent and
 atomic, if the deletion request is valid and the endpoint exists,
-deletion will occur even if errors are encounted in the process. If
+deletion will occur even if errors are encountered in the process. If
 errors have been encountered, the code 202 will be returned, otherwise
 200 on success.
 

--- a/cilium/cmd/monitor.go
+++ b/cilium/cmd/monitor.go
@@ -32,7 +32,7 @@ import (
 var monitorCmd = &cobra.Command{
 	Use:   "monitor",
 	Short: "Monitoring",
-	Long: `The monitor displays notifications and events ommited by the BPF
+	Long: `The monitor displays notifications and events omitted by the BPF
 programs attached to endpoints and devices. This includes:
   * Dropped packet notifications
   * Captured packet traces

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -297,7 +297,7 @@ func (c *ConsulClient) GASNewL3n4AddrID(basePath string, baseID uint32, lAddrID 
 
 	beginning := baseID
 	for {
-		log.Debugf("Trying to aquire a new free ID %d", baseID)
+		log.Debugf("Trying to acquire a new free ID %d", baseID)
 		keyPath := path.Join(basePath, strconv.FormatUint(uint64(baseID), 10))
 
 		lockPair := &consulAPI.KVPair{Key: GetLockPath(keyPath), Session: session}

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -178,7 +178,7 @@ func (e *EtcdClient) GetMaxID(key string, firstID uint32) (uint32, error) {
 	for {
 		switch value, err = e.GetValue(key); {
 		case attempts == 0:
-			err = fmt.Errorf("Unable to retreive last free ID because key is always empty")
+			err = fmt.Errorf("Unable to retrieve last free ID because key is always empty")
 			log.Error(err)
 			fallthrough
 		case err != nil:

--- a/pkg/kvstore/local.go
+++ b/pkg/kvstore/local.go
@@ -90,7 +90,7 @@ func (l *LocalClient) GetMaxID(key string, firstID uint32) (uint32, error) {
 	for {
 		switch value, err = l.GetValue(key); {
 		case attempts == 0:
-			err = fmt.Errorf("Unable to retreive last free ID because key is always empty")
+			err = fmt.Errorf("Unable to retrieve last free ID because key is always empty")
 			log.Error(err)
 			fallthrough
 		case value == nil:


### PR DESCRIPTION
Few corrections to improve go report "misspell" section score.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/321%23discussion_r106566210%22%2C%20%22https%3A//github.com/cilium/cilium/pull/321%23issuecomment-287244471%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/321%23issuecomment-287244471%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks%20%40mskarbek%21%22%2C%20%22created_at%22%3A%20%222017-03-17T01%3A49%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20dcf5217dbbdc76d8bb65ab7d5816e27a80543d57%20api/v1/client/endpoint/endpoint_client.go%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/321%23discussion_r106566210%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Given%20the%20code%20in%20%60api/v1/%60%20is%20automatically%20generated%20with%20go-swagger%2C%20can%20you%20fix%20all%20the%20typos%20in%20the%20file%20%60api/v1/openapi.yaml%60%20as%20well%3F%20Otherwise%20we%20will%20undo%20these%20fixes%20when%20we%20generate%20the%20API%20side%20code%20the%20next%20time.%22%2C%20%22created_at%22%3A%20%222017-03-17T01%3A05%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20api/v1/client/endpoint/endpoint_client.go%3AL27-34%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull dcf5217dbbdc76d8bb65ab7d5816e27a80543d57 api/v1/client/endpoint/endpoint_client.go 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/321#discussion_r106566210'>File: api/v1/client/endpoint/endpoint_client.go:L27-34</a></b>
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> Given the code in `api/v1/` is automatically generated with go-swagger, can you fix all the typos in the file `api/v1/openapi.yaml` as well? Otherwise we will undo these fixes when we generate the API side code the next time.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/321#issuecomment-287244471'>General Comment</a></b>
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> Thanks @mskarbek!


<a href='https://www.codereviewhub.com/cilium/cilium/pull/321?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/321?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/321'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>