### PR TITLE
docs(K8s): fix kubectl ingress create command

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -169,7 +169,7 @@ You now have a set of pods and services inside your cluster. That isn't too much
 helpful unless they are exposed outside of the cluster.
 
 ```
-kubectl -f create examples/kubernetes/deployments/guestbook/ingress/ingress.yml
+kubectl create -f  examples/kubernetes/deployments/guestbook/ingress/guestbook-ingress.yml
 ```
 ```
 ingress "guestbook-ingress" created


### PR DESCRIPTION
fix the `kubectl create` command to create the guestbook ingress.