### PR TITLE
cilium: on ep destruction also remove id from cilium_policy tail call…

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -374,6 +374,12 @@ func (d *Daemon) deleteEndpoint(ep *endpoint.Endpoint) int {
 		errors++
 	}
 
+	// Remove handle_policy() tail call entry for EP
+	if ep.RemoveFromGlobalPolicyMap() != nil {
+		log.Warningf("Unable to remove EP from global policy map!")
+		errors++
+	}
+
 	d.removeEndpoint(ep)
 
 	if !d.conf.IPv4Disabled {

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -156,3 +156,13 @@ func OpenMap(path string) (*PolicyMap, bool, error) {
 
 	return m, isNewMap, nil
 }
+
+func OpenGlobalMap(path string) (*PolicyMap, error) {
+	fd, err := bpf.ObjGet(path)
+	if err != nil {
+		return nil, err
+	}
+
+	m := &PolicyMap{path: path, Fd: fd}
+	return m, nil
+}


### PR DESCRIPTION
… map

tc auto-loads the tail call related to handle_policy() into cilium_policy
map at index LXC_ID:

  __section_tail(CILIUM_MAP_POLICY, LXC_ID)
  int handle_policy(struct __sk_buff *skb)

If we don't remove it from the map on endpoint deletion, we waste a
lot of resources since endpoint IDs are not immediately recycled and
therefore the tail called handle_policy() prog (and related maps) for
each endpoint won't get released in the kernel since the map slot still
holds a reference on them.

Signed-off-by: Daniel Borkmann <daniel@cilium.io>