### PR TITLE
endpoint: Add policy direction to ProxyID

### DIFF
--- a/cilium/cmd/config.go
+++ b/cilium/cmd/config.go
@@ -79,15 +79,19 @@ func configDaemon(cmd *cobra.Command, opts []string) {
 		Fatalf("Error while retrieving configuration: %s", err)
 	}
 
-	if numPages > 0 && numPages != int(resp.NodeMonitor.Npages) {
-		dOpts["MonitorNumPages"] = strconv.Itoa(numPages)
+	if numPages > 0 {
+		if resp.NodeMonitor != nil && numPages != int(resp.NodeMonitor.Npages) {
+			dOpts["MonitorNumPages"] = strconv.Itoa(numPages)
+		}
 	} else if len(opts) == 0 {
 		dumpConfig(resp.Configuration.Immutable)
 		dumpConfig(resp.Configuration.Mutable)
 		fmt.Printf("%-24s %s\n", "k8s-configuration", resp.K8sConfiguration)
 		fmt.Printf("%-24s %s\n", "k8s-endpoint", resp.K8sEndpoint)
 		fmt.Printf("%-24s %s\n", "PolicyEnforcement", resp.PolicyEnforcement)
-		fmt.Printf("%-24s %d\n", "MonitorNumPages", resp.NodeMonitor.Npages)
+		if resp.NodeMonitor != nil {
+			fmt.Printf("%-24s %d\n", "MonitorNumPages", resp.NodeMonitor.Npages)
+		}
 		return
 	}
 

--- a/daemon/status.go
+++ b/daemon/status.go
@@ -103,7 +103,9 @@ func (h *getHealthz) Handle(params GetHealthzParams) middleware.Responder {
 
 	sr.IPAM = d.DumpIPAM()
 
-	sr.NodeMonitor = d.nodeMonitor.State()
+	if nm := d.nodeMonitor; nm != nil {
+		sr.NodeMonitor = d.nodeMonitor.State()
+	}
 
 	return NewGetHealthzOK().WithPayload(&sr)
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -96,7 +96,11 @@ func (e *Endpoint) invalidatePolicy() {
 
 // ProxyID returns a unique string to identify a proxy mapping
 func (e *Endpoint) ProxyID(l4 *policy.L4Filter) string {
-	return fmt.Sprintf("%d:%s:%d", e.ID, l4.Protocol, l4.Port)
+	direction := "ingress"
+	if !l4.Ingress {
+		direction = "egress"
+	}
+	return fmt.Sprintf("%d:%s:%s:%d", e.ID, direction, l4.Protocol, l4.Port)
 }
 
 func (e *Endpoint) addRedirect(owner Owner, l4 *policy.L4Filter) (uint16, error) {

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -163,12 +163,50 @@ function wait_for_kubectl_cilium_status {
 }
 
 function wait_for_cilium_ep_gen {
+  set +x
   local NUM_DESIRED="0"
   local CMD="cilium endpoint list | grep -c regenerating"
   local INFO_CMD="true"
   local MAX_MINS="2"
   local ERROR_OUTPUT="Timeout while waiting for endpoints to regenerate"
-  wait_for_desired_state "$NUM_DESIRED" "$CMD" "$INFO_CMD" "$MAX_MINS" "$ERROR_OUTPUT"
+ 
+  # Track the amount of times the command has succeeded in a row. 
+  local check_cmd_iter=0 
+  # Need to have a timeout that tracks total number of iterations so tests can exit.
+  local total_cmd_iter=0
+  local sleep_time=1
+ 
+  while [[ "$check_cmd_iter" -lt "10" ]]; do    
+    if [[ "$total_cmd_iter" -gt $((${MAX_MINS}*60/$sleep_time)) ]]; then
+      echo ""
+      echo "$ERROR_OUTPUT"
+      exit 1
+    fi
+
+    local iter=0
+    local found=$(eval "$CMD")
+    echo "found: $found"
+
+    while [[ "$found" -ne "$NUM_DESIRED" ]]; do
+      if [[ $((iter++)) -gt $((${MAX_MINS}*60/$sleep_time)) ]]; then
+        echo ""
+        echo $ERROR_OUTPUT
+        exit 1
+      else
+        eval "$INFO_CMD"
+        echo -n " [$found/$NUM_DESIRED]"
+        # If command fails and iter is non-zero, reset iter back to zero.
+        check_cmd_iter=0
+        sleep $sleep_time
+      fi
+      found=$(eval "${CMD}")
+      echo "found: $found"
+    done
+    check_cmd_iter=$(expr $check_cmd_iter + 1)
+    total_cmd_iter=$(expr $total_cmd_iter + 1)
+    sleep .25
+  done
+  set -x
 }
 
 function wait_for_daemon_set_not_ready {

--- a/tests/k8s/helpers.bash
+++ b/tests/k8s/helpers.bash
@@ -39,7 +39,7 @@ function gather_k8s_logs {
   for pod in $CILIUM_PODS; do 
     local NODE_NAME=$(kubectl get pod -n ${NAMESPACE} $pod  -o wide | tail -n +2 | awk '{print $7}')
     kubectl logs -n ${NAMESPACE} ${pod} > ${LOGS_DIR}/${pod}-${NODE_NAME}-logs || true
-    kubectl logs -n ${NAMESPACE} ${pod} --previous > ${LOGS_DIR}/${pod}-$NODE_NAME}-logs-previous || true
+    kubectl logs -n ${NAMESPACE} ${pod} --previous > ${LOGS_DIR}/${pod}-${NODE_NAME}-logs-previous || true
   done
   kubectl logs -n kube-system kube-apiserver-k8s-1 > ${LOGS_DIR}/kube-apiserver-k8s-1-logs || true
   kubectl logs -n kube-system kube-controller-manager-k8s-1 > ${LOGS_DIR}/kube-controller-manager-k8s-1-logs || true


### PR DESCRIPTION
This is required to ensure unique allocation of proxies for ingress and
egress direction.

Fixes: #1432

Signed-off-by: Thomas Graf <thomas@cilium.io>