### PR TITLE
Add src-k8s-yaml, dst-k8s-yaml as parameters to `cilium policy trace`

### DIFF
--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -140,7 +140,7 @@ func defaultLabelPrefixCfg() *LabelPrefixCfg {
 	}
 
 	expressions := []string{
-		"io.kubernetes.pod.namespace",                              // include io.kubernetes.pod.namspace
+		K8sNamespaceLabel,                                          // include io.kubernetes.pod.namspace
 		"!io.kubernetes",                                           // ignore all other io.kubernetes labels
 		"!.*kubernetes.io",                                         // ignore all other kubernetes.io labels (annotation.*.k8s.io)
 		"!pod-template-hash",                                       // ignore pod-template-hash

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -136,6 +136,9 @@ const (
 
 	// LabelSourceReservedKeyPrefix is the prefix of a reserved label
 	LabelSourceReservedKeyPrefix = LabelSourceReserved + "."
+
+	// K8sNamespaceLabel is the key that maps to the namespace for a pod.
+	K8sNamespaceLabel = "io.kubernetes.pod.namespace"
 )
 
 // Label is the cilium's representation of a container label.
@@ -529,4 +532,16 @@ func LabelSliceSHA256Sum(labels []*Label) (string, error) {
 		return "", err
 	}
 	return fmt.Sprintf("%x", sha.Sum(nil)), nil
+}
+
+// generateLabelString generates the string representation of a label with
+// the provided source, key, and value in the format "source:key=value".
+func generateLabelString(source, key, value string) string {
+	return fmt.Sprintf("%s:%s=%s", source, key, value)
+}
+
+// GenerateK8sLabelString generates the string representation of a label with
+// the provided source, key, and value in the format "LabelSourceK8s:key=value".
+func GenerateK8sLabelString(k, v string) string {
+	return generateLabelString(LabelSourceK8s, k, v)
 }

--- a/pkg/policy/trace/yaml.go
+++ b/pkg/policy/trace/yaml.go
@@ -1,0 +1,115 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/cilium/cilium/pkg/labels"
+
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/v1"
+	// Use a blank import for calls to Decode the contents of YAML files.
+	_ "k8s.io/client-go/pkg/api/install"
+	// Use a blank import for calls to Decode the contents of YAML files.
+	_ "k8s.io/client-go/pkg/apis/extensions/install"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+const (
+	// DefaultNamespace represents the default Kubernetes namespace.
+	DefaultNamespace = "default"
+)
+
+// GetLabelsFromYaml iterates through the provided YAML file and for each
+// section in the YAML, returns the labels or an error if the labels could not
+// be parsed.
+func GetLabelsFromYaml(file string) ([][]string, error) {
+	reader, err := os.Open(file)
+
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	byteArr, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	splitYamlLabels := [][]string{}
+	yamlDocs := bytes.Split(byteArr, []byte("---"))
+	for _, v := range yamlDocs {
+		yamlLabels := []string{}
+
+		// Ignore empty documents, e.g., file starting with --- or ---\n
+		if len(v) < 2 {
+			continue
+		}
+
+		obj, _, err := api.Codecs.UniversalDeserializer().Decode(v, nil, nil)
+		if err != nil {
+			return nil, err
+		}
+		switch obj.(type) {
+		case *v1beta1.Deployment:
+			deployment := obj.(*v1beta1.Deployment)
+			var ns string
+			if deployment.Namespace != "" {
+				ns = deployment.Namespace
+			} else {
+				ns = DefaultNamespace
+			}
+			yamlLabels = append(yamlLabels, labels.GenerateK8sLabelString(labels.K8sNamespaceLabel, ns))
+
+			for k, v := range deployment.Spec.Template.Labels {
+				yamlLabels = append(yamlLabels, labels.GenerateK8sLabelString(k, v))
+			}
+		case *v1.ReplicationController:
+			controller := obj.(*v1.ReplicationController)
+			var ns string
+			if controller.Namespace != "" {
+				ns = controller.Namespace
+			} else {
+				ns = DefaultNamespace
+			}
+			yamlLabels = append(yamlLabels, labels.GenerateK8sLabelString(labels.K8sNamespaceLabel, ns))
+
+			for k, v := range controller.Spec.Template.Labels {
+				yamlLabels = append(yamlLabels, labels.GenerateK8sLabelString(k, v))
+			}
+		case *v1beta1.ReplicaSet:
+			rep := obj.(*v1beta1.ReplicaSet)
+			var ns string
+			if rep.Namespace != "" {
+				ns = rep.Namespace
+			} else {
+				ns = DefaultNamespace
+			}
+			yamlLabels = append(yamlLabels, labels.GenerateK8sLabelString(labels.K8sNamespaceLabel, ns))
+
+			for k, v := range rep.Spec.Template.Labels {
+				yamlLabels = append(yamlLabels, labels.GenerateK8sLabelString(k, v))
+			}
+		default:
+			return nil, fmt.Errorf("unsupported type provided in YAML file: %T", obj)
+		}
+		splitYamlLabels = append(splitYamlLabels, yamlLabels)
+	}
+	return splitYamlLabels, nil
+}

