### PR TITLE
daemon: use endpoint specific error in endpoint TriggerPolicyUpdates

### DIFF
--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -83,13 +83,9 @@ func (d *Daemon) TriggerPolicyUpdates(added []policy.NumericIdentity) {
 
 	for k := range d.endpoints {
 		go func(ep *endpoint.Endpoint) {
-			ep.Mutex.RLock()
-			epID := ep.StringIDLocked()
-			ep.Mutex.RUnlock()
 			policyChanges, err := ep.TriggerPolicyUpdates(d)
 			if err != nil {
-				log.Warningf("Error while handling policy updates for endpoint %s: %s\n",
-					epID, err)
+				log.Warningf("Error while handling policy updates for endpoint %s\n", err)
 				ep.LogStatus(endpoint.Policy, endpoint.Failure, err.Error())
 			} else {
 				ep.LogStatusOK(endpoint.Policy, "Policy regenerated")

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -453,7 +453,13 @@ func (e *Endpoint) TriggerPolicyUpdates(owner Owner) (bool, error) {
 	if e.Consumable == nil {
 		return false, nil
 	}
-	return e.regeneratePolicy(owner)
+
+	changed, err := e.regeneratePolicy(owner)
+	if err != nil {
+		return changed, fmt.Errorf("%s: %s", e.StringIDLocked(), err)
+	}
+
+	return changed, err
 }
 
 func (e *Endpoint) SetIdentity(owner Owner, id *policy.Identity) {


### PR DESCRIPTION
In the endpoint we already have a lock for generating the policy. By using the
endpoint id in the error we can remove the lock for reading the endpoint id in
the daemon TriggerPolicyUpdates.

Closes: #677 (ep.TriggerPolicyUpdates() should generate ep specific errors)
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>