### PR TITLE
daemon: fixing cilium deadlock

### DIFF
--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -100,6 +100,7 @@ func (d *Daemon) TriggerPolicyUpdates(added []policy.NumericIdentity) {
 
 // UpdatePolicyEnforcement returns whether policy enforcement needs to be
 // enabled for the specified endpoint.
+// Endpoint needs to be called with RLock set.
 func (d *Daemon) UpdatePolicyEnforcement(e *endpoint.Endpoint) bool {
 	if d.conf.EnablePolicy == endpoint.AlwaysEnforce {
 		return true
@@ -113,13 +114,13 @@ func (d *Daemon) UpdatePolicyEnforcement(e *endpoint.Endpoint) bool {
 			return false
 		}
 	} else if d.conf.EnablePolicy == endpoint.DefaultEnforcement && d.conf.IsK8sEnabled() {
-		e.Mutex.RLock()
+		e.Consumable.Mutex.RLock()
 		// Convert to LabelArray so we can pass to Matches function later.
 		var endpointLabels labels.LabelArray
 		for _, lbl := range e.Consumable.LabelList {
 			endpointLabels = append(endpointLabels, lbl)
 		}
-		e.Mutex.RUnlock()
+		e.Consumable.Mutex.RUnlock()
 		// Check if rules match the labels for this endpoint.
 		// If so, enable policy enforcement.
 		return d.GetPolicyRepository().GetRulesMatching(endpointLabels)


### PR DESCRIPTION
When cilium was being used with kubernetes, the endpoint RLock was
called while the endpoint's Lock was already held. By calling
UpdatePolicyEnforcement with the lock held, it is not necessary use the
RLock inside this function.

Signed-off-by: André Martins <andre@cilium.io>