### PR TITLE
tests: reduce sleep calls

### DIFF
--- a/tests/00-no-sleep.sh
+++ b/tests/00-no-sleep.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+source "./helpers.bash"
+
+if grep -r "sleep" | grep -v "00-no-sleep" | grep -v "helpers.bash"; then
+    echo "Please do not use sleep, consider using one of the wait helper functions."
+    echo "If none of the provided wait functions fit your use case please discuss your use case on Slack and / or file a bug."
+    exit 1
+fi

--- a/tests/02-perf.sh
+++ b/tests/02-perf.sh
@@ -54,8 +54,8 @@ NODE_MAC=$(cilium endpoint get $SERVER_ID | grep host-mac | awk '{print $2}' | s
 LXC_MAC=$(cilium endpoint get $SERVER_ID | grep mac | awk '{print $2}' | sed 's/"//g' | sed 's/,$//')
 
 
-# FIXME IPv6 DAD period
-sleep 5
+wait_for_docker_ipv6_addr client
+wait_for_docker_ipv6_addr server
 set -x
 
 cat <<EOF | cilium -D policy import -

--- a/tests/03-docker.sh
+++ b/tests/03-docker.sh
@@ -36,27 +36,22 @@ docker run -dt --net=$TEST_NET --name server -l $SERVER_LABEL $NETPERF_IMAGE
 SERVER_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server)
 
 monitor_clear
