### PR TITLE
Vagrantfile: use different intnet per build

### DIFF
--- a/tests/k8s/Vagrantfile
+++ b/tests/k8s/Vagrantfile
@@ -37,6 +37,11 @@ $testsuite = <<SCRIPT
 make -C ~/go/src/github.com/cilium/cilium/ k8s-tests || exit 1
 SCRIPT
 
+# Create unique ID for use in vboxnet name so Jenkins pipeline can have concurrent builds.
+$job_name = ENV['JOB_NAME'] || "local"
+$build_number = ENV['BUILD_NUMBER'] || "0"
+$build_id = "#{$job_name}-#{$build_number}"
+$node_ip = "192.168.33.15"
 Vagrant.configure(2) do |config|
     config.vm.box = "bento/ubuntu-16.10"
 
@@ -45,6 +50,9 @@ Vagrant.configure(2) do |config|
         s.privileged = false
         s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
     end
+
+    config.vm.network "private_network", ip: "#{$node_ip}",
+        virtualbox__intnet: "cilium-k8s-test-#{$build_id}"
 
     # install docker runtime
     #config.vm.provision :docker


### PR DESCRIPTION
Create a different VirtualBox internal network for each build to
increase isolation between builds.

Signed-off by: Ian Vernon <ian@covalent.io>

Fixes: #931 