--- a/tests/12-policy-import.sh
+++ b/tests/12-policy-import.sh
@@ -108,6 +108,7 @@ cat <<EOF | cilium -D policy import -
 EOF
 
 read -d '' EXPECTED_POLICY <<"EOF" || true
+----------------------------------------------------------------
 Tracing From: [any:id.foo] => To: [any:id.bar]
 * Rule 0 {"matchLabels":{"any:id.bar":""}}: match
     Allows from labels {"matchLabels":{"reserved:host":""}}
@@ -119,6 +120,7 @@ Result: ALLOWED
 L3 verdict: allowed
 
 Verdict: allowed
+
 EOF
 
 echo "------ verify trace for expected output ------"
@@ -161,6 +163,7 @@ cat <<EOF | cilium -D policy import -
 EOF
 
 read -d '' EXPECTED_POLICY <<"EOF" || true
+----------------------------------------------------------------
 Tracing From: [any:id.foo] => To: [any:id.bar]
 * Rule 0 {"matchLabels":{"any:id.bar":""}}: match
     Allows from labels {"matchLabels":{"any:id.foo":""}}
@@ -170,6 +173,7 @@ Result: ALLOWED
 L3 verdict: allowed
 
 Verdict: allowed
+
 EOF
 
 echo "------ verify trace for expected output ------"
@@ -179,6 +183,7 @@ if [[ "$DIFF" != "" ]]; then
 fi
 
 read -d '' EXPECTED_POLICY <<"EOF" || true
+----------------------------------------------------------------
 Tracing From: [any:id.foo] => To: [any:id.bar]
 * Rule 0 {"matchLabels":{"any:id.bar":""}}: match
     Allows from labels {"matchLabels":{"any:id.foo":""}}
@@ -189,6 +194,7 @@ Result: ALLOWED
 L3 verdict: allowed
 
 Verdict: allowed
+
 EOF
 
 
@@ -204,6 +210,7 @@ FOO_SEC_ID=$(cilium endpoint list | grep id.foo | awk '{ print $3}')
 BAR_SEC_ID=$(cilium endpoint list | grep id.bar | awk '{print $3}')
 
 read -d '' EXPECTED_POLICY <<"EOF" || true
+----------------------------------------------------------------
 Tracing From: [container:id.foo, container:id.teamA] => To: [container:id.bar, container:id.teamA]
 * Rule 0 {"matchLabels":{"any:id.bar":""}}: match
     Allows from labels {"matchLabels":{"any:id.foo":""}}
@@ -216,6 +223,7 @@ Result: ALLOWED
 L3 verdict: allowed
 
 Verdict: allowed
+
 EOF
 
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -86,5 +86,5 @@ gopkg.in/inf.v0 v0.9.0
 gopkg.in/yaml.v2 f7716cbe52baa25d2e9b0d0da546fcf909fc16b4
 k8s.io/apiextensions-apiserver be41f5093e2b05c7a0befe35b04b715eb325ab43
 k8s.io/apimachinery release-1.7
-k8s.io/client-go v4.0.0-beta.0
+k8s.io/client-go v4.0.0
 k8s.io/kubernetes v1.5.1

