### PR TITLE
policy: fix index out of range for MatchExpressions

### DIFF
--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -77,7 +77,7 @@ func (n EndpointSelector) MarshalJSON() ([]byte, error) {
 		ls.MatchLabels = newLabels
 	}
 	if n.MatchExpressions != nil {
-		newMatchExpr := make([]metav1.LabelSelectorRequirement, len(ls.MatchExpressions))
+		newMatchExpr := make([]metav1.LabelSelectorRequirement, len(n.MatchExpressions))
 		for i, v := range n.MatchExpressions {
 			v.Key = labels.GetCiliumKeyFrom(v.Key)
 			newMatchExpr[i] = v


### PR DESCRIPTION
Fixes an index out of range if the user would use a MatchExpression in
any cilium policy selectors.

Add more unit tests for Json Marshalling CiliumNetworkPolicy.

Signed-off-by: André Martins <andre@cilium.io>