### PR TITLE
tests: Less verbose log & shorter runtime

### DIFF
--- a/contrib/packaging/docker/Makefile
+++ b/contrib/packaging/docker/Makefile
@@ -14,14 +14,14 @@ docker-image-dev: clean
 	@$(CURDIR)/../cp-dirs.sh $(BUILDDIR)
 	cp -v ../../../Dockerfile.dev $(BUILDDIR)/Dockerfile
 	find $(BUILDDIR) -name ".*" -prune ! -name ".git" -exec $(RM) -rf {} \;
-	docker build -t "cilium:$(DOCKER_IMAGE_TAG)" $(BUILDDIR)
+	docker build -q -t "cilium:$(DOCKER_IMAGE_TAG)" $(BUILDDIR)
 
 docker-image-dependencies: clean
 	mkdir -p $(BUILDDIR)
 	@$(CURDIR)/../cp-dirs.sh $(BUILDDIR)
 	cp -v ../../../Dockerfile.deps $(BUILDDIR)/Dockerfile
 	find $(BUILDDIR) -name ".*" -prune ! -name ".git" -exec $(RM) -rf {} \;
-	docker build -t "cilium:dependencies" $(BUILDDIR)
+	docker build -q -t "cilium:dependencies" $(BUILDDIR)
 clean:
 	ls -d ./* | grep -vE "Makefile|clang-3.8.1.key|build_dockerfile.sh" | xargs $(RM) -rf
 

--- a/tests/11-getting-started.sh
+++ b/tests/11-getting-started.sh
@@ -113,7 +113,7 @@ fi
 
 monitor_clear
 echo "------ performing HTTP GET on ${HTTPD_CONTAINER_NAME}/private from service2 ------"
-RETURN=$(docker run --rm -i --net ${TEST_NET} -l "${ID_SERVICE2}" ${DEMO_CONTAINER} /bin/bash -c "curl -s --output /dev/stderr -w '%{http_code}' -XGET http://${HTTPD_CONTAINER_NAME}/private")
+RETURN=$(docker run --rm -i --net ${TEST_NET} -l "${ID_SERVICE2}" ${DEMO_CONTAINER} /bin/bash -c "curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 15 -XGET http://${HTTPD_CONTAINER_NAME}/private")
 # FIXME: re-renable when redirect issue is resolved
 #if [[ "${RETURN//$'\n'}" != "403" ]]; then
 #  abort "Error: Unexpected success reaching ${HTTPD_CONTAINER_NAME}/private on port 80"

--- a/tests/k8s/cluster/cluster-manager.bash
+++ b/tests/k8s/cluster/cluster-manager.bash
@@ -77,7 +77,7 @@ function generate_certs(){
 
 function install_etcd(){
     wget -nv https://github.com/coreos/etcd/releases/download/${etcd_version}/etcd-${etcd_version}-linux-amd64.tar.gz
-    tar -xvf etcd-${etcd_version}-linux-amd64.tar.gz
+    tar -xf etcd-${etcd_version}-linux-amd64.tar.gz
     sudo mv etcd-${etcd_version}-linux-amd64/etcd* /usr/bin/
 }
 

--- a/tests/k8s/cluster/cluster-manager.bash
+++ b/tests/k8s/cluster/cluster-manager.bash
@@ -178,20 +178,18 @@ EOF
 }
 
 function install_kubeadm_dependencies(){
-    sudo apt-get update && sudo apt-get install -y apt-transport-https
     sudo touch /etc/apt/sources.list.d/kubernetes.list
     curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg  | sudo apt-key add -
     sudo bash -c "cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 "
-
-    sudo apt-get update && sudo apt-get install -y docker-engine
+    sudo apt-get -qq update && sudo apt-get -qq install -y apt-transport-https docker-engine
     sudo usermod -aG docker vagrant
 }
 
 function install_kubeadm() {
-    sudo apt-get install --allow-downgrades -y kubelet=${k8s_version} kubeadm=${k8s_version} kubectl=${k8s_version} kubernetes-cni
+    sudo apt-get -qq install --allow-downgrades -y kubelet=${k8s_version} kubeadm=${k8s_version} kubectl=${k8s_version} kubernetes-cni
 }
 
 function install_cilium_config(){

--- a/tests/k8s/tests/00-gsg-test.sh
+++ b/tests/k8s/tests/00-gsg-test.sh
@@ -94,7 +94,7 @@ echo "----- confirming that \`cilium policy trace\` shows that app2 can reach ap
 diff_timeout "echo $ALLOWED" "kubectl exec -n kube-system $CILIUM_POD_1 --  cilium policy trace --src-k8s-pod default:$APP2_POD --dst-k8s-pod default:$APP1_POD -v | grep Result:"
 
 echo "----- testing that app3 cannot reach app 1 (expected behavior: cannot reach)"
-RETURN=$(kubectl exec $APP3_POD -- curl -s --output /dev/stderr -w '%{http_code}' -XGET $SVC_IP || true)
+RETURN=$(kubectl exec $APP3_POD -- curl --connect-timeout 15 -s --output /dev/stderr -w '%{http_code}' -XGET $SVC_IP || true)
 if [[ "${RETURN//$'\n'}" != "000" ]]; then
 	abort "Error: unexpectedly reached pod allowed by L3 L4 Policy, received return code ${RETURN}"
 fi
@@ -136,7 +136,7 @@ if [[ "${RETURN//$'\n'}" != "200" ]]; then
 fi
 
 echo "------ performing HTTP GET on ${SVC_IP}/private from service2 ------"
-RETURN=$(kubectl exec $APP2_POD -- curl -s --output /dev/stderr -w '%{http_code}' --connect-timeout 15 http://${SVC_IP}/private || true)
+RETURN=$(kubectl exec $APP2_POD -- curl --connect-timeout 15 -s --output /dev/stderr -w '%{http_code}' --connect-timeout 15 http://${SVC_IP}/private || true)
 if [[ "${RETURN//$'\n'}" != "403" ]]; then
 	abort "Error: Unexpected success reaching  ${SVC_IP}/private on port 80"
 fi

--- a/tests/k8s/tests/02-cnp-specs.sh
+++ b/tests/k8s/tests/02-cnp-specs.sh
@@ -122,7 +122,7 @@ kubectl exec -t ${reviews_pod_v1} wget -- --tries=5 ratings:9080/health
 
 if [ $? -ne 0 ]; then abort "Error: could not connect from reviews-v1 to ratings:9080/health service" ; fi
 
-kubectl exec -t ${reviews_pod_v1} wget -- --tries=2 ratings:9080
+kubectl exec -t ${reviews_pod_v1} wget -- --connect-timeout=10 --tries=2 ratings:9080
 
 if [ $? -eq 0 ]; then abort "Error: unexpected success from reviews-v1 to ratings:9080 service" ; fi
 
@@ -139,11 +139,11 @@ kubectl exec -t ${productpage_v1} wget -- --tries=5 details:9080
 if [ $? -ne 0 ]; then abort "Error: could not connect from productpage-v1 to details:9080 service" ; fi
 
 # But it should fail while reaching out Ratings
-kubectl exec -t ${productpage_v1} wget -- --tries=2 ratings:9080/health
+kubectl exec -t ${productpage_v1} wget -- --connect-timeout=10 --tries=2 ratings:9080/health
 
 if [ $? -eq 0 ]; then abort "Error: unexpected success from productpage-v1 to ratings:9080/health service" ; fi
 
-kubectl exec -t ${productpage_v1} wget -- --tries=2 ratings:9080
+kubectl exec -t ${productpage_v1} wget -- --connect-timeout=10 --tries=2 ratings:9080
 
 if [ $? -eq 0 ]; then abort "Error: unexpected success from productpage-v1 to ratings:9080 service" ; fi
 

--- a/tests/k8s/tests/03-l7-stresstest.sh
+++ b/tests/k8s/tests/03-l7-stresstest.sh
@@ -110,7 +110,7 @@ code=$(kubectl exec -n qa -i ${frontend_pod} -- curl -s -o /dev/null -w "%{http_
 
 if [ ${code} -ne 200 ]; then abort "Error: unable to connect between frontend and backend" ; fi
 
-code=$(kubectl exec -n qa -i ${frontend_pod} -- curl -s -o /dev/null -w "%{http_code}" http://${backend_svc_ip}:80/health)
+code=$(kubectl exec -n qa -i ${frontend_pod} -- curl --connect-timeout 20 -s -o /dev/null -w "%{http_code}" http://${backend_svc_ip}:80/health)
 
 if [ ${code} -ne 403 ]; then abort "Error: unexpected connection between frontend and backend. wanted HTTP 403, got: HTTP ${code}" ; fi
 


### PR DESCRIPTION
c9bccb64692 removes all timeouts to provide immediate relieve for flaky
tests. Re-establish shortened timeouts for connectivity tests which are
expected to fail.

Signed-off-by: Thomas Graf <thomas@cilium.io>