--- a/vendor/k8s.io/client-go/pkg/api/install/install.go
+++ b/vendor/k8s.io/client-go/pkg/api/install/install.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package install installs the v1 monolithic api, making it available as an
+// option to all of the API encoding/decoding machinery.
+package install
+
+import (
+	"k8s.io/apimachinery/pkg/apimachinery/announced"
+	"k8s.io/apimachinery/pkg/apimachinery/registered"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+func init() {
+	Install(api.GroupFactoryRegistry, api.Registry, api.Scheme)
+}
+
+// Install registers the API group and adds types to a scheme
+func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
+	if err := announced.NewGroupMetaFactory(
+		&announced.GroupMetaFactoryArgs{
+			GroupName:                  api.GroupName,
+			VersionPreferenceOrder:     []string{v1.SchemeGroupVersion.Version},
+			ImportPrefix:               "k8s.io/client-go/pkg/api",
+			AddInternalObjectsToScheme: api.AddToScheme,
+			RootScopedKinds: sets.NewString(
+				"Node",
+				"Namespace",
+				"PersistentVolume",
+				"ComponentStatus",
+			),
+			IgnoredKinds: sets.NewString(
+				"ListOptions",
+				"DeleteOptions",
+				"Status",
+				"PodLogOptions",
+				"PodExecOptions",
+				"PodAttachOptions",
+				"PodPortForwardOptions",
+				"PodProxyOptions",
+				"NodeProxyOptions",
+				"ServiceProxyOptions",
+				"ThirdPartyResource",
+				"ThirdPartyResourceData",
+				"ThirdPartyResourceList",
+			),
+		},
+		announced.VersionToSchemeFunc{
+			v1.SchemeGroupVersion.Version: v1.AddToScheme,
+		},
+	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
+		panic(err)
+	}
+}

--- a/vendor/k8s.io/client-go/pkg/apis/extensions/install/install.go
+++ b/vendor/k8s.io/client-go/pkg/apis/extensions/install/install.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package install installs the experimental API group, making it available as
+// an option to all of the API encoding/decoding machinery.
+package install
+
+import (
+	"k8s.io/apimachinery/pkg/apimachinery/announced"
+	"k8s.io/apimachinery/pkg/apimachinery/registered"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/apis/extensions"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+func init() {
+	Install(api.GroupFactoryRegistry, api.Registry, api.Scheme)
+}
+
+// Install registers the API group and adds types to a scheme
+func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
+	if err := announced.NewGroupMetaFactory(
+		&announced.GroupMetaFactoryArgs{
+			GroupName:                  extensions.GroupName,
+			VersionPreferenceOrder:     []string{v1beta1.SchemeGroupVersion.Version},
+			ImportPrefix:               "k8s.io/client-go/pkg/apis/extensions",
+			RootScopedKinds:            sets.NewString("PodSecurityPolicy", "ThirdPartyResource"),
+			AddInternalObjectsToScheme: extensions.AddToScheme,
+		},
+		announced.VersionToSchemeFunc{
+			v1beta1.SchemeGroupVersion.Version: v1beta1.AddToScheme,
+		},
+	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
+		panic(err)
+	}
+}

--- a/vendor/k8s.io/client-go/pkg/util/util.go
+++ b/vendor/k8s.io/client-go/pkg/util/util.go
@@ -84,6 +84,15 @@ func FileExists(filename string) (bool, error) {
 	return true, nil
 }
 
+func FileOrSymlinkExists(filename string) (bool, error) {
+	if _, err := os.Lstat(filename); os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // ReadDirNoStat returns a string of files/directories contained
 // in dirname without calling lstat on them.
 func ReadDirNoStat(dirname string) ([]string, error) {

--- a/vendor/k8s.io/client-go/pkg/version/base.go
+++ b/vendor/k8s.io/client-go/pkg/version/base.go
@@ -51,7 +51,7 @@ var (
 	// semantic version is a git hash, but the version itself is no
 	// longer the direct output of "git describe", but a slight
 	// translation to be semver compliant.
-	gitVersion   string = "v1.7.1-beta.0+$Format:%h$"
+	gitVersion   string = "v1.7.3-beta.0+$Format:%h$"
 	gitCommit    string = "$Format:%H$"    // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 


### PR DESCRIPTION
* Add ability to pass in a path to a YAML file containing Deployments,
ReplicaSets, and ReplicationControllers to `cilium policy trace`.
The set of labels provided to the YAML are extracted, and are used
as the source and destination labels to test whether the currently
imported policies allow for L3 or L4 communication.
* Added more informative output for when policy enforcement is not
enabled between two endpoints.
* Updated tests to account for new formatting in `cilium policy trace`
output.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #1005 