### PR TITLE
golint: fix warnings for pkg/client/endpoint.go

### DIFF
--- a/pkg/client/endpoint.go
+++ b/pkg/client/endpoint.go
@@ -20,7 +20,7 @@ import (
 	pkgEndpoint "github.com/cilium/cilium/pkg/endpoint"
 )
 
-// Get list of endpoints
+// EndpointList returns list of endpoints
 func (c *Client) EndpointList() ([]*models.Endpoint, error) {
 	resp, err := c.Endpoint.GetEndpoint(nil)
 	if err != nil {
@@ -29,7 +29,7 @@ func (c *Client) EndpointList() ([]*models.Endpoint, error) {
 	return resp.Payload, nil
 }
 
-// Get endpoint by ID
+// EndpointGet returns endpoint by ID
 func (c *Client) EndpointGet(id string) (*models.Endpoint, error) {
 	params := endpoint.NewGetEndpointIDParams().WithID(id)
 	resp, err := c.Endpoint.GetEndpointID(params)
@@ -39,7 +39,7 @@ func (c *Client) EndpointGet(id string) (*models.Endpoint, error) {
 	return resp.Payload, nil
 }
 
-// Create endpoint
+// EndpointCreate creates a new endpoint
 func (c *Client) EndpointCreate(ep *models.EndpointChangeRequest) error {
 	id := pkgEndpoint.NewCiliumID(ep.ID)
 	params := endpoint.NewPutEndpointIDParams().WithID(id).WithEndpoint(ep)
@@ -47,21 +47,21 @@ func (c *Client) EndpointCreate(ep *models.EndpointChangeRequest) error {
 	return err
 }
 
-// Modify endpoint
+// EndpointPatch modifies the endpoint
 func (c *Client) EndpointPatch(id string, ep *models.EndpointChangeRequest) error {
 	params := endpoint.NewPatchEndpointIDParams().WithID(id).WithEndpoint(ep)
 	_, err := c.Endpoint.PatchEndpointID(params)
 	return err
 }
 
-// Delete endpoint
+// EndpointDelete deletes endpoint
 func (c *Client) EndpointDelete(id string) error {
 	params := endpoint.NewDeleteEndpointIDParams().WithID(id)
 	_, _, err := c.Endpoint.DeleteEndpointID(params)
 	return err
 }
 
-// Get endpoint configuration
+// EndpointConfigGet returns endpoint configuration
 func (c *Client) EndpointConfigGet(id string) (*models.Configuration, error) {
 	params := endpoint.NewGetEndpointIDConfigParams().WithID(id)
 	resp, err := c.Endpoint.GetEndpointIDConfig(params)
@@ -71,7 +71,7 @@ func (c *Client) EndpointConfigGet(id string) (*models.Configuration, error) {
 	return resp.Payload, nil
 }
 
-// Modify endpoint configuration
+// EndpointConfigPatch modifies endpoint configuration
 func (c *Client) EndpointConfigPatch(id string, cfg models.ConfigurationMap) error {
 	params := endpoint.NewPatchEndpointIDConfigParams().WithID(id)
 	if cfg != nil {
@@ -82,7 +82,7 @@ func (c *Client) EndpointConfigPatch(id string, cfg models.ConfigurationMap) err
 	return err
 }
 
-// Get endpoint label configuration
+// EndpointLabelsGet returns endpoint label configuration
 func (c *Client) EndpointLabelsGet(id string) (*models.LabelConfiguration, error) {
 	params := endpoint.NewGetEndpointIDLabelsParams().WithID(id)
 	resp, err := c.Endpoint.GetEndpointIDLabels(params)
@@ -92,7 +92,7 @@ func (c *Client) EndpointLabelsGet(id string) (*models.LabelConfiguration, error
 	return resp.Payload, nil
 }
 
-// Modify endpoint label configuration
+// EndpointLabelsPut modifies endpoint label configuration
 func (c *Client) EndpointLabelsPut(id string, cfg *models.LabelConfigurationModifier) error {
 	params := endpoint.NewPutEndpointIDLabelsParams().WithID(id)
 	_, err := c.Endpoint.PutEndpointIDLabels(params.WithConfiguration(cfg))


### PR DESCRIPTION
Fixes the following warnings

Line 23: warning: comment on exported method Client.EndpointList should be of the form "EndpointList ..." (golint)
Line 32: warning: comment on exported method Client.EndpointGet should be of the form "EndpointGet ..." (golint)
Line 42: warning: comment on exported method Client.EndpointCreate should be of the form "EndpointCreate ..." (golint)
Line 50: warning: comment on exported method Client.EndpointPatch should be of the form "EndpointPatch ..." (golint)
Line 57: warning: comment on exported method Client.EndpointDelete should be of the form "EndpointDelete ..." (golint)
Line 64: warning: comment on exported method Client.EndpointConfigGet should be of the form "EndpointConfigGet ..." (golint)
Line 74: warning: comment on exported method Client.EndpointConfigPatch should be of the form "EndpointConfigPatch ..." (golint)
Line 85: warning: comment on exported method Client.EndpointLabelsGet should be of the form "EndpointLabelsGet ..." (golint)
Line 95: warning: comment on exported method Client.EndpointLabelsPut should be of the form "EndpointLabelsPut ..." (golint)

Related-to: #153 (Resolve golint warnings)
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/426?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/426'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>