### PR TITLE
daemon: add more logs for AnnotateEndpoint

### DIFF
--- a/daemon/docker_watcher.go
+++ b/daemon/docker_watcher.go
@@ -272,6 +272,7 @@ func (d *Daemon) handleCreateContainer(id string, retry bool) {
 				podNamespace := k8sDockerLbls.GetPodNamespace(dockerContainer.Config.Labels)
 				podName := k8sDockerLbls.GetPodName(dockerContainer.Config.Labels)
 				ep.PodName = fmt.Sprintf("%s:%s", podNamespace, podName)
+				log.Debugf("endpoint %d pod name set to %s", ep.PodName)
 			}
 		}
 		ep.Mutex.Unlock()


### PR DESCRIPTION
Add more logs in AnnotateEndpoint function for daemon as well as when the endpoint's PodName field is populated.
Also refactor AnnotateEndpoint to be more clean and have less code.

Signed-off by: Ian Vernon <ian@cilium.io>

This was done due to a build failure documented in #1467 