### PR TITLE
Jenkinsfile: add timestamps to builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,20 +4,21 @@ pipeline {
     }
     options {
         timeout(time: 40, unit: 'MINUTES')
+        timestamps()
     }
     stages {
         stage ('Tests') {
-                environment {
-                    MEMORY = '4096'
-                    RUN_TEST_SUITE = '1'
-		}
-		steps {
-                    parallel(
-                        "Runtime Tests": { sh './contrib/vagrant/start.sh' }, 
-                        "K8s Tests": { sh './tests/k8s/start' },
-                        "K8s multi node Tests": { sh './tests/k8s/multi-node/start.sh' }
-                    )
-	        }
+            environment {
+                MEMORY = '4096'
+                RUN_TEST_SUITE = '1'
+            }
+            steps {
+                parallel(
+                    "Runtime Tests": { sh './contrib/vagrant/start.sh' },
+                    "K8s Tests": { sh './tests/k8s/start' },
+                    "K8s multi node Tests": { sh './tests/k8s/multi-node/start.sh' }
+                )
+            }
         }
     }
     post {


### PR DESCRIPTION
To understand the issue https://github.com/cilium/cilium/issues/1099 better, it was added timestamps to the jenkins builds.

Before:
```
[K8s multi node Tests] ==> k8s1-build-1: Checking if box 'bento/ubuntu-16.10' is up to date...
[K8s multi node Tests] ==> k8s1-build-1: A newer version of the box 'bento/ubuntu-16.10' is available! You currently
[K8s multi node Tests] ==> k8s1-build-1: have version '2.3.5'. The latest is version '2.3.7'. Run
[K8s multi node Tests] ==> k8s1-build-1: `vagrant box update` to update.
```
After:
```
21:30:28 [K8s multi node Tests] ==> k8s1-build-1: Checking if box 'bento/ubuntu-16.10' is up to date...
21:30:29 [K8s multi node Tests] ==> k8s1-build-1: A newer version of the box 'bento/ubuntu-16.10' is available! You currently
21:30:29 [K8s multi node Tests] ==> k8s1-build-1: have version '2.3.5'. The latest is version '2.3.7'. Run
21:30:29 [K8s multi node Tests] ==> k8s1-build-1: `vagrant box update` to update.
```