### PR TITLE
kvstore: Move all code to pkg/kvstore and add singleton client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ tests-etcd:
 	echo "mode: count" > coverage.out
 	$(foreach pkg,$(GOFILES),\
 	go test \
-            -ldflags "-X "github.com/cilium/cilium/daemon".kvBackend=etcd" \
+            -ldflags "-X "github.com/cilium/cilium/pkg/kvstore".backend=etcd" \
             -timeout 30s -coverprofile=coverage.out -covermode=count $(pkg) || exit 1;\
             tail -n +2 coverage.out >> coverage-all.out;)
 	go tool cover -html=coverage-all.out -o=coverage-all.html
@@ -51,7 +51,7 @@ tests-consul:
 	echo "mode: count" > coverage.out
 	$(foreach pkg,$(GOFILES),\
 	go test \
-            -ldflags "-X "github.com/cilium/cilium/daemon".kvBackend=consul" \
+            -ldflags "-X "github.com/cilium/cilium/pkg/kvstore".backend=consul" \
             -timeout 30s -coverprofile=coverage.out -covermode=count $(pkg) || exit 1;\
             tail -n +2 coverage.out >> coverage-all.out;)
 	go tool cover -html=coverage-all.out -o=coverage-all.html

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -15,24 +15,14 @@
 package main
 
 import (
-	"fmt"
 	"net"
 	"sync"
 
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/daemon/options"
-	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/option"
-
-	log "github.com/Sirupsen/logrus"
-	etcdAPI "github.com/coreos/etcd/clientv3"
-	consulAPI "github.com/hashicorp/consul/api"
-)
-
-var (
-	kvBackend = ""
 )
 
 const (
@@ -61,14 +51,10 @@ type Config struct {
 	Device         string                  // Receive device
 	HostV4Addr     net.IP                  // Host v4 address of the snooping device
 	HostV6Addr     net.IP                  // Host v6 address of the snooping device
-	ConsulConfig   *consulAPI.Config       // Consul configuration
-	EtcdConfig     *etcdAPI.Config         // Etcd Configuration
-	EtcdCfgPath    string                  // Etcd Configuration path
 	DockerEndpoint string                  // Docker endpoint
 	IPv4Disabled   bool                    // Disable IPv4 allocation
 	K8sEndpoint    string                  // Kubernetes endpoint
 	K8sCfgPath     string                  // Kubeconfig path
-	KVStore        string                  // key-value store type
 	LBInterface    string                  // Set with name of the interface to loadbalance packets from
 	EnablePolicy   string                  // Whether policy enforcement is enabled.
 	Tunnel         string                  // Tunnel mode
@@ -110,25 +96,4 @@ func (c *Config) IsK8sEnabled() bool {
 
 func (c *Config) IsLBEnabled() bool {
 	return c.LBInterface != ""
-}
-
-// SetKVBackend is only used for test purposes
-func (c *Config) SetKVBackend() error {
-	switch kvBackend {
-	case kvstore.Consul:
-		log.Infof("using consul as key-value store")
-		consulConfig := consulAPI.DefaultConfig()
-		consulConfig.Address = "127.0.0.1:8501"
-		c.ConsulConfig = consulConfig
-		c.KVStore = kvstore.Consul
-		return nil
-	case kvstore.Etcd:
-		log.Infof("using etcd as key-value store")
-		c.EtcdConfig = &etcdAPI.Config{}
-		c.EtcdConfig.Endpoints = []string{"http://127.0.0.1:4002"}
-		c.KVStore = kvstore.Etcd
-		return nil
-	default:
-		return fmt.Errorf("invalid backend %s", kvBackend)
-	}
 }

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -422,7 +422,7 @@ func (d *Daemon) delK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 		repPorts[svcPort.Port] = false
 
 		if svcPort.ID != 0 {
-			if err := d.DeleteL3n4AddrIDByUUID(uint32(svcPort.ID)); err != nil {
+			if err := DeleteL3n4AddrIDByUUID(uint32(svcPort.ID)); err != nil {
 				log.Warningf("Error while cleaning service ID: %s", err)
 			}
 		}
@@ -470,7 +470,7 @@ func (d *Daemon) addK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 				log.Errorf("Error while creating a new L3n4Addr: %s. Ignoring service...", err)
 				continue
 			}
-			feAddrID, err := d.PutL3n4Addr(*feAddr, 0)
+			feAddrID, err := PutL3n4Addr(*feAddr, 0)
 			if err != nil {
 				log.Errorf("Error while getting a new service ID: %s. Ignoring service %v...", err, feAddr)
 				continue
@@ -652,7 +652,7 @@ func (d *Daemon) ingressModFn(oldObj interface{}, newObj interface{}) {
 				log.Errorf("Error while creating a new L3n4Addr: %s. Ignoring ingress %s/%s...", err, newIngress.Namespace, newIngress.Name)
 				continue
 			}
-			feAddrID, err := d.PutL3n4Addr(*feAddr, 0)
+			feAddrID, err := PutL3n4Addr(*feAddr, 0)
 			if err != nil {
 				log.Errorf("Error while getting a new service ID: %s. Ignoring ingress %s/%s...", err, newIngress.Namespace, newIngress.Name)
 				continue

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -56,12 +56,12 @@ func (d *Daemon) SVCAdd(feL3n4Addr types.L3n4AddrID, be []types.LBBackEnd, addRe
 		return false, fmt.Errorf("invalid service ID 0")
 	}
 	// Check if the service is already registered with this ID.
-	feAddr, err := d.GetL3n4AddrID(uint32(feL3n4Addr.ID))
+	feAddr, err := GetL3n4AddrID(uint32(feL3n4Addr.ID))
 	if err != nil {
 		return false, fmt.Errorf("unable to get the service with ID %d: %s", feL3n4Addr.ID, err)
 	}
 	if feAddr == nil {
-		feAddr, err = d.PutL3n4Addr(feL3n4Addr.L3n4Addr, uint32(feL3n4Addr.ID))
+		feAddr, err = PutL3n4Addr(feL3n4Addr.L3n4Addr, uint32(feL3n4Addr.ID))
 		if err != nil {
 			return false, fmt.Errorf("unable to put the service %s: %s", feL3n4Addr.L3n4Addr.String(), err)
 		}
@@ -187,7 +187,7 @@ func (h *deleteServiceID) Handle(params DeleteServiceIDParams) middleware.Respon
 	}
 
 	// FIXME: How to handle error?
-	d.DeleteL3n4AddrIDByUUID(uint32(params.ID))
+	DeleteL3n4AddrIDByUUID(uint32(params.ID))
 
 	if err := h.d.svcDelete(svc); err != nil {
 		return apierror.Error(DeleteServiceIDFailureCode, err)
@@ -476,7 +476,7 @@ func (d *Daemon) SyncLBMap() error {
 	// Let's check if the services read from the lbmap have the same ID set in the
 	// KVStore.
 	for k, svc := range newSVCMap {
-		kvL3n4AddrID, err := d.PutL3n4Addr(svc.FE.L3n4Addr, 0)
+		kvL3n4AddrID, err := PutL3n4Addr(svc.FE.L3n4Addr, 0)
 		if err != nil {
 			log.Errorf("Unable to retrieve service ID of: %s from KVStore: %s."+
 				" This entry will be removed from the bpf's LB map.", svc.FE.L3n4Addr.String(), err)

--- a/daemon/services_test.go
+++ b/daemon/services_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/common/types"
+	"github.com/cilium/cilium/pkg/kvstore"
 
 	. "gopkg.in/check.v1"
 )
@@ -45,102 +46,102 @@ var (
 func (ds *DaemonSuite) TestServices(c *C) {
 	var nilL3n4AddrID *types.L3n4AddrID
 	// Set up last free ID with zero
-	id, err := ds.d.GetMaxServiceID()
+	id, err := GetMaxServiceID()
 	c.Assert(err, Equals, nil)
 	c.Assert(id, Equals, common.FirstFreeServiceID)
 
 	ffsIDu16 := types.ServiceID(uint16(common.FirstFreeServiceID))
 
-	l3n4AddrID, err := ds.d.PutL3n4Addr(l3n4Addr1, 0)
+	l3n4AddrID, err := PutL3n4Addr(l3n4Addr1, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(l3n4AddrID.ID, Equals, ffsIDu16)
 
-	l3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr1, 0)
+	l3n4AddrID, err = PutL3n4Addr(l3n4Addr1, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(l3n4AddrID.ID, Equals, ffsIDu16)
 
-	l3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr2, 0)
+	l3n4AddrID, err = PutL3n4Addr(l3n4Addr2, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(l3n4AddrID.ID, Equals, ffsIDu16+1)
 
 	// l3n4Addr3 should have the same ID as l3n4Addr2 since we are omitting the
 	// protocol type.
-	l3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr3, 0)
+	l3n4AddrID, err = PutL3n4Addr(l3n4Addr3, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(l3n4AddrID.ID, Equals, ffsIDu16+1)
 
-	gotL3n4AddrID, err := ds.d.GetL3n4AddrID(common.FirstFreeServiceID)
+	gotL3n4AddrID, err := GetL3n4AddrID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
 	wantL3n4AddrID.ID = ffsIDu16
 	wantL3n4AddrID.L3n4Addr = l3n4Addr1
 	c.Assert(gotL3n4AddrID, DeepEquals, wantL3n4AddrID)
 
-	err = ds.d.DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID)
+	err = DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
-	gotL3n4AddrID, err = ds.d.GetL3n4AddrID(common.FirstFreeServiceID)
+	gotL3n4AddrID, err = GetL3n4AddrID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID, Equals, nilL3n4AddrID)
 
-	gotL3n4AddrID, err = ds.d.GetL3n4AddrID(common.FirstFreeServiceID + 1)
+	gotL3n4AddrID, err = GetL3n4AddrID(common.FirstFreeServiceID + 1)
 	c.Assert(err, Equals, nil)
 	wantL3n4AddrID.ID = types.ServiceID(common.FirstFreeServiceID + 1)
 	wantL3n4AddrID.L3n4Addr = l3n4Addr2
 	c.Assert(gotL3n4AddrID, DeepEquals, wantL3n4AddrID)
 
-	err = ds.d.DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID)
+	err = DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
 
-	err = ds.d.kvClient.SetMaxID(common.LastFreeServiceIDKeyPath, common.FirstFreeServiceID, common.FirstFreeServiceID)
+	err = kvstore.Client.SetMaxID(common.LastFreeServiceIDKeyPath, common.FirstFreeServiceID, common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
 
-	err = ds.d.DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID)
+	err = DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
-	gotL3n4AddrID, err = ds.d.GetL3n4AddrID(common.FirstFreeServiceID)
+	gotL3n4AddrID, err = GetL3n4AddrID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID, Equals, nilL3n4AddrID)
 
-	gotL3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr2, 0)
+	gotL3n4AddrID, err = PutL3n4Addr(l3n4Addr2, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID.ID, Equals, types.ServiceID(common.FirstFreeServiceID+1))
 
 	sha256sum := l3n4Addr2.SHA256Sum()
-	gotL3n4AddrID, err = ds.d.GetL3n4AddrIDBySHA256(sha256sum)
+	gotL3n4AddrID, err = GetL3n4AddrIDBySHA256(sha256sum)
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID, DeepEquals, wantL3n4AddrID)
 
-	err = ds.d.DeleteL3n4AddrIDBySHA256(sha256sum)
+	err = DeleteL3n4AddrIDBySHA256(sha256sum)
 	c.Assert(err, Equals, nil)
-	err = ds.d.DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID + 1)
+	err = DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID + 1)
 	c.Assert(err, Equals, nil)
-	err = ds.d.DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID + 1)
+	err = DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID + 1)
 	c.Assert(err, Equals, nil)
 
-	gotL3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr2, 0)
+	gotL3n4AddrID, err = PutL3n4Addr(l3n4Addr2, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID.ID, Equals, ffsIDu16)
 
