### PR TITLE
daemon: update policy enforcement w/ no endpoints

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -760,15 +760,18 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 
 	changes := d.conf.Opts.Apply(params.Configuration, changedOption, d)
 	log.Debugf("Applied %d changes", changes)
-	if changes > 0 {
-		_, ok := params.Configuration[endpoint.OptionPolicy]
-		if ok {
-			if config.Opts.IsEnabled(endpoint.OptionPolicy) && config.EnablePolicy != endpoint.AlwaysEnforce {
-				config.EnablePolicy = endpoint.AlwaysEnforce
-			} else if !config.Opts.IsEnabled(endpoint.OptionPolicy) && config.EnablePolicy != endpoint.NeverEnforce {
-				config.EnablePolicy = endpoint.NeverEnforce
-			}
+
+	// Check explicitly for endpoint.OptionPolicy updates because its state
+	// is coupled with config's EnablePolicy flag.
+	_, ok := params.Configuration[endpoint.OptionPolicy]
+	if ok {
+		if config.Opts.IsEnabled(endpoint.OptionPolicy) && config.EnablePolicy != endpoint.AlwaysEnforce {
+			config.EnablePolicy = endpoint.AlwaysEnforce
+		} else if !config.Opts.IsEnabled(endpoint.OptionPolicy) && config.EnablePolicy != endpoint.NeverEnforce {
+			config.EnablePolicy = endpoint.NeverEnforce
 		}
+	}
+	if changes > 0 {
 		if err := d.compileBase(); err != nil {
 			msg := fmt.Errorf("Unable to recompile base programs: %s\n", err)
 			log.Warningf("%s", msg)

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -31,8 +31,12 @@ type Owner interface {
 	// PolicyEnabled returns whether policy enforcement is enabled
 	PolicyEnabled() bool
 
-	// UpdatePolicyEnforcement returns whether policy enforcement needs to be updated.
-	UpdatePolicyEnforcement(ep *Endpoint) bool
+	// EnablePolicyEnforcement returns whether owner should enable policy enforcement.
+	EnablePolicyEnforcement() bool
+
+	// UpdateEndpointPolicyEnforcement returns whether policy enforcement
+	// should be enabled for the specified endpoint.
+	UpdateEndpointPolicyEnforcement(e *Endpoint) bool
 
 	// GetPolicyEnforcementType returns the type of policy enforcement for the Owner.
 	PolicyEnforcement() string

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -293,7 +293,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner) (bool, error) {
 		opts[OptionConntrack] = "enabled"
 	}
 
-	if owner.UpdatePolicyEnforcement(e) {
+	if owner.UpdateEndpointPolicyEnforcement(e) {
 		opts[OptionPolicy] = "enabled"
 	} else {
 		opts[OptionPolicy] = "disabled"


### PR DESCRIPTION
fixed bug in the daemon where if no endpoints were added, the policy
enforcement flag for the daemon was not updated if a policy was added.
fixes bug in the daemon where if the configuration flag for the boolean
option for policy enforcement was updated, the value of PolicyEnabled
within the daemon was not updated.
added tests to test policy enforcement flag when endpoints are not
added, as well as ping tests to ensure that policy enforcement
configuration updates are reflected in the networking configuration of
endpoints.

Signed-off by: Ian Vernon <ian@covalent.io>