### PR TITLE
Documentation/bpf: some formatting issues and typos

### DIFF
--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -5,10 +5,10 @@ BPF and XDP Reference Guide
 ***************************
 
 .. note:: This documentation section is targeted at developers and users who
-          want want to understand BPF and XDP in great technical depth. While
-          reading this reference guide may help broaden yur understanding of
+          want to understand BPF and XDP in great technical depth. While
+          reading this reference guide may help broaden your understanding of
           Cilium, it is not a requirement to use Cilium. Please refer to the
-          :ref:`_gs_guide` and :ref:`_arch_guide` for a higher level
+          :ref:`gs_guide` and :ref:`arch_guide` for a higher level
           introduction.
 
 BPF is a highly flexible and efficient "virtual machine"-like construct in the
@@ -27,7 +27,7 @@ BPF unless explicit differences between eBPF and cBPF are being pointed out.
 
 Even though the name Berkley Packet Filter hints at a packet filtering specific
 purpose, the instruction set is generic and flexible enough these days that
-there are many use cases for BPF apart from networking. See :ref:`_bpf_users`
+there are many use cases for BPF apart from networking. See :ref:`bpf_users`
 for a list of projects which use BPF.
 
 Cilium uses BPF heavily in its data path, see :ref:`arch_guide` for further


### PR DESCRIPTION
o s/_bpf_users/bpf_users
o s/_gs_guide/gs_guide
o s/_arch_guide/arch_guide
o s/yur/your/
o s/want want/want/

Related-to: #592 (BPF Documentation updates)
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>