-	gotL3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr1, 0)
+	gotL3n4AddrID, err = PutL3n4Addr(l3n4Addr1, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID.ID, Equals, types.ServiceID(common.FirstFreeServiceID+1))
 
-	gotL3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr1, 99)
+	gotL3n4AddrID, err = PutL3n4Addr(l3n4Addr1, 99)
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID.ID, Equals, types.ServiceID(common.FirstFreeServiceID+1))
 
-	err = ds.d.DeleteL3n4AddrIDByUUID(uint32(common.FirstFreeServiceID + 1))
+	err = DeleteL3n4AddrIDByUUID(uint32(common.FirstFreeServiceID + 1))
 	c.Assert(err, Equals, nil)
 
-	gotL3n4AddrID, err = ds.d.PutL3n4Addr(l3n4Addr1, 99)
+	gotL3n4AddrID, err = PutL3n4Addr(l3n4Addr1, 99)
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID.ID, Equals, types.ServiceID(99))
 }
 
 func (ds *DaemonSuite) TestGetMaxServiceID(c *C) {
 	lastID := uint32(common.MaxSetOfServiceID - 1)
-	err := ds.d.kvClient.SetValue(common.LastFreeServiceIDKeyPath, lastID)
+	err := kvstore.Client.SetValue(common.LastFreeServiceIDKeyPath, lastID)
 	c.Assert(err, Equals, nil)
 
-	id, err := ds.d.GetMaxServiceID()
+	id, err := GetMaxServiceID()
 	c.Assert(err, Equals, nil)
 	c.Assert(id, Equals, (common.MaxSetOfServiceID - 1))
 }

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -188,7 +188,7 @@ func (d *Daemon) syncLabels(ep *endpoint.Endpoint) error {
 	}
 
 	sha256sum := ep.SecLabel.Labels.SHA256Sum()
