### PR TITLE
Add timeouts to test helper functions

### DIFF
--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -22,60 +22,69 @@ for bin in "../cilium/cilium" \
 done
 
 function monitor_start {
-	cilium monitor -v $@ > $DUMP_FILE &
-	MONITOR_PID=$!
+  cilium monitor -v $@ > $DUMP_FILE &
+  MONITOR_PID=$!
 }
 
 function monitor_resume {
-	cilium monitor -v $@ >> $DUMP_FILE &
-	MONITOR_PID=$!
+  cilium monitor -v $@ >> $DUMP_FILE &
+  MONITOR_PID=$!
 }
 
 function monitor_clear {
-	set +x
-	cp /dev/null $DUMP_FILE
-	nstat > /dev/null
-	set -x
+  set +x
+  cp /dev/null $DUMP_FILE
+  nstat > /dev/null
+  set -x
 }
 
 function monitor_dump {
-	nstat
-	cat $DUMP_FILE
+  nstat
+  cat $DUMP_FILE
 }
 
 function monitor_stop {
-	if [ ! -z "$MONITOR_PID" ]; then
-		kill $MONITOR_PID || true
-	fi
+  if [ ! -z "$MONITOR_PID" ]; then
+    kill $MONITOR_PID || true
+  fi
 }
 
 function logs_clear {
-    LAST_LOG_DATE="$(date +'%F %T')"
+  LAST_LOG_DATE="$(date +'%F %T')"
 }
 
 function abort {
-	set +x
+  set +x
 
-	echo "------------------------------------------------------------------------"
-	echo "                            Test Failed"
-	echo "$*"
-	echo ""
-	echo "------------------------------------------------------------------------"
+  echo "------------------------------------------------------------------------"
+  echo "                            Test Failed"
+  echo "$*"
+  echo ""
+  echo "------------------------------------------------------------------------"
 
-	monitor_dump
-	monitor_stop
+  monitor_dump
+  monitor_stop
 
-	echo "------------------------------------------------------------------------"
-	echo "                            Cilium logs"
-	journalctl --no-pager --since "${LAST_LOG_DATE}" -u cilium
-	echo ""
-	echo "------------------------------------------------------------------------"
+  echo "------------------------------------------------------------------------"
+  echo "                            Cilium logs"
+  journalctl --no-pager --since "${LAST_LOG_DATE}" -u cilium
+  echo ""
+  echo "------------------------------------------------------------------------"
 
-	exit 1
+  exit 1
 }
 
 function micro_sleep {
-    sleep 0.5
+  sleep 0.5
+}
+
+function check_num_params {
+  local NUM_PARAMS=$1
+  local NUM_EXPECTED_PARAMS=$2
+  if [ "$NUM_PARAMS" -ne "$NUM_EXPECTED_PARAMS" ]; then
+    echo "${FUNCNAME[ 1 ]}: invalid number of parameters, expected $NUM_EXPECTED_PARAMS parameter(s)"
+    exit 1
+  fi
 }
 
 function wait_for_endpoints {
@@ -97,37 +106,38 @@ function k8s_num_ready {
 }
 
 function wait_for_k8s_endpoints {
-	set +x
-	local NAMESPACE=$1
-	local CILIUM_POD=$2
-	local NUM=$3
-	local FILTER=$4
-	echo "Waiting for $NUM endpoints in namespace $NAMESPACE managed by $CILIUM_POD"
+  set +x
+  check_num_params "$#" 3
+  local NAMESPACE=$1
+  local CILIUM_POD=$2
+  local NUM=$3
+  local FILTER=$4
+  echo "Waiting for $NUM endpoints in namespace $NAMESPACE managed by $CILIUM_POD"
 
-	# Wait some time for at least one endpoint to get into regenerating state
-	# FIXME: Remove when this is reliable
-	sleep 5
+  # Wait some time for at least one endpoint to get into regenerating state
+  # FIXME: Remove when this is reliable
+  sleep 5
 
-	local sleep_time=1
-	local iter=0
-	local found=$(k8s_num_ready $NAMESPACE $CILIUM_POD $FILTER)
-	echo "found: $found"
-	while [[ "$found" -ne "$NUM" ]]; do
-		if [[ $((iter++)) -gt $((5*60/$sleep_time)) ]]; then
-			echo ""
-			echo "Timeout while waiting for $NUM endpoints"
-			exit 1
-		else
-			kubectl -n ${NAMESPACE} exec ${CILIUM_POD} cilium endpoint list
-			echo -n " [${found}/${NUM}]"
-			sleep $sleep_time
-		fi
-		found=$(k8s_num_ready $NAMESPACE $CILIUM_POD $FILTER)
-		echo "found: $found"
-	done
+  local sleep_time=1
+  local iter=0
+  local found=$(k8s_num_ready $NAMESPACE $CILIUM_POD $FILTER)
+  echo "found: $found"
+  while [[ "$found" -ne "$NUM" ]]; do
+    if [[ $((iter++)) -gt $((5*60/$sleep_time)) ]]; then
+      echo ""
+      echo "Timeout while waiting for $NUM endpoints"
+      exit 1
+    else
+      kubectl -n ${NAMESPACE} exec ${CILIUM_POD} cilium endpoint list
+      echo -n " [${found}/${NUM}]"
+      sleep $sleep_time
+    fi
+    found=$(k8s_num_ready $NAMESPACE $CILIUM_POD $FILTER)
+    echo "found: $found"
+  done
 
-	set -x
-	kubectl -n ${NAMESPACE} exec ${CILIUM_POD} cilium endpoint list
+  set -x
+  kubectl -n ${NAMESPACE} exec ${CILIUM_POD} cilium endpoint list
 }
 
 function wait_for_cilium_status {
@@ -164,37 +174,34 @@ function wait_for_cilium_ep_gen {
 }
 
 function wait_for_daemon_set_not_ready {
-	set +x
+  set +x
 
-	if [ "$#" -ne 2 ]; then
-		echo "wait_for_daemon_set_not_ready: illegal number of parameters"
-		exit 1
-	fi
+  check_num_params "$#" "2"
 
-	local namespace="${1}"
-	local name="${2}"
+  local namespace="${1}"
+  local name="${2}"
 
-	echo "Waiting for instances of Cilium daemon $name in namespace $namespace to be clean up"
+  echo "Waiting for instances of Cilium daemon $name in namespace $namespace to be clean up"
 
-	local sleep_time=2
-	local iter=0
-	local found="0"
-	until [[ "$found" -eq "1" ]]; do
-		if [[ $((iter++)) -gt $((5*60/$sleep_time)) ]]; then
-			echo ""
-			echo "Timeout while waiting for cilium agent to be clean up by kubernetes"
-			print_k8s_cilium_logs
-			exit 1
-		else
-			kubectl -n ${namespace} get pods -o wide
-			sleep $sleep_time
-		fi
-		kubectl get pods -n ${namespace} | grep ${name} -q
-		found=$?
-	done
+  local sleep_time=2
+  local iter=0
+  local found="0"
+  until [[ "$found" -eq "1" ]]; do
+    if [[ $((iter++)) -gt $((5*60/$sleep_time)) ]]; then
+      echo ""
+      echo "Timeout while waiting for cilium agent to be clean up by kubernetes"
+      print_k8s_cilium_logs
+      exit 1
+    else
+      kubectl -n ${namespace} get pods -o wide
+      sleep $sleep_time
+    fi
+    kubectl get pods -n ${namespace} | grep ${name} -q
+    found=$?
+   done
 
-	set -x
-	kubectl -n kube-system get pods -o wide
+   set -x
+   kubectl -n kube-system get pods -o wide
 }
 
 function wait_for_policy_enforcement {
@@ -211,13 +218,14 @@ function count_lines_in_log {
 }
 
 function wait_for_log_entries {
-    set +x
-    expected=$(($1 + $(count_lines_in_log)))
+  set +x
+  check_num_params "$#" "1"
+  expected=$(($1 + $(count_lines_in_log)))
 
-    while [ $(count_lines_in_log) -lt "$expected" ]; do
-        micro_sleep
-    done
-    set -x
+  while [ $(count_lines_in_log) -lt "$expected" ]; do
+    micro_sleep
+  done
+  set -x
 }
 
 function wait_for_docker_ipv6_addr {
@@ -234,14 +242,14 @@ function wait_for_docker_ipv6_addr {
 }
 
 function wait_for_running_pod {
-    set +x
-    pod=$1
-    namespace=${2:-default}
-    echo "Waiting for ${pod} pod to be Running..."
-    while [[ "$(kubectl get pods -n ${namespace} -o wide | grep ${pod} | grep -c Running)" -ne "1" ]] ; do
-        micro_sleep
-    done
-    set -x
+  set +x
+  pod=$1
+  namespace=${2:-default}
+  echo "Waiting for ${pod} pod to be Running..."
+  while [[ "$(kubectl get pods -n ${namespace} -o wide | grep ${pod} | grep -c Running)" -ne "1" ]] ; do
+    micro_sleep
+  done
+  set -x
 }
 
 function wait_for_no_pods {
@@ -256,280 +264,285 @@ function wait_for_no_pods {
 }
 
 function wait_for_n_running_pods {
-	set +x
-	local NPODS=$1
-	echo -n "Waiting for $NPODS running pods"
+  set +x
+  check_num_params "$#" "1"
+  local NPODS=$1
+  echo -n "Waiting for $NPODS running pods"
 
-	local sleep_time=1
-	local iter=0
-	local found=$(kubectl get pod | grep Running -c || true)
-	until [[ "$found" -eq "$NPODS" ]]; do
-		if [[ $((iter++)) -gt $((5*60/$sleep_time)) ]]; then
-			echo ""
-			echo "Timeout while waiting for $NPODS running pods"
-			exit 1
-		else
-			kubectl get pod -o wide
-			echo -n " [${found}/${NPODS}]"
-			sleep $sleep_time
-		fi
-		found=$(kubectl get pod | grep Running -c || true)
-	done
+  local sleep_time=1
+  local iter=0
+  local found=$(kubectl get pod | grep Running -c || true)
+  until [[ "$found" -eq "$NPODS" ]]; do
+    if [[ $((iter++)) -gt $((5*60/$sleep_time)) ]]; then
+      echo ""
+      echo "Timeout while waiting for $NPODS running pods"
+      exit 1
+    else
+      kubectl get pod -o wide
+      echo -n " [${found}/${NPODS}]"
+      sleep $sleep_time
+    fi
+    found=$(kubectl get pod | grep Running -c || true)
+  done
 
-	set -x
-	kubectl get pod -o wide
+  set -x
+  kubectl get pod -o wide
 }
 
 # Wait for healthy k8s cluster on $1 nodes
 function wait_for_healthy_k8s_cluster {
-	set +x
-	local NNODES=$1
-	echo "Waiting for healthy k8s cluster with $NNODES nodes"
+  set +x
+  local NNODES=$1
+  echo "Waiting for healthy k8s cluster with $NNODES nodes"
 
-	local sleep_time=2
-	local iter=0
-	local found=$(kubectl get cs | grep -v "STATUS" | grep -c "Healthy")
-	until [[ "$found" -eq "3" ]]; do
-		if [[ $((iter++)) -gt $((1*60/$sleep_time)) ]]; then
-			echo ""
-			echo "Timeout while waiting for healthy kubernetes cluster"
-			exit 1
-		else
-			kubectl get cs
-			echo "K8S Components ready: [${found}/3]"
-			sleep $sleep_time
-		fi
-		found=$(kubectl get cs | grep -v "STATUS" | grep -c "Healthy")
-	done
-	set -x
-	kubectl get cs
-	local iter=0
-	local found=$(kubectl get nodes | grep Ready -c)
-	until [[ "$found" -eq "$NNODES" ]]; do
-		if [[ $((iter++)) -gt $((1*60/$sleep_time)) ]]; then
-			echo ""
-			echo "Timeout while waiting for all nodes to be Ready"
-			exit 1
-		else
-			kubectl get nodes
-			echo "Nodes ready [${found}/${NNODES}]"
-			sleep $sleep_time
-		fi
-		found=$(kubectl get nodes | grep Ready -c)
-	done
+  local sleep_time=2
+  local iter=0
+  local found=$(kubectl get cs | grep -v "STATUS" | grep -c "Healthy")
+  until [[ "$found" -eq "3" ]]; do
+    if [[ $((iter++)) -gt $((1*60/$sleep_time)) ]]; then
+      echo ""
+      echo "Timeout while waiting for healthy kubernetes cluster"
+      exit 1
+    else
+      kubectl get cs
+      echo "K8S Components ready: [${found}/3]"
+      sleep $sleep_time
+    fi
+    found=$(kubectl get cs | grep -v "STATUS" | grep -c "Healthy")
+  done
+  set -x
+  kubectl get cs
+  local iter=0
+  local found=$(kubectl get nodes | grep Ready -c)
+  until [[ "$found" -eq "$NNODES" ]]; do
+    if [[ $((iter++)) -gt $((1*60/$sleep_time)) ]]; then
+      echo ""
+      echo "Timeout while waiting for all nodes to be Ready"
+      exit 1
+    else
+      kubectl get nodes
+      echo "Nodes ready [${found}/${NNODES}]"
+      sleep $sleep_time
+    fi
+    found=$(kubectl get nodes | grep Ready -c)
+  done
 }
 
 function gather_files {
-    set -xv
-    TEST_NAME=$1
-    TEST_SUITE=$2
-    CILIUM_ROOT="src/github.com/cilium/cilium"
-    if [ -z "${TEST_SUITE}" ]; then 
-      TEST_SUITE="runtime-tests"
-    fi
-    if [ -z "${GOPATH}" ]; then 
-      local GOPATH="/home/vagrant/go"
-    fi 
-    if [[ "${TEST_SUITE}" == "runtime-tests" ]]; then
-      CILIUM_DIR="${GOPATH}/${CILIUM_ROOT}/tests/cilium-files/${TEST_NAME}"
-    elif [[ "${TEST_SUITE}" == "k8s-tests" ]]; then 
-      CILIUM_DIR="${GOPATH}/${CILIUM_ROOT}/tests/k8s/tests/cilium-files/${TEST_NAME}"
-    else
-      echo "${TEST_SUITE} not a valid value, continuing"
-      CILIUM_DIR="${GOPATH}/${CILIUM_ROOT}/tests/cilium-files/${TEST_NAME}"
-    fi 
-    RUN="/var/run/cilium"
-    LIB="/var/lib/cilium"
-    RUN_DIR="${CILIUM_DIR}${RUN}"
-    LIB_DIR="${CILIUM_DIR}${LIB}"
-    mkdir -p ${CILIUM_DIR}
-    mkdir -p ${RUN_DIR}
-    mkdir -p ${LIB_DIR}
-    if [[ "${TEST_SUITE}" == "runtime-tests" ]]; then
-      CLI_OUT_DIR="${CILIUM_DIR}/cli"
-      mkdir -p ${CLI_OUT_DIR}
-      dump_cli_output ${CLI_OUT_DIR} || true
-    fi
-    sudo cp -r ${RUN}/state ${RUN_DIR} || true
-    sudo cp -r ${LIB}/* ${LIB_DIR} || true 
-    find ${CILIUM_DIR} -type d -exec sudo chmod 777 {} \;
-    find ${CILIUM_DIR} -exec sudo chmod a+r {} \;
+  set -xv
+  check_num_params "$#" "2"
+  local TEST_NAME=$1
+  local TEST_SUITE=$2
+  local CILIUM_ROOT="src/github.com/cilium/cilium"
+  if [ -z "${TEST_SUITE}" ]; then
+    TEST_SUITE="runtime-tests"
+  fi
+  if [ -z "${GOPATH}" ]; then
+    local GOPATH="/home/vagrant/go"
+  fi
+  if [[ "${TEST_SUITE}" == "runtime-tests" ]]; then
+    CILIUM_DIR="${GOPATH}/${CILIUM_ROOT}/tests/cilium-files/${TEST_NAME}"
+  elif [[ "${TEST_SUITE}" == "k8s-tests" ]]; then
+    CILIUM_DIR="${GOPATH}/${CILIUM_ROOT}/tests/k8s/tests/cilium-files/${TEST_NAME}"
+  else
+    echo "${TEST_SUITE} not a valid value, continuing"
+    CILIUM_DIR="${GOPATH}/${CILIUM_ROOT}/tests/cilium-files/${TEST_NAME}"
+  fi
+  local RUN="/var/run/cilium"
+  local LIB="/var/lib/cilium"
+  local RUN_DIR="${CILIUM_DIR}${RUN}"
+  local LIB_DIR="${CILIUM_DIR}${LIB}"
+  mkdir -p ${CILIUM_DIR}
+  mkdir -p ${RUN_DIR}
+  mkdir -p ${LIB_DIR}
+  if [[ "${TEST_SUITE}" == "runtime-tests" ]]; then
+    local CLI_OUT_DIR="${CILIUM_DIR}/cli"
+    mkdir -p ${CLI_OUT_DIR}
+    dump_cli_output ${CLI_OUT_DIR} || true
+  fi
+  sudo cp -r ${RUN}/state ${RUN_DIR} || true
+  sudo cp -r ${LIB}/* ${LIB_DIR} || true
+  find ${CILIUM_DIR} -type d -exec sudo chmod 777 {} \;
+  find ${CILIUM_DIR} -exec sudo chmod a+r {} \;
 }
 
 function dump_cli_output {
-    local DIR=$1
-    cilium endpoint list > ${DIR}/endpoint_list.txt
-    local EPS=$(cilium endpoint list | tail -n+3 | awk '{print $1}' | grep -o '[0-9]*')
-    for ep in ${EPS} ; do 
-      cilium endpoint get ${ep} > ${DIR}/endpoint_get_${ep}.txt
-      cilium bpf policy list ${ep} > ${DIR}/bpf_policy_list_${ep}.txt
-    done
-    cilium service list > ${DIR}/service_list.txt
-    local SVCS=$(cilium service list | tail -n+2 | awk '{print $1}')
-    for svc in ${SVCS} ; do 
-      cilium service get ${svc} > ${DIR}/service_get_${svc}.txt
-    done
-    local IDS=$(cilium endpoint list | tail -n+3 | awk '{print $3}' | grep -o '[0-9]*')
-    for id in ${IDS} ; do 
-      cilium identity get ${id} > ${DIR}/identity_get_${id}.txt
-    done
-    cilium config > ${DIR}/config.txt
-    cilium bpf lb list > ${DIR}/bpf_lb_list.txt
-    cilium bpf ct list global > ${DIR}/bpf_ct_list_global.txt
-    cilium bpf tunnel list > ${DIR}/bpf_tunnel_list.txt
-    cilium policy get > ${DIR}/policy_get.txt
-    cilium status > ${DIR}/status.txt
+  check_num_params "$#" "1"
+  local DIR=$1
+  cilium endpoint list > ${DIR}/endpoint_list.txt
+  local EPS=$(cilium endpoint list | tail -n+3 | awk '{print $1}' | grep -o '[0-9]*')
+  for ep in ${EPS} ; do
+    cilium endpoint get ${ep} > ${DIR}/endpoint_get_${ep}.txt
+    cilium bpf policy list ${ep} > ${DIR}/bpf_policy_list_${ep}.txt
+  done
+  cilium service list > ${DIR}/service_list.txt
+  local SVCS=$(cilium service list | tail -n+2 | awk '{print $1}')
+  for svc in ${SVCS} ; do
+    cilium service get ${svc} > ${DIR}/service_get_${svc}.txt
+  done
+  local IDS=$(cilium endpoint list | tail -n+3 | awk '{print $3}' | grep -o '[0-9]*')
+  for id in ${IDS} ; do
+    cilium identity get ${id} > ${DIR}/identity_get_${id}.txt
+  done
+  cilium config > ${DIR}/config.txt
+  cilium bpf lb list > ${DIR}/bpf_lb_list.txt
+  cilium bpf ct list global > ${DIR}/bpf_ct_list_global.txt
+  cilium bpf tunnel list > ${DIR}/bpf_tunnel_list.txt
+  cilium policy get > ${DIR}/policy_get.txt
+  cilium status > ${DIR}/status.txt
 }
 
 function print_k8s_cilium_logs {
-	for pod in $(kubectl -n kube-system get pods -o wide| grep cilium | awk '{print $1}'); do
-		kubectl -n kube-system logs $pod
-		if [ $? -ne 0 ]; then
-			kubectl -n kube-system logs $pod --previous
-		fi
-	done
+  for pod in $(kubectl -n kube-system get pods -o wide| grep cilium | awk '{print $1}'); do
+    kubectl -n kube-system logs $pod
+    if [ $? -ne 0 ]; then
+      kubectl -n kube-system logs $pod --previous
+    fi
+  done
 }
 
 function wait_for_daemon_set_ready {
-	set +x
+  set +x
 
-	if [ "$#" -ne 3 ]; then
-		echo "wait_for_daemon_set_ready: illegal number of parameters"
-		exit 1
-	fi
+  check_num_params "$#" "3"
 
-	local namespace="${1}"
-	local name="${2}"
-	local n_ds_expected="${3}"
+  local namespace="${1}"
+  local name="${2}"
+  local n_ds_expected="${3}"
 
-	echo "Waiting for $n_ds_expected instances of Cilium daemon $name in namespace $namespace to become ready"
+  echo "Waiting for $n_ds_expected instances of Cilium daemon $name in namespace $namespace to become ready"
 
-	local sleep_time=2
-	local iter=0
-	local found="0"
-	until [[ "$found" -eq "$n_ds_expected" ]]; do
-		if [[ $((iter++)) -gt $((5*60/$sleep_time)) ]]; then
-			echo ""
-			echo "Timeout while waiting for cilium agent"
-			print_k8s_cilium_logs
-			exit 1
-		else
-			kubectl -n kube-system get ds
-			kubectl -n kube-system get pods -o wide
-			echo -n " [${found}/${n_ds_expected}]"
-			sleep $sleep_time
-		fi
-		found=$(kubectl get ds -n ${namespace} ${name} 2>&1 | awk 'NR==2{ print $4 }')
-	done
-
-	set -x
-	kubectl -n kube-system get pods -o wide
+  local sleep_time=2
+  local iter=0
+  local found="0"
+  until [[ "$found" -eq "$n_ds_expected" ]]; do
+    if [[ $((iter++)) -gt $((5*60/$sleep_time)) ]]; then
+      echo ""
+      echo "Timeout while waiting for cilium agent"
+      print_k8s_cilium_logs
+      exit 1
+    else
+      kubectl -n kube-system get ds
+      kubectl -n kube-system get pods -o wide
+      echo -n " [${found}/${n_ds_expected}]"
+      sleep $sleep_time
+    fi
+    found=$(kubectl get ds -n ${namespace} ${name} 2>&1 | awk 'NR==2{ print $4 }')
+  done
+  set -x
+  kubectl -n kube-system get pods -o wide
 }
 
 function k8s_wait_for_cilium_status_ready {
-	local pod
-	local namespace=$1
-	local pods=$(kubectl -n $namespace get pods -l k8s-app=cilium | grep cilium- | awk '{print $1}')
+  local pod
+  check_num_params "$#" "1"
+  local namespace=$1
+  local pods=$(kubectl -n $namespace get pods -l k8s-app=cilium | grep cilium- | awk '{print $1}')
 
-	for pod in $pods; do
-	    wait_for_kubectl_cilium_status $namespace $pod
-	done
+  for pod in $pods; do
+    wait_for_kubectl_cilium_status $namespace $pod
+  done
 }
 
 function k8s_count_all_cluster_cilium_eps {
-	local total=0
-	local pod
-	local namespace=$1
-	local pods=$(kubectl -n $namespace get pods -l k8s-app=cilium | grep cilium- | awk '{print $1}')
+  local total=0
+  check_num_params "$#" "1"
+  local pod
+  local namespace=$1
+  local pods=$(kubectl -n $namespace get pods -l k8s-app=cilium | grep cilium- | awk '{print $1}')
 
-	for pod in $pods; do
-		local n_eps=$(kubectl -n $namespace exec $pod -- cilium endpoint list --no-headers | wc -l)
-		total=$(( $total + $n_eps ))
-	done
+  for pod in $pods; do
+    local n_eps=$(kubectl -n $namespace exec $pod -- cilium endpoint list --no-headers | wc -l)
+    total=$(( $total + $n_eps ))
+  done
 
-    echo "$total"
+  echo "$total"
 }
 
 function wait_for_api_server_ready {
-    set +x
-    echo "Waiting for kube-apiserver to spin up"
-    while ! kubectl get cs; do
-        micro_sleep
-    done
-    set -x
+  set +x
+  echo "Waiting for kube-apiserver to spin up"
+  while ! kubectl get cs; do
+    micro_sleep
+  done
+  set -x
 }
 
 function wait_for_service_endpoints_ready {
-    set +x
-    if [ "$#" -ne 3 ]; then
-        echo "wait_for_service_endpoints_ready: illegal number of parameters"
-        exit 1
-    fi
-    local namespace="${1}"
-    local name="${2}"
-    local port="${3}"
+  set +x
+  if [ "$#" -ne 3 ]; then
+    echo "wait_for_service_endpoints_ready: illegal number of parameters"
+    exit 1
+  fi
+  local namespace="${1}"
+  local name="${2}"
+  local port="${3}"
 
-    echo "Waiting for ${name} service endpoints to be ready"
-    until [ "$(kubectl get endpoints -n ${namespace} ${name} | grep ":${port}")" ]; do
-        micro_sleep
-    done
-    set -x
+  echo "Waiting for ${name} service endpoints to be ready"
+  until [ "$(kubectl get endpoints -n ${namespace} ${name} | grep ":${port}")" ]; do
+    micro_sleep
+  done
+  set -x
 }
 
 function k8s_apply_policy {
-	declare -A currentRevison
-	local i
-	local pod
-	local namespace=$1
-	local action=$2
-	local policy=$3
-	local pods=$(kubectl -n $namespace get pods -l k8s-app=cilium | grep cilium- | awk '{print $1}')
+  declare -A currentRevison
+  local i
+  local pod
+  check_num_params "$#" "2"
+  local namespace=$1
+  local action=$2
+  local policy=$2
+  local pods=$(kubectl -n $namespace get pods -l k8s-app=cilium | grep cilium- | awk '{print $1}')
 
-	for pod in $pods; do
-		local rev=$(kubectl -n $namespace exec $pod -- cilium policy get | grep Revision: | awk '{print $2}')
-		currentRevison[$pod]=$rev
-	done
+  for pod in $pods; do
+    local rev=$(kubectl -n $namespace exec $pod -- cilium policy get | grep Revision: | awk '{print $2}')
+    currentRevison[$pod]=$rev
+  done
 
-	echo "Current policy revisions:"
-	for i in "${!currentRevison[@]}"
-	do
-		echo "  $i: ${currentRevison[$i]}"
-	done
+  echo "Current policy revisions:"
+  for i in "${!currentRevison[@]}"
+  do
+    echo "  $i: ${currentRevison[$i]}"
+  done
 
-	kubectl $action -f $policy
+  kubectl $action -f $policy
 
-	for pod in $pods; do
-		local nextRev=$(expr ${currentRevison[$pod]} + 1)
-		echo "Waiting for agent $pod endpoints to get to revision $nextRev"
-		kubectl -n $namespace exec $pod -- cilium policy wait $nextRev
-	done
+  for pod in $pods; do
+    local nextRev=$(expr ${currentRevison[$pod]} + 1)
+    echo "Waiting for agent $pod endpoints to get to revision $nextRev"
+    kubectl -n $namespace exec $pod -- cilium policy wait $nextRev
+  done
 
-	# Adding sleep as workaround for l7 stresstests
-	sleep 10s
+  # Adding sleep as workaround for l7 stresstests
+  sleep 10s
 }
 
 function policy_delete_and_wait {
-	rev=$(cilium policy delete $* | grep Revision: | awk '{print $2}')
-	timeout 120s cilium policy wait $rev
+  rev=$(cilium policy delete $* | grep Revision: | awk '{print $2}')
+  timeout 120s cilium policy wait $rev
 }
 
 function policy_import_and_wait {
-	rev=$(cilium policy import $* | grep Revision: | awk '{print $2}')
-	timeout 120s cilium policy wait $rev
+  rev=$(cilium policy import $* | grep Revision: | awk '{print $2}')
+  timeout 120s cilium policy wait $rev
 }
 
 function get_vm_identity_file {
+  check_num_params "$#" "1"
   local VM_NAME=$1
   vagrant ssh-config ${VM_NAME} | grep IdentityFile | awk '{print $2}'
 }
 
 function get_vm_ssh_port {
+  check_num_params "$#" "1"
   local VM_NAME=$1
   vagrant ssh-config ${VM_NAME} | grep Port | awk '{ print $2 }'
 }
 
 function copy_files_vm {
-  local VM_NAME=$1 
+  check_num_params "$#" "2"
+  local VM_NAME=$1
   local FILES_DIR=$2
 
   # Check that the VM is running before we try to gather logs from it.
@@ -551,8 +564,9 @@ function copy_files_vm {
 }
 
 function get_k8s_vm_name {
+  check_num_params "$#" "1"
   local VM_PREFIX=$1
-  
+
   if [ ! -z ${BUILD_NUMBER} ] ; then
     local BUILD_ID_NAME="-build-${BUILD_ID}"
   fi
@@ -567,26 +581,28 @@ function get_cilium_master_vm_name {
   if [ ! -z ${BUILD_NUMBER} ] ; then
     local BUILD_ID_NAME="-build-${BUILD_ID}"
   fi
-  
+
   echo "cilium${K8S_TAG}-master${BUILD_ID_NAME}"
 }
 
 function check_vm_running {
+  check_num_params "$#" "1"
   local VM=$1
   echo "----- getting status of VM $VM -----"
   vagrant status $VM
   echo "----- done getting status of VM $VM -----"
 
   local VM_STATUS=`vagrant status $VM | grep $VM | awk '{print $2}'`
-  if [[ "${VM_STATUS}" != "running" ]]; then 
+  if [[ "${VM_STATUS}" != "running" ]]; then
     echo "$VM is not in \"running\" state; exiting"
     exit 0
-  else 
+  else
     echo "$VM is \"running\" continuing"
   fi
 }
 
 function wait_for_agent_socket {
+  check_num_params "$#" "1"
   MAX_WAIT=$1
   local i=0
 
@@ -601,6 +617,7 @@ function wait_for_agent_socket {
 }
 
 function wait_for_kill {
+  check_num_params "$#" "2"
   TARGET_PID=$1
   MAX_WAIT=$2
   local i=0

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -224,8 +224,7 @@ function wait_for_log_entries {
 }
 
 function wait_for_docker_ipv6_addr {
-  #set +x
-  set -xv
+  set +x
   check_num_params "$#" "1"
   name=$1
   wait_specified_time_test "test \"\$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' $name)\" != \"\"" "2"
@@ -242,12 +241,11 @@ function wait_for_running_pod {
 }
 
 function wait_for_no_pods {
-  #set +x
-  set -xv
+  set +x
   namespace=${1:-default}
   echo "Waiting for no pods to be Running in namespace ${namespace}"
   wait_specified_time_test "test \"\$(kubectl get pods -n ${namespace} -o wide 2>&1 | grep -c 'No resources found')\" -eq \"1\"" "5"
-  set -xv
+  set -x
 }
 
 function wait_for_n_running_pods {
@@ -700,6 +698,7 @@ function wait_for_desired_state {
 #   None
 #######################################
 function wait_specified_time_test {
+  set +x
   local CMD="$1"
   local MAX_MINS="$2"
 

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -657,3 +657,52 @@ function diff_timeout() {
     fi
   done
 }
+
+#######################################
+# Waits for MAX_MINS until the output of CMD
+# reaches NUM_DESIRED. While the state is not
+# realized, INFO_CMD is emitted. If the state
+# is not realized after MAX_MINS, ERROR_OUTPUT
+# is emitted.
+# Globals: 
+# Arguments:
+#   NUM_DESIRED: desired number output by CMD.
+#   CMD: command to run.
+#   INFO_CMD: command to run while state is not
+#             realized
+#   MAX_MINS: maximum minutes to wait for desired
+#             state
+#   ERROR_OUTPUT: message that is emitted if desired
+#                 state is not realized in MAX_MINS.
+# Returns:
+#   None
+#######################################
+function wait_for_desired_state {
+  check_num_params "$#" "5"
+  local NUM_DESIRED="$1"
+  local CMD="$2"
+  local INFO_CMD="$3"
+  local MAX_MINS="$4"
+  local ERROR_OUTPUT="$5"
+  set +x
+  local sleep_time=1
+  local iter=0
+  local found=$(eval "$CMD")
+  echo "found: $found"
+
+  while [[ "$found" -ne "$NUM_DESIRED" ]]; do
+    if [[ $((iter++)) -gt $((${MAX_MINS}*60/$sleep_time)) ]]; then
+      echo ""
+      echo $ERROR_OUTPUT
+      exit 1
+    else
+      eval "$INFO_CMD"
+      echo -n " [$found/$NUM_DESIRED]"
+      sleep $sleep_time
+    fi
+    found=$(eval "${CMD}")
+    echo "found: $found"
+  done
+  set -x
+  eval "${INFO_CMD}"
+}

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -98,11 +98,11 @@ function wait_for_endpoints {
 }
 
 function k8s_num_ready {
-	local NAMESPACE=$1
-	local CILIUM_POD=$2
-	local FILTER=$3
+  local NAMESPACE=$1
+  local CILIUM_POD=$2
+  local FILTER=$3
 
-	kubectl -n ${NAMESPACE} exec ${CILIUM_POD} cilium endpoint list | grep $FILTER | grep -v 'not-ready' | grep -c 'ready' || true
+  kubectl -n ${NAMESPACE} exec ${CILIUM_POD} cilium endpoint list | grep $FILTER | grep -v 'not-ready' | grep -c 'ready' || true
 }
 
 function wait_for_k8s_endpoints {

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -488,7 +488,7 @@ function k8s_apply_policy {
   for pod in $pods; do
     local nextRev=$(expr ${currentRevison[$pod]} + 1)
     echo "Waiting for agent $pod endpoints to get to revision $nextRev"
-    kubectl -n $namespace exec $pod -- cilium policy wait $nextRev
+    timeout 180s kubectl -n $namespace exec $pod -- cilium policy wait $nextRev
   done
 
   # Adding sleep as workaround for l7 stresstests

--- a/tests/k8s/tests/001-policy-enforcement.sh
+++ b/tests/k8s/tests/001-policy-enforcement.sh
@@ -35,12 +35,14 @@ echo "CILIUM_POD_2: $CILIUM_POD_2"
 NUM_ENDPOINTS=4
 
 function cleanup {
+  echo "----- beginning cleanup for ${TEST_NAME} -----"
   kubectl delete -f "${MINIKUBE}/l3_l4_l7_policy.yaml" 2> /dev/null || true
   kubectl delete -f "${MINIKUBE}/l3_l4_policy_deprecated.yaml" 2> /dev/null || true
   kubectl delete -f "${MINIKUBE}/l3_l4_policy.yaml" 2> /dev/null || true
   kubectl delete -f "${GSGDIR}/demo.yaml" 2> /dev/null || true
   wait_for_no_pods
   kubectl exec -n ${NAMESPACE} ${CILIUM_POD_1} -- cilium config PolicyEnforcement=default || true
+  echo "----- cleanup finished for ${TEST_NAME} -----"
 }
 
 function finish_test {


### PR DESCRIPTION
* Refactored the helper functions in `tests/helpers.bash` to timeout after a specified duration instead of infinitely looping until a specific desired state is realized.
* Added two new generic functions that wait a specified amount of time for certain conditions to be realized to reduce duplicate / boilerplate code in `tests/helpers.bash`

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #1326 