### PR TITLE
endpointmanager: fixed remove locked for DockerEndpointID

### DIFF
--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -142,7 +142,7 @@ func RemoveLocked(ep *endpoint.Endpoint) {
 	}
 
 	if ep.DockerEndpointID != "" {
-		delete(endpointsAux, endpoint.NewID(endpoint.DockerEndpointPrefix, ep.DockerID))
+		delete(endpointsAux, endpoint.NewID(endpoint.DockerEndpointPrefix, ep.DockerEndpointID))
 	}
 
 	if ep.IPv4.String() != "" {


### PR DESCRIPTION
The endpointsAux stores the same EP value with different keys. When
removing the endpoint, all of those keys where removed from the map
except the ep.DockerEndpointID since it was wrongly set with
ep.DockerID

Signed-off-by: André Martins <andre@cilium.io>