### PR TITLE
Service / LoadBalancer synchronization fixes

### DIFF
--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -32,42 +32,52 @@ import (
 // RevNAT value (feCilium.L3n4Addr) to the lb's RevNAT map for the given feCilium.ID.
 func (d *Daemon) addSVC2BPFMap(feCilium types.L3n4AddrID, feBPF lbmap.ServiceKey,
 	besBPF []lbmap.ServiceValue, addRevNAT bool) error {
+	log.Debugf("adding service %s to BPF maps", feCilium.String())
 
-	err := lbmap.AddSVC2BPFMap(feBPF, besBPF, addRevNAT, int(feCilium.ID))
+	// Try to delete service before adding it and ignore errors as it might not exist.
+	err := d.svcDeleteByFrontendLocked(&feCilium.L3n4Addr)
+	if err != nil {
+		log.Debugf("error deleting service %s before adding it: %s", feCilium.L3n4Addr.String(), err)
+	}
+
+	err = lbmap.AddSVC2BPFMap(feBPF, besBPF, addRevNAT, int(feCilium.ID))
 	if err != nil {
 		if addRevNAT {
 			delete(d.loadBalancer.RevNATMap, feCilium.ID)
 		}
 		return err
 	}
+
 	if addRevNAT {
+		log.Debugf("adding service %s to RevNATMap", feCilium.String())
 		d.loadBalancer.RevNATMap[feCilium.ID] = *feCilium.L3n4Addr.DeepCopy()
 	}
 	return nil
 }
 
 // SVCAdd is the public method to add services. We assume the ID provided is not in
-// synced with the KVStore. If that's the case the service won't be used and an error is
+// sync with the KVStore. If that's the, case the service won't be used and an error is
 // returned to the caller.
 //
-// Returns true if service was created
+// Returns true if service was created.
 func (d *Daemon) SVCAdd(feL3n4Addr types.L3n4AddrID, be []types.LBBackEnd, addRevNAT bool) (bool, error) {
+	log.Debugf("adding service %s", feL3n4Addr)
 	if feL3n4Addr.ID == 0 {
 		return false, fmt.Errorf("invalid service ID 0")
 	}
 	// Check if the service is already registered with this ID.
 	feAddr, err := GetL3n4AddrID(uint32(feL3n4Addr.ID))
 	if err != nil {
-		return false, fmt.Errorf("unable to get the service with ID %d: %s", feL3n4Addr.ID, err)
+		return false, fmt.Errorf("unable to get service %d: %s", feL3n4Addr.ID, err)
 	}
 	if feAddr == nil {
 		feAddr, err = PutL3n4Addr(feL3n4Addr.L3n4Addr, uint32(feL3n4Addr.ID))
 		if err != nil {
-			return false, fmt.Errorf("unable to put the service %s: %s", feL3n4Addr.L3n4Addr.String(), err)
+			return false, fmt.Errorf("unable to store service %s in kvstore: %s", feL3n4Addr.String(), err)
 		}
 		// This won't be atomic so we need to check if the baseID, feL3n4Addr.ID was given to the service
 		if feAddr.ID != feL3n4Addr.ID {
-			return false, fmt.Errorf("the service provided %s is already registered with ID %d, please select that ID instead of %d", feL3n4Addr.L3n4Addr.String(), feAddr.ID, feL3n4Addr.ID)
+			return false, fmt.Errorf("the service provided %s is already registered with ID %d, please use that ID instead of %d", feL3n4Addr.L3n4Addr.String(), feAddr.ID, feL3n4Addr.ID)
 		}
 	}
 
@@ -75,7 +85,7 @@ func (d *Daemon) SVCAdd(feL3n4Addr types.L3n4AddrID, be []types.LBBackEnd, addRe
 	feL3n4Addr256Sum := feL3n4Addr.L3n4Addr.SHA256Sum()
 
 	if feAddr256Sum != feL3n4Addr256Sum {
-		return false, fmt.Errorf("service ID %d is already registered to service %s, please choose a different ID", feL3n4Addr.ID, feAddr.String())
+		return false, fmt.Errorf("service ID %d is already registered to L3n4Addr %s, please choose a different ID", feL3n4Addr.ID, feAddr.String())
 	}
 
 	return d.svcAdd(feL3n4Addr, be, addRevNAT)
@@ -89,7 +99,8 @@ func (d *Daemon) SVCAdd(feL3n4Addr types.L3n4AddrID, be []types.LBBackEnd, addRe
 // therefore there won't be any traffic going to the given backends.
 // All of the backends added will be DeepCopied to the internal load balancer map.
 func (d *Daemon) svcAdd(feL3n4Addr types.L3n4AddrID, bes []types.LBBackEnd, addRevNAT bool) (bool, error) {
-	// We will move the slice to the loadbalancer map which have a mutex. If we don't
+	log.Debugf("adding service %s", feL3n4Addr.String())
+	// Move the slice to the loadbalancer map which has a mutex. If we don't
 	// copy the slice we might risk changing memory that should be locked.
 	beCpy := []types.LBBackEnd{}
 	for _, v := range bes {
@@ -103,6 +114,7 @@ func (d *Daemon) svcAdd(feL3n4Addr types.L3n4AddrID, bes []types.LBBackEnd, addR
 	}
 
 	fe, besValues, err := lbmap.LBSVC2ServiceKeynValue(svc)
+
 	if err != nil {
 		return false, err
 	}
@@ -182,25 +194,27 @@ func (h *deleteServiceID) Handle(params DeleteServiceIDParams) middleware.Respon
 	defer d.loadBalancer.BPFMapMU.Unlock()
 
 	svc, ok := d.loadBalancer.SVCMapID[types.ServiceID(params.ID)]
+
 	if !ok {
 		return NewDeleteServiceIDNotFound()
 	}
 
 	// FIXME: How to handle error?
-	DeleteL3n4AddrIDByUUID(uint32(params.ID))
+	err := DeleteL3n4AddrIDByUUID(uint32(params.ID))
+
+	if err != nil {
+		log.Warningf("error, DeleteL3n4AddrIDByUUID failed: %s", err)
+	}
 
 	if err := h.d.svcDelete(svc); err != nil {
+		log.Warningf("DELETE /service/{id}: error deleting service %v: %s", svc, err)
 		return apierror.Error(DeleteServiceIDFailureCode, err)
 	}
 
 	return NewDeleteServiceIDOK()
 }
 
-// Deletes a service by the frontend address
-func (d *Daemon) svcDeleteByFrontend(frontend *types.L3n4Addr) error {
-	d.loadBalancer.BPFMapMU.Lock()
-	defer d.loadBalancer.BPFMapMU.Unlock()
-
+func (d *Daemon) svcDeleteByFrontendLocked(frontend *types.L3n4Addr) error {
 	svc, ok := d.loadBalancer.SVCMap[frontend.SHA256Sum()]
 	if !ok {
 		return fmt.Errorf("Service frontend not found %+v", frontend)
@@ -208,7 +222,24 @@ func (d *Daemon) svcDeleteByFrontend(frontend *types.L3n4Addr) error {
 	return d.svcDelete(&svc)
 }
 
+// Deletes a service by the frontend address
+func (d *Daemon) svcDeleteByFrontend(frontend *types.L3n4Addr) error {
+	d.loadBalancer.BPFMapMU.Lock()
+	defer d.loadBalancer.BPFMapMU.Unlock()
+
+	return d.svcDeleteByFrontendLocked(frontend)
+}
+
 func (d *Daemon) svcDelete(svc *types.LBSVC) error {
+	if err := d.svcDeleteBPF(svc); err != nil {
+		return err
+	}
+	d.loadBalancer.DeleteService(svc)
+	return nil
+}
+
+func (d *Daemon) svcDeleteBPF(svc *types.LBSVC) error {
+	log.Debugf("deleting service %s from BPF maps", svc.FE.String())
 	var svcKey lbmap.ServiceKey
 	if !svc.FE.IsIPv6() {
 		svcKey = lbmap.NewService4Key(svc.FE.IP, svc.FE.Port, 0)
@@ -218,11 +249,34 @@ func (d *Daemon) svcDelete(svc *types.LBSVC) error {
 
 	svcKey.SetBackend(0)
 
-	if err := lbmap.DeleteService(svcKey); err != nil {
-		return err
+	// Get count of backends from master.
+	val, err := svcKey.Map().Lookup(svcKey.ToNetwork())
+	if err != nil {
+		return fmt.Errorf("key %s is not in lbmap", svcKey.ToNetwork())
 	}
 
-	d.loadBalancer.DeleteService(svc)
+	vval := val.(lbmap.ServiceValue)
+	numBackends := uint16(vval.GetCount())
+
+	// ServiceKeys are unique by their slave number, which corresponds to the number of backends. Delete each of these.
+	for i := numBackends; i > 0; i-- {
+		var slaveKey lbmap.ServiceKey
+		if !svc.FE.IsIPv6() {
+			slaveKey = lbmap.NewService4Key(svc.FE.IP, svc.FE.Port, i)
+		} else {
+			slaveKey = lbmap.NewService6Key(svc.FE.IP, svc.FE.Port, i)
+		}
+		log.Debugf("deleting backend %d for %s", i, slaveKey)
+		if err := lbmap.DeleteService(slaveKey); err != nil {
+			return fmt.Errorf("deleting service failed for %s: %s", slaveKey, err)
+
+		}
+	}
+
+	log.Debugf("done deleting service %d slaves, now deleting master service", svc.FE.ID)
+	if err := lbmap.DeleteService(svcKey); err != nil {
+		return fmt.Errorf("deleting service failed for %s: %s", svcKey, err)
+	}
 
 	return nil
 }
@@ -258,7 +312,7 @@ func (d *Daemon) svcGetBySHA256Sum(feL3n4SHA256Sum string) *types.LBSVC {
 	if !ok {
 		return nil
 	}
-	// We will move the slice from the loadbalancer map which have a mutex. If
+	// We will move the slice from the loadbalancer map which has a mutex. If
 	// we don't copy the slice we might risk changing memory that should be
 	// locked.
 	beCpy := []types.LBBackEnd{}
@@ -337,9 +391,9 @@ func (d *Daemon) RevNATDelete(id types.ServiceID) error {
 
 // RevNATDeleteAll deletes all RevNAT4, if IPv4 is enabled on daemon, and all RevNAT6
 // stored on the daemon and on the bpf maps.
+//
+// Must be called with d.loadBalancer.BPFMapMU locked.
 func (d *Daemon) RevNATDeleteAll() error {
-	d.loadBalancer.BPFMapMU.Lock()
-	defer d.loadBalancer.BPFMapMU.Unlock()
 
 	if !d.conf.IPv4Disabled {
 		if err := lbmap.RevNat4Map.DeleteAll(); err != nil {
@@ -389,47 +443,24 @@ func (d *Daemon) RevNATDump() ([]types.L3n4AddrID, error) {
 // KVStore's ID, that entry will be updated on the bpf map accordingly with the new ID
 // retrieved from the KVStore.
 func (d *Daemon) SyncLBMap() error {
+	log.Debugf("syncing BPF LBMaps with daemon's LB maps")
 	d.loadBalancer.BPFMapMU.Lock()
 	defer d.loadBalancer.BPFMapMU.Unlock()
 
 	newSVCMap := types.SVCMap{}
+	newSVCList := []*types.LBSVC{}
 	newSVCMapID := types.SVCMapID{}
 	newRevNATMap := types.RevNATMap{}
 	failedSyncSVC := []types.LBSVC{}
 	failedSyncRevNAT := map[types.ServiceID]types.L3n4Addr{}
 
-	parseSVCEntries := func(key bpf.MapKey, value bpf.MapValue) {
-		svcKey := key.(lbmap.ServiceKey)
-		//It's the frontend service so we don't add this one
-		if svcKey.GetBackend() == 0 {
-			return
-		}
-		svcValue := value.(lbmap.ServiceValue)
-		fe, be, err := lbmap.ServiceKeynValue2FEnBE(svcKey, svcValue)
-		if err != nil {
-			log.Errorf("%s", err)
-			return
-		}
-
-		newSVCMap.AddFEnBE(fe, be, svcKey.GetBackend())
-	}
-
-	parseRevNATEntries := func(key bpf.MapKey, value bpf.MapValue) {
-		revNatK := key.(lbmap.RevNatKey)
-		revNatV := value.(lbmap.RevNatValue)
-		fe, err := lbmap.RevNatValue2L3n4AddrID(revNatK, revNatV)
-		if err != nil {
-			log.Errorf("%s", err)
-			return
-		}
-		newRevNATMap[fe.ID] = fe.L3n4Addr
-	}
-
 	addSVC2BPFMap := func(oldID types.ServiceID, svc types.LBSVC) error {
-		// check if the reverser nat is present on the bpf map and update the
-		// reverse nat key and delete the old one.
+		log.Debugf("adding service ID %d with SHA %s", oldID, svc.FE.SHA256Sum())
+		// check if the ID for revNat is present in the bpf map, update the
+		// reverse nat key, delete the old one.
 		revNAT, ok := newRevNATMap[oldID]
 		if ok {
+			log.Debugf("%d is present in BPF map, updating revnat key", oldID)
 			revNATK, revNATV := lbmap.L3n4Addr2RevNatKeynValue(svc.FE.ID, revNAT)
 			err := lbmap.UpdateRevNat(revNATK, revNATV)
 			if err != nil {
@@ -443,7 +474,9 @@ func (d *Daemon) SyncLBMap() error {
 				log.Warningf("Unable to remove old rev NAT entry with ID %d: %s", oldID, err)
 			}
 
+			log.Debugf("deleting old ID %d from newRevNATMap", oldID)
 			delete(newRevNATMap, oldID)
+			log.Debugf("adding service %s --> revNAT: %s to newRevNATMap", svc.FE.String(), revNAT)
 			newRevNATMap[svc.FE.ID] = revNAT
 		}
 
@@ -461,39 +494,90 @@ func (d *Daemon) SyncLBMap() error {
 		return nil
 	}
 
+	parseSVCEntries := func(key bpf.MapKey, value bpf.MapValue) {
+		svcKey := key.(lbmap.ServiceKey)
+		//It's the frontend service so we don't add this one
+		if svcKey.GetBackend() == 0 {
+			return
+		}
+		svcValue := value.(lbmap.ServiceValue)
+		log.Debugf("parsing service mapping %s --> %s", svcKey, svcValue)
+		fe, be, err := lbmap.ServiceKeynValue2FEnBE(svcKey, svcValue)
+		if err != nil {
+			log.Errorf("SyncLBMap: %s", err)
+			return
+		}
+
+		svc := newSVCMap.AddFEnBE(fe, be, svcKey.GetBackend())
+		newSVCList = append(newSVCList, svc)
+	}
+
+	parseRevNATEntries := func(key bpf.MapKey, value bpf.MapValue) {
+		revNatK := key.(lbmap.RevNatKey)
+		revNatV := value.(lbmap.RevNatValue)
+		log.Debugf("parsing BPF revNAT mapping %s --> %s", revNatK, revNatV)
+		fe, err := lbmap.RevNatValue2L3n4AddrID(revNatK, revNatV)
+		if err != nil {
+			log.Errorf("%s", err)
+			return
+		}
+		newRevNATMap[fe.ID] = fe.L3n4Addr
+	}
+
 	if !d.conf.IPv4Disabled {
 		// lbmap.RRSeq4Map is updated as part of Service4Map and does
 		// not need separate dump.
-		lbmap.Service4Map.Dump(lbmap.Service4DumpParser, parseSVCEntries)
-		lbmap.RevNat4Map.Dump(lbmap.RevNat4DumpParser, parseRevNATEntries)
+		err := lbmap.Service4Map.Dump(lbmap.Service4DumpParser, parseSVCEntries)
+		if err != nil {
+			log.Warningf("error dumping Service4Map: %s", err)
+		}
+		err = lbmap.RevNat4Map.Dump(lbmap.RevNat4DumpParser, parseRevNATEntries)
+		if err != nil {
+			log.Warningf("error dumping RevNat4Map: %s", err)
+		}
 	}
 
 	// lbmap.RRSeq6Map is updated as part of Service6Map and does not need
 	// separate dump.
-	lbmap.Service6Map.Dump(lbmap.Service6DumpParser, parseSVCEntries)
+	err := lbmap.Service6Map.Dump(lbmap.Service6DumpParser, parseSVCEntries)
+	if err != nil {
+		log.Warningf("error dumping Service6Map: %s", err)
+	}
 	lbmap.RevNat6Map.Dump(lbmap.RevNat6DumpParser, parseRevNATEntries)
+	if err != nil {
+		log.Warningf("error dumping RevNat6Map: %s", err)
+	}
 
-	// Let's check if the services read from the lbmap have the same ID set in the
-	// KVStore.
-	for k, svc := range newSVCMap {
+	// Need to do this outside of parseSVCEntries to avoid deadlock, because we
+	// are modifying the BPF maps, and calling Dump on a Map RLocks the maps.
+	for _, svc := range newSVCList {
+		// Check if the services read from the lbmap have the same ID set in the
+		// KVStore.
+		log.Debugf("iterating over services read from BPF LB Map and seeing if they have the same ID set in the KV store")
 		kvL3n4AddrID, err := PutL3n4Addr(svc.FE.L3n4Addr, 0)
 		if err != nil {
 			log.Errorf("Unable to retrieve service ID of: %s from KVStore: %s."+
 				" This entry will be removed from the bpf's LB map.", svc.FE.L3n4Addr.String(), err)
-			failedSyncSVC = append(failedSyncSVC, svc)
-			delete(newSVCMap, k)
+			failedSyncSVC = append(failedSyncSVC, *svc)
+			delete(newSVCMap, svc.Sha256)
+			// Don't update the maps of services since the service failed to
+			// sync.
 			continue
 		}
 
+		// Mismatch detected between BPF Maps and KVstore, so we need to update
+		// the ID in the BPF Maps to reflect the ID of the KVstore.
 		if svc.FE.ID != kvL3n4AddrID.ID {
-			log.Infof("Service ID was out of sync, got new ID %d -> %d", svc.FE.ID, kvL3n4AddrID.ID)
+			log.Infof("service ID %d read from BPF map was out of sync with KVStore, got new ID %d", svc.FE.ID, kvL3n4AddrID.ID)
 			oldID := svc.FE.ID
 			svc.FE.ID = kvL3n4AddrID.ID
-			if err := addSVC2BPFMap(oldID, svc); err != nil {
+			// If we cannot add the service to the BPF maps, update the list of
+			// services that failed to sync.
+			if err := addSVC2BPFMap(oldID, *svc); err != nil {
 				log.Errorf("%s", err)
 
-				failedSyncSVC = append(failedSyncSVC, svc)
-				delete(newSVCMap, k)
+				failedSyncSVC = append(failedSyncSVC, *svc)
+				delete(newSVCMap, svc.Sha256)
 
 				revNAT, ok := newRevNATMap[svc.FE.ID]
 				if ok {
@@ -502,33 +586,24 @@ func (d *Daemon) SyncLBMap() error {
 					failedSyncRevNAT[svc.FE.ID] = revNAT
 					delete(newRevNATMap, svc.FE.ID)
 				}
+				// Don't update the maps of services since the service failed to
+				// sync.
 				continue
 			}
-			newSVCMap[k] = svc
-			newSVCMapID[svc.FE.ID] = &svc
 		}
+		newSVCMapID[svc.FE.ID] = svc
 	}
 
-	// Clean services and rev nats that failed while restoring
+	// Clean services and rev nats from BPF maps that failed to be restored.
 	for _, svc := range failedSyncSVC {
-		log.Debugf("Removing service: %s", svc.FE)
-		feL3n4 := svc.FE
-		var svcKey lbmap.ServiceKey
-		if !feL3n4.IsIPv6() {
-			svcKey = lbmap.NewService4Key(feL3n4.IP, feL3n4.Port, 0)
-		} else {
-			svcKey = lbmap.NewService6Key(feL3n4.IP, feL3n4.Port, 0)
-		}
-
-		svcKey.SetBackend(0)
-
-		if err := lbmap.DeleteService(svcKey); err != nil {
+		log.Debugf("Unable to restore, so removing service: %s", svc.FE)
+		if err := d.svcDeleteBPF(&svc); err != nil {
 			log.Warningf("Unable to clean service %s from BPF map: %s", svc.FE, err)
 		}
 	}
 
 	for id, revNAT := range failedSyncRevNAT {
-		log.Debugf("Removing revNAT: %s", revNAT)
+		log.Debugf("unable to restore, so removing revNAT: %s", revNAT)
 		var revNATK lbmap.RevNatKey
 		if !revNAT.IsIPv6() {
 			revNATK = lbmap.NewRevNat4Key(uint16(id))
@@ -541,6 +616,7 @@ func (d *Daemon) SyncLBMap() error {
 		}
 	}
 
+	log.Debugf("updating daemon's loadbalancer maps")
 	d.loadBalancer.SVCMap = newSVCMap
 	d.loadBalancer.SVCMapID = newSVCMapID
 	d.loadBalancer.RevNATMap = newRevNATMap

--- a/daemon/services.go
+++ b/daemon/services.go
@@ -91,6 +91,7 @@ func getL3n4AddrID(keyPath string) (*types.L3n4AddrID, error) {
 		return nil, err
 	}
 	if rmsg == nil {
+		log.Debugf("no value mapped to key %s in KVStore", keyPath)
 		return nil, nil
 	}
 
@@ -104,6 +105,7 @@ func getL3n4AddrID(keyPath string) (*types.L3n4AddrID, error) {
 // GetL3n4AddrID returns the L3n4AddrID that belongs to the given id.
 func GetL3n4AddrID(id uint32) (*types.L3n4AddrID, error) {
 	strID := strconv.FormatUint(uint64(id), 10)
+	log.Debugf("getting L3n4AddrID for ID %s", strID)
 	return getL3n4AddrID(path.Join(common.ServiceIDKeyPath, strID))
 }
 
@@ -112,8 +114,9 @@ func GetL3n4AddrIDBySHA256(sha256sum string) (*types.L3n4AddrID, error) {
 	return getL3n4AddrID(path.Join(common.ServicesKeyPath, sha256sum))
 }
 
-// DeleteL3n4AddrIDByUUID deletes the L3n4AddrID belonging to the given id.
+// DeleteL3n4AddrIDByUUID deletes the L3n4AddrID belonging to the given id from the kvstore.
 func DeleteL3n4AddrIDByUUID(id uint32) error {
+	log.Debugf("deleting L3n4Addr %d", id)
 	l3n4AddrID, err := GetL3n4AddrID(id)
 	if err != nil {
 		return err
@@ -125,9 +128,10 @@ func DeleteL3n4AddrIDByUUID(id uint32) error {
 	return DeleteL3n4AddrIDBySHA256(l3n4AddrID.SHA256Sum())
 }
 
-// DeleteL3n4AddrIDBySHA256 deletes the L3n4AddrID that belong to the serviceL4ID'
+// DeleteL3n4AddrIDBySHA256 deletes the L3n4AddrID from the kvstore corresponding to the service's
 // sha256Sum.
 func DeleteL3n4AddrIDBySHA256(sha256Sum string) error {
+	log.Debugf("deleting L3n4AddrID with SHA256 %s", sha256Sum)
 	if sha256Sum == "" {
 		return nil
 	}
@@ -159,7 +163,6 @@ func DeleteL3n4AddrIDBySHA256(sha256Sum string) error {
 	if err := updateL3n4AddrIDRef(oldL3n4ID, l3n4AddrID); err != nil {
 		return err
 	}
-
 	return kvstore.Client().SetValue(svcPath, l3n4AddrID)
 }
 


### PR DESCRIPTION
* common/types: add String() function for LBBackend & L3n4AddrID, add Slave
member to L3n4AddrID, add debug logs throughout, and update LBSVC object
with its SHA256 hash.
* daemon: clean all LB, RevNAT maps on host when restore mode is not enabled.
Add debug logs in the service-related code. When a service is updated or
deleted, clean BPF LB maps of old map entries for the given service. Fix
logic for syncing Cilium's LB maps with the BPF maps on disk when Cilium is
restarted and restore mode is enabled.
* pkg/maps/lbmap: add logs when services or RevNAT entries change state.
* tests: refactor 06-lb.sh into functions to reduce duplicate code, and add
test that ensures restore mode works appropriately for LB Maps when Cilium
is restarted.
    
Signed-off by: Ian Vernon <ian@cilium.io>
Fixes #1295 