### PR TITLE
renew cilium policy setup script in examples

### DIFF
--- a/examples/kubernetes-ingress/scripts/08-cilium.sh
+++ b/examples/kubernetes-ingress/scripts/08-cilium.sh
@@ -12,13 +12,34 @@ kubectl get networkpolicy
 
 # TODO remove sudo once socket permissions are set with cilium group
 cat <<EOF | sudo cilium -D policy import -
-{
-        "name": "root",
-        "rules": [{
-                "coverage": ["reserved:world"],
-                "allow": ["k8s:io.cilium.k8s.k8s-app=kube-dns"]
-        }]
-}
+[{
+    "endpointSelector": {"matchLabels":{"k8s-app":"kube-dns"}},
+    "ingress": [{
+        "from": [
+           {
+            "namespaceSelector": {
+              "matchLabels": {
+                "kube-system": ""
+              }
+            }
+          },
+             {
+            "namespaceSelector": {
+              "matchLabels": {
+                "default": ""
+              }
+            }
+          },
+          {
+            "podSelector": {
+              "matchLabels": {
+                "io.cilium.reserved": "host"
+              }
+            }
+          }
+        ]
+    }]
+}]
 EOF
 
-sudo cilium policy get root
+sudo cilium policy get


### PR DESCRIPTION
the json format of cilium policy is out of date in 08-cilium.sh script.
I think it was designed based on policy.Node, which is replaced by api.Rules

Signed-off-by: peiqi <uestc.shi@gmail.com>