### PR TITLE
pkg/endpoint: Endpoint's deadlock fix

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -383,12 +383,14 @@ func (e *Endpoint) TriggerPolicyUpdates(owner Owner) (bool, error) {
 
 func (e *Endpoint) SetIdentity(owner Owner, id *policy.Identity) {
 	tree := owner.GetPolicyTree()
-	tree.Mutex.Lock()
-	defer tree.Mutex.Unlock()
 	cache := owner.GetConsumableCache()
 
 	e.Mutex.Lock()
 	defer e.Mutex.Unlock()
+
+	tree.Mutex.Lock()
+	defer tree.Mutex.Unlock()
+
 	if e.Consumable != nil {
 		if e.SecLabel != nil && id.ID == e.Consumable.ID {
 			e.SecLabel = id


### PR DESCRIPTION
This commit fixes a deadlock where:
1) endpoint locked, somewhere in the code, is called by thread 1
2) tree locked is called by thread 2, in the modified lines
3) thread 2 wants to call endpoint lock but it has to wait for thread 1 to finish
4) thread 1 has endpoint locked now wants to lock tree which is locked by thread2

Signed-off-by: André Martins <andre@cilium.io>