### PR TITLE
common/logging: handle errors from net.SplitHostPort

### DIFF
--- a/common/logging.go
+++ b/common/logging.go
@@ -216,6 +216,9 @@ func setupFluentD(logOpts map[string]string, debug bool) {
 	}
 
 	host, strPort, err := net.SplitHostPort(hostAndPort)
+	if err != nil {
+		logrus.Fatal(err)
+	}
 	port, err := strconv.Atoi(strPort)
 	if err != nil {
 		logrus.Fatal(err)


### PR DESCRIPTION
When starting cilium-agent with an ill-formatted host/port combination,
we get the following:

  $ cilium-agent --log-driver fluentd --log-opt fluentd.address=192.168.4.42-24224
  [...]
  strconv.Atoi: parsing \"\": invalid syntax

Fix it by checking the err return value of net.SplitHostPort and calling
logrus.Fatal accordingly. Now we get:

  $ cilium-agent --log-driver fluentd --log-opt fluentd.address=192.168.4.42-24224
  address 192.168.4.42-24224: missing port in address

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>