### PR TITLE
Documentation/architecture: correct wrong type for Children

### DIFF
--- a/Documentation/architecture.rst
+++ b/Documentation/architecture.rst
@@ -840,8 +840,8 @@ Name : string (optional)
     attached to the same parent.
 Rules : array of rules
     List of rules, see :ref:`_arch_rules`
-Children : Array of nodes (optional)
-    List of policy node children. The name of each child policy node is
+Children:  Map with node entries (optional)
+    Map holding children policy nodes. The name of each child policy node is
     prefixed with the name of its parent policy node using a `.` delimiter,
     e.g. a node `child` attached to the root node will have the absolute name
     `root.child`.


### PR DESCRIPTION
The documentation currently says that Children is an array of nodes but
if you read the examples and the implementation that is not the case.

    Children map[string]*Node `json:"children,omitempty"`

Replacing `Array of` with `Map with` should make the documentation match
the code. Reworded the lines with @aanm.

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>