### PR TITLE
1379: Added check on BPFFS mount

### DIFF
--- a/Documentation/install.rst
+++ b/Documentation/install.rst
@@ -231,16 +231,9 @@ to be automatically mounted when the node boots.
      bpffs			/sys/fs/bpf		bpf	defaults 0 0
 
 If you are using systemd to manage the kubelet, another option is to add a
-``ExecStartPre`` line in the ``/etc/systemd/kubelet.service`` file as follows:
+mountd systemd service on all hosts:
 
-.. code:: bash
-
-	[Service]
-        ExecStartPre=/bin/bash -c ' \\
-                if [[ \$(/bin/mount | /bin/grep /sys/fs/bpf -c) -eq 0 ]]; then \\
-                   /bin/mount bpffs /sys/fs/bpf -t bpf; \\
-                fi'
-
+.. literalinclude:: ../contrib/systemd/sys-fs-bpf.mount
 
 CNI Configuation
 ----------------

--- a/contrib/packaging/deb/Dockerfile
+++ b/contrib/packaging/deb/Dockerfile
@@ -6,7 +6,7 @@ ENV GOLANG_VERSION 1.8.3
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         dh-golang devscripts fakeroot dh-make clang git ca-certificates libdistro-info-perl \
-        dh-systemd build-essential curl gcc make libc6-dev.i386 git-buildpackage && \
+        dh-systemd build-essential curl gcc make libc6-dev.i386 git-buildpackage llvm && \
     curl -Sslk -o go.tar.gz \
         "https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz" && \
     tar -C /usr/local -xzf go.tar.gz && \

--- a/contrib/packaging/deb/debian/rules
+++ b/contrib/packaging/deb/debian/rules
@@ -11,10 +11,10 @@ override_dh_auto_build:
 
 override_dh_installinit:
 
-	for svc in $(shell ls ./contrib/systemd/*.service ); do \
+	for svc in $(shell ls ./contrib/systemd/*.* ); do \
 		cp -f "$$svc" "./debian/"; \
-		service=$$(echo $$svc | sed -E -n 's/.*(cilium.*?).service/\1/p'); \
-		dh_installinit --name=$$service; \
+		service=$$(echo $$svc | sed -E -n 's/.*\/(.*?).(service|mount)/\1/p'); \
+		dh_installinit --name=$${service}; \
 	done
 
 	mkdir -p "$(DEST_DIR)/etc/sysconfig/"

--- a/contrib/packaging/rpm/cfg/cilium.spec.envsubst
+++ b/contrib/packaging/rpm/cfg/cilium.spec.envsubst
@@ -44,6 +44,7 @@ mkdir -p "%{buildroot}%{_usr}/lib/systemd/system"
 mkdir -p "%{buildroot}%{_sysconfdir}/sysconfig"
 
 cp contrib/systemd/*.service "%{buildroot}%{_usr}/lib/systemd/system"
+cp contrib/systemd/*.mount "%{buildroot}%{_usr}/lib/systemd/system"
 chmod 644 %{buildroot}%{_usr}/lib/systemd/system/*
 
 cp contrib/systemd/cilium "%{buildroot}%{_sysconfdir}/sysconfig"

--- a/contrib/systemd/sys-fs-bpf.mount
+++ b/contrib/systemd/sys-fs-bpf.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description=Cilium BPF mounts
+Documentation=http://docs.cilium.io/
+DefaultDependencies=no
+Before=local-fs.target umount.target
+After=swap.target
+
+[Mount]
+What=bpffs
+Where=/sys/fs/bpf
+Type=bpf

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"unsafe"
 
+	log "github.com/Sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -276,6 +277,9 @@ func OpenOrCreateMap(path string, mapType int, keySize, valueSize, maxEntries, f
 
 	err := unix.Setrlimit(unix.RLIMIT_MEMLOCK, &rl)
 	if err != nil {
+		if os.IsPermission(err) {
+			log.Error("Unable to set RLimits, insufficient permissions")
+		}
 		return 0, isNewMap, fmt.Errorf("Unable to increase rlimit: %s", err)
 	}
 

--- a/pkg/node/manager.go
+++ b/pkg/node/manager.go
@@ -43,7 +43,7 @@ func deleteNodeCIDR(ip *net.IPNet) {
 	}
 
 	if err := tunnel.DeleteTunnelEndpoint(ip.IP); err != nil {
-		log.Debugf("bpf: Unable to delete %s in tunnel endpoint map: %s", ip, err)
+		log.Errorf("bpf: Unable to delete %s in tunnel endpoint map: %s", ip, err)
 	}
 }
 
@@ -53,7 +53,7 @@ func updateNodeCIDR(ip *net.IPNet, host net.IP) {
 	}
 
 	if err := tunnel.SetTunnelEndpoint(ip.IP, host); err != nil {
-		log.Debugf("bpf: Unable to update %s in tunnel endpoint map: %s", ip, err)
+		log.Errorf("bpf: Unable to update %s in tunnel endpoint map: %s", ip, err)
 	}
 }
 


### PR DESCRIPTION
Hello!

Quick thing about this, the main issue is when the host doesn't have mounted
the BPFfs so it didn't work correctly.

The commit related with the mount was working correctly, but when you run
cilium into the container it detects as a valid mountpoint. I added a function
to check if the mountpoint is a valid BPF filesystem. In case of no valid BPF
filesystem, the system will die, cilium will not work if no valid BPF.

Finally, I changed some debug messages to error messages. On the other hand, I
added an error message on Setrlimit, sometimes users don't add the
'SYS_RESOURCE' capability and you can't create limits.

On the other hand, I added a new systemd service. This service is going to
mount the BPF filesystem and users don't need to know that.


Possible things to improve:

- Delete the mountpoint command on bpffs.go? Not sure, happy to work on that.

