### PR TITLE
Add SHA256 to access log and identity API

### DIFF
--- a/api/v1/models/identity.go
+++ b/api/v1/models/identity.go
@@ -16,7 +16,7 @@ type Identity struct {
 	// Unique identifier
 	ID int64 `json:"id,omitempty"`
 
-	// label SHA256
+	// SHA256 of labels
 	LabelSHA256 string `json:"labelSHA256,omitempty"`
 
 	// Labels describing the identity

--- a/api/v1/models/identity.go
+++ b/api/v1/models/identity.go
@@ -16,11 +16,11 @@ type Identity struct {
 	// Unique identifier
 	ID int64 `json:"id,omitempty"`
 
-	// SHA256 of labels
-	LabelSHA256 string `json:"labelSHA256,omitempty"`
-
 	// Labels describing the identity
 	Labels Labels `json:"labels"`
+
+	// SHA256 of labels
+	LabelsSHA256 string `json:"labelsSHA256,omitempty"`
 }
 
 // Validate validates this identity

--- a/api/v1/models/identity.go
+++ b/api/v1/models/identity.go
@@ -16,6 +16,9 @@ type Identity struct {
 	// Unique identifier
 	ID int64 `json:"id,omitempty"`
 
+	// label SHA256
+	LabelSHA256 string `json:"labelSHA256,omitempty"`
+
 	// Labels describing the identity
 	Labels Labels `json:"labels"`
 }

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -857,7 +857,7 @@ definitions:
         description: Labels describing the identity
         "$ref": "#/definitions/Labels"
       labelSHA256:
-        description: label SHA256
+        description: SHA256 of labels
         type: string
   Labels:
     description: Set of labels

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -856,6 +856,9 @@ definitions:
       labels:
         description: Labels describing the identity
         "$ref": "#/definitions/Labels"
+      labelSHA256:
+        description: label SHA256
+        type: string
   Labels:
     description: Set of labels
     type: array

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -856,7 +856,7 @@ definitions:
       labels:
         description: Labels describing the identity
         "$ref": "#/definitions/Labels"
-      labelSHA256:
+      labelsSHA256:
         description: SHA256 of labels
         type: string
   Labels:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1205,7 +1205,7 @@ func init() {
           "type": "integer"
         },
         "labelSHA256": {
-          "description": "label SHA256",
+          "description": "SHA256 of labels",
           "type": "string"
         },
         "labels": {

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1204,13 +1204,13 @@ func init() {
           "description": "Unique identifier",
           "type": "integer"
         },
-        "labelSHA256": {
-          "description": "SHA256 of labels",
-          "type": "string"
-        },
         "labels": {
           "description": "Labels describing the identity",
           "$ref": "#/definitions/Labels"
+        },
+        "labelsSHA256": {
+          "description": "SHA256 of labels",
+          "type": "string"
         }
       }
     },

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1204,6 +1204,10 @@ func init() {
           "description": "Unique identifier",
           "type": "integer"
         },
+        "labelSHA256": {
+          "description": "label SHA256",
+          "type": "string"
+        },
         "labels": {
           "description": "Labels describing the identity",
           "$ref": "#/definitions/Labels"

--- a/daemon/labels.go
+++ b/daemon/labels.go
@@ -269,6 +269,7 @@ func (h *getIdentityID) Handle(params GetIdentityIDParams) middleware.Responder 
 	} else if id == nil {
 		return NewGetIdentityIDNotFound()
 	} else {
+		id.LabelsSHA256 = id.Labels.SHA256Sum()
 		return NewGetIdentityIDOK().WithPayload(id.GetModel())
 	}
 }

--- a/daemon/labels.go
+++ b/daemon/labels.go
@@ -199,7 +199,7 @@ func (d *Daemon) LookupIdentity(id policy.NumericIdentity) (*policy.Identity, er
 		secLbl.AssociateEndpoint(lbl.String())
 		secLbl.ID = id
 		secLbl.Labels = labels.Labels{
-			labels.LabelSourceReserved: lbl,
+			key: lbl,
 		}
 
 		return secLbl, nil

--- a/daemon/labels.go
+++ b/daemon/labels.go
@@ -269,7 +269,7 @@ func (h *getIdentityID) Handle(params GetIdentityIDParams) middleware.Responder 
 	} else if id == nil {
 		return NewGetIdentityIDNotFound()
 	} else {
-		id.LabelSHA256 = id.Labels.SHA256Sum()
+		id.LabelsSHA256 = id.Labels.SHA256Sum()
 		return NewGetIdentityIDOK().WithPayload(id.GetModel())
 	}
 }

