### PR TITLE
Monitor: omiting panic when no events Fix #757

### DIFF
--- a/cilium/cmd/monitor.go
+++ b/cilium/cmd/monitor.go
@@ -178,7 +178,8 @@ func runMonitor() {
 
 	events, err := bpf.NewPerCpuEvents(&eventConfig)
 	if err != nil {
-		panic(err)
+		fmt.Printf("Error: Unable to get BPF events (%s)\n", err)
+		os.Exit(1)
 	}
 
 	if eventType != "" {

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -267,7 +267,7 @@ func ObjGet(pathname string) (int, error) {
 	)
 
 	if fd == 0 || err != 0 {
-		return 0, fmt.Errorf("Unable to get object: %s", err)
+		return 0, fmt.Errorf("Unable to get object %s: %s", pathname, err)
 	}
 
 	return int(fd), nil


### PR DESCRIPTION
Hey! 

My first PR :-) 

This fix issue #757. The new output will be like this: 
```
ubuntu-zesty ➜  cilium git:(757) ✗ ./cilium/cilium monitor
Error: Unable to get BPF events (Unable to get object: /sys/fs/bpf/tc/globals/cilium_events)
```

Regards