### PR TITLE
Vagrantfile: install pip by default

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ end
 
 $bootstrap = <<SCRIPT
 sudo apt-get -y update || true
-sudo apt-get -y install socat curl jq realpath pv tmux python-sphinx
+sudo apt-get -y install socat curl jq realpath pv tmux python-sphinx python-pip
 sudo pip install --upgrade pip
 sudo pip install sphinx sphinxcontrib-httpdomain sphinxcontrib-openapi
 echo 'cd ~/go/src/github.com/cilium/cilium' >> /home/vagrant/.bashrc

--- a/tests/00-documentation-link-check.sh
+++ b/tests/00-documentation-link-check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DOC_DIR=./Documentation
+DOC_DIR=../Documentation
 LINKCHECK_OUTPUT=$DOC_DIR/_build/linkcheck/output.txt
 
 make -C $DOC_DIR clean || true


### PR DESCRIPTION
Required for installing the sphinx dependencies.

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>