### PR TITLE
Makefile: allow to specify go command

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -3,6 +3,7 @@ BINDIR?=$(PREFIX)/bin
 RUNDIR?=/var/run
 CONFDIR?=/etc
 
+GO = go
 INSTALL = install
 
 VERSION = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/VERSION)

--- a/cilium/Makefile
+++ b/cilium/Makefile
@@ -3,13 +3,13 @@ include ../Makefile.defs
 TARGET=cilium
 SOURCES := $(shell find ../api ../daemon ../common ../pkg cmd . -name '*.go')
 $(TARGET): $(SOURCES)
-	go build -i $(GOBUILD) -o $(TARGET)
+	$(GO) build -i $(GOBUILD) -o $(TARGET)
 
 all: $(TARGET)
 
 clean:
 	rm -f $(TARGET)
-	go clean
+	$(GO) clean
 
 install:
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)

--- a/common/tests/Makefile
+++ b/common/tests/Makefile
@@ -3,7 +3,7 @@ include ../../Makefile.defs
 all: perf-event-test bpf-event-test.o
 
 perf-event-test: perf-event-test.go
-	go build -i $(GOBUILD) -o $@ $<
+	$(GO) build -i $(GOBUILD) -o $@ $<
 
 bpf-event-test.o: bpf-event-test.c
 	clang -I../../bpf/include -O2 -emit-llvm -D__NR_CPUS__=$(shell nproc) -c $< -o - | llc -march=bpf -filetype=obj -o $@

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -10,7 +10,7 @@ include ../Makefile.defs
 TARGET=cilium-agent
 SOURCES := $(shell find ../api ../common ../daemon ../pkg . -name '*.go')
 $(TARGET): $(SOURCES) check-bindata
-	go build -i $(GOBUILD) -o $(TARGET)
+	$(GO) build -i $(GOBUILD) -o $(TARGET)
 
 GO_BINDATA := go-bindata -prefix ../ -mode 0640 -modtime 1450269211 \
 	-ignore Makefile -ignore bpf_features.h -ignore lxc_config.h \
@@ -21,7 +21,7 @@ all: $(TARGET)
 
 clean:
 	rm -f $(TARGET)
-	go clean
+	$(GO) clean
 
 ifeq ("$(PKG_BUILD)","")
 

--- a/plugins/cilium-cni/Makefile
+++ b/plugins/cilium-cni/Makefile
@@ -5,13 +5,13 @@ all: cilium-cni
 TARGET=cilium-cni
 
 clean:
-	go clean
+	$(GO) clean
 	rm -f $(TARGET)
 
 SOURCES := $(shell find ../../api/v1/models ../../common ../../pkg/client ../../pkg/endpoint . -name '*.go')
 
 $(TARGET): $(SOURCES)
-	go build -i $(GOBUILD) -o $(TARGET) ./cilium-cni.go
+	$(GO) build -i $(GOBUILD) -o $(TARGET) ./cilium-cni.go
 
 install:
 	$(INSTALL) -m 0755 -d $(DESTDIR)/etc/cni/net.d

--- a/plugins/cilium-docker/Makefile
+++ b/plugins/cilium-docker/Makefile
@@ -7,13 +7,13 @@ all: $(TARGET)
 SOURCES := $(shell find ../../api/v1 ../../common ../../pkg/client ../../pkg/endpoint driver . -name '*.go')
 
 $(TARGET): $(SOURCES)
-	go build -i $(GOBUILD) -o $(TARGET)
+	$(GO) build -i $(GOBUILD) -o $(TARGET)
 
 run:
 	./cilium-docker -d
 
 clean:
-	go clean
+	$(GO) clean
 	rm -f $(TARGET)
 
 install:


### PR DESCRIPTION
In order to build cilium with different go versions (e.g. beta or rc
releases), allow to set the go command used by the Makefiles via the GO
variable:

  $ make GO=go1.9rc1

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>