### PR TITLE
tests: fixed 00-fmt.sh test

### DIFF
--- a/tests/00-fmt.sh
+++ b/tests/00-fmt.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-diff="$(find . ! \( -path './vendor' -prune \) -type f -name '*.go' -print0 | grep -v bindata.go | xargs -0 gofmt -d -l -s )"
+diff="$(find . ! \( -path './vendor' -prune \) ! -samefile ./daemon/bindata.go -type f -name '*.go' -print0 | xargs -0 gofmt -d -l -s )"
 
 if [ -n "$diff" ]; then
 	echo "Unformatted Go source code:"


### PR DESCRIPTION
grep -v bindata.go was removing all filenames since they where being
printed with -print0 option.

Add ! -samefile option to ignore the ./daemon/bindata.go file

Signed-off-by: André Martins <andre@cilium.io>

Depends on #665 