### PR TITLE
k8s/rbac: Grant access to componentstatues

### DIFF
--- a/examples/kubernetes/rbac.yaml
+++ b/examples/kubernetes/rbac.yaml
@@ -10,6 +10,7 @@ rules:
   - namespaces
   - nodes
   - endpoints
+  - componentstatuses
   verbs:
   - get
   - list

--- a/examples/minikube/cilium-ds.yaml
+++ b/examples/minikube/cilium-ds.yaml
@@ -10,6 +10,7 @@ rules:
   - namespaces
   - nodes
   - endpoints
+  - componentstatuses
   verbs:
   - get
   - list


### PR DESCRIPTION
Resolves:
User "system:node:vagrant" cannot get componentstatuses at the cluster scope. (get componentstatuses controller-manager)

Signed-off-by: Thomas Graf <thomas@cilium.io>