### PR TITLE
golint: fix warnings for daemon/ct.go

### DIFF
--- a/daemon/ct.go
+++ b/daemon/ct.go
@@ -26,6 +26,7 @@ import (
 )
 
 const (
+	// GcInterval is the garbage collection interval.
 	GcInterval int = 10
 )
 
@@ -58,6 +59,7 @@ func runGC(e *endpoint.Endpoint, name string, ctType ctmap.CtType) {
 	f.Close()
 }
 
+// EnableConntrackGC enables the connection tracking garbage collection.
 func (d *Daemon) EnableConntrackGC() {
 	go func() {
 		for {


### PR DESCRIPTION
Fixes the following warnings

daemon/ct.go:29:2: exported const GcInterval should have comment (or a comment on this block) or be unexported
daemon/ct.go:61:1: exported method Daemon.EnableConntrackGC should have comment or be unexported

Related-to: #153 (Resolve golint warnings)

Please let me know if anything should be reworded, thanks.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/442?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/442'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>