### PR TITLE
godoc: add documentation file for events package

### DIFF
--- a/pkg/events/doc.go
+++ b/pkg/events/doc.go
@@ -1,0 +1,3 @@
+/*Package events is used to trigger events across the daemon.
+*/
+package events


### PR DESCRIPTION
This should show a synopsis on godoc[0].

[0]: https://godoc.org/github.com/cilium/cilium
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>