### PR TITLE
daemon: add automatic v6 l3 routes

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1087,7 +1087,8 @@ func NewDaemon(c *Config) (*Daemon, error) {
 	}
 
 	// Populate list of nodes with local node entry
-	node.UpdateNode(nodeaddress.GetNode())
+	ni, n := nodeaddress.GetNode()
+	node.UpdateNode(ni, n, node.TunnelRoute, nil)
 
 	if c.IsK8sEnabled() {
 		err := k8s.AnnotateNodeCIDR(d.k8sClient, nodeaddress.GetName(),

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -63,6 +63,9 @@ var (
 	config = NewConfig()
 
 	// Arguments variables keep in alphabetical order
+
+	// autoIPv6NodeRoutes automatically adds L3 direct routing when using direct mode (-d)
+	autoIPv6NodeRoutes    bool
 	bpfRoot               string
 	disableConntrack      bool
 	enableTracing         bool
@@ -257,6 +260,8 @@ func init() {
 		"agent-labels", []string{}, "Additional labels to identify this agent")
 	flags.StringVar(&config.AllowLocalhost,
 		"allow-localhost", AllowLocalhostAuto, "Policy when to allow local stack to reach local endpoints { auto | always | policy } ")
+	flags.Bool(
+		"auto-ipv6-node-routes", false, "Automatically adds IPv6 L3 routes to reach other nodes for non-overlay mode (--device) (BETA)")
 	flags.StringVar(&bpfRoot,
 		"bpf-root", "", "Path to BPF filesystem")
 	flags.StringVar(&cfgFile,
@@ -458,6 +463,8 @@ func initEnv() {
 	if viper.GetBool("debug") {
 		config.Opts.Set(endpoint.OptionDebug, true)
 	}
+
+	autoIPv6NodeRoutes = viper.GetBool("auto-ipv6-node-routes")
 
 	config.Opts.Set(endpoint.OptionDropNotify, true)
 	config.Opts.Set(endpoint.OptionTraceNotify, true)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -42,6 +42,9 @@ type Node struct {
 	// IPv6AllocCIDR if set, is the IPv6 address pool out of which the node
 	// allocates IPs for local endpoints from
 	IPv6AllocCIDR *net.IPNet
+
+	// dev contains the device name to where the IPv6 traffic should be send
+	dev string
 }
 
 // Address is a node address which contains an IP and the address type.


### PR DESCRIPTION
When using non-overlay mode with IPv6, cilium could not be able to reach
the containers running on the other nodes. This commit adds the ability
to add a L3 route based on the node IPs gathered by kubernetes annotations.

Signed-off-by: André Martins <andre@cilium.io>