### PR TITLE
daemon: fix composite literal uses unkeyed fields

### DIFF
--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -150,15 +150,16 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 }
 
 func (ds *DaemonSuite) TestReplacePolicy(c *C) {
+	lblBar := labels.ParseLabel("bar")
 	lbls := labels.ParseLabelArray("foo", "bar")
 	rules := api.Rules{
 		{
 			Labels:           lbls,
-			EndpointSelector: api.EndpointSelector{labels.ParseLabel("foo")},
+			EndpointSelector: api.NewESFromLabels(lblBar),
 		},
 		{
 			Labels:           lbls,
-			EndpointSelector: api.EndpointSelector{labels.ParseLabel("foo")},
+			EndpointSelector: api.NewESFromLabels(lblBar),
 		},
 	}
 


### PR DESCRIPTION
daemon/policy_test.go:157: github.com/cilium/cilium/pkg/policy/api.EndpointSelector composite literal uses unkeyed fields

Fixes: #759 

Signed-off-by: Thomas Graf <thomas@cilium.io>