### PR TITLE
tests/k8s: ignoring kubectl error messages

### DIFF
--- a/tests/k8s/tests/01-guestbook-test.sh
+++ b/tests/k8s/tests/01-guestbook-test.sh
@@ -134,8 +134,14 @@ echo "SUCCESS!"
 
 set +e
 
-k8s_apply_policy $NAMESPACE delete "${guestbook_dir}/"
-k8s_apply_policy $NAMESPACE delete "${guestbook_dir}/policies"
+kubectl delete -f "${guestbook_dir}/"
+
+if [[ "${k8s_version}" == 1.7.* ]]; then
+  k8s_apply_policy $NAMESPACE delete "${guestbook_dir}/policies/guestbook-policy-web.json"
+  k8s_apply_policy $NAMESPACE delete "${guestbook_dir}/policies/guestbook-policy-redis.json"
+else
+  k8s_apply_policy $NAMESPACE delete "${guestbook_dir}/policies/guestbook-policy-web-deprecated.yaml"
+if
 
 docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=guestbook-web 2>/dev/null
 


### PR DESCRIPTION
Since we might execute some actions in policies that don't exist in
kubernetes, we can ignore the error messages from kubectl.

Signed-off-by: André Martins <andre@cilium.io>

Fixes #1395 