### PR TITLE
forcely setting UTC for Time.Now()

### DIFF
--- a/daemon/labels_test.go
+++ b/daemon/labels_test.go
@@ -50,7 +50,7 @@ var (
 	wantSecCtxLbls = policy.Identity{
 		ID: 123,
 		Endpoints: map[string]time.Time{
-			"cc08ff400e355f736dce1c291a6a4007ab9f2d56d42e1f3630ba87b861d45307": time.Now(),
+			"cc08ff400e355f736dce1c291a6a4007ab9f2d56d42e1f3630ba87b861d45307": time.Now().UTC(),
 		},
 		Labels: lbls,
 	}
@@ -195,12 +195,7 @@ func (ds *DaemonSuite) TestLabels(c *C) {
 	sha256sum := lbls2.SHA256Sum()
 	gotSecCtxLbl, err = ds.d.LookupIdentityBySHA256(sha256sum)
 	c.Assert(err, IsNil)
-
-	// Disabled for now, currently errors out after go 1.8.3 update.
-	//
-	// [Runtime Tests] ==> cilium-master: ... obtained *policy.Identity = &policy.Identity{ID:0x101, Labels:labels.Labels{"foo":(*labels.Label)(0xc4218dea00), "foo2":(*labels.Label)(0xc4218dea40)}, Endpoints:map[string]time.Time{"containerLabel2-1":time.Time{sec:63632695538, nsec:946048357, loc:(*time.Location)(nil)}, "containerLabel2-2":time.Time{sec:63632695538, nsec:962378505, loc:(*time.Location)(nil)}, "containerLabel2-3":time.Time{sec:63632695539, nsec:32317355, loc:(*time.Location)(nil)}}}
-	// [Runtime Tests] ==> cilium-master: ... expected *policy.Identity = &policy.Identity{ID:0x101, Labels:labels.Labels{"foo":(*labels.Label)(0xc4218c0e00), "foo2":(*labels.Label)(0xc4218c0e40)}, Endpoints:map[string]time.Time{"containerLabel2-1":time.Time{sec:63632695538, nsec:946048357, loc:(*time.Location)(nil)}, "containerLabel2-2":time.Time{sec:63632695538, nsec:962378505, loc:(*time.Location)(nil)}, "containerLabel2-3":time.Time{sec:63632695539, nsec:32317355, loc:(*time.Location)(0x29dbd80)}}}
-	//c.Assert(gotSecCtxLbl, DeepEquals, secCtxLbl)
+	c.Assert(gotSecCtxLbl, DeepEquals, secCtxLbl)
 
 	err = ds.d.DeleteIdentityBySHA256(sha256sum, "containerLabel2-1")
 	c.Assert(err, IsNil)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -766,7 +766,7 @@ func (e *Endpoint) LogStatus(typ StatusType, code StatusCode, msg string) {
 			Msg:  msg,
 			Type: typ,
 		},
-		Timestamp: time.Now(),
+		Timestamp: time.Now().UTC(),
 	}
 	e.Status.addStatusLog(sts)
 }
@@ -778,7 +778,7 @@ func (e *Endpoint) LogStatusOK(typ StatusType, msg string) {
 	defer e.Status.indexMU.Unlock()
 	sts := &statusLogMsg{
 		Status:    NewStatusOK(typ, msg),
-		Timestamp: time.Now(),
+		Timestamp: time.Now().UTC(),
 	}
 	e.Status.addStatusLog(sts)
 }

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -44,7 +44,7 @@ type Event struct {
 func NewEvent(t EventType, obj interface{}) *Event {
 	return &Event{
 		Type:      t,
-		Timestamp: time.Now(),
+		Timestamp: time.Now().UTC(),
 		Obj:       obj,
 	}
 }

--- a/pkg/policy/identity.go
+++ b/pkg/policy/identity.go
@@ -130,7 +130,7 @@ func NewIdentity() *Identity {
 
 // AssociateEndpoint associates the endpoint with identity.
 func (id *Identity) AssociateEndpoint(epID string) {
-	id.Endpoints[epID] = time.Now()
+	id.Endpoints[epID] = time.Now().UTC()
 }
 
 // DisassociateEndpoint disassociates the endpoint endpoint with identity and
@@ -147,7 +147,7 @@ func (id *Identity) DisassociateEndpoint(epID string) bool {
 func (id *Identity) RefCount() int {
 	refCount := 0
 	for _, t := range id.Endpoints {
-		if t.Add(secLabelTimeout).After(time.Now()) {
+		if t.Add(secLabelTimeout).After(time.Now().UTC()) {
 			refCount++
 		}
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -264,7 +264,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, source Pr
 	}
 
 	redirect := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		startDelta := time.Now()
+		startDelta := time.Now().UTC()
 		record := &LogRecord{
 			req:       req,
 			timeStart: time.Time{},


### PR DESCRIPTION
Since time's location is not stored in Time.Now() objects, this commits
forcely sets them to UTC by default.

Signed-off-by: André Martins <andre@cilium.io>

Fixes #955 