### PR TITLE
Synchronize compilation of base, endpoint programs

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 
 	. "gopkg.in/check.v1"
+	"sync"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -50,6 +51,7 @@ type DaemonSuite struct {
 	OnRemoveFromEndpointQueue         func(epID uint64)
 	OnDebugEnabled                    func() bool
 	OnAnnotateEndpoint                func(e *e.Endpoint, annotationKey, annotationValue string)
+	OnGetCompilationLock              func() *sync.RWMutex
 }
 
 var _ = Suite(&DaemonSuite{})
@@ -186,4 +188,11 @@ func (ds *DaemonSuite) DebugEnabled() bool {
 		return ds.OnDebugEnabled()
 	}
 	panic("DebugEnabled should not have been called")
+}
+
+func (ds *DaemonSuite) GetCompilationLock() *sync.RWMutex {
+	if ds.OnGetCompilationLock != nil {
+		return ds.OnGetCompilationLock()
+	}
+	panic("GetCompilationLock should not have been called")
 }

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cilium/cilium/common/addressing"
@@ -115,6 +116,8 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 		}
 	}()
 
+	ds.d.compilationMutex = new(sync.RWMutex)
+
 	ds.OnGetStateDir = func() string {
 		return baseDir
 	}
@@ -141,6 +144,10 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 	}
 	ds.OnDryModeEnabled = func() bool {
 		return true
+	}
+
+	ds.OnGetCompilationLock = func() *sync.RWMutex {
+		return ds.d.compilationMutex
 	}
 
 	// Create a dummy consumable cache
@@ -254,7 +261,7 @@ func networksMock() func(req *http.Request) (*http.Response, error) {
 	}
 }
 
-func (ds *DaemonSuite) TestCleanUpDockerDandling(c *C) {
+func (ds *DaemonSuite) TestCleanUpDockerDangling(c *C) {
 	epsWanted, epsMap := createEndpoints()
 	var err error
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -335,6 +335,11 @@ func (e *Endpoint) runInit(libdir, rundir, epdir, debug string) error {
 func (e *Endpoint) regenerateBPF(owner Owner, epdir string) error {
 	var err error
 
+	// Make sure that owner is not compiling base programs while we are
+	// regenerating an endpoint.
+	owner.GetCompilationLock().RLock()
+	defer owner.GetCompilationLock().RUnlock()
+
 	if err = e.writeHeaderfile(epdir, owner); err != nil {
 		return fmt.Errorf("unable to write header file: %s", err)
 	}

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -15,6 +15,8 @@
 package endpoint
 
 import (
+	"sync"
+
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 )
@@ -76,6 +78,10 @@ type Owner interface {
 
 	// Annotates endpoint e with an annotation with key annotationKey, and value annotationValue.
 	AnnotateEndpoint(e *Endpoint, annotationKey, annotationValue string)
+
+	// GetCompilationLock returns the mutex responsible for synchronizing compilation
+	// of BPF programs.
+	GetCompilationLock() *sync.RWMutex
 }
 
 // Request is used to create the endpoint's request and send it to the endpoints


### PR DESCRIPTION
Add a new mutex for the daemon, compilationMU, which is Locked when the
daemon's base programs are being compiled. This mutex is RLocked when
endpoints are having their BPF programs generated.

Signed-off by: Ian Vernon <ian@covalent.io>

Fixes: #1430 