### PR TITLE
cilium: include versions in clang/kernel version error report

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -160,8 +160,10 @@ func checkMinRequirements() {
 		clangMajor > majorMinClangVersion) &&
 		((kernelMajor < majorMinKernelVersion) ||
 			(kernelMajor == majorMinKernelVersion && kernelMinor < minorRecommendedKernelVersion)) {
-		log.Fatalf("clang and kernel version: NOT OK: please upgrade "+
-			"your kernel version to at least %d.%d", majorMinKernelVersion,
+		log.Fatalf("clang (%d.%d) and kernel (%d.%d) version: NOT OK: please upgrade "+
+			"your kernel version to at least %d.%d",
+			clangMajor, clangMinor, kernelMajor, kernelMinor,
+			majorMinKernelVersion,
 			minorRecommendedKernelVersion)
 	}
 	log.Infof("clang and kernel versions: OK!")


### PR DESCRIPTION
I find it helpful when I have many versions of kernels and clang on
a system for cilium to report which versions it found of each when
an error is detected.

New output reads,

FATA[0000] clang (5.0) and kernel (4.8) version: NOT OK: please upgrade your kernel version to at least 4.9

Signed-off-by: John Fastabend <john.fastabend@gmail.com>