### PR TITLE
fix overflow of arguments array

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -449,7 +449,7 @@ func (d *Daemon) compileBase() error {
 		return err
 	}
 
-	args = make([]string, initArgMax-1)
+	args = make([]string, initArgMax)
 
 	args[initArgLib] = d.conf.BpfDir
 	args[initArgRundir] = d.conf.StateDir


### PR DESCRIPTION
length of the array should be initArgMax since const starts from 0. Set it to
initArgMax -1 makes setting initArgDevice overflow (test with --device some-device)