### PR TITLE
pkg/endpoint: Enforce synchronous endpoint creation

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -787,8 +787,9 @@ func (e *Endpoint) RegenerateIfReady(owner Owner) error {
 	}
 	e.Mutex.RUnlock()
 
-	// TODO: Should we change RegenerateIfReady to block/non-block like
-	// e.Regenerate?
-	e.Regenerate(owner)
+	if !<-e.Regenerate(owner) {
+		return fmt.Errorf("error while regenerating endpoint."+
+			" For more info run: 'cilium endpoint get %d'", e.ID)
+	}
 	return nil
 }


### PR DESCRIPTION
When the endpoints parallelization was introduced (e7c1e02) it was
assumed all bpf endpoint's operations should be asynchronous. This was a
wrong assumption since the users will expect the endpoint will be ready
to use as soon the container is started. Thus, the endpoint creation
will always be synchronous and the regeneration operations will be
asynchronous.

Signed-off-by: André Martins <andre@cilium.io>

For 10 containers started, (#436), this commit introduces latency in comparison to master's:
master's:
```
real 7.44
user 1.80
sys 0.38
```
This commit:
```
real 18.55 (+59.8922%)
user 1.66 (-8.43373%)
sys 0.35 (-8.57143%)
```