### PR TITLE
cilium/cmd: erroring if cilium monitor runs without root

### DIFF
--- a/cilium/cmd/monitor.go
+++ b/cilium/cmd/monitor.go
@@ -94,6 +94,11 @@ func receiveEvent(msg *bpf.PerfEventSample, cpu int) {
 }
 
 func runMonitor() {
+	if os.Getuid() != 0 {
+		fmt.Fprintf(os.Stderr, "Please run the monitor with root privileges.\n")
+		os.Exit(1)
+	}
+
 	events, err := bpf.NewPerCpuEvents(&eventConfig)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Fixes #393

Signed-off-by: André Martins <andre@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/401?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/401'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>