### PR TITLE
k8s: Do not error out if k8s node does not have a CIDR assigned

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -327,7 +327,8 @@ func (d *Daemon) useK8sNodeCIDR(nodeName string) error {
 		return err
 	}
 	if k8sNode.Spec.PodCIDR == "" {
-		return fmt.Errorf("Empty PodCIDR defined in kubernetes spec for node %s", nodeName)
+		log.Warningf("K8s node %s spec did not provide a CIDR", nodeName)
+		return nil
 	}
 	ip, _, err := net.ParseCIDR(k8sNode.Spec.PodCIDR)
 	if err != nil {


### PR DESCRIPTION
Deriving the CIDR based on the node CIDR is optional, instead
of erroring out if not available, revert back to allocating a
CIDR automatically.

Signed-off-by: Thomas Graf <thomas@cilium.io>