### PR TITLE
bpf: map: Add new map-in-map types introduced upstream

### DIFF
--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -49,6 +49,8 @@ const (
 	MapTypeLRUHash
 	MapTypeLRUPerCPUHash
 	MapTypeLPMTrie
+	MapTypeArrayOfMaps
+	MapTypeHashOfMaps
 )
 
 func (t MapType) String() string {
@@ -75,6 +77,10 @@ func (t MapType) String() string {
 		return "LRU per-CPU hash"
 	case MapTypeLPMTrie:
 		return "Longest prefix match trie"
+	case MapTypeArrayOfMaps:
+		return "Array of maps"
+	case MapTypeHashOfMaps:
+		return "Hash of maps"
 	}
 
 	return "Unknown"


### PR DESCRIPTION
Add the new map types MapTypeArrayOfMaps and MapTypeHashOfMaps to match
BPF_MAP_TYPE_ARRAY_OF_MAPS and BPF_MAP_TYPE_HASH_OF_MAPS. They were
introduced in the net-next tree in commits 56f668dfe00d ("bpf: Add array
of maps support") and bcc6b1b7ebf8 ("bpf: Add hash of maps support"),
respectively.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/425?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/425'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>