### PR TITLE
daemon: Separate state directory inside runtime directory

### DIFF
--- a/Documentation/admin.rst
+++ b/Documentation/admin.rst
@@ -369,7 +369,7 @@ cilium-docker binary automatically registers itself with the local Docker daemon
 
 The cilium-docker binary also communicates
 with the main Cilium Agent via the agent's UNIX domain
-socket (``/var/run/cilium.sock``), so the plugin binary
+socket (``/var/run/cilium/cilium.sock``), so the plugin binary
 must have permissions to send/receive calls to this socket.
 
 Network Creation

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -62,6 +62,9 @@ type Config struct {
 	KeepConfig    bool // Keep configuration of existing endpoints when starting up.
 	KeepTemplates bool // Do not overwrite the template files
 
+	// StateDir is the directory where runtime state of endpoints is stored
+	StateDir string
+
 	// Options changeable at runtime
 	Opts   *option.BoolOptions
 	OptsMU sync.RWMutex

--- a/daemon/defaults/defaults.go
+++ b/daemon/defaults/defaults.go
@@ -19,16 +19,22 @@ const (
 	RuntimePath = "/var/run/cilium"
 
 	// RuntimePathRights are the default access rights of the RuntimePath directory
-	RuntimePathRights = 0770
+	RuntimePathRights = 0775
 
-	// BpfDir is the default path for template files relative to RuntimePath
+	// StateDirRights are the default access rights of the state directory
+	StateDirRights = 0770
+
+	//StateDir is the default path for the state directory relative to RuntimePath
+	StateDir = "state"
+
+	// BpfDir is the default path for template files relative to LibDir
 	BpfDir = "bpf"
 
 	// LibraryPath is the default path to the cilium libraries directory
 	LibraryPath = "/var/lib/cilium"
 
 	// SockPath is the path to the UNIX domain socket exposing the API to clients locally
-	SockPath = "/var/run/cilium.sock"
+	SockPath = RuntimePath + "/cilium.sock"
 
 	// SockPathEnv is the environment variable to overwrite SockPath
 	SockPathEnv = "CILIUM_SOCK"

--- a/daemon/labels_test.go
+++ b/daemon/labels_test.go
@@ -72,6 +72,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 		Opts:    option.NewBoolOptions(&options.Library),
 	}
 	daemonConf.RunDir = tempRunDir
+	daemonConf.StateDir = tempRunDir
 	daemonConf.LXCMap = nil
 	daemonConf.NodeAddress = nodeAddress
 	daemonConf.DockerEndpoint = "tcp://127.0.0.1"

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -220,7 +220,7 @@ func writeGeneve(prefix string, e *Endpoint) ([]byte, error) {
 
 func (e *Endpoint) runInit(owner Owner, prefix string) error {
 	libdir := owner.GetBpfDir()
-	rundir := owner.GetRuntimeDir()
+	rundir := owner.GetStateDir()
 	args := []string{libdir, rundir, prefix, e.IfName}
 
 	out, err := exec.Command(filepath.Join(libdir, "join_ep.sh"), args...).CombinedOutput()

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -49,8 +49,8 @@ type Owner interface {
 	// Must synchronize endpoint object with datapath
 	WriteEndpoint(ep *Endpoint) error
 
-	// Must return path to runtime directory
-	GetRuntimeDir() string
+	// GetStateDir must return path to the state directory
+	GetStateDir() string
 
 	// Must return path to BPF template files directory
 	GetBpfDir() string


### PR DESCRIPTION
Moves all endpoint state into the state/ subdirectory inside the
existing runtime directory. This allows to establish different
permissions for the default runtime directory which can be mounted
into container images and the actual state which must be protected.

Allows moving cilium.sock back into the runtime directory for easy
sharing in and out of containers.

Signed-off-by: Thomas Graf <thomas@cilium.io>