### PR TITLE
k8s: upgrading kubeadm to 1.7.0

### DIFF
--- a/tests/k8s/cluster/cluster-manager.bash
+++ b/tests/k8s/cluster/cluster-manager.bash
@@ -6,7 +6,9 @@ source "${dir}/../helpers.bash"
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 etcd_version="v3.1.0"
-k8s_version="1.6.6-00"
+# due a kubeadm bug, only upgrade directly to >=1.7.3 once it's released!
+# more info github.com/kubernetes/kubeadm/issues/354
+k8s_version="1.7.0-00"
 
 certs_dir="${dir}/certs"
 k8s_dir="${dir}/k8s"


### PR DESCRIPTION
Since the introduction of NetworkPolicy in k8s 1.7 we also need to
upgrade the kubeadm version to 1.7 otherwise tests will fail since
kubernetes <1.7 doesn't recognize the kubernetes network policy object.

Signed-off-by: André Martins <andre@cilium.io>