### PR TITLE
policy: create parent node if doesn't exist

### DIFF
--- a/pkg/policy/node.go
+++ b/pkg/policy/node.go
@@ -403,12 +403,12 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 
 // CanMerge returns an error if obj cannot be safely merged into an existing node
 func (n *Node) CanMerge(obj *Node) error {
-	if obj.Name != n.Name {
-		return fmt.Errorf("node name mismatch %s != %s", obj.Name, n.Name)
+	if n.Name != obj.Name {
+		return fmt.Errorf("node name mismatch %q != %q", n.Name, obj.Name)
 	}
 
-	if obj.path != n.path {
-		return fmt.Errorf("node path mismatch %s != %s", obj.path, n.path)
+	if obj.path != "" && n.path != obj.path {
+		return fmt.Errorf("node path mismatch %q != %q", n.path, obj.path)
 	}
 
 	if !n.IsMergeable() || !obj.IsMergeable() {
@@ -426,7 +426,7 @@ func (n *Node) CanMerge(obj *Node) error {
 	return nil
 }
 
-// Merge incorporates the rules and children of obj into an existnig node
+// Merge incorporates the rules and children of obj into an existing node
 func (n *Node) Merge(obj *Node) (bool, error) {
 	if err := n.CanMerge(obj); err != nil {
 		return false, fmt.Errorf("cannot merge node: %s", err)

--- a/pkg/policy/tree_test.go
+++ b/pkg/policy/tree_test.go
@@ -54,19 +54,21 @@ func (ds *PolicyTestSuite) TestAddDelete(c *C) {
 	c.Assert(n, IsNil)
 	c.Assert(p, IsNil)
 
-	// Added a child if no root node exist must fail
-	added, err = tree.Add(RootNodeName, &Node{Name: "foo"})
-	c.Assert(added, Equals, false)
-	c.Assert(err, Not(IsNil))
+	// Added a child if no root node exist must add parents of that node
+	foo := &Node{Name: "foo"}
+	added, err = tree.Add(RootNodeName+".bar", foo)
+	c.Assert(added, Equals, true)
+	c.Assert(err, IsNil)
 
-	// The node should not exist afterwards
-	n, p = tree.Lookup("root.foo")
-	c.Assert(n, IsNil)
-	c.Assert(p, IsNil)
+	// The node should exist afterwards
+	n, pBar := tree.Lookup(RootNodeName + ".bar.foo")
+	c.Assert(n, Equals, foo)
+	c.Assert(pBar.Name, Equals, "bar")
+	c.Assert(pBar.path, Equals, RootNodeName+".bar")
 
-	// No root node should have been added
+	// The root node should have been added
 	n, p = tree.Lookup(RootNodeName)
-	c.Assert(n, IsNil)
+	c.Assert(n, Not(IsNil))
 	c.Assert(p, IsNil)
 
 	fooNode := Node{}
@@ -77,21 +79,25 @@ func (ds *PolicyTestSuite) TestAddDelete(c *C) {
 		},
 	}
 
-	// Add root ndoe with children, should succeed
+	// Add root node with children, should succeed
 	added, err = tree.Add(RootNodeName, &root)
 	c.Assert(added, Equals, true)
 	c.Assert(err, IsNil)
 
 	// lookup of root node should succeed now
 	n, p = tree.Lookup(RootNodeName)
-	c.Assert(n, Equals, &root)
+	// The "root" node was merged into the tree's root, therefore we need to
+	// make it the same with this hack
+	root.Children["bar"] = pBar
+	root.resolved = true
+	c.Assert(n, DeepEquals, &root)
 	c.Assert(n.Name, Equals, RootNodeName)
 	c.Assert(p, IsNil)
 
 	// lookup of child foo should succeed
 	n, p = tree.Lookup("root.foo")
 	c.Assert(n, Equals, &fooNode)
-	c.Assert(p, Equals, &root)
+	c.Assert(p, DeepEquals, &root)
 
 	// delete root node
 	deleted = tree.Delete("root", "")


### PR DESCRIPTION
When a user add a policy where the parent node didn't exist, the policy
insertion would fail. Now the user will be able to add a policy node and
its parent node will be automatically created.

Signed-off-by: André Martins <andre@cilium.io>

Fixes #382
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/392%23discussion_r107297273%22%2C%20%22https%3A//github.com/cilium/cilium/pull/392%23discussion_r107299313%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%204481bf2b7769a0264c602a6937c0cd79f515c211%20pkg/policy/tree.go%2041%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/392%23discussion_r107297273%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20the%20%60ResolveTree%28%29%60%20at%20the%20end%20not%20sufficient%3F%22%2C%20%22created_at%22%3A%20%222017-03-21T23%3A00%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%2C%20%7B%22body%22%3A%20%22Note%20the%20%60ResolveTree%28%29%60%20at%20the%20end%20is%20for%20%60node%60%20as%20this%20%60ResolveTree%28%29%60%20is%20for%20%60t.Root%60%2C%20the%20merge%20merges%20the%20%60node%60%20into%20the%20%60t.Root%60%20and%20doesn%27t%20mean%20that%20%60node%60%3D%3D%60t.Root%60.%22%2C%20%22created_at%22%3A%20%222017-03-21T23%3A14%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pkg/policy/tree.go%3AL205-226%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 4481bf2b7769a0264c602a6937c0cd79f515c211 pkg/policy/tree.go 41'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/392#discussion_r107297273'>File: pkg/policy/tree.go:L205-226</a></b>
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> Is the `ResolveTree()` at the end not sufficient?
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> Note the `ResolveTree()` at the end is for `node` as this `ResolveTree()` is for `t.Root`, the merge merges the `node` into the `t.Root` and doesn't mean that `node`==`t.Root`.


<a href='https://www.codereviewhub.com/cilium/cilium/pull/392?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/392?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/392'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>