### PR TITLE
use \$(RM) instead of rm for cleaning

### DIFF
--- a/contrib/packaging/deb/Makefile
+++ b/contrib/packaging/deb/Makefile
@@ -14,7 +14,7 @@ build: clean
 	docker run --rm cilium:cilium-bin-deb-$(VERSION) bash -c 'cd .. && tar -c cilium_$(VERSION)*' | tar -xvC .
 
 clean:
-	ls -d ./* | grep -vE Makefile\|cfg | xargs rm -rf
+	ls -d ./* | grep -vE Makefile\|cfg | xargs $(RM) -rf
 
 .PHONY: force build clean
 force :;

--- a/contrib/packaging/docker/Makefile
+++ b/contrib/packaging/docker/Makefile
@@ -6,11 +6,11 @@ build: clean
 	mkdir -p $(BUILDDIR)
 	@$(CURDIR)/../cp-dirs.sh $(BUILDDIR)
 	cp -v ../../../Dockerfile $(BUILDDIR)
-	find $(BUILDDIR) -name ".*" -prune ! -name ".git"  -exec rm -rf {} \;
+	find $(BUILDDIR) -name ".*" -prune ! -name ".git"  -exec $(RM) -rf {} \;
 	docker build -t "cilium:$(DOCKER_IMAGE_TAG)" $(BUILDDIR)
 
 clean:
-	ls -d ./* | grep -vE "Makefile|clang-3.8.1.key" | xargs rm -rf
+	ls -d ./* | grep -vE "Makefile|clang-3.8.1.key" | xargs $(RM) -rf
 
 .PHONY: clean build force
 force :;

--- a/contrib/packaging/rpm/Makefile
+++ b/contrib/packaging/rpm/Makefile
@@ -14,8 +14,8 @@ build: clean
 		'tar -c root/cilium-$(VERSION)*.rpm root/x86_64/cilium-$(VERSION)*.rpm' | tar --strip-components=1 -xvC .
 
 clean:
-	ls -d ./* | grep -vE Makefile\|cfg | xargs rm -rf
-	ls -d ./cfg/* | grep -vE Dockerfile\|create-rpm.sh\|cilium.spec.envsubst | xargs rm -rf
+	ls -d ./* | grep -vE Makefile\|cfg | xargs $(RM) -rf
+	ls -d ./cfg/* | grep -vE Dockerfile\|create-rpm.sh\|cilium.spec.envsubst | xargs $(RM) -rf
 
 .PHONY: force build clean
 force :;


### PR DESCRIPTION
$(RM) handles missing targets

https://github.com/cilium/cilium/issues/1050