### PR TITLE
add fluentd integration with logrus

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -26,6 +26,11 @@
 			"Rev": "be52937128b38f1d99787bb476c789e2af1147f1"
 		},
 		{
+			"ImportPath": "github.com/Sirupsen/logrus/hooks/syslog",
+			"Comment": "v0.9.0",
+			"Rev": "be52937128b38f1d99787bb476c789e2af1147f1"
+		},
+		{
 			"ImportPath": "github.com/asaskevich/govalidator",
 			"Comment": "v5-20-gfdf1978",
 			"Rev": "fdf19785fd3558d619ef81212f5edf1d6c2a5911"
@@ -38,6 +43,10 @@
 			"ImportPath": "github.com/braintree/manners",
 			"Comment": "0.4.0-15-g82a8879",
 			"Rev": "82a8879fc5fd0381fa8b2d8033b19bf255252088"
+		},
+		{
+			"ImportPath": "github.com/bshuster-repo/logrus-logstash-hook",
+			"Rev": "c78042226c66460be064be6d1c26d276de19fbcf"
 		},
 		{
 			"ImportPath": "github.com/cloudfoundry-incubator/candiedyaml",
@@ -287,9 +296,19 @@
 			"Rev": "e9659cd7f08d0627d51c7a0193a6902890a9908b"
 		},
 		{
+			"ImportPath": "github.com/evalphobia/logrus_fluent",
+			"Comment": "v0.1.0-1-g92541fc",
+			"Rev": "92541fcfe55451eaf2811be04d38e001475c294f"
+		},
+		{
 			"ImportPath": "github.com/fatih/color",
 			"Comment": "v0.1-17-g533cd7f",
 			"Rev": "533cd7fd8a85905f67a1753afb4deddc85ea174f"
+		},
+		{
+			"ImportPath": "github.com/fluent/fluent-logger-golang/fluent",
+			"Comment": "v1.2.1-18-gd1deca7",
+			"Rev": "d1deca7ddb1b2d3fdbfaaf15d8a7b4f5feadc461"
 		},
 		{
 			"ImportPath": "github.com/fsnotify/fsnotify",
@@ -565,6 +584,10 @@
 			"Rev": "22139eb5469018e7374b3e7ef653de37ffb44f72"
 		},
 		{
+			"ImportPath": "github.com/philhofer/fwd",
+			"Rev": "98c11a7a6ec829d672b03833c3d69a7fae1ca972"
+		},
+		{
 			"ImportPath": "github.com/prometheus/client_golang/prometheus",
 			"Comment": "0.7.0-70-g15006a7",
 			"Rev": "15006a7ed88e73201c4e6142a2e66b54ae5fdf00"
@@ -617,6 +640,11 @@
 		{
 			"ImportPath": "github.com/spf13/viper",
 			"Rev": "7538d73b4eb9511d85a9f1dfef202eeb8ac260f4"
+		},
+		{
+			"ImportPath": "github.com/tinylib/msgp/msgp",
+			"Comment": "v1.0-1-g362bfb3",
+			"Rev": "362bfb3384d53ae4d5dd745983a4d70b6d23628c"
 		},
 		{
 			"ImportPath": "github.com/tylerb/graceful",

--- a/cilium/cmd/endpoint_labels.go
+++ b/cilium/cmd/endpoint_labels.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/labels"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 

--- a/cilium/cmd/policy.go
+++ b/cilium/cmd/policy.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/policy/api"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 

--- a/cilium/cmd/policy_import.go
+++ b/cilium/cmd/policy_import.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 

--- a/cilium/cmd/root.go
+++ b/cilium/cmd/root.go
@@ -96,9 +96,9 @@ func initConfig() {
 	}
 
 	if viper.GetBool("debug") {
-		common.SetupLogging([]string{"syslog"}, map[string]string{"syslog.level": "debug"}, "cilium-cmd", true)
+		common.SetupLogging([]string{common.Syslog}, map[string]string{common.SLevel: "debug"}, "cilium-cmd", true)
 	} else {
-		common.SetupLogging([]string{"syslog"}, map[string]string{"syslog.level": "info"}, "cilium-cmd", false)
+		common.SetupLogging([]string{common.Syslog}, map[string]string{common.SLevel: "info"}, "cilium-cmd", false)
 	}
 
 	if cl, err := clientPkg.NewClient(viper.GetString("host")); err != nil {

--- a/cilium/cmd/root.go
+++ b/cilium/cmd/root.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cilium/cilium/common"
 	clientPkg "github.com/cilium/cilium/pkg/client"
 
-	l "github.com/op/go-logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -29,7 +28,6 @@ import (
 var (
 	cfgFile string
 	client  *clientPkg.Client
-	log     = l.MustGetLogger("cilium")
 )
 
 const (
@@ -98,9 +96,9 @@ func initConfig() {
 	}
 
 	if viper.GetBool("debug") {
-		common.SetupLOG(log, "DEBUG")
+		common.SetupLogging([]string{"syslog"}, map[string]string{"syslog.level": "debug"}, "cilium-cmd", true)
 	} else {
-		common.SetupLOG(log, "INFO")
+		common.SetupLogging([]string{"syslog"}, map[string]string{"syslog.level": "info"}, "cilium-cmd", false)
 	}
 
 	if cl, err := clientPkg.NewClient(viper.GetString("host")); err != nil {

--- a/common/config.go
+++ b/common/config.go
@@ -1,0 +1,86 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Validator returns a validated string along with a possible error.
+type Validator func(val string) (string, error)
+
+// MapOptions holds a map of values and a validation function.
+type MapOptions struct {
+	vals      map[string]string
+	validator Validator
+}
+
+// NamedMapOptions is a MapOptions struct with a configuration name.
+// This struct is useful to keep reference to the assigned
+// field name in the internal configuration struct.
+type NamedMapOptions struct {
+	name string
+	MapOptions
+}
+
+// NewNamedMapOptions creates a reference to a new NamedMapOpts struct.
+func NewNamedMapOptions(name string, values *map[string]string, validator Validator) *NamedMapOptions {
+	fmt.Printf("NewNamedMapOptionss: %v, %p\n", *values, values)
+	return &NamedMapOptions{
+		name:       name,
+		MapOptions: *NewMapOpts(*values, validator),
+	}
+}
+
+// NewMapOpts creates a new MapOpts with the specified map of values and an
+// optional validator.
+func NewMapOpts(values map[string]string, validator Validator) *MapOptions {
+	if values == nil {
+		values = make(map[string]string)
+	}
+	return &MapOptions{
+		vals:      values,
+		validator: validator,
+	}
+}
+
+func (opts *MapOptions) String() string {
+	return fmt.Sprintf("%v", map[string]string((opts.vals)))
+}
+
+// Type returns a string name for this Option type
+func (opts *MapOptions) Type() string {
+	return "map"
+}
+
+// Set validates, if needed, the input value and adds it to the internal map,
+// by splitting on '='.
+func (opts *MapOptions) Set(value string) error {
+	if opts.validator != nil {
+		v, err := opts.validator(value)
+		if err != nil {
+			return err
+		}
+		value = v
+	}
+	vals := strings.SplitN(value, "=", 2)
+	if len(vals) == 1 {
+		(opts.vals)[vals[0]] = ""
+	} else {
+		(opts.vals)[vals[0]] = vals[1]
+	}
+	return nil
+}

--- a/common/logging.go
+++ b/common/logging.go
@@ -31,18 +31,18 @@ import (
 )
 
 const (
-	fAddr = "fluentd.address"
-	fTag = "fluentd.tag"
+	fAddr  = "fluentd.address"
+	fTag   = "fluentd.tag"
 	fLevel = "fluentd.level"
 
 	SLevel = "syslog.level"
 
-	lAddr = "logstash.address"
-	lLevel = "logstash.level"
+	lAddr     = "logstash.address"
+	lLevel    = "logstash.level"
 	lProtocol = "logstash.protocol"
 
-	Syslog = "syslog"
-	Fluentd = "fluentd"
+	Syslog   = "syslog"
+	Fluentd  = "fluentd"
 	Logstash = "logstash"
 )
 
@@ -53,14 +53,14 @@ var syslogOpts = map[string]bool{
 
 // fluentDOpts is the set of supported options for fluentD configuration.
 var fluentDOpts = map[string]bool{
-	fAddr: true,
-	fTag:     true,
-	fLevel:   true,
+	fAddr:  true,
+	fTag:   true,
+	fLevel: true,
 }
 
 // logstashOpts is the set of supported options for logstash configuration.
 var logstashOpts = map[string]bool{
-	lAddr:  true,
+	lAddr:     true,
 	lLevel:    true,
 	lProtocol: true,
 }

--- a/common/logging.go
+++ b/common/logging.go
@@ -1,0 +1,266 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log/syslog"
+	"net"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus/hooks/syslog"
+	"github.com/bshuster-repo/logrus-logstash-hook"
+	"github.com/evalphobia/logrus_fluent"
+	"regexp"
+)
+
+// syslogOpts is the set of supported options for syslog configuration.
+var syslogOpts = map[string]bool{
+	"syslog.level": true,
+}
+
+// fluentDOpts is the set of supported options for fluentD configuration.
+var fluentDOpts = map[string]bool{
+	"fluentd.address": true,
+	"fluentd.tag":     true,
+	"fluentd.level":   true,
+}
+
+// logstashOpts is the set of supported options for logstash configuration.
+var logstashOpts = map[string]bool{
+	"logstash.address":  true,
+	"logstash.level":    true,
+	"logstash.protocol": true,
+}
+
+// syslogLevelMap maps logrus.Level values to syslog.Priority levels.
+var syslogLevelMap = map[logrus.Level]syslog.Priority{
+	logrus.PanicLevel: syslog.LOG_ALERT,
+	logrus.FatalLevel: syslog.LOG_CRIT,
+	logrus.ErrorLevel: syslog.LOG_ERR,
+	logrus.WarnLevel:  syslog.LOG_WARNING,
+	logrus.InfoLevel:  syslog.LOG_INFO,
+	logrus.DebugLevel: syslog.LOG_DEBUG,
+}
+
+// setFireLevels sets the
+func setFireLevels(level logrus.Level) []logrus.Level {
+	switch level {
+	case logrus.PanicLevel:
+		return []logrus.Level{logrus.PanicLevel}
+	case logrus.FatalLevel:
+		return []logrus.Level{logrus.PanicLevel, logrus.FatalLevel}
+	case logrus.ErrorLevel:
+		return []logrus.Level{logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel}
+	case logrus.WarnLevel:
+		return []logrus.Level{logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel, logrus.WarnLevel}
+	case logrus.InfoLevel:
+		return []logrus.Level{logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel, logrus.WarnLevel, logrus.InfoLevel}
+	case logrus.DebugLevel:
+		return []logrus.Level{logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel, logrus.WarnLevel, logrus.InfoLevel, logrus.DebugLevel}
+	default:
+		logrus.Infof("logrus level %v is not supported at this time; defaulting to info level", level)
+		return []logrus.Level{logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel, logrus.WarnLevel, logrus.InfoLevel}
+	}
+}
+
+// SetupLogging sets up each logging service provided in loggers and configures
+// each logger with the provided logOpts.
+func SetupLogging(loggers []string, logOpts map[string]string, tag string, debug bool) error {
+	setupFormatter()
+
+	// Always setup syslog.
+	valuesToValidate := getLogDriverConfig("syslog", logOpts)
+	err := validateOpts("syslog", valuesToValidate, syslogOpts)
+	if err != nil {
+		return err
+	}
+
+	// Logrus has a default logger that outputs to os.stderr. Set this
+	// default output to go to ioutil.Discard to not have duplicate logs.
+	logrus.SetOutput(ioutil.Discard)
+	setupSyslog(valuesToValidate, tag, debug)
+
+	// Iterate through all provided loggers and configure them according
+	// to user-provided settings.
+	for _, logger := range loggers {
+		valuesToValidate := getLogDriverConfig(logger, logOpts)
+		switch logger {
+		case "syslog":
+			// Syslog is always set up; do not want to error out, so continue.
+			continue
+		case "fluentd":
+			err := validateOpts(logger, valuesToValidate, fluentDOpts)
+			if err != nil {
+				return err
+			}
+			setupFluentD(valuesToValidate, debug)
+			//TODO - need to finish logstash integration.
+		/*case "logstash":
+		fmt.Printf("SetupLogging: in logstash case\n")
+		err := validateOpts(logger, valuesToValidate, logstashOpts)
+		fmt.Printf("SetupLogging: validating options for logstash complete\n")
+		if err != nil {
+			fmt.Printf("SetupLogging: error validating logstash opts %v\n", err.Error())
+			return err
+		}
+		fmt.Printf("SetupLogging: about to setup logstash\n")
+		setupLogstash(valuesToValidate)
+		*/
+		default:
+			return fmt.Errorf("provided log driver %q is not a supported log driver", logger)
+		}
+	}
+	return nil
+}
+
+// setupSyslog sets up and configures syslog with the provided options in
+// logOpts. If some options are not provided, sensible defaults are used.
+func setupSyslog(logOpts map[string]string, tag string, debug bool) {
+	logLevel, ok := logOpts["syslog.level"]
+	if !ok {
+		if debug {
+			logLevel = "debug"
+		} else {
+			logLevel = "info"
+		}
+	}
+
+	//Validate provided log level.
+	level, err := logrus.ParseLevel(logLevel)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	logrus.SetLevel(level)
+	// Create syslog hook.
+	h, err := logrus_syslog.NewSyslogHook("", "", syslogLevelMap[level], tag)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	logrus.AddHook(h)
+}
+
+// setupFormatter sets up the text formatting for logs output by logrus.
+func setupFormatter() {
+	fileFormat := new(logrus.TextFormatter)
+	fileFormat.DisableColors = true
+	switch os.Getenv("INITSYSTEM") {
+	case "SYSTEMD":
+		fileFormat.DisableTimestamp = true
+		fileFormat.FullTimestamp = true
+	default:
+		fileFormat.TimestampFormat = time.RFC3339
+	}
+	logrus.SetFormatter(fileFormat)
+}
+
+// setupFluentD sets up and configures FluentD with the provided options in
+// logOpts. If some options are not provided, sensible defaults are used.
+func setupFluentD(logOpts map[string]string, debug bool) {
+	//If no logging level set for fluentd, use debug value if it is set.
+	// Logging level set for fluentd takes precedence over debug flag
+	// fluent.level provided.
+	logLevel, ok := logOpts["fluentd.level"]
+	if !ok {
+		if debug {
+			logLevel = "debug"
+		} else {
+			logLevel = "info"
+		}
+	}
+	level, err := logrus.ParseLevel(logLevel)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	hostAndPort, ok := logOpts["fluentd.address"]
+	if !ok {
+		hostAndPort = "localhost:24224"
+	}
+
+	host, strPort, err := net.SplitHostPort(hostAndPort)
+	port, err := strconv.Atoi(strPort)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	h, err := logrus_fluent.New(host, port)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	tag, ok := logOpts["fluentd.tag"]
+	if ok {
+		h.SetTag(tag)
+	}
+
+	// set custom fire level
+	h.SetLevels(setFireLevels(level))
+	logrus.AddHook(h)
+}
+
+// setupLogstash sets up and configures Logstash with the provided options in
+// logOpts. If some options are not provided, sensible defaults are used.
+/// TODO fix me later - needs to be tested with a working logstash setup.
+func setupLogstash(logOpts map[string]string) {
+	hostAndPort, ok := logOpts["logstash.address"]
+	if !ok {
+		hostAndPort = "172.17.0.2:999"
+	}
+
+	protocol, ok := logOpts["logstash.protocol"]
+	if !ok {
+		protocol = "tcp"
+	}
+
+	h, err := logrustash.NewHook(protocol, hostAndPort, "cilium")
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	logrus.AddHook(h)
+}
+
+// validateOpts iterates through all of the keys in logOpts, and errors out if
+// the key in logOpts is not a key in supportedOpts.
+func validateOpts(logDriver string, logOpts map[string]string, supportedOpts map[string]bool) error {
+	for k := range logOpts {
+		if !supportedOpts[k] {
+			return fmt.Errorf("provided configuration value %q is not supported as a logging option for log driver %s", k, logDriver)
+		}
+	}
+	return nil
+}
+
+// getLogDriverConfig returns a map containing the key-value pairs that start
+// with string logDriver from map logOpts.
+func getLogDriverConfig(logDriver string, logOpts map[string]string) map[string]string {
+	keysToValidate := make(map[string]string)
+	for k, v := range logOpts {
+		ok, err := regexp.MatchString(logDriver+".*", k)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		if ok {
+			keysToValidate[k] = v
+		}
+	}
+	return keysToValidate
+}

--- a/common/plugins/add_endpoint.go
+++ b/common/plugins/add_endpoint.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 
-	"github.com/op/go-logging"
+	log "github.com/Sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
 
@@ -32,7 +32,7 @@ const (
 )
 
 var (
-	log = logging.MustGetLogger("cilium-net")
+//log = logging.MustGetLogger("cilium-net")
 )
 
 // Endpoint2IfName returns the host interface name for the given endpointID.

--- a/common/plugins/add_endpoint.go
+++ b/common/plugins/add_endpoint.go
@@ -31,10 +31,6 @@ const (
 	temporaryInterfacePrefix = "tmp"
 )
 
-var (
-//log = logging.MustGetLogger("cilium-net")
-)
-
 // Endpoint2IfName returns the host interface name for the given endpointID.
 func Endpoint2IfName(endpointID string) string {
 	return hostInterfacePrefix + endpointID[:5]

--- a/common/utils.go
+++ b/common/utils.go
@@ -22,9 +22,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
-
-	l "github.com/op/go-logging"
 )
 
 // goArray2C transforms a byte slice into its hexadecimal string representation.
@@ -67,33 +64,6 @@ func Swab16(n uint16) uint16 {
 func Swab32(n uint32) uint32 {
 	return ((n & 0x000000ff) << 24) | ((n & 0x0000ff00) << 8) |
 		((n & 0x00ff0000) >> 8) | ((n & 0xff000000) >> 24)
-}
-
-// SetupLOG sets up logger with the correct parameters for the whole cilium architecture.
-func SetupLOG(logger *l.Logger, logLevel string) {
-
-	var fileFormat l.Formatter
-	switch os.Getenv("INITSYSTEM") {
-	case "SYSTEMD":
-		fileFormat = l.MustStringFormatter(
-			`%{level:.4s} %{message}`)
-	default:
-		fileFormat = l.MustStringFormatter(
-			`%{color}%{time:` + time.RFC3339 +
-				`} %{level:.4s} %{color:reset}%{message}`)
-	}
-
-	level, err := l.LogLevel(logLevel)
-	if err != nil {
-		logger.Fatal(err)
-	}
-
-	backend := l.NewLogBackend(os.Stderr, "", 0)
-	oBF := l.NewBackendFormatter(backend, fileFormat)
-
-	backendLeveled := l.SetBackend(oBF)
-	backendLeveled.SetLevel(level, "")
-	logger.SetBackend(backendLeveled)
 }
 
 // GetGroupIDByName returns the group ID for the given grpName.

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/option"
 
+	log "github.com/Sirupsen/logrus"
 	etcdAPI "github.com/coreos/etcd/clientv3"
 	consulAPI "github.com/hashicorp/consul/api"
 )

--- a/daemon/ct.go
+++ b/daemon/ct.go
@@ -22,6 +22,8 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 const (

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -53,6 +53,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy"
 
+	log "github.com/Sirupsen/logrus"
 	cniTypes "github.com/containernetworking/cni/pkg/types"
 	hb "github.com/containernetworking/cni/plugins/ipam/host-local/backend/allocator"
 	dClient "github.com/docker/engine-api/client"

--- a/daemon/docker_watcher.go
+++ b/daemon/docker_watcher.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 
+	log "github.com/Sirupsen/logrus"
 	dTypes "github.com/docker/engine-api/types"
 	dTypesEvents "github.com/docker/engine-api/types/events"
 	dNetwork "github.com/docker/engine-api/types/network"

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/go-openapi/runtime/middleware"
 )
 

--- a/daemon/events.go
+++ b/daemon/events.go
@@ -14,6 +14,8 @@
 
 package main
 
+import log "github.com/Sirupsen/logrus"
+
 func (d *Daemon) listenForCiliumEvents() {
 	go func() {
 		for {

--- a/daemon/ipam.go
+++ b/daemon/ipam.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/apierror"
 	"github.com/cilium/cilium/pkg/endpoint"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
 	k8sAPI "k8s.io/kubernetes/pkg/api"

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -26,6 +26,7 @@ import (
 	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/labels"
 
+	log "github.com/Sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/daemon/kvstore_watcher.go
+++ b/daemon/kvstore_watcher.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/policy"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 // EnableKVStoreWatcher watches for kvstore changes in the common.LastFreeIDKeyPath key.

--- a/daemon/labels.go
+++ b/daemon/labels.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/go-openapi/runtime/middleware"
 )
 

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/go-openapi/runtime/middleware"
 )
 

--- a/daemon/logstash.go
+++ b/daemon/logstash.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/policy"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 // LogstashStat is used to collect stats from the policy dumps.

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/bpfdebug"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 func (d *Daemon) receiveEvent(msg *bpf.PerfEventSample, cpu int) {

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/op/go-logging"
 )

--- a/daemon/services.go
+++ b/daemon/services.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/common/types"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 func (d *Daemon) updateL3n4AddrIDRef(id types.ServiceID, l3n4AddrID types.L3n4AddrID) error {

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/events"
 
+	log "github.com/Sirupsen/logrus"
 	dockerAPI "github.com/docker/engine-api/client"
 	ctx "golang.org/x/net/context"
 )

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -33,6 +33,8 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/u8proto"
 	"github.com/cilium/cilium/pkg/version"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 const (

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -36,13 +36,12 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 
-	"github.com/op/go-logging"
+	log "github.com/Sirupsen/logrus"
 )
 
 var (
 	//IPv4Enabled can be set to false to indicate IPv6 only operation
 	IPv4Enabled = true
-	log         = logging.MustGetLogger("cilium-endpoint")
 )
 
 // PortMap is the port mapping representation for a particular endpoint.

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -22,6 +22,8 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 func (e *Endpoint) checkEgressAccess(owner Owner, opts models.ConfigurationMap, dstID policy.NumericIdentity, opt string) {

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/common/types"
 	"github.com/cilium/cilium/pkg/policy"
 
+	log "github.com/Sirupsen/logrus"
 	consulAPI "github.com/hashicorp/consul/api"
 )
 

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/common/types"
 	"github.com/cilium/cilium/pkg/policy"
 
+	log "github.com/Sirupsen/logrus"
 	client "github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/coreos/etcd/mvcc/mvccpb"

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -20,12 +20,6 @@ import (
 
 	"github.com/cilium/cilium/common/types"
 	"github.com/cilium/cilium/pkg/policy"
-
-	"github.com/op/go-logging"
-)
-
-var (
-	log = logging.MustGetLogger("cilium-net")
 )
 
 // Supported key-value store types.

--- a/pkg/kvstore/local.go
+++ b/pkg/kvstore/local.go
@@ -26,6 +26,8 @@ import (
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/common/types"
 	"github.com/cilium/cilium/pkg/policy"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 type LocalClient struct {

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -24,12 +24,6 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/common"
-
-	"github.com/op/go-logging"
-)
-
-var (
-	log = logging.MustGetLogger("cilium-labels")
 )
 
 const (

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -22,10 +22,8 @@ import (
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/bpf"
 
-	"github.com/op/go-logging"
+	log "github.com/Sirupsen/logrus"
 )
-
-var log = logging.MustGetLogger("cilium")
 
 const (
 	MapName6       = "cilium_ct6_"

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -22,12 +22,6 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/common"
-
-	"github.com/op/go-logging"
-)
-
-var (
-	log = logging.MustGetLogger("cilium-option")
 )
 
 // VerifyFunc validates option key with value and may return an error if the

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -21,6 +21,8 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/policy/api"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 // Consumer is the entity that consumes a Consumable.

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -22,11 +22,8 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/labels"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/op/go-logging"
-)
-
-var (
-	log = logging.MustGetLogger("cilium-policy")
 )
 
 type Tracing int

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -28,15 +28,14 @@ import (
 
 	"github.com/cilium/cilium/pkg/policy"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/braintree/manners"
-	"github.com/op/go-logging"
 	"github.com/spf13/viper"
 	"github.com/vulcand/oxy/forward"
 	"github.com/vulcand/route"
 )
 
 var (
-	log     = logging.MustGetLogger("cilium-proxy")
 	logFile *os.File
 	logBuf  *bufio.Writer
 )

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -40,7 +40,7 @@ import (
 )
 
 func init() {
-	common.SetupLogging([]string{"syslog"}, map[string]string{"syslog.level": "debug"}, "cilium-net-cni", true)
+	common.SetupLogging([]string{common.Syslog}, map[string]string{common.SLevel: "debug"}, "cilium-net-cni", true)
 
 	// this ensures that main runs only on main thread (thread group leader).
 	// since namespace ops (unshare, setns) are done for a single thread, we

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -30,19 +30,17 @@ import (
 	"github.com/cilium/cilium/pkg/client"
 	"github.com/cilium/cilium/pkg/endpoint"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/containernetworking/cni/pkg/ns"
 	"github.com/containernetworking/cni/pkg/skel"
 	cniTypes "github.com/containernetworking/cni/pkg/types"
 	cniTypesVer "github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
-	l "github.com/op/go-logging"
 	"github.com/vishvananda/netlink"
 )
 
-var log = l.MustGetLogger("cilium-net-cni")
-
 func init() {
-	common.SetupLOG(log, "DEBUG")
+	common.SetupLogging([]string{"syslog"}, map[string]string{"syslog.level": "debug"}, "cilium-net-cni", true)
 
 	// this ensures that main runs only on main thread (thread group leader).
 	// since namespace ops (unshare, setns) are done for a single thread, we

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -28,14 +28,12 @@ import (
 	"github.com/cilium/cilium/pkg/client"
 	endpointPkg "github.com/cilium/cilium/pkg/endpoint"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/drivers/remote/api"
 	lnTypes "github.com/docker/libnetwork/types"
 	"github.com/gorilla/mux"
-	l "github.com/op/go-logging"
 	"github.com/vishvananda/netlink"
 )
-
-var log = l.MustGetLogger("cilium-docker")
 
 const (
 	// ContainerInterfacePrefix is the container's internal interface name prefix.

--- a/plugins/cilium-docker/driver/ipam.go
+++ b/plugins/cilium-docker/driver/ipam.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/client"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/ipams/remote/api"
 )
 

--- a/plugins/cilium-docker/main.go
+++ b/plugins/cilium-docker/main.go
@@ -77,9 +77,9 @@ func init() {
 
 func initConfig() {
 	if debug {
-		common.SetupLogging([]string{"syslog"}, map[string]string{"syslog.level": "debug"}, "cilium-docker", true)
+		common.SetupLogging([]string{common.Syslog}, map[string]string{common.SLevel: "debug"}, "cilium-docker", true)
 	} else {
-		common.SetupLogging([]string{"syslog"}, map[string]string{"syslog.level": "info"}, "cilium-docker", false)
+		common.SetupLogging([]string{common.Syslog}, map[string]string{common.SLevel: "info"}, "cilium-docker", false)
 	}
 
 	// The cilium-docker plugin must be run as root user.

--- a/plugins/cilium-docker/main.go
+++ b/plugins/cilium-docker/main.go
@@ -15,14 +15,14 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path"
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/plugins/cilium-docker/driver"
 
-	"fmt"
-	l "github.com/op/go-logging"
+	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -31,7 +31,6 @@ var (
 	driverSock string
 	debug      bool
 	ciliumAPI  string
-	log        = l.MustGetLogger("cilium-docker")
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -78,9 +77,9 @@ func init() {
 
 func initConfig() {
 	if debug {
-		common.SetupLOG(log, "DEBUG")
+		common.SetupLogging([]string{"syslog"}, map[string]string{"syslog.level": "debug"}, "cilium-docker", true)
 	} else {
-		common.SetupLOG(log, "INFO")
+		common.SetupLogging([]string{"syslog"}, map[string]string{"syslog.level": "info"}, "cilium-docker", false)
 	}
 
 	// The cilium-docker plugin must be run as root user.

--- a/vendor/github.com/Sirupsen/logrus/hooks/syslog/README.md
+++ b/vendor/github.com/Sirupsen/logrus/hooks/syslog/README.md
@@ -1,0 +1,39 @@
+# Syslog Hooks for Logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/>
+
+## Usage
+
+```go
+import (
+  "log/syslog"
+  "github.com/Sirupsen/logrus"
+  logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
+)
+
+func main() {
+  log       := logrus.New()
+  hook, err := logrus_syslog.NewSyslogHook("udp", "localhost:514", syslog.LOG_INFO, "")
+
+  if err == nil {
+    log.Hooks.Add(hook)
+  }
+}
+```
+
+If you want to connect to local syslog (Ex. "/dev/log" or "/var/run/syslog" or "/var/run/log"). Just assign empty string to the first two parameters of `NewSyslogHook`. It should look like the following.
+
+```go
+import (
+  "log/syslog"
+  "github.com/Sirupsen/logrus"
+  logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
+)
+
+func main() {
+  log       := logrus.New()
+  hook, err := logrus_syslog.NewSyslogHook("", "", syslog.LOG_INFO, "")
+
+  if err == nil {
+    log.Hooks.Add(hook)
+  }
+}
+```

--- a/vendor/github.com/Sirupsen/logrus/hooks/syslog/syslog.go
+++ b/vendor/github.com/Sirupsen/logrus/hooks/syslog/syslog.go
@@ -1,0 +1,61 @@
+// +build !windows,!nacl,!plan9
+
+package logrus_syslog
+
+import (
+	"fmt"
+	"github.com/Sirupsen/logrus"
+	"log/syslog"
+	"os"
+)
+
+// SyslogHook to send logs via syslog.
+type SyslogHook struct {
+	Writer        *syslog.Writer
+	SyslogNetwork string
+	SyslogRaddr   string
+}
+
+// Creates a hook to be added to an instance of logger. This is called with
+// `hook, err := NewSyslogHook("udp", "localhost:514", syslog.LOG_DEBUG, "")`
+// `if err == nil { log.Hooks.Add(hook) }`
+func NewSyslogHook(network, raddr string, priority syslog.Priority, tag string) (*SyslogHook, error) {
+	w, err := syslog.Dial(network, raddr, priority, tag)
+	return &SyslogHook{w, network, raddr}, err
+}
+
+func (hook *SyslogHook) Fire(entry *logrus.Entry) error {
+	line, err := entry.String()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to read entry, %v", err)
+		return err
+	}
+
+	switch entry.Level {
+	case logrus.PanicLevel:
+		return hook.Writer.Crit(line)
+	case logrus.FatalLevel:
+		return hook.Writer.Crit(line)
+	case logrus.ErrorLevel:
+		return hook.Writer.Err(line)
+	case logrus.WarnLevel:
+		return hook.Writer.Warning(line)
+	case logrus.InfoLevel:
+		return hook.Writer.Info(line)
+	case logrus.DebugLevel:
+		return hook.Writer.Debug(line)
+	default:
+		return nil
+	}
+}
+
+func (hook *SyslogHook) Levels() []logrus.Level {
+	return []logrus.Level{
+		logrus.PanicLevel,
+		logrus.FatalLevel,
+		logrus.ErrorLevel,
+		logrus.WarnLevel,
+		logrus.InfoLevel,
+		logrus.DebugLevel,
+	}
+}

--- a/vendor/github.com/bshuster-repo/logrus-logstash-hook/.gitignore
+++ b/vendor/github.com/bshuster-repo/logrus-logstash-hook/.gitignore
@@ -1,0 +1,26 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+.idea
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+*.iml

--- a/vendor/github.com/bshuster-repo/logrus-logstash-hook/.travis.yml
+++ b/vendor/github.com/bshuster-repo/logrus-logstash-hook/.travis.yml
@@ -1,0 +1,19 @@
+language: go
+sudo: false
+
+matrix:
+  include:
+    - go: 1.3
+    - go: 1.4
+    - go: 1.5
+    - go: 1.6
+    - go: tip
+
+install:
+  - # Skip
+
+script:
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d .)
+  - go tool vet .
+  - go test -v -race ./...

--- a/vendor/github.com/bshuster-repo/logrus-logstash-hook/CHANGELOG.md
+++ b/vendor/github.com/bshuster-repo/logrus-logstash-hook/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 0.4
+
+ * Update the name of the package from `logrus_logstash` to `logrustash`.
+ * Add TimeFormat to Hook
+
+## 0.3
+
+ * Fix the Logstash format to set `@version` to `"1"`
+ * Add unit-tests to logstash.go
+ * Remove the assert package
+ * Add prefix filtering
+
+## Before that (major changes)
+
+ * Update LICENSE to MIT from GPL

--- a/vendor/github.com/bshuster-repo/logrus-logstash-hook/LICENSE
+++ b/vendor/github.com/bshuster-repo/logrus-logstash-hook/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Boaz Shuster
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/bshuster-repo/logrus-logstash-hook/README.md
+++ b/vendor/github.com/bshuster-repo/logrus-logstash-hook/README.md
@@ -1,0 +1,106 @@
+# Logstash hook for logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:" /> [![Build Status](https://travis-ci.org/bshuster-repo/logrus-logstash-hook.svg?branch=master)](https://travis-ci.org/bshuster-repo/logrus-logstash-hook)
+Use this hook to send the logs to [Logstash](https://www.elastic.co/products/logstash) over both UDP and TCP.
+
+## Usage
+
+```go
+package main
+
+import (
+        "github.com/Sirupsen/logrus"
+        "github.com/bshuster-repo/logrus-logstash-hook"
+)
+
+func main() {
+        log := logrus.New()
+        hook, err := logrustash.NewHook("tcp", "172.17.0.2:9999", "myappName")
+
+        if err != nil {
+                log.Fatal(err)
+        }
+        log.Hooks.Add(hook)
+        ctx := log.WithFields(logrus.Fields{
+          "method": "main",
+        })
+        ...
+        ctx.Info("Hello World!")
+}
+```
+
+This is how it will look like:
+
+```ruby
+{
+    "@timestamp" => "2016-02-29T16:57:23.000Z",
+      "@version" => "1",
+         "level" => "info",
+       "message" => "Hello World!",
+        "method" => "main",
+          "host" => "172.17.0.1",
+          "port" => 45199,
+          "type" => "myappName"
+}
+```
+## Hook Fields
+Fields can be added to the hook, which will always be in the log context.
+This can be done when creating the hook:
+
+```go
+
+hook, err := logrustash.NewHookWithFields("tcp", "172.17.0.2:9999", "myappName", logrus.Fields{
+        "hostname":    os.Hostname(),
+        "serviceName": "myServiceName",
+})
+```
+
+Or afterwards:
+
+```go
+
+hook.WithFields(logrus.Fields{
+        "hostname":    os.Hostname(),
+        "serviceName": "myServiceName",
+})
+```
+This allows you to set up the hook so logging is available immediately, and add important fields as they become available.
+
+Single fields can be added/updated using 'WithField':
+
+```go
+
+hook.WithField("status", "running")
+```
+
+
+
+## Field prefix
+
+The hook allows you to send logging to logstash and also retain the default std output in text format.
+However to keep this console output readable some fields might need to be omitted from the default non-hooked log output.
+Each hook can be configured with a prefix used to identify fields which are only to be logged to the logstash connection.
+For example if you don't want to see the hostname and serviceName on each log line in the console output you can add a prefix:
+
+```go
+
+
+hook, err := logrustash.NewHookWithFields("tcp", "172.17.0.2:9999", "myappName", logrus.Fields{
+        "_hostname":    os.Hostname(),
+        "_serviceName": "myServiceName",
+})
+...
+hook.WithPrefix("_")
+```
+
+There are also constructors available which allow you to specify the prefix from the start.
+The std-out will not have the '\_hostname' and '\_servicename' fields, and the logstash output will, but the prefix will be dropped from the name.
+
+
+# Authors
+
+Name         | Github    | Twitter    |
+------------ | --------- | ---------- |
+Boaz Shuster | ripcurld0 | @ripcurld0 |
+
+# License
+
+MIT.

--- a/vendor/github.com/bshuster-repo/logrus-logstash-hook/logstash.go
+++ b/vendor/github.com/bshuster-repo/logrus-logstash-hook/logstash.go
@@ -1,0 +1,133 @@
+package logrustash
+
+import (
+	"net"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// Hook represents a connection to a Logstash instance
+type Hook struct {
+	conn             net.Conn
+	appName          string
+	alwaysSentFields logrus.Fields
+	hookOnlyPrefix   string
+	TimeFormat       string
+}
+
+// NewHook creates a new hook to a Logstash instance, which listens on
+// `protocol`://`address`.
+func NewHook(protocol, address, appName string) (*Hook, error) {
+	return NewHookWithFields(protocol, address, appName, make(logrus.Fields))
+}
+
+// NewHookWithConn creates a new hook to a Logstash instance, using the supplied connection
+func NewHookWithConn(conn net.Conn, appName string) (*Hook, error) {
+	return NewHookWithFieldsAndConn(conn, appName, make(logrus.Fields))
+}
+
+// NewHookWithFields creates a new hook to a Logstash instance, which listens on
+// `protocol`://`address`. alwaysSentFields will be sent with every log entry.
+func NewHookWithFields(protocol, address, appName string, alwaysSentFields logrus.Fields) (*Hook, error) {
+	return NewHookWithFieldsAndPrefix(protocol, address, appName, alwaysSentFields, "")
+}
+
+// NewHookWithFieldsAndPrefix creates a new hook to a Logstash instance, which listens on
+// `protocol`://`address`. alwaysSentFields will be sent with every log entry. prefix is used to select fields to filter
+func NewHookWithFieldsAndPrefix(protocol, address, appName string, alwaysSentFields logrus.Fields, prefix string) (*Hook, error) {
+	conn, err := net.Dial(protocol, address)
+	if err != nil {
+		return nil, err
+	}
+	return NewHookWithFieldsAndConnAndPrefix(conn, appName, alwaysSentFields, prefix)
+}
+
+// NewHookWithFieldsAndConn creates a new hook to a Logstash instance using the supplied connection
+func NewHookWithFieldsAndConn(conn net.Conn, appName string, alwaysSentFields logrus.Fields) (*Hook, error) {
+	return NewHookWithFieldsAndConnAndPrefix(conn, appName, alwaysSentFields, "")
+}
+
+//NewHookWithFieldsAndConnAndPrefix creates a new hook to a Logstash instance using the suppolied connection and prefix
+func NewHookWithFieldsAndConnAndPrefix(conn net.Conn, appName string, alwaysSentFields logrus.Fields, prefix string) (*Hook, error) {
+	return &Hook{conn: conn, appName: appName, alwaysSentFields: alwaysSentFields, hookOnlyPrefix: prefix}, nil
+}
+
+//NewFilterHook makes a new hook which does not forward to logstash, but simply enforces the prefix rules
+func NewFilterHook() *Hook {
+	return NewFilterHookWithPrefix("")
+}
+
+//NewFilterHookWithPrefix make a new hook which does not forward to logstash, but simply enforces the specified prefix
+func NewFilterHookWithPrefix(prefix string) *Hook {
+	return &Hook{conn: nil, appName: "", alwaysSentFields: make(logrus.Fields), hookOnlyPrefix: prefix}
+}
+
+func (h *Hook) filterHookOnly(entry *logrus.Entry) {
+	if h.hookOnlyPrefix != "" {
+		for key := range entry.Data {
+			if strings.HasPrefix(key, h.hookOnlyPrefix) {
+				delete(entry.Data, key)
+			}
+		}
+	}
+
+}
+
+//WithPrefix sets a prefix filter to use in all subsequent logging
+func (h *Hook) WithPrefix(prefix string) {
+	h.hookOnlyPrefix = prefix
+}
+
+func (h *Hook) WithField(key string, value interface{}) {
+	h.alwaysSentFields[key] = value
+}
+
+func (h *Hook) WithFields(fields logrus.Fields) {
+	//Add all the new fields to the 'alwaysSentFields', possibly overwriting exising fields
+	for key, value := range fields {
+		h.alwaysSentFields[key] = value
+	}
+}
+
+func (h *Hook) Fire(entry *logrus.Entry) error {
+	//make sure we always clear the hookonly fields from the entry
+	defer h.filterHookOnly(entry)
+
+	// Add in the alwaysSentFields. We don't override fields that are already set.
+	for k, v := range h.alwaysSentFields {
+		if _, inMap := entry.Data[k]; !inMap {
+			entry.Data[k] = v
+		}
+	}
+
+	//For a filteringHook, stop here
+	if h.conn == nil {
+		return nil
+	}
+
+	formatter := LogstashFormatter{Type: h.appName}
+	if h.TimeFormat != "" {
+		formatter.TimestampFormat = h.TimeFormat
+	}
+
+	dataBytes, err := formatter.FormatWithPrefix(entry, h.hookOnlyPrefix)
+	if err != nil {
+		return err
+	}
+	if _, err = h.conn.Write(dataBytes); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *Hook) Levels() []logrus.Level {
+	return []logrus.Level{
+		logrus.PanicLevel,
+		logrus.FatalLevel,
+		logrus.ErrorLevel,
+		logrus.WarnLevel,
+		logrus.InfoLevel,
+		logrus.DebugLevel,
+	}
+}

--- a/vendor/github.com/bshuster-repo/logrus-logstash-hook/logstash_formatter.go
+++ b/vendor/github.com/bshuster-repo/logrus-logstash-hook/logstash_formatter.go
@@ -1,0 +1,80 @@
+package logrustash
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// Formatter generates json in logstash format.
+// Logstash site: http://logstash.net/
+type LogstashFormatter struct {
+	Type string // if not empty use for logstash type field.
+
+	// TimestampFormat sets the format used for timestamps.
+	TimestampFormat string
+}
+
+func (f *LogstashFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	return f.FormatWithPrefix(entry, "")
+}
+
+func (f *LogstashFormatter) FormatWithPrefix(entry *logrus.Entry, prefix string) ([]byte, error) {
+	fields := make(logrus.Fields)
+	for k, v := range entry.Data {
+		//remvove the prefix when sending the fields to logstash
+		if prefix != "" && strings.HasPrefix(k, prefix) {
+			k = strings.TrimPrefix(k, prefix)
+		}
+
+		switch v := v.(type) {
+		case error:
+			// Otherwise errors are ignored by `encoding/json`
+			// https://github.com/Sirupsen/logrus/issues/377
+			fields[k] = v.Error()
+		default:
+			fields[k] = v
+		}
+	}
+
+	fields["@version"] = "1"
+
+	timeStampFormat := f.TimestampFormat
+
+	if timeStampFormat == "" {
+		timeStampFormat = logrus.DefaultTimestampFormat
+	}
+
+	fields["@timestamp"] = entry.Time.Format(timeStampFormat)
+
+	// set message field
+	v, ok := entry.Data["message"]
+	if ok {
+		fields["fields.message"] = v
+	}
+	fields["message"] = entry.Message
+
+	// set level field
+	v, ok = entry.Data["level"]
+	if ok {
+		fields["fields.level"] = v
+	}
+	fields["level"] = entry.Level.String()
+
+	// set type field
+	if f.Type != "" {
+		v, ok = entry.Data["type"]
+		if ok {
+			fields["fields.type"] = v
+		}
+		fields["type"] = f.Type
+	}
+
+	serialized, err := json.Marshal(fields)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
+	}
+	return append(serialized, '\n'), nil
+}

--- a/vendor/github.com/evalphobia/logrus_fluent/.gitignore
+++ b/vendor/github.com/evalphobia/logrus_fluent/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/evalphobia/logrus_fluent/.travis.yml
+++ b/vendor/github.com/evalphobia/logrus_fluent/.travis.yml
@@ -1,0 +1,17 @@
+sudo: false
+language: go
+go:
+  - 1.4
+  - 1.5
+  - 1.6
+  - 1.7
+  - tip
+matrix:
+  allow_failures:
+    - go: tip
+before_install:
+  - go get github.com/axw/gocov/gocov
+  - go get github.com/mattn/goveralls
+  - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+script:
+    - $HOME/gopath/bin/goveralls -service=travis-ci

--- a/vendor/github.com/evalphobia/logrus_fluent/LICENSE
+++ b/vendor/github.com/evalphobia/logrus_fluent/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/github.com/evalphobia/logrus_fluent/README.md
+++ b/vendor/github.com/evalphobia/logrus_fluent/README.md
@@ -1,0 +1,52 @@
+[![Build Status](https://travis-ci.org/evalphobia/logrus_fluent.svg?branch=master)](https://travis-ci.org/evalphobia/logrus_fluent)  [![Coverage Status](https://coveralls.io/repos/evalphobia/logrus_fluent/badge.svg?branch=master&service=github)](https://coveralls.io/github/evalphobia/logrus_fluent?branch=master) [![GoDoc](https://godoc.org/github.com/evalphobia/logrus_fluent?status.svg)](https://godoc.org/github.com/evalphobia/logrus_fluent)
+
+
+# Fluentd Hook for Logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/>
+
+## Usage
+
+```go
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/evalphobia/logrus_fluent"
+)
+
+func main() {
+	hook, err := logrus_fluent.New("localhost", 24224)
+	if err != nil {
+		panic(err)
+	}
+
+	// set custom fire level
+	hook.SetLevels([]logrus.Level{
+		logrus.PanicLevel,
+		logrus.ErrorLevel,
+	})
+
+	// set static tag
+	hook.SetTag("original.tag")
+
+	// ignore field
+	hook.AddIgnore("context")
+
+	// filter func
+	hook.AddFilter("error", logrus_fluent.FilterError)
+
+	logrus.AddHook(hook)
+}
+
+func logging(ctx context.Context) {
+	logrus.WithFields(logrus.Fields{
+		"value":   "some content...",
+		"error":   errors.New("unknown error"), // this field will be applied filter function in the hook.
+		"context": ctx,                         // this field will be ignored in the hook.
+	}).Error("error message")
+}
+```
+
+
+## Special fields
+
+Some logrus fields have a special meaning in this hook.
+
+- `tag` is used as a fluentd tag. (if `tag` is omitted, Entry.Message is used as a fluentd tag, unless a static tag is set for the hook with `hook.SetTag`)

--- a/vendor/github.com/evalphobia/logrus_fluent/filter.go
+++ b/vendor/github.com/evalphobia/logrus_fluent/filter.go
@@ -1,0 +1,9 @@
+package logrus_fluent
+
+// FilterError is a filter function to convert error type to string type.
+func FilterError(v interface{}) interface{} {
+	if err, ok := v.(error); ok {
+		return err.Error()
+	}
+	return v
+}

--- a/vendor/github.com/evalphobia/logrus_fluent/fluent.go
+++ b/vendor/github.com/evalphobia/logrus_fluent/fluent.go
@@ -1,0 +1,186 @@
+package logrus_fluent
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/fluent/fluent-logger-golang/fluent"
+)
+
+const (
+	// TagName is struct field tag name.
+	// Some basic option is allowed in the field tag,
+	//
+	// type myStruct {
+	//     Value1: `fluent:"value_1"`    // change field name.
+	//     Value2: `fluent:"-"`          // always omit this field.
+	//     Value3: `fluent:",omitempty"` // omit this field when zero-value.
+	// }
+	TagName = "fluent"
+	// TagField is logrus field name used as fluentd tag
+	TagField = "tag"
+	// MessageField is logrus field name used as message.
+	// If missing in the log fields, entry.Message is set to this field.
+	MessageField = "message"
+)
+
+var defaultLevels = []logrus.Level{
+	logrus.PanicLevel,
+	logrus.FatalLevel,
+	logrus.ErrorLevel,
+	logrus.WarnLevel,
+	logrus.InfoLevel,
+}
+
+// FluentHook is logrus hook for fluentd.
+type FluentHook struct {
+	// Fluent is actual fluentd logger.
+	// If set, this logger is used for logging.
+	// otherwise new logger is created every time.
+	Fluent *fluent.Fluent
+
+	host   string
+	port   int
+	levels []logrus.Level
+	tag    *string
+
+	ignoreFields map[string]struct{}
+	filters      map[string]func(interface{}) interface{}
+}
+
+// New returns initialized logrus hook for fluentd with persistent fluentd logger.
+func New(host string, port int) (*FluentHook, error) {
+	fd, err := fluent.New(fluent.Config{FluentHost: host, FluentPort: port})
+	if err != nil {
+		return nil, err
+	}
+
+	return &FluentHook{
+		levels:       defaultLevels,
+		Fluent:       fd,
+		ignoreFields: make(map[string]struct{}),
+		filters:      make(map[string]func(interface{}) interface{}),
+	}, nil
+}
+
+// NewHook returns initialized logrus hook for fluentd.
+// (** deperecated: use New() **)
+func NewHook(host string, port int) *FluentHook {
+	return &FluentHook{
+		host:         host,
+		port:         port,
+		levels:       defaultLevels,
+		tag:          nil,
+		ignoreFields: make(map[string]struct{}),
+		filters:      make(map[string]func(interface{}) interface{}),
+	}
+}
+
+// Levels returns logging level to fire this hook.
+func (hook *FluentHook) Levels() []logrus.Level {
+	return hook.levels
+}
+
+// SetLevels sets logging level to fire this hook.
+func (hook *FluentHook) SetLevels(levels []logrus.Level) {
+	hook.levels = levels
+}
+
+// Tag returns custom static tag.
+func (hook *FluentHook) Tag() string {
+	if hook.tag == nil {
+		return ""
+	}
+
+	return *hook.tag
+}
+
+// SetTag sets custom static tag to override tag in the message fields.
+func (hook *FluentHook) SetTag(tag string) {
+	hook.tag = &tag
+}
+
+// AddIgnore adds field name to ignore.
+func (hook *FluentHook) AddIgnore(name string) {
+	hook.ignoreFields[name] = struct{}{}
+}
+
+// AddFilter adds a custom filter function.
+func (hook *FluentHook) AddFilter(name string, fn func(interface{}) interface{}) {
+	hook.filters[name] = fn
+}
+
+// Fire is invoked by logrus and sends log to fluentd logger.
+func (hook *FluentHook) Fire(entry *logrus.Entry) error {
+	var logger *fluent.Fluent
+	var err error
+
+	switch {
+	case hook.Fluent != nil:
+		logger = hook.Fluent
+	default:
+		logger, err = fluent.New(fluent.Config{
+			FluentHost: hook.host,
+			FluentPort: hook.port,
+		})
+		if err != nil {
+			return err
+		}
+		defer logger.Close()
+	}
+
+	// Create a map for passing to FluentD
+	data := make(logrus.Fields)
+	for k, v := range entry.Data {
+		if _, ok := hook.ignoreFields[k]; ok {
+			continue
+		}
+		if fn, ok := hook.filters[k]; ok {
+			v = fn(v)
+		}
+		data[k] = v
+	}
+
+	setLevelString(entry, data)
+	tag := hook.getTagAndDel(entry, data)
+	if tag != entry.Message {
+		setMessage(entry, data)
+	}
+
+	fluentData := ConvertToValue(data, TagName)
+	err = logger.PostWithTime(tag, entry.Time, fluentData)
+	return err
+}
+
+// getTagAndDel extracts tag data from log entry and custom log fields.
+// 1. if tag is set in the hook, use it.
+// 2. if tag is set in custom fields, use it.
+// 3. if cannot find tag data, use entry.Message as tag.
+func (hook *FluentHook) getTagAndDel(entry *logrus.Entry, data logrus.Fields) string {
+	// use static tag from
+	if hook.tag != nil {
+		return *hook.tag
+	}
+
+	tagField, ok := data[TagField]
+	if !ok {
+		return entry.Message
+	}
+
+	tag, ok := tagField.(string)
+	if !ok {
+		return entry.Message
+	}
+
+	// remove tag from data fields
+	delete(data, TagField)
+	return tag
+}
+
+func setLevelString(entry *logrus.Entry, data logrus.Fields) {
+	data["level"] = entry.Level.String()
+}
+
+func setMessage(entry *logrus.Entry, data logrus.Fields) {
+	if _, ok := data[MessageField]; !ok {
+		data[MessageField] = entry.Message
+	}
+}

--- a/vendor/github.com/evalphobia/logrus_fluent/reflect.go
+++ b/vendor/github.com/evalphobia/logrus_fluent/reflect.go
@@ -1,0 +1,132 @@
+package logrus_fluent
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// ConvertToValue make map data from struct and tags
+func ConvertToValue(p interface{}, tagName string) interface{} {
+	rv := toValue(p)
+	switch rv.Kind() {
+	case reflect.Struct:
+		return converFromStruct(rv.Interface(), tagName)
+	case reflect.Map:
+		return convertFromMap(rv, tagName)
+	case reflect.Slice:
+		return convertFromSlice(rv, tagName)
+	case reflect.Chan:
+		return nil
+	case reflect.Invalid:
+		return nil
+	default:
+		return rv.Interface()
+	}
+}
+
+func convertFromMap(rv reflect.Value, tagName string) interface{} {
+	result := make(map[string]interface{})
+	for _, key := range rv.MapKeys() {
+		kv := rv.MapIndex(key)
+		result[fmt.Sprint(key.Interface())] = ConvertToValue(kv.Interface(), tagName)
+	}
+	return result
+}
+
+func convertFromSlice(rv reflect.Value, tagName string) interface{} {
+	var result []interface{}
+	for i, max := 0, rv.Len(); i < max; i++ {
+		result = append(result, ConvertToValue(rv.Index(i).Interface(), tagName))
+	}
+	return result
+}
+
+// converFromStruct converts struct to value
+// see: https://github.com/fatih/structs/
+func converFromStruct(p interface{}, tagName string) interface{} {
+	result := make(map[string]interface{})
+	t := toType(p)
+	values := toValue(p)
+	for i, max := 0, t.NumField(); i < max; i++ {
+		f := t.Field(i)
+		if f.PkgPath != "" && !f.Anonymous {
+			continue // skip private field
+		}
+		tag, opts := parseTag(f, tagName)
+		if tag == "-" {
+			continue // skip `-` tag
+		}
+
+		v := values.Field(i)
+		if opts.Has("omitempty") && isZero(v) {
+			continue // skip zero-value when omitempty option exists in tag
+		}
+		name := getNameFromTag(f, tagName)
+		result[name] = ConvertToValue(v.Interface(), TagName)
+	}
+	return result
+}
+
+// toValue converts any value to reflect.Value
+func toValue(p interface{}) reflect.Value {
+	v := reflect.ValueOf(p)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	return v
+}
+
+// toType converts any value to reflect.Type
+func toType(p interface{}) reflect.Type {
+	t := reflect.ValueOf(p).Type()
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t
+}
+
+// isZero checks the value is zero-value or not
+func isZero(v reflect.Value) bool {
+	zero := reflect.Zero(v.Type()).Interface()
+	value := v.Interface()
+	return reflect.DeepEqual(value, zero)
+}
+
+// getNameFromTag return the value in tag or field name in the struct field
+func getNameFromTag(f reflect.StructField, tagName string) string {
+	tag, _ := parseTag(f, tagName)
+	if tag != "" {
+		return tag
+	}
+	return f.Name
+}
+
+// getTagValues returns tag value of the struct field
+func getTagValues(f reflect.StructField, tag string) string {
+	return f.Tag.Get(tag)
+}
+
+// parseTag returns the first tag value of the struct field
+func parseTag(f reflect.StructField, tag string) (string, options) {
+	return splitTags(getTagValues(f, tag))
+}
+
+// splitTags returns the first tag value and rest slice
+func splitTags(tags string) (string, options) {
+	res := strings.Split(tags, ",")
+	return res[0], res[1:]
+}
+
+// TagOptions is wrapper struct for rest tag values
+type options []string
+
+// Has checks the value exists in the rest values or not
+func (t options) Has(tag string) bool {
+	for _, opt := range t {
+		if opt == tag {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/fluent/fluent-logger-golang/LICENSE
+++ b/vendor/github.com/fluent/fluent-logger-golang/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/fluent/fluent-logger-golang/fluent/fluent.go
+++ b/vendor/github.com/fluent/fluent-logger-golang/fluent/fluent.go
@@ -1,0 +1,329 @@
+package fluent
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"reflect"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const (
+	defaultHost                   = "127.0.0.1"
+	defaultNetwork                = "tcp"
+	defaultSocketPath             = ""
+	defaultPort                   = 24224
+	defaultTimeout                = 3 * time.Second
+	defaultWriteTimeout           = time.Duration(0) // Write() will not time out
+	defaultBufferLimit            = 8 * 1024 * 1024
+	defaultRetryWait              = 500
+	defaultMaxRetry               = 13
+	defaultReconnectWaitIncreRate = 1.5
+	// Default sub-second precision value to false since it is only compatible
+	// with fluentd versions v0.14 and above.
+	defaultSubSecondPrecision = false
+)
+
+type Config struct {
+	FluentPort       int           `json:"fluent_port"`
+	FluentHost       string        `json:"fluent_host"`
+	FluentNetwork    string        `json:"fluent_network"`
+	FluentSocketPath string        `json:"fluent_socket_path"`
+	Timeout          time.Duration `json:"timeout"`
+	WriteTimeout     time.Duration `json:"write_timeout"`
+	BufferLimit      int           `json:"buffer_limit"`
+	RetryWait        int           `json:"retry_wait"`
+	MaxRetry         int           `json:"max_retry"`
+	TagPrefix        string        `json:"tag_prefix"`
+	AsyncConnect     bool          `json:"async_connect"`
+	MarshalAsJSON    bool          `json:"marshal_as_json"`
+
+	// Sub-second precision timestamps are only possible for those using fluentd
+	// v0.14+ and serializing their messages with msgpack.
+	SubSecondPrecision bool `json:"sub_second_precision"`
+}
+
+type Fluent struct {
+	Config
+
+	mubuff  sync.Mutex
+	pending []byte
+
+	muconn       sync.Mutex
+	conn         net.Conn
+	reconnecting bool
+}
+
+// New creates a new Logger.
+func New(config Config) (f *Fluent, err error) {
+	if config.FluentNetwork == "" {
+		config.FluentNetwork = defaultNetwork
+	}
+	if config.FluentHost == "" {
+		config.FluentHost = defaultHost
+	}
+	if config.FluentPort == 0 {
+		config.FluentPort = defaultPort
+	}
+	if config.FluentSocketPath == "" {
+		config.FluentSocketPath = defaultSocketPath
+	}
+	if config.Timeout == 0 {
+		config.Timeout = defaultTimeout
+	}
+	if config.WriteTimeout == 0 {
+		config.WriteTimeout = defaultWriteTimeout
+	}
+	if config.BufferLimit == 0 {
+		config.BufferLimit = defaultBufferLimit
+	}
+	if config.RetryWait == 0 {
+		config.RetryWait = defaultRetryWait
+	}
+	if config.MaxRetry == 0 {
+		config.MaxRetry = defaultMaxRetry
+	}
+	if config.AsyncConnect {
+		f = &Fluent{Config: config, reconnecting: true}
+		go f.reconnect()
+	} else {
+		f = &Fluent{Config: config, reconnecting: false}
+		err = f.connect()
+	}
+	return
+}
+
+// Post writes the output for a logging event.
+//
+// Examples:
+//
+//  // send string
+//  f.Post("tag_name", "data")
+//
+//  // send map[string]
+//  mapStringData := map[string]string{
+//  	"foo":  "bar",
+//  }
+//  f.Post("tag_name", mapStringData)
+//
+//  // send message with specified time
+//  mapStringData := map[string]string{
+//  	"foo":  "bar",
+//  }
+//  tm := time.Now()
+//  f.PostWithTime("tag_name", tm, mapStringData)
+//
+//  // send struct
+//  structData := struct {
+//  		Name string `msg:"name"`
+//  } {
+//  		"john smith",
+//  }
+//  f.Post("tag_name", structData)
+//
+func (f *Fluent) Post(tag string, message interface{}) error {
+	timeNow := time.Now()
+	return f.PostWithTime(tag, timeNow, message)
+}
+
+func (f *Fluent) PostWithTime(tag string, tm time.Time, message interface{}) error {
+	if len(f.TagPrefix) > 0 {
+		tag = f.TagPrefix + "." + tag
+	}
+
+	msg := reflect.ValueOf(message)
+	msgtype := msg.Type()
+
+	if msgtype.Kind() == reflect.Struct {
+		// message should be tagged by "codec" or "msg"
+		kv := make(map[string]interface{})
+		fields := msgtype.NumField()
+		for i := 0; i < fields; i++ {
+			field := msgtype.Field(i)
+			name := field.Name
+			if n1 := field.Tag.Get("msg"); n1 != "" {
+				name = n1
+			} else if n2 := field.Tag.Get("codec"); n2 != "" {
+				name = n2
+			}
+			kv[name] = msg.FieldByIndex(field.Index).Interface()
+		}
+		return f.EncodeAndPostData(tag, tm, kv)
+	}
+
+	if msgtype.Kind() != reflect.Map {
+		return errors.New("fluent#PostWithTime: message must be a map")
+	} else if msgtype.Key().Kind() != reflect.String {
+		return errors.New("fluent#PostWithTime: map keys must be strings")
+	}
+
+	kv := make(map[string]interface{})
+	for _, k := range msg.MapKeys() {
+		kv[k.String()] = msg.MapIndex(k).Interface()
+	}
+
+	return f.EncodeAndPostData(tag, tm, kv)
+}
+
+func (f *Fluent) EncodeAndPostData(tag string, tm time.Time, message interface{}) error {
+	var data []byte
+	var err error
+	if data, err = f.EncodeData(tag, tm, message); err != nil {
+		return fmt.Errorf("fluent#EncodeAndPostData: can't convert '%#v' to msgpack:%v", message, err)
+	}
+	return f.postRawData(data)
+}
+
+// Deprecated: Use EncodeAndPostData instead
+func (f *Fluent) PostRawData(data []byte) {
+	f.postRawData(data)
+}
+
+func (f *Fluent) postRawData(data []byte) error {
+	if err := f.appendBuffer(data); err != nil {
+		return err
+	}
+	if err := f.send(); err != nil {
+		f.close()
+		return err
+	}
+	return nil
+}
+
+// For sending forward protocol adopted JSON
+type MessageChunk struct {
+	message Message
+}
+
+// Golang default marshaler does not support
+// ["value", "value2", {"key":"value"}] style marshaling.
+// So, it should write JSON marshaler by hand.
+func (chunk *MessageChunk) MarshalJSON() ([]byte, error) {
+	data, err := json.Marshal(chunk.message.Record)
+	return []byte(fmt.Sprintf("[\"%s\",%d,%s,null]", chunk.message.Tag,
+		chunk.message.Time, data)), err
+}
+
+func (f *Fluent) EncodeData(tag string, tm time.Time, message interface{}) (data []byte, err error) {
+	timeUnix := tm.Unix()
+	if f.Config.MarshalAsJSON {
+		msg := Message{Tag: tag, Time: timeUnix, Record: message}
+		chunk := &MessageChunk{message: msg}
+		data, err = json.Marshal(chunk)
+	} else if f.Config.SubSecondPrecision {
+		msg := &MessageExt{Tag: tag, Time: EventTime(tm), Record: message}
+		data, err = msg.MarshalMsg(nil)
+	} else {
+		msg := &Message{Tag: tag, Time: timeUnix, Record: message}
+		data, err = msg.MarshalMsg(nil)
+	}
+	return
+}
+
+// Close closes the connection.
+func (f *Fluent) Close() (err error) {
+	if len(f.pending) > 0 {
+		err = f.send()
+	}
+	f.close()
+	return
+}
+
+// appendBuffer appends data to buffer with lock.
+func (f *Fluent) appendBuffer(data []byte) error {
+	f.mubuff.Lock()
+	defer f.mubuff.Unlock()
+	if len(f.pending)+len(data) > f.Config.BufferLimit {
+		return errors.New(fmt.Sprintf("fluent#appendBuffer: Buffer full, limit %v", f.Config.BufferLimit))
+	}
+	f.pending = append(f.pending, data...)
+	return nil
+}
+
+// close closes the connection.
+func (f *Fluent) close() {
+	f.muconn.Lock()
+	if f.conn != nil {
+		f.conn.Close()
+		f.conn = nil
+	}
+	f.muconn.Unlock()
+}
+
+// connect establishes a new connection using the specified transport.
+func (f *Fluent) connect() (err error) {
+	f.muconn.Lock()
+	defer f.muconn.Unlock()
+
+	switch f.Config.FluentNetwork {
+	case "tcp":
+		f.conn, err = net.DialTimeout(f.Config.FluentNetwork, f.Config.FluentHost+":"+strconv.Itoa(f.Config.FluentPort), f.Config.Timeout)
+	case "unix":
+		f.conn, err = net.DialTimeout(f.Config.FluentNetwork, f.Config.FluentSocketPath, f.Config.Timeout)
+	default:
+		err = net.UnknownNetworkError(f.Config.FluentNetwork)
+	}
+
+	if err == nil {
+		f.reconnecting = false
+	}
+	return
+}
+
+func e(x, y float64) int {
+	return int(math.Pow(x, y))
+}
+
+func (f *Fluent) reconnect() {
+	for i := 0; ; i++ {
+		err := f.connect()
+		if err == nil {
+			f.send()
+			return
+		}
+		if i == f.Config.MaxRetry {
+			// TODO: What we can do when connection failed MaxRetry times?
+			panic("fluent#reconnect: failed to reconnect!")
+		}
+		waitTime := f.Config.RetryWait * e(defaultReconnectWaitIncreRate, float64(i-1))
+		time.Sleep(time.Duration(waitTime) * time.Millisecond)
+	}
+}
+
+func (f *Fluent) send() error {
+	f.muconn.Lock()
+	defer f.muconn.Unlock()
+
+	if f.conn == nil {
+		if f.reconnecting == false {
+			f.reconnecting = true
+			go f.reconnect()
+		}
+		return errors.New("fluent#send: can't send logs, client is reconnecting")
+	}
+
+	f.mubuff.Lock()
+	defer f.mubuff.Unlock()
+
+	var err error
+	if len(f.pending) > 0 {
+		t := f.Config.WriteTimeout
+		if time.Duration(0) < t {
+			f.conn.SetWriteDeadline(time.Now().Add(t))
+		} else {
+			f.conn.SetWriteDeadline(time.Time{})
+		}
+		_, err = f.conn.Write(f.pending)
+		if err != nil {
+			f.conn.Close()
+			f.conn = nil
+		} else {
+			f.pending = f.pending[:0]
+		}
+	}
+	return err
+}

--- a/vendor/github.com/fluent/fluent-logger-golang/fluent/proto.go
+++ b/vendor/github.com/fluent/fluent-logger-golang/fluent/proto.go
@@ -1,0 +1,96 @@
+//go:generate msgp
+
+package fluent
+
+import (
+	"time"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+//msgp:tuple Entry
+type Entry struct {
+	Time   int64       `msg:"time"`
+	Record interface{} `msg:"record"`
+}
+
+//msgp:tuple Forward
+type Forward struct {
+	Tag     string      `msg:"tag"`
+	Entries []Entry     `msg:"entries"`
+	Option  interface{} `msg:"option"`
+}
+
+//msgp:tuple Message
+type Message struct {
+	Tag    string      `msg:"tag"`
+	Time   int64       `msg:"time"`
+	Record interface{} `msg:"record"`
+	Option interface{} `msg:"option"`
+}
+
+//msgp:tuple MessageExt
+type MessageExt struct {
+	Tag    string      `msg:"tag"`
+	Time   EventTime   `msg:"time,extension"`
+	Record interface{} `msg:"record"`
+	Option interface{} `msg:"option"`
+}
+
+// EventTime is an extension to the serialized time value. It builds in support
+// for sub-second (nanosecond) precision in serialized timestamps.
+//
+// You can find the full specification for the msgpack message payload here:
+// https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1.
+//
+// You can find more information on msgpack extension types here:
+// https://github.com/tinylib/msgp/wiki/Using-Extensions.
+type EventTime time.Time
+
+const (
+	extensionType = 0
+	length        = 8
+)
+
+func init() {
+	msgp.RegisterExtension(extensionType, func() msgp.Extension { return new(EventTime) })
+}
+
+func (t *EventTime) ExtensionType() int8 { return extensionType }
+
+func (t *EventTime) Len() int { return length }
+
+func (t *EventTime) MarshalBinaryTo(b []byte) error {
+	// Unwrap to Golang time
+	goTime := time.Time(*t)
+
+	// There's no support for timezones in fluentd's protocol for EventTime.
+	// Convert to UTC.
+	utc := goTime.UTC()
+
+	// Warning! Converting seconds to an int32 is a lossy operation. This code
+	// will hit the "Year 2038" problem.
+	sec := int32(utc.Unix())
+	nsec := utc.Nanosecond()
+
+	// Fill the buffer with 4 bytes for the second component of the timestamp.
+	b[0] = byte(sec >> 24)
+	b[1] = byte(sec >> 16)
+	b[2] = byte(sec >> 8)
+	b[3] = byte(sec)
+
+	// Fill the buffer with 4 bytes for the nanosecond component of the
+	// timestamp.
+	b[4] = byte(nsec >> 24)
+	b[5] = byte(nsec >> 16)
+	b[6] = byte(nsec >> 8)
+	b[7] = byte(nsec)
+
+	return nil
+}
+
+// UnmarshalBinary is not implemented since decoding messages is not supported
+// by this library.
+func (t *EventTime) UnmarshalBinary(b []byte) error {
+	return nil
+}

--- a/vendor/github.com/fluent/fluent-logger-golang/fluent/proto_gen.go
+++ b/vendor/github.com/fluent/fluent-logger-golang/fluent/proto_gen.go
@@ -1,0 +1,489 @@
+package fluent
+
+// NOTE: THIS FILE WAS PRODUCED BY THE
+// MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
+// DO NOT EDIT
+
+import (
+	"github.com/tinylib/msgp/msgp"
+)
+
+// DecodeMsg implements msgp.Decodable
+func (z *Entry) DecodeMsg(dc *msgp.Reader) (err error) {
+	var zxvk uint32
+	zxvk, err = dc.ReadArrayHeader()
+	if err != nil {
+		return
+	}
+	if zxvk != 2 {
+		err = msgp.ArrayError{Wanted: 2, Got: zxvk}
+		return
+	}
+	z.Time, err = dc.ReadInt64()
+	if err != nil {
+		return
+	}
+	z.Record, err = dc.ReadIntf()
+	if err != nil {
+		return
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z Entry) EncodeMsg(en *msgp.Writer) (err error) {
+	// array header, size 2
+	err = en.Append(0x92)
+	if err != nil {
+		return err
+	}
+	err = en.WriteInt64(z.Time)
+	if err != nil {
+		return
+	}
+	err = en.WriteIntf(z.Record)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z Entry) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// array header, size 2
+	o = append(o, 0x92)
+	o = msgp.AppendInt64(o, z.Time)
+	o, err = msgp.AppendIntf(o, z.Record)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *Entry) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var zbzg uint32
+	zbzg, bts, err = msgp.ReadArrayHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	if zbzg != 2 {
+		err = msgp.ArrayError{Wanted: 2, Got: zbzg}
+		return
+	}
+	z.Time, bts, err = msgp.ReadInt64Bytes(bts)
+	if err != nil {
+		return
+	}
+	z.Record, bts, err = msgp.ReadIntfBytes(bts)
+	if err != nil {
+		return
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z Entry) Msgsize() (s int) {
+	s = 1 + msgp.Int64Size + msgp.GuessSize(z.Record)
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *Forward) DecodeMsg(dc *msgp.Reader) (err error) {
+	var zcmr uint32
+	zcmr, err = dc.ReadArrayHeader()
+	if err != nil {
+		return
+	}
+	if zcmr != 3 {
+		err = msgp.ArrayError{Wanted: 3, Got: zcmr}
+		return
+	}
+	z.Tag, err = dc.ReadString()
+	if err != nil {
+		return
+	}
+	var zajw uint32
+	zajw, err = dc.ReadArrayHeader()
+	if err != nil {
+		return
+	}
+	if cap(z.Entries) >= int(zajw) {
+		z.Entries = (z.Entries)[:zajw]
+	} else {
+		z.Entries = make([]Entry, zajw)
+	}
+	for zbai := range z.Entries {
+		var zwht uint32
+		zwht, err = dc.ReadArrayHeader()
+		if err != nil {
+			return
+		}
+		if zwht != 2 {
+			err = msgp.ArrayError{Wanted: 2, Got: zwht}
+			return
+		}
+		z.Entries[zbai].Time, err = dc.ReadInt64()
+		if err != nil {
+			return
+		}
+		z.Entries[zbai].Record, err = dc.ReadIntf()
+		if err != nil {
+			return
+		}
+	}
+	z.Option, err = dc.ReadIntf()
+	if err != nil {
+		return
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *Forward) EncodeMsg(en *msgp.Writer) (err error) {
+	// array header, size 3
+	err = en.Append(0x93)
+	if err != nil {
+		return err
+	}
+	err = en.WriteString(z.Tag)
+	if err != nil {
+		return
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Entries)))
+	if err != nil {
+		return
+	}
+	for zbai := range z.Entries {
+		// array header, size 2
+		err = en.Append(0x92)
+		if err != nil {
+			return err
+		}
+		err = en.WriteInt64(z.Entries[zbai].Time)
+		if err != nil {
+			return
+		}
+		err = en.WriteIntf(z.Entries[zbai].Record)
+		if err != nil {
+			return
+		}
+	}
+	err = en.WriteIntf(z.Option)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *Forward) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// array header, size 3
+	o = append(o, 0x93)
+	o = msgp.AppendString(o, z.Tag)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Entries)))
+	for zbai := range z.Entries {
+		// array header, size 2
+		o = append(o, 0x92)
+		o = msgp.AppendInt64(o, z.Entries[zbai].Time)
+		o, err = msgp.AppendIntf(o, z.Entries[zbai].Record)
+		if err != nil {
+			return
+		}
+	}
+	o, err = msgp.AppendIntf(o, z.Option)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *Forward) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var zhct uint32
+	zhct, bts, err = msgp.ReadArrayHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	if zhct != 3 {
+		err = msgp.ArrayError{Wanted: 3, Got: zhct}
+		return
+	}
+	z.Tag, bts, err = msgp.ReadStringBytes(bts)
+	if err != nil {
+		return
+	}
+	var zcua uint32
+	zcua, bts, err = msgp.ReadArrayHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	if cap(z.Entries) >= int(zcua) {
+		z.Entries = (z.Entries)[:zcua]
+	} else {
+		z.Entries = make([]Entry, zcua)
+	}
+	for zbai := range z.Entries {
+		var zxhx uint32
+		zxhx, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			return
+		}
+		if zxhx != 2 {
+			err = msgp.ArrayError{Wanted: 2, Got: zxhx}
+			return
+		}
+		z.Entries[zbai].Time, bts, err = msgp.ReadInt64Bytes(bts)
+		if err != nil {
+			return
+		}
+		z.Entries[zbai].Record, bts, err = msgp.ReadIntfBytes(bts)
+		if err != nil {
+			return
+		}
+	}
+	z.Option, bts, err = msgp.ReadIntfBytes(bts)
+	if err != nil {
+		return
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *Forward) Msgsize() (s int) {
+	s = 1 + msgp.StringPrefixSize + len(z.Tag) + msgp.ArrayHeaderSize
+	for zbai := range z.Entries {
+		s += 1 + msgp.Int64Size + msgp.GuessSize(z.Entries[zbai].Record)
+	}
+	s += msgp.GuessSize(z.Option)
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *Message) DecodeMsg(dc *msgp.Reader) (err error) {
+	var zlqf uint32
+	zlqf, err = dc.ReadArrayHeader()
+	if err != nil {
+		return
+	}
+	if zlqf != 4 {
+		err = msgp.ArrayError{Wanted: 4, Got: zlqf}
+		return
+	}
+	z.Tag, err = dc.ReadString()
+	if err != nil {
+		return
+	}
+	z.Time, err = dc.ReadInt64()
+	if err != nil {
+		return
+	}
+	z.Record, err = dc.ReadIntf()
+	if err != nil {
+		return
+	}
+	z.Option, err = dc.ReadIntf()
+	if err != nil {
+		return
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *Message) EncodeMsg(en *msgp.Writer) (err error) {
+	// array header, size 4
+	err = en.Append(0x94)
+	if err != nil {
+		return err
+	}
+	err = en.WriteString(z.Tag)
+	if err != nil {
+		return
+	}
+	err = en.WriteInt64(z.Time)
+	if err != nil {
+		return
+	}
+	err = en.WriteIntf(z.Record)
+	if err != nil {
+		return
+	}
+	err = en.WriteIntf(z.Option)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *Message) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// array header, size 4
+	o = append(o, 0x94)
+	o = msgp.AppendString(o, z.Tag)
+	o = msgp.AppendInt64(o, z.Time)
+	o, err = msgp.AppendIntf(o, z.Record)
+	if err != nil {
+		return
+	}
+	o, err = msgp.AppendIntf(o, z.Option)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *Message) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var zdaf uint32
+	zdaf, bts, err = msgp.ReadArrayHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	if zdaf != 4 {
+		err = msgp.ArrayError{Wanted: 4, Got: zdaf}
+		return
+	}
+	z.Tag, bts, err = msgp.ReadStringBytes(bts)
+	if err != nil {
+		return
+	}
+	z.Time, bts, err = msgp.ReadInt64Bytes(bts)
+	if err != nil {
+		return
+	}
+	z.Record, bts, err = msgp.ReadIntfBytes(bts)
+	if err != nil {
+		return
+	}
+	z.Option, bts, err = msgp.ReadIntfBytes(bts)
+	if err != nil {
+		return
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *Message) Msgsize() (s int) {
+	s = 1 + msgp.StringPrefixSize + len(z.Tag) + msgp.Int64Size + msgp.GuessSize(z.Record) + msgp.GuessSize(z.Option)
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *MessageExt) DecodeMsg(dc *msgp.Reader) (err error) {
+	var zpks uint32
+	zpks, err = dc.ReadArrayHeader()
+	if err != nil {
+		return
+	}
+	if zpks != 4 {
+		err = msgp.ArrayError{Wanted: 4, Got: zpks}
+		return
+	}
+	z.Tag, err = dc.ReadString()
+	if err != nil {
+		return
+	}
+	err = dc.ReadExtension(&z.Time)
+	if err != nil {
+		return
+	}
+	z.Record, err = dc.ReadIntf()
+	if err != nil {
+		return
+	}
+	z.Option, err = dc.ReadIntf()
+	if err != nil {
+		return
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *MessageExt) EncodeMsg(en *msgp.Writer) (err error) {
+	// array header, size 4
+	err = en.Append(0x94)
+	if err != nil {
+		return err
+	}
+	err = en.WriteString(z.Tag)
+	if err != nil {
+		return
+	}
+	err = en.WriteExtension(&z.Time)
+	if err != nil {
+		return
+	}
+	err = en.WriteIntf(z.Record)
+	if err != nil {
+		return
+	}
+	err = en.WriteIntf(z.Option)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *MessageExt) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// array header, size 4
+	o = append(o, 0x94)
+	o = msgp.AppendString(o, z.Tag)
+	o, err = msgp.AppendExtension(o, &z.Time)
+	if err != nil {
+		return
+	}
+	o, err = msgp.AppendIntf(o, z.Record)
+	if err != nil {
+		return
+	}
+	o, err = msgp.AppendIntf(o, z.Option)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *MessageExt) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var zjfb uint32
+	zjfb, bts, err = msgp.ReadArrayHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	if zjfb != 4 {
+		err = msgp.ArrayError{Wanted: 4, Got: zjfb}
+		return
+	}
+	z.Tag, bts, err = msgp.ReadStringBytes(bts)
+	if err != nil {
+		return
+	}
+	bts, err = msgp.ReadExtensionBytes(bts, &z.Time)
+	if err != nil {
+		return
+	}
+	z.Record, bts, err = msgp.ReadIntfBytes(bts)
+	if err != nil {
+		return
+	}
+	z.Option, bts, err = msgp.ReadIntfBytes(bts)
+	if err != nil {
+		return
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *MessageExt) Msgsize() (s int) {
+	s = 1 + msgp.StringPrefixSize + len(z.Tag) + msgp.ExtensionPrefixSize + z.Time.Len() + msgp.GuessSize(z.Record) + msgp.GuessSize(z.Option)
+	return
+}

--- a/vendor/github.com/fluent/fluent-logger-golang/fluent/version.go
+++ b/vendor/github.com/fluent/fluent-logger-golang/fluent/version.go
@@ -1,0 +1,3 @@
+package fluent
+
+const Version = "1.2.1"

--- a/vendor/github.com/philhofer/fwd/LICENSE.md
+++ b/vendor/github.com/philhofer/fwd/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright (c) 2014-2015, Philip Hofer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/philhofer/fwd/README.md
+++ b/vendor/github.com/philhofer/fwd/README.md
@@ -1,0 +1,315 @@
+
+# fwd
+    import "github.com/philhofer/fwd"
+
+The `fwd` package provides a buffered reader
+and writer. Each has methods that help improve
+the encoding/decoding performance of some binary
+protocols.
+
+The `fwd.Writer` and `fwd.Reader` type provide similar
+functionality to their counterparts in `bufio`, plus
+a few extra utility methods that simplify read-ahead
+and write-ahead. I wrote this package to improve serialization
+performance for <a href="http://github.com/tinylib/msgp">http://github.com/tinylib/msgp</a>,
+where it provided about a 2x speedup over `bufio` for certain
+workloads. However, care must be taken to understand the semantics of the
+extra methods provided by this package, as they allow
+the user to access and manipulate the buffer memory
+directly.
+
+The extra methods for `fwd.Reader` are `Peek`, `Skip`
+and `Next`. `(*fwd.Reader).Peek`, unlike `(*bufio.Reader).Peek`,
+will re-allocate the read buffer in order to accommodate arbitrarily
+large read-ahead. `(*fwd.Reader).Skip` skips the next `n` bytes
+in the stream, and uses the `io.Seeker` interface if the underlying
+stream implements it. `(*fwd.Reader).Next` returns a slice pointing
+to the next `n` bytes in the read buffer (like `Peek`), but also
+increments the read position. This allows users to process streams
+in arbitrary block sizes without having to manage appropriately-sized
+slices. Additionally, obviating the need to copy the data from the
+buffer to another location in memory can improve performance dramatically
+in CPU-bound applications.
+
+`fwd.Writer` only has one extra method, which is `(*fwd.Writer).Next`, which
+returns a slice pointing to the next `n` bytes of the writer, and increments
+the write position by the length of the returned slice. This allows users
+to write directly to the end of the buffer.
+
+
+
+
+## Constants
+``` go
+const (
+    // DefaultReaderSize is the default size of the read buffer
+    DefaultReaderSize = 2048
+)
+```
+``` go
+const (
+    // DefaultWriterSize is the
+    // default write buffer size.
+    DefaultWriterSize = 2048
+)
+```
+
+
+
+## type Reader
+``` go
+type Reader struct {
+    // contains filtered or unexported fields
+}
+```
+Reader is a buffered look-ahead reader
+
+
+
+
+
+
+
+
+
+### func NewReader
+``` go
+func NewReader(r io.Reader) *Reader
+```
+NewReader returns a new *Reader that reads from 'r'
+
+
+### func NewReaderSize
+``` go
+func NewReaderSize(r io.Reader, n int) *Reader
+```
+NewReaderSize returns a new *Reader that
+reads from 'r' and has a buffer size 'n'
+
+
+
+
+### func (\*Reader) BufferSize
+``` go
+func (r *Reader) BufferSize() int
+```
+BufferSize returns the total size of the buffer
+
+
+
+### func (\*Reader) Buffered
+``` go
+func (r *Reader) Buffered() int
+```
+Buffered returns the number of bytes currently in the buffer
+
+
+
+### func (\*Reader) Next
+``` go
+func (r *Reader) Next(n int) ([]byte, error)
+```
+Next returns the next 'n' bytes in the stream.
+Unlike Peek, Next advances the reader position.
+The returned bytes point to the same
+data as the buffer, so the slice is
+only valid until the next reader method call.
+An EOF is considered an unexpected error.
+If an the returned slice is less than the
+length asked for, an error will be returned,
+and the reader position will not be incremented.
+
+
+
+### func (\*Reader) Peek
+``` go
+func (r *Reader) Peek(n int) ([]byte, error)
+```
+Peek returns the next 'n' buffered bytes,
+reading from the underlying reader if necessary.
+It will only return a slice shorter than 'n' bytes
+if it also returns an error. Peek does not advance
+the reader. EOF errors are *not* returned as
+io.ErrUnexpectedEOF.
+
+
+
+### func (\*Reader) Read
+``` go
+func (r *Reader) Read(b []byte) (int, error)
+```
+Read implements `io.Reader`
+
+
+
+### func (\*Reader) ReadByte
+``` go
+func (r *Reader) ReadByte() (byte, error)
+```
+ReadByte implements `io.ByteReader`
+
+
+
+### func (\*Reader) ReadFull
+``` go
+func (r *Reader) ReadFull(b []byte) (int, error)
+```
+ReadFull attempts to read len(b) bytes into
+'b'. It returns the number of bytes read into
+'b', and an error if it does not return len(b).
+EOF is considered an unexpected error.
+
+
+
+### func (\*Reader) Reset
+``` go
+func (r *Reader) Reset(rd io.Reader)
+```
+Reset resets the underlying reader
+and the read buffer.
+
+
+
+### func (\*Reader) Skip
+``` go
+func (r *Reader) Skip(n int) (int, error)
+```
+Skip moves the reader forward 'n' bytes.
+Returns the number of bytes skipped and any
+errors encountered. It is analogous to Seek(n, 1).
+If the underlying reader implements io.Seeker, then
+that method will be used to skip forward.
+
+If the reader encounters
+an EOF before skipping 'n' bytes, it
+returns io.ErrUnexpectedEOF. If the
+underlying reader implements io.Seeker, then
+those rules apply instead. (Many implementations
+will not return `io.EOF` until the next call
+to Read.)
+
+
+
+### func (\*Reader) WriteTo
+``` go
+func (r *Reader) WriteTo(w io.Writer) (int64, error)
+```
+WriteTo implements `io.WriterTo`
+
+
+
+## type Writer
+``` go
+type Writer struct {
+    // contains filtered or unexported fields
+}
+```
+Writer is a buffered writer
+
+
+
+
+
+
+
+
+
+### func NewWriter
+``` go
+func NewWriter(w io.Writer) *Writer
+```
+NewWriter returns a new writer
+that writes to 'w' and has a buffer
+that is `DefaultWriterSize` bytes.
+
+
+### func NewWriterSize
+``` go
+func NewWriterSize(w io.Writer, size int) *Writer
+```
+NewWriterSize returns a new writer
+that writes to 'w' and has a buffer
+that is 'size' bytes.
+
+
+
+
+### func (\*Writer) BufferSize
+``` go
+func (w *Writer) BufferSize() int
+```
+BufferSize returns the maximum size of the buffer.
+
+
+
+### func (\*Writer) Buffered
+``` go
+func (w *Writer) Buffered() int
+```
+Buffered returns the number of buffered bytes
+in the reader.
+
+
+
+### func (\*Writer) Flush
+``` go
+func (w *Writer) Flush() error
+```
+Flush flushes any buffered bytes
+to the underlying writer.
+
+
+
+### func (\*Writer) Next
+``` go
+func (w *Writer) Next(n int) ([]byte, error)
+```
+Next returns the next 'n' free bytes
+in the write buffer, flushing the writer
+as necessary. Next will return `io.ErrShortBuffer`
+if 'n' is greater than the size of the write buffer.
+Calls to 'next' increment the write position by
+the size of the returned buffer.
+
+
+
+### func (\*Writer) ReadFrom
+``` go
+func (w *Writer) ReadFrom(r io.Reader) (int64, error)
+```
+ReadFrom implements `io.ReaderFrom`
+
+
+
+### func (\*Writer) Write
+``` go
+func (w *Writer) Write(p []byte) (int, error)
+```
+Write implements `io.Writer`
+
+
+
+### func (\*Writer) WriteByte
+``` go
+func (w *Writer) WriteByte(b byte) error
+```
+WriteByte implements `io.ByteWriter`
+
+
+
+### func (\*Writer) WriteString
+``` go
+func (w *Writer) WriteString(s string) (int, error)
+```
+WriteString is analogous to Write, but it takes a string.
+
+
+
+
+
+
+
+
+
+- - -
+Generated by [godoc2md](http://godoc.org/github.com/davecheney/godoc2md)

--- a/vendor/github.com/philhofer/fwd/reader.go
+++ b/vendor/github.com/philhofer/fwd/reader.go
@@ -1,0 +1,379 @@
+// The `fwd` package provides a buffered reader
+// and writer. Each has methods that help improve
+// the encoding/decoding performance of some binary
+// protocols.
+//
+// The `fwd.Writer` and `fwd.Reader` type provide similar
+// functionality to their counterparts in `bufio`, plus
+// a few extra utility methods that simplify read-ahead
+// and write-ahead. I wrote this package to improve serialization
+// performance for http://github.com/tinylib/msgp,
+// where it provided about a 2x speedup over `bufio` for certain
+// workloads. However, care must be taken to understand the semantics of the
+// extra methods provided by this package, as they allow
+// the user to access and manipulate the buffer memory
+// directly.
+//
+// The extra methods for `fwd.Reader` are `Peek`, `Skip`
+// and `Next`. `(*fwd.Reader).Peek`, unlike `(*bufio.Reader).Peek`,
+// will re-allocate the read buffer in order to accommodate arbitrarily
+// large read-ahead. `(*fwd.Reader).Skip` skips the next `n` bytes
+// in the stream, and uses the `io.Seeker` interface if the underlying
+// stream implements it. `(*fwd.Reader).Next` returns a slice pointing
+// to the next `n` bytes in the read buffer (like `Peek`), but also
+// increments the read position. This allows users to process streams
+// in arbitrary block sizes without having to manage appropriately-sized
+// slices. Additionally, obviating the need to copy the data from the
+// buffer to another location in memory can improve performance dramatically
+// in CPU-bound applications.
+//
+// `fwd.Writer` only has one extra method, which is `(*fwd.Writer).Next`, which
+// returns a slice pointing to the next `n` bytes of the writer, and increments
+// the write position by the length of the returned slice. This allows users
+// to write directly to the end of the buffer.
+//
+package fwd
+
+import "io"
+
+const (
+	// DefaultReaderSize is the default size of the read buffer
+	DefaultReaderSize = 2048
+
+	// minimum read buffer; straight from bufio
+	minReaderSize = 16
+)
+
+// NewReader returns a new *Reader that reads from 'r'
+func NewReader(r io.Reader) *Reader {
+	return NewReaderSize(r, DefaultReaderSize)
+}
+
+// NewReaderSize returns a new *Reader that
+// reads from 'r' and has a buffer size 'n'
+func NewReaderSize(r io.Reader, n int) *Reader {
+	rd := &Reader{
+		r:    r,
+		data: make([]byte, 0, max(minReaderSize, n)),
+	}
+	if s, ok := r.(io.Seeker); ok {
+		rd.rs = s
+	}
+	return rd
+}
+
+// Reader is a buffered look-ahead reader
+type Reader struct {
+	r io.Reader // underlying reader
+
+	// data[n:len(data)] is buffered data; data[len(data):cap(data)] is free buffer space
+	data  []byte // data
+	n     int    // read offset
+	state error  // last read error
+
+	// if the reader past to NewReader was
+	// also an io.Seeker, this is non-nil
+	rs io.Seeker
+}
+
+// Reset resets the underlying reader
+// and the read buffer.
+func (r *Reader) Reset(rd io.Reader) {
+	r.r = rd
+	r.data = r.data[0:0]
+	r.n = 0
+	r.state = nil
+	if s, ok := rd.(io.Seeker); ok {
+		r.rs = s
+	} else {
+		r.rs = nil
+	}
+}
+
+// more() does one read on the underlying reader
+func (r *Reader) more() {
+	// move data backwards so that
+	// the read offset is 0; this way
+	// we can supply the maximum number of
+	// bytes to the reader
+	if r.n != 0 {
+		if r.n < len(r.data) {
+			r.data = r.data[:copy(r.data[0:], r.data[r.n:])]
+		} else {
+			r.data = r.data[:0]
+		}
+		r.n = 0
+	}
+	var a int
+	a, r.state = r.r.Read(r.data[len(r.data):cap(r.data)])
+	if a == 0 && r.state == nil {
+		r.state = io.ErrNoProgress
+		return
+	}
+	r.data = r.data[:len(r.data)+a]
+}
+
+// pop error
+func (r *Reader) err() (e error) {
+	e, r.state = r.state, nil
+	return
+}
+
+// pop error; EOF -> io.ErrUnexpectedEOF
+func (r *Reader) noEOF() (e error) {
+	e, r.state = r.state, nil
+	if e == io.EOF {
+		e = io.ErrUnexpectedEOF
+	}
+	return
+}
+
+// buffered bytes
+func (r *Reader) buffered() int { return len(r.data) - r.n }
+
+// Buffered returns the number of bytes currently in the buffer
+func (r *Reader) Buffered() int { return len(r.data) - r.n }
+
+// BufferSize returns the total size of the buffer
+func (r *Reader) BufferSize() int { return cap(r.data) }
+
+// Peek returns the next 'n' buffered bytes,
+// reading from the underlying reader if necessary.
+// It will only return a slice shorter than 'n' bytes
+// if it also returns an error. Peek does not advance
+// the reader. EOF errors are *not* returned as
+// io.ErrUnexpectedEOF.
+func (r *Reader) Peek(n int) ([]byte, error) {
+	// in the degenerate case,
+	// we may need to realloc
+	// (the caller asked for more
+	// bytes than the size of the buffer)
+	if cap(r.data) < n {
+		old := r.data[r.n:]
+		r.data = make([]byte, n+r.buffered())
+		r.data = r.data[:copy(r.data, old)]
+		r.n = 0
+	}
+
+	// keep filling until
+	// we hit an error or
+	// read enough bytes
+	for r.buffered() < n && r.state == nil {
+		r.more()
+	}
+
+	// we must have hit an error
+	if r.buffered() < n {
+		return r.data[r.n:], r.err()
+	}
+
+	return r.data[r.n : r.n+n], nil
+}
+
+// Skip moves the reader forward 'n' bytes.
+// Returns the number of bytes skipped and any
+// errors encountered. It is analogous to Seek(n, 1).
+// If the underlying reader implements io.Seeker, then
+// that method will be used to skip forward.
+//
+// If the reader encounters
+// an EOF before skipping 'n' bytes, it
+// returns io.ErrUnexpectedEOF. If the
+// underlying reader implements io.Seeker, then
+// those rules apply instead. (Many implementations
+// will not return `io.EOF` until the next call
+// to Read.)
+func (r *Reader) Skip(n int) (int, error) {
+
+	// fast path
+	if r.buffered() >= n {
+		r.n += n
+		return n, nil
+	}
+
+	// use seeker implementation
+	// if we can
+	if r.rs != nil {
+		return r.skipSeek(n)
+	}
+
+	// loop on filling
+	// and then erasing
+	o := n
+	for r.buffered() < n && r.state == nil {
+		r.more()
+		// we can skip forward
+		// up to r.buffered() bytes
+		step := min(r.buffered(), n)
+		r.n += step
+		n -= step
+	}
+	// at this point, n should be
+	// 0 if everything went smoothly
+	return o - n, r.noEOF()
+}
+
+// Next returns the next 'n' bytes in the stream.
+// Unlike Peek, Next advances the reader position.
+// The returned bytes point to the same
+// data as the buffer, so the slice is
+// only valid until the next reader method call.
+// An EOF is considered an unexpected error.
+// If an the returned slice is less than the
+// length asked for, an error will be returned,
+// and the reader position will not be incremented.
+func (r *Reader) Next(n int) ([]byte, error) {
+
+	// in case the buffer is too small
+	if cap(r.data) < n {
+		old := r.data[r.n:]
+		r.data = make([]byte, n+r.buffered())
+		r.data = r.data[:copy(r.data, old)]
+		r.n = 0
+	}
+
+	// fill at least 'n' bytes
+	for r.buffered() < n && r.state == nil {
+		r.more()
+	}
+
+	if r.buffered() < n {
+		return r.data[r.n:], r.noEOF()
+	}
+	out := r.data[r.n : r.n+n]
+	r.n += n
+	return out, nil
+}
+
+// skipSeek uses the io.Seeker to seek forward.
+// only call this function when n > r.buffered()
+func (r *Reader) skipSeek(n int) (int, error) {
+	o := r.buffered()
+	// first, clear buffer
+	n -= o
+	r.n = 0
+	r.data = r.data[:0]
+
+	// then seek forward remaning bytes
+	i, err := r.rs.Seek(int64(n), 1)
+	return int(i) + o, err
+}
+
+// Read implements `io.Reader`
+func (r *Reader) Read(b []byte) (int, error) {
+	// if we have data in the buffer, just
+	// return that.
+	if r.buffered() != 0 {
+		x := copy(b, r.data[r.n:])
+		r.n += x
+		return x, nil
+	}
+	var n int
+	// we have no buffered data; determine
+	// whether or not to buffer or call
+	// the underlying reader directly
+	if len(b) >= cap(r.data) {
+		n, r.state = r.r.Read(b)
+	} else {
+		r.more()
+		n = copy(b, r.data)
+		r.n = n
+	}
+	if n == 0 {
+		return 0, r.err()
+	}
+	return n, nil
+}
+
+// ReadFull attempts to read len(b) bytes into
+// 'b'. It returns the number of bytes read into
+// 'b', and an error if it does not return len(b).
+// EOF is considered an unexpected error.
+func (r *Reader) ReadFull(b []byte) (int, error) {
+	var n int  // read into b
+	var nn int // scratch
+	l := len(b)
+	// either read buffered data,
+	// or read directly for the underlying
+	// buffer, or fetch more buffered data.
+	for n < l && r.state == nil {
+		if r.buffered() != 0 {
+			nn = copy(b[n:], r.data[r.n:])
+			n += nn
+			r.n += nn
+		} else if l-n > cap(r.data) {
+			nn, r.state = r.r.Read(b[n:])
+			n += nn
+		} else {
+			r.more()
+		}
+	}
+	if n < l {
+		return n, r.noEOF()
+	}
+	return n, nil
+}
+
+// ReadByte implements `io.ByteReader`
+func (r *Reader) ReadByte() (byte, error) {
+	for r.buffered() < 1 && r.state == nil {
+		r.more()
+	}
+	if r.buffered() < 1 {
+		return 0, r.err()
+	}
+	b := r.data[r.n]
+	r.n++
+	return b, nil
+}
+
+// WriteTo implements `io.WriterTo`
+func (r *Reader) WriteTo(w io.Writer) (int64, error) {
+	var (
+		i   int64
+		ii  int
+		err error
+	)
+	// first, clear buffer
+	if r.buffered() > 0 {
+		ii, err = w.Write(r.data[r.n:])
+		i += int64(ii)
+		if err != nil {
+			return i, err
+		}
+		r.data = r.data[0:0]
+		r.n = 0
+	}
+	for r.state == nil {
+		// here we just do
+		// 1:1 reads and writes
+		r.more()
+		if r.buffered() > 0 {
+			ii, err = w.Write(r.data)
+			i += int64(ii)
+			if err != nil {
+				return i, err
+			}
+			r.data = r.data[0:0]
+			r.n = 0
+		}
+	}
+	if r.state != io.EOF {
+		return i, r.err()
+	}
+	return i, nil
+}
+
+func min(a int, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a int, b int) int {
+	if a < b {
+		return b
+	}
+	return a
+}

--- a/vendor/github.com/philhofer/fwd/writer.go
+++ b/vendor/github.com/philhofer/fwd/writer.go
@@ -1,0 +1,224 @@
+package fwd
+
+import "io"
+
+const (
+	// DefaultWriterSize is the
+	// default write buffer size.
+	DefaultWriterSize = 2048
+
+	minWriterSize = minReaderSize
+)
+
+// Writer is a buffered writer
+type Writer struct {
+	w   io.Writer // writer
+	buf []byte    // 0:len(buf) is bufered data
+}
+
+// NewWriter returns a new writer
+// that writes to 'w' and has a buffer
+// that is `DefaultWriterSize` bytes.
+func NewWriter(w io.Writer) *Writer {
+	if wr, ok := w.(*Writer); ok {
+		return wr
+	}
+	return &Writer{
+		w:   w,
+		buf: make([]byte, 0, DefaultWriterSize),
+	}
+}
+
+// NewWriterSize returns a new writer
+// that writes to 'w' and has a buffer
+// that is 'size' bytes.
+func NewWriterSize(w io.Writer, size int) *Writer {
+	if wr, ok := w.(*Writer); ok && cap(wr.buf) >= size {
+		return wr
+	}
+	return &Writer{
+		w:   w,
+		buf: make([]byte, 0, max(size, minWriterSize)),
+	}
+}
+
+// Buffered returns the number of buffered bytes
+// in the reader.
+func (w *Writer) Buffered() int { return len(w.buf) }
+
+// BufferSize returns the maximum size of the buffer.
+func (w *Writer) BufferSize() int { return cap(w.buf) }
+
+// Flush flushes any buffered bytes
+// to the underlying writer.
+func (w *Writer) Flush() error {
+	l := len(w.buf)
+	if l > 0 {
+		n, err := w.w.Write(w.buf)
+
+		// if we didn't write the whole
+		// thing, copy the unwritten
+		// bytes to the beginnning of the
+		// buffer.
+		if n < l && n > 0 {
+			w.pushback(n)
+			if err == nil {
+				err = io.ErrShortWrite
+			}
+		}
+		if err != nil {
+			return err
+		}
+		w.buf = w.buf[:0]
+		return nil
+	}
+	return nil
+}
+
+// Write implements `io.Writer`
+func (w *Writer) Write(p []byte) (int, error) {
+	c, l, ln := cap(w.buf), len(w.buf), len(p)
+	avail := c - l
+
+	// requires flush
+	if avail < ln {
+		if err := w.Flush(); err != nil {
+			return 0, err
+		}
+		l = len(w.buf)
+	}
+	// too big to fit in buffer;
+	// write directly to w.w
+	if c < ln {
+		return w.w.Write(p)
+	}
+
+	// grow buf slice; copy; return
+	w.buf = w.buf[:l+ln]
+	return copy(w.buf[l:], p), nil
+}
+
+// WriteString is analogous to Write, but it takes a string.
+func (w *Writer) WriteString(s string) (int, error) {
+	c, l, ln := cap(w.buf), len(w.buf), len(s)
+	avail := c - l
+
+	// requires flush
+	if avail < ln {
+		if err := w.Flush(); err != nil {
+			return 0, err
+		}
+		l = len(w.buf)
+	}
+	// too big to fit in buffer;
+	// write directly to w.w
+	//
+	// yes, this is unsafe. *but*
+	// io.Writer is not allowed
+	// to mutate its input or
+	// maintain a reference to it,
+	// per the spec in package io.
+	//
+	// plus, if the string is really
+	// too big to fit in the buffer, then
+	// creating a copy to write it is
+	// expensive (and, strictly speaking,
+	// unnecessary)
+	if c < ln {
+		return w.w.Write(unsafestr(s))
+	}
+
+	// grow buf slice; copy; return
+	w.buf = w.buf[:l+ln]
+	return copy(w.buf[l:], s), nil
+}
+
+// WriteByte implements `io.ByteWriter`
+func (w *Writer) WriteByte(b byte) error {
+	if len(w.buf) == cap(w.buf) {
+		if err := w.Flush(); err != nil {
+			return err
+		}
+	}
+	w.buf = append(w.buf, b)
+	return nil
+}
+
+// Next returns the next 'n' free bytes
+// in the write buffer, flushing the writer
+// as necessary. Next will return `io.ErrShortBuffer`
+// if 'n' is greater than the size of the write buffer.
+// Calls to 'next' increment the write position by
+// the size of the returned buffer.
+func (w *Writer) Next(n int) ([]byte, error) {
+	c, l := cap(w.buf), len(w.buf)
+	if n > c {
+		return nil, io.ErrShortBuffer
+	}
+	avail := c - l
+	if avail < n {
+		if err := w.Flush(); err != nil {
+			return nil, err
+		}
+		l = len(w.buf)
+	}
+	w.buf = w.buf[:l+n]
+	return w.buf[l:], nil
+}
+
+// take the bytes from w.buf[n:len(w.buf)]
+// and put them at the beginning of w.buf,
+// and resize to the length of the copied segment.
+func (w *Writer) pushback(n int) {
+	w.buf = w.buf[:copy(w.buf, w.buf[n:])]
+}
+
+// ReadFrom implements `io.ReaderFrom`
+func (w *Writer) ReadFrom(r io.Reader) (int64, error) {
+	// anticipatory flush
+	if err := w.Flush(); err != nil {
+		return 0, err
+	}
+
+	w.buf = w.buf[0:cap(w.buf)] // expand buffer
+
+	var nn int64  // written
+	var err error // error
+	var x int     // read
+
+	// 1:1 reads and writes
+	for err == nil {
+		x, err = r.Read(w.buf)
+		if x > 0 {
+			n, werr := w.w.Write(w.buf[:x])
+			nn += int64(n)
+
+			if err != nil {
+				if n < x && n > 0 {
+					w.pushback(n - x)
+				}
+				return nn, werr
+			}
+			if n < x {
+				w.pushback(n - x)
+				return nn, io.ErrShortWrite
+			}
+		} else if err == nil {
+			err = io.ErrNoProgress
+			break
+		}
+	}
+	if err != io.EOF {
+		return nn, err
+	}
+
+	// we only clear here
+	// because we are sure
+	// the writes have
+	// succeeded. otherwise,
+	// we retain the data in case
+	// future writes succeed.
+	w.buf = w.buf[0:0]
+
+	return nn, nil
+}

--- a/vendor/github.com/philhofer/fwd/writer_appengine.go
+++ b/vendor/github.com/philhofer/fwd/writer_appengine.go
@@ -1,0 +1,5 @@
+// +build appengine
+
+package fwd
+
+func unsafestr(s string) []byte { return []byte(s) }

--- a/vendor/github.com/philhofer/fwd/writer_unsafe.go
+++ b/vendor/github.com/philhofer/fwd/writer_unsafe.go
@@ -1,0 +1,18 @@
+// +build !appengine
+
+package fwd
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// unsafe cast string as []byte
+func unsafestr(b string) []byte {
+	l := len(b)
+	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+		Len:  l,
+		Cap:  l,
+		Data: (*reflect.StringHeader)(unsafe.Pointer(&b)).Data,
+	}))
+}

--- a/vendor/github.com/tinylib/msgp/LICENSE
+++ b/vendor/github.com/tinylib/msgp/LICENSE
@@ -1,0 +1,8 @@
+Copyright (c) 2014 Philip Hofer
+Portions Copyright (c) 2009 The Go Authors (license at http://golang.org) where indicated
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/tinylib/msgp/msgp/advise_linux.go
+++ b/vendor/github.com/tinylib/msgp/msgp/advise_linux.go
@@ -1,0 +1,24 @@
+// +build linux,!appengine
+
+package msgp
+
+import (
+	"os"
+	"syscall"
+)
+
+func adviseRead(mem []byte) {
+	syscall.Madvise(mem, syscall.MADV_SEQUENTIAL|syscall.MADV_WILLNEED)
+}
+
+func adviseWrite(mem []byte) {
+	syscall.Madvise(mem, syscall.MADV_SEQUENTIAL)
+}
+
+func fallocate(f *os.File, sz int64) error {
+	err := syscall.Fallocate(int(f.Fd()), 0, 0, sz)
+	if err == syscall.ENOTSUP {
+		return f.Truncate(sz)
+	}
+	return err
+}

--- a/vendor/github.com/tinylib/msgp/msgp/advise_other.go
+++ b/vendor/github.com/tinylib/msgp/msgp/advise_other.go
@@ -1,0 +1,17 @@
+// +build !linux appengine
+
+package msgp
+
+import (
+	"os"
+)
+
+// TODO: darwin, BSD support
+
+func adviseRead(mem []byte) {}
+
+func adviseWrite(mem []byte) {}
+
+func fallocate(f *os.File, sz int64) error {
+	return f.Truncate(sz)
+}

--- a/vendor/github.com/tinylib/msgp/msgp/appengine.go
+++ b/vendor/github.com/tinylib/msgp/msgp/appengine.go
@@ -1,0 +1,15 @@
+// +build appengine
+
+package msgp
+
+// let's just assume appengine
+// uses 64-bit hardware...
+const smallint = false
+
+func UnsafeString(b []byte) string {
+	return string(b)
+}
+
+func UnsafeBytes(s string) []byte {
+	return []byte(s)
+}

--- a/vendor/github.com/tinylib/msgp/msgp/circular.go
+++ b/vendor/github.com/tinylib/msgp/msgp/circular.go
@@ -1,0 +1,39 @@
+package msgp
+
+type timer interface {
+	StartTimer()
+	StopTimer()
+}
+
+// EndlessReader is an io.Reader
+// that loops over the same data
+// endlessly. It is used for benchmarking.
+type EndlessReader struct {
+	tb     timer
+	data   []byte
+	offset int
+}
+
+// NewEndlessReader returns a new endless reader
+func NewEndlessReader(b []byte, tb timer) *EndlessReader {
+	return &EndlessReader{tb: tb, data: b, offset: 0}
+}
+
+// Read implements io.Reader. In practice, it
+// always returns (len(p), nil), although it
+// fills the supplied slice while the benchmark
+// timer is stopped.
+func (c *EndlessReader) Read(p []byte) (int, error) {
+	c.tb.StopTimer()
+	var n int
+	l := len(p)
+	m := len(c.data)
+	for n < l {
+		nn := copy(p[n:], c.data[c.offset:])
+		n += nn
+		c.offset += nn
+		c.offset %= m
+	}
+	c.tb.StartTimer()
+	return n, nil
+}

--- a/vendor/github.com/tinylib/msgp/msgp/defs.go
+++ b/vendor/github.com/tinylib/msgp/msgp/defs.go
@@ -1,0 +1,142 @@
+// This package is the support library for the msgp code generator (http://github.com/tinylib/msgp).
+//
+// This package defines the utilites used by the msgp code generator for encoding and decoding MessagePack
+// from []byte and io.Reader/io.Writer types. Much of this package is devoted to helping the msgp code
+// generator implement the Marshaler/Unmarshaler and Encodable/Decodable interfaces.
+//
+// This package defines four "families" of functions:
+// 	- AppendXxxx() appends an object to a []byte in MessagePack encoding.
+// 	- ReadXxxxBytes() reads an object from a []byte and returns the remaining bytes.
+// 	- (*Writer).WriteXxxx() writes an object to the buffered *Writer type.
+// 	- (*Reader).ReadXxxx() reads an object from a buffered *Reader type.
+//
+// Once a type has satisfied the `Encodable` and `Decodable` interfaces,
+// it can be written and read from arbitrary `io.Writer`s and `io.Reader`s using
+// 		msgp.Encode(io.Writer, msgp.Encodable)
+// and
+//		msgp.Decode(io.Reader, msgp.Decodable)
+//
+// There are also methods for converting MessagePack to JSON without
+// an explicit de-serialization step.
+//
+// For additional tips, tricks, and gotchas, please visit
+// the wiki at http://github.com/tinylib/msgp
+package msgp
+
+const last4 = 0x0f
+const first4 = 0xf0
+const last5 = 0x1f
+const first3 = 0xe0
+const last7 = 0x7f
+
+func isfixint(b byte) bool {
+	return b>>7 == 0
+}
+
+func isnfixint(b byte) bool {
+	return b&first3 == mnfixint
+}
+
+func isfixmap(b byte) bool {
+	return b&first4 == mfixmap
+}
+
+func isfixarray(b byte) bool {
+	return b&first4 == mfixarray
+}
+
+func isfixstr(b byte) bool {
+	return b&first3 == mfixstr
+}
+
+func wfixint(u uint8) byte {
+	return u & last7
+}
+
+func rfixint(b byte) uint8 {
+	return b
+}
+
+func wnfixint(i int8) byte {
+	return byte(i) | mnfixint
+}
+
+func rnfixint(b byte) int8 {
+	return int8(b)
+}
+
+func rfixmap(b byte) uint8 {
+	return b & last4
+}
+
+func wfixmap(u uint8) byte {
+	return mfixmap | (u & last4)
+}
+
+func rfixstr(b byte) uint8 {
+	return b & last5
+}
+
+func wfixstr(u uint8) byte {
+	return (u & last5) | mfixstr
+}
+
+func rfixarray(b byte) uint8 {
+	return (b & last4)
+}
+
+func wfixarray(u uint8) byte {
+	return (u & last4) | mfixarray
+}
+
+// These are all the byte
+// prefixes defined by the
+// msgpack standard
+const (
+	// 0XXXXXXX
+	mfixint uint8 = 0x00
+
+	// 111XXXXX
+	mnfixint uint8 = 0xe0
+
+	// 1000XXXX
+	mfixmap uint8 = 0x80
+
+	// 1001XXXX
+	mfixarray uint8 = 0x90
+
+	// 101XXXXX
+	mfixstr uint8 = 0xa0
+
+	mnil      uint8 = 0xc0
+	mfalse    uint8 = 0xc2
+	mtrue     uint8 = 0xc3
+	mbin8     uint8 = 0xc4
+	mbin16    uint8 = 0xc5
+	mbin32    uint8 = 0xc6
+	mext8     uint8 = 0xc7
+	mext16    uint8 = 0xc8
+	mext32    uint8 = 0xc9
+	mfloat32  uint8 = 0xca
+	mfloat64  uint8 = 0xcb
+	muint8    uint8 = 0xcc
+	muint16   uint8 = 0xcd
+	muint32   uint8 = 0xce
+	muint64   uint8 = 0xcf
+	mint8     uint8 = 0xd0
+	mint16    uint8 = 0xd1
+	mint32    uint8 = 0xd2
+	mint64    uint8 = 0xd3
+	mfixext1  uint8 = 0xd4
+	mfixext2  uint8 = 0xd5
+	mfixext4  uint8 = 0xd6
+	mfixext8  uint8 = 0xd7
+	mfixext16 uint8 = 0xd8
+	mstr8     uint8 = 0xd9
+	mstr16    uint8 = 0xda
+	mstr32    uint8 = 0xdb
+	marray16  uint8 = 0xdc
+	marray32  uint8 = 0xdd
+	mmap16    uint8 = 0xde
+	mmap32    uint8 = 0xdf
+)

--- a/vendor/github.com/tinylib/msgp/msgp/edit.go
+++ b/vendor/github.com/tinylib/msgp/msgp/edit.go
@@ -1,0 +1,241 @@
+package msgp
+
+import (
+	"math"
+)
+
+// Locate returns a []byte pointing to the field
+// in a messagepack map with the provided key. (The returned []byte
+// points to a sub-slice of 'raw'; Locate does no allocations.) If the
+// key doesn't exist in the map, a zero-length []byte will be returned.
+func Locate(key string, raw []byte) []byte {
+	s, n := locate(raw, key)
+	return raw[s:n]
+}
+
+// Replace takes a key ("key") in a messagepack map ("raw")
+// and replaces its value with the one provided and returns
+// the new []byte. The returned []byte may point to the same
+// memory as "raw". Replace makes no effort to evaluate the validity
+// of the contents of 'val'. It may use up to the full capacity of 'raw.'
+// Replace returns 'nil' if the field doesn't exist or if the object in 'raw'
+// is not a map.
+func Replace(key string, raw []byte, val []byte) []byte {
+	start, end := locate(raw, key)
+	if start == end {
+		return nil
+	}
+	return replace(raw, start, end, val, true)
+}
+
+// CopyReplace works similarly to Replace except that the returned
+// byte slice does not point to the same memory as 'raw'. CopyReplace
+// returns 'nil' if the field doesn't exist or 'raw' isn't a map.
+func CopyReplace(key string, raw []byte, val []byte) []byte {
+	start, end := locate(raw, key)
+	if start == end {
+		return nil
+	}
+	return replace(raw, start, end, val, false)
+}
+
+// Remove removes a key-value pair from 'raw'. It returns
+// 'raw' unchanged if the key didn't exist.
+func Remove(key string, raw []byte) []byte {
+	start, end := locateKV(raw, key)
+	if start == end {
+		return raw
+	}
+	raw = raw[:start+copy(raw[start:], raw[end:])]
+	return resizeMap(raw, -1)
+}
+
+// HasKey returns whether the map in 'raw' has
+// a field with key 'key'
+func HasKey(key string, raw []byte) bool {
+	sz, bts, err := ReadMapHeaderBytes(raw)
+	if err != nil {
+		return false
+	}
+	var field []byte
+	for i := uint32(0); i < sz; i++ {
+		field, bts, err = ReadStringZC(bts)
+		if err != nil {
+			return false
+		}
+		if UnsafeString(field) == key {
+			return true
+		}
+	}
+	return false
+}
+
+func replace(raw []byte, start int, end int, val []byte, inplace bool) []byte {
+	ll := end - start // length of segment to replace
+	lv := len(val)
+
+	if inplace {
+		extra := lv - ll
+
+		// fastest case: we're doing
+		// a 1:1 replacement
+		if extra == 0 {
+			copy(raw[start:], val)
+			return raw
+
+		} else if extra < 0 {
+			// 'val' smaller than replaced value
+			// copy in place and shift back
+
+			x := copy(raw[start:], val)
+			y := copy(raw[start+x:], raw[end:])
+			return raw[:start+x+y]
+
+		} else if extra < cap(raw)-len(raw) {
+			// 'val' less than (cap-len) extra bytes
+			// copy in place and shift forward
+			raw = raw[0 : len(raw)+extra]
+			// shift end forward
+			copy(raw[end+extra:], raw[end:])
+			copy(raw[start:], val)
+			return raw
+		}
+	}
+
+	// we have to allocate new space
+	out := make([]byte, len(raw)+len(val)-ll)
+	x := copy(out, raw[:start])
+	y := copy(out[x:], val)
+	copy(out[x+y:], raw[end:])
+	return out
+}
+
+// locate does a naive O(n) search for the map key; returns start, end
+// (returns 0,0 on error)
+func locate(raw []byte, key string) (start int, end int) {
+	var (
+		sz    uint32
+		bts   []byte
+		field []byte
+		err   error
+	)
+	sz, bts, err = ReadMapHeaderBytes(raw)
+	if err != nil {
+		return
+	}
+
+	// loop and locate field
+	for i := uint32(0); i < sz; i++ {
+		field, bts, err = ReadStringZC(bts)
+		if err != nil {
+			return 0, 0
+		}
+		if UnsafeString(field) == key {
+			// start location
+			l := len(raw)
+			start = l - len(bts)
+			bts, err = Skip(bts)
+			if err != nil {
+				return 0, 0
+			}
+			end = l - len(bts)
+			return
+		}
+		bts, err = Skip(bts)
+		if err != nil {
+			return 0, 0
+		}
+	}
+	return 0, 0
+}
+
+// locate key AND value
+func locateKV(raw []byte, key string) (start int, end int) {
+	var (
+		sz    uint32
+		bts   []byte
+		field []byte
+		err   error
+	)
+	sz, bts, err = ReadMapHeaderBytes(raw)
+	if err != nil {
+		return 0, 0
+	}
+
+	for i := uint32(0); i < sz; i++ {
+		tmp := len(bts)
+		field, bts, err = ReadStringZC(bts)
+		if err != nil {
+			return 0, 0
+		}
+		if UnsafeString(field) == key {
+			start = len(raw) - tmp
+			bts, err = Skip(bts)
+			if err != nil {
+				return 0, 0
+			}
+			end = len(raw) - len(bts)
+			return
+		}
+		bts, err = Skip(bts)
+		if err != nil {
+			return 0, 0
+		}
+	}
+	return 0, 0
+}
+
+// delta is delta on map size
+func resizeMap(raw []byte, delta int64) []byte {
+	var sz int64
+	switch raw[0] {
+	case mmap16:
+		sz = int64(big.Uint16(raw[1:]))
+		if sz+delta <= math.MaxUint16 {
+			big.PutUint16(raw[1:], uint16(sz+delta))
+			return raw
+		}
+		if cap(raw)-len(raw) >= 2 {
+			raw = raw[0 : len(raw)+2]
+			copy(raw[5:], raw[3:])
+			big.PutUint32(raw[1:], uint32(sz+delta))
+			return raw
+		}
+		n := make([]byte, 0, len(raw)+5)
+		n = AppendMapHeader(n, uint32(sz+delta))
+		return append(n, raw[3:]...)
+
+	case mmap32:
+		sz = int64(big.Uint32(raw[1:]))
+		big.PutUint32(raw[1:], uint32(sz+delta))
+		return raw
+
+	default:
+		sz = int64(rfixmap(raw[0]))
+		if sz+delta < 16 {
+			raw[0] = wfixmap(uint8(sz + delta))
+			return raw
+		} else if sz+delta <= math.MaxUint16 {
+			if cap(raw)-len(raw) >= 2 {
+				raw = raw[0 : len(raw)+2]
+				copy(raw[3:], raw[1:])
+				raw[0] = mmap16
+				big.PutUint16(raw[1:], uint16(sz+delta))
+				return raw
+			}
+			n := make([]byte, 0, len(raw)+5)
+			n = AppendMapHeader(n, uint32(sz+delta))
+			return append(n, raw[1:]...)
+		}
+		if cap(raw)-len(raw) >= 4 {
+			raw = raw[0 : len(raw)+4]
+			copy(raw[5:], raw[1:])
+			raw[0] = mmap32
+			big.PutUint32(raw[1:], uint32(sz+delta))
+			return raw
+		}
+		n := make([]byte, 0, len(raw)+5)
+		n = AppendMapHeader(n, uint32(sz+delta))
+		return append(n, raw[1:]...)
+	}
+}

--- a/vendor/github.com/tinylib/msgp/msgp/elsize.go
+++ b/vendor/github.com/tinylib/msgp/msgp/elsize.go
@@ -1,0 +1,99 @@
+package msgp
+
+// size of every object on the wire,
+// plus type information. gives us
+// constant-time type information
+// for traversing composite objects.
+//
+var sizes = [256]bytespec{
+	mnil:      {size: 1, extra: constsize, typ: NilType},
+	mfalse:    {size: 1, extra: constsize, typ: BoolType},
+	mtrue:     {size: 1, extra: constsize, typ: BoolType},
+	mbin8:     {size: 2, extra: extra8, typ: BinType},
+	mbin16:    {size: 3, extra: extra16, typ: BinType},
+	mbin32:    {size: 5, extra: extra32, typ: BinType},
+	mext8:     {size: 3, extra: extra8, typ: ExtensionType},
+	mext16:    {size: 4, extra: extra16, typ: ExtensionType},
+	mext32:    {size: 6, extra: extra32, typ: ExtensionType},
+	mfloat32:  {size: 5, extra: constsize, typ: Float32Type},
+	mfloat64:  {size: 9, extra: constsize, typ: Float64Type},
+	muint8:    {size: 2, extra: constsize, typ: UintType},
+	muint16:   {size: 3, extra: constsize, typ: UintType},
+	muint32:   {size: 5, extra: constsize, typ: UintType},
+	muint64:   {size: 9, extra: constsize, typ: UintType},
+	mint8:     {size: 2, extra: constsize, typ: IntType},
+	mint16:    {size: 3, extra: constsize, typ: IntType},
+	mint32:    {size: 5, extra: constsize, typ: IntType},
+	mint64:    {size: 9, extra: constsize, typ: IntType},
+	mfixext1:  {size: 3, extra: constsize, typ: ExtensionType},
+	mfixext2:  {size: 4, extra: constsize, typ: ExtensionType},
+	mfixext4:  {size: 6, extra: constsize, typ: ExtensionType},
+	mfixext8:  {size: 10, extra: constsize, typ: ExtensionType},
+	mfixext16: {size: 18, extra: constsize, typ: ExtensionType},
+	mstr8:     {size: 2, extra: extra8, typ: StrType},
+	mstr16:    {size: 3, extra: extra16, typ: StrType},
+	mstr32:    {size: 5, extra: extra32, typ: StrType},
+	marray16:  {size: 3, extra: array16v, typ: ArrayType},
+	marray32:  {size: 5, extra: array32v, typ: ArrayType},
+	mmap16:    {size: 3, extra: map16v, typ: MapType},
+	mmap32:    {size: 5, extra: map32v, typ: MapType},
+}
+
+func init() {
+	// set up fixed fields
+
+	// fixint
+	for i := mfixint; i < 0x80; i++ {
+		sizes[i] = bytespec{size: 1, extra: constsize, typ: IntType}
+	}
+
+	// nfixint
+	for i := uint16(mnfixint); i < 0x100; i++ {
+		sizes[uint8(i)] = bytespec{size: 1, extra: constsize, typ: IntType}
+	}
+
+	// fixstr gets constsize,
+	// since the prefix yields the size
+	for i := mfixstr; i < 0xc0; i++ {
+		sizes[i] = bytespec{size: 1 + rfixstr(i), extra: constsize, typ: StrType}
+	}
+
+	// fixmap
+	for i := mfixmap; i < 0x90; i++ {
+		sizes[i] = bytespec{size: 1, extra: varmode(2 * rfixmap(i)), typ: MapType}
+	}
+
+	// fixarray
+	for i := mfixarray; i < 0xa0; i++ {
+		sizes[i] = bytespec{size: 1, extra: varmode(rfixarray(i)), typ: ArrayType}
+	}
+}
+
+// a valid bytespsec has
+// non-zero 'size' and
+// non-zero 'typ'
+type bytespec struct {
+	size  uint8   // prefix size information
+	extra varmode // extra size information
+	typ   Type    // type
+	_     byte    // makes bytespec 4 bytes (yes, this matters)
+}
+
+// size mode
+// if positive, # elements for composites
+type varmode int8
+
+const (
+	constsize varmode = 0  // constant size (size bytes + uint8(varmode) objects)
+	extra8            = -1 // has uint8(p[1]) extra bytes
+	extra16           = -2 // has be16(p[1:]) extra bytes
+	extra32           = -3 // has be32(p[1:]) extra bytes
+	map16v            = -4 // use map16
+	map32v            = -5 // use map32
+	array16v          = -6 // use array16
+	array32v          = -7 // use array32
+)
+
+func getType(v byte) Type {
+	return sizes[v].typ
+}

--- a/vendor/github.com/tinylib/msgp/msgp/errors.go
+++ b/vendor/github.com/tinylib/msgp/msgp/errors.go
@@ -1,0 +1,142 @@
+package msgp
+
+import (
+	"fmt"
+	"reflect"
+)
+
+var (
+	// ErrShortBytes is returned when the
+	// slice being decoded is too short to
+	// contain the contents of the message
+	ErrShortBytes error = errShort{}
+
+	// this error is only returned
+	// if we reach code that should
+	// be unreachable
+	fatal error = errFatal{}
+)
+
+// Error is the interface satisfied
+// by all of the errors that originate
+// from this package.
+type Error interface {
+	error
+
+	// Resumable returns whether
+	// or not the error means that
+	// the stream of data is malformed
+	// and  the information is unrecoverable.
+	Resumable() bool
+}
+
+type errShort struct{}
+
+func (e errShort) Error() string   { return "msgp: too few bytes left to read object" }
+func (e errShort) Resumable() bool { return false }
+
+type errFatal struct{}
+
+func (f errFatal) Error() string   { return "msgp: fatal decoding error (unreachable code)" }
+func (f errFatal) Resumable() bool { return false }
+
+// ArrayError is an error returned
+// when decoding a fix-sized array
+// of the wrong size
+type ArrayError struct {
+	Wanted uint32
+	Got    uint32
+}
+
+// Error implements the error interface
+func (a ArrayError) Error() string {
+	return fmt.Sprintf("msgp: wanted array of size %d; got %d", a.Wanted, a.Got)
+}
+
+// Resumable is always 'true' for ArrayErrors
+func (a ArrayError) Resumable() bool { return true }
+
+// IntOverflow is returned when a call
+// would downcast an integer to a type
+// with too few bits to hold its value.
+type IntOverflow struct {
+	Value         int64 // the value of the integer
+	FailedBitsize int   // the bit size that the int64 could not fit into
+}
+
+// Error implements the error interface
+func (i IntOverflow) Error() string {
+	return fmt.Sprintf("msgp: %d overflows int%d", i.Value, i.FailedBitsize)
+}
+
+// Resumable is always 'true' for overflows
+func (i IntOverflow) Resumable() bool { return true }
+
+// UintOverflow is returned when a call
+// would downcast an unsigned integer to a type
+// with too few bits to hold its value
+type UintOverflow struct {
+	Value         uint64 // value of the uint
+	FailedBitsize int    // the bit size that couldn't fit the value
+}
+
+// Error implements the error interface
+func (u UintOverflow) Error() string {
+	return fmt.Sprintf("msgp: %d overflows uint%d", u.Value, u.FailedBitsize)
+}
+
+// Resumable is always 'true' for overflows
+func (u UintOverflow) Resumable() bool { return true }
+
+// A TypeError is returned when a particular
+// decoding method is unsuitable for decoding
+// a particular MessagePack value.
+type TypeError struct {
+	Method  Type // Type expected by method
+	Encoded Type // Type actually encoded
+}
+
+// Error implements the error interface
+func (t TypeError) Error() string {
+	return fmt.Sprintf("msgp: attempted to decode type %q with method for %q", t.Encoded, t.Method)
+}
+
+// Resumable returns 'true' for TypeErrors
+func (t TypeError) Resumable() bool { return true }
+
+// returns either InvalidPrefixError or
+// TypeError depending on whether or not
+// the prefix is recognized
+func badPrefix(want Type, lead byte) error {
+	t := sizes[lead].typ
+	if t == InvalidType {
+		return InvalidPrefixError(lead)
+	}
+	return TypeError{Method: want, Encoded: t}
+}
+
+// InvalidPrefixError is returned when a bad encoding
+// uses a prefix that is not recognized in the MessagePack standard.
+// This kind of error is unrecoverable.
+type InvalidPrefixError byte
+
+// Error implements the error interface
+func (i InvalidPrefixError) Error() string {
+	return fmt.Sprintf("msgp: unrecognized type prefix 0x%x", byte(i))
+}
+
+// Resumable returns 'false' for InvalidPrefixErrors
+func (i InvalidPrefixError) Resumable() bool { return false }
+
+// ErrUnsupportedType is returned
+// when a bad argument is supplied
+// to a function that takes `interface{}`.
+type ErrUnsupportedType struct {
+	T reflect.Type
+}
+
+// Error implements error
+func (e *ErrUnsupportedType) Error() string { return fmt.Sprintf("msgp: type %q not supported", e.T) }
+
+// Resumable returns 'true' for ErrUnsupportedType
+func (e *ErrUnsupportedType) Resumable() bool { return true }

--- a/vendor/github.com/tinylib/msgp/msgp/extension.go
+++ b/vendor/github.com/tinylib/msgp/msgp/extension.go
@@ -1,0 +1,548 @@
+package msgp
+
+import (
+	"fmt"
+	"math"
+)
+
+const (
+	// Complex64Extension is the extension number used for complex64
+	Complex64Extension = 3
+
+	// Complex128Extension is the extension number used for complex128
+	Complex128Extension = 4
+
+	// TimeExtension is the extension number used for time.Time
+	TimeExtension = 5
+)
+
+// our extensions live here
+var extensionReg = make(map[int8]func() Extension)
+
+// RegisterExtension registers extensions so that they
+// can be initialized and returned by methods that
+// decode `interface{}` values. This should only
+// be called during initialization. f() should return
+// a newly-initialized zero value of the extension. Keep in
+// mind that extensions 3, 4, and 5 are reserved for
+// complex64, complex128, and time.Time, respectively,
+// and that MessagePack reserves extension types from -127 to -1.
+//
+// For example, if you wanted to register a user-defined struct:
+//
+//  msgp.RegisterExtension(10, func() msgp.Extension { &MyExtension{} })
+//
+// RegisterExtension will panic if you call it multiple times
+// with the same 'typ' argument, or if you use a reserved
+// type (3, 4, or 5).
+func RegisterExtension(typ int8, f func() Extension) {
+	switch typ {
+	case Complex64Extension, Complex128Extension, TimeExtension:
+		panic(fmt.Sprint("msgp: forbidden extension type:", typ))
+	}
+	if _, ok := extensionReg[typ]; ok {
+		panic(fmt.Sprint("msgp: RegisterExtension() called with typ", typ, "more than once"))
+	}
+	extensionReg[typ] = f
+}
+
+// ExtensionTypeError is an error type returned
+// when there is a mis-match between an extension type
+// and the type encoded on the wire
+type ExtensionTypeError struct {
+	Got  int8
+	Want int8
+}
+
+// Error implements the error interface
+func (e ExtensionTypeError) Error() string {
+	return fmt.Sprintf("msgp: error decoding extension: wanted type %d; got type %d", e.Want, e.Got)
+}
+
+// Resumable returns 'true' for ExtensionTypeErrors
+func (e ExtensionTypeError) Resumable() bool { return true }
+
+func errExt(got int8, wanted int8) error {
+	return ExtensionTypeError{Got: got, Want: wanted}
+}
+
+// Extension is the interface fulfilled
+// by types that want to define their
+// own binary encoding.
+type Extension interface {
+	// ExtensionType should return
+	// a int8 that identifies the concrete
+	// type of the extension. (Types <0 are
+	// officially reserved by the MessagePack
+	// specifications.)
+	ExtensionType() int8
+
+	// Len should return the length
+	// of the data to be encoded
+	Len() int
+
+	// MarshalBinaryTo should copy
+	// the data into the supplied slice,
+	// assuming that the slice has length Len()
+	MarshalBinaryTo([]byte) error
+
+	UnmarshalBinary([]byte) error
+}
+
+// RawExtension implements the Extension interface
+type RawExtension struct {
+	Data []byte
+	Type int8
+}
+
+// ExtensionType implements Extension.ExtensionType, and returns r.Type
+func (r *RawExtension) ExtensionType() int8 { return r.Type }
+
+// Len implements Extension.Len, and returns len(r.Data)
+func (r *RawExtension) Len() int { return len(r.Data) }
+
+// MarshalBinaryTo implements Extension.MarshalBinaryTo,
+// and returns a copy of r.Data
+func (r *RawExtension) MarshalBinaryTo(d []byte) error {
+	copy(d, r.Data)
+	return nil
+}
+
+// UnmarshalBinary implements Extension.UnmarshalBinary,
+// and sets r.Data to the contents of the provided slice
+func (r *RawExtension) UnmarshalBinary(b []byte) error {
+	if cap(r.Data) >= len(b) {
+		r.Data = r.Data[0:len(b)]
+	} else {
+		r.Data = make([]byte, len(b))
+	}
+	copy(r.Data, b)
+	return nil
+}
+
+// WriteExtension writes an extension type to the writer
+func (mw *Writer) WriteExtension(e Extension) error {
+	l := e.Len()
+	var err error
+	switch l {
+	case 0:
+		o, err := mw.require(3)
+		if err != nil {
+			return err
+		}
+		mw.buf[o] = mext8
+		mw.buf[o+1] = 0
+		mw.buf[o+2] = byte(e.ExtensionType())
+	case 1:
+		o, err := mw.require(2)
+		if err != nil {
+			return err
+		}
+		mw.buf[o] = mfixext1
+		mw.buf[o+1] = byte(e.ExtensionType())
+	case 2:
+		o, err := mw.require(2)
+		if err != nil {
+			return err
+		}
+		mw.buf[o] = mfixext2
+		mw.buf[o+1] = byte(e.ExtensionType())
+	case 4:
+		o, err := mw.require(2)
+		if err != nil {
+			return err
+		}
+		mw.buf[o] = mfixext4
+		mw.buf[o+1] = byte(e.ExtensionType())
+	case 8:
+		o, err := mw.require(2)
+		if err != nil {
+			return err
+		}
+		mw.buf[o] = mfixext8
+		mw.buf[o+1] = byte(e.ExtensionType())
+	case 16:
+		o, err := mw.require(2)
+		if err != nil {
+			return err
+		}
+		mw.buf[o] = mfixext16
+		mw.buf[o+1] = byte(e.ExtensionType())
+	default:
+		switch {
+		case l < math.MaxUint8:
+			o, err := mw.require(3)
+			if err != nil {
+				return err
+			}
+			mw.buf[o] = mext8
+			mw.buf[o+1] = byte(uint8(l))
+			mw.buf[o+2] = byte(e.ExtensionType())
+		case l < math.MaxUint16:
+			o, err := mw.require(4)
+			if err != nil {
+				return err
+			}
+			mw.buf[o] = mext16
+			big.PutUint16(mw.buf[o+1:], uint16(l))
+			mw.buf[o+3] = byte(e.ExtensionType())
+		default:
+			o, err := mw.require(6)
+			if err != nil {
+				return err
+			}
+			mw.buf[o] = mext32
+			big.PutUint32(mw.buf[o+1:], uint32(l))
+			mw.buf[o+5] = byte(e.ExtensionType())
+		}
+	}
+	// we can only write directly to the
+	// buffer if we're sure that it
+	// fits the object
+	if l <= mw.bufsize() {
+		o, err := mw.require(l)
+		if err != nil {
+			return err
+		}
+		return e.MarshalBinaryTo(mw.buf[o:])
+	}
+	// here we create a new buffer
+	// just large enough for the body
+	// and save it as the write buffer
+	err = mw.flush()
+	if err != nil {
+		return err
+	}
+	buf := make([]byte, l)
+	err = e.MarshalBinaryTo(buf)
+	if err != nil {
+		return err
+	}
+	mw.buf = buf
+	mw.wloc = l
+	return nil
+}
+
+// peek at the extension type, assuming the next
+// kind to be read is Extension
+func (m *Reader) peekExtensionType() (int8, error) {
+	p, err := m.R.Peek(2)
+	if err != nil {
+		return 0, err
+	}
+	spec := sizes[p[0]]
+	if spec.typ != ExtensionType {
+		return 0, badPrefix(ExtensionType, p[0])
+	}
+	if spec.extra == constsize {
+		return int8(p[1]), nil
+	}
+	size := spec.size
+	p, err = m.R.Peek(int(size))
+	if err != nil {
+		return 0, err
+	}
+	return int8(p[size-1]), nil
+}
+
+// peekExtension peeks at the extension encoding type
+// (must guarantee at least 1 byte in 'b')
+func peekExtension(b []byte) (int8, error) {
+	spec := sizes[b[0]]
+	size := spec.size
+	if spec.typ != ExtensionType {
+		return 0, badPrefix(ExtensionType, b[0])
+	}
+	if len(b) < int(size) {
+		return 0, ErrShortBytes
+	}
+	// for fixed extensions,
+	// the type information is in
+	// the second byte
+	if spec.extra == constsize {
+		return int8(b[1]), nil
+	}
+	// otherwise, it's in the last
+	// part of the prefix
+	return int8(b[size-1]), nil
+}
+
+// ReadExtension reads the next object from the reader
+// as an extension. ReadExtension will fail if the next
+// object in the stream is not an extension, or if
+// e.Type() is not the same as the wire type.
+func (m *Reader) ReadExtension(e Extension) (err error) {
+	var p []byte
+	p, err = m.R.Peek(2)
+	if err != nil {
+		return
+	}
+	lead := p[0]
+	var read int
+	var off int
+	switch lead {
+	case mfixext1:
+		if int8(p[1]) != e.ExtensionType() {
+			err = errExt(int8(p[1]), e.ExtensionType())
+			return
+		}
+		p, err = m.R.Peek(3)
+		if err != nil {
+			return
+		}
+		err = e.UnmarshalBinary(p[2:])
+		if err == nil {
+			_, err = m.R.Skip(3)
+		}
+		return
+
+	case mfixext2:
+		if int8(p[1]) != e.ExtensionType() {
+			err = errExt(int8(p[1]), e.ExtensionType())
+			return
+		}
+		p, err = m.R.Peek(4)
+		if err != nil {
+			return
+		}
+		err = e.UnmarshalBinary(p[2:])
+		if err == nil {
+			_, err = m.R.Skip(4)
+		}
+		return
+
+	case mfixext4:
+		if int8(p[1]) != e.ExtensionType() {
+			err = errExt(int8(p[1]), e.ExtensionType())
+			return
+		}
+		p, err = m.R.Peek(6)
+		if err != nil {
+			return
+		}
+		err = e.UnmarshalBinary(p[2:])
+		if err == nil {
+			_, err = m.R.Skip(6)
+		}
+		return
+
+	case mfixext8:
+		if int8(p[1]) != e.ExtensionType() {
+			err = errExt(int8(p[1]), e.ExtensionType())
+			return
+		}
+		p, err = m.R.Peek(10)
+		if err != nil {
+			return
+		}
+		err = e.UnmarshalBinary(p[2:])
+		if err == nil {
+			_, err = m.R.Skip(10)
+		}
+		return
+
+	case mfixext16:
+		if int8(p[1]) != e.ExtensionType() {
+			err = errExt(int8(p[1]), e.ExtensionType())
+			return
+		}
+		p, err = m.R.Peek(18)
+		if err != nil {
+			return
+		}
+		err = e.UnmarshalBinary(p[2:])
+		if err == nil {
+			_, err = m.R.Skip(18)
+		}
+		return
+
+	case mext8:
+		p, err = m.R.Peek(3)
+		if err != nil {
+			return
+		}
+		if int8(p[2]) != e.ExtensionType() {
+			err = errExt(int8(p[2]), e.ExtensionType())
+			return
+		}
+		read = int(uint8(p[1]))
+		off = 3
+
+	case mext16:
+		p, err = m.R.Peek(4)
+		if err != nil {
+			return
+		}
+		if int8(p[3]) != e.ExtensionType() {
+			err = errExt(int8(p[3]), e.ExtensionType())
+			return
+		}
+		read = int(big.Uint16(p[1:]))
+		off = 4
+
+	case mext32:
+		p, err = m.R.Peek(6)
+		if err != nil {
+			return
+		}
+		if int8(p[5]) != e.ExtensionType() {
+			err = errExt(int8(p[5]), e.ExtensionType())
+			return
+		}
+		read = int(big.Uint32(p[1:]))
+		off = 6
+
+	default:
+		err = badPrefix(ExtensionType, lead)
+		return
+	}
+
+	p, err = m.R.Peek(read + off)
+	if err != nil {
+		return
+	}
+	err = e.UnmarshalBinary(p[off:])
+	if err == nil {
+		_, err = m.R.Skip(read + off)
+	}
+	return
+}
+
+// AppendExtension appends a MessagePack extension to the provided slice
+func AppendExtension(b []byte, e Extension) ([]byte, error) {
+	l := e.Len()
+	var o []byte
+	var n int
+	switch l {
+	case 0:
+		o, n = ensure(b, 3)
+		o[n] = mext8
+		o[n+1] = 0
+		o[n+2] = byte(e.ExtensionType())
+		return o[:n+3], nil
+	case 1:
+		o, n = ensure(b, 3)
+		o[n] = mfixext1
+		o[n+1] = byte(e.ExtensionType())
+		n += 2
+	case 2:
+		o, n = ensure(b, 4)
+		o[n] = mfixext2
+		o[n+1] = byte(e.ExtensionType())
+		n += 2
+	case 4:
+		o, n = ensure(b, 6)
+		o[n] = mfixext4
+		o[n+1] = byte(e.ExtensionType())
+		n += 2
+	case 8:
+		o, n = ensure(b, 10)
+		o[n] = mfixext8
+		o[n+1] = byte(e.ExtensionType())
+		n += 2
+	case 16:
+		o, n = ensure(b, 18)
+		o[n] = mfixext16
+		o[n+1] = byte(e.ExtensionType())
+		n += 2
+	}
+	switch {
+	case l < math.MaxUint8:
+		o, n = ensure(b, l+3)
+		o[n] = mext8
+		o[n+1] = byte(uint8(l))
+		o[n+2] = byte(e.ExtensionType())
+		n += 3
+	case l < math.MaxUint16:
+		o, n = ensure(b, l+4)
+		o[n] = mext16
+		big.PutUint16(o[n+1:], uint16(l))
+		o[n+3] = byte(e.ExtensionType())
+		n += 4
+	default:
+		o, n = ensure(b, l+6)
+		o[n] = mext32
+		big.PutUint32(o[n+1:], uint32(l))
+		o[n+5] = byte(e.ExtensionType())
+		n += 6
+	}
+	return o, e.MarshalBinaryTo(o[n:])
+}
+
+// ReadExtensionBytes reads an extension from 'b' into 'e'
+// and returns any remaining bytes.
+// Possible errors:
+// - ErrShortBytes ('b' not long enough)
+// - ExtensionTypeErorr{} (wire type not the same as e.Type())
+// - TypeErorr{} (next object not an extension)
+// - InvalidPrefixError
+// - An umarshal error returned from e.UnmarshalBinary
+func ReadExtensionBytes(b []byte, e Extension) ([]byte, error) {
+	l := len(b)
+	if l < 3 {
+		return b, ErrShortBytes
+	}
+	lead := b[0]
+	var (
+		sz  int // size of 'data'
+		off int // offset of 'data'
+		typ int8
+	)
+	switch lead {
+	case mfixext1:
+		typ = int8(b[1])
+		sz = 1
+		off = 2
+	case mfixext2:
+		typ = int8(b[1])
+		sz = 2
+		off = 2
+	case mfixext4:
+		typ = int8(b[1])
+		sz = 4
+		off = 2
+	case mfixext8:
+		typ = int8(b[1])
+		sz = 8
+		off = 2
+	case mfixext16:
+		typ = int8(b[1])
+		sz = 16
+		off = 2
+	case mext8:
+		sz = int(uint8(b[1]))
+		typ = int8(b[2])
+		off = 3
+		if sz == 0 {
+			return b[3:], e.UnmarshalBinary(b[3:3])
+		}
+	case mext16:
+		if l < 4 {
+			return b, ErrShortBytes
+		}
+		sz = int(big.Uint16(b[1:]))
+		typ = int8(b[3])
+		off = 4
+	case mext32:
+		if l < 6 {
+			return b, ErrShortBytes
+		}
+		sz = int(big.Uint32(b[1:]))
+		typ = int8(b[5])
+		off = 6
+	default:
+		return b, badPrefix(ExtensionType, lead)
+	}
+
+	if typ != e.ExtensionType() {
+		return b, errExt(typ, e.ExtensionType())
+	}
+
+	// the data of the extension starts
+	// at 'off' and is 'sz' bytes long
+	if len(b[off:]) < sz {
+		return b, ErrShortBytes
+	}
+	tot := off + sz
+	return b[tot:], e.UnmarshalBinary(b[off:tot])
+}

--- a/vendor/github.com/tinylib/msgp/msgp/file.go
+++ b/vendor/github.com/tinylib/msgp/msgp/file.go
@@ -1,0 +1,92 @@
+// +build linux darwin dragonfly freebsd netbsd openbsd
+// +build !appengine
+
+package msgp
+
+import (
+	"os"
+	"syscall"
+)
+
+// ReadFile reads a file into 'dst' using
+// a read-only memory mapping. Consequently,
+// the file must be mmap-able, and the
+// Unmarshaler should never write to
+// the source memory. (Methods generated
+// by the msgp tool obey that constraint, but
+// user-defined implementations may not.)
+//
+// Reading and writing through file mappings
+// is only efficient for large files; small
+// files are best read and written using
+// the ordinary streaming interfaces.
+//
+func ReadFile(dst Unmarshaler, file *os.File) error {
+	stat, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	data, err := syscall.Mmap(int(file.Fd()), 0, int(stat.Size()), syscall.PROT_READ, syscall.MAP_SHARED)
+	if err != nil {
+		return err
+	}
+	adviseRead(data)
+	_, err = dst.UnmarshalMsg(data)
+	uerr := syscall.Munmap(data)
+	if err == nil {
+		err = uerr
+	}
+	return err
+}
+
+// MarshalSizer is the combination
+// of the Marshaler and Sizer
+// interfaces.
+type MarshalSizer interface {
+	Marshaler
+	Sizer
+}
+
+// WriteFile writes a file from 'src' using
+// memory mapping. It overwrites the entire
+// contents of the previous file.
+// The mapping size is calculated
+// using the `Msgsize()` method
+// of 'src', so it must produce a result
+// equal to or greater than the actual encoded
+// size of the object. Otherwise,
+// a fault (SIGBUS) will occur.
+//
+// Reading and writing through file mappings
+// is only efficient for large files; small
+// files are best read and written using
+// the ordinary streaming interfaces.
+//
+// NOTE: The performance of this call
+// is highly OS- and filesystem-dependent.
+// Users should take care to test that this
+// performs as expected in a production environment.
+// (Linux users should run a kernel and filesystem
+// that support fallocate(2) for the best results.)
+func WriteFile(src MarshalSizer, file *os.File) error {
+	sz := src.Msgsize()
+	err := fallocate(file, int64(sz))
+	if err != nil {
+		return err
+	}
+	data, err := syscall.Mmap(int(file.Fd()), 0, sz, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+	if err != nil {
+		return err
+	}
+	adviseWrite(data)
+	chunk := data[:0]
+	chunk, err = src.MarshalMsg(chunk)
+	if err != nil {
+		return err
+	}
+	uerr := syscall.Munmap(data)
+	if uerr != nil {
+		return uerr
+	}
+	return file.Truncate(int64(len(chunk)))
+}

--- a/vendor/github.com/tinylib/msgp/msgp/file_port.go
+++ b/vendor/github.com/tinylib/msgp/msgp/file_port.go
@@ -1,0 +1,47 @@
+// +build windows appengine
+
+package msgp
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+// MarshalSizer is the combination
+// of the Marshaler and Sizer
+// interfaces.
+type MarshalSizer interface {
+	Marshaler
+	Sizer
+}
+
+func ReadFile(dst Unmarshaler, file *os.File) error {
+	if u, ok := dst.(Decodable); ok {
+		return u.DecodeMsg(NewReader(file))
+	}
+
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		return err
+	}
+	_, err = dst.UnmarshalMsg(data)
+	return err
+}
+
+func WriteFile(src MarshalSizer, file *os.File) error {
+	if e, ok := src.(Encodable); ok {
+		w := NewWriter(file)
+		err := e.EncodeMsg(w)
+		if err == nil {
+			err = w.Flush()
+		}
+		return err
+	}
+
+	raw, err := src.MarshalMsg(nil)
+	if err != nil {
+		return err
+	}
+	_, err = file.Write(raw)
+	return err
+}

--- a/vendor/github.com/tinylib/msgp/msgp/integers.go
+++ b/vendor/github.com/tinylib/msgp/msgp/integers.go
@@ -1,0 +1,174 @@
+package msgp
+
+/* ----------------------------------
+	integer encoding utilities
+	(inline-able)
+
+	TODO(tinylib): there are faster,
+	albeit non-portable solutions
+	to the code below. implement
+	byteswap?
+   ---------------------------------- */
+
+func putMint64(b []byte, i int64) {
+	b[0] = mint64
+	b[1] = byte(i >> 56)
+	b[2] = byte(i >> 48)
+	b[3] = byte(i >> 40)
+	b[4] = byte(i >> 32)
+	b[5] = byte(i >> 24)
+	b[6] = byte(i >> 16)
+	b[7] = byte(i >> 8)
+	b[8] = byte(i)
+}
+
+func getMint64(b []byte) int64 {
+	return (int64(b[1]) << 56) | (int64(b[2]) << 48) |
+		(int64(b[3]) << 40) | (int64(b[4]) << 32) |
+		(int64(b[5]) << 24) | (int64(b[6]) << 16) |
+		(int64(b[7]) << 8) | (int64(b[8]))
+}
+
+func putMint32(b []byte, i int32) {
+	b[0] = mint32
+	b[1] = byte(i >> 24)
+	b[2] = byte(i >> 16)
+	b[3] = byte(i >> 8)
+	b[4] = byte(i)
+}
+
+func getMint32(b []byte) int32 {
+	return (int32(b[1]) << 24) | (int32(b[2]) << 16) | (int32(b[3]) << 8) | (int32(b[4]))
+}
+
+func putMint16(b []byte, i int16) {
+	b[0] = mint16
+	b[1] = byte(i >> 8)
+	b[2] = byte(i)
+}
+
+func getMint16(b []byte) (i int16) {
+	return (int16(b[1]) << 8) | int16(b[2])
+}
+
+func putMint8(b []byte, i int8) {
+	b[0] = mint8
+	b[1] = byte(i)
+}
+
+func getMint8(b []byte) (i int8) {
+	return int8(b[1])
+}
+
+func putMuint64(b []byte, u uint64) {
+	b[0] = muint64
+	b[1] = byte(u >> 56)
+	b[2] = byte(u >> 48)
+	b[3] = byte(u >> 40)
+	b[4] = byte(u >> 32)
+	b[5] = byte(u >> 24)
+	b[6] = byte(u >> 16)
+	b[7] = byte(u >> 8)
+	b[8] = byte(u)
+}
+
+func getMuint64(b []byte) uint64 {
+	return (uint64(b[1]) << 56) | (uint64(b[2]) << 48) |
+		(uint64(b[3]) << 40) | (uint64(b[4]) << 32) |
+		(uint64(b[5]) << 24) | (uint64(b[6]) << 16) |
+		(uint64(b[7]) << 8) | (uint64(b[8]))
+}
+
+func putMuint32(b []byte, u uint32) {
+	b[0] = muint32
+	b[1] = byte(u >> 24)
+	b[2] = byte(u >> 16)
+	b[3] = byte(u >> 8)
+	b[4] = byte(u)
+}
+
+func getMuint32(b []byte) uint32 {
+	return (uint32(b[1]) << 24) | (uint32(b[2]) << 16) | (uint32(b[3]) << 8) | (uint32(b[4]))
+}
+
+func putMuint16(b []byte, u uint16) {
+	b[0] = muint16
+	b[1] = byte(u >> 8)
+	b[2] = byte(u)
+}
+
+func getMuint16(b []byte) uint16 {
+	return (uint16(b[1]) << 8) | uint16(b[2])
+}
+
+func putMuint8(b []byte, u uint8) {
+	b[0] = muint8
+	b[1] = byte(u)
+}
+
+func getMuint8(b []byte) uint8 {
+	return uint8(b[1])
+}
+
+func getUnix(b []byte) (sec int64, nsec int32) {
+	sec = (int64(b[0]) << 56) | (int64(b[1]) << 48) |
+		(int64(b[2]) << 40) | (int64(b[3]) << 32) |
+		(int64(b[4]) << 24) | (int64(b[5]) << 16) |
+		(int64(b[6]) << 8) | (int64(b[7]))
+
+	nsec = (int32(b[8]) << 24) | (int32(b[9]) << 16) | (int32(b[10]) << 8) | (int32(b[11]))
+	return
+}
+
+func putUnix(b []byte, sec int64, nsec int32) {
+	b[0] = byte(sec >> 56)
+	b[1] = byte(sec >> 48)
+	b[2] = byte(sec >> 40)
+	b[3] = byte(sec >> 32)
+	b[4] = byte(sec >> 24)
+	b[5] = byte(sec >> 16)
+	b[6] = byte(sec >> 8)
+	b[7] = byte(sec)
+	b[8] = byte(nsec >> 24)
+	b[9] = byte(nsec >> 16)
+	b[10] = byte(nsec >> 8)
+	b[11] = byte(nsec)
+}
+
+/* -----------------------------
+		prefix utilities
+   ----------------------------- */
+
+// write prefix and uint8
+func prefixu8(b []byte, pre byte, sz uint8) {
+	b[0] = pre
+	b[1] = byte(sz)
+}
+
+// write prefix and big-endian uint16
+func prefixu16(b []byte, pre byte, sz uint16) {
+	b[0] = pre
+	b[1] = byte(sz >> 8)
+	b[2] = byte(sz)
+}
+
+// write prefix and big-endian uint32
+func prefixu32(b []byte, pre byte, sz uint32) {
+	b[0] = pre
+	b[1] = byte(sz >> 24)
+	b[2] = byte(sz >> 16)
+	b[3] = byte(sz >> 8)
+	b[4] = byte(sz)
+}
+
+func prefixu64(b []byte, pre byte, sz uint64) {
+	b[0] = pre
+	b[1] = byte(sz >> 56)
+	b[2] = byte(sz >> 48)
+	b[3] = byte(sz >> 40)
+	b[4] = byte(sz >> 32)
+	b[5] = byte(sz >> 24)
+	b[6] = byte(sz >> 16)
+	b[7] = byte(sz >> 8)
+	b[8] = byte(sz)
+}

--- a/vendor/github.com/tinylib/msgp/msgp/json.go
+++ b/vendor/github.com/tinylib/msgp/msgp/json.go
@@ -1,0 +1,542 @@
+package msgp
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"strconv"
+	"unicode/utf8"
+)
+
+var (
+	null = []byte("null")
+	hex  = []byte("0123456789abcdef")
+)
+
+var defuns [_maxtype]func(jsWriter, *Reader) (int, error)
+
+// note: there is an initialization loop if
+// this isn't set up during init()
+func init() {
+	// since none of these functions are inline-able,
+	// there is not much of a penalty to the indirect
+	// call. however, this is best expressed as a jump-table...
+	defuns = [_maxtype]func(jsWriter, *Reader) (int, error){
+		StrType:        rwString,
+		BinType:        rwBytes,
+		MapType:        rwMap,
+		ArrayType:      rwArray,
+		Float64Type:    rwFloat64,
+		Float32Type:    rwFloat32,
+		BoolType:       rwBool,
+		IntType:        rwInt,
+		UintType:       rwUint,
+		NilType:        rwNil,
+		ExtensionType:  rwExtension,
+		Complex64Type:  rwExtension,
+		Complex128Type: rwExtension,
+		TimeType:       rwTime,
+	}
+}
+
+// this is the interface
+// used to write json
+type jsWriter interface {
+	io.Writer
+	io.ByteWriter
+	WriteString(string) (int, error)
+}
+
+// CopyToJSON reads MessagePack from 'src' and copies it
+// as JSON to 'dst' until EOF.
+func CopyToJSON(dst io.Writer, src io.Reader) (n int64, err error) {
+	r := NewReader(src)
+	n, err = r.WriteToJSON(dst)
+	freeR(r)
+	return
+}
+
+// WriteToJSON translates MessagePack from 'r' and writes it as
+// JSON to 'w' until the underlying reader returns io.EOF. It returns
+// the number of bytes written, and an error if it stopped before EOF.
+func (r *Reader) WriteToJSON(w io.Writer) (n int64, err error) {
+	var j jsWriter
+	var bf *bufio.Writer
+	if jsw, ok := w.(jsWriter); ok {
+		j = jsw
+	} else {
+		bf = bufio.NewWriter(w)
+		j = bf
+	}
+	var nn int
+	for err == nil {
+		nn, err = rwNext(j, r)
+		n += int64(nn)
+	}
+	if err != io.EOF {
+		if bf != nil {
+			bf.Flush()
+		}
+		return
+	}
+	err = nil
+	if bf != nil {
+		err = bf.Flush()
+	}
+	return
+}
+
+func rwNext(w jsWriter, src *Reader) (int, error) {
+	t, err := src.NextType()
+	if err != nil {
+		return 0, err
+	}
+	return defuns[t](w, src)
+}
+
+func rwMap(dst jsWriter, src *Reader) (n int, err error) {
+	var comma bool
+	var sz uint32
+	var field []byte
+
+	sz, err = src.ReadMapHeader()
+	if err != nil {
+		return
+	}
+
+	if sz == 0 {
+		return dst.WriteString("{}")
+	}
+
+	err = dst.WriteByte('{')
+	if err != nil {
+		return
+	}
+	n++
+	var nn int
+	for i := uint32(0); i < sz; i++ {
+		if comma {
+			err = dst.WriteByte(',')
+			if err != nil {
+				return
+			}
+			n++
+		}
+
+		field, err = src.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		nn, err = rwquoted(dst, field)
+		n += nn
+		if err != nil {
+			return
+		}
+
+		err = dst.WriteByte(':')
+		if err != nil {
+			return
+		}
+		n++
+		nn, err = rwNext(dst, src)
+		n += nn
+		if err != nil {
+			return
+		}
+		if !comma {
+			comma = true
+		}
+	}
+
+	err = dst.WriteByte('}')
+	if err != nil {
+		return
+	}
+	n++
+	return
+}
+
+func rwArray(dst jsWriter, src *Reader) (n int, err error) {
+	err = dst.WriteByte('[')
+	if err != nil {
+		return
+	}
+	var sz uint32
+	var nn int
+	sz, err = src.ReadArrayHeader()
+	if err != nil {
+		return
+	}
+	comma := false
+	for i := uint32(0); i < sz; i++ {
+		if comma {
+			err = dst.WriteByte(',')
+			if err != nil {
+				return
+			}
+			n++
+		}
+		nn, err = rwNext(dst, src)
+		n += nn
+		if err != nil {
+			return
+		}
+		comma = true
+	}
+
+	err = dst.WriteByte(']')
+	if err != nil {
+		return
+	}
+	n++
+	return
+}
+
+func rwNil(dst jsWriter, src *Reader) (int, error) {
+	err := src.ReadNil()
+	if err != nil {
+		return 0, err
+	}
+	return dst.Write(null)
+}
+
+func rwFloat32(dst jsWriter, src *Reader) (int, error) {
+	f, err := src.ReadFloat32()
+	if err != nil {
+		return 0, err
+	}
+	src.scratch = strconv.AppendFloat(src.scratch[:0], float64(f), 'f', -1, 64)
+	return dst.Write(src.scratch)
+}
+
+func rwFloat64(dst jsWriter, src *Reader) (int, error) {
+	f, err := src.ReadFloat64()
+	if err != nil {
+		return 0, err
+	}
+	src.scratch = strconv.AppendFloat(src.scratch[:0], f, 'f', -1, 32)
+	return dst.Write(src.scratch)
+}
+
+func rwInt(dst jsWriter, src *Reader) (int, error) {
+	i, err := src.ReadInt64()
+	if err != nil {
+		return 0, err
+	}
+	src.scratch = strconv.AppendInt(src.scratch[:0], i, 10)
+	return dst.Write(src.scratch)
+}
+
+func rwUint(dst jsWriter, src *Reader) (int, error) {
+	u, err := src.ReadUint64()
+	if err != nil {
+		return 0, err
+	}
+	src.scratch = strconv.AppendUint(src.scratch[:0], u, 10)
+	return dst.Write(src.scratch)
+}
+
+func rwBool(dst jsWriter, src *Reader) (int, error) {
+	b, err := src.ReadBool()
+	if err != nil {
+		return 0, err
+	}
+	if b {
+		return dst.WriteString("true")
+	}
+	return dst.WriteString("false")
+}
+
+func rwTime(dst jsWriter, src *Reader) (int, error) {
+	t, err := src.ReadTime()
+	if err != nil {
+		return 0, err
+	}
+	bts, err := t.MarshalJSON()
+	if err != nil {
+		return 0, err
+	}
+	return dst.Write(bts)
+}
+
+func rwExtension(dst jsWriter, src *Reader) (n int, err error) {
+	et, err := src.peekExtensionType()
+	if err != nil {
+		return 0, err
+	}
+
+	// registered extensions can override
+	// the JSON encoding
+	if j, ok := extensionReg[et]; ok {
+		var bts []byte
+		e := j()
+		err = src.ReadExtension(e)
+		if err != nil {
+			return
+		}
+		bts, err = json.Marshal(e)
+		if err != nil {
+			return
+		}
+		return dst.Write(bts)
+	}
+
+	e := RawExtension{}
+	e.Type = et
+	err = src.ReadExtension(&e)
+	if err != nil {
+		return
+	}
+
+	var nn int
+	err = dst.WriteByte('{')
+	if err != nil {
+		return
+	}
+	n++
+
+	nn, err = dst.WriteString(`"type:"`)
+	n += nn
+	if err != nil {
+		return
+	}
+
+	src.scratch = strconv.AppendInt(src.scratch[0:0], int64(e.Type), 10)
+	nn, err = dst.Write(src.scratch)
+	n += nn
+	if err != nil {
+		return
+	}
+
+	nn, err = dst.WriteString(`,"data":"`)
+	n += nn
+	if err != nil {
+		return
+	}
+
+	enc := base64.NewEncoder(base64.StdEncoding, dst)
+
+	nn, err = enc.Write(e.Data)
+	n += nn
+	if err != nil {
+		return
+	}
+	err = enc.Close()
+	if err != nil {
+		return
+	}
+	nn, err = dst.WriteString(`"}`)
+	n += nn
+	return
+}
+
+func rwString(dst jsWriter, src *Reader) (n int, err error) {
+	var p []byte
+	p, err = src.R.Peek(1)
+	if err != nil {
+		return
+	}
+	lead := p[0]
+	var read int
+
+	if isfixstr(lead) {
+		read = int(rfixstr(lead))
+		src.R.Skip(1)
+		goto write
+	}
+
+	switch lead {
+	case mstr8:
+		p, err = src.R.Next(2)
+		if err != nil {
+			return
+		}
+		read = int(uint8(p[1]))
+	case mstr16:
+		p, err = src.R.Next(3)
+		if err != nil {
+			return
+		}
+		read = int(big.Uint16(p[1:]))
+	case mstr32:
+		p, err = src.R.Next(5)
+		if err != nil {
+			return
+		}
+		read = int(big.Uint32(p[1:]))
+	default:
+		err = badPrefix(StrType, lead)
+		return
+	}
+write:
+	p, err = src.R.Next(read)
+	if err != nil {
+		return
+	}
+	n, err = rwquoted(dst, p)
+	return
+}
+
+func rwBytes(dst jsWriter, src *Reader) (n int, err error) {
+	var nn int
+	err = dst.WriteByte('"')
+	if err != nil {
+		return
+	}
+	n++
+	src.scratch, err = src.ReadBytes(src.scratch[:0])
+	if err != nil {
+		return
+	}
+	enc := base64.NewEncoder(base64.StdEncoding, dst)
+	nn, err = enc.Write(src.scratch)
+	n += nn
+	if err != nil {
+		return
+	}
+	err = enc.Close()
+	if err != nil {
+		return
+	}
+	err = dst.WriteByte('"')
+	if err != nil {
+		return
+	}
+	n++
+	return
+}
+
+// Below (c) The Go Authors, 2009-2014
+// Subject to the BSD-style license found at http://golang.org
+//
+// see: encoding/json/encode.go:(*encodeState).stringbytes()
+func rwquoted(dst jsWriter, s []byte) (n int, err error) {
+	var nn int
+	err = dst.WriteByte('"')
+	if err != nil {
+		return
+	}
+	n++
+	start := 0
+	for i := 0; i < len(s); {
+		if b := s[i]; b < utf8.RuneSelf {
+			if 0x20 <= b && b != '\\' && b != '"' && b != '<' && b != '>' && b != '&' {
+				i++
+				continue
+			}
+			if start < i {
+				nn, err = dst.Write(s[start:i])
+				n += nn
+				if err != nil {
+					return
+				}
+			}
+			switch b {
+			case '\\', '"':
+				err = dst.WriteByte('\\')
+				if err != nil {
+					return
+				}
+				n++
+				err = dst.WriteByte(b)
+				if err != nil {
+					return
+				}
+				n++
+			case '\n':
+				err = dst.WriteByte('\\')
+				if err != nil {
+					return
+				}
+				n++
+				err = dst.WriteByte('n')
+				if err != nil {
+					return
+				}
+				n++
+			case '\r':
+				err = dst.WriteByte('\\')
+				if err != nil {
+					return
+				}
+				n++
+				err = dst.WriteByte('r')
+				if err != nil {
+					return
+				}
+				n++
+			default:
+				nn, err = dst.WriteString(`\u00`)
+				n += nn
+				if err != nil {
+					return
+				}
+				err = dst.WriteByte(hex[b>>4])
+				if err != nil {
+					return
+				}
+				n++
+				err = dst.WriteByte(hex[b&0xF])
+				if err != nil {
+					return
+				}
+				n++
+			}
+			i++
+			start = i
+			continue
+		}
+		c, size := utf8.DecodeRune(s[i:])
+		if c == utf8.RuneError && size == 1 {
+			if start < i {
+				nn, err = dst.Write(s[start:i])
+				n += nn
+				if err != nil {
+					return
+				}
+				nn, err = dst.WriteString(`\ufffd`)
+				n += nn
+				if err != nil {
+					return
+				}
+				i += size
+				start = i
+				continue
+			}
+		}
+		if c == '\u2028' || c == '\u2029' {
+			if start < i {
+				nn, err = dst.Write(s[start:i])
+				n += nn
+				if err != nil {
+					return
+				}
+				nn, err = dst.WriteString(`\u202`)
+				n += nn
+				if err != nil {
+					return
+				}
+				err = dst.WriteByte(hex[c&0xF])
+				if err != nil {
+					return
+				}
+				n++
+			}
+		}
+		i += size
+	}
+	if start < len(s) {
+		nn, err = dst.Write(s[start:])
+		n += nn
+		if err != nil {
+			return
+		}
+	}
+	err = dst.WriteByte('"')
+	if err != nil {
+		return
+	}
+	n++
+	return
+}

--- a/vendor/github.com/tinylib/msgp/msgp/json_bytes.go
+++ b/vendor/github.com/tinylib/msgp/msgp/json_bytes.go
@@ -1,0 +1,363 @@
+package msgp
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"strconv"
+	"time"
+)
+
+var unfuns [_maxtype]func(jsWriter, []byte, []byte) ([]byte, []byte, error)
+
+func init() {
+
+	// NOTE(pmh): this is best expressed as a jump table,
+	// but gc doesn't do that yet. revisit post-go1.5.
+	unfuns = [_maxtype]func(jsWriter, []byte, []byte) ([]byte, []byte, error){
+		StrType:        rwStringBytes,
+		BinType:        rwBytesBytes,
+		MapType:        rwMapBytes,
+		ArrayType:      rwArrayBytes,
+		Float64Type:    rwFloat64Bytes,
+		Float32Type:    rwFloat32Bytes,
+		BoolType:       rwBoolBytes,
+		IntType:        rwIntBytes,
+		UintType:       rwUintBytes,
+		NilType:        rwNullBytes,
+		ExtensionType:  rwExtensionBytes,
+		Complex64Type:  rwExtensionBytes,
+		Complex128Type: rwExtensionBytes,
+		TimeType:       rwTimeBytes,
+	}
+}
+
+// UnmarshalAsJSON takes raw messagepack and writes
+// it as JSON to 'w'. If an error is returned, the
+// bytes not translated will also be returned. If
+// no errors are encountered, the length of the returned
+// slice will be zero.
+func UnmarshalAsJSON(w io.Writer, msg []byte) ([]byte, error) {
+	var (
+		scratch []byte
+		cast    bool
+		dst     jsWriter
+		err     error
+	)
+	if jsw, ok := w.(jsWriter); ok {
+		dst = jsw
+		cast = true
+	} else {
+		dst = bufio.NewWriterSize(w, 512)
+	}
+	for len(msg) > 0 && err == nil {
+		msg, scratch, err = writeNext(dst, msg, scratch)
+	}
+	if !cast && err == nil {
+		err = dst.(*bufio.Writer).Flush()
+	}
+	return msg, err
+}
+
+func writeNext(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+	if len(msg) < 1 {
+		return msg, scratch, ErrShortBytes
+	}
+	t := getType(msg[0])
+	if t == InvalidType {
+		return msg, scratch, InvalidPrefixError(msg[0])
+	}
+	if t == ExtensionType {
+		et, err := peekExtension(msg)
+		if err != nil {
+			return nil, scratch, err
+		}
+		if et == TimeExtension {
+			t = TimeType
+		}
+	}
+	return unfuns[t](w, msg, scratch)
+}
+
+func rwArrayBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+	sz, msg, err := ReadArrayHeaderBytes(msg)
+	if err != nil {
+		return msg, scratch, err
+	}
+	err = w.WriteByte('[')
+	if err != nil {
+		return msg, scratch, err
+	}
+	for i := uint32(0); i < sz; i++ {
+		if i != 0 {
+			err = w.WriteByte(',')
+			if err != nil {
+				return msg, scratch, err
+			}
+		}
+		msg, scratch, err = writeNext(w, msg, scratch)
+		if err != nil {
+			return msg, scratch, err
+		}
+	}
+	err = w.WriteByte(']')
+	return msg, scratch, err
+}
+
+func rwMapBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+	sz, msg, err := ReadMapHeaderBytes(msg)
+	if err != nil {
+		return msg, scratch, err
+	}
+	err = w.WriteByte('{')
+	if err != nil {
+		return msg, scratch, err
+	}
+	for i := uint32(0); i < sz; i++ {
+		if i != 0 {
+			err = w.WriteByte(',')
+			if err != nil {
+				return msg, scratch, err
+			}
+		}
+		msg, scratch, err = rwMapKeyBytes(w, msg, scratch)
+		if err != nil {
+			return msg, scratch, err
+		}
+		err = w.WriteByte(':')
+		if err != nil {
+			return msg, scratch, err
+		}
+		msg, scratch, err = writeNext(w, msg, scratch)
+		if err != nil {
+			return msg, scratch, err
+		}
+	}
+	err = w.WriteByte('}')
+	return msg, scratch, err
+}
+
+func rwMapKeyBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+	msg, scratch, err := rwStringBytes(w, msg, scratch)
+	if err != nil {
+		if tperr, ok := err.(TypeError); ok && tperr.Encoded == BinType {
+			return rwBytesBytes(w, msg, scratch)
+		}
+	}
+	return msg, scratch, err
+}
+
+func rwStringBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+	str, msg, err := ReadStringZC(msg)
+	if err != nil {
+		return msg, scratch, err
+	}
+	_, err = rwquoted(w, str)
+	return msg, scratch, err
+}
+
+func rwBytesBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+	bts, msg, err := ReadBytesZC(msg)
+	if err != nil {
+		return msg, scratch, err
+	}
+	l := base64.StdEncoding.EncodedLen(len(bts))
+	if cap(scratch) >= l {
+		scratch = scratch[0:l]
+	} else {
+		scratch = make([]byte, l)
+	}
+	base64.StdEncoding.Encode(scratch, bts)
+	err = w.WriteByte('"')
+	if err != nil {
+		return msg, scratch, err
+	}
+	_, err = w.Write(scratch)
+	if err != nil {
+		return msg, scratch, err
+	}
+	err = w.WriteByte('"')
+	return msg, scratch, err
+}
+
+func rwNullBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+	msg, err := ReadNilBytes(msg)
+	if err != nil {
+		return msg, scratch, err
+	}
+	_, err = w.Write(null)
+	return msg, scratch, err
+}
+
+func rwBoolBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+	b, msg, err := ReadBoolBytes(msg)
+	if err != nil {
+		return msg, scratch, err
+	}
+	if b {
+		_, err = w.WriteString("true")
+		return msg, scratch, err
+	}
+	_, err = w.WriteString("false")
+	return msg, scratch, err
+}
+
+func rwIntBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+	i, msg, err := ReadInt64Bytes(msg)
+	if err != nil {
+		return msg, scratch, err
+	}
+	scratch = strconv.AppendInt(scratch[0:0], i, 10)
+	_, err = w.Write(scratch)
+	return msg, scratch, err
+}
+
+func rwUintBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+	u, msg, err := ReadUint64Bytes(msg)
+	if err != nil {
+		return msg, scratch, err
+	}
+	scratch = strconv.AppendUint(scratch[0:0], u, 10)
+	_, err = w.Write(scratch)
+	return msg, scratch, err
+}
+
+func rwFloatBytes(w jsWriter, msg []byte, f64 bool, scratch []byte) ([]byte, []byte, error) {
+	var f float64
+	var err error
+	var sz int
+	if f64 {
+		sz = 64
+		f, msg, err = ReadFloat64Bytes(msg)
+	} else {
+		sz = 32
+		var v float32
+		v, msg, err = ReadFloat32Bytes(msg)
+		f = float64(v)
+	}
+	if err != nil {
+		return msg, scratch, err
+	}
+	scratch = strconv.AppendFloat(scratch, f, 'f', -1, sz)
+	_, err = w.Write(scratch)
+	return msg, scratch, err
+}
+
+func rwFloat32Bytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+	var f float32
+	var err error
+	f, msg, err = ReadFloat32Bytes(msg)
+	if err != nil {
+		return msg, scratch, err
+	}
+	scratch = strconv.AppendFloat(scratch[:0], float64(f), 'f', -1, 32)
+	_, err = w.Write(scratch)
+	return msg, scratch, err
+}
+
+func rwFloat64Bytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+	var f float64
+	var err error
+	f, msg, err = ReadFloat64Bytes(msg)
+	if err != nil {
+		return msg, scratch, err
+	}
+	scratch = strconv.AppendFloat(scratch[:0], f, 'f', -1, 64)
+	_, err = w.Write(scratch)
+	return msg, scratch, err
+}
+
+func rwTimeBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+	var t time.Time
+	var err error
+	t, msg, err = ReadTimeBytes(msg)
+	if err != nil {
+		return msg, scratch, err
+	}
+	bts, err := t.MarshalJSON()
+	if err != nil {
+		return msg, scratch, err
+	}
+	_, err = w.Write(bts)
+	return msg, scratch, err
+}
+
+func rwExtensionBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+	var err error
+	var et int8
+	et, err = peekExtension(msg)
+	if err != nil {
+		return msg, scratch, err
+	}
+
+	// if it's time.Time
+	if et == TimeExtension {
+		var tm time.Time
+		tm, msg, err = ReadTimeBytes(msg)
+		if err != nil {
+			return msg, scratch, err
+		}
+		bts, err := tm.MarshalJSON()
+		if err != nil {
+			return msg, scratch, err
+		}
+		_, err = w.Write(bts)
+		return msg, scratch, err
+	}
+
+	// if the extension is registered,
+	// use its canonical JSON form
+	if f, ok := extensionReg[et]; ok {
+		e := f()
+		msg, err = ReadExtensionBytes(msg, e)
+		if err != nil {
+			return msg, scratch, err
+		}
+		bts, err := json.Marshal(e)
+		if err != nil {
+			return msg, scratch, err
+		}
+		_, err = w.Write(bts)
+		return msg, scratch, err
+	}
+
+	// otherwise, write `{"type": <num>, "data": "<base64data>"}`
+	r := RawExtension{}
+	r.Type = et
+	msg, err = ReadExtensionBytes(msg, &r)
+	if err != nil {
+		return msg, scratch, err
+	}
+	scratch, err = writeExt(w, r, scratch)
+	return msg, scratch, err
+}
+
+func writeExt(w jsWriter, r RawExtension, scratch []byte) ([]byte, error) {
+	_, err := w.WriteString(`{"type":`)
+	if err != nil {
+		return scratch, err
+	}
+	scratch = strconv.AppendInt(scratch[0:0], int64(r.Type), 10)
+	_, err = w.Write(scratch)
+	if err != nil {
+		return scratch, err
+	}
+	_, err = w.WriteString(`,"data":"`)
+	if err != nil {
+		return scratch, err
+	}
+	l := base64.StdEncoding.EncodedLen(len(r.Data))
+	if cap(scratch) >= l {
+		scratch = scratch[0:l]
+	} else {
+		scratch = make([]byte, l)
+	}
+	base64.StdEncoding.Encode(scratch, r.Data)
+	_, err = w.Write(scratch)
+	if err != nil {
+		return scratch, err
+	}
+	_, err = w.WriteString(`"}`)
+	return scratch, err
+}

