### PR TITLE
kubernetes: Delay health check for 180 seconds to account for long re…

### DIFF
--- a/examples/kubernetes/cilium-ds.yaml
+++ b/examples/kubernetes/cilium-ds.yaml
@@ -48,7 +48,7 @@ spec:
             command:
             - cilium
             - status
-          initialDelaySeconds: 10
+          initialDelaySeconds: 180
           failureThreshold: 10
           periodSeconds: 10
         readinessProbe:
@@ -56,7 +56,7 @@ spec:
             command:
             - cilium
             - status
-          initialDelaySeconds: 10
+          initialDelaySeconds: 180
           periodSeconds: 15
         volumeMounts:
           - name: bpf-maps


### PR DESCRIPTION
…store

If many endpoints have been running before restart, endpoint restore can
eventually take a while due to contacting the kvstore and compilation of
endpoints. Bump the initial delay befor health checks occurs to 180
seconds to avoid unneeded pod restarts.

Signed-off-by: Thomas Graf <thomas@cilium.io>