### PR TITLE
build: add -i option to go build

### DIFF
--- a/cilium/Makefile
+++ b/cilium/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.defs
 TARGET=cilium
 SOURCES := $(shell find ../api ../daemon ../common ../pkg cmd . -name '*.go')
 $(TARGET): $(SOURCES)
-	go build $(GOBUILD) -o $(TARGET)
+	go build -i $(GOBUILD) -o $(TARGET)
 
 all: $(TARGET)
 

--- a/common/tests/Makefile
+++ b/common/tests/Makefile
@@ -3,7 +3,7 @@ include ../../Makefile.defs
 all: perf-event-test bpf-event-test.o
 
 perf-event-test: perf-event-test.go
-	go build $(GOBUILD) -o $@ $<
+	go build -i $(GOBUILD) -o $@ $<
 
 bpf-event-test.o: bpf-event-test.c
 	clang -I../../bpf/include -O2 -emit-llvm -D__NR_CPUS__=$(shell nproc) -c $< -o - | llc -march=bpf -filetype=obj -o $@

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -10,7 +10,7 @@ include ../Makefile.defs
 TARGET=cilium-agent
 SOURCES := $(shell find ../api ../common ../daemon ../pkg . -name '*.go')
 $(TARGET): $(SOURCES) check-bindata
-	go build $(GOBUILD) -o $(TARGET)
+	go build -i $(GOBUILD) -o $(TARGET)
 
 GO_BINDATA := go-bindata -prefix ../ -mode 0640 -modtime 1450269211 \
 	-ignore Makefile -ignore bpf_features.h -ignore lxc_config.h \

--- a/plugins/cilium-cni/Makefile
+++ b/plugins/cilium-cni/Makefile
@@ -11,7 +11,7 @@ clean:
 SOURCES := $(shell find ../../api/v1/models ../../common ../../pkg/client ../../pkg/endpoint . -name '*.go')
 
 $(TARGET): $(SOURCES)
-	go build $(GOBUILD) -o $(TARGET) ./cilium-cni.go
+	go build -i $(GOBUILD) -o $(TARGET) ./cilium-cni.go
 
 install:
 	$(INSTALL) -m 0755 -d $(DESTDIR)/etc/cni/net.d

--- a/plugins/cilium-docker/Makefile
+++ b/plugins/cilium-docker/Makefile
@@ -7,7 +7,7 @@ all: $(TARGET)
 SOURCES := $(shell find ../../api/v1 ../../common ../../pkg/client ../../pkg/endpoint driver . -name '*.go')
 
 $(TARGET): $(SOURCES)
-	go build $(GOBUILD) -o $(TARGET)
+	go build -i $(GOBUILD) -o $(TARGET)
 
 run:
 	./cilium-docker -d


### PR DESCRIPTION
This reduces the build from almost 2min to 30s or less in my
environment.

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>