### PR TITLE
tests: put `cilium endpoint list` output in var

### DIFF
--- a/tests/96-restore-endpoints.sh
+++ b/tests/96-restore-endpoints.sh
@@ -30,8 +30,8 @@ docker run -dt --net=$TEST_NET --name server2 -l id.server2 $NETPERF_IMAGE
 
 wait_for_cilium_ep_gen
 
-before_restart_md5=$(cilium endpoint list | md5sum)
 before_restart=$(cilium endpoint list)
+before_restart_md5=$(echo "${before_restart}" | md5sum)
 
 sudo service cilium restart
 
@@ -39,8 +39,8 @@ wait_for_cilium_status
 
 wait_for_cilium_ep_gen
 
-after_restart_md5=$(cilium endpoint list | md5sum)
 after_restart=$(cilium endpoint list)
+after_restart_md5=$(echo "${after_restart}" | md5sum)
 
 if [[ "${before_restart_md5}" != "${after_restart_md5}" ]]; then
     echo "Wanted:"


### PR DESCRIPTION
In tests/96-restore-endpoint.sh, we took the md5sum of `cilium enpdoint list`,
and then ran `cilium endpoint list` again to store its output in a variable.
However, inbetween getting the md5sum and storing the output in a variable,
the output of `cilium endpoint list` may have changed. Store the output of
`cilium endpoint list` in a variable, then find the md5sum of the contents
of that variable.

Signed-off by: Ian Vernon <ian@cilium.io>