### PR TITLE
Documentation/bpf: add git to Ubuntu dependencies list

### DIFF
--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -1950,7 +1950,7 @@ Ubuntu 17.04
 ::
 
 	sudo apt-get install -y make gcc libssl-dev bc libelf-dev libcap-dev \
-	clang gcc-multilib llvm libncurses5-dev
+	clang gcc-multilib llvm libncurses5-dev git
 
 Compiling the kernel
 --------------------


### PR DESCRIPTION
Missed this earlier. It should be installed by default, but for other
Debian based systems it might not be.

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>