### PR TITLE
Adding IP CIDRs in node annotation

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -83,7 +83,7 @@ type Daemon struct {
 	dockerClient      *dClient.Client
 	events            chan events.Event
 	ipamConf          *ipam.IPAMConfig
-	k8sClient         *kubernetes.Clientset
+	k8sClient         kubernetes.Interface
 	l7Proxy           *proxy.Proxy
 	loadBalancer      *types.LoadBalancer
 	loopbackIPv4      net.IP
@@ -452,7 +452,7 @@ func (d *Daemon) useK8sNodeCIDR(nodeName string) error {
 	if d.conf.IPv4Disabled {
 		return nil
 	}
-	k8sNode, err := d.k8sClient.Nodes().Get(nodeName, metav1.GetOptions{})
+	k8sNode, err := d.k8sClient.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/daemon/docker_watcher.go
+++ b/daemon/docker_watcher.go
@@ -171,7 +171,7 @@ func (d *Daemon) fetchK8sLabels(dockerLbls map[string]string) (map[string]string
 	}
 	log.Debugf("Connecting to kubernetes to retrieve labels for pod %s ns %s", podName, ns)
 
-	result, err := d.k8sClient.Pods(ns).Get(podName, metav1.GetOptions{})
+	result, err := d.k8sClient.CoreV1().Pods(ns).Get(podName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -93,7 +93,7 @@ func (d *Daemon) createThirdPartyResources() error {
 		},
 	}
 
-	_, err := d.k8sClient.Extensions().ThirdPartyResources().Create(res)
+	_, err := d.k8sClient.ExtensionsV1beta1().ThirdPartyResources().Create(res)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}

--- a/daemon/labels_test.go
+++ b/daemon/labels_test.go
@@ -71,7 +71,6 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	daemonConf.RunDir = tempRunDir
 	daemonConf.StateDir = tempRunDir
 	daemonConf.DockerEndpoint = "tcp://127.0.0.1"
-	daemonConf.K8sEndpoint = "tcp://127.0.0.1"
 	daemonConf.ValidLabelPrefixes = nil
 	daemonConf.Opts.Set(endpoint.OptionDropNotify, true)
 	daemonConf.Device = "undefined"

--- a/daemon/status.go
+++ b/daemon/status.go
@@ -30,7 +30,7 @@ import (
 func (d *Daemon) getK8sStatus() *models.Status {
 	var k8sStatus *models.Status
 	if d.conf.IsK8sEnabled() {
-		if v, err := d.k8sClient.ComponentStatuses().Get("controller-manager", metav1.GetOptions{}); err != nil {
+		if v, err := d.k8sClient.CoreV1().ComponentStatuses().Get("controller-manager", metav1.GetOptions{}); err != nil {
 			k8sStatus = &models.Status{State: models.StatusStateFailure, Msg: err.Error()}
 		} else if len(v.Conditions) == 0 {
 			k8sStatus = &models.Status{

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -16,12 +16,19 @@
 package k8s
 
 import (
+	"net"
+	"time"
+
+	"github.com/cilium/cilium/pkg/nodeaddress"
+
+	log "github.com/Sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -79,4 +86,59 @@ func CreateTPRClient(config *rest.Config) (*rest.RESTClient, error) {
 	schemeBuilder.AddToScheme(api.Scheme)
 
 	return rest.RESTClientFor(config)
+}
+
+// AnnotateNodeCIDR writes both v4 and v6 CIDRs in the given k8sNode.
+// In case of failure while updating the node, this function while spawn a go
+// routine to retry the node update indefinitely.
+func AnnotateNodeCIDR(c kubernetes.Interface, k8sNode *v1.Node, v4CIDR, v6CIDR *net.IPNet) {
+	// register IP CIDRs in node's annotations
+	log.Debugf("k8s: Storing IPv4 CIDR %s in k8s node %s's annotations", v4CIDR, k8sNode.Name)
+	log.Debugf("k8s: Storing IPv6 CIDR %s in k8s node %s's annotations", v6CIDR, k8sNode.Name)
+	k8sNode.Annotations[Annotationv4CIDRName] = v4CIDR.String()
+	k8sNode.Annotations[Annotationv6CIDRName] = v6CIDR.String()
+
+	_, err := c.CoreV1().Nodes().Update(k8sNode)
+	if err != nil {
+		go func(c kubernetes.Interface, k8sServerNode *v1.Node, v4CIDR, v6CIDR *net.IPNet, err error) {
+			// TODO: Retry forever?
+			for n := 0; err != nil; {
+				log.Errorf("K8s: unable to update node %s with IPv6 CIDR annotation: %s, retrying...", k8sServerNode.Name, err)
+				// In case of an error let's retry until
+				// we were able to set the annotations properly
+				k8sServerNode.Annotations[Annotationv4CIDRName] = v4CIDR.String()
+				k8sServerNode.Annotations[Annotationv6CIDRName] = v6CIDR.String()
+				k8sServerNode, err = c.CoreV1().Nodes().Update(k8sNode)
+				if n < 30 {
+					n++
+				}
+				time.Sleep(time.Duration(n) * time.Second)
+			}
+		}(c, k8sNode, v4CIDR, v6CIDR, err)
+	}
+}
+
+// UseNodeCIDR sets the ipv4-range and ipv6-range values from the
+// cluster-node-cidr defined in  the kube-apiserver or / and the CIDRs defined
+// in that node's annotations.
+func UseNodeCIDR(c kubernetes.Interface, nodeName string) error {
+	k8sNode, err := c.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	node := ParseNode(k8sNode)
+
+	if node.IPv4AllocCIDR != nil {
+		log.Infof("Retrieved %s for node %s. Using it for ipv4-range", node.IPv4AllocCIDR, nodeName)
+		nodeaddress.SetIPv4AllocRange(node.IPv4AllocCIDR)
+	}
+	if node.IPv6AllocCIDR != nil {
+		log.Infof("Retrieved %s for node %s. Using it for ipv6-range", node.IPv6AllocCIDR, nodeName)
+		if err := nodeaddress.SetIPv6NodeRange(node.IPv6AllocCIDR); err != nil {
+			log.Warningf("k8s: Can't use CIDR '%s' from kubernetes: %s", node.IPv6AllocCIDR, err)
+		}
+	}
+
+	return nil
 }

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -1,0 +1,155 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cilium/cilium/pkg/nodeaddress"
+
+	. "gopkg.in/check.v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+func (s *K8sSuite) TestUseNodeCIDR(c *C) {
+	// Test IPv4
+	node1 := v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			Annotations: map[string]string{
+				Annotationv4CIDRName: "10.254.0.0/16",
+			},
+		},
+		Spec: v1.NodeSpec{
+			PodCIDR: "10.2.0.0/16",
+		},
+	}
+
+	// set buffer to 2 to prevent blocking when calling UseNodeCIDR
+	// and we need to wait for the response of the channel.
+	updateChan := make(chan bool, 2)
+	k8sClient := &Clientset{
+		OnCoreV1: func() corev1.CoreV1Interface {
+			return &CoreV1Client{
+				OnNodes: func() corev1.NodeInterface {
+					return &NodeInterfaceClient{
+						OnGet: func(name string, options metav1.GetOptions) (*v1.Node, error) {
+							c.Assert(name, Equals, "node1")
+							c.Assert(options, DeepEquals, metav1.GetOptions{})
+							n1copy := v1.Node(node1)
+							return &n1copy, nil
+						},
+						OnUpdate: func(n *v1.Node) (*v1.Node, error) {
+							updateChan <- true
+							n1copy := v1.Node(node1)
+							n1copy.Annotations[Annotationv4CIDRName] = "10.2.0.0/16"
+							n1copy.Annotations[Annotationv6CIDRName] = "beef:beef:beef:beef:aaaa:aaaa:1111:0/96"
+							c.Assert(n, DeepEquals, &n1copy)
+							return &n1copy, nil
+						},
+					}
+				},
+			}
+		},
+	}
+
+	err := UseNodeCIDR(k8sClient, "node1")
+	c.Assert(err, IsNil)
+	c.Assert(nodeaddress.GetIPv4AllocRange().String(), Equals, "10.2.0.0/16")
+	// IPv6 Node range is not checked because it shouldn't be changed.
+
+	k8sNode, err := k8sClient.CoreV1().Nodes().Get("node1", metav1.GetOptions{})
+	c.Assert(err, IsNil)
+
+	AnnotateNodeCIDR(k8sClient, k8sNode,
+		nodeaddress.GetIPv4AllocRange(),
+		nodeaddress.GetIPv6NodeRange())
+
+	select {
+	case <-updateChan:
+	case <-time.Tick(5 * time.Second):
+		c.Errorf("d.k8sClient.CoreV1().Nodes().Update() was not called")
+		c.FailNow()
+	}
+
+	// Test IPv6
+	node1 = v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node2",
+			Annotations: map[string]string{
+				Annotationv4CIDRName: "10.254.0.0/16",
+			},
+		},
+		Spec: v1.NodeSpec{
+			PodCIDR: "aaaa:aaaa:aaaa:aaaa:beef:beef::/96",
+		},
+	}
+
+	failAttempts := 0
+	k8sClient = &Clientset{
+		OnCoreV1: func() corev1.CoreV1Interface {
+			return &CoreV1Client{
+				OnNodes: func() corev1.NodeInterface {
+					return &NodeInterfaceClient{
+						OnGet: func(name string, options metav1.GetOptions) (*v1.Node, error) {
+							c.Assert(name, Equals, "node2")
+							c.Assert(options, DeepEquals, metav1.GetOptions{})
+							n1copy := v1.Node(node1)
+							return &n1copy, nil
+						},
+						OnUpdate: func(n *v1.Node) (*v1.Node, error) {
+							// also test retrying in case of error
+							if failAttempts == 0 {
+								failAttempts++
+								return nil, fmt.Errorf("failing on purpose")
+							}
+							updateChan <- true
+							n1copy := v1.Node(node1)
+							n1copy.Annotations[Annotationv4CIDRName] = "10.2.0.0/16"
+							n1copy.Annotations[Annotationv6CIDRName] = "aaaa:aaaa:aaaa:aaaa:beef:beef::/96"
+							c.Assert(n, DeepEquals, &n1copy)
+							return &n1copy, nil
+						},
+					}
+				},
+			}
+		},
+	}
+
+	err = UseNodeCIDR(k8sClient, "node2")
+	c.Assert(err, IsNil)
+	// We use the node's annotation for the IPv4 and the PodCIDR for the
+	// IPv6.
+	c.Assert(nodeaddress.GetIPv4AllocRange().String(), Equals, "10.254.0.0/16")
+	c.Assert(nodeaddress.GetIPv6NodeRange().String(), Equals, "aaaa:aaaa:aaaa:aaaa:beef:beef::/96")
+
+	k8sNode, err = k8sClient.CoreV1().Nodes().Get("node2", metav1.GetOptions{})
+	c.Assert(err, IsNil)
+
+	AnnotateNodeCIDR(k8sClient, k8sNode,
+		nodeaddress.GetIPv4AllocRange(),
+		nodeaddress.GetIPv6NodeRange())
+
+	select {
+	case <-updateChan:
+	case <-time.Tick(5 * time.Second):
+		c.Errorf("d.k8sClient.CoreV1().Nodes().Update() was not called")
+		c.FailNow()
+	}
+
+}

--- a/pkg/k8s/const.go
+++ b/pkg/k8s/const.go
@@ -24,6 +24,13 @@ const (
 	// rules should be applied to.
 	AnnotationName = "io.cilium.name"
 
+	// Annotationv4CIDRName is the annotation name used to store the IPv4
+	// pod CIDR in the node's annotations.
+	Annotationv4CIDRName = "io.cilium.network.ipv4-pod-cidr"
+	// Annotationv6CIDRName is the annotation name used to store the IPv6
+	// pod CIDR in the node's annotations.
+	Annotationv6CIDRName = "io.cilium.network.ipv6-pod-cidr"
+
 	// EnvNodeNameSpec is the environment label used by Kubernetes to
 	// specify the node's name.
 	EnvNodeNameSpec = "K8S_NODE_NAME"

--- a/pkg/k8s/k8s_mock_test.go
+++ b/pkg/k8s/k8s_mock_test.go
@@ -1,0 +1,335 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"fmt"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/discovery"
+	appsv1beta1 "k8s.io/client-go/kubernetes/typed/apps/v1beta1"
+	authenticationv1 "k8s.io/client-go/kubernetes/typed/authentication/v1"
+	authenticationv1beta1 "k8s.io/client-go/kubernetes/typed/authentication/v1beta1"
+	authorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	authorizationv1beta1 "k8s.io/client-go/kubernetes/typed/authorization/v1beta1"
+	autoscalingv1 "k8s.io/client-go/kubernetes/typed/autoscaling/v1"
+	autoscalingv2alpha1 "k8s.io/client-go/kubernetes/typed/autoscaling/v2alpha1"
+	batchv1 "k8s.io/client-go/kubernetes/typed/batch/v1"
+	batchv2alpha1 "k8s.io/client-go/kubernetes/typed/batch/v2alpha1"
+	certificatesv1beta1 "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	extensionsv1beta1 "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
+	policyv1beta1 "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
+	rbacv1alpha1 "k8s.io/client-go/kubernetes/typed/rbac/v1alpha1"
+	rbacv1beta1 "k8s.io/client-go/kubernetes/typed/rbac/v1beta1"
+	settingsv1alpha1 "k8s.io/client-go/kubernetes/typed/settings/v1alpha1"
+	storagev1 "k8s.io/client-go/kubernetes/typed/storage/v1"
+	storagev1beta1 "k8s.io/client-go/kubernetes/typed/storage/v1beta1"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/rest"
+)
+
+type NodeInterfaceClient struct {
+	OnCreate           func(*v1.Node) (*v1.Node, error)
+	OnUpdate           func(*v1.Node) (*v1.Node, error)
+	OnUpdateStatus     func(*v1.Node) (*v1.Node, error)
+	OnDelete           func(name string, options *meta_v1.DeleteOptions) error
+	OnDeleteCollection func(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error
+	OnGet              func(name string, options meta_v1.GetOptions) (*v1.Node, error)
+	OnList             func(opts meta_v1.ListOptions) (*v1.NodeList, error)
+	OnWatch            func(opts meta_v1.ListOptions) (watch.Interface, error)
+	OnPatch            func(name string, pt k8sTypes.PatchType, data []byte, subresources ...string) (result *v1.Node, err error)
+	OnPatchStatus      func(nodeName string, data []byte) (*v1.Node, error)
+}
+
+func (nc *NodeInterfaceClient) Create(n *v1.Node) (*v1.Node, error) {
+	if nc.OnCreate != nil {
+		return nc.OnCreate(n)
+	}
+	return nil, fmt.Errorf("Method Create should not have been called")
+}
+
+func (nc *NodeInterfaceClient) Update(n *v1.Node) (*v1.Node, error) {
+	if nc.OnUpdate != nil {
+		return nc.OnUpdate(n)
+	}
+	return nil, fmt.Errorf("Method Update should not have been called")
+}
+
+func (nc *NodeInterfaceClient) UpdateStatus(n *v1.Node) (*v1.Node, error) {
+	if nc.OnUpdateStatus != nil {
+		return nc.OnUpdateStatus(n)
+	}
+	return nil, fmt.Errorf("Method UpdateStatus should not have been called")
+}
+
+func (nc *NodeInterfaceClient) Delete(name string, options *meta_v1.DeleteOptions) error {
+	if nc.OnDelete != nil {
+		return nc.OnDelete(name, options)
+	}
+	return fmt.Errorf("Method Delete should not have been called")
+}
+
+func (nc *NodeInterfaceClient) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
+	if nc.OnDeleteCollection != nil {
+		return nc.OnDeleteCollection(options, listOptions)
+	}
+	return fmt.Errorf("Method DeleteCollection should not have been called")
+}
+
+func (nc *NodeInterfaceClient) Get(name string, options meta_v1.GetOptions) (*v1.Node, error) {
+	if nc.OnGet != nil {
+		return nc.OnGet(name, options)
+	}
+	return nil, fmt.Errorf("Method Get should not have been called")
+}
+
+func (nc *NodeInterfaceClient) List(opts meta_v1.ListOptions) (*v1.NodeList, error) {
+	if nc.OnList != nil {
+		return nc.OnList(opts)
+	}
+	return nil, fmt.Errorf("Method List should not have been called")
+}
+
+func (nc *NodeInterfaceClient) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	if nc.OnWatch != nil {
+		return nc.OnWatch(opts)
+	}
+	return nil, fmt.Errorf("Method Watch should not have been called")
+}
+
+func (nc *NodeInterfaceClient) Patch(name string, pt k8sTypes.PatchType, data []byte, subresources ...string) (result *v1.Node, err error) {
+	if nc.OnPatch != nil {
+		return nc.OnPatch(name, pt, data, subresources...)
+	}
+	return nil, fmt.Errorf("Method Patch should not have been called")
+}
+
+func (nc *NodeInterfaceClient) PatchStatus(nodeName string, data []byte) (*v1.Node, error) {
+	if nc.OnPatchStatus != nil {
+		return nc.OnPatchStatus(nodeName, data)
+	}
+	return nil, fmt.Errorf("Method PatchStatus should not have been called")
+}
+
+//
+// CoreV1Client is used to interact with features provided by the  group.
+type CoreV1Client struct {
+	OnNodes func() corev1.NodeInterface
+}
+
+func (c *CoreV1Client) RESTClient() rest.Interface {
+	return nil
+}
+
+func (c *CoreV1Client) ComponentStatuses() corev1.ComponentStatusInterface {
+	return nil
+}
+
+func (c *CoreV1Client) ConfigMaps(namespace string) corev1.ConfigMapInterface {
+	return nil
+}
+
+func (c *CoreV1Client) Endpoints(namespace string) corev1.EndpointsInterface {
+	return nil
+}
+
+func (c *CoreV1Client) Events(namespace string) corev1.EventInterface {
+	return nil
+}
+
+func (c *CoreV1Client) LimitRanges(namespace string) corev1.LimitRangeInterface {
+	return nil
+}
+
+func (c *CoreV1Client) Namespaces() corev1.NamespaceInterface {
+	return nil
+}
+
+func (c *CoreV1Client) Nodes() corev1.NodeInterface {
+	if c.OnNodes != nil {
+		return c.OnNodes()
+	}
+	panic("Method Nodes should not have been called")
+}
+
+func (c *CoreV1Client) PersistentVolumes() corev1.PersistentVolumeInterface {
+	return nil
+}
+
+func (c *CoreV1Client) PersistentVolumeClaims(namespace string) corev1.PersistentVolumeClaimInterface {
+	return nil
+}
+
+func (c *CoreV1Client) Pods(namespace string) corev1.PodInterface {
+	return nil
+}
+
+func (c *CoreV1Client) PodTemplates(namespace string) corev1.PodTemplateInterface {
+	return nil
+}
+
+func (c *CoreV1Client) ReplicationControllers(namespace string) corev1.ReplicationControllerInterface {
+	return nil
+}
+
+func (c *CoreV1Client) ResourceQuotas(namespace string) corev1.ResourceQuotaInterface {
+	return nil
+}
+
+func (c *CoreV1Client) Secrets(namespace string) corev1.SecretInterface {
+	return nil
+}
+
+func (c *CoreV1Client) Services(namespace string) corev1.ServiceInterface {
+	return nil
+}
+
+func (c *CoreV1Client) ServiceAccounts(namespace string) corev1.ServiceAccountInterface {
+	return nil
+}
+
+type Clientset struct {
+	OnCoreV1 func() corev1.CoreV1Interface
+}
+
+func (c Clientset) CoreV1() corev1.CoreV1Interface {
+	if c.OnCoreV1 != nil {
+		return c.OnCoreV1()
+	}
+	panic("Method CoreV1 should not have been called")
+}
+
+func (c Clientset) Core() corev1.CoreV1Interface {
+	return nil
+}
+
+func (c Clientset) AppsV1beta1() appsv1beta1.AppsV1beta1Interface {
+	return nil
+}
+
+func (c Clientset) Apps() appsv1beta1.AppsV1beta1Interface {
+	return nil
+}
+
+func (c Clientset) AuthenticationV1() authenticationv1.AuthenticationV1Interface {
+	return nil
+}
+
+func (c Clientset) Authentication() authenticationv1.AuthenticationV1Interface {
+	return nil
+}
+
+func (c Clientset) AuthenticationV1beta1() authenticationv1beta1.AuthenticationV1beta1Interface {
+	return nil
+}
+
+func (c Clientset) AuthorizationV1() authorizationv1.AuthorizationV1Interface {
+	return nil
+}
+
+func (c Clientset) Authorization() authorizationv1.AuthorizationV1Interface {
+	return nil
+}
+
+func (c Clientset) AuthorizationV1beta1() authorizationv1beta1.AuthorizationV1beta1Interface {
+	return nil
+}
+
+func (c Clientset) AutoscalingV1() autoscalingv1.AutoscalingV1Interface {
+	return nil
+}
+
+func (c Clientset) Autoscaling() autoscalingv1.AutoscalingV1Interface {
+	return nil
+}
+
+func (c Clientset) AutoscalingV2alpha1() autoscalingv2alpha1.AutoscalingV2alpha1Interface {
+	return nil
+}
+
+func (c Clientset) BatchV1() batchv1.BatchV1Interface {
+	return nil
+}
+
+func (c Clientset) Batch() batchv1.BatchV1Interface {
+	return nil
+}
+
+func (c Clientset) BatchV2alpha1() batchv2alpha1.BatchV2alpha1Interface {
+	return nil
+}
+
+func (c Clientset) CertificatesV1beta1() certificatesv1beta1.CertificatesV1beta1Interface {
+	return nil
+}
+
+func (c Clientset) Certificates() certificatesv1beta1.CertificatesV1beta1Interface {
+	return nil
+}
+
+func (c Clientset) ExtensionsV1beta1() extensionsv1beta1.ExtensionsV1beta1Interface {
+	return nil
+}
+
+func (c Clientset) Extensions() extensionsv1beta1.ExtensionsV1beta1Interface {
+	return nil
+}
+
+func (c Clientset) PolicyV1beta1() policyv1beta1.PolicyV1beta1Interface {
+	return nil
+}
+
+func (c Clientset) Policy() policyv1beta1.PolicyV1beta1Interface {
+	return nil
+}
+
+func (c Clientset) RbacV1beta1() rbacv1beta1.RbacV1beta1Interface {
+	return nil
+}
+
+func (c Clientset) Rbac() rbacv1beta1.RbacV1beta1Interface {
+	return nil
+}
+
+func (c Clientset) RbacV1alpha1() rbacv1alpha1.RbacV1alpha1Interface {
+	return nil
+}
+
+func (c Clientset) SettingsV1alpha1() settingsv1alpha1.SettingsV1alpha1Interface {
+	return nil
+}
+
+func (c Clientset) Settings() settingsv1alpha1.SettingsV1alpha1Interface {
+	return nil
+}
+
+func (c Clientset) StorageV1beta1() storagev1beta1.StorageV1beta1Interface {
+	return nil
+}
+
+func (c Clientset) StorageV1() storagev1.StorageV1Interface {
+	return nil
+}
+
+func (c Clientset) Storage() storagev1.StorageV1Interface {
+	return nil
+}
+
+func (c Clientset) Discovery() discovery.DiscoveryInterface {
+	return nil
+}

--- a/pkg/k8s/node_test.go
+++ b/pkg/k8s/node_test.go
@@ -1,0 +1,83 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	. "gopkg.in/check.v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+func (s *K8sSuite) TestParseNode(c *C) {
+	// PodCIDR takes precedence over annotations
+	k8sNode := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			Annotations: map[string]string{
+				Annotationv4CIDRName: "10.254.0.0/16",
+				Annotationv6CIDRName: "f00d:aaaa:bbbb:cccc:dddd:eeee::/112",
+			},
+		},
+		Spec: v1.NodeSpec{
+			PodCIDR: "10.1.0.0/16",
+		},
+	}
+
+	n := ParseNode(k8sNode)
+	c.Assert(n.Name, Equals, "node1")
+	c.Assert(n.IPv4AllocCIDR, NotNil)
+	c.Assert(n.IPv4AllocCIDR.String(), Equals, "10.1.0.0/16")
+	c.Assert(n.IPv6AllocCIDR, NotNil)
+	c.Assert(n.IPv6AllocCIDR.String(), Equals, "f00d:aaaa:bbbb:cccc:dddd:eeee::/112")
+
+	// No IPv6 annotation
+	k8sNode = &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node2",
+			Annotations: map[string]string{
+				Annotationv4CIDRName: "10.254.0.0/16",
+			},
+		},
+		Spec: v1.NodeSpec{
+			PodCIDR: "10.1.0.0/16",
+		},
+	}
+
+	n = ParseNode(k8sNode)
+	c.Assert(n.Name, Equals, "node2")
+	c.Assert(n.IPv4AllocCIDR, NotNil)
+	c.Assert(n.IPv4AllocCIDR.String(), Equals, "10.1.0.0/16")
+	c.Assert(n.IPv6AllocCIDR, IsNil)
+
+	// No IPv6 annotation but PodCIDR with v6
+	k8sNode = &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node2",
+			Annotations: map[string]string{
+				Annotationv4CIDRName: "10.254.0.0/16",
+			},
+		},
+		Spec: v1.NodeSpec{
+			PodCIDR: "f00d:aaaa:bbbb:cccc:dddd:eeee::/112",
+		},
+	}
+
+	n = ParseNode(k8sNode)
+	c.Assert(n.Name, Equals, "node2")
+	c.Assert(n.IPv4AllocCIDR, NotNil)
+	c.Assert(n.IPv4AllocCIDR.String(), Equals, "10.254.0.0/16")
+	c.Assert(n.IPv6AllocCIDR, NotNil)
+	c.Assert(n.IPv6AllocCIDR.String(), Equals, "f00d:aaaa:bbbb:cccc:dddd:eeee::/112")
+}


### PR DESCRIPTION
- Changed kubernetes client struct to use kubernetes client interface.
- Add functionality to store both IPv4 and IPv6 CIDR in kubernetes node annotations.