### PR TITLE
cmd: get ep with labels, pod / container name, ID

### DIFF
--- a/api/v1/client/endpoint/delete_endpoint_id_parameters.go
+++ b/api/v1/client/endpoint/delete_endpoint_id_parameters.go
@@ -70,6 +70,8 @@ type DeleteEndpointIDParams struct {
 	  - cilium-local: Local Cilium endpoint UUID, e.g. cilium-local:3389595
 	  - cilium-global: Global Cilium endpoint UUID, e.g. cilium-global:cluster1:nodeX:452343
 	  - container-id: Container runtime ID, e.g. container-id:22222
+	  - container-name: Container name, e.g. container-name:foobar
+	  - pod-name: pod name for this container if K8s is enabled, e.g. pod-name:default:foobar
 	  - docker-net-endpoint: Docker libnetwork endpoint ID, e.g. docker-net-endpoint:4444
 
 

--- a/api/v1/client/endpoint/endpoint_client.go
+++ b/api/v1/client/endpoint/endpoint_client.go
@@ -68,9 +68,9 @@ func (a *Client) DeleteEndpointID(params *DeleteEndpointIDParams) (*DeleteEndpoi
 }
 
 /*
-GetEndpoint gets list of all endpoints
+GetEndpoint retrieves a list of endpoints that have metadata matching the provided parameters
 
-Returns an array of all local endpoints.
+Retrieves a list of endpoints that have metadata matching the provided parameters, or all endpoints if no parameters provided.
 
 */
 func (a *Client) GetEndpoint(params *GetEndpointParams) (*GetEndpointOK, error) {

--- a/api/v1/client/endpoint/get_endpoint_id_config_parameters.go
+++ b/api/v1/client/endpoint/get_endpoint_id_config_parameters.go
@@ -70,6 +70,8 @@ type GetEndpointIDConfigParams struct {
 	  - cilium-local: Local Cilium endpoint UUID, e.g. cilium-local:3389595
 	  - cilium-global: Global Cilium endpoint UUID, e.g. cilium-global:cluster1:nodeX:452343
 	  - container-id: Container runtime ID, e.g. container-id:22222
+	  - container-name: Container name, e.g. container-name:foobar
+	  - pod-name: pod name for this container if K8s is enabled, e.g. pod-name:default:foobar
 	  - docker-net-endpoint: Docker libnetwork endpoint ID, e.g. docker-net-endpoint:4444
 
 

--- a/api/v1/client/endpoint/get_endpoint_id_labels_parameters.go
+++ b/api/v1/client/endpoint/get_endpoint_id_labels_parameters.go
@@ -70,6 +70,8 @@ type GetEndpointIDLabelsParams struct {
 	  - cilium-local: Local Cilium endpoint UUID, e.g. cilium-local:3389595
 	  - cilium-global: Global Cilium endpoint UUID, e.g. cilium-global:cluster1:nodeX:452343
 	  - container-id: Container runtime ID, e.g. container-id:22222
+	  - container-name: Container name, e.g. container-name:foobar
+	  - pod-name: pod name for this container if K8s is enabled, e.g. pod-name:default:foobar
 	  - docker-net-endpoint: Docker libnetwork endpoint ID, e.g. docker-net-endpoint:4444
 
 

--- a/api/v1/client/endpoint/get_endpoint_id_parameters.go
+++ b/api/v1/client/endpoint/get_endpoint_id_parameters.go
@@ -70,6 +70,8 @@ type GetEndpointIDParams struct {
 	  - cilium-local: Local Cilium endpoint UUID, e.g. cilium-local:3389595
 	  - cilium-global: Global Cilium endpoint UUID, e.g. cilium-global:cluster1:nodeX:452343
 	  - container-id: Container runtime ID, e.g. container-id:22222
+	  - container-name: Container name, e.g. container-name:foobar
+	  - pod-name: pod name for this container if K8s is enabled, e.g. pod-name:default:foobar
 	  - docker-net-endpoint: Docker libnetwork endpoint ID, e.g. docker-net-endpoint:4444
 
 

--- a/api/v1/client/endpoint/get_endpoint_parameters.go
+++ b/api/v1/client/endpoint/get_endpoint_parameters.go
@@ -14,12 +14,14 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
+
+	"github.com/cilium/cilium/api/v1/models"
 )
 
 // NewGetEndpointParams creates a new GetEndpointParams object
 // with the default values initialized.
 func NewGetEndpointParams() *GetEndpointParams {
-
+	var ()
 	return &GetEndpointParams{
 
 		timeout: cr.DefaultTimeout,
@@ -29,7 +31,7 @@ func NewGetEndpointParams() *GetEndpointParams {
 // NewGetEndpointParamsWithTimeout creates a new GetEndpointParams object
 // with the default values initialized, and the ability to set a timeout on a request
 func NewGetEndpointParamsWithTimeout(timeout time.Duration) *GetEndpointParams {
-
+	var ()
 	return &GetEndpointParams{
 
 		timeout: timeout,
@@ -39,7 +41,7 @@ func NewGetEndpointParamsWithTimeout(timeout time.Duration) *GetEndpointParams {
 // NewGetEndpointParamsWithContext creates a new GetEndpointParams object
 // with the default values initialized, and the ability to set a context for a request
 func NewGetEndpointParamsWithContext(ctx context.Context) *GetEndpointParams {
-
+	var ()
 	return &GetEndpointParams{
 
 		Context: ctx,
@@ -49,7 +51,7 @@ func NewGetEndpointParamsWithContext(ctx context.Context) *GetEndpointParams {
 // NewGetEndpointParamsWithHTTPClient creates a new GetEndpointParams object
 // with the default values initialized, and the ability to set a custom HTTPClient for a request
 func NewGetEndpointParamsWithHTTPClient(client *http.Client) *GetEndpointParams {
-
+	var ()
 	return &GetEndpointParams{
 		HTTPClient: client,
 	}
@@ -59,6 +61,14 @@ func NewGetEndpointParamsWithHTTPClient(client *http.Client) *GetEndpointParams 
 for the get endpoint operation typically these are written to a http.Request
 */
 type GetEndpointParams struct {
+
+	/*Labels
+	  List of labels
+
+
+	*/
+	Labels models.Labels
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -97,6 +107,17 @@ func (o *GetEndpointParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithLabels adds the labels to the get endpoint params
+func (o *GetEndpointParams) WithLabels(labels models.Labels) *GetEndpointParams {
+	o.SetLabels(labels)
+	return o
+}
+
+// SetLabels adds the labels to the get endpoint params
+func (o *GetEndpointParams) SetLabels(labels models.Labels) {
+	o.Labels = labels
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *GetEndpointParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -104,6 +125,10 @@ func (o *GetEndpointParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 		return err
 	}
 	var res []error
+
+	if err := r.SetBodyParam(o.Labels); err != nil {
+		return err
+	}
 
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/api/v1/client/endpoint/get_endpoint_responses.go
+++ b/api/v1/client/endpoint/get_endpoint_responses.go
@@ -30,6 +30,13 @@ func (o *GetEndpointReader) ReadResponse(response runtime.ClientResponse, consum
 		}
 		return result, nil
 
+	case 404:
+		result := NewGetEndpointNotFound()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
+
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -58,6 +65,27 @@ func (o *GetEndpointOK) readResponse(response runtime.ClientResponse, consumer r
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
 	}
+
+	return nil
+}
+
+// NewGetEndpointNotFound creates a GetEndpointNotFound with default headers values
+func NewGetEndpointNotFound() *GetEndpointNotFound {
+	return &GetEndpointNotFound{}
+}
+
+/*GetEndpointNotFound handles this case with default header values.
+
+Endpoints with provided parameters not found
+*/
+type GetEndpointNotFound struct {
+}
+
+func (o *GetEndpointNotFound) Error() string {
+	return fmt.Sprintf("[GET /endpoint][%d] getEndpointNotFound ", 404)
+}
+
+func (o *GetEndpointNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/api/v1/client/endpoint/patch_endpoint_id_config_parameters.go
+++ b/api/v1/client/endpoint/patch_endpoint_id_config_parameters.go
@@ -74,6 +74,8 @@ type PatchEndpointIDConfigParams struct {
 	  - cilium-local: Local Cilium endpoint UUID, e.g. cilium-local:3389595
 	  - cilium-global: Global Cilium endpoint UUID, e.g. cilium-global:cluster1:nodeX:452343
 	  - container-id: Container runtime ID, e.g. container-id:22222
+	  - container-name: Container name, e.g. container-name:foobar
+	  - pod-name: pod name for this container if K8s is enabled, e.g. pod-name:default:foobar
 	  - docker-net-endpoint: Docker libnetwork endpoint ID, e.g. docker-net-endpoint:4444
 
 

--- a/api/v1/client/endpoint/patch_endpoint_id_parameters.go
+++ b/api/v1/client/endpoint/patch_endpoint_id_parameters.go
@@ -74,6 +74,8 @@ type PatchEndpointIDParams struct {
 	  - cilium-local: Local Cilium endpoint UUID, e.g. cilium-local:3389595
 	  - cilium-global: Global Cilium endpoint UUID, e.g. cilium-global:cluster1:nodeX:452343
 	  - container-id: Container runtime ID, e.g. container-id:22222
+	  - container-name: Container name, e.g. container-name:foobar
+	  - pod-name: pod name for this container if K8s is enabled, e.g. pod-name:default:foobar
 	  - docker-net-endpoint: Docker libnetwork endpoint ID, e.g. docker-net-endpoint:4444
 
 

--- a/api/v1/client/endpoint/put_endpoint_id_labels_parameters.go
+++ b/api/v1/client/endpoint/put_endpoint_id_labels_parameters.go
@@ -74,6 +74,8 @@ type PutEndpointIDLabelsParams struct {
 	  - cilium-local: Local Cilium endpoint UUID, e.g. cilium-local:3389595
 	  - cilium-global: Global Cilium endpoint UUID, e.g. cilium-global:cluster1:nodeX:452343
 	  - container-id: Container runtime ID, e.g. container-id:22222
+	  - container-name: Container name, e.g. container-name:foobar
+	  - pod-name: pod name for this container if K8s is enabled, e.g. pod-name:default:foobar
 	  - docker-net-endpoint: Docker libnetwork endpoint ID, e.g. docker-net-endpoint:4444
 
 

--- a/api/v1/client/endpoint/put_endpoint_id_parameters.go
+++ b/api/v1/client/endpoint/put_endpoint_id_parameters.go
@@ -74,6 +74,8 @@ type PutEndpointIDParams struct {
 	  - cilium-local: Local Cilium endpoint UUID, e.g. cilium-local:3389595
 	  - cilium-global: Global Cilium endpoint UUID, e.g. cilium-global:cluster1:nodeX:452343
 	  - container-id: Container runtime ID, e.g. container-id:22222
+	  - container-name: Container name, e.g. container-name:foobar
+	  - pod-name: pod name for this container if K8s is enabled, e.g. pod-name:default:foobar
 	  - docker-net-endpoint: Docker libnetwork endpoint ID, e.g. docker-net-endpoint:4444
 
 

--- a/api/v1/models/endpoint.go
+++ b/api/v1/models/endpoint.go
@@ -22,6 +22,9 @@ type Endpoint struct {
 	// ID assigned by container runtime
 	ContainerID string `json:"container-id,omitempty"`
 
+	// Name assigned to container
+	ContainerName string `json:"container-name,omitempty"`
+
 	// Docker endpoint ID
 	DockerEndpointID string `json:"docker-endpoint-id,omitempty"`
 
@@ -43,8 +46,14 @@ type Endpoint struct {
 	// Name of network device
 	InterfaceName string `json:"interface-name,omitempty"`
 
+	// Labels describing the identity
+	Labels Labels `json:"labels"`
+
 	// MAC address
 	Mac string `json:"mac,omitempty"`
+
+	// K8s pod for this endpoint
+	PodName string `json:"pod-name,omitempty"`
 
 	// Policy information of endpoint
 	Policy *EndpointPolicy `json:"policy,omitempty"`

--- a/api/v1/models/endpoint_change_request.go
+++ b/api/v1/models/endpoint_change_request.go
@@ -21,6 +21,9 @@ type EndpointChangeRequest struct {
 	// ID assigned by container runtime
 	ContainerID string `json:"container-id,omitempty"`
 
+	// Name assigned to container
+	ContainerName string `json:"container-name,omitempty"`
+
 	// Docker endpoint ID
 	DockerEndpointID string `json:"docker-endpoint-id,omitempty"`
 

--- a/api/v1/models/label_configuration.go
+++ b/api/v1/models/label_configuration.go
@@ -19,8 +19,11 @@ type LabelConfiguration struct {
 	// Labels derived from orchestration system which have been disabled.
 	Disabled Labels `json:"disabled"`
 
-	// Labels derived from orchestration system
-	OrchestrationSystem Labels `json:"orchestration-system"`
+	// Labels derived from orchestration system that are used in computing a security identity
+	OrchestrationIdentity Labels `json:"orchestration-identity"`
+
+	// Labels derived from orchestration system that are not used in computing a security identity
+	OrchestrationInfo Labels `json:"orchestration-info"`
 }
 
 // Validate validates this label configuration

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -169,11 +169,13 @@ paths:
           description: Endpoint not found
   "/endpoint":
     get:
-      summary: Get list of all endpoints
+      summary: Retrieves a list of endpoints that have metadata matching the provided parameters.
       description: |
-        Returns an array of all local endpoints.
+        Retrieves a list of endpoints that have metadata matching the provided parameters, or all endpoints if no parameters provided.
       tags:
       - endpoint
+      parameters:
+      - "$ref": "#/parameters/labels"
       responses:
         '200':
           description: Success
@@ -181,6 +183,8 @@ paths:
             type: array
             items:
               "$ref": "#/definitions/Endpoint"
+        '404':
+          description: Endpoints with provided parameters not found
   "/endpoint/{id}/config":
     get:
       summary: Retrieve endpoint configuration
@@ -443,7 +447,7 @@ paths:
       parameters:
       - name: labels
         in: body
-        required: true
+        required: false
         schema:
           "$ref": "#/definitions/Labels"
       responses:
@@ -557,6 +561,8 @@ parameters:
         - cilium-local: Local Cilium endpoint UUID, e.g. cilium-local:3389595
         - cilium-global: Global Cilium endpoint UUID, e.g. cilium-global:cluster1:nodeX:452343
         - container-id: Container runtime ID, e.g. container-id:22222
+        - container-name: Container name, e.g. container-name:foobar
+        - pod-name: pod name for this container if K8s is enabled, e.g. pod-name:default:foobar
         - docker-net-endpoint: Docker libnetwork endpoint ID, e.g. docker-net-endpoint:4444
     in: path
     required: true
@@ -574,6 +580,14 @@ parameters:
     in: path
     required: true
     type: string
+  labels:
+    name: labels
+    description: |
+      List of labels
+    in: body
+    required: true
+    schema:
+      "$ref": "#/definitions/Labels"
   policy-rules:
     name: policy
     description: Policy rules
@@ -581,6 +595,13 @@ parameters:
     in: body
     schema:
       type: string
+  pod-name:
+    name: pod
+    description: |
+      K8s pod name
+    required: true
+    in: path
+    type: string
   identity-context:
     name: identity-context
     description: Context to provide policy evaluation on
@@ -632,6 +653,9 @@ definitions:
       container-id:
         description: ID assigned by container runtime
         type: string
+      container-name:
+        description: Name assigned to container
+        type: string
       docker-endpoint-id:
         description: Docker endpoint ID
         type: string
@@ -666,6 +690,9 @@ definitions:
       identity:
         description: Security identity
         "$ref": "#/definitions/Identity"
+      pod-name:
+        description: K8s pod for this endpoint
+        type: string
       policy:
         description: Policy information of endpoint
         "$ref": "#/definitions/EndpointPolicy"
@@ -684,6 +711,9 @@ definitions:
         type: integer
       container-id:
         description: ID assigned by container runtime
+        type: string
+      container-name:
+        description: Name assigned to container
         type: string
       docker-endpoint-id:
         description: Docker endpoint ID
@@ -815,8 +845,11 @@ definitions:
     description: Label configuration of an endpoint
     type: object
     properties:
-      orchestration-system:
-        description: "Labels derived from orchestration system"
+      orchestration-identity:
+        description: "Labels derived from orchestration system that are used in computing a security identity"
+        "$ref": "#/definitions/Labels"
+      orchestration-info:
+        description: "Labels derived from orchestration system that are not used in computing a security identity"
         "$ref": "#/definitions/Labels"
       custom:
         description: "Custom labels in addition to orchestration system labels."

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -80,11 +80,16 @@ func init() {
     },
     "/endpoint": {
       "get": {
-        "description": "Returns an array of all local endpoints.\n",
+        "description": "Retrieves a list of endpoints that have metadata matching the provided parameters, or all endpoints if no parameters provided.\n",
         "tags": [
           "endpoint"
         ],
-        "summary": "Get list of all endpoints",
+        "summary": "Retrieves a list of endpoints that have metadata matching the provided parameters.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/labels"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Success",
@@ -94,6 +99,9 @@ func init() {
                 "$ref": "#/definitions/Endpoint"
               }
             }
+          },
+          "404": {
+            "description": "Endpoints with provided parameters not found"
           }
         }
       }
@@ -646,7 +654,6 @@ func init() {
           {
             "name": "labels",
             "in": "body",
-            "required": true,
             "schema": {
               "$ref": "#/definitions/Labels"
             }
@@ -888,6 +895,10 @@ func init() {
           "description": "ID assigned by container runtime",
           "type": "string"
         },
+        "container-name": {
+          "description": "Name assigned to container",
+          "type": "string"
+        },
         "docker-endpoint-id": {
           "description": "Docker endpoint ID",
           "type": "string"
@@ -916,8 +927,16 @@ func init() {
           "description": "Name of network device",
           "type": "string"
         },
+        "labels": {
+          "description": "Labels describing the identity",
+          "$ref": "#/definitions/Labels"
+        },
         "mac": {
           "description": "MAC address",
+          "type": "string"
+        },
+        "pod-name": {
+          "description": "K8s pod for this endpoint",
           "type": "string"
         },
         "policy": {
@@ -967,6 +986,10 @@ func init() {
         },
         "container-id": {
           "description": "ID assigned by container runtime",
+          "type": "string"
+        },
+        "container-name": {
+          "description": "Name assigned to container",
           "type": "string"
         },
         "docker-endpoint-id": {
@@ -1198,8 +1221,12 @@ func init() {
           "description": "Labels derived from orchestration system which have been disabled.",
           "$ref": "#/definitions/Labels"
         },
-        "orchestration-system": {
-          "description": "Labels derived from orchestration system",
+        "orchestration-identity": {
+          "description": "Labels derived from orchestration system that are used in computing a security identity",
+          "$ref": "#/definitions/Labels"
+        },
+        "orchestration-info": {
+          "description": "Labels derived from orchestration system that are not used in computing a security identity",
           "$ref": "#/definitions/Labels"
         }
       }
@@ -1397,7 +1424,7 @@ func init() {
     },
     "endpoint-id": {
       "type": "string",
-      "description": "String describing an endpoint with the format ` + "`" + `[prefix:]id` + "`" + `. If no prefix\nis specified, a prefix of ` + "`" + `cilium-local:` + "`" + ` is assumed. Not all endpoints\nwill be addressable by all endpoint ID prefixes with the exception of the\nlocal Cilium UUID which is assigned to all endpoints.\n\nSupported endpoint id prefixes:\n  - cilium-local: Local Cilium endpoint UUID, e.g. cilium-local:3389595\n  - cilium-global: Global Cilium endpoint UUID, e.g. cilium-global:cluster1:nodeX:452343\n  - container-id: Container runtime ID, e.g. container-id:22222\n  - docker-net-endpoint: Docker libnetwork endpoint ID, e.g. docker-net-endpoint:4444\n",
+      "description": "String describing an endpoint with the format ` + "`" + `[prefix:]id` + "`" + `. If no prefix\nis specified, a prefix of ` + "`" + `cilium-local:` + "`" + ` is assumed. Not all endpoints\nwill be addressable by all endpoint ID prefixes with the exception of the\nlocal Cilium UUID which is assigned to all endpoints.\n\nSupported endpoint id prefixes:\n  - cilium-local: Local Cilium endpoint UUID, e.g. cilium-local:3389595\n  - cilium-global: Global Cilium endpoint UUID, e.g. cilium-global:cluster1:nodeX:452343\n  - container-id: Container runtime ID, e.g. container-id:22222\n  - container-name: Container name, e.g. container-name:foobar\n  - pod-name: pod name for this container if K8s is enabled, e.g. pod-name:default:foobar\n  - docker-net-endpoint: Docker libnetwork endpoint ID, e.g. docker-net-endpoint:4444\n",
       "name": "id",
       "in": "path",
       "required": true
@@ -1430,6 +1457,22 @@ func init() {
       "type": "string",
       "description": "IP address",
       "name": "ip",
+      "in": "path",
+      "required": true
+    },
+    "labels": {
+      "description": "List of labels\n",
+      "name": "labels",
+      "in": "body",
+      "required": true,
+      "schema": {
+        "$ref": "#/definitions/Labels"
+      }
+    },
+    "pod-name": {
+      "type": "string",
+      "description": "K8s pod name\n",
+      "name": "pod",
       "in": "path",
       "required": true
     },

--- a/api/v1/server/restapi/cilium_api.go
+++ b/api/v1/server/restapi/cilium_api.go
@@ -401,9 +401,6 @@ func (o *CiliumAPI) HandlerFor(method, path string) (http.Handler, bool) {
 	if _, ok := o.handlers[um]; !ok {
 		return nil, false
 	}
-	if path == "/" {
-		path = ""
-	}
 	h, ok := o.handlers[um][path]
 	return h, ok
 }

--- a/api/v1/server/restapi/endpoint/delete_endpoint_id_parameters.go
+++ b/api/v1/server/restapi/endpoint/delete_endpoint_id_parameters.go
@@ -37,6 +37,8 @@ type DeleteEndpointIDParams struct {
 	  - cilium-local: Local Cilium endpoint UUID, e.g. cilium-local:3389595
 	  - cilium-global: Global Cilium endpoint UUID, e.g. cilium-global:cluster1:nodeX:452343
 	  - container-id: Container runtime ID, e.g. container-id:22222
+	  - container-name: Container name, e.g. container-name:foobar
+	  - pod-name: pod name for this container if K8s is enabled, e.g. pod-name:default:foobar
 	  - docker-net-endpoint: Docker libnetwork endpoint ID, e.g. docker-net-endpoint:4444
 
 	  Required: true

--- a/api/v1/server/restapi/endpoint/get_endpoint.go
+++ b/api/v1/server/restapi/endpoint/get_endpoint.go
@@ -29,9 +29,9 @@ func NewGetEndpoint(ctx *middleware.Context, handler GetEndpointHandler) *GetEnd
 
 /*GetEndpoint swagger:route GET /endpoint endpoint getEndpoint
 
-Get list of all endpoints
+Retrieves a list of endpoints that have metadata matching the provided parameters.
 
-Returns an array of all local endpoints.
+Retrieves a list of endpoints that have metadata matching the provided parameters, or all endpoints if no parameters provided.
 
 
 */

--- a/api/v1/server/restapi/endpoint/get_endpoint_id_config_parameters.go
+++ b/api/v1/server/restapi/endpoint/get_endpoint_id_config_parameters.go
@@ -37,6 +37,8 @@ type GetEndpointIDConfigParams struct {
 	  - cilium-local: Local Cilium endpoint UUID, e.g. cilium-local:3389595
 	  - cilium-global: Global Cilium endpoint UUID, e.g. cilium-global:cluster1:nodeX:452343
 	  - container-id: Container runtime ID, e.g. container-id:22222
+	  - container-name: Container name, e.g. container-name:foobar
+	  - pod-name: pod name for this container if K8s is enabled, e.g. pod-name:default:foobar
 	  - docker-net-endpoint: Docker libnetwork endpoint ID, e.g. docker-net-endpoint:4444
 
 	  Required: true

--- a/api/v1/server/restapi/endpoint/get_endpoint_id_labels_parameters.go
+++ b/api/v1/server/restapi/endpoint/get_endpoint_id_labels_parameters.go
@@ -37,6 +37,8 @@ type GetEndpointIDLabelsParams struct {
 	  - cilium-local: Local Cilium endpoint UUID, e.g. cilium-local:3389595
 	  - cilium-global: Global Cilium endpoint UUID, e.g. cilium-global:cluster1:nodeX:452343
 	  - container-id: Container runtime ID, e.g. container-id:22222
+	  - container-name: Container name, e.g. container-name:foobar
+	  - pod-name: pod name for this container if K8s is enabled, e.g. pod-name:default:foobar
 	  - docker-net-endpoint: Docker libnetwork endpoint ID, e.g. docker-net-endpoint:4444
 
 	  Required: true

--- a/api/v1/server/restapi/endpoint/get_endpoint_id_parameters.go
+++ b/api/v1/server/restapi/endpoint/get_endpoint_id_parameters.go
@@ -37,6 +37,8 @@ type GetEndpointIDParams struct {
 	  - cilium-local: Local Cilium endpoint UUID, e.g. cilium-local:3389595
 	  - cilium-global: Global Cilium endpoint UUID, e.g. cilium-global:cluster1:nodeX:452343
 	  - container-id: Container runtime ID, e.g. container-id:22222
+	  - container-name: Container name, e.g. container-name:foobar
+	  - pod-name: pod name for this container if K8s is enabled, e.g. pod-name:default:foobar
 	  - docker-net-endpoint: Docker libnetwork endpoint ID, e.g. docker-net-endpoint:4444
 
 	  Required: true

--- a/api/v1/server/restapi/endpoint/get_endpoint_responses.go
+++ b/api/v1/server/restapi/endpoint/get_endpoint_responses.go
@@ -56,3 +56,24 @@ func (o *GetEndpointOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 	}
 
 }
+
+// GetEndpointNotFoundCode is the HTTP code returned for type GetEndpointNotFound
+const GetEndpointNotFoundCode int = 404
+
+/*GetEndpointNotFound Endpoints with provided parameters not found
+
+swagger:response getEndpointNotFound
+*/
+type GetEndpointNotFound struct {
+}
+
+// NewGetEndpointNotFound creates GetEndpointNotFound with default headers values
+func NewGetEndpointNotFound() *GetEndpointNotFound {
+	return &GetEndpointNotFound{}
+}
+
+// WriteResponse to the client
+func (o *GetEndpointNotFound) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(404)
+}

--- a/api/v1/server/restapi/endpoint/patch_endpoint_id_config_parameters.go
+++ b/api/v1/server/restapi/endpoint/patch_endpoint_id_config_parameters.go
@@ -46,6 +46,8 @@ type PatchEndpointIDConfigParams struct {
 	  - cilium-local: Local Cilium endpoint UUID, e.g. cilium-local:3389595
 	  - cilium-global: Global Cilium endpoint UUID, e.g. cilium-global:cluster1:nodeX:452343
 	  - container-id: Container runtime ID, e.g. container-id:22222
+	  - container-name: Container name, e.g. container-name:foobar
+	  - pod-name: pod name for this container if K8s is enabled, e.g. pod-name:default:foobar
 	  - docker-net-endpoint: Docker libnetwork endpoint ID, e.g. docker-net-endpoint:4444
 
 	  Required: true

--- a/api/v1/server/restapi/endpoint/patch_endpoint_id_parameters.go
+++ b/api/v1/server/restapi/endpoint/patch_endpoint_id_parameters.go
@@ -46,6 +46,8 @@ type PatchEndpointIDParams struct {
 	  - cilium-local: Local Cilium endpoint UUID, e.g. cilium-local:3389595
 	  - cilium-global: Global Cilium endpoint UUID, e.g. cilium-global:cluster1:nodeX:452343
 	  - container-id: Container runtime ID, e.g. container-id:22222
+	  - container-name: Container name, e.g. container-name:foobar
+	  - pod-name: pod name for this container if K8s is enabled, e.g. pod-name:default:foobar
 	  - docker-net-endpoint: Docker libnetwork endpoint ID, e.g. docker-net-endpoint:4444
 
 	  Required: true

--- a/api/v1/server/restapi/endpoint/put_endpoint_id_labels_parameters.go
+++ b/api/v1/server/restapi/endpoint/put_endpoint_id_labels_parameters.go
@@ -46,6 +46,8 @@ type PutEndpointIDLabelsParams struct {
 	  - cilium-local: Local Cilium endpoint UUID, e.g. cilium-local:3389595
 	  - cilium-global: Global Cilium endpoint UUID, e.g. cilium-global:cluster1:nodeX:452343
 	  - container-id: Container runtime ID, e.g. container-id:22222
+	  - container-name: Container name, e.g. container-name:foobar
+	  - pod-name: pod name for this container if K8s is enabled, e.g. pod-name:default:foobar
 	  - docker-net-endpoint: Docker libnetwork endpoint ID, e.g. docker-net-endpoint:4444
 
 	  Required: true

--- a/api/v1/server/restapi/endpoint/put_endpoint_id_parameters.go
+++ b/api/v1/server/restapi/endpoint/put_endpoint_id_parameters.go
@@ -46,6 +46,8 @@ type PutEndpointIDParams struct {
 	  - cilium-local: Local Cilium endpoint UUID, e.g. cilium-local:3389595
 	  - cilium-global: Global Cilium endpoint UUID, e.g. cilium-global:cluster1:nodeX:452343
 	  - container-id: Container runtime ID, e.g. container-id:22222
+	  - container-name: Container name, e.g. container-name:foobar
+	  - pod-name: pod name for this container if K8s is enabled, e.g. pod-name:default:foobar
 	  - docker-net-endpoint: Docker libnetwork endpoint ID, e.g. docker-net-endpoint:4444
 
 	  Required: true

--- a/api/v1/server/restapi/policy/delete_policy_parameters.go
+++ b/api/v1/server/restapi/policy/delete_policy_parameters.go
@@ -4,7 +4,6 @@ package policy
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"io"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -31,7 +30,6 @@ type DeletePolicyParams struct {
 	HTTPRequest *http.Request
 
 	/*
-	  Required: true
 	  In: body
 	*/
 	Labels models.Labels
@@ -47,12 +45,7 @@ func (o *DeletePolicyParams) BindRequest(r *http.Request, route *middleware.Matc
 		defer r.Body.Close()
 		var body models.Labels
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
-			if err == io.EOF {
-				res = append(res, errors.Required("labels", "body"))
-			} else {
-				res = append(res, errors.NewParseError("labels", "body", "", err))
-			}
-
+			res = append(res, errors.NewParseError("labels", "body", "", err))
 		} else {
 
 			if len(res) == 0 {
@@ -60,8 +53,6 @@ func (o *DeletePolicyParams) BindRequest(r *http.Request, route *middleware.Matc
 			}
 		}
 
-	} else {
-		res = append(res, errors.Required("labels", "body"))
 	}
 
 	if len(res) > 0 {

--- a/cilium/cmd/endpoint_labels.go
+++ b/cilium/cmd/endpoint_labels.go
@@ -74,7 +74,7 @@ func printEndpointLabels(lbls *labels.OpLabels) {
 	log.Debugf("All Labels %#v", *lbls)
 	w := tabwriter.NewWriter(os.Stdout, 2, 0, 3, ' ', 0)
 
-	for _, v := range lbls.Enabled() {
+	for _, v := range lbls.IdentityLabels() {
 		text := common.Green("Enabled")
 		fmt.Fprintf(w, "%s\t%s\n", v, text)
 	}

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -101,9 +101,9 @@ func (d *Daemon) createThirdPartyResources() error {
 	return nil
 }
 
-// EnableK8sWatcher watches for policy, services and endpoint changes on the kurbenetes
+// EnableK8sWatcher watches for policy, services and endpoint changes on the Kubernetes
 // api server defined in the receiver's daemon k8sClient. Re-syncs all state from the
-// kubernetes api server at the given reSyncPeriod duration.
+// Kubernetes api server at the given reSyncPeriod duration.
 func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 	if !d.conf.IsK8sEnabled() {
 		return nil

--- a/daemon/labels.go
+++ b/daemon/labels.go
@@ -143,7 +143,7 @@ func (d *Daemon) CreateOrUpdateIdentity(lbls labels.Labels, epid string) (*polic
 }
 
 func (d *Daemon) updateEndpointIdentity(epID, oldLabelsHash string, opLabels *labels.OpLabels) (*policy.Identity, string, error) {
-	lbls := opLabels.Enabled()
+	lbls := opLabels.IdentityLabels()
 	log.Debugf("Endpoint %s is resolving identity for labels %+v", epID, lbls)
 
 	newLabelsHash := lbls.SHA256Sum()

--- a/pkg/client/endpoint.go
+++ b/pkg/client/endpoint.go
@@ -20,7 +20,7 @@ import (
 	pkgEndpoint "github.com/cilium/cilium/pkg/endpoint"
 )
 
-// EndpointList returns list of endpoints
+// EndpointList returns a list of all endpoints
 func (c *Client) EndpointList() ([]*models.Endpoint, error) {
 	resp, err := c.Endpoint.GetEndpoint(nil)
 	if err != nil {

--- a/pkg/endpoint/id.go
+++ b/pkg/endpoint/id.go
@@ -29,6 +29,8 @@ const (
 	CiliumGlobalIdPrefix            = "cilium-global"
 	ContainerIdPrefix               = "container-id"
 	DockerEndpointPrefix            = "docker-endpoint"
+	ContainerNamePrefix             = "container-name"
+	PodNamePrefix                   = "pod-name"
 
 	// IPv4Prefix is the prefix used in Cilium IDs when the identifier is
 	// the IPv4 address of the endpoint
@@ -47,6 +49,10 @@ func NewID(prefix PrefixType, id string) string {
 func SplitID(id string) (PrefixType, string) {
 	if s := strings.Split(id, ":"); len(s) == 2 {
 		return PrefixType(s[0]), s[1]
+	} else if len(s) == 3 {
+		// PodNamePrefix case, e.g. "pod-name:default:foobar" where the prefix is
+		// pod-name, the pod namespace is default, and the pod-name is foobar.
+		return PrefixType(s[0]), strings.Join([]string{s[1], s[2]}, ":")
 	}
 	// default prefix
 	return CiliumLocalIdPrefix, id
@@ -77,7 +83,7 @@ func ParseID(id string) (PrefixType, string, error) {
 			return "", "", err
 		}
 		return prefix, eid, nil
-	case CiliumGlobalIdPrefix, ContainerIdPrefix, DockerEndpointPrefix:
+	case CiliumGlobalIdPrefix, ContainerIdPrefix, DockerEndpointPrefix, ContainerNamePrefix, PodNamePrefix:
 		// FIXME: Validate IDs
 		return prefix, eid, nil
 	}

--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -192,9 +192,11 @@ func readLabelPrefixCfgFrom(fileName string) (*LabelPrefixCfg, error) {
 }
 
 // FilterLabels returns Labels from the given labels that have the same source and the
-// same prefix as one of lpc valid prefixes.
-func (cfg *LabelPrefixCfg) FilterLabels(lbls Labels) Labels {
-	filteredLabels := Labels{}
+// same prefix as one of lpc valid prefixes, as well as labels that do not match
+// the aforementioned filtering criteria.
+func (cfg *LabelPrefixCfg) FilterLabels(lbls Labels) (identityLabels, informationLabels Labels) {
+	identityLabels = Labels{}
+	informationLabels = Labels{}
 	for k, v := range lbls {
 		included, ignored := 0, 0
 
@@ -227,8 +229,10 @@ func (cfg *LabelPrefixCfg) FilterLabels(lbls Labels) Labels {
 		if (!cfg.whitelist && ignored == 0) || included > ignored {
 			// Just want to make sure we don't have labels deleted in
 			// on side and disappearing in the other side...
-			filteredLabels[k] = v.DeepCopy()
+			identityLabels[k] = v.DeepCopy()
+		} else {
+			informationLabels[k] = v.DeepCopy()
 		}
 	}
-	return filteredLabels
+	return identityLabels, informationLabels
 }

--- a/pkg/labels/filter_test.go
+++ b/pkg/labels/filter_test.go
@@ -54,11 +54,11 @@ func (s *LabelsPrefCfgSuite) TestFilterLabels(c *C) {
 		"annotation.kubernetes.io/config.seen": "2017-05-30T14:22:17.691491034Z",
 	}
 	allLabels := Map2Labels(allNormalLabels, LabelSourceContainer)
-	filtered := dlpcfg.FilterLabels(allLabels)
+	filtered, _ := dlpcfg.FilterLabels(allLabels)
 	c.Assert(len(filtered), Equals, 1)
 	allLabels["id.lizards"] = NewLabel("id.lizards", "web", LabelSourceContainer)
 	allLabels["id.lizards.k8s"] = NewLabel("id.lizards.k8s", "web", LabelSourceK8s)
-	filtered = dlpcfg.FilterLabels(allLabels)
+	filtered, _ = dlpcfg.FilterLabels(allLabels)
 	c.Assert(len(filtered), Equals, 3)
 	c.Assert(filtered, DeepEquals, wanted)
 

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -40,33 +40,62 @@ type OpLabels struct {
 	// Active labels that are enabled and disabled but not deleted
 	Custom Labels
 	// Labels derived from orchestration system
-	Orchestration Labels
-	// Orchestration labels which have been disabled
+	OrchestrationIdentity Labels
+
+	//OrchestrationIdentity
+	// OrchestrationIdentity labels which have been disabled
 	Disabled Labels
+
+	//OrchestrationInfo - labels from orchestration which are not used in determining a security identity
+	OrchestrationInfo Labels
 }
 
 // DeepCopy returns deep copy of the label.
 func (o *OpLabels) DeepCopy() *OpLabels {
 	return &OpLabels{
-		Custom:        o.Custom.DeepCopy(),
-		Disabled:      o.Disabled.DeepCopy(),
-		Orchestration: o.Orchestration.DeepCopy(),
+		Custom:                o.Custom.DeepCopy(),
+		Disabled:              o.Disabled.DeepCopy(),
+		OrchestrationIdentity: o.OrchestrationIdentity.DeepCopy(),
+		OrchestrationInfo:     o.OrchestrationInfo.DeepCopy(),
 	}
 }
 
-// Enabled returns map of enabled labels.
-func (o *OpLabels) Enabled() Labels {
-	enabled := make(Labels, len(o.Custom)+len(o.Orchestration))
+// IdentityLabels returns map of labels that are used when determining a
+// security identity.
+func (o *OpLabels) IdentityLabels() Labels {
+	enabled := make(Labels, len(o.Custom)+len(o.OrchestrationIdentity))
 
 	for k, v := range o.Custom {
 		enabled[k] = v
 	}
 
-	for k, v := range o.Orchestration {
+	for k, v := range o.OrchestrationIdentity {
 		enabled[k] = v
 	}
 
 	return enabled
+}
+
+// AllLabels returns all Labels within the provided OpLabels.
+func (o *OpLabels) AllLabels() Labels {
+	all := make(Labels, len(o.Custom)+len(o.OrchestrationInfo)+len(o.OrchestrationIdentity)+len(o.Disabled))
+
+	for k, v := range o.Custom {
+		all[k] = v
+	}
+
+	for k, v := range o.Disabled {
+		all[k] = v
+	}
+
+	for k, v := range o.OrchestrationIdentity {
+		all[k] = v
+	}
+
+	for k, v := range o.OrchestrationInfo {
+		all[k] = v
+	}
+	return all
 }
 
 // NewOplabelsFromModel creates new label from the model.
@@ -76,9 +105,10 @@ func NewOplabelsFromModel(base *models.LabelConfiguration) *OpLabels {
 	}
 
 	return &OpLabels{
-		Custom:        NewLabelsFromModel(base.Custom),
-		Disabled:      NewLabelsFromModel(base.Disabled),
-		Orchestration: NewLabelsFromModel(base.OrchestrationSystem),
+		Custom:                NewLabelsFromModel(base.Custom),
+		Disabled:              NewLabelsFromModel(base.Disabled),
+		OrchestrationIdentity: NewLabelsFromModel(base.OrchestrationIdentity),
+		OrchestrationInfo:     NewLabelsFromModel(base.OrchestrationInfo),
 	}
 }
 


### PR DESCRIPTION
cmd: get ep with labels, pod / container name, ID
    
* daemon: add handlers for new /endpoints API, update endpoint structures with container ID / pod name
* pkg/endpoint: support new API models
* pkg/endpointmanager: add pod name, container name entries as keys mapping to endpoints
* pkg/labels: change Orchestration labels -> OrchestrationIdentity labels (labels used in computing a security identity) and OrchrestationInfo labels (labels not used in computing a security identity)
    
`cilium endpoint get` now supports the following:
* `cilium endpoint get -l <set of labels>`
* `cilium endpoint get <eID, pod name, container name, etc.>`

api: add pod / container name, labels for GET ep
    
* add new fields to Endpoint (pod-name, container-name)
* GET /endpoint now takes an optional array of labels to return a list of endpoints whose labels match the provided array.
    
Signed-off by: Ian Vernon <ian@covalent.io>