### PR TITLE
contrib / daemon: error out if config vals for kvstore incongruent

### DIFF
--- a/contrib/systemd/cilium
+++ b/contrib/systemd/cilium
@@ -1,3 +1,3 @@
 PATH=/usr/lib/llvm-3.8/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
-CILIUM_OPTS=--consul "127.0.0.1:8500"
+CILIUM_OPTS=--kvstore consul --consul "127.0.0.1:8500"
 INITSYSTEM=SYSTEMD

--- a/contrib/upstart/cilium.conf
+++ b/contrib/upstart/cilium.conf
@@ -1,2 +1,2 @@
 env PATH=/usr/local/clang/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
-exec cilium-agent --debug --consul "127.0.0.1:8500"
+exec cilium-agent --kvstore consul --debug --consul "127.0.0.1:8500"

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -234,7 +234,7 @@ func init() {
 	flags.StringVar(&config.K8sCfgPath, "k8s-kubeconfig-path", "", "Absolute path to the kubeconfig file")
 	flags.StringSliceVar(&k8sLabels, "k8s-prefix", []string{},
 		"Key values that will be read from kubernetes. (Default: k8s-app, version)")
-	flags.StringVar(&kvStore, "kvstore", kvstore.Local, "Key-value store type")
+	flags.StringVar(&kvStore, "kvstore", "", "Key-value store type")
 	flags.BoolVar(&config.KeepConfig, "keep-config", false,
 		"When restoring state, keeps containers' configuration in place")
 	flags.StringVar(&labelPrefixFile, "label-prefix-file", "", "File with valid label prefixes")
@@ -409,6 +409,13 @@ func initEnv() {
 		}
 	case kvstore.Local:
 		log.Infof("Using local storage for key-value store")
+	// Case where no kvstore flag is provided. Ensure that no kvstore-related configuration flags are provided if this is the case.
+	case "":
+		if consulAddr != "" || len(etcdAddr) != 0 || config.EtcdCfgPath != "" {
+			log.Fatalf("no kvstore specified but kvstore-related configuration flags have been provided; please explicitly specify a kvstore with --kvstore")
+		}
+		log.Infof("No specific kvstore configuration provided; using local storage for key-value store")
+		kvStore = kvstore.Local
 	default:
 		log.Fatalf("unsupported key-value store %q provided", kvStore)
 	}


### PR DESCRIPTION
contrib: update cilium options to include kvstore flag in files where it wasn't added before
daemon: crash daemon is kvstore related configuration values are provided if kvstore flag isn't set.

Fixes: #623 

Signed-off by: Ian Vernon <ian@covalent.io>