### PR TITLE
Vagrantfile: Do not inherit DNS server of host

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -87,6 +87,10 @@ Vagrant.configure(2) do |config|
     end
 
     config.vm.provider "virtualbox" do |vb|
+        # Do not inherit DNS server from host, use proxy
+        vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+        vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+
         config.vm.box = "cilium/ubuntu-16.10"
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i

--- a/examples/getting-started/Vagrantfile
+++ b/examples/getting-started/Vagrantfile
@@ -46,6 +46,12 @@ Vagrant.configure(2) do |config|
 
     config.vm.synced_folder "../..", "/home/vagrant/cilium", disabled: false
 
+    config.vm.provider "virtualbox" do |vb|
+        # Do not inherit DNS server from host, use proxy
+        vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+        vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+    end
+
     # install docker runtime
     config.vm.provision :docker, images: [
 	"consul:0.8.3",

--- a/tests/k8s/Vagrantfile
+++ b/tests/k8s/Vagrantfile
@@ -60,6 +60,10 @@ Vagrant.configure(2) do |config|
     config.vm.provision "k8s", type: "shell", inline: $k8s
     config.vm.provision "build", type: "shell", inline: $build, env: {"DOCKER_IMAGE_TAG" => $docker_image_tag}
     config.vm.provider "virtualbox" do |vb|
+        # Do not inherit DNS server from host, use proxy
+        vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+        vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+
         # Ignore contrib/packaging/docker/stage to prevent concurrent
         # problems when using rsync on multiple VMs
         config.vm.synced_folder '../../', '/home/vagrant/go/src/github.com/cilium/cilium', type: "rsync",

--- a/tests/k8s/multi-node/Vagrantfile
+++ b/tests/k8s/multi-node/Vagrantfile
@@ -74,6 +74,10 @@ Vagrant.configure(2) do |config|
 
 	config.vm.provision "k8s", type: "shell", inline: $k8s_install
 	config.vm.provider "virtualbox" do |vb|
+		# Do not inherit DNS server from host, use proxy
+		vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+		vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+
 		config.vm.synced_folder '../../../', '/home/vagrant/go/src/github.com/cilium/cilium'
 	end
 


### PR DESCRIPTION
Inheriting the DNS server from the host is very fragile on any host such
as a laptop that typically uses DHCP to derive the DNS server. Use of
DHCP leads to DNS server IPs which are only valid temporarily. Use a DNS
proxy instead which will ask the host.

Signed-off-by: Thomas Graf <thomas@cilium.io>