### PR TITLE
retrieving K8s PodCIDR from k8s-apiserver

### DIFF
--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -1,0 +1,62 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"net"
+
+	"github.com/cilium/cilium/pkg/node"
+
+	log "github.com/Sirupsen/logrus"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+// ParseNode parses a kubernetes node to a cilium node
+func ParseNode(k8sNode *v1.Node) *node.Node {
+	addrs := []node.Address{}
+	for _, addr := range k8sNode.Status.Addresses {
+		// We only care about this address types,
+		// we ignore all other types.
+		switch addr.Type {
+		case v1.NodeLegacyHostIP, v1.NodeInternalIP, v1.NodeExternalIP:
+		default:
+			continue
+		}
+		ip := net.ParseIP(addr.Address)
+		if ip == nil {
+			log.Debugf("k8s: Ignoring invalid node IP %s of type %s", addr.Address, addr.Type)
+			continue
+		}
+		na := node.Address{
+			AddressType: addr.Type,
+			IP:          ip,
+		}
+		addrs = append(addrs, na)
+	}
+
+	var endpointsCIDR *net.IPNet
+	if len(k8sNode.Spec.PodCIDR) != 0 {
+		var err error
+		_, endpointsCIDR, err = net.ParseCIDR(k8sNode.Spec.PodCIDR)
+		if err != nil {
+			log.Warningf("k8s: Invalid PodCIDR value '%s' for node %s: %s", k8sNode.Spec.PodCIDR, err)
+		}
+	}
+	return &node.Node{
+		Name:          k8sNode.Name,
+		IPAddresses:   addrs,
+		EndpointsCIDR: endpointsCIDR,
+	}
+}

--- a/pkg/node/manager.go
+++ b/pkg/node/manager.go
@@ -1,0 +1,60 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"sync"
+)
+
+var (
+	mutex sync.RWMutex
+	nodes = map[Identity]*Node{}
+)
+
+// GetNode returns the node with the given identity, if exists, from the nodes
+// map.
+func GetNode(ni Identity) *Node {
+	mutex.RLock()
+	n := nodes[ni]
+	mutex.RUnlock()
+	return n
+}
+
+// UpdateNode updates the new node in the nodes' map with the given identity.
+func UpdateNode(ni Identity, n *Node) {
+	mutex.Lock()
+	//if oldNode, ok := nodes[ni]; ok {
+	// oldNode
+	// remove oldNode metadata (IPs-> endpoints CIDR) from bpf map
+	//}
+
+	// FIXME if PodCIDR is empty retrieve the CIDR from the KVStore
+
+	// add new node changes to bpf map.
+	// **note**: this will eventually add pod-cidr routes for the own node.
+
+	nodes[ni] = n
+	mutex.Unlock()
+
+}
+
+// DeleteNode remove the node from the nodes' maps.
+func DeleteNode(ni Identity) {
+	// remove node from bpf map
+
+	mutex.Lock()
+	delete(nodes, ni)
+	mutex.Unlock()
+}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1,0 +1,75 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"net"
+
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+// Identity represents the node identity of a node.
+type Identity struct {
+	Name string
+}
+
+// String returns the string representation on NodeIdentity.
+func (nn Identity) String() string {
+	return nn.Name
+}
+
+// Node contains the nodes name, the list of addresses to this address
+type Node struct {
+	Name          string
+	IPAddresses   []Address
+	EndpointsCIDR *net.IPNet
+}
+
+// Address is a node address which contains an IP and the address type.
+type Address struct {
+	AddressType v1.NodeAddressType
+	IP          net.IP
+}
+
+// GetNodeIP returns one of the node's IP addresses available with the
+// following priority:
+// - NodeInternalIP
+// - NodeExternalIP
+// - other IP address type
+func (n *Node) GetNodeIP(ipv6 bool) net.IP {
+	var backupIP net.IP
+	for _, addr := range n.IPAddresses {
+		if (ipv6 && addr.IP.To4() != nil) ||
+			(!ipv6 && addr.IP.To4() == nil) {
+			continue
+		}
+		switch addr.AddressType {
+		// Always prefer a cluster internal IP
+		case v1.NodeInternalIP:
+			return addr.IP
+		case v1.NodeExternalIP:
+			// Fall back to external Node IP
+			// if no internal IP could be found
+			backupIP = addr.IP
+		default:
+			// As a last resort, if no internal or external
+			// IP was found, use any node address available
+			if backupIP == nil {
+				backupIP = addr.IP
+			}
+		}
+	}
+	return backupIP
+}

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -1,0 +1,76 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"net"
+	"testing"
+
+	. "gopkg.in/check.v1"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type NodeSuite struct{}
+
+var _ = Suite(&NodeSuite{})
+
+func (s *NodeSuite) TestGetNodeIP(c *C) {
+	n := Node{
+		Name: "node-1",
+		IPAddresses: []Address{
+			{IP: net.ParseIP("203.0.113.1"), AddressType: v1.NodeLegacyHostIP},
+		},
+		EndpointsCIDR: nil,
+	}
+	ip := n.GetNodeIP(false)
+	// Return the only IP present
+	c.Assert(ip.Equal(net.ParseIP("203.0.113.1")), Equals, true)
+
+	n.IPAddresses = append(n.IPAddresses, Address{IP: net.ParseIP("192.0.2.3"), AddressType: v1.NodeExternalIP})
+	ip = n.GetNodeIP(false)
+	// The next priority should be NodeExternalIP
+	c.Assert(ip.Equal(net.ParseIP("192.0.2.3")), Equals, true)
+
+	n.IPAddresses = append(n.IPAddresses, Address{IP: net.ParseIP("198.51.100.2"), AddressType: v1.NodeInternalIP})
+	ip = n.GetNodeIP(false)
+	// The next priority should be NodeInternalIP
+	c.Assert(ip.Equal(net.ParseIP("198.51.100.2")), Equals, true)
+
+	n.IPAddresses = append(n.IPAddresses, Address{IP: net.ParseIP("2001:DB8::1"), AddressType: v1.NodeExternalIP})
+	ip = n.GetNodeIP(true)
+	// The next priority should be NodeExternalIP and IPv6
+	c.Assert(ip.Equal(net.ParseIP("2001:DB8::1")), Equals, true)
+
+	n.IPAddresses = append(n.IPAddresses, Address{IP: net.ParseIP("2001:DB8::3"), AddressType: v1.NodeLegacyHostIP})
+	ip = n.GetNodeIP(true)
+	// Should still return the NodeExternalIP and IPv6
+	c.Assert(ip.Equal(net.ParseIP("2001:DB8::1")), Equals, true)
+
+	n.IPAddresses = append(n.IPAddresses, Address{IP: net.ParseIP("2001:DB8::2"), AddressType: v1.NodeInternalIP})
+	ip = n.GetNodeIP(true)
+	// The next priority should be NodeInternalIP and IPv6
+	c.Assert(ip.Equal(net.ParseIP("2001:DB8::2")), Equals, true)
+
+	n.IPAddresses = append(n.IPAddresses, Address{IP: net.ParseIP("198.51.100.2"), AddressType: v1.NodeInternalIP})
+	ip = n.GetNodeIP(false)
+	// Should still return NodeInternalIP and IPv4
+	c.Assert(ip.Equal(net.ParseIP("198.51.100.2")), Equals, true)
+
+}


### PR DESCRIPTION
Add integration with kubernetes to retrive all nodes addresses and, if
set, their pod CIDR.

This will allow cilium to route endpoints's network traffic
automatically to the destination without the user manually inserting the
necessary routes.

Signed-off-by: André Martins <andre@cilium.io>