### PR TITLE
Documentation: add TPR -> CRD instructions

### DIFF
--- a/Documentation/admin.rst
+++ b/Documentation/admin.rst
@@ -470,6 +470,75 @@ worker node:
 
 .. _admin_k8s_troubleshooting:
 
+
+Migrating Cilium ThirdPartyResource to CustomResourceDefinition 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Prior to Kubernetes 1.7, Cilium Network Policy (CNP) objects were imported as a `Kubernetes ThirdPartyResource (TPRs) <https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-third-party-resource/>`_.
+In Kubernetes ``>=1.7.0``, TPRs are now deprecated, and will be removed in Kubernetes 1.8. TPRs are  replaced by `Custom Resource Definitions (CRDs) <https://kubernetes.io/docs/concepts/api-extension/custom-resources/#customresourcedefinitions>`_.  Thus, as part of the upgrade process to Kubernetes 1.7, Kubernetes has provided documentation for `migrating TPRs to CRDS <http://cilium.link/migrate-tpr>`_. 
+
+The following instructions document how to migrate CiliumNetworkPolicies existing as TPRs from a Kubernetes cluster which was previously running versions ``< 1.7.0`` to CRDs on a Kubernetes cluster running versions ``>= 1.7.0``. This is meant to correspond to steps 4-6 of the `aforementioned guide <http://cilium.link/migrate-tpr>`_.
+
+Cilium adds the CNP CRD automatically; check to see that the CNP CRD has been added by Cilium:
+
+.. code:: bash
+
+       $ kubectl get customresourcedefinition
+       NAME                              KIND
+       ciliumnetworkpolicies.cilium.io   CustomResourceDefinition.v1beta1.apiextensions.k8s.io
+
+Save your existing CNPs which were previously added as TPRs:
+
+.. code:: bash
+
+       $ kubectl get ciliumnetworkpolicies --all-namespaces -o yaml > cnps.yaml
+
+Change the version of the Cilium API from v1 to v2 in the YAML file to which you just saved your old CNPs. The Cilium API is versioned to account for the change from TPR to CRD:
+
+.. code:: bash
+
+       $ cp cnps.yaml cnps.yaml.new
+       $ # Edit the version
+       $ vi cnps.yaml.new
+       $ # The diff of the old vs. new YAML file should be similar to the output below.
+       $ diff cnps.yaml cnps.yaml.new
+       3c3
+       < - apiVersion: cilium.io/v1
+       ---
+       > - apiVersion: cilium.io/v2
+       10c10
+       <     selfLink: /apis/cilium.io/v1/namespaces/default/ciliumnetworkpolicies/guestbook-web-deprecated
+       ---
+       >     selfLink: /apis/cilium.io/v2/namespaces/default/ciliumnetworkpolicies/guestbook-web-deprecated
+
+Delete your old CNPs:
+
+.. code:: bash
+
+       $ kubectl delete ciliumnetworkpolicies --all
+       $ kubectl delete thirdpartyresource cilium-network-policy.cilium.io
+
+Add the changed CNPs back as CRDs:
+
+.. code:: bash
+
+       $ kubectl create -f cnps.yaml.new
+
+Check that your CNPs are added:
+
+.. code:: bash
+
+       $ kubectl get ciliumnetworkpolicies
+       NAME                       KIND
+       guestbook-web-deprecated   CiliumNetworkPolicy.v2.cilium.io
+       multi-rules-deprecated     CiliumNetworkPolicy.v2.cilium.io   Policy to test multiple rules in a single file   2 item(s)
+
+Now if you try to create a CNP as a TPR, you will get an error:
+
+.. code:: bash
+
+       $ Error from server (BadRequest): error when creating "cilium-tpr.yaml": the API version in the data (cilium.io/v1) does not match the expected API version (cilium.io/v2)
+
 Troubleshooting
 ^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Add instructions for how to migrate CiliumNetworkPolicies stored as ThirdPartyResources to CustomResourceDefinitions.

Signed-off by: Ian Vernon <ian@covalent.io>

Fixes: #1218 