### PR TITLE
pkg/endpoint: fix race condition for endpoint leave

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -752,6 +752,7 @@ func (e *Endpoint) Update(owner Owner, opts models.ConfigurationMap) error {
 // LeaveLocked removes the endpoint's directory from the system. Must be called
 // with Endpoint's mutex locked.
 func (e *Endpoint) LeaveLocked(owner Owner) {
+	e.State = StateDisconnected
 	owner.RemoveFromEndpointQueue(uint64(e.ID))
 	if c := e.Consumable; c != nil {
 		c.Mutex.RLock()


### PR DESCRIPTION
This commits fixed a race condition that would allow an endpoint to be
regenerated after it was deleted by thee container runtime.

Signed-off-by: André Martins <andre@cilium.io>

Fixees #633