### PR TITLE
add loopback binary op for cni_install script

### DIFF
--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -6,12 +6,13 @@ HOST_PREFIX=${HOST_PREFIX:-/host}
 CNI_CONF_NAME=${CNI_CONF_NAME:-10-cilium.conf}
 MTU=${MTU:-1450}
 
-CILIUM_CNI=${CILIUM_CNI:-${HOST_PREFIX}/opt/cni/bin/cilium-cni}
+CILIUM_CNI=${CILIUM_CNI:-${HOST_PREFIX}/opt/cni/bin/}
 CILIUM_CNI_CONF=${CILIUM_CNI_CONF:-${HOST_PREFIX}/etc/cni/net.d/${CNI_CONF_NAME}}
 
-# Install cilium-cni binary tohost
+# Install cilium-cni and loopback binary to host
 echo "Installing $CILIUM_CNI ..."
 cp /opt/cni/bin/cilium-cni ${CILIUM_CNI}
+cp /opt/cni/bin/loopback ${CILIUM_CNI}
 
 cat > ${CNI_CONF_NAME} <<EOF
 {

--- a/plugins/cilium-cni/cni-uninstall.sh
+++ b/plugins/cilium-cni/cni-uninstall.sh
@@ -5,11 +5,11 @@ set -eu
 HOST_PREFIX=${HOST_PREFIX:-/host}
 CNI_CONF_NAME=${CNI_CONF_NAME:-10-cilium.conf}
 
-CILIUM_CNI=${CILIUM_CNI:-${HOST_PREFIX}/opt/cni/bin/cilium-cni}
+CILIUM_CNI=${CILIUM_CNI:-${HOST_PREFIX}/opt/cni/bin/}
 CILIUM_CNI_CONF=${CILIUM_CNI_CONF:-${HOST_PREFIX}/etc/cni/net.d/${CNI_CONF_NAME}}
 
 echo "Removing ${CILIUM_CNI} ..."
-rm -f ${CILIUM_CNI}
+rm -rf ${CILIUM_CNI}
 
 echo "Removing ${CILIUM_CNI_CONF} ..."
 rm -f ${CILIUM_CNI_CONF}


### PR DESCRIPTION
complete cni install/unstall scripts for kubernetes
as loopback is necessary when using cni plugin.

Signed-off-by: peiqi <uestc.shi@gmail.com>