### PR TITLE
gofmt: reformat monitor.go and kvstore.go

### DIFF
--- a/cilium/cmd/monitor.go
+++ b/cilium/cmd/monitor.go
@@ -25,8 +25,8 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/bpfdebug"
 
-	"golang.org/x/sys/unix"
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
 )
 
 // monitorCmd represents the monitor command

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -30,9 +30,9 @@ var (
 
 // Supported key-value store types.
 const (
-	Local = "local"
+	Local  = "local"
 	Consul = "consul"
-	Etcd = "etcd"
+	Etcd   = "etcd"
 )
 
 type KVClient interface {


### PR DESCRIPTION
Fixes the following warning

cilium/cilium/cmd/monitor.go
Line 1: warning: file is not gofmted with -s (gofmt)
cilium/pkg/kvstore/kvstore.go
Line 1: warning: file is not gofmted with -s (gofmt)

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>