### PR TITLE
contrib/packaging: generate Dockerfiles w/ script

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 LABEL "Maintainer: Andre Martins <andre@cilium.io>"
-ADD . /tmp/cilium-net-build/src/github.com/cilium/cilium
+RUN mkdir -p /tmp/cilium-net-build/src/github.com/cilium/cilium
+ADD ./contrib/packaging/docker/clang-3.8.1.key /tmp/cilium-net-build/src/github.com/cilium/cilium/contrib/packaging/docker/clang-3.8.1.key
 RUN apt-get update && \
 
 apt-get install -y --no-install-recommends gcc make libelf-dev bison flex git ca-certificates libc6-dev.i386 iptables libgcc-5-dev binutils && \
@@ -60,22 +61,4 @@ cd /tmp/cilium-net-build/src/github.com/cilium/cilium && \
 export GOROOT=/usr/local/go && \
 export GOPATH=/tmp/cilium-net-build && \
 export PATH="$GOROOT/bin:/usr/local/clang+llvm/bin:$GOPATH/bin:$PATH" && \
-go get -u github.com/jteeuwen/go-bindata/... && \
-cd /tmp/cilium-net-build/src/github.com/cilium/cilium && \
-export GOROOT=/usr/local/go && \
-export GOPATH=/tmp/cilium-net-build && \
-export PATH="$GOROOT/bin:/usr/local/clang+llvm/bin:$GOPATH/bin:$PATH" && \
-make clean-container all && \
-make PKG_BUILD=1 install && \
-groupadd -f cilium && \
-
-apt-get purge --auto-remove -y gcc make bison flex git curl xz-utils ca-certificates && \
-apt-get clean && \
-rm -fr /root /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/local/go
-ADD plugins/cilium-cni/cni-install.sh /cni-install.sh
-ADD plugins/cilium-cni/cni-uninstall.sh /cni-uninstall.sh
-
-ENV PATH="/usr/local/clang+llvm/bin:$PATH"
-ENV INITSYSTEM="SYSTEMD"
-
-CMD ["/usr/bin/cilium"]
+go get -u github.com/jteeuwen/go-bindata/...

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,18 @@
+FROM cilium/dependencies:0.11.90
+LABEL "Maintainer: Andre Martins <andre@cilium.io>"
+
+ADD . /tmp/cilium-net-build/src/github.com/cilium/cilium
+RUN cd /tmp/cilium-net-build/src/github.com/cilium/cilium && \
+export GOROOT=/usr/local/go && \
+export GOPATH=/tmp/cilium-net-build && \
+export PATH="$GOROOT/bin:/usr/local/clang+llvm/bin:$GOPATH/bin:$PATH" && \
+make clean-container all && \
+make PKG_BUILD=1 install && \
+groupadd -f cilium
+ADD plugins/cilium-cni/cni-install.sh /cni-install.sh
+ADD plugins/cilium-cni/cni-uninstall.sh /cni-uninstall.sh
+
+ENV PATH="/usr/local/clang+llvm/bin:$PATH"
+ENV INITSYSTEM="SYSTEMD"
+
+CMD ["/usr/bin/cilium"]

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,14 @@ install:
 	for i in $(SUBDIRS); do $(MAKE) -C $$i install; done
 	for i in $(SUBDIRSLIB); do $(MAKE) -C $$i install; done
 
-docker-image:
-	$(MAKE) -C ./contrib/packaging/docker
+docker-image-prod:
+	$(MAKE) -C ./contrib/packaging/docker docker-image-prod
+
+docker-image-dependencies:
+	$(MAKE) -C ./contrib/packaging/docker docker-image-dependencies
+
+docker-image-dev:
+	$(MAKE) -C ./contrib/packaging/docker docker-image-dev
 
 build-deb:
 	$(MAKE) -C ./contrib/packaging/deb

--- a/contrib/packaging/docker/Makefile
+++ b/contrib/packaging/docker/Makefile
@@ -2,15 +2,28 @@ include ../../../Makefile.defs
 
 BUILDDIR := "$(CURDIR)/stage/cilium-$(VERSION)"
 
-build: clean
+docker-image-prod: clean
 	mkdir -p $(BUILDDIR)
 	@$(CURDIR)/../cp-dirs.sh $(BUILDDIR)
 	cp -v ../../../Dockerfile $(BUILDDIR)
