### PR TITLE
getting-started/Vagrantfile: Update box.

### DIFF
--- a/examples/getting-started/Vagrantfile
+++ b/examples/getting-started/Vagrantfile
@@ -39,7 +39,7 @@ sudo -E docker-compose up -d --remove-orphans
 SCRIPT
 
 Vagrant.configure(2) do |config|
-    config.vm.box = "bento/ubuntu-16.10"
+    config.vm.box = "cilium/ubuntu-16.10"
 
     # http://foo-o-rama.com/vagrant--stdin-is-not-a-tty--fix.html
     config.vm.provision "fix-no-tty", type: "shell" do |s|


### PR DESCRIPTION
Use cilium/ubuntu-16.10 instead of the one from bento/, as the cilium/
version is required to work with the libvirt vagrant provider.

Signed-off-by: Russell Bryant <russell@russellbryant.net>