### PR TITLE
tests: hidding docker rm -f error messages

### DIFF
--- a/tests/k8s/cluster/cluster-manager.bash
+++ b/tests/k8s/cluster/cluster-manager.bash
@@ -213,7 +213,7 @@ function start_etcd(){
 function clean_all(){
     sudo kubeadm reset
     sudo service etcd stop
-    sudo docker rm -f `sudo docker ps -aq`
+    sudo docker rm -f `sudo docker ps -aq` 2>/dev/null
     sudo rm -fr /var/lib/etcd
 }
 


### PR DESCRIPTION
Since we remove all existing, or non-existing, docker containers we
might see an error message regarding containers not found.
This commit hides non important error messages regarding the
`docker rm -f` command.

Signed-off-by: André Martins <andre@cilium.io>

Fixes #1173