### PR TITLE
daemon: fix nil pointer when using k8s-prefix

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -472,6 +472,7 @@ func initEnv() {
 	if len(k8sLabelsPrefixes) == 0 {
 		config.ValidK8sLabelPrefixes = labels.DefaultK8sLabelPrefixCfg()
 	} else {
+		config.ValidK8sLabelPrefixes = &labels.LabelPrefixCfg{}
 		for _, prefix := range k8sLabelsPrefixes {
 			config.ValidK8sLabelPrefixes.LabelPrefixes = append(
 				config.ValidK8sLabelPrefixes.LabelPrefixes,


### PR DESCRIPTION
When the user specified a k8s-prefix, the ValidK8sLabelPrefixes was not
initialized resulting in a nil pointer.

Signed-off-by: André Martins <andre@cilium.io>