### PR TITLE
Makefile.defs: fixed go version checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ include Makefile.defs
 
 SUBDIRS = plugins bpf cilium daemon
 GOFILES = $(shell go list ./... | grep -v /vendor/)
-GOLANGVERSION = $(shell go version 2>/dev/null | grep -Eo '(go[0-9].[0-9](.[0-9])?)')
+GOLANGVERSION = $(shell go version 2>/dev/null | grep -Eo '(go[0-9].[0-9])')
 
 all: check-golang $(SUBDIRS)
 


### PR DESCRIPTION

Fixed regular expression to detect golang 1.8.x to prevent cilium from
being build with golang >= 1.8.
    
More info: #580

Signed-off-by: André Martins <andre@cilium.io>