### PR TITLE
common/logging: send logs to stdout by default

### DIFF
--- a/cilium/cmd/endpoint_labels.go
+++ b/cilium/cmd/endpoint_labels.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/labels"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 

--- a/cilium/cmd/policy.go
+++ b/cilium/cmd/policy.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/policy/api"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 

--- a/cilium/cmd/policy_import.go
+++ b/cilium/cmd/policy_import.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 

--- a/cilium/cmd/root.go
+++ b/cilium/cmd/root.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cilium/cilium/common"
 	clientPkg "github.com/cilium/cilium/pkg/client"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -28,6 +28,7 @@ import (
 var (
 	cfgFile string
 	client  *clientPkg.Client
+	log     = logrus.New()
 )
 
 const (
@@ -96,9 +97,9 @@ func initConfig() {
 	}
 
 	if viper.GetBool("debug") {
-		common.SetupLogging([]string{common.Syslog}, map[string]string{common.SLevel: "debug"}, "cilium-cmd", true)
+		log.Level = logrus.DebugLevel
 	} else {
-		common.SetupLogging([]string{common.Syslog}, map[string]string{common.SLevel: "info"}, "cilium-cmd", false)
+		log.Level = logrus.InfoLevel
 	}
 
 	if cl, err := clientPkg.NewClient(viper.GetString("host")); err != nil {

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -24,13 +24,12 @@ import (
 	"strings"
 
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/common/plugins"
 	"github.com/cilium/cilium/pkg/client"
 	"github.com/cilium/cilium/pkg/endpoint"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/containernetworking/cni/pkg/ns"
 	"github.com/containernetworking/cni/pkg/skel"
 	cniTypes "github.com/containernetworking/cni/pkg/types"
@@ -39,12 +38,12 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func init() {
-	common.SetupLogging([]string{common.Syslog}, map[string]string{common.SLevel: "debug"}, "cilium-net-cni", true)
+var (
+	log = logrus.New()
+)
 
-	// this ensures that main runs only on main thread (thread group leader).
-	// since namespace ops (unshare, setns) are done for a single thread, we
-	// must ensure that the goroutine does not jump from OS thread to thread
+func init() {
+	log.Level = logrus.DebugLevel
 	runtime.LockOSThread()
 }
 

--- a/plugins/cilium-docker/main.go
+++ b/plugins/cilium-docker/main.go
@@ -19,10 +19,9 @@ import (
 	"os"
 	"path"
 
-	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/plugins/cilium-docker/driver"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -31,6 +30,7 @@ var (
 	driverSock string
 	debug      bool
 	ciliumAPI  string
+	log        = logrus.New()
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -77,9 +77,9 @@ func init() {
 
 func initConfig() {
 	if debug {
-		common.SetupLogging([]string{common.Syslog}, map[string]string{common.SLevel: "debug"}, "cilium-docker", true)
+		log.Level = logrus.DebugLevel
 	} else {
-		common.SetupLogging([]string{common.Syslog}, map[string]string{common.SLevel: "info"}, "cilium-docker", false)
+		log.Level = logrus.InfoLevel
 	}
 
 	// The cilium-docker plugin must be run as root user.


### PR DESCRIPTION
Opt-in to sending logs to syslog instead of setting up handler by
default. Output logs to stdout by default. Have cilium commands and
cilium-cni log output to console by default instead of setup syslog
hooks.

Signed-off by: Ian Vernon <ian@covalent.io>

Fixes: #770 