### PR TITLE
[k8s] daemonset scheduling on master node

### DIFF
--- a/examples/kubernetes/cilium-ds.yaml
+++ b/examples/kubernetes/cilium-ds.yaml
@@ -104,3 +104,10 @@ spec:
         - name: kubeconfig-cert
           hostPath:
               path: /var/lib/kubernetes/ca.pem
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+


### PR DESCRIPTION
Hello! 

This PR added the tolerations needed on Kubernetes 1.7.4. Mainly this adds the option to schedule the cilium DS on the master node. 

On the other hand, I added the tolerations on all uninitialized nodes. These are the same tolerations as Kube-proxy. 

On the tests, this is working due the k8s-1 node is taint to schedule pods. 

Working on my env + tested on a fresh install. 

Regards.

PS: I think that the annotations section can be deleted too, but I was not sure so I keep it.  