### PR TITLE
golint: fix warnings for common/const.go

### DIFF
--- a/common/const.go
+++ b/common/const.go
@@ -39,7 +39,7 @@ const (
 	MaxSetOfLabels = uint32(0xFFFF)
 	// LastFreeServiceIDKeyPath is the path where the Last free UUID is stored in consul.
 	LastFreeServiceIDKeyPath = OperationalPath + "/Services/LastUUID"
-	// ServiceKeyPath is the base path where services are stored in consul.
+	// ServicesKeyPath is the base path where services are stored in consul.
 	ServicesKeyPath = OperationalPath + "/Services/SHA256SUMServices"
 	// ServiceIDKeyPath is the base path where the IDs are stored in consul.
 	ServiceIDKeyPath = OperationalPath + "/Services/IDs"
@@ -68,11 +68,11 @@ const (
 	// K8sAnnotationParentName is the annotation name used for the cilium policy
 	// parent name in the kubernetes network policy.
 	K8sAnnotationParentName = "io.cilium.parent"
-	// K8s environment variable label
+	// K8sEnvNodeNameSpec is the environment variable label.
 	K8sEnvNodeNameSpec = "K8S_NODE_NAME"
-	// Label source for reserved types
+	// ReservedLabelSource is the label source for reserved types.
 	ReservedLabelSource = "reserved"
-	// Label used to represent the reserved source
+	// ReservedLabelKey is the label used to represent the reserved source.
 	ReservedLabelKey = "io.cilium." + ReservedLabelSource
 	// EndpointsPerHost is the maximum number of endpoints allowed per host. It should
 	// represent the same number of IPv6 addresses supported on each node.
@@ -85,7 +85,7 @@ const (
 	// CHeaderFileName is the name of the C header file for BPF programs for a
 	// particular endpoint.
 	CHeaderFileName = "lxc_config.h"
-	// Name of the header file used for bpf_netdev.c and bpf_overlay.c
+	// NetdevHeaderFileName is the name of the header file used for bpf_netdev.c and bpf_overlay.c.
 	NetdevHeaderFileName = "netdev_config.h"
 	// CiliumCHeaderPrefix is the prefix using when printing/writing an endpoint in a
 	// base64 form.


### PR DESCRIPTION
Fixes the following warnings

Line 42: warning: comment on exported const ServicesKeyPath should be of the form "ServicesKeyPath ..." (golint)
Line 71: warning: comment on exported const K8sEnvNodeNameSpec should be of the form "K8sEnvNodeNameSpec ..." (golint)
Line 73: warning: comment on exported const ReservedLabelSource should be of the form "ReservedLabelSource ..." (golint)
Line 75: warning: comment on exported const ReservedLabelKey should be of the form "ReservedLabelKey ..." (golint)
Line 88: warning: comment on exported const NetdevHeaderFileName should be of the form "NetdevHeaderFileName ..." (golint)

Related-to: #153 (Resolve golint warnings)
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/430?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/430'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>