### PR TITLE
Add support for filtering events and minor related changes

### DIFF
--- a/cilium/cmd/monitor.go
+++ b/cilium/cmd/monitor.go
@@ -43,11 +43,23 @@ programs attached to endpoints and devices. This includes:
 	},
 }
 
+func listEventTypes() []string {
+	types := []string{}
+	for k := range eventTypes {
+		types = append(types, k)
+	}
+	return types
+}
+
 func init() {
 	RootCmd.AddCommand(monitorCmd)
 	monitorCmd.Flags().IntVarP(&eventConfig.NumCpus, "num-cpus", "c", runtime.NumCPU(), "Number of CPUs")
 	monitorCmd.Flags().IntVarP(&eventConfig.NumPages, "num-pages", "n", 64, "Number of pages for ring buffer")
 	monitorCmd.Flags().BoolVarP(&dissect, "dissect", "d", false, "Dissect packet data")
+	monitorCmd.Flags().StringVarP(&eventType, "type", "t", "", fmt.Sprintf("Filter by event types %v", listEventTypes()))
+	monitorCmd.Flags().Uint16Var(&fromSource, "from", 0, "Filter by source endpoint id")
+	monitorCmd.Flags().Uint32Var(&toDst, "to", 0, "Filter by destination endpoint id")
+	monitorCmd.Flags().Uint32Var(&related, "related-to", 0, "Filter by either source or destination endpoint id")
 }
 
 var (
@@ -59,38 +71,105 @@ var (
 		SampleType:   bpf.PERF_SAMPLE_RAW,
 		WakeupEvents: 1,
 	}
+	eventTypeIdx = -1 // for integer comparison
+	eventType    = ""
+	eventTypes   = map[string]int{
+		"drop":    bpfdebug.MessageTypeDrop,
+		"debug":   bpfdebug.MessageTypeDebug,
+		"capture": bpfdebug.MessageTypeCapture,
+	}
+	fromSource = uint16(0)
+	toDst      = uint32(0)
+	related    = uint32(0)
 )
 
 func lostEvent(lost *bpf.PerfEventLost, cpu int) {
 	fmt.Printf("CPU %02d: Lost %d events\n", cpu, lost.Lost)
 }
 
