### PR TITLE
Documentation/admin.rst: update enable-policy flag

### DIFF
--- a/Documentation/admin.rst
+++ b/Documentation/admin.rst
@@ -623,7 +623,8 @@ Command Line Options
 +---------------------+--------------------------------------+----------------------+
 | disable-conntrack   | Disable connection tracking          | false                |
 +---------------------+--------------------------------------+----------------------+
-| enable-policy       | Enable policy enforcement            | false                |
+| enable-policy       | Enable policy enforcement            | default              |
+|                     | (default, false, true)               |                      |
 +---------------------+--------------------------------------+----------------------+
 | docker              | Docker socket endpoint               |                      |
 +---------------------+--------------------------------------+----------------------+


### PR DESCRIPTION
Update description for enable-policy flag for daemon to include possible
values (default, true, false) as well as default value to 'default'.

Signed-off by: Ian Vernon <ian@covalent.io>