### PR TITLE
go: upgrade go to 1.8.3 due security fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ make install && \
 
 cd /tmp && \
 curl -Sslk -o go.linux-amd64.tar.gz \
-https://storage.googleapis.com/golang/go1.8.1.linux-amd64.tar.gz && \
+https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz && \
 tar -C /usr/local -xzf go.linux-amd64.tar.gz && \
 cd /tmp/cilium-net-build/src/github.com/cilium/cilium && \
 export GOROOT=/usr/local/go && \

--- a/contrib/packaging/deb/cfg/Dockerfile
+++ b/contrib/packaging/deb/cfg/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update && \
 apt-get install -y --no-install-recommends dh-golang devscripts fakeroot dh-make \
     build-essential curl gcc make libc6-dev.i386
 RUN cd /tmp && \
-curl -Sslk -o go1.8.1.linux-amd64.tar.gz \
-https://storage.googleapis.com/golang/go1.8.1.linux-amd64.tar.gz && \
-tar -C /usr/local -xzf go1.8.1.linux-amd64.tar.gz && \
-rm -f go1.8.1.linux-amd64.tar.gz
+curl -Sslk -o go1.8.3.linux-amd64.tar.gz \
+https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz && \
+tar -C /usr/local -xzf go1.8.3.linux-amd64.tar.gz && \
+rm -f go1.8.3.linux-amd64.tar.gz
 
 ADD . /tmp/cilium-net-build/src/github.com/cilium/cilium
 


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>