### PR TITLE
Move labels to ep

### DIFF
--- a/api/v1/models/endpoint_change_request.go
+++ b/api/v1/models/endpoint_change_request.go
@@ -39,6 +39,9 @@ type EndpointChangeRequest struct {
 	// Name of network device
 	InterfaceName string `json:"interface-name,omitempty"`
 
+	// Labels describing the identity
+	Labels Labels `json:"labels"`
+
 	// MAC address
 	Mac string `json:"mac,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -635,6 +635,9 @@ definitions:
       docker-endpoint-id:
         description: Docker endpoint ID
         type: string
+      labels:
+        description: Labels describing the identity
+        "$ref": "#/definitions/Labels"
       docker-network-id:
         description: Docker network ID
         type: string
@@ -685,6 +688,9 @@ definitions:
       docker-endpoint-id:
         description: Docker endpoint ID
         type: string
+      labels:
+        description: Labels describing the identity
+        "$ref": "#/definitions/Labels"
       docker-network-id:
         description: Docker network ID
         type: string

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -993,6 +993,10 @@ func init() {
           "description": "Name of network device",
           "type": "string"
         },
+        "labels": {
+          "description": "Labels describing the identity",
+          "$ref": "#/definitions/Labels"
+        },
         "mac": {
           "description": "MAC address",
           "type": "string"

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -121,7 +121,8 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder 
 			"endpoint ID cannot be 0")
 	}
 
-	ep, err := endpoint.NewEndpointFromChangeModel(epTemplate)
+	addLabels := labels.ParseStringLabels(params.Endpoint.Labels)
+	ep, err := endpoint.NewEndpointFromChangeModel(epTemplate, addLabels)
 	if err != nil {
 		return apierror.Error(PutEndpointIDInvalidCode, err)
 	}
@@ -151,7 +152,20 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder 
 
 	endpointmanager.Insert(ep)
 
-	return NewPutEndpointIDCreated()
+	add := labels.NewLabelsFromModel(params.Endpoint.Labels)
+
+	if len(add) > 0 {
+		endpointmanager.Mutex.Unlock()
+		errLabelsAdd := h.d.UpdateSecLabels(params.ID, add, labels.Labels{})
+		endpointmanager.Mutex.Lock()
+		if errLabelsAdd != nil {
+			log.Errorf("Could not add labels %v while creating an ep %s due to %s", add, params.ID, errLabelsAdd)
+			return errLabelsAdd
+		}
+	}
+
+	ret := NewPutEndpointIDCreated()
+	return ret
 }
 
 type patchEndpointID struct {
@@ -168,7 +182,8 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 	epTemplate := params.Endpoint
 
 	// Validate the template. Assignment afterwards is atomic.
-	newEp, err2 := endpoint.NewEndpointFromChangeModel(epTemplate)
+	addLabels := labels.ParseStringLabels(params.Endpoint.Labels)
+	newEp, err2 := endpoint.NewEndpointFromChangeModel(epTemplate, addLabels)
 	if err2 != nil {
 		return apierror.Error(PutEndpointIDInvalidCode, err2)
 	}
@@ -254,6 +269,11 @@ func (d *Daemon) deleteEndpoint(ep *endpoint.Endpoint) int {
 	defer ep.Mutex.Unlock()
 	ep.LeaveLocked(d)
 
+	sha256sum := ep.OpLabels.Enabled().SHA256Sum()
+	if err := d.DeleteIdentityBySHA256(sha256sum, ep.StringID()); err != nil {
+		log.Errorf("Error while deleting labels (SHA256SUM:%s) %+v: %s",
+			sha256sum, ep.OpLabels.Enabled(), err)
+	}
 	errors := lxcmap.DeleteElement(ep)
 
 	if ep.Consumable != nil {
@@ -439,9 +459,9 @@ func (h *getEndpointIDLabels) Handle(params GetEndpointIDLabelsParams) middlewar
 
 	cont.Mutex.RLock()
 	cfg := models.LabelConfiguration{
-		Disabled:            cont.OpLabels.Disabled.GetModel(),
-		Custom:              cont.OpLabels.Custom.GetModel(),
-		OrchestrationSystem: cont.OpLabels.Orchestration.GetModel(),
+		Disabled:            ep.OpLabels.Disabled.GetModel(),
+		Custom:              ep.OpLabels.Custom.GetModel(),
+		OrchestrationSystem: ep.OpLabels.Orchestration.GetModel(),
 	}
 	cont.Mutex.RUnlock()
 
@@ -474,18 +494,17 @@ func (d *Daemon) UpdateSecLabels(id string, add, del labels.Labels) middleware.R
 
 	ep.Mutex.RLock()
 	epDockerID := ep.DockerID
+	oldLabels := ep.OpLabels.DeepCopy()
 	ep.Mutex.RUnlock()
 
 	d.containersMU.RLock()
 	cont := d.containers[epDockerID]
 	d.containersMU.RUnlock()
-	if cont == nil {
-		return NewPutEndpointIDLabelsNotFound()
-	}
 
-	cont.Mutex.RLock()
-	oldLabels := cont.OpLabels.DeepCopy()
-	cont.Mutex.RUnlock()
+	contID := ""
+	if cont != nil {
+		contID = cont.ID
+	}
 
 	if len(delLabels) > 0 {
 		for k := range delLabels {
@@ -527,15 +546,14 @@ func (d *Daemon) UpdateSecLabels(id string, add, del labels.Labels) middleware.R
 		}
 	}
 
-	identity, newHash, err2 := d.updateContainerIdentity(cont.ID, cont.LabelsHash, oldLabels)
+	identity, newHash, err2 := d.updateEndpointIdentity(ep.StringID(), ep.LabelsHash, oldLabels)
 	if err2 != nil {
 		return apierror.Error(PutEndpointIDLabelsUpdateFailedCode, err2)
 	}
-	cont.Mutex.Lock()
-	cont.LabelsHash = newHash
-	cont.OpLabels = *oldLabels
-	contID := cont.ID
-	cont.Mutex.Unlock()
+	ep.Mutex.Lock()
+	ep.LabelsHash = newHash
+	ep.OpLabels = *oldLabels
+	ep.Mutex.Unlock()
 
 	// FIXME: Undo identity update?
 
@@ -552,7 +570,7 @@ func (d *Daemon) UpdateSecLabels(id string, add, del labels.Labels) middleware.R
 	d.containersMU.RUnlock()
 
 	if !containerFound {
-		return NewPutEndpointIDLabelsNotFound()
+		log.Debugf("NewPutEndpointIDLabelsNotFound container %s for endpoint %s not found", id, ep.StringID())
 	}
 
 	d.SetEndpointIdentity(ep, contID, "", identity)

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -197,7 +197,7 @@ func (d *Daemon) syncLabels(ep *endpoint.Endpoint) error {
 	}
 
 	if labels == nil {
-		l, _, err := d.CreateOrUpdateIdentity(ep.SecLabel.Labels, ep.DockerID)
+		l, _, err := d.CreateOrUpdateIdentity(ep.SecLabel.Labels, ep.StringID())
 		if err != nil {
 			return fmt.Errorf("Unable to put labels %+v: %s\n", ep.SecLabel.Labels, err)
 		}

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -17,8 +17,6 @@ package container
 import (
 	"sync"
 
-	"github.com/cilium/cilium/pkg/labels"
-
 	dTypes "github.com/docker/engine-api/types"
 )
 
@@ -26,19 +24,12 @@ type Container struct {
 	// Mutex internal mutex for the whole container structure
 	Mutex sync.RWMutex
 	dTypes.ContainerJSON
-	LabelsHash string
-	OpLabels   labels.OpLabels
 }
 
 // NewContainer a Container with its labels initialized.
-func NewContainer(dc *dTypes.ContainerJSON, l labels.Labels) *Container {
+func NewContainer(dc *dTypes.ContainerJSON) *Container {
 	// FIXME should we calculate LabelsHash here?
 	return &Container{
 		ContainerJSON: *dc,
-		OpLabels: labels.OpLabels{
-			Custom:        labels.Labels{},
-			Disabled:      labels.Labels{},
-			Orchestration: l.DeepCopy(),
-		},
 	}
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
+	pkgLabels "github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/maps/cidrmap"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
@@ -173,12 +174,14 @@ const (
 // Endpoint contains all the details for a particular LXC and the host interface to where
 // is connected to.
 type Endpoint struct {
-	ID               uint16                // Endpoint ID.
-	Mutex            sync.RWMutex          // Protects all variables from this structure below this line
-	DockerID         string                // Docker ID.
-	DockerNetworkID  string                // Docker network ID.
-	DockerEndpointID string                // Docker endpoint ID.
-	IfName           string                // Container's interface name.
+	ID               uint16       // Endpoint ID.
+	Mutex            sync.RWMutex // Protects all variables from this structure below this line
+	DockerID         string       // Docker ID.
+	DockerNetworkID  string       // Docker network ID.
+	DockerEndpointID string       // Docker endpoint ID.
+	IfName           string       // Container's interface name.
+	LabelsHash       string
+	OpLabels         pkgLabels.OpLabels
 	LXCMAC           mac.MAC               // Container MAC address.
 	IPv6             addressing.CiliumIPv6 // Container IPv6 address.
 	IPv4             addressing.CiliumIPv4 // Container IPv4 address.
@@ -199,7 +202,8 @@ type Endpoint struct {
 	PolicyCalculated bool
 }
 
-func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, error) {
+// NewEndpointFromChangeModel creates a new endpoint from a request
+func NewEndpointFromChangeModel(base *models.EndpointChangeRequest, l pkgLabels.Labels) (*Endpoint, error) {
 	if base == nil {
 		return nil, nil
 	}
@@ -211,8 +215,13 @@ func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, 
 		DockerEndpointID: base.DockerEndpointID,
 		IfName:           base.InterfaceName,
 		IfIndex:          int(base.InterfaceIndex),
-		State:            string(base.State),
-		Status:           NewEndpointStatus(),
+		OpLabels: pkgLabels.OpLabels{
+			Custom:        pkgLabels.Labels{},
+			Disabled:      pkgLabels.Labels{},
+			Orchestration: l.DeepCopy(),
+		},
+		State:  string(base.State),
+		Status: NewEndpointStatus(),
 	}
 
 	if base.Mac != "" {
@@ -538,17 +547,9 @@ func (e *Endpoint) DeepCopy() *Endpoint {
 	return cpy
 }
 
-// StringIDLocked returns the endpoint's ID in a string. Must be called with
-// the endpoint's mutex locked.
-func (e *Endpoint) StringIDLocked() string {
+// StringID returns the endpoint's ID in a string.
+func (e *Endpoint) StringID() string {
 	return strconv.Itoa(int(e.ID))
-}
-
-// SetID sets the endpoint's host local unique ID.
-func (e *Endpoint) SetID() {
-	e.Mutex.Lock()
-	e.ID = e.IPv6.EndpointID()
-	e.Mutex.Unlock()
 }
 
 func (e *Endpoint) GetIdentity() policy.NumericIdentity {
@@ -901,6 +902,35 @@ func (e *Endpoint) Update(owner Owner, opts models.ConfigurationMap) error {
 	return nil
 }
 
+// UpdateOrchLabels updates orchestration labels for the endpoint
+func (e *Endpoint) UpdateOrchLabels(l pkgLabels.Labels) bool {
+	changed := false
+
+	e.OpLabels.Orchestration.MarkAllForDeletion()
+	e.OpLabels.Disabled.MarkAllForDeletion()
+
+	for k, v := range l {
+		if e.OpLabels.Disabled[k] != nil {
+			e.OpLabels.Disabled[k].DeletionMark = false
+		} else {
+			if e.OpLabels.Orchestration[k] != nil {
+				e.OpLabels.Orchestration[k].DeletionMark = false
+			} else {
+				tmp := v.DeepCopy()
+				log.Debugf("Assigning orchestration label %+v", tmp)
+				e.OpLabels.Orchestration[k] = tmp
+				changed = true
+			}
+		}
+	}
+
+	if e.OpLabels.Orchestration.DeleteMarked() || e.OpLabels.Disabled.DeleteMarked() {
+		changed = true
+	}
+
+	return changed
+}
+
 // LeaveLocked removes the endpoint's directory from the system. Must be called
 // with Endpoint's mutex locked.
 func (e *Endpoint) LeaveLocked(owner Owner) {
@@ -933,8 +963,8 @@ func (e *Endpoint) removeDirectory() {
 
 func (e *Endpoint) RemoveDirectory() {
 	e.Mutex.Lock()
+	defer e.Mutex.Unlock()
 	e.removeDirectory()
-	e.Mutex.Unlock()
 }
 
 func (e *Endpoint) CreateDirectory() error {

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -44,8 +44,7 @@ type EndpointSuite struct{}
 var _ = Suite(&EndpointSuite{})
 
 func (s *EndpointSuite) TestEndpointID(c *C) {
-	e := Endpoint{IPv6: IPv6Addr, IPv4: IPv4Addr}
-	e.SetID()
+	e := Endpoint{ID: IPv6Addr.EndpointID(), IPv6: IPv6Addr, IPv4: IPv4Addr}
 	c.Assert(e.ID, Equals, uint16(4370)) //"0x1112"
 	c.Assert(bytes.Compare(e.IPv6, IPv6Addr) == 0, Equals, true)
 	c.Assert(bytes.Compare(e.IPv4, IPv4Addr) == 0, Equals, true)

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -296,7 +296,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner) (bool, error) {
 }
 
 func (e *Endpoint) regenerate(owner Owner) error {
-	origDir := filepath.Join(".", e.StringIDLocked())
+	origDir := filepath.Join(".", e.StringID())
 
 	// This is the temporary directory to store the generated headers,
 	// the original existing directory is not overwritten until the
@@ -427,7 +427,7 @@ func (e *Endpoint) TriggerPolicyUpdates(owner Owner) (bool, error) {
 
 	changed, err := e.regeneratePolicy(owner)
 	if err != nil {
-		return changed, fmt.Errorf("%s: %s", e.StringIDLocked(), err)
+		return changed, fmt.Errorf("%s: %s", e.StringID(), err)
 	}
 
 	return changed, err


### PR DESCRIPTION
Decouple labels from containers and store them in endpoints.

- change api to allow passing labels during endpoint creation
- regenerate swagger API
- remove labels from containers
- store labels in endpoints

https://github.com/cilium/cilium/issues/1041