### PR TITLE
tests: gather /var/run/cilium, /var/lib/cilium as part of Jenkins builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,13 +14,15 @@ pipeline {
 		steps {
                     parallel(
                         "Runtime Tests": { sh './contrib/vagrant/start.sh' }, 
-                         "K8s Tests": { sh './tests/k8s/start' } 
+                        "K8s Tests": { sh './tests/k8s/start' }
                     )
 	        }
         }
     }
     post {
         always {
+            sh './tests/copy_files'
+            archiveArtifacts "cilium-files.tar.gz"
             sh 'vagrant destroy -f'
             sh 'cd ./tests/k8s && vagrant destroy -f'
         }

--- a/tests/01-ct.sh
+++ b/tests/01-ct.sh
@@ -7,6 +7,7 @@ set -e
 TEST_NET="cilium"
 
 function cleanup {
+	gather_files 01-ct
 	docker rm -f server client httpd1 httpd2 curl 2> /dev/null || true
 	monitor_stop
 }

--- a/tests/02-perf.sh
+++ b/tests/02-perf.sh
@@ -18,6 +18,7 @@ if [ -z $BENCHMARK ]; then
 fi
 
 function cleanup {
+	gather_files 02-perf
 	docker rm -f server client 2> /dev/null || true
 
 	cilium config DropNotification=true Debug=true

--- a/tests/03-docker.sh
+++ b/tests/03-docker.sh
@@ -8,6 +8,7 @@ TEST_NET="cilium"
 NETPERF_IMAGE="tgraf/netperf"
 
 function cleanup {
+	gather_files 03-docker
 	cilium policy delete --all 2> /dev/null || true
 	docker rm -f server client 2> /dev/null || true
 	monitor_stop

--- a/tests/05-cni.sh
+++ b/tests/05-cni.sh
@@ -60,6 +60,7 @@ function clean_container {
 }
 
 function cleanup {
+	gather_files 05-cni
 	cilium policy delete --all 2> /dev/null || true
 	kill_cni_container $server_id cni-server
 	kill_cni_container $client_id cni-client

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -25,6 +25,7 @@ NETPERF_IMAGE="tgraf/netperf"
 logs_clear
 
 function cleanup {
+	gather_files 06-lb
 	docker rm -f server1 server2 server3 server4 server5 client misc 2> /dev/null || true
 	rm netdev_config.h tmp_lb.o 2> /dev/null || true
 	rm /sys/fs/bpf/tc/globals/lbtest 2> /dev/null || true

--- a/tests/08-nat46.sh
+++ b/tests/08-nat46.sh
@@ -7,6 +7,7 @@ set -e
 TEST_NET="cilium"
 
 function cleanup {
+	gather_files 08-nat46
 	cilium policy delete --all 2> /dev/null || true
         docker rm -f server client 2> /dev/null || true
         monitor_stop

--- a/tests/10-proxy.sh
+++ b/tests/10-proxy.sh
@@ -3,6 +3,7 @@
 source "./helpers.bash"
 
 function cleanup {
+	gather_files 10-proxy
 	cilium policy delete --all 2> /dev/null || true
 	docker rm -f server client 2> /dev/null || true
 }

--- a/tests/11-getting-started.sh
+++ b/tests/11-getting-started.sh
@@ -10,6 +10,7 @@ ID_SERVICE1="id.service1"
 ID_SERVICE2="id.service2"
 
 function cleanup {
+  gather_files 11-getting-started
   cilium policy delete --all 2> /dev/null || true
   docker rm -f ${HTTPD_CONTAINER_NAME}  2> /dev/null || true
   docker network rm ${TEST_NET} 2> /dev/null || true

--- a/tests/12-policy-import.sh
+++ b/tests/12-policy-import.sh
@@ -5,6 +5,7 @@ source "./helpers.bash"
 TEST_NET="cilium"
 
 function cleanup {
+	gather_files 12-policy-import
 	cilium policy delete --all 2> /dev/null || true
 	docker rm -f foo foo bar baz 2> /dev/null || true
 }

--- a/tests/13-monitor-filtering.sh
+++ b/tests/13-monitor-filtering.sh
@@ -11,6 +11,7 @@ CLIENT_LABEL="client"
 CONTAINER=monitor_tests
 
 function cleanup {
+  gather_files 14-monitoring-filtering
   docker rm -f $CONTAINER 2> /dev/null || true
   docker network rm $NETWORK > /dev/null 2>&1
   monitor_stop

--- a/tests/15-policy-config.sh
+++ b/tests/15-policy-config.sh
@@ -39,6 +39,7 @@ EOF
 }
 
 function cleanup {
+	gather_files 15-policy-config
 	cilium policy delete --all 2> /dev/null || true
 	docker rm -f foo foo bar baz 2> /dev/null || true
 }

--- a/tests/16-cidr-ingress-policy.sh
+++ b/tests/16-cidr-ingress-policy.sh
@@ -16,6 +16,7 @@ IPV4_OTHERNET=99.11.0.0/16
 IPV6_HOST=fdff::ff
 
 function cleanup {
+  gather_files 16-cidr-ingress-policy	
   ip addr del dev lo ${IPV4_HOST}/32 2> /dev/null || true
   ip addr del dev lo ${IPV6_HOST}/128 2> /dev/null || true
   cilium policy delete --all 2> /dev/null || true

--- a/tests/copy_files
+++ b/tests/copy_files
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+sudo rm -rf ./cilium-files
+
+set -e
+
+IDENTITY_FILE=$(vagrant ssh-config | grep IdentityFile | awk '{print $2}')
+PORT=$(vagrant ssh-config cilium-master | grep Port | awk '{ print $2 }')
+
+vagrant ssh cilium-master -c 'sudo -E bash -c "journalctl --no-pager -u cilium > ${GOPATH}/src/github.com/cilium/cilium/tests/cilium-files/cilium-logs && chmod a+r ${GOPATH}/src/github.com/cilium/cilium/tests/cilium-files/cilium-logs"'
+
+scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -r -P ${PORT} -i ${IDENTITY_FILE} vagrant@127.0.0.1:~/go/src/github.com/cilium/cilium/tests/cilium-files .
+
+sudo tar -czvf cilium-files.tar.gz cilium-files

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -65,7 +65,6 @@ function wait_for_endpoints {
 	until [ "$(cilium endpoint list | grep ready -c)" -eq "$1" ]; do
 	    micro_sleep
 	done
-	set -x
 }
 
 function wait_for_cilium_status {
@@ -73,7 +72,6 @@ function wait_for_cilium_status {
 	while ! cilium status; do
 	    micro_sleep
 	done
-	set -x
 }
 
 function wait_for_kubectl_cilium_status {
@@ -85,7 +83,6 @@ function wait_for_kubectl_cilium_status {
     while ! kubectl -n ${namespace} exec ${pod} cilium status; do
         micro_sleep
     done
-    set -x
 }
 
 function wait_for_cilium_ep_gen {
@@ -96,7 +93,6 @@ function wait_for_cilium_ep_gen {
         fi
         micro_sleep
     done
-	set -x
 }
 
 function count_lines_in_log {
@@ -110,7 +106,6 @@ function wait_for_log_entries {
     while [ $(count_lines_in_log) -lt "$expected" ]; do
         micro_sleep
     done
-    set -x
 }
 
 function wait_for_docker_ipv6_addr {
@@ -123,7 +118,6 @@ function wait_for_docker_ipv6_addr {
          fi
          micro_sleep
     done
-    set -x
 }
 
 function wait_for_running_pod {
@@ -133,5 +127,20 @@ function wait_for_running_pod {
     while [[ "$(kubectl get pods | grep ${pod} | grep Running -c)" -ne "1" ]] ; do
         micro_sleep
     done
-    set -x
+}
+
+function gather_files {
+    TEST_NAME=$1
+    CILIUM_DIR="${GOPATH}/src/github.com/cilium/cilium/tests/cilium-files/${TEST_NAME}"
+    RUN="/var/run/cilium"
+    LIB="/var/lib/cilium"
+    RUN_DIR="${CILIUM_DIR}${RUN}"
+    LIB_DIR="${CILIUM_DIR}${LIB}"
+    mkdir -p ${CILIUM_DIR}
+    mkdir -p ${RUN_DIR}
+    mkdir -p ${LIB_DIR}
+    sudo cp -r ${RUN}/state ${RUN_DIR}
+    sudo cp -r ${LIB}/* ${LIB_DIR}
+    find . -type d -exec sudo chmod 777 {} \;
+    find ${CILIUM_DIR} -exec sudo chmod a+r {} \;
 }


### PR DESCRIPTION
 Gather contents of /var/run/cilium, /var/lib/cilium for each test that is ran in tests/ directory, as well as cilium logs, and package up and archive for each build job.
    
Signed-off by: Ian Vernon <ian@covalent.io>

Fixes: #1016 