### PR TITLE
Documentation: minor nitpicks

### DIFF
--- a/Documentation/gettingstarted.rst
+++ b/Documentation/gettingstarted.rst
@@ -463,7 +463,7 @@ Step 6: Start an Example Service with Docker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In this tutorial, we'll use a container running a simple HTTP server to
-represent a microservice application which we will refer to a *app1*.  As a result, we
+represent a microservice application which we will refer to as *app1*.  As a result, we
 will start this container with the label "id=app1", so we can create Cilium
 security policies for that service.
 
@@ -490,7 +490,7 @@ security policies, which are automatically applied to any container with that
 label, no matter where or when it is run within a container cluster.
 
 We'll start with an overly simple example where we create two additional
-appss, *app2* and *app3*, and we want *app2* containers to be able
+apps, *app2* and *app3*, and we want *app2* containers to be able
 to reach *app1* containers, but *app3* containers should not be allowed
 to reach *app1* containers.  Additionally, we only want to allow *app1*
 to be reachable on port 80, but no other ports.  This is a simple policy that

--- a/Documentation/intro.rst
+++ b/Documentation/intro.rst
@@ -12,7 +12,7 @@ management platforms like Docker and Kubernetes.
 
 At the foundation of Cilium is a new Linux kernel technology called BPF, which
 enables the dynamic insertion of powerful security visibility and control logic
-within Linux itself.  Because BPF runs inside the Linux kernel itself, Cilium
+within Linux itself.  Because BPF runs inside the Linux kernel, Cilium
 security policies can be applied and updated without any changes to the
 application code or container configuration.
 
@@ -37,7 +37,7 @@ balancing tables and access control lists carrying hundreds of thousands of
 rules that need to be updated with a continuously growing frequency. Protocol
 ports (e.g. TCP port 80 for HTTP traffic) can no longer be used to
 differentiate between application traffic for security purposes as the port is
-utilized for a wide range of messages across services
+utilized for a wide range of messages across services.
 
 An additional challenge is the ability to provide accurate visibility as
 traditional systems are using IP addresses as primary identification vehicle
@@ -80,11 +80,11 @@ Getting Help
 ------------
 
 We use Github issues to maintain a list of `Cilium Frequently Asked Questions (FAQ)
-<https://github.com/cilium/cilium/issues?utf8=%E2%9C%93&q=is%3Aissue%20label%3Aquestion%20>`_ .
+<https://github.com/cilium/cilium/issues?utf8=%E2%9C%93&q=is%3Aissue%20label%3Aquestion%20>`_.
 Check there to see if your question(s) is already addressed.
 
 The best way to get help if you get stuck is to contact us on the
-`Cilium Slack channel <https://cilium.herokuapp.com>`_ .
+`Cilium Slack channel <https://cilium.herokuapp.com>`_.
 
 If you are confident that you have found a bug, or if you have a feature
 request, please go ahead and create an issue on our


### PR DESCRIPTION
o Remove repeated word.
o Add missing period.
o Remove extra spaces.
o s/to a/to as/
o s/appss/apps/

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>