-	find $(BUILDDIR) -name ".*" -prune ! -name ".git"  -exec $(RM) -rf {} \;
+	find $(BUILDDIR) -name ".*" -prune ! -name ".git" -exec $(RM) -rf {} \;
 	docker build -t "cilium:$(DOCKER_IMAGE_TAG)" $(BUILDDIR)
 
+docker-image-dev: clean
+	mkdir -p $(BUILDDIR)
+	@$(CURDIR)/../cp-dirs.sh $(BUILDDIR)
+	cp -v ../../../Dockerfile.dev $(BUILDDIR)/Dockerfile
+	find $(BUILDDIR) -name ".*" -prune ! -name ".git" -exec $(RM) -rf {} \;
+	docker build -t "cilium:$(DOCKER_IMAGE_TAG)" $(BUILDDIR)
+
+docker-image-dependencies: clean
+	mkdir -p $(BUILDDIR)
+	@$(CURDIR)/../cp-dirs.sh $(BUILDDIR)
+	cp -v ../../../Dockerfile.deps $(BUILDDIR)/Dockerfile
+	find $(BUILDDIR) -name ".*" -prune ! -name ".git" -exec $(RM) -rf {} \;
+	docker build -t "cilium:dependencies" $(BUILDDIR)
 clean:
-	ls -d ./* | grep -vE "Makefile|clang-3.8.1.key" | xargs $(RM) -rf
+	ls -d ./* | grep -vE "Makefile|clang-3.8.1.key|build_dockerfile.sh" | xargs $(RM) -rf
 
 .PHONY: clean build force
 force :;

--- a/contrib/packaging/docker/build_dockerfile.sh
+++ b/contrib/packaging/docker/build_dockerfile.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+cd "${dir}"
+
+function build_dockerfile_dev {
+   cat <<EOF > ./Dockerfile
+FROM cilium/dependencies:`cat ../../../VERSION`
+LABEL "Maintainer: Andre Martins <andre@cilium.io>"
+
+ADD . /tmp/cilium-net-build/src/github.com/cilium/cilium
+RUN 
+EOF
+
+  # Remove trailing newline.
+  printf %s "$(< Dockerfile)" > Dockerfile
+
+  add_build_cilium_cmd
+  add_cilium_run_cmd
+}
+
+function add_build_cilium_cmd {
+  cat <<EOF >> ./Dockerfile
+cd /tmp/cilium-net-build/src/github.com/cilium/cilium && \\
+export GOROOT=/usr/local/go && \\
+export GOPATH=/tmp/cilium-net-build && \\
+export PATH="\$GOROOT/bin:/usr/local/clang+llvm/bin:\$GOPATH/bin:\$PATH" && \\
+make clean-container all && \\
+make PKG_BUILD=1 install && \\
+groupadd -f cilium
+EOF
+}
+
+function add_golang_install_cmd {
+  cat <<EOF >> ./Dockerfile
+cd /tmp && \\
+curl -Sslk -o go.linux-amd64.tar.gz \\
+https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz && \\
+tar -C /usr/local -xzf go.linux-amd64.tar.gz && \\
+cd /tmp/cilium-net-build/src/github.com/cilium/cilium && \\
+export GOROOT=/usr/local/go && \\
+export GOPATH=/tmp/cilium-net-build && \\
+export PATH="\$GOROOT/bin:/usr/local/clang+llvm/bin:\$GOPATH/bin:\$PATH" && \\
+go get -u github.com/jteeuwen/go-bindata/...
+EOF
+
+}
+
+function build_dockerfile_dependencies {
+ cat <<EOF > ./Dockerfile
+FROM ubuntu:16.04
+LABEL "Maintainer: Andre Martins <andre@cilium.io>"
+RUN mkdir -p /tmp/cilium-net-build/src/github.com/cilium/cilium
+ADD ./contrib/packaging/docker/clang-3.8.1.key /tmp/cilium-net-build/src/github.com/cilium/cilium/contrib/packaging/docker/clang-3.8.1.key
+EOF
+  append_docker_install_deps
+  add_golang_install_cmd
+
+}
+
+function build_dockerfile_prod {
+  cat <<EOF > ./Dockerfile
+FROM ubuntu:16.04
+LABEL "Maintainer: Andre Martins <andre@cilium.io>"
+ADD . /tmp/cilium-net-build/src/github.com/cilium/cilium
+EOF
+
+  append_docker_install_deps
+  add_golang_install_cmd
+  printf %s "$(< Dockerfile)" > Dockerfile
+  local OUTPUT=' && \\'
+  echo "$(cat ./Dockerfile) && \\" > Dockerfile
+  add_build_cilium_cmd
+
+  printf %s "$(< Dockerfile)" > Dockerfile
+  local OUTPUT=' && \\'
+  echo "$(cat ./Dockerfile) && \\" > Dockerfile
+  cat <<EOF >> ./Dockerfile
+
+apt-get purge --auto-remove -y gcc make bison flex git curl xz-utils ca-certificates && \\
+apt-get clean && \\
+rm -fr /root /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/local/go
+EOF
+  add_cilium_run_cmd
+}
+
+function add_cilium_run_cmd {
+ cat <<EOF >> ./Dockerfile
+ADD plugins/cilium-cni/cni-install.sh /cni-install.sh
+ADD plugins/cilium-cni/cni-uninstall.sh /cni-uninstall.sh
+
+ENV PATH="/usr/local/clang+llvm/bin:\$PATH"
+ENV INITSYSTEM="SYSTEMD"
+
+CMD ["/usr/bin/cilium"]
+EOF
+
+
+}
+
+function append_docker_install_deps {
+  cat <<EOF >> ./Dockerfile
+RUN apt-get update && \\
+
+apt-get install -y --no-install-recommends gcc make libelf-dev bison flex git ca-certificates libc6-dev.i386 iptables libgcc-5-dev binutils && \\
+
+# clang-3.8.1-begin
+apt-get install -y --no-install-recommends curl xz-utils && \\
+cd /tmp && \\
+gpg --import /tmp/cilium-net-build/src/github.com/cilium/cilium/contrib/packaging/docker/clang-3.8.1.key && \\
+curl -Ssl -o clang+llvm.tar.xz \\
+http://releases.llvm.org/3.8.1/clang+llvm-3.8.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz && \\
+curl -Ssl -o clang+llvm.tar.xz.sig \\
+http://releases.llvm.org/3.8.1/clang+llvm-3.8.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz.sig && \\
+gpg --verify clang+llvm.tar.xz.sig && \\
+mkdir -p /usr/local && \\
+tar -C /usr/local -xJf ./clang+llvm.tar.xz && \\
+mv /usr/local/clang+llvm-3.8.1-x86_64-linux-gnu-ubuntu-16.04 /usr/local/clang+llvm && \\
+rm clang+llvm.tar.xz && \\
+rm -fr /usr/local/clang+llvm/include/llvm-c && \\
+rm -fr /usr/local/clang+llvm/include/clang-c && \\
+rm -fr /usr/local/clang+llvm/include/c++ && \\
+rm -fr /usr/local/clang+llvm/share && \\
+ls -d /usr/local/clang+llvm/lib/* | grep -vE clang$ | xargs rm -r && \\
+ls -d /usr/local/clang+llvm/bin/* | grep -vE "clang$|clang-3.8$|llc$" | xargs rm -r && \\
+# clang-3.8.1-end
+
+# iproute2-begin
+cd /tmp && \\
+git clone -b v4.10.0 git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git && \\
+cd /tmp/iproute2 && \\
+./configure && \\
+make -j \`getconf _NPROCESSORS_ONLN\` && \\
+make install && \\
+# iproute2-end
+
+# bpf-map-begin
+curl -SsL https://github.com/cilium/bpf-map/releases/download/v1.0/bpf-map -o bpf-map && \\
+chmod +x bpf-map && \\
+mv bpf-map /usr/bin && \\
+# bpf-map-end
+
+# cni-begin
+#Include the loopback binary in the image
+mkdir -p tmp && cd tmp && \\
+curl -sS -L https://storage.googleapis.com/kubernetes-release/network-plugins/cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz -o cni.tar.gz && \\
+tar -xvf cni.tar.gz && \\
+mkdir /cni && \\
+cp bin/loopback /cni && \\
+cd .. && \\
+rm -r tmp && \\
+# cni-end
+
+EOF
+}
+
+eval $@

--- a/tests/00-check-generated-dockerfile.sh
+++ b/tests/00-check-generated-dockerfile.sh
@@ -1,0 +1,44 @@
+#!/bin/bash 
+DEV_DOCKERFILE="$PWD/../Dockerfile.dev"
+PROD_DOCKERFILE="$PWD/../Dockerfile"
+DEP_DOCKERFILE="$PWD/../Dockerfile.deps"
+DOCKERFILE_SCRIPT="$PWD/../contrib/packaging/docker/build_dockerfile.sh"
+
+function cleanup {
+  rm ./Dockerfile.dev.tmpgen || true
+  rm ./Dockerfile.prod.tmpgen || true
+  rm ./Dockerfile.deps.tmpgen || true
+}
+
+
+# error_if_files_diff returns a non-zero return code if the contents of the provided files are different.
+# Arguments:
+#  FILE1: path to first file
+#  FILE2: path to second file
+function error_if_files_diff {
+  FILE1=$1
+  FILE2=$2
+
+  diff="$(diff $FILE1 $FILE2)"
+
+
+  if [ -n "$diff" ]; then 
+    echo "$FILE1 differs from $FILE2; please rebuild the corresponding Dockerfile using the script: contrib/packaging/docker/build_dockerfile.sh"
+    echo "diff: $diff"
+    exit 1
+  else 
+    echo "============ $FILE1 does not differ from $FILE2; OK ================="
+  fi 
+}
+
+trap cleanup EXIT
+
+# Generate each separate Dockerfile.
+${DOCKERFILE_SCRIPT} build_dockerfile_dev && mv ${PWD}/../contrib/packaging/docker/Dockerfile Dockerfile.dev.tmpgen
+${DOCKERFILE_SCRIPT} build_dockerfile_prod && mv ${PWD}/../contrib/packaging/docker/Dockerfile Dockerfile.prod.tmpgen
+${DOCKERFILE_SCRIPT} build_dockerfile_dependencies && mv ${PWD}/../contrib/packaging/docker/Dockerfile Dockerfile.deps.tmpgen
+
+# Check if the generated Dockerfiles differ from those that are already in the repo.
+error_if_files_diff ${DEV_DOCKERFILE} ./Dockerfile.dev.tmpgen
+error_if_files_diff ${PROD_DOCKERFILE} ./Dockerfile.prod.tmpgen
+error_if_files_diff ${DEP_DOCKERFILE} ./Dockerfile.deps.tmpgen

--- a/tests/k8s/Vagrantfile
+++ b/tests/k8s/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.require_version ">= 1.8.3"
 $build_docker_image = <<SCRIPT
 certs_dir="/home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/cluster/certs"
 cd /home/vagrant/go/src/github.com/cilium/cilium/
-make docker-image
+make docker-image-dev
 docker run -d -p 5000:5000 --name registry -v ${certs_dir}:/certs \
         -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/kubernetes.pem \
         -e REGISTRY_HTTP_TLS_KEY=/certs/kubernetes-key.pem \
@@ -103,3 +103,4 @@ Vagrant.configure(2) do |config|
         end
     end
 end
+


### PR DESCRIPTION
In order to reduce the build time for Docker images for dev testing, this commit has added three separate Dockerfiles:
    
* Dockerfile.deps: Dockerfile which builds a container that contains all of the dependencies needed to build Cilium / run Cilium
* Dockerfile.dev: Dockerfile which builds Cilium using the container built from Dockerfile.deps as a base
* Dockerfile: Dockerfile which is used to build containers that will run in production environments
    
The file `contrib/packaging/build_dockerfile.sh` generates these Dockerfiles, as there is some overlap in the code used between each Dockerfile.
    
The test `tests/00-check-generated-dockerfile.sh` checks that the Dockerfiles generated by `contrib/packaging/build_dockerfile.sh` do not differ with those that are stored at the base of the repository. This ensures that all Dockerfiles are kept in sync and that they are generated using the `contrib/packaging/build_dockerfile.sh` script.
    
The following Makefile targets build these different containers:
* docker-image-prod: builds using Dockerfile
* docker-image-dev: builds using Dockerfile.dev
* docker-image-dependencies: builds using Dockerfile.deps
    
Signed-off by: Ian Vernon <ian@covalent.io>