### PR TITLE
daemon: add kvstore-opt flag for kvstore config

### DIFF
--- a/contrib/scripts/cilium-up.sh
+++ b/contrib/scripts/cilium-up.sh
@@ -28,4 +28,4 @@ docker run -d \
    agent -client=0.0.0.0 -server -bootstrap-expect 1
 
 $dir/plugins/cilium-docker/cilium-docker&
-$dir/daemon/cilium-agent --kvstore consul --consul 127.0.0.1:8501 $*
+$dir/daemon/cilium-agent --kvstore consul --kvstore-opt consul.address=127.0.0.1:8501 $*

--- a/contrib/systemd/cilium
+++ b/contrib/systemd/cilium
@@ -1,3 +1,3 @@
 PATH=/usr/lib/llvm-3.8/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
-CILIUM_OPTS=--kvstore consul --consul "127.0.0.1:8500"
+CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500
 INITSYSTEM=SYSTEMD

--- a/contrib/upstart/cilium.conf
+++ b/contrib/upstart/cilium.conf
@@ -1,2 +1,2 @@
 env PATH=/usr/local/clang/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
-exec cilium-agent --debug --kvstore consul --consul "127.0.0.1:8500"
+exec cilium-agent --debug --kvstore consul --kvstore-opt consul.address=127.0.0.1:8500

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -269,13 +269,13 @@ function write_cilium_cfg() {
 
     if [ -n "${K8S}" ]; then
         cilium_options+=" --k8s-api-server http://${MASTER_IPV4}:8080"
-        cilium_options+=" --etcd-config-path /var/lib/cilium/etcd-config.yml"
+        cilium_options+=" --kvstore-opt etcd.confg=/var/lib/cilium/etcd-config.yml"
         cilium_options+=" --kvstore etcd"
     else
         if [[ "${IPV4}" -eq "1" ]]; then
-            cilium_options+=" --consul ${MASTER_IPV4}:8500"
+            cilium_options+=" --kvstore-opt consul.address=${MASTER_IPV4}:8500"
         else
-            cilium_options+=" --consul [${ipv6_addr}]:8500"
+            cilium_options+=" --kvstore-opt consul.address=[${ipv6_addr}]:8500"
         fi
         cilium_options+=" --kvstore consul"
     fi

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -30,6 +30,17 @@ import (
 	consulAPI "github.com/hashicorp/consul/api"
 )
 
+const (
+	// CAddr is the string representing the key mapping to the value of the
+	// address for Consul.
+	CAddr = "consul.address"
+)
+
+// / ConsulOpts is the set of supported options for Consul configuration.
+var ConsulOpts = map[string]bool{
+	CAddr: true,
+}
+
 var (
 	maxRetries = 30
 	retrySleep = 2 * time.Second

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -34,6 +34,21 @@ import (
 	ctx "golang.org/x/net/context"
 )
 
+const (
+	// EAddr is the string representing the key mapping to the value of the
+	// address for Etcd.
+	EAddr = "etcd.address"
+	// ECfg is the string representing the key mapping to the path of the
+	// configuration for Etcd.
+	ECfg = "etcd.config"
+)
+
+// EtcdOpts is the set of supported options for Etcd configuration.
+var EtcdOpts = map[string]bool{
+	EAddr: true,
+	ECfg:  true,
+}
+
 type EtcdClient struct {
 	cli         *client.Client
 	sessionMU   sync.RWMutex

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"fmt"
 	"github.com/cilium/cilium/common/types"
 	"github.com/cilium/cilium/pkg/policy"
 )
@@ -54,4 +55,15 @@ type KVLocker interface {
 // GetLockPath returns the lock path representation of the given path.
 func GetLockPath(path string) string {
 	return path + ".lock"
+}
+
+// ValidateOpts iterates through all of the keys in kvStoreOpts, and errors out
+// if the key in kvStoreOpts is not a supported key in supportedOpts.
+func ValidateOpts(kvStore string, kvStoreOpts map[string]string, supportedOpts map[string]bool) error {
+	for k := range kvStoreOpts {
+		if !supportedOpts[k] {
+			return fmt.Errorf("provided configuration value %q is not supported as a key-value store option for kvstore %s", k, kvStore)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Add kvstore-opt flag, which maps a key (configuration flag) to a value.
This results in only needing one flag in the CLI for key-value store
related configuration, as opposed to many different flags for each
different key-value. If any key is provided that maps to a different
key-value store than the key-value store provided to the CLI, the daemon
exits. We also ensure that the user-provided flags are supported flags;
if the flag is not supported, the daemon exits. Remove the consul,
etcd-config-path, etcd flags as valid options for the daemon.

Signed-off by: Ian Vernon <ian@covalent.io>

Fixes: #623 