### PR TITLE
Documentation: remove empty page from latexpdf target

### DIFF
--- a/Documentation/_themes/sphinx_rtd_theme/demo_docs/source/conf.py
+++ b/Documentation/_themes/sphinx_rtd_theme/demo_docs/source/conf.py
@@ -193,6 +193,7 @@ latex_elements = {
 
 # Additional stuff for the LaTeX preamble.
 #'preamble': '',
+'extraclassoptions': 'openany',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -123,6 +123,7 @@ latex_elements = {
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
+    'extraclassoptions': 'openany',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples


### PR DESCRIPTION
When printing out this really adds no value and seeing TOC earlier is
more interesting.

Reference: https://github.com/sphinx-doc/sphinx/issues/2622
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>