### PR TITLE
go-bindata: adding modtime to go-bindata files

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -4,9 +4,9 @@ TARGET=cilium-agent
 SOURCES := $(shell find ../api ../common ../daemon ../pkg . -name '*.go')
 $(TARGET): $(SOURCES) check-bindata
 	go build $(GOBUILD) -ldflags "-X "github.com/cilium/cilium/common".Version=$(VERSION)" -o $(TARGET)
-GO_BINDATA := go-bindata -prefix ../ -mode 0640 -ignore Makefile -ignore bpf_features.h \
-	-ignore lxc_config.h -ignore netdev_config.h -ignore node_config.h \
-	-ignore '.+\.o$$'
+GO_BINDATA := go-bindata -prefix ../ -mode 0640 -modtime 1450269211 \
+	-ignore Makefile -ignore bpf_features.h -ignore lxc_config.h \
+	-ignore netdev_config.h -ignore node_config.h -ignore '.+\.o$$'
 
 all: $(TARGET)
 

--- a/daemon/bindata.go
+++ b/daemon/bindata.go
@@ -136,7 +136,7 @@ func bpfCopying() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/COPYING", size: 18012, mode: os.FileMode(416), modTime: time.Unix(1481040726, 0)}
+	info := bindataFileInfo{name: "bpf/COPYING", size: 18012, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -156,7 +156,7 @@ func bpfBpf_lbC() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/bpf_lb.c", size: 5637, mode: os.FileMode(416), modTime: time.Unix(1490134889, 0)}
+	info := bindataFileInfo{name: "bpf/bpf_lb.c", size: 5637, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -176,7 +176,7 @@ func bpfBpf_lxcC() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/bpf_lxc.c", size: 21713, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/bpf_lxc.c", size: 21713, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -196,7 +196,7 @@ func bpfBpf_netdevC() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/bpf_netdev.c", size: 5621, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/bpf_netdev.c", size: 5621, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -216,7 +216,7 @@ func bpfBpf_overlayC() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/bpf_overlay.c", size: 4523, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/bpf_overlay.c", size: 4523, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -236,7 +236,7 @@ func bpfIncludeBpfApiH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/bpf/api.h", size: 6875, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/include/bpf/api.h", size: 6875, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -256,7 +256,7 @@ func bpfIncludeIproute2Bpf_elfH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/iproute2/bpf_elf.h", size: 905, mode: os.FileMode(416), modTime: time.Unix(1481040726, 0)}
+	info := bindataFileInfo{name: "bpf/include/iproute2/bpf_elf.h", size: 905, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -276,7 +276,7 @@ func bpfIncludeLinuxBpfH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/linux/bpf.h", size: 14138, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/include/linux/bpf.h", size: 14138, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -296,7 +296,7 @@ func bpfIncludeLinuxBpf_commonH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/linux/bpf_common.h", size: 1230, mode: os.FileMode(416), modTime: time.Unix(1468446420, 0)}
+	info := bindataFileInfo{name: "bpf/include/linux/bpf_common.h", size: 1230, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -316,7 +316,7 @@ func bpfIncludeLinuxByteorderBig_endianH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/linux/byteorder/big_endian.h", size: 3419, mode: os.FileMode(416), modTime: time.Unix(1468446420, 0)}
+	info := bindataFileInfo{name: "bpf/include/linux/byteorder/big_endian.h", size: 3419, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -336,7 +336,7 @@ func bpfIncludeLinuxByteorderLittle_endianH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/linux/byteorder/little_endian.h", size: 3494, mode: os.FileMode(416), modTime: time.Unix(1468446420, 0)}
+	info := bindataFileInfo{name: "bpf/include/linux/byteorder/little_endian.h", size: 3494, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -356,7 +356,7 @@ func bpfIncludeLinuxByteorderH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/linux/byteorder.h", size: 247, mode: os.FileMode(416), modTime: time.Unix(1468446420, 0)}
+	info := bindataFileInfo{name: "bpf/include/linux/byteorder.h", size: 247, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -376,7 +376,7 @@ func bpfIncludeLinuxIcmpH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/linux/icmp.h", size: 2898, mode: os.FileMode(416), modTime: time.Unix(1468446420, 0)}
+	info := bindataFileInfo{name: "bpf/include/linux/icmp.h", size: 2898, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -396,7 +396,7 @@ func bpfIncludeLinuxIcmpv6H() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/linux/icmpv6.h", size: 3916, mode: os.FileMode(416), modTime: time.Unix(1468446420, 0)}
+	info := bindataFileInfo{name: "bpf/include/linux/icmpv6.h", size: 3916, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -416,7 +416,7 @@ func bpfIncludeLinuxIf_arpH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/linux/if_arp.h", size: 5491, mode: os.FileMode(416), modTime: time.Unix(1468446420, 0)}
+	info := bindataFileInfo{name: "bpf/include/linux/if_arp.h", size: 5491, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -436,7 +436,7 @@ func bpfIncludeLinuxIf_etherH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/linux/if_ether.h", size: 7077, mode: os.FileMode(416), modTime: time.Unix(1468446420, 0)}
+	info := bindataFileInfo{name: "bpf/include/linux/if_ether.h", size: 7077, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -456,7 +456,7 @@ func bpfIncludeLinuxInH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/linux/in.h", size: 7163, mode: os.FileMode(416), modTime: time.Unix(1468446420, 0)}
+	info := bindataFileInfo{name: "bpf/include/linux/in.h", size: 7163, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -476,7 +476,7 @@ func bpfIncludeLinuxIn6H() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/linux/in6.h", size: 3887, mode: os.FileMode(416), modTime: time.Unix(1468446420, 0)}
+	info := bindataFileInfo{name: "bpf/include/linux/in6.h", size: 3887, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -496,7 +496,7 @@ func bpfIncludeLinuxIoctlH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/linux/ioctl.h", size: 3153, mode: os.FileMode(416), modTime: time.Unix(1468446420, 0)}
+	info := bindataFileInfo{name: "bpf/include/linux/ioctl.h", size: 3153, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -516,7 +516,7 @@ func bpfIncludeLinuxIpH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/linux/ip.h", size: 3557, mode: os.FileMode(416), modTime: time.Unix(1468446420, 0)}
+	info := bindataFileInfo{name: "bpf/include/linux/ip.h", size: 3557, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -536,7 +536,7 @@ func bpfIncludeLinuxIpv6H() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/linux/ipv6.h", size: 3164, mode: os.FileMode(416), modTime: time.Unix(1468446420, 0)}
+	info := bindataFileInfo{name: "bpf/include/linux/ipv6.h", size: 3164, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -556,7 +556,7 @@ func bpfIncludeLinuxPerf_eventH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/linux/perf_event.h", size: 28514, mode: os.FileMode(416), modTime: time.Unix(1468446420, 0)}
+	info := bindataFileInfo{name: "bpf/include/linux/perf_event.h", size: 28514, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -576,7 +576,7 @@ func bpfIncludeLinuxSwabH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/linux/swab.h", size: 6498, mode: os.FileMode(416), modTime: time.Unix(1468446420, 0)}
+	info := bindataFileInfo{name: "bpf/include/linux/swab.h", size: 6498, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -596,7 +596,7 @@ func bpfIncludeLinuxTcpH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/linux/tcp.h", size: 2204, mode: os.FileMode(416), modTime: time.Unix(1468446420, 0)}
+	info := bindataFileInfo{name: "bpf/include/linux/tcp.h", size: 2204, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -616,7 +616,7 @@ func bpfIncludeLinuxType_mapperH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/linux/type_mapper.h", size: 476, mode: os.FileMode(416), modTime: time.Unix(1468446420, 0)}
+	info := bindataFileInfo{name: "bpf/include/linux/type_mapper.h", size: 476, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -636,7 +636,7 @@ func bpfIncludeLinuxUdpH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/include/linux/udp.h", size: 1313, mode: os.FileMode(416), modTime: time.Unix(1468446420, 0)}
+	info := bindataFileInfo{name: "bpf/include/linux/udp.h", size: 1313, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -656,7 +656,7 @@ func bpfInitSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/init.sh", size: 5139, mode: os.FileMode(416), modTime: time.Unix(1490134889, 0)}
+	info := bindataFileInfo{name: "bpf/init.sh", size: 5139, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -676,7 +676,7 @@ func bpfJoin_epSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/join_ep.sh", size: 1174, mode: os.FileMode(416), modTime: time.Unix(1490134889, 0)}
+	info := bindataFileInfo{name: "bpf/join_ep.sh", size: 1174, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -696,7 +696,7 @@ func bpfLibArpH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/arp.h", size: 3095, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/lib/arp.h", size: 3095, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -716,7 +716,7 @@ func bpfLibCommonH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/common.h", size: 5395, mode: os.FileMode(416), modTime: time.Unix(1490134889, 0)}
+	info := bindataFileInfo{name: "bpf/lib/common.h", size: 5395, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -736,7 +736,7 @@ func bpfLibConntrackH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/conntrack.h", size: 15500, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/lib/conntrack.h", size: 15500, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -756,7 +756,7 @@ func bpfLibCsumH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/csum.h", size: 2441, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/lib/csum.h", size: 2441, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -776,7 +776,7 @@ func bpfLibDbgH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/dbg.h", size: 3458, mode: os.FileMode(416), modTime: time.Unix(1490134889, 0)}
+	info := bindataFileInfo{name: "bpf/lib/dbg.h", size: 3458, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -796,7 +796,7 @@ func bpfLibDropH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/drop.h", size: 4390, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/lib/drop.h", size: 4390, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -816,7 +816,7 @@ func bpfLibEthH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/eth.h", size: 1942, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/lib/eth.h", size: 1942, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -836,7 +836,7 @@ func bpfLibEventsH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/events.h", size: 1067, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/lib/events.h", size: 1067, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -856,7 +856,7 @@ func bpfLibGeneveH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/geneve.h", size: 1894, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/lib/geneve.h", size: 1894, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -876,7 +876,7 @@ func bpfLibIcmp6H() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/icmp6.h", size: 12116, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/lib/icmp6.h", size: 12116, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -896,7 +896,7 @@ func bpfLibIpv4H() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/ipv4.h", size: 1495, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/lib/ipv4.h", size: 1495, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -916,7 +916,7 @@ func bpfLibIpv6H() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/ipv6.h", size: 7874, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/lib/ipv6.h", size: 7874, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -936,7 +936,7 @@ func bpfLibL3H() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/l3.h", size: 5524, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/lib/l3.h", size: 5524, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -956,7 +956,7 @@ func bpfLibL4H() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/l4.h", size: 6633, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/lib/l4.h", size: 6633, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -976,7 +976,7 @@ func bpfLibLbH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/lb.h", size: 18059, mode: os.FileMode(416), modTime: time.Unix(1490191323, 0)}
+	info := bindataFileInfo{name: "bpf/lib/lb.h", size: 18059, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -996,7 +996,7 @@ func bpfLibLxcH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/lxc.h", size: 1972, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/lib/lxc.h", size: 1972, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1016,7 +1016,7 @@ func bpfLibMapsH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/maps.h", size: 1967, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/lib/maps.h", size: 1967, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1036,7 +1036,7 @@ func bpfLibNat46H() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/nat46.h", size: 10798, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/lib/nat46.h", size: 10798, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1056,7 +1056,7 @@ func bpfLibPolicyH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/policy.h", size: 2265, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/lib/policy.h", size: 2265, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1076,7 +1076,7 @@ func bpfLibUtilsH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/lib/utils.h", size: 1306, mode: os.FileMode(416), modTime: time.Unix(1489968939, 0)}
+	info := bindataFileInfo{name: "bpf/lib/utils.h", size: 1306, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1096,7 +1096,7 @@ func bpfProbesRaw_change_tailT() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/probes/raw_change_tail.t", size: 541, mode: os.FileMode(416), modTime: time.Unix(1490134889, 0)}
+	info := bindataFileInfo{name: "bpf/probes/raw_change_tail.t", size: 541, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1116,7 +1116,7 @@ func bpfProbesRaw_insnH() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/probes/raw_insn.h", size: 5008, mode: os.FileMode(416), modTime: time.Unix(1490134889, 0)}
+	info := bindataFileInfo{name: "bpf/probes/raw_insn.h", size: 5008, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1136,7 +1136,7 @@ func bpfProbesRaw_mainC() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/probes/raw_main.c", size: 4595, mode: os.FileMode(416), modTime: time.Unix(1490152578, 0)}
+	info := bindataFileInfo{name: "bpf/probes/raw_main.c", size: 4595, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1156,7 +1156,7 @@ func bpfProbesRaw_map_val_adjT() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/probes/raw_map_val_adj.t", size: 1162, mode: os.FileMode(416), modTime: time.Unix(1490152578, 0)}
+	info := bindataFileInfo{name: "bpf/probes/raw_map_val_adj.t", size: 1162, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1176,7 +1176,7 @@ func bpfProbesRaw_mark_map_valT() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/probes/raw_mark_map_val.t", size: 1445, mode: os.FileMode(416), modTime: time.Unix(1490152578, 0)}
+	info := bindataFileInfo{name: "bpf/probes/raw_mark_map_val.t", size: 1445, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1196,7 +1196,7 @@ func bpfRun_probesSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "bpf/run_probes.sh", size: 2266, mode: os.FileMode(416), modTime: time.Unix(1490219641, 0)}
+	info := bindataFileInfo{name: "bpf/run_probes.sh", size: 2266, mode: os.FileMode(416), modTime: time.Unix(1450269211, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
Since files can be modifed or accidentally removed, git checkout doesn't
restore their timestamps, for that reason we should save go-bindata with
the timestamp hardcode or otherwise go-bindata check might complain
about different timestamps in the files generated files.

Signed-off-by: André Martins <andre@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/422?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/422'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>