### PR TITLE
daemon: Speed up initial synchronization with container runtime

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/server"
@@ -270,10 +269,8 @@ func runDaemon() {
 
 	d.EnableMonitor()
 
-	var wg sync.WaitGroup
 	sinceLastSync := time.Now()
-	d.SyncDocker(&wg)
-	wg.Wait()
+	d.SyncDocker()
 
 	// Register event listener in docker endpoint
 	if err := d.EnableDockerEventListener(sinceLastSync); err != nil {
@@ -286,7 +283,7 @@ func runDaemon() {
 		log.Warningf("Error while enabling k8s watcher %s", err)
 	}
 
-	go d.EnableDockerSync()
+	d.RunBackgroundContainerSync()
 
 	swaggerSpec, err := loads.Analyzed(server.SwaggerJSON, "")
 	if err != nil {


### PR DESCRIPTION
The current behaviour was to walk all local containers currently running
and check if they are supposed to be managed by Cilium. The function to
do so was shared with the logic is used when f.e. Docker sends an event
that a container has been created. This logic assumes that another event
is received later on which requests to handle networking for this
container.

While this logic makes sense when handling container create events, it
is very unlikely that this event will be received for an already running
container unless the container has just been start. Thus, the handler
would always time out waiting for the event. The daemon startup was
delayed until this happened.

This commit changes behaviour to:
 - No longer wait for the network manage event to be received on the
   initial container sync and on the regular sync. The first means that
   we simply ignore local containers if no network event was received.
   For the regular sync every N seconds, do not wait either as we
   retry anyway later on.
 - Continue waiting in the go routine when handling actual container
   create events.

Fixes: #259

Signed-off-by:  <thomas@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/346%23issuecomment-287569697%22%2C%20%22https%3A//github.com/cilium/cilium/pull/346%23issuecomment-287571003%22%2C%20%22https%3A//github.com/cilium/cilium/pull/346%23issuecomment-287571414%22%2C%20%22https%3A//github.com/cilium/cilium/pull/346%23issuecomment-287571510%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/346%23issuecomment-287569697%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20totally%20fixes%20%23259%3F%20The%20restore%20functionality%20is%20currently%20broken.%22%2C%20%22created_at%22%3A%20%222017-03-18T19%3A41%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20This%20totally%20fixes%20%23259%3F%20The%20restore%20functionality%20is%20currently%20broken.%5Cr%5Cn%5Cr%5CnWhich%20part%20is%20broken%3F%20agent%20needs%20to%20be%20started%20with%20%60--restore%60%20flag.%20This%20resolves%20the%20major%20slowdown%20while%20starting%20up%20for%20me.%22%2C%20%22created_at%22%3A%20%222017-03-18T20%3A03%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20I%20thought%20it%20was%20set%20with%20%60--restore%60%20by%20default%22%2C%20%22created_at%22%3A%20%222017-03-18T20%3A09%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20Ah%2C%20I%20thought%20it%20was%20set%20with%20--restore%20by%20default%5Cr%5Cn%5Cr%5CnI%27m%20fine%20enabling%20restore%20by%20default%20given%20how%20fast%20it%20is%20now%20for%20me%20but%20I%20would%20like%20to%20test%20it%20a%20bit%20more.%22%2C%20%22created_at%22%3A%20%222017-03-18T20%3A11%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/346#issuecomment-287569697'>General Comment</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> This totally fixes #259? The restore functionality is currently broken.
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> > This totally fixes #259? The restore functionality is currently broken.
Which part is broken? agent needs to be started with `--restore` flag. This resolves the major slowdown while starting up for me.
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> Ah, I thought it was set with `--restore` by default
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> > Ah, I thought it was set with --restore by default
I'm fine enabling restore by default given how fast it is now for me but I would like to test it a bit more.


<a href='https://www.codereviewhub.com/cilium/cilium/pull/346?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/346?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/346'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>