### PR TITLE
Dockerfile: adding required libraries for checkers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,8 @@ make PKG_BUILD=1 install && \
 # cilium-end
 #
 apt-get purge --auto-remove -y gcc make bison flex git curl xz-utils && \
+# Needed for system minimal requirements checkers
+apt-get install -y --no-install-recommends libgcc-5-dev binutils && \
 apt-get clean && \
 rm -fr /root /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/local/go && \
 echo '#!/usr/bin/env bash\ncp /opt/cni/bin/cilium-cni /tmp/cni/bin && /usr/bin/cilium-agent $@' > /home/with-cni.sh && \


### PR DESCRIPTION
clang needs 2 more files, `ld` which is provided by binutils and
`crtbegin.o` which is provided by libgcc-5-dev.

Signed-off-by: André Martins <andre@cilium.io>