### PR TITLE
golint: fix typo

### DIFF
--- a/pkg/policy/node.go
+++ b/pkg/policy/node.go
@@ -75,7 +75,7 @@ func (node *Node) ResolveName(name string) string {
 // according to to the path specified. Takes a node with a list of optional
 // children and the path to where the node is/will be located in the tree.
 //
-// 1. If the name of a node is ommitted, the node name will be derived from
+// 1. If the name of a node is omitted, the node name will be derived from
 // the path. The element after the last node path delimiter is assumed to
 // be the node name, e.g. rootNode.parentNode.name
 //


### PR DESCRIPTION
Fixes the following warning

"ommitted" is a misspelling of "omitted" (misspell)

Related-to: #153 (Resolve golint warnings)
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/342?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/342'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>