### PR TITLE
Fix #1257 Refuse to start if bpffs filesystem is mounted multiple times

### DIFF
--- a/pkg/bpf/bpffs.go
+++ b/pkg/bpf/bpffs.go
@@ -200,11 +200,12 @@ func mountFS() error {
 		num, err := strconv.ParseInt(parts[0], 10, 32)
 		if err != nil {
 			return fmt.Errorf("command execution failed: %s", err)
-		} else {
-			if num > 1 {
-				return fmt.Errorf("multiple mount points detected at %s", mapRoot)
-			}
 		}
+
+		if num > 1 {
+			return fmt.Errorf("multiple mount points detected at %s", mapRoot)
+		}
+
 	}
 	if !isBpffs(mapRoot) {
 		log.Fatalf("BPF: '%s' is not mounted as BPF filesystem.", mapRoot)


### PR DESCRIPTION
This change executes a "mount | grep mapRoot  | wc -l | cut -f1 -d' '" command on the mapRoot and if we are mounted more than once,
it fails the cilium daemon from executing any further.
Fix #1257  

Signed-off by: Manali Bhutiyani manali@covalent.io