### PR TITLE
Reduce logging metadata to improve readability

### DIFF
--- a/common/const.go
+++ b/common/const.go
@@ -15,10 +15,6 @@
 package common
 
 const (
-	// RFC3339Milli is the RFC3339 with milliseconds for the default timestamp format
-	// log files.
-	RFC3339Milli = "2006-01-02T15:04:05.000Z07:00"
-
 	// Consul dedicated constants
 
 	// OperationalPath is the base path to store the operational details in consul.

--- a/common/utils.go
+++ b/common/utils.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	l "github.com/op/go-logging"
 )
@@ -75,12 +76,11 @@ func SetupLOG(logger *l.Logger, logLevel string) {
 	switch os.Getenv("INITSYSTEM") {
 	case "SYSTEMD":
 		fileFormat = l.MustStringFormatter(
-			`%{level:.4s} %{id:03x} %{shortfunc} > %{message}`)
+			`%{level:.4s} %{message}`)
 	default:
-		hostname, _ := os.Hostname()
 		fileFormat = l.MustStringFormatter(
-			`%{time:` + RFC3339Milli + `} ` + hostname +
-				` %{level:.4s} %{id:03x} %{shortfunc} > %{message}`)
+			`%{color}%{time:` + time.RFC3339 +
+				`} %{level:.4s} %{color:reset}%{message}`)
 	}
 
 	level, err := l.LogLevel(logLevel)

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -242,6 +242,12 @@ func initConfig() {
 		common.SetupLOG(log, "INFO")
 	}
 
+	log.Info("     _ _ _")
+	log.Info(" ___|_| |_|_ _ _____")
+	log.Info("|  _| | | | | |     |")
+	log.Info("|___|_|_|_|___|_|_|_|")
+	log.Infof("Cilium %s", version.Version)
+
 	if config.IPv4Disabled {
 		endpoint.IPv4Enabled = false
 	}


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cilium/cilium/pull/499%23discussion_r109304213%22%2C%20%22https%3A//github.com/cilium/cilium/pull/499%23discussion_r109305435%22%2C%20%22https%3A//github.com/cilium/cilium/pull/499%23discussion_r109305467%22%2C%20%22https%3A//github.com/cilium/cilium/pull/499%23discussion_r109305830%22%2C%20%22https%3A//github.com/cilium/cilium/pull/499%23discussion_r109306032%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20d3b2f0fd7416ba641b3ef55517666cab9f7bf0c4%20common/utils.go%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/499%23discussion_r109304213%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20%60shortfunc%60%20is%20really%20helpful%20for%20debugging%2C%20can%20you%20add%20a%20conditional%20statement%20in%20case%20of%20debug%3F%20%22%2C%20%22created_at%22%3A%20%222017-04-02T09%3A10%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22Go%20ahead%20and%20add%20it.%20Honestly%2C%20given%20the%20length%20of%20some%20of%20the%20functions%20this%20adds%20more%20noise%20than%20value%20for%20me.%20The%20function%20name%20without%20any%20package%20context%20has%20very%20limited%20value.%22%2C%20%22created_at%22%3A%20%222017-04-02T10%3A29%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%2C%20%7B%22body%22%3A%20%22There%27s%20the%20%60callpath%60%20to%20show%20you%20the%20callpath%20of%20that%20log%20message%2C%20and%20the%20%60shortpkg%60%20to%20print%20the%20package%20of%20that%20functioname.%22%2C%20%22created_at%22%3A%20%222017-04-02T10%3A55%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/5714066%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aanm%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60callpath%60%20is%20even%20more%20verbose.%20The%20debugging%20output%20is%20currently%20very%20hard%20to%20use%20because%20of%20all%20the%20noise.%20If%20you%20want%20to%20have%20all%20that%20noise%20we%20should%20add%20it%20behind%20an%20option%20in%20a%20new%20PR.%20This%20PR%20is%20an%20immediate%20resolution%20to%20the%20problem%20of%20noise%20in%20even%20normal%20warning%20messages.%22%2C%20%22created_at%22%3A%20%222017-04-02T11%3A08%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20common/utils.go%3AL75-86%22%7D%2C%20%22Pull%20d3b2f0fd7416ba641b3ef55517666cab9f7bf0c4%20common/const.go%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cilium/cilium/pull/499%23discussion_r109305435%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Done%22%2C%20%22created_at%22%3A%20%222017-04-02T10%3A28%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1417913%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgraf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20common/const.go%3AL15-23%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull d3b2f0fd7416ba641b3ef55517666cab9f7bf0c4 common/utils.go 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/499#discussion_r109304213'>File: common/utils.go:L75-86</a></b>
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> The `shortfunc` is really helpful for debugging, can you add a conditional statement in case of debug?
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> Go ahead and add it. Honestly, given the length of some of the functions this adds more noise than value for me. The function name without any package context has very limited value.
- <a href='https://github.com/aanm'><img border=0 src='https://avatars3.githubusercontent.com/u/5714066?v=3' height=16 width=16></a> There's the `callpath` to show you the callpath of that log message, and the `shortpkg` to print the package of that functioname.
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> `callpath` is even more verbose. The debugging output is currently very hard to use because of all the noise. If you want to have all that noise we should add it behind an option in a new PR. This PR is an immediate resolution to the problem of noise in even normal warning messages.
- [x] <a href='#crh-comment-Pull d3b2f0fd7416ba641b3ef55517666cab9f7bf0c4 common/const.go 8'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cilium/cilium/pull/499#discussion_r109305435'>File: common/const.go:L15-23</a></b>
- <a href='https://github.com/tgraf'><img border=0 src='https://avatars2.githubusercontent.com/u/1417913?v=3' height=16 width=16></a> Done


<a href='https://www.codereviewhub.com/cilium/cilium/pull/499?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cilium/cilium/pull/499?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cilium/cilium/pull/499'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>