### PR TITLE
bpfdebug: Improve debug message in case of policy evaluation is denied

### DIFF
--- a/pkg/bpfdebug/debug.go
+++ b/pkg/bpfdebug/debug.go
@@ -145,7 +145,7 @@ func (n *DebugMsg) Dump(data []byte, prefix string) {
 	case DbgLxcFound:
 		fmt.Printf("Local container found ifindex %d seclabel %d\n", n.Arg1, common.Swab16(uint16(n.Arg2)))
 	case DbgPolicyDenied:
-		fmt.Printf("Policy denied from %d to %d\n", n.Arg1, n.Arg2)
+		fmt.Printf("Policy evaluation would deny packet from %d to %d\n", n.Arg1, n.Arg2)
 	case DbgCtLookup:
 		fmt.Printf("CT lookup: %s\n", ctInfo(n.Arg1, n.Arg2))
 	case DbgCtLookup4:


### PR DESCRIPTION
The message "Policy denied from %d to %d" was confusing as it's only an
intermediate step and the packet is not actually dropped if the
connection is later evaluated as being established.

Fixes: #437

Signed-off-by: Thomas Graf <thomas@cilium.io>