### PR TITLE
cilium: fix CiliumIPv6 string handler

### DIFF
--- a/common/addressing/ip.go
+++ b/common/addressing/ip.go
@@ -16,6 +16,7 @@ package addressing
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -31,6 +32,7 @@ type CiliumIP interface {
 	EndpointPrefix() *net.IPNet
 	IP() net.IP
 	String() string
+	StringNoZeroComp() string
 	IsIPv6() bool
 }
 
@@ -150,6 +152,38 @@ func (ip CiliumIPv6) String() string {
 	return net.IP(ip).String()
 }
 
+// StringNoZeroComp is similar to String but without generating
+// zero compression in the address dump.
+func (ip CiliumIPv6) StringNoZeroComp() string {
+	const maxLen = len("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+	out := make([]byte, 0, maxLen)
+	raw := ip
+
+	if ip == nil {
+		return ""
+	}
+	if len(ip) == 0 {
+		return "<nil>"
+	}
+
+	for i := 0; i < 16; i += 2 {
+		if i > 0 {
+			out = append(out, ':')
+		}
+		src := []byte{raw[i], raw[i+1]}
+		tmp := make([]byte, hex.EncodedLen(len(src)))
+		hex.Encode(tmp, src)
+		if tmp[0] == tmp[1] && tmp[2] == tmp[3] &&
+			tmp[0] == tmp[2] && tmp[0] == '0' {
+			out = append(out, tmp[0])
+		} else {
+			out = append(out, tmp[0], tmp[1], tmp[2], tmp[3])
+		}
+	}
+
+	return string(out)
+}
+
 func (ip CiliumIPv6) MarshalJSON() ([]byte, error) {
 	return json.Marshal(net.IP(ip))
 }
@@ -242,6 +276,11 @@ func (ip CiliumIPv4) String() string {
 	}
 
 	return net.IP(ip).String()
+}
+
+// StringNoZeroComp is same as String
+func (ip CiliumIPv4) StringNoZeroComp() string {
+	return ip.String()
 }
 
 func (ip CiliumIPv4) MarshalJSON() ([]byte, error) {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -316,13 +316,13 @@ func (d *Daemon) compileBase() error {
 			mode = "direct"
 		}
 
-		args = []string{d.conf.BpfDir, d.conf.StateDir, d.conf.NodeAddress.String(), d.conf.NodeAddress.IPv4Address.String(), mode, d.conf.Device}
+		args = []string{d.conf.BpfDir, d.conf.StateDir, d.conf.NodeAddress.IPv6Address.StringNoZeroComp(), d.conf.NodeAddress.IPv4Address.String(), mode, d.conf.Device}
 	} else {
 		if d.conf.IsLBEnabled() {
 			//FIXME: allow LBMode in tunnel
 			return fmt.Errorf("Unable to run LB mode with tunnel mode")
 		}
-		args = []string{d.conf.BpfDir, d.conf.StateDir, d.conf.NodeAddress.String(), d.conf.NodeAddress.IPv4Address.String(), d.conf.Tunnel}
+		args = []string{d.conf.BpfDir, d.conf.StateDir, d.conf.NodeAddress.IPv6Address.StringNoZeroComp(), d.conf.NodeAddress.IPv4Address.String(), d.conf.Tunnel}
 	}
 
 	prog := filepath.Join(d.conf.BpfDir, "init.sh")


### PR DESCRIPTION
For func (ip CiliumIPv6) String() we cannot use net.IP(ip).String()
since it will compress zeroes at the end of the address, for example,
x:y:z::. In bpf/init.sh we need to match the last 0 in the address
for the case of HOST_IP (HOST_IP=$(echo $ADDR | sed 's/:0$/:ffff/')).
What would be preferred is to have a rfc5952 compliant string handler,
but one that doesn't compress zeroes all the way like the native
golang library handler. There are multiple ways to address it, I went
with an own string handler, which seems hacky, but still feels less
hacky than messing with this in shell. Related GH issue #819.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>