### PR TITLE
daemon: add kernel major/minor version to error message

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -134,7 +134,7 @@ func checkMinRequirements() {
 	if kernelMajor < majorMinKernelVersion ||
 		(kernelMajor == majorMinKernelVersion && kernelMinor < minorMinKernelVersion) {
 		log.Fatalf("kernel version: NOT OK: minimal supported kernel "+
-			"version is >= %d.%d", majorMinKernelVersion, minorMinKernelVersion)
+			"version is >= %d.%d; kernel version that is running is: %d.%d", majorMinKernelVersion, minorMinKernelVersion, kernelMajor, kernelMinor)
 	}
 
 	clangVersion, err := exec.Command("clang", "--version").CombinedOutput()


### PR DESCRIPTION
Add the major and minor version of the kernel being used if the parsed version does not meet the minimal requirements needed by Cilium.
    
Fixes: #603 

Signed-off by: Ian Vernon <ian@covalent.io>