### PR TITLE
tests: add separate script for pulling in docker images

### DIFF
--- a/tests/00-pull-docker-images.sh
+++ b/tests/00-pull-docker-images.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+for img in tgraf/netperf httpd cilium/demo-httpd \
+  cilium/demo-client tgraf/nettools borkmann/misc \
+  registry busybox:latest; do
+  docker pull $img &
+done
+
+for p in `jobs -p`; do
+  wait $p
+done


### PR DESCRIPTION
Have not measured, but expecting this to reduce at most a minute but
probably less when running the runtime tests.

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>