### PR TITLE
daemon: Read bpf_features.log from state directory

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -198,7 +198,7 @@ func checkMinRequirements() {
 	if _, err := os.Stat(filepath.Join(globalsDir, "bpf_features.h")); os.IsNotExist(err) {
 		log.Fatalf("BPF Verifier: NOT OK. Unable to read bpf_features.h: %s", err)
 	}
-	bpfLogPath := filepath.Join(config.RunDir, "bpf_features.log")
+	bpfLogPath := filepath.Join(config.StateDir, "bpf_features.log")
 	if _, err := os.Stat(bpfLogPath); os.IsNotExist(err) {
 		log.Infof("BPF Verifier: OK!")
 	} else if err == nil {

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -213,7 +213,7 @@ ip route add 2.2.2.2/32 via 3.3.3.3 src $SRC
 
 ip link set lbtest2 up
 LIB=/var/lib/cilium/bpf
-RUN=/var/run/cilium
+RUN=/var/run/cilium/state
 NH_IFINDEX=$(cat /sys/class/net/cilium_host/ifindex)
 NH_MAC=$(ip link show cilium_host | grep ether | awk '{print $2}')
 NH_MAC="{.addr=$(mac2array $NH_MAC)}"


### PR DESCRIPTION
Fixes: 880f9cc41 ("daemon: Separate state directory inside runtime directory")

Signed-off-by: Thomas Graf <thomas@cilium.io>