### PR TITLE
cilium: don't invoke deprecated cilium daemon

### DIFF
--- a/tests/02-perf.sh
+++ b/tests/02-perf.sh
@@ -16,7 +16,7 @@ fi
 function cleanup {
 	docker rm -f server client 2> /dev/null || true
 
-	cilium daemon config DropNotification=true Debug=true
+	cilium config DropNotification=true Debug=true
 }
 
 trap cleanup EXIT
@@ -146,7 +146,7 @@ function perf_pktgen() {
 	done
 }
 
-cilium daemon config DropNotification=false Debug=false
+cilium config DropNotification=false Debug=false
 cilium endpoint config $SERVER_ID DropNotification=false Debug=false
 cilium endpoint config $CLIENT_ID DropNotification=false Debug=false
 perf_test

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -46,7 +46,7 @@ cleanup
 
 set -x
 
-#cilium daemon config Debug=true DropNotification=true
+#cilium config Debug=true DropNotification=true
 
 # Test the addition and removal of services with and without daemon
 
@@ -450,7 +450,7 @@ cilium service update --rev --frontend "$SVC_IP4:80" --id 2233 \
 			--backend "$SERVER2_IP4:80"
 
 
-#cilium daemon config Debug=false DropNotification=false
+#cilium config Debug=false DropNotification=false
 #cilium endpoint config $SERVER1_ID Debug=false DropNotification=false
 #cilium endpoint config $SERVER2_ID Debug=false DropNotification=false
 
@@ -475,7 +475,7 @@ docker exec -i ab ab -t 30 -c 20 -v 1 "http://$SVC_IP4/" || {
 	abort "Error: Unable to reach local IPv4 node via loadbalancer"
 }
 
-#cilium daemon config Debug=true DropNotification=true
+#cilium config Debug=true DropNotification=true
 
 cleanup
 cilium -D policy delete root

--- a/tests/09-perf-gce.sh
+++ b/tests/09-perf-gce.sh
@@ -68,7 +68,7 @@ function cleanup_cilium {
     cleanup_k8s
 
     for line in ${server_cilium} ${client_cilium}; do
-        kubectl exec -i ${line} -- cilium daemon config DropNotification=true Debug=true
+        kubectl exec -i ${line} -- cilium config DropNotification=true Debug=true
     done
 }
 
@@ -193,8 +193,8 @@ function perf_test() {
 	fi
 }
 
-kubectl exec ${server_cilium} -- cilium daemon config DropNotification=false Debug=false
-kubectl exec ${client_cilium} -- cilium daemon config DropNotification=false Debug=false
+kubectl exec ${server_cilium} -- cilium config DropNotification=false Debug=false
+kubectl exec ${client_cilium} -- cilium config DropNotification=false Debug=false
 kubectl exec ${server_cilium} -- cilium endpoint config $SERVER_ID DropNotification=false Debug=false
 kubectl exec ${client_cilium} -- cilium endpoint config $CLIENT_ID DropNotification=false Debug=false
 perf_test


### PR DESCRIPTION
Commit c7d4002534d6 ("Switch to spf13/cobra and spf13/viper to
implement CLI & config") split the daemon and the cli into two
separate binaries, as a result 'cilium daemon' doesn't exist
anymore. There are a few letfover spots in the test suite that
are using 'cilium daemon' and throwing error messages such as:

  # BENCHMARK=1 ./02-perf.sh
  [...]
  + cilium daemon config DropNotification=false Debug=false
  Error: unknown command "daemon" for "cilium"
  Run 'cilium --help' for usage.
  unknown command "daemon" for "cilium"
  [...]
  ++ cilium daemon config DropNotification=true Debug=true
  Error: unknown command "daemon" for "cilium"
  Run 'cilium --help' for usage.
  unknown command "daemon" for "cilium"
  [...]

Just drop the deprecated daemon command from these test cases,
and after that we get:

  [...]
  + cilium config DropNotification=false Debug=false
  + cilium endpoint config 63464 DropNotification=false Debug=false
  [...]

Fixes: c7d4002534d6 ("Switch to spf13/cobra and spf13/viper to implement CLI & config")
Signed-off-by: Daniel Borkmann <daniel@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/333?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/333'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>