### PR TITLE
Improve logging of BPF generation errors

### DIFF
--- a/common/logging.go
+++ b/common/logging.go
@@ -99,7 +99,8 @@ func setFireLevels(level logrus.Level) []logrus.Level {
 // SetupLogging sets up each logging service provided in loggers and configures
 // each logger with the provided logOpts.
 func SetupLogging(loggers []string, logOpts map[string]string, tag string, debug bool) error {
-	setupFormatter()
+	// FIXME: Disabled for now
+	//setupFormatter()
 
 	// Set default logger to output to stdout if no loggers are provided.
 	if len(loggers) == 0 {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -331,7 +332,11 @@ func (d *Daemon) compileBase() error {
 	if err != nil {
 		log.Warningf("Command execution %s %s failed: %s", prog,
 			strings.Join(args, " "), err)
-		log.Warningf("Command output:\n%s", out)
+
+		scanner := bufio.NewScanner(bytes.NewReader(out))
+		for scanner.Scan() {
+			log.Warning(scanner.Text())
+		}
 		return err
 	}
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -16,6 +16,7 @@ package endpoint
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -310,7 +311,10 @@ func (e *Endpoint) runInit(libdir, rundir, prefix, debug string) error {
 	}
 	if err != nil {
 		log.Warningf("Command execution failed: %s", err)
-		log.Warningf("Command output:\n%s", out)
+		scanner := bufio.NewScanner(bytes.NewReader(out))
+		for scanner.Scan() {
+			log.Warning(scanner.Text())
+		}
 		return fmt.Errorf("error: %q command output: %q", err, out)
 	}
 

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -143,12 +143,12 @@ func (c *ConsulClient) InitializeFreeID(path string, firstID uint32) error {
 		// FreeID already set
 		return nil
 	}
-	log.Info("Trying to put free ID...")
+	log.Debugf("Trying to put free ID...")
 	_, err = c.KV().Put(p, nil)
 	if err != nil {
 		return err
 	}
-	log.Infof("Free ID for path %s successfully initialized", path)
+	log.Debugf("Free ID for path %s successfully initialized", path)
 
 	return nil
 }
@@ -183,7 +183,7 @@ func (c *ConsulClient) GetMaxID(key string, firstID uint32) (uint32, error) {
 	}
 	if k == nil {
 		// FreeID is empty? We should set it out!
-		log.Infof("Empty FreeID, setting it up with default value %d", firstID)
+		log.Debugf("Empty FreeID, setting it up with default value %d", firstID)
 		if err := c.InitializeFreeID(key, firstID); err != nil {
 			return 0, err
 		}

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -230,12 +230,12 @@ func (e *EtcdClient) InitializeFreeID(path string, firstID uint32) error {
 		// FreeID already set
 		return nil
 	}
-	log.Info("Trying to put free ID...")
+	log.Debugf("Trying to put free ID...")
 	err = e.SetValue(path, firstID)
 	if err != nil {
 		return err
 	}
-	log.Infof("Free ID for path %s successfully initialized", path)
+	log.Debugf("Free ID for path %s successfully initialized", path)
 
 	return nil
 }
@@ -256,7 +256,7 @@ func (e *EtcdClient) GetMaxID(key string, firstID uint32) (uint32, error) {
 		case err != nil:
 			return 0, err
 		case value == nil:
-			log.Infof("Empty FreeID, setting it up with default value %d", firstID)
+			log.Debugf("Empty FreeID, setting it up with default value %d", firstID)
 			if err := e.InitializeFreeID(key, firstID); err != nil {
 				return 0, err
 			}
@@ -278,7 +278,7 @@ func (e *EtcdClient) SetMaxID(key string, firstID, maxID uint32) error {
 	}
 	if value == nil {
 		// FreeID is empty? We should set it out!
-		log.Infof("Empty FreeID, setting it up with default value %d", firstID)
+		log.Debugf("Empty FreeID, setting it up with default value %d", firstID)
 		if err := e.InitializeFreeID(key, firstID); err != nil {
 			return err
 		}

--- a/pkg/kvstore/local.go
+++ b/pkg/kvstore/local.go
@@ -103,7 +103,7 @@ func (l *LocalClient) GetMaxID(key string, firstID uint32) (uint32, error) {
 			log.Error(err)
 			fallthrough
 		case value == nil:
-			log.Infof("Empty FreeID, setting it up with default value %d", firstID)
+			log.Debugf("Empty FreeID, setting it up with default value %d", firstID)
 			if err := l.InitializeFreeID(key, firstID); err != nil {
 				return 0, err
 			}
@@ -122,7 +122,7 @@ func (l *LocalClient) SetMaxID(key string, firstID, maxID uint32) error {
 	value, _ := l.GetValue(key)
 	if value == nil {
 		// FreeID is empty? We should set it out!
-		log.Infof("Empty FreeID, setting it up with default value %d", firstID)
+		log.Debugf("Empty FreeID, setting it up with default value %d", firstID)
 		if err := l.InitializeFreeID(key, firstID); err != nil {
 			return err
 		}

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -332,7 +332,7 @@ func (driver *driver) createEndpoint(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Infof("Created new endpoint: endpoint-id=%s", create.EndpointID)
+	log.Debugf("Created new endpoint: endpoint-id=%s", create.EndpointID)
 
 	respIface := &api.EndpointInterface{
 		// Fixme: the lxcmac is an empty string at this point and we only know the


### PR DESCRIPTION
Produces clear and easy to understand error messages:
```
WARN[0002] + OPTS='-DSECLABEL=2 -DPOLICY_MAP=cilium_policy_reserved_2 -DCALLS_MAP=cilium_calls_overlay_2'
WARN[0002] + IN=bpf_overlay.c
WARN[0002] + OUT=bpf_overlay.o
WARN[0002] ++ ip link show cilium_vxlan


WARN[0002] ++ grep ether
WARN[0002] ++ awk '{print $2}'
WARN[0002] + NODE_MAC=76:f9:95:b7:8f:81
WARN[0002] ++ mac2array 76:f9:95:b7:8f:81
WARN[0002] ++ echo '{0x76,0xf9,0x95,0xb7,0x8f,0x81}'
WARN[0002] + NODE_MAC='{.addr={0x76,0xf9,0x95,0xb7,0x8f,0x81}}'
WARN[0002] + clang -D__NR_CPUS__=2 -O2 -target bpf -I/run/cilium/state/globals -I. -I/var/lib/cilium/bpf/include -DENABLE_ARP_RESPONDER -DHANDLE_NS -Wno-address-of-packed-member -Wno-unknown-warning-option -DSECLABEL=2 -DPOLICY_MAP=cilium_policy_reserved_2 -DCALLS_MAP=cilium_calls_overlay_2 '-DNODE_MAC={.addr={0x76,0xf9,0x95,0xb7,0x8f,0x81}}' -c /var/lib/cilium/bpf/bpf_overlay.c -o bpf_overlay.o
WARN[0002] In file included from /var/lib/cilium/bpf/bpf_overlay.c:27:
WARN[0002] In file included from /var/lib/cilium/bpf/lib/common.h:21:
WARN[0002] /run/cilium/state/globals/bpf_features.h:1:2: error: unterminated conditional directive
WARN[0002] #ifndef BPF_FEATURES_H_
WARN[0002]  ^
WARN[0002] 1 error generated.
ERRO[0002] Error while initializing daemon: exit status 1

FATA[0002] Error while creating daemon: exit status 1
```