### PR TITLE
monitor: Be specific about policy drop reason

### DIFF
--- a/pkg/bpfdebug/drop.go
+++ b/pkg/bpfdebug/drop.go
@@ -44,7 +44,7 @@ var errors = map[uint8]string{
 	130: "Invalid source mac",
 	131: "Invalid destination mac",
 	132: "Invalid source ip",
-	133: "Policy denied",
+	133: "Policy denied (L3)",
 	134: "Invalid packet",
 	135: "CT: Truncated or invalid header",
 	136: "CT: Missing TCP ACK flag",


### PR DESCRIPTION
Report L3 policy violations as "Policy denied (L3)" instead of just
"Policy denied" to clearly indicate the reason for the drop.

Related-to: #1299 

Signed-off-by: Thomas Graf <thomas@cilium.io>