### PR TITLE
golint: fix warnings for common/addressing/defaults.go

### DIFF
--- a/common/addressing/defaults.go
+++ b/common/addressing/defaults.go
@@ -19,18 +19,19 @@ import (
 )
 
 const (
-	// Default prefix for all IPv6 addresses.
+	// DefaultIPv6Prefix is the prefix for all the IPv6 addresses.
 	DefaultIPv6Prefix = "f00d::"
-	// Prefix length to allocate container IPv6 addresses from
+	// DefaultIPv6PrefixLen is the length used to allocate container IPv6 addresses from.
 	DefaultIPv6PrefixLen = 112
-	// Default prefix for all IPv4 addresses. %d is substituted with the
-	// last byte of first global IPv4 address configured on the system.
+	// DefaultIPv4Prefix is the prefix for all the IPv4 addresses.
+	// %d is substituted with the last byte of first global IPv4 address
+	// configured on the system.
 	DefaultIPv4Prefix = "10.%d.0.1"
-	// Prefix length to allocate container IPv4 addresses from
+	// DefaultIPv4PrefixLen is the length used to allocate container IPv4 addresses from.
 	DefaultIPv4PrefixLen = 16
-	// Default IPv4 prefix length of entire cluster
+	// DefaultIPv4ClusterPrefixLen is the IPv4 prefix length of the entire cluster.
 	DefaultIPv4ClusterPrefixLen = 8
-	// Default IPv6 prefix to represent NATed IPv4 addresses
+	// DefaultNAT46Prefix is the IPv6 prefix to represent NATed IPv4 addresses.
 	DefaultNAT46Prefix = "0:0:0:0:0:FFFF::/96"
 )
 
@@ -42,20 +43,22 @@ var (
 	// state:                   beef:beef:beef:beef:<node>:<node>:<state>:/112
 	// lxc:                     beef:beef:beef:beef:<node>:<node>:<state>:<lxc>/128
 
-	// ClusterIPv6Mask represents the CIDR Mask for an entire cluster
+	// ClusterIPv6Mask represents the CIDR Mask for an entire cluster.
 	ClusterIPv6Mask = net.CIDRMask(64, 128)
 	// NodeIPv6Mask represents the CIDR Mask for the cilium node.
 	NodeIPv6Mask = net.CIDRMask(96, 128)
 	// StateIPv6Mask represents the CIDR Mask for the state position.
 	StateIPv6Mask = net.CIDRMask(112, 128)
 
-	// IPv6 prefix length for address assigned to container. The default is
-	// L3 only and thus /128.
+	// ContainerIPv6Mask is the IPv6 prefix length for address assigned to
+	// container. The default is L3 only and thus /128.
 	ContainerIPv6Mask = net.CIDRMask(128, 128)
-	// IPv4 prefix length for address assigned to container. The default is
-	// L3 only and thus /32
+	// ContainerIPv4Mask is the IPv4 prefix length for address assigned to
+	// container. The default is L3 only and thus /32.
 	ContainerIPv4Mask = net.CIDRMask(32, 32)
 
+	// IPv6DefaultRoute is the default IPv6 route.
 	IPv6DefaultRoute = net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)}
+	// IPv4DefaultRoute is the default IPv4 route.
 	IPv4DefaultRoute = net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)}
 )


### PR DESCRIPTION
Fixes the following warnings

Line 22: warning: comment on exported const DefaultIPv6Prefix should be of the form "DefaultIPv6Prefix ..." (golint)
Line 24: warning: comment on exported const DefaultIPv6PrefixLen should be of the form "DefaultIPv6PrefixLen ..." (golint)
Line 26: warning: comment on exported const DefaultIPv4Prefix should be of the form "DefaultIPv4Prefix ..." (golint)
Line 29: warning: comment on exported const DefaultIPv4PrefixLen should be of the form "DefaultIPv4PrefixLen ..." (golint)
Line 31: warning: comment on exported const DefaultIPv4ClusterPrefixLen should be of the form "DefaultIPv4ClusterPrefixLen ..." (golint)
Line 33: warning: comment on exported const DefaultNAT46Prefix should be of the form "DefaultNAT46Prefix ..." (golint)
Line 52: warning: comment on exported var ContainerIPv6Mask should be of the form "ContainerIPv6Mask ..." (golint)
Line 55: warning: comment on exported var ContainerIPv4Mask should be of the form "ContainerIPv4Mask ..." (golint)
Line 59: warning: exported var IPv6DefaultRoute should have comment or be unexported (golint)

Related-to: #153 (Resolve golint warnings)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/427%23discussion_r107724704%22%2C%20%22https%3A//github.com/cilium/cilium/pull/427%23discussion_r107739576%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2087a9008674b05dc5b56011916b46165217fe24e6%20common/addressing/defaults.go%2038%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/427%23discussion_r107724704%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22ContainerIPv4Mask%20is%20the%20IPv4%20pre%22%2C%20%22created_at%22%3A%20%222017-03-23T16%3A58%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%2C%20%7B%22body%22%3A%20%22Tried%20addressing%20your%20comments%2C%20thanks.%22%2C%20%22created_at%22%3A%20%222017-03-23T17%3A54%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/925044%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/scanf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20common/addressing/defaults.go%3AL50-65%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 87a9008674b05dc5b56011916b46165217fe24e6 common/addressing/defaults.go 38'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/427#discussion_r107724704'>File: common/addressing/defaults.go:L50-65</a></b>
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> ContainerIPv4Mask is the IPv4 pre
- <a href='https://github.com/scanf'><img border=0 src='https://avatars2.githubusercontent.com/u/925044?v=3' height=16 width=16></a> Tried addressing your comments, thanks.


<a href='https://www.codereviewhub.com/cilium/cilium/pull/427?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/427?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/427'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>