### PR TITLE
daemon: moved RestoreAssets to daemon's main

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -442,16 +442,6 @@ func (c *Config) createIPAMConf() (*ipam.IPAMConfig, error) {
 	return ipamConf, nil
 }
 
-func (d *Daemon) restoreBPFtemplates() error {
-	if !d.conf.KeepTemplates {
-		if err := RestoreAssets(d.conf.RunDir, "bpf"); err != nil {
-			return fmt.Errorf("Unable to restore agent assets: %s", err)
-		}
-	}
-
-	return nil
-}
-
 // NewDaemon creates and returns a new Daemon with the parameters set in c.
 func NewDaemon(c *Config) (*Daemon, error) {
 	if c == nil {
@@ -499,10 +489,6 @@ func NewDaemon(c *Config) (*Daemon, error) {
 		consumableCache:   policy.NewConsumableCache(),
 		policy:            policy.Tree{},
 		ignoredContainers: make(map[string]int),
-	}
-
-	if err := d.restoreBPFtemplates(); err != nil {
-		return nil, err
 	}
 
 	d.listenForCiliumEvents()

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -206,6 +206,11 @@ func initConfig() {
 	} else {
 		common.SetupLOG(log, "INFO")
 	}
+	if !config.KeepTemplates {
+		if err := RestoreAssets(config.RunDir, "bpf"); err != nil {
+			log.Fatalf("Unable to restore agent assets: %s", err)
+		}
+	}
 	checkMinRequirements()
 }
 


### PR DESCRIPTION
Since checkMinRequirements uses Assets files it is essential they are
restored before calling checkMinRequirements.

Fixes: e4020b36b5 ("daemon: checking minimal requirements ASAP")

Signed-off-by: André Martins <andre@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/403?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/403'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>