### PR TITLE
cilium: Print component status message

### DIFF
--- a/cilium/cmd/status.go
+++ b/cilium/cmd/status.go
@@ -45,16 +45,17 @@ func statusDaemon(cmd *cobra.Command, args []string) {
 		sr := resp.Payload
 		w := tabwriter.NewWriter(os.Stdout, 2, 0, 3, ' ', 0)
 		if sr.Kvstore != nil {
-			fmt.Fprintf(w, "KVStore:\t%s\n", sr.Kvstore.State)
+			fmt.Fprintf(w, "KVStore:\t%s\t%s\n", sr.Kvstore.State, sr.Kvstore.Msg)
 		}
 		if sr.ContainerRuntime != nil {
-			fmt.Fprintf(w, "ContainerRuntime:\t%s\n", sr.ContainerRuntime.State)
+			fmt.Fprintf(w, "ContainerRuntime:\t%s\t%s\n",
+				sr.ContainerRuntime.State, sr.ContainerRuntime.Msg)
 		}
 		if sr.Kubernetes != nil {
-			fmt.Fprintf(w, "Kubernetes:\t%s\n", sr.Kubernetes.State)
+			fmt.Fprintf(w, "Kubernetes:\t%s\t%s\n", sr.Kubernetes.State, sr.Kubernetes.Msg)
 		}
 		if sr.Cilium != nil {
-			fmt.Fprintf(w, "Cilium:\t%s\n", sr.Cilium.State)
+			fmt.Fprintf(w, "Cilium:\t%s\t%s\n", sr.Cilium.State, sr.Cilium.Msg)
 		}
 
 		if sr.IPAM != nil {


### PR DESCRIPTION
Correctly reports status message now:
```
kubectl -n kube-system exec cilium-d2qx2 cilium status
KVStore:            Ok        Consul: 127.0.0.1:8300
ContainerRuntime:   Ok
Kubernetes:         Failure   User "system:node:vagrant" cannot get componentstatuses at the cluster scope. (get componentstatuses controller-manager)
Cilium:             Failure   Kubernetes service is not ready
```