### PR TITLE
Documentation: minor nitpicks and rewording

### DIFF
--- a/Documentation/admin.rst
+++ b/Documentation/admin.rst
@@ -24,7 +24,7 @@ Summary
 ^^^^^^^
 
 When running Cilium using the container image ``cilium/cilium``, these are
-the requirements your system has to fulfil:
+the requirements your system has to fulfill:
 
 - `Linux kernel`_ >= 4.8 (>= 4.9.17 LTS recommended)
 - Key-Value store (see :ref:`req_kvstore` for version details)
@@ -73,7 +73,7 @@ Cilium leverages and builds on the kernel functionality BPF as well as various
 subsystems which integrate with BPF. Therefore, all systems that will run a
 Cilium agent are required to run the Linux kernel version 4.8.0 or later.
 
-The 4.8.0 kernel is minimal kernel version required, more recent kernels may
+The 4.8.0 kernel is the minimal kernel version required, more recent kernels may
 provide additional BPF functionality. Cilium will automatically detect
 additional available functionality by probing for the functionality when the
 agent starts.
@@ -146,13 +146,13 @@ Installation on Kubernetes
 --------------------------
 
 This section describes how to install and run Cilium on Kubernetes. The
-deployment method using is called DaemonSet_ which is the easiest way to deploy
+deployment method we are using is called DaemonSet_ which is the easiest way to deploy
 Cilium in a Kubernetes environment. It will request Kubernetes to automatically
 deploy and run a ``cilium/cilium`` container image as a pod on all Kubernetes
 worker nodes.
 
 Should you encounter any issues during the installation, please refer to the
-:ref:`admin_k8s_troubleshooting` section and/or seek help on `Slack channel`_.
+:ref:`admin_k8s_troubleshooting` section and / or seek help on `Slack channel`_.
 
 TL;DR Version (Expert Mode)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -553,7 +553,7 @@ Installation From Source
 
 If for some reason you do not want to run Cilium as a contaimer image.
 Installing it from source is possible as well. It does come with additional
-dependencies described in :ref:` admin_system_reqs`.
+dependencies described in :ref:`admin_system_reqs`.
 
 1. Download & extract the latest Cilium release from the ReleasesPage_
 
@@ -570,7 +570,7 @@ dependencies described in :ref:` admin_system_reqs`.
 .. code:: bash
 
    $ make
-   $ sudo make instal
+   $ sudo make install
 
 3. Optional: Install systemd/upstart init files:
 
@@ -587,7 +587,7 @@ The networking configuration required on your Linux container node
 depends on the IP interconnectivity model in use and whether the
 deployment requires containers in the cluster to reach or be reached by
 resources outside the cluster.  For more details, see the
-Architecture Guide's section on :ref:`arch_ip_connectivity` .
+Architecture Guide's section on :ref:`arch_ip_connectivity`.
 
 Overlay Mode - Container-to-Container Access
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -911,7 +911,7 @@ from the BPF based datapath. Debugging messages are sent if either the
 mode of the agent can be enabled by starting ``cilium-agent`` with the option
 ``--debug`` enabled or by running ``cilium config debug=true`` for an already
 running agent. Debugging of an individual endpoint can be enabled by running
-``cilium endpoint config ID Debug=true```
+``cilium endpoint config ID Debug=true``
 
 
 .. code:: bash

--- a/Documentation/architecture.rst
+++ b/Documentation/architecture.rst
@@ -153,7 +153,7 @@ Labels
 
 Labels are a generic, flexible and highly scaleable way of addressing a large
 set of resources as they allow for arbitrary grouping and creation of sets.
-Whenever something needs to be descried, addressed or selected this is done
+Whenever something needs to be described, addressed or selected this is done
 based on labels:
 
 - Endpoints are assigned labels as derived from container runtime or the
@@ -174,7 +174,7 @@ is optional and can be omitted, e.g. ``io.cilium.mykey``.
 Key names should typically consist of the character set ``[a-z0-9-.]``.
 
 When using labels to select resources, both the key and the value must match,
-e.g. when a policy should be applied to all endpoints will label
+e.g. when a policy should be applied to all endpoints with the label
 ``my.corp.foo`` then the label ``my.corp.foo=bar`` will not match the
 selector.
 

--- a/Documentation/gettingstarted.rst
+++ b/Documentation/gettingstarted.rst
@@ -5,7 +5,7 @@ Getting Started Guide
 
 This document serves as the easiest introduction to using Cilium.
 It is a detailed walk through of getting a single-node Cilium environment running on
-your laptop/desktop.  It is designed to take 15-30 minutes.
+your machine. It is designed to take 15-30 minutes.
 
 If you haven't read the :ref:`intro` yet, we'd encourage you to do that first.
 
@@ -17,7 +17,7 @@ Both guides follow the same basic flow.   The flow in the Kubernetes variant
 is more realistic of a production deployment, but is also a bit more complex.
 
 The best way to get help if you get stuck is to ask a question on the `Cilium
-Slack channel <https://cilium.herokuapp.com>`_ .  With Cilium contributors
+Slack channel <https://cilium.herokuapp.com>`_.  With Cilium contributors
 across the globe, there is almost always someone available to help.
 
 Getting Started Using Kubernetes
@@ -26,7 +26,7 @@ Getting Started Using Kubernetes
 This guide uses `minikube <https://kubernetes.io/docs/getting-started-guides/minikube/>`_
 to demonstrate deployment and operation of Cilium in a single-node Kubernetes cluster.
 The minikube VM requires approximately 2 GB of RAM and supports hypervisors like VirtualBox
-that run on Linux, Mac OS X, and Windows.
+that run on Linux, macOS, and Windows.
 
 If you instead want to understand the details of
 deploying Cilium on a full fledged Kubernetes cluster, then go straight to
@@ -38,7 +38,7 @@ Step 0: Install kubectl & minikube
 Install ``kubectl`` version ``>= 1.6.3`` as described in the `Kubernetes Docs
 <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_.
 
-Install one of the `hypervisors supported by minikube <https://kubernetes.io/docs/tasks/tools/install-minikube/>`_ .
+Install one of the `hypervisors supported by minikube <https://kubernetes.io/docs/tasks/tools/install-minikube/>`_.
 
 Install ``minikube`` 0.19 as described on `minikube's github page
 <https://github.com/kubernetes/minikube/releases>`_.
@@ -119,7 +119,7 @@ to access *app1*.
 
 .. image:: cilium_gsg_k8s_topo.png
 
-The file ``demo.yaml`` contains a Kubernetes Deployment for each of three applications,
+The file ``demo.yaml`` contains a Kubernetes Deployment for each of the three applications,
 with each deployment identified using the Kubernetes labels id=app1, id=app2,
 and id=app3.
 It also include a app1-service, which load-balances traffic to all pods with label id=app1.
@@ -388,7 +388,7 @@ Getting Started Using Docker
 -----------------------------
 
 The tutorial leverages Vagrant and VirtualBox , and as such should run on any
-operating system supported by Vagrant, including Linux, MacOS X, and Windows.
+operating system supported by Vagrant, including Linux, macOS, and Windows.
 
 Step 0: Install Vagrant
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -441,7 +441,7 @@ it will print:
 
 If the script exits with an error message, do not attempt to proceed with the
 tutorial, as later steps will not work properly.   Instead, contact us on the
-`Cilium Slack channel <https://cilium.herokuapp.com>`_ .
+`Cilium Slack channel <https://cilium.herokuapp.com>`_.
 
 Step 3: Accessing the VM
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
These are just the things which sticked out while reading the PDF version from June 09. Let me know what to drop or reword.

. s/laptop\\/desktop/machine/g
. s/Mac OS X/macOS/g
. remove space before period
. add space before and after slash
. add 'the'
. s/descried/described/g
. s/will label/with the label/g
. s/fulfil/fulfill/g
. s/method using/method we are using/g
. fix broken link to system requirements
. s/make instal/make install/g
. remove extra backtick