### PR TITLE
Fixing tests

### DIFF
--- a/tests/05-cni.sh
+++ b/tests/05-cni.sh
@@ -95,7 +95,8 @@ export NETCONFPATH=`pwd`/net.d
 
 git clone 'https://github.com/containernetworking/cni'
 cd cni
-./build
+git checkout tags/v0.5.2
+./build.sh
 export CNI_PATH=`pwd`/bin
 cp "${dir}/../plugins/cilium-cni/cilium-cni" "${CNI_PATH}"
 cd scripts

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -374,7 +374,7 @@ cilium bpf ct list $SERVER1_ID
 cilium service update --rev --frontend "$SVC_IP4:0"  --id 223 \
 			--backends "$SERVER1_IP4:0"
 
-docker exec -ti server1 ping -c 4 $SVC_IP4 || {
+docker exec -i server1 ping -c 4 $SVC_IP4 || {
 	abort "Error: Unable to reach own service IP"
 }
 

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -234,7 +234,7 @@ docker run -dt --net=$TEST_NET --name server2 -l id.server -l server2 httpd
 docker run -dt --net=$TEST_NET --name server3 -l id.server -l server3 httpd
 docker run -dt --net=$TEST_NET --name server4 -l id.server -l server4 httpd
 docker run -dt --net=$TEST_NET --name server5 -l id.server -l server5 httpd
-docker run -dt --net=$TEST_NET --name client -l id.client noironetworks/nettools
+docker run -dt --net=$TEST_NET --name client -l id.client tgraf/nettools
 
 # FIXME IPv6 DAD period
 sleep 5

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -379,6 +379,12 @@ docker exec -i server1 ping -c 4 $SVC_IP4 || {
 }
 
 ## Test 5: Run wrk & ab from container => bpf_lxc (LB) => local container
+# Only run these tests if BENCHMARK=1 has been set
+if [ -z $BENCHMARK ]; then
+	echo "Skipping Test 5, not in benchmark mode."
+	echo "Run with BENCHMARK=1 to enable this test"
+	exit 0
+fi
 
 cilium service update --rev --frontend "[$SVC_IP6]:80" --id 2223 \
                         --backends "[$SERVER1_IP]:80" \

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -354,7 +354,7 @@ docker exec -i client ping6 -c 4 $SVC_IP6 || {
 }
 
 docker exec -i client ping -c 4 $SVC_IP4 || {
-	abort "Error: Unable to reach netperf TCP IPv6 endpoint"
+	abort "Error: Unable to reach netperf TCP IPv4 endpoint"
 }
 
 cilium endpoint config $CLIENT_ID Policy=false

--- a/tests/08-nat46.sh
+++ b/tests/08-nat46.sh
@@ -23,8 +23,8 @@ docker network inspect $TEST_NET 2> /dev/null || {
         docker network create --ipv6 --subnet ::1/112 --ipam-driver cilium --driver cilium $TEST_NET
 }
 
-docker run -dt -ti --net=$TEST_NET --name server -l $SERVER_LABEL $NETPERF_IMAGE
-docker run -dt -ti --net=$TEST_NET --name client -l $CLIENT_LABEL $NETPERF_IMAGE
+docker run -d -i --net=$TEST_NET --name server -l $SERVER_LABEL $NETPERF_IMAGE
+docker run -d -i --net=$TEST_NET --name client -l $CLIENT_LABEL $NETPERF_IMAGE
 
 CLIENT_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' client)
 CLIENT_IP4=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' client)

--- a/tests/08-nat46.sh
+++ b/tests/08-nat46.sh
@@ -54,6 +54,9 @@ cat <<EOF | cilium -D policy import -
 }
 EOF
 
+cilium endpoint config ${CLIENT_ID} NAT46=true
+cilium endpoint config ${SERVER_ID} NAT46=true
+
 function connectivity_test64() {
         # ICMPv4 echo request from client to server should succeed
         monitor_clear

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 for test in *.sh; do
 	./$test
 done


### PR DESCRIPTION
Fixes #331

On my machine `06-lb.sh` hang on line 422. Lets see how it does in jenkins.

@tgraf We are currently skipping `04-k8s.sh` which tests cilium ingress controller with DSR.
Should I make a new test script to run without ingress controller with DSR and simply test k8s network policy?