### PR TITLE
k8s: Use existing `10-cilium.conf` CNI configuration if it exists

### DIFF
--- a/Documentation/admin.rst
+++ b/Documentation/admin.rst
@@ -223,8 +223,7 @@ provided DaemonSet_. The script ``cni-install.sh`` is automatically run via the
 configuration suits you, then you can skip the rest of this section.
 
 If you want to adjust the CNI configuration you may do so by creating the CNI
-configuration manually. Do so by running the following commands on all your
-servers:
+configuration manually.
 
 .. code:: bash
 
@@ -234,7 +233,10 @@ servers:
         "type": "cilium-cni",
         "mtu": 1450
     }
-    " > /etc/cni/net.d/10-cilium-cni.conf'
+    " > /etc/cni/net.d/10-cilium.conf'
+
+Cilium will use any existing ``/etc/cni/net.d/10-cilium.conf`` file if it
+already exists on a workder node and only create it if it does not exist yet.
 
 Since kubernetes ``v1.3.5`` you also need to install the ``loopback`` cni
 plugin:

--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -13,7 +13,11 @@ CILIUM_CNI_CONF=${CILIUM_CNI_CONF:-${HOST_PREFIX}/etc/cni/net.d/${CNI_CONF_NAME}
 echo "Installing $CILIUM_CNI ..."
 cp /opt/cni/bin/cilium-cni ${CILIUM_CNI}
 
-cat > ${CNI_CONF_NAME} <<EOF
+if [ -f "${CILIUM_CNI_CONF}" ]; then
+	echo "Using existing ${CILIUM_CNI_CONF}..."
+else
+	echo "Installing new $CILIUM_CNI_CONF ..."
+	cat > ${CNI_CONF_NAME} <<EOF
 {
     "name": "cilium",
     "type": "cilium-cni",
@@ -21,6 +25,5 @@ cat > ${CNI_CONF_NAME} <<EOF
 }
 EOF
 
-# Install CNI configuration to host
-echo "Installing $CILIUM_CNI_CONF ..."
-mv ${CNI_CONF_NAME} ${CILIUM_CNI_CONF}
+	mv ${CNI_CONF_NAME} ${CILIUM_CNI_CONF}
+fi


### PR DESCRIPTION
Allows users to define their own CNI configuration

Signed-off-by: Thomas Graf <thomas@cilium.io>