### PR TITLE
golint: drop remaining else statement followed by return

### DIFF
--- a/bpf/lbmap/ipv4.go
+++ b/bpf/lbmap/ipv4.go
@@ -113,12 +113,12 @@ func (s *Service4Value) SetCount(count int)          { s.Count = uint16(count) }
 func (s *Service4Value) GetCount() int               { return int(s.Count) }
 func (s *Service4Value) SetRevNat(id int)            { s.RevNat = uint16(id) }
 func (s *Service4Value) SetAddress(ip net.IP) error {
-	if ip4 := ip.To4(); ip4 == nil {
+	ip4 := ip.To4()
+	if ip4 == nil {
 		return fmt.Errorf("Not an IPv4 address")
-	} else {
-		copy(s.Address[:], ip4)
-		return nil
 	}
+	copy(s.Address[:], ip4)
+	return nil
 }
 
 func (v *Service4Value) Convert() ServiceValue {

--- a/cilium/cmd/policy.go
+++ b/cilium/cmd/policy.go
@@ -179,16 +179,16 @@ func loadPolicy(name string) (*policy.Node, error) {
 			continue
 		}
 
-		if p, err := loadPolicyFile(filepath.Join(name, f.Name())); err != nil {
+		p, err := loadPolicyFile(filepath.Join(name, f.Name()))
+		if err != nil {
 			return nil, err
-		} else {
-			if node != nil {
-				if _, err := node.Merge(p); err != nil {
-					return nil, fmt.Errorf("Error: %s: %s", f.Name(), err)
-				}
-			} else {
-				node = p
+		}
+		if node != nil {
+			if _, err := node.Merge(p); err != nil {
+				return nil, fmt.Errorf("Error: %s: %s", f.Name(), err)
 			}
+		} else {
+			node = p
 		}
 	}
 
@@ -199,16 +199,16 @@ func loadPolicy(name string) (*policy.Node, error) {
 				continue
 			}
 			subpath := filepath.Join(name, f.Name())
-			if p, err := loadPolicy(subpath); err != nil {
+			p, err := loadPolicy(subpath)
+			if err != nil {
 				return nil, err
-			} else {
-				if p.Name == "" {
-					return nil, fmt.Errorf("Policy node import from %s did not derive a name",
-						subpath)
-				}
-
-				node.AddChild(p.Name, p)
 			}
+			if p.Name == "" {
+				return nil, fmt.Errorf("Policy node import from %s did not derive a name",
+					subpath)
+			}
+
+			node.AddChild(p.Name, p)
 		}
 	}
 

--- a/common/addressing/ip.go
+++ b/common/addressing/ip.go
@@ -51,11 +51,11 @@ func NewCiliumIPv6(address string) (CiliumIPv6, error) {
 	// As result of ParseIP, ip is either a valid IPv6 or IPv4 address. net.IP
 	// represents both versions on 16 bytes, so a more reliable way to tell
 	// IPv4 and IPv6 apart is to see if it fits 4 bytes
-	if ip4 := ip.To4(); ip4 != nil {
+	ip4 := ip.To4()
+	if ip4 != nil {
 		return nil, fmt.Errorf("Not an IPv6 address: %s", address)
-	} else {
-		return DeriveCiliumIPv6(ip.To16()), nil
 	}
+	return DeriveCiliumIPv6(ip.To16()), nil
 }
 
 func DeriveCiliumIPv6(src net.IP) CiliumIPv6 {
@@ -184,11 +184,11 @@ func NewCiliumIPv4(address string) (CiliumIPv4, error) {
 		}
 	}
 
-	if ip4 := ip.To4(); ip4 == nil {
+	ip4 := ip.To4()
+	if ip4 == nil {
 		return nil, fmt.Errorf("Not an IPv4 address")
-	} else {
-		return DeriveCiliumIPv4(ip4), nil
 	}
+	return DeriveCiliumIPv4(ip4), nil
 }
 
 func DeriveCiliumIPv4(src net.IP) CiliumIPv4 {

--- a/common/plugins/ipam.go
+++ b/common/plugins/ipam.go
@@ -58,42 +58,42 @@ func (a ByMask) Swap(i, j int) {
 
 // Returns IPv6 routes to be installed in endpoint's networking namespace
 func IPv6Routes(addr *models.NodeAddressing) ([]Route, error) {
-	if ip := net.ParseIP(addr.IPV6.IP); ip == nil {
+	ip := net.ParseIP(addr.IPV6.IP)
+	if ip == nil {
 		return []Route{}, fmt.Errorf("Invalid IP address: %s", addr.IPV6.IP)
-	} else {
-		return []Route{
-			{
-				Prefix: net.IPNet{
-					IP:   ip,
-					Mask: addressing.ContainerIPv6Mask,
-				},
-			},
-			{
-				Prefix:  addressing.IPv6DefaultRoute,
-				Nexthop: &ip,
-			},
-		}, nil
 	}
+	return []Route{
+		{
+			Prefix: net.IPNet{
+				IP:   ip,
+				Mask: addressing.ContainerIPv6Mask,
+			},
+		},
+		{
+			Prefix:  addressing.IPv6DefaultRoute,
+			Nexthop: &ip,
+		},
+	}, nil
 }
 
 // Returns IPv4 routes to be installed in endpoint's networking namespace
 func IPv4Routes(addr *models.NodeAddressing) ([]Route, error) {
-	if ip := net.ParseIP(addr.IPV4.IP); ip == nil {
+	ip := net.ParseIP(addr.IPV4.IP)
+	if ip == nil {
 		return []Route{}, fmt.Errorf("Invalid IP address: %s", addr.IPV4.IP)
-	} else {
-		return []Route{
-			{
-				Prefix: net.IPNet{
-					IP:   ip,
-					Mask: addressing.ContainerIPv4Mask,
-				},
-			},
-			{
-				Prefix:  addressing.IPv4DefaultRoute,
-				Nexthop: &ip,
-			},
-		}, nil
 	}
+	return []Route{
+		{
+			Prefix: net.IPNet{
+				IP:   ip,
+				Mask: addressing.ContainerIPv4Mask,
+			},
+		},
+		{
+			Prefix:  addressing.IPv4DefaultRoute,
+			Nexthop: &ip,
+		},
+	}, nil
 }
 
 func SufficientAddressing(addr *models.NodeAddressing) error {

--- a/daemon/ipam.go
+++ b/daemon/ipam.go
@@ -55,11 +55,11 @@ func (d *Daemon) AllocateIP(ip net.IP) *apierror.ApiError {
 }
 
 func (d *Daemon) allocateIP(ipAddr string) *apierror.ApiError {
-	if ip := net.ParseIP(ipAddr); ip == nil {
+	ip := net.ParseIP(ipAddr)
+	if ip == nil {
 		return apierror.New(PostIPAMIPInvalidCode, "Invalid IP address: %s", ipAddr)
-	} else {
-		return d.AllocateIP(ip)
 	}
+	return d.AllocateIP(ip)
 }
 
 func (d *Daemon) ReleaseIP(ip net.IP) *apierror.ApiError {
@@ -88,11 +88,11 @@ func (d *Daemon) ReleaseIP(ip net.IP) *apierror.ApiError {
 }
 
 func (d *Daemon) releaseIP(ipAddr string) *apierror.ApiError {
-	if ip := net.ParseIP(ipAddr); ip == nil {
+	ip := net.ParseIP(ipAddr)
+	if ip == nil {
 		return apierror.New(DeleteIPAMIPInvalidCode, "Invalid IP address: %s", ipAddr)
-	} else {
-		return d.ReleaseIP(ip)
 	}
+	return d.ReleaseIP(ip)
 }
 
 type postIPAM struct {

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -270,11 +270,11 @@ func (h *getPolicyPath) Handle(params GetPolicyPathParams) middleware.Responder 
 	d.policy.Mutex.RLock()
 	defer d.policy.Mutex.RUnlock()
 
-	if node, _ := d.policy.Lookup(params.Path); node == nil {
+	node, _ := d.policy.Lookup(params.Path)
+	if node == nil {
 		return NewGetPolicyPathNotFound()
-	} else {
-		return NewGetPolicyPathOK().WithPayload(models.PolicyTree(node.JSONMarshal()))
 	}
+	return NewGetPolicyPathOK().WithPayload(models.PolicyTree(node.JSONMarshal()))
 }
 
 func (d *Daemon) PolicyInit() error {
@@ -295,12 +295,12 @@ func (d *Daemon) PolicyInit() error {
 			return fmt.Errorf("Could not create policy BPF map '%s': %s", policyMapPath, err)
 		}
 
-		if c := d.consumableCache.GetOrCreate(v, secLbl); c == nil {
+		c := d.consumableCache.GetOrCreate(v, secLbl)
+		if c == nil {
 			return fmt.Errorf("Unable to initialize consumable for %v", secLbl)
-		} else {
-			d.consumableCache.AddReserved(c)
-			c.AddMap(policyMap)
 		}
+		d.consumableCache.AddReserved(c)
+		c.AddMap(policyMap)
 	}
 
 	return nil

--- a/pkg/client/endpoint.go
+++ b/pkg/client/endpoint.go
@@ -32,11 +32,11 @@ func (c *Client) EndpointList() ([]*models.Endpoint, error) {
 // Get endpoint by ID
 func (c *Client) EndpointGet(id string) (*models.Endpoint, error) {
 	params := endpoint.NewGetEndpointIDParams().WithID(id)
-	if resp, err := c.Endpoint.GetEndpointID(params); err != nil {
+	resp, err := c.Endpoint.GetEndpointID(params)
+	if err != nil {
 		return nil, err
-	} else {
-		return resp.Payload, nil
 	}
+	return resp.Payload, nil
 }
 
 // Create endpoint
@@ -64,11 +64,11 @@ func (c *Client) EndpointDelete(id string) error {
 // Get endpoint configuration
 func (c *Client) EndpointConfigGet(id string) (*models.Configuration, error) {
 	params := endpoint.NewGetEndpointIDConfigParams().WithID(id)
-	if resp, err := c.Endpoint.GetEndpointIDConfig(params); err != nil {
+	resp, err := c.Endpoint.GetEndpointIDConfig(params)
+	if err != nil {
 		return nil, err
-	} else {
-		return resp.Payload, nil
 	}
+	return resp.Payload, nil
 }
 
 // Modify endpoint configuration
@@ -85,11 +85,11 @@ func (c *Client) EndpointConfigPatch(id string, cfg models.ConfigurationMap) err
 // Get endpoint label configuration
 func (c *Client) EndpointLabelsGet(id string) (*models.LabelConfiguration, error) {
 	params := endpoint.NewGetEndpointIDLabelsParams().WithID(id)
-	if resp, err := c.Endpoint.GetEndpointIDLabels(params); err != nil {
+	resp, err := c.Endpoint.GetEndpointIDLabels(params)
+	if err != nil {
 		return nil, err
-	} else {
-		return resp.Payload, nil
 	}
+	return resp.Payload, nil
 }
 
 // Modify endpoint label configuration

--- a/pkg/client/identity.go
+++ b/pkg/client/identity.go
@@ -23,9 +23,9 @@ import (
 func (c *Client) IdentityGet(id string) (*models.Identity, error) {
 	params := policy.NewGetIdentityIDParams().WithID(id)
 
-	if resp, err := c.Policy.GetIdentityID(params); err != nil {
+	resp, err := c.Policy.GetIdentityID(params)
+	if err != nil {
 		return nil, err
-	} else {
-		return resp.Payload, nil
 	}
+	return resp.Payload, nil
 }

--- a/pkg/client/policy.go
+++ b/pkg/client/policy.go
@@ -22,29 +22,28 @@ import (
 // Modify a node in the policy tree
 func (c *Client) PolicyPut(path string, policyJSON string) (string, error) {
 	params := policy.NewPutPolicyPathParams().WithPath(path).WithPolicy(&policyJSON)
-	if resp, err := c.Policy.PutPolicyPath(params); err != nil {
+	resp, err := c.Policy.PutPolicyPath(params)
+	if err != nil {
 		return "", err
-	} else {
-		return string(resp.Payload), nil
 	}
+	return string(resp.Payload), nil
 }
 
 // Get policy tree or subtree
 func (c *Client) PolicyGet(path string) (string, error) {
 	if path == "" {
-		if resp, err := c.Policy.GetPolicy(nil); err != nil {
+		resp, err := c.Policy.GetPolicy(nil)
+		if err != nil {
 			return "", err
-		} else {
-			return string(resp.Payload), nil
 		}
-	} else {
-		params := policy.NewGetPolicyPathParams().WithPath(path)
-		if resp, err := c.Policy.GetPolicyPath(params); err != nil {
-			return "", err
-		} else {
-			return string(resp.Payload), nil
-		}
+		return string(resp.Payload), nil
 	}
+	params := policy.NewGetPolicyPathParams().WithPath(path)
+	resp, err := c.Policy.GetPolicyPath(params)
+	if err != nil {
+		return "", err
+	}
+	return string(resp.Payload), nil
 }
 
 // Delete a node in the policy tree
@@ -57,9 +56,9 @@ func (c *Client) PolicyDelete(path string) error {
 // Resolve policy for a context with source and destination identity
 func (c *Client) PolicyResolveGet(context *models.IdentityContext) (*models.PolicyTraceResult, error) {
 	params := policy.NewGetPolicyResolveParams().WithIdentityContext(context)
-	if resp, err := c.Policy.GetPolicyResolve(params); err != nil {
+	resp, err := c.Policy.GetPolicyResolve(params)
+	if err != nil {
 		return nil, err
-	} else {
-		return resp.Payload, nil
 	}
+	return resp.Payload, nil
 }

--- a/pkg/client/service.go
+++ b/pkg/client/service.go
@@ -21,21 +21,21 @@ import (
 
 // Get list of all services
 func (c *Client) GetServices() ([]*models.Service, error) {
-	if resp, err := c.Service.GetService(nil); err != nil {
+	resp, err := c.Service.GetService(nil)
+	if err != nil {
 		return nil, err
-	} else {
-		return resp.Payload, nil
 	}
+	return resp.Payload, nil
 }
 
 // Get service by ID
 func (c *Client) GetServiceID(id int64) (*models.Service, error) {
 	params := service.NewGetServiceIDParams().WithID(id)
-	if resp, err := c.Service.GetServiceID(params); err != nil {
+	resp, err := c.Service.GetServiceID(params)
+	if err != nil {
 		return nil, err
-	} else {
-		return resp.Payload, nil
 	}
+	return resp.Payload, nil
 }
 
 // Create or update service. Returns true if service was created

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -175,36 +175,36 @@ func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, 
 	}
 
 	if base.Mac != "" {
-		if m, err := mac.ParseMAC(base.Mac); err != nil {
+		m, err := mac.ParseMAC(base.Mac)
+		if err != nil {
 			return nil, err
-		} else {
-			ep.LXCMAC = m
 		}
+		ep.LXCMAC = m
 	}
 
 	if base.HostMac != "" {
-		if m, err := mac.ParseMAC(base.HostMac); err != nil {
+		m, err := mac.ParseMAC(base.HostMac)
+		if err != nil {
 			return nil, err
-		} else {
-			ep.NodeMAC = m
 		}
+		ep.NodeMAC = m
 	}
 
 	if base.Addressing != nil {
 		if ip := base.Addressing.IPV6; ip != "" {
-			if ip6, err := addressing.NewCiliumIPv6(ip); err != nil {
+			ip6, err := addressing.NewCiliumIPv6(ip)
+			if err != nil {
 				return nil, err
-			} else {
-				ep.IPv6 = ip6
 			}
+			ep.IPv6 = ip6
 		}
 
 		if ip := base.Addressing.IPV4; ip != "" {
-			if ip4, err := addressing.NewCiliumIPv4(ip); err != nil {
+			ip4, err := addressing.NewCiliumIPv4(ip)
+			if err != nil {
 				return nil, err
-			} else {
-				ep.IPv4 = ip4
 			}
+			ep.IPv4 = ip4
 		}
 	}
 
@@ -380,9 +380,8 @@ func (e *Endpoint) DirectoryPath() string {
 func (e *Endpoint) Allows(id policy.NumericIdentity) bool {
 	if e.Consumable != nil {
 		return e.Consumable.Allows(id)
-	} else {
-		return false
 	}
+	return false
 }
 
 // String returns endpoint on a JSON format.

--- a/pkg/endpoint/id.go
+++ b/pkg/endpoint/id.go
@@ -43,23 +43,22 @@ func NewID(prefix PrefixType, id string) string {
 func SplitID(id string) (PrefixType, string) {
 	if s := strings.Split(id, ":"); len(s) == 2 {
 		return PrefixType(s[0]), s[1]
-	} else {
-		// default prefix
-		return CiliumLocalIdPrefix, id
 	}
+	// default prefix
+	return CiliumLocalIdPrefix, id
 }
 
 // Parses id as cilium endpoint id and returns numeric portion
 func ParseCiliumID(id string) (int64, error) {
-	if prefix, id := SplitID(id); prefix != CiliumLocalIdPrefix {
+	prefix, id := SplitID(id)
+	if prefix != CiliumLocalIdPrefix {
 		return 0, fmt.Errorf("not a cilium identifier")
-	} else {
-		if n, err := strconv.ParseInt(id, 0, 64); err != nil {
-			return 0, fmt.Errorf("invalid numeric cilium id: %s", err)
-		} else {
-			return n, nil
-		}
 	}
+	n, err := strconv.ParseInt(id, 0, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid numeric cilium id: %s", err)
+	}
+	return n, nil
 }
 
 // FIXME:
@@ -84,9 +83,9 @@ func ParseID(id string) (PrefixType, string, error) {
 
 // Parses specified id and returns normalized id as string
 func ValidateID(id string) (PrefixType, string, error) {
-	if prefix, _, err := ParseID(id); err != nil {
+	prefix, _, err := ParseID(id)
+	if err != nil {
 		return "", "", err
-	} else {
-		return prefix, id, nil
 	}
+	return prefix, id, nil
 }

--- a/pkg/kvstore/local.go
+++ b/pkg/kvstore/local.go
@@ -54,11 +54,11 @@ func (l *LocalClient) GetValue(k string) (json.RawMessage, error) {
 }
 
 func (l *LocalClient) SetValue(k string, v interface{}) error {
-	if vByte, err := json.Marshal(v); err != nil {
+	vByte, err := json.Marshal(v)
+	if err != nil {
 		return err
-	} else {
-		l.store[k] = string(vByte)
 	}
+	l.store[k] = string(vByte)
 
 	return nil
 }

--- a/pkg/policy/identity.go
+++ b/pkg/policy/identity.go
@@ -34,11 +34,11 @@ const (
 type NumericIdentity uint32
 
 func ParseNumericIdentity(id string) (NumericIdentity, error) {
-	if nid, err := strconv.ParseUint(id, 0, 32); err != nil {
+	nid, err := strconv.ParseUint(id, 0, 32)
+	if err != nil {
 		return NumericIdentity(0), err
-	} else {
-		return NumericIdentity(nid), nil
 	}
+	return NumericIdentity(nid), nil
 }
 
 func (id NumericIdentity) StringID() string {

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -160,11 +160,11 @@ func (driver *driver) Listen(socket string) error {
 	handleMethod("IpamDriver.RequestAddress", driver.requestAddress)
 	handleMethod("IpamDriver.ReleaseAddress", driver.releaseAddress)
 
-	if listener, err := net.Listen("unix", socket); err != nil {
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
 		return err
-	} else {
-		return http.Serve(listener, router)
 	}
+	return http.Serve(listener, router)
 }
 
 func notFound(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This is a follow up to 777cddbc6208 (golint: drop some else statement followed
by return, 2017-03-17). These were unstaged previosly because they broke the
build, they are now reworked to not introduce any new errors. After this there
should be no more warnings like the following

... if block ends with a return statement, so drop this else and outdent its
    block (golint)

Related-to: #153 (Resolve golint warnings)
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/345?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/345'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>