### PR TITLE
tests: be more strict in wait_ep_gen

### DIFF
--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -163,12 +163,50 @@ function wait_for_kubectl_cilium_status {
 }
 
 function wait_for_cilium_ep_gen {
+  set +x
   local NUM_DESIRED="0"
   local CMD="cilium endpoint list | grep -c regenerating"
   local INFO_CMD="true"
   local MAX_MINS="2"
   local ERROR_OUTPUT="Timeout while waiting for endpoints to regenerate"
-  wait_for_desired_state "$NUM_DESIRED" "$CMD" "$INFO_CMD" "$MAX_MINS" "$ERROR_OUTPUT"
+ 
+  # Track the amount of times the command has succeeded in a row. 
+  local check_cmd_iter=0 
+  # Need to have a timeout that tracks total number of iterations so tests can exit.
+  local total_cmd_iter=0
+  local sleep_time=1
+ 
+  while [[ "$check_cmd_iter" -lt "10" ]]; do    
+    if [[ "$total_cmd_iter" -gt $((${MAX_MINS}*60/$sleep_time)) ]]; then
+      echo ""
+      echo "$ERROR_OUTPUT"
+      exit 1
+    fi
+
+    local iter=0
+    local found=$(eval "$CMD")
+    echo "found: $found"
+
+    while [[ "$found" -ne "$NUM_DESIRED" ]]; do
+      if [[ $((iter++)) -gt $((${MAX_MINS}*60/$sleep_time)) ]]; then
+        echo ""
+        echo $ERROR_OUTPUT
+        exit 1
+      else
+        eval "$INFO_CMD"
+        echo -n " [$found/$NUM_DESIRED]"
+        # If command fails and iter is non-zero, reset iter back to zero.
+        check_cmd_iter=0
+        sleep $sleep_time
+      fi
+      found=$(eval "${CMD}")
+      echo "found: $found"
+    done
+    check_cmd_iter=$(expr $check_cmd_iter + 1)
+    total_cmd_iter=$(expr $total_cmd_iter + 1)
+    sleep .25
+  done
+  set -x
 }
 
 function wait_for_daemon_set_not_ready {


### PR DESCRIPTION
Previously, wait_for_ep_gen waited until all endpoints were listed as being in
'ready' state. However, there was a possibility that all endpoints were briefly
in 'ready' state before one starts regenerating, resulting in the function
prematurely returning. Add a stricter check for endpoints being in ready state
by making sure that the output of `cilium endpoint list` shows all endpoints
in 'ready' state 10 times in a row after sleeping briefly between each check.

 Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #1405 