### PR TITLE
DO NOT MERGE: jenkins test

### DIFF
--- a/cilium/cmd/endpoint_list.go
+++ b/cilium/cmd/endpoint_list.go
@@ -43,8 +43,14 @@ func init() {
 }
 
 func listEndpoint(w *tabwriter.Writer, ep *models.Endpoint, id string, label string) {
-	fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t\n",
-		ep.ID, id, label, ep.Addressing.IPV6, ep.Addressing.IPV4, ep.State)
+	var isPolicyEnabled string
+	if ep.PolicyEnabled {
+		isPolicyEnabled = "Enabled"
+	} else {
+		isPolicyEnabled = "Disabled"
+	}
+	fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
+		ep.ID, isPolicyEnabled, id, label, ep.Addressing.IPV6, ep.Addressing.IPV4, ep.State)
 }
 
 func listEndpoints() {
@@ -58,17 +64,20 @@ func listEndpoints() {
 	w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
 
 	const (
-		labelsIDTitle  = "IDENTITY"
-		labelsDesTitle = "LABELS (source:key[=value])"
-		ipv6Title      = "IPv6"
-		ipv4Title      = "IPv4"
-		endpointTitle  = "ENDPOINT"
-		statusTitle    = "STATUS"
+		labelsIDTitle    = "IDENTITY"
+		labelsDesTitle   = "LABELS (source:key[=value])"
+		ipv6Title        = "IPv6"
+		ipv4Title        = "IPv4"
+		endpointTitle    = "ENDPOINT"
+		statusTitle      = "STATUS"
+		policyTitle      = "POLICY"
+		enforcementTitle = "ENFORCEMENT"
 	)
 
 	if !noHeaders {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t\n",
-			endpointTitle, labelsIDTitle, labelsDesTitle, ipv6Title, ipv4Title, statusTitle)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
+			endpointTitle, policyTitle, labelsIDTitle, labelsDesTitle, ipv6Title, ipv4Title, statusTitle)
+		fmt.Fprintf(w, "\t%s\t\t\t\t\t\t\n", enforcementTitle)
 	}
 
 	for _, ep := range eps {
@@ -88,7 +97,7 @@ func listEndpoints() {
 						listEndpoint(w, ep, id, lbl)
 						first = false
 					} else {
-						fmt.Fprintf(w, "\t\t%s\t\t\t\t\n", lbl)
+						fmt.Fprintf(w, "\t\t\t%s\t\t\t\t\n", lbl)
 					}
 				}
 			}

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -70,6 +70,7 @@ type Config struct {
 	K8sCfgPath     string                  // Kubeconfig path
 	KVStore        string                  // key-value store type
 	LBInterface    string                  // Set with name of the interface to loadbalance packets from
+	EnablePolicy   string                  // Whether policy enforcement is enabled.
 	Tunnel         string                  // Tunnel mode
 
 	ValidLabelPrefixesMU  sync.RWMutex           // Protects the 2 variables below
@@ -103,6 +104,7 @@ func NewConfig() *Config {
 	}
 }
 
