### PR TITLE
 daemon: check if policy enforcement is being updated

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -762,10 +762,13 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 	changes := d.conf.Opts.Apply(params.Configuration, changedOption, d)
 	log.Debugf("Applied %d changes", changes)
 	if changes > 0 {
-		if config.Opts.IsEnabled(endpoint.OptionPolicy) && config.EnablePolicy != endpoint.AlwaysEnforce {
-			config.EnablePolicy = endpoint.AlwaysEnforce
-		} else if !config.Opts.IsEnabled(endpoint.OptionPolicy) && config.EnablePolicy != endpoint.NeverEnforce {
-			config.EnablePolicy = endpoint.NeverEnforce
+		_, ok := params.Configuration[endpoint.OptionPolicy]
+		if ok {
+			if config.Opts.IsEnabled(endpoint.OptionPolicy) && config.EnablePolicy != endpoint.AlwaysEnforce {
+				config.EnablePolicy = endpoint.AlwaysEnforce
+			} else if !config.Opts.IsEnabled(endpoint.OptionPolicy) && config.EnablePolicy != endpoint.NeverEnforce {
+				config.EnablePolicy = endpoint.NeverEnforce
+			}
 		}
 		if err := d.compileBase(); err != nil {
 			msg := fmt.Errorf("Unable to recompile base programs: %s\n", err)

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -104,14 +104,11 @@ func (d *Daemon) UpdatePolicyEnforcement(e *endpoint.Endpoint) bool {
 	if d.conf.EnablePolicy == endpoint.AlwaysEnforce {
 		return true
 	} else if d.conf.EnablePolicy == endpoint.DefaultEnforcement && !d.conf.IsK8sEnabled() {
-		log.Infof("updatePolicyEnforcement: default enforcement, no k8s")
 		if d.GetPolicyRepository().NumRules() > 0 {
-			log.Infof("updatePolicyEnforcement: set to true, num rules > 0 ")
 			// TODO - revisit setting Daemon endpoint.OptionPolicy here
 			d.conf.Opts.Set(endpoint.OptionPolicy, true)
 			return true
 		} else {
-			log.Infof("updatePolicyEnforcement: set to false, num rules == 0")
 			d.conf.Opts.Set(endpoint.OptionPolicy, false)
 			return false
 		}
@@ -123,8 +120,6 @@ func (d *Daemon) UpdatePolicyEnforcement(e *endpoint.Endpoint) bool {
 			endpointLabels = append(endpointLabels, lbl)
 		}
 		e.Mutex.RUnlock()
-		d.GetPolicyRepository().Mutex.RLock()
-		defer d.GetPolicyRepository().Mutex.RUnlock()
 		// Check if rules match the labels for this endpoint.
 		// If so, enable policy enforcement.
 		return d.GetPolicyRepository().GetRulesMatching(endpointLabels)


### PR DESCRIPTION
This fixes a bug where if any configuration update was applied to the daemon, the daemon would update the daemon's EnablePolicy configuration value regardless of if there was an update to the Policy Enforcement configuration flag in the daemon or not. Now, the daemon only checks if the option is present in the update, and then if so, updates the EnablePolicy flag if needed.

Signed-off by: Ian Vernon <ian@covalent.io>