### PR TITLE
Documentation: fix broken links

### DIFF
--- a/Documentation/admin.rst
+++ b/Documentation/admin.rst
@@ -336,10 +336,10 @@ The following tests connectivity from a container to the outside world:
     64 bytes from zrh04s07-in-x04.1e100.net: icmp_seq=2 ttl=56 time=8.63 ms
     64 bytes from zrh04s07-in-x04.1e100.net: icmp_seq=3 ttl=56 time=8.83 ms
 
-Note that an appropriate policy must be loaded or policy enforcement
-will drop the relevant packets. An example policy can be found in
-`examples/policy/test/ <../examples/policy/test>`_ which will allow
-the above container with the label ``io.cilium`` to be reached from
+Note that an appropriate policy must be loaded or policy enforcement will drop
+the relevant packets. An example policy can be found in `examples/policy/test/
+<https://github.com/cilium/cilium/tree/master/examples/policy/test>`_ which
+will allow the above container with the label ``io.cilium`` to be reached from
 world scope. To load and test:
 
 ::

--- a/Documentation/architecture.rst
+++ b/Documentation/architecture.rst
@@ -839,7 +839,7 @@ Name : string (optional)
     rules belong to the root node. Must be unique across all siblings which are
     attached to the same parent.
 Rules : array of rules
-    List of rules, see :ref:`_arch_rules`
+    List of rules, see :ref:`arch_rules`
 Children:  Map with node entries (optional)
     Map holding children policy nodes. The name of each child policy node is
     prefixed with the name of its parent policy node using a `.` delimiter,

--- a/Documentation/commit-access.rst
+++ b/Documentation/commit-access.rst
@@ -42,7 +42,7 @@ Expectations for Developers with commit access
 Pre-requisites
 ~~~~~~~~~~~~~~
 
-Be familiar with the `contributing <contributing.rst>`__ guide.
+Be familiar with the :ref:`dev_guide`.
 
 Review
 ~~~~~~
@@ -104,7 +104,7 @@ syntax.
 Use Reported-by: and Tested-by: tags in commit messages to indicate the
 source of a bug report.
 
-Keep the `AUTHORS <../AUTHORS>`__ file up to date.
+Keep the `AUTHORS <https://github.com/cilium/cilium/blob/master/AUTHORS>`__ file up to date.
 
 Granting Commit Access
 ----------------------

--- a/Documentation/gettingstarted.rst
+++ b/Documentation/gettingstarted.rst
@@ -15,7 +15,8 @@ Docker + Cilium requires about 3 GB of RAM, so if your laptop has limited
 resources, you may want to close other memory intensive applications.
 
 The vagrant box is currently available for the following hypervisors. Please
-contact us on :ref:`slack` to request building for additional hypervisors.
+contact us on `slack <https://cilium.herokuapp.com>`_ to request building for
+additional hypervisors.
  * VirtualBox
  * libvirt
 


### PR DESCRIPTION
o AUTHORS, examples: use github link.
o contributing: link to dev_guide.
o s/_arch_rules/arch_rules/
o correct link for first mention of slack.

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>