### PR TITLE
pkg/policy: removed dispensable IP tag for CIDR slice

### DIFF
--- a/pkg/k8s/third_party_test.go
+++ b/pkg/k8s/third_party_test.go
@@ -53,11 +53,7 @@ var (
 						Rules: &api.L7Rules{HTTP: []api.PortRuleHTTP{{Path: "/public", Method: "GET"}}},
 					},
 				},
-				ToCIDR: []api.CIDR{
-					{
-						IP: "10.0.0.1",
-					},
-				},
+				ToCIDR: []api.CIDR{"10.0.0.1"},
 			},
 		},
 	}
@@ -90,11 +86,7 @@ var (
 						Rules: &api.L7Rules{HTTP: []api.PortRuleHTTP{{Path: "/public", Method: "GET"}}},
 					},
 				},
-				ToCIDR: []api.CIDR{
-					{
-						IP: "10.0.0.1",
-					},
-				},
+				ToCIDR: []api.CIDR{"10.0.0.1"},
 			},
 		},
 		Labels: labels.ParseLabelArray(fmt.Sprintf("%s=%s", PolicyLabelName, "rule1")),
@@ -170,9 +162,7 @@ var (
                     }
                 ],
                 "toCIDR": [
-                    {
-                        "ip": "10.0.0.1"
-                    }
+                    "10.0.0.1"
                 ]
             }
         ]

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -152,14 +152,9 @@ type EgressRule struct {
 	ToCIDR []CIDR `json:"toCIDR,omitempty"`
 }
 
