### PR TITLE
Fixed L7 proxy with policies loaded

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -19,8 +19,6 @@ import (
 	"net"
 	"time"
 
-	"github.com/cilium/cilium/pkg/nodeaddress"
-
 	log "github.com/Sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -116,29 +114,4 @@ func AnnotateNodeCIDR(c kubernetes.Interface, k8sNode *v1.Node, v4CIDR, v6CIDR *
 			}
 		}(c, k8sNode, v4CIDR, v6CIDR, err)
 	}
-}
-
-// UseNodeCIDR sets the ipv4-range and ipv6-range values from the
-// cluster-node-cidr defined in  the kube-apiserver or / and the CIDRs defined
-// in that node's annotations.
-func UseNodeCIDR(c kubernetes.Interface, nodeName string) error {
-	k8sNode, err := c.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-
-	node := ParseNode(k8sNode)
-
-	if node.IPv4AllocCIDR != nil {
-		log.Infof("Retrieved %s for node %s. Using it for ipv4-range", node.IPv4AllocCIDR, nodeName)
-		nodeaddress.SetIPv4AllocRange(node.IPv4AllocCIDR)
-	}
-	if node.IPv6AllocCIDR != nil {
-		log.Infof("Retrieved %s for node %s. Using it for ipv6-range", node.IPv6AllocCIDR, nodeName)
-		if err := nodeaddress.SetIPv6NodeRange(node.IPv6AllocCIDR); err != nil {
-			log.Warningf("k8s: Can't use CIDR '%s' from kubernetes: %s", node.IPv6AllocCIDR, err)
-		}
-	}
-
-	return nil
 }

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -75,12 +75,11 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 	c.Assert(nodeaddress.GetIPv4AllocRange().String(), Equals, "10.2.0.0/16")
 	// IPv6 Node range is not checked because it shouldn't be changed.
 
