### PR TITLE
cilium: Print valid label prefixes into log

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -209,6 +209,11 @@ func initEnv() {
 		config.ValidLabelPrefixes.Append(labels.ParseLabelPrefix(label))
 	}
 
+	log.Infof("Valid label prefix configuration:")
+	for _, l := range config.ValidLabelPrefixes.LabelPrefixes {
+		log.Infof(" - %s", l)
+	}
+
 	config.ValidLabelPrefixesMU.Unlock()
 
 	_, r, err := net.ParseCIDR(nat46prefix)

--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -34,6 +34,10 @@ type LabelPrefix struct {
 	Source string `json:"source"`
 }
 
+func (p LabelPrefix) String() string {
+	return fmt.Sprintf("%s:%s", p.Source, p.Prefix)
+}
+
 func ParseLabelPrefix(label string) *LabelPrefix {
 	labelPrefix := LabelPrefix{}
 	t := strings.SplitN(label, ":", 2)


### PR DESCRIPTION
Signed-off-by:  <thomas@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/337%23discussion_r106748858%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20428f58190fac4f5c3a78765f47a2cc27c7b6ddc2%20pkg/labels/filter.go%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/337%23discussion_r106748858%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Should%20we%20use%20%60labels.go%3AparseSource%60%20here%3F%22%2C%20%22created_at%22%3A%20%222017-03-17T21%3A26%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pkg/labels/filter.go%3AL34-44%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 428f58190fac4f5c3a78765f47a2cc27c7b6ddc2 pkg/labels/filter.go 8'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/337#discussion_r106748858'>File: pkg/labels/filter.go:L34-44</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> Should we use `labels.go:parseSource` here?


<a href='https://www.codereviewhub.com/cilium/cilium/pull/337?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/337?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/337'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>