### PR TITLE
pkg/bpf: remove #define depending on CI_BUILD

### DIFF
--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -21,10 +21,6 @@ package bpf
 #include <sys/resource.h>
 #include <time.h>
 
-#if !defined __NR_bpf && defined CI_BUILD
-#define __NR_bpf 1
-#endif
-
 static __u64 ptr_to_u64(const void *ptr)
 {
 	return (__u64) (unsigned long) ptr;


### PR DESCRIPTION
The CI_BUILD macro is no longer defined since travis CI integration was
removed in commit b7483ba03d59 ("build: Remove travis integration").
Remove the last remaining bit wich depends on CI_BUILD being defined.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>