### PR TITLE
daemon / kvstore: add kvstore flag for daemon CLI

### DIFF
--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -268,12 +268,14 @@ function write_cilium_cfg() {
     if [ -n "${K8S}" ]; then
         cilium_options+=" --k8s-api-server http://${MASTER_IPV4}:8080"
         cilium_options+=" --etcd-config-path /var/lib/cilium/etcd-config.yml"
+        cilium_options+=" --kvstore etcd"
     else
         if [[ "${IPV4}" -eq "1" ]]; then
             cilium_options+=" --consul ${MASTER_IPV4}:8500"
         else
             cilium_options+=" --consul [${ipv6_addr}]:8500"
         fi
+        cilium_options+=" --kvstore consul"
     fi
 
     if [ "$LB" = 1 ]; then

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -525,21 +525,32 @@ func NewDaemon(c *Config) (*Daemon, error) {
 
 	var kvClient kvstore.KVClient
 
-	// FIXME: This should really be a single configuration flag
-	if c.ConsulConfig != nil {
-		c, err := kvstore.NewConsulClient(c.ConsulConfig)
-		if err != nil {
-			return nil, err
+	// Create new key-value store client structures based on provided kvstore type.
+	switch c.KVStore {
+	case kvstore.Consul:
+		if c.ConsulConfig != nil {
+			log.Infof("Using consul as key-value store")
+			c, err := kvstore.NewConsulClient(c.ConsulConfig)
+			if err != nil {
+				return nil, err
+			}
+			kvClient = c
+		} else {
+			return nil, fmt.Errorf("invalid configuration for consul provided; please specify the address to a consul instance with the --consul option")
 		}
-		kvClient = c
-	} else if c.EtcdCfgPath != "" || c.EtcdConfig != nil {
-		c, err := kvstore.NewEtcdClient(c.EtcdConfig, c.EtcdCfgPath)
-		if err != nil {
-			return nil, err
+	case kvstore.Etcd:
+		if c.EtcdCfgPath != "" || c.EtcdConfig != nil {
+			log.Infof("Using etcd as key-value store")
+			c, err := kvstore.NewEtcdClient(c.EtcdConfig, c.EtcdCfgPath)
+			if err != nil {
+				return nil, err
+			}
+			kvClient = c
+		} else {
+			return nil, fmt.Errorf("invalid configuration for etcd provided; please specify an etcd configuration path with --etcd-config-path or an etcd agent address with --etcd")
 		}
-		kvClient = c
-	} else {
-		log.Infof("No key/value store configuration. Using local storage.")
+	case kvstore.Local:
+		log.Infof("Using local storage as key-value store")
 		kvClient = kvstore.NewLocalClient()
 	}
 

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/cilium/daemon/options"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/version"
 
@@ -62,22 +63,23 @@ var (
 	log    = logging.MustGetLogger("cilium")
 
 	// Arguments variables keep in alphabetical order
+	bpfRoot            string
 	consulAddr         string
 	disableConntrack   bool
 	enablePolicy       bool
 	enableTracing      bool
 	enableLogstash     bool
 	etcdAddr           []string
+	kvStore            string
 	k8sLabels          []string
 	validLabels        []string
 	labelPrefixFile    string
 	logstashAddr       string
 	logstashProbeTimer uint32
+	nat46prefix        string
 	socketPath         string
 	v4Prefix           string
 	v6Address          string
-	nat46prefix        string
-	bpfRoot            string
 )
 
 var cfgFile string
@@ -232,6 +234,7 @@ func init() {
 	flags.StringVar(&config.K8sCfgPath, "k8s-kubeconfig-path", "", "Absolute path to the kubeconfig file")
 	flags.StringSliceVar(&k8sLabels, "k8s-prefix", []string{},
 		"Key values that will be read from kubernetes. (Default: k8s-app, version)")
+	flags.StringVar(&kvStore, "kvstore", kvstore.Local, "Key-value store type")
 	flags.BoolVar(&config.KeepConfig, "keep-config", false,
 		"When restoring state, keeps containers' configuration in place")
 	flags.StringVar(&labelPrefixFile, "label-prefix-file", "", "File with valid label prefixes")
@@ -381,6 +384,36 @@ func initEnv() {
 	config.Opts.Set(endpoint.OptionConntrackAccounting, !disableConntrack)
 	config.Opts.Set(endpoint.OptionPolicy, enablePolicy)
 
+	//Validate specified key-value store type and related flags for the given key-value store type.
+	switch kvStore {
+	case kvstore.Consul:
+		if consulAddr != "" {
+			consulDefaultAPI := consulAPI.DefaultConfig()
+			consulSplitAddr := strings.Split(consulAddr, "://")
+			if len(consulSplitAddr) == 2 {
+				consulAddr = consulSplitAddr[1]
+			} else if len(consulSplitAddr) == 1 {
+				consulAddr = consulSplitAddr[0]
+			}
+			consulDefaultAPI.Address = consulAddr
+			config.ConsulConfig = consulDefaultAPI
+		} else {
+			log.Fatalf("invalid configuration for consul provided; please specify the address to a consul instance with the --consul option")
+		}
+	case kvstore.Etcd:
+		if len(etcdAddr) != 0 && config.EtcdCfgPath == "" {
+			config.EtcdConfig = &etcdAPI.Config{}
+			config.EtcdConfig.Endpoints = etcdAddr
+		} else {
+			log.Fatalf("invalid configuration for etcd provided; please specify an etcd configuration path with --etcd-config-path or an etcd agent address with --etcd")
+		}
+	case kvstore.Local:
+		log.Infof("Using local storage for key-value store")
+	default:
+		log.Fatalf("unsupported key-value store %q provided", kvStore)
+	}
+	config.KVStore = kvStore
+
 	config.ValidLabelPrefixesMU.Lock()
 	if labelPrefixFile != "" {
 		var err error
@@ -434,22 +467,6 @@ func initEnv() {
 }
 
 func runDaemon() {
-	if consulAddr != "" {
-		consulDefaultAPI := consulAPI.DefaultConfig()
-		consulSplitAddr := strings.Split(consulAddr, "://")
-		if len(consulSplitAddr) == 2 {
-			consulAddr = consulSplitAddr[1]
-		} else if len(consulSplitAddr) == 1 {
-			consulAddr = consulSplitAddr[0]
-		}
-		consulDefaultAPI.Address = consulAddr
-		config.ConsulConfig = consulDefaultAPI
-	}
-	if len(etcdAddr) != 0 && config.EtcdCfgPath == "" {
-		config.EtcdConfig = &etcdAPI.Config{}
-		config.EtcdConfig.Endpoints = etcdAddr
-	}
-
 	d, err := NewDaemon(config)
 	if err != nil {
 		log.Fatalf("Error while creating daemon: %s", err)

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -28,6 +28,13 @@ var (
 	log = logging.MustGetLogger("cilium-net")
 )
 
+// Supported key-value store types.
+const (
+	Local = "local"
+	Consul = "consul"
+	Etcd = "etcd"
+)
+
 type KVClient interface {
 	LockPath(path string) (KVLocker, error)
 	GetValue(k string) (json.RawMessage, error)


### PR DESCRIPTION
daemon: add kvstore flag for cilium-daemon CLI and allowed types of kvstores in kvstore pkg
kvstore: add kvstore type and officially supported kvstore types

Signed-off by: Ian Vernon <ian@covalent.io>

Fixes: #387 