### PR TITLE
Set Jenkins timeout to 30 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,9 @@ pipeline {
     agent {
         label 'vagrant'
     }
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+    }
     stages {
         stage('Build') {
             environment {


### PR DESCRIPTION
Abort the Jenkins build if it takes more than 30 minutes.

Signed-off-by: Michi Mutsuzaki <michi@covalent.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/428?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/428'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>