### PR TITLE
bpf: Add empty install target

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -33,5 +33,7 @@ all:
 
 endif
 
+install:
+
 clean:
 	rm -fr *.o


### PR DESCRIPTION
Silences the following build warning:
==> cilium-master: make[1]: *** No rule to make target `install'.  Stop.

Signed-off-by: Thomas Graf <thomas@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/456?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/456'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>