### PR TITLE
tests: refactor functions to copy files from VMs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,13 +70,18 @@ $workers_ipv6_addrs = $workers_ipv6_addrs_str.split(' ')
 
 # Create unique ID for use in vboxnet name so Jenkins pipeline can have concurrent builds.
 $job_name = ENV['JOB_NAME'] || "local"
+
+if $job_name != "local"
+ $job_name = $job_name.slice($job_name.index("PR")..-1)
+end
+
 $build_number = ENV['BUILD_NUMBER'] || "0"
 $build_id = "#{$job_name}-#{$build_number}"
 
 # Only create the build_id_name for Jenkins environment so that
 # we can run VMs locally without having any the `build_id` in the name.
 if ENV['BUILD_NUMBER'] then
-    $build_id_name = "-build-#{$build_number}"
+    $build_id_name = "-build-#{$build_id}"
 end
 
 if ENV['K8S'] then

--- a/tests/copy_files
+++ b/tests/copy_files
@@ -1,15 +1,22 @@
 #!/bin/bash
 
-sudo rm -rf ./cilium-files
-sudo rm -rf *.tar.gz 
+set -xv
 
-IDENTITY_FILE=$(vagrant ssh-config | grep IdentityFile | awk '{print $2}')
-PORT=$(vagrant ssh-config cilium-master | grep Port | awk '{ print $2 }')
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source "${dir}/helpers.bash"
+# dir might have been overwritten by helpers.bash
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-vagrant ssh cilium-master -c 'sudo -E bash -c "journalctl --no-pager -u cilium > ${GOPATH}/src/github.com/cilium/cilium/tests/cilium-files/cilium-logs && chmod a+r ${GOPATH}/src/github.com/cilium/cilium/tests/cilium-files/cilium-logs"'
+function copy_runtime_test_files {
+  local VM=$(get_cilium_master_vm_name)
+  local RUNTIME_TESTS_DIR="tests/${CILIUM_FILES}"
+   
+  sudo rm -rf ./cilium-files
+  sudo rm -rf *.tar.gz
 
-scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -r -P ${PORT} -i ${IDENTITY_FILE} vagrant@127.0.0.1:~/go/src/github.com/cilium/cilium/tests/cilium-files .
+  copy_files_vm ${VM} ${RUNTIME_TESTS_DIR}
 
-sudo tar -czvf cilium-files-runtime.tar.gz cilium-files
+  sudo tar -czvf ${CILIUM_FILES}-runtime.tar.gz ${CILIUM_FILES}-*
+}
 
-exit 0
+copy_runtime_test_files

--- a/tests/k8s/Vagrantfile
+++ b/tests/k8s/Vagrantfile
@@ -41,6 +41,11 @@ echo "FD01::B k8s-2" >> /etc/hosts
 SCRIPT
 
 $job_name = ENV['JOB_NAME'] || "local"
+
+if $job_name != "local"
+ $job_name = $job_name.slice($job_name.index("PR")..-1)
+end
+
 $build_number = ENV['BUILD_NUMBER'] || "0"
 $build_id = "#{$job_name}-#{$build_number}"
 $docker_image_tag=ENV['DOCKER_IMAGE_TAG'] || "local_build"
@@ -48,7 +53,7 @@ $docker_image_tag=ENV['DOCKER_IMAGE_TAG'] || "local_build"
 # Only create the build_id_name for Jenkins environment so that
 # we can run VMs locally without having any the `build_id` in the name.
 if ENV['BUILD_NUMBER'] then
-    $build_id_name = "-build-#{$build_number}"
+    $build_id_name = "-build-#{$build_id}"
 end
 
 Vagrant.configure(2) do |config|

--- a/tests/k8s/copy_files
+++ b/tests/k8s/copy_files
@@ -1,15 +1,32 @@
 #!/bin/bash
 
-OLD_DIR=`pwd`
-sudo rm -rf ./cilium-files
-sudo rm -rf *.tar.gz
+set -xv 
 
-cd ./tests/k8s
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source "${dir}/../helpers.bash"
+# dir might have been overwritten by helpers.bash
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-IDENTITY_FILE=$(vagrant ssh-config | grep IdentityFile | awk '{print $2}')
-PORT=$(vagrant ssh-config default | grep Port | awk '{ print $2 }')
+function copy_k8s_test_files {
+  local OLD_DIR=`pwd`
+  local K8S1="k8s1"
+  local K8S2="k8s2"
+  local K8S_FILES_DIR="tests/${CILIUM_FILES}"
+  local VM1=$(get_k8s_vm_name $K8S1)
+  local VM2=$(get_k8s_vm_name $K8S2)
+  
+  echo "VM1: $VM1"
+  echo "VM2: $VM2"
+ 
+  sudo rm -rf ./cilium-files
+  sudo rm -rf *.tar.gz
+  
+  cd ./tests/k8s
+  copy_files_vm ${VM1} ${K8S_FILES_DIR}
+  copy_files_vm ${VM2} ${K8S_FILES_DIR}
 
-scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -r -P ${PORT} -i ${IDENTITY_FILE} vagrant@127.0.0.1:~/go/src/github.com/cilium/cilium/tests/k8s/cilium-files .
+  sudo tar -czvf ${CILIUM_FILES}-k8s.tar.gz ${CILIUM_FILES}-*
+  mv ${CILIUM_FILES}-k8s.tar.gz ${OLD_DIR}
+}
 
-sudo tar -czvf cilium-files-k8s.tar.gz cilium-files
-mv cilium-files-k8s.tar.gz ${OLD_DIR}
+copy_k8s_test_files

--- a/tests/k8s/run-tests.bash
+++ b/tests/k8s/run-tests.bash
@@ -2,10 +2,13 @@
 
 set -ex
 
-vm_suffix="${BUILD_NUMBER:+-build-$BUILD_NUMBER}"
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source "${dir}/../helpers.bash"
+# dir might have been overwritten by helpers.bash
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-node1="k8s1${vm_suffix}"
-node2="k8s2${vm_suffix}"
+node1=$(get_k8s_vm_name k8s1)
+node2=$(get_k8s_vm_name k8s2)
 
 function reinstall_ipv4(){
     vm="${1}"


### PR DESCRIPTION
The scripts that copy files off of the VMs for k8s and runtime tests were using VM names that were out-of-date. This commit refactors the file copying code to work with each build in a more generic way.
    
Signed-off by: Ian Vernon <ian@covalent.io>