-// CIDR specifies a block of IP addresses
-type CIDR struct {
-	// IP specifies the block of IP addresses to allow
-	//
-	// Example:
-	// 10.0.1.0/24
-	IP string `json:"ip"`
-}
+// CIDR specifies a block of IP addresses.
+// Example: 192.0.2.1/32
+type CIDR string
 
 // PortProtocol specifies an L4 port with an optional transport protocol
 type PortProtocol struct {

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -107,11 +107,12 @@ func (pp PortProtocol) Validate() error {
 
 // Validate CIDR
 func (cidr CIDR) Validate() error {
-	if cidr.IP == "" {
+	strCIDR := string(cidr)
+	if strCIDR == "" {
 		return fmt.Errorf("IP must be specified")
 	}
 
-	_, ipnet, err := net.ParseCIDR(cidr.IP)
+	_, ipnet, err := net.ParseCIDR(strCIDR)
 	if err == nil {
 		// Returns the prefix length as zero if the mask is not continuous.
 		ones, _ := ipnet.Mask.Size()
@@ -120,7 +121,7 @@ func (cidr CIDR) Validate() error {
 		}
 	} else {
 		// Try to parse as a fully masked IP or an IP subnetwork
-		ip := net.ParseIP(cidr.IP)
+		ip := net.ParseIP(strCIDR)
 		if ip == nil {
 			return fmt.Errorf("Unable to parse CIDR: %s", err)
 		}

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -123,9 +123,10 @@ func mergeL3(ctx *SearchContext, dir string, ipRules []api.CIDR, resMap *L3Polic
 	found := 0
 
 	for _, r := range ipRules {
-		ctx.PolicyTrace("  Allows %s IP %s\n", dir, r.IP)
+		strCIDR := string(r)
+		ctx.PolicyTrace("  Allows %s IP %s\n", dir, strCIDR)
 
-		found += resMap.Insert(r.IP)
+		found += resMap.Insert(strCIDR)
 	}
 
 	return found

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -159,19 +159,19 @@ func (ds *PolicyTestSuite) TestL3Policy(c *C) {
 		Ingress: []api.IngressRule{
 			{
 				FromCIDR: []api.CIDR{
-					{IP: "10.0.1.0/24"},
-					{IP: "192.168.2.0"},
-					{IP: "10.0.3.1"},
-					{IP: "2001:db8::1/48"},
-					{IP: "2001:db9::"},
+					"10.0.1.0/24",
+					"192.168.2.0",
+					"10.0.3.1",
+					"2001:db8::1/48",
+					"2001:db9::",
 				},
 			},
 		},
 		Egress: []api.EgressRule{
 			{
 				ToCIDR: []api.CIDR{
-					{IP: "10.1.0.0/16"},
-					{IP: "2001:dbf::/64"},
+					"10.1.0.0/16",
+					"2001:dbf::/64",
 				},
 			},
 		},
@@ -211,7 +211,7 @@ func (ds *PolicyTestSuite) TestL3Policy(c *C) {
 	// Must be parsable, make sure Validate fails when not.
 	err = api.Rule{
 		Ingress: []api.IngressRule{{
-			FromCIDR: []api.CIDR{{IP: "10.0.1..0/24"}},
+			FromCIDR: []api.CIDR{"10.0.1..0/24"},
 		}},
 	}.Validate()
 	c.Assert(err, Not(IsNil))
@@ -219,7 +219,7 @@ func (ds *PolicyTestSuite) TestL3Policy(c *C) {
 	// Must have a mask, make sure Validate fails when not.
 	err = api.Rule{
 		Ingress: []api.IngressRule{{
-			FromCIDR: []api.CIDR{{IP: "10.0.1.0/0"}},
+			FromCIDR: []api.CIDR{"10.0.1.0/0"},
 		}},
 	}.Validate()
 	c.Assert(err, Not(IsNil))
@@ -228,7 +228,7 @@ func (ds *PolicyTestSuite) TestL3Policy(c *C) {
 	// Validate fails if given prefix length is out of range.
 	err = api.Rule{
 		Ingress: []api.IngressRule{{
-			FromCIDR: []api.CIDR{{IP: "10.0.1.0/34"}},
+			FromCIDR: []api.CIDR{"10.0.1.0/34"},
 		}},
 	}.Validate()
 	c.Assert(err, Not(IsNil))

--- a/tests/16-cidr-ingress-policy.sh
+++ b/tests/16-cidr-ingress-policy.sh
@@ -63,8 +63,8 @@ cat <<EOF | policy_import_and_wait -
     "endpointSelector": {"matchLabels":{"${ID_SERVICE2}":""}},
     "egress": [{
 	"toCIDR": [
-	    {"ip": "${IPV4_OTHERHOST}/24"},
-	    {"ip": "${IPV4_OTHERHOST}/20"}
+	    "${IPV4_OTHERHOST}/24",
+	    "${IPV4_OTHERHOST}/20"
 	]
     }]
 }]
@@ -92,7 +92,7 @@ cat <<EOF | policy_import_and_wait -
     "endpointSelector": {"matchLabels":{"${ID_SERVICE2}":""}},
     "egress": [{
 	"toCIDR": [
-	    {"ip": "${IPV6_HOST}"}
+	    "${IPV6_HOST}"
 	]
     }]
 }]
@@ -154,8 +154,8 @@ cat <<EOF | policy_import_and_wait -
 	    {"matchLabels":{"${ID_SERVICE2}":""}}
 	],
 	"fromCIDR": [
-	    {"ip": "${IPV4_PREFIX}"},
-	    {"ip": "${IPV6_PREFIX}"}
+	    "${IPV4_PREFIX}",
+	    "${IPV6_PREFIX}"
 	]
     }]
 }]
@@ -184,7 +184,7 @@ cat <<EOF | policy_import_and_wait -
 	    {"matchLabels":{"${ID_SERVICE2}":""}}
 	],
 	"fromCIDR": [
-	    {"ip": "${IPV4_OTHERNET}"}
+	    "${IPV4_OTHERNET}"
 	]
     }]
 }]


### PR DESCRIPTION
Since CIDR slice only contained IPs it doesn't make sense to continue
having the `ip` tag for json / yaml objects.

The cilium network policy object in kubernetes should be changed from:
```
egress:
- toCIDR:
  - ip: "192.0.2.1/32"
```

to:
```
egress:
- toCIDR:
  - "192.0.2.1/32"
```

Signed-off-by: André Martins <andre@cilium.io>

Do we have any docs / examples with `toCIDR`?

Fixes #1318