### PR TITLE
Vagrant: Simplified Vagrantfile to get started

### DIFF
--- a/Documentation/gettingstarted.rst
+++ b/Documentation/gettingstarted.rst
@@ -53,31 +53,27 @@ Step 2: Starting the Docker + Cilium VM
 
 Open a terminal and cd into the top of the cilium source directory.
 
-The script ``contrib/vagrant/start.sh`` will setup a Vagrant VM, with Docker
-and Cilium installed and running as services.  Simply run the following command
-to get started:
+Then cd into `examples/getting-started` and run `vagrant up`:
 
 ::
 
-    $ contrib/vagrant/start.sh
+    $ cd examples/getting-started
+    $ vagrant up
 
-The script usually takes a few minutes, but may take much longer if you are on
-a slow Internet connection.   When the script completes successfully, it will
-print:
-
-::
-
-   $ ==> cilium-master: Cilium successfully started!
-
-If the script exits with the following error message, something went wrong:
+The script usually takes a few minutes depending on the speed of your internet
+connection. Vagrant will set up a VM, install the Docker container runtime and
+run Cilium with the help of Docker compose. When the script completes successfully,
+it will print:
 
 ::
+    ==> cilium-1: Creating cilium-kvstore
+    ==> cilium-1: Creating cilium
+    ==> cilium-1: Creating cilium-docker-plugin
+    $
 
-   $ ==> cilium-master: Timeout waiting for Cilium to start...
-
-If this error appears, do not attempt to proceed with the tutorial, as later
-steps will not work properly.   Instead, contact us on the `Cilium Slack
-channel <https://cilium.herokuapp.com>`_ .
+If the script exits with an error message, do not attempt to proceed with the
+tutorial, as later steps will not work properly.   Instead, contact us on the
+`Cilium Slack channel <https://cilium.herokuapp.com>`_ .
 
 Step 3: Accessing the VM
 ------------------------

--- a/examples/getting-started/Vagrantfile
+++ b/examples/getting-started/Vagrantfile
@@ -1,0 +1,71 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.require_version ">= 1.8.3"
+
+num_nodes = (ENV['NNODES'] || 1).to_i
+cilium_version = (ENV['CILIUM_VERSION'] || "v0.8.1")
+cilium_opts = (ENV['CILIUM_OPTS'] || "--consul 192.168.33.11:8500 -t vxlan")
+cilium_tag = (ENV['CILIUM_TAG'] || "0.8")
+
+# This runs only once when vagrant box is provisioned for the first time
+$bootstrap = <<SCRIPT
+# install docker-compose
+curl -sS -L "https://github.com/docker/compose/releases/download/1.11.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+
+# install cilium client
+curl -sS -L "https://github.com/cilium/cilium/releases/download/#{cilium_version}/cilium-x86_64" -o /usr/local/bin/cilium
+chmod +x /usr/local/bin/cilium
+
+# Store specified tag and options for docker-compose so we can rerun easily
+cat > /home/vagrant/cilium/examples/getting-started/.env <<EOF
+CILIUM_TAG=#{cilium_tag}
+CILIUM_OPTS=#{cilium_opts}
+EOF
+
+# workaround for cilium binaries < 0.8.2
+echo 'export CILIUM_SOCK=/var/run/cilium/cilium.sock' >> /home/vagrant/.bashrc
+
+# cd into getting-started directory by default
+echo 'cd ~/cilium/examples/getting-started' >> /home/vagrant/.bashrc
+SCRIPT
+
+# This is run every time vagrant box is booted
+$run = <<SCRIPT
+sudo mount bpffs /sys/fs/bpf -t bpf
+cd ~/cilium/examples/getting-started
+sudo -E docker-compose up -d --remove-orphans
+SCRIPT
+
+Vagrant.configure(2) do |config|
+    config.vm.box = "bento/ubuntu-16.10"
+
+    # http://foo-o-rama.com/vagrant--stdin-is-not-a-tty--fix.html
+    config.vm.provision "fix-no-tty", type: "shell" do |s|
+	s.privileged = false
+	s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
+    end
+
+    config.vm.synced_folder "../..", "/home/vagrant/cilium", disabled: false
+
+    # install docker runtime
+    config.vm.provision :docker, images: [
+	"consul:v0.6.4",
+	"cilium/cilium:#{cilium_tag}"
+    ]
+
+    config.vm.provision "bootstrap", type: "shell", inline: $bootstrap
+    config.vm.provision "run", type: "shell", run: "always",
+       env: {"CILIUM_TAG" => cilium_tag, "CILIUM_OPTS" => cilium_opts},
+       privileged: false, inline: $run
+
+    (1..num_nodes).each do |n|
+        node_vm_name = "cilium-#{n}"
+        config.vm.define node_vm_name do |node|
+            node.vm.hostname = node_vm_name
+            node_ip = "192.168.33.1#{n}"
+            node.vm.network "private_network", ip: "#{node_ip}"
+        end
+    end
+end

--- a/examples/getting-started/docker-compose.yml
+++ b/examples/getting-started/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2'
+services:
+  cilium:
+    container_name: cilium
+    image: cilium/cilium:${CILIUM_TAG}
+    command: cilium-agent ${CILIUM_OPTS}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/cilium:/var/run/cilium
+      - /run/docker/plugins:/run/docker/plugins
+      - /sys/fs/bpf:/sys/fs/bpf
+    network_mode: "host"
+    cap_add:
+      - "NET_ADMIN"
+    privileged: true
+    depends_on:
+      - consul
+
+  cilium_docker:
+    container_name: cilium-docker-plugin
+    image: cilium/cilium:${CILIUM_TAG}
+    command: cilium-docker
+    volumes:
+      - /var/run/cilium:/var/run/cilium
+      - /run/docker/plugins:/run/docker/plugins
+    network_mode: "host"
+    cap_add:
+      - "NET_ADMIN"
+    privileged: true
+    depends_on:
+      - cilium
+
+  consul:
+    container_name: cilium-kvstore
+    ports:
+      - "8500:8500"
+    environment:
+      - "CONSUL_LOCAL_CONFIG={\"skip_leave_on_interrupt\": true}"
+    image: consul:v0.6.4
+    command: agent -client=0.0.0.0 -server -bootstrap-expect 1


### PR DESCRIPTION
This new Vagrantfile is based on bento/ubuntu and uses the stock
Linux kernel as provided by Ubuntu. It install a Docker runtime
and then runs the Cilium agent and Cilium Docker plugin using the
released container images. The client binary is installed natively
for easy use.

Backports: 6c6f4c7125a1dd3d82e0199a9307d61d9939b05d

Signed-off-by: Thomas Graf <thomas@cilium.io>