### PR TITLE
AUTHORS: update authors list

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,12 +13,15 @@ Gianluca Arbezzano    gianarb92@gmail.com
 Ian Vernon            ianvernon@covalent.io
 Ivar Lazzaro          ivarlazzaro@gmail.com
 Jan-Erik Rediger      badboy@archlinux.us
+Katarzyna Borkmann    kasia@iogearbox.net
 Madhu Challa          madhu@cilium.io
 Marcin Skarbek        git@skarbek.name
 Michi Mutsuzaki       michi@covalent.io
 Raghu Gyambavantha    r.grizzly@gmail.com
+Russell Bryant        russell@russellbryant.net
 Thomas Graf           thomas@cilium.io
 Tobias Klauser        tklauser@distanz.ch
+Trevor Roberts Jr     trevor.roberts.jr@gmail.com
 
 The following additional people are mentioned in commit logs as having provided
 helpful bug reports, suggestions or have otherwise provided value to the


### PR DESCRIPTION
synchronized with `git shortlog -s -e | cut -c8-`

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>