-	k8sNode, err := k8sClient.CoreV1().Nodes().Get("node1", metav1.GetOptions{})
-	c.Assert(err, IsNil)
-
-	AnnotateNodeCIDR(k8sClient, k8sNode,
+	AnnotateNodeCIDR(k8sClient, "node1",
 		nodeaddress.GetIPv4AllocRange(),
 		nodeaddress.GetIPv6NodeRange())
+
+	c.Assert(err, IsNil)
 
 	select {
 	case <-updateChan:
@@ -142,12 +141,11 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 	c.Assert(nodeaddress.GetIPv4AllocRange().String(), Equals, "10.254.0.0/16")
 	c.Assert(nodeaddress.GetIPv6NodeRange().String(), Equals, "aaaa:aaaa:aaaa:aaaa:beef:beef::/96")
 
-	k8sNode, err = k8sClient.CoreV1().Nodes().Get("node2", metav1.GetOptions{})
-	c.Assert(err, IsNil)
-
-	AnnotateNodeCIDR(k8sClient, k8sNode,
+	err = AnnotateNodeCIDR(k8sClient, "node2",
 		nodeaddress.GetIPv4AllocRange(),
 		nodeaddress.GetIPv6NodeRange())
+
+	c.Assert(err, IsNil)
 
 	select {
 	case <-updateChan:

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -20,6 +20,8 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 
 	log "github.com/Sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
 )
 
@@ -94,4 +96,11 @@ func ParseNode(k8sNode *v1.Node) *node.Node {
 	}
 
 	return node
+}
+
+// GetNode returns the kubernetes nodeName's node information from the
+// kubernetes api server
+func GetNode(c kubernetes.Interface, nodeName string) (*v1.Node, error) {
+	// Try to retrieve node's cidr and addresses from k8s's configuration
+	return c.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
 }

--- a/pkg/nodeaddress/node_address.go
+++ b/pkg/nodeaddress/node_address.go
@@ -340,3 +340,37 @@ func GetNode() (node.Identity, *node.Node) {
 
 	return node.Identity{Name: nodeName}, &n
 }
+
+// UseNodeCIDR sets the ipv4-range and ipv6-range values values from the
+// addresses defined in the given node.
+func UseNodeCIDR(node *node.Node) error {
+	if node.IPv4AllocCIDR != nil {
+		log.Infof("Retrieved %s for node %s. Using it for ipv4-range", node.IPv4AllocCIDR, node.Name)
+		SetIPv4AllocRange(node.IPv4AllocCIDR)
+	}
+	if node.IPv6AllocCIDR != nil {
+		log.Infof("Retrieved %s for node %s. Using it for ipv6-range", node.IPv6AllocCIDR, node.Name)
+		if err := SetIPv6NodeRange(node.IPv6AllocCIDR); err != nil {
+			log.Warningf("k8s: Can't use CIDR '%s' from kubernetes: %s", node.IPv6AllocCIDR, err)
+		}
+	}
+
+	return nil
+}
+
+// UseNodeAddresses sets the local ipv4-node and ipv6-node values from the
+// addresses defined in the given node.
+func UseNodeAddresses(node *node.Node) error {
+	nodeIP4 := node.GetNodeIP(false)
+	if nodeIP4 != nil {
+		log.Infof("Automatically retrieved %s for node %s. Using it for ipv4-node", nodeIP4, node.Name)
+		SetExternalIPv4(nodeIP4)
+	}
+	nodeIP6 := node.GetNodeIP(true)
+	if nodeIP6 != nil {
+		log.Infof("Automatically retrieved %s for node %s. Using it for ipv6-node", nodeIP6, node.Name)
+		SetIPv6(nodeIP6)
+	}
+
+	return nil
+}

--- a/tests/k8s/tests/03-l7-stresstest.sh
+++ b/tests/k8s/tests/03-l7-stresstest.sh
@@ -31,8 +31,7 @@ sed "s/\$kube_node_selector/${node_selector}/" \
     "${l7_stresstest_dir}/1-frontend.json.sed" > "${l7_stresstest_dir}/1-frontend.json"
 
 # Set backend on k8s-2 to force inter-node communication
-# FIXME FIXME FIXME replace with k8s-2 when the l3 + l7 policies are working
-node_selector="k8s-1"
+node_selector="k8s-2"
 
 sed "s/\$kube_node_selector/${node_selector}/" \
     "${l7_stresstest_dir}/2-backend-server.json.sed" > "${l7_stresstest_dir}/2-backend-server.json"
@@ -43,14 +42,15 @@ kubectl create namespace development
 
 kubectl create -f "${l7_stresstest_dir}"
 
-kubectl get pods -n qa -o wide
-kubectl get pods -n development -o wide
-
 wait_for_running_pod frontend qa
 wait_for_running_pod backend development
 
 wait_for_service_endpoints_ready development backend 80
 # frontend doesn't have any endpoints
+
+kubectl get pods -n qa -o wide
+kubectl get pods -n development -o wide
+kubectl describe svc -n development backend
 
 frontend_pod=$(kubectl get pods -n qa | grep frontend | awk '{print $1}')
 backend_pod=$(kubectl get pods -n development | grep backend | awk '{print $1}')
@@ -58,34 +58,34 @@ backend_pod=$(kubectl get pods -n development | grep backend | awk '{print $1}')
 backend_svc_ip=$(kubectl get svc -n development | awk 'NR==2{print $2}')
 
 echo "Running tests WITHOUT Policy / Proxy loaded"
-kubectl exec -n qa -i ${frontend_pod} -- wrk -t20 -c1000 -d60 "http://${backend_svc_ip}:80/"
-kubectl exec -n qa -i ${frontend_pod} -- ab -r -n 1000000 -c 200 -s 60 -v 1 "http://${backend_svc_ip}:80/"
 
 code=$(kubectl exec -n qa -i ${frontend_pod} -- curl -s -o /dev/null -w "%{http_code}" http://${backend_svc_ip}:80/)
 
-if [ ${code} -ne 200 ]; then abort "Error: unable to connect between frontend and backend" ; fi
+if [ ${code} -ne 200 ]; then abort "Error: unable to connect between frontend and backend:80/" ; fi
+
+kubectl exec -n qa -i ${frontend_pod} -- wrk -t20 -c1000 -d60 "http://${backend_svc_ip}:80/"
+kubectl exec -n qa -i ${frontend_pod} -- ab -r -n 1000000 -c 200 -s 60 -v 1 "http://${backend_svc_ip}:80/"
 
 kubectl create -f "${l7_stresstest_dir}/policies"
 
 wait_all_k8s_regenerated
 
 echo "Running tests WITH Policy / Proxy loaded"
-kubectl exec -n qa -i ${frontend_pod} -- wrk -t20 -c1000 -d60 "http://${backend_svc_ip}:80/"
 
+code=$(kubectl exec -n qa -i ${frontend_pod} -- curl --connect-timeout 10 -s -o /dev/null -w "%{http_code}" http://${backend_svc_ip}:80/)
+
+if [ ${code} -ne 200 ]; then abort "Error: unable to connect between frontend and backend" ; fi
+
+code=$(kubectl exec -n qa -i ${frontend_pod} -- curl --connect-timeout 10 -s -o /dev/null -w "%{http_code}" http://${backend_svc_ip}:80/health)
+
+if [ ${code} -ne 403 ]; then abort "Error: unexpected connection between frontend and backend. wanted HTTP 403, got: HTTP ${code}" ; fi
+
+kubectl exec -n qa -i ${frontend_pod} -- wrk -t20 -c1000 -d60 "http://${backend_svc_ip}:80/"
 # FIXME: Due proxy constrains (memory?) it's impossible to execute the test
 # with 1000000 requests and 200 parallel connections. It was tested with
 # 1 request and 1 parallel connection with no success.
 #
 #kubectl exec -n qa -i ${frontend_pod} -- ab -r -n 1000000 -c 200 -s 60 -v 1 "http://${backend_svc_ip}:80/"
-
-code=$(kubectl exec -n qa -i ${frontend_pod} -- curl -s -o /dev/null -w "%{http_code}" http://${backend_svc_ip}:80/)
-
-if [ ${code} -ne 200 ]; then abort "Error: unable to connect between frontend and backend" ; fi
-
-code=$(kubectl exec -n qa -i ${frontend_pod} -- curl -s -o /dev/null -w "%{http_code}" http://${backend_svc_ip}:80/health)
-
-if [ ${code} -ne 403 ]; then abort "Error: unexpected connection between frontend and backend. wanted HTTP 403, got: HTTP ${code}" ; fi
-
 
 echo "SUCCESS!"
 


### PR DESCRIPTION
- Fixed labels' keep-alive in kvstore
- Add ability to get `ipv4-node` and `ipv6-node` addresses from kubernetes node.
- Fix IPv6AllocCIDR annotation bug
- Removed L7 workaround, to test L7 proxy on a single node, since we are able to have L7 proxy on a multi node environment with policies enabled.