### PR TITLE
ep: propagate err from owner.WriteEndpoint to defer func

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -288,5 +288,6 @@ func (e *Endpoint) regenerateBPF(owner Owner, prefix string) error {
 	}
 
 	// The last operation hooks the endpoint into the endpoint table and exposes it
-	return owner.WriteEndpoint(e)
+	err = owner.WriteEndpoint(e)
+	return err
 }


### PR DESCRIPTION
Otherwise in case of error from owner.WriteEndpoint(), the defer func
will never see err != nil.

Signed-off-by: Daniel Borkmann <daniel@cilium.io>