### PR TITLE
Separate generic and cilium specific BPF bits in bpf package

### DIFF
--- a/cilium/cmd/monitor.go
+++ b/cilium/cmd/monitor.go
@@ -24,6 +24,7 @@ import (
 	"syscall"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/bpfdebug"
 
 	"github.com/spf13/cobra"
 )
@@ -68,21 +69,21 @@ func receiveEvent(msg *bpf.PerfEventSample, cpu int) {
 	prefix := fmt.Sprintf("CPU %02d:", cpu)
 
 	data := msg.DataDirect()
-	if data[0] == bpf.CILIUM_NOTIFY_DROP {
-		dn := bpf.DropNotify{}
+	if data[0] == bpfdebug.MessageTypeDrop {
+		dn := bpfdebug.DropNotify{}
 		if err := binary.Read(bytes.NewReader(data), binary.LittleEndian, &dn); err != nil {
 			fmt.Printf("Error while parsing drop notification message: %s\n", err)
 		}
 		dn.Dump(dissect, data, prefix)
-	} else if data[0] == bpf.CILIUM_DBG_MSG {
-		dm := bpf.DebugMsg{}
+	} else if data[0] == bpfdebug.MessageTypeDebug {
+		dm := bpfdebug.DebugMsg{}
 		if err := binary.Read(bytes.NewReader(data), binary.LittleEndian, &dm); err != nil {
 			fmt.Printf("Error while parsing debug message: %s\n", err)
 		} else {
 			dm.Dump(data, prefix)
 		}
-	} else if data[0] == bpf.CILIUM_DBG_CAPTURE {
-		dc := bpf.DebugCapture{}
+	} else if data[0] == bpfdebug.MessageTypeCapture {
+		dc := bpfdebug.DebugCapture{}
 		if err := binary.Read(bytes.NewReader(data), binary.LittleEndian, &dc); err != nil {
 			fmt.Printf("Error while parsing debug capture message: %s\n", err)
 		}

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -26,12 +26,13 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/bpfdebug"
 )
 
 func (d *Daemon) receiveEvent(msg *bpf.PerfEventSample, cpu int) {
 	data := msg.DataDirect()
-	if data[0] == bpf.CILIUM_NOTIFY_DROP {
-		dn := bpf.DropNotify{}
+	if data[0] == bpfdebug.MessageTypeDrop {
+		dn := bpfdebug.DropNotify{}
 		if err := binary.Read(bytes.NewReader(data), binary.LittleEndian, &dn); err != nil {
 			log.Warningf("Error while parsing drop notification message: %s\n", err)
 			return

--- a/pkg/bpfdebug/dissect.go
+++ b/pkg/bpfdebug/dissect.go
@@ -41,8 +41,10 @@ var (
 // Dissect parses and prints the provided data if dissect is set to true,
 // otherwise the data is printed as HEX output
 func Dissect(dissect bool, data []byte) {
-	lock.Lock()
 	if dissect {
+		lock.Lock()
+		defer lock.Unlock()
+
 		parser.DecodeLayers(data, &decoded)
 
 		for _, typ := range decoded {
@@ -72,5 +74,4 @@ func Dissect(dissect bool, data []byte) {
 	} else {
 		fmt.Println(hex.Dump(data))
 	}
-	lock.Unlock()
 }

--- a/pkg/bpfdebug/dissect.go
+++ b/pkg/bpfdebug/dissect.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bpf
+package bpfdebug
 
 import (
 	"encoding/hex"
@@ -38,6 +38,8 @@ var (
 	lock    sync.Mutex
 )
 
+// Dissect parses and prints the provided data if dissect is set to true,
+// otherwise the data is printed as HEX output
 func Dissect(dissect bool, data []byte) {
 	lock.Lock()
 	if dissect {


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/351%23discussion_r106821759%22%2C%20%22https%3A//github.com/cilium/cilium/pull/351%23discussion_r106821783%22%2C%20%22https%3A//github.com/cilium/cilium/pull/351%23discussion_r106822339%22%2C%20%22https%3A//github.com/cilium/cilium/pull/351%23discussion_r106822370%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20401cd585cab9e63d2e6859266c967ca97f8eac79%20pkg/bpfdebug/dissect.go%2018%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/351%23discussion_r106821783%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%27s%20this%20lock%20for%3F%22%2C%20%22created_at%22%3A%20%222017-03-19T22%3A59%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22Because%20%60decoded%60%20is%20shared%20between%20multiple%20invocations.%20%20This%20is%20currently%20faster%20than%20creating%20a%20new%20parser%20for%20every%20dissect%20but%20ideally%20we%20have%20one%20parser%20per%20CPU%20so%20we%20don%27t%20have%20to%20share%20the%20state%20among%20CPUs.%22%2C%20%22created_at%22%3A%20%222017-03-19T23%3A21%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pkg/bpfdebug/dissect.go%3AL38-51%22%7D%2C%20%22Pull%20401cd585cab9e63d2e6859266c967ca97f8eac79%20pkg/bpfdebug/debug.go%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/351%23discussion_r106821759%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20do%20we%20use%20%60bpf/lib/common%60%20values%20instead%3F%22%2C%20%22created_at%22%3A%20%222017-03-19T22%3A58%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20want%20to%20get%20away%20from%20cgo%20long%20term.%20It%20seriously%20slows%20down%20the%20build%20and%20requires%20a%20ton%20of%20memory.%20These%20numbers%20are%20absolutely%20set%20in%20stone%20and%20can%20never%20change%20again.%22%2C%20%22created_at%22%3A%20%222017-03-19T23%3A22%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pkg/bpfdebug/debug.go%3AL12-116%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> Why do we use `bpf/lib/common` values instead?
- [ ] <a href='#crh-comment-Pull 401cd585cab9e63d2e6859266c967ca97f8eac79 pkg/bpfdebug/debug.go 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/351#discussion_r106821759'>File: pkg/bpfdebug/debug.go:L12-116</a></b>
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> I want to get away from cgo long term. It seriously slows down the build and requires a ton of memory. These numbers are absolutely set in stone and can never change again.
- [ ] <a href='#crh-comment-Pull 401cd585cab9e63d2e6859266c967ca97f8eac79 pkg/bpfdebug/dissect.go 18'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/351#discussion_r106821783'>File: pkg/bpfdebug/dissect.go:L38-51</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> What's this lock for?
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> Because `decoded` is shared between multiple invocations.  This is currently faster than creating a new parser for every dissect but ideally we have one parser per CPU so we don't have to share the state among CPUs.


<a href='https://www.codereviewhub.com/cilium/cilium/pull/351?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/351?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/351'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>