### PR TITLE
all: switch from package syscall to x/sys/unix

### DIFF
--- a/cilium/cmd/monitor.go
+++ b/cilium/cmd/monitor.go
@@ -21,11 +21,11 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
-	"syscall"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/bpfdebug"
 
+	"golang.org/x/sys/unix"
 	"github.com/spf13/cobra"
 )
 
@@ -129,7 +129,7 @@ func runMonitor() {
 
 	for {
 		todo, err := events.Poll(5000)
-		if err != nil && err != syscall.EINTR {
+		if err != nil && err != unix.EINTR {
 			panic(err)
 		}
 		if todo > 0 {

--- a/common/addressing/node_address.go
+++ b/common/addressing/node_address.go
@@ -18,9 +18,10 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"syscall"
 
 	"github.com/vishvananda/netlink"
+
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -106,7 +107,7 @@ func firstGlobalV4Addr(intf string) (net.IP, error) {
 	}
 
 	for _, a := range addr {
-		if a.Scope == syscall.RT_SCOPE_UNIVERSE {
+		if a.Scope == unix.RT_SCOPE_UNIVERSE {
 			if len(a.IP) < 4 {
 				return nil, ErrIPv4Invalid
 			}

--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -29,8 +29,9 @@ import (
 	"os"
 	"path"
 	"sync"
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 type MapType int
@@ -255,7 +256,7 @@ func (m *Map) Open() error {
 
 func (m *Map) Close() error {
 	if m.fd != 0 {
-		syscall.Close(m.fd)
+		unix.Close(m.fd)
 		m.fd = 0
 	}
 


### PR DESCRIPTION
The syscall package is locked down and the comment in [1] advises to
switch code to use the corresponding package from golang.org/x/sys. Do
so and replace usage of package syscall with package
golang.org/x/sys/unix. This will also allow to get updates and fixes
without having to use a new go version.

[1] https://github.com/golang/go/blob/master/src/syscall/syscall.go#L21-L24