### PR TITLE
daemon: remove unnecessary cgo integration

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -14,12 +14,6 @@
 
 package main
 
-/*
-#cgo CFLAGS: -I../../bpf/include
-#include <linux/perf_event.h>
-*/
-import "C"
-
 import (
 	"bytes"
 	"encoding/binary"


### PR DESCRIPTION
No C code is called from within daemon/monitor.go, so the cgo
integration can be removed.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>