### PR TITLE
Vagrantfile: Bump memory to 3G

### DIFF
--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -33,7 +33,7 @@ export 'IPV6_INTERNAL_CIDR'=${IPV4+"FD01::"}
 #   worker 1: FD02::C0A8:210C:0:0/96
 export 'CILIUM_IPV6_NODE_CIDR'=${CILIUM_IPV6_NODE_CIDR:-"FD02::"}
 # VM memory
-export 'VM_MEMORY'=${MEMORY:-2048}
+export 'VM_MEMORY'=${MEMORY:-3072}
 # Number of CPUs
 export 'VM_CPUS'=${CPUS:-2}
 # K8STAG tag is only set if K8S option is active


### PR DESCRIPTION
I'm frequently seeing the following errors when running out of memory
with vagrant:

==> cilium-master: # github.com/cilium/cilium/daemon
==> cilium-master: /usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: fork/exec /usr/bin/gcc: cannot allocate memory

Signed-off-by: Thomas Graf <thomas@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/michi-covalent%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/25494577%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/434%23issuecomment-288849084%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222017-03-23T20%3A25%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/25494577%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/michi-covalent%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/434%23issuecomment-288849084%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/michi-covalent'><img src='https://avatars2.githubusercontent.com/u/25494577?v=3' width=34 height=34></a>

<a href='https://www.codereviewhub.com/cilium/cilium/pull/434?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/434?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/434'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>