### PR TITLE
tests: add K8s getting-started-guide test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,22 +3,26 @@ pipeline {
         label 'vagrant'
     }
     options {
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 40, unit: 'MINUTES')
     }
     stages {
-        stage('Build') {
-            environment {
-                MEMORY = '4096'
-                RUN_TEST_SUITE = '1'
-            }
-            steps {
-                sh './contrib/vagrant/start.sh'
-            }
+        stage ('Tests') {
+                environment {
+                    MEMORY = '4096'
+                    RUN_TEST_SUITE = '1'
+		}
+		steps {
+                    parallel(
+                        "Runtime Tests": { sh './contrib/vagrant/start.sh' }, 
+                         "K8s Tests": { sh './tests/k8s/start' } 
+                    )
+	        }
         }
     }
     post {
         always {
             sh 'vagrant destroy -f'
+            sh 'cd ./tests/k8s && vagrant destroy -f'
         }
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,9 @@ build-rpm:
 runtime-tests:
 	$(MAKE) -C tests runtime-tests
 
+k8s-tests:
+	$(MAKE) -C tests k8s-tests
+
 generate-api:
 	swagger generate server -t api/v1 -f api/v1/openapi.yaml -a restapi \
 	    -s server --default-scheme=unix -C api/v1/cilium-server.yml

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,3 +3,6 @@ include ../Makefile.defs
 
 runtime-tests:
 	./run-tests
+
+k8s-tests:
+	$(MAKE) -C k8s k8s-tests

--- a/tests/k8s/Makefile
+++ b/tests/k8s/Makefile
@@ -1,0 +1,4 @@
+include ../../Makefile.defs
+
+k8s-tests:
+	./run-tests

--- a/tests/k8s/Vagrantfile
+++ b/tests/k8s/Vagrantfile
@@ -1,0 +1,58 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.require_version ">= 1.8.3"
+
+$build = <<SCRIPT
+docker run -d -p 5000:5000 registry
+cd /home/vagrant/go/src/github.com/cilium/cilium/
+docker build -t cilium:build_test /home/vagrant/go/src/github.com/cilium/cilium
+export ID=$(docker images | grep "build_test" | awk '{print $3}')
+docker tag $ID localhost:5000/cilium:build_test
+docker push localhost:5000/cilium:build_test
+SCRIPT
+
+$k8s = <<SCRIPT
+sudo apt-get update && sudo apt-get install -y apt-transport-https
+sudo touch /etc/apt/sources.list.d/kubernetes.list
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg  | sudo apt-key add -
+sudo bash -c "cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
+deb http://apt.kubernetes.io/ kubernetes-xenial main
+EOF
+"
+sudo apt-get update
+sudo apt-get install -y docker-engine
+sudo apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+sudo kubeadm init
+sudo cp /etc/kubernetes/admin.conf /home/vagrant/admin.conf
+sudo chown 1000:1000 /home/vagrant/admin.conf
+echo "export KUBECONFIG=/home/vagrant/admin.conf" >> /home/vagrant/.bashrc
+echo "export KUBECONFIG=/home/vagrant/admin.conf" >> /home/vagrant/.profile
+export KUBECONFIG=/home/vagrant/admin.conf
+kubectl taint nodes --all node-role.kubernetes.io/master-
+SCRIPT
+
+$testsuite = <<SCRIPT
+make -C ~/go/src/github.com/cilium/cilium/ k8s-tests || exit 1
+SCRIPT
+
+Vagrant.configure(2) do |config|
+    config.vm.box = "bento/ubuntu-16.10"
+
+    # http://foo-o-rama.com/vagrant--stdin-is-not-a-tty--fix.html
+    config.vm.provision "fix-no-tty", type: "shell" do |s|
+        s.privileged = false
+        s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
+    end
+
+    # install docker runtime
+    #config.vm.provision :docker
+    config.vm.provision "k8s", type: "shell", inline: $k8s
+    config.vm.provision "build", type: "shell", inline: $build
+    config.vm.provider "virtualbox" do |vb|
+        config.vm.synced_folder '../../', '/home/vagrant/go/src/github.com/cilium/cilium', type: "rsync"
+    end
+    if ENV['RUN_TEST_SUITE'] then
+        config.vm.provision "testsuite", run: "always", type: "shell", privileged: false, inline: $testsuite
+    end
+end

--- a/tests/k8s/k8s-gsg-test.sh
+++ b/tests/k8s/k8s-gsg-test.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+NAMESPACE="kube-system" 
+
+source "../helpers.bash"
+source /home/vagrant/.profile
+function cleanup {
+	kubectl delete -f https://raw.githubusercontent.com/cilium/cilium/master/examples/minikube/l3_l4_l7_policy.yaml
+	kubectl delete -f https://raw.githubusercontent.com/cilium/cilium/master/examples/minikube/l3_l4_policy.yaml
+	kubectl delete -f https://raw.githubusercontent.com/cilium/cilium/master/examples/minikube/demo.yaml
+	kubectl delete -f cilium-ds.yaml
+	kubectl delete -f https://raw.githubusercontent.com/cilium/cilium/master/examples/kubernetes/rbac.yaml
+}
+
+trap cleanup exit
+
+echo "KUBECONFIG: $KUBECONFIG"
+
+cleanup
+
+until [ "$(kubectl get cs | grep -v "STATUS" | grep -c "Healthy")" -eq "3" ]; do 
+	echo "---- Waiting for cluster to get into a good state ----"
+	sleep 5
+done
+
+
+echo "----- adding RBAC for Cilium -----"
+kubectl create -f https://raw.githubusercontent.com/cilium/cilium/master/examples/kubernetes/rbac.yaml
+
+echo "----- deploying Cilium Daemon Set onto cluster -----"
+wget https://raw.githubusercontent.com/cilium/cilium/master/examples/kubernetes/cilium-ds.yaml
+sed -i s/"\/var\/lib\/kubelet\/kubeconfig"/"\/etc\/kubernetes\/kubelet.conf"/g cilium-ds.yaml
+sed -i s/"cilium\/cilium:stable"/"localhost:5000\/cilium:build_test"/g cilium-ds.yaml
+kubectl apply -f cilium-ds.yaml
+
+until [ "$(kubectl get ds --namespace ${NAMESPACE} | grep -v 'READY' | awk '{ print $4}' | grep -c '1')" -eq "3" ]; do
+	echo "----- Waiting for Cilium to get into 'ready' state in Minikube cluster -----"
+	sleep 5
+done
+
+# Let Cilium spin up.
+sleep 15
+
+echo "----- deploying demo application onto cluster -----"
+kubectl create -f https://raw.githubusercontent.com/cilium/cilium/master/examples/minikube/demo.yaml
+
+until [ "$(kubectl get pods | grep -v STATUS | grep -c "Running")" -eq "4" ]; do
+	echo "----- Waiting for demo apps to get into 'Running' state -----"
+	sleep 5
+done
+
+echo "----- adding L3 L4 policy  -----"
+kubectl create -f https://raw.githubusercontent.com/cilium/cilium/master/examples/minikube/l3_l4_policy.yaml
+
+CILIUM_POD=$(kubectl -n ${NAMESPACE} get pods -l k8s-app=cilium | grep -v 'AGE' | awk '{ print $1 }')
+until [ "$(kubectl -n ${NAMESPACE} exec ${CILIUM_POD} cilium endpoint list | grep -c 'ready')" -eq "5" ]; do
+	echo "----- Waiting for endpoints to get into 'ready' state -----"
+	sleep 5	      
+done
+
+echo "----- testing L3/L4 policy -----"
+APP2_POD=$(kubectl get pods -l id=app2 -o jsonpath='{.items[0].metadata.name}')
+SVC_IP=$(kubectl get svc app1-service -o jsonpath='{.spec.clusterIP}' )
+
+echo "----- testing app2 can reach app1 (expected behavior: can reach) -----"
+RETURN=$(kubectl $ID exec $APP2_POD -- curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 -XGET $SVC_IP)
+if [[ "${RETURN//$'\n'}" != "200" ]]; then
+	abort "Error: could not reach pod allowed by L3 L4 policy"
+fi
+
+echo "----- testing that app3 cannot reach app 1 (expected behavior: cannot reach)"
+APP3_POD=$(kubectl get pods -l id=app3 -o jsonpath='{.items[0].metadata.name}')
+RETURN=$(kubectl exec $APP3_POD -- curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 -XGET $SVC_IP)
+if [[ "${RETURN//$'\n'}" != "000" ]]; then
+	abort "Error: unexpectedly reached pod allowed by L3 L4 Policy, received return code ${RETURN}"
+fi
+
+echo "------ performing HTTP GET on ${SVC_IP}/public from service2 ------"
+RETURN=$(kubectl exec $APP2_POD -- curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 http://${SVC_IP}/public)
+if [[ "${RETURN//$'\n'}" != "200" ]]; then
+	abort "Error: Could not reach ${SVC_IP}/public on port 80"
+fi
+
+echo "------ performing HTTP GET on ${SVC_IP}/private from service2 ------"
+RETURN=$(kubectl exec $APP2_POD -- curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 http://${SVC_IP}/private)
+if [[ "${RETURN//$'\n'}" != "200" ]]; then
+	abort "Error: Could not reach ${SVC_IP}/public on port 80"
+fi
+
+echo "----- creating L7-aware policy -----"
+kubectl create -f https://raw.githubusercontent.com/cilium/cilium/master/examples/minikube/l3_l4_l7_policy.yaml
+
+CILIUM_POD=$(kubectl -n ${NAMESPACE} get pods -l k8s-app=cilium | grep -v 'AGE' | awk '{ print $1 }')
+until [ "$(kubectl -n ${NAMESPACE} exec ${CILIUM_POD} cilium endpoint list | grep -c 'ready')" -eq "5" ]; do
+       echo "----- Waiting for endpoints to get into 'ready' state -----"
+       sleep 5
+done
+
+echo "------ performing HTTP GET on ${SVC_IP}/public from service2 ------"
+RETURN=$(kubectl exec $APP2_POD -- curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 http://${SVC_IP}/public)
+if [[ "${RETURN//$'\n'}" != "200" ]]; then
+	abort "Error: Could not reach ${SVC_IP}/public on port 80"
+fi
+
+echo "------ performing HTTP GET on ${SVC_IP}/private from service2 ------"
+RETURN=$(kubectl exec $APP2_POD -- curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 http://${SVC_IP}/private)
+if [[ "${RETURN//$'\n'}" != "403" ]]; then
+	abort "Error: Unexpected success reaching  ${SVC_IP}/private on port 80"
+fi
+
+echo "------ L7 policy success ! ------"

--- a/tests/k8s/run-tests
+++ b/tests/k8s/run-tests
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+# Set path to contain Go binaries explicitly; see issue 566.
+export PATH=$PATH:/usr/local/go/bin:/usr/local/clang/bin:/home/vagrant/go/bin:/home/vagrant/bin
+
+for test in *.sh; do
+	./$test
+done

--- a/tests/k8s/start
+++ b/tests/k8s/start
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -exv 
+
+cd ./tests/k8s
+RUN_TEST_SUITE=1 vagrant up


### PR DESCRIPTION
This commit adds a new test that tests the Cilium K8s getting started
guide inside of a Vagrant VM. This test runs in parallel with the
runtime-tests in order to not extend build time.
    
Signed-off by: Ian Vernon <ian@covalent.io>

Fixes #768 