### PR TITLE
kvstore: New kvstore abstraction API

### DIFF
--- a/daemon/kvstore_watcher.go
+++ b/daemon/kvstore_watcher.go
@@ -30,14 +30,14 @@ func (d *Daemon) EnableKVStoreWatcher(maxSeconds time.Duration) {
 	if maxID, err := GetMaxLabelID(); err == nil {
 		d.setCachedMaxLabelID(maxID)
 	}
-	ch := kvstore.Client.GetWatcher(common.LastFreeLabelIDKeyPath, maxSeconds)
+	ch := kvstore.Client().GetWatcher(common.LastFreeLabelIDKeyPath, maxSeconds)
 	go func() {
 		for {
 			select {
 			case updates, updateOk := <-ch:
 				if !updateOk {
 					log.Debugf("Watcher for %s closed, reacquiring it", common.LastFreeLabelIDKeyPath)
-					ch = kvstore.Client.GetWatcher(common.LastFreeLabelIDKeyPath, maxSeconds)
+					ch = kvstore.Client().GetWatcher(common.LastFreeLabelIDKeyPath, maxSeconds)
 				}
 				if len(updates) != 0 {
 					d.setCachedMaxLabelID(updates[0])

--- a/daemon/labels.go
+++ b/daemon/labels.go
@@ -36,7 +36,7 @@ import (
 
 func updateSecLabelIDRef(id policy.Identity) error {
 	key := path.Join(common.LabelIDKeyPath, strconv.FormatUint(uint64(id.ID), 10))
-	return kvstore.Client.SetValue(key, id)
+	return kvstore.Client().SetValue(key, id)
 }
 
 // gasNewSecLabelID gets and sets a New SecLabel ID.
@@ -46,7 +46,7 @@ func gasNewSecLabelID(id *policy.Identity) error {
 		return err
 	}
 
-	return kvstore.Client.GASNewSecLabelID(common.LabelIDKeyPath, uint32(baseID), id)
+	return kvstore.Client().GASNewSecLabelID(common.LabelIDKeyPath, uint32(baseID), id)
 }
 
 // type putIdentity struct {
@@ -85,14 +85,14 @@ func (d *Daemon) CreateOrUpdateIdentity(lbls labels.Labels, epid string) (*polic
 	identityPath := path.Join(common.LabelsKeyPath, lbls.SHA256Sum())
 
 	// Lock the identity
-	lockKey, err := kvstore.Client.LockPath(identityPath)
+	lockKey, err := kvstore.Client().LockPath(identityPath)
 	if err != nil {
 		return nil, false, err
 	}
 	defer lockKey.Unlock()
 
 	// Retrieve current identity for labels
-	rmsg, err := kvstore.Client.GetValue(identityPath)
+	rmsg, err := kvstore.Client().GetValue(identityPath)
 	if err != nil {
 		return nil, false, err
 	}
@@ -138,7 +138,7 @@ func (d *Daemon) CreateOrUpdateIdentity(lbls labels.Labels, epid string) (*polic
 	}
 
 	// store updated identity entry
-	if err = kvstore.Client.SetValue(identityPath, identity); err != nil {
+	if err = kvstore.Client().SetValue(identityPath, identity); err != nil {
 		return nil, false, err
 	}
 
@@ -206,7 +206,7 @@ func (d *Daemon) LookupIdentity(id policy.NumericIdentity) (*policy.Identity, er
 	}
 
 	strID := strconv.FormatUint(uint64(id), 10)
-	rmsg, err := kvstore.Client.GetValue(path.Join(common.LabelIDKeyPath, strID))
+	rmsg, err := kvstore.Client().GetValue(path.Join(common.LabelIDKeyPath, strID))
 	if err != nil {
 		return nil, apierror.Error(GetIdentityUnreachableCode, err)
 	}
@@ -215,7 +215,7 @@ func (d *Daemon) LookupIdentity(id policy.NumericIdentity) (*policy.Identity, er
 }
 
 func LookupIdentityBySHA256(sha256sum string) (*policy.Identity, error) {
-	rmsg, err := kvstore.Client.GetValue(path.Join(common.LabelsKeyPath, sha256sum))
+	rmsg, err := kvstore.Client().GetValue(path.Join(common.LabelsKeyPath, sha256sum))
 	if err != nil {
 		return nil, apierror.Error(GetIdentityUnreachableCode, err)
 	}
@@ -329,14 +329,14 @@ func (d *Daemon) DeleteIdentityBySHA256(sha256Sum string, epid string) error {
 	}
 	lblPath := path.Join(common.LabelsKeyPath, sha256Sum)
 	// Lock that sha256Sum
-	lockKey, err := kvstore.Client.LockPath(lblPath)
+	lockKey, err := kvstore.Client().LockPath(lblPath)
 	if err != nil {
 		return err
 	}
 	defer lockKey.Unlock()
 
 	// After lock complete, get label's path
-	rmsg, err := kvstore.Client.GetValue(lblPath)
+	rmsg, err := kvstore.Client().GetValue(lblPath)
 	if err != nil {
 		return err
 	}
@@ -365,7 +365,7 @@ func (d *Daemon) DeleteIdentityBySHA256(sha256Sum string, epid string) error {
 
 	log.Debugf("Decremented label %d ref-count to %d", dbSecCtxLbls.ID, dbSecCtxLbls.RefCount())
 
-	if err := kvstore.Client.SetValue(lblPath, dbSecCtxLbls); err != nil {
+	if err := kvstore.Client().SetValue(lblPath, dbSecCtxLbls); err != nil {
 		return err
 	}
 
@@ -380,6 +380,6 @@ func (d *Daemon) DeleteIdentityBySHA256(sha256Sum string, epid string) error {
 
 // GetMaxLabelID returns the maximum possible free UUID stored in consul.
 func GetMaxLabelID() (policy.NumericIdentity, error) {
-	n, err := kvstore.Client.GetMaxID(common.LastFreeLabelIDKeyPath, policy.MinimalNumericIdentity.Uint32())
+	n, err := kvstore.Client().GetMaxID(common.LastFreeLabelIDKeyPath, policy.MinimalNumericIdentity.Uint32())
 	return policy.NumericIdentity(n), err
 }

--- a/daemon/labels_test.go
+++ b/daemon/labels_test.go
@@ -82,7 +82,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	d, err := NewDaemon(daemonConf)
 	c.Assert(err, IsNil)
 	ds.d = d
-	kvstore.Client.DeleteTree(common.OperationalPath)
+	kvstore.Client().DeleteTree(common.OperationalPath)
 	// Needs to be less than 1 second otherwise GetCachedMaxLabelID might
 	// not work properly
 	d.EnableKVStoreWatcher(time.Nanosecond)
@@ -172,7 +172,7 @@ func (ds *DaemonSuite) TestLabels(c *C) {
 	var emptySecCtxLblPtr *policy.Identity
 	c.Assert(gotSecCtxLbl, Equals, emptySecCtxLblPtr)
 
-	err = kvstore.Client.SetMaxID(common.LastFreeLabelIDKeyPath, policy.MinimalNumericIdentity.Uint32(), policy.MinimalNumericIdentity.Uint32())
+	err = kvstore.Client().SetMaxID(common.LastFreeLabelIDKeyPath, policy.MinimalNumericIdentity.Uint32(), policy.MinimalNumericIdentity.Uint32())
 	c.Assert(err, IsNil)
 
 	err = ds.d.DeleteIdentity(policy.MinimalNumericIdentity, "containerLabel1-non-existent")
@@ -214,7 +214,7 @@ func (ds *DaemonSuite) TestLabels(c *C) {
 
 func (ds *DaemonSuite) TestGetMaxID(c *C) {
 	lastID := policy.NumericIdentity(common.MaxSetOfLabels - 1)
-	err := kvstore.Client.SetValue(common.LastFreeLabelIDKeyPath, lastID)
+	err := kvstore.Client().SetValue(common.LastFreeLabelIDKeyPath, lastID)
 	c.Assert(err, IsNil)
 
 	id, err := GetMaxLabelID()

--- a/daemon/services.go
+++ b/daemon/services.go
@@ -28,7 +28,7 @@ import (
 
 func updateL3n4AddrIDRef(id types.ServiceID, l3n4AddrID types.L3n4AddrID) error {
 	key := path.Join(common.ServiceIDKeyPath, strconv.FormatUint(uint64(id), 10))
-	return kvstore.Client.SetValue(key, l3n4AddrID)
+	return kvstore.Client().SetValue(key, l3n4AddrID)
 }
 
 // gasNewL3n4AddrID gets and sets a new L3n4Addr ID. If baseID is different than zero,
@@ -42,7 +42,7 @@ func gasNewL3n4AddrID(l3n4AddrID *types.L3n4AddrID, baseID uint32) error {
 		}
 	}
 
-	return kvstore.Client.GASNewL3n4AddrID(common.ServiceIDKeyPath, baseID, l3n4AddrID)
+	return kvstore.Client().GASNewL3n4AddrID(common.ServiceIDKeyPath, baseID, l3n4AddrID)
 }
 
 // PutL3n4Addr stores the given service in the kvstore and returns the L3n4AddrID
@@ -56,14 +56,14 @@ func PutL3n4Addr(l3n4Addr types.L3n4Addr, baseID uint32) (*types.L3n4AddrID, err
 	svcPath := path.Join(common.ServicesKeyPath, sha256Sum)
 
 	// Lock that sha256Sum
-	lockKey, err := kvstore.Client.LockPath(svcPath)
+	lockKey, err := kvstore.Client().LockPath(svcPath)
 	if err != nil {
 		return nil, err
 	}
 	defer lockKey.Unlock()
 
 	// After lock complete, get svc's path
-	rmsg, err := kvstore.Client.GetValue(svcPath)
+	rmsg, err := kvstore.Client().GetValue(svcPath)
 	if err != nil {
 		return nil, err
 	}
@@ -79,14 +79,14 @@ func PutL3n4Addr(l3n4Addr types.L3n4Addr, baseID uint32) (*types.L3n4AddrID, err
 		if err := gasNewL3n4AddrID(&sl4KV, baseID); err != nil {
 			return nil, err
 		}
-		err = kvstore.Client.SetValue(svcPath, sl4KV)
+		err = kvstore.Client().SetValue(svcPath, sl4KV)
 	}
 
 	return &sl4KV, err
 }
 
 func getL3n4AddrID(keyPath string) (*types.L3n4AddrID, error) {
-	rmsg, err := kvstore.Client.GetValue(keyPath)
+	rmsg, err := kvstore.Client().GetValue(keyPath)
 	if err != nil {
 		return nil, err
 	}
@@ -133,14 +133,14 @@ func DeleteL3n4AddrIDBySHA256(sha256Sum string) error {
 	}
 	svcPath := path.Join(common.ServicesKeyPath, sha256Sum)
 	// Lock that sha256Sum
-	lockKey, err := kvstore.Client.LockPath(svcPath)
+	lockKey, err := kvstore.Client().LockPath(svcPath)
 	if err != nil {
 		return err
 	}
 	defer lockKey.Unlock()
 
 	// After lock complete, get label's path
-	rmsg, err := kvstore.Client.GetValue(svcPath)
+	rmsg, err := kvstore.Client().GetValue(svcPath)
 	if err != nil {
 		return err
 	}
@@ -160,10 +160,10 @@ func DeleteL3n4AddrIDBySHA256(sha256Sum string) error {
 		return err
 	}
 
-	return kvstore.Client.SetValue(svcPath, l3n4AddrID)
+	return kvstore.Client().SetValue(svcPath, l3n4AddrID)
 }
 
 // GetMaxServiceID returns the maximum possible free UUID stored in the kvstore.
 func GetMaxServiceID() (uint32, error) {
-	return kvstore.Client.GetMaxID(common.LastFreeServiceIDKeyPath, common.FirstFreeServiceID)
+	return kvstore.Client().GetMaxID(common.LastFreeServiceIDKeyPath, common.FirstFreeServiceID)
 }

--- a/daemon/services_test.go
+++ b/daemon/services_test.go
@@ -91,7 +91,7 @@ func (ds *DaemonSuite) TestServices(c *C) {
 	err = DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
 
-	err = kvstore.Client.SetMaxID(common.LastFreeServiceIDKeyPath, common.FirstFreeServiceID, common.FirstFreeServiceID)
+	err = kvstore.Client().SetMaxID(common.LastFreeServiceIDKeyPath, common.FirstFreeServiceID, common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
 
 	err = DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID)
@@ -138,7 +138,7 @@ func (ds *DaemonSuite) TestServices(c *C) {
 
 func (ds *DaemonSuite) TestGetMaxServiceID(c *C) {
 	lastID := uint32(common.MaxSetOfServiceID - 1)
-	err := kvstore.Client.SetValue(common.LastFreeServiceIDKeyPath, lastID)
+	err := kvstore.Client().SetValue(common.LastFreeServiceIDKeyPath, lastID)
 	c.Assert(err, Equals, nil)
 
 	id, err := GetMaxServiceID()

--- a/daemon/status.go
+++ b/daemon/status.go
@@ -68,7 +68,7 @@ func (h *getHealthz) Handle(params GetHealthzParams) middleware.Responder {
 	d := h.daemon
 	sr := models.StatusResponse{}
 
-	if info, err := kvstore.Client.Status(); err != nil {
+	if info, err := kvstore.Client().Status(); err != nil {
 		sr.Kvstore = &models.Status{State: models.StatusStateFailure, Msg: fmt.Sprintf("Err: %s - %s", err, info)}
 	} else {
 		sr.Kvstore = &models.Status{State: models.StatusStateOk, Msg: info}

--- a/pkg/kvstore/config.go
+++ b/pkg/kvstore/config.go
@@ -22,6 +22,12 @@ import (
 	consulAPI "github.com/hashicorp/consul/api"
 )
 
+// Supported key-value store types.
+const (
+	Consul = "consul"
+	Etcd   = "etcd"
+)
+
 var (
 	// this variable is set via Makefile for test purposes and allows to tie a
 	// binary to a particular backend

--- a/pkg/kvstore/doc.go
+++ b/pkg/kvstore/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package kvstore abstracts KVstore access and provides a high level API to
+// atomically manage cluster wide resources
+package kvstore

--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -17,7 +17,6 @@ package kvstore
 import (
 	"fmt"
 	"io"
-	"testing"
 	"time"
 
 	etcdAPI "github.com/coreos/etcd/clientv3"
@@ -25,16 +24,16 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) {
-	TestingT(t)
-}
-
-type KVStore struct {
+type EtcdSuite struct {
 	etcd EtcdClient
 }
 
-var _ = Suite(&KVStore{})
+var _ = Suite(&EtcdSuite{})
+
+func (s *EtcdSuite) SetUpTest(c *C) {
+	err := SetupDummy()
+	c.Assert(err, IsNil)
+}
 
 type MaintenanceMocker struct {
 	OnAlarmList   func(ctx context.Context) (*etcdAPI.AlarmResponse, error)
@@ -79,7 +78,7 @@ func (m MaintenanceMocker) Snapshot(ctx context.Context) (io.ReadCloser, error) 
 	return nil, fmt.Errorf("Method Snapshot should not have been called")
 }
 
-func (s *KVStore) TestETCDVersionCheck(c *C) {
+func (s *EtcdSuite) TestETCDVersionCheck(c *C) {
 	badVersionStr := "3.0.0"
 	goodVersion := "3.1.0"
 	mm := MaintenanceMocker{

--- a/pkg/kvstore/events.go
+++ b/pkg/kvstore/events.go
@@ -1,0 +1,125 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvstore
+
+import (
+	log "github.com/Sirupsen/logrus"
+)
+
+// EventType defines the type of watch event that occured
+type EventType int
+
+const (
+	// EventTypeCreate represents a newly created key
+	EventTypeCreate EventType = iota
+	// EventTypeModify represents a modified key
+	EventTypeModify
+	// EventTypeDelete represents a deleted key
+	EventTypeDelete
+)
+
+// String() returns the human readable format of an event type
+func (t EventType) String() string {
+	switch t {
+	case EventTypeCreate:
+		return "create"
+	case EventTypeModify:
+		return "modify"
+	case EventTypeDelete:
+		return "delete"
+	default:
+		return "unknown"
+	}
+}
+
+// KeyValueEvent is a change event for a Key/Value pair
+type KeyValueEvent struct {
+	// Typ is the type of event { EventTypeCreate | EventTypeModify | EventTypeDelete }
+	Typ EventType
+
+	// Key is the kvstore key that changed
+	Key string
+
+	// Value is the kvstore value associated with the key
+	Value []byte
+}
+
+// EventChan is a channel to receive events on
+type EventChan chan KeyValueEvent
+
+// stopChan is the channel used to indicate stopping of the watcher
+type stopChan chan struct{}
+
+// Watcher represents a KVstore watcher
+type Watcher struct {
+	// Events is the channel to which change notifications will be sent to
+	Events EventChan
+
+	name      string
+	prefix    string
+	stopWatch stopChan
+
+	stopped bool
+}
+
+// String returns the name of the wather
+func (w *Watcher) String() string {
+	return w.name
+}
+
+func watch(name, prefix string, chanSize int, list bool) *Watcher {
+	w := &Watcher{
+		name:      name,
+		prefix:    prefix,
+		Events:    make(EventChan, chanSize),
+		stopWatch: make(stopChan, 0),
+	}
+
+	log.Debugf("Starting watcher %s list=%v...", name, list)
+	Client().Watch(w, list)
+
+	return w
+}
+
+// Watch creates a new watcher which will watch the specified prefix for
+// changes. Name can be set to anything and is used for logging messages. The
+// Events channel is created with the specified sizes. Upon every change
+// observed, a KeyValueEvent will be sent to the Events channel
+func Watch(name, prefix string, chanSize int) *Watcher {
+	return watch(name, prefix, chanSize, false)
+
+}
+
+// ListAndWatch creates a new watcher which will watch the specified prefix for
+// changes. Before doing this, it will list the current keys matching the
+// prefix and report them as new keys. Name can be set to anything and is used
+// for logging messages. The Events channel is created with the specified
+// sizes. Upon every change observed, a KeyValueEvent will be sent to the
+// Events channel
+func ListAndWatch(name, prefix string, chanSize int) *Watcher {
+	return watch(name, prefix, chanSize, true)
+}
+
+// Stop stops a watcher previously created and started with Watch()
+func (w *Watcher) Stop() {
+	if w.stopped {
+		return
+	}
+
+	close(w.Events)
+	close(w.stopWatch)
+	log.Debugf("Stopped watcher %s", w.name)
+	w.stopped = true
+}

--- a/pkg/kvstore/events_tests.go
+++ b/pkg/kvstore/events_tests.go
@@ -1,0 +1,125 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvstore
+
+import (
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	. "gopkg.in/check.v1"
+)
+
+type KvstoreSuite struct{}
+
+var _ = Suite(&KvstoreSuite{})
+
+func (s *KvstoreSuite) SetUpTest(c *C) {
+	log.SetLevel(log.DebugLevel)
+
+	err := SetupDummy()
+	c.Assert(err, IsNil)
+}
+
+func drainEvents(w *Watcher) {
+	for len(w.Events) > 0 {
+		<-w.Events
+	}
+}
+
+func expectEvent(c *C, w *Watcher, typ EventType, key string, val []byte) {
+	select {
+	case event := <-w.Events:
+		c.Assert(event.Typ, Equals, typ)
+		c.Assert(event.Key, DeepEquals, key)
+
+		// etcd does not provide the value of deleted keys
+		if backend == "consul" {
+			c.Assert(event.Value, DeepEquals, val)
+		}
+	case <-time.After(10 * time.Second):
+		c.Fatal("timeout while waiting for kvstore watcher event")
+	}
+}
+
+func (s *KvstoreSuite) TestWatch(c *C) {
+	DeleteTree("foo/")
+	defer DeleteTree("foo/")
+
+	w := Watch("testWatcher1", "foo/", 100)
+	c.Assert(c, Not(IsNil))
+
+	key1, key2 := "foo/key1", "foo/key2"
+	val1, val2 := []byte("val1"), []byte("val2")
+
+	err := CreateOnly(key1, val1, false)
+	c.Assert(err, IsNil)
+	expectEvent(c, w, EventTypeCreate, key1, val1)
+
+	err = Set(key1, val2)
+	c.Assert(err, IsNil)
+	expectEvent(c, w, EventTypeModify, key1, val2)
+
+	err = CreateOnly(key2, val2, false)
+	c.Assert(err, IsNil)
+	expectEvent(c, w, EventTypeCreate, key2, val2)
+
+	err = Delete(key1)
+	c.Assert(err, IsNil)
+	expectEvent(c, w, EventTypeDelete, key1, val2)
+
+	err = Delete(key2)
+	c.Assert(err, IsNil)
+	expectEvent(c, w, EventTypeDelete, key2, val2)
+
+	w.Stop()
+}
+
+func (s *KvstoreSuite) TestListAndWatch(c *C) {
+	key1, key2 := "foo2/key1", "foo2/key2"
+	val1, val2 := []byte("val1"), []byte("val2")
+
+	DeleteTree("foo2/")
+	defer DeleteTree("foo2/")
+
+	err := CreateOnly(key1, val1, false)
+	c.Assert(err, IsNil)
+
+	w := ListAndWatch("testWatcher2", "foo2/", 100)
+	c.Assert(c, Not(IsNil))
+
+	expectEvent(c, w, EventTypeCreate, key1, val1)
+
+	err = CreateOnly(key2, val2, false)
+	c.Assert(err, IsNil)
+	expectEvent(c, w, EventTypeCreate, key2, val2)
+
+	err = Delete(key1)
+	c.Assert(err, IsNil)
+	expectEvent(c, w, EventTypeDelete, key1, val1)
+
+	err = CreateOnly(key1, val1, false)
+	c.Assert(err, IsNil)
+	expectEvent(c, w, EventTypeCreate, key1, val1)
+
+	err = Delete(key1)
+	c.Assert(err, IsNil)
+	expectEvent(c, w, EventTypeDelete, key1, val1)
+
+	err = Delete(key2)
+	c.Assert(err, IsNil)
+	expectEvent(c, w, EventTypeDelete, key2, val2)
+
+	w.Stop()
+}

--- a/pkg/kvstore/keepalive.go
+++ b/pkg/kvstore/keepalive.go
@@ -1,0 +1,68 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvstore
+
+import (
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+var (
+	// LeaseTTL is the time-to-live ofthe lease
+	LeaseTTL = 15 * time.Minute // 15 minutes
+
+	// KeepAliveInterval is the interval in which the lease is being
+	// renewed. This must be set to a value lesser than the LeaseTTL
+	KeepAliveInterval = 5 * time.Minute
+
+	// RetryInterval is the interval in which retries occur in the case of
+	// errors in communication with the KVstore. THis should be set to a
+	// small value to account for temporary errors while communicating with
+	// the KVstore.
+	RetryInterval = 1 * time.Minute
+)
+
+// CreateLease creates a new lease with the given ttl
+func CreateLease(ttl time.Duration) (interface{}, error) {
+	lease, err := Client().CreateLease(ttl)
+	trace("CreateLease ttl=%d => %v, err=%v", ttl, lease, err)
+	return lease, err
+}
+
+// KeepAlive keeps a lease created with CreateLease alive
+func KeepAlive(lease interface{}) error {
+	err := Client().KeepAlive(lease)
+	trace("KeepAlive %v => err=%v", lease, err)
+	return err
+}
+
+func init() {
+	go func() {
+		// start with very short interval until client and lease appear
+		sleepTime := time.Duration(1) * time.Second
+		for {
+			if clientInstance != nil && leaseInstance != nil {
+				// once we have client and lease, keep alive in regular interval
+				sleepTime = KeepAliveInterval
+				if err := KeepAlive(leaseInstance); err != nil {
+					log.Warningf("Unable to keep lease alive: %s", err)
+					sleepTime = RetryInterval
+				}
+			}
+			time.Sleep(sleepTime)
+		}
+	}()
+}

--- a/pkg/kvstore/trace.go
+++ b/pkg/kvstore/trace.go
@@ -1,0 +1,35 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvstore
+
+import (
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+var (
+	// Debug enables kvstore tracing messages
+	//
+	// Debugging can be enabled at compile with:
+	// -ldflags "-X "github.com/cilium/cilium/pkg/kvstore".Debug=true"
+	Debug string
+)
+
+func trace(format string, a ...interface{}) {
+	if strings.ToLower(Debug) == "true" {
+		log.Debugf("[kvstore] "+format, a...)
+	}
+}


### PR DESCRIPTION
 - Basic lockless operations:
    - Get, GetPrefix, ListPrefix, Set, Delete
    - CreateOnly
    - Watch, ListAndWatch CreateLease, KeepAlive

Required for #1259 

Signed-off-by: Thomas Graf <thomas@cilium.io>