### PR TITLE
endpoint: Fix endpoint test

### DIFF
--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -88,6 +88,7 @@ func (s *EndpointSuite) TestDeepCopy(c *C) {
 		NodeIP:           net.ParseIP("192.168.0.1"),
 		PortMap:          make([]PortMap, 2),
 		Opts:             option.NewBoolOptions(&EndpointOptionLibrary),
+		Status:           NewEndpointStatus(),
 	}
 	cpy := epWant.DeepCopy()
 	c.Assert(*cpy, DeepEquals, *epWant)


### PR DESCRIPTION
Addition of status always being present broke the DeepCopy() test

Signed-off-by: Thomas Graf <thomas@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/483?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/483'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>