### PR TITLE
pkg/bpf: explicitly include stdint.h

### DIFF
--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -16,6 +16,7 @@ package bpf
 
 /*
 #cgo CFLAGS: -I../../bpf/include
+#include <stdint.h>
 #include <linux/unistd.h>
 #include <linux/bpf.h>
 #include <sys/resource.h>


### PR DESCRIPTION
The pkg/bpf/bpf.o uses C.uint64_t from the stdint.h C header but only
implicitly includes it through other headers. Add an explicit include to
avoid potential issues when other headers are changed.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>