### PR TITLE
tests: fix logic to pick up k8s, cilium logs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,9 +25,9 @@ pipeline {
     post {
         always {
             sh './tests/copy_files || true'
-            archiveArtifacts artifacts: "cilium-files-runtime.tar.gz", allowEmptyArchive: true
+            archiveArtifacts artifacts: "cilium-files-runtime-${JOB_BASE_NAME}-${BUILD_NUMBER}.tar.gz", allowEmptyArchive: true
             sh './tests/k8s/copy_files || true'
-            archiveArtifacts artifacts: "cilium-files-k8s.tar.gz", allowEmptyArchive: true
+            archiveArtifacts artifacts: "cilium-files-k8s-${JOB_BASE_NAME}-${BUILD_NUMBER}.tar.gz", allowEmptyArchive: true
             sh 'vagrant destroy -f'
             sh 'cd ./tests/k8s && vagrant destroy -f'
         }

--- a/tests/copy_files
+++ b/tests/copy_files
@@ -10,13 +10,11 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 function copy_runtime_test_files {
   local VM=$(get_cilium_master_vm_name)
   local RUNTIME_TESTS_DIR="tests/${CILIUM_FILES}"
-   
-  sudo rm -rf ./cilium-files
-  sudo rm -rf *.tar.gz
 
   copy_files_vm ${VM} ${RUNTIME_TESTS_DIR}
 
-  sudo tar -czvf ${CILIUM_FILES}-runtime.tar.gz ${CILIUM_FILES}-*
+  # BUILD_ID is generated in helpers.bash.
+  sudo tar -czvf ${CILIUM_FILES}-runtime-${BUILD_ID}.tar.gz ${CILIUM_FILES}-${VM}
 }
 
 copy_runtime_test_files

--- a/tests/k8s/copy_files
+++ b/tests/k8s/copy_files
@@ -18,15 +18,14 @@ function copy_k8s_test_files {
   echo "VM1: $VM1"
   echo "VM2: $VM2"
  
-  sudo rm -rf ./cilium-files
-  sudo rm -rf *.tar.gz
-  
   cd ./tests/k8s
+
   copy_files_vm ${VM1} ${K8S_FILES_DIR}
   copy_files_vm ${VM2} ${K8S_FILES_DIR}
 
-  sudo tar -czvf ${CILIUM_FILES}-k8s.tar.gz ${CILIUM_FILES}-*
-  mv ${CILIUM_FILES}-k8s.tar.gz ${OLD_DIR}
+  # BUILD_ID is generated in helpers.bash. 
+  sudo tar -czvf ${CILIUM_FILES}-k8s-${BUILD_ID}.tar.gz ${CILIUM_FILES}-${K8S1}-build-${BUILD_ID} ${CILIUM_FILES}-${K8S2}-build-${BUILD_ID}
+  mv ${CILIUM_FILES}-k8s-${BUILD_ID}.tar.gz ${OLD_DIR}
 }
 
 copy_k8s_test_files

--- a/tests/k8s/tests/00-gsg-test.bash
+++ b/tests/k8s/tests/00-gsg-test.bash
@@ -29,12 +29,15 @@ function cleanup {
 }
 
 function gather_logs {
-	mkdir -p ./cilium-files/logs
-	kubectl logs -n kube-system ${CILIUM_POD_1} > ./cilium-files/logs/cilium-logs-1 || true
-	kubectl logs -n kube-system ${CILIUM_POD_2} > ./cilium-files/logs/cilium-logs-2 || true
-	kubectl logs -n kube-system kube-apiserver-k8s-1 > ./cilium-files/logs/kube-apiserver-k8s-1-logs || true
-	kubectl logs -n kube-system kube-controller-manager-k8s-1 > ./cilium-files/logs/kube-controller-manager-k8s-1-logs || true
-	journalctl -au kubelet > ./cilium-files/logs/kubelet-k8s-1-logs || true
+  local CILIUM_ROOT="src/github.com/cilium/cilium"
+  local LOGS_DIR="${GOPATH}/${CILIUM_ROOT}/tests/cilium-files/logs"
+  echo "storing K8s-relevant logs at: ${LOGS_DIR}"
+  mkdir -p ${LOGS_DIR}
+  kubectl logs -n kube-system ${CILIUM_POD_1} > ${LOGS_DIR}/cilium-logs-1 || true
+  kubectl logs -n kube-system ${CILIUM_POD_2} > ${LOGS_DIR}/cilium-logs-2 || true
+  kubectl logs -n kube-system kube-apiserver-k8s-1 > ${LOGS_DIR}/kube-apiserver-k8s-1-logs || true
+  kubectl logs -n kube-system kube-controller-manager-k8s-1 > ${LOGS_DIR}/kube-controller-manager-k8s-1-logs || true
+  journalctl -au kubelet > ${LOGS_DIR}/kubelet-k8s-1-logs || true
 }
 
 function finish_test {


### PR DESCRIPTION
* k8s tests: pick up kubelet, kube-controller-manager, kube-apiserver, cilium logs from both nodes.
* runtime tests: pick up cilium logs using journalctl
* name each tar.gz file using JOB_BASE_NAME-BUILD_NUMBER to differentiate between tar.gz files downloaded locally.
    
Signed-off by: Ian Vernon <ian@covalent.io>