### PR TITLE
labels: Support regular expressions in label filters

### DIFF
--- a/pkg/labels/filter_test.go
+++ b/pkg/labels/filter_test.go
@@ -34,7 +34,14 @@ func (s *LabelsPrefCfgSuite) TestFilterLabels(c *C) {
 	}
 
 	dlpcfg := defaultLabelPrefixCfg()
-	dlpcfg.Append(parseLabelPrefix("!ignore"))
+	d, err := parseLabelPrefix("!ignor[eE]")
+	c.Assert(err, IsNil)
+	c.Assert(d, Not(IsNil))
+	dlpcfg.LabelPrefixes = append(dlpcfg.LabelPrefixes, d)
+	d, err = parseLabelPrefix("id.*")
+	c.Assert(err, IsNil)
+	c.Assert(d, Not(IsNil))
+	dlpcfg.LabelPrefixes = append(dlpcfg.LabelPrefixes, d)
 	allNormalLabels := map[string]string{
 		"io.kubernetes.container.hash":                   "cf58006d",
 		"io.kubernetes.container.name":                   "POD",
@@ -42,9 +49,11 @@ func (s *LabelsPrefCfgSuite) TestFilterLabels(c *C) {
 		"io.kubernetes.container.terminationMessagePath": "",
 		"io.kubernetes.pod.name":                         "my-nginx-3800858182-07i3n",
 		"io.kubernetes.pod.namespace":                    "default",
+		"annotation.kubectl.kubernetes.io":               "foo",
 		"io.kubernetes.pod.terminationGracePeriod":       "30",
 		"io.kubernetes.pod.uid":                          "c2e22414-dfc3-11e5-9792-080027755f5a",
 		"ignore":                                         "foo",
+		"ignorE":                                         "foo",
 		"annotation.kubernetes.io/config.seen": "2017-05-30T14:22:17.691491034Z",
 	}
 	allLabels := Map2Labels(allNormalLabels, common.CiliumLabelSource)


### PR DESCRIPTION
Support for golang 'regexp' when whitelisting or ignoring labels.  This
allows to ignore labels such as '*.kubernetes.io'

Allows to ignore '.*kubernetes.io' to catch annotation.*.kubernetes.io
labels.

Signed-off-by: Thomas Graf <thomas@cilium.io>