### PR TITLE
tests/k8s/Vagrantfile: reset kubeadm before init

### DIFF
--- a/tests/k8s/Vagrantfile
+++ b/tests/k8s/Vagrantfile
@@ -23,6 +23,7 @@ EOF
 sudo apt-get update
 sudo apt-get install -y docker-engine
 sudo apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+sudo kubeadm reset
 sudo kubeadm init
 sudo cp /etc/kubernetes/admin.conf /home/vagrant/admin.conf
 sudo chown 1000:1000 /home/vagrant/admin.conf


### PR DESCRIPTION
kubeadm init sometimes fails when starting the K8s Tests Vagrant VM
because files exist in /var/lib/kubelet, so reset kubeadm before
initializing it to clear any state that might have been stored there by
installation of kubelet and other K8s-related processes.

Signed-off by: Ian Vernon <ian@covalent.io>