### PR TITLE
Jenkinsfile: print environment available to jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,9 @@ pipeline {
                 RUN_TEST_SUITE = '1'
             }
             steps {
+     		           
                 parallel(
+                    "Print Environment": { sh 'env' },
                     "Runtime Tests": { sh './contrib/vagrant/start.sh' },
                     "K8s multi node Tests": { sh './tests/k8s/start.sh' }
                 )


### PR DESCRIPTION
Prints out the environment variables set by Jenkins for informational purposes.

Signed-off by: Ian Vernon <ian@covalent.io>