### PR TITLE
README: fix link syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ functionality backported.
 
 ## Installation
 
-See the [Installation instructions](installation)
+See the [Installation instructions][installation]
 
 ## Presentations
 


### PR DESCRIPTION
The link should now point to the documentation.

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>