### PR TITLE
cilium-docker: removed duplicate DelLinkByName

### DIFF
--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -456,8 +456,5 @@ func (driver *driver) leaveEndpoint(w http.ResponseWriter, r *http.Request) {
 		log.Warningf("Leaving the endpoint failed: %s", err)
 	}
 
-	if err := plugins.DelLinkByName(plugins.Endpoint2IfName(l.EndpointID)); err != nil {
-		log.Warningf("Error while deleting link: %s", err)
-	}
 	emptyResponse(w)
 }


### PR DESCRIPTION
Since docker calls leaveEndpoint first and then deleteEndpoint we don't
need to call DelLinkByName twice.

Signed-off-by: André Martins <andre@cilium.io>

Fix #355
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/402?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/402'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>