-	labels, err := d.LookupIdentityBySHA256(sha256sum)
+	labels, err := LookupIdentityBySHA256(sha256sum)
 	if err != nil {
 		return fmt.Errorf("Unable to get labels of sha256sum:%s: %+v\n", sha256sum, err)
 	}

--- a/daemon/status.go
+++ b/daemon/status.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
+	"github.com/cilium/cilium/pkg/kvstore"
 
 	"github.com/go-openapi/runtime/middleware"
 	ctx "golang.org/x/net/context"
@@ -67,7 +68,7 @@ func (h *getHealthz) Handle(params GetHealthzParams) middleware.Responder {
 	d := h.daemon
 	sr := models.StatusResponse{}
 
-	if info, err := d.kvClient.Status(); err != nil {
+	if info, err := kvstore.Client.Status(); err != nil {
 		sr.Kvstore = &models.Status{State: models.StatusStateFailure, Msg: fmt.Sprintf("Err: %s - %s", err, info)}
 	} else {
 		sr.Kvstore = &models.Status{State: models.StatusStateOk, Msg: info}

--- a/pkg/kvstore/client.go
+++ b/pkg/kvstore/client.go
@@ -1,0 +1,63 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvstore
+
+import (
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// Client is the instance of the key-value as configured
+var Client KVClient
+
+func initClient() error {
+	switch backend {
+	case Consul:
+		if consulConfig == nil {
+			return fmt.Errorf("mising consul server address, please specify, e.g. --kvstore-opt consul.address=127.0.0.1:8501")
+		}
+
+		c, err := newConsulClient(consulConfig)
+		if err != nil {
+			return err
+		}
+
+		log.Infof("Using consul as key-value store")
+		Client = c
+
+	case Etcd:
+		if etcdCfgPath == "" && etcdConfig == nil {
+			return fmt.Errorf("missing etcd endpoints; please specify , e.g. --kvstore-opt etcd.address=....")
+		}
+
+		c, err := newEtcdClient(etcdConfig, etcdCfgPath)
+		if err != nil {
+			return err
+		}
+
+		log.Infof("Using etcd as key-value store")
+		Client = c
+
+	case Local:
+		log.Infof("Using local storage as key-value store")
+		Client = NewLocalClient()
+
+	default:
+		panic("BUG: kvstore backend not specified")
+	}
+
+	return nil
+}

--- a/pkg/kvstore/config.go
+++ b/pkg/kvstore/config.go
@@ -1,0 +1,121 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvstore
+
+import (
+	"fmt"
+	"strings"
+
+	etcdAPI "github.com/coreos/etcd/clientv3"
+	consulAPI "github.com/hashicorp/consul/api"
+)
+
+var (
+	// this variable is set via Makefile for test purposes and allows to tie a
+	// binary to a particular backend
+	backend = ""
+
+	consulConfig *consulAPI.Config // Consul configuration
+	etcdConfig   *etcdAPI.Config   // Etcd Configuration
+	etcdCfgPath  string            // Etcd Configuration path
+)
+
+// validateOpts iterates through all of the keys in kvStoreOpts, and errors out
+// if the key in kvStoreOpts is not a supported key in supportedOpts.
+func validateOpts(kvStore string, kvStoreOpts map[string]string, supportedOpts map[string]bool) error {
+	for k := range kvStoreOpts {
+		if !supportedOpts[k] {
+			return fmt.Errorf("provided configuration value %q is not supported as a key-value store option for kvstore %s", k, kvStore)
+		}
+	}
+	return nil
+}
+
+// SetupDummy sets up kvstore for tests
+func SetupDummy() error {
+	switch backend {
+	case Consul:
+		consulConfig = consulAPI.DefaultConfig()
+		consulConfig.Address = "127.0.0.1:8501"
+
+	case Etcd:
+		etcdConfig = &etcdAPI.Config{}
+		etcdConfig.Endpoints = []string{"http://127.0.0.1:4002"}
+
+	default:
+		return fmt.Errorf("Unknown kvstore backend: %s", backend)
+	}
+
+	return initClient()
+}
+
+// Setup sets up the key-value store specified in kvStore and configures
+// it with the options provided in kvStoreOpts.
+func Setup(selectedBackend string, opts map[string]string) error {
+	backend = selectedBackend
+
+	switch backend {
+	case Etcd:
+		err := validateOpts(backend, opts, EtcdOpts)
+		if err != nil {
+			return err
+		}
+		addr, ok := opts[eAddr]
+		config, ok2 := opts[eCfg]
+		if ok || ok2 {
+			etcdConfig = &etcdAPI.Config{}
+			etcdCfgPath = config
+			etcdConfig.Endpoints = []string{addr}
+		} else {
+			return fmt.Errorf("invalid configuration for etcd provided; please specify an etcd configuration path with --kvstore-opt %s=<path> or an etcd agent address with --kvstore-opt %s=<address>", eCfg, eAddr)
+		}
+
+	case Consul:
+		err := validateOpts(backend, opts, ConsulOpts)
+		if err != nil {
+			return err
+		}
+		consulAddr, ok := opts[cAddr]
+		if ok {
+			consulDefaultAPI := consulAPI.DefaultConfig()
+			consulSplitAddr := strings.Split(consulAddr, "://")
+			if len(consulSplitAddr) == 2 {
+				consulAddr = consulSplitAddr[1]
+			} else if len(consulSplitAddr) == 1 {
+				consulAddr = consulSplitAddr[0]
+			}
+			consulDefaultAPI.Address = consulAddr
+			consulConfig = consulDefaultAPI
+		} else {
+			return fmt.Errorf("invalid configuration for consul provided; please specify the address to a consul instance with --kvstore-opt %s=<consul address> option", cAddr)
+		}
+
+	case Local:
+		// Local storage doesn't take any configuration, but we want to
+		// make sure user is not passing configuration for other types of kvstores.
+		err := validateOpts(backend, opts, map[string]bool{})
+		if err != nil {
+			return err
+		}
+
+	case "":
+		return fmt.Errorf("kvstore not configured. Please specify --kvstore. See http://cilium.link/err-kvstore for details.")
+
+	default:
+		return fmt.Errorf("unsupported key-value store %q provided; check http://cilium.link/err-kvstore for more information about how to properly configure key-value store", backend)
+	}
+
+	return initClient()
+}

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -31,14 +31,14 @@ import (
 )
 
 const (
-	// CAddr is the string representing the key mapping to the value of the
+	// cAddr is the string representing the key mapping to the value of the
 	// address for Consul.
-	CAddr = "consul.address"
+	cAddr = "consul.address"
 )
 
 // / ConsulOpts is the set of supported options for Consul configuration.
 var ConsulOpts = map[string]bool{
-	CAddr: true,
+	cAddr: true,
 }
 
 var (
@@ -50,7 +50,7 @@ type ConsulClient struct {
 	*consulAPI.Client
 }
 
-func NewConsulClient(config *consulAPI.Config) (KVClient, error) {
+func newConsulClient(config *consulAPI.Config) (KVClient, error) {
 	var (
 		c   *consulAPI.Client
 		err error

--- a/pkg/kvstore/consul_test.go
+++ b/pkg/kvstore/consul_test.go
@@ -57,7 +57,7 @@ func TestConsulClientRetry(t *testing.T) {
 		http.Error(w, "retry test error", http.StatusInternalServerError)
 	}
 
-	_, err := NewConsulClient(&consulAPI.Config{
+	_, err := newConsulClient(&consulAPI.Config{
 		Address: ":8000",
 	})
 
@@ -84,7 +84,7 @@ func TestConsulClientOk(t *testing.T) {
 		close(doneC)
 	}
 
-	_, err := NewConsulClient(&consulAPI.Config{
+	_, err := newConsulClient(&consulAPI.Config{
 		Address: ":8000",
 	})
 

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -36,12 +36,12 @@ import (
 )
 
 const (
-	// EAddr is the string representing the key mapping to the value of the
+	// eAddr is the string representing the key mapping to the value of the
 	// address for Etcd.
-	EAddr = "etcd.address"
-	// ECfg is the string representing the key mapping to the path of the
+	eAddr = "etcd.address"
+	// eCfg is the string representing the key mapping to the path of the
 	// configuration for Etcd.
-	ECfg = "etcd.config"
+	eCfg = "etcd.config"
 )
 
 var (
@@ -50,8 +50,8 @@ var (
 
 // EtcdOpts is the set of supported options for Etcd configuration.
 var EtcdOpts = map[string]bool{
-	EAddr: true,
-	ECfg:  true,
+	eAddr: true,
+	eCfg:  true,
 }
 
 type EtcdClient struct {
@@ -68,7 +68,7 @@ type EtcdLocker struct {
 	path      string
 }
 
-func NewEtcdClient(config *client.Config, cfgPath string) (KVClient, error) {
+func newEtcdClient(config *client.Config, cfgPath string) (KVClient, error) {
 	var (
 		c   *client.Client
 		err error

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"fmt"
 	"github.com/cilium/cilium/common/types"
 	"github.com/cilium/cilium/pkg/policy"
 )
@@ -55,15 +54,4 @@ type KVLocker interface {
 // GetLockPath returns the lock path representation of the given path.
 func GetLockPath(path string) string {
 	return path + ".lock"
-}
-
-// ValidateOpts iterates through all of the keys in kvStoreOpts, and errors out
-// if the key in kvStoreOpts is not a supported key in supportedOpts.
-func ValidateOpts(kvStore string, kvStoreOpts map[string]string, supportedOpts map[string]bool) error {
-	for k := range kvStoreOpts {
-		if !supportedOpts[k] {
-			return fmt.Errorf("provided configuration value %q is not supported as a key-value store option for kvstore %s", k, kvStore)
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
 - Isolates all kvstore in a single package
 - Allows simple access to kvstore client via `kvstore.Client`

Signed-off-by: Thomas Graf <thomas@cilium.io>