### PR TITLE
Add a newline in the proxy access log

### DIFF
--- a/pkg/proxy/log.go
+++ b/pkg/proxy/log.go
@@ -76,7 +76,7 @@ func SetMetadata(md []string) {
 }
 
 func logString(outStr string, retry bool) {
-	_, err := logBuf.WriteString(outStr)
+	_, err := logBuf.WriteString(outStr + "\n")
 	if err != nil {
 		if retry {
 			log.WithFields(log.Fields{


### PR DESCRIPTION
- Add a newline after logging each record in the proxy access log.

Signed-off-by: ashwin@covalent.io