### PR TITLE
Makefile: add target to list running VMs in VirtualBox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,5 +89,8 @@ generate-api:
 	    -s server --default-scheme=unix -C api/v1/cilium-server.yml
 	swagger generate client -t api/v1 -f api/v1/openapi.yaml -a restapi
 
+vps:
+	VBoxManage list runningvms
+
 .PHONY: force
 force :;


### PR DESCRIPTION
This makes it a litte bit easier to check running virtualbox vms, compared to using the mixed case `VBoxManage`.

    $ make vps
    VBoxManage list runningvms
    "default" {a18b9117-78d7-4506-ba39-cdb069bdc58c}
    "cilium_cilium-master_1494337266676_16697" {c854e14e-68df-49d9-ab2c-7cb96c1d8ee0}

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>