### PR TITLE
Flexible IPv4 cluster prefix

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -733,6 +733,8 @@ func NewDaemon(c *Config) (*Daemon, error) {
 		}
 	}
 
+	nodeaddress.SetIPv4ClusterCidrMaskSize(v4ClusterCidrMaskSize)
+
 	if v4Prefix != AutoCIDR {
 		_, net, err := net.ParseCIDR(v4Prefix)
 		if err != nil {

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -359,6 +359,7 @@ func initConfig() {
 
 	if config.IPv4Disabled {
 		endpoint.IPv4Enabled = false
+		nodeaddress.EnableIPv4 = false
 	}
 
 	config.BpfDir = filepath.Join(config.LibDir, defaults.BpfDir)

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -62,24 +62,25 @@ var (
 	config = NewConfig()
 
 	// Arguments variables keep in alphabetical order
-	bpfRoot            string
-	disableConntrack   bool
-	enableTracing      bool
-	enableLogstash     bool
-	k8sLabelsPrefixes  []string
-	kvStore            string
-	validLabels        []string
-	labelPrefixFile    string
-	logstashAddr       string
-	logstashProbeTimer uint32
-	loggers            []string
-	nat46prefix        string
-	socketPath         string
-	v4Prefix           string
-	v6Prefix           string
-	v4Address          string
-	v6Address          string
-	masquerade         bool
+	bpfRoot               string
+	disableConntrack      bool
+	enableTracing         bool
+	enableLogstash        bool
+	k8sLabelsPrefixes     []string
+	kvStore               string
+	validLabels           []string
+	labelPrefixFile       string
+	logstashAddr          string
+	logstashProbeTimer    uint32
+	loggers               []string
+	nat46prefix           string
+	socketPath            string
+	v4Prefix              string
+	v6Prefix              string
+	v4Address             string
+	v6Address             string
+	masquerade            bool
+	v4ClusterCidrMaskSize int
 )
 
 var logOpts = make(map[string]string)
@@ -232,6 +233,8 @@ func init() {
 		"bpf-root", "", "Path to BPF filesystem")
 	flags.StringVar(&cfgFile,
 		"config", "", `Configuration file (default "$HOME/ciliumd.yaml")`)
+	flags.IntVar(&v4ClusterCidrMaskSize,
+		"ipv4-cluster-cidr-mask-size", 8, "Mask size for the cluster wide CIDR")
 	flags.BoolP(
 		"debug", "D", false, "Enable debugging mode")
 	flags.StringVarP(&config.Device,

--- a/pkg/nodeaddress/node_address.go
+++ b/pkg/nodeaddress/node_address.go
@@ -28,6 +28,8 @@ import (
 )
 
 var (
+	ipv4ClusterCidrMaskSize = DefaultIPv4ClusterPrefixLen
+
 	ipv4Address       net.IP
 	ipv6Address       net.IP
 	ipv6RouterAddress net.IP
@@ -98,6 +100,11 @@ func findIPv6NodeAddr() net.IP {
 	return nil
 }
 
+// SetIPv4ClusterCidrMaskSize sets the size of the mask of the IPv4 cluster prefix
+func SetIPv4ClusterCidrMaskSize(size int) {
+	ipv4ClusterCidrMaskSize = size
+}
+
 // InitDefaultPrefix initializes the node address and allocation prefixes with
 // default values derived from the system. device can be set to the primary
 // network device of the system in which case the first address with global
@@ -138,7 +145,7 @@ func init() {
 
 // GetIPv4ClusterRange returns the IPv4 prefix of the cluster
 func GetIPv4ClusterRange() *net.IPNet {
-	mask := net.CIDRMask(DefaultIPv4ClusterPrefixLen, 32)
+	mask := net.CIDRMask(ipv4ClusterCidrMaskSize, 32)
 	return &net.IPNet{
 		IP:   ipv4AllocRange.IP.Mask(mask),
 		Mask: mask,

--- a/pkg/nodeaddress/node_address.go
+++ b/pkg/nodeaddress/node_address.go
@@ -28,6 +28,9 @@ import (
 )
 
 var (
+	// EnableIPv4 can be set to false to disable Ipv4
+	EnableIPv4 = true
+
 	ipv4ClusterCidrMaskSize = DefaultIPv4ClusterPrefixLen
 
 	ipv4Address       net.IP
@@ -224,6 +227,14 @@ func ValidatePostInit() error {
 
 	if ipv6Address == nil {
 		ipv6Address = makeIPv6HostIP(ipv6AllocRange.IP)
+	}
+
+	if EnableIPv4 {
+		ones, _ := ipv4AllocRange.Mask.Size()
+		if ipv4ClusterCidrMaskSize > ones {
+			return fmt.Errorf("IPv4 per node allocation prefix (%s) must be inside cluster prefix (%s)",
+				ipv4AllocRange, GetIPv4ClusterRange())
+		}
 	}
 
 	return nil

--- a/pkg/nodeaddress/node_address_test.go
+++ b/pkg/nodeaddress/node_address_test.go
@@ -1,0 +1,39 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeaddress
+
+import (
+	"net"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *NodeAddressSuite) TestMaskCheck(c *C) {
+	SetIPv4ClusterCidrMaskSize(24)
+
+	_, cidr, _ := net.ParseCIDR("1.1.1.1/16")
+	SetIPv4AllocRange(cidr)
+
+	// must fail, cluster /24 > per node alloc prefix /16
+	c.Assert(ValidatePostInit(), Not(IsNil))
+
+	// OK, cluster /16 == per node alloc prefix /16
+	SetIPv4ClusterCidrMaskSize(16)
+	c.Assert(ValidatePostInit(), IsNil)
+
+	// OK, cluster /8 < per node alloc prefix /16
+	SetIPv4ClusterCidrMaskSize(8)
+	c.Assert(ValidatePostInit(), IsNil)
+}


### PR DESCRIPTION
This allows to specify a random IPv4 cluster prefix size via a new option `--ipv4-cluster-cidr-mask-size`. It still defaults to `8`.