### PR TITLE
cilium: remove stale id also from policy map

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -994,6 +994,7 @@ func (d *Daemon) staleMapWalker(path string) error {
 		policymap.MapName,
 		ctmap.MapName6,
 		ctmap.MapName4,
+		endpoint.CallsMapName,
 	}
 
 	d.checkStaleGlobalMap(path, filename)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -948,10 +948,19 @@ func (d *Daemon) removeStaleMap(path string) {
 	}
 }
 
+func (d *Daemon) removeStaleIDFromPolicyMap(id uint32) {
+	gpm, err := policymap.OpenGlobalMap(bpf.MapPath(endpoint.PolicyGlobalMapName))
+	if err == nil {
+		gpm.DeleteConsumer(id)
+		gpm.Close()
+	}
+}
+
 // call with endpointmanager.Mutex.RLocked
 func (d *Daemon) checkStaleMap(path string, filename string, id string) {
 	if tmp, err := strconv.ParseUint(id, 0, 16); err == nil {
 		if _, ok := endpointmanager.Endpoints[uint16(tmp)]; !ok {
+			d.removeStaleIDFromPolicyMap(uint32(tmp))
 			d.removeStaleMap(path)
 		}
 	}


### PR DESCRIPTION
Commit 37776f088422 ("cilium: on ep destruction also remove
id from cilium_policy tail call map") initiated removal of
eps from global policy map, but we should also do so when
we check and remove stale maps in case on non-graceful exit.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>