### PR TITLE
daemon: Change name of bindata.go to go-bindata

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -18,5 +18,5 @@ install: all
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
 
-bindata.go: $(shell find ../bpf)
+go-bindata: $(shell find ../bpf)
 	go-bindata -prefix ../ -ignore Makefile -ignore '.+\.o$$' ../bpf/...


### PR DESCRIPTION
Naming the target bindata.go caused the target to be executed
as part of the regular build.

Signed-off-by: Thomas Graf <thomas@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/377?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/377'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>