### PR TITLE
Vagrantfile, tests: change VM naming scheme

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,11 +69,7 @@ $workers_ipv6_addrs_str = ENV['IPV6_PUBLIC_WORKERS_ADDRS'] || ""
 $workers_ipv6_addrs = $workers_ipv6_addrs_str.split(' ')
 
 # Create unique ID for use in vboxnet name so Jenkins pipeline can have concurrent builds.
-$job_name = ENV['JOB_NAME'] || "local"
-
-if $job_name != "local"
- $job_name = $job_name.slice($job_name.index("PR")..-1)
-end
+$job_name = ENV['JOB_BASE_NAME'] || "local"
 
 $build_number = ENV['BUILD_NUMBER'] || "0"
 $build_id = "#{$job_name}-#{$build_number}"
@@ -198,3 +194,5 @@ Vagrant.configure(2) do |config|
         end
     end
 end
+
+

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -396,11 +396,9 @@ function copy_files_vm {
 function get_k8s_vm_name {
   local VM_PREFIX=$1
   local BUILD_NUM="${BUILD_NUMBER:-0}"
-  local JOB_NAME="${JOB_NAME:-local}"
-  if [[ "${JOB_NAME}" != "local" ]] ; then
-    local JOB_NAME=$(echo ${JOB_NAME} | awk -F/ '{ print $NF }')
-  fi
-  local BUILD_ID="${JOB_NAME}-${BUILD_NUM}"
+  local JOB_BASE="${JOB_BASE_NAME:-local}"
+  local BUILD_ID="${JOB_BASE}-${BUILD_NUM}"
+  
   if [ ! -z ${BUILD_NUMBER} ] ; then
     local BUILD_ID_NAME="-build-${BUILD_ID}"
   fi
@@ -413,13 +411,8 @@ function get_cilium_master_vm_name {
   fi
 
   local BUILD_NUM="${BUILD_NUMBER:-0}"
-  local JOB_NAME="${JOB_NAME:-local}"
- 
-  if [[ "${JOB_NAME}" != "local" ]] ; then
-    local JOB_NAME=$(echo ${JOB_NAME} | awk -F/ '{ print $NF }')
-  fi
-
-  local BUILD_ID="${JOB_NAME}-${BUILD_NUM}"
+  local JOB_BASE="${JOB_BASE_NAME:-local}"
+  local BUILD_ID="${JOB_BASE}-${BUILD_NUM}"
 
   if [ ! -z ${BUILD_NUMBER} ] ; then
     local BUILD_ID_NAME="-build-${BUILD_ID}"


### PR DESCRIPTION
Use JOB_BASE_NAME variable instead of JOB_NAME for VM names

Signed-off by: Ian Vernon <ian@covalent.io>