### PR TITLE
tests: Fix wait_for_k8s_endpoints

### DIFF
--- a/tests/k8s/tests/001-policy-enforcement.sh
+++ b/tests/k8s/tests/001-policy-enforcement.sh
@@ -16,6 +16,9 @@ ALLOWED="Result: ALLOWED"
 TEST_NAME="001-policy-enforcement"
 LOGS_DIR="${dir}/cilium-files/${TEST_NAME}/logs"
 
+# string present in labels for all real workloads being tested
+POD_FILTER=k8s:id=app
+
 MINIKUBE="${dir}/../../../examples/minikube"
 K8SDIR="${dir}/../../../examples/kubernetes"
 GSGDIR="${dir}/deployments/gsg"
@@ -144,7 +147,7 @@ kubectl exec -n ${NAMESPACE} ${CILIUM_POD_2} -- cilium endpoint list
 # no rules applying to them. Since no policies have been imported, all endpoints should have 
 # policy enforcement disabled.
 echo "---- Test 1: default mode: test configuration with no policy imported ----"
-wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS}
+wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}
 check_endpoints_policy_disabled ${NUM_ENDPOINTS} ${CILIUM_POD_1}
 
 # Test 2: default mode, K8s, import policy.
@@ -153,7 +156,7 @@ check_endpoints_policy_disabled ${NUM_ENDPOINTS} ${CILIUM_POD_1}
 # should be enabled for only one endpoint (app3), and should be disabled for all other endpoints.
 echo "---- Test 2: default mode: test with policy imported  ----"
 import_policy
-wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS}
+wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}
 
 echo "---- Policies in cilium ----"
 kubectl exec -n ${NAMESPACE} ${CILIUM_POD_1} -- cilium policy get
@@ -166,7 +169,7 @@ check_endpoints_policy_disabled 2 ${CILIUM_POD_1}
 # that all endpoints should have policy enforcement disabled.
 echo "---- Test 3: default mode: check that policy enforcement for each endpoint is disabled after all policies are removed ----"
 delete_policy
-wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS}
+wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}
 check_endpoints_policy_disabled ${NUM_ENDPOINTS} ${CILIUM_POD_1}
 
 # Test 4: default --> always mode, K8s, no policy imported.
@@ -174,14 +177,14 @@ check_endpoints_policy_disabled ${NUM_ENDPOINTS} ${CILIUM_POD_1}
 # We expect that all endpoints should have policy enforcement enabled after this configuration is applied.
 echo "---- Test 4: default --> always mode: check that each endpoint has policy enforcement enabled with no policy imported ----"
 kubectl exec -n ${NAMESPACE} ${CILIUM_POD_1} -- cilium config PolicyEnforcement=always
-wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS}
+wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}
 check_endpoints_policy_enabled ${NUM_ENDPOINTS} ${CILIUM_POD_1}
 
 # Test 5: always --> never mode, K8s, no policy imported.
 # We expect that all endpoints should have policy enforcement disabled after this configuration is applied.
 echo "---- Test 5: always --> never mode: check that each endpoint has policy enforcement disabled with no policy imported ----"
 kubectl exec -n ${NAMESPACE} ${CILIUM_POD_1} -- cilium config PolicyEnforcement=never
-wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS}
+wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}
 check_endpoints_policy_disabled ${NUM_ENDPOINTS} ${CILIUM_POD_1}
 
 # Test 6: never mode, K8s, import policy.
@@ -189,82 +192,82 @@ check_endpoints_policy_disabled ${NUM_ENDPOINTS} ${CILIUM_POD_1}
 # Policy enforcement should be disabled for all endpoints.
 echo "---- Test 6: disabled mode: check that each endpoint has policy enforcement disabled with policy imported ----"
 import_policy
-wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS}
+wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}
 check_endpoints_policy_disabled ${NUM_ENDPOINTS} ${CILIUM_POD_1}
 
 # Test 7: never --> always mode, K8s, policy imported.
 # Policy enforcement should be enabled for all endpoints.
 echo "---- Test 7: never --> always mode: check that each endpoint has policy enforcement enabled with policy imported----"
 kubectl exec -n ${NAMESPACE} ${CILIUM_POD_1} -- cilium config PolicyEnforcement=always
-wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS}
+wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}
 check_endpoints_policy_enabled ${NUM_ENDPOINTS} ${CILIUM_POD_1}
 
 # Test 8: always --> default mode, K8s, policy imported.
 # Policy enforcement should be enabled for only one endpoint.
 echo "---- Test 8: always --> default mode: check that 2 endpoints have policy enforcement enabled with policy imported ----"
 kubectl exec -n ${NAMESPACE} ${CILIUM_POD_1} -- cilium config PolicyEnforcement=default
-wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS}
+wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}
 check_endpoints_policy_enabled 2 ${CILIUM_POD_1}
 
 # Test 9: default --> always mode, K8s, policy imported.
 # Policy enforcement should be enabled for all endpoints.
 echo "---- Test 9: default --> always mode: check that each endpoint has policy enforcement enabled with policy imported----"
 kubectl exec -n ${NAMESPACE} ${CILIUM_POD_1} -- cilium config PolicyEnforcement=always
-wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS}
+wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}
 check_endpoints_policy_enabled ${NUM_ENDPOINTS} ${CILIUM_POD_1}
 
 # Test 10: always mode, K8s, delete policy.
 # Policy enforcement should be 'true' for all endpoints.
 echo "---- Test 10: always mode: check that each endpoint has policy enforcement enabled with no policy imported ----"
 delete_policy
-wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS}
+wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}
 check_endpoints_policy_enabled ${NUM_ENDPOINTS} ${CILIUM_POD_1}
 
 # Test 11: always mode, K8s, import policy.
 # All endpoints should have policy enforcement enabled.
 echo "---- Test 11: always mode: check that each endpoint has policy enforcement enabled with policy imported ----"
 import_policy
-wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS}
+wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}
 check_endpoints_policy_enabled ${NUM_ENDPOINTS} ${CILIUM_POD_1}
 
 # Test 12: always --> never mode, K8s, policy imported.
 # All endpoints should have policy enforcement disabled. 
 echo "---- Test 12: always --> never mode: check that each endpoint has policy enforcement disabled with policy imported ----"
 kubectl exec -n ${NAMESPACE} ${CILIUM_POD_1} -- cilium config PolicyEnforcement=never
-wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS}
+wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}
 check_endpoints_policy_disabled ${NUM_ENDPOINTS} ${CILIUM_POD_1}
 
 # Test 13: never mode, K8s, delete policy.
 # All endpoints should have policy enforcement disabled.
 echo "---- Test 13: never mode: check that each endpoint has policy enforcement disabled after policy deleted ----"
 delete_policy
-wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS}
+wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}
 check_endpoints_policy_disabled ${NUM_ENDPOINTS} ${CILIUM_POD_1}
 
 # Test 14: never --> always, K8s, no policy imported.
 # All endpoints should have policy enforcement enabled.
 echo "---- Test 14: never --> always mode: check that each endpoint has policy enforcement enabled with no policy imported ----"
 kubectl exec -n ${NAMESPACE} ${CILIUM_POD_1} -- cilium config PolicyEnforcement=always
-wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS}
+wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}
 check_endpoints_policy_enabled ${NUM_ENDPOINTS} ${CILIUM_POD_1}
 
 # Test 15: always --> default, K8s, no policy imported.
 # All endpoints should have policy enforcement disabled.
 echo "---- Test 15: always --> default mode: check that each endpoint has policy enforcement disabled with no policy imported ----"
 kubectl exec -n ${NAMESPACE} ${CILIUM_POD_1} -- cilium config PolicyEnforcement=default
-wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS}
+wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}
 check_endpoints_policy_disabled ${NUM_ENDPOINTS} ${CILIUM_POD_1}
 
 # Test 16: default --> never, K8s, no policy imported.
 # All endpoints should have policy enforcement disabled.
 echo "---- Test 16: default --> never mode: check that each endpoint has policy enforcement disabled with no policy ipmorted ----"
 kubectl exec -n ${NAMESPACE} ${CILIUM_POD_1} -- cilium config PolicyEnforcement=never
-wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS}
+wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}
 check_endpoints_policy_disabled ${NUM_ENDPOINTS} ${CILIUM_POD_1}
 
 # Test 17: never --> default, K8s, no policy imported.
 # All endpoints should have policy enforcement disabled.
 echo "---- Test 17: never --> default mode: check that each endpoint has policy enforcement disabled with no policy imported ----"
 kubectl exec -n ${NAMESPACE} ${CILIUM_POD_1} -- cilium config PolicyEnforcement=default
-wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS}
+wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}
 check_endpoints_policy_disabled ${NUM_ENDPOINTS} ${CILIUM_POD_1}


### PR DESCRIPTION
The existing wait_for_k8s_endpoints waited for N endpoints to show up as
ready. Cilium manages system relevant pods such as kube-dns as well
though. In the event when kube-dns was restarted by Kubernetes, kube-dns
did show up as endpoint in `cilium endpoint list` which caused 5 of the
desired endpoints to be reported.

Improve the test by taking a label filter to identify real workload
endpoints.

Fixes: #1389

Signed-off-by: Thomas Graf <thomas@cilium.io>