### PR TITLE
policy: fixed LookupLocked bug

### DIFF
--- a/pkg/policy/tree.go
+++ b/pkg/policy/tree.go
@@ -135,15 +135,17 @@ func (t *Tree) ResolveL4Policy(ctx *SearchContext) *L4Policy {
 	return result
 }
 
-// LookupLocked returns a policy node and its parent for a given path
+// LookupLocked returns a policy node and its parent for a given path.
+// The `RootNodeName` is optional. If `path` is "", `node` will be the tree's
+// root and `parent` will be `nil`.
+//
+// If `path` does not start with `RootNodeName`, it will be assumed `path` is a
+// root's child. Thus, if `path` is a single node, the `parent` returned will be
+// the tree's root.
 func (t *Tree) LookupLocked(path string) (node, parent *Node) {
 	// Empty tree
 	if t.Root == nil {
 		return nil, nil
-	}
-
-	if path == RootNodeName {
-		return t.Root, nil
 	}
 
 	path = removeRootPrefix(path)
@@ -163,7 +165,7 @@ func (t *Tree) LookupLocked(path string) (node, parent *Node) {
 			node = child
 		} else {
 			// Return parent if we failed at last element
-			if index > 0 && index == len(elements)-1 {
+			if index == len(elements)-1 {
 				return nil, node
 			}
 			return nil, nil

--- a/pkg/policy/tree_test.go
+++ b/pkg/policy/tree_test.go
@@ -134,6 +134,11 @@ func (ds *PolicyTestSuite) TestLookup(c *C) {
 	c.Assert(n, IsNil)
 	c.Assert(p, Equals, foo)
 
+	// search for root.io, should return nil, root
+	n, p = tree.LookupLocked("root.io")
+	c.Assert(n, IsNil)
+	c.Assert(p, Equals, tree.Root)
+
 	// adding bar to foo
 	bar := NewNode("bar", nil)
 	added, err = tree.Add("root.foo", bar)
@@ -147,12 +152,12 @@ func (ds *PolicyTestSuite) TestLookup(c *C) {
 	c.Assert(n.Name, Equals, "foo")
 	c.Assert(p.Name, Equals, "root")
 
-	// lookup of bar should fail
+	// lookup of bar should return nil, root
 	n, p = tree.LookupLocked("bar")
 	c.Assert(n, IsNil)
-	c.Assert(p, IsNil)
+	c.Assert(p, Equals, tree.Root)
 
-	// lookup of foo.bar should suceed
+	// lookup of foo.bar should succeed
 	n, p = tree.LookupLocked("foo.bar")
 	c.Assert(n, Equals, bar)
 	c.Assert(n.path, Equals, "root.foo.bar")

--- a/pkg/policy/utils.go
+++ b/pkg/policy/utils.go
@@ -33,12 +33,14 @@ func JoinPath(a, b string) string {
 	return a + NodePathDelimiter + b
 }
 
-// removeRootPrefix removes an eventual "root." prefix from the path
+// removeRootPrefix removes an eventual `root.` or `root` prefix from the path.
 func removeRootPrefix(path string) string {
+	if path == RootNodeName {
+		return ""
+	}
 	cut := JoinPath(RootNodeName, "")
 	if strings.HasPrefix(path, cut) {
 		path = strings.TrimPrefix(path, cut)
 	}
-
 	return path
 }

--- a/pkg/policy/utils_test.go
+++ b/pkg/policy/utils_test.go
@@ -1,0 +1,78 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+func (s *PolicyTestSuite) TestSplitNodePath(c *C) {
+	var removeRootTests = []struct {
+		input     string // input
+		expected1 string // expected result 1
+		expected2 string // expected result 2
+	}{
+		{"", "", ""},
+		{"root", "root", ""},
+		{"root.", "root", ""},
+		{"rootless..foo", "rootless.", "foo"},
+		{"root.foo", "root", "foo"},
+		{"foo.bar", "foo", "bar"},
+		{".bar", "", "bar"},
+	}
+	for _, tt := range removeRootTests {
+		actual1, actual2 := SplitNodePath(tt.input)
+		c.Assert(actual1, Equals, tt.expected1)
+		c.Assert(actual2, Equals, tt.expected2)
+	}
+}
+
+func (s *PolicyTestSuite) TestJoinPath(c *C) {
+	var joinPathTests = []struct {
+		input1   string // input 1
+		input2   string // input 2
+		expected string // expected result
+	}{
+		{"", "", "."},
+		{"root", "", "root."},
+		{"root.", "", "root.."},
+		{"root", "less", "root.less"},
+		{"root.foo", "bar", "root.foo.bar"},
+	}
+	for _, tt := range joinPathTests {
+		actual := JoinPath(tt.input1, tt.input2)
+		c.Assert(actual, Equals, tt.expected)
+	}
+}
+
+func (s *PolicyTestSuite) TestremoveRootPrefix(c *C) {
+	var removeRootTests = []struct {
+		input    string // input
+		expected string // expected result
+	}{
+		{"", ""},
+		{"root", ""},
+		{"root.", ""},
+		{"root.root.", "root."},
+		{"rootless", "rootless"},
+		{"root.foo", "foo"},
+		{"root..foo", ".foo"},
+		{"foo.bar", "foo.bar"},
+	}
+	for _, tt := range removeRootTests {
+		actual := removeRootPrefix(tt.input)
+		c.Assert(actual, Equals, tt.expected)
+	}
+}


### PR DESCRIPTION
This commit gives consistency to the LookupLocked function since
searching `io.cilium` returned `io` as parent and `cilium` as node. The
same principle should be applied if some searches `io` and `io` doesn't
exist, thus if LookupLocked should return `root` as parent and `io`,
if found, as node.

Signed-off-by: André Martins <andre@cilium.io>