### PR TITLE
tests: don't invoke deprecated endpoint inspect

### DIFF
--- a/tests/02-perf.sh
+++ b/tests/02-perf.sh
@@ -31,6 +31,13 @@ docker network inspect $TEST_NET || {
 docker run -dt --net=$TEST_NET --name server -l $SERVER_LABEL $NETPERF_IMAGE
 docker run -dt --net=$TEST_NET --name client -l $CLIENT_LABEL $NETPERF_IMAGE
 
+until [ -n "$(cilium endpoint list | grep $CLIENT_LABEL | awk '{ print $1}')" ]; do
+    echo "Waiting for client endpoint to have an identity"
+done
+until [ -n "$(cilium endpoint list | grep $SERVER_LABEL | awk '{ print $1}')" ]; do
+    echo "Waiting for server endpoint to have an identity"
+done
+
 CLIENT_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' client)
 CLIENT_IP4=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' client)
 CLIENT_ID=$(cilium endpoint list | grep $CLIENT_LABEL | awk '{ print $1}')
@@ -38,9 +45,9 @@ SERVER_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalI
 SERVER_IP4=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' server)
 SERVER_ID=$(cilium endpoint list | grep $SERVER_LABEL | awk '{ print $1}')
 HOST_IP=$(echo $SERVER_IP | sed -e 's/:[0-9a-f]\{4\}$/:ffff/')
-SERVER_DEV=$(cilium endpoint inspect $SERVER_ID | grep interface-name | awk '{print $2}' | sed 's/"//g' | sed 's/,$//')
-NODE_MAC=$(cilium endpoint inspect $SERVER_ID | grep node-mac | awk '{print $2}' | sed 's/"//g' | sed 's/,$//')
-LXC_MAC=$(cilium endpoint inspect $SERVER_ID | grep lxc-mac | awk '{print $2}' | sed 's/"//g' | sed 's/,$//')
+SERVER_DEV=$(cilium endpoint get $SERVER_ID | grep interface-name | awk '{print $2}' | sed 's/"//g' | sed 's/,$//')
+NODE_MAC=$(cilium endpoint get $SERVER_ID | grep host-mac | awk '{print $2}' | sed 's/"//g' | sed 's/,$//')
+LXC_MAC=$(cilium endpoint get $SERVER_ID | grep mac | awk '{print $2}' | sed 's/"//g' | sed 's/,$//')
 
 
 # FIXME IPv6 DAD period

--- a/tests/09-perf-gce.sh
+++ b/tests/09-perf-gce.sh
@@ -82,9 +82,9 @@ SERVER_IP4=$(kubectl exec ${server_pod} -- ip -4 a s | grep global | tr -s ' ' |
 SERVER_ID=$(kubectl exec ${server_cilium} -- cilium endpoint list | grep $SERVER_LABEL | awk '{ print $1}')
 
 HOST_IP=$(echo $SERVER_IP | sed -e 's/:[0-9a-f]\{4\}$/:ffff/')
-SERVER_DEV=$(kubectl exec ${server_cilium} -- cilium endpoint inspect $SERVER_ID | grep interface-name | awk '{print $2}' | sed 's/"//g' | sed 's/,$//')
-NODE_MAC=$(kubectl exec ${server_cilium} -- cilium endpoint inspect $SERVER_ID | grep node-mac | awk '{print $2}' | sed 's/"//g' | sed 's/,$//')
-LXC_MAC=$(kubectl exec ${server_cilium} -- cilium endpoint inspect $SERVER_ID | grep lxc-mac | awk '{print $2}' | sed 's/"//g' | sed 's/,$//')
+SERVER_DEV=$(kubectl exec ${server_cilium} -- cilium endpoint get $SERVER_ID | grep interface-name | awk '{print $2}' | sed 's/"//g' | sed 's/,$//')
+NODE_MAC=$(kubectl exec ${server_cilium} -- cilium endpoint get $SERVER_ID | grep host-mac | awk '{print $2}' | sed 's/"//g' | sed 's/,$//')
+LXC_MAC=$(kubectl exec ${server_cilium} -- cilium endpoint get $SERVER_ID | grep mac | awk '{print $2}' | sed 's/"//g' | sed 's/,$//')
 
 echo "... Done"
 


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/334%23discussion_r106714959%22%2C%20%22https%3A//github.com/cilium/cilium/pull/334%23discussion_r106722844%22%2C%20%22https%3A//github.com/cilium/cilium/pull/334%23issuecomment-287451199%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/334%23issuecomment-287451199%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20once%20hit%20this%20one%20%2802-perf%20test%29%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%5Broot%40localhost%20tests%5D%23%20BENCHMARK%3D1%20./02-perf.sh%20%5Cr%5Cn%2B%20TEST_NET%3Dcilium%5Cr%5Cn%2B%20NETPERF_IMAGE%3Dnoironetworks/netperf%5Cr%5Cn%2B%20TEST_TIME%3D30%5Cr%5Cn%2B%20%27%5B%27%20-z%201%20%27%5D%27%5Cr%5Cn%2B%20trap%20cleanup%20EXIT%5Cr%5Cn%2B%20SERVER_LABEL%3Did.server%5Cr%5Cn%2B%20CLIENT_LABEL%3Did.client%5Cr%5Cn%2B%20docker%20network%20inspect%20cilium%5Cr%5Cn%5B%5Cr%5Cn%20%20%20%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Name%5C%22%3A%20%5C%22cilium%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Id%5C%22%3A%20%5C%22569d7b794e9256be99fa0c8e9c47b45865ff458e23e92644646481698cd03ea3%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Scope%5C%22%3A%20%5C%22local%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Driver%5C%22%3A%20%5C%22cilium%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22EnableIPv6%5C%22%3A%20true%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22IPAM%5C%22%3A%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Driver%5C%22%3A%20%5C%22cilium%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Options%5C%22%3A%20%7B%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Config%5C%22%3A%20%5B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Subnet%5C%22%3A%20%5C%220.0.0.0/0%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Gateway%5C%22%3A%20%5C%2210.4.0.1/32%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Subnet%5C%22%3A%20%5C%22%3A%3A1/112%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5D%5Cr%5Cn%20%20%20%20%20%20%20%20%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Internal%5C%22%3A%20false%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Containers%5C%22%3A%20%7B%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Options%5C%22%3A%20%7B%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Labels%5C%22%3A%20%7B%7D%5Cr%5Cn%20%20%20%20%7D%5Cr%5Cn%5D%5Cr%5Cn%2B%20docker%20run%20-dt%20--net%3Dcilium%20--name%20server%20-l%20id.server%20noironetworks/netperf%5Cr%5Cn74d8a3077c593964fc8075bd752ede791287014c4f669416305df347b3e4ea19%5Cr%5Cn%2B%20docker%20run%20-dt%20--net%3Dcilium%20--name%20client%20-l%20id.client%20noironetworks/netperf%5Cr%5Cn9f1db0a247395c4e02325b6e292a6644fc32480b382f5b3b7d7ba21bc9a56563%5Cr%5Cn%2B%20sleep%202s%5Cr%5Cn%2B%2B%20docker%20inspect%20--format%20%27%7B%7B%20.NetworkSettings.Networks.cilium.GlobalIPv6Address%20%7D%7D%27%20client%5Cr%5Cn%2B%20CLIENT_IP%3Df00d%3A%3Aac14%3Aa04%3A0%3Adc06%5Cr%5Cn%2B%2B%20docker%20inspect%20--format%20%27%7B%7B%20.NetworkSettings.Networks.cilium.IPAddress%20%7D%7D%27%20client%5Cr%5Cn%2B%20CLIENT_IP4%3D10.4.129.91%5Cr%5Cn%2B%2B%20cilium%20endpoint%20list%5Cr%5Cn%2B%2B%20grep%20id.client%5Cr%5Cn%2B%2B%20awk%20%27%7B%20print%20%241%7D%27%5Cr%5Cn%2B%20CLIENT_ID%3D%5Cr%5Cn%2B%2B%20docker%20inspect%20--format%20%27%7B%7B%20.NetworkSettings.Networks.cilium.GlobalIPv6Address%20%7D%7D%27%20server%5Cr%5Cn%2B%20SERVER_IP%3Df00d%3A%3Aac14%3Aa04%3A0%3Af236%5Cr%5Cn%2B%2B%20docker%20inspect%20--format%20%27%7B%7B%20.NetworkSettings.Networks.cilium.IPAddress%20%7D%7D%27%20server%5Cr%5Cn%2B%20SERVER_IP4%3D10.4.116.202%5Cr%5Cn%2B%2B%20cilium%20endpoint%20list%5Cr%5Cn%2B%2B%20grep%20id.server%5Cr%5Cn%2B%2B%20awk%20%27%7B%20print%20%241%7D%27%5Cr%5Cn%2B%20SERVER_ID%3D62006%5Cr%5Cn%2B%2B%20echo%20f00d%3A%3Aac14%3Aa04%3A0%3Af236%5Cr%5Cn%2B%2B%20sed%20-e%20%27s/%3A%5B0-9a-f%5D%5C%5C%7B4%5C%5C%7D%24/%3Affff/%27%5Cr%5Cn%2B%20HOST_IP%3Df00d%3A%3Aac14%3Aa04%3A0%3Affff%5Cr%5Cn%2B%2B%20cilium%20endpoint%20get%2062006%5Cr%5Cn%2B%2B%20grep%20interface-name%5Cr%5Cn%2B%2B%20awk%20%27%7Bprint%20%242%7D%27%5Cr%5Cn%2B%2B%20sed%20%27s/%2C%24//%27%5Cr%5Cn%2B%2B%20sed%20%27s/%5C%22//g%27%5Cr%5CnError%3A%20Cannot%20get%20endpoint%2062006%3A%20context%20deadline%20exceeded%5Cr%5Cn%5Cr%5Cn%2B%20SERVER_DEV%3D%5Cr%5Cn%2B%2B%20cilium%20endpoint%20get%2062006%5Cr%5Cn%2B%2B%20grep%20host-mac%5Cr%5Cn%2B%2B%20sed%20%27s/%2C%24//%27%5Cr%5Cn%2B%2B%20awk%20%27%7Bprint%20%242%7D%27%5Cr%5Cn%2B%2B%20sed%20%27s/%5C%22//g%27%5Cr%5Cn%2B%20NODE_MAC%3Dce%3A46%3A5b%3Aa1%3A91%3Adb%5Cr%5Cn%2B%2B%20cilium%20endpoint%20get%2062006%5Cr%5Cn%2B%2B%20grep%20mac%5Cr%5Cn%2B%2B%20sed%20%27s/%5C%22//g%27%5Cr%5Cn%2B%2B%20awk%20%27%7Bprint%20%242%7D%27%5Cr%5Cn%2B%2B%20sed%20%27s/%2C%24//%27%5Cr%5Cn%2B%20LXC_MAC%3D%27ce%3A46%3A5b%3Aa1%3A91%3Adb%5Cr%5Cn42%3A86%3A28%3A4a%3Aa0%3A02%27%5Cr%5Cn%2B%20sleep%205%5Cr%5Cn%2B%20set%20-x%5Cr%5Cn%2B%20cat%5Cr%5Cn%2B%20cilium%20-D%20policy%20import%20-%5Cr%5Cn2017-03-17T20%3A02%3A15.344%2B01%3A00%20localhost.localdomain%20DEBU%20001%20loadPolicy%20%3E%20Entering%20directory%20-...%5Cr%5Cn2017-03-17T20%3A02%3A15.344%2B01%3A00%20localhost.localdomain%20DEBU%20002%20loadPolicyFile%20%3E%20Loading%20file%20-%5Cr%5Cn2017-03-17T20%3A02%3A15.344%2B01%3A00%20localhost.localdomain%20DEBU%20003%20UnmarshalJSON%20%3E%20Resolving%20tree%3A%20%26%7Bpath%3A%20Name%3Aroot%20Parent%3A%3Cnil%3E%20Rules%3A%5BCoverage%3A%20%5Bcilium%3Aid.server%5D%20Allowing%3A%20%5B%7Baccept%20reserved%3Ahost%7D%20%7Baccept%20cilium%3Aid.client%7D%5D%5D%20Children%3Amap%5B%5D%20mergeable%3Afalse%20resolved%3Afalse%7D%5Cr%5Cn2017-03-17T20%3A02%3A15.345%2B01%3A00%20localhost.localdomain%20DEBU%20004%20ResolveTree%20%3E%20Resolving%20policy%20node%20%26%7Bpath%3A%20Name%3Aroot%20Parent%3A%3Cnil%3E%20Rules%3A%5BCoverage%3A%20%5Bcilium%3Aid.server%5D%20Allowing%3A%20%5B%7Baccept%20reserved%3Ahost%7D%20%7Baccept%20cilium%3Aid.client%7D%5D%5D%20Children%3Amap%5B%5D%20mergeable%3Afalse%20resolved%3Afalse%7D%5Cr%5Cn2017-03-17T20%3A02%3A15.345%2B01%3A00%20localhost.localdomain%20DEBU%20005%20resolveRules%20%3E%20Resolving%20rules%20of%20node%20%26%7Bpath%3Aroot%20Name%3Aroot%20Parent%3A%3Cnil%3E%20Rules%3A%5BCoverage%3A%20%5Bcilium%3Aid.server%5D%20Allowing%3A%20%5B%7Baccept%20reserved%3Ahost%7D%20%7Baccept%20cilium%3Aid.client%7D%5D%5D%20Children%3Amap%5B%5D%20mergeable%3Afalse%20resolved%3Afalse%7D%5Cr%5Cn2017-03-17T20%3A02%3A15.345%2B01%3A00%20localhost.localdomain%20DEBU%20006%20Resolve%20%3E%20Resolving%20consumer%20rule%20Coverage%3A%20%5Bcilium%3Aid.server%5D%20Allowing%3A%20%5B%7Baccept%20reserved%3Ahost%7D%20%7Baccept%20cilium%3Aid.client%7D%5D%5Cr%5Cn2017-03-17T20%3A02%3A15.345%2B01%3A00%20localhost.localdomain%20DEBU%20007%20Resolve%20%3E%20Resolved%20label%20cilium%3Aid.server%20to%20path%20root.id.server%5Cr%5Cn2017-03-17T20%3A02%3A15.345%2B01%3A00%20localhost.localdomain%20DEBU%20008%20Resolve%20%3E%20Resolved%20label%20reserved%3Ahost%20to%20path%20root.host%5Cr%5Cn2017-03-17T20%3A02%3A15.345%2B01%3A00%20localhost.localdomain%20DEBU%20009%20Resolve%20%3E%20Resolved%20label%20cilium%3Aid.client%20to%20path%20root.id.client%5Cr%5Cn2017-03-17T20%3A02%3A15.345%2B01%3A00%20localhost.localdomain%20DEBU%2000a%20UnmarshalJSON%20%3E%20Resolved%20tree%3A%20%26%7Bpath%3Aroot%20Name%3Aroot%20Parent%3A%3Cnil%3E%20Rules%3A%5BCoverage%3A%20%5Bcilium%3Aid.server%5D%20Allowing%3A%20%5B%7Baccept%20reserved%3Ahost%7D%20%7Baccept%20cilium%3Aid.client%7D%5D%5D%20Children%3Amap%5B%5D%20mergeable%3Atrue%20resolved%3Atrue%7D%5Cr%5Cn2017-03-17T20%3A02%3A15.345%2B01%3A00%20localhost.localdomain%20DEBU%2000b%20func17%20%3E%20Constructed%20policy%20object%20for%20import%20%26%7Bpath%3Aroot%20Name%3Aroot%20Parent%3A%3Cnil%3E%20Rules%3A%5BCoverage%3A%20%5Bcilium%3Aid.server%5D%20Allowing%3A%20%5B%7Baccept%20reserved%3Ahost%7D%20%7Baccept%20cilium%3Aid.client%7D%5D%5D%20Children%3Amap%5B%5D%20mergeable%3Atrue%20resolved%3Atrue%7D%5Cr%5CnError%3A%20Cannot%20import%20policy%20-%3A%20context%20deadline%20exceeded%5Cr%5Cn%5Cr%5Cn%2B%20cilium%20config%20DropNotification%3Dfalse%20Debug%3Dfalse%5Cr%5Cn%2B%20cilium%20endpoint%20config%2062006%20DropNotification%3Dfalse%20Debug%3Dfalse%5Cr%5CnError%3A%20Cannot%20update%20endpoint%2062006%3A%20context%20deadline%20exceeded%5Cr%5Cn%2B%20cilium%20endpoint%20config%20DropNotification%3Dfalse%20Debug%3Dfalse%5Cr%5CnError%3A%20Cannot%20parse%20endpoint%20id%20%5C%22DropNotification%3Dfalse%5C%22%3A%20invalid%20numeric%20cilium%20id%3A%20strconv.ParseInt%3A%20parsing%20%5C%22DropNotification%3Dfalse%5C%22%3A%20invalid%20syntax%5Cr%5Cn%2B%20perf_test%5Cr%5Cn%2B%20docker%20exec%20-i%20client%20netperf%20-l%2030%20-t%20TCP_STREAM%20-H%20f00d%3A%3Aac14%3Aa04%3A0%3Af236%5Cr%5CnMIGRATED%20TCP%20STREAM%20TEST%20from%20%3A%3A0%20%28%3A%3A%29%20port%200%20AF_INET6%20to%20f00d%3A%3Aac14%3Aa04%3A0%3Af236%20%28%29%20port%200%20AF_INET6%5Cr%5Cnpanic%3A%20runtime%20error%3A%20cgo%20argument%20has%20Go%20pointer%20to%20Go%20pointer%5Cr%5Cn%5Cr%5Cngoroutine%201%20%5Brunning%5D%3A%5Cr%5Cnpanic%280x13d81a0%2C%200xc4214826d0%29%5Cr%5Cn%5Ct/usr/lib/golang/src/runtime/panic.go%3A500%20%2B0x1a1%5Cr%5Cngithub.com/cilium/cilium/pkg/bpf._cgoCheckPointer0%280xc4214795c0%2C%200xc4214826c0%2C%200x1%2C%200x1%2C%200xc42148263a%29%5Cr%5Cn%5Ct%3F%3F%3A0%20%2B0x59%5Cr%5Cngithub.com/cilium/cilium/pkg/bpf.%28%2APerfEvent%29.Read%280xc420054c80%2C%200x1617008%2C%200x1617000%2C%200xc4204bd908%2C%200x1%29%5Cr%5Cn%5Ct/usr/lib/golang/src/github.com/cilium/cilium/pkg/bpf/perf.go%3A332%20%2B0x2fc%5Cr%5Cngithub.com/cilium/cilium/pkg/bpf.%28%2APerCpuEvents%29.ReadAll%280xc420408540%2C%200x1617008%2C%200x1617000%2C%200x0%2C%200x0%29%5Cr%5Cn%5Ct/usr/lib/golang/src/github.com/cilium/cilium/pkg/bpf/perf.go%3A506%20%2B0xa7%5Cr%5Cngithub.com/cilium/cilium/cilium/cmd.runMonitor%28%29%5Cr%5Cn%5Ct/usr/lib/golang/src/github.com/cilium/cilium/cilium/cmd/monitor.go%3A130%20%2B0x2cb%5Cr%5Cngithub.com/cilium/cilium/cilium/cmd.glob..func14%280x1fee080%2C%200x2596ac0%2C%200x0%2C%200x0%29%5Cr%5Cn%5Ct/usr/lib/golang/src/github.com/cilium/cilium/cilium/cmd/monitor.go%3A41%20%2B0x14%5Cr%5Cngithub.com/cilium/cilium/vendor/github.com/spf13/cobra.%28%2ACommand%29.execute%280x1fee080%2C%200x2596ac0%2C%200x0%2C%200x0%2C%200x1fee080%2C%200x2596ac0%29%5Cr%5Cn%5Ct/usr/lib/golang/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go%3A648%20%2B0x443%5Cr%5Cngithub.com/cilium/cilium/vendor/github.com/spf13/cobra.%28%2ACommand%29.ExecuteC%280x1feb820%2C%200xc42006c058%2C%200x0%2C%200x46779e%29%5Cr%5Cn%5Ct/usr/lib/golang/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go%3A735%20%2B0x367%5Cr%5Cngithub.com/cilium/cilium/vendor/github.com/spf13/cobra.%28%2ACommand%29.Execute%280x1feb820%2C%200x0%2C%200x0%29%5Cr%5Cn%5Ct/usr/lib/golang/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go%3A693%20%2B0x2b%5Cr%5Cngithub.com/cilium/cilium/cilium/cmd.Execute%28%29%5Cr%5Cn%5Ct/usr/lib/golang/src/github.com/cilium/cilium/cilium/cmd/root.go%3A69%20%2B0x31%5Cr%5Cnmain.main%28%29%5Cr%5Cn%5Ct/usr/lib/golang/src/github.com/cilium/cilium/cilium/main.go%3A20%20%2B0x14%5Cr%5CnRecv%20%20%20Send%20%20%20%20Send%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5CnSocket%20Socket%20%20Message%20%20Elapsed%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5CnSize%20%20%20Size%20%20%20%20Size%20%20%20%20%20Time%20%20%20%20%20Throughput%20%20%5Cr%5Cnbytes%20%20bytes%20%20%20bytes%20%20%20%20secs.%20%20%20%2010%5E6bits/sec%20%20%5Cr%5Cn%5Cr%5Cn%2087380%20%2016384%20%2016384%20%20%20%2030.00%20%20%20%2011997.13%20%20%20%5Cr%5Cn%2B%20%27%5B%27%2010.4.116.202%20%27%5D%27%5Cr%5Cn%2B%20docker%20exec%20-i%20client%20netperf%20-l%2030%20-t%20TCP_STREAM%20-H%2010.4.116.202%5Cr%5CnMIGRATED%20TCP%20STREAM%20TEST%20from%200.0.0.0%20%280.0.0.0%29%20port%200%20AF_INET%20to%2010.4.116.202%20%2810.4.11%29%20port%200%20AF_INET%5Cr%5CnRecv%20%20%20Send%20%20%20%20Send%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5CnSocket%20Socket%20%20Message%20%20Elapsed%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5CnSize%20%20%20Size%20%20%20%20Size%20%20%20%20%20Time%20%20%20%20%20Throughput%20%20%5Cr%5Cnbytes%20%20bytes%20%20%20bytes%20%20%20%20secs.%20%20%20%2010%5E6bits/sec%20%20%5Cr%5Cn%5Cr%5Cn%2087380%20%2016384%20%2016384%20%20%20%2030.00%20%20%20%2011589.28%20%20%20%5Cr%5Cn%2B%20docker%20exec%20-i%20client%20netperf%20-l%2030%20-t%20TCP_SENDFILE%20-H%20f00d%3A%3Aac14%3Aa04%3A0%3Af236%5Cr%5CnTCP%20SENDFILE%20TEST%20from%20%3A%3A0%20%28%3A%3A%29%20port%200%20AF_INET6%20to%20f00d%3A%3Aac14%3Aa04%3A0%3Af236%20%28%29%20port%200%20AF_INET6%5Cr%5Cn%5EC%2B%2B%20cleanup%5Cr%5Cn%2B%2B%20docker%20rm%20-f%20server%20client%5Cr%5Cnserver%5Cr%5Cn%60%60%60%5Cr%5CnBut%20usual%20get%20these%20errors.%20In%20any%20case%20%60context%20deadline%20exceeded%60%20might%20be%20the%20main%20cause%20%28seems%20a%20timeout%20on%20something%29%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%5Broot%40localhost%20tests%5D%23%20BENCHMARK%3D1%20./02-perf.sh%20%5Cr%5Cn%2B%20TEST_NET%3Dcilium%5Cr%5Cn%2B%20NETPERF_IMAGE%3Dnoironetworks/netperf%5Cr%5Cn%2B%20TEST_TIME%3D30%5Cr%5Cn%2B%20%27%5B%27%20-z%201%20%27%5D%27%5Cr%5Cn%2B%20trap%20cleanup%20EXIT%5Cr%5Cn%2B%20SERVER_LABEL%3Did.server%5Cr%5Cn%2B%20CLIENT_LABEL%3Did.client%5Cr%5Cn%2B%20docker%20network%20inspect%20cilium%5Cr%5Cn%5B%5Cr%5Cn%20%20%20%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Name%5C%22%3A%20%5C%22cilium%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Id%5C%22%3A%20%5C%22569d7b794e9256be99fa0c8e9c47b45865ff458e23e92644646481698cd03ea3%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Scope%5C%22%3A%20%5C%22local%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Driver%5C%22%3A%20%5C%22cilium%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22EnableIPv6%5C%22%3A%20true%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22IPAM%5C%22%3A%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Driver%5C%22%3A%20%5C%22cilium%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Options%5C%22%3A%20%7B%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Config%5C%22%3A%20%5B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Subnet%5C%22%3A%20%5C%220.0.0.0/0%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Gateway%5C%22%3A%20%5C%2210.4.0.1/32%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Subnet%5C%22%3A%20%5C%22%3A%3A1/112%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5D%5Cr%5Cn%20%20%20%20%20%20%20%20%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Internal%5C%22%3A%20false%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Containers%5C%22%3A%20%7B%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Options%5C%22%3A%20%7B%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Labels%5C%22%3A%20%7B%7D%5Cr%5Cn%20%20%20%20%7D%5Cr%5Cn%5D%5Cr%5Cn%2B%20docker%20run%20-dt%20--net%3Dcilium%20--name%20server%20-l%20id.server%20noironetworks/netperf%5Cr%5Cn3c35f81d1eafd716c08c62e640e9887f6ac7636acbcc564ece70feca6e67336e%5Cr%5Cn%2B%20docker%20run%20-dt%20--net%3Dcilium%20--name%20client%20-l%20id.client%20noironetworks/netperf%5Cr%5Cn52a24eb19e309b57495abc02d6b76c68ffef21915ea0ac5673b7161c92170028%5Cr%5Cn%2B%20sleep%202s%5Cr%5Cn%2B%2B%20docker%20inspect%20--format%20%27%7B%7B%20.NetworkSettings.Networks.cilium.GlobalIPv6Address%20%7D%7D%27%20client%5Cr%5Cn%2B%20CLIENT_IP%3Df00d%3A%3Aac14%3Aa04%3A0%3Af236%5Cr%5Cn%2B%2B%20docker%20inspect%20--format%20%27%7B%7B%20.NetworkSettings.Networks.cilium.IPAddress%20%7D%7D%27%20client%5Cr%5Cn%2B%20CLIENT_IP4%3D10.4.116.202%5Cr%5Cn%2B%2B%20cilium%20endpoint%20list%5Cr%5Cn%2B%2B%20grep%20id.client%5Cr%5Cn%2B%2B%20awk%20%27%7B%20print%20%241%7D%27%5Cr%5Cn%2B%20CLIENT_ID%3D%5Cr%5Cn%2B%2B%20docker%20inspect%20--format%20%27%7B%7B%20.NetworkSettings.Networks.cilium.GlobalIPv6Address%20%7D%7D%27%20server%5Cr%5Cn%2B%20SERVER_IP%3Df00d%3A%3Aac14%3Aa04%3A0%3Af7e8%5Cr%5Cn%2B%2B%20docker%20inspect%20--format%20%27%7B%7B%20.NetworkSettings.Networks.cilium.IPAddress%20%7D%7D%27%20server%5Cr%5Cn%2B%20SERVER_IP4%3D10.4.138.214%5Cr%5Cn%2B%2B%20cilium%20endpoint%20list%5Cr%5Cn%2B%2B%20awk%20%27%7B%20print%20%241%7D%27%5Cr%5Cn%2B%2B%20grep%20id.server%5Cr%5Cn%2B%20SERVER_ID%3D63464%5Cr%5Cn%2B%2B%20echo%20f00d%3A%3Aac14%3Aa04%3A0%3Af7e8%5Cr%5Cn%2B%2B%20sed%20-e%20%27s/%3A%5B0-9a-f%5D%5C%5C%7B4%5C%5C%7D%24/%3Affff/%27%5Cr%5Cn%2B%20HOST_IP%3Df00d%3A%3Aac14%3Aa04%3A0%3Affff%5Cr%5Cn%2B%2B%20cilium%20endpoint%20get%2063464%5Cr%5Cn%2B%2B%20awk%20%27%7Bprint%20%242%7D%27%5Cr%5Cn%2B%2B%20sed%20%27s/%5C%22//g%27%5Cr%5Cn%2B%2B%20grep%20interface-name%5Cr%5Cn%2B%2B%20sed%20%27s/%2C%24//%27%5Cr%5CnError%3A%20Cannot%20get%20endpoint%2063464%3A%20context%20deadline%20exceeded%5Cr%5Cn%5Cr%5Cn%2B%20SERVER_DEV%3D%5Cr%5Cn%2B%2B%20cilium%20endpoint%20get%2063464%5Cr%5Cn%2B%2B%20grep%20host-mac%5Cr%5Cn%2B%2B%20sed%20%27s/%5C%22//g%27%5Cr%5Cn%2B%2B%20awk%20%27%7Bprint%20%242%7D%27%5Cr%5Cn%2B%2B%20sed%20%27s/%2C%24//%27%5Cr%5Cn%2B%20NODE_MAC%3Df6%3A54%3Ac7%3A0d%3A61%3A28%5Cr%5Cn%2B%2B%20cilium%20endpoint%20get%2063464%5Cr%5Cn%2B%2B%20grep%20mac%5Cr%5Cn%2B%2B%20sed%20%27s/%5C%22//g%27%5Cr%5Cn%2B%2B%20sed%20%27s/%2C%24//%27%5Cr%5Cn%2B%2B%20awk%20%27%7Bprint%20%242%7D%27%5Cr%5Cn%2B%20LXC_MAC%3D%27f6%3A54%3Ac7%3A0d%3A61%3A28%5Cr%5Cnd6%3A54%3Ab2%3A12%3A6b%3A18%27%5Cr%5Cn%2B%20sleep%205%5Cr%5Cn%2B%20set%20-x%5Cr%5Cn%2B%20cat%5Cr%5Cn%2B%20cilium%20-D%20policy%20import%20-%5Cr%5Cn2017-03-17T20%3A27%3A32.097%2B01%3A00%20localhost.localdomain%20DEBU%20001%20loadPolicy%20%3E%20Entering%20directory%20-...%5Cr%5Cn2017-03-17T20%3A27%3A32.097%2B01%3A00%20localhost.localdomain%20DEBU%20002%20loadPolicyFile%20%3E%20Loading%20file%20-%5Cr%5Cn2017-03-17T20%3A27%3A32.097%2B01%3A00%20localhost.localdomain%20DEBU%20003%20UnmarshalJSON%20%3E%20Resolving%20tree%3A%20%26%7Bpath%3A%20Name%3Aroot%20Parent%3A%3Cnil%3E%20Rules%3A%5BCoverage%3A%20%5Bcilium%3Aid.server%5D%20Allowing%3A%20%5B%7Baccept%20reserved%3Ahost%7D%20%7Baccept%20cilium%3Aid.client%7D%5D%5D%20Children%3Amap%5B%5D%20mergeable%3Afalse%20resolved%3Afalse%7D%5Cr%5Cn2017-03-17T20%3A27%3A32.097%2B01%3A00%20localhost.localdomain%20DEBU%20004%20ResolveTree%20%3E%20Resolving%20policy%20node%20%26%7Bpath%3A%20Name%3Aroot%20Parent%3A%3Cnil%3E%20Rules%3A%5BCoverage%3A%20%5Bcilium%3Aid.server%5D%20Allowing%3A%20%5B%7Baccept%20reserved%3Ahost%7D%20%7Baccept%20cilium%3Aid.client%7D%5D%5D%20Children%3Amap%5B%5D%20mergeable%3Afalse%20resolved%3Afalse%7D%5Cr%5Cn2017-03-17T20%3A27%3A32.097%2B01%3A00%20localhost.localdomain%20DEBU%20005%20resolveRules%20%3E%20Resolving%20rules%20of%20node%20%26%7Bpath%3Aroot%20Name%3Aroot%20Parent%3A%3Cnil%3E%20Rules%3A%5BCoverage%3A%20%5Bcilium%3Aid.server%5D%20Allowing%3A%20%5B%7Baccept%20reserved%3Ahost%7D%20%7Baccept%20cilium%3Aid.client%7D%5D%5D%20Children%3Amap%5B%5D%20mergeable%3Afalse%20resolved%3Afalse%7D%5Cr%5Cn2017-03-17T20%3A27%3A32.097%2B01%3A00%20localhost.localdomain%20DEBU%20006%20Resolve%20%3E%20Resolving%20consumer%20rule%20Coverage%3A%20%5Bcilium%3Aid.server%5D%20Allowing%3A%20%5B%7Baccept%20reserved%3Ahost%7D%20%7Baccept%20cilium%3Aid.client%7D%5D%5Cr%5Cn2017-03-17T20%3A27%3A32.097%2B01%3A00%20localhost.localdomain%20DEBU%20007%20Resolve%20%3E%20Resolved%20label%20cilium%3Aid.server%20to%20path%20root.id.server%5Cr%5Cn2017-03-17T20%3A27%3A32.097%2B01%3A00%20localhost.localdomain%20DEBU%20008%20Resolve%20%3E%20Resolved%20label%20reserved%3Ahost%20to%20path%20root.host%5Cr%5Cn2017-03-17T20%3A27%3A32.097%2B01%3A00%20localhost.localdomain%20DEBU%20009%20Resolve%20%3E%20Resolved%20label%20cilium%3Aid.client%20to%20path%20root.id.client%5Cr%5Cn2017-03-17T20%3A27%3A32.097%2B01%3A00%20localhost.localdomain%20DEBU%2000a%20UnmarshalJSON%20%3E%20Resolved%20tree%3A%20%26%7Bpath%3Aroot%20Name%3Aroot%20Parent%3A%3Cnil%3E%20Rules%3A%5BCoverage%3A%20%5Bcilium%3Aid.server%5D%20Allowing%3A%20%5B%7Baccept%20reserved%3Ahost%7D%20%7Baccept%20cilium%3Aid.client%7D%5D%5D%20Children%3Amap%5B%5D%20mergeable%3Atrue%20resolved%3Atrue%7D%5Cr%5Cn2017-03-17T20%3A27%3A32.097%2B01%3A00%20localhost.localdomain%20DEBU%2000b%20func17%20%3E%20Constructed%20policy%20object%20for%20import%20%26%7Bpath%3Aroot%20Name%3Aroot%20Parent%3A%3Cnil%3E%20Rules%3A%5BCoverage%3A%20%5Bcilium%3Aid.server%5D%20Allowing%3A%20%5B%7Baccept%20reserved%3Ahost%7D%20%7Baccept%20cilium%3Aid.client%7D%5D%5D%20Children%3Amap%5B%5D%20mergeable%3Atrue%20resolved%3Atrue%7D%5Cr%5CnError%3A%20Cannot%20import%20policy%20-%3A%20context%20deadline%20exceeded%5Cr%5Cn%5Cr%5Cn%2B%20cilium%20config%20DropNotification%3Dfalse%20Debug%3Dfalse%5Cr%5Cn%2B%20cilium%20endpoint%20config%2063464%20DropNotification%3Dfalse%20Debug%3Dfalse%5Cr%5CnError%3A%20Cannot%20update%20endpoint%2063464%3A%20context%20deadline%20exceeded%5Cr%5Cn%2B%20cilium%20endpoint%20config%20DropNotification%3Dfalse%20Debug%3Dfalse%5Cr%5CnError%3A%20Cannot%20parse%20endpoint%20id%20%5C%22DropNotification%3Dfalse%5C%22%3A%20invalid%20numeric%20cilium%20id%3A%20strconv.ParseInt%3A%20parsing%20%5C%22DropNotification%3Dfalse%5C%22%3A%20invalid%20syntax%5Cr%5Cn%2B%20perf_test%5Cr%5Cn%2B%20docker%20exec%20-i%20client%20netperf%20-l%2030%20-t%20TCP_STREAM%20-H%20f00d%3A%3Aac14%3Aa04%3A0%3Af7e8%5Cr%5CnMIGRATED%20TCP%20STREAM%20TEST%20from%20%3A%3A0%20%28%3A%3A%29%20port%200%20AF_INET6%20to%20f00d%3A%3Aac14%3Aa04%3A0%3Af7e8%20%28%29%20port%200%20AF_INET6%5Cr%5CnRecv%20%20%20Send%20%20%20%20Send%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5CnSocket%20Socket%20%20Message%20%20Elapsed%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5CnSize%20%20%20Size%20%20%20%20Size%20%20%20%20%20Time%20%20%20%20%20Throughput%20%20%5Cr%5Cnbytes%20%20bytes%20%20%20bytes%20%20%20%20secs.%20%20%20%2010%5E6bits/sec%20%20%5Cr%5Cn%5Cr%5Cn%2087380%20%2016384%20%2016384%20%20%20%2030.00%20%20%20%2012813.20%20%20%20%5Cr%5Cn%2B%20%27%5B%27%2010.4.138.214%20%27%5D%27%5Cr%5Cn%2B%20docker%20exec%20-i%20client%20netperf%20-l%2030%20-t%20TCP_STREAM%20-H%2010.4.138.214%5Cr%5CnMIGRATED%20TCP%20STREAM%20TEST%20from%200.0.0.0%20%280.0.0.0%29%20port%200%20AF_INET%20to%2010.4.138.214%20%2810.4.13%29%20port%200%20AF_INET%5Cr%5CnRecv%20%20%20Send%20%20%20%20Send%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5CnSocket%20Socket%20%20Message%20%20Elapsed%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5CnSize%20%20%20Size%20%20%20%20Size%20%20%20%20%20Time%20%20%20%20%20Throughput%20%20%5Cr%5Cnbytes%20%20bytes%20%20%20bytes%20%20%20%20secs.%20%20%20%2010%5E6bits/sec%20%20%5Cr%5Cn%5Cr%5Cn%2087380%20%2016384%20%2016384%20%20%20%2030.00%20%20%20%2012721.16%20%20%20%5Cr%5Cn%2B%20docker%20exec%20-i%20client%20netperf%20-l%2030%20-t%20TCP_SENDFILE%20-H%20f00d%3A%3Aac14%3Aa04%3A0%3Af7e8%5Cr%5CnTCP%20SENDFILE%20TEST%20from%20%3A%3A0%20%28%3A%3A%29%20port%200%20AF_INET6%20to%20f00d%3A%3Aac14%3Aa04%3A0%3Af7e8%20%28%29%20port%200%20AF_INET6%5Cr%5Cn%5EC%2B%2B%20cleanup%5Cr%5Cn%2B%2B%20docker%20rm%20-f%20server%20client%5Cr%5Cnserver%5Cr%5Cnclient%5Cr%5Cn%2B%2B%20cilium%20config%20DropNotification%3Dtrue%20Debug%3Dtrue%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222017-03-17T19%3A35%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/677393%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/borkmann%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20f39824421e9542010db71d056670da62efbfb636%20tests/02-perf.sh%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/334%23discussion_r106714959%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Was%20the%20IP%20not%20assigned%20yet%20or%20what%20is%20the%20reason%20for%20the%20required%20sleep%3F%22%2C%20%22created_at%22%3A%20%222017-03-17T18%3A19%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20IP%20was%20assigned%20but%20the%20ID%20was%20not%3A%5Cr%5Cn%60%60%60%5Cr%5CnENDPOINT%20%20%20IDENTITY%20%20%20%20%20%20%20%20LABELS%20%28source%3Akey%5B%3Dvalue%5D%29%20%20%20IPv6%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20IPv4%20%20%20%20%20%20%20%20%20%20%20%20STATUS%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn38593%20%20%20%20%20%20264%20%20%20%20%20%20%20%20%20%20%20%20%20cilium%3Aid.server%20%20%20%20%20%20%20%20%20%20%20%20%20%20f00d%3A%3Aa00%3A20f%3A0%3A96c1%20%20%2010.15.125.138%20%20%20ready%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn13233%20%20%20%20%20%20%3Cno%20label%20id%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20f00d%3A%3Aa00%3A20f%3A0%3A33b1%20%20%2010.15.113.22%20%20%20%20waiting-for-identity%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222017-03-17T18%3A56%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/02-perf.sh%3AL31-49%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull f39824421e9542010db71d056670da62efbfb636 tests/02-perf.sh 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/334#discussion_r106714959'>File: tests/02-perf.sh:L31-49</a></b>
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> Was the IP not assigned yet or what is the reason for the required sleep?
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> The IP was assigned but the ID was not:
```
ENDPOINT   IDENTITY        LABELS (source:key[=value])   IPv6                   IPv4            STATUS
38593      264             cilium:id.server              f00d::a00:20f:0:96c1   10.15.125.138   ready
13233      <no label id>                                 f00d::a00:20f:0:33b1   10.15.113.22    waiting-for-identity
```
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/334#issuecomment-287451199'>General Comment</a></b>
- <a href='https://github.com/borkmann'><img border=0 src='https://avatars2.githubusercontent.com/u/677393?v=3' height=16 width=16></a> I once hit this one (02-perf test):
```
[root@localhost tests]# BENCHMARK=1 ./02-perf.sh
+ TEST_NET=cilium
+ NETPERF_IMAGE=noironetworks/netperf
+ TEST_TIME=30
+ '[' -z 1 ']'
+ trap cleanup EXIT
+ SERVER_LABEL=id.server
+ CLIENT_LABEL=id.client
+ docker network inspect cilium
[
{
"Name": "cilium",
"Id": "569d7b794e9256be99fa0c8e9c47b45865ff458e23e92644646481698cd03ea3",
"Scope": "local",
"Driver": "cilium",
"EnableIPv6": true,
"IPAM": {
"Driver": "cilium",
"Options": {},
"Config": [
{
"Subnet": "0.0.0.0/0",
"Gateway": "10.4.0.1/32"
},
{
"Subnet": "::1/112"
}
]
},
"Internal": false,
"Containers": {},
"Options": {},
"Labels": {}
}
]
+ docker run -dt --net=cilium --name server -l id.server noironetworks/netperf
74d8a3077c593964fc8075bd752ede791287014c4f669416305df347b3e4ea19
+ docker run -dt --net=cilium --name client -l id.client noironetworks/netperf
9f1db0a247395c4e02325b6e292a6644fc32480b382f5b3b7d7ba21bc9a56563
+ sleep 2s
++ docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' client
+ CLIENT_IP=f00d::ac14:a04:0:dc06
++ docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' client
+ CLIENT_IP4=10.4.129.91
++ cilium endpoint list
++ grep id.client
++ awk '{ print $1}'
+ CLIENT_ID=
++ docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server
+ SERVER_IP=f00d::ac14:a04:0:f236
++ docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' server
+ SERVER_IP4=10.4.116.202
++ cilium endpoint list
++ grep id.server
++ awk '{ print $1}'
+ SERVER_ID=62006
++ echo f00d::ac14:a04:0:f236
++ sed -e 's/:[0-9a-f]\{4\}$/:ffff/'
+ HOST_IP=f00d::ac14:a04:0:ffff
++ cilium endpoint get 62006
++ grep interface-name
++ awk '{print $2}'
++ sed 's/,$//'
++ sed 's/"//g'
Error: Cannot get endpoint 62006: context deadline exceeded
+ SERVER_DEV=
++ cilium endpoint get 62006
++ grep host-mac
++ sed 's/,$//'
++ awk '{print $2}'
++ sed 's/"//g'
+ NODE_MAC=ce:46:5b:a1:91:db
++ cilium endpoint get 62006
++ grep mac
++ sed 's/"//g'
++ awk '{print $2}'
++ sed 's/,$//'
+ LXC_MAC='ce:46:5b:a1:91:db
42:86:28:4a:a0:02'
+ sleep 5
+ set -x
+ cat
+ cilium -D policy import -
2017-03-17T20:02:15.344+01:00 localhost.localdomain DEBU 001 loadPolicy > Entering directory -...
2017-03-17T20:02:15.344+01:00 localhost.localdomain DEBU 002 loadPolicyFile > Loading file -
2017-03-17T20:02:15.344+01:00 localhost.localdomain DEBU 003 UnmarshalJSON > Resolving tree: &{path: Name:root Parent:<nil> Rules:[Coverage: [cilium:id.server] Allowing: [{accept reserved:host} {accept cilium:id.client}]] Children:map[] mergeable:false resolved:false}
2017-03-17T20:02:15.345+01:00 localhost.localdomain DEBU 004 ResolveTree > Resolving policy node &{path: Name:root Parent:<nil> Rules:[Coverage: [cilium:id.server] Allowing: [{accept reserved:host} {accept cilium:id.client}]] Children:map[] mergeable:false resolved:false}
2017-03-17T20:02:15.345+01:00 localhost.localdomain DEBU 005 resolveRules > Resolving rules of node &{path:root Name:root Parent:<nil> Rules:[Coverage: [cilium:id.server] Allowing: [{accept reserved:host} {accept cilium:id.client}]] Children:map[] mergeable:false resolved:false}
2017-03-17T20:02:15.345+01:00 localhost.localdomain DEBU 006 Resolve > Resolving consumer rule Coverage: [cilium:id.server] Allowing: [{accept reserved:host} {accept cilium:id.client}]
2017-03-17T20:02:15.345+01:00 localhost.localdomain DEBU 007 Resolve > Resolved label cilium:id.server to path root.id.server
2017-03-17T20:02:15.345+01:00 localhost.localdomain DEBU 008 Resolve > Resolved label reserved:host to path root.host
2017-03-17T20:02:15.345+01:00 localhost.localdomain DEBU 009 Resolve > Resolved label cilium:id.client to path root.id.client
2017-03-17T20:02:15.345+01:00 localhost.localdomain DEBU 00a UnmarshalJSON > Resolved tree: &{path:root Name:root Parent:<nil> Rules:[Coverage: [cilium:id.server] Allowing: [{accept reserved:host} {accept cilium:id.client}]] Children:map[] mergeable:true resolved:true}
2017-03-17T20:02:15.345+01:00 localhost.localdomain DEBU 00b func17 > Constructed policy object for import &{path:root Name:root Parent:<nil> Rules:[Coverage: [cilium:id.server] Allowing: [{accept reserved:host} {accept cilium:id.client}]] Children:map[] mergeable:true resolved:true}
Error: Cannot import policy -: context deadline exceeded
+ cilium config DropNotification=false Debug=false
+ cilium endpoint config 62006 DropNotification=false Debug=false
Error: Cannot update endpoint 62006: context deadline exceeded
+ cilium endpoint config DropNotification=false Debug=false
Error: Cannot parse endpoint id "DropNotification=false": invalid numeric cilium id: strconv.ParseInt: parsing "DropNotification=false": invalid syntax
+ perf_test
+ docker exec -i client netperf -l 30 -t TCP_STREAM -H f00d::ac14:a04:0:f236
MIGRATED TCP STREAM TEST from ::0 (::) port 0 AF_INET6 to f00d::ac14:a04:0:f236 () port 0 AF_INET6
panic: runtime error: cgo argument has Go pointer to Go pointer
goroutine 1 [running]:
panic(0x13d81a0, 0xc4214826d0)
/usr/lib/golang/src/runtime/panic.go:500 +0x1a1
github.com/cilium/cilium/pkg/bpf._cgoCheckPointer0(0xc4214795c0, 0xc4214826c0, 0x1, 0x1, 0xc42148263a)
??:0 +0x59
github.com/cilium/cilium/pkg/bpf.(*PerfEvent).Read(0xc420054c80, 0x1617008, 0x1617000, 0xc4204bd908, 0x1)
/usr/lib/golang/src/github.com/cilium/cilium/pkg/bpf/perf.go:332 +0x2fc
github.com/cilium/cilium/pkg/bpf.(*PerCpuEvents).ReadAll(0xc420408540, 0x1617008, 0x1617000, 0x0, 0x0)
/usr/lib/golang/src/github.com/cilium/cilium/pkg/bpf/perf.go:506 +0xa7
github.com/cilium/cilium/cilium/cmd.runMonitor()
/usr/lib/golang/src/github.com/cilium/cilium/cilium/cmd/monitor.go:130 +0x2cb
github.com/cilium/cilium/cilium/cmd.glob..func14(0x1fee080, 0x2596ac0, 0x0, 0x0)
/usr/lib/golang/src/github.com/cilium/cilium/cilium/cmd/monitor.go:41 +0x14
github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).execute(0x1fee080, 0x2596ac0, 0x0, 0x0, 0x1fee080, 0x2596ac0)
/usr/lib/golang/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:648 +0x443
github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x1feb820, 0xc42006c058, 0x0, 0x46779e)
/usr/lib/golang/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:735 +0x367
github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).Execute(0x1feb820, 0x0, 0x0)
/usr/lib/golang/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:693 +0x2b
github.com/cilium/cilium/cilium/cmd.Execute()
/usr/lib/golang/src/github.com/cilium/cilium/cilium/cmd/root.go:69 +0x31
main.main()
/usr/lib/golang/src/github.com/cilium/cilium/cilium/main.go:20 +0x14
Recv   Send    Send
Socket Socket  Message  Elapsed
Size   Size    Size     Time     Throughput
bytes  bytes   bytes    secs.    10^6bits/sec
87380  16384  16384    30.00    11997.13
+ '[' 10.4.116.202 ']'
+ docker exec -i client netperf -l 30 -t TCP_STREAM -H 10.4.116.202
MIGRATED TCP STREAM TEST from 0.0.0.0 (0.0.0.0) port 0 AF_INET to 10.4.116.202 (10.4.11) port 0 AF_INET
Recv   Send    Send
Socket Socket  Message  Elapsed
Size   Size    Size     Time     Throughput
bytes  bytes   bytes    secs.    10^6bits/sec
87380  16384  16384    30.00    11589.28
+ docker exec -i client netperf -l 30 -t TCP_SENDFILE -H f00d::ac14:a04:0:f236
TCP SENDFILE TEST from ::0 (::) port 0 AF_INET6 to f00d::ac14:a04:0:f236 () port 0 AF_INET6
^C++ cleanup
++ docker rm -f server client
server
```
But usual get these errors. In any case `context deadline exceeded` might be the main cause (seems a timeout on something):
```
[root@localhost tests]# BENCHMARK=1 ./02-perf.sh
+ TEST_NET=cilium
+ NETPERF_IMAGE=noironetworks/netperf
+ TEST_TIME=30
+ '[' -z 1 ']'
+ trap cleanup EXIT
+ SERVER_LABEL=id.server
+ CLIENT_LABEL=id.client
+ docker network inspect cilium
[
{
"Name": "cilium",
"Id": "569d7b794e9256be99fa0c8e9c47b45865ff458e23e92644646481698cd03ea3",
"Scope": "local",
"Driver": "cilium",
"EnableIPv6": true,
"IPAM": {
"Driver": "cilium",
"Options": {},
"Config": [
{
"Subnet": "0.0.0.0/0",
"Gateway": "10.4.0.1/32"
},
{
"Subnet": "::1/112"
}
]
},
"Internal": false,
"Containers": {},
"Options": {},
"Labels": {}
}
]
+ docker run -dt --net=cilium --name server -l id.server noironetworks/netperf
3c35f81d1eafd716c08c62e640e9887f6ac7636acbcc564ece70feca6e67336e
+ docker run -dt --net=cilium --name client -l id.client noironetworks/netperf
52a24eb19e309b57495abc02d6b76c68ffef21915ea0ac5673b7161c92170028
+ sleep 2s
++ docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' client
+ CLIENT_IP=f00d::ac14:a04:0:f236
++ docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' client
+ CLIENT_IP4=10.4.116.202
++ cilium endpoint list
++ grep id.client
++ awk '{ print $1}'
+ CLIENT_ID=
++ docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server
+ SERVER_IP=f00d::ac14:a04:0:f7e8
++ docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' server
+ SERVER_IP4=10.4.138.214
++ cilium endpoint list
++ awk '{ print $1}'
++ grep id.server
+ SERVER_ID=63464
++ echo f00d::ac14:a04:0:f7e8
++ sed -e 's/:[0-9a-f]\{4\}$/:ffff/'
+ HOST_IP=f00d::ac14:a04:0:ffff
++ cilium endpoint get 63464
++ awk '{print $2}'
++ sed 's/"//g'
++ grep interface-name
++ sed 's/,$//'
Error: Cannot get endpoint 63464: context deadline exceeded
+ SERVER_DEV=
++ cilium endpoint get 63464
++ grep host-mac
++ sed 's/"//g'
++ awk '{print $2}'
++ sed 's/,$//'
+ NODE_MAC=f6:54:c7:0d:61:28
++ cilium endpoint get 63464
++ grep mac
++ sed 's/"//g'
++ sed 's/,$//'
++ awk '{print $2}'
+ LXC_MAC='f6:54:c7:0d:61:28
d6:54:b2:12:6b:18'
+ sleep 5
+ set -x
+ cat
+ cilium -D policy import -
2017-03-17T20:27:32.097+01:00 localhost.localdomain DEBU 001 loadPolicy > Entering directory -...
2017-03-17T20:27:32.097+01:00 localhost.localdomain DEBU 002 loadPolicyFile > Loading file -
2017-03-17T20:27:32.097+01:00 localhost.localdomain DEBU 003 UnmarshalJSON > Resolving tree: &{path: Name:root Parent:<nil> Rules:[Coverage: [cilium:id.server] Allowing: [{accept reserved:host} {accept cilium:id.client}]] Children:map[] mergeable:false resolved:false}
2017-03-17T20:27:32.097+01:00 localhost.localdomain DEBU 004 ResolveTree > Resolving policy node &{path: Name:root Parent:<nil> Rules:[Coverage: [cilium:id.server] Allowing: [{accept reserved:host} {accept cilium:id.client}]] Children:map[] mergeable:false resolved:false}
2017-03-17T20:27:32.097+01:00 localhost.localdomain DEBU 005 resolveRules > Resolving rules of node &{path:root Name:root Parent:<nil> Rules:[Coverage: [cilium:id.server] Allowing: [{accept reserved:host} {accept cilium:id.client}]] Children:map[] mergeable:false resolved:false}
2017-03-17T20:27:32.097+01:00 localhost.localdomain DEBU 006 Resolve > Resolving consumer rule Coverage: [cilium:id.server] Allowing: [{accept reserved:host} {accept cilium:id.client}]
2017-03-17T20:27:32.097+01:00 localhost.localdomain DEBU 007 Resolve > Resolved label cilium:id.server to path root.id.server
2017-03-17T20:27:32.097+01:00 localhost.localdomain DEBU 008 Resolve > Resolved label reserved:host to path root.host
2017-03-17T20:27:32.097+01:00 localhost.localdomain DEBU 009 Resolve > Resolved label cilium:id.client to path root.id.client
2017-03-17T20:27:32.097+01:00 localhost.localdomain DEBU 00a UnmarshalJSON > Resolved tree: &{path:root Name:root Parent:<nil> Rules:[Coverage: [cilium:id.server] Allowing: [{accept reserved:host} {accept cilium:id.client}]] Children:map[] mergeable:true resolved:true}
2017-03-17T20:27:32.097+01:00 localhost.localdomain DEBU 00b func17 > Constructed policy object for import &{path:root Name:root Parent:<nil> Rules:[Coverage: [cilium:id.server] Allowing: [{accept reserved:host} {accept cilium:id.client}]] Children:map[] mergeable:true resolved:true}
Error: Cannot import policy -: context deadline exceeded
+ cilium config DropNotification=false Debug=false
+ cilium endpoint config 63464 DropNotification=false Debug=false
Error: Cannot update endpoint 63464: context deadline exceeded
+ cilium endpoint config DropNotification=false Debug=false
Error: Cannot parse endpoint id "DropNotification=false": invalid numeric cilium id: strconv.ParseInt: parsing "DropNotification=false": invalid syntax
+ perf_test
+ docker exec -i client netperf -l 30 -t TCP_STREAM -H f00d::ac14:a04:0:f7e8
MIGRATED TCP STREAM TEST from ::0 (::) port 0 AF_INET6 to f00d::ac14:a04:0:f7e8 () port 0 AF_INET6
Recv   Send    Send
Socket Socket  Message  Elapsed
Size   Size    Size     Time     Throughput
bytes  bytes   bytes    secs.    10^6bits/sec
87380  16384  16384    30.00    12813.20
+ '[' 10.4.138.214 ']'
+ docker exec -i client netperf -l 30 -t TCP_STREAM -H 10.4.138.214
MIGRATED TCP STREAM TEST from 0.0.0.0 (0.0.0.0) port 0 AF_INET to 10.4.138.214 (10.4.13) port 0 AF_INET
Recv   Send    Send
Socket Socket  Message  Elapsed
Size   Size    Size     Time     Throughput
bytes  bytes   bytes    secs.    10^6bits/sec
87380  16384  16384    30.00    12721.16
+ docker exec -i client netperf -l 30 -t TCP_SENDFILE -H f00d::ac14:a04:0:f7e8
TCP SENDFILE TEST from ::0 (::) port 0 AF_INET6 to f00d::ac14:a04:0:f7e8 () port 0 AF_INET6
^C++ cleanup
++ docker rm -f server client
server
client
++ cilium config DropNotification=true Debug=true
```


<a href='https://www.codereviewhub.com/cilium/cilium/pull/334?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/334?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/334'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>