### PR TITLE
Fix k8s testsuite

### DIFF
--- a/tests/k8s/Vagrantfile
+++ b/tests/k8s/Vagrantfile
@@ -64,6 +64,8 @@ Vagrant.configure(2) do |config|
         # problems when using rsync on multiple VMs
         config.vm.synced_folder '../../', '/home/vagrant/go/src/github.com/cilium/cilium', type: "rsync",
         rsync__exclude: "contrib/packaging/docker/stage"
+
+        vb.memory = 2048
     end
     if ENV['RUN_TEST_SUITE'] then
         config.vm.provision "testsuite", run: "always", type: "shell", privileged: false, inline: $testsuite, env: {"DOCKER_IMAGE_TAG" => $docker_image_tag}

--- a/tests/k8s/k8s-gsg-test.sh
+++ b/tests/k8s/k8s-gsg-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 NAMESPACE="kube-system" 
 
@@ -24,11 +24,7 @@ echo "KUBECONFIG: $KUBECONFIG"
 
 cleanup
 
-echo -n "---- Waiting for cluster to get into a good state"
-until [ "$(kubectl get cs | grep -v "STATUS" | grep -c "Healthy")" -eq "3" ]; do 
-	echo -n "."
-done
-
+wait_for_healthy_k8s_cluster 3
 
 echo "----- adding RBAC for Cilium -----"
 kubectl create -f $K8SDIR/rbac.yaml
@@ -39,10 +35,7 @@ sed -i s/"\/var\/lib\/kubelet\/kubeconfig"/"\/etc\/kubernetes\/kubelet.conf"/g c
 sed -i s/"cilium\/cilium:stable"/"localhost:5000\/cilium:${DOCKER_IMAGE_TAG}"/g cilium-ds.yaml
 kubectl create -f cilium-ds.yaml
 
-echo -n "----- Waiting for Cilium to get into 'ready' state in Minikube cluster"
-until [ "$(kubectl get ds --namespace ${NAMESPACE} | grep -v 'READY' | awk '{ print $4}' | grep -c '1')" -eq "3" ]; do
-	echo -n "."
-done
+wait_for_daemon_set_ready ${NAMESPACE} cilium 1
 
 CILIUM_POD=$(kubectl -n ${NAMESPACE} get pods -l k8s-app=cilium | grep -v 'AGE' | awk '{ print $1 }')
 wait_for_kubectl_cilium_status ${NAMESPACE} ${CILIUM_POD}
@@ -50,44 +43,38 @@ wait_for_kubectl_cilium_status ${NAMESPACE} ${CILIUM_POD}
 echo "----- deploying demo application onto cluster -----"
 kubectl create -f $MINIKUBE/demo.yaml
 
-echo -n "----- Waiting for demo apps to get into 'Running' state"
-until [ "$(kubectl get pods | grep -v STATUS | grep -c "Running")" -eq "4" ]; do
-	echo -n "."
-done
+wait_for_n_running_pods 4
 
 echo "----- adding L3 L4 policy  -----"
 kubectl create -f $MINIKUBE/l3_l4_policy.yaml
 
-echo -n "----- Waiting for endpoints to get into 'ready' state"
-until [ "$(kubectl -n ${NAMESPACE} exec ${CILIUM_POD} cilium endpoint list | grep -c 'ready')" -eq "5" ]; do
-	echo -n "."
-done
+wait_for_k8s_endpoints kube-system ${CILIUM_POD} 5
 
 echo "----- testing L3/L4 policy -----"
 APP2_POD=$(kubectl get pods -l id=app2 -o jsonpath='{.items[0].metadata.name}')
 SVC_IP=$(kubectl get svc app1-service -o jsonpath='{.spec.clusterIP}' )
 
 echo "----- testing app2 can reach app1 (expected behavior: can reach) -----"
-RETURN=$(kubectl $ID exec $APP2_POD -- curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 -XGET $SVC_IP)
+RETURN=$(kubectl $ID exec $APP2_POD -- curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 -XGET $SVC_IP || true)
 if [[ "${RETURN//$'\n'}" != "200" ]]; then
 	abort "Error: could not reach pod allowed by L3 L4 policy"
 fi
 
 echo "----- testing that app3 cannot reach app 1 (expected behavior: cannot reach)"
 APP3_POD=$(kubectl get pods -l id=app3 -o jsonpath='{.items[0].metadata.name}')
-RETURN=$(kubectl exec $APP3_POD -- curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 -XGET $SVC_IP)
+RETURN=$(kubectl exec $APP3_POD -- curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 -XGET $SVC_IP || true)
 if [[ "${RETURN//$'\n'}" != "000" ]]; then
 	abort "Error: unexpectedly reached pod allowed by L3 L4 Policy, received return code ${RETURN}"
 fi
 
 echo "------ performing HTTP GET on ${SVC_IP}/public from service2 ------"
-RETURN=$(kubectl exec $APP2_POD -- curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 http://${SVC_IP}/public)
+RETURN=$(kubectl exec $APP2_POD -- curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 http://${SVC_IP}/public || true)
 if [[ "${RETURN//$'\n'}" != "200" ]]; then
 	abort "Error: Could not reach ${SVC_IP}/public on port 80"
 fi
 
 echo "------ performing HTTP GET on ${SVC_IP}/private from service2 ------"
-RETURN=$(kubectl exec $APP2_POD -- curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 http://${SVC_IP}/private)
+RETURN=$(kubectl exec $APP2_POD -- curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 http://${SVC_IP}/private || true)
 if [[ "${RETURN//$'\n'}" != "200" ]]; then
 	abort "Error: Could not reach ${SVC_IP}/public on port 80"
 fi
@@ -101,13 +88,13 @@ until [ "$(kubectl -n ${NAMESPACE} exec ${CILIUM_POD} cilium endpoint list | gre
 done
 
 echo "------ performing HTTP GET on ${SVC_IP}/public from service2 ------"
-RETURN=$(kubectl exec $APP2_POD -- curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 http://${SVC_IP}/public)
+RETURN=$(kubectl exec $APP2_POD -- curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 http://${SVC_IP}/public || true)
 if [[ "${RETURN//$'\n'}" != "200" ]]; then
 	abort "Error: Could not reach ${SVC_IP}/public on port 80"
 fi
 
 echo "------ performing HTTP GET on ${SVC_IP}/private from service2 ------"
-RETURN=$(kubectl exec $APP2_POD -- curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 http://${SVC_IP}/private)
+RETURN=$(kubectl exec $APP2_POD -- curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 10 http://${SVC_IP}/private || true)
 if [[ "${RETURN//$'\n'}" != "403" ]]; then
 	abort "Error: Unexpected success reaching  ${SVC_IP}/private on port 80"
 fi

--- a/tests/k8s/k8s-gsg-test.sh
+++ b/tests/k8s/k8s-gsg-test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 NAMESPACE="kube-system" 
 
 source "../helpers.bash"


### PR DESCRIPTION
- Fixes invalid paths in the k8s tests introduced by #1073 
- Makes the k8s test fail on errors in the script
- Adds timeouts of 5 minutes on expected state changes instead of timing out after 40 minutes total time
- Prints logs of daemons and prints progress for state changes for simplified debugging
- Increases VM memory size to 2G to avoid swapping