-docker run --rm -i --net=$TEST_NET --name client -l $CLIENT_LABEL tgraf/nettools sh -c "sleep 5s && ping6 -c 5 $SERVER_IP" || {
+docker run --rm -i --net=$TEST_NET --name client -l $CLIENT_LABEL tgraf/nettools sh -c "ping6 -c 5 $SERVER_IP" || {
 	abort "Error: Could not ping server container"
 }
 
-#monitor_clear
-#docker run --rm -i --net=$TEST_NET --name client -l $CLIENT_LABEL tgraf/nettools sh -c "sleep 5s && tracepath6 $SERVER_IP" || {
-#	abort "Error: Could not traceroute to server"
-#}
-
 monitor_clear
-docker run --rm -i --net=$TEST_NET --name netperf -l $CLIENT_LABEL $NETPERF_IMAGE sh -c "sleep 5s && netperf -c -C -H $SERVER_IP" || {
+docker run --rm -i --net=$TEST_NET --name netperf -l $CLIENT_LABEL $NETPERF_IMAGE sh -c "netperf -c -C -H $SERVER_IP" || {
 	abort "Error: Could not netperf to server"
 }
 
 monitor_clear
-docker run --rm -i --net=$TEST_NET --name netperf -l $CLIENT_LABEL $NETPERF_IMAGE sh -c "sleep 5s && netperf -c -C -t TCP_SENDFILE -H $SERVER_IP" || {
+docker run --rm -i --net=$TEST_NET --name netperf -l $CLIENT_LABEL $NETPERF_IMAGE sh -c "netperf -c -C -t TCP_SENDFILE -H $SERVER_IP" || {
 	abort "Error: Could not netperf to server"
 }
 
 monitor_clear
-docker run --rm -i --net=$TEST_NET --name netperf -l $CLIENT_LABEL $NETPERF_IMAGE sh -c "sleep 5s && super_netperf 10 -c -C -t TCP_SENDFILE -H $SERVER_IP" || {
+docker run --rm -i --net=$TEST_NET --name netperf -l $CLIENT_LABEL $NETPERF_IMAGE sh -c "super_netperf 10 -c -C -t TCP_SENDFILE -H $SERVER_IP" || {
 	abort "Error: Could not netperf to server"
 }
 

--- a/tests/04-k8s.sh
+++ b/tests/04-k8s.sh
@@ -29,7 +29,6 @@ fi
 
 function cleanup {
     echo "Cleaning up"
-    sleep 3s
     monitor_stop
     "${dir}/../examples/kubernetes-ingress/scripts/11-cleanup.sh"
 }
@@ -57,7 +56,7 @@ monitor_clear
 
 echo "Testing connectivity between pods"
 
-kubectl exec `kubectl get pods | grep -Eo 'guestbook[^ ]+'` -- sh -c 'sleep 60 && nc redis-master 6379 <<EOF
+kubectl exec `kubectl get pods | grep -Eo 'guestbook[^ ]+'` -- sh -c 'nc redis-master 6379 <<EOF
 PING
 EOF' || {
         abort "Unable to nc redis-master 6379"

--- a/tests/05-cni.sh
+++ b/tests/05-cni.sh
@@ -24,7 +24,7 @@ function run_cni_container {
 		shift
 	done
 
-	contid=$(docker run -d --net=none $LABELS busybox:latest /bin/sleep 10000000)
+	contid=$(docker run -t -d --net=none $LABELS busybox:latest)
 	pid=$(docker inspect -f '{{ .State.Pid }}' $contid)
 	netnspath=/proc/$pid/ns/net
 
@@ -114,7 +114,14 @@ server_ip=$(extract_ip6 $server_id)
 server_ip4=$(extract_ip4 $server_id)
 
 echo "Waiting for containers to come up"
-sleep 3s
+while true; do
+    output=`docker ps -a`
+
+    if echo ${output} | grep cni-server && \
+        echo ${output} | grep cni-client; then
+        break
+    fi
+done
 
 monitor_clear
 docker exec -i cni-client ping6 -c 5 $server_ip

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -267,8 +267,9 @@ docker run -dt --net=$TEST_NET --name server5 -l id.server -l server5 httpd
 docker run -dt --net=$TEST_NET --name client -l id.client tgraf/nettools
 docker run -dt --net=$TEST_NET --name misc   -l id.client borkmann/misc
 
-# FIXME IPv6 DAD period
-sleep 5
+for i in server{1..5} client misc; do
+    wait_for_docker_ipv6_addr ${i}
+done
 
 CLIENT_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' client)
 CLIENT_ID=$(cilium endpoint list | grep $CLIENT_IP | awk '{ print $1}')

--- a/tests/08-nat46.sh
+++ b/tests/08-nat46.sh
@@ -43,8 +43,9 @@ echo SERVER_IP=$SERVER_IP
 echo SERVER_IP4=$SERVER_IP4
 echo SERVER_ID=$SERVER_ID
 
-# FIXME IPv6 DAD period
-sleep 5
+wait_for_docker_ipv6_addr client
+wait_for_docker_ipv6_addr server
+
 set -x
 
 cat <<EOF | cilium -D policy import -

--- a/tests/09-perf-gce.sh
+++ b/tests/09-perf-gce.sh
@@ -41,15 +41,8 @@ trap cleanup_k8s EXIT
 kubectl create -f ./gce-deployment/client.json
 kubectl create -f ./gce-deployment/server.json
 
-while [[ "$(kubectl get pods | grep ${CLIENT_NAME} | grep Running -c)" -ne "1" ]] ; do
-    echo "Waiting for ${CLIENT_NAME} pod to be Running..."
-    sleep 2s
-done
-
-while [[ "$(kubectl get pods | grep ${SERVER_NAME} | grep Running -c)" -ne "1" ]] ; do
-    echo "Waiting for ${SERVER_NAME} pod to be Running..."
-    sleep 2s
-done
+wait_for_running_pod ${CLIENT_NAME}
+wait_for_running_pod ${SERVER_NAME}
 
 echo "Getting Client and Server IPv6, IPv4 and ID from containers"
 
@@ -88,7 +81,6 @@ LXC_MAC=$(kubectl exec ${server_cilium} -- cilium endpoint get $SERVER_ID | grep
 
 echo "... Done"
 
-sleep 5
 set -x
 
 cat <<EOF | kubectl exec -i "${server_cilium}" -- cilium -D policy import -

--- a/tests/11-getting-started.sh
+++ b/tests/11-getting-started.sh
@@ -101,7 +101,7 @@ cat <<EOF | cilium policy import -
 }]
 EOF
 
-sleep 5
+wait_for_cilium_ep_gen
 
 monitor_clear
 echo "------ performing HTTP GET on ${HTTPD_CONTAINER_NAME}/public from service2 ------"

--- a/tests/13-monitor-filtering.sh
+++ b/tests/13-monitor-filtering.sh
@@ -41,7 +41,7 @@ function test_event_types {
     setup
     monitor_start --type ${event_types[i]}
     spin_up_container
-    sleep 10
+    wait_for_log_entries 3
     if grep "${expected_log_entry[i]}" $DUMP_FILE; then
       echo Test for ${event_types[i]} succeded
     else
@@ -64,12 +64,12 @@ function test_from {
   setup
   spin_up_container
   monitor_start --type debug --from $(last_endpoint_id)
-  sleep 10
+  wait_for_log_entries 2
   # We are not expecting drop events so fail if they occur.
   if grep "Packet dropped" $DUMP_FILE; then
     abort
   fi
-  sleep 10
+  wait_for_log_entries 1
   if grep "FROM $(last_endpoint_id) DEBUG: " $DUMP_FILE; then
     echo Test succeded test_from
   else
@@ -83,7 +83,6 @@ function test_to {
   setup
   spin_up_container
   monitor_start --type drop --to $(last_endpoint_id)
-  sleep 10
   ping6 -c 3 $(container_addr)
   if grep "FROM $(last_endpoint_id) Packet dropped" $DUMP_FILE; then
     echo Test succeded test_to
@@ -102,7 +101,6 @@ function test_related_to {
   monitor_stop
   monitor_resume --type debug --related-to $(last_endpoint_id)
   ping6 -c 3 $(container_addr)
-  sleep 10
   if grep "FROM $(last_endpoint_id) DEBUG: " $DUMP_FILE && \
    grep "FROM $(last_endpoint_id) Packet dropped" $DUMP_FILE; then
     echo Test succeded test_from

--- a/tests/15-policy-config.sh
+++ b/tests/15-policy-config.sh
@@ -19,8 +19,8 @@ function remove_containers {
 function restart_cilium {
 	echo "------ restarting cilium ------"
 	service cilium restart
-	echo "------ sleeping for 10 seconds to let cilium agent get up and running ------"
-	sleep 10
+	echo "------ waiting for cilium agent get up and running ------"
+	wait_for_cilium_status
 }
 
 function import_test_policy {
@@ -69,7 +69,6 @@ function check_endpoints_policy_disabled {
 
 function check_config_policy_enabled {
 	echo "------ checking if cilium daemon has policy enforcement enabled ------"
-	sleep 5
 	POLICY_ENFORCED=`eval ${CFG_CMD}`
 	for line in $POLICY_ENFORCED; do
 		if [[ "$line" != "Enabled" ]]; then
@@ -82,7 +81,6 @@ function check_config_policy_enabled {
 
 function check_config_policy_disabled {
 	echo "------ checking if cilium daemon has policy enforcement disabled ------"
-	sleep 5
 	POLICY_ENFORCED=`eval ${CFG_CMD}`
 	for line in $POLICY_ENFORCED; do
 		if [[ "$line" != "Disabled" ]]; then
@@ -205,7 +203,7 @@ function ping_fail {
 	C1=$1
 	C2=$2
 	echo "------ pinging $C2 from $C1 (expecting failure) ------"
-	docker exec -i  ${C1} bash -c "sleep 10 && ping -c 5 ${C2}" && {
+	docker exec -i  ${C1} bash -c "ping -c 5 ${C2}" && {
   		abort "Error: Unexpected success pinging ${C2} from ${C1}"
   	}
 }
@@ -214,7 +212,7 @@ function ping_success {
 	C1=$1
 	C2=$2
 	echo "------ pinging $C2 from $C1 (expecting success) ------"
-	docker exec -i ${C1} bash -c "sleep 10 && ping -c 5 ${C2}" || {
+	docker exec -i ${C1} bash -c "ping -c 5 ${C2}" || {
 		abort "Error: Could not ping ${C2} from ${C1}"
 	}
 }

--- a/tests/manual-multi-node.bash
+++ b/tests/manual-multi-node.bash
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
+
+source "./helpers.bash"
+
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
 
 set -e
 
@@ -39,7 +43,6 @@ function init {
 function test_run {
 	SERVER=$(node_run_quiet cilium-master 'docker run -d --net cilium -l id.server --name server tgraf/netperf')
 	CLIENT=$(node_run_quiet cilium-node-2 'docker run -d --net cilium -l id.client --name client tgraf/netperf')
-	sleep 5s
 
 	SERVER_IP=$(node_run_quiet cilium-master "docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server" | tr -d '\r')
 	echo "Server IPv6: $SERVER_IP"
@@ -68,7 +71,7 @@ function test_nodes {
 	node_run cilium-node-2 "sudo cp /etc/init/cilium.conf tmp; sudo sed -i '/exec/d' tmp; echo \"exec cilium-agent --debug -n f00d::c0a8:210c:0:0 --ipv4-range 10.2.0.1 $OPTS -c 192.168.33.11:8500\" | sudo tee -a tmp; sudo cp tmp /etc/init/cilium.conf; sudo service cilium restart"
 
 	echo "Waiting for daemon to start up..."
-	sleep 5s
+	wait_for_cilium_status
 
 	node_run cilium-master 'cilium policy import ~/go/src/github.com/cilium/cilium/examples/policy/default/'
 	node_run cilium-node-2 'cilium policy import ~/go/src/github.com/cilium/cilium/examples/policy/default/'

--- a/tests/wait-for-k8s-pod.bash
+++ b/tests/wait-for-k8s-pod.bash
@@ -19,7 +19,6 @@ i=1
 while [[ -z "${isRunning}" && ${i} -le ${tries} ]] ; do
 	echo "Waiting for pod ${name}. Attempt ${i}/${tries}..."
 	isRunning=$(kubectl get pods | grep "${name}" | grep -o "Running")
-	sleep 2
 	i=$(( $i + 1 ))
 done
 


### PR DESCRIPTION
The sleep calls are slowing down the runtime tests. Without having carefully
measured at it's slowest the duration has been between 21-38 minutes.

The sleep calls made are waiting for something very specific like endpoint
generation, container launch, traffic generation, etc.  In order to wait for
the related events to be completed a couple of helper functions have been added
which basically just run loops and check conditional statements. This is faster
because we are continually checking if our condition is met without any delays.

Also to hopefully prevent future slow down of the tests. A new test to fail
when sleep is in use has been added.
