### PR TITLE
daemon: replaced all returned *apierror.APIError with error

### DIFF
--- a/daemon/labels_test.go
+++ b/daemon/labels_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/daemon/options"
-	"github.com/cilium/cilium/pkg/apierror"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
@@ -54,7 +53,6 @@ var (
 		},
 		Labels: lbls,
 	}
-	nilAPIError *apierror.APIError
 )
 
 func (ds *DaemonSuite) SetUpTest(c *C) {

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -287,7 +287,7 @@ func (d *Daemon) policyAdd(rules api.Rules, opts *AddOptions) (uint64, error) {
 // k8s is not enabled. Otherwise, if k8s is enabled, policy is enabled on the
 // pods which are selected. Eventual changes in policy rules are propagated to
 // all locally managed endpoints.
-func (d *Daemon) PolicyAdd(rules api.Rules, opts *AddOptions) (uint64, *apierror.APIError) {
+func (d *Daemon) PolicyAdd(rules api.Rules, opts *AddOptions) (uint64, error) {
 	log.Debugf("Policy Add Request: %+v", rules)
 
 	for _, r := range rules {
@@ -311,7 +311,7 @@ func (d *Daemon) PolicyAdd(rules api.Rules, opts *AddOptions) (uint64, *apierror
 // If cover256Sum is set it finds the rule with the respective coverage that
 // rule from the node. If the path's node becomes ruleless it is removed from
 // the tree.
-func (d *Daemon) PolicyDelete(labels labels.LabelArray) (uint64, *apierror.APIError) {
+func (d *Daemon) PolicyDelete(labels labels.LabelArray) (uint64, error) {
 	log.Debugf("Policy Delete Request: %+v", labels)
 
 	// An error is only returned if a label filter was provided and then

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -79,7 +79,7 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 	}
 
 	_, err3 := ds.d.PolicyAdd(rules, nil)
-	c.Assert(err3, Equals, nilAPIError)
+	c.Assert(err3, Equals, nil)
 
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := ds.d.CreateOrUpdateIdentity(qaBarLbls, "cc08ff400e355f736dce1c291a6a4007ab9f2d56d42e1f3630ba87b861d45307")


### PR DESCRIPTION
Using `*apierror.APIError` as a return value of a func, causes false
positives for unnexpected not nils. For example:

    rules, err := rule.Parse()
    if err == nil {
        if len(rules) > 0 {
            _, err = d.PolicyAdd(rules, &AddOptions{Replace: true})
        }
    }

    if err != nil {
        // `err` is not `nil` here but it's `<nil>` (*apierror.APIError
        // nil pointer )
        log.Warningf("Unable to add CiliumNetworkPolicy %s: %s", rule.Metadata.Name, err)
    } else {
        log.Infof("Imported CiliumNetworkPolicy %s", rule.Metadata.Name)
    }

Signed-off-by: André Martins <andre@cilium.io>