### PR TITLE
gofmt: reformat events.go and tree_test.go

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -19,14 +19,14 @@ import (
 )
 
 const (
-        // IdentityAdd is the event type used when a new identity is added to
-        // the K/V store.
+	// IdentityAdd is the event type used when a new identity is added to
+	// the K/V store.
 	IdentityAdd EventType = iota
-        // IdentityMod is the event type used when a existing identity is
-        // scheduled for deletion but there are still reference counts to it.
+	// IdentityMod is the event type used when a existing identity is
+	// scheduled for deletion but there are still reference counts to it.
 	IdentityMod
-        // IdentityDel is the event type used when a existing identity is
-        // deleted.
+	// IdentityDel is the event type used when a existing identity is
+	// deleted.
 	IdentityDel
 )
 

--- a/pkg/policy/tree_test.go
+++ b/pkg/policy/tree_test.go
@@ -121,10 +121,10 @@ func (ds *PolicyTestSuite) TestAddDelete(c *C) {
 var defaultCtx = &SearchContext{
 	Trace: TRACE_ENABLED,
 	From: []labels.Label{
-		labels.Label{Key: "id.foo", Source: "cilium"},
+		{Key: "id.foo", Source: "cilium"},
 	},
 	To: []labels.Label{
-		labels.Label{Key: "id.bar", Source: "cilium"},
+		{Key: "id.bar", Source: "cilium"},
 	},
 }
 


### PR DESCRIPTION
Fixes the following warnings

cilium/pkg/events/events.go
	Line 1: warning: file is not gofmted with -s (gofmt)
cilium/pkg/policy/tree_test.go
	Line 1: warning: file is not gofmted with -s (gofmt)

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>