### PR TITLE
daemon: checking minimal requirements ASAP

### DIFF
--- a/contrib/packaging/rpm/cfg/cilium.spec
+++ b/contrib/packaging/rpm/cfg/cilium.spec
@@ -6,7 +6,7 @@ License:    Apache
 URL:        https://github/cilium/cilium
 BuildArch:  x86_64
 Source0:    %{name}-%{version}.tar.gz
-Requires:   docker-engine >= 1.12, clang >= 3.8, glibc-devel(x86-32), iproute >= 4.6, kernel >= 4.8
+Requires:   docker-engine >= 1.12, clang >= 3.8, clang < 3.9, glibc-devel(x86-32), iproute >= 4.6, kernel >= 4.8
 
 %description
 Cilium provides fast in-kernel networking and security policy enforcement


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

And with this I'm unable to run cilium in our vagrantbox:

```
Mar 21 17:04:22 cilium-k8s-master cilium-agent[10971]: INFO 001 checkMinRequirements > Checking minimal requirements...
Mar 21 17:04:22 cilium-k8s-master cilium-agent[10971]: INFO 002 checkMinRequirements > clang 3.8.x version: OK!
Mar 21 17:04:22 cilium-k8s-master cilium-agent[10971]: INFO 003 checkMinRequirements > libraries: OK!
Mar 21 17:04:22 cilium-k8s-master cilium-agent[10971]: CRIT 004 checkMinRequirements > BPF Verifier: NOT OK. Verifier is too old to detect identical registers with map value after bpf_map_lookup_elem(). Some clang versions might generate code that spills such registers to stack before a NULL test. Recommendation is to run 4.10+ kernels.
```

Should I comment the BPF verifier for now?

Partially fixes #310
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/398%23discussion_r107313899%22%2C%20%22https%3A//github.com/cilium/cilium/pull/398%23discussion_r107315332%22%2C%20%22https%3A//github.com/cilium/cilium/pull/398%23discussion_r107324277%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%206a5592d21be712a7bc71d0c6a18eec42800b69d3%20daemon/main.go%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/398%23discussion_r107315332%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%27s%20the%20best%20way%20to%20do%20it%3F%20I%20couldn%27t%20find%20the%20default%20include%20paths%20used%20by%20clang.%20I%20wouldn%27t%20like%20to%20do%20it%20like%20%60find%20/usr/include%20-name%20stubs-32.h%60.%5Cr%5Cn%5Cr%5CnWithout%20%60glibc-devel%60%20I%20get%20this%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5CnIn%20file%20included%20from%20/var/run/cilium/bpf/bpf_netdev.c%3A27%3A%5Cr%5CnIn%20file%20included%20from%20/var/run/cilium/bpf/include/bpf/api.h%3A11%3A%5Cr%5CnIn%20file%20included%20from%20/var/run/cilium/bpf/include/linux/type_mapper.h%3A4%3A%5Cr%5CnIn%20file%20included%20from%20/usr/bin/../lib64/clang/3.8.0/include/stdint.h%3A63%3A%5Cr%5CnIn%20file%20included%20from%20/usr/include/stdint.h%3A25%3A%5Cr%5CnIn%20file%20included%20from%20/usr/include/features.h%3A392%3A%5Cr%5Cn/usr/include/gnu/stubs.h%3A7%3A11%3A%20fatal%20error%3A%20%27gnu/stubs-32.h%27%20file%20not%20found%5Cr%5Cn%23%20include%20%3Cgnu/stubs-32.h%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222017-03-22T01%3A25%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22Using%20%60find%60%20is%20too%20expensive.%20Let%27s%20go%20with%20what%20you%20have%20and%20if%20we%20get%20complaints%20we%20can%20add%20additional%20paths%20or%20convert%20it%20into%20a%20warning.%22%2C%20%22created_at%22%3A%20%222017-03-22T03%3A02%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20daemon/main.go%3AL86-147%22%7D%2C%20%22Pull%206a5592d21be712a7bc71d0c6a18eec42800b69d3%20daemon/main.go%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/398%23discussion_r107313899%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20you%20want%20to%20check%20for%20%5C%22%203.8.%5C%22%20to%20avoid%20matching%20on%204.3.8%20long%20term%20%40%22%2C%20%22created_at%22%3A%20%222017-03-22T01%3A11%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20daemon/main.go%3AL86-147%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 6a5592d21be712a7bc71d0c6a18eec42800b69d3 daemon/main.go 23'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/398#discussion_r107313899'>File: daemon/main.go:L86-147</a></b>
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> I think you want to check for " 3.8." to avoid matching on 4.3.8 long term @
- [x] <a href='#crh-comment-Pull 6a5592d21be712a7bc71d0c6a18eec42800b69d3 daemon/main.go 37'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/398#discussion_r107315332'>File: daemon/main.go:L86-147</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> What's the best way to do it? I couldn't find the default include paths used by clang. I wouldn't like to do it like `find /usr/include -name stubs-32.h`.
Without `glibc-devel` I get this:
```
In file included from /var/run/cilium/bpf/bpf_netdev.c:27:
In file included from /var/run/cilium/bpf/include/bpf/api.h:11:
In file included from /var/run/cilium/bpf/include/linux/type_mapper.h:4:
In file included from /usr/bin/../lib64/clang/3.8.0/include/stdint.h:63:
In file included from /usr/include/stdint.h:25:
In file included from /usr/include/features.h:392:
/usr/include/gnu/stubs.h:7:11: fatal error: 'gnu/stubs-32.h' file not found
# include <gnu/stubs-32.h
```
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> Using `find` is too expensive. Let's go with what you have and if we get complaints we can add additional paths or convert it into a warning.


<a href='https://www.codereviewhub.com/cilium/cilium/pull/398?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/398?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/398'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>