### PR TITLE
Revert "add loopback binary in cni_install"

### DIFF
--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -6,13 +6,12 @@ HOST_PREFIX=${HOST_PREFIX:-/host}
 CNI_CONF_NAME=${CNI_CONF_NAME:-10-cilium.conf}
 MTU=${MTU:-1450}
 
-CILIUM_CNI=${CILIUM_CNI:-${HOST_PREFIX}/opt/cni/bin/}
+CILIUM_CNI=${CILIUM_CNI:-${HOST_PREFIX}/opt/cni/bin/cilium-cni}
 CILIUM_CNI_CONF=${CILIUM_CNI_CONF:-${HOST_PREFIX}/etc/cni/net.d/${CNI_CONF_NAME}}
 
-# Install cilium-cni and loopback binary to host
+# Install cilium-cni binary tohost
 echo "Installing $CILIUM_CNI ..."
 cp /opt/cni/bin/cilium-cni ${CILIUM_CNI}
-cp /opt/cni/bin/loopback ${CILIUM_CNI}
 
 cat > ${CNI_CONF_NAME} <<EOF
 {

--- a/plugins/cilium-cni/cni-uninstall.sh
+++ b/plugins/cilium-cni/cni-uninstall.sh
@@ -5,11 +5,11 @@ set -eu
 HOST_PREFIX=${HOST_PREFIX:-/host}
 CNI_CONF_NAME=${CNI_CONF_NAME:-10-cilium.conf}
 
-CILIUM_CNI=${CILIUM_CNI:-${HOST_PREFIX}/opt/cni/bin/}
+CILIUM_CNI=${CILIUM_CNI:-${HOST_PREFIX}/opt/cni/bin/cilium-cni}
 CILIUM_CNI_CONF=${CILIUM_CNI_CONF:-${HOST_PREFIX}/etc/cni/net.d/${CNI_CONF_NAME}}
 
 echo "Removing ${CILIUM_CNI} ..."
-rm -rf ${CILIUM_CNI}
+rm -f ${CILIUM_CNI}
 
 echo "Removing ${CILIUM_CNI_CONF} ..."
 rm -f ${CILIUM_CNI_CONF}


### PR DESCRIPTION
The `loopback` binary is not present and causes errors. Need
to revert this for now.

```
kube-system   cilium-k97k5   0/1       PostStart handler: command '/cni-install.sh' exited with 1: cp: cannot stat '/opt/cni/bin/loopback': No such file or directory
```

This reverts commit 2d2cd407506fed93b570ff121a4e59d5f31bfe93.

Signed-off-by: Thomas Graf <thomas@cilium.io>