### PR TITLE
Documentation: fix typos

### DIFF
--- a/Documentation/gettingstarted.rst
+++ b/Documentation/gettingstarted.rst
@@ -12,7 +12,7 @@ hungry applications.
 
 The best way to get help if you get stuck is to ask a question on the
 `Cilium Slack channel <https://cilium.herokuapp.com>`_ .  With Cilium contributors
-accross the globe, there's almost alway someone available to help.
+across the globe, there's almost always someone available to help.
 
 Step 0: Install Vagrant
 -----------------------

--- a/Documentation/installation.rst
+++ b/Documentation/installation.rst
@@ -100,7 +100,7 @@ Private IPv6 addresses for containers
 -------------------------------------
 
 If privates IPv6 addresses are being used to address containers. The
-addresses must be masquaraded. This can be done on each node or at the
+addresses must be masqueraded. This can be done on each node or at the
 gateway/edge as the packets leave the internal network. An example
 ip6tables rule to achieve this is:
 

--- a/Documentation/k8s.rst
+++ b/Documentation/k8s.rst
@@ -10,7 +10,7 @@ kept updated as possible.
 Kubernetes loadbalancer (kube-proxy)
 ------------------------------------
 
-Kubernetes has developed the Services abstration which provides the user
+Kubernetes has developed the Services abstraction which provides the user
 the ability to load balance network traffic to different pods. This
 abstraction allows the pods reaching out to other pods by a single IP
 address, a virtual IP address, without knowing all the pods that are

--- a/Documentation/policy.rst
+++ b/Documentation/policy.rst
@@ -76,12 +76,12 @@ Policy Specification
           requires:           // List of additional labels required to consume selected pods (optional)
             - labels:         // Label selector
 
-Rule matching precendence: 1. The default decision is deny (undecided)
+Rule matching precedence: 1. The default decision is deny (undecided)
 2. If a rule matches and the from portion the source pod, the decision
 is changed to allow but the evaluation continues. If multiple rules in a
-policy element overlap, then the negated selector takes precendence. 3.
+policy element overlap, then the negated selector takes precedence. 3.
 If a from rules has the always boolean set, the decision is final
-immediately, the evaulation is not continued. 4. If a requires rule is
-encounted, the additional list of labels is added to the list of
+immediately, the evaluation is not continued. 4. If a requires rule is
+encountered, the additional list of labels is added to the list of
 required labels of a possible source. The rule itself does not change
 the decision though.


### PR DESCRIPTION
o s/accross/across
o s/masquaraded/masqueraded
o s/abstration/abstraction
o s/precendence/precedence
o s/encounted/encountered
o s/alway/always
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/458%23issuecomment-289243390%22%2C%20%22https%3A//github.com/cilium/cilium/pull/458%23issuecomment-289270206%22%2C%20%22https%3A//github.com/cilium/cilium/pull/458%23issuecomment-289577503%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/458%23issuecomment-289243390%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Dan%20is%20working%20on%20a%20bigger%20doc%20update%2C%20we%27ll%20wait%20with%20this%20as%20this%20is%20easier%20to%20rebase%20on%20top%20of%20his%20work%20than%20the%20other%20way%20around.%22%2C%20%22created_at%22%3A%20%222017-03-25T22%3A17%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%2C%20%7B%22body%22%3A%20%22On%20Sat%2C%20Mar%2025%2C%202017%20at%2003%3A17%3A25PM%20-0700%2C%20Thomas%20Graf%20wrote%3A%5Cn%3E%20Dan%20is%20working%20on%20a%20bigger%20doc%20update%2C%20we%27ll%20wait%20with%20this%20as%20this%20is%20easier%5Cn%3E%20to%20rebase%20on%20top%20of%20his%20work%20than%20the%20other%20way%20around.%5Cn%3E%5CnOK%2C%20looking%20forward%20to%20reading%20it.%5Cn%5Cn--%20%5CnMit%20freundlichen%20Gr%5Cu00fc%5Cu00dfen%5Cn%5CnAlexander%20Alemayhu%5Cn%22%2C%20%22created_at%22%3A%20%222017-03-26T10%3A05%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/925044%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/scanf%22%7D%7D%2C%20%7B%22body%22%3A%20%22Looks%20like%20these%20will%20be%20handled%20in%20other%20prs.%22%2C%20%22created_at%22%3A%20%222017-03-27T20%3A34%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/925044%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/scanf%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/458#issuecomment-289243390'>General Comment</a></b>
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> Dan is working on a bigger doc update, we'll wait with this as this is easier to rebase on top of his work than the other way around.
- <a href='https://github.com/scanf'><img border=0 src='https://avatars2.githubusercontent.com/u/925044?v=3' height=16 width=16></a> On Sat, Mar 25, 2017 at 03:17:25PM -0700, Thomas Graf wrote:
> Dan is working on a bigger doc update, we'll wait with this as this is easier
> to rebase on top of his work than the other way around.
>
OK, looking forward to reading it.
--
Mit freundlichen Grüßen
Alexander Alemayhu
- <a href='https://github.com/scanf'><img border=0 src='https://avatars2.githubusercontent.com/u/925044?v=3' height=16 width=16></a> Looks like these will be handled in other prs.


<a href='https://www.codereviewhub.com/cilium/cilium/pull/458?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/458?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/458'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>