### PR TITLE
daemon: ignore running containers

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -534,6 +534,11 @@ func NewDaemon(c *Config) (*Daemon, error) {
 		if err := d.SyncLBMap(); err != nil {
 			log.Warningf("Error while recovering endpoints: %s\n", err)
 		}
+	} else {
+		// We need to read all docker containers so we know we won't
+		// going to allocate the same IP addresses and we will ignore
+		// these containers from reading.
+		d.IgnoreRunningContainers()
 	}
 
 	d.endpointsMU.Lock()


### PR DESCRIPTION
If some containers were created with a cilium instance and that cilium
instance is stopped those containers should be kept with their network
running as best effort.

If a new cilium instance is started in the same machine, cilium could
potentially allocate conflicting IP addresses used by the containers
started by the previous cilium instance.

This could cause conflicting endpoint IDs and at worst case, it could
wrongly assign security IDs to the new containers with the conflicting
IP addresses.

With this commit, we check for running containers and add them to the
list of ignored containers plus allocate their running containers.

Reported-by: Dan Wendlandt <danwent@gmail.com>
Signed-off-by: André Martins <andre@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/448%23discussion_r108038776%22%2C%20%22https%3A//github.com/cilium/cilium/pull/448%23discussion_r108044200%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%205909268b90d70d95a96674a4985c471e89230d9f%20daemon/docker_watcher.go%2030%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/448%23discussion_r108038776%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Docker%20libnetworks%20differentiates%20between%20multiple%20networks%2C%20should%20we%20check%20if%20the%20driver%20type%20of%20the%20network%20is%20Cilium%3F%20I%27m%20not%20familiar%20with%20docker%20network%20to%20understand%20if%20conflicting%20IPs%20across%20Docker%20networks%20is%20a%20supported%20model.%22%2C%20%22created_at%22%3A%20%222017-03-25T15%3A44%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20check%20this%2C%20the%20map%20have%20the%20name%20%28not%20type%29%20as%20key%20and%20the%20endpoint%20settings%20as%20values.%20The%20user%20can%20decide%20whatever%20network%20we%20would%20like%20to%20the%20network%20name%2C%20for%20example%3A%5Cr%5Cn%60docker%20network%20create%20--ipv6%20--subnet%20%3A%3A1/112%20--ipam-driver%20cilium%20--driver%20cilium%20foo-cilium%60%5Cr%5CnWhile%20inspecting%20the%20container%20you%20will%20see%20something%20like%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Networks%5C%22%3A%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22foo-cilium%5C%22%3A%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22IPAMConfig%5C%22%3A%20null%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Links%5C%22%3A%20null%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Aliases%5C%22%3A%20%5B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%2242062ac9e052%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22NetworkID%5C%22%3A%20%5C%22006d05ef51786264e63bc3cdaea378ceb49b4bf0e5518c25b49f86c5ec3d474a%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22EndpointID%5C%22%3A%20%5C%22816c59aa0408ff543fa20fde30ec1b038ebc3c958acb10690f97308af75e12ef%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Gateway%5C%22%3A%20%5C%22%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22IPAddress%5C%22%3A%20%5C%2210.15.116.202%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22IPPrefixLen%5C%22%3A%2032%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22IPv6Gateway%5C%22%3A%20%5C%22f00d%3A%3Aa00%3A20f%3A0%3A0%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22GlobalIPv6Address%5C%22%3A%20%5C%22f00d%3A%3Aa00%3A20f%3A0%3Af236%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22GlobalIPv6PrefixLen%5C%22%3A%20128%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22MacAddress%5C%22%3A%20%5C%22%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cr%5Cn%60%60%60%5Cr%5CnRegarding%20the%20conflicting%20IPs%20across%20docker%20networks%2C%20I%20was%20able%20to%20create%20conflicting%20networks%20but%20I%20think%20it%20was%20because%20we%20are%20assigning%20the%20subnet%20%600.0.0.0/0%60%20to%20cilium%5Cr%5Cn%5Cr%5Cn%60%60%60vagrant%40cilium-k8s-master%3A%7E/go/src/github.com/cilium/cilium%24%20docker%20network%20create%20--subnet%3D10.15.0.0/16%20--ip-range%2010.15.0.0/24%20--gateway%2010.15.0.1%20--driver%20bridge%20%20conflicting-ips%20%20%5Cr%5Cn46926b026d890a1a6589b4efdf42a2dda5a13accd611b469cc2b0844ca6ad91d%5Cr%5Cnvagrant%40cilium-k8s-master%3A%7E/go/src/github.com/cilium/cilium%24%20docker%20network%20ls%5Cr%5CnNETWORK%20ID%20%20%20%20%20%20%20%20%20%20NAME%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20DRIVER%20%20%20%20%20%20%20%20%20%20%20%20%20%20SCOPE%5Cr%5Cn0cb2b91ae70c%20%20%20%20%20%20%20%20bridge%20%20%20%20%20%20%20%20%20%20%20%20%20%20bridge%20%20%20%20%20%20%20%20%20%20%20%20%20%20local%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn46926b026d89%20%20%20%20%20%20%20%20conflicting-ips%20%20%20%20%20bridge%20%20%20%20%20%20%20%20%20%20%20%20%20%20local%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn006d05ef5178%20%20%20%20%20%20%20%20foo-cilium%20%20%20%20%20%20%20%20%20%20cilium%20%20%20%20%20%20%20%20%20%20%20%20%20%20local%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn1fc1aa3113cc%20%20%20%20%20%20%20%20foo-cilium-2%20%20%20%20%20%20%20%20cilium%20%20%20%20%20%20%20%20%20%20%20%20%20%20local%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn99abdbf2eba0%20%20%20%20%20%20%20%20host%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20host%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20local%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn6e7c120bf9bf%20%20%20%20%20%20%20%20none%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20null%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20local%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cnvagrant%40cilium-k8s-master%3A%7E/go/src/github.com/cilium/cilium%24%20docker%20network%20inspect%20conflicting-ips%5Cr%5Cn%5B%5Cr%5Cn%20%20%20%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Name%5C%22%3A%20%5C%22conflicting-ips%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Id%5C%22%3A%20%5C%2246926b026d890a1a6589b4efdf42a2dda5a13accd611b469cc2b0844ca6ad91d%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Scope%5C%22%3A%20%5C%22local%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Driver%5C%22%3A%20%5C%22bridge%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22EnableIPv6%5C%22%3A%20false%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22IPAM%5C%22%3A%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Driver%5C%22%3A%20%5C%22default%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Options%5C%22%3A%20%7B%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Config%5C%22%3A%20%5B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Subnet%5C%22%3A%20%5C%2210.15.0.0/16%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22IPRange%5C%22%3A%20%5C%2210.15.0.0/24%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Gateway%5C%22%3A%20%5C%2210.15.0.1%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5D%5Cr%5Cn%20%20%20%20%20%20%20%20%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Internal%5C%22%3A%20false%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Containers%5C%22%3A%20%7B%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Options%5C%22%3A%20%7B%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Labels%5C%22%3A%20%7B%7D%5Cr%5Cn%20%20%20%20%7D%5Cr%5Cn%5D%5Cr%5Cn%24%20docker%20network%20inspect%20foo-cilium-2%5Cr%5Cn%5B%5Cr%5Cn%20%20%20%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Name%5C%22%3A%20%5C%22foo-cilium-2%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Id%5C%22%3A%20%5C%221fc1aa3113cc19c67fa030f6886c4dd7afb1b14778489644fba3b53b1925684a%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Scope%5C%22%3A%20%5C%22local%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Driver%5C%22%3A%20%5C%22cilium%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22EnableIPv6%5C%22%3A%20true%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22IPAM%5C%22%3A%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Driver%5C%22%3A%20%5C%22cilium%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Options%5C%22%3A%20%7B%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Config%5C%22%3A%20%5B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Subnet%5C%22%3A%20%5C%220.0.0.0/0%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Gateway%5C%22%3A%20%5C%2210.15.0.1/32%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Subnet%5C%22%3A%20%5C%22%3A%3A1/112%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5D%5Cr%5Cn%20%20%20%20%20%20%20%20%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Internal%5C%22%3A%20false%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Containers%5C%22%3A%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%22a5f8cdb23f9e41064f30b7e2aef18e736625a00066c96145e50f34b3fe85dc38%5C%22%3A%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22Name%5C%22%3A%20%5C%22server-4%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22EndpointID%5C%22%3A%20%5C%22403e09230878b4c0b0584da0a5f2b0287cbab038504ef618835c13daf1e6b4d2%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22MacAddress%5C%22%3A%20%5C%22%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22IPv4Address%5C%22%3A%20%5C%2210.15.129.91/32%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22IPv6Address%5C%22%3A%20%5C%22f00d%3A%3Aa00%3A20f%3A0%3Adc06/128%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cr%5Cn%20%20%20%20%20%20%20%20%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Options%5C%22%3A%20%7B%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22Labels%5C%22%3A%20%7B%7D%5Cr%5Cn%20%20%20%20%7D%5Cr%5Cn%5D%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222017-03-25T20%3A06%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20daemon/docker_watcher.go%3AL124-157%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 5909268b90d70d95a96674a4985c471e89230d9f daemon/docker_watcher.go 30'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/448#discussion_r108038776'>File: daemon/docker_watcher.go:L124-157</a></b>
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> Docker libnetworks differentiates between multiple networks, should we check if the driver type of the network is Cilium? I'm not familiar with docker network to understand if conflicting IPs across Docker networks is a supported model.
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> I check this, the map have the name (not type) as key and the endpoint settings as values. The user can decide whatever network we would like to the network name, for example:
`docker network create --ipv6 --subnet ::1/112 --ipam-driver cilium --driver cilium foo-cilium`
While inspecting the container you will see something like:
```
"Networks": {
"foo-cilium": {
"IPAMConfig": null,
"Links": null,
"Aliases": [
"42062ac9e052"
],
"NetworkID": "006d05ef51786264e63bc3cdaea378ceb49b4bf0e5518c25b49f86c5ec3d474a",
"EndpointID": "816c59aa0408ff543fa20fde30ec1b038ebc3c958acb10690f97308af75e12ef",
"Gateway": "",
"IPAddress": "10.15.116.202",
"IPPrefixLen": 32,
"IPv6Gateway": "f00d::a00:20f:0:0",
"GlobalIPv6Address": "f00d::a00:20f:0:f236",
"GlobalIPv6PrefixLen": 128,
"MacAddress": ""
}
}
```
Regarding the conflicting IPs across docker networks, I was able to create conflicting networks but I think it was because we are assigning the subnet `0.0.0.0/0` to cilium
```vagrant@cilium-k8s-master:~/go/src/github.com/cilium/cilium$ docker network create --subnet=10.15.0.0/16 --ip-range 10.15.0.0/24 --gateway 10.15.0.1 --driver bridge  conflicting-ips
46926b026d890a1a6589b4efdf42a2dda5a13accd611b469cc2b0844ca6ad91d
vagrant@cilium-k8s-master:~/go/src/github.com/cilium/cilium$ docker network ls
NETWORK ID          NAME                DRIVER              SCOPE
0cb2b91ae70c        bridge              bridge              local
46926b026d89        conflicting-ips     bridge              local
006d05ef5178        foo-cilium          cilium              local
1fc1aa3113cc        foo-cilium-2        cilium              local
99abdbf2eba0        host                host                local
6e7c120bf9bf        none                null                local
vagrant@cilium-k8s-master:~/go/src/github.com/cilium/cilium$ docker network inspect conflicting-ips
[
{
"Name": "conflicting-ips",
"Id": "46926b026d890a1a6589b4efdf42a2dda5a13accd611b469cc2b0844ca6ad91d",
"Scope": "local",
"Driver": "bridge",
"EnableIPv6": false,
"IPAM": {
"Driver": "default",
"Options": {},
"Config": [
{
"Subnet": "10.15.0.0/16",
"IPRange": "10.15.0.0/24",
"Gateway": "10.15.0.1"
}
]
},
"Internal": false,
"Containers": {},
"Options": {},
"Labels": {}
}
]
$ docker network inspect foo-cilium-2
[
{
"Name": "foo-cilium-2",
"Id": "1fc1aa3113cc19c67fa030f6886c4dd7afb1b14778489644fba3b53b1925684a",
"Scope": "local",
"Driver": "cilium",
"EnableIPv6": true,
"IPAM": {
"Driver": "cilium",
"Options": {},
"Config": [
{
"Subnet": "0.0.0.0/0",
"Gateway": "10.15.0.1/32"
},
{
"Subnet": "::1/112"
}
]
},
"Internal": false,
"Containers": {
"a5f8cdb23f9e41064f30b7e2aef18e736625a00066c96145e50f34b3fe85dc38": {
"Name": "server-4",
"EndpointID": "403e09230878b4c0b0584da0a5f2b0287cbab038504ef618835c13daf1e6b4d2",
"MacAddress": "",
"IPv4Address": "10.15.129.91/32",
"IPv6Address": "f00d::a00:20f:0:dc06/128"
}
},
"Options": {},
"Labels": {}
}
]
```


<a href='https://www.codereviewhub.com/cilium/cilium/pull/448?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/448?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/448'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>