### PR TITLE
docs: update authors file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,10 +3,12 @@ off on commits in the Cilium repository:
 
 Alban Crequy          alban.crequy@gmail.com
 Alexander Alemayhu    alexander@alemayhu.com
+Alexei Starovoitov    ast@kernel.org
 André Martins         andre@cilium.io
 Dan Wendlandt         danwent@gmail.com
 Daniel Borkmann       daniel@cilium.io
 Gianluca Arbezzano    gianarb92@gmail.com
+Ian Vernon            ianvernon@covalent.io
 Ivar Lazzaro          ivarlazzaro@gmail.com
 Jan-Erik Rediger      badboy@archlinux.us
 Madhu Challa          madhu@cilium.io
@@ -20,7 +22,6 @@ The following additional people are mentioned in commit logs as having provided
 helpful bug reports, suggestions or have otherwise provided value to the
 project:
 
-Alexei Starovoitov    ast@plumgrid.com
 Brenden Blanco        bblanco@plumgrid.com
 Salvatore Orlando     salv.orlando@gmail.com
 Tomás Senart          tsenart@gmail.com


### PR DESCRIPTION
Move Alexei into authors list for his recent patch and update his
email address to the one from the patch. Also add Ian to the list
for his patches.

Signed-off-by: Daniel Borkmann <daniel@cilium.io>