### PR TITLE
tests: add and augment helper functions

### DIFF
--- a/tests/k8s/tests/00-setup-kubedns.sh
+++ b/tests/k8s/tests/00-setup-kubedns.sh
@@ -7,4 +7,9 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 source "${dir}/../cluster/env.bash"
 
-wait_for_service_endpoints_ready kube-system kube-dns 53
+NAMESPACE="kube-system"
+LOCAL_CILIUM_POD="$(kubectl get pods -n kube-system -o wide | grep $(hostname) | awk '{ print $1 }' | grep cilium)"
+
+wait_for_service_endpoints_ready ${NAMESPACE} kube-dns 53
+wait_for_service_ready_cilium_pod ${NAMESPACE} ${LOCAL_CILIUM_POD} 53 53
+wait_for_cilium_ep_gen k8s ${NAMESPACE} ${LOCAL_CILIUM_POD}

--- a/tests/k8s/tests/03-l7-stresstest.sh
+++ b/tests/k8s/tests/03-l7-stresstest.sh
@@ -25,6 +25,7 @@ source "${dir}/../cluster/env.bash"
 NAMESPACE="kube-system"
 TEST_NAME="03-l7-stresstest"
 LOGS_DIR="${dir}/cilium-files/${TEST_NAME}/logs"
+LOCAL_CILIUM_POD="$(kubectl get pods -n kube-system -o wide | grep $(hostname) | awk '{ print $1 }' | grep cilium)"
 
 function finish_test {
   gather_files ${TEST_NAME} k8s-tests
@@ -57,6 +58,9 @@ wait_for_running_pod frontend qa
 wait_for_running_pod backend development
 
 wait_for_service_endpoints_ready development backend 80
+wait_for_service_ready_cilium_pod ${NAMESPACE} ${LOCAL_CILIUM_POD} 80 80
+wait_for_cilium_ep_gen k8s ${NAMESPACE} ${LOCAL_CILIUM_POD}
+
 # frontend doesn't have any endpoints
 
 kubectl get pods -n qa -o wide


### PR DESCRIPTION
* add capability for wait_for_cilium_ep_gen to check if endpoints are ready
when Cilium is running as a Kubernetes pod.
* add new function, wait_for_service_ready_cilium_pod which checks if a service
appears in the output of `cilium service list` when Cilium is running as a
Kubernetes pod.
* add log messages to some of the helper functions for easier parsing of
output.
* Utilize the aforementioned helper functions in the tests.
    
Signed-off by: Ian Vernon <ian@covalent.io>

Partially fixes: #1442 