### PR TITLE
cmd: file policy import bug fix

### DIFF
--- a/cilium/cmd/policy.go
+++ b/cilium/cmd/policy.go
@@ -173,7 +173,7 @@ func loadPolicy(name string) (*policy.Node, error) {
 
 	var node *policy.Node
 
-	if err = processAllFilesFirst(name, node, files); err != nil {
+	if err = processAllFilesFirst(name, &node, files); err != nil {
 		return nil, err
 	}
 
@@ -186,7 +186,7 @@ func loadPolicy(name string) (*policy.Node, error) {
 	return node, nil
 }
 
-func processAllFilesFirst(name string, node *policy.Node, files []os.FileInfo) error {
+func processAllFilesFirst(name string, node **policy.Node, files []os.FileInfo) error {
 	for _, f := range files {
 		if f.IsDir() || ignoredFile(path.Base(f.Name())) {
 			continue
@@ -196,12 +196,12 @@ func processAllFilesFirst(name string, node *policy.Node, files []os.FileInfo) e
 		if err != nil {
 			return err
 		}
-		if node != nil {
-			if _, err := node.Merge(p); err != nil {
+		if *node != nil {
+			if _, err := (*node).Merge(p); err != nil {
 				return fmt.Errorf("Error: %s: %s", f.Name(), err)
 			}
 		} else {
-			node = p
+			*node = p
 		}
 	}
 	return nil

--- a/tests/03-docker.sh
+++ b/tests/03-docker.sh
@@ -13,6 +13,7 @@ function cleanup {
 }
 
 trap cleanup EXIT
+cleanup
 
 SERVER_LABEL="id.server"
 CLIENT_LABEL="id.client"

--- a/tests/policy/test.policy
+++ b/tests/policy/test.policy
@@ -1,5 +1,5 @@
 {
-        "name": "root",
+	"name": "root",
 	"rules": [{
 		"coverage": ["id.qa"],
 		"requires": ["id.qa"]


### PR DESCRIPTION
While processing all files when importing from a directory, the policy
was not properly imported to the daemon. This was due the incorrect
assumption that a pointer's value could be assigned inside a function.
By passing a pointer of the pointer's value, it is possible to assign a
new value inside the function.

Signed-off-by: André Martins <andre@cilium.io>