### PR TITLE
pkg/bpf: switch from package syscall to x/sys/unix

### DIFF
--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -99,7 +99,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -269,7 +268,7 @@ func ObjGet(pathname string) (int, error) {
 // ObjClose closes the map's fd.
 func ObjClose(fd int) error {
 	if fd > 0 {
-		return syscall.Close(fd)
+		return unix.Close(fd)
 	}
 	return nil
 }


### PR DESCRIPTION
Commit ed2d75b9b9e3 ("cmd, daemon, pkg: fix fd leakage") reintroduced
usage of the syscall package where golang.org/x/sys/unix could have been
used instead.

The syscall package is locked down and the comment in [1] advises to
switch code to use the corresponding package from golang.org/x/sys. Do
so and replace usage of package syscall with package
golang.org/x/sys/unix. This will also allow to get updates and fixes
without having to use a new go version.

[1] https://github.com/golang/go/blob/master/src/syscall/syscall.go#L21-L24

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>