### PR TITLE
bpf/Makefile: add sparse to check target

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.defs
 
-CLANG_FLAGS := -Iinclude -D__NR_CPUS__=$(shell nproc) -O2 -target bpf -I.
+FLAGS := -Iinclude -I. -D__NR_CPUS__=$(shell nproc) -O2
+CLANG_FLAGS :=  ${FLAGS} -target bpf
 
 # eBPF verifier enforces unaligned access checks where necessary, so don't
 # let clang complain too early.
@@ -20,6 +21,7 @@ all: $(BPF)
 	${CLANG} ${CLANG_FLAGS} -c $< -o $@
 
 check:
+	sparse -Wsparse-all ${FLAGS} *.c
 	clang ${CLANG_FLAGS} --analyze *.c
 
 LB_OPTIONS = \


### PR DESCRIPTION
For now just turn on all the warnings, but that can be changed later if
there is too many false positives.

Also moved non clang specific bits into seperate field since sparse
doesn't understand `--target bpf`.

Closes: #1025 (sparse checks for C-bpf code)
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>