### PR TITLE
pkg/bpfdebug: printing IPv6 + Port with []

### DIFF
--- a/pkg/bpfdebug/dissect.go
+++ b/pkg/bpfdebug/dissect.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
+	"strconv"
 )
 
 var (
@@ -80,7 +81,7 @@ func GetConnectionSummary(data []byte) string {
 
 	var (
 		srcIP, dstIP     net.IP
-		srcPort, dstPort uint16
+		srcPort, dstPort string
 		icmpCode, proto  string
 		hasIP, hasEth    bool
 	)
@@ -97,10 +98,10 @@ func GetConnectionSummary(data []byte) string {
 			srcIP, dstIP = ip6.SrcIP, ip6.DstIP
 		case layers.LayerTypeTCP:
 			proto = "tcp"
-			srcPort, dstPort = uint16(tcp.SrcPort), uint16(tcp.DstPort)
+			srcPort, dstPort = strconv.Itoa(int(tcp.SrcPort)), strconv.Itoa(int(tcp.DstPort))
 		case layers.LayerTypeUDP:
 			proto = "udp"
-			srcPort, dstPort = uint16(udp.SrcPort), uint16(udp.DstPort)
+			srcPort, dstPort = strconv.Itoa(int(udp.SrcPort)), strconv.Itoa(int(udp.DstPort))
 		case layers.LayerTypeICMPv4:
 			icmpCode = icmp4.TypeCode.String()
 		case layers.LayerTypeICMPv6:
@@ -112,7 +113,10 @@ func GetConnectionSummary(data []byte) string {
 	case icmpCode != "":
 		return fmt.Sprintf("%s -> %s %s", srcIP, dstIP, icmpCode)
 	case proto != "":
-		s := fmt.Sprintf("%s:%d -> %s:%d %s", srcIP, srcPort, dstIP, dstPort, proto)
+		s := fmt.Sprintf("%s -> %s %s",
+			net.JoinHostPort(srcIP.String(), srcPort),
+			net.JoinHostPort(dstIP.String(), dstPort),
+			proto)
 		if proto == "tcp" {
 			s += " " + getTCPInfo()
 		}


### PR DESCRIPTION
Changed the output of IPv6 Port to contain brackets for easy reading

```
-> endpoint 38061, identity 315: fd03::1:443 -> fd02::c0a8:210c:0:94ad:54804 tcp ACK
<- endpoint 38061, identity 315: fd02::c0a8:210c:0:94ad:54804 -> fd03::1:443 tcp ACK
```
to
```
<- endpoint 3365, identity 316: [fd02::c0a8:210c:0:d25]:33958 -> [fd03::be]:6379 tcp ACK
-> endpoint 11004, identity 313: [fd02::c0a8:210c:0:d25]:33958 -> [fd02::c0a8:210c:0:2afc]:6379 tcp ACK
```

Signed-off-by: André Martins <andre@cilium.io>