### PR TITLE
endpoint: removing unnecessary os.Open

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -769,19 +769,6 @@ func (e *Endpoint) LeaveLocked(owner Owner) {
 		}
 	}
 
-	if f, err := os.Open(e.Ct6MapPathLocked()); err != nil {
-		log.Debugf("Unable to close IPv6 CT map %s: %s", e.Ct6MapPathLocked(), err)
-	} else {
-		f.Close()
-	}
-
-	log.Debugf("Closing e.Ct4MapPathLocked")
-	if f, err := os.Open(e.Ct4MapPathLocked()); err != nil {
-		log.Debugf("Unable to close IPv4 CT map %s: %s", e.Ct4MapPathLocked(), err)
-	} else {
-		f.Close()
-	}
-
 	e.removeDirectory()
 }
 


### PR DESCRIPTION
The CT maps are only used by GC, where their FD are properly closed
there. Thus it is unnecessary to have them Open and Close when the
endpoint is being removed.

Fixes: 4145526970 ("endpoint: Closing EP FD bpf maps on Leave")

Signed-off-by: André Martins <andre@cilium.io>