### PR TITLE
policy: Improve unit tests of L4 rules

### DIFF
--- a/pkg/policy/rule_l4_test.go
+++ b/pkg/policy/rule_l4_test.go
@@ -22,23 +22,89 @@ import (
 )
 
 func (s *PolicyTestSuite) TestGetL4Policy(c *C) {
-	lblFoo := labels.NewLabel("root.foo", "", common.CiliumLabelSource)
-	lblBar := labels.NewLabel("root.bar", "", common.CiliumLabelSource)
-	lblBaz := labels.NewLabel("root.baz", "", common.CiliumLabelSource)
+	// -> [bar]
+	toBar := SearchContext{
+		To: []*labels.Label{
+			labels.NewLabel("root.bar", "", common.CiliumLabelSource),
+		},
+	}
 
-	// -> [Foo]
-	toFoo := SearchContext{To: []*labels.Label{lblFoo}}
+	// -> [foo]
+	toFoo := SearchContext{
+		To: []*labels.Label{
+			labels.NewLabel("root.foo", "", common.CiliumLabelSource),
+		},
+	}
 
-	// -> [Baz, Bar]
-	toBazBar := SearchContext{To: []*labels.Label{lblBaz, lblBar}}
+	// -> [bar, baz]
+	toBarBaz := SearchContext{
+		To: []*labels.Label{
+			labels.NewLabel("root.bar", "", common.CiliumLabelSource),
+			labels.NewLabel("root.baz", "", common.CiliumLabelSource),
+		},
+	}
 
 	http1 := L4Filter{Port: 80, Protocol: "tcp"}
 	http2 := L4Filter{Port: 8080, Protocol: "tcp"}
 
-	filterHttp := AllowL4{
+	filterIngressHTTP := AllowL4{
 		Ingress: []L4Filter{http1, http2},
 		Egress:  []L4Filter{},
 	}
+
+	filterEgressHTTP := AllowL4{
+		Ingress: []L4Filter{},
+		Egress:  []L4Filter{http1, http2},
+	}
+
+	filterIngressEgressHTTP := AllowL4{
+		Ingress: []L4Filter{http1, http2},
+		Egress:  []L4Filter{http1, http2},
+	}
+
+	// coverage: [Bar], allow: ingressHTTP
+	ruleBarIngressHTTP := RuleL4{
+		RuleBase{[]*labels.Label{labels.NewLabel("root.bar", "", common.CiliumLabelSource)}},
+		[]AllowL4{filterIngressHTTP},
+	}
+
+	expected := NewL4Policy()
+	expected.Ingress["tcp:80"] = http1
+	expected.Ingress["tcp:8080"] = http2
+
+	c.Assert(*ruleBarIngressHTTP.GetL4Policy(&toBar, NewL4Policy()), DeepEquals, *expected)
+	c.Assert(ruleBarIngressHTTP.GetL4Policy(&toFoo, NewL4Policy()), IsNil)
+	c.Assert(*ruleBarIngressHTTP.GetL4Policy(&toBarBaz, NewL4Policy()), DeepEquals, *expected)
+
+	// coverage: [bar], allow: egressHTTP
+	ruleBarEgressHTTP := RuleL4{
+		RuleBase{[]*labels.Label{labels.NewLabel("root.bar", "", common.CiliumLabelSource)}},
+		[]AllowL4{filterEgressHTTP},
+	}
+
+	expected = NewL4Policy()
+	expected.Egress["tcp:80"] = http1
+	expected.Egress["tcp:8080"] = http2
+
+	c.Assert(*ruleBarEgressHTTP.GetL4Policy(&toBar, NewL4Policy()), DeepEquals, *expected)
+	c.Assert(ruleBarEgressHTTP.GetL4Policy(&toFoo, NewL4Policy()), IsNil)
+	c.Assert(*ruleBarEgressHTTP.GetL4Policy(&toBarBaz, NewL4Policy()), DeepEquals, *expected)
+
+	// coverage: [Bar], allow: ingressHTTP, egressHTTP
+	ruleBarIngressEgressHTTP := RuleL4{
+		RuleBase{[]*labels.Label{labels.NewLabel("root.bar", "", common.CiliumLabelSource)}},
+		[]AllowL4{filterIngressEgressHTTP},
+	}
+
+	expected = NewL4Policy()
+	expected.Ingress["tcp:80"] = http1
+	expected.Ingress["tcp:8080"] = http2
+	expected.Egress["tcp:80"] = http1
+	expected.Egress["tcp:8080"] = http2
+
+	c.Assert(*ruleBarIngressEgressHTTP.GetL4Policy(&toBar, NewL4Policy()), DeepEquals, *expected)
+	c.Assert(ruleBarIngressEgressHTTP.GetL4Policy(&toFoo, NewL4Policy()), IsNil)
+	c.Assert(*ruleBarIngressEgressHTTP.GetL4Policy(&toBarBaz, NewL4Policy()), DeepEquals, *expected)
 
 	filter90To92 := AllowL4{
 		Ingress: []L4Filter{
@@ -46,23 +112,12 @@ func (s *PolicyTestSuite) TestGetL4Policy(c *C) {
 			{Port: 91},
 			{Port: 92},
 		},
-		Egress: []L4Filter{},
+		Egress: []L4Filter{
+			{Port: 90},
+			{Port: 91},
+			{Port: 92},
+		},
 	}
-
-	rule1 := RuleL4{
-		RuleBase{[]*labels.Label{lblBar}},
-		[]AllowL4{filterHttp},
-	}
-
-	res := NewL4Policy()
-	c.Assert(rule1.GetL4Policy(&toFoo, res), IsNil)
-
-	expected := NewL4Policy()
-	expected.Ingress["tcp:80"] = http1
-	expected.Ingress["tcp:8080"] = http2
-
-	res = NewL4Policy()
-	c.Assert(*rule1.GetL4Policy(&toBazBar, res), DeepEquals, *expected)
 
 	rule2 := RuleL4{
 		Allow: []AllowL4{filter90To92},
@@ -70,7 +125,7 @@ func (s *PolicyTestSuite) TestGetL4Policy(c *C) {
 
 	rootNode := Node{
 		Name:  RootNodeName,
-		Rules: []PolicyRule{&rule1},
+		Rules: []PolicyRule{&ruleBarEgressHTTP},
 		Children: map[string]*Node{
 			"foo": {},
 			"bar": {


### PR DESCRIPTION
L4 egress policies were not correctly resolved based on the
source context.

Signed-off-by: Thomas Graf <thomas@cilium.io>