### PR TITLE
Refactor k8s.Client

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -707,7 +707,12 @@ func NewDaemon(c *Config) (*Daemon, error) {
 	d.listenForCiliumEvents()
 
 	if c.IsK8sEnabled() {
-		d.k8sClient, err = k8s.CreateClient(c.K8sEndpoint, c.K8sCfgPath)
+		restConfig, err := k8s.CreateConfig(c.K8sEndpoint, c.K8sCfgPath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create rest configuration: %s", err)
+		}
+
+		d.k8sClient, err = k8s.CreateClient(restConfig)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create k8s client: %s", err)
 		}

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -113,7 +113,12 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 		return fmt.Errorf("Unable to create third party resource: %s", err)
 	}
 
-	tprClient, err := k8s.CreateTPRClient(d.conf.K8sEndpoint, d.conf.K8sCfgPath)
+	restConfig, err := k8s.CreateConfig(d.conf.K8sEndpoint, d.conf.K8sCfgPath)
+	if err != nil {
+		return fmt.Errorf("Unable to create rest configuration: %s", err)
+	}
+
+	tprClient, err := k8s.CreateTPRClient(restConfig)
 	if err != nil {
 		return fmt.Errorf("Unable to create third party resource client: %s", err)
 	}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -34,7 +34,8 @@ const (
 	ThirdPartyResourceVersion = "v1"
 )
 
-func createConfig(endpoint, kubeCfgPath string) (*rest.Config, error) {
+// CreateConfig creates a rest.Config for a given endpoint using a kubeconfig file.
+func CreateConfig(endpoint, kubeCfgPath string) (*rest.Config, error) {
 	if kubeCfgPath != "" {
 		return clientcmd.BuildConfigFromFlags("", kubeCfgPath)
 	}
@@ -46,12 +47,7 @@ func createConfig(endpoint, kubeCfgPath string) (*rest.Config, error) {
 }
 
 // CreateClient creates a new client to access the Kubernetes API
-func CreateClient(endpoint, kubeCfgPath string) (*kubernetes.Clientset, error) {
-	config, err := createConfig(endpoint, kubeCfgPath)
-	if err != nil {
-		return nil, err
-	}
-
+func CreateClient(config *rest.Config) (*kubernetes.Clientset, error) {
 	return kubernetes.NewForConfig(config)
 }
 
@@ -71,12 +67,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 }
 
 // CreateTPRClient creates a new k8s client for third party resources
-func CreateTPRClient(endpoint, kubeCfgPath string) (*rest.RESTClient, error) {
-	config, err := createConfig(endpoint, kubeCfgPath)
-	if err != nil {
-		return nil, err
-	}
-
+func CreateTPRClient(config *rest.Config) (*rest.RESTClient, error) {
 	config.GroupVersion = &schema.GroupVersion{
 		Group:   ThirdPartyResourceGroup,
 		Version: ThirdPartyResourceVersion,


### PR DESCRIPTION
This patch exposes k8s.CreateConfig, and changes k8s.CreateClient()
and k8s.CreateTPRClient() to accept rest.Config as an input instead
of endpoint and kubeconfig file path. This allows the caller to pass
rest.Config that has been created some other way, for example using
rest.InClusterConfig().

Signed-off-by: Michi Mutsuzaki <michi@covalent.io>