### PR TITLE
pkg/endpoint: remove unused ID log msg

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -72,7 +72,6 @@ func (e *Endpoint) evaluateConsumerSource(owner Owner, ctx *policy.SearchContext
 
 	// Skip currently unused IDs
 	if ctx.From == nil || len(ctx.From) == 0 {
-		log.Debugf("[%s] Ignoring unused ID %v", e.PolicyID(), ctx)
 		return nil
 	}
 


### PR DESCRIPTION
Remove log message that specified when an unused ID was being ignored by Cilium,
as it logs a considerable number of times.

Signed-off by: Ian Vernon <ian@cilium.io>