### PR TITLE
ct: Closing map if open successfully

### DIFF
--- a/cilium/cmd/bpf_ct_list.go
+++ b/cilium/cmd/bpf_ct_list.go
@@ -50,8 +50,6 @@ func dumpCtProto(mapType, eID string) {
 
 	file := bpf.MapPath(mapType + eID)
 	m, err := bpf.OpenMap(file)
-	defer m.Close()
-
 	if err != nil {
 		if err == os.ErrNotExist {
 			Fatalf("Unable to open %s: %s: please try using \"cilium bpf ct list global\"", file, err)
@@ -59,6 +57,7 @@ func dumpCtProto(mapType, eID string) {
 			Fatalf("Unable to open %s: %s", file, err)
 		}
 	}
+	defer m.Close()
 	out, err := ctmap.ToString(m, mapType)
 	if err != nil {
 		Fatalf("Error while dumping BPF Map: %s", err)

--- a/daemon/ct.go
+++ b/daemon/ct.go
@@ -55,12 +55,12 @@ func runGC(e *endpoint.Endpoint, isIPv6 bool) {
 	}
 
 	m, err := bpf.OpenMap(file)
-	defer m.Close()
-
 	if err != nil {
 		log.Warningf("Unable to open map %s: %s", file, err)
 		e.LogStatus(endpoint.BPF, endpoint.Warning, fmt.Sprintf("Unable to open CT map %s: %s", file, err))
+		return
 	}
+	defer m.Close()
 
 	// If LRUHashtable, no need to garbage collect as LRUHashtable cleans itself up.
 	if m.MapInfo.MapType == bpf.MapTypeLRUHash {


### PR DESCRIPTION
In case it was not possible to open the map, defer would run causing a
nil panic.

Signed-off-by: André Martins <andre@cilium.io>