### PR TITLE
endpointmanager: Lock auxEndpoints for writing

### DIFF
--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -144,8 +144,8 @@ func updateReferences(ep *endpoint.Endpoint) {
 // UpdateReferences makes an endpoint available by all possible reference
 // fields as available for this endpoint (containerID, IPv4 address, ...)
 func UpdateReferences(ep *endpoint.Endpoint) {
-	Mutex.RLock()
-	defer Mutex.RUnlock()
+	Mutex.Lock()
+	defer Mutex.Unlock()
 
 	updateReferences(ep)
 }


### PR DESCRIPTION
`endpointsAux` is being written to so we need to acquire the lock for writing.

Signed-off-by: Thomas Graf <thomas@cilium.io>