### PR TITLE
Ignoring all cilium annotations

### DIFF
--- a/common/const.go
+++ b/common/const.go
@@ -59,6 +59,11 @@ const (
 	// base64 form.
 	CiliumCHeaderPrefix = "CILIUM_BASE64_"
 
+	// CiliumK8sAnnotationPrefix is the prefix key for the annotations used in kubernetes.
+	CiliumK8sAnnotationPrefix = "cilium.io/"
+
 	// CiliumIdentityAnnotation is the annotation key used to map to an endpoint's security identity.
-	CiliumIdentityAnnotation = "cilium-identity"
+	CiliumIdentityAnnotation = CiliumK8sAnnotationPrefix + "identity"
+	// CiliumIdentityAnnotationDeprecated is the previous annotation key used to map to an endpoint's security identity.
+	CiliumIdentityAnnotationDeprecated = "cilium-identity"
 )

--- a/daemon/labels_test.go
+++ b/daemon/labels_test.go
@@ -71,7 +71,10 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	daemonConf.RunDir = tempRunDir
 	daemonConf.StateDir = tempRunDir
 	daemonConf.DockerEndpoint = "tcp://127.0.0.1"
-	daemonConf.ValidLabelPrefixes = nil
+	// Get the default labels prefix filter
+	lblsPrefix, err := labels.ParseLabelPrefixCfg(nil, "")
+	c.Assert(err, IsNil)
+	daemonConf.ValidLabelPrefixes = lblsPrefix
 	daemonConf.Opts.Set(endpoint.OptionDropNotify, true)
 	daemonConf.Device = "undefined"
 

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -202,6 +202,13 @@ func (d *Daemon) syncLabels(ep *endpoint.Endpoint) error {
 		return fmt.Errorf("Endpoint doesn't have a security label.")
 	}
 
+	// Filter the restored labels with the new daemon's filter
+	d.conf.ValidLabelPrefixesMU.RLock()
+	idtyLbls, _ := d.conf.ValidLabelPrefixes.FilterLabels(ep.SecLabel.Labels)
+	d.conf.ValidLabelPrefixesMU.RUnlock()
+
+	ep.SecLabel.Labels = idtyLbls
+
 	sha256sum := ep.SecLabel.Labels.SHA256Sum()
 	labels, err := LookupIdentityBySHA256(sha256sum)
 	if err != nil {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -468,6 +468,7 @@ func (e *Endpoint) SetIdentity(owner Owner, id *policy.Identity) {
 		cache.Remove(e.Consumable)
 	}
 	e.SecLabel = id
+	e.LabelsHash = e.SecLabel.Labels.SHA256Sum()
 	e.Consumable = cache.GetOrCreate(id.ID, id)
 
 	if e.State == StateWaitingForIdentity {

--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/cilium/cilium/common"
 )
 
 const (
@@ -138,11 +140,13 @@ func defaultLabelPrefixCfg() *LabelPrefixCfg {
 	}
 
 	expressions := []string{
-		"io.kubernetes.pod.namespace", // include io.kubernetes.pod.namspace
-		"!io.kubernetes",              // ignore all other io.kubernetes labels
-		"!.*kubernetes.io",            // ignore all other kubernetes.io labels (annotation.*.k8s.io)
-		"!pod-template-hash",          // ignore pod-template-hash
-		"!controller-revision-hash",   // ignore controller-revision-hash
+		"io.kubernetes.pod.namespace",                              // include io.kubernetes.pod.namspace
+		"!io.kubernetes",                                           // ignore all other io.kubernetes labels
+		"!.*kubernetes.io",                                         // ignore all other kubernetes.io labels (annotation.*.k8s.io)
+		"!pod-template-hash",                                       // ignore pod-template-hash
+		"!controller-revision-hash",                                // ignore controller-revision-hash
+		"!annotation." + common.CiliumK8sAnnotationPrefix,          // ignore all cilium annotations
+		"!annotation." + common.CiliumIdentityAnnotationDeprecated, // ignore all cilium annotations
 	}
 
 	for _, e := range expressions {


### PR DESCRIPTION
This PR fixes a bug that was printing up the cilium annotations under cilium endpoint list

```
ENDPOINT   POLICY        IDENTITY   LABELS (source:key[=value])                   IPv6                     IPv4            STATUS   
           ENFORCEMENT                                                                                                              
3365       Enabled       316        container:annotation.cilium-identity=308      fd02::c0a8:210c:0:d25    10.12.191.0     ready    
                                    k8s:io.kubernetes.pod.namespace=default                                                         
                                    k8s:k8s-app.guestbook=redis                                                                     
                                    k8s:role=slave                                                                                  
11004      Enabled       317        k8s:io.kubernetes.pod.namespace=default       fd02::c0a8:210c:0:2afc   10.12.54.125    ready    
                                    k8s:k8s-app.guestbook=web                                                                       
38061      Disabled      315        container:annotation.cilium-identity=306      fd02::c0a8:210c:0:94ad   10.12.0.173     ready    
                                    k8s:io.kubernetes.pod.namespace=kube-system                                                     
                                    k8s:k8s-app=kube-dns                                                                            
38062      Enabled       318        k8s:io.kubernetes.pod.namespace=default       fd02::c0a8:210c:0:94ae   10.12.0.173     ready    
                                    k8s:k8s-app.guestbook=redis                                                                     
                                    k8s:role=master                                                                                 
49508      Enabled       319        k8s:io.kubernetes.pod.namespace=default       fd02::c0a8:210c:0:c164   10.12.114.197   ready    
                                    k8s:k8s-app.guestbook=redis                                                                     
                                    k8s:role=slave
```

With these changes the `container:annotation.cilium-identity=` won't show up again.