### PR TITLE
daemon: Remove unnecessary package aliases

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/server"
 	"github.com/cilium/cilium/api/v1/server/restapi"
-	common "github.com/cilium/cilium/common"
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/daemon/defaults"
 	"github.com/cilium/cilium/daemon/options"
@@ -33,7 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 
 	etcdAPI "github.com/coreos/etcd/clientv3"
-	loads "github.com/go-openapi/loads"
+	"github.com/go-openapi/loads"
 	consulAPI "github.com/hashicorp/consul/api"
 	flags "github.com/jessevdk/go-flags"
 	logging "github.com/op/go-logging"


### PR DESCRIPTION
Remove package aliases where they already correspond to the package
name.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/359?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/359'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>