### PR TITLE
tests: Wait for endpoints to become available before invoking netperf

### DIFF
--- a/tests/03-docker.sh
+++ b/tests/03-docker.sh
@@ -33,26 +33,29 @@ monitor_start
 set -x
 
 docker run -dt --net=$TEST_NET --name server -l $SERVER_LABEL $NETPERF_IMAGE
+docker run -dt --net=$TEST_NET --name client -l $CLIENT_LABEL $NETPERF_IMAGE
+
+wait_for_endpoints 2
 
 SERVER_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server)
 
 monitor_clear
-docker run --rm -i --net=$TEST_NET --name client -l $CLIENT_LABEL tgraf/nettools sh -c "ping6 -c 5 $SERVER_IP" || {
+docker exec -i client ping6 -c 5 $SERVER_IP || {
 	abort "Error: Could not ping server container"
 }
 
 monitor_clear
-docker run --rm -i --net=$TEST_NET --name netperf -l $CLIENT_LABEL $NETPERF_IMAGE sh -c "netperf -c -C -H $SERVER_IP" || {
+docker exec -i client netperf -c -C -H $SERVER_IP || {
 	abort "Error: Could not netperf to server"
 }
 
 monitor_clear
-docker run --rm -i --net=$TEST_NET --name netperf -l $CLIENT_LABEL $NETPERF_IMAGE sh -c "netperf -c -C -t TCP_SENDFILE -H $SERVER_IP" || {
+docker exec -i client netperf -c -C -t TCP_SENDFILE -H $SERVER_IP || {
 	abort "Error: Could not netperf to server"
 }
 
 monitor_clear
-docker run --rm -i --net=$TEST_NET --name netperf -l $CLIENT_LABEL $NETPERF_IMAGE sh -c "super_netperf 10 -c -C -t TCP_SENDFILE -H $SERVER_IP" || {
+docker exec -i client super_netperf 10 -c -C -t TCP_SENDFILE -H $SERVER_IP || {
 	abort "Error: Could not netperf to server"
 }
 


### PR DESCRIPTION
netperf was invoked with `docker run [...] netperf [...]` which will
cause netperf to be started while the labels and policy is being
rlicesolved for that endpoint in parallel. This can cause to random test
failyure if the policy is not put in place in time before netperf's
control  TCP connection gives up retrying.

Fixes: #1059

Signed-off-by: Thomas Graf <thomas@cilium.io>