### PR TITLE
Documentation: remove unnecessary page 'Indices and tables'

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -15,10 +15,3 @@ Welcome to Cilium's documentation!
    architecture
    admin
    contributing
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
There is already a TOC which has more info.

Fixes: #522
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>