### PR TITLE
Makefile: checking golang version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,15 @@ include Makefile.defs
 
 SUBDIRS = plugins bpf cilium daemon
 GOFILES = $(shell go list ./... | grep -v /vendor/)
+GOLANGVERSION = $(shell go version 2>/dev/null | grep -Eo '(go[0-9].[0-9](.[0-9])?)')
 
-all: $(SUBDIRS)
+all: check-golang $(SUBDIRS)
+
+check-golang:
+	if [ "${GOLANGVERSION}" = "go1.8" ]; then \
+		echo "golang 1.8 is currently not supported, please downgrade to a lower version"; \
+		exit 1; \
+	fi
 
 $(SUBDIRS): force
 	@ $(MAKE) -C $@ all


### PR DESCRIPTION
Since we don't yet support golang 1.8 we need to check it if the
developer wants to build the project.

$ make
if [[ "go1.8" == "go1.8" ]]; then \
        echo "golang 1.8 is currently not supported, please downgrade to a lower version"; \
        exit 1; \
fi
golang 1.8 is currently not supported, please downgrade to a lower version
Makefile:10: recipe for target 'check-golang' failed
make: *** [check-golang] Error 1

Signed-off-by: André Martins <andre@cilium.io>