### PR TITLE
Add go-bindata to build requirements

### DIFF
--- a/contrib/packaging/rpm/cfg/cilium.spec.envsubst
+++ b/contrib/packaging/rpm/cfg/cilium.spec.envsubst
@@ -9,7 +9,7 @@ License:       Apache
 URL:           https://github/cilium/cilium
 ExclusiveArch: x86_64
 Source0:       https://github.com/cilium/%{name}/archive/%{commit0}.tar.gz#/%{name}-%{shortcommit0}.tar.gz
-BuildRequires: golang, glibc-devel(x86-32)
+BuildRequires: golang, go-bindata, glibc-devel(x86-32)
 Requires:      docker-engine >= 1.12, glibc-devel(x86-32), iproute >= 4.10, clang
 %{?fc25:Requires: clang >= 3.8, clang < 3.9}
 


### PR DESCRIPTION
Fixes the following build issue:

```make[2]: Entering directory '/infrastructure/support/cilium-rpm-builder/rpmbuild/BUILD/cilium-f8626a9dba1405e81951bf291d4ef8b1d7d756c4/src/github.com/cilium/cilium/daemon'
go-bindata -prefix ../ -mode 0640 -modtime 1450269211 -ignore Makefile -ignore bpf_features.h -ignore lxc_config.h -ignore netdev_config.h -ignore node_config.h -ignore '.+\.o$' -ignore '.+\.orig$' -ignore '.+~$' -ignore '\.DS_Store' -o ./bindata.go `git ls-files ../bpf/`
/bin/sh: go-bindata: command not found
Makefile:49: recipe for target 'go-bindata' failed
make[2]: *** [go-bindata] Error 127
make[2]: Leaving directory '/infrastructure/support/cilium-rpm-builder/rpmbuild/BUILD/cilium-f8626a9dba1405e81951bf291d4ef8b1d7d756c4/src/github.com/cilium/cilium/daemon'
Makefile:10: recipe for target 'daemon' failed
make[1]: *** [daemon] Error 2
make[1]: Leaving directory '/infrastructure/support/cilium-rpm-builder/rpmbuild/BUILD/cilium-f8626a9dba1405e81951bf291d4ef8b1d7d756c4/src/github.com/cilium/cilium'
error: Bad exit status from /var/tmp/rpm-tmp.12e2Of (%build)


RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.12e2Of (%build)
Makefile:18: recipe for target 'build' failed
make: *** [build] Error 1
```