### PR TITLE
policy: Fix policy Lookup() function

### DIFF
--- a/pkg/policy/tree.go
+++ b/pkg/policy/tree.go
@@ -143,11 +143,9 @@ func (t *Tree) Lookup(path string) (node, parent *Node) {
 		return t.Root, nil
 	}
 
-	cut := JoinPath(RootNodeName, "")
-	if strings.HasPrefix(path, cut) {
-		path = strings.TrimPrefix(path, cut)
-	}
+	path = removeRootPrefix(path)
 
+	// "root." returns root node
 	if path == "" {
 		return t.Root, nil
 	}
@@ -157,14 +155,13 @@ func (t *Tree) Lookup(path string) (node, parent *Node) {
 
 	elements := strings.Split(path, NodePathDelimiter)
 	for index, nodeName := range elements {
-		log.Debugf("Looking for %s in %+v", nodeName, node)
 		if child, ok := node.Children[nodeName]; ok {
 			parent = node
 			node = child
 		} else {
 			// Return parent if we failed at last element
-			if index == len(elements)-1 {
-				return nil, parent
+			if index > 0 && index == len(elements)-1 {
+				return nil, node
 			}
 			return nil, nil
 		}

--- a/pkg/policy/utils.go
+++ b/pkg/policy/utils.go
@@ -16,6 +16,7 @@ package policy
 
 import (
 	"path/filepath"
+	"strings"
 )
 
 // SplitNodePath returns path without extension and the extension if any.
@@ -30,4 +31,14 @@ func SplitNodePath(fullPath string) (string, string) {
 // JoinPath returns a joined path from a and b.
 func JoinPath(a, b string) string {
 	return a + NodePathDelimiter + b
+}
+
+// removeRootPrefix removes an eventual "root." prefix from the path
+func removeRootPrefix(path string) string {
+	cut := JoinPath(RootNodeName, "")
+	if strings.HasPrefix(path, cut) {
+		path = strings.TrimPrefix(path, cut)
+	}
+
+	return path
 }


### PR DESCRIPTION
A bug in the tree.Lookup() function caused path dependencies to
not be correctly created. Fixes this bug and adds several additional
unit tests to cover this better.

Signed-off-by: Thomas Graf <thomas@cilium.io>