### PR TITLE
Fixing ct gc

### DIFF
--- a/daemon/ct.go
+++ b/daemon/ct.go
@@ -31,14 +31,14 @@ const (
 	GcInterval int = 10
 )
 
-func runGC(e *endpoint.Endpoint, isIPv6 bool) {
+func runGC(e *endpoint.Endpoint, isLocal, isIPv6 bool) {
 	var file string
 	var mapType string
 	// TODO: We need to optimize this a bit in future, so we traverse
 	// the global table less often.
 
 	// Use local or global conntrack maps depending on configuration settings.
-	if e.Opts.IsEnabled(endpoint.OptionConntrackLocal) {
+	if isLocal {
 		if isIPv6 {
 			mapType = ctmap.MapName6
 		} else {
@@ -108,13 +108,14 @@ func (d *Daemon) EnableConntrackGC() {
 					}
 					seenGlobal = true
 				}
+				isLocal := e.Opts.IsEnabled(endpoint.OptionConntrackLocal)
 
 				e.Mutex.RUnlock()
 				// We can unlock the endpoint mutex sense
 				// in runGC it will be locked as needed.
-				runGC(e, true)
+				runGC(e, isLocal, true)
 				if !d.conf.IPv4Disabled {
-					runGC(e, false)
+					runGC(e, isLocal, false)
 				}
 			}
 

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -245,11 +245,9 @@ func GC(m *bpf.Map, mapName string) int {
 	deleted := 0
 
 	switch mapName {
-	case MapName6:
-	case MapName6Global:
+	case MapName6, MapName6Global:
 		doGC6(m, &deleted, uint32(tsec))
-	case MapName4:
-	case MapName4Global:
+	case MapName4, MapName4Global:
 		doGC4(m, &deleted, uint32(tsec))
 	}
 

--- a/pkg/maps/ctmap/ipv6.go
+++ b/pkg/maps/ctmap/ipv6.go
@@ -27,8 +27,8 @@ import (
 
 //CtKey6 represents the key for IPv6 entries in the local BPF conntrack map.
 type CtKey6 struct {
-	saddr   types.IPv6
 	daddr   types.IPv6
+	saddr   types.IPv6
 	sport   uint16
 	dport   uint16
 	nexthdr u8proto.U8proto


### PR DESCRIPTION
EDIT: The unit test error was on my side.

~One of the commits seems to brake the `./03-docker.sh` test:~
```
+ docker run --rm -i --net=cilium --name netperf -l id.client tgraf/netperf sh -c 'sleep 5s && netperf -c -C -t TCP_SENDFILE -H fd02::c0a8:210b:0:fabd'
establish control: are you sure there is a netserver listening on fd02::c0a8:210b:0:fabd at port 12865?
establish_control could not establish the control connection from ::0 port 0 address family AF_UNSPEC to fd02::c0a8:210b:0:fabd port 12865 address family AF_INET6
+ abort 'Error: Could not netperf to server'
``` 

~I can't figure out which one since sometimes happens sometimes it doesn't~