### PR TITLE
cilium/cmd/monitor: Fix typo.

### DIFF
--- a/cilium/cmd/monitor.go
+++ b/cilium/cmd/monitor.go
@@ -33,7 +33,7 @@ import (
 var monitorCmd = &cobra.Command{
 	Use:   "monitor",
 	Short: "Monitoring",
-	Long: `The monitor displays notifications and events omitted by the BPF
+	Long: `The monitor displays notifications and events emitted by the BPF
 programs attached to endpoints and devices. This includes:
   * Dropped packet notifications
   * Captured packet traces


### PR DESCRIPTION
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>