+// match checks if the event type, from endpoint and / or to endpoint match
+// when they are supplied. The either part of from and to endpoint depends on
+// related to, which can match on both.  If either one of them is less than or
+// equal to zero, then it is assumed user did not use them.
+func match(messageType int, src uint16, dst uint32) bool {
+	if eventTypeIdx > bpfdebug.MessageTypeUnspec && messageType != eventTypeIdx {
+		return false
+	} else if fromSource > 0 && fromSource != src {
+		return false
+	} else if toDst > 0 && toDst != dst {
+		return false
+	} else if related > 0 && uint16(related) != src && related != dst {
+		return false
+	}
+
+	return true
+}
+
+// dropEvents prints out all the received drop notifications.
+func dropEvents(prefix string, data []byte) {
+	dn := bpfdebug.DropNotify{}
+
+	if err := binary.Read(bytes.NewReader(data), binary.LittleEndian, &dn); err != nil {
+		fmt.Printf("Error while parsing drop notification message: %s\n", err)
+	}
+	if match(bpfdebug.MessageTypeDrop, dn.Source, dn.DstID) {
+		dn.Dump(dissect, data, prefix)
+	}
+}
+
+// debugEvents prints out all the debug messages.
+func debugEvents(prefix string, data []byte) {
+	dm := bpfdebug.DebugMsg{}
+
+	if err := binary.Read(bytes.NewReader(data), binary.LittleEndian, &dm); err != nil {
+		fmt.Printf("Error while parsing debug message: %s\n", err)
+	}
+	if match(bpfdebug.MessageTypeDebug, dm.Source, 0) {
+		dm.Dump(data, prefix)
+	}
+}
+
+// captureEvents prints out all the capture messages.
+func captureEvents(prefix string, data []byte) {
+	dc := bpfdebug.DebugCapture{}
+
+	if err := binary.Read(bytes.NewReader(data), binary.LittleEndian, &dc); err != nil {
+		fmt.Printf("Error while parsing debug capture message: %s\n", err)
+	}
+	if match(bpfdebug.MessageTypeCapture, dc.Source, 0) {
+		dc.Dump(dissect, data, prefix)
+	}
+}
+
+// receiveEvent forwards all the per CPU events to the appropriate type function.
 func receiveEvent(msg *bpf.PerfEventSample, cpu int) {
 	prefix := fmt.Sprintf("CPU %02d:", cpu)
-
 	data := msg.DataDirect()
-	if data[0] == bpfdebug.MessageTypeDrop {
-		dn := bpfdebug.DropNotify{}
-		if err := binary.Read(bytes.NewReader(data), binary.LittleEndian, &dn); err != nil {
-			fmt.Printf("Error while parsing drop notification message: %s\n", err)
-		}
-		dn.Dump(dissect, data, prefix)
-	} else if data[0] == bpfdebug.MessageTypeDebug {
-		dm := bpfdebug.DebugMsg{}
-		if err := binary.Read(bytes.NewReader(data), binary.LittleEndian, &dm); err != nil {
-			fmt.Printf("Error while parsing debug message: %s\n", err)
-		} else {
-			dm.Dump(data, prefix)
-		}
-	} else if data[0] == bpfdebug.MessageTypeCapture {
-		dc := bpfdebug.DebugCapture{}
-		if err := binary.Read(bytes.NewReader(data), binary.LittleEndian, &dc); err != nil {
-			fmt.Printf("Error while parsing debug capture message: %s\n", err)
-		}
-		dc.Dump(dissect, data, prefix)
-	} else {
+	messageType := data[0]
+
+	switch messageType {
+	case bpfdebug.MessageTypeDrop:
+		dropEvents(prefix, data)
+	case bpfdebug.MessageTypeDebug:
+		debugEvents(prefix, data)
+	case bpfdebug.MessageTypeCapture:
+		captureEvents(prefix, data)
+	default:
 		fmt.Printf("%s Unknonwn event: %+v\n", prefix, msg)
 	}
+}
+
+// validateEventTypeFilter does some input validation to give the user feedback if they
+// wrote something close that did not match for example 'srop' instead of
+// 'drop'.
+func validateEventTypeFilter() {
+	i, err := eventTypes[eventType]
+	if !err {
+		err := "Unknown type (%s). Please use one of the following ones %v\n"
+		fmt.Printf(err, eventType, listEventTypes())
+		os.Exit(1)
+	}
+	eventTypeIdx = i
 }
 
 func runMonitor() {
@@ -102,6 +181,10 @@ func runMonitor() {
 	events, err := bpf.NewPerCpuEvents(&eventConfig)
 	if err != nil {
 		panic(err)
+	}
+
+	if eventType != "" {
+		validateEventTypeFilter()
 	}
 
 	signalChan := make(chan os.Signal, 1)

--- a/cilium/cmd/monitor.go
+++ b/cilium/cmd/monitor.go
@@ -62,7 +62,7 @@ var (
 )
 
 func lostEvent(lost *bpf.PerfEventLost, cpu int) {
-	fmt.Printf("Lost %d events\n", lost.Lost)
+	fmt.Printf("CPU %02d: Lost %d events\n", cpu, lost.Lost)
 }
 
 func receiveEvent(msg *bpf.PerfEventSample, cpu int) {

--- a/tests/13-monitor-filtering.sh
+++ b/tests/13-monitor-filtering.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+source "./helpers.bash"
+
+logs_clear
+
+echo "------ monitor filtering ------"
+
+NETWORK="cilium"
+CLIENT_LABEL="client"
+CONTAINER=monitor_tests
+
+function cleanup {
+  docker rm -f $CONTAINER 2> /dev/null || true
+  docker network rm $NETWORK > /dev/null 2>&1
+  monitor_stop
+}
+
+function spin_up_container {
+  docker run -d --net cilium --name $CONTAINER -l $CLIENT_LABEL tgraf/netperf > /dev/null 2>&1
+  docker exec -ti $CONTAINER ip -6 address list > /dev/null 2>&1
+  docker exec -ti $CONTAINER ip -6 route list dev cilium0 > /dev/null 2>&1
+}
+
+function setup {
+  cleanup
+  docker network create --ipv6 --subnet ::1/112 --driver cilium --ipam-driver cilium $NETWORK > /dev/null 2>&1
+  logs_clear
+  monitor_clear
+}
+
+function test_event_types {
+  echo "------ event filter ------"
+  cilium config Debug=true DropNotification=true
+
+  event_types=( drop debug capture )
+  expected_log_entry=( "Packet dropped" "DEBUG:" "DEBUG:" )
+
+  for ((i=0;i<${#event_types[@]};++i)); do
+    setup
+    monitor_start --type ${event_types[i]}
+    spin_up_container
+    sleep 3
+    if grep "${expected_log_entry[i]}" $DUMP_FILE; then
+      echo Test for ${event_types[i]} succeded
+    else
+      abort
+    fi
+  done
+}
+
+function last_endpoint_id {
+  echo `cilium endpoint list|tail -n1|awk '{ print $1}'`
+}
+
+function container_addr {
+  echo `docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' $CONTAINER`
+}
+
+function test_from {
+  echo "------ from filter ------"
+  cilium config Debug=true DropNotification=true
+  setup
+  spin_up_container
+  monitor_start --type debug --from $(last_endpoint_id)
+  sleep 3
+  # We are not expecting drop events so fail if they occur.
+  if grep "Packet dropped" $DUMP_FILE; then
+    abort
+  fi
+  sleep 3
+  if grep "FROM $(last_endpoint_id) DEBUG: " $DUMP_FILE; then
+    echo Test succeded test_from
+  else
+    abort
+  fi
+}
+
+function test_to {
+  echo "------ to filter ------"
+  cilium config Debug=true DropNotification=true Policy=true
+  setup
+  spin_up_container
+  monitor_start --type drop --to $(last_endpoint_id)
+  sleep 3
+  ping6 -c 3 $(container_addr)
+  if grep "FROM $(last_endpoint_id) Packet dropped" $DUMP_FILE; then
+    echo Test succeded test_to
+  else
+    abort
+  fi
+}
+
+function test_related_to {
+  echo "------ related to filter ------"
+  cilium config Debug=true DropNotification=true Policy=true
+  setup
+  spin_up_container
+  monitor_start --type drop --related-to $(last_endpoint_id)
+  ping6 -c 3 $(container_addr)
+  monitor_stop
+  monitor_resume --type debug --related-to $(last_endpoint_id)
+  ping6 -c 3 $(container_addr)
+  sleep 2
+  if grep "FROM $(last_endpoint_id) DEBUG: " $DUMP_FILE && \
+   grep "FROM $(last_endpoint_id) Packet dropped" $DUMP_FILE; then
+    echo Test succeded test_from
+  else
+    abort
+  fi
+}
+
+trap cleanup EXIT
+
+test_event_types
+test_from
+test_to
+test_related_to
+cleanup

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -3,7 +3,7 @@ MONITOR_PID=""
 LAST_LOG_DATE=""
 
 function monitor_start {
-	cilium monitor > $DUMP_FILE &
+	cilium monitor $@ > $DUMP_FILE &
 	MONITOR_PID=$!
 }
 

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -7,6 +7,11 @@ function monitor_start {
 	MONITOR_PID=$!
 }
 
+function monitor_resume {
+	cilium monitor $@ >> $DUMP_FILE &
+	MONITOR_PID=$!
+}
+
 function monitor_clear {
 	set +x
 	sleep 1s


### PR DESCRIPTION
The new filtering support consists of `--type`, `--to` and `--from`.
The `cilium help monitor` output now looks like this:

    The monitor displays notifications and events omitted by the BPF
    programs attached to endpoints and devices. This includes:
      * Dropped packet notifications
      * Captured packet traces
      * Debugging information

    Usage:
      cilium monitor [flags]

    Flags:
      -d, --dissect             Dissect packet data
          --from uint16         filter by source endpoint id
      -c, --num-cpus int        Number of CPUs (default 2)
      -n, --num-pages int       Number of pages for ring buffer (default 64)
          --related-to uint32   filter by either source or destination endpoint id
          --to uint32           filter by destination endpoint id
      -t, --type string         Filter by event types [drop debug capture]

    Global Flags:
          --config string   config file (default is $HOME/.cilium.yaml)
      -D, --debug           Enable debug messages
      -H, --host string     URI to server-side API

Some example usage:

- `cilium monitor --type drop` will only show you messages for packets being
dropped.
- `cilium monitor --type drop --from 173` is same as above but will only match
when the source has the provided id.
- `cilium monitor --type drop --to 123` should match when we get a drop event
and the destination has the provided id.
- `cilium monitor --type drop --related-to 749` shows drop notifications where
the source or destination has the provided id.

Closes: #473 (Feature: Add filtering to cilium monitor)