### PR TITLE
cilum/cmd: ensure all 'cilium bpf' cmds run as root

### DIFF
--- a/cilium/cmd/bpf.go
+++ b/cilium/cmd/bpf.go
@@ -26,5 +26,4 @@ var bpfCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(bpfCmd)
-
 }

--- a/cilium/cmd/bpf_policy_add.go
+++ b/cilium/cmd/bpf_policy_add.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"strconv"
 
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/policy"
@@ -30,6 +31,7 @@ var bpfPolicyAddCmd = &cobra.Command{
 	Short:  "Add/update policy entry",
 	PreRun: requireEndpointID,
 	Run: func(cmd *cobra.Command, args []string) {
+		common.RequireRootPrivilege("cilium bpf policy add")
 		updatePolicyKey(cmd, args, true)
 	},
 }

--- a/cilium/cmd/bpf_policy_delete.go
+++ b/cilium/cmd/bpf_policy_delete.go
@@ -15,6 +15,8 @@
 package cmd
 
 import (
+	"github.com/cilium/cilium/common"
+
 	"github.com/spf13/cobra"
 )
 
@@ -24,6 +26,7 @@ var bpfPolicyDeleteCmd = &cobra.Command{
 	Short:  "Delete a policy entry",
 	PreRun: requireEndpointID,
 	Run: func(cmd *cobra.Command, args []string) {
+		common.RequireRootPrivilege("cilium bpf policy delete")
 		updatePolicyKey(cmd, args, false)
 	},
 }

--- a/cilium/cmd/bpf_policy_list.go
+++ b/cilium/cmd/bpf_policy_list.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"text/tabwriter"
 
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/policy"
@@ -36,6 +37,7 @@ var bpfPolicyListCmd = &cobra.Command{
 	Short:  "List contents of a policy BPF map",
 	PreRun: requireEndpointID,
 	Run: func(cmd *cobra.Command, args []string) {
+		common.RequireRootPrivilege("cilium bpf policy list")
 		listMap(cmd, args)
 	},
 }

--- a/common/utils.go
+++ b/common/utils.go
@@ -152,3 +152,11 @@ func GetCiliumVersionString(epCHeaderFilePath string) (string, error) {
 		}
 	}
 }
+
+// RequireRootPrivilege checks if the user running cmd is root. If not, it exits the program
+func RequireRootPrivilege(cmd string) {
+	if os.Getuid() != 0 {
+		fmt.Fprintf(os.Stderr, "Please run %q commands with root privileges.\n", cmd)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
common: add RequireRootPrivilege function which checks if running user
is root and exits if not.

Exit gracefully if any 'cilium bpf' command is not ran as root.

Signed-off by: Ian Vernon <ian@covalent.io>

Fixes: #385 