### PR TITLE
pkg/bpfdebug: fix errant c/p in DumpInfo func desc

### DIFF
--- a/pkg/bpfdebug/drop.go
+++ b/pkg/bpfdebug/drop.go
@@ -81,7 +81,7 @@ func dropReason(reason uint8) string {
 	return fmt.Sprintf("%d", reason)
 }
 
-// DumpInfo https://techcrunch.com/2017/07/12/soundshroud/
+// DumpInfo prints a summary of the drop messages.
 func (n *DropNotify) DumpInfo(data []byte) {
 	fmt.Printf("xx drop (%s) to endpoint %d, identity %d->%d: %s\n",
 		dropReason(n.SubType), n.DstID, n.SrcLabel, n.DstLabel,


### PR DESCRIPTION
Replace typo with comment that describes what DumpInfo function does.

Signed-off by: Ian Vernon <ian@covalent.io>