### PR TITLE
tests: get Consul logs from runtime-tests

### DIFF
--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -343,6 +343,9 @@ function gather_files {
     local CLI_OUT_DIR="${CILIUM_DIR}/cli"
     mkdir -p ${CLI_OUT_DIR}
     dump_cli_output ${CLI_OUT_DIR} || true
+    # Get logs from Consul container.
+    mkdir -p ${CILIUM_DIR}/consul
+    docker logs cilium-consul > ${CILIUM_DIR}/consul/consul-logs.txt 2>/dev/null
   fi
   sudo cp -r ${RUN}/state ${RUN_DIR} || true
   sudo cp -r ${LIB}/* ${LIB_DIR} || true


### PR DESCRIPTION
Previously, if the tests errored out due to Consul-related errors, we had no
information for debugging. Gather the Consul logs as well for debugging if
needed.

Signed-off by: Ian Vernon <ian@cilium.io>