### PR TITLE
tests: add local cilium binary to PATH from helpers

### DIFF
--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -10,6 +10,15 @@ BUILD_NUM="${BUILD_NUMBER:-0}"
 JOB_BASE="${JOB_BASE_NAME:-local}"
 BUILD_ID="${JOB_BASE}-${BUILD_NUM}"
 
+# Prefer local build if binary file detected.
+for bin in "../cilium/cilium" \
+  "../daemon/cilium-agent" \
+  "../plugins/cilium-docker/cilium-docker"; do
+        if [ -f $bin ]; then
+          export PATH=$PWD/`dirname $bin`:$PATH
+        fi
+done
+
 function monitor_start {
 	cilium monitor -v $@ > $DUMP_FILE &
 	MONITOR_PID=$!

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -6,11 +6,6 @@ set -e
 export PATH=$PATH:/usr/local/go/bin:/usr/local/clang/bin:/home/vagrant/go/bin:/home/vagrant/bin
 export TEST_SUITE="runtime-tests"
 
-# Prefer local build if binary file detected.
-if [ -f ../cilium/cilium ]; then
-  export PATH=$PWD/../cilium:$PATH
-fi
-
 for test in *.sh; do
 	echo
 	echo "Starting test $test"


### PR DESCRIPTION
This way it gets picked up for a single test as well since most of the
relevant ones source `helpers.bash`.

Also added cilium-agent and cilium-docker.

Closes: #1125 (Modify PATH to prefer local build when running tests)
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>