### PR TITLE
cilium, doc: fix documentation links

### DIFF
--- a/Documentation/commit-access.rst
+++ b/Documentation/commit-access.rst
@@ -42,7 +42,7 @@ Expectations for Developers with commit access
 Pre-requisites
 ~~~~~~~~~~~~~~
 
-Be familiar with the `contributing <contributing.md>`__ guide.
+Be familiar with the `contributing <contributing.rst>`__ guide.
 
 Review
 ~~~~~~
@@ -350,7 +350,7 @@ Invitation to Accepted Committer
     Developers with commit access must agree to fulfill specific
     responsibilities described in the source repository:
 
-        /doc/commit-access.md
+        /Documentation/commit-access.rst
 
     Please let us know if you would like to accept commit access and if so that
     you agree to fulfill these responsibilities. Once we receive your response

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ for containers.
 
  * 5-min Quickstart: [Using the prebuilt docker images](examples/docker-compose/README.md)
  * For Developers: [Setting up a vagrant environment](Documentation/vagrant.rst)
- * Manual installation: [Detailed installation instructions](Documentation/installation.rst)
+ * Manual installation: [Detailed installation instructions](Documentation/admin.rst)
  * Frequently Asked Questions: [FAQ](https://github.com/cilium/cilium/issues?utf8=%E2%9C%93&q=is%3Aissue%20label%3Aquestion%20)
 
 ## Demo Tutorials
@@ -100,7 +100,7 @@ buffer.
 
 The easiest way to meet the prerequisites is to use the provided vagrant box
 which provides all prerequisites in a sandbox environment. Please see the
-[vagrant guide](doc/vagrant.md) for more details.
+[vagrant guide](Documentation/vagrant.rst) for more details.
 
 In order to meet the prerequisites for an installation outside of vagrant,
 the following components must be installed in at least the version specified:
@@ -120,18 +120,18 @@ functionality backported.
 
 ## Installation
 
-See the [installation instructions](Documentation/installation.md).
+See the [installation instructions](Documentation/admin.rst).
 
 ## Integration
 
 Cilium provides integration plugins for the following orchestration systems:
   * CNI (Kubernetes/Mesos) [Installation instructions](examples/kubernetes/README.md)
-  * libnetwork (Docker) [Installation instructions](Documentation/docker.md)
+  * libnetwork (Docker) [Installation instructions](examples/docker-compose/README.md)
 
 ## Contributions
 
 We are eager to receive feedback and contributions. Please see the
-[contributing guide](Documentation/contributing.md) for further instructions and ideas
+[contributing guide](Documentation/contributing.rst) for further instructions and ideas
 on how to contribute.
 
 ## Presentations

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -5,7 +5,7 @@ docker containers using the cilium docker image.
 
 ## Requirements
 
-The easiest way is to use the [vagrant box](../../doc/vagrant.md) and just
+The easiest way is to use the [vagrant box](../../Documentation/vagrant.rst) and just
 install docker-compose >=1.7.1 in it.
 
 If you want to install the dependencies manually, you need:


### PR DESCRIPTION
Fix the links that are currently not working due to the doc rework
and point them to the correct locations.

Signed-off-by: Daniel Borkmann <daniel@cilium.io>
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/489?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/489'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>