### PR TITLE
k8s rbac: add k8s GA network policies to RBAC

### DIFF
--- a/examples/kubernetes/rbac.yaml
+++ b/examples/kubernetes/rbac.yaml
@@ -4,6 +4,14 @@ metadata:
   name: cilium
 rules:
 - apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - pods
@@ -18,7 +26,7 @@ rules:
 - apiGroups:
   - extensions
   resources:
-  - networkpolicies
+  - networkpolicies #FIXME remove this in k8s 1.8
   - thirdpartyresources
   - ingresses
   verbs:


### PR DESCRIPTION
With kubernetes network policy changed to GA we also need to change
RBAC accordingly.

Signed-off-by: André Martins <andre@cilium.io>

@tgraf do we need to `create` networkpolicies with cilium?