### PR TITLE
tests/k8s/Vagrantfile: fix Vagrant naming scheme

### DIFF
--- a/tests/k8s/Vagrantfile
+++ b/tests/k8s/Vagrantfile
@@ -40,11 +40,7 @@ echo 'FD01::C k8s-1' >> /etc/hosts
 echo "FD01::B k8s-2" >> /etc/hosts
 SCRIPT
 
-$job_name = ENV['JOB_NAME'] || "local"
-
-if $job_name != "local"
- $job_name = $job_name.slice($job_name.index("PR")..-1)
-end
+$job_name = ENV['JOB_BASE_NAME'] || "local"
 
 $build_number = ENV['BUILD_NUMBER'] || "0"
 $build_id = "#{$job_name}-#{$build_number}"


### PR DESCRIPTION
Use JOB_BASE_NAME variable instead of JOB_NAME for VM names for k8s tests.

Signed-off by: Ian Vernon <ian@covalent.io>