### PR TITLE
golint: use consistent receiver names

### DIFF
--- a/common/types/loadbalancer.go
+++ b/common/types/loadbalancer.go
@@ -333,39 +333,39 @@ func (b *LBBackEnd) GetBackendModel() *models.BackendAddress {
 
 // String returns the L3n4Addr in the "IPv4:Port" format for IPv4 and "[IPv6]:Port" format
 // for IPv6.
-func (l *L3n4Addr) String() string {
-	if l.IsIPv6() {
-		return fmt.Sprintf("[%s]:%d", l.IP.String(), l.Port)
+func (a *L3n4Addr) String() string {
+	if a.IsIPv6() {
+		return fmt.Sprintf("[%s]:%d", a.IP.String(), a.Port)
 	}
-	return fmt.Sprintf("%s:%d", l.IP.String(), l.Port)
+	return fmt.Sprintf("%s:%d", a.IP.String(), a.Port)
 }
 
 // DeepCopy returns a DeepCopy of the given L3n4Addr.
-func (l *L3n4Addr) DeepCopy() *L3n4Addr {
-	copyIP := make(net.IP, len(l.IP))
-	copy(copyIP, l.IP)
+func (a *L3n4Addr) DeepCopy() *L3n4Addr {
+	copyIP := make(net.IP, len(a.IP))
+	copy(copyIP, a.IP)
 	return &L3n4Addr{
 		IP:     copyIP,
-		L4Addr: *l.L4Addr.DeepCopy(),
+		L4Addr: *a.L4Addr.DeepCopy(),
 	}
 }
 
 // SHA256Sum calculates L3n4Addr's internal SHA256Sum.
-func (l3n4Addr L3n4Addr) SHA256Sum() string {
+func (a L3n4Addr) SHA256Sum() string {
 	// FIXME: Remove Protocol's omission once we care about protocols.
-	protoBak := l3n4Addr.Protocol
-	l3n4Addr.Protocol = ""
+	protoBak := a.Protocol
+	a.Protocol = ""
 	defer func() {
-		l3n4Addr.Protocol = protoBak
+		a.Protocol = protoBak
 	}()
 
-	str := []byte(fmt.Sprintf("%+v", l3n4Addr))
+	str := []byte(fmt.Sprintf("%+v", a))
 	return fmt.Sprintf("%x", sha512.New512_256().Sum(str))
 }
 
 // IsIPv6 returns true if the IP address in the given L3n4Addr is IPv6 or not.
-func (l *L3n4Addr) IsIPv6() bool {
-	return l.IP.To4() == nil
+func (a *L3n4Addr) IsIPv6() bool {
+	return a.IP.To4() == nil
 }
 
 // L3n4AddrID is used to store, as an unique L3+L4 plus the assigned ID, in the

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -181,11 +181,11 @@ func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 }
 
 // FIXME: Clean this function up
-func writeGeneve(prefix string, ep *Endpoint) ([]byte, error) {
+func writeGeneve(prefix string, e *Endpoint) ([]byte, error) {
 	// Write container options values for each available option in
 	// bpf/lib/geneve.h
 	// GENEVE_CLASS_EXPERIMENTAL, GENEVE_TYPE_SECLABEL
-	err := geneve.WriteOpts(filepath.Join(prefix, "geneve_opts.cfg"), "0xffff", "0x1", "4", fmt.Sprintf("%08x", ep.SecLabel.ID.Uint32()))
+	err := geneve.WriteOpts(filepath.Join(prefix, "geneve_opts.cfg"), "0xffff", "0x1", "4", fmt.Sprintf("%08x", e.SecLabel.ID.Uint32()))
 	if err != nil {
 		return nil, fmt.Errorf("Could not write geneve options %s", err)
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -394,13 +394,13 @@ func (e *EndpointStatus) String() string {
 	return OK.String()
 }
 
-func (es *EndpointStatus) DeepCopy() *EndpointStatus {
+func (e *EndpointStatus) DeepCopy() *EndpointStatus {
 	cpy := NewEndpointStatus()
-	es.indexMU.RLock()
-	defer es.indexMU.RUnlock()
-	cpy.Index = es.Index
+	e.indexMU.RLock()
+	defer e.indexMU.RUnlock()
+	cpy.Index = e.Index
 	cpy.Log = statusLog{}
-	for _, v := range es.Log {
+	for _, v := range e.Log {
 		cpy.Log = append(cpy.Log, v)
 	}
 	return cpy
@@ -490,17 +490,17 @@ func (e *Endpoint) ApplyOpts(opts map[string]string) bool {
 	return e.Opts.Apply(opts, OptionChanged, e) > 0
 }
 
-func (ep *Endpoint) SetDefaultOpts(opts *option.BoolOptions) {
-	if ep.Opts == nil {
-		ep.Opts = option.NewBoolOptions(&EndpointOptionLibrary)
+func (e *Endpoint) SetDefaultOpts(opts *option.BoolOptions) {
+	if e.Opts == nil {
+		e.Opts = option.NewBoolOptions(&EndpointOptionLibrary)
 	}
-	if ep.Opts.Library == nil {
-		ep.Opts.Library = &EndpointOptionLibrary
+	if e.Opts.Library == nil {
+		e.Opts.Library = &EndpointOptionLibrary
 	}
 
 	if opts != nil {
 		for k := range EndpointMutableOptionLibrary {
-			ep.Opts.Set(k, opts.IsEnabled(k))
+			e.Opts.Set(k, opts.IsEnabled(k))
 		}
 	}
 }
@@ -541,8 +541,8 @@ func (epS *epSorter) Less(i, j int) bool {
 }
 
 // Base64 returns the endpoint in a base64 format.
-func (ep Endpoint) Base64() (string, error) {
-	jsonBytes, err := json.Marshal(ep)
+func (e Endpoint) Base64() (string, error) {
+	jsonBytes, err := json.Marshal(e)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/kvstore/local.go
+++ b/pkg/kvstore/local.go
@@ -264,6 +264,6 @@ func (l *LocalClient) GetWatcher(key string, timeSleep time.Duration) <-chan []p
 	return make(chan []policy.NumericIdentity, 1)
 }
 
-func (e *LocalClient) Status() (string, error) {
+func (l *LocalClient) Status() (string, error) {
 	return "Local: OK", nil
 }

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -310,9 +310,9 @@ func Map2Labels(m map[string]string, source string) Labels {
 	return o
 }
 
-func (lbls Labels) DeepCopy() Labels {
+func (l Labels) DeepCopy() Labels {
 	o := Labels{}
-	for k, v := range lbls {
+	for k, v := range l {
 		o[k] = &Label{
 			Key:    v.Key,
 			Value:  v.Value,
@@ -333,9 +333,9 @@ func NewLabelsFromModel(base []string) Labels {
 	return lbls
 }
 
-func (lbls Labels) GetModel() []string {
+func (l Labels) GetModel() []string {
 	res := []string{}
-	for _, v := range lbls {
+	for _, v := range l {
 		res = append(res, v.String())
 	}
 	return res
@@ -349,22 +349,22 @@ func (lbls Labels) GetModel() []string {
 // to.MergeLabels(from)
 // fmt.Printf("%+v\n", to)
 //   Labels{Label{key1, value3, source4}, Label{key2, value3, source4}}
-func (lbls Labels) MergeLabels(from Labels) {
+func (l Labels) MergeLabels(from Labels) {
 	fromCpy := from.DeepCopy()
 	for k, v := range fromCpy {
-		lbls[k] = v
+		l[k] = v
 	}
 }
 
-// SHA256Sum calculates lbls' internal SHA256Sum. For a particular set of labels is
+// SHA256Sum calculates l' internal SHA256Sum. For a particular set of labels is
 // guarantee that it will always have the same SHA256Sum.
-func (lbls Labels) SHA256Sum() string {
-	return fmt.Sprintf("%x", sha512.New512_256().Sum(lbls.sortedList()))
+func (l Labels) SHA256Sum() string {
+	return fmt.Sprintf("%x", sha512.New512_256().Sum(l.sortedList()))
 }
 
-func (lbls Labels) sortedList() []byte {
+func (l Labels) sortedList() []byte {
 	var keys []string
-	for k := range lbls {
+	for k := range l {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
@@ -373,16 +373,16 @@ func (lbls Labels) sortedList() []byte {
 	for _, k := range keys {
 		// We don't care if the values already have a '=' since this method is
 		// only used to calculate a SHA256Sum
-		result += fmt.Sprintf(`%s=%s;`, k, lbls[k].Value)
+		result += fmt.Sprintf(`%s=%s;`, k, l[k].Value)
 	}
 
 	return []byte(result)
 }
 
 /// ToSlice returns a slice of label with the values of the given Labels' map.
-func (lbls Labels) ToSlice() []Label {
+func (l Labels) ToSlice() []Label {
 	labels := []Label{}
-	for _, v := range lbls {
+	for _, v := range l {
 		labels = append(labels, *v)
 	}
 	return labels

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -132,20 +132,20 @@ func (s *Service4Value) SetAddress(ip net.IP) error {
 	return nil
 }
 
-func (v *Service4Value) Convert() ServiceValue {
-	n := *v
+func (s *Service4Value) Convert() ServiceValue {
+	n := *s
 	n.RevNat = common.Swab16(n.RevNat)
 	n.Port = common.Swab16(n.Port)
 	n.Weight = common.Swab16(n.Weight)
 	return &n
 }
 
-func (v *Service4Value) RevNatKey() RevNatKey {
-	return &RevNat4Key{v.RevNat}
+func (s *Service4Value) RevNatKey() RevNatKey {
+	return &RevNat4Key{s.RevNat}
 }
 
-func (v *Service4Value) String() string {
-	return fmt.Sprintf("%s:%d (%d)", v.Address, v.Port, v.RevNat)
+func (s *Service4Value) String() string {
+	return fmt.Sprintf("%s:%d (%d)", s.Address, s.Port, s.RevNat)
 }
 
 func Service4DumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue, error) {

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -129,16 +129,16 @@ func (s *Service6Value) SetAddress(ip net.IP) error {
 	return nil
 }
 
-func (v *Service6Value) Convert() ServiceValue {
-	n := *v
+func (s *Service6Value) Convert() ServiceValue {
+	n := *s
 	n.RevNat = common.Swab16(n.RevNat)
 	n.Port = common.Swab16(n.Port)
 	n.Weight = common.Swab16(n.Weight)
 	return &n
 }
 
-func (v *Service6Value) String() string {
-	return fmt.Sprintf("[%s]:%d (%d)", v.Address, v.Port, v.RevNat)
+func (s *Service6Value) String() string {
+	return fmt.Sprintf("[%s]:%d (%d)", s.Address, s.Port, s.RevNat)
 }
 
 func Service6DumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue, error) {
@@ -183,15 +183,15 @@ func NewRevNat6Key(value uint16) *RevNat6Key {
 	return &RevNat6Key{value}
 }
 
-func (k *RevNat6Key) IsIPv6() bool              { return true }
-func (k *RevNat6Key) Map() *bpf.Map             { return RevNat6Map }
-func (k *RevNat6Key) NewValue() bpf.MapValue    { return &RevNat6Value{} }
-func (k *RevNat6Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
-func (k *RevNat6Key) String() string            { return fmt.Sprintf("%d", k.Key) }
-func (k *RevNat6Key) GetKey() uint16            { return k.Key }
+func (v *RevNat6Key) IsIPv6() bool              { return true }
+func (v *RevNat6Key) Map() *bpf.Map             { return RevNat6Map }
+func (v *RevNat6Key) NewValue() bpf.MapValue    { return &RevNat6Value{} }
+func (v *RevNat6Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(v) }
+func (v *RevNat6Key) String() string            { return fmt.Sprintf("%d", v.Key) }
+func (v *RevNat6Key) GetKey() uint16            { return v.Key }
 
-func (k *RevNat6Key) Convert() RevNatKey {
-	n := *k
+func (v *RevNat6Key) Convert() RevNatKey {
+	n := *v
 	n.Key = common.Swab16(n.Key)
 	return &n
 }
@@ -211,7 +211,7 @@ func NewRevNat6Value(ip net.IP, port uint16) *RevNat6Value {
 	return &revNat
 }
 
-func (k *RevNat6Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(k) }
+func (v *RevNat6Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
 func (v *RevNat6Value) String() string              { return fmt.Sprintf("%s:%d", v.Address, v.Port) }
 
 func (v *RevNat6Value) Convert() RevNatValue {

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -37,10 +37,10 @@ type PolicyMap struct {
 	Fd   int
 }
 
-func (p *PolicyMap) DeepCopy() *PolicyMap {
+func (pm *PolicyMap) DeepCopy() *PolicyMap {
 	return &PolicyMap{
-		path: p.path,
-		Fd:   p.Fd,
+		path: pm.path,
+		Fd:   pm.Fd,
 	}
 }
 
@@ -48,8 +48,8 @@ const (
 	MAX_KEYS = 1024
 )
 
-func (e *PolicyEntry) String() string {
-	return string(e.Action)
+func (pe *PolicyEntry) String() string {
+	return string(pe.Action)
 }
 
 type PolicyEntry struct {
@@ -69,27 +69,27 @@ type PolicyEntryDump struct {
 	ID uint32
 }
 
-func (m *PolicyMap) AllowConsumer(id uint32) error {
+func (pm *PolicyMap) AllowConsumer(id uint32) error {
 	entry := PolicyEntry{Action: 1}
-	return bpf.UpdateElement(m.Fd, unsafe.Pointer(&id), unsafe.Pointer(&entry), 0)
+	return bpf.UpdateElement(pm.Fd, unsafe.Pointer(&id), unsafe.Pointer(&entry), 0)
 }
 
-func (m *PolicyMap) ConsumerExists(id uint32) bool {
+func (pm *PolicyMap) ConsumerExists(id uint32) bool {
 	var entry PolicyEntry
-	return bpf.LookupElement(m.Fd, unsafe.Pointer(&id), unsafe.Pointer(&entry)) == nil
+	return bpf.LookupElement(pm.Fd, unsafe.Pointer(&id), unsafe.Pointer(&entry)) == nil
 }
 
-func (m *PolicyMap) DeleteConsumer(id uint32) error {
-	return bpf.DeleteElement(m.Fd, unsafe.Pointer(&id))
+func (pm *PolicyMap) DeleteConsumer(id uint32) error {
+	return bpf.DeleteElement(pm.Fd, unsafe.Pointer(&id))
 }
 
-func (m *PolicyMap) String() string {
-	return m.path
+func (pm *PolicyMap) String() string {
+	return pm.path
 }
 
-func (m *PolicyMap) Dump() (string, error) {
+func (pm *PolicyMap) Dump() (string, error) {
 	var buffer bytes.Buffer
-	entries, err := m.DumpToSlice()
+	entries, err := pm.DumpToSlice()
 	if err != nil {
 		return "", err
 	}
@@ -100,14 +100,14 @@ func (m *PolicyMap) Dump() (string, error) {
 	return buffer.String(), nil
 }
 
-func (m *PolicyMap) DumpToSlice() ([]PolicyEntryDump, error) {
+func (pm *PolicyMap) DumpToSlice() ([]PolicyEntryDump, error) {
 	var key, nextKey uint32
 	key = MAX_KEYS
 	entries := []PolicyEntryDump{}
 	for {
 		var entry PolicyEntry
 		err := bpf.GetNextKey(
-			m.Fd,
+			pm.Fd,
 			unsafe.Pointer(&key),
 			unsafe.Pointer(&nextKey),
 		)
@@ -117,7 +117,7 @@ func (m *PolicyMap) DumpToSlice() ([]PolicyEntryDump, error) {
 		}
 
 		err = bpf.LookupElement(
-			m.Fd,
+			pm.Fd,
 			unsafe.Pointer(&nextKey),
 			unsafe.Pointer(&entry),
 		)

--- a/pkg/policy/identity.go
+++ b/pkg/policy/identity.go
@@ -104,13 +104,13 @@ func (id *Identity) GetModel() *models.Identity {
 	return ret
 }
 
-func (s *Identity) DeepCopy() *Identity {
+func (id *Identity) DeepCopy() *Identity {
 	cpy := &Identity{
-		ID:        s.ID,
-		Labels:    s.Labels.DeepCopy(),
-		Endpoints: make(map[string]time.Time, len(s.Endpoints)),
+		ID:        id.ID,
+		Labels:    id.Labels.DeepCopy(),
+		Endpoints: make(map[string]time.Time, len(id.Endpoints)),
 	}
-	for k, v := range s.Endpoints {
+	for k, v := range id.Endpoints {
 		cpy.Endpoints[k] = v
 	}
 	return cpy
@@ -124,23 +124,23 @@ func NewIdentity() *Identity {
 }
 
 // Associate endpoint with identity
-func (s *Identity) AssociateEndpoint(id string) {
-	s.Endpoints[id] = time.Now()
+func (id *Identity) AssociateEndpoint(epID string) {
+	id.Endpoints[epID] = time.Now()
 }
 
 // Disassociate endpoint with identity and return true if successful
-func (s *Identity) DisassociateEndpoint(id string) bool {
-	if _, ok := s.Endpoints[id]; ok {
-		delete(s.Endpoints, id)
+func (id *Identity) DisassociateEndpoint(epID string) bool {
+	if _, ok := id.Endpoints[epID]; ok {
+		delete(id.Endpoints, epID)
 		return true
 	}
 
 	return false
 }
 
-func (s *Identity) RefCount() int {
+func (id *Identity) RefCount() int {
 	refCount := 0
-	for _, t := range s.Endpoints {
+	for _, t := range id.Endpoints {
 		if t.Add(secLabelTimeout).After(time.Now()) {
 			refCount++
 		}

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -75,8 +75,8 @@ func (p *Privilege) UnmarshalJSON(b []byte) error {
 	return fmt.Errorf("unknown '%s' privilege", string(b))
 }
 
-func (d Privilege) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%s"`, d)), nil
+func (p Privilege) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, p)), nil
 }
 
 type ConsumableDecision byte

--- a/pkg/policy/rule_consumers.go
+++ b/pkg/policy/rule_consumers.go
@@ -130,20 +130,20 @@ func (prc *RuleConsumers) String() string {
 	return fmt.Sprintf("Coverage: %s Allowing: %s", prc.Coverage, prc.Allow)
 }
 
-func (c *RuleConsumers) Allows(ctx *SearchContext) ConsumableDecision {
+func (prc *RuleConsumers) Allows(ctx *SearchContext) ConsumableDecision {
 	// A decision is undecided until we encoutner a DENY or ACCEPT.
 	// An ACCEPT can still be overwritten by a DENY inside the same rule.
 	decision := UNDECIDED
 
-	if len(c.Coverage) > 0 && !ctx.TargetCoveredBy(c.Coverage) {
-		policyTrace(ctx, "Rule has no coverage: [%s]\n", c.String())
+	if len(prc.Coverage) > 0 && !ctx.TargetCoveredBy(prc.Coverage) {
+		policyTrace(ctx, "Rule has no coverage: [%s]\n", prc.String())
 		return UNDECIDED
 	}
 
-	policyTrace(ctx, "Found coverage rule: [%s]", c.String())
+	policyTrace(ctx, "Found coverage rule: [%s]", prc.String())
 
-	for k := range c.Allow {
-		allowRule := &c.Allow[k]
+	for k := range prc.Allow {
+		allowRule := &prc.Allow[k]
 		switch allowRule.Allows(ctx) {
 		case DENY:
 			return DENY
@@ -158,10 +158,10 @@ func (c *RuleConsumers) Allows(ctx *SearchContext) ConsumableDecision {
 	return decision
 }
 
-func (c *RuleConsumers) Resolve(node *Node) error {
-	log.Debugf("Resolving consumer rule %+v\n", c)
-	for k := range c.Coverage {
-		l := &c.Coverage[k]
+func (prc *RuleConsumers) Resolve(node *Node) error {
+	log.Debugf("Resolving consumer rule %+v\n", prc)
+	for k := range prc.Coverage {
+		l := &prc.Coverage[k]
 		l.Resolve(node)
 
 		if !strings.HasPrefix(l.AbsoluteKey(), node.Path()) &&
@@ -171,22 +171,22 @@ func (c *RuleConsumers) Resolve(node *Node) error {
 		}
 	}
 
-	for k := range c.Allow {
-		r := &c.Allow[k]
+	for k := range prc.Allow {
+		r := &prc.Allow[k]
 		r.Label.Resolve(node)
 	}
 
 	return nil
 }
 
-func (c *RuleConsumers) SHA256Sum() (string, error) {
+func (prc *RuleConsumers) SHA256Sum() (string, error) {
 	sha := sha512.New512_256()
-	if err := json.NewEncoder(sha).Encode(c); err != nil {
+	if err := json.NewEncoder(sha).Encode(prc); err != nil {
 		return "", err
 	}
 	return fmt.Sprintf("%x", sha.Sum(nil)), nil
 }
 
-func (c *RuleConsumers) CoverageSHA256Sum() (string, error) {
-	return labels.LabelSliceSHA256Sum(c.Coverage)
+func (prc *RuleConsumers) CoverageSHA256Sum() (string, error) {
+	return labels.LabelSliceSHA256Sum(prc.Coverage)
 }

--- a/pkg/policy/rule_l4.go
+++ b/pkg/policy/rule_l4.go
@@ -74,11 +74,11 @@ func (l4 *L4Filter) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (f *L4Filter) Merge(result *L4Policy, m map[string]L4Filter, proto string) {
-	fmt := fmt.Sprintf("%s:%d", proto, f.Port)
+func (l4 *L4Filter) Merge(result *L4Policy, m map[string]L4Filter, proto string) {
+	fmt := fmt.Sprintf("%s:%d", proto, l4.Port)
 
 	if _, ok := m[fmt]; !ok {
-		m[fmt] = *f
+		m[fmt] = *l4
 	}
 }
 

--- a/pkg/policy/rule_requires.go
+++ b/pkg/policy/rule_requires.go
@@ -43,11 +43,11 @@ func (prr *RuleRequires) String() string {
 // access can be denied but fullfillment of the requirement only leads to
 // the decision being UNDECIDED waiting on an explicit allow rule further
 // down the tree
-func (r *RuleRequires) Allows(ctx *SearchContext) ConsumableDecision {
-	if len(r.Coverage) > 0 && ctx.TargetCoveredBy(r.Coverage) {
-		policyTrace(ctx, "Found coverage rule: %s\n", r.String())
-		for k := range r.Requires {
-			reqLabel := &r.Requires[k]
+func (prr *RuleRequires) Allows(ctx *SearchContext) ConsumableDecision {
+	if len(prr.Coverage) > 0 && ctx.TargetCoveredBy(prr.Coverage) {
+		policyTrace(ctx, "Found coverage rule: %s\n", prr.String())
+		for k := range prr.Requires {
+			reqLabel := &prr.Requires[k]
 			match := false
 
 			for k2 := range ctx.From {
@@ -59,22 +59,22 @@ func (r *RuleRequires) Allows(ctx *SearchContext) ConsumableDecision {
 
 			if match == false {
 				ctx.Depth++
-				policyTrace(ctx, "No matching labels in required rule [%s], verdict: [%s]\n", r.Requires, DENY.String())
+				policyTrace(ctx, "No matching labels in required rule [%s], verdict: [%s]\n", prr.Requires, DENY.String())
 				ctx.Depth--
 				return DENY
 			}
 		}
 	} else {
-		policyTrace(ctx, "Rule has no coverage: %s\n", r)
+		policyTrace(ctx, "Rule has no coverage: %s\n", prr)
 	}
 
 	return UNDECIDED
 }
 
-func (c *RuleRequires) Resolve(node *Node) error {
-	log.Debugf("Resolving requires rule %+v\n", c)
-	for k := range c.Coverage {
-		l := &c.Coverage[k]
+func (prr *RuleRequires) Resolve(node *Node) error {
+	log.Debugf("Resolving requires rule %+v\n", prr)
+	for k := range prr.Coverage {
+		l := &prr.Coverage[k]
 		l.Resolve(node)
 
 		if !strings.HasPrefix(l.AbsoluteKey(), node.Path()) {
@@ -83,25 +83,25 @@ func (c *RuleRequires) Resolve(node *Node) error {
 		}
 	}
 
-	for k := range c.Requires {
-		l := &c.Requires[k]
+	for k := range prr.Requires {
+		l := &prr.Requires[k]
 		l.Resolve(node)
 	}
 
 	return nil
 }
 
-func (c *RuleRequires) SHA256Sum() (string, error) {
+func (prr *RuleRequires) SHA256Sum() (string, error) {
 	sha := sha512.New512_256()
-	if err := json.NewEncoder(sha).Encode(c); err != nil {
+	if err := json.NewEncoder(sha).Encode(prr); err != nil {
 		return "", err
 	}
 	return fmt.Sprintf("%x", sha.Sum(nil)), nil
 }
 
-func (c *RuleRequires) CoverageSHA256Sum() (string, error) {
+func (prr *RuleRequires) CoverageSHA256Sum() (string, error) {
 	sha := sha512.New512_256()
-	if err := json.NewEncoder(sha).Encode(c.Coverage); err != nil {
+	if err := json.NewEncoder(sha).Encode(prr.Coverage); err != nil {
 		return "", err
 	}
 	return fmt.Sprintf("%x", sha.Sum(nil)), nil


### PR DESCRIPTION
Fixes all of the warnings with the following pattern

... receiver name x should be consistent with previous receiver name y for Z (golint)

Related-to: #153 (Resolve golint warnings)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/366%23issuecomment-287895951%22%2C%20%22https%3A//github.com/cilium/cilium/pull/366%23issuecomment-287897740%22%2C%20%22https%3A//github.com/cilium/cilium/pull/366%23issuecomment-287913380%22%2C%20%22https%3A//github.com/cilium/cilium/pull/366%23issuecomment-287986812%22%2C%20%22https%3A//github.com/cilium/cilium/pull/366%23discussion_r107012503%22%2C%20%22https%3A//github.com/cilium/cilium/pull/366%23discussion_r107012769%22%2C%20%22https%3A//github.com/cilium/cilium/pull/366%23discussion_r107013144%22%2C%20%22https%3A//github.com/cilium/cilium/pull/366%23discussion_r107013533%22%2C%20%22https%3A//github.com/cilium/cilium/pull/366%23discussion_r107013558%22%2C%20%22https%3A//github.com/cilium/cilium/pull/366%23discussion_r107025315%22%2C%20%22https%3A//github.com/cilium/cilium/pull/366%23discussion_r107027070%22%2C%20%22https%3A//github.com/cilium/cilium/pull/366%23discussion_r107027373%22%2C%20%22https%3A//github.com/cilium/cilium/pull/366%23discussion_r107027728%22%2C%20%22https%3A//github.com/cilium/cilium/pull/366%23discussion_r107051352%22%2C%20%22https%3A//github.com/cilium/cilium/pull/366%23discussion_r107080225%22%2C%20%22https%3A//github.com/cilium/cilium/pull/366%23discussion_r107080227%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/366%23issuecomment-287895951%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20are%20the%20golint%20errors%3F%20Is%20because%20the%20receiver%27s%20variable%20doesn%27t%20start%20with%20the%20same%20letter%20as%20the%20struct%27s%20name%3F%22%2C%20%22created_at%22%3A%20%222017-03-20T20%3A59%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20What%20are%20the%20golint%20errors%3F%20Is%20because%20the%20receiver%27s%20variable%20doesn%27t%20start%20with%20the%20same%20letter%20as%20the%20struct%27s%20name%3F%5Cr%5Cn%5Cr%5CnI%20think%20the%20error%20states%20that%20if%20you%20have%20multiple%20functions%20for%20the%20same%20struct%20they%20should%20all%20share%20the%20same%20variable%20name%20in%20the%20func%20prototype.%22%2C%20%22created_at%22%3A%20%222017-03-20T21%3A05%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40aanm%20TBH%2C%20I%20don%27t%20know%20how%20goreportcard%20works%20so%20not%20sure%20why%20it%20reports%20_712%20warning%20but%20only%2085%20issues%20across%20343%20files_.%20The%20numbers%20are%20straight%20from%20https%3A//goreportcard.com/report/github.com/cilium/cilium%5Cr%5Cn%5Cr%5CnFrom%20the%20golang%20wiki%20there%20is%20a%20section%20called%20%2A%2AReceiver%20Names%2A%2A%5Cr%5Cn%3EThe%20name%20of%20a%20method%27s%20receiver%20should%20be%20a%20reflection%20of%20its%20identity%3B%20often%20a%20one%20or%20two%20letter%20abbreviation%20of%20its%20type%20suffices%20%28such%20as%20%5C%22c%5C%22%20or%20%5C%22cl%5C%22%20for%20%5C%22Client%5C%22%29.%20Don%27t%20use%20generic%20names%20such%20as%20%5C%22me%5C%22%2C%20%5C%22this%5C%22%20or%20%5C%22self%5C%22%2C%20identifiers%20typical%20of%20object-oriented%20languages%20that%20place%20more%20emphasis%20on%20methods%20as%20opposed%20to%20functions.%20The%20name%20need%20not%20be%20as%20descriptive%20as%20that%20of%20a%20method%20argument%2C%20as%20its%20role%20is%20obvious%20and%20serves%20no%20documentary%20purpose.%20It%20can%20be%20very%20short%20as%20it%20will%20appear%20on%20almost%20every%20line%20of%20every%20method%20of%20the%20type%3B%20familiarity%20admits%20brevity.%20Be%20consistent%2C%20too%3A%20if%20you%20call%20the%20receiver%20%5C%22c%5C%22%20in%20one%20method%2C%20don%27t%20call%20it%20%5C%22cl%5C%22%20in%20another.%5Cr%5Cn%5Cr%5Cnhttps%3A//github.com/golang/go/wiki/CodeReviewComments%23receiver-names%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-03-20T22%3A07%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/925044%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/scanf%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222017-03-21T06%3A15%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/925044%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/scanf%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%206ded4488144e9a9e40e6b7977c6eda1080f3f23c%20pkg/policy/identity.go%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/366%23discussion_r107013533%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60s%60-%3E%20%60id%60%20and%20%60id%60%20-%3E%20%60epID%60%22%2C%20%22created_at%22%3A%20%222017-03-20T20%3A52%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222017-03-20T21%3A59%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/925044%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/scanf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pkg/policy/identity.go%3AL124-147%22%7D%2C%20%22Pull%206ded4488144e9a9e40e6b7977c6eda1080f3f23c%20pkg/labels/labels.go%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/366%23discussion_r107012503%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Can%20you%20change%20the%20function%20comment%20as%20well%3F%20%28%5C%22lbls%5C%22%20-%3E%20%5C%22receiver%27s%20Labels%20%60l%60%5C%22%29%22%2C%20%22created_at%22%3A%20%222017-03-20T20%3A48%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222017-03-20T21%3A47%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/925044%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/scanf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pkg/labels/labels.go%3AL349-371%22%7D%2C%20%22Pull%206ded4488144e9a9e40e6b7977c6eda1080f3f23c%20pkg/policy/identity.go%2033%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/366%23discussion_r107013558%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60s%60-%3E%20%60id%60%20and%20%60id%60%20-%3E%20%60epID%60%22%2C%20%22created_at%22%3A%20%222017-03-20T20%3A53%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222017-03-21T06%3A15%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/925044%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/scanf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pkg/policy/identity.go%3AL124-147%22%7D%2C%20%22Pull%206ded4488144e9a9e40e6b7977c6eda1080f3f23c%20pkg/maps/lbmap/ipv6.go%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/366%23discussion_r107012769%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20this%20one%20should%20be%20%60v%60%20instead%20of%20%60k%60%2C%20no%3F%20%28And%20the%20following%20ones%20would%20be%20kept%20as%20%60v%60%29%22%2C%20%22created_at%22%3A%20%222017-03-20T20%3A49%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222017-03-20T21%3A56%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/925044%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/scanf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pkg/maps/lbmap/ipv6.go%3AL184-194%22%7D%2C%20%22Pull%206ded4488144e9a9e40e6b7977c6eda1080f3f23c%20pkg/maps/policymap/policymap.go%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/366%23discussion_r107013144%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20%60PolicyEntry%60%20is%20%60pe%60%20but%20%60PolicyMap%60%20is%20not%20%60pm%60%3F%22%2C%20%22created_at%22%3A%20%222017-03-20T20%3A51%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22IIRC%2C%20there%20was%20a%20mix%20and%20I%20tried%20to%20pick%20whatever%20was%20previously%20used%20in%20the%20file.%22%2C%20%22created_at%22%3A%20%222017-03-20T21%3A57%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/925044%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/scanf%22%7D%7D%2C%20%7B%22body%22%3A%20%22Can%20you%20change%20it%20to%20%60pm%60%3F%20Just%20to%20be%20consistent%20with%20the%20%60PolicyEntry%60%20-%3E%20%60pe%60%22%2C%20%22created_at%22%3A%20%222017-03-21T00%3A44%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222017-03-21T06%3A15%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/925044%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/scanf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pkg/maps/policymap/policymap.go%3AL69-96%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 6ded4488144e9a9e40e6b7977c6eda1080f3f23c pkg/labels/labels.go 37'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/366#discussion_r107012503'>File: pkg/labels/labels.go:L349-371</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> Can you change the function comment as well? ("lbls" -> "receiver's Labels `l`")
- [x] <a href='#crh-comment-Pull 6ded4488144e9a9e40e6b7977c6eda1080f3f23c pkg/maps/lbmap/ipv6.go 23'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/366#discussion_r107012769'>File: pkg/maps/lbmap/ipv6.go:L184-194</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> I think this one should be `v` instead of `k`, no? (And the following ones would be kept as `v`)
- [x] <a href='#crh-comment-Pull 6ded4488144e9a9e40e6b7977c6eda1080f3f23c pkg/maps/policymap/policymap.go 16'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/366#discussion_r107013144'>File: pkg/maps/policymap/policymap.go:L69-96</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> Why `PolicyEntry` is `pe` but `PolicyMap` is not `pm`?
- <a href='https://github.com/scanf'><img border=0 src='https://avatars2.githubusercontent.com/u/925044?v=3' height=16 width=16></a> IIRC, there was a mix and I tried to pick whatever was previously used in the file.
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> Can you change it to `pm`? Just to be consistent with the `PolicyEntry` -> `pe`
- [x] <a href='#crh-comment-Pull 6ded4488144e9a9e40e6b7977c6eda1080f3f23c pkg/policy/identity.go 23'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/366#discussion_r107013533'>File: pkg/policy/identity.go:L124-147</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> `s`-> `id` and `id` -> `epID`
- [x] <a href='#crh-comment-Pull 6ded4488144e9a9e40e6b7977c6eda1080f3f23c pkg/policy/identity.go 33'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/366#discussion_r107013558'>File: pkg/policy/identity.go:L124-147</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> `s`-> `id` and `id` -> `epID`
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/366#issuecomment-287895951'>General Comment</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> What are the golint errors? Is because the receiver's variable doesn't start with the same letter as the struct's name?
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> > What are the golint errors? Is because the receiver's variable doesn't start with the same letter as the struct's name?
I think the error states that if you have multiple functions for the same struct they should all share the same variable name in the func prototype.
- <a href='https://github.com/scanf'><img border=0 src='https://avatars2.githubusercontent.com/u/925044?v=3' height=16 width=16></a> @aanm TBH, I don't know how goreportcard works so not sure why it reports _712 warning but only 85 issues across 343 files_. The numbers are straight from https://goreportcard.com/report/github.com/cilium/cilium
From the golang wiki there is a section called **Receiver Names**
>The name of a method's receiver should be a reflection of its identity; often a one or two letter abbreviation of its type suffices (such as "c" or "cl" for "Client"). Don't use generic names such as "me", "this" or "self", identifiers typical of object-oriented languages that place more emphasis on methods as opposed to functions. The name need not be as descriptive as that of a method argument, as its role is obvious and serves no documentary purpose. It can be very short as it will appear on almost every line of every method of the type; familiarity admits brevity. Be consistent, too: if you call the receiver "c" in one method, don't call it "cl" in another.
https://github.com/golang/go/wiki/CodeReviewComments#receiver-names


<a href='https://www.codereviewhub.com/cilium/cilium/pull/366?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/366?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/366'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>