### PR TITLE
Documentation: Fix DaemonSet yaml in getting started guide

### DIFF
--- a/Documentation/gettingstarted.rst
+++ b/Documentation/gettingstarted.rst
@@ -83,7 +83,7 @@ To deploy the Cilium Daemon Set, run:
 
 ::
 
-    $ kubectl create -f https://raw.githubusercontent.com/cilium/cilium/master/examples/kubernetes/cilium-ds.yaml
+    $ kubectl create -f https://raw.githubusercontent.com/cilium/cilium/master/examples/minikube/cilium-ds.yaml
     clusterrole "cilium" created
     serviceaccount "cilium" created
     clusterrolebinding "cilium" created


### PR DESCRIPTION
The link to the daemonset yaml was wrong in the getting started guide and did not point to the minikube specific DaemonSet.

Reported-by: Jon D via Slack
Signed-off-by: Thomas Graf <thomas@cilium.io>