### PR TITLE
Stability improvements

### DIFF
--- a/cilium/cmd/bpf_ct_list.go
+++ b/cilium/cmd/bpf_ct_list.go
@@ -47,6 +47,7 @@ func dumpCtProto(name string, ctType ctmap.CtType) {
 	file := bpf.MapPath(name)
 
 	fd, err := bpf.ObjGet(file)
+	defer bpf.ObjClose(fd)
 	if err != nil {
 		Fatalf("Unable to open %s: %s\n", file, err)
 	}

--- a/cilium/cmd/bpf_policy_list.go
+++ b/cilium/cmd/bpf_policy_list.go
@@ -61,6 +61,7 @@ func listMap(cmd *cobra.Command, args []string) {
 	if err != nil {
 		Fatalf("%s\n", err)
 	}
+	defer bpf.ObjClose(fd)
 
 	m := policymap.PolicyMap{Fd: fd}
 	statsMap, err := m.DumpToSlice()

--- a/daemon/ct.go
+++ b/daemon/ct.go
@@ -52,9 +52,7 @@ func runGC(e *endpoint.Endpoint, nameLocal string, nameGlobal string, ctType ctm
 		e.LogStatus(endpoint.BPF, endpoint.Warning, fmt.Sprintf("Unable to open CT map %s: %s", file, err))
 		return
 	}
-
-	f := os.NewFile(uintptr(fd), file)
-	defer f.Close()
+	defer bpf.ObjClose(fd)
 
 	info, err := bpf.GetMapInfo(os.Getpid(), fd)
 	if err != nil {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -763,6 +763,25 @@ func (e *Endpoint) LeaveLocked(owner Owner) {
 		c.Mutex.RUnlock()
 	}
 
+	if e.PolicyMap != nil {
+		if err := e.PolicyMap.Close(); err != nil {
+			log.Warningf("Unable to close policy map %s: %s", e.PolicyMapPathLocked(), err)
+		}
+	}
+
+	if f, err := os.Open(e.Ct6MapPathLocked()); err != nil {
+		log.Debugf("Unable to close IPv6 CT map %s: %s", e.Ct6MapPathLocked(), err)
+	} else {
+		f.Close()
+	}
+
+	log.Debugf("Closing e.Ct4MapPathLocked")
+	if f, err := os.Open(e.Ct4MapPathLocked()); err != nil {
+		log.Debugf("Unable to close IPv4 CT map %s: %s", e.Ct4MapPathLocked(), err)
+	} else {
+		f.Close()
+	}
+
 	e.removeDirectory()
 }
 

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -134,6 +134,11 @@ func (pm *PolicyMap) DumpToSlice() ([]PolicyEntryDump, error) {
 	return entries, nil
 }
 
+// Close closes the FD of the given PolicyMap
+func (pm *PolicyMap) Close() error {
+	return bpf.ObjClose(pm.Fd)
+}
+
 func OpenMap(path string) (*PolicyMap, bool, error) {
 	fd, isNewMap, err := bpf.OpenOrCreateMap(
 		path,

--- a/tests/13-fd-open.sh
+++ b/tests/13-fd-open.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+source "./helpers.bash"
+
+threshold=5000
+
+fd_open=$(sudo lsof 2>/dev/null | grep cilium | wc -l)
+
+if [[ ${fd_open} -gt ${threshold} ]]; then
+    abort "Number of fd open seems abnormal: ${fd_open} (expecting less than ${threshold})"
+fi


### PR DESCRIPTION
Before this PR, only 3 iterations of `./tests/11-getting-started.sh` were resulting in 403 FD open (went up from 72 to 403)
```
$ sudo lsof 2>/dev/null | grep bpf-map  | wc -l
403
```
With this PR, after running countless iterations of `./tests/11-getting-started.sh` in 30 minutes, the number of fd opens remains constant to 117:

```
$ sudo lsof 2>/dev/null | grep bpf-map  | wc -l
117
```