### PR TITLE
k8s: add namespace awareness to network policy

### DIFF
--- a/pkg/k8s/const.go
+++ b/pkg/k8s/const.go
@@ -21,6 +21,9 @@ import (
 )
 
 const (
+	// AnnotationIsolationNS is the annotation key used in the annotation
+	// map for the network isolation on the respective namespace.
+	AnnotationIsolationNS = "net.beta.kubernetes.io/network-policy"
 	// AnnotationName is an optional annotation to the NetworkPolicy
 	// resource which specifies the name of the policy node to which all
 	// rules should be applied to.
@@ -36,8 +39,11 @@ const (
 	LabelSourceKeyPrefix = LabelSource + common.PathDelimiter
 
 	// PolicyLabelName is the name of the policy label which refers to the
-	// k8s policy name
+	// k8s policy name.
 	PolicyLabelName = "io.cilium.k8s-policy-name"
+	// PolicyNSLabelName is the name of the namespace label which refers to
+	// the NS name.
+	PolicyNSLabelName = "io.cilium.k8s-namespace-name"
 	// PodNamespaceLabel is the label used in kubernetes containers to
 	// specify which namespace they belong to.
 	PodNamespaceLabel = types.KubernetesPodNamespaceLabel

--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -80,6 +80,10 @@ func DefaultLabelPrefixCfg() *LabelPrefixCfg {
 				Prefix: k8s.PodNamespaceLabel,
 				Source: k8s.LabelSource,
 			},
+			{
+				Prefix: k8s.PodNamespaceMetaLabels,
+				Source: k8s.LabelSource,
+			},
 		},
 	}
 }


### PR DESCRIPTION
- Enforced namespace IngressIsolationPolicy
- Use all namespaces's labels in cilium endpoints from k8s.
- Changed valid prefixes to the new prefixes needed for by the
  namespace IngressIsolationPolicy functionality.

Signed-off-by: André Martins <andre@cilium.io>