--- a/vendor/github.com/tinylib/msgp/msgp/number.go
+++ b/vendor/github.com/tinylib/msgp/msgp/number.go
@@ -1,0 +1,267 @@
+package msgp
+
+import (
+	"math"
+	"strconv"
+)
+
+// The portable parts of the Number implementation
+
+// Number can be
+// an int64, uint64, float32,
+// or float64 internally.
+// It can decode itself
+// from any of the native
+// messagepack number types.
+// The zero-value of Number
+// is Int(0). Using the equality
+// operator with Number compares
+// both the type and the value
+// of the number.
+type Number struct {
+	// internally, this
+	// is just a tagged union.
+	// the raw bits of the number
+	// are stored the same way regardless.
+	bits uint64
+	typ  Type
+}
+
+// AsInt sets the number to an int64.
+func (n *Number) AsInt(i int64) {
+
+	// we always store int(0)
+	// as {0, InvalidType} in
+	// order to preserve
+	// the behavior of the == operator
+	if i == 0 {
+		n.typ = InvalidType
+		n.bits = 0
+		return
+	}
+
+	n.typ = IntType
+	n.bits = uint64(i)
+}
+
+// AsUint sets the number to a uint64.
+func (n *Number) AsUint(u uint64) {
+	n.typ = UintType
+	n.bits = u
+}
+
+// AsFloat32 sets the value of the number
+// to a float32.
+func (n *Number) AsFloat32(f float32) {
+	n.typ = Float32Type
+	n.bits = uint64(math.Float32bits(f))
+}
+
+// AsFloat64 sets the value of the
+// number to a float64.
+func (n *Number) AsFloat64(f float64) {
+	n.typ = Float64Type
+	n.bits = math.Float64bits(f)
+}
+
+// Int casts the number as an int64, and
+// returns whether or not that was the
+// underlying type.
+func (n *Number) Int() (int64, bool) {
+	return int64(n.bits), n.typ == IntType || n.typ == InvalidType
+}
+
+// Uint casts the number as a uint64, and returns
+// whether or not that was the underlying type.
+func (n *Number) Uint() (uint64, bool) {
+	return n.bits, n.typ == UintType
+}
+
+// Float casts the number to a float64, and
+// returns whether or not that was the underlying
+// type (either a float64 or a float32).
+func (n *Number) Float() (float64, bool) {
+	switch n.typ {
+	case Float32Type:
+		return float64(math.Float32frombits(uint32(n.bits))), true
+	case Float64Type:
+		return math.Float64frombits(n.bits), true
+	default:
+		return 0.0, false
+	}
+}
+
+// Type will return one of:
+// Float64Type, Float32Type, UintType, or IntType.
+func (n *Number) Type() Type {
+	if n.typ == InvalidType {
+		return IntType
+	}
+	return n.typ
+}
+
+// DecodeMsg implements msgp.Decodable
+func (n *Number) DecodeMsg(r *Reader) error {
+	typ, err := r.NextType()
+	if err != nil {
+		return err
+	}
+	switch typ {
+	case Float32Type:
+		f, err := r.ReadFloat32()
+		if err != nil {
+			return err
+		}
+		n.AsFloat32(f)
+		return nil
+	case Float64Type:
+		f, err := r.ReadFloat64()
+		if err != nil {
+			return err
+		}
+		n.AsFloat64(f)
+		return nil
+	case IntType:
+		i, err := r.ReadInt64()
+		if err != nil {
+			return err
+		}
+		n.AsInt(i)
+		return nil
+	case UintType:
+		u, err := r.ReadUint64()
+		if err != nil {
+			return err
+		}
+		n.AsUint(u)
+		return nil
+	default:
+		return TypeError{Encoded: typ, Method: IntType}
+	}
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (n *Number) UnmarshalMsg(b []byte) ([]byte, error) {
+	typ := NextType(b)
+	switch typ {
+	case IntType:
+		i, o, err := ReadInt64Bytes(b)
+		if err != nil {
+			return b, err
+		}
+		n.AsInt(i)
+		return o, nil
+	case UintType:
+		u, o, err := ReadUint64Bytes(b)
+		if err != nil {
+			return b, err
+		}
+		n.AsUint(u)
+		return o, nil
+	case Float64Type:
+		f, o, err := ReadFloat64Bytes(b)
+		if err != nil {
+			return b, err
+		}
+		n.AsFloat64(f)
+		return o, nil
+	case Float32Type:
+		f, o, err := ReadFloat32Bytes(b)
+		if err != nil {
+			return b, err
+		}
+		n.AsFloat32(f)
+		return o, nil
+	default:
+		return b, TypeError{Method: IntType, Encoded: typ}
+	}
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (n *Number) MarshalMsg(b []byte) ([]byte, error) {
+	switch n.typ {
+	case IntType:
+		return AppendInt64(b, int64(n.bits)), nil
+	case UintType:
+		return AppendUint64(b, uint64(n.bits)), nil
+	case Float64Type:
+		return AppendFloat64(b, math.Float64frombits(n.bits)), nil
+	case Float32Type:
+		return AppendFloat32(b, math.Float32frombits(uint32(n.bits))), nil
+	default:
+		return AppendInt64(b, 0), nil
+	}
+}
+
+// EncodeMsg implements msgp.Encodable
+func (n *Number) EncodeMsg(w *Writer) error {
+	switch n.typ {
+	case IntType:
+		return w.WriteInt64(int64(n.bits))
+	case UintType:
+		return w.WriteUint64(n.bits)
+	case Float64Type:
+		return w.WriteFloat64(math.Float64frombits(n.bits))
+	case Float32Type:
+		return w.WriteFloat32(math.Float32frombits(uint32(n.bits)))
+	default:
+		return w.WriteInt64(0)
+	}
+}
+
+// Msgsize implements msgp.Sizer
+func (n *Number) Msgsize() int {
+	switch n.typ {
+	case Float32Type:
+		return Float32Size
+	case Float64Type:
+		return Float64Size
+	case IntType:
+		return Int64Size
+	case UintType:
+		return Uint64Size
+	default:
+		return 1 // fixint(0)
+	}
+}
+
+// MarshalJSON implements json.Marshaler
+func (n *Number) MarshalJSON() ([]byte, error) {
+	t := n.Type()
+	if t == InvalidType {
+		return []byte{'0'}, nil
+	}
+	out := make([]byte, 0, 32)
+	switch t {
+	case Float32Type, Float64Type:
+		f, _ := n.Float()
+		return strconv.AppendFloat(out, f, 'f', -1, 64), nil
+	case IntType:
+		i, _ := n.Int()
+		return strconv.AppendInt(out, i, 10), nil
+	case UintType:
+		u, _ := n.Uint()
+		return strconv.AppendUint(out, u, 10), nil
+	default:
+		panic("(*Number).typ is invalid")
+	}
+}
+
+// String implements fmt.Stringer
+func (n *Number) String() string {
+	switch n.typ {
+	case InvalidType:
+		return "0"
+	case Float32Type, Float64Type:
+		f, _ := n.Float()
+		return strconv.FormatFloat(f, 'f', -1, 64)
+	case IntType:
+		i, _ := n.Int()
+		return strconv.FormatInt(i, 10)
+	case UintType:
+		u, _ := n.Uint()
+		return strconv.FormatUint(u, 10)
+	default:
+		panic("(*Number).typ is invalid")
+	}
+}

--- a/vendor/github.com/tinylib/msgp/msgp/read.go
+++ b/vendor/github.com/tinylib/msgp/msgp/read.go
@@ -1,0 +1,1265 @@
+package msgp
+
+import (
+	"io"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/philhofer/fwd"
+)
+
+// where we keep old *Readers
+var readerPool = sync.Pool{New: func() interface{} { return &Reader{} }}
+
+// Type is a MessagePack wire type,
+// including this package's built-in
+// extension types.
+type Type byte
+
+// MessagePack Types
+//
+// The zero value of Type
+// is InvalidType.
+const (
+	InvalidType Type = iota
+
+	// MessagePack built-in types
+
+	StrType
+	BinType
+	MapType
+	ArrayType
+	Float64Type
+	Float32Type
+	BoolType
+	IntType
+	UintType
+	NilType
+	ExtensionType
+
+	// pseudo-types provided
+	// by extensions
+
+	Complex64Type
+	Complex128Type
+	TimeType
+
+	_maxtype
+)
+
+// String implements fmt.Stringer
+func (t Type) String() string {
+	switch t {
+	case StrType:
+		return "str"
+	case BinType:
+		return "bin"
+	case MapType:
+		return "map"
+	case ArrayType:
+		return "array"
+	case Float64Type:
+		return "float64"
+	case Float32Type:
+		return "float32"
+	case BoolType:
+		return "bool"
+	case UintType:
+		return "uint"
+	case IntType:
+		return "int"
+	case ExtensionType:
+		return "ext"
+	case NilType:
+		return "nil"
+	default:
+		return "<invalid>"
+	}
+}
+
+func freeR(m *Reader) {
+	readerPool.Put(m)
+}
+
+// Unmarshaler is the interface fulfilled
+// by objects that know how to unmarshal
+// themselves from MessagePack.
+// UnmarshalMsg unmarshals the object
+// from binary, returing any leftover
+// bytes and any errors encountered.
+type Unmarshaler interface {
+	UnmarshalMsg([]byte) ([]byte, error)
+}
+
+// Decodable is the interface fulfilled
+// by objects that know how to read
+// themselves from a *Reader.
+type Decodable interface {
+	DecodeMsg(*Reader) error
+}
+
+// Decode decodes 'd' from 'r'.
+func Decode(r io.Reader, d Decodable) error {
+	rd := NewReader(r)
+	err := d.DecodeMsg(rd)
+	freeR(rd)
+	return err
+}
+
+// NewReader returns a *Reader that
+// reads from the provided reader. The
+// reader will be buffered.
+func NewReader(r io.Reader) *Reader {
+	p := readerPool.Get().(*Reader)
+	if p.R == nil {
+		p.R = fwd.NewReader(r)
+	} else {
+		p.R.Reset(r)
+	}
+	return p
+}
+
+// NewReaderSize returns a *Reader with a buffer of the given size.
+// (This is vastly preferable to passing the decoder a reader that is already buffered.)
+func NewReaderSize(r io.Reader, sz int) *Reader {
+	return &Reader{R: fwd.NewReaderSize(r, sz)}
+}
+
+// Reader wraps an io.Reader and provides
+// methods to read MessagePack-encoded values
+// from it. Readers are buffered.
+type Reader struct {
+	// R is the buffered reader
+	// that the Reader uses
+	// to decode MessagePack.
+	// The Reader itself
+	// is stateless; all the
+	// buffering is done
+	// within R.
+	R       *fwd.Reader
+	scratch []byte
+}
+
+// Read implements `io.Reader`
+func (m *Reader) Read(p []byte) (int, error) {
+	return m.R.Read(p)
+}
+
+// CopyNext reads the next object from m without decoding it and writes it to w.
+// It avoids unnecessary copies internally.
+func (m *Reader) CopyNext(w io.Writer) (int64, error) {
+	sz, o, err := getNextSize(m.R)
+	if err != nil {
+		return 0, err
+	}
+
+	var n int64
+	// Opportunistic optimization: if we can fit the whole thing in the m.R
+	// buffer, then just get a pointer to that, and pass it to w.Write,
+	// avoiding an allocation.
+	if int(sz) <= m.R.BufferSize() {
+		var nn int
+		var buf []byte
+		buf, err = m.R.Next(int(sz))
+		if err != nil {
+			if err == io.ErrUnexpectedEOF {
+				err = ErrShortBytes
+			}
+			return 0, err
+		}
+		nn, err = w.Write(buf)
+		n += int64(nn)
+	} else {
+		// Fall back to io.CopyN.
+		// May avoid allocating if w is a ReaderFrom (e.g. bytes.Buffer)
+		n, err = io.CopyN(w, m.R, int64(sz))
+		if err == io.ErrUnexpectedEOF {
+			err = ErrShortBytes
+		}
+	}
+	if err != nil {
+		return n, err
+	} else if n < int64(sz) {
+		return n, io.ErrShortWrite
+	}
+
+	// for maps and slices, read elements
+	for x := uintptr(0); x < o; x++ {
+		var n2 int64
+		n2, err = m.CopyNext(w)
+		if err != nil {
+			return n, err
+		}
+		n += n2
+	}
+	return n, nil
+}
+
+// ReadFull implements `io.ReadFull`
+func (m *Reader) ReadFull(p []byte) (int, error) {
+	return m.R.ReadFull(p)
+}
+
+// Reset resets the underlying reader.
+func (m *Reader) Reset(r io.Reader) { m.R.Reset(r) }
+
+// Buffered returns the number of bytes currently in the read buffer.
+func (m *Reader) Buffered() int { return m.R.Buffered() }
+
+// BufferSize returns the capacity of the read buffer.
+func (m *Reader) BufferSize() int { return m.R.BufferSize() }
+
+// NextType returns the next object type to be decoded.
+func (m *Reader) NextType() (Type, error) {
+	p, err := m.R.Peek(1)
+	if err != nil {
+		return InvalidType, err
+	}
+	t := getType(p[0])
+	if t == InvalidType {
+		return t, InvalidPrefixError(p[0])
+	}
+	if t == ExtensionType {
+		v, err := m.peekExtensionType()
+		if err != nil {
+			return InvalidType, err
+		}
+		switch v {
+		case Complex64Extension:
+			return Complex64Type, nil
+		case Complex128Extension:
+			return Complex128Type, nil
+		case TimeExtension:
+			return TimeType, nil
+		}
+	}
+	return t, nil
+}
+
+// IsNil returns whether or not
+// the next byte is a null messagepack byte
+func (m *Reader) IsNil() bool {
+	p, err := m.R.Peek(1)
+	return err == nil && p[0] == mnil
+}
+
+// getNextSize returns the size of the next object on the wire.
+// returns (obj size, obj elements, error)
+// only maps and arrays have non-zero obj elements
+// for maps and arrays, obj size does not include elements
+//
+// use uintptr b/c it's guaranteed to be large enough
+// to hold whatever we can fit in memory.
+func getNextSize(r *fwd.Reader) (uintptr, uintptr, error) {
+	b, err := r.Peek(1)
+	if err != nil {
+		return 0, 0, err
+	}
+	lead := b[0]
+	spec := &sizes[lead]
+	size, mode := spec.size, spec.extra
+	if size == 0 {
+		return 0, 0, InvalidPrefixError(lead)
+	}
+	if mode >= 0 {
+		return uintptr(size), uintptr(mode), nil
+	}
+	b, err = r.Peek(int(size))
+	if err != nil {
+		return 0, 0, err
+	}
+	switch mode {
+	case extra8:
+		return uintptr(size) + uintptr(b[1]), 0, nil
+	case extra16:
+		return uintptr(size) + uintptr(big.Uint16(b[1:])), 0, nil
+	case extra32:
+		return uintptr(size) + uintptr(big.Uint32(b[1:])), 0, nil
+	case map16v:
+		return uintptr(size), 2 * uintptr(big.Uint16(b[1:])), nil
+	case map32v:
+		return uintptr(size), 2 * uintptr(big.Uint32(b[1:])), nil
+	case array16v:
+		return uintptr(size), uintptr(big.Uint16(b[1:])), nil
+	case array32v:
+		return uintptr(size), uintptr(big.Uint32(b[1:])), nil
+	default:
+		return 0, 0, fatal
+	}
+}
+
+// Skip skips over the next object, regardless of
+// its type. If it is an array or map, the whole array
+// or map will be skipped.
+func (m *Reader) Skip() error {
+	var (
+		v   uintptr // bytes
+		o   uintptr // objects
+		err error
+		p   []byte
+	)
+
+	// we can use the faster
+	// method if we have enough
+	// buffered data
+	if m.R.Buffered() >= 5 {
+		p, err = m.R.Peek(5)
+		if err != nil {
+			return err
+		}
+		v, o, err = getSize(p)
+		if err != nil {
+			return err
+		}
+	} else {
+		v, o, err = getNextSize(m.R)
+		if err != nil {
+			return err
+		}
+	}
+
+	// 'v' is always non-zero
+	// if err == nil
+	_, err = m.R.Skip(int(v))
+	if err != nil {
+		return err
+	}
+
+	// for maps and slices, skip elements
+	for x := uintptr(0); x < o; x++ {
+		err = m.Skip()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReadMapHeader reads the next object
+// as a map header and returns the size
+// of the map and the number of bytes written.
+// It will return a TypeError{} if the next
+// object is not a map.
+func (m *Reader) ReadMapHeader() (sz uint32, err error) {
+	var p []byte
+	var lead byte
+	p, err = m.R.Peek(1)
+	if err != nil {
+		return
+	}
+	lead = p[0]
+	if isfixmap(lead) {
+		sz = uint32(rfixmap(lead))
+		_, err = m.R.Skip(1)
+		return
+	}
+	switch lead {
+	case mmap16:
+		p, err = m.R.Next(3)
+		if err != nil {
+			return
+		}
+		sz = uint32(big.Uint16(p[1:]))
+		return
+	case mmap32:
+		p, err = m.R.Next(5)
+		if err != nil {
+			return
+		}
+		sz = big.Uint32(p[1:])
+		return
+	default:
+		err = badPrefix(MapType, lead)
+		return
+	}
+}
+
+// ReadMapKey reads either a 'str' or 'bin' field from
+// the reader and returns the value as a []byte. It uses
+// scratch for storage if it is large enough.
+func (m *Reader) ReadMapKey(scratch []byte) ([]byte, error) {
+	out, err := m.ReadStringAsBytes(scratch)
+	if err != nil {
+		if tperr, ok := err.(TypeError); ok && tperr.Encoded == BinType {
+			return m.ReadBytes(scratch)
+		}
+		return nil, err
+	}
+	return out, nil
+}
+
+// MapKeyPtr returns a []byte pointing to the contents
+// of a valid map key. The key cannot be empty, and it
+// must be shorter than the total buffer size of the
+// *Reader. Additionally, the returned slice is only
+// valid until the next *Reader method call. Users
+// should exercise extreme care when using this
+// method; writing into the returned slice may
+// corrupt future reads.
+func (m *Reader) ReadMapKeyPtr() ([]byte, error) {
+	p, err := m.R.Peek(1)
+	if err != nil {
+		return nil, err
+	}
+	lead := p[0]
+	var read int
+	if isfixstr(lead) {
+		read = int(rfixstr(lead))
+		m.R.Skip(1)
+		goto fill
+	}
+	switch lead {
+	case mstr8, mbin8:
+		p, err = m.R.Next(2)
+		if err != nil {
+			return nil, err
+		}
+		read = int(p[1])
+	case mstr16, mbin16:
+		p, err = m.R.Next(3)
+		if err != nil {
+			return nil, err
+		}
+		read = int(big.Uint16(p[1:]))
+	case mstr32, mbin32:
+		p, err = m.R.Next(5)
+		if err != nil {
+			return nil, err
+		}
+		read = int(big.Uint32(p[1:]))
+	default:
+		return nil, badPrefix(StrType, lead)
+	}
+fill:
+	if read == 0 {
+		return nil, ErrShortBytes
+	}
+	return m.R.Next(read)
+}
+
+// ReadArrayHeader reads the next object as an
+// array header and returns the size of the array
+// and the number of bytes read.
+func (m *Reader) ReadArrayHeader() (sz uint32, err error) {
+	var lead byte
+	var p []byte
+	p, err = m.R.Peek(1)
+	if err != nil {
+		return
+	}
+	lead = p[0]
+	if isfixarray(lead) {
+		sz = uint32(rfixarray(lead))
+		_, err = m.R.Skip(1)
+		return
+	}
+	switch lead {
+	case marray16:
+		p, err = m.R.Next(3)
+		if err != nil {
+			return
+		}
+		sz = uint32(big.Uint16(p[1:]))
+		return
+
+	case marray32:
+		p, err = m.R.Next(5)
+		if err != nil {
+			return
+		}
+		sz = big.Uint32(p[1:])
+		return
+
+	default:
+		err = badPrefix(ArrayType, lead)
+		return
+	}
+}
+
+// ReadNil reads a 'nil' MessagePack byte from the reader
+func (m *Reader) ReadNil() error {
+	p, err := m.R.Peek(1)
+	if err != nil {
+		return err
+	}
+	if p[0] != mnil {
+		return badPrefix(NilType, p[0])
+	}
+	_, err = m.R.Skip(1)
+	return err
+}
+
+// ReadFloat64 reads a float64 from the reader.
+// (If the value on the wire is encoded as a float32,
+// it will be up-cast to a float64.)
+func (m *Reader) ReadFloat64() (f float64, err error) {
+	var p []byte
+	p, err = m.R.Peek(9)
+	if err != nil {
+		// we'll allow a coversion from float32 to float64,
+		// since we don't lose any precision
+		if err == io.EOF && len(p) > 0 && p[0] == mfloat32 {
+			ef, err := m.ReadFloat32()
+			return float64(ef), err
+		}
+		return
+	}
+	if p[0] != mfloat64 {
+		// see above
+		if p[0] == mfloat32 {
+			ef, err := m.ReadFloat32()
+			return float64(ef), err
+		}
+		err = badPrefix(Float64Type, p[0])
+		return
+	}
+	f = math.Float64frombits(getMuint64(p))
+	_, err = m.R.Skip(9)
+	return
+}
+
+// ReadFloat32 reads a float32 from the reader
+func (m *Reader) ReadFloat32() (f float32, err error) {
+	var p []byte
+	p, err = m.R.Peek(5)
+	if err != nil {
+		return
+	}
+	if p[0] != mfloat32 {
+		err = badPrefix(Float32Type, p[0])
+		return
+	}
+	f = math.Float32frombits(getMuint32(p))
+	_, err = m.R.Skip(5)
+	return
+}
+
+// ReadBool reads a bool from the reader
+func (m *Reader) ReadBool() (b bool, err error) {
+	var p []byte
+	p, err = m.R.Peek(1)
+	if err != nil {
+		return
+	}
+	switch p[0] {
+	case mtrue:
+		b = true
+	case mfalse:
+	default:
+		err = badPrefix(BoolType, p[0])
+		return
+	}
+	_, err = m.R.Skip(1)
+	return
+}
+
+// ReadInt64 reads an int64 from the reader
+func (m *Reader) ReadInt64() (i int64, err error) {
+	var p []byte
+	var lead byte
+	p, err = m.R.Peek(1)
+	if err != nil {
+		return
+	}
+	lead = p[0]
+
+	if isfixint(lead) {
+		i = int64(rfixint(lead))
+		_, err = m.R.Skip(1)
+		return
+	} else if isnfixint(lead) {
+		i = int64(rnfixint(lead))
+		_, err = m.R.Skip(1)
+		return
+	}
+
+	switch lead {
+	case mint8:
+		p, err = m.R.Next(2)
+		if err != nil {
+			return
+		}
+		i = int64(getMint8(p))
+		return
+
+	case mint16:
+		p, err = m.R.Next(3)
+		if err != nil {
+			return
+		}
+		i = int64(getMint16(p))
+		return
+
+	case mint32:
+		p, err = m.R.Next(5)
+		if err != nil {
+			return
+		}
+		i = int64(getMint32(p))
+		return
+
+	case mint64:
+		p, err = m.R.Next(9)
+		if err != nil {
+			return
+		}
+		i = getMint64(p)
+		return
+
+	default:
+		err = badPrefix(IntType, lead)
+		return
+	}
+}
+
+// ReadInt32 reads an int32 from the reader
+func (m *Reader) ReadInt32() (i int32, err error) {
+	var in int64
+	in, err = m.ReadInt64()
+	if in > math.MaxInt32 || in < math.MinInt32 {
+		err = IntOverflow{Value: in, FailedBitsize: 32}
+		return
+	}
+	i = int32(in)
+	return
+}
+
+// ReadInt16 reads an int16 from the reader
+func (m *Reader) ReadInt16() (i int16, err error) {
+	var in int64
+	in, err = m.ReadInt64()
+	if in > math.MaxInt16 || in < math.MinInt16 {
+		err = IntOverflow{Value: in, FailedBitsize: 16}
+		return
+	}
+	i = int16(in)
+	return
+}
+
+// ReadInt8 reads an int8 from the reader
+func (m *Reader) ReadInt8() (i int8, err error) {
+	var in int64
+	in, err = m.ReadInt64()
+	if in > math.MaxInt8 || in < math.MinInt8 {
+		err = IntOverflow{Value: in, FailedBitsize: 8}
+		return
+	}
+	i = int8(in)
+	return
+}
+
+// ReadInt reads an int from the reader
+func (m *Reader) ReadInt() (i int, err error) {
+	if smallint {
+		var in int32
+		in, err = m.ReadInt32()
+		i = int(in)
+		return
+	}
+	var in int64
+	in, err = m.ReadInt64()
+	i = int(in)
+	return
+}
+
+// ReadUint64 reads a uint64 from the reader
+func (m *Reader) ReadUint64() (u uint64, err error) {
+	var p []byte
+	var lead byte
+	p, err = m.R.Peek(1)
+	if err != nil {
+		return
+	}
+	lead = p[0]
+	if isfixint(lead) {
+		u = uint64(rfixint(lead))
+		_, err = m.R.Skip(1)
+		return
+	}
+	switch lead {
+	case muint8:
+		p, err = m.R.Next(2)
+		if err != nil {
+			return
+		}
+		u = uint64(getMuint8(p))
+		return
+
+	case muint16:
+		p, err = m.R.Next(3)
+		if err != nil {
+			return
+		}
+		u = uint64(getMuint16(p))
+		return
+
+	case muint32:
+		p, err = m.R.Next(5)
+		if err != nil {
+			return
+		}
+		u = uint64(getMuint32(p))
+		return
+
+	case muint64:
+		p, err = m.R.Next(9)
+		if err != nil {
+			return
+		}
+		u = getMuint64(p)
+		return
+
+	default:
+		err = badPrefix(UintType, lead)
+		return
+
+	}
+}
+
+// ReadUint32 reads a uint32 from the reader
+func (m *Reader) ReadUint32() (u uint32, err error) {
+	var in uint64
+	in, err = m.ReadUint64()
+	if in > math.MaxUint32 {
+		err = UintOverflow{Value: in, FailedBitsize: 32}
+		return
+	}
+	u = uint32(in)
+	return
+}
+
+// ReadUint16 reads a uint16 from the reader
+func (m *Reader) ReadUint16() (u uint16, err error) {
+	var in uint64
+	in, err = m.ReadUint64()
+	if in > math.MaxUint16 {
+		err = UintOverflow{Value: in, FailedBitsize: 16}
+		return
+	}
+	u = uint16(in)
+	return
+}
+
+// ReadUint8 reads a uint8 from the reader
+func (m *Reader) ReadUint8() (u uint8, err error) {
+	var in uint64
+	in, err = m.ReadUint64()
+	if in > math.MaxUint8 {
+		err = UintOverflow{Value: in, FailedBitsize: 8}
+		return
+	}
+	u = uint8(in)
+	return
+}
+
+// ReadUint reads a uint from the reader
+func (m *Reader) ReadUint() (u uint, err error) {
+	if smallint {
+		var un uint32
+		un, err = m.ReadUint32()
+		u = uint(un)
+		return
+	}
+	var un uint64
+	un, err = m.ReadUint64()
+	u = uint(un)
+	return
+}
+
+// ReadByte is analogous to ReadUint8.
+//
+// NOTE: this is *not* an implementation
+// of io.ByteReader.
+func (m *Reader) ReadByte() (b byte, err error) {
+	var in uint64
+	in, err = m.ReadUint64()
+	if in > math.MaxUint8 {
+		err = UintOverflow{Value: in, FailedBitsize: 8}
+		return
+	}
+	b = byte(in)
+	return
+}
+
+// ReadBytes reads a MessagePack 'bin' object
+// from the reader and returns its value. It may
+// use 'scratch' for storage if it is non-nil.
+func (m *Reader) ReadBytes(scratch []byte) (b []byte, err error) {
+	var p []byte
+	var lead byte
+	p, err = m.R.Peek(2)
+	if err != nil {
+		return
+	}
+	lead = p[0]
+	var read int64
+	switch lead {
+	case mbin8:
+		read = int64(p[1])
+		m.R.Skip(2)
+	case mbin16:
+		p, err = m.R.Next(3)
+		if err != nil {
+			return
+		}
+		read = int64(big.Uint16(p[1:]))
+	case mbin32:
+		p, err = m.R.Next(5)
+		if err != nil {
+			return
+		}
+		read = int64(big.Uint32(p[1:]))
+	default:
+		err = badPrefix(BinType, lead)
+		return
+	}
+	if int64(cap(scratch)) < read {
+		b = make([]byte, read)
+	} else {
+		b = scratch[0:read]
+	}
+	_, err = m.R.ReadFull(b)
+	return
+}
+
+// ReadBytesHeader reads the size header
+// of a MessagePack 'bin' object. The user
+// is responsible for dealing with the next
+// 'sz' bytes from the reader in an application-specific
+// way.
+func (m *Reader) ReadBytesHeader() (sz uint32, err error) {
+	var p []byte
+	p, err = m.R.Peek(1)
+	if err != nil {
+		return
+	}
+	switch p[0] {
+	case mbin8:
+		p, err = m.R.Next(2)
+		if err != nil {
+			return
+		}
+		sz = uint32(p[1])
+		return
+	case mbin16:
+		p, err = m.R.Next(3)
+		if err != nil {
+			return
+		}
+		sz = uint32(big.Uint16(p[1:]))
+		return
+	case mbin32:
+		p, err = m.R.Next(5)
+		if err != nil {
+			return
+		}
+		sz = uint32(big.Uint32(p[1:]))
+		return
+	default:
+		err = badPrefix(BinType, p[0])
+		return
+	}
+}
+
+// ReadExactBytes reads a MessagePack 'bin'-encoded
+// object off of the wire into the provided slice. An
+// ArrayError will be returned if the object is not
+// exactly the length of the input slice.
+func (m *Reader) ReadExactBytes(into []byte) error {
+	p, err := m.R.Peek(2)
+	if err != nil {
+		return err
+	}
+	lead := p[0]
+	var read int64 // bytes to read
+	var skip int   // prefix size to skip
+	switch lead {
+	case mbin8:
+		read = int64(p[1])
+		skip = 2
+	case mbin16:
+		p, err = m.R.Peek(3)
+		if err != nil {
+			return err
+		}
+		read = int64(big.Uint16(p[1:]))
+		skip = 3
+	case mbin32:
+		p, err = m.R.Peek(5)
+		if err != nil {
+			return err
+		}
+		read = int64(big.Uint32(p[1:]))
+		skip = 5
+	default:
+		return badPrefix(BinType, lead)
+	}
+	if read != int64(len(into)) {
+		return ArrayError{Wanted: uint32(len(into)), Got: uint32(read)}
+	}
+	m.R.Skip(skip)
+	_, err = m.R.ReadFull(into)
+	return err
+}
+
+// ReadStringAsBytes reads a MessagePack 'str' (utf-8) string
+// and returns its value as bytes. It may use 'scratch' for storage
+// if it is non-nil.
+func (m *Reader) ReadStringAsBytes(scratch []byte) (b []byte, err error) {
+	var p []byte
+	var lead byte
+	p, err = m.R.Peek(1)
+	if err != nil {
+		return
+	}
+	lead = p[0]
+	var read int64
+
+	if isfixstr(lead) {
+		read = int64(rfixstr(lead))
+		m.R.Skip(1)
+		goto fill
+	}
+
+	switch lead {
+	case mstr8:
+		p, err = m.R.Next(2)
+		if err != nil {
+			return
+		}
+		read = int64(uint8(p[1]))
+	case mstr16:
+		p, err = m.R.Next(3)
+		if err != nil {
+			return
+		}
+		read = int64(big.Uint16(p[1:]))
+	case mstr32:
+		p, err = m.R.Next(5)
+		if err != nil {
+			return
+		}
+		read = int64(big.Uint32(p[1:]))
+	default:
+		err = badPrefix(StrType, lead)
+		return
+	}
+fill:
+	if int64(cap(scratch)) < read {
+		b = make([]byte, read)
+	} else {
+		b = scratch[0:read]
+	}
+	_, err = m.R.ReadFull(b)
+	return
+}
+
+// ReadStringHeader reads a string header
+// off of the wire. The user is then responsible
+// for dealing with the next 'sz' bytes from
+// the reader in an application-specific manner.
+func (m *Reader) ReadStringHeader() (sz uint32, err error) {
+	var p []byte
+	p, err = m.R.Peek(1)
+	if err != nil {
+		return
+	}
+	lead := p[0]
+	if isfixstr(lead) {
+		sz = uint32(rfixstr(lead))
+		m.R.Skip(1)
+		return
+	}
+	switch lead {
+	case mstr8:
+		p, err = m.R.Next(2)
+		if err != nil {
+			return
+		}
+		sz = uint32(p[1])
+		return
+	case mstr16:
+		p, err = m.R.Next(3)
+		if err != nil {
+			return
+		}
+		sz = uint32(big.Uint16(p[1:]))
+		return
+	case mstr32:
+		p, err = m.R.Next(5)
+		if err != nil {
+			return
+		}
+		sz = big.Uint32(p[1:])
+		return
+	default:
+		err = badPrefix(StrType, lead)
+		return
+	}
+}
+
+// ReadString reads a utf-8 string from the reader
+func (m *Reader) ReadString() (s string, err error) {
+	var p []byte
+	var lead byte
+	var read int64
+	p, err = m.R.Peek(1)
+	if err != nil {
+		return
+	}
+	lead = p[0]
+
+	if isfixstr(lead) {
+		read = int64(rfixstr(lead))
+		m.R.Skip(1)
+		goto fill
+	}
+
+	switch lead {
+	case mstr8:
+		p, err = m.R.Next(2)
+		if err != nil {
+			return
+		}
+		read = int64(uint8(p[1]))
+	case mstr16:
+		p, err = m.R.Next(3)
+		if err != nil {
+			return
+		}
+		read = int64(big.Uint16(p[1:]))
+	case mstr32:
+		p, err = m.R.Next(5)
+		if err != nil {
+			return
+		}
+		read = int64(big.Uint32(p[1:]))
+	default:
+		err = badPrefix(StrType, lead)
+		return
+	}
+fill:
+	if read == 0 {
+		s, err = "", nil
+		return
+	}
+	// reading into the memory
+	// that will become the string
+	// itself has vastly superior
+	// worst-case performance, because
+	// the reader buffer doesn't have
+	// to be large enough to hold the string.
+	// the idea here is to make it more
+	// difficult for someone malicious
+	// to cause the system to run out of
+	// memory by sending very large strings.
+	//
+	// NOTE: this works because the argument
+	// passed to (*fwd.Reader).ReadFull escapes
+	// to the heap; its argument may, in turn,
+	// be passed to the underlying reader, and
+	// thus escape analysis *must* conclude that
+	// 'out' escapes.
+	out := make([]byte, read)
+	_, err = m.R.ReadFull(out)
+	if err != nil {
+		return
+	}
+	s = UnsafeString(out)
+	return
+}
+
+// ReadComplex64 reads a complex64 from the reader
+func (m *Reader) ReadComplex64() (f complex64, err error) {
+	var p []byte
+	p, err = m.R.Peek(10)
+	if err != nil {
+		return
+	}
+	if p[0] != mfixext8 {
+		err = badPrefix(Complex64Type, p[0])
+		return
+	}
+	if int8(p[1]) != Complex64Extension {
+		err = errExt(int8(p[1]), Complex64Extension)
+		return
+	}
+	f = complex(math.Float32frombits(big.Uint32(p[2:])),
+		math.Float32frombits(big.Uint32(p[6:])))
+	_, err = m.R.Skip(10)
+	return
+}
+
+// ReadComplex128 reads a complex128 from the reader
+func (m *Reader) ReadComplex128() (f complex128, err error) {
+	var p []byte
+	p, err = m.R.Peek(18)
+	if err != nil {
+		return
+	}
+	if p[0] != mfixext16 {
+		err = badPrefix(Complex128Type, p[0])
+		return
+	}
+	if int8(p[1]) != Complex128Extension {
+		err = errExt(int8(p[1]), Complex128Extension)
+		return
+	}
+	f = complex(math.Float64frombits(big.Uint64(p[2:])),
+		math.Float64frombits(big.Uint64(p[10:])))
+	_, err = m.R.Skip(18)
+	return
+}
+
+// ReadMapStrIntf reads a MessagePack map into a map[string]interface{}.
+// (You must pass a non-nil map into the function.)
+func (m *Reader) ReadMapStrIntf(mp map[string]interface{}) (err error) {
+	var sz uint32
+	sz, err = m.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for key := range mp {
+		delete(mp, key)
+	}
+	for i := uint32(0); i < sz; i++ {
+		var key string
+		var val interface{}
+		key, err = m.ReadString()
+		if err != nil {
+			return
+		}
+		val, err = m.ReadIntf()
+		if err != nil {
+			return
+		}
+		mp[key] = val
+	}
+	return
+}
+
+// ReadTime reads a time.Time object from the reader.
+// The returned time's location will be set to time.Local.
+func (m *Reader) ReadTime() (t time.Time, err error) {
+	var p []byte
+	p, err = m.R.Peek(15)
+	if err != nil {
+		return
+	}
+	if p[0] != mext8 || p[1] != 12 {
+		err = badPrefix(TimeType, p[0])
+		return
+	}
+	if int8(p[2]) != TimeExtension {
+		err = errExt(int8(p[2]), TimeExtension)
+		return
+	}
+	sec, nsec := getUnix(p[3:])
+	t = time.Unix(sec, int64(nsec)).Local()
+	_, err = m.R.Skip(15)
+	return
+}
+
+// ReadIntf reads out the next object as a raw interface{}.
+// Arrays are decoded as []interface{}, and maps are decoded
+// as map[string]interface{}. Integers are decoded as int64
+// and unsigned integers are decoded as uint64.
+func (m *Reader) ReadIntf() (i interface{}, err error) {
+	var t Type
+	t, err = m.NextType()
+	if err != nil {
+		return
+	}
+	switch t {
+	case BoolType:
+		i, err = m.ReadBool()
+		return
+
+	case IntType:
+		i, err = m.ReadInt64()
+		return
+
+	case UintType:
+		i, err = m.ReadUint64()
+		return
+
+	case BinType:
+		i, err = m.ReadBytes(nil)
+		return
+
+	case StrType:
+		i, err = m.ReadString()
+		return
+
+	case Complex64Type:
+		i, err = m.ReadComplex64()
+		return
+
+	case Complex128Type:
+		i, err = m.ReadComplex128()
+		return
+
+	case TimeType:
+		i, err = m.ReadTime()
+		return
+
+	case ExtensionType:
+		var t int8
+		t, err = m.peekExtensionType()
+		if err != nil {
+			return
+		}
+		f, ok := extensionReg[t]
+		if ok {
+			e := f()
+			err = m.ReadExtension(e)
+			i = e
+			return
+		}
+		var e RawExtension
+		e.Type = t
+		err = m.ReadExtension(&e)
+		i = &e
+		return
+
+	case MapType:
+		mp := make(map[string]interface{})
+		err = m.ReadMapStrIntf(mp)
+		i = mp
+		return
+
+	case NilType:
+		err = m.ReadNil()
+		i = nil
+		return
+
+	case Float32Type:
+		i, err = m.ReadFloat32()
+		return
+
+	case Float64Type:
+		i, err = m.ReadFloat64()
+		return
+
+	case ArrayType:
+		var sz uint32
+		sz, err = m.ReadArrayHeader()
+
+		if err != nil {
+			return
+		}
+		out := make([]interface{}, int(sz))
+		for j := range out {
+			out[j], err = m.ReadIntf()
+			if err != nil {
+				return
+			}
+		}
+		i = out
+		return
+
+	default:
+		return nil, fatal // unreachable
+	}
+}

--- a/vendor/github.com/tinylib/msgp/msgp/read_bytes.go
+++ b/vendor/github.com/tinylib/msgp/msgp/read_bytes.go
@@ -1,0 +1,1089 @@
+package msgp
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"time"
+)
+
+var big = binary.BigEndian
+
+// NextType returns the type of the next
+// object in the slice. If the length
+// of the input is zero, it returns
+// InvalidType.
+func NextType(b []byte) Type {
+	if len(b) == 0 {
+		return InvalidType
+	}
+	spec := sizes[b[0]]
+	t := spec.typ
+	if t == ExtensionType && len(b) > int(spec.size) {
+		var tp int8
+		if spec.extra == constsize {
+			tp = int8(b[1])
+		} else {
+			tp = int8(b[spec.size-1])
+		}
+		switch tp {
+		case TimeExtension:
+			return TimeType
+		case Complex128Extension:
+			return Complex128Type
+		case Complex64Extension:
+			return Complex64Type
+		default:
+			return ExtensionType
+		}
+	}
+	return t
+}
+
+// IsNil returns true if len(b)>0 and
+// the leading byte is a 'nil' MessagePack
+// byte; false otherwise
+func IsNil(b []byte) bool {
+	if len(b) != 0 && b[0] == mnil {
+		return true
+	}
+	return false
+}
+
+// Raw is raw MessagePack.
+// Raw allows you to read and write
+// data without interpreting its contents.
+type Raw []byte
+
+// MarshalMsg implements msgp.Marshaler.
+// It appends the raw contents of 'raw'
+// to the provided byte slice. If 'raw'
+// is 0 bytes, 'nil' will be appended instead.
+func (r Raw) MarshalMsg(b []byte) ([]byte, error) {
+	i := len(r)
+	if i == 0 {
+		return AppendNil(b), nil
+	}
+	o, l := ensure(b, i)
+	copy(o[l:], []byte(r))
+	return o, nil
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler.
+// It sets the contents of *Raw to be the next
+// object in the provided byte slice.
+func (r *Raw) UnmarshalMsg(b []byte) ([]byte, error) {
+	l := len(b)
+	out, err := Skip(b)
+	if err != nil {
+		return b, err
+	}
+	rlen := l - len(out)
+	if cap(*r) < rlen {
+		*r = make(Raw, rlen)
+	} else {
+		*r = (*r)[0:rlen]
+	}
+	copy(*r, b[:rlen])
+	return out, nil
+}
+
+// EncodeMsg implements msgp.Encodable.
+// It writes the raw bytes to the writer.
+// If r is empty, it writes 'nil' instead.
+func (r Raw) EncodeMsg(w *Writer) error {
+	if len(r) == 0 {
+		return w.WriteNil()
+	}
+	_, err := w.Write([]byte(r))
+	return err
+}
+
+// DecodeMsg implements msgp.Decodable.
+// It sets the value of *Raw to be the
+// next object on the wire.
+func (r *Raw) DecodeMsg(f *Reader) error {
+	*r = (*r)[:0]
+	return appendNext(f, (*[]byte)(r))
+}
+
+// Msgsize implements msgp.Sizer
+func (r Raw) Msgsize() int {
+	l := len(r)
+	if l == 0 {
+		return 1 // for 'nil'
+	}
+	return l
+}
+
+func appendNext(f *Reader, d *[]byte) error {
+	amt, o, err := getNextSize(f.R)
+	if err != nil {
+		return err
+	}
+	var i int
+	*d, i = ensure(*d, int(amt))
+	_, err = f.R.ReadFull((*d)[i:])
+	if err != nil {
+		return err
+	}
+	for o > 0 {
+		err = appendNext(f, d)
+		if err != nil {
+			return err
+		}
+		o--
+	}
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler
+func (r *Raw) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	_, err := UnmarshalAsJSON(&buf, []byte(*r))
+	return buf.Bytes(), err
+}
+
+// ReadMapHeaderBytes reads a map header size
+// from 'b' and returns the remaining bytes.
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError{} (not a map)
+func ReadMapHeaderBytes(b []byte) (sz uint32, o []byte, err error) {
+	l := len(b)
+	if l < 1 {
+		err = ErrShortBytes
+		return
+	}
+
+	lead := b[0]
+	if isfixmap(lead) {
+		sz = uint32(rfixmap(lead))
+		o = b[1:]
+		return
+	}
+
+	switch lead {
+	case mmap16:
+		if l < 3 {
+			err = ErrShortBytes
+			return
+		}
+		sz = uint32(big.Uint16(b[1:]))
+		o = b[3:]
+		return
+
+	case mmap32:
+		if l < 5 {
+			err = ErrShortBytes
+			return
+		}
+		sz = big.Uint32(b[1:])
+		o = b[5:]
+		return
+
+	default:
+		err = badPrefix(MapType, lead)
+		return
+	}
+}
+
+// ReadMapKeyZC attempts to read a map key
+// from 'b' and returns the key bytes and the remaining bytes
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError{} (not a str or bin)
+func ReadMapKeyZC(b []byte) ([]byte, []byte, error) {
+	o, b, err := ReadStringZC(b)
+	if err != nil {
+		if tperr, ok := err.(TypeError); ok && tperr.Encoded == BinType {
+			return ReadBytesZC(b)
+		}
+		return nil, b, err
+	}
+	return o, b, nil
+}
+
+// ReadArrayHeaderBytes attempts to read
+// the array header size off of 'b' and return
+// the size and remaining bytes.
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError{} (not an array)
+func ReadArrayHeaderBytes(b []byte) (sz uint32, o []byte, err error) {
+	if len(b) < 1 {
+		return 0, nil, ErrShortBytes
+	}
+	lead := b[0]
+	if isfixarray(lead) {
+		sz = uint32(rfixarray(lead))
+		o = b[1:]
+		return
+	}
+
+	switch lead {
+	case marray16:
+		if len(b) < 3 {
+			err = ErrShortBytes
+			return
+		}
+		sz = uint32(big.Uint16(b[1:]))
+		o = b[3:]
+		return
+
+	case marray32:
+		if len(b) < 5 {
+			err = ErrShortBytes
+			return
+		}
+		sz = big.Uint32(b[1:])
+		o = b[5:]
+		return
+
+	default:
+		err = badPrefix(ArrayType, lead)
+		return
+	}
+}
+
+// ReadNilBytes tries to read a "nil" byte
+// off of 'b' and return the remaining bytes.
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError{} (not a 'nil')
+// - InvalidPrefixError
+func ReadNilBytes(b []byte) ([]byte, error) {
+	if len(b) < 1 {
+		return nil, ErrShortBytes
+	}
+	if b[0] != mnil {
+		return b, badPrefix(NilType, b[0])
+	}
+	return b[1:], nil
+}
+
+// ReadFloat64Bytes tries to read a float64
+// from 'b' and return the value and the remaining bytes.
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError{} (not a float64)
+func ReadFloat64Bytes(b []byte) (f float64, o []byte, err error) {
+	if len(b) < 9 {
+		if len(b) >= 5 && b[0] == mfloat32 {
+			var tf float32
+			tf, o, err = ReadFloat32Bytes(b)
+			f = float64(tf)
+			return
+		}
+		err = ErrShortBytes
+		return
+	}
+
+	if b[0] != mfloat64 {
+		if b[0] == mfloat32 {
+			var tf float32
+			tf, o, err = ReadFloat32Bytes(b)
+			f = float64(tf)
+			return
+		}
+		err = badPrefix(Float64Type, b[0])
+		return
+	}
+
+	f = math.Float64frombits(getMuint64(b))
+	o = b[9:]
+	return
+}
+
+// ReadFloat32Bytes tries to read a float64
+// from 'b' and return the value and the remaining bytes.
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError{} (not a float32)
+func ReadFloat32Bytes(b []byte) (f float32, o []byte, err error) {
+	if len(b) < 5 {
+		err = ErrShortBytes
+		return
+	}
+
+	if b[0] != mfloat32 {
+		err = TypeError{Method: Float32Type, Encoded: getType(b[0])}
+		return
+	}
+
+	f = math.Float32frombits(getMuint32(b))
+	o = b[5:]
+	return
+}
+
+// ReadBoolBytes tries to read a float64
+// from 'b' and return the value and the remaining bytes.
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError{} (not a bool)
+func ReadBoolBytes(b []byte) (bool, []byte, error) {
+	if len(b) < 1 {
+		return false, b, ErrShortBytes
+	}
+	switch b[0] {
+	case mtrue:
+		return true, b[1:], nil
+	case mfalse:
+		return false, b[1:], nil
+	default:
+		return false, b, badPrefix(BoolType, b[0])
+	}
+}
+
+// ReadInt64Bytes tries to read an int64
+// from 'b' and return the value and the remaining bytes.
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError (not a int)
+func ReadInt64Bytes(b []byte) (i int64, o []byte, err error) {
+	l := len(b)
+	if l < 1 {
+		return 0, nil, ErrShortBytes
+	}
+
+	lead := b[0]
+	if isfixint(lead) {
+		i = int64(rfixint(lead))
+		o = b[1:]
+		return
+	}
+	if isnfixint(lead) {
+		i = int64(rnfixint(lead))
+		o = b[1:]
+		return
+	}
+
+	switch lead {
+	case mint8:
+		if l < 2 {
+			err = ErrShortBytes
+			return
+		}
+		i = int64(getMint8(b))
+		o = b[2:]
+		return
+
+	case mint16:
+		if l < 3 {
+			err = ErrShortBytes
+			return
+		}
+		i = int64(getMint16(b))
+		o = b[3:]
+		return
+
+	case mint32:
+		if l < 5 {
+			err = ErrShortBytes
+			return
+		}
+		i = int64(getMint32(b))
+		o = b[5:]
+		return
+
+	case mint64:
+		if l < 9 {
+			err = ErrShortBytes
+			return
+		}
+		i = getMint64(b)
+		o = b[9:]
+		return
+
+	default:
+		err = badPrefix(IntType, lead)
+		return
+	}
+}
+
+// ReadInt32Bytes tries to read an int32
+// from 'b' and return the value and the remaining bytes.
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError{} (not a int)
+// - IntOverflow{} (value doesn't fit in int32)
+func ReadInt32Bytes(b []byte) (int32, []byte, error) {
+	i, o, err := ReadInt64Bytes(b)
+	if i > math.MaxInt32 || i < math.MinInt32 {
+		return 0, o, IntOverflow{Value: i, FailedBitsize: 32}
+	}
+	return int32(i), o, err
+}
+
+// ReadInt16Bytes tries to read an int16
+// from 'b' and return the value and the remaining bytes.
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError{} (not a int)
+// - IntOverflow{} (value doesn't fit in int16)
+func ReadInt16Bytes(b []byte) (int16, []byte, error) {
+	i, o, err := ReadInt64Bytes(b)
+	if i > math.MaxInt16 || i < math.MinInt16 {
+		return 0, o, IntOverflow{Value: i, FailedBitsize: 16}
+	}
+	return int16(i), o, err
+}
+
+// ReadInt8Bytes tries to read an int16
+// from 'b' and return the value and the remaining bytes.
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError{} (not a int)
+// - IntOverflow{} (value doesn't fit in int8)
+func ReadInt8Bytes(b []byte) (int8, []byte, error) {
+	i, o, err := ReadInt64Bytes(b)
+	if i > math.MaxInt8 || i < math.MinInt8 {
+		return 0, o, IntOverflow{Value: i, FailedBitsize: 8}
+	}
+	return int8(i), o, err
+}
+
+// ReadIntBytes tries to read an int
+// from 'b' and return the value and the remaining bytes.
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError{} (not a int)
+// - IntOverflow{} (value doesn't fit in int; 32-bit platforms only)
+func ReadIntBytes(b []byte) (int, []byte, error) {
+	if smallint {
+		i, b, err := ReadInt32Bytes(b)
+		return int(i), b, err
+	}
+	i, b, err := ReadInt64Bytes(b)
+	return int(i), b, err
+}
+
+// ReadUint64Bytes tries to read a uint64
+// from 'b' and return the value and the remaining bytes.
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError{} (not a uint)
+func ReadUint64Bytes(b []byte) (u uint64, o []byte, err error) {
+	l := len(b)
+	if l < 1 {
+		return 0, nil, ErrShortBytes
+	}
+
+	lead := b[0]
+	if isfixint(lead) {
+		u = uint64(rfixint(lead))
+		o = b[1:]
+		return
+	}
+
+	switch lead {
+	case muint8:
+		if l < 2 {
+			err = ErrShortBytes
+			return
+		}
+		u = uint64(getMuint8(b))
+		o = b[2:]
+		return
+
+	case muint16:
+		if l < 3 {
+			err = ErrShortBytes
+			return
+		}
+		u = uint64(getMuint16(b))
+		o = b[3:]
+		return
+
+	case muint32:
+		if l < 5 {
+			err = ErrShortBytes
+			return
+		}
+		u = uint64(getMuint32(b))
+		o = b[5:]
+		return
+
+	case muint64:
+		if l < 9 {
+			err = ErrShortBytes
+			return
+		}
+		u = getMuint64(b)
+		o = b[9:]
+		return
+
+	default:
+		err = badPrefix(UintType, lead)
+		return
+	}
+}
+
+// ReadUint32Bytes tries to read a uint32
+// from 'b' and return the value and the remaining bytes.
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError{} (not a uint)
+// - UintOverflow{} (value too large for uint32)
+func ReadUint32Bytes(b []byte) (uint32, []byte, error) {
+	v, o, err := ReadUint64Bytes(b)
+	if v > math.MaxUint32 {
+		return 0, nil, UintOverflow{Value: v, FailedBitsize: 32}
+	}
+	return uint32(v), o, err
+}
+
+// ReadUint16Bytes tries to read a uint16
+// from 'b' and return the value and the remaining bytes.
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError{} (not a uint)
+// - UintOverflow{} (value too large for uint16)
+func ReadUint16Bytes(b []byte) (uint16, []byte, error) {
+	v, o, err := ReadUint64Bytes(b)
+	if v > math.MaxUint16 {
+		return 0, nil, UintOverflow{Value: v, FailedBitsize: 16}
+	}
+	return uint16(v), o, err
+}
+
+// ReadUint8Bytes tries to read a uint8
+// from 'b' and return the value and the remaining bytes.
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError{} (not a uint)
+// - UintOverflow{} (value too large for uint8)
+func ReadUint8Bytes(b []byte) (uint8, []byte, error) {
+	v, o, err := ReadUint64Bytes(b)
+	if v > math.MaxUint8 {
+		return 0, nil, UintOverflow{Value: v, FailedBitsize: 8}
+	}
+	return uint8(v), o, err
+}
+
+// ReadUintBytes tries to read a uint
+// from 'b' and return the value and the remaining bytes.
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError{} (not a uint)
+// - UintOverflow{} (value too large for uint; 32-bit platforms only)
+func ReadUintBytes(b []byte) (uint, []byte, error) {
+	if smallint {
+		u, b, err := ReadUint32Bytes(b)
+		return uint(u), b, err
+	}
+	u, b, err := ReadUint64Bytes(b)
+	return uint(u), b, err
+}
+
+// ReadByteBytes is analogous to ReadUint8Bytes
+func ReadByteBytes(b []byte) (byte, []byte, error) {
+	return ReadUint8Bytes(b)
+}
+
+// ReadBytesBytes reads a 'bin' object
+// from 'b' and returns its vaue and
+// the remaining bytes in 'b'.
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError{} (not a 'bin' object)
+func ReadBytesBytes(b []byte, scratch []byte) (v []byte, o []byte, err error) {
+	return readBytesBytes(b, scratch, false)
+}
+
+func readBytesBytes(b []byte, scratch []byte, zc bool) (v []byte, o []byte, err error) {
+	l := len(b)
+	if l < 1 {
+		return nil, nil, ErrShortBytes
+	}
+
+	lead := b[0]
+	var read int
+	switch lead {
+	case mbin8:
+		if l < 2 {
+			err = ErrShortBytes
+			return
+		}
+
+		read = int(b[1])
+		b = b[2:]
+
+	case mbin16:
+		if l < 3 {
+			err = ErrShortBytes
+			return
+		}
+		read = int(big.Uint16(b[1:]))
+		b = b[3:]
+
+	case mbin32:
+		if l < 5 {
+			err = ErrShortBytes
+			return
+		}
+		read = int(big.Uint32(b[1:]))
+		b = b[5:]
+
+	default:
+		err = badPrefix(BinType, lead)
+		return
+	}
+
+	if len(b) < read {
+		err = ErrShortBytes
+		return
+	}
+
+	// zero-copy
+	if zc {
+		v = b[0:read]
+		o = b[read:]
+		return
+	}
+
+	if cap(scratch) >= read {
+		v = scratch[0:read]
+	} else {
+		v = make([]byte, read)
+	}
+
+	o = b[copy(v, b):]
+	return
+}
+
+// ReadBytesZC extracts the messagepack-encoded
+// binary field without copying. The returned []byte
+// points to the same memory as the input slice.
+// Possible errors:
+// - ErrShortBytes (b not long enough)
+// - TypeError{} (object not 'bin')
+func ReadBytesZC(b []byte) (v []byte, o []byte, err error) {
+	return readBytesBytes(b, nil, true)
+}
+
+func ReadExactBytes(b []byte, into []byte) (o []byte, err error) {
+	l := len(b)
+	if l < 1 {
+		err = ErrShortBytes
+		return
+	}
+
+	lead := b[0]
+	var read uint32
+	var skip int
+	switch lead {
+	case mbin8:
+		if l < 2 {
+			err = ErrShortBytes
+			return
+		}
+
+		read = uint32(b[1])
+		skip = 2
+
+	case mbin16:
+		if l < 3 {
+			err = ErrShortBytes
+			return
+		}
+		read = uint32(big.Uint16(b[1:]))
+		skip = 3
+
+	case mbin32:
+		if l < 5 {
+			err = ErrShortBytes
+			return
+		}
+		read = uint32(big.Uint32(b[1:]))
+		skip = 5
+
+	default:
+		err = badPrefix(BinType, lead)
+		return
+	}
+
+	if read != uint32(len(into)) {
+		err = ArrayError{Wanted: uint32(len(into)), Got: read}
+		return
+	}
+
+	o = b[skip+copy(into, b[skip:]):]
+	return
+}
+
+// ReadStringZC reads a messagepack string field
+// without copying. The returned []byte points
+// to the same memory as the input slice.
+// Possible errors:
+// - ErrShortBytes (b not long enough)
+// - TypeError{} (object not 'str')
+func ReadStringZC(b []byte) (v []byte, o []byte, err error) {
+	l := len(b)
+	if l < 1 {
+		return nil, nil, ErrShortBytes
+	}
+
+	lead := b[0]
+	var read int
+
+	if isfixstr(lead) {
+		read = int(rfixstr(lead))
+		b = b[1:]
+	} else {
+		switch lead {
+		case mstr8:
+			if l < 2 {
+				err = ErrShortBytes
+				return
+			}
+			read = int(b[1])
+			b = b[2:]
+
+		case mstr16:
+			if l < 3 {
+				err = ErrShortBytes
+				return
+			}
+			read = int(big.Uint16(b[1:]))
+			b = b[3:]
+
+		case mstr32:
+			if l < 5 {
+				err = ErrShortBytes
+				return
+			}
+			read = int(big.Uint32(b[1:]))
+			b = b[5:]
+
+		default:
+			err = TypeError{Method: StrType, Encoded: getType(lead)}
+			return
+		}
+	}
+
+	if len(b) < read {
+		err = ErrShortBytes
+		return
+	}
+
+	v = b[0:read]
+	o = b[read:]
+	return
+}
+
+// ReadStringBytes reads a 'str' object
+// from 'b' and returns its value and the
+// remaining bytes in 'b'.
+// Possible errors:
+// - ErrShortBytes (b not long enough)
+// - TypeError{} (not 'str' type)
+// - InvalidPrefixError
+func ReadStringBytes(b []byte) (string, []byte, error) {
+	v, o, err := ReadStringZC(b)
+	return string(v), o, err
+}
+
+// ReadStringAsBytes reads a 'str' object
+// into a slice of bytes. 'v' is the value of
+// the 'str' object, which may reside in memory
+// pointed to by 'scratch.' 'o' is the remaining bytes
+// in 'b.''
+// Possible errors:
+// - ErrShortBytes (b not long enough)
+// - TypeError{} (not 'str' type)
+// - InvalidPrefixError (unknown type marker)
+func ReadStringAsBytes(b []byte, scratch []byte) (v []byte, o []byte, err error) {
+	var tmp []byte
+	tmp, o, err = ReadStringZC(b)
+	v = append(scratch[:0], tmp...)
+	return
+}
+
+// ReadComplex128Bytes reads a complex128
+// extension object from 'b' and returns the
+// remaining bytes.
+// Possible errors:
+// - ErrShortBytes (not enough bytes in 'b')
+// - TypeError{} (object not a complex128)
+// - InvalidPrefixError
+// - ExtensionTypeError{} (object an extension of the correct size, but not a complex128)
+func ReadComplex128Bytes(b []byte) (c complex128, o []byte, err error) {
+	if len(b) < 18 {
+		err = ErrShortBytes
+		return
+	}
+	if b[0] != mfixext16 {
+		err = badPrefix(Complex128Type, b[0])
+		return
+	}
+	if int8(b[1]) != Complex128Extension {
+		err = errExt(int8(b[1]), Complex128Extension)
+		return
+	}
+	c = complex(math.Float64frombits(big.Uint64(b[2:])),
+		math.Float64frombits(big.Uint64(b[10:])))
+	o = b[18:]
+	return
+}
+
+// ReadComplex64Bytes reads a complex64
+// extension object from 'b' and returns the
+// remaining bytes.
+// Possible errors:
+// - ErrShortBytes (not enough bytes in 'b')
+// - TypeError{} (object not a complex64)
+// - ExtensionTypeError{} (object an extension of the correct size, but not a complex64)
+func ReadComplex64Bytes(b []byte) (c complex64, o []byte, err error) {
+	if len(b) < 10 {
+		err = ErrShortBytes
+		return
+	}
+	if b[0] != mfixext8 {
+		err = badPrefix(Complex64Type, b[0])
+		return
+	}
+	if b[1] != Complex64Extension {
+		err = errExt(int8(b[1]), Complex64Extension)
+		return
+	}
+	c = complex(math.Float32frombits(big.Uint32(b[2:])),
+		math.Float32frombits(big.Uint32(b[6:])))
+	o = b[10:]
+	return
+}
+
+// ReadTimeBytes reads a time.Time
+// extension object from 'b' and returns the
+// remaining bytes.
+// Possible errors:
+// - ErrShortBytes (not enough bytes in 'b')
+// - TypeError{} (object not a complex64)
+// - ExtensionTypeError{} (object an extension of the correct size, but not a time.Time)
+func ReadTimeBytes(b []byte) (t time.Time, o []byte, err error) {
+	if len(b) < 15 {
+		err = ErrShortBytes
+		return
+	}
+	if b[0] != mext8 || b[1] != 12 {
+		err = badPrefix(TimeType, b[0])
+		return
+	}
+	if int8(b[2]) != TimeExtension {
+		err = errExt(int8(b[2]), TimeExtension)
+		return
+	}
+	sec, nsec := getUnix(b[3:])
+	t = time.Unix(sec, int64(nsec)).Local()
+	o = b[15:]
+	return
+}
+
+// ReadMapStrIntfBytes reads a map[string]interface{}
+// out of 'b' and returns the map and remaining bytes.
+// If 'old' is non-nil, the values will be read into that map.
+func ReadMapStrIntfBytes(b []byte, old map[string]interface{}) (v map[string]interface{}, o []byte, err error) {
+	var sz uint32
+	o = b
+	sz, o, err = ReadMapHeaderBytes(o)
+
+	if err != nil {
+		return
+	}
+
+	if old != nil {
+		for key := range old {
+			delete(old, key)
+		}
+		v = old
+	} else {
+		v = make(map[string]interface{}, int(sz))
+	}
+
+	for z := uint32(0); z < sz; z++ {
+		if len(o) < 1 {
+			err = ErrShortBytes
+			return
+		}
+		var key []byte
+		key, o, err = ReadMapKeyZC(o)
+		if err != nil {
+			return
+		}
+		var val interface{}
+		val, o, err = ReadIntfBytes(o)
+		if err != nil {
+			return
+		}
+		v[string(key)] = val
+	}
+	return
+}
+
+// ReadIntfBytes attempts to read
+// the next object out of 'b' as a raw interface{} and
+// return the remaining bytes.
+func ReadIntfBytes(b []byte) (i interface{}, o []byte, err error) {
+	if len(b) < 1 {
+		err = ErrShortBytes
+		return
+	}
+
+	k := NextType(b)
+
+	switch k {
+	case MapType:
+		i, o, err = ReadMapStrIntfBytes(b, nil)
+		return
+
+	case ArrayType:
+		var sz uint32
+		sz, o, err = ReadArrayHeaderBytes(b)
+		if err != nil {
+			return
+		}
+		j := make([]interface{}, int(sz))
+		i = j
+		for d := range j {
+			j[d], o, err = ReadIntfBytes(o)
+			if err != nil {
+				return
+			}
+		}
+		return
+
+	case Float32Type:
+		i, o, err = ReadFloat32Bytes(b)
+		return
+
+	case Float64Type:
+		i, o, err = ReadFloat64Bytes(b)
+		return
+
+	case IntType:
+		i, o, err = ReadInt64Bytes(b)
+		return
+
+	case UintType:
+		i, o, err = ReadUint64Bytes(b)
+		return
+
+	case BoolType:
+		i, o, err = ReadBoolBytes(b)
+		return
+
+	case TimeType:
+		i, o, err = ReadTimeBytes(b)
+		return
+
+	case Complex64Type:
+		i, o, err = ReadComplex64Bytes(b)
+		return
+
+	case Complex128Type:
+		i, o, err = ReadComplex128Bytes(b)
+		return
+
+	case ExtensionType:
+		var t int8
+		t, err = peekExtension(b)
+		if err != nil {
+			return
+		}
+		// use a user-defined extension,
+		// if it's been registered
+		f, ok := extensionReg[t]
+		if ok {
+			e := f()
+			o, err = ReadExtensionBytes(b, e)
+			i = e
+			return
+		}
+		// last resort is a raw extension
+		e := RawExtension{}
+		e.Type = int8(t)
+		o, err = ReadExtensionBytes(b, &e)
+		i = &e
+		return
+
+	case NilType:
+		o, err = ReadNilBytes(b)
+		return
+
+	case BinType:
+		i, o, err = ReadBytesBytes(b, nil)
+		return
+
+	case StrType:
+		i, o, err = ReadStringBytes(b)
+		return
+
+	default:
+		err = InvalidPrefixError(b[0])
+		return
+	}
+}
+
+// Skip skips the next object in 'b' and
+// returns the remaining bytes. If the object
+// is a map or array, all of its elements
+// will be skipped.
+// Possible Errors:
+// - ErrShortBytes (not enough bytes in b)
+// - InvalidPrefixError (bad encoding)
+func Skip(b []byte) ([]byte, error) {
+	sz, asz, err := getSize(b)
+	if err != nil {
+		return b, err
+	}
+	if uintptr(len(b)) < sz {
+		return b, ErrShortBytes
+	}
+	b = b[sz:]
+	for asz > 0 {
+		b, err = Skip(b)
+		if err != nil {
+			return b, err
+		}
+		asz--
+	}
+	return b, nil
+}
+
+// returns (skip N bytes, skip M objects, error)
+func getSize(b []byte) (uintptr, uintptr, error) {
+	l := len(b)
+	if l == 0 {
+		return 0, 0, ErrShortBytes
+	}
+	lead := b[0]
+	spec := &sizes[lead] // get type information
+	size, mode := spec.size, spec.extra
+	if size == 0 {
+		return 0, 0, InvalidPrefixError(lead)
+	}
+	if mode >= 0 { // fixed composites
+		return uintptr(size), uintptr(mode), nil
+	}
+	if l < int(size) {
+		return 0, 0, ErrShortBytes
+	}
+	switch mode {
+	case extra8:
+		return uintptr(size) + uintptr(b[1]), 0, nil
+	case extra16:
+		return uintptr(size) + uintptr(big.Uint16(b[1:])), 0, nil
+	case extra32:
+		return uintptr(size) + uintptr(big.Uint32(b[1:])), 0, nil
+	case map16v:
+		return uintptr(size), 2 * uintptr(big.Uint16(b[1:])), nil
+	case map32v:
+		return uintptr(size), 2 * uintptr(big.Uint32(b[1:])), nil
+	case array16v:
+		return uintptr(size), uintptr(big.Uint16(b[1:])), nil
+	case array32v:
+		return uintptr(size), uintptr(big.Uint32(b[1:])), nil
+	default:
+		return 0, 0, fatal
+	}
+}

--- a/vendor/github.com/tinylib/msgp/msgp/size.go
+++ b/vendor/github.com/tinylib/msgp/msgp/size.go
@@ -1,0 +1,38 @@
+package msgp
+
+// The sizes provided
+// are the worst-case
+// encoded sizes for
+// each type. For variable-
+// length types ([]byte, string),
+// the total encoded size is
+// the prefix size plus the
+// length of the object.
+const (
+	Int64Size      = 9
+	IntSize        = Int64Size
+	UintSize       = Int64Size
+	Int8Size       = 2
+	Int16Size      = 3
+	Int32Size      = 5
+	Uint8Size      = 2
+	ByteSize       = Uint8Size
+	Uint16Size     = 3
+	Uint32Size     = 5
+	Uint64Size     = Int64Size
+	Float64Size    = 9
+	Float32Size    = 5
+	Complex64Size  = 10
+	Complex128Size = 18
+
+	TimeSize = 15
+	BoolSize = 1
+	NilSize  = 1
+
+	MapHeaderSize   = 5
+	ArrayHeaderSize = 5
+
+	BytesPrefixSize     = 5
+	StringPrefixSize    = 5
+	ExtensionPrefixSize = 6
+)

--- a/vendor/github.com/tinylib/msgp/msgp/unsafe.go
+++ b/vendor/github.com/tinylib/msgp/msgp/unsafe.go
@@ -1,0 +1,40 @@
+// +build !appengine
+
+package msgp
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// NOTE:
+// all of the definition in this file
+// should be repeated in appengine.go,
+// but without using unsafe
+
+const (
+	// spec says int and uint are always
+	// the same size, but that int/uint
+	// size may not be machine word size
+	smallint = unsafe.Sizeof(int(0)) == 4
+)
+
+// UnsafeString returns the byte slice as a volatile string
+// THIS SHOULD ONLY BE USED BY THE CODE GENERATOR.
+// THIS IS EVIL CODE.
+// YOU HAVE BEEN WARNED.
+func UnsafeString(b []byte) string {
+	return *(*string)(unsafe.Pointer(&reflect.StringHeader{Data: uintptr(unsafe.Pointer(&b[0])), Len: len(b)}))
+}
+
+// UnsafeBytes returns the string as a byte slice
+// THIS SHOULD ONLY BE USED BY THE CODE GENERATOR.
+// THIS IS EVIL CODE.
+// YOU HAVE BEEN WARNED.
+func UnsafeBytes(s string) []byte {
+	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+		Len:  len(s),
+		Cap:  len(s),
+		Data: (*(*reflect.StringHeader)(unsafe.Pointer(&s))).Data,
+	}))
+}

--- a/vendor/github.com/tinylib/msgp/msgp/write.go
+++ b/vendor/github.com/tinylib/msgp/msgp/write.go
@@ -1,0 +1,845 @@
+package msgp
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"reflect"
+	"sync"
+	"time"
+)
+
+// Sizer is an interface implemented
+// by types that can estimate their
+// size when MessagePack encoded.
+// This interface is optional, but
+// encoding/marshaling implementations
+// may use this as a way to pre-allocate
+// memory for serialization.
+type Sizer interface {
+	Msgsize() int
+}
+
+var (
+	// Nowhere is an io.Writer to nowhere
+	Nowhere io.Writer = nwhere{}
+
+	btsType    = reflect.TypeOf(([]byte)(nil))
+	writerPool = sync.Pool{
+		New: func() interface{} {
+			return &Writer{buf: make([]byte, 2048)}
+		},
+	}
+)
+
+func popWriter(w io.Writer) *Writer {
+	wr := writerPool.Get().(*Writer)
+	wr.Reset(w)
+	return wr
+}
+
+func pushWriter(wr *Writer) {
+	wr.w = nil
+	wr.wloc = 0
+	writerPool.Put(wr)
+}
+
+// freeW frees a writer for use
+// by other processes. It is not necessary
+// to call freeW on a writer. However, maintaining
+// a reference to a *Writer after calling freeW on
+// it will cause undefined behavior.
+func freeW(w *Writer) { pushWriter(w) }
+
+// Require ensures that cap(old)-len(old) >= extra.
+func Require(old []byte, extra int) []byte {
+	l := len(old)
+	c := cap(old)
+	r := l + extra
+	if c >= r {
+		return old
+	} else if l == 0 {
+		return make([]byte, 0, extra)
+	}
+	// the new size is the greater
+	// of double the old capacity
+	// and the sum of the old length
+	// and the number of new bytes
+	// necessary.
+	c <<= 1
+	if c < r {
+		c = r
+	}
+	n := make([]byte, l, c)
+	copy(n, old)
+	return n
+}
+
+// nowhere writer
+type nwhere struct{}
+
+func (n nwhere) Write(p []byte) (int, error) { return len(p), nil }
+
+// Marshaler is the interface implemented
+// by types that know how to marshal themselves
+// as MessagePack. MarshalMsg appends the marshalled
+// form of the object to the provided
+// byte slice, returning the extended
+// slice and any errors encountered.
+type Marshaler interface {
+	MarshalMsg([]byte) ([]byte, error)
+}
+
+// Encodable is the interface implemented
+// by types that know how to write themselves
+// as MessagePack using a *msgp.Writer.
+type Encodable interface {
+	EncodeMsg(*Writer) error
+}
+
+// Writer is a buffered writer
+// that can be used to write
+// MessagePack objects to an io.Writer.
+// You must call *Writer.Flush() in order
+// to flush all of the buffered data
+// to the underlying writer.
+type Writer struct {
+	w    io.Writer
+	buf  []byte
+	wloc int
+}
+
+// NewWriter returns a new *Writer.
+func NewWriter(w io.Writer) *Writer {
+	if wr, ok := w.(*Writer); ok {
+		return wr
+	}
+	return popWriter(w)
+}
+
+// NewWriterSize returns a writer with a custom buffer size.
+func NewWriterSize(w io.Writer, sz int) *Writer {
+	// we must be able to require() 18
+	// contiguous bytes, so that is the
+	// practical minimum buffer size
+	if sz < 18 {
+		sz = 18
+	}
+
+	return &Writer{
+		w:   w,
+		buf: make([]byte, sz),
+	}
+}
+
+// Encode encodes an Encodable to an io.Writer.
+func Encode(w io.Writer, e Encodable) error {
+	wr := NewWriter(w)
+	err := e.EncodeMsg(wr)
+	if err == nil {
+		err = wr.Flush()
+	}
+	freeW(wr)
+	return err
+}
+
+func (mw *Writer) flush() error {
+	if mw.wloc == 0 {
+		return nil
+	}
+	n, err := mw.w.Write(mw.buf[:mw.wloc])
+	if err != nil {
+		if n > 0 {
+			mw.wloc = copy(mw.buf, mw.buf[n:mw.wloc])
+		}
+		return err
+	}
+	mw.wloc = 0
+	return nil
+}
+
+// Flush flushes all of the buffered
+// data to the underlying writer.
+func (mw *Writer) Flush() error { return mw.flush() }
+
+// Buffered returns the number bytes in the write buffer
+func (mw *Writer) Buffered() int { return len(mw.buf) - mw.wloc }
+
+func (mw *Writer) avail() int { return len(mw.buf) - mw.wloc }
+
+func (mw *Writer) bufsize() int { return len(mw.buf) }
+
+// NOTE: this should only be called with
+// a number that is guaranteed to be less than
+// len(mw.buf). typically, it is called with a constant.
+//
+// NOTE: this is a hot code path
+func (mw *Writer) require(n int) (int, error) {
+	c := len(mw.buf)
+	wl := mw.wloc
+	if c-wl < n {
+		if err := mw.flush(); err != nil {
+			return 0, err
+		}
+		wl = mw.wloc
+	}
+	mw.wloc += n
+	return wl, nil
+}
+
+func (mw *Writer) Append(b ...byte) error {
+	if mw.avail() < len(b) {
+		err := mw.flush()
+		if err != nil {
+			return err
+		}
+	}
+	mw.wloc += copy(mw.buf[mw.wloc:], b)
+	return nil
+}
+
+// push one byte onto the buffer
+//
+// NOTE: this is a hot code path
+func (mw *Writer) push(b byte) error {
+	if mw.wloc == len(mw.buf) {
+		if err := mw.flush(); err != nil {
+			return err
+		}
+	}
+	mw.buf[mw.wloc] = b
+	mw.wloc++
+	return nil
+}
+
+func (mw *Writer) prefix8(b byte, u uint8) error {
+	const need = 2
+	if len(mw.buf)-mw.wloc < need {
+		if err := mw.flush(); err != nil {
+			return err
+		}
+	}
+	prefixu8(mw.buf[mw.wloc:], b, u)
+	mw.wloc += need
+	return nil
+}
+
+func (mw *Writer) prefix16(b byte, u uint16) error {
+	const need = 3
+	if len(mw.buf)-mw.wloc < need {
+		if err := mw.flush(); err != nil {
+			return err
+		}
+	}
+	prefixu16(mw.buf[mw.wloc:], b, u)
+	mw.wloc += need
+	return nil
+}
+
+func (mw *Writer) prefix32(b byte, u uint32) error {
+	const need = 5
+	if len(mw.buf)-mw.wloc < need {
+		if err := mw.flush(); err != nil {
+			return err
+		}
+	}
+	prefixu32(mw.buf[mw.wloc:], b, u)
+	mw.wloc += need
+	return nil
+}
+
+func (mw *Writer) prefix64(b byte, u uint64) error {
+	const need = 9
+	if len(mw.buf)-mw.wloc < need {
+		if err := mw.flush(); err != nil {
+			return err
+		}
+	}
+	prefixu64(mw.buf[mw.wloc:], b, u)
+	mw.wloc += need
+	return nil
+}
+
+// Write implements io.Writer, and writes
+// data directly to the buffer.
+func (mw *Writer) Write(p []byte) (int, error) {
+	l := len(p)
+	if mw.avail() < l {
+		if err := mw.flush(); err != nil {
+			return 0, err
+		}
+		if l > len(mw.buf) {
+			return mw.w.Write(p)
+		}
+	}
+	mw.wloc += copy(mw.buf[mw.wloc:], p)
+	return l, nil
+}
+
+// implements io.WriteString
+func (mw *Writer) writeString(s string) error {
+	l := len(s)
+	if mw.avail() < l {
+		if err := mw.flush(); err != nil {
+			return err
+		}
+		if l > len(mw.buf) {
+			_, err := io.WriteString(mw.w, s)
+			return err
+		}
+	}
+	mw.wloc += copy(mw.buf[mw.wloc:], s)
+	return nil
+}
+
+// Reset changes the underlying writer used by the Writer
+func (mw *Writer) Reset(w io.Writer) {
+	mw.buf = mw.buf[:cap(mw.buf)]
+	mw.w = w
+	mw.wloc = 0
+}
+
+// WriteMapHeader writes a map header of the given
+// size to the writer
+func (mw *Writer) WriteMapHeader(sz uint32) error {
+	switch {
+	case sz <= 15:
+		return mw.push(wfixmap(uint8(sz)))
+	case sz <= math.MaxUint16:
+		return mw.prefix16(mmap16, uint16(sz))
+	default:
+		return mw.prefix32(mmap32, sz)
+	}
+}
+
+// WriteArrayHeader writes an array header of the
+// given size to the writer
+func (mw *Writer) WriteArrayHeader(sz uint32) error {
+	switch {
+	case sz <= 15:
+		return mw.push(wfixarray(uint8(sz)))
+	case sz <= math.MaxUint16:
+		return mw.prefix16(marray16, uint16(sz))
+	default:
+		return mw.prefix32(marray32, sz)
+	}
+}
+
+// WriteNil writes a nil byte to the buffer
+func (mw *Writer) WriteNil() error {
+	return mw.push(mnil)
+}
+
+// WriteFloat64 writes a float64 to the writer
+func (mw *Writer) WriteFloat64(f float64) error {
+	return mw.prefix64(mfloat64, math.Float64bits(f))
+}
+
+// WriteFloat32 writes a float32 to the writer
+func (mw *Writer) WriteFloat32(f float32) error {
+	return mw.prefix32(mfloat32, math.Float32bits(f))
+}
+
+// WriteInt64 writes an int64 to the writer
+func (mw *Writer) WriteInt64(i int64) error {
+	if i >= 0 {
+		switch {
+		case i <= math.MaxInt8:
+			return mw.push(wfixint(uint8(i)))
+		case i <= math.MaxInt16:
+			return mw.prefix16(mint16, uint16(i))
+		case i <= math.MaxInt32:
+			return mw.prefix32(mint32, uint32(i))
+		default:
+			return mw.prefix64(mint64, uint64(i))
+		}
+	}
+	switch {
+	case i >= -32:
+		return mw.push(wnfixint(int8(i)))
+	case i >= math.MinInt8:
+		return mw.prefix8(mint8, uint8(i))
+	case i >= math.MinInt16:
+		return mw.prefix16(mint16, uint16(i))
+	case i >= math.MinInt32:
+		return mw.prefix32(mint32, uint32(i))
+	default:
+		return mw.prefix64(mint64, uint64(i))
+	}
+}
+
+// WriteInt8 writes an int8 to the writer
+func (mw *Writer) WriteInt8(i int8) error { return mw.WriteInt64(int64(i)) }
+
+// WriteInt16 writes an int16 to the writer
+func (mw *Writer) WriteInt16(i int16) error { return mw.WriteInt64(int64(i)) }
+
+// WriteInt32 writes an int32 to the writer
+func (mw *Writer) WriteInt32(i int32) error { return mw.WriteInt64(int64(i)) }
+
+// WriteInt writes an int to the writer
+func (mw *Writer) WriteInt(i int) error { return mw.WriteInt64(int64(i)) }
+
+// WriteUint64 writes a uint64 to the writer
+func (mw *Writer) WriteUint64(u uint64) error {
+	switch {
+	case u <= (1<<7)-1:
+		return mw.push(wfixint(uint8(u)))
+	case u <= math.MaxUint8:
+		return mw.prefix8(muint8, uint8(u))
+	case u <= math.MaxUint16:
+		return mw.prefix16(muint16, uint16(u))
+	case u <= math.MaxUint32:
+		return mw.prefix32(muint32, uint32(u))
+	default:
+		return mw.prefix64(muint64, u)
+	}
+}
+
+// WriteByte is analogous to WriteUint8
+func (mw *Writer) WriteByte(u byte) error { return mw.WriteUint8(uint8(u)) }
+
+// WriteUint8 writes a uint8 to the writer
+func (mw *Writer) WriteUint8(u uint8) error { return mw.WriteUint64(uint64(u)) }
+
+// WriteUint16 writes a uint16 to the writer
+func (mw *Writer) WriteUint16(u uint16) error { return mw.WriteUint64(uint64(u)) }
+
+// WriteUint32 writes a uint32 to the writer
+func (mw *Writer) WriteUint32(u uint32) error { return mw.WriteUint64(uint64(u)) }
+
+// WriteUint writes a uint to the writer
+func (mw *Writer) WriteUint(u uint) error { return mw.WriteUint64(uint64(u)) }
+
+// WriteBytes writes binary as 'bin' to the writer
+func (mw *Writer) WriteBytes(b []byte) error {
+	sz := uint32(len(b))
+	var err error
+	switch {
+	case sz <= math.MaxUint8:
+		err = mw.prefix8(mbin8, uint8(sz))
+	case sz <= math.MaxUint16:
+		err = mw.prefix16(mbin16, uint16(sz))
+	default:
+		err = mw.prefix32(mbin32, sz)
+	}
+	if err != nil {
+		return err
+	}
+	_, err = mw.Write(b)
+	return err
+}
+
+// WriteBytesHeader writes just the size header
+// of a MessagePack 'bin' object. The user is responsible
+// for then writing 'sz' more bytes into the stream.
+func (mw *Writer) WriteBytesHeader(sz uint32) error {
+	switch {
+	case sz <= math.MaxUint8:
+		return mw.prefix8(mbin8, uint8(sz))
+	case sz <= math.MaxUint16:
+		return mw.prefix16(mbin16, uint16(sz))
+	default:
+		return mw.prefix32(mbin32, sz)
+	}
+}
+
+// WriteBool writes a bool to the writer
+func (mw *Writer) WriteBool(b bool) error {
+	if b {
+		return mw.push(mtrue)
+	}
+	return mw.push(mfalse)
+}
+
+// WriteString writes a messagepack string to the writer.
+// (This is NOT an implementation of io.StringWriter)
+func (mw *Writer) WriteString(s string) error {
+	sz := uint32(len(s))
+	var err error
+	switch {
+	case sz <= 31:
+		err = mw.push(wfixstr(uint8(sz)))
+	case sz <= math.MaxUint8:
+		err = mw.prefix8(mstr8, uint8(sz))
+	case sz <= math.MaxUint16:
+		err = mw.prefix16(mstr16, uint16(sz))
+	default:
+		err = mw.prefix32(mstr32, sz)
+	}
+	if err != nil {
+		return err
+	}
+	return mw.writeString(s)
+}
+
+// WriteStringHeader writes just the string size
+// header of a MessagePack 'str' object. The user
+// is responsible for writing 'sz' more valid UTF-8
+// bytes to the stream.
+func (mw *Writer) WriteStringHeader(sz uint32) error {
+	switch {
+	case sz <= 31:
+		return mw.push(wfixstr(uint8(sz)))
+	case sz <= math.MaxUint8:
+		return mw.prefix8(mstr8, uint8(sz))
+	case sz <= math.MaxUint16:
+		return mw.prefix16(mstr16, uint16(sz))
+	default:
+		return mw.prefix32(mstr32, sz)
+	}
+}
+
+// WriteStringFromBytes writes a 'str' object
+// from a []byte.
+func (mw *Writer) WriteStringFromBytes(str []byte) error {
+	sz := uint32(len(str))
+	var err error
+	switch {
+	case sz <= 31:
+		err = mw.push(wfixstr(uint8(sz)))
+	case sz <= math.MaxUint8:
+		err = mw.prefix8(mstr8, uint8(sz))
+	case sz <= math.MaxUint16:
+		err = mw.prefix16(mstr16, uint16(sz))
+	default:
+		err = mw.prefix32(mstr32, sz)
+	}
+	if err != nil {
+		return err
+	}
+	_, err = mw.Write(str)
+	return err
+}
+
+// WriteComplex64 writes a complex64 to the writer
+func (mw *Writer) WriteComplex64(f complex64) error {
+	o, err := mw.require(10)
+	if err != nil {
+		return err
+	}
+	mw.buf[o] = mfixext8
+	mw.buf[o+1] = Complex64Extension
+	big.PutUint32(mw.buf[o+2:], math.Float32bits(real(f)))
+	big.PutUint32(mw.buf[o+6:], math.Float32bits(imag(f)))
+	return nil
+}
+
+// WriteComplex128 writes a complex128 to the writer
+func (mw *Writer) WriteComplex128(f complex128) error {
+	o, err := mw.require(18)
+	if err != nil {
+		return err
+	}
+	mw.buf[o] = mfixext16
+	mw.buf[o+1] = Complex128Extension
+	big.PutUint64(mw.buf[o+2:], math.Float64bits(real(f)))
+	big.PutUint64(mw.buf[o+10:], math.Float64bits(imag(f)))
+	return nil
+}
+
+// WriteMapStrStr writes a map[string]string to the writer
+func (mw *Writer) WriteMapStrStr(mp map[string]string) (err error) {
+	err = mw.WriteMapHeader(uint32(len(mp)))
+	if err != nil {
+		return
+	}
+	for key, val := range mp {
+		err = mw.WriteString(key)
+		if err != nil {
+			return
+		}
+		err = mw.WriteString(val)
+		if err != nil {
+			return
+		}
+	}
+	return nil
+}
+
+// WriteMapStrIntf writes a map[string]interface to the writer
+func (mw *Writer) WriteMapStrIntf(mp map[string]interface{}) (err error) {
+	err = mw.WriteMapHeader(uint32(len(mp)))
+	if err != nil {
+		return
+	}
+	for key, val := range mp {
+		err = mw.WriteString(key)
+		if err != nil {
+			return
+		}
+		err = mw.WriteIntf(val)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// WriteTime writes a time.Time object to the wire.
+//
+// Time is encoded as Unix time, which means that
+// location (time zone) data is removed from the object.
+// The encoded object itself is 12 bytes: 8 bytes for
+// a big-endian 64-bit integer denoting seconds
+// elapsed since "zero" Unix time, followed by 4 bytes
+// for a big-endian 32-bit signed integer denoting
+// the nanosecond offset of the time. This encoding
+// is intended to ease portability across languages.
+// (Note that this is *not* the standard time.Time
+// binary encoding, because its implementation relies
+// heavily on the internal representation used by the
+// time package.)
+func (mw *Writer) WriteTime(t time.Time) error {
+	t = t.UTC()
+	o, err := mw.require(15)
+	if err != nil {
+		return err
+	}
+	mw.buf[o] = mext8
+	mw.buf[o+1] = 12
+	mw.buf[o+2] = TimeExtension
+	putUnix(mw.buf[o+3:], t.Unix(), int32(t.Nanosecond()))
+	return nil
+}
+
+// WriteIntf writes the concrete type of 'v'.
+// WriteIntf will error if 'v' is not one of the following:
+//  - A bool, float, string, []byte, int, uint, or complex
+//  - A map of supported types (with string keys)
+//  - An array or slice of supported types
+//  - A pointer to a supported type
+//  - A type that satisfies the msgp.Encodable interface
+//  - A type that satisfies the msgp.Extension interface
+func (mw *Writer) WriteIntf(v interface{}) error {
+	if v == nil {
+		return mw.WriteNil()
+	}
+	switch v := v.(type) {
+
+	// preferred interfaces
+
+	case Encodable:
+		return v.EncodeMsg(mw)
+	case Extension:
+		return mw.WriteExtension(v)
+
+	// concrete types
+
+	case bool:
+		return mw.WriteBool(v)
+	case float32:
+		return mw.WriteFloat32(v)
+	case float64:
+		return mw.WriteFloat64(v)
+	case complex64:
+		return mw.WriteComplex64(v)
+	case complex128:
+		return mw.WriteComplex128(v)
+	case uint8:
+		return mw.WriteUint8(v)
+	case uint16:
+		return mw.WriteUint16(v)
+	case uint32:
+		return mw.WriteUint32(v)
+	case uint64:
+		return mw.WriteUint64(v)
+	case uint:
+		return mw.WriteUint(v)
+	case int8:
+		return mw.WriteInt8(v)
+	case int16:
+		return mw.WriteInt16(v)
+	case int32:
+		return mw.WriteInt32(v)
+	case int64:
+		return mw.WriteInt64(v)
+	case int:
+		return mw.WriteInt(v)
+	case string:
+		return mw.WriteString(v)
+	case []byte:
+		return mw.WriteBytes(v)
+	case map[string]string:
+		return mw.WriteMapStrStr(v)
+	case map[string]interface{}:
+		return mw.WriteMapStrIntf(v)
+	case time.Time:
+		return mw.WriteTime(v)
+	}
+
+	val := reflect.ValueOf(v)
+	if !isSupported(val.Kind()) || !val.IsValid() {
+		return fmt.Errorf("msgp: type %s not supported", val)
+	}
+
+	switch val.Kind() {
+	case reflect.Ptr:
+		if val.IsNil() {
+			return mw.WriteNil()
+		}
+		return mw.WriteIntf(val.Elem().Interface())
+	case reflect.Slice:
+		return mw.writeSlice(val)
+	case reflect.Map:
+		return mw.writeMap(val)
+	}
+	return &ErrUnsupportedType{val.Type()}
+}
+
+func (mw *Writer) writeMap(v reflect.Value) (err error) {
+	if v.Elem().Kind() != reflect.String {
+		return errors.New("msgp: map keys must be strings")
+	}
+	ks := v.MapKeys()
+	err = mw.WriteMapHeader(uint32(len(ks)))
+	if err != nil {
+		return
+	}
+	for _, key := range ks {
+		val := v.MapIndex(key)
+		err = mw.WriteString(key.String())
+		if err != nil {
+			return
+		}
+		err = mw.WriteIntf(val.Interface())
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+func (mw *Writer) writeSlice(v reflect.Value) (err error) {
+	// is []byte
+	if v.Type().ConvertibleTo(btsType) {
+		return mw.WriteBytes(v.Bytes())
+	}
+
+	sz := uint32(v.Len())
+	err = mw.WriteArrayHeader(sz)
+	if err != nil {
+		return
+	}
+	for i := uint32(0); i < sz; i++ {
+		err = mw.WriteIntf(v.Index(int(i)).Interface())
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+func (mw *Writer) writeStruct(v reflect.Value) error {
+	if enc, ok := v.Interface().(Encodable); ok {
+		return enc.EncodeMsg(mw)
+	}
+	return fmt.Errorf("msgp: unsupported type: %s", v.Type())
+}
+
+func (mw *Writer) writeVal(v reflect.Value) error {
+	if !isSupported(v.Kind()) {
+		return fmt.Errorf("msgp: msgp/enc: type %q not supported", v.Type())
+	}
+
+	// shortcut for nil values
+	if v.IsNil() {
+		return mw.WriteNil()
+	}
+	switch v.Kind() {
+	case reflect.Bool:
+		return mw.WriteBool(v.Bool())
+
+	case reflect.Float32, reflect.Float64:
+		return mw.WriteFloat64(v.Float())
+
+	case reflect.Complex64, reflect.Complex128:
+		return mw.WriteComplex128(v.Complex())
+
+	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int8:
+		return mw.WriteInt64(v.Int())
+
+	case reflect.Interface, reflect.Ptr:
+		if v.IsNil() {
+			mw.WriteNil()
+		}
+		return mw.writeVal(v.Elem())
+
+	case reflect.Map:
+		return mw.writeMap(v)
+
+	case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint8:
+		return mw.WriteUint64(v.Uint())
+
+	case reflect.String:
+		return mw.WriteString(v.String())
+
+	case reflect.Slice, reflect.Array:
+		return mw.writeSlice(v)
+
+	case reflect.Struct:
+		return mw.writeStruct(v)
+
+	}
+	return fmt.Errorf("msgp: msgp/enc: type %q not supported", v.Type())
+}
+
+// is the reflect.Kind encodable?
+func isSupported(k reflect.Kind) bool {
+	switch k {
+	case reflect.Func, reflect.Chan, reflect.Invalid, reflect.UnsafePointer:
+		return false
+	default:
+		return true
+	}
+}
+
+// GuessSize guesses the size of the underlying
+// value of 'i'. If the underlying value is not
+// a simple builtin (or []byte), GuessSize defaults
+// to 512.
+func GuessSize(i interface{}) int {
+	if i == nil {
+		return NilSize
+	}
+
+	switch i := i.(type) {
+	case Sizer:
+		return i.Msgsize()
+	case Extension:
+		return ExtensionPrefixSize + i.Len()
+	case float64:
+		return Float64Size
+	case float32:
+		return Float32Size
+	case uint8, uint16, uint32, uint64, uint:
+		return UintSize
+	case int8, int16, int32, int64, int:
+		return IntSize
+	case []byte:
+		return BytesPrefixSize + len(i)
+	case string:
+		return StringPrefixSize + len(i)
+	case complex64:
+		return Complex64Size
+	case complex128:
+		return Complex128Size
+	case bool:
+		return BoolSize
+	case map[string]interface{}:
+		s := MapHeaderSize
+		for key, val := range i {
+			s += StringPrefixSize + len(key) + GuessSize(val)
+		}
+		return s
+	case map[string]string:
+		s := MapHeaderSize
+		for key, val := range i {
+			s += 2*StringPrefixSize + len(key) + len(val)
+		}
+		return s
+	default:
+		return 512
+	}
+}

--- a/vendor/github.com/tinylib/msgp/msgp/write_bytes.go
+++ b/vendor/github.com/tinylib/msgp/msgp/write_bytes.go
@@ -1,0 +1,411 @@
+package msgp
+
+import (
+	"math"
+	"reflect"
+	"time"
+)
+
+// ensure 'sz' extra bytes in 'b' btw len(b) and cap(b)
+func ensure(b []byte, sz int) ([]byte, int) {
+	l := len(b)
+	c := cap(b)
+	if c-l < sz {
+		o := make([]byte, (2*c)+sz) // exponential growth
+		n := copy(o, b)
+		return o[:n+sz], n
+	}
+	return b[:l+sz], l
+}
+
+// AppendMapHeader appends a map header with the
+// given size to the slice
+func AppendMapHeader(b []byte, sz uint32) []byte {
+	switch {
+	case sz <= 15:
+		return append(b, wfixmap(uint8(sz)))
+
+	case sz <= math.MaxUint16:
+		o, n := ensure(b, 3)
+		prefixu16(o[n:], mmap16, uint16(sz))
+		return o
+
+	default:
+		o, n := ensure(b, 5)
+		prefixu32(o[n:], mmap32, sz)
+		return o
+	}
+}
+
+// AppendArrayHeader appends an array header with
+// the given size to the slice
+func AppendArrayHeader(b []byte, sz uint32) []byte {
+	switch {
+	case sz <= 15:
+		return append(b, wfixarray(uint8(sz)))
+
+	case sz <= math.MaxUint16:
+		o, n := ensure(b, 3)
+		prefixu16(o[n:], marray16, uint16(sz))
+		return o
+
+	default:
+		o, n := ensure(b, 5)
+		prefixu32(o[n:], marray32, sz)
+		return o
+	}
+}
+
+// AppendNil appends a 'nil' byte to the slice
+func AppendNil(b []byte) []byte { return append(b, mnil) }
+
+// AppendFloat64 appends a float64 to the slice
+func AppendFloat64(b []byte, f float64) []byte {
+	o, n := ensure(b, Float64Size)
+	prefixu64(o[n:], mfloat64, math.Float64bits(f))
+	return o
+}
+
+// AppendFloat32 appends a float32 to the slice
+func AppendFloat32(b []byte, f float32) []byte {
+	o, n := ensure(b, Float32Size)
+	prefixu32(o[n:], mfloat32, math.Float32bits(f))
+	return o
+}
+
+// AppendInt64 appends an int64 to the slice
+func AppendInt64(b []byte, i int64) []byte {
+	if i >= 0 {
+		switch {
+		case i <= math.MaxInt8:
+			return append(b, wfixint(uint8(i)))
+		case i <= math.MaxInt16:
+			o, n := ensure(b, 3)
+			putMint16(o[n:], int16(i))
+			return o
+		case i <= math.MaxInt32:
+			o, n := ensure(b, 5)
+			putMint32(o[n:], int32(i))
+			return o
+		default:
+			o, n := ensure(b, 9)
+			putMint64(o[n:], i)
+			return o
+		}
+	}
+	switch {
+	case i >= -32:
+		return append(b, wnfixint(int8(i)))
+	case i >= math.MinInt8:
+		o, n := ensure(b, 2)
+		putMint8(o[n:], int8(i))
+		return o
+	case i >= math.MinInt16:
+		o, n := ensure(b, 3)
+		putMint16(o[n:], int16(i))
+		return o
+	case i >= math.MinInt32:
+		o, n := ensure(b, 5)
+		putMint32(o[n:], int32(i))
+		return o
+	default:
+		o, n := ensure(b, 9)
+		putMint64(o[n:], i)
+		return o
+	}
+}
+
+// AppendInt appends an int to the slice
+func AppendInt(b []byte, i int) []byte { return AppendInt64(b, int64(i)) }
+
+// AppendInt8 appends an int8 to the slice
+func AppendInt8(b []byte, i int8) []byte { return AppendInt64(b, int64(i)) }
+
+// AppendInt16 appends an int16 to the slice
+func AppendInt16(b []byte, i int16) []byte { return AppendInt64(b, int64(i)) }
+
+// AppendInt32 appends an int32 to the slice
+func AppendInt32(b []byte, i int32) []byte { return AppendInt64(b, int64(i)) }
+
+// AppendUint64 appends a uint64 to the slice
+func AppendUint64(b []byte, u uint64) []byte {
+	switch {
+	case u <= (1<<7)-1:
+		return append(b, wfixint(uint8(u)))
+
+	case u <= math.MaxUint8:
+		o, n := ensure(b, 2)
+		putMuint8(o[n:], uint8(u))
+		return o
+
+	case u <= math.MaxUint16:
+		o, n := ensure(b, 3)
+		putMuint16(o[n:], uint16(u))
+		return o
+
+	case u <= math.MaxUint32:
+		o, n := ensure(b, 5)
+		putMuint32(o[n:], uint32(u))
+		return o
+
+	default:
+		o, n := ensure(b, 9)
+		putMuint64(o[n:], u)
+		return o
+
+	}
+}
+
+// AppendUint appends a uint to the slice
+func AppendUint(b []byte, u uint) []byte { return AppendUint64(b, uint64(u)) }
+
+// AppendUint8 appends a uint8 to the slice
+func AppendUint8(b []byte, u uint8) []byte { return AppendUint64(b, uint64(u)) }
+
+// AppendByte is analogous to AppendUint8
+func AppendByte(b []byte, u byte) []byte { return AppendUint8(b, uint8(u)) }
+
+// AppendUint16 appends a uint16 to the slice
+func AppendUint16(b []byte, u uint16) []byte { return AppendUint64(b, uint64(u)) }
+
+// AppendUint32 appends a uint32 to the slice
+func AppendUint32(b []byte, u uint32) []byte { return AppendUint64(b, uint64(u)) }
+
+// AppendBytes appends bytes to the slice as MessagePack 'bin' data
+func AppendBytes(b []byte, bts []byte) []byte {
+	sz := len(bts)
+	var o []byte
+	var n int
+	switch {
+	case sz <= math.MaxUint8:
+		o, n = ensure(b, 2+sz)
+		prefixu8(o[n:], mbin8, uint8(sz))
+		n += 2
+	case sz <= math.MaxUint16:
+		o, n = ensure(b, 3+sz)
+		prefixu16(o[n:], mbin16, uint16(sz))
+		n += 3
+	default:
+		o, n = ensure(b, 5+sz)
+		prefixu32(o[n:], mbin32, uint32(sz))
+		n += 5
+	}
+	return o[:n+copy(o[n:], bts)]
+}
+
+// AppendBool appends a bool to the slice
+func AppendBool(b []byte, t bool) []byte {
+	if t {
+		return append(b, mtrue)
+	}
+	return append(b, mfalse)
+}
+
+// AppendString appends a string as a MessagePack 'str' to the slice
+func AppendString(b []byte, s string) []byte {
+	sz := len(s)
+	var n int
+	var o []byte
+	switch {
+	case sz <= 31:
+		o, n = ensure(b, 1+sz)
+		o[n] = wfixstr(uint8(sz))
+		n++
+	case sz <= math.MaxUint8:
+		o, n = ensure(b, 2+sz)
+		prefixu8(o[n:], mstr8, uint8(sz))
+		n += 2
+	case sz <= math.MaxUint16:
+		o, n = ensure(b, 3+sz)
+		prefixu16(o[n:], mstr16, uint16(sz))
+		n += 3
+	default:
+		o, n = ensure(b, 5+sz)
+		prefixu32(o[n:], mstr32, uint32(sz))
+		n += 5
+	}
+	return o[:n+copy(o[n:], s)]
+}
+
+// AppendStringFromBytes appends a []byte
+// as a MessagePack 'str' to the slice 'b.'
+func AppendStringFromBytes(b []byte, str []byte) []byte {
+	sz := len(str)
+	var n int
+	var o []byte
+	switch {
+	case sz <= 31:
+		o, n = ensure(b, 1+sz)
+		o[n] = wfixstr(uint8(sz))
+		n++
+	case sz <= math.MaxUint8:
+		o, n = ensure(b, 2+sz)
+		prefixu8(o[n:], mstr8, uint8(sz))
+		n += 2
+	case sz <= math.MaxUint16:
+		o, n = ensure(b, 3+sz)
+		prefixu16(o[n:], mstr16, uint16(sz))
+		n += 3
+	default:
+		o, n = ensure(b, 5+sz)
+		prefixu32(o[n:], mstr32, uint32(sz))
+		n += 5
+	}
+	return o[:n+copy(o[n:], str)]
+}
+
+// AppendComplex64 appends a complex64 to the slice as a MessagePack extension
+func AppendComplex64(b []byte, c complex64) []byte {
+	o, n := ensure(b, Complex64Size)
+	o[n] = mfixext8
+	o[n+1] = Complex64Extension
+	big.PutUint32(o[n+2:], math.Float32bits(real(c)))
+	big.PutUint32(o[n+6:], math.Float32bits(imag(c)))
+	return o
+}
+
+// AppendComplex128 appends a complex128 to the slice as a MessagePack extension
+func AppendComplex128(b []byte, c complex128) []byte {
+	o, n := ensure(b, Complex128Size)
+	o[n] = mfixext16
+	o[n+1] = Complex128Extension
+	big.PutUint64(o[n+2:], math.Float64bits(real(c)))
+	big.PutUint64(o[n+10:], math.Float64bits(imag(c)))
+	return o
+}
+
+// AppendTime appends a time.Time to the slice as a MessagePack extension
+func AppendTime(b []byte, t time.Time) []byte {
+	o, n := ensure(b, TimeSize)
+	t = t.UTC()
+	o[n] = mext8
+	o[n+1] = 12
+	o[n+2] = TimeExtension
+	putUnix(o[n+3:], t.Unix(), int32(t.Nanosecond()))
+	return o
+}
+
+// AppendMapStrStr appends a map[string]string to the slice
+// as a MessagePack map with 'str'-type keys and values
+func AppendMapStrStr(b []byte, m map[string]string) []byte {
+	sz := uint32(len(m))
+	b = AppendMapHeader(b, sz)
+	for key, val := range m {
+		b = AppendString(b, key)
+		b = AppendString(b, val)
+	}
+	return b
+}
+
+// AppendMapStrIntf appends a map[string]interface{} to the slice
+// as a MessagePack map with 'str'-type keys.
+func AppendMapStrIntf(b []byte, m map[string]interface{}) ([]byte, error) {
+	sz := uint32(len(m))
+	b = AppendMapHeader(b, sz)
+	var err error
+	for key, val := range m {
+		b = AppendString(b, key)
+		b, err = AppendIntf(b, val)
+		if err != nil {
+			return b, err
+		}
+	}
+	return b, nil
+}
+
+// AppendIntf appends the concrete type of 'i' to the
+// provided []byte. 'i' must be one of the following:
+//  - 'nil'
+//  - A bool, float, string, []byte, int, uint, or complex
+//  - A map[string]interface{} or map[string]string
+//  - A []T, where T is another supported type
+//  - A *T, where T is another supported type
+//  - A type that satisfieds the msgp.Marshaler interface
+//  - A type that satisfies the msgp.Extension interface
+func AppendIntf(b []byte, i interface{}) ([]byte, error) {
+	if i == nil {
+		return AppendNil(b), nil
+	}
+
+	// all the concrete types
+	// for which we have methods
+	switch i := i.(type) {
+	case Marshaler:
+		return i.MarshalMsg(b)
+	case Extension:
+		return AppendExtension(b, i)
+	case bool:
+		return AppendBool(b, i), nil
+	case float32:
+		return AppendFloat32(b, i), nil
+	case float64:
+		return AppendFloat64(b, i), nil
+	case complex64:
+		return AppendComplex64(b, i), nil
+	case complex128:
+		return AppendComplex128(b, i), nil
+	case string:
+		return AppendString(b, i), nil
+	case []byte:
+		return AppendBytes(b, i), nil
+	case int8:
+		return AppendInt8(b, i), nil
+	case int16:
+		return AppendInt16(b, i), nil
+	case int32:
+		return AppendInt32(b, i), nil
+	case int64:
+		return AppendInt64(b, i), nil
+	case int:
+		return AppendInt64(b, int64(i)), nil
+	case uint:
+		return AppendUint64(b, uint64(i)), nil
+	case uint8:
+		return AppendUint8(b, i), nil
+	case uint16:
+		return AppendUint16(b, i), nil
+	case uint32:
+		return AppendUint32(b, i), nil
+	case uint64:
+		return AppendUint64(b, i), nil
+	case time.Time:
+		return AppendTime(b, i), nil
+	case map[string]interface{}:
+		return AppendMapStrIntf(b, i)
+	case map[string]string:
+		return AppendMapStrStr(b, i), nil
+	case []interface{}:
+		b = AppendArrayHeader(b, uint32(len(i)))
+		var err error
+		for _, k := range i {
+			b, err = AppendIntf(b, k)
+			if err != nil {
+				return b, err
+			}
+		}
+		return b, nil
+	}
+
+	var err error
+	v := reflect.ValueOf(i)
+	switch v.Kind() {
+	case reflect.Array, reflect.Slice:
+		l := v.Len()
+		b = AppendArrayHeader(b, uint32(l))
+		for i := 0; i < l; i++ {
+			b, err = AppendIntf(b, v.Index(i).Interface())
+			if err != nil {
+				return b, err
+			}
+		}
+		return b, nil
+	case reflect.Ptr:
+		if v.IsNil() {
+			return AppendNil(b), err
+		}
+		b, err = AppendIntf(b, v.Elem().Interface())
+		return b, err
+	default:
+		return b, &ErrUnsupportedType{T: v.Type()}
+	}
+}


### PR DESCRIPTION
move to using logrus for logging support. currently, fluentd and syslog are supported. move daemon, cilium/cmd, pkg/endpoint, pkg/kvstore, pkg/labels, pkg/maps/ctmap, pkg/option, pkg/policy, pkg/proxy from go-logging to logrus for logging. add new vendor dependencies needed for logrus. add new configuration option for CLI so user can use key-value pairs for configuration options related to logging, and add log-driver and log-opt options for cilium-agent.

Signed-off by: Ian Vernon <ian@covalent.io>

Fixes: #656 