### PR TITLE
cmd: add description for cilium command

### DIFF
--- a/cilium/cmd/root.go
+++ b/cilium/cmd/root.go
@@ -57,8 +57,8 @@ __custom_func() {
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "cilium",
-	Short: "A brief description of your application",
-	Long:  `TBD`,
+	Short: "CLI",
+	Long:  `CLI for interacting with the local Cilium Agent`,
 	BashCompletionFunction: bashCompletionFunc,
 }
 


### PR DESCRIPTION
Closes: #1049 (Improve description of cilium command when used without parameters)
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>