--- a/daemon/labels.go
+++ b/daemon/labels.go
@@ -269,7 +269,7 @@ func (h *getIdentityID) Handle(params GetIdentityIDParams) middleware.Responder 
 	} else if id == nil {
 		return NewGetIdentityIDNotFound()
 	} else {
-		id.LabelsSHA256 = id.Labels.SHA256Sum()
+		id.LabelSHA256 = id.Labels.SHA256Sum()
 		return NewGetIdentityIDOK().WithPayload(id.GetModel())
 	}
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -438,7 +438,6 @@ func (e *Endpoint) GetLabels() []string {
 	return e.SecLabel.Labels.GetModel()
 }
 
-
 // GetLabels returns the SHA of labels
 func (e *Endpoint) GetLabelSHA() string {
 	if e.SecLabel == nil {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -444,9 +444,9 @@ func (e *Endpoint) GetLabelsSHA() string {
 		return ""
 	}
 
-	e.SecLabel.LabelSHA256 = e.SecLabel.Labels.SHA256Sum()
+	e.SecLabel.LabelsSHA256 = e.SecLabel.Labels.SHA256Sum()
 
-	return e.SecLabel.LabelSHA256
+	return e.SecLabel.LabelsSHA256
 }
 
 // GetIPv4Address returns the IPv4 address of the endpoint

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -438,14 +438,14 @@ func (e *Endpoint) GetLabels() []string {
 	return e.SecLabel.Labels.GetModel()
 }
 
-// GetLabels returns the SHA of labels
-func (e *Endpoint) GetLabelSHA() string {
+// GetLabelsSHA returns the SHA of labels
+func (e *Endpoint) GetLabelsSHA() string {
 	if e.SecLabel == nil {
 		return ""
 	}
-	if e.SecLabel.LabelSHA256 == "" {
-		e.SecLabel.LabelSHA256 = e.SecLabel.Labels.SHA256Sum()
-	}
+
+	e.SecLabel.LabelSHA256 = e.SecLabel.Labels.SHA256Sum()
+
 	return e.SecLabel.LabelSHA256
 }
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -438,6 +438,18 @@ func (e *Endpoint) GetLabels() []string {
 	return e.SecLabel.Labels.GetModel()
 }
 
+
+// GetLabels returns the SHA of labels
+func (e *Endpoint) GetLabelSHA() string {
+	if e.SecLabel == nil {
+		return ""
+	}
+	if e.SecLabel.LabelSHA256 == "" {
+		e.SecLabel.LabelSHA256 = e.SecLabel.Labels.SHA256Sum()
+	}
+	return e.SecLabel.LabelSHA256
+}
+
 // GetIPv4Address returns the IPv4 address of the endpoint
 func (e *Endpoint) GetIPv4Address() string {
 	return e.IPv4.String()

--- a/pkg/policy/identity.go
+++ b/pkg/policy/identity.go
@@ -71,7 +71,7 @@ type Identity struct {
 	// Endpoints that have this Identity where their value is the last time they were seen.
 	Labels labels.Labels `json:"labels"`
 	// SHA256 of labels.
-	LabelSHA256 string  `json:"labelSHA256"`
+	LabelSHA256 string `json:"labelSHA256"`
 	// Set of labels that belong to this Identity.
 	Endpoints map[string]time.Time `json:"containers"`
 }
@@ -100,8 +100,8 @@ func (id *Identity) GetModel() *models.Identity {
 	}
 
 	ret := &models.Identity{
-		ID:     int64(id.ID),
-		Labels: []string{},
+		ID:          int64(id.ID),
+		Labels:      []string{},
 		LabelSHA256: "",
 	}
 

--- a/pkg/policy/identity.go
+++ b/pkg/policy/identity.go
@@ -71,7 +71,7 @@ type Identity struct {
 	// Endpoints that have this Identity where their value is the last time they were seen.
 	Labels labels.Labels `json:"labels"`
 	// SHA256 of labels.
-	LabelSHA256 string `json:"labelSHA256"`
+	LabelsSHA256 string `json:"labelsSHA256"`
 	// Set of labels that belong to this Identity.
 	Endpoints map[string]time.Time `json:"containers"`
 }
@@ -100,15 +100,15 @@ func (id *Identity) GetModel() *models.Identity {
 	}
 
 	ret := &models.Identity{
-		ID:          int64(id.ID),
-		Labels:      []string{},
-		LabelSHA256: "",
+		ID:           int64(id.ID),
+		Labels:       []string{},
+		LabelsSHA256: "",
 	}
 
 	for _, v := range id.Labels {
 		ret.Labels = append(ret.Labels, v.String())
 	}
-	ret.LabelSHA256 = id.LabelSHA256
+	ret.LabelsSHA256 = id.LabelsSHA256
 	return ret
 }
 

--- a/pkg/policy/identity.go
+++ b/pkg/policy/identity.go
@@ -70,6 +70,8 @@ type Identity struct {
 	ID NumericIdentity `json:"id"`
 	// Endpoints that have this Identity where their value is the last time they were seen.
 	Labels labels.Labels `json:"labels"`
+	// SHA256 of labels.
+	LabelsSHA256 string  `json:"labelsSHA256"`
 	// Set of labels that belong to this Identity.
 	Endpoints map[string]time.Time `json:"containers"`
 }
@@ -100,12 +102,13 @@ func (id *Identity) GetModel() *models.Identity {
 	ret := &models.Identity{
 		ID:     int64(id.ID),
 		Labels: []string{},
+		LabelSHA256: "",
 	}
 
 	for _, v := range id.Labels {
 		ret.Labels = append(ret.Labels, v.String())
 	}
-
+	ret.LabelSHA256 = id.LabelsSHA256
 	return ret
 }
 

--- a/pkg/policy/identity.go
+++ b/pkg/policy/identity.go
@@ -71,7 +71,7 @@ type Identity struct {
 	// Endpoints that have this Identity where their value is the last time they were seen.
 	Labels labels.Labels `json:"labels"`
 	// SHA256 of labels.
-	LabelsSHA256 string  `json:"labelsSHA256"`
+	LabelSHA256 string  `json:"labelSHA256"`
 	// Set of labels that belong to this Identity.
 	Endpoints map[string]time.Time `json:"containers"`
 }
@@ -108,7 +108,7 @@ func (id *Identity) GetModel() *models.Identity {
 	for _, v := range id.Labels {
 		ret.Labels = append(ret.Labels, v.String())
 	}
-	ret.LabelSHA256 = id.LabelsSHA256
+	ret.LabelSHA256 = id.LabelSHA256
 	return ret
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -68,6 +68,7 @@ type ProxySource interface {
 	GetID() uint64
 	RLock()
 	GetLabels() []string
+	GetLabelSHA() string
 	GetIdentity() policy.NumericIdentity
 	GetIPv4Address() string
 	GetIPv6Address() string
@@ -199,6 +200,7 @@ func (r *Redirect) localEndpointInfo(info *EndpointInfo) {
 	info.IPv4 = r.source.GetIPv4Address()
 	info.IPv6 = r.source.GetIPv6Address()
 	info.Labels = r.source.GetLabels()
+	info.LabelSHA256 = r.source.GetLabelSHA()
 	info.Identity = uint64(r.source.GetIdentity())
 	r.source.RUnlock()
 }
@@ -214,6 +216,7 @@ func parseIPPort(ipstr string, info *EndpointInfo) {
 				if ep != nil {
 					info.ID = uint64(ep.ID)
 					info.Labels = ep.GetLabels()
+					info.LabelSHA256 = ep.GetLabelSHA()
 					info.Identity = uint64(ep.GetIdentity())
 				}
 			}
@@ -228,6 +231,7 @@ func parseIPPort(ipstr string, info *EndpointInfo) {
 				ep.RLock()
 				if ep != nil {
 					info.Labels = ep.GetLabels()
+					info.LabelSHA256 = ep.GetLabelSHA()
 					info.Identity = uint64(ep.GetIdentity())
 				}
 				ep.RUnlock()

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -68,7 +68,7 @@ type ProxySource interface {
 	GetID() uint64
 	RLock()
 	GetLabels() []string
-	GetLabelSHA() string
+	GetLabelsSHA() string
 	GetIdentity() policy.NumericIdentity
 	GetIPv4Address() string
 	GetIPv6Address() string
@@ -200,7 +200,7 @@ func (r *Redirect) localEndpointInfo(info *EndpointInfo) {
 	info.IPv4 = r.source.GetIPv4Address()
 	info.IPv6 = r.source.GetIPv6Address()
 	info.Labels = r.source.GetLabels()
-	info.LabelSHA256 = r.source.GetLabelSHA()
+	info.LabelsSHA256 = r.source.GetLabelsSHA()
 	info.Identity = uint64(r.source.GetIdentity())
 	r.source.RUnlock()
 }
@@ -216,7 +216,7 @@ func parseIPPort(ipstr string, info *EndpointInfo) {
 				if ep != nil {
 					info.ID = uint64(ep.ID)
 					info.Labels = ep.GetLabels()
-					info.LabelSHA256 = ep.GetLabelSHA()
+					info.LabelsSHA256 = ep.GetLabelsSHA()
 					info.Identity = uint64(ep.GetIdentity())
 				}
 			}
@@ -231,7 +231,7 @@ func parseIPPort(ipstr string, info *EndpointInfo) {
 				ep.RLock()
 				if ep != nil {
 					info.Labels = ep.GetLabels()
-					info.LabelSHA256 = ep.GetLabelSHA()
+					info.LabelsSHA256 = ep.GetLabelsSHA()
 					info.Identity = uint64(ep.GetIdentity())
 				}
 				ep.RUnlock()

--- a/pkg/proxy/record.go
+++ b/pkg/proxy/record.go
@@ -68,13 +68,13 @@ const (
 // EndpointInfo contains information about the endpoint sending/receiving the
 // request/response
 type EndpointInfo struct {
-	ID          uint64
-	IPv4        string
-	IPv6        string
-	Port        uint16
-	Identity    uint64
-	LabelSHA256 string
-	Labels      []string
+	ID           uint64
+	IPv4         string
+	IPv6         string
+	Port         uint16
+	Identity     uint64
+	LabelsSHA256 string
+	Labels       []string
 }
 
 // NodeAddressInfo holds addressing information of the node the agent runs on

--- a/pkg/proxy/record.go
+++ b/pkg/proxy/record.go
@@ -68,12 +68,13 @@ const (
 // EndpointInfo contains information about the endpoint sending/receiving the
 // request/response
 type EndpointInfo struct {
-	ID       uint64
-	IPv4     string
-	IPv6     string
-	Port     uint16
-	Identity uint64
-	Labels   []string
+	ID       	uint64
+	IPv4    	string
+	IPv6     	string
+	Port     	uint16
+	Identity 	uint64
+	LabelSHA256 string
+	Labels   	[]string
 }
 
 // NodeAddressInfo holds addressing information of the node the agent runs on
@@ -103,10 +104,10 @@ type LogRecord struct {
 	// ObservationPoint indicates where the request/response was observed
 	ObservationPoint ObservationPoint
 
-	// SourceEndpoint is information about the soure endpoint if available
+	// SourceEndpoint is information about the source endpoint if available
 	SourceEndpoint EndpointInfo
 
-	// DestinationEndpoint is information about the soure endpoint if available
+	// DestinationEndpoint is information about the destination endpoint if available
 	DestinationEndpoint EndpointInfo
 
 	// IPVersion indicates the version of the IP protocol in use

--- a/pkg/proxy/record.go
+++ b/pkg/proxy/record.go
@@ -68,13 +68,13 @@ const (
 // EndpointInfo contains information about the endpoint sending/receiving the
 // request/response
 type EndpointInfo struct {
-	ID       	uint64
-	IPv4    	string
-	IPv6     	string
-	Port     	uint16
-	Identity 	uint64
+	ID          uint64
+	IPv4        string
+	IPv6        string
+	Port        uint16
+	Identity    uint64
 	LabelSHA256 string
-	Labels   	[]string
+	Labels      []string
 }
 
 // NodeAddressInfo holds addressing information of the node the agent runs on

--- a/tests/19-identity-get.sh
+++ b/tests/19-identity-get.sh
@@ -57,10 +57,10 @@ function test_identity_get {
     # Find the index of first occurrence of substring in response str
     index=$(awk -v a="$str" -v b="$substring" 'BEGIN{print index(a,b)}')
     substring=${str:index + len - 1}
-    sha256="$( cut -d '"' -f 1 <<< "substring" )"
+    sha256="$( cut -d '"' -f 1 <<< "$substring" )"
 
     echo "Endpoint security ID is: $ID"
-    expected_response='{   "Payload": {     "id": '$ID',     "labelsSHA256": "'$sha256'",     "labels": [       "container:id.foo"     ]   } }'
+    expected_response='{   "Payload": {     "id": '$ID',     "labels": [       "container:id.foo"     ],     "labelsSHA256": "'$sha256'"   } }'
 
     echo "Response is $response"
 


### PR DESCRIPTION

Issue :#1348 Add SHA256 to access log and GET /identity API

This change extends the  GET /identity API to display the SHA256 of the labels. Additionally it writes the SHA256 to the access log.

