### PR TITLE
daemon: Only attempt to resolve CIDR from k8s API if client is available

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -592,12 +592,12 @@ func NewDaemon(c *Config) (*Daemon, error) {
 		if err != nil {
 			return nil, err
 		}
-	}
 
-	if nodeName := os.Getenv(common.K8sEnvNodeNameSpec); nodeName != "" {
-		// Try to retrieve node's cidr from k8s's configuration
-		if err := d.useK8sNodeCIDR(nodeName); err != nil {
-			return nil, err
+		if nodeName := os.Getenv(common.K8sEnvNodeNameSpec); nodeName != "" {
+			// Try to retrieve node's cidr from k8s's configuration
+			if err := d.useK8sNodeCIDR(nodeName); err != nil {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes the following panic:
anic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x4105b4]

goroutine 1 [running]:
panic(0x1998a80, 0xc420012050)
	/usr/local/go/src/runtime/panic.go:500 +0x1a1
main.(*Daemon).useK8sNodeCIDR(0xc4200c8b40, 0xc42000e08e, 0x8, 0x8, 0xc421d895f0)
	/tmp/cilium-net-build/src/github.com/cilium/cilium/daemon/daemon.go:268 +0x54
main.NewDaemon(0xc420322000, 0x0, 0x0, 0x0)
	/tmp/cilium-net-build/src/github.com/cilium/cilium/daemon/daemon.go:512 +0xf68
main.runDaemon()
	/tmp/cilium-net-build/src/github.com/cilium/cilium/daemon/main.go:449 +0x88
main.glob..func1(0x2986f80, 0xc42008e050, 0x2, 0x5)
	/tmp/cilium-net-build/src/github.com/cilium/cilium/daemon/main.go:91 +0x19
github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).execute(0x2986f80, 0xc42000c130, 0x5, 0x5, 0x2986f80, 0xc42000c130)
	/tmp/cilium-net-build/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:648 +0x443
github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x2986f80, 0x0, 0x1bc4d3c, 0x9)
	/tmp/cilium-net-build/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:735 +0x367
github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).Execute(0x2986f80, 0x0, 0x0)
	/tmp/cilium-net-build/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:693 +0x2b
main.main()
	/tmp/cilium-net-build/src/github.com/cilium/cilium/daemon/main.go:96 +0x31

Signed-off-by: Thomas Graf <thomas@cilium.io>