### PR TITLE
Disable kvstore timeout test for now

### DIFF
--- a/tests/18-kvstore-fail.sh
+++ b/tests/18-kvstore-fail.sh
@@ -52,12 +52,13 @@ function test_kvstore {
       fi
 }
 
-trap cleanup EXIT
-
-systemctl stop cilium
-
-test_kvstore consul "8500"
-
-systemctl start cilium-etcd
-
-test_kvstore etcd "4001"
+# FIXME: Re-enable when test is stable
+#trap cleanup EXIT
+#
+#systemctl stop cilium
+#
+#test_kvstore consul "8500"
+#
+#systemctl start cilium-etcd
+#
+#test_kvstore etcd "4001"


### PR DESCRIPTION
The kvstore timeout test is not reliable for some reason. The timeout may not be sufficiently long. Disable the test for now until we can provide a more reliable test. False negatives are slowing down all developers by a lot.