### PR TITLE
Make LB WRR seq access depend on HAVE_MAP_VAL_ADJ

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -90,6 +90,7 @@ struct bpf_elf_map __section_maps cilium_lb4_rr_seq = {
 #define cilium_trace_lb(a, b, c, d)
 #endif
 
+#ifdef HAVE_MAP_VAL_ADJ
 static inline int lb_next_rr(struct __sk_buff *skb,
 			     struct lb_sequence *seq,
 			     __be16 hash)
@@ -105,20 +106,24 @@ static inline int lb_next_rr(struct __sk_buff *skb,
 
 	return slave;
 }
+#endif
 
 static inline int lb6_select_slave(struct __sk_buff *skb,
 				   struct lb6_key *key,
 				   __u16 count, __u16 weight)
 {
 	__be16 hash = get_hash_recalc(skb);
-	struct lb_sequence *seq;
 	int slave = 0;
 
+#ifdef HAVE_MAP_VAL_ADJ
 	if (weight) {
+		struct lb_sequence *seq;
+
 		seq = map_lookup_elem(&cilium_lb6_rr_seq, key);
 		if (seq && seq->count != 0)
 			slave = lb_next_rr(skb, seq, hash);
 	}
+#endif
 
 	if (slave == 0) {
 		/* Slave 0 is reserved for the master slot */
@@ -134,14 +139,17 @@ static inline int lb4_select_slave(struct __sk_buff *skb,
 				   __u16 count, __u16 weight)
 {
 	__be16 hash = get_hash_recalc(skb);
-	struct lb_sequence *seq;
 	int slave = 0;
 
+#ifdef HAVE_MAP_VAL_ADJ
 	if (weight) {
+		struct lb_sequence *seq;
+
 		seq = map_lookup_elem(&cilium_lb4_rr_seq, key);
 		if (seq && seq->count != 0)
 			slave = lb_next_rr(skb, seq, hash);
 	}
+#endif
 
 	if (slave == 0) {
 		/* Slave 0 is reserved for the master slot */


### PR DESCRIPTION
- This disables WRR LB for kernels < 4.9 falling back to simple hash based LB.

Fixes: #399 

Signed-off-by: Madhu Challa madhu@cilium.io
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/406?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/406'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>