### PR TITLE
tests: add test for documentation link

### DIFF
--- a/tests/00-documentation-link-check.sh
+++ b/tests/00-documentation-link-check.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+DOC_DIR=../Documentation
+LINKCHECK_OUTPUT=$DOC_DIR/_build/linkcheck/output.txt
+
+make -C $DOC_DIR clean || true
+make -C $DOC_DIR linkcheck || true
+
+if grep "Not Found for url" $LINKCHECK_OUTPUT; then
+  exit 1
+fi
+
+# TODO: also check the README.md


### PR DESCRIPTION
This is expected to fail for now, because

    admin.rst:536: [broken] https://github.com/cilium/cilium/tree/master/examples/policy/test: 404 Client Error: Not Found for url: https://github.com/cilium/cilium/tree/master/examples/policy/test