### PR TITLE
L7 HTTP Policy does not work

### DIFF
--- a/pkg/policy/rule_l4.go
+++ b/pkg/policy/rule_l4.go
@@ -89,7 +89,7 @@ func (l4 *L4Filter) UnmarshalJSON(data []byte) error {
 
 	l4.Port = l4filter.Port
 	l4.Protocol = l4filter.Protocol
-	l4.L7Rules = l4filter.L7Rules
+	l4.L7Parser = l4filter.L7Parser
 	l4.L7RedirectPort = l4filter.L7RedirectPort
 	l4.L7Rules = make([]AuxRule, len(l4filter.L7Rules))
 	copy(l4.L7Rules, l4filter.L7Rules)


### PR DESCRIPTION
The commit for "proxy: Rename L7 fields in L4 policy"
(sha: 30c0a6a6521fe0873fca26d07b50e342ba099f9a) updated the policy
fields. The json field 'redirect' was updated to 'l7-parser'. The
corresponding golang variable L7Parser was not being set, causing
the HTTP L7 policies, for example the one specified in the Getting
Started Guide, to not function properly.

The fix simply sets the L7Parser variable correctly

Signed-off-by: Raghu G <r.grizzly@gmail.com>