### PR TITLE
tests / Jenkinsfile: add logs and check if VMs are running

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
                          sh './contrib/vagrant/start.sh'
                      },
                     "K8s multi node Tests": {
+                         sh 'cd ./tests/k8s && vagrant destroy -f || true'
                          sh './tests/k8s/start.sh'
                     }
                 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,8 +16,14 @@ pipeline {
      		           
                 parallel(
                     "Print Environment": { sh 'env' },
-                    "Runtime Tests": { sh './contrib/vagrant/start.sh' },
-                    "K8s multi node Tests": { sh './tests/k8s/start.sh' }
+                    "Runtime Tests": {
+                         // Make sure that VMs from prior runs are cleaned up in case something went wrong in a prior build.
+                         sh 'vagrant destroy -f || true'
+                         sh './contrib/vagrant/start.sh'
+                     },
+                    "K8s multi node Tests": {
+                         sh './tests/k8s/start.sh'
+                    }
                 )
             }
         }

--- a/tests/copy_files
+++ b/tests/copy_files
@@ -14,7 +14,9 @@ function copy_runtime_test_files {
   copy_files_vm ${VM} ${RUNTIME_TESTS_DIR}
 
   # BUILD_ID is generated in helpers.bash.
+  echo "----- creating a tarball of files copied from $VM -----"
   sudo tar -czvf ${CILIUM_FILES}-runtime-${BUILD_ID}.tar.gz ${CILIUM_FILES}-${VM}
+  echo "----- done creating a tarball of files copied from $VM -----"
 }
 
 copy_runtime_test_files

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -405,15 +405,24 @@ function get_vm_ssh_port {
 }
 
 function copy_files_vm {
-  set -xv
   local VM_NAME=$1 
   local FILES_DIR=$2
+
+  # Check that the VM is running before we try to gather logs from it.
+  check_vm_running $VM_NAME
+
+  echo "----- getting the VM identity file for $VM_NAME -----"
   local ID_FILE=$(get_vm_identity_file $VM_NAME)
+  echo "----- getting the port for $VM_NAME to SSH -----"
   local PORT=$(get_vm_ssh_port $VM_NAME)
 
+  echo "----- getting cilium logs from $VM_NAME -----"
   vagrant ssh $VM_NAME -c 'sudo -E bash -c "journalctl --no-pager -u cilium > /home/vagrant/go/src/github.com/cilium/cilium/tests/cilium-files/cilium-logs && chmod a+r /home/vagrant/go/src/github.com/cilium/cilium/tests/cilium-files/cilium-logs"'
+
+  echo "----- listing all logs that will be gathered from $VM_NAME -----"
   vagrant ssh $VM_NAME -c 'ls -altr /home/vagrant/go/src/github.com/cilium/cilium/tests/cilium-files'
 
+  echo "----- copying logs from $VM_NAME onto VM host for accessibility after VM is destroyed -----"
   scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -r -P ${PORT} -i ${ID_FILE} vagrant@127.0.0.1:/home/vagrant/go/src/github.com/cilium/cilium/${FILES_DIR} ./cilium-files-${VM_NAME}
 }
 
@@ -436,5 +445,20 @@ function get_cilium_master_vm_name {
   fi
   
   echo "cilium${K8S_TAG}-master${BUILD_ID_NAME}"
+}
+
+function check_vm_running {
+  local VM=$1
+  echo "----- getting status of VM $VM -----"
+  vagrant status $VM
+  echo "----- done getting status of VM $VM -----"
+
+  local VM_STATUS=`vagrant status $VM | grep $VM | awk '{print $2}'`
+  if [[ "${VM_STATUS}" != "running" ]]; then 
+    echo "$VM is not in \"running\" state; exiting"
+    exit 0
+  else 
+    echo "$VM is \"running\" continuing"
+  fi
 }
 

--- a/tests/k8s/copy_files
+++ b/tests/k8s/copy_files
@@ -23,8 +23,11 @@ function copy_k8s_test_files {
   copy_files_vm ${VM1} ${K8S_FILES_DIR}
   copy_files_vm ${VM2} ${K8S_FILES_DIR}
 
+  echo "----- creating a tarball of files copied from $VM -----"
   # BUILD_ID is generated in helpers.bash. 
   sudo tar -czvf ${CILIUM_FILES}-k8s-${BUILD_ID}.tar.gz ${CILIUM_FILES}-${K8S1}-build-${BUILD_ID} ${CILIUM_FILES}-${K8S2}-build-${BUILD_ID}
+  echo "----- done creating a tarball of files copied from $VM -----"
+
   mv ${CILIUM_FILES}-k8s-${BUILD_ID}.tar.gz ${OLD_DIR}
 }
 

--- a/tests/k8s/start.sh
+++ b/tests/k8s/start.sh
@@ -4,5 +4,7 @@ set -exv
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 cd "${dir}"
+# Clean up VMs that were already running in case something went wrong in a prior build.
+vagrant destroy -f
 VAGRANT_DEFAULT_PROVIDER=virtualbox vagrant up --provider=virtualbox
 make k8s-multi-node-tests

--- a/tests/k8s/start.sh
+++ b/tests/k8s/start.sh
@@ -4,7 +4,5 @@ set -exv
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 cd "${dir}"
-# Clean up VMs that were already running in case something went wrong in a prior build.
-vagrant destroy -f
 VAGRANT_DEFAULT_PROVIDER=virtualbox vagrant up --provider=virtualbox
 make k8s-multi-node-tests


### PR DESCRIPTION
* Before each build, attempt to destroy the VMs if they for some reason were not destroyed from a prior build as part of the same pull-request.
* Add logs to the log-gathering scripts that are ran as post-build actions in Jenkins.
* Do not try to collect logs if the VMs are not in `running` state.
    
Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #1261 
Fixes: #1251 