### PR TITLE
cmd, model: add verbose field to IdentityContext

### DIFF
--- a/api/v1/models/identity_context.go
+++ b/api/v1/models/identity_context.go
@@ -26,6 +26,10 @@ type IdentityContext struct {
 
 	// to
 	To Labels `json:"to"`
+
+	// Enable verbose tracing.
+	//
+	Verbose bool `json:"verbose,omitempty"`
 }
 
 // Validate validates this identity context

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -971,6 +971,10 @@ definitions:
         type: array
         items:
           "$ref": "#/definitions/Port"
+      verbose:
+        description: |
+          Enable verbose tracing.
+        type: boolean
   FrontendAddress:
     description: Layer 4 address
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1152,6 +1152,10 @@ func init() {
         },
         "to": {
           "$ref": "#/definitions/Labels"
+        },
+        "verbose": {
+          "description": "Enable verbose tracing.\n",
+          "type": "boolean"
         }
       }
     },

--- a/cilium/cmd/policy_trace.go
+++ b/cilium/cmd/policy_trace.go
@@ -26,6 +26,7 @@ import (
 )
 
 var src, dst, dports []string
+var verbose bool
 
 // policyTraceCmd represents the policy_trace command
 var policyTraceCmd = &cobra.Command{
@@ -53,9 +54,10 @@ dports can be can be for example: 80/tcp, 53 or 23/udp.`,
 		}
 
 		search := models.IdentityContext{
-			From:   srcSlice,
-			To:     dstSlice,
-			Dports: dports,
+			From:    srcSlice,
+			To:      dstSlice,
+			Dports:  dports,
+			Verbose: verbose,
 		}
 
 		params := NewGetPolicyResolveParams().WithIdentityContext(&search)
@@ -75,6 +77,7 @@ func init() {
 	policyTraceCmd.Flags().StringSliceVarP(&dst, "dst", "d", []string{}, "Destination label context")
 	policyTraceCmd.MarkFlagRequired("dst")
 	policyTraceCmd.Flags().StringSliceVarP(&dports, "dport", "", []string{}, "L4 destination port to search on outgoing traffic of the source label context and on incoming traffic of the destination label context")
+	policyTraceCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "set tracing to TRACE_VERBOSE")
 }
 
 func parseAllowedSlice(slice []string) ([]string, error) {

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -172,6 +172,9 @@ func (h *getPolicyResolve) Handle(params GetPolicyResolveParams) middleware.Resp
 		To:      labels.NewSelectLabelArrayFromModel(ctx.To),
 		DPorts:  ctx.Dports,
 	}
+	if ctx.Verbose {
+		searchCtx.Trace = policy.TRACE_VERBOSE
+	}
 
 	d.policy.Mutex.RLock()
 


### PR DESCRIPTION
Used `make generate-api` to update the API files.

Also add one check in policy import test for verbose and remove test
network on cleanup.

Closes: #693 (Add flag to cilium policy trace to enable TRACE_VERBOSE)