### PR TITLE
proxy: Extended logging of requests

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -105,6 +105,11 @@ func (d *Daemon) GetProxy() *proxy.Proxy {
 	return d.l7Proxy
 }
 
+// GetNodeAddress returns the node's address
+func (d *Daemon) GetNodeAddress() addressing.NodeAddress {
+	return *d.conf.NodeAddress
+}
+
 func (d *Daemon) WriteEndpoint(e *endpoint.Endpoint) error {
 	if err := d.conf.LXCMap.WriteEndpoint(e); err != nil {
 		return fmt.Errorf("Unable to update eBPF map: %s", err)

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -260,6 +260,7 @@ func init() {
 	flags.StringVarP(&config.Tunnel, "tunnel", "t", "vxlan", "Tunnel mode vxlan or geneve, vxlan is the default")
 	flags.StringVar(&bpfRoot, "bpf-root", "", "Path to mounted BPF filesystem")
 	flags.String("access-log", "", "Path to access log of all HTTP requests observed")
+	flags.StringSlice("agent-labels", []string{}, "Additional labels to identify this agent")
 	flags.Bool("version", false, "Print version information")
 	flags.StringSliceVar(&loggers, "log-driver", []string{}, "logging endpoints to use")
 	flags.Var(option.NewNamedMapOptions("log-opts", &logOpts, nil), "log-opt", "log driver options for cilium")

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -283,6 +283,40 @@ func (e *Endpoint) GetModel() *models.Endpoint {
 	}
 }
 
+// GetID returns the endpoint's ID
+func (e *Endpoint) GetID() uint64 {
+	return uint64(e.ID)
+}
+
+// RLock locks the endpoint for reading
+func (e *Endpoint) RLock() {
+	e.Mutex.RLock()
+}
+
+// RUnlock unlocks the endpoint after reading
+func (e *Endpoint) RUnlock() {
+	e.Mutex.RUnlock()
+}
+
+// GetLabels returns the labels as slice
+func (e *Endpoint) GetLabels() []string {
+	if e.SecLabel == nil {
+		return []string{}
+	}
+
+	return e.SecLabel.Labels.GetModel()
+}
+
+// GetIPv4Address returns the IPv4 address of the endpoint
+func (e *Endpoint) GetIPv4Address() string {
+	return e.IPv4.String()
+}
+
+// GetIPv6Address returns the IPv6 address of the endpoint
+func (e *Endpoint) GetIPv6Address() string {
+	return e.IPv6.String()
+}
+
 // statusLogMsg represents a log message.
 type statusLogMsg struct {
 	Status    Status    `json:"status"`

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -15,6 +15,7 @@
 package endpoint
 
 import (
+	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy"
@@ -77,6 +78,9 @@ type Owner interface {
 
 	// Returns true if debugging has been enabled
 	DebugEnabled() bool
+
+	// GetNodeAddress returns the node's address
+	GetNodeAddress() addressing.NodeAddress
 }
 
 // Request is used to create the endpoint's request and send it to the endpoints

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -101,6 +101,7 @@ func (s *K8sSuite) TestParseNetworkPolicy(c *C) {
 			"80/tcp": policy.L4Filter{
 				Port: 80, Protocol: "tcp", L7Parser: "",
 				L7RedirectPort: 0, L7Rules: []policy.AuxRule(nil),
+				Ingress: true,
 			},
 		},
 		Egress: policy.L4PolicyMap{},

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -30,19 +30,21 @@ type AuxRule struct {
 
 type L4Filter struct {
 	// Port is the destination port to allow
-	Port int `json:"port,omitempty"`
+	Port int
 	// Protocol is the L4 protocol to allow or NONE
-	Protocol string `json:"protocol,omitempty"`
+	Protocol string
 	// L7Parser specifies the L7 protocol parser (optional)
-	L7Parser string `json:"l7-parser,omitempty"`
+	L7Parser string
 	// L7RedirectPort is the L7 proxy port to redirect to (optional)
-	L7RedirectPort int `json:"l7-redirect-port,omitempty"`
+	L7RedirectPort int
 	// L7Rules is a list of L7 rules which are passed to the L7 proxy (optional)
-	L7Rules []AuxRule `json:"l7-rules,omitempty"`
+	L7Rules []AuxRule
+	// Ingress is true if filter applies at ingress
+	Ingress bool
 }
 
 // CreateL4Filter creates an L4Filter based on an api.PortRule and api.PortProtocol
-func CreateL4Filter(rule api.PortRule, port api.PortProtocol, protocol string) L4Filter {
+func CreateL4Filter(rule api.PortRule, port api.PortProtocol, direction string, protocol string) L4Filter {
 	// already validated via PortRule.Validate()
 	p, _ := strconv.ParseUint(port.Port, 0, 16)
 
@@ -50,6 +52,10 @@ func CreateL4Filter(rule api.PortRule, port api.PortProtocol, protocol string) L
 		Port:           int(p),
 		Protocol:       protocol,
 		L7RedirectPort: rule.RedirectPort,
+	}
+
+	if strings.ToLower(direction) == "ingress" {
+		l4.Ingress = true
 	}
 
 	if rule.Rules != nil {

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -41,14 +41,14 @@ func (r *rule) validate() error {
 	return nil
 }
 
-func mergeL4Port(ctx *SearchContext, r api.PortRule, p api.PortProtocol, proto string, resMap L4PolicyMap) int {
+func mergeL4Port(ctx *SearchContext, r api.PortRule, p api.PortProtocol, dir string, proto string, resMap L4PolicyMap) int {
 	fmt := p.Port + "/" + proto
 	v, ok := resMap[fmt]
 	if !ok {
-		resMap[fmt] = CreateL4Filter(r, p, proto)
+		resMap[fmt] = CreateL4Filter(r, p, dir, proto)
 		return 1
 	}
-	l4Filter := CreateL4Filter(r, p, proto)
+	l4Filter := CreateL4Filter(r, p, dir, proto)
 	if l4Filter.L7Parser != "" {
 		v.L7Parser = l4Filter.L7Parser
 	}
@@ -78,10 +78,10 @@ func mergeL4(ctx *SearchContext, dir string, portRules []api.PortRule, resMap L4
 
 		for _, p := range r.Ports {
 			if p.Protocol != "" {
-				found += mergeL4Port(ctx, r, p, p.Protocol, resMap)
+				found += mergeL4Port(ctx, r, p, dir, p.Protocol, resMap)
 			} else {
-				found += mergeL4Port(ctx, r, p, "tcp", resMap)
-				found += mergeL4Port(ctx, r, p, "udp", resMap)
+				found += mergeL4Port(ctx, r, p, dir, "tcp", resMap)
+				found += mergeL4Port(ctx, r, p, dir, "udp", resMap)
 			}
 		}
 	}

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -136,10 +136,10 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	}
 
 	expected := NewL4Policy()
-	expected.Ingress["80/tcp"] = L4Filter{Port: 80, Protocol: "tcp", L7Parser: "http", L7Rules: l7rules}
-	expected.Ingress["8080/tcp"] = L4Filter{Port: 8080, Protocol: "tcp", L7Parser: "http", L7Rules: l7rules}
-	expected.Egress["3000/tcp"] = L4Filter{Port: 3000, Protocol: "tcp"}
-	expected.Egress["3000/udp"] = L4Filter{Port: 3000, Protocol: "udp"}
+	expected.Ingress["80/tcp"] = L4Filter{Port: 80, Protocol: "tcp", L7Parser: "http", L7Rules: l7rules, Ingress: true}
+	expected.Ingress["8080/tcp"] = L4Filter{Port: 8080, Protocol: "tcp", L7Parser: "http", L7Rules: l7rules, Ingress: true}
+	expected.Egress["3000/tcp"] = L4Filter{Port: 3000, Protocol: "tcp", Ingress: false}
+	expected.Egress["3000/udp"] = L4Filter{Port: 3000, Protocol: "udp", Ingress: false}
 
 	state := traceState{}
 	res := rule1.resolveL4Policy(toBar, &state, NewL4Policy())

--- a/pkg/proxy/log.go
+++ b/pkg/proxy/log.go
@@ -1,0 +1,101 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+)
+
+var (
+	logFile  *os.File
+	logBuf   *bufio.Writer
+	metadata []string
+)
+
+// OpenLogfile opens a file for logging
+func OpenLogfile(lf string) error {
+	var err error
+
+	if logFile, err = os.OpenFile(lf, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666); err != nil {
+		return err
+	}
+
+	logBuf = bufio.NewWriter(logFile)
+	return nil
+}
+
+// CloseLogfile closes the logfile
+func CloseLogfile() {
+	logBuf.Flush()
+	logFile.Close()
+}
+
+// SetMetadata sets the metadata to include in each record
+func SetMetadata(md []string) {
+	metadata = md
+}
+
+// NewIPPort creates an IPPort struct based on a host:port string
+func NewIPPort(hostport string) IPPort {
+	ipport := IPPort{}
+
+	host, port, err := net.SplitHostPort(hostport)
+	if err != nil {
+		ipport.IP = hostport
+		ipport.Port = 0
+	} else {
+		ipport.IP = host
+		p, err := strconv.ParseUint(port, 10, 16)
+		if err == nil {
+			ipport.Port = uint16(p)
+		}
+	}
+
+	return ipport
+}
+
+// Log logs a record to the logfile and flushes the buffer
+func Log(l *LogRecord, direction FlowDirection, verdict FlowVerdict, code int) {
+	if logBuf == nil {
+		return
+	}
+
+	l.Source = NewIPPort(l.request.RemoteAddr)
+	l.Direction = direction
+	l.Verdict = verdict
+	l.Metadata = metadata
+
+	l.HTTP = LogRecordHTTP{
+		Code:     code,
+		Method:   l.request.Method,
+		URL:      l.request.URL,
+		Protocol: l.request.Proto,
+		Header:   l.request.Header,
+	}
+
+	b, err := json.Marshal(*l)
+	if err != nil {
+		fmt.Fprintln(logBuf, err.Error())
+	} else {
+		fmt.Fprintln(logBuf, string(b))
+	}
+
+	logBuf.Flush()
+}

--- a/pkg/proxy/record.go
+++ b/pkg/proxy/record.go
@@ -1,0 +1,145 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+)
+
+// FlowDirection is the type to indicate the flow direction
+type FlowDirection string
+
+const (
+	// TypeRequest is a request message
+	TypeRequest = "Request"
+
+	// TypeResponse is a response to a request
+	TypeResponse = "Response"
+)
+
+// FlowVerdict is the verdict taken on request/response
+type FlowVerdict string
+
+const (
+	// VerdictForwared indicates that the request/response was forwarded
+	VerdictForwared FlowVerdict = "Forwarded"
+
+	// VerdictDenied indicates that the request/response was denied
+	VerdictDenied = "Denied"
+
+	// VerdictError indicates that there was an error processing the request/response
+	VerdictError = "Error"
+)
+
+// ObservationPoint is the type used to describe point of observation
+type ObservationPoint string
+
+const (
+	// Ingress indicates event was generated at ingress
+	Ingress ObservationPoint = "Ingress"
+
+	// Egress indicates event was generated at egress
+	Egress = "Egress"
+)
+
+// EndpointInfo contains information about the endpoint sending/receiving the
+// request/response
+type EndpointInfo struct {
+	ID       uint64
+	IPv4     string
+	IPv6     string
+	Identity uint64
+	Labels   []string
+}
+
+// NodeAddressInfo holds addressing information of the node the agent runs on
+type NodeAddressInfo struct {
+	IPv4 string
+	IPv6 string
+}
+
+// IPPort bundles an IP address and port number
+type IPPort struct {
+	IP   string
+	Port uint16
+}
+
+// LogRecord is the structure used to log individual request/response
+// processing events
+type LogRecord struct {
+	// Direction is the direction of the flow
+	Direction FlowDirection
+
+	// Timestamp is the start of a request and then end of a response
+	Timestamp string
+
+	// NodeAddressInfo contains the IPs of the node where the event was generated
+	NodeAddressInfo NodeAddressInfo
+
+	// ObservationPoint indicates where the request/response was observed
+	ObservationPoint ObservationPoint
+
+	// SourceEndpoint is information about the soure endpoint if available
+	SourceEndpoint EndpointInfo `json:"SourceEndpoint,omitempty"`
+
+	// DestinationEndpoint is information about the soure endpoint if available
+	DestinationEndpoint EndpointInfo `json:"DestinationEndpoint,omitempty"`
+
+	// Source is the IP and port of the endpoint that generated the
+	// request
+	Source IPPort
+
+	// Destination is the IP and port of the endpoint that is receiving the
+	// request
+	Destination IPPort
+
+	// Verdict is the verdict on the flow taken
+	Verdict FlowVerdict
+
+	// Info includes information about the rule that matched or the error
+	// that occurred. This is informational.
+	Info string
+
+	// Metadata is additional arbitrary metadata
+	Metadata []string
+
+	// The following are the protocol specific parts. Only one of the
+	// following should ever be set. Unused fields will be omitted
+
+	// HTTP contains information for HTTP request/responses
+	HTTP LogRecordHTTP `json:"HTTP,omitempty"`
+
+	// internal
+	request http.Request
+}
+
+// LogRecordHTTP contains the HTTP specific portion of a log record
+type LogRecordHTTP struct {
+	// Code is the HTTP code being returned
+	Code int
+
+	// Method is the method of the request
+	Method string
+
+	// URL is the URL of the request
+	URL *url.URL
+
+	// Protocol is the HTTP protocol in use
+	Protocol string
+
+	// Header is the HTTP header in use
+	Header http.Header
+}


### PR DESCRIPTION
When logging L7 requests to the access log using --access-log. The
logfile will now contain extended information about the request written
as individual JSON objects of type proxy.LogRecord

Additional metadata can be passed into using the --agent-labels option
to annotate log records

Signed-off-by: Thomas Graf <thomas@cilium.io>