### PR TITLE
fix(minikube): switch to using --kvstore-opt

### DIFF
--- a/Documentation/admin.rst
+++ b/Documentation/admin.rst
@@ -155,8 +155,10 @@ Here is an example Daemon Set definition:
 	        args:
 	          - "-t"
 	          - "vxlan"
-	          - "--etcd-config-path"
-	          - "/var/lib/cilium/etcd-config.yml"
+	          - "--kvstore"
+	          - "etcd"
+	          - "--kvstore-opt"
+	          - "etcd.config=/var/lib/cilium/etcd-config.yml"
 	          - "--k8s-kubeconfig-path"
 	          - "/var/lib/kubelet/kubeconfig"
 	        env:
@@ -535,8 +537,6 @@ Cilium Agent Command Line Options
 +---------------------+--------------------------------------+----------------------+
 | config              | config file                          | $HOME/ciliumd.yaml   |
 +---------------------+--------------------------------------+----------------------+
-| consul              | Consul agent address                 |                      |
-+---------------------+--------------------------------------+----------------------+
 | debug               | Enable debug messages                | false                |
 +---------------------+--------------------------------------+----------------------+
 | device              | Ethernet device to snoop on          |                      |
@@ -546,10 +546,6 @@ Cilium Agent Command Line Options
 | enable-policy       | Enable policy enforcement            | false                |
 +---------------------+--------------------------------------+----------------------+
 | docker              | Docker socket endpoint               |                      |
-+---------------------+--------------------------------------+----------------------+
-| etcd                | etcd agent address                   |                      |
-+---------------------+--------------------------------------+----------------------+
-| etcd-config-path    | absolute path to the etcd config     |                      |
 +---------------------+--------------------------------------+----------------------+
 | enable-tracing      | enable policy tracing                |                      |
 +---------------------+--------------------------------------+----------------------+
@@ -563,6 +559,20 @@ Cilium Agent Command Line Options
 +---------------------+--------------------------------------+----------------------+
 | keep-config         | When restoring state, keeps          | false                |
 |                     | containers' configuration in place   |                      |
++---------------------+--------------------------------------+----------------------+
+| kvstore             | Key Value Store Type:                |                      |
+|                     | (consul, etcd, local)                |                      |
++---------------------+--------------------------------------+----------------------+
+| kvstore-opt         | Local:                               |                      |
+|                     |    - None                            |                      |
+|                     | Etcd:                                |                      |
+|                     |    - etcd.address: Etcd agent        |                      |
+|                     |      address.                        |                      |
+|                     |    - etcd.config: Absolute path to   |                      |
+|                     |      the etcd configuration file.    |                      |
+|                     | Consul:                              |                      |
+|                     |    - consul.address: Consul agent    |                      |
+|                     |      agent address.                  |                      |
 +---------------------+--------------------------------------+----------------------+
 | label-prefix-file   | file with label prefixes cilium      |                      |
 |                     | Cilium should use for policy         |                      |

--- a/contrib/packaging/k8s/daemon-set.yaml
+++ b/contrib/packaging/k8s/daemon-set.yaml
@@ -19,8 +19,10 @@ spec:
           - "--ipv4"
           - "-t"
           - "vxlan"
-          - "--etcd-config-path"
-          - "/var/lib/cilium/etcd-config.yml"
+          - "--kvstore"
+          - "etcd"
+          - "--kvstore-opt"
+          - "etcd.config=/var/lib/cilium/etcd-config.yml"
           - "--k8s-kubeconfig-path"
           - "/var/lib/kubelet/kubeconfig"
         env:

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -547,7 +547,7 @@ func NewDaemon(c *Config) (*Daemon, error) {
 			}
 			kvClient = c
 		} else {
-			return nil, fmt.Errorf("invalid configuration for consul provided; please specify the address to a consul instance with the --consul option")
+			return nil, fmt.Errorf("invalid configuration for consul provided; please specify the address to a consul instance with the consul.address option")
 		}
 	case kvstore.Etcd:
 		if c.EtcdCfgPath != "" || c.EtcdConfig != nil {
@@ -558,7 +558,7 @@ func NewDaemon(c *Config) (*Daemon, error) {
 			}
 			kvClient = c
 		} else {
-			return nil, fmt.Errorf("invalid configuration for etcd provided; please specify an etcd configuration path with --etcd-config-path or an etcd agent address with --etcd")
+			return nil, fmt.Errorf("invalid configuration for etcd provided; please specify an etcd configuration path with etcd.config or an etcd agent address with etcd.address")
 		}
 	case kvstore.Local:
 		log.Infof("Using local storage as key-value store")

--- a/examples/getting-started/Vagrantfile
+++ b/examples/getting-started/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.require_version ">= 1.8.3"
 
 num_nodes = (ENV['NNODES'] || 1).to_i
 cilium_version = (ENV['CILIUM_VERSION'] || "v0.8.1")
-cilium_opts = (ENV['CILIUM_OPTS'] || "--consul 192.168.33.11:8500 -t vxlan")
+cilium_opts = (ENV['CILIUM_OPTS'] || "--kvstore consul --kvstore-opt consul.address 192.168.33.11:8500 -t vxlan")
 cilium_tag = (ENV['CILIUM_TAG'] || "0.8")
 
 # This runs only once when vagrant box is provisioned for the first time

--- a/examples/minikube/cilium-ds.yaml
+++ b/examples/minikube/cilium-ds.yaml
@@ -97,8 +97,8 @@ spec:
           - "role,app"
           - "--kvstore"
           - "consul"
-          - "--consul"
-          - "http://127.0.0.1:8500"
+          - "--kvstore-opt"
+          - "consul.address=http://127.0.0.1:8500"
           - "-d"
           - "eth0"
         lifecycle:


### PR DESCRIPTION
Switch to using the --kvstore-opt in the cilium daemonset example for minikube.

Fixes: #791