### PR TITLE
Fix label name so getting-started example works

### DIFF
--- a/Documentation/gettingstarted.rst
+++ b/Documentation/gettingstarted.rst
@@ -666,14 +666,14 @@ import this policy to Cilium by running:
 
 ::
 
-    $ docker run --rm -ti --net cilium-net -l "id.app2" cilium/demo-client curl -si 'http://app1/public'
+    $ docker run --rm -ti --net cilium-net -l "id=app2" cilium/demo-client curl -si 'http://app1/public'
     { 'val': 'this is public' }
 
 and
 
 ::
 
-    $ docker run --rm -ti --net cilium-net -l "id.app2" cilium/demo-client curl -si 'http://app1/private'
+    $ docker run --rm -ti --net cilium-net -l "id=app2" cilium/demo-client curl -si 'http://app1/private'
     Access denied
 
 As you can see, with Cilium L7 security policies, we are able to permit


### PR DESCRIPTION
When trying to run the getting-started example I noticed the `docker run` command has an incorrect label.

```
vagrant@cilium-1:~/cilium/examples/getting-started$ docker run --rm -ti --net cilium-net -l "id.app2" cilium/demo-client curl -si 'http://app1/public'
^C
^C^C
^C
^C
^C
# showing that it hangs
```

Using the proper label yields

```
vagrant@cilium-1:~/cilium/examples/getting-started$ docker run --rm -ti --net cilium-net -l "id=app2" cilium/demo-client curl -si 'http://app1/public'
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 28
Date: Thu, 27 Jul 2017 16:07:45 GMT
Etag: "1c-54bb868cec400"
Last-Modified: Mon, 27 Mar 2017 15:58:08 GMT
Server: Apache/2.4.25 (Unix)
Content-Type: text/plain; charset=utf-8

{ 'val': 'this is public' }
```