### PR TITLE
Add option to always allow localhost to reach endpoints

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -34,6 +34,21 @@ var (
 	kvBackend = ""
 )
 
+const (
+	// AllowLocalhostAuto defaults to policy except when running in
+	// Kubernetes where it then defaults to "always"
+	AllowLocalhostAuto = "auto"
+
+	// AllowLocalhostAlways always allows the local stack to reach local
+	// endpoints
+	AllowLocalhostAlways = "always"
+
+	// AllowLocalhostPolicy requires a policy rule to allow the local stack
+	// to reach particular endpoints or policy enforcement must be
+	// disabled.
+	AllowLocalhostPolicy = "policy"
+)
+
 // Config is the configuration used by Daemon.
 type Config struct {
 	BpfDir         string                  // BPF template files directory
@@ -64,6 +79,15 @@ type Config struct {
 	RestoreState  bool // RestoreState restores the state from previous running daemons.
 	KeepConfig    bool // Keep configuration of existing endpoints when starting up.
 	KeepTemplates bool // Do not overwrite the template files
+
+	// AllowLocalhost defines when to allows the local stack to local endpoints
+	// values: { auto | always | policy }
+	AllowLocalhost string
+
+	// alwaysAllowLocalhost is set based on the value of AllowLocalhost and
+	// is either set to true when localhost can always reach local
+	// endpoints or false when policy should be evaluated
+	alwaysAllowLocalhost bool
 
 	// StateDir is the directory where runtime state of endpoints is stored
 	StateDir string

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -203,6 +203,12 @@ func (d *Daemon) DryModeEnabled() bool {
 	return d.conf.DryMode
 }
 
+// AlwaysAllowLocalhost returns true if the daemon has the option set that
+// localhost can always reach local endpoints
+func (d *Daemon) AlwaysAllowLocalhost() bool {
+	return d.conf.alwaysAllowLocalhost
+}
+
 func (d *Daemon) PolicyEnabled() bool {
 	return d.conf.Opts.IsEnabled(endpoint.OptionPolicy)
 }
@@ -597,6 +603,15 @@ func NewDaemon(c *Config) (*Daemon, error) {
 			if err := d.useK8sNodeCIDR(nodeName); err != nil {
 				return nil, err
 			}
+		}
+
+		// Kubernetes demands that the localhost can always reach local
+		// pods. Therefore unless the AllowLocalhost policy is set to a
+		// specific mode, always allow localhost to reach local
+		// endpoints.
+		if d.conf.AllowLocalhost == AllowLocalhostAuto {
+			log.Infof("k8s mode: Allowing localhost to reach local endpoints")
+			config.alwaysAllowLocalhost = true
 		}
 	}
 

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -235,6 +235,8 @@ func init() {
 	flags.StringVar(&config.K8sCfgPath, "k8s-kubeconfig-path", "", "Absolute path to the kubeconfig file")
 	flags.StringSliceVar(&k8sLabelsPrefixes, "k8s-prefix", []string{},
 		"Key values that will be read from kubernetes. (Default: k8s-app, version)")
+	flags.StringVar(&config.AllowLocalhost, "allow-localhost", AllowLocalhostAuto,
+		"Policy when to allow local stack to reach local endpoints { auto | always | policy } ")
 	flags.StringVar(&kvStore, "kvstore", kvstore.Local, "Key-value store type")
 	flags.BoolVar(&config.KeepConfig, "keep-config", false,
 		"When restoring state, keeps containers' configuration in place")
@@ -352,6 +354,17 @@ func initConfig() {
 		}
 	}
 	checkMinRequirements()
+
+	config.AllowLocalhost = strings.ToLower(config.AllowLocalhost)
+	switch config.AllowLocalhost {
+	case AllowLocalhostAlways:
+		config.alwaysAllowLocalhost = true
+	case AllowLocalhostAuto, AllowLocalhostPolicy:
+		config.alwaysAllowLocalhost = false
+	default:
+		log.Fatalf("Invalid setting for --allow-localhost, must be { %s, %s, %s }",
+			AllowLocalhostAuto, AllowLocalhostAlways, AllowLocalhostPolicy)
+	}
 }
 
 func initEnv() {

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -31,6 +31,10 @@ type Owner interface {
 	// PolicyEnabled returns true if policy enforcement has been enabled
 	PolicyEnabled() bool
 
+	// AlwaysAllowLocalhost returns true if localhost is always allowed to
+	// reach local endpoints
+	AlwaysAllowLocalhost() bool
+
 	// Must return an instance of a ConsumableCache
 	GetConsumableCache() *policy.ConsumableCache
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -193,8 +193,7 @@ func (e *Endpoint) regenerateConsumable(owner Owner) (bool, error) {
 
 	c.L4Policy = newL4policy
 
-	if newL4policy.HasRedirect() {
-		log.Debugf("[%s] Interaction with proxy, allowing localhost", e.PolicyID())
+	if newL4policy.HasRedirect() || owner.AlwaysAllowLocalhost() {
 		e.allowConsumer(owner, policy.ID_HOST)
 	}
 


### PR DESCRIPTION
A new option `--allow-localhost { auto | always | policy }` defines the
policy on how to determine whether the localhost should be able to reach
local endpoints. The default is auto which means:
 - "always" when run in a Kubernetes environment
 - "policy" in all other environments

Fixes: #748 