### PR TITLE
k8s: Ignore annotation.kubernetes.io labels

### DIFF
--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -124,6 +124,11 @@ func defaultLabelPrefixCfg() *LabelPrefixCfg {
 				Prefix: "io.kubernetes",
 			},
 			{
+				// Ignore all annotation.kubernete.io labels
+				Ignore: true,
+				Prefix: "annotation.kubernetes.io",
+			},
+			{
 				// Ignore pod-template-hash
 				Ignore: true,
 				Prefix: "pod-template-hash",

--- a/pkg/labels/filter_test.go
+++ b/pkg/labels/filter_test.go
@@ -45,6 +45,7 @@ func (s *LabelsPrefCfgSuite) TestFilterLabels(c *C) {
 		"io.kubernetes.pod.terminationGracePeriod":       "30",
 		"io.kubernetes.pod.uid":                          "c2e22414-dfc3-11e5-9792-080027755f5a",
 		"ignore":                                         "foo",
+		"annotation.kubernetes.io/config.seen": "2017-05-30T14:22:17.691491034Z",
 	}
 	allLabels := Map2Labels(allNormalLabels, common.CiliumLabelSource)
 	filtered := dlpcfg.FilterLabels(allLabels)


### PR DESCRIPTION
Example:
cilium:annotation.kubernetes.io/config.seen=2017-05-30T14:22:17.718886499Z
cilium:annotation.kubernetes.io/config.source=api
cilium:annotation.kubernetes.io/created-by={"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicaSet","namespace":"default","name":"app3-640085774","uid":"628aadb4-4543-11e7-bdbb-080027f02591","apiVersion":"extensions","resourceVersion":"517"}}

Signed-off-by: Thomas Graf <thomas@cilium.io>