### PR TITLE
kubernetes: Add scheduler tolerations to schedule Cilium on NotReady …

### DIFF
--- a/examples/kubernetes/cilium-ds.yaml
+++ b/examples/kubernetes/cilium-ds.yaml
@@ -9,6 +9,9 @@ spec:
       labels:
         k8s-app: consul
         kubernetes.io/cluster-service: "true"
+      annotations:
+        scheduler.alpha.kubernetes.io/tolerations: >-
+          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
     spec:
       containers:
       - image: consul:0.8.3
@@ -55,6 +58,9 @@ spec:
       labels:
         k8s-app: cilium
         kubernetes.io/cluster-service: "true"
+      annotations:
+        scheduler.alpha.kubernetes.io/tolerations: >-
+          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
     spec:
       serviceAccountName: cilium
       containers:

--- a/examples/minikube/cilium-ds.yaml
+++ b/examples/minikube/cilium-ds.yaml
@@ -64,6 +64,9 @@ spec:
       labels:
         k8s-app: consul
         kubernetes.io/cluster-service: "true"
+      annotations:
+        scheduler.alpha.kubernetes.io/tolerations: >-
+          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
     spec:
       containers:
       - image: consul:0.8.3
@@ -110,6 +113,9 @@ spec:
       labels:
         k8s-app: cilium
         kubernetes.io/cluster-service: "true"
+      annotations:
+        scheduler.alpha.kubernetes.io/tolerations: >-
+          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
     spec:
       serviceAccountName: cilium
       containers:


### PR DESCRIPTION
…nodes

On a fresh Kubernetes, when no CNI plugin has been installed yet. Nodes
will be marked NotReady. Allow the Cilium DaemonSet to be scheduled onto
such nodes. The nodes will become ready automatically.

Signed-off-by: Thomas Graf <thomas@cilium.io>