### PR TITLE
tests/k8s/cluster: reset kubeadm before start

### DIFF
--- a/tests/k8s/cluster/cluster-manager.bash
+++ b/tests/k8s/cluster/cluster-manager.bash
@@ -260,7 +260,8 @@ function fresh_install(){
     fi
     install_kubeadm_dependencies
     install_kubeadm
-
+    
+    clean_kubeadm
     start_kubeadm
 
     install_cilium_config


### PR DESCRIPTION
* Reset kubeadm before starting it on fresh installation

Signed-off by: Ian Vernon <ian@covalent.io>

Fixes: #1279 