### PR TITLE
examples/kubernetes-ingress: continue if k8s master is not ready

### DIFF
--- a/examples/kubernetes-ingress/scripts/04-2-run-inside-vms-kubernetes-controller.sh
+++ b/examples/kubernetes-ingress/scripts/04-2-run-inside-vms-kubernetes-controller.sh
@@ -110,4 +110,4 @@ sudo systemctl status kube-scheduler --no-pager
 
 sleep 2s
 
-kubectl -s http://${controllers_ips[0]}:8080 get componentstatuses
+kubectl -s http://${controllers_ips[0]}:8080 get componentstatuses || true


### PR DESCRIPTION
While setting up k8s in for development environment, kubernetes cluster
might not be ready when kubectl wants to check for component status. We
can append a `|| true` to that particular command since the failure of
this command prevents the VM from finishing up its configuration.

Signed-off-by: André Martins <andre@cilium.io>