### PR TITLE
Propagate status field to cilium network policy

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -16,10 +16,14 @@
 package k8s
 
 import (
+	"fmt"
 	"net"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,6 +37,15 @@ import (
 )
 
 const (
+	// CustomResourceDefinitionSingularName is the singular name of custom resource definition
+	CustomResourceDefinitionSingularName = "ciliumnetworkpolicy"
+
+	// CustomResourceDefinitionPluralName is the plural name of custom resource definition
+	CustomResourceDefinitionPluralName = "ciliumnetworkpolicies"
+
+	// CustomResourceDefinitionKind is the Kind name of custom resource definition
+	CustomResourceDefinitionKind = "CiliumNetworkPolicy"
+
 	// CustomResourceDefinitionGroup is the name of the third party resource group
 	CustomResourceDefinitionGroup = "cilium.io"
 
@@ -85,6 +98,66 @@ func CreateClient(config *rest.Config) (*kubernetes.Clientset, error) {
 func isConnReady(c *kubernetes.Clientset) error {
 	_, err := c.CoreV1().ComponentStatuses().Get("controller-manager", metav1.GetOptions{})
 	return err
+}
+
+// CreateCustomResourceDefinitions creates the CRD object in the kubernetes
+// cluster
+func CreateCustomResourceDefinitions(clientset apiextensionsclient.Interface) error {
+	cnpCRDName := CustomResourceDefinitionPluralName + "." + CustomResourceDefinitionGroup
+
+	res := &apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cnpCRDName,
+		},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Group:   CustomResourceDefinitionGroup,
+			Version: CustomResourceDefinitionVersion,
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Plural:     CustomResourceDefinitionPluralName,
+				Singular:   CustomResourceDefinitionSingularName,
+				ShortNames: []string{"cnp", "ciliumnp"},
+				Kind:       CustomResourceDefinitionKind,
+			},
+			Scope: apiextensionsv1beta1.NamespaceScoped,
+		},
+	}
+
+	_, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Create(res)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	log.Infof("k8s: Waiting for CRD to be established in k8s api-server...")
+	// wait for CRD being established
+	err = wait.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
+		crd, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(cnpCRDName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		for _, cond := range crd.Status.Conditions {
+			switch cond.Type {
+			case apiextensionsv1beta1.Established:
+				if cond.Status == apiextensionsv1beta1.ConditionTrue {
+					return true, err
+				}
+			case apiextensionsv1beta1.NamesAccepted:
+				if cond.Status == apiextensionsv1beta1.ConditionFalse {
+					log.Errorf("Name conflict: %v", cond.Reason)
+					return false, err
+				}
+			}
+		}
+		return false, err
+	})
+	if err != nil {
+		deleteErr := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(cnpCRDName, nil)
+		if deleteErr != nil {
+			return fmt.Errorf("k8s: unable to delete CRD %s. Deleting CRD due: %s", deleteErr, err)
+		}
+		return err
+	}
+
+	return nil
 }
 
 func addKnownTypesCRD(scheme *runtime.Scheme) error {

--- a/pkg/k8s/const.go
+++ b/pkg/k8s/const.go
@@ -16,6 +16,7 @@ package k8s
 
 import (
 	"k8s.io/kubernetes/pkg/kubelet/types"
+	"time"
 )
 
 const (
@@ -44,4 +45,8 @@ const (
 	// PodNamespaceMetaLabels is the label used to store the labels of the
 	// kubernetes namespace's labels.
 	PodNamespaceMetaLabels = "ns-labels"
+
+	// BackOffLoopTimeout is the default duration when trying to reach the
+	// kube-apiserver.
+	BackOffLoopTimeout = 2 * time.Minute
 )

--- a/tests/k8s/tests/01-guestbook-test.sh
+++ b/tests/k8s/tests/01-guestbook-test.sh
@@ -38,8 +38,12 @@ if [ $? -ne 0 ]; then abort "guestbook-policy-redis-deprecated policy was not in
 # TPR in k8s < 1.7.0
 if [[ "${k8s_version}" == 1.7.* ]]; then
     k8s_apply_policy kube-system create "${guestbook_dir}/policies/guestbook-policy-web.yaml"
+
+    k8s_nodes_policy_status 2 default guestbook-web
 else
     k8s_apply_policy kube-system create "${guestbook_dir}/policies/guestbook-policy-web-deprecated.yaml"
+
+    k8s_nodes_policy_status 2 default guestbook-web-deprecated
 fi
 
 cilium_id=$(docker ps -aq --filter=name=cilium-agent)


### PR DESCRIPTION
Fixes #1222

`kubectl get ciliumnetworkpolicies multi-rules -o json`

```
...
    "status": {
        "Nodes": {
            "cilium-k8s-master": {
                "LastSeen": "2017-08-22T20:16:23.471822307-07:00",
                "Message": "\u003cnil\u003e",
                "OK": false
            },
            "cilium-k8s-node-2": {
                "LastSeen": "2017-08-22T20:15:59.540742656-07:00",
                "Message": "\u003cnil\u003e",
                "OK": false
            }
        }
    }

```