### PR TITLE
cilium: only drop consumer from map when really needed

### DIFF
--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -177,9 +177,13 @@ func (c *Consumable) deleteReverseRule(consumable NumericIdentity, consumer Nume
 	}
 
 	if reverse := c.cache.Lookup(consumable); reverse != nil {
-		delete(reverse.ReverseRules, consumer)
-		if reverse.wasLastRule(consumer) {
-			reverse.removeFromMaps(consumer)
+		// In case Conntrack is disabled, we'll find a reverse
+		// policy rule here that we can delete.
+		if _, ok := reverse.ReverseRules[consumer]; ok {
+			delete(reverse.ReverseRules, consumer)
+			if reverse.wasLastRule(consumer) {
+				reverse.removeFromMaps(consumer)
+			}
 		}
 	}
 }


### PR DESCRIPTION
My log is often spammed with "Update of policy map failed: Unable to
delete element: no such file or directory" and it's unsure whether it's
a real issue related to policy or not. Debugging this, it turns out we
always hit this on deleteEndpoint() when we delete the Consumable and
search and remove corresponding reverse rules. What happens is that
in deleteReverseRule() the found reverse Consumable has empty ReverseRules[]
where we nevertheless try to delete consumer ID from it and given that
reverse.wasLastRule() holds true we try to remove the consumer ID also
from the map via reverse.removeFromMaps(), but the map doesn't contain
any such ID. This is due to Conntrack being used, so given Conntrack
would have been disabled, then we would find a corresponding reverse
entry here as well. Thus, only delete it when really needed.

Fixes: #1205

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>