### PR TITLE
GH-1463: Add cilium identity list command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+tests/cilium-files
 
 # Architecture specific extensions/prefixes
 *.cgo1.go

--- a/api/v1/client/policy/get_identity_parameters.go
+++ b/api/v1/client/policy/get_identity_parameters.go
@@ -62,7 +62,11 @@ for the get identity operation typically these are written to a http.Request
 */
 type GetIdentityParams struct {
 
-	/*Labels*/
+	/*Labels
+	  List of labels
+
+
+	*/
 	Labels models.Labels
 
 	timeout    time.Duration

--- a/api/v1/client/policy/get_identity_responses.go
+++ b/api/v1/client/policy/get_identity_responses.go
@@ -66,7 +66,7 @@ func NewGetIdentityOK() *GetIdentityOK {
 Success
 */
 type GetIdentityOK struct {
-	Payload *models.Identity
+	Payload []*models.Identity
 }
 
 func (o *GetIdentityOK) Error() string {
@@ -75,10 +75,8 @@ func (o *GetIdentityOK) Error() string {
 
 func (o *GetIdentityOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.Identity)
-
 	// response payload
-	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -92,7 +90,7 @@ func NewGetIdentityNotFound() *GetIdentityNotFound {
 
 /*GetIdentityNotFound handles this case with default header values.
 
-Identity not found
+Identities with provided parameters not found
 */
 type GetIdentityNotFound struct {
 }

--- a/api/v1/client/policy/policy_client.go
+++ b/api/v1/client/policy/policy_client.go
@@ -51,7 +51,10 @@ func (a *Client) DeletePolicy(params *DeletePolicyParams) (*DeletePolicyOK, erro
 }
 
 /*
-GetIdentity retrieves identity by labels
+GetIdentity retrieves a list of identities that have metadata matching the provided parameters
+
+Retrieves a list of identities that have metadata matching the provided parameters, or all identities if no parameters are provided.
+
 */
 func (a *Client) GetIdentity(params *GetIdentityParams) (*GetIdentityOK, error) {
 	// TODO: Validate the params before sending

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -280,22 +280,22 @@ paths:
             "$ref": "#/definitions/Error"
   "/identity":
     get:
-      summary: Retrieve identity by labels
+      summary: Retrieves a list of identities that have metadata matching the provided parameters.
+      description: |
+        Retrieves a list of identities that have metadata matching the provided parameters, or all identities if no parameters are provided.
       tags:
       - policy
       parameters:
-      - name: labels
-        in: body
-        required: true
-        schema:
-          "$ref": "#/definitions/Labels"
+      - "$ref": "#/parameters/labels"
       responses:
         '200':
           description: Success
           schema:
-            "$ref": "#/definitions/Identity"
+            type: array
+            items:
+              "$ref": "#/definitions/Identity"
         '404':
-          description: Identity not found
+          description: Identities with provided parameters not found
         '520':
           description: Identity storage unreachable. Likely a network problem.
           x-go-name: Unreachable

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -396,29 +396,28 @@ func init() {
     },
     "/identity": {
       "get": {
+        "description": "Retrieves a list of identities that have metadata matching the provided parameters, or all identities if no parameters are provided.\n",
         "tags": [
           "policy"
         ],
-        "summary": "Retrieve identity by labels",
+        "summary": "Retrieves a list of identities that have metadata matching the provided parameters.",
         "parameters": [
           {
-            "name": "labels",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Labels"
-            }
+            "$ref": "#/parameters/labels"
           }
         ],
         "responses": {
           "200": {
             "description": "Success",
             "schema": {
-              "$ref": "#/definitions/Identity"
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Identity"
+              }
             }
           },
           "404": {
-            "description": "Identity not found"
+            "description": "Identities with provided parameters not found"
           },
           "520": {
             "description": "Identity storage unreachable. Likely a network problem.",

--- a/api/v1/server/restapi/policy/get_identity.go
+++ b/api/v1/server/restapi/policy/get_identity.go
@@ -29,7 +29,10 @@ func NewGetIdentity(ctx *middleware.Context, handler GetIdentityHandler) *GetIde
 
 /*GetIdentity swagger:route GET /identity policy getIdentity
 
-Retrieve identity by labels
+Retrieves a list of identities that have metadata matching the provided parameters.
+
+Retrieves a list of identities that have metadata matching the provided parameters, or all identities if no parameters are provided.
+
 
 */
 type GetIdentity struct {

--- a/api/v1/server/restapi/policy/get_identity_parameters.go
+++ b/api/v1/server/restapi/policy/get_identity_parameters.go
@@ -30,7 +30,8 @@ type GetIdentityParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request
 
-	/*
+	/*List of labels
+
 	  Required: true
 	  In: body
 	*/

--- a/api/v1/server/restapi/policy/get_identity_responses.go
+++ b/api/v1/server/restapi/policy/get_identity_responses.go
@@ -23,7 +23,7 @@ type GetIdentityOK struct {
 	/*
 	  In: Body
 	*/
-	Payload *models.Identity `json:"body,omitempty"`
+	Payload []*models.Identity `json:"body,omitempty"`
 }
 
 // NewGetIdentityOK creates GetIdentityOK with default headers values
@@ -32,13 +32,13 @@ func NewGetIdentityOK() *GetIdentityOK {
 }
 
 // WithPayload adds the payload to the get identity o k response
-func (o *GetIdentityOK) WithPayload(payload *models.Identity) *GetIdentityOK {
+func (o *GetIdentityOK) WithPayload(payload []*models.Identity) *GetIdentityOK {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the get identity o k response
-func (o *GetIdentityOK) SetPayload(payload *models.Identity) {
+func (o *GetIdentityOK) SetPayload(payload []*models.Identity) {
 	o.Payload = payload
 }
 
@@ -46,18 +46,21 @@ func (o *GetIdentityOK) SetPayload(payload *models.Identity) {
 func (o *GetIdentityOK) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(200)
-	if o.Payload != nil {
-		payload := o.Payload
-		if err := producer.Produce(rw, payload); err != nil {
-			panic(err) // let the recovery middleware deal with this
-		}
+	payload := o.Payload
+	if payload == nil {
+		payload = make([]*models.Identity, 0, 50)
 	}
+
+	if err := producer.Produce(rw, payload); err != nil {
+		panic(err) // let the recovery middleware deal with this
+	}
+
 }
 
 // GetIdentityNotFoundCode is the HTTP code returned for type GetIdentityNotFound
 const GetIdentityNotFoundCode int = 404
 
-/*GetIdentityNotFound Identity not found
+/*GetIdentityNotFound Identities with provided parameters not found
 
 swagger:response getIdentityNotFound
 */

--- a/cilium/cmd/identity_get.go
+++ b/cilium/cmd/identity_get.go
@@ -17,32 +17,24 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/cilium/cilium/pkg/policy"
 
 	identityApi "github.com/cilium/cilium/api/v1/client/policy"
+	"github.com/cilium/cilium/pkg/policy"
 
 	"github.com/spf13/cobra"
 )
-
-var listID bool
 
 // identityGetCmd represents the identity_get command
 var identityGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Retrieve the identity of the specified label",
 	Run: func(cmd *cobra.Command, args []string) {
-		if listID {
-			for k, v := range policy.ReservedIdentities {
-				fmt.Printf("%-15s %3d\n", k, v)
-			}
-			return
-		}
-
 		if len(args) < 1 || args[0] == "" {
 			Usagef(cmd, "Invalid identity ID")
 		}
 
 		if id := policy.GetReservedID(args[0]); id != policy.ID_UNKNOWN {
+			//DO NOT modify the output format. This is being used by script(s).
 			fmt.Printf("%d\n", id)
 		} else {
 			params := identityApi.NewGetIdentityIDParams().WithID(args[0])
@@ -59,5 +51,4 @@ var identityGetCmd = &cobra.Command{
 
 func init() {
 	identityCmd.AddCommand(identityGetCmd)
-	identityGetCmd.Flags().BoolVarP(&listID, "list", "", false, "List all identities")
 }

--- a/cilium/cmd/identity_list.go
+++ b/cilium/cmd/identity_list.go
@@ -1,0 +1,65 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	identityApi "github.com/cilium/cilium/api/v1/client/policy"
+	"github.com/cilium/cilium/pkg/policy"
+
+	"github.com/spf13/cobra"
+)
+
+// identityListCmd represents the identity_list command
+var identityListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all identities",
+	Run: func(cmd *cobra.Command, args []string) {
+		listIdentities(args)
+	},
+}
+var reservedIDs bool
+
+func init() {
+	identityCmd.AddCommand(identityListCmd)
+	identityListCmd.Flags().BoolVarP(&reservedIDs, "reserved", "", false,
+		"List all reserved identities")
+}
+
+func listIdentities(args []string) {
+	if reservedIDs {
+		fmt.Println("Reserved identities:")
+		for k, v := range policy.ReservedIdentities {
+			fmt.Printf("%3d %-15s \n", v, k)
+		}
+	}
+	fmt.Println("Identities in use by endpoints:\n" +
+		"(Note: If labels have been provided as parameters, only matching identities will be displayed)")
+
+	var params *identityApi.GetIdentityParams
+	if len(args) != 0 {
+		params = identityApi.NewGetIdentityParams().WithLabels(args)
+	}
+
+	if identities, err := client.Policy.GetIdentity(params); err != nil {
+		Fatalf("Cannot get identities for given labels %v. err: %s\n", params.Labels, err.Error())
+	} else if b, err := json.MarshalIndent(identities, "", "  "); err != nil {
+		Fatalf("Cannot marshal identities %s", err.Error())
+	} else {
+		fmt.Println(string(b))
+	}
+}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"runtime"
+	"sync"
 	"testing"
 
 	e "github.com/cilium/cilium/pkg/endpoint"
@@ -23,7 +24,6 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 
 	. "gopkg.in/check.v1"
-	"sync"
 )
 
 // Hook up gocheck into the "go test" runner.


### PR DESCRIPTION
- cilium identity get command should list individual identities.
- To be consistent with the other cilium API definitions, the
cilium identity list is the right command to display a list of
all/filtered identities.
- This patch adds the implementation of cilium identity list.
- Added new unit test for cilium identity list
- Added new unit test for cilium identity list --reserved
- Updated .gitignore

Signed-off-by: Ashwin Paranjpe <ashwin@covalent.io>