### PR TITLE
Jenkinsfile: remove cilium-files directory from workspace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
             archiveArtifacts artifacts: "cilium-files-runtime-${JOB_BASE_NAME}-${BUILD_NUMBER}.tar.gz", allowEmptyArchive: true
             sh './tests/k8s/copy_files || true'
             archiveArtifacts artifacts: "cilium-files-k8s-${JOB_BASE_NAME}-${BUILD_NUMBER}.tar.gz", allowEmptyArchive: true
-            sh 'rm -rf cilium-files*${JOB_BASE_NAME}-${BUILD_NUMBER}*'
+            sh 'rm -rf ${WORKSPACE}/cilium-files*${JOB_BASE_NAME}-${BUILD_NUMBER}* ${WORKSPACE}/tests/cilium-files ${WORKSPACE}/tests/k8s/tests/cilium-files'
             sh 'ls'
             sh 'vagrant destroy -f'
             sh 'cd ./tests/k8s && vagrant destroy -f'


### PR DESCRIPTION
We also need to remove the cilium-files directory after each build is complete to avoid buildup of cruft over time in a given workspace.

Signed-off by: Ian Vernon <ian@covalent.io>