### PR TITLE
kvstore: clearing old services path

### DIFF
--- a/common/const.go
+++ b/common/const.go
@@ -17,24 +17,26 @@ package common
 const (
 	// Consul dedicated constants
 
-	// OperationalPath is the base path to store the operational details in consul.
+	// OperationalPath is the base path to store the operational details in the kvstore.
 	OperationalPath = "cilium-net/operational"
 
-	// LastFreeLabelIDKeyPath is the path where the Last free UUID is stored in consul.
+	// LastFreeLabelIDKeyPath is the path where the Last free UUID is stored in the kvstore.
 	LastFreeLabelIDKeyPath = OperationalPath + "/Labels/LastUUID"
-	// LabelsKeyPath is the base path where labels are stored in consul.
+	// LabelsKeyPath is the base path where labels are stored in the kvstore.
 	LabelsKeyPath = OperationalPath + "/Labels/SHA256SUMLabels"
-	// LabelIDKeyPath is the base path where the IDs are stored in consul.
+	// LabelIDKeyPath is the base path where the IDs are stored in the kvstore.
 	LabelIDKeyPath = OperationalPath + "/Labels/IDs"
-	// MaxSetOfLabels is maximum number of set of labels that can be stored in consul.
+	// MaxSetOfLabels is maximum number of set of labels that can be stored in the kvstore.
 	MaxSetOfLabels = uint32(0xFFFF)
-	// LastFreeServiceIDKeyPath is the path where the Last free UUID is stored in consul.
-	LastFreeServiceIDKeyPath = OperationalPath + "/Services/LastUUID"
-	// ServicesKeyPath is the base path where services are stored in consul.
-	ServicesKeyPath = OperationalPath + "/Services/SHA256SUMServices"
-	// ServiceIDKeyPath is the base path where the IDs are stored in consul.
-	ServiceIDKeyPath = OperationalPath + "/Services/IDs"
-	// MaxSetOfServiceID is maximum number of set of service IDs that can be stored in consul.
+	// LastFreeServiceIDKeyPath is the path where the Last free UUID is stored in the kvstore.
+	LastFreeServiceIDKeyPath = OperationalPath + "/ServicesV2/LastUUID"
+	// ServicesKeyPath is the base path where services are stored in the kvstore.
+	ServicesKeyPath = OperationalPath + "/ServicesV2/SHA256SUMServices"
+	// ServiceIDKeyPath is the base path where the IDs are stored in the kvstore.
+	ServiceIDKeyPath = OperationalPath + "/ServicesV2/IDs"
+	// ServicePathV1 is the base path for the services stored in the kvstore.
+	ServicePathV1 = OperationalPath + "/Services/"
+	// MaxSetOfServiceID is maximum number of set of service IDs that can be stored in the kvstore.
 	MaxSetOfServiceID = uint32(0xFFFF)
 	// FirstFreeServiceID is the first ID for which the services should be assigned.
 	FirstFreeServiceID = uint32(1)

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -86,9 +86,12 @@ func newConsulClient(config *consulAPI.Config) (KVClient, error) {
 		log.Error(e)
 		return nil, e
 	}
+	cc := &ConsulClient{c}
+	// Clean-up old services path
+	cc.DeleteTree(common.ServicePathV1)
 
 	log.Info("Consul client ready")
-	return &ConsulClient{c}, nil
+	return cc, nil
 }
 
 func (c *ConsulClient) LockPath(path string) (KVLocker, error) {

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -101,6 +101,8 @@ func newEtcdClient(config *client.Config, cfgPath string) (KVClient, error) {
 	if err := ec.CheckMinVersion(15 * time.Second); err != nil {
 		log.Fatalf("%s", err)
 	}
+	// Clean-up old services path
+	ec.DeleteTree(common.ServicePathV1)
 	go func() {
 		for {
 			<-ec.session.Done()


### PR DESCRIPTION
Since the bug fixed in 4a6646c1d0 (kvstore/etcd: bug fix concurrent
service ID allocation) left the kvstore services path on a non
conformance state, we have to clean up the old services path and
create new services version path to properly start allocating service
IDs to services.

Signed-off-by: André Martins <andre@cilium.io>