### PR TITLE
Makefile: If go-bindata is available, warn if bindata.go is out of date

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -1,10 +1,8 @@
 include ../Makefile.defs
 
-all:
-
 TARGET=cilium-agent
 SOURCES := $(shell find ../api ../common ../daemon ../pkg . -name '*.go')
-$(TARGET): $(SOURCES)
+$(TARGET): $(SOURCES) check-bindata
 	go build $(GOBUILD) -ldflags "-X "github.com/cilium/cilium/common".Version=$(VERSION)" -o $(TARGET)
 
 all: $(TARGET)
@@ -17,6 +15,18 @@ install: all
 	groupadd -f cilium
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
+
+.PHONY: check-bindata
+check-bindata:
+	@which go-bindata > /dev/null 2> /dev/null || exit 0 && \
+	(go-bindata -prefix ../ -ignore Makefile -ignore '.+\.o$$' -o bindata.tmp ../bpf/...; \
+	diff -Nru bindata.go bindata.tmp; FAIL=$$?; rm bindata.tmp; test $$FAIL -eq 1 && (\
+	echo "##################################################################"; \
+	echo ""; \
+	echo "  ERROR: bindata.go is out of date. Run 'make go-bindata' in daemon/"; \
+	echo ""; \
+	echo "##################################################################" ); \
+	exit $$FAIL)
 
 go-bindata: $(shell find ../bpf)
 	go-bindata -prefix ../ -ignore Makefile -ignore '.+\.o$$' ../bpf/...


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/404%23issuecomment-288413352%22%2C%20%22https%3A//github.com/cilium/cilium/pull/404%23issuecomment-288415062%22%2C%20%22https%3A//github.com/cilium/cilium/pull/404%23issuecomment-288417679%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/404%23issuecomment-288413352%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3E%20Should%20we%20add%20.PHONY%3A%20check-bindata%20to%20make%20sure%20this%20target%20is%20always%20out%20of%20date%20and%20needs%20to%20be%20run%3F%5Cr%5Cn%5Cr%5CnGood%20point%2C%20will%20update%22%2C%20%22created_at%22%3A%20%222017-03-22T14%3A20%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3EShould%20we%20add%20.PHONY%3A%20check-bindata%20to%20make%20sure%20this%20target%20is%20always%20out%20of%20date%20and%20needs%20to%20be%20run%3F%5Cr%5Cn%5Cr%5CnDoes%20that%20means%20gobindata%20regeneration%20will%20run%20for%20every%20build%3F%22%2C%20%22created_at%22%3A%20%222017-03-22T14%3A25%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22Since%20the%20target%20depends%20on%20it%2C%20we%20test%20for%20potential%20out%20of%20date%20bindata%20every%20time.%20Doesn%27t%20mean%20you%20need%20to%20rebuild%20the%20daemon%20each%20time.%20From%20my%20side%2C%20the%20go%20bindata%20generation%20is%20done%20rather%20quick%2C%20so%20I%20think%20it%20makes%20sense%2C%20otherwise%20why%20having%20the%20check%20then.%22%2C%20%22created_at%22%3A%20%222017-03-22T14%3A33%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/677393%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/borkmann%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/404#issuecomment-288413352'>General Comment</a></b>
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> > Should we add .PHONY: check-bindata to make sure this target is always out of date and needs to be run?
Good point, will update
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> >Should we add .PHONY: check-bindata to make sure this target is always out of date and needs to be run?
Does that means gobindata regeneration will run for every build?
- <a href='https://github.com/borkmann'><img border=0 src='https://avatars2.githubusercontent.com/u/677393?v=3' height=16 width=16></a> Since the target depends on it, we test for potential out of date bindata every time. Doesn't mean you need to rebuild the daemon each time. From my side, the go bindata generation is done rather quick, so I think it makes sense, otherwise why having the check then.


<a href='https://www.codereviewhub.com/cilium/cilium/pull/404?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/404?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/404'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>