### PR TITLE
Reduce cgo usage in pkg/bpf

### DIFF
--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -113,6 +113,13 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const (
+	BPF_MAP_TYPE_HASH     = C.BPF_MAP_TYPE_HASH
+	BPF_MAP_TYPE_LPM_TRIE = C.BPF_MAP_TYPE_LPM_TRIE
+
+	BPF_F_NO_PREALLOC = C.BPF_F_NO_PREALLOC
+)
+
 // CreateMap creates a Map of type mapType, with key size keySize, a value size of
 // valueSize and the maximum amount of entries of maxEntries.
 // mapType should be one of the bpf_map_type in "uapi/linux/bpf.h"

--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -14,15 +14,6 @@
 
 package bpf
 
-/*
-#cgo CFLAGS: -I../../bpf/include
-#include <linux/unistd.h>
-#include <linux/bpf.h>
-#include <sys/resource.h>
-*/
-
-import "C"
-
 import (
 	"bufio"
 	"fmt"

--- a/pkg/maps/cidrmap/cidrmap.go
+++ b/pkg/maps/cidrmap/cidrmap.go
@@ -14,12 +14,6 @@
 
 package cidrmap
 
-/*
-#cgo CFLAGS: -I../../../bpf/include
-#include <linux/bpf.h>
-*/
-import "C"
-
 import (
 	"fmt"
 	"net"
@@ -113,11 +107,11 @@ func OpenMap(path string, prefixlen int) (*CIDRMap, bool, error) {
 	bytes := (prefixlen-1)/8 + 1
 	fd, isNewMap, err := bpf.OpenOrCreateMap(
 		path,
-		C.BPF_MAP_TYPE_LPM_TRIE,
+		bpf.BPF_MAP_TYPE_LPM_TRIE,
 		uint32(unsafe.Sizeof(uint32(0))+uintptr(bytes)),
 		uint32(LPM_MAP_VALUE_SIZE),
 		MAX_KEYS,
-		C.BPF_F_NO_PREALLOC,
+		bpf.BPF_F_NO_PREALLOC,
 	)
 
 	if err != nil {

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -14,12 +14,6 @@
 
 package lxcmap
 
-/*
-#cgo CFLAGS: -I../../../bpf/include
-#include <linux/bpf.h>
-*/
-import "C"
-
 import (
 	"fmt"
 	"net"
@@ -210,7 +204,7 @@ func OpenMap() (*LXCMap, error) {
 
 	fd, _, err := bpf.OpenOrCreateMap(
 		path,
-		C.BPF_MAP_TYPE_HASH,
+		bpf.BPF_MAP_TYPE_HASH,
 		uint32(unsafe.Sizeof(uint32(0))),
 		uint32(unsafe.Sizeof(LXCInfo{})),
 		MaxKeys,

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -14,12 +14,6 @@
 
 package policymap
 
-/*
-#cgo CFLAGS: -I../../../bpf/include
-#include <linux/bpf.h>
-*/
-import "C"
-
 import (
 	"bytes"
 	"fmt"
@@ -142,7 +136,7 @@ func (pm *PolicyMap) Close() error {
 func OpenMap(path string) (*PolicyMap, bool, error) {
 	fd, isNewMap, err := bpf.OpenOrCreateMap(
 		path,
-		C.BPF_MAP_TYPE_HASH,
+		bpf.BPF_MAP_TYPE_HASH,
 		uint32(unsafe.Sizeof(uint32(0))),
 		uint32(unsafe.Sizeof(PolicyEntry{})),
 		MAX_KEYS,


### PR DESCRIPTION
Two more changes reducing cgo usage in pkg/bpf and its users:

* Remove unnecessary cgo integration from pkg/bpf/map.go, akin to commit 0578b6db95dd917141eb462cb07cdbe80e9bb115
* Provide wrapper constants for bpf map types and flags in order to confine cgo usage to within pkg/bpf/bpf.go. Users of the package will no longer need to import "C" to get the constants.