+// IsK8sEnabled checks if Cilium is being used in tandem with Kubernetes.
 func (c *Config) IsK8sEnabled() bool {
 	return c.K8sEndpoint != "" || c.K8sCfgPath != ""
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -214,6 +214,10 @@ func (d *Daemon) PolicyEnabled() bool {
 	return d.conf.Opts.IsEnabled(endpoint.OptionPolicy)
 }
 
+func (d *Daemon) PolicyEnforcement() string {
+	return d.conf.EnablePolicy
+}
+
 // DebugEnabled returns whether if debug mode is enabled.
 func (d *Daemon) DebugEnabled() bool {
 	return d.conf.Opts.IsEnabled(endpoint.OptionDebug)
@@ -758,6 +762,11 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 	changes := d.conf.Opts.Apply(params.Configuration, changedOption, d)
 	log.Debugf("Applied %d changes", changes)
 	if changes > 0 {
+		if config.Opts.IsEnabled(endpoint.OptionPolicy) && config.EnablePolicy != endpoint.AlwaysEnforce {
+			config.EnablePolicy = endpoint.AlwaysEnforce
+		} else if !config.Opts.IsEnabled(endpoint.OptionPolicy) && config.EnablePolicy != endpoint.NeverEnforce {
+			config.EnablePolicy = endpoint.NeverEnforce
+		}
 		if err := d.compileBase(); err != nil {
 			msg := fmt.Errorf("Unable to recompile base programs: %s\n", err)
 			log.Warningf("%s", msg)

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -213,6 +213,7 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder 
 	}
 
 	ep.SetDefaultOpts(h.d.conf.Opts)
+	ep.Opts.Set(endpoint.OptionPolicy, h.d.PolicyEnabled())
 
 	h.d.endpointsMU.Lock()
 	defer h.d.endpointsMU.Unlock()

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -156,7 +156,7 @@ func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 	}
 	fw.WriteString(" */\n\n")
 
-	if !e.PolicyCalculated && owner.PolicyEnabled() {
+	if !e.PolicyCalculated && e.Opts.IsEnabled(OptionPolicy) && owner.PolicyEnforcement() != NeverEnforce {
 		fw.WriteString("#define DROP_ALL\n")
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -61,6 +61,9 @@ const (
 	OptionDropNotify          = "DropNotification"
 	OptionNAT46               = "NAT46"
 	OptionPolicy              = "Policy"
+	AlwaysEnforce             = "always"
+	NeverEnforce              = "never"
+	DefaultEnforcement        = "default"
 
 	maxLogs = 256
 )
@@ -268,6 +271,7 @@ func (e *Endpoint) GetModel() *models.Endpoint {
 		HostMac:          e.NodeMAC.String(),
 		State:            currentState, // TODO: Validate
 		Policy:           e.Consumable.GetModel(),
+		PolicyEnabled:    e.Opts.IsEnabled(OptionPolicy),
 		Status:           e.Status.GetModel(),
 		Addressing: &models.EndpointAddressing{
 			IPV4: e.IPv4.String(),

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -28,8 +28,14 @@ type Owner interface {
 	// Must return true if dry mode is enabled
 	DryModeEnabled() bool
 
-	// PolicyEnabled returns true if policy enforcement has been enabled
+	// PolicyEnabled returns whether policy enforcement is enabled
 	PolicyEnabled() bool
+
+	// UpdatePolicyEnforcement returns whether policy enforcement needs to be updated.
+	UpdatePolicyEnforcement(ep *Endpoint) bool
+
+	// GetPolicyEnforcementType returns the type of policy enforcement for the Owner.
+	PolicyEnforcement() string
 
 	// AlwaysAllowLocalhost returns true if localhost is always allowed to
 	// reach local endpoints

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -263,6 +263,13 @@ func (e *Endpoint) regeneratePolicy(owner Owner) (bool, error) {
 	e.Consumable.Mutex.RUnlock()
 	repo.Mutex.RUnlock()
 
+	enable := owner.UpdatePolicyEnforcement(e)
+	if enable {
+		opts[OptionPolicy] = "enabled"
+	} else {
+		opts[OptionPolicy] = "disabled"
+	}
+
 	optsChanged := e.ApplyOptsLocked(opts)
 
 	if !e.PolicyCalculated {

--- a/pkg/policy/identity.go
+++ b/pkg/policy/identity.go
@@ -134,7 +134,7 @@ func (id *Identity) AssociateEndpoint(epID string) {
 }
 
 // DisassociateEndpoint disassociates the endpoint endpoint with identity and
-// return true if successful.
+// returns true if successful.
 func (id *Identity) DisassociateEndpoint(epID string) bool {
 	if _, ok := id.Endpoints[epID]; ok {
 		delete(id.Endpoints, epID)

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -227,3 +227,24 @@ func (p *Repository) GetJSON() string {
 
 	return JSONMarshalRules(result)
 }
+
+// GetRulesMatching returns whether any of the rules in a repository contain a
+// rule with labels matching the labels in the provided LabelArray.
+func (p *Repository) GetRulesMatching(labels labels.LabelArray) bool {
+	p.Mutex.RLock()
+	defer p.Mutex.RUnlock()
+	for _, r := range p.rules {
+		rulesMatch := r.EndpointSelector.Matches(labels)
+		if rulesMatch {
+			return true
+		}
+	}
+	return false
+}
+
+// NumRules returns the amount of rules in the policy repository.
+func (p *Repository) NumRules() int {
+	p.Mutex.RLock()
+	defer p.Mutex.RUnlock()
+	return len(p.rules)
+}

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -250,23 +250,23 @@ CLIENT_ID=$(cilium endpoint list | grep $CLIENT_IP | awk '{ print $1}')
 
 SERVER1_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server1)
 SERVER1_ID=$(cilium endpoint list | grep $SERVER1_IP | awk '{ print $1}')
-SERVER1_IP4=$(cilium endpoint list | grep $SERVER1_IP | awk '{ print $5}')
+SERVER1_IP4=$(cilium endpoint list | grep $SERVER1_IP | awk '{ print $6}')
 
 SERVER2_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server2)
 SERVER2_ID=$(cilium endpoint list | grep $SERVER2_IP | awk '{ print $1}')
-SERVER2_IP4=$(cilium endpoint list | grep $SERVER2_IP | awk '{ print $5}')
+SERVER2_IP4=$(cilium endpoint list | grep $SERVER2_IP | awk '{ print $6}')
 
 SERVER3_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server3)
 SERVER3_ID=$(cilium endpoint list | grep $SERVER3_IP | awk '{ print $1}')
-SERVER3_IP4=$(cilium endpoint list | grep $SERVER3_IP | awk '{ print $5}')
+SERVER3_IP4=$(cilium endpoint list | grep $SERVER3_IP | awk '{ print $6}')
 
 SERVER4_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server4)
 SERVER4_ID=$(cilium endpoint list | grep $SERVER4_IP | awk '{ print $1}')
-SERVER4_IP4=$(cilium endpoint list | grep $SERVER4_IP | awk '{ print $5}')
+SERVER4_IP4=$(cilium endpoint list | grep $SERVER4_IP | awk '{ print $6}')
 
 SERVER5_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server5)
 SERVER5_ID=$(cilium endpoint list | grep $SERVER5_IP | awk '{ print $1}')
-SERVER5_IP4=$(cilium endpoint list | grep $SERVER5_IP | awk '{ print $5}')
+SERVER5_IP4=$(cilium endpoint list | grep $SERVER5_IP | awk '{ print $6}')
 
 cilium endpoint config $CLIENT_ID  | grep ConntrackLocal
 cilium endpoint config $SERVER1_ID | grep ConntrackLocal

--- a/tests/11-getting-started.sh
+++ b/tests/11-getting-started.sh
@@ -99,6 +99,8 @@ cat <<EOF | cilium policy import -
 }]
 EOF
 
+sleep 5
+
 monitor_clear
 echo "------ performing HTTP GET on ${HTTPD_CONTAINER_NAME}/public from service2 ------"
 RETURN=$(docker run --rm -i --net ${TEST_NET} -l "${ID_SERVICE2}" ${DEMO_CONTAINER} /bin/bash -c "curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 -XGET http://${HTTPD_CONTAINER_NAME}/public")

--- a/tests/12-policy-import.sh
+++ b/tests/12-policy-import.sh
@@ -126,7 +126,7 @@ if [[ "$DIFF" != "" ]]; then
 fi
 
 BAR_ID=$(cilium endpoint list | grep id.bar | awk '{ print $1}')
-FOO_SEC_ID=$(cilium endpoint list | grep id.foo | awk '{ print $2}')
+FOO_SEC_ID=$(cilium endpoint list | grep id.foo | awk '{ print $3}')
 
 EXPECTED_CONSUMER="1\n$FOO_SEC_ID"
 
@@ -177,7 +177,7 @@ if [[ "$DIFF" != "" ]]; then
 fi
 
 BAR_ID=$(cilium endpoint list | grep id.bar | awk '{ print $1}')
-FOO_SEC_ID=$(cilium endpoint list | grep id.foo | awk '{ print $2}')
+FOO_SEC_ID=$(cilium endpoint list | grep id.foo | awk '{ print $3}')
 
 EXPECTED_CONSUMER="$FOO_SEC_ID"
 

--- a/tests/15-policy-config.sh
+++ b/tests/15-policy-config.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+
+source "./helpers.bash"
+
+TEST_NET="cilium"
+LIST_CMD="cilium endpoint list | awk '{print \$2}' | grep 'Enabled\|Disabled'"
+CFG_CMD="cilium config | grep Policy | grep -v PolicyTracing | awk '{print \$2}'"
+
+function start_containers {
+	docker run -dt --net=$TEST_NET --name foo -l id.foo -l id.teamA tgraf/netperf
+	docker run -dt --net=$TEST_NET --name bar -l id.bar -l id.teamA tgraf/netperf
+	docker run -dt --net=$TEST_NET --name baz -l id.baz tgraf/netperf
+}
+
+function remove_containers {
+	docker rm -f foo foo bar baz 2> /dev/null || true
+}
+
+function import_test_policy {
+	echo "------ adding policy ------"
+	cat <<EOF | cilium -D policy import -
+	[{
+		"endpointSelector": {"matchLabels":{"id.bar":""}},
+		"ingress": [{
+			"fromEndpoints": [
+			{"matchLabels":{"reserved:host":""}},
+			{"matchLabels":{"id.foo":""}}
+		]
+	        }]
+	}]
+EOF
+}
+
+function cleanup {
+	cilium policy delete --all 2> /dev/null || true
+	docker rm -f foo foo bar baz 2> /dev/null || true
+}
+
+function wait_endpoints_ready {
+	until [ "$(cilium endpoint list | grep ready -c)" -eq "3" ]; do
+		echo "Waiting for all endpoints to be ready"
+		sleep 2s
+	done
+}
+
+function check_endpoints_policy_enabled {
+	echo "------ checking if all endpoints have policy enforcement enabled ------"
+	POLICY_ENFORCED=`eval ${LIST_CMD}`
+	for line in $POLICY_ENFORCED; do
+		if [[ "$line" != "Enabled" ]]; then
+			cilium config
+			cilium endpoint list
+			abort "Policy Enabled should be set to 'Enabled' since there are policies added to Cilium"
+		fi
+	done
+}
+
+function check_endpoints_policy_disabled {
+	echo "------ checking if all endpoints have policy enforcement disabled ------"
+	POLICY_ENFORCED=`eval ${LIST_CMD}`
+	for line in $POLICY_ENFORCED; do
+		if [[ "$line" != "Disabled" ]]; then
+			cilium config
+			cilium endpoint list
+			abort "Policy Enforcement  should be set to 'Disabled' since policy enforcement was set to never be enabled"
+		fi
+	done
+}
+
+function check_config_policy_enabled {
+	echo "------ checking if cilium daemon has policy enforcement enabled ------"
+	sleep 5
+	POLICY_ENFORCED=`eval ${CFG_CMD}`
+	for line in $POLICY_ENFORCED; do
+		if [[ "$line" != "Enabled" ]]; then
+                        cilium config
+		        cilium endpoint list	
+			abort "Policy Enforcement should be set to 'Enabled' for the daemon"
+		fi
+	done
+}
+
+function check_config_policy_disabled {
+	echo "------ checking if cilium daemon has policy enforcement disabled ------"
+	sleep 5
+	POLICY_ENFORCED=`eval ${CFG_CMD}`
+	for line in $POLICY_ENFORCED; do
+		if [[ "$line" != "Disabled" ]]; then
+			cilium config
+			cilium endpoint list
+			abort "Policy Enforcement should be set to 'Disabled' for the daemon"
+		fi
+	done
+}
+
+function test_default_policy_configuration {
+echo "------ test default configuration for enable-policy ------"
+	# cilium-agent has enable-policy flag, which by default is set as "default".
+	# Expected behavior is that if Kubernetes is not enabled, policy enforcement is enabled if at least one policy exists.
+	# If no policy exists, then policy enforcement is disabled.
+	remove_containers
+	sudo service cilium restart
+	sleep 10
+	start_containers
+
+	wait_endpoints_ready
+	check_config_policy_disabled
+	check_endpoints_policy_disabled
+	
+	import_test_policy
+	wait_endpoints_ready
+	check_config_policy_enabled
+	check_endpoints_policy_enabled
+	
+	cilium policy delete --all
+	wait_endpoints_ready
+	check_config_policy_disabled
+}
+
+function test_true_policy_configuration {
+	echo "------ test true configuration for enable-policy ------"
+	remove_containers
+	cilium config Policy=true
+	start_containers
+
+	wait_endpoints_ready
+	check_config_policy_enabled
+	check_endpoints_policy_enabled
+	import_test_policy
+	
+	wait_endpoints_ready
+	check_config_policy_enabled
+	check_endpoints_policy_enabled
+	cilium policy delete --all
+	
+	wait_endpoints_ready
+	check_config_policy_enabled
+}
+
+function test_false_policy_configuration {
+	echo "------ test false configuration for enable-policy ------"
+	remove_containers
+	cilium config Policy=false
+	start_containers
+
+	wait_endpoints_ready
+	check_config_policy_disabled
+	check_endpoints_policy_disabled
+	import_test_policy
+	wait_endpoints_ready
+	check_config_policy_disabled
+	check_endpoints_policy_disabled
+	cilium policy delete --all
+	wait_endpoints_ready
+	check_config_policy_disabled
+}
+
+trap cleanup EXIT
+
+cleanup
+logs_clear
+
+docker network inspect $TEST_NET 2> /dev/null || {
+        docker network create --ipv6 --subnet ::1/112 --ipam-driver cilium --driver cilium $TEST_NET
+}
+test_default_policy_configuration
+test_true_policy_configuration
+test_false_policy_configuration 


### PR DESCRIPTION
Extend policy flag to daemon to have three modes:

default, where policy enforcement is enabled if at least one policy
exists if K8s is not enabled, or, if k8s is enabled, policy enforcement
is enabled on the
pods that are selected by a NetworkPolicy.
true: policy enforcement is always enabled
false: policy enforcement is always disabled

Signed-off-by: Ian Vernon <ian@covalent.io>