### PR TITLE
pkg/bpf: add new sock ops prog type

### DIFF
--- a/pkg/bpf/prog.go
+++ b/pkg/bpf/prog.go
@@ -32,6 +32,7 @@ const (
 	ProgTypeLwtIn
 	ProgTypeLwtOut
 	ProgTypeLwtXmit
+	ProgTypeSockOps
 )
 
 func (t ProgType) String() string {
@@ -60,6 +61,8 @@ func (t ProgType) String() string {
 		return "LWT out"
 	case ProgTypeLwtXmit:
 		return "LWT xmit"
+	case ProgTypeSockOps:
+		return "Sock ops"
 	}
 
 	return "Unknown"


### PR DESCRIPTION
Add prog type ProgTypeSockOps to match BPF_PROG_TYPE_SOCK_OPS,
introduced in the net-next tree in commit 40304b2a1567 ("bpf: BPF
support for sock_ops").

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>