### PR TITLE
golint: fix warnings for pkg/policy/utils.go

### DIFF
--- a/pkg/policy/utils.go
+++ b/pkg/policy/utils.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 )
 
+// SplitNodePath returns path without extension and the extension if any.
 func SplitNodePath(fullPath string) (string, string) {
 	var extension = filepath.Ext(fullPath)
 	if len(extension) > 0 {
@@ -26,6 +27,7 @@ func SplitNodePath(fullPath string) (string, string) {
 	return fullPath[0 : len(fullPath)-len(extension)], extension
 }
 
+// JoinPath returns a joined path from a and b.
 func JoinPath(a, b string) string {
 	return a + NodePathDelimiter + b
 }


### PR DESCRIPTION
Fixes the following warnings

pkg/policy/utils.go:21:1: exported function SplitNodePath should have comment or be unexported
pkg/policy/utils.go:29:1: exported function JoinPath should have comment or be unexported

Related-to: #153 (Resolve golint warnings)
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cilium/cilium/pull/496?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/496'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>