### PR TITLE
Fix broken links to Kubernetes docs

### DIFF
--- a/Documentation/architecture.rst
+++ b/Documentation/architecture.rst
@@ -620,7 +620,7 @@ The security policy can be specified in the following formats:
 
 * The Kubernetes *NetworkPolicy* specification which offers to configure a
   subset of the full Cilium security. For fun see `Kubernetes Network Policies
-  <https://kubernetes.io/docs/concepts/services-networking/networkpolicies/>`_
+  <https://kubernetes.io/docs/concepts/services-networking/network-policies/>`_
   for details on how to configure Kubernetes network policies. It is possible
   to define base rules using the Kubernetes specification and then
   extend these using additional Cilium specific rules.
@@ -1081,12 +1081,12 @@ External-to-Pod Service-based Load-balancing
 TODO: Verify this
 
 Kubernetes supports an abstraction known as `Ingress
-<https://kubernetes.io/docs/user-guide/ingress/#what-is-ingress>`_ that allows
-a Pod-based Kubernetes service to expose itself for access outside of the
-cluster in a load-balanced way.  In a typical setup, the external traffic would
-be sent to a publicly reachable IP + port on the host running the Kubernetes
-master, and then be load-balanced to the pods implementing the current service
-within the cluster.
+<https://kubernetes.io/docs/concepts/services-networking/ingress/#what-is-ingress>`_
+that allows a Pod-based Kubernetes service to expose itself for access outside
+of the cluster in a load-balanced way.  In a typical setup, the external traffic
+would be sent to a publicly reachable IP + port on the host running the
+Kubernetes master, and then be load-balanced to the pods implementing the
+current service within the cluster.
 
 Cilium supports Ingress with TCP-based load-balancing.  Moreover, it supports
 ''direct server return'', meaning that reply traffic from the pod to the

--- a/README.md
+++ b/README.md
@@ -146,6 +146,6 @@ under the [General Public License, Version 2.0](bpf/COPYING).
 [containerd]: https://github.com/containerd/containerd
 [k8s_service]: https://kubernetes.io/docs/concepts/services-networking/service/
 [k8s_ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/
-[k8s_netpolicy]: https://kubernetes.io/docs/concepts/services-networking/networkpolicies/
+[k8s_netpolicy]: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 [k8s_labels]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 [fluentd]: http://www.fluentd.org/

--- a/examples/kubernetes-ingress/README.md
+++ b/examples/kubernetes-ingress/README.md
@@ -8,7 +8,7 @@ This tutorial demonstrates how to set up Kubernetes using Cilium to:
 - Run the BPF based kube-proxy replacement for services and ingress objects
 
 On top of this, the pods will have some labels assigned by kubernetes and cilium
-will enforce the kubernetes policy created via [kubernetes network policy API](https://kubernetes.io/docs/concepts/services-networking/networkpolicies/).
+will enforce the kubernetes policy created via [kubernetes network policy API](https://kubernetes.io/docs/concepts/services-networking/network-policies/).
 
 Besides the network policy enforcement, kubernetes will be running **without**
 kube-proxy and will enforce a basic set of ingress rules from an ingress object,


### PR DESCRIPTION
Fix two broken links to the Kubernetes docs in Documenation and README files.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>