### PR TITLE
policy: create an empty map for Unmarshaled Nodes.

### DIFF
--- a/pkg/policy/node.go
+++ b/pkg/policy/node.go
@@ -336,8 +336,13 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 	}
 
 	n.Name = policyNode.Name
-	n.Children = policyNode.Children
 	n.IgnoreNameCoverage = policyNode.IgnoreNameCoverage
+
+	if policyNode.Children != nil {
+		n.Children = policyNode.Children
+	} else {
+		n.Children = map[string]*Node{}
+	}
 
 	for _, rawMsg := range policyNode.Rules {
 		var om map[string]*json.RawMessage


### PR DESCRIPTION
If a policy added to the tree contained a node without any children, the
user would get a nil pointer if later on would try to add a policy node
as a grandchildren to that same node.

Signed-off-by: André Martins <andre@cilium.io>