### PR TITLE
pkg/bpf/ctmap: refactor to utilize pkg/bpf/map

### DIFF
--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -384,7 +384,7 @@ func (d *Daemon) RevNATDump() ([]types.L3n4AddrID, error) {
 }
 
 // SyncLBMap syncs the bpf lbmap with the daemon's lb map. All bpf entries will overwrite
-// the daemon's LB map. If the bpf lbmap entry have a different service ID than the
+// the daemon's LB map. If the bpf lbmap entry has a different service ID than the
 // KVStore's ID, that entry will be updated on the bpf map accordingly with the new ID
 // retrieved from the KVStore.
 func (d *Daemon) SyncLBMap() error {

--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -282,10 +282,8 @@ func (m *Map) Dump(parser DumpParser, cb DumpCallback) error {
 	nextKey := make([]byte, m.KeySize)
 	value := make([]byte, m.ValueSize)
 
-	if m.fd == 0 {
-		if err := m.Open(); err != nil {
-			return err
-		}
+	if err := m.Open(); err != nil {
+		return err
 	}
 
 	for {
@@ -329,10 +327,8 @@ func (m *Map) Lookup(key MapKey) (MapValue, error) {
 
 	value := key.NewValue()
 
-	if m.fd == 0 {
-		if err := m.Open(); err != nil {
-			return nil, err
-		}
+	if err := m.Open(); err != nil {
+		return nil, err
 	}
 
 	err := LookupElement(m.fd, key.GetKeyPtr(), value.GetValuePtr())
@@ -346,10 +342,8 @@ func (m *Map) Update(key MapKey, value MapValue) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	if m.fd == 0 {
-		if err := m.Open(); err != nil {
-			return err
-		}
+	if err := m.Open(); err != nil {
+		return err
 	}
 
 	return UpdateElement(m.fd, key.GetKeyPtr(), value.GetValuePtr(), 0)
@@ -359,10 +353,8 @@ func (m *Map) Delete(key MapKey) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	if m.fd == 0 {
-		if err := m.Open(); err != nil {
-			return err
-		}
+	if err := m.Open(); err != nil {
+		return err
 	}
 
 	return DeleteElement(m.fd, key.GetKeyPtr())
@@ -378,10 +370,8 @@ func (m *Map) DeleteAll() error {
 	key := make([]byte, m.KeySize)
 	nextKey := make([]byte, m.KeySize)
 
-	if m.fd == 0 {
-		if err := m.Open(); err != nil {
-			return err
-		}
+	if err := m.Open(); err != nil {
+		return err
 	}
 
 	for {
@@ -404,4 +394,13 @@ func (m *Map) DeleteAll() error {
 	}
 
 	return nil
+}
+
+//GetNextKey returns the next key in the Map after key.
+func (m *Map) GetNextKey(key MapKey, nextKey MapKey) error {
+	if err := m.Open(); err != nil {
+		return err
+	}
+
+	return GetNextKey(m.fd, key.GetKeyPtr(), nextKey.GetKeyPtr())
 }

--- a/pkg/maps/ctmap/ipv4.go
+++ b/pkg/maps/ctmap/ipv4.go
@@ -1,0 +1,142 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctmap
+
+import (
+	"bytes"
+	"fmt"
+	"unsafe"
+
+	"github.com/cilium/cilium/common"
+	"github.com/cilium/cilium/common/types"
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/u8proto"
+)
+
+//CtKey4 represents the key for IPv4 entries in the local BPF conntrack map.
+type CtKey4 struct {
+	addr    types.IPv4
+	sport   uint16
+	dport   uint16
+	nexthdr u8proto.U8proto
+	flags   uint8
+}
+
+// GetKeyPtr returns the unsafe.Pointer for k.
+func (k *CtKey4) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
+
+//NewValue creates a new bpf.MapValue.
+func (k *CtKey4) NewValue() bpf.MapValue { return &CtEntry{} }
+
+// Convert converts CtKey4 ports between host bye order and map byte order.
+func (k *CtKey4) Convert() CtKey {
+	n := *k
+	n.sport = common.Swab16(n.sport)
+	n.dport = common.Swab16(n.dport)
+	return &n
+}
+
+func (k *CtKey4) String() string {
+	return fmt.Sprintf("%s:%d, %d, %d, %d", k.addr, k.sport, k.dport, k.nexthdr, k.flags)
+}
+
+// Dump writes the contents of key to buffer and returns true if the value for
+// next header in the key is nonzero.
+func (k CtKey4) Dump(buffer *bytes.Buffer) bool {
+	if k.nexthdr == 0 {
+		return false
+	}
+
+	if k.flags&TUPLE_F_IN != 0 {
+		buffer.WriteString(fmt.Sprintf("%s IN %s %d:%d ",
+			k.nexthdr.String(),
+			k.addr.IP().String(),
+			k.sport, k.dport),
+		)
+
+	} else {
+		buffer.WriteString(fmt.Sprintf("%s OUT %s %d:%d ",
+			k.nexthdr.String(),
+			k.addr.IP().String(),
+			k.dport,
+			k.sport),
+		)
+	}
+
+	if k.flags&TUPLE_F_RELATED != 0 {
+		buffer.WriteString("related ")
+	}
+
+	return true
+}
+
+//CtKey4Global represents the key for IPv4 entries in the global BPF conntrack
+// map.
+type CtKey4Global struct {
+	daddr   types.IPv4
+	saddr   types.IPv4
+	sport   uint16
+	dport   uint16
+	nexthdr u8proto.U8proto
+	flags   uint8
+}
+
+// GetKeyPtr returns the unsafe.Pointer for k.
+func (k *CtKey4Global) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
+
+//NewValue creates a new bpf.MapValue.
+func (k *CtKey4Global) NewValue() bpf.MapValue { return &CtEntry{} }
+
+// Convert converts CtKey4Global ports between host bye order and map byte
+// order.
+func (k *CtKey4Global) Convert() CtKey {
+	n := *k
+	n.sport = common.Swab16(n.sport)
+	n.dport = common.Swab16(n.dport)
+	return &n
+}
+
+func (k *CtKey4Global) String() string {
+	return fmt.Sprintf("%s:%d --> %s:%d, %d, %d", k.saddr, k.sport, k.daddr, k.dport, k.nexthdr, k.flags)
+}
+
+// Dump writes the contents of key to buffer and returns true if the value for
+// next header in the key is nonzero.
+func (k CtKey4Global) Dump(buffer *bytes.Buffer) bool {
+	if k.nexthdr == 0 {
+		return false
+	}
+
+	if k.flags&TUPLE_F_IN != 0 {
+		buffer.WriteString(fmt.Sprintf("%s IN %s:%d -> %s:%d ",
+			k.nexthdr.String(),
+			k.saddr.IP().String(), k.sport,
+			k.daddr.IP().String(), k.dport),
+		)
+
+	} else {
+		buffer.WriteString(fmt.Sprintf("%s OUT %s%d -> %s:%d ",
+			k.nexthdr.String(),
+			k.saddr.IP().String(), k.sport,
+			k.daddr.IP().String(), k.dport),
+		)
+	}
+
+	if k.flags&TUPLE_F_RELATED != 0 {
+		buffer.WriteString("related ")
+	}
+
+	return true
+}

--- a/pkg/maps/ctmap/ipv6.go
+++ b/pkg/maps/ctmap/ipv6.go
@@ -1,0 +1,140 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctmap
+
+import (
+	"bytes"
+	"fmt"
+	"unsafe"
+
+	"github.com/cilium/cilium/common"
+	"github.com/cilium/cilium/common/types"
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/u8proto"
+)
+
+//CtKey6 represents the key for IPv6 entries in the local BPF conntrack map.
+type CtKey6 struct {
+	addr    types.IPv6
+	sport   uint16
+	dport   uint16
+	nexthdr u8proto.U8proto
+	flags   uint8
+}
+
+// GetKeyPtr returns the unsafe.Pointer for k.
+func (k *CtKey6) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
+
+//NewValue creates a new bpf.MapValue.
+func (k *CtKey6) NewValue() bpf.MapValue { return &CtEntry{} }
+
+// Convert converts CtKey6 ports between host bye order and map byte order.
+func (k *CtKey6) Convert() CtKey {
+	n := *k
+	n.sport = common.Swab16(n.sport)
+	n.dport = common.Swab16(n.dport)
+	return &n
+}
+
+func (k *CtKey6) String() string {
+	return fmt.Sprintf("%s:%d, %d, %d, %d", k.addr, k.sport, k.dport, k.nexthdr, k.flags)
+}
+
+// Dump writes the contents of key to buffer and returns true if the value for
+// next header in the key is nonzero.
+func (k CtKey6) Dump(buffer *bytes.Buffer) bool {
+	if k.nexthdr == 0 {
+		return false
+	}
+
+	if k.flags&TUPLE_F_IN != 0 {
+		buffer.WriteString(fmt.Sprintf("%s IN %s %d:%d ",
+			k.nexthdr.String(),
+			k.addr.IP().String(),
+			k.sport, k.dport),
+		)
+
+	} else {
+		buffer.WriteString(fmt.Sprintf("%s OUT %s %d:%d ",
+			k.nexthdr.String(),
+			k.addr.IP().String(),
+			k.dport,
+			k.sport),
+		)
+	}
+
+	if k.flags&TUPLE_F_RELATED != 0 {
+		buffer.WriteString("related ")
+	}
+
+	return true
+}
+
+//CtKey6Global represents the key for IPv6 entries in the global BPF conntrack map.
+type CtKey6Global struct {
+	daddr   types.IPv6
+	saddr   types.IPv6
+	sport   uint16
+	dport   uint16
+	nexthdr u8proto.U8proto
+	flags   uint8
+}
+
+// GetKeyPtr returns the unsafe.Pointer for k.
+func (k *CtKey6Global) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
+
+//NewValue creates a new bpf.MapValue.
+func (k *CtKey6Global) NewValue() bpf.MapValue { return &CtEntry{} }
+
+// Convert converts CtKey6Global ports between host bye order and map byte order.
+func (k *CtKey6Global) Convert() CtKey {
+	n := *k
+	n.sport = common.Swab16(n.sport)
+	n.dport = common.Swab16(n.dport)
+	return &n
+}
+
+func (k *CtKey6Global) String() string {
+	return fmt.Sprintf("%s:%d --> %s:%d, %d, %d", k.saddr, k.sport, k.daddr, k.dport, k.nexthdr, k.flags)
+}
+
+// Dump writes the contents of key to buffer and returns true if the value for
+// next header in the key is nonzero.
+func (k CtKey6Global) Dump(buffer *bytes.Buffer) bool {
+	if k.nexthdr == 0 {
+		return false
+	}
+
+	if k.flags&TUPLE_F_IN != 0 {
+		buffer.WriteString(fmt.Sprintf("%s IN [%s]:%d -> [%s]:%d ",
+			k.nexthdr.String(),
+			k.saddr.IP().String(), k.sport,
+			k.daddr.IP().String(), k.dport),
+		)
+
+	} else {
+		buffer.WriteString(fmt.Sprintf("%s OUT [%s]:%d -> [%s]:%d ",
+			k.nexthdr.String(),
+			k.saddr.IP().String(), k.sport,
+			k.daddr.IP().String(), k.dport),
+		)
+	}
+
+	if k.flags&TUPLE_F_RELATED != 0 {
+		buffer.WriteString("related ")
+	}
+
+	return true
+}

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -406,8 +406,8 @@ func ServiceKey2L3n4Addr(svcKey ServiceKey) (*types.L3n4Addr, error) {
 	return types.NewL3n4Addr(types.TCP, feIP, fePort)
 }
 
-// ServiceKeynValue2FEnBE converts the given svcKey and svcValue to a frontend int the
-// form of L3n4AddrID and backend int he form of L3n4Addr.
+// ServiceKeynValue2FEnBE converts the given svcKey and svcValue to a frontend in the
+// form of L3n4AddrID and backend in the form of L3n4Addr.
 func ServiceKeynValue2FEnBE(svcKey ServiceKey, svcValue ServiceValue) (*types.L3n4AddrID, *types.LBBackEnd, error) {
 	var (
 		beIP     net.IP


### PR DESCRIPTION
Refactor pkg/bpf/ctmap to utilize pkg/bpf/map implementation.
Add GetNextKey wrapper in pkg/bpf/map.go.

Signed-off by: Ian Vernon <ian@covalent.io>

Fixes: #357  