### PR TITLE
daemon: update policy enforcement w/ no endpoints

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -761,15 +761,18 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 
 	changes := d.conf.Opts.Apply(params.Configuration, changedOption, d)
 	log.Debugf("Applied %d changes", changes)
-	if changes > 0 {
-		_, ok := params.Configuration[endpoint.OptionPolicy]
-		if ok {
-			if config.Opts.IsEnabled(endpoint.OptionPolicy) && config.EnablePolicy != endpoint.AlwaysEnforce {
-				config.EnablePolicy = endpoint.AlwaysEnforce
-			} else if !config.Opts.IsEnabled(endpoint.OptionPolicy) && config.EnablePolicy != endpoint.NeverEnforce {
-				config.EnablePolicy = endpoint.NeverEnforce
-			}
+
+	// Check explicitly for endpoint.OptionPolicy updates because its state
+	// is coupled with config's EnablePolicy flag.
+	_, ok := params.Configuration[endpoint.OptionPolicy]
+	if ok {
+		if config.Opts.IsEnabled(endpoint.OptionPolicy) && config.EnablePolicy != endpoint.AlwaysEnforce {
+			config.EnablePolicy = endpoint.AlwaysEnforce
+		} else if !config.Opts.IsEnabled(endpoint.OptionPolicy) && config.EnablePolicy != endpoint.NeverEnforce {
+			config.EnablePolicy = endpoint.NeverEnforce
 		}
+	}
+	if changes > 0 {
 		if err := d.compileBase(); err != nil {
 			msg := fmt.Errorf("Unable to recompile base programs: %s\n", err)
 			log.Warningf("%s", msg)

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -76,7 +76,12 @@ func (d *Daemon) TriggerPolicyUpdates(added []policy.NumericIdentity) {
 		d.invalidateCache()
 	}
 
+	d.GetPolicyRepository().Mutex.RLock()
+	d.EnablePolicyEnforcement()
+	d.GetPolicyRepository().Mutex.RUnlock()
+
 	d.endpointsMU.RLock()
+
 	for k := range d.endpoints {
 		go func(ep *endpoint.Endpoint) {
 			ep.Mutex.RLock()
@@ -98,11 +103,31 @@ func (d *Daemon) TriggerPolicyUpdates(added []policy.NumericIdentity) {
 	d.endpointsMU.RUnlock()
 }
 
-// UpdatePolicyEnforcement returns whether policy enforcement needs to be
+// UpdateEndpointPolicyEnforcement returns whether policy enforcement needs to be
 // enabled for the specified endpoint.
 //
-// Must be called with e.Consumable.Mutex and d.GetPolicyRepositor().Mutex held
-func (d *Daemon) UpdatePolicyEnforcement(e *endpoint.Endpoint) bool {
+// Must be called with e.Consumable.Mutex and d.GetPolicyRepository().Mutex held
+func (d *Daemon) UpdateEndpointPolicyEnforcement(e *endpoint.Endpoint) bool {
+	if d.EnablePolicyEnforcement() {
+		return true
+	} else if d.conf.EnablePolicy == endpoint.DefaultEnforcement && d.conf.IsK8sEnabled() {
+		// Convert to LabelArray so we can pass to Matches function later.
+		var endpointLabels labels.LabelArray
+		for _, lbl := range e.Consumable.LabelList {
+			endpointLabels = append(endpointLabels, lbl)
+		}
+		// Check if rules match the labels for this endpoint.
+		// If so, enable policy enforcement.
+		return d.GetPolicyRepository().GetRulesMatching(endpointLabels)
+	}
+	return false
+}
+
+// EnablePolicyEnforcement returns whether policy enforcement needs to be
+// enabled for the daemon.
+//
+// Must be called d.GetPolicyRepository().Mutex held
+func (d *Daemon) EnablePolicyEnforcement() bool {
 	if d.conf.EnablePolicy == endpoint.AlwaysEnforce {
 		return true
 	} else if d.conf.EnablePolicy == endpoint.DefaultEnforcement && !d.conf.IsK8sEnabled() {
@@ -114,15 +139,6 @@ func (d *Daemon) UpdatePolicyEnforcement(e *endpoint.Endpoint) bool {
 			d.conf.Opts.Set(endpoint.OptionPolicy, false)
 			return false
 		}
-	} else if d.conf.EnablePolicy == endpoint.DefaultEnforcement && d.conf.IsK8sEnabled() {
-		// Convert to LabelArray so we can pass to Matches function later.
-		var endpointLabels labels.LabelArray
-		for _, lbl := range e.Consumable.LabelList {
-			endpointLabels = append(endpointLabels, lbl)
-		}
-		// Check if rules match the labels for this endpoint.
-		// If so, enable policy enforcement.
-		return d.GetPolicyRepository().GetRulesMatching(endpointLabels)
 	}
 	return false
 }

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -31,8 +31,12 @@ type Owner interface {
 	// PolicyEnabled returns whether policy enforcement is enabled
 	PolicyEnabled() bool
 
-	// UpdatePolicyEnforcement returns whether policy enforcement needs to be updated.
-	UpdatePolicyEnforcement(ep *Endpoint) bool
+	// EnablePolicyEnforcement returns whether owner should enable policy enforcement.
+	EnablePolicyEnforcement() bool
+
+	// UpdateEndpointPolicyEnforcement returns whether policy enforcement
+	// should be enabled for the specified endpoint.
+	UpdateEndpointPolicyEnforcement(e *Endpoint) bool
 
 	// GetPolicyEnforcementType returns the type of policy enforcement for the Owner.
 	PolicyEnforcement() string

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -260,7 +260,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner) (bool, error) {
 		opts[OptionConntrack] = "enabled"
 	}
 
-	if owner.UpdatePolicyEnforcement(e) {
+	if owner.UpdateEndpointPolicyEnforcement(e) {
 		opts[OptionPolicy] = "enabled"
 	} else {
 		opts[OptionPolicy] = "disabled"

--- a/tests/15-policy-config.sh
+++ b/tests/15-policy-config.sh
@@ -16,6 +16,13 @@ function remove_containers {
 	docker rm -f foo foo bar baz 2> /dev/null || true
 }
 
+function restart_cilium {
+	echo "------ restarting cilium ------"
+	service cilium restart
+	echo "------ sleeping for 10 seconds to let cilium agent get up and running ------"
+	sleep 10
+}
+
 function import_test_policy {
 	echo "------ adding policy ------"
 	cat <<EOF | cilium -D policy import -
@@ -99,60 +106,124 @@ echo "------ test default configuration for enable-policy ------"
 	# Expected behavior is that if Kubernetes is not enabled, policy enforcement is enabled if at least one policy exists.
 	# If no policy exists, then policy enforcement is disabled.
 	remove_containers
-	sudo service cilium restart
-	sleep 10
+	restart_cilium
 	start_containers
 
 	wait_endpoints_ready
 	check_config_policy_disabled
 	check_endpoints_policy_disabled
-	
+	# TODO - renable when we clear conntrack state upon policy deletion.
+	#ping_success foo bar
+	#ping_success foo baz
+
 	import_test_policy
 	wait_endpoints_ready
 	check_config_policy_enabled
 	check_endpoints_policy_enabled
-	
+	ping_success foo bar
+	ping_fail foo baz
+
 	cilium policy delete --all
 	wait_endpoints_ready
+	check_config_policy_disabled
+	ping_success foo baz
+	ping_success foo bar
+}
+
+function test_default_to_true_policy_configuration {
+	echo "------ test that policy enforcement flag gets updated with no running endpoints: true ------"
+	remove_containers
+	# Make sure cilium agent starts in 'default' mode, so restart it.
+	restart_cilium
+	import_test_policy
+	check_config_policy_enabled
+	echo "------ setting cilium agent Policy=true"
+	cilium config Policy=true
+	check_config_policy_enabled
+	echo "------ deleting policy ------"
+	cilium policy delete --all
+	# After policy is deleted, policy enforcement should still be enabled.
+	check_config_policy_enabled
+}
+
+function test_default_to_false_policy_configuration {
+	 echo "------ test that policy enforcement flag gets updated with no running endpoints: false ------"
+	remove_containers
+	# Make sure cilium agent starts in 'default' mode, so restart it.
+	restart_cilium
+	import_test_policy
+	check_config_policy_enabled
+	echo "------ setting cilium agent Policy=false"
+	cilium config Policy=false
+	check_config_policy_disabled
+	echo "------ deleting policy ------"
+	cilium policy delete --all
+	# After policy is deleted, policy enforcement should be disabled.
 	check_config_policy_disabled
 }
 
 function test_true_policy_configuration {
 	echo "------ test true configuration for enable-policy ------"
 	remove_containers
+	restart_cilium
 	cilium config Policy=true
 	start_containers
 
 	wait_endpoints_ready
 	check_config_policy_enabled
 	check_endpoints_policy_enabled
+	ping_fail foo bar	
 	import_test_policy
 	
 	wait_endpoints_ready
 	check_config_policy_enabled
 	check_endpoints_policy_enabled
+	ping_success foo bar
 	cilium policy delete --all
 	
 	wait_endpoints_ready
 	check_config_policy_enabled
+	# TODO - renable when we clear conntrack state upon policy deletion. 
+	# ping_fail foo bar
 }
 
 function test_false_policy_configuration {
 	echo "------ test false configuration for enable-policy ------"
 	remove_containers
+	restart_cilium
 	cilium config Policy=false
 	start_containers
 
 	wait_endpoints_ready
 	check_config_policy_disabled
 	check_endpoints_policy_disabled
+	ping_success foo bar
 	import_test_policy
 	wait_endpoints_ready
 	check_config_policy_disabled
 	check_endpoints_policy_disabled
+	ping_success foo bar
 	cilium policy delete --all
 	wait_endpoints_ready
 	check_config_policy_disabled
+}
+
+function ping_fail {
+	C1=$1
+	C2=$2
+	echo "------ pinging $C2 from $C1 (expecting failure) ------"
+	docker exec -i  ${C1} bash -c "sleep 10 && ping -c 5 ${C2}" && {
+  		abort "Error: Unexpected success pinging ${C2} from ${C1}"
+  	}
+}
+
+function ping_success {
+	C1=$1
+	C2=$2
+	echo "------ pinging $C2 from $C1 (expecting success) ------"
+	docker exec -i ${C1} bash -c "sleep 10 && ping -c 5 ${C2}" || {
+		abort "Error: Could not ping ${C2} from ${C1}"
+	}
 }
 
 trap cleanup EXIT
@@ -163,6 +234,9 @@ logs_clear
 docker network inspect $TEST_NET 2> /dev/null || {
         docker network create --ipv6 --subnet ::1/112 --ipam-driver cilium --driver cilium $TEST_NET
 }
+
 test_default_policy_configuration
+test_default_to_true_policy_configuration
+test_default_to_false_policy_configuration
 test_true_policy_configuration
 test_false_policy_configuration 


### PR DESCRIPTION
* daemon: fixed bug in the daemon where if no endpoints were added, the policy
enforcement flag for the daemon was not updated if a policy was added.

* daemon: fixes bug in the daemon where if the configuration flag for the boolean
option for policy enforcement was updated, the value of PolicyEnabled
within the daemon was not updated.

* tests: added tests to test policy enforcement flag when endpoints are not
added

* tests: added ping tests to ensure that policy enforcement
configuration updates are reflected in the networking configuration of
endpoints.

Signed-off by: Ian Vernon <ian@covalent.io>