### PR TITLE
k8s: omitting k8s namespace for reserved labels

### DIFF
--- a/pkg/k8s/types/third_party.go
+++ b/pkg/k8s/types/third_party.go
@@ -17,6 +17,7 @@ package k8s
 import (
 	"fmt"
 
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -79,6 +80,9 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 					retRule.Ingress[i].FromEndpoints[j] = api.NewESFromK8sLabelSelector("", ep.LabelSelector)
 					if retRule.Ingress[i].FromEndpoints[j].MatchLabels == nil {
 						retRule.Ingress[i].FromEndpoints[j].MatchLabels = map[string]string{}
+					}
+					if retRule.Ingress[i].FromEndpoints[j].HasKeyPrefix(common.ReservedLabelSourceKeyPrefix) {
+						continue
 					}
 					retRule.Ingress[i].FromEndpoints[j].MatchLabels[k8s.LabelSourceKeyPrefix+k8s.PodNamespaceLabel] = namespace
 				}

--- a/pkg/k8s/types/third_party_test.go
+++ b/pkg/k8s/types/third_party_test.go
@@ -44,6 +44,11 @@ var (
                         "matchLabels": {
                             "role": "frontend"
                         }
+                    },
+                    {
+                        "matchLabels": {
+                            "reserved:world": ""
+                        }
                     }
                 ],
                 "toPorts": [
@@ -110,6 +115,9 @@ func (s *K8sSuite) TestParseThirdParty(c *C) {
 						api.NewESFromLabels(
 							labels.ParseLabel("any:role=frontend"),
 						),
+						api.NewESFromLabels(
+							labels.ParseLabel("reserved:world"),
+						),
 					},
 					ToPorts: []api.PortRule{
 						{
@@ -145,6 +153,9 @@ func (s *K8sSuite) TestParseThirdParty(c *C) {
 					api.NewESFromLabels(
 						labels.ParseLabel("any:role=frontend"),
 						labels.ParseLabel("k8s:"+k8s.PodNamespaceLabel+"=default"),
+					),
+					api.NewESFromLabels(
+						labels.ParseLabel("reserved:world"),
 					),
 				},
 				ToPorts: []api.PortRule{

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/labels"
@@ -84,6 +85,22 @@ func (n EndpointSelector) MarshalJSON() ([]byte, error) {
 		ls.MatchExpressions = newMatchExpr
 	}
 	return json.Marshal(ls)
+}
+
+// HasKeyPrefix checks if the endpoint selector contains the given key prefix in
+// its MatchLabels map and MatchExpressions slice.
+func (n EndpointSelector) HasKeyPrefix(prefix string) bool {
+	for k := range n.MatchLabels {
+		if strings.HasPrefix(k, prefix) {
+			return true
+		}
+	}
+	for _, v := range n.MatchExpressions {
+		if strings.HasPrefix(v.Key, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // NewESFromLabels creates a new endpoint selector from the given labels.


### PR DESCRIPTION
If the user specifies any reserved label for the endpoint selector in
the k8s cilium TPR, the k8s namespace is not inserted to that same
selector.

Signed-off-by: André Martins <andre@cilium.io>