### PR TITLE
0.8.2 backports

### DIFF
--- a/Documentation/admin.rst
+++ b/Documentation/admin.rst
@@ -369,7 +369,7 @@ cilium-docker binary automatically registers itself with the local Docker daemon
 
 The cilium-docker binary also communicates
 with the main Cilium Agent via the agent's UNIX domain
-socket (``/var/run/cilium.sock``), so the plugin binary
+socket (``/var/run/cilium/cilium.sock``), so the plugin binary
 must have permissions to send/receive calls to this socket.
 
 Network Creation

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -6,6 +6,7 @@ HEAD
 ====
 
 - Separate state directory inside runtime directory (`GH #537 <https://github.com/cilium/cilium/pull/537>`_)
+- Fix all remaining testsuites and have Jenkins fail properly on all failures (`GH #513 <https://github.com/cilium/cilium/pull/513>`_)
 
 0.8.1
 =====

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -7,6 +7,7 @@ HEAD
 
 - Separate state directory inside runtime directory (`GH #537 <https://github.com/cilium/cilium/pull/537>`_)
 - Fix all remaining testsuites and have Jenkins fail properly on all failures (`GH #513 <https://github.com/cilium/cilium/pull/513>`_)
+- policy: Support carrying part of the path in the name (`GH #533 <https://github.com/cilium/cilium/pull/533>`_)
 
 0.8.1
 =====

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -2,6 +2,11 @@
 NEWS
 ****
 
