### PR TITLE
bpf, tests: cleanup really all server1-5 containers

### DIFF
--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -21,7 +21,7 @@ TEST_NET="cilium"
 NETPERF_IMAGE="tgraf/netperf"
 
 function cleanup {
-	docker rm -f server1 server2 client misc bomb 2> /dev/null || true
+	docker rm -f server1 server2 server3 server4 server5 client misc bomb 2> /dev/null || true
 	rm netdev_config.h tmp_lb.o 2> /dev/null || true
 	ip link del lbtest1 2> /dev/null || true
 }


### PR DESCRIPTION
On cleanup, we need to remove server1 to server5, not just server1
and server2.

Signed-off-by: Daniel Borkmann <daniel@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/471?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/471'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>