### PR TITLE
k8s-tests: Use files of local git tree

### DIFF
--- a/tests/k8s/k8s-gsg-test.sh
+++ b/tests/k8s/k8s-gsg-test.sh
@@ -4,12 +4,15 @@ NAMESPACE="kube-system"
 
 source "../helpers.bash"
 source /home/vagrant/.profile
+
+K8SDIR=../../examples/minikube
+
 function cleanup {
-	kubectl delete -f https://raw.githubusercontent.com/cilium/cilium/master/examples/minikube/l3_l4_l7_policy.yaml
-	kubectl delete -f https://raw.githubusercontent.com/cilium/cilium/master/examples/minikube/l3_l4_policy.yaml
-	kubectl delete -f https://raw.githubusercontent.com/cilium/cilium/master/examples/minikube/demo.yaml
-	kubectl delete -f cilium-ds.yaml
-	kubectl delete -f https://raw.githubusercontent.com/cilium/cilium/master/examples/kubernetes/rbac.yaml
+	kubectl delete -f $K8SDIR/l3_l4_l7_policy.yaml 2> /dev/null
+	kubectl delete -f $K8SDIR/l3_l4_policy.yaml 2> /dev/null
+	kubectl delete -f $K8SDIR/demo.yaml 2> /dev/null
+	kubectl delete -f $K8SDIR/cilium-ds.yaml 2> /dev/null
+	kubectl delete -f $K8SDIR/rbac.yaml 2> /dev/null
 }
 
 trap cleanup exit
@@ -18,39 +21,43 @@ echo "KUBECONFIG: $KUBECONFIG"
 
 cleanup
 
+echo -n "---- Waiting for cluster to get into a good state"
 until [ "$(kubectl get cs | grep -v "STATUS" | grep -c "Healthy")" -eq "3" ]; do 
-	echo "---- Waiting for cluster to get into a good state ----"
+	echo -n "."
 done
 
 
 echo "----- adding RBAC for Cilium -----"
-kubectl create -f https://raw.githubusercontent.com/cilium/cilium/master/examples/kubernetes/rbac.yaml
+kubectl create -f $K8SDIR/rbac.yaml
 
 echo "----- deploying Cilium Daemon Set onto cluster -----"
-wget https://raw.githubusercontent.com/cilium/cilium/master/examples/kubernetes/cilium-ds.yaml
+cp $K8SDIR/cilium-ds.yaml .
 sed -i s/"\/var\/lib\/kubelet\/kubeconfig"/"\/etc\/kubernetes\/kubelet.conf"/g cilium-ds.yaml
 sed -i s/"cilium\/cilium:stable"/"localhost:5000\/cilium:${DOCKER_IMAGE_TAG}"/g cilium-ds.yaml
 kubectl apply -f cilium-ds.yaml
 
+echo -n "----- Waiting for Cilium to get into 'ready' state in Minikube cluster"
 until [ "$(kubectl get ds --namespace ${NAMESPACE} | grep -v 'READY' | awk '{ print $4}' | grep -c '1')" -eq "3" ]; do
-	echo "----- Waiting for Cilium to get into 'ready' state in Minikube cluster -----"
+	echo -n "."
 done
 
 CILIUM_POD=$(kubectl -n ${NAMESPACE} get pods -l k8s-app=cilium | grep -v 'AGE' | awk '{ print $1 }')
 wait_for_kubectl_cilium_status ${NAMESPACE} ${CILIUM_POD}
 
 echo "----- deploying demo application onto cluster -----"
-kubectl create -f https://raw.githubusercontent.com/cilium/cilium/master/examples/minikube/demo.yaml
+kubectl create -f $K8SDIR/demo.yaml
 
+echo -n "----- Waiting for demo apps to get into 'Running' state"
 until [ "$(kubectl get pods | grep -v STATUS | grep -c "Running")" -eq "4" ]; do
-	echo "----- Waiting for demo apps to get into 'Running' state -----"
+	echo -n "."
 done
 
 echo "----- adding L3 L4 policy  -----"
-kubectl create -f https://raw.githubusercontent.com/cilium/cilium/master/examples/minikube/l3_l4_policy.yaml
+kubectl create -f $K8SDIR/l3_l4_policy.yaml
 
+echo -n "----- Waiting for endpoints to get into 'ready' state"
 until [ "$(kubectl -n ${NAMESPACE} exec ${CILIUM_POD} cilium endpoint list | grep -c 'ready')" -eq "5" ]; do
-	echo "----- Waiting for endpoints to get into 'ready' state -----"
+	echo -n "."
 done
 
 echo "----- testing L3/L4 policy -----"
@@ -83,7 +90,7 @@ if [[ "${RETURN//$'\n'}" != "200" ]]; then
 fi
 
 echo "----- creating L7-aware policy -----"
-kubectl create -f https://raw.githubusercontent.com/cilium/cilium/master/examples/minikube/l3_l4_l7_policy.yaml
+kubectl create -f $K8SDIR/l3_l4_l7_policy.yaml
 
 CILIUM_POD=$(kubectl -n ${NAMESPACE} get pods -l k8s-app=cilium | grep -v 'AGE' | awk '{ print $1 }')
 until [ "$(kubectl -n ${NAMESPACE} exec ${CILIUM_POD} cilium endpoint list | grep -c 'ready')" -eq "5" ]; do


### PR DESCRIPTION
- Do not run testsuite against DaemonSet, policy and demo yaml of git
  master. Use the local checked out git tree instead.

- Be less verbose when running test

Signed-off-by: Thomas Graf <thomas@cilium.io>