+HEAD
+====
+
+- Separate state directory inside runtime directory (`GH #537 <https://github.com/cilium/cilium/pull/537>`_)
+
 0.8.1
 =====
 

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -62,6 +62,9 @@ type Config struct {
 	KeepConfig    bool // Keep configuration of existing endpoints when starting up.
 	KeepTemplates bool // Do not overwrite the template files
 
+	// StateDir is the directory where runtime state of endpoints is stored
+	StateDir string
+
 	// Options changeable at runtime
 	Opts   *option.BoolOptions
 	OptsMU sync.RWMutex

--- a/daemon/defaults/defaults.go
+++ b/daemon/defaults/defaults.go
@@ -19,16 +19,22 @@ const (
 	RuntimePath = "/var/run/cilium"
 
 	// RuntimePathRights are the default access rights of the RuntimePath directory
-	RuntimePathRights = 0770
+	RuntimePathRights = 0775
 
-	// BpfDir is the default path for template files relative to RuntimePath
+	// StateDirRights are the default access rights of the state directory
+	StateDirRights = 0770
+
+	//StateDir is the default path for the state directory relative to RuntimePath
+	StateDir = "state"
+
+	// BpfDir is the default path for template files relative to LibDir
 	BpfDir = "bpf"
 
 	// LibraryPath is the default path to the cilium libraries directory
 	LibraryPath = "/var/lib/cilium"
 
 	// SockPath is the path to the UNIX domain socket exposing the API to clients locally
-	SockPath = "/var/run/cilium.sock"
+	SockPath = RuntimePath + "/cilium.sock"
 
 	// SockPathEnv is the environment variable to overwrite SockPath
 	SockPathEnv = "CILIUM_SOCK"

--- a/daemon/labels_test.go
+++ b/daemon/labels_test.go
@@ -72,6 +72,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 		Opts:    option.NewBoolOptions(&options.Library),
 	}
 	daemonConf.RunDir = tempRunDir
+	daemonConf.StateDir = tempRunDir
 	daemonConf.LXCMap = nil
 	daemonConf.NodeAddress = nodeAddress
 	daemonConf.DockerEndpoint = "tcp://127.0.0.1"

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -117,15 +117,16 @@ func checkMinRequirements() {
 	log.Infof("libraries: OK!")
 
 	// Checking for bpf_features
-	globalsDir := filepath.Join(config.RunDir, "globals")
-	if err := os.MkdirAll(globalsDir, defaults.RuntimePathRights); err != nil {
+	globalsDir := filepath.Join(config.StateDir, "globals")
+	if err := os.MkdirAll(globalsDir, defaults.StateDirRights); err != nil {
 		log.Fatalf("Could not create runtime directory %q: %s", globalsDir, err)
 	}
 	if err := os.Chdir(config.LibDir); err != nil {
 		log.Fatalf("Could not change to runtime directory %q: %s",
 			config.LibDir, err)
 	}
-	if err := exec.Command("./bpf/run_probes.sh", "./bpf", config.RunDir).Run(); err != nil {
+	probeScript := filepath.Join(config.BpfDir, "run_probes.sh")
+	if err := exec.Command(probeScript, config.BpfDir, config.StateDir).Run(); err != nil {
 		log.Fatalf("BPF Verifier: NOT OK. Unable to run checker for bpf_features: %s", err)
 	}
 	if _, err := os.Stat(filepath.Join(globalsDir, "bpf_features.h")); os.IsNotExist(err) {
@@ -256,8 +257,14 @@ func initConfig() {
 	if err := os.MkdirAll(config.RunDir, defaults.RuntimePathRights); err != nil {
 		log.Fatalf("Could not create runtime directory %q: %s", config.RunDir, err)
 	}
+
+	config.StateDir = filepath.Join(config.RunDir, defaults.StateDir)
+	if err := os.MkdirAll(config.StateDir, defaults.StateDirRights); err != nil {
+		log.Fatalf("Could not create state directory %q: %s", config.StateDir, err)
+	}
+
 	if err := os.MkdirAll(config.LibDir, defaults.RuntimePathRights); err != nil {
-		log.Fatalf("Could not create library directory %q: %s", config.RunDir, err)
+		log.Fatalf("Could not create library directory %q: %s", config.LibDir, err)
 	}
 	if !config.KeepTemplates {
 		if err := RestoreAssets(config.LibDir, defaults.BpfDir); err != nil {

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -132,7 +132,7 @@ func checkMinRequirements() {
 	if _, err := os.Stat(filepath.Join(globalsDir, "bpf_features.h")); os.IsNotExist(err) {
 		log.Fatalf("BPF Verifier: NOT OK. Unable to read bpf_features.h: %s", err)
 	}
-	bpfLogPath := filepath.Join(config.RunDir, "bpf_features.log")
+	bpfLogPath := filepath.Join(config.StateDir, "bpf_features.log")
 	if _, err := os.Stat(bpfLogPath); os.IsNotExist(err) {
 		log.Infof("BPF Verifier: OK!")
 	} else if err == nil {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -220,7 +220,7 @@ func writeGeneve(prefix string, e *Endpoint) ([]byte, error) {
 
 func (e *Endpoint) runInit(owner Owner, prefix string) error {
 	libdir := owner.GetBpfDir()
-	rundir := owner.GetRuntimeDir()
+	rundir := owner.GetStateDir()
 	args := []string{libdir, rundir, prefix, e.IfName}
 
 	out, err := exec.Command(filepath.Join(libdir, "join_ep.sh"), args...).CombinedOutput()

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -49,8 +49,8 @@ type Owner interface {
 	// Must synchronize endpoint object with datapath
 	WriteEndpoint(ep *Endpoint) error
 
-	// Must return path to runtime directory
-	GetRuntimeDir() string
+	// GetStateDir must return path to the state directory
+	GetStateDir() string
 
 	// Must return path to BPF template files directory
 	GetBpfDir() string

--- a/tests/05-cni.sh
+++ b/tests/05-cni.sh
@@ -95,7 +95,8 @@ export NETCONFPATH=`pwd`/net.d
 
 git clone 'https://github.com/containernetworking/cni'
 cd cni
-./build
+git checkout tags/v0.5.2
+./build.sh
 export CNI_PATH=`pwd`/bin
 cp "${dir}/../plugins/cilium-cni/cilium-cni" "${CNI_PATH}"
 cd scripts

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -213,7 +213,7 @@ ip route add 2.2.2.2/32 via 3.3.3.3 src $SRC
 
 ip link set lbtest2 up
 LIB=/var/lib/cilium/bpf
-RUN=/var/run/cilium
+RUN=/var/run/cilium/state
 NH_IFINDEX=$(cat /sys/class/net/cilium_host/ifindex)
 NH_MAC=$(ip link show cilium_host | grep ether | awk '{print $2}')
 NH_MAC="{.addr=$(mac2array $NH_MAC)}"

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -374,7 +374,7 @@ cilium bpf ct list $SERVER1_ID
 cilium service update --rev --frontend "$SVC_IP4:0"  --id 223 \
 			--backends "$SERVER1_IP4:0"
 
-docker exec -ti server1 ping -c 4 $SVC_IP4 || {
+docker exec -i server1 ping -c 4 $SVC_IP4 || {
 	abort "Error: Unable to reach own service IP"
 }
 

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -234,7 +234,7 @@ docker run -dt --net=$TEST_NET --name server2 -l id.server -l server2 httpd
 docker run -dt --net=$TEST_NET --name server3 -l id.server -l server3 httpd
 docker run -dt --net=$TEST_NET --name server4 -l id.server -l server4 httpd
 docker run -dt --net=$TEST_NET --name server5 -l id.server -l server5 httpd
-docker run -dt --net=$TEST_NET --name client -l id.client noironetworks/nettools
+docker run -dt --net=$TEST_NET --name client -l id.client tgraf/nettools
 
 # FIXME IPv6 DAD period
 sleep 5

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -379,6 +379,12 @@ docker exec -i server1 ping -c 4 $SVC_IP4 || {
 }
 
 ## Test 5: Run wrk & ab from container => bpf_lxc (LB) => local container
+# Only run these tests if BENCHMARK=1 has been set
+if [ -z $BENCHMARK ]; then
+	echo "Skipping Test 5, not in benchmark mode."
+	echo "Run with BENCHMARK=1 to enable this test"
+	exit 0
+fi
 
 cilium service update --rev --frontend "[$SVC_IP6]:80" --id 2223 \
                         --backends "[$SERVER1_IP]:80" \

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -354,7 +354,7 @@ docker exec -i client ping6 -c 4 $SVC_IP6 || {
 }
 
 docker exec -i client ping -c 4 $SVC_IP4 || {
-	abort "Error: Unable to reach netperf TCP IPv6 endpoint"
+	abort "Error: Unable to reach netperf TCP IPv4 endpoint"
 }
 
 cilium endpoint config $CLIENT_ID Policy=false

--- a/tests/08-nat46.sh
+++ b/tests/08-nat46.sh
@@ -23,8 +23,8 @@ docker network inspect $TEST_NET 2> /dev/null || {
         docker network create --ipv6 --subnet ::1/112 --ipam-driver cilium --driver cilium $TEST_NET
 }
 
-docker run -dt -ti --net=$TEST_NET --name server -l $SERVER_LABEL $NETPERF_IMAGE
-docker run -dt -ti --net=$TEST_NET --name client -l $CLIENT_LABEL $NETPERF_IMAGE
+docker run -d -i --net=$TEST_NET --name server -l $SERVER_LABEL $NETPERF_IMAGE
+docker run -d -i --net=$TEST_NET --name client -l $CLIENT_LABEL $NETPERF_IMAGE
 
 CLIENT_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' client)
 CLIENT_IP4=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' client)

--- a/tests/08-nat46.sh
+++ b/tests/08-nat46.sh
@@ -54,6 +54,9 @@ cat <<EOF | cilium -D policy import -
 }
 EOF
 
+cilium endpoint config ${CLIENT_ID} NAT46=true
+cilium endpoint config ${SERVER_ID} NAT46=true
+
 function connectivity_test64() {
         # ICMPv4 echo request from client to server should succeed
         monitor_clear

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 for test in *.sh; do
 	./$test
 done


### PR DESCRIPTION
This backports the following PRs:
 - #513 #537 #539 #533 

#513 ensures that we have a functional Jenkins in the stable branch. #537 and #539 are required to run the stable branch inside container images. #533 simplifies managing policies from kubernetes as nodes with the name "io.k8s" can be imported directly.