### PR TITLE
GH-1278 Complete implementation of `cilium identity get`

### DIFF
--- a/cilium/cmd/identity_get.go
+++ b/cilium/cmd/identity_get.go
@@ -15,10 +15,11 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
-	"os"
-
 	"github.com/cilium/cilium/pkg/policy"
+
+	identityApi "github.com/cilium/cilium/api/v1/client/policy"
 
 	"github.com/spf13/cobra"
 )
@@ -44,7 +45,14 @@ var identityGetCmd = &cobra.Command{
 		if id := policy.GetReservedID(args[0]); id != policy.ID_UNKNOWN {
 			fmt.Printf("%d\n", id)
 		} else {
-			os.Exit(1)
+			params := identityApi.NewGetIdentityIDParams().WithID(args[0])
+			if id, err := client.Policy.GetIdentityID(params); err != nil {
+				Fatalf("Cannot get identity for given ID %s: %s\n", id, err)
+			} else if b, err := json.MarshalIndent(id, "", "  "); err != nil {
+				Fatalf("Cannot marshal identity %s", err.Error())
+			} else {
+				fmt.Println(string(b))
+			}
 		}
 	},
 }

--- a/daemon/labels.go
+++ b/daemon/labels.go
@@ -84,7 +84,7 @@ func (d *Daemon) CreateOrUpdateIdentity(lbls labels.Labels, epid string) (*polic
 	// Calculate hash over identity labels and generate path
 	identityPath := path.Join(common.LabelsKeyPath, lbls.SHA256Sum())
 
-	// Lock the idendity
+	// Lock the identity
 	lockKey, err := kvstore.Client.LockPath(identityPath)
 	if err != nil {
 		return nil, false, err

--- a/tests/19-identity-get.sh
+++ b/tests/19-identity-get.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Tests to validate `cilium identity get` CLI commands.
+
+source "./helpers.bash"
+
+TEST_NET="cilium-net"
+
+function start_containers {
+    docker run -dt --net=$TEST_NET --name foo -l id.foo tgraf/netperf
+    docker run -dt --net=$TEST_NET --name bar -l id.bar tgraf/netperf
+    docker run -dt --net=$TEST_NET --name baz -l id.baz tgraf/netperf
+}
+
+function remove_containers {
+    docker rm -f foo foo bar baz 2> /dev/null || true
+}
+
+function restart_cilium {
+    echo "------ restarting cilium ------"
+    service cilium restart
+    echo "------ waiting for cilium agent get up and running ------"
+    wait_for_cilium_status
+}
+
+function cleanup {
+    gather_files 15-policy-config ${TEST_SUITE}
+    cilium policy delete --all 2> /dev/null || true
+    docker rm -f foo foo bar baz 2> /dev/null || true
+}
+
+trap cleanup EXIT
+
+cleanup
+logs_clear
+
+# Checks that the `cilium identity get <ID>` response matches expectations.
+#
+# The test launches three containers and waits until 3 endpoints are created in Cilium. It then extracts the security ID
+# from the `cilium endpoint list` output.
+function test_identity_get {
+    remove_containers
+    restart_cilium
+    start_containers
+    wait_for_endpoints 3
+    cilium endpoint list
+    ID=$(cilium endpoint list | grep id.foo | awk '{print $3}')
+    echo "Endpoint security ID is: $ID"
+    expected_response='{   "Payload": {     "id": '$ID',     "labels": [       "container:id.foo"     ]   } }'
+
+    # Replace all newline chars with a single space.
+    response=$(cilium identity get $ID | sed ':a;N;$!ba;s/\n/ /g')
+    echo "Response is $response"
+
+    if [[ "${expected_response}" != "${response}" ]]; then
+        abort "Expected: ${expected_response}; Got: ${response}"
+    fi
+}
+
+cilium endpoint list
+cilium identity get --list
+
+docker network inspect $TEST_NET 2> /dev/null || {
+        docker network create --ipv6 --subnet ::1/112 --ipam-driver cilium --driver cilium $TEST_NET
+}
+
+test_identity_get


### PR DESCRIPTION
- Complete the implementation of cilium identity get <ID>
- Add a unit test for cilium identity get <ID>

NOTE: cilium identity get --list still returns only the reserved identities. This is a limitation of this patch. Fixing this requires changes to the API, which will be done in a separate ticket/PR.