### PR TITLE
README: remove periods from FAQ link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ for containers.
  * 5-min Quickstart: [Using the prebuilt docker images](examples/docker-compose/README.md)
  * For Developers: [Setting up a vagrant environment](doc/vagrant.md)
  * Manual installation: [Detailed installation instructions](doc/installation.md)
- * F.A.Q.: [F.A.Q.](doc/faq.md)
+ * F.A.Q.: [FAQ](doc/faq.md)
 
 ## Demo Tutorials
 


### PR DESCRIPTION
Also having the combination without periods makes it easier for people
searching the site to find the link '^F faq'.

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/353?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/353'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>