### PR TITLE
proxy: Fix race when looking up endpoint metadata

### DIFF
--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -25,6 +25,10 @@ import (
 
 var (
 	// Mutex protects Endpoints and endpointsAux
+	//
+	// Warning: This lock may not be taken while an individual endpoint
+	// lock is being held. If you require to hold both, then the global
+	// endpointmanager lock must always be acquired first.
 	Mutex sync.RWMutex
 
 	// Endpoints is the global list of endpoints indexed by ID. Mutex must


### PR DESCRIPTION
When acquiring metadata for an HTTP request being processed, the
endpoint lock is being to read metadata. While this lock was being held,
we then looked up the endpoint of the remote endpoint through the
endpointmanager. This requires to acquire the global endpoint lock which
then races with many existing code paths which hold the global lock,
iterate over all endpoints and take individual locks do perform
operations on the endpoints.

Fix this and leave a comment in the global endpoint lock to avoid this
behaviour.

Signed-off-by: Thomas Graf <thomas@cilium.io>