### PR TITLE
endpoint: Factor our endpoint management into pkg/endpoint

### DIFF
--- a/daemon/logstash.go
+++ b/daemon/logstash.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/policy"
 
@@ -67,8 +68,8 @@ func (d *Daemon) EnableLogstash(LogstashAddr string, refreshTime int) {
 			timeToProcess1 := time.Now()
 
 			allPes := map[uint16][]policymap.PolicyEntryDump{}
-			d.endpointsMU.RLock()
-			for _, ep := range d.endpoints {
+			endpointmanager.Mutex.RLock()
+			for _, ep := range endpointmanager.Endpoints {
 				ep.Mutex.RLock()
 				pes, err := ep.PolicyMap.DumpToSlice()
 				if err != nil {
@@ -77,7 +78,7 @@ func (d *Daemon) EnableLogstash(LogstashAddr string, refreshTime int) {
 				allPes[ep.ID] = pes
 				ep.Mutex.RUnlock()
 			}
-			d.endpointsMU.RUnlock()
+			endpointmanager.Mutex.RUnlock()
 			lss := d.processStats(allPes)
 			for _, ls := range lss {
 				if err := json.NewEncoder(c).Encode(ls); err != nil {

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/cilium/daemon/options"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
@@ -448,7 +449,7 @@ func runDaemon() {
 		log.Fatalf("Unable to initialize policy: %s", err)
 	}
 
-	d.EnableConntrackGC()
+	endpointmanager.EnableConntrackGC(!d.conf.IPv4Disabled, true)
 
 	if enableLogstash {
 		go d.EnableLogstash(logstashAddr, int(logstashProbeTimer))

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -52,7 +52,7 @@ func (e *Endpoint) checkEgressAccess(owner Owner, opts models.ConfigurationMap, 
 	}
 }
 
-// allowConsumer must be called with endpointsMU held
+// allowConsumer must be called with global endpoint.Mutex held
 func (e *Endpoint) allowConsumer(owner Owner, id policy.NumericIdentity) {
 	cache := owner.GetConsumableCache()
 	if !e.Opts.IsEnabled(OptionConntrack) {
@@ -149,7 +149,7 @@ func (e *Endpoint) cleanUnusedRedirects(owner Owner, oldMap policy.L4PolicyMap, 
 	}
 }
 
-// Must be called with endpointsMU held
+// Must be called with global endpoint.Mutex held
 func (e *Endpoint) regenerateConsumable(owner Owner) (bool, error) {
 	c := e.Consumable
 
@@ -247,7 +247,7 @@ func (e *Endpoint) regenerateConsumable(owner Owner) (bool, error) {
 	return true, nil
 }
 
-// Must be called with endpointsMU held
+// Must be called with global endpoint.Mutex held
 func (e *Endpoint) regenerateL3Policy(owner Owner) (bool, error) {
 	c := e.Consumable
 

--- a/pkg/endpointmanager/doc.go
+++ b/pkg/endpointmanager/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package endpointmanager manages the list of all local endpoints
+package endpointmanager

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -1,0 +1,168 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpointmanager
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+var (
+	// Mutex protects Endpoints and endpointsAux
+	Mutex sync.RWMutex
+
+	// Endpoints is the global list of endpoints indexed by ID. Mutex must
+	// be held to read and write.
+	//
+	// FIXME: This is currently exported, as more code moves from daemon
+	// into pkg/endpoint, we might be able to unexport this
+	Endpoints    = map[uint16]*endpoint.Endpoint{}
+	endpointsAux = map[string]*endpoint.Endpoint{}
+)
+
+// LookupCiliumIDLocked looks up endpoint by endpoint ID with Mutex held
+func LookupCiliumIDLocked(id uint16) *endpoint.Endpoint {
+	if ep, ok := Endpoints[id]; ok {
+		return ep
+	}
+	return nil
+}
+
+// LookupCiliumID looks up endpoint by endpoint ID
+func LookupCiliumID(id uint16) *endpoint.Endpoint {
+	Mutex.Lock()
+	defer Mutex.Unlock()
+
+	return LookupCiliumIDLocked(id)
+}
+
+func lookupDockerEndpointLocked(id string) *endpoint.Endpoint {
+	if ep, ok := endpointsAux[endpoint.NewID(endpoint.DockerEndpointPrefix, id)]; ok {
+		return ep
+	}
+	return nil
+}
+
+// LookupDockerID looks up endpoint by Docker ID
+func LookupDockerID(id string) *endpoint.Endpoint {
+	Mutex.Lock()
+	defer Mutex.Unlock()
+
+	return lookupDockerIDLocked(id)
+}
+
+func lookupDockerIDLocked(id string) *endpoint.Endpoint {
+	if ep, ok := endpointsAux[endpoint.NewID(endpoint.ContainerIdPrefix, id)]; ok {
+		return ep
+	}
+	return nil
+}
+
+func linkContainerID(ep *endpoint.Endpoint) {
+	endpointsAux[endpoint.NewID(endpoint.ContainerIdPrefix, ep.DockerID)] = ep
+}
+
+// LinkContainerID links an endpoint and makes it searchable by Docker ID.
+// Mutex must be held
+func LinkContainerID(ep *endpoint.Endpoint) {
+	linkContainerID(ep)
+}
+
+// Insert inserts the endpoint into the global maps
+func Insert(ep *endpoint.Endpoint) {
+	Endpoints[ep.ID] = ep
+
+	if ep.DockerID != "" {
+		linkContainerID(ep)
+	}
+
+	if ep.DockerEndpointID != "" {
+		endpointsAux[endpoint.NewID(endpoint.DockerEndpointPrefix, ep.DockerEndpointID)] = ep
+	}
+}
+
+// RemoveLocked removes the endpoint from the global maps. Mutex must be held
+func RemoveLocked(ep *endpoint.Endpoint) {
+	delete(Endpoints, ep.ID)
+
+	if ep.DockerID != "" {
+		delete(endpointsAux, endpoint.NewID(endpoint.ContainerIdPrefix, ep.DockerID))
+	}
+
+	if ep.DockerEndpointID != "" {
+		delete(endpointsAux, endpoint.NewID(endpoint.DockerEndpointPrefix, ep.DockerID))
+	}
+}
+
+// Lookup looks up the endpoint by prefix id
+func Lookup(id string) (*endpoint.Endpoint, error) {
+	Mutex.RLock()
+	defer Mutex.RUnlock()
+
+	return LookupLocked(id)
+}
+
+// LookupLocked looks up the endpoint by prefix id with the Mutex already held
+func LookupLocked(id string) (*endpoint.Endpoint, error) {
+	prefix, eid, err := endpoint.ParseID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	switch prefix {
+	case endpoint.CiliumLocalIdPrefix:
+		n, _ := endpoint.ParseCiliumID(id)
+		return LookupCiliumIDLocked(uint16(n)), nil
+
+	case endpoint.CiliumGlobalIdPrefix:
+		return nil, fmt.Errorf("Unsupported id format for now")
+
+	case endpoint.ContainerIdPrefix:
+		return lookupDockerIDLocked(eid), nil
+
+	case endpoint.DockerEndpointPrefix:
+		return lookupDockerEndpointLocked(eid), nil
+
+	default:
+		return nil, fmt.Errorf("Unknown endpoint prefix %s", prefix)
+	}
+}
+
+// TriggerPolicyUpdates calls TriggerPolicyUpdates for each endpoint and
+// regenerates as required. During this process, the endpoint list is locked
+// and cannot be modified.
+func TriggerPolicyUpdates(owner endpoint.Owner) {
+	Mutex.RLock()
+
+	for k := range Endpoints {
+		go func(ep *endpoint.Endpoint) {
+			policyChanges, err := ep.TriggerPolicyUpdates(owner)
+			if err != nil {
+				log.Warningf("Error while handling policy updates for endpoint %s\n", err)
+				ep.LogStatus(endpoint.Policy, endpoint.Failure, err.Error())
+			} else {
+				ep.LogStatusOK(endpoint.Policy, "Policy regenerated")
+			}
+			if policyChanges {
+				ep.Regenerate(owner)
+			}
+		}(Endpoints[k])
+	}
+	Mutex.RUnlock()
+}


### PR DESCRIPTION
This is a first step for a cleanup of endpoint management. The Endpoints
map and lock is global for now. Long term this should be put behind
proper APIs.

This makes endpoints available outside of daemon context for now.

Signed-off-by: Thomas Graf <thomas@cilium.io>