### PR TITLE
tests: have GSG test use local Docker image

### DIFF
--- a/examples/kubernetes/rbac.yaml
+++ b/examples/kubernetes/rbac.yaml
@@ -4,6 +4,14 @@ metadata:
   name: cilium
 rules:
 - apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - pods
@@ -18,7 +26,7 @@ rules:
 - apiGroups:
   - extensions
   resources:
-  - networkpolicies
+  - networkpolicies #FIXME remove this in k8s 1.8
   - thirdpartyresources
   - ingresses
   verbs:

--- a/examples/minikube/l3_l4_policy.yaml
+++ b/examples/minikube/l3_l4_policy.yaml
@@ -1,5 +1,5 @@
 kind: NetworkPolicy
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: access-backend
 spec:

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -79,6 +79,10 @@ function wait_for_k8s_endpoints {
 	local NUM=$3
 	echo "Waiting for $NUM endpoints in namespace $NAMESPACE managed by $CILIUM_POD"
 
+	# Wait some time for at least one endpoint to get into regenerating state
+	# FIXME: Remove when this is reliable
+	sleep 5
+
 	local sleep_time=1
 	local iter=0
 	local found=$(kubectl -n ${NAMESPACE} exec ${CILIUM_POD} cilium endpoint list | grep -c 'ready')
@@ -143,6 +147,10 @@ function wait_for_policy_enforcement {
 }
 
 function wait_all_k8s_regenerated {
+    # Wait some time for at least one endpoint to get into regenerating state
+    # FIXME: Remove when this is reliable
+    sleep 5
+
     local cilium_k8s_npods=$(kubectl get pods -n kube-system | grep cilium | wc -l)
     set +x
     { for i in $(seq 1 ${cilium_k8s_npods}); do

--- a/tests/k8s/tests/00-gsg-test.bash
+++ b/tests/k8s/tests/00-gsg-test.bash
@@ -24,7 +24,7 @@ function cleanup {
 	kubectl delete -f "${MINIKUBE}/l3_l4_l7_policy.yaml" 2> /dev/null || true
 	kubectl delete -f "${MINIKUBE}/l3_l4_policy.yaml" 2> /dev/null || true
 	kubectl delete -f "${GSGDIR}/demo.yaml" 2> /dev/null || true
-	kubectl delete -f "${K8SDIR}/cilium-ds-gsg.yaml" 2> /dev/null || true
+	kubectl delete -f "${GSGDIR}/cilium-ds.yaml" 2> /dev/null || true
 	kubectl delete -f "${K8SDIR}/rbac.yaml" 2> /dev/null || true
 }
 
@@ -53,10 +53,7 @@ echo "----- adding RBAC for Cilium -----"
 kubectl create -f "${K8SDIR}/rbac.yaml"
 
 echo "----- deploying Cilium Daemon Set onto cluster -----"
-cp "${K8SDIR}/cilium-ds-gsg.yaml" ./cilium-ds.yaml
-sed -i s+/var/lib/kubelet/kubeconfig+/etc/kubernetes/kubelet.conf+g cilium-ds.yaml
-sed -i s+/cilium/cilium:stable+localhost:5000/cilium:${DOCKER_IMAGE_TAG}+g cilium-ds.yaml
-kubectl create -f cilium-ds.yaml
+kubectl create -f ${GSGDIR}/cilium-ds.yaml
 
 wait_for_daemon_set_ready ${NAMESPACE} cilium 2
 

--- a/tests/k8s/tests/deployments/gsg/cilium-ds.yaml
+++ b/tests/k8s/tests/deployments/gsg/cilium-ds.yaml
@@ -64,8 +64,8 @@ spec:
     spec:
       serviceAccountName: cilium
       containers:
-      - image: cilium/cilium:stable
-        imagePullPolicy: Always
+      - image: cilium:local_build
+        imagePullPolicy: Never
         name: cilium-agent
         command: [ "cilium-agent" ]
         args:
@@ -77,7 +77,7 @@ spec:
           - "-t"
           - "vxlan"
           - "--k8s-kubeconfig-path"
-          - "/var/lib/kubelet/kubeconfig"
+          - "/etc/kubernetes/kubelet.conf"
         lifecycle:
           postStart:
             exec:
@@ -120,7 +120,7 @@ spec:
             mountPath: /var/run/docker.sock
             readOnly: true
           - name: kubeconfig-path
-            mountPath: /var/lib/kubelet/kubeconfig
+            mountPath: /etc/kubernetes/kubelet.conf
             readOnly: true
           - name: kubeconfig-cert
             mountPath: /var/lib/kubernetes/ca.pem
@@ -149,7 +149,7 @@ spec:
               path: /etc/cni/net.d
         - name: kubeconfig-path
           hostPath:
-              path: /var/lib/kubelet/kubeconfig
+              path: /etc/kubernetes/kubelet.conf
         - name: kubeconfig-cert
           hostPath:
               path: /var/lib/kubernetes/ca.pem


### PR DESCRIPTION
The build was not properly testing the built Docker image, and was instead testing cilium/cilium:stable. This fixes the GSG test to use the locally built Docker image to ensure that code being merged is not causing regressions with Cilium operating with Kubernetes. Also add wide output for `kubectl` commands in the helper functions file for tests for more informative output.
    
Signed-off by: Ian Vernon <ian@covalent.io>

Fixes: #1174 