### PR TITLE
updated getting started guide with corrected VM name in vagrant syntax

### DIFF
--- a/Documentation/gettingstarted.rst
+++ b/Documentation/gettingstarted.rst
@@ -335,11 +335,11 @@ the cilium directory and run:
 
 ::
 
-    $ vagrant destroy cilium-master
+    $ vagrant destroy cilium-1
 
 You can always re-create the VM using the steps described above.
 
 If instead you just want to shut down the VM but may use it later,
-``vagrant halt cilium-master`` will work, and you can start it again later
+``vagrant halt cilium-1`` will work, and you can start it again later
 using the contrib/vagrant/start.sh script.
 


### PR DESCRIPTION
Step 10 in the Getting Started guide references the vagrant VM by the name cilium-master. Due to the current state of the Vagrantfile, the VM name should be cilium-n, where n is the number of nodes specified to deploy.

I updated the document so that the Vagrant syntax references cilium-1 instead.