### PR TITLE
contrib: use label instead of MAINTAINER

### DIFF
--- a/contrib/packaging/deb/cfg/Dockerfile
+++ b/contrib/packaging/deb/cfg/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-MAINTAINER "Andre Martins <andre@cilium.io>"
+LABEL maintainer "Andre Martins <andre@cilium.io>"
 
 RUN apt-get update && \
 apt-get install -y --no-install-recommends dh-golang devscripts fakeroot dh-make \

--- a/contrib/packaging/rpm/cfg/Dockerfile
+++ b/contrib/packaging/rpm/cfg/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:24
 
-MAINTAINER "Andre Martins <andre@cilium.io>"
+LABEL maintainer "Andre Martins <andre@cilium.io>"
 
 RUN dnf install -y gettext curl gcc fedora-packager fedora-review && \
 cd /tmp && \


### PR DESCRIPTION
The field has been deprecated[0].

[0]: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/452?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/452'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>