### PR TITLE
Add version command and flag to tools

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -6,6 +6,8 @@ CONFDIR?=/etc
 INSTALL = install
 
 VERSION = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/VERSION)
+BUILD = $(VERSION) $(shell git show -s --format='format:%h %aD') $(shell go version)
+GOBUILD = -ldflags '-X "github.com/cilium/cilium/pkg/version.Version=$(BUILD)"'
 
 # Uncomment to enable race detection
-#GOBUILD = -race
+#GOBUILD += -race

--- a/cilium/Makefile
+++ b/cilium/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.defs
 TARGET=cilium
 SOURCES := $(shell find ../api ../daemon ../common ../pkg cmd . -name '*.go')
 $(TARGET): $(SOURCES)
-	go build $(GOBUILD) -ldflags "-X "github.com/cilium/cilium/common".Version=$(VERSION)" -o $(TARGET)
+	go build $(GOBUILD) -o $(TARGET)
 
 all: $(TARGET)
 

--- a/cilium/cmd/version.go
+++ b/cilium/cmd/version.go
@@ -1,0 +1,35 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/version"
+
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("Cilium %s\n", version.Version)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}

--- a/common/const.go
+++ b/common/const.go
@@ -14,11 +14,6 @@
 
 package common
 
-var (
-	// Version number needs to be var since we override the value when building
-	Version = "dev"
-)
-
 const (
 	// RFC3339Milli is the RFC3339 with milliseconds for the default timestamp format
 	// log files.

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.defs
 TARGET=cilium-agent
 SOURCES := $(shell find ../api ../common ../daemon ../pkg . -name '*.go')
 $(TARGET): $(SOURCES) check-bindata
-	go build $(GOBUILD) -ldflags "-X "github.com/cilium/cilium/common".Version=$(VERSION)" -o $(TARGET)
+	go build $(GOBUILD) -o $(TARGET)
 GO_BINDATA := go-bindata -prefix ../ -mode 0640 -modtime 1450269211 \
 	-ignore Makefile -ignore bpf_features.h -ignore lxc_config.h \
 	-ignore netdev_config.h -ignore node_config.h -ignore '.+\.o$$'

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/version"
 
 	etcdAPI "github.com/coreos/etcd/clientv3"
 	"github.com/go-openapi/loads"
@@ -187,6 +188,7 @@ func init() {
 	flags.StringVarP(&config.Tunnel, "tunnel", "t", "vxlan", "Tunnel mode vxlan or geneve, vxlan is the default")
 	flags.StringVar(&bpfRoot, "bpf-root", "", "Path to mounted BPF filesystem")
 	flags.String("access-log", "", "Path to access log of all HTTP requests observed")
+	flags.Bool("version", false, "Print version information")
 	viper.BindPFlags(flags)
 }
 
@@ -216,6 +218,11 @@ func RestoreExecPermissions(searchDir string, patterns ...string) error {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
+	if viper.GetBool("version") {
+		fmt.Printf("Cilium %s\n", version.Version)
+		os.Exit(0)
+	}
+
 	if cfgFile != "" { // enable ability to specify config file via flag
 		viper.SetConfigFile(cfgFile)
 	}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/u8proto"
+	"github.com/cilium/cilium/pkg/version"
 )
 
 const (
@@ -108,7 +109,7 @@ func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 
 	if epStr64, err := e.Base64(); err == nil {
 		fmt.Fprintf(fw, " * %s%s:%s\n * \n", common.CiliumCHeaderPrefix,
-			common.Version, epStr64)
+			version.Version, epStr64)
 	} else {
 		e.LogStatus(BPF, Warning, fmt.Sprintf("Unable to create a base64: %s", err))
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,17 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+var Version string

--- a/plugins/cilium-docker/Makefile
+++ b/plugins/cilium-docker/Makefile
@@ -7,7 +7,7 @@ all: $(TARGET)
 SOURCES := $(shell find ../../api/v1 ../../common ../../pkg/client ../../pkg/endpoint driver . -name '*.go')
 
 $(TARGET): $(SOURCES)
-	go build $(GOBUILD) -ldflags "-X "github.com/cilium/cilium/common".Version=$(VERSION)" -o $(TARGET)
+	go build $(GOBUILD) -o $(TARGET)
 
 run:
 	./cilium-docker -d


### PR DESCRIPTION
cilium version
cilium-agent --version

Encodes version, git sha abbrev, git commit date, and go build version

Fixes: #449

Signed-off-by: Thomas Graf <thomas@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/464?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/464'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>