### PR TITLE
tests/k8s: remove useless mv command

### DIFF
--- a/tests/k8s/copy_files
+++ b/tests/k8s/copy_files
@@ -29,8 +29,6 @@ function copy_k8s_test_files {
   # BUILD_ID is generated in helpers.bash. 
   sudo tar -czvf ${CILIUM_FILES}-k8s-${BUILD_ID}.tar.gz ${CILIUM_FILES}-${K8S1}-build-${BUILD_ID} ${CILIUM_FILES}-${K8S2}-build-${BUILD_ID}
   echo "----- done creating a tarball of files copied from $VM -----"
-
-  mv ${CILIUM_FILES}-k8s-${BUILD_ID}.tar.gz ${OLD_DIR}
 }
 
 copy_k8s_test_files


### PR DESCRIPTION
We don't need to move the tarball of K8s VM logs anymore, as the build picks
up the tarball at the root of the Jenkins Workspace now.

Signed-off by: Ian Vernon <ian@cilium.io>