### PR TITLE
daemon: pkg: plugins: remove trailing newlines from log calls

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -444,7 +444,7 @@ func (d *Daemon) compileBase() error {
 	var mode string
 
 	if err := d.writeNetdevHeader("./"); err != nil {
-		log.Warningf("Unable to write netdev header: %s\n", err)
+		log.Warningf("Unable to write netdev header: %s", err)
 		return err
 	}
 
@@ -915,7 +915,7 @@ func NewDaemon(c *Config) (*Daemon, error) {
 	}
 
 	if err = d.init(); err != nil {
-		log.Errorf("Error while initializing daemon: %s\n", err)
+		log.Errorf("Error while initializing daemon: %s", err)
 		return nil, err
 	}
 
@@ -924,10 +924,10 @@ func NewDaemon(c *Config) (*Daemon, error) {
 
 	if c.RestoreState {
 		if err := d.SyncState(d.conf.StateDir, true); err != nil {
-			log.Warningf("Error while recovering endpoints: %s\n", err)
+			log.Warningf("Error while recovering endpoints: %s", err)
 		}
 		if err := d.SyncLBMap(); err != nil {
-			log.Warningf("Error while recovering endpoints: %s\n", err)
+			log.Warningf("Error while recovering endpoints: %s", err)
 		}
 	} else {
 		// We need to read all docker containers so we know we won't
@@ -1059,7 +1059,7 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 	}
 	if changes > 0 {
 		if err := d.compileBase(); err != nil {
-			msg := fmt.Errorf("Unable to recompile base programs: %s\n", err)
+			msg := fmt.Errorf("Unable to recompile base programs: %s", err)
 			log.Warningf("%s", msg)
 			return apierror.Error(PatchConfigFailureCode, msg)
 		}

--- a/daemon/ipam.go
+++ b/daemon/ipam.go
@@ -121,7 +121,7 @@ func (h *postIPAM) Handle(params ipam.PostIPAMParams) middleware.Responder {
 
 	family := strings.ToLower(swag.StringValue(params.Family))
 
-	log.Debugf("%+v %+v\n", family, d.ipamConf.IPv4Allocator)
+	log.Debugf("%+v %+v", family, d.ipamConf.IPv4Allocator)
 
 	if (family == "ipv6" || family == "") && d.ipamConf.IPv6Allocator != nil {
 		ipConf, err := d.ipamConf.IPv6Allocator.AllocateNext()

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -143,7 +143,7 @@ func createCustomResourceDefinitions(clientset apiextensionsclient.Interface) er
 				}
 			case apiextensionsv1beta1.NamesAccepted:
 				if cond.Status == apiextensionsv1beta1.ConditionFalse {
-					log.Errorf("Name conflict: %v\n", cond.Reason)
+					log.Errorf("Name conflict: %v", cond.Reason)
 					return false, err
 				}
 			}

--- a/daemon/labels.go
+++ b/daemon/labels.go
@@ -126,12 +126,12 @@ func (d *Daemon) CreateOrUpdateIdentity(lbls labels.Labels, epid string) (*polic
 	// K/V store operations
 
 	if isNew {
-		log.Debugf("Creating new identity %d ref-count to %d\n", identity.ID, identity.RefCount())
+		log.Debugf("Creating new identity %d ref-count to %d", identity.ID, identity.RefCount())
 		if err := gasNewSecLabelID(identity); err != nil {
 			return nil, false, err
 		}
 	} else {
-		log.Debugf("Incrementing identity %d ref-count to %d\n", identity.ID, identity.RefCount())
+		log.Debugf("Incrementing identity %d ref-count to %d", identity.ID, identity.RefCount())
 		if err := updateSecLabelIDRef(*identity); err != nil {
 			return nil, false, err
 		}
@@ -357,7 +357,7 @@ func (d *Daemon) DeleteIdentityBySHA256(sha256Sum string, epid string) error {
 		return err
 	}
 
-	log.Debugf("Decremented label %d ref-count to %d\n", dbSecCtxLbls.ID, dbSecCtxLbls.RefCount())
+	log.Debugf("Decremented label %d ref-count to %d", dbSecCtxLbls.ID, dbSecCtxLbls.RefCount())
 
 	if err := kvstore.Client.SetValue(lblPath, dbSecCtxLbls); err != nil {
 		return err

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -218,7 +218,7 @@ func checkMinRequirements() {
 		if err != nil {
 			log.Fatalf("BPF Verifier: NOT OK. Unable to read %q: %s", bpfLogPath, err)
 		}
-		log.Infof("BPF Verifier: NOT OK:\n%s", string(bpfFeaturesLog))
+		log.Infof("BPF Verifier: NOT OK:%s", string(bpfFeaturesLog))
 	} else {
 		log.Fatalf("BPF Verifier: NOT OK. Unable to read %q: %s", bpfLogPath, err)
 	}
@@ -430,7 +430,7 @@ func initEnv() {
 	if bpfRoot != "" {
 		bpf.SetMapRoot(bpfRoot)
 	} else if err := bpf.MountFS(); err != nil {
-		log.Fatalf("Unable to mount BPF filesystem: %s\n", err)
+		log.Fatalf("Unable to mount BPF filesystem: %s", err)
 	}
 
 	if viper.GetBool("debug") {

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -73,7 +73,7 @@ func (d *Daemon) TriggerPolicyUpdates(added []policy.NumericIdentity) *sync.Wait
 		log.Debugf("Full policy recalculation triggered")
 		d.invalidateCache()
 	} else {
-		log.Debugf("Partial policy recalculation triggered: %d\n", added)
+		log.Debugf("Partial policy recalculation triggered: %d", added)
 		// FIXME: Invalidate only cache that is affected
 		d.invalidateCache()
 	}

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -144,7 +144,7 @@ func readEPsFromDirNames(basePath string, eptsDirNames []string) []*endpoint.End
 	for _, epID := range eptsDirNames {
 		epDir := filepath.Join(basePath, epID)
 		readDir := func() string {
-			log.Debugf("Reading directory %s\n", epDir)
+			log.Debugf("Reading directory %s", epDir)
 			epFiles, err := ioutil.ReadDir(epDir)
 			if err != nil {
 				log.Warningf("Error while reading directory %q. Ignoring it...", epDir)
@@ -163,15 +163,15 @@ func readEPsFromDirNames(basePath string, eptsDirNames []string) []*endpoint.End
 		if cHeaderFile == "" {
 			cHeaderFile = readDir()
 		}
-		log.Debugf("Found endpoint C header file %q\n", cHeaderFile)
+		log.Debugf("Found endpoint C header file %q", cHeaderFile)
 		strEp, err := common.GetCiliumVersionString(cHeaderFile)
 		if err != nil {
-			log.Warningf("Unable to read the C header file %q: %s\n", cHeaderFile, err)
+			log.Warningf("Unable to read the C header file %q: %s", cHeaderFile, err)
 			continue
 		}
 		ep, err := endpoint.ParseEndpoint(strEp)
 		if err != nil {
-			log.Warningf("Unable to read the C header file %q: %s\n", cHeaderFile, err)
+			log.Warningf("Unable to read the C header file %q: %s", cHeaderFile, err)
 			continue
 		}
 		possibleEPs = append(possibleEPs, ep)
@@ -211,7 +211,7 @@ func (d *Daemon) syncLabels(ep *endpoint.Endpoint) error {
 
 	if labels.ID != ep.SecLabel.ID {
 		log.Infof("Security label ID for endpoint %d is different "+
-			"that the one stored, updating from %d to %d\n",
+			"that the one stored, updating from %d to %d",
 			ep.ID, ep.SecLabel.ID, labels.ID)
 	}
 	ep.SetIdentity(d, labels)

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -39,7 +39,7 @@ func (e *Endpoint) checkEgressAccess(owner Owner, opts models.ConfigurationMap, 
 
 	ctx.To, err = owner.GetCachedLabelList(dstID)
 	if err != nil {
-		log.Warningf("Unable to get label list for ID %d, access for endpoint may be restricted\n", dstID)
+		log.Warningf("Unable to get label list for ID %d, access for endpoint may be restricted", dstID)
 		return
 	}
 
@@ -211,7 +211,7 @@ func (e *Endpoint) regenerateConsumable(owner Owner) (bool, error) {
 	// Result is valid until cache iteration advances
 	c.Iteration = repo.GetRevision()
 
-	log.Debugf("[%s] Iteration %d: new consumable %d, consumers = %+v\n",
+	log.Debugf("[%s] Iteration %d: new consumable %d, consumers = %+v",
 		e.PolicyID(), c.Iteration, c.ID, c.Consumers)
 
 	// FIXME: Optimize this and only return true if L4 policy changed

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -241,7 +241,7 @@ func TriggerPolicyUpdates(owner endpoint.Owner) *sync.WaitGroup {
 		go func(ep *endpoint.Endpoint, wg *sync.WaitGroup) {
 			policyChanges, err := ep.TriggerPolicyUpdates(owner)
 			if err != nil {
-				log.Warningf("Error while handling policy updates for endpoint %s\n", err)
+				log.Warningf("Error while handling policy updates for endpoint %s", err)
 				ep.LogStatus(endpoint.Policy, endpoint.Failure, err.Error())
 			} else {
 				ep.LogStatusOK(endpoint.Policy, "Policy regenerated")

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -165,7 +165,7 @@ func (c *Consumable) AddMap(m *policymap.PolicyMap) {
 	// this consumable
 	for _, c := range c.Consumers {
 		if err := m.AllowConsumer(c.ID.Uint32()); err != nil {
-			log.Warningf("Update of policy map failed: %s\n", err)
+			log.Warningf("Update of policy map failed: %s", err)
 		}
 	}
 }
@@ -232,9 +232,9 @@ func (c *Consumable) addToMaps(id NumericIdentity) {
 			continue
 		}
 
-		log.Debugf("Updating policy BPF map %s: allowing %d\n", m.String(), id)
+		log.Debugf("Updating policy BPF map %s: allowing %d", m.String(), id)
 		if err := m.AllowConsumer(id.Uint32()); err != nil {
-			log.Warningf("Update of policy map failed: %s\n", err)
+			log.Warningf("Update of policy map failed: %s", err)
 		}
 	}
 }
@@ -245,9 +245,9 @@ func (c *Consumable) wasLastRule(id NumericIdentity) bool {
 
 func (c *Consumable) removeFromMaps(id NumericIdentity) {
 	for _, m := range c.Maps {
-		log.Debugf("Updating policy BPF map %s: denying %d\n", m.String(), id)
+		log.Debugf("Updating policy BPF map %s: denying %d", m.String(), id)
 		if err := m.DeleteConsumer(id.Uint32()); err != nil {
-			log.Warningf("Update of policy map failed: %s\n", err)
+			log.Warningf("Update of policy map failed: %s", err)
 		}
 	}
 }
@@ -268,11 +268,11 @@ func (c *Consumable) AllowConsumerLocked(cache *ConsumableCache, id NumericIdent
 // consumers map and the given consumable to the given consumer's consumers map.
 // Must be called with Consumable mutex Locked.
 func (c *Consumable) AllowConsumerAndReverseLocked(cache *ConsumableCache, id NumericIdentity) {
-	log.Debugf("Allowing direction %d -> %d\n", id, c.ID)
+	log.Debugf("Allowing direction %d -> %d", id, c.ID)
 	c.AllowConsumerLocked(cache, id)
 
 	if reverse := cache.Lookup(id); reverse != nil {
-		log.Debugf("Allowing reverse direction %d -> %d\n", c.ID, id)
+		log.Debugf("Allowing reverse direction %d -> %d", c.ID, id)
 		if _, ok := reverse.ReverseRules[c.ID]; !ok {
 			reverse.addToMaps(c.ID)
 			reverse.ReverseRules[c.ID] = NewConsumer(c.ID)
@@ -286,7 +286,7 @@ func (c *Consumable) AllowConsumerAndReverseLocked(cache *ConsumableCache, id Nu
 // map. Must be called with the Consumable mutex locked.
 func (c *Consumable) BanConsumerLocked(id NumericIdentity) {
 	if consumer, ok := c.Consumers[id.StringID()]; ok {
-		log.Debugf("Removing consumer %v\n", consumer)
+		log.Debugf("Removing consumer %v", consumer)
 		delete(c.Consumers, id.StringID())
 
 		if c.wasLastRule(id) {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -392,7 +392,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, source Pr
 			for {
 				time.Sleep(time.Duration(10) * time.Second)
 				if deleted := GC(); deleted > 0 {
-					log.Debugf("Evicted %d entries from proxy table\n", deleted)
+					log.Debugf("Evicted %d entries from proxy table", deleted)
 				}
 			}
 		}()
@@ -472,7 +472,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, source Pr
 				return
 			} else {
 				ar := rule.(policy.AuxRule)
-				log.Debugf("Allowing request based on rule %+v\n", ar)
+				log.Debugf("Allowing request based on rule %+v", ar)
 				record.Info = fmt.Sprintf("rule: %+v", ar)
 			}
 		}

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -450,7 +450,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	}
 
 	if err := client.EndpointDelete(id); err != nil {
-		log.Warningf("Deletion of endpoint failed: %s\n", err)
+		log.Warningf("Deletion of endpoint failed: %s", err)
 	}
 
 	return ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {

--- a/tests/00-no-newlines-in-log-call.sh
+++ b/tests/00-no-newlines-in-log-call.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+source ./helpers.bash
+
+if grep --include \*.go -r log\. ../ | grep -v vendor \
+  | grep -v contrib \
+  | grep -v logging.go \
+  | grep -F "\n"; then
+  abort "found newline(s) in log call(s), please remove ending \n"
+fi


### PR DESCRIPTION
Closes: #1230 (Remove all trailing \n from log.*f() function calls)
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>