### PR TITLE
[CMD]: Added json and jsonpath output

### DIFF
--- a/cilium/cmd/endpoint_list.go
+++ b/cilium/cmd/endpoint_list.go
@@ -41,6 +41,7 @@ var endpointListCmd = &cobra.Command{
 func init() {
 	endpointCmd.AddCommand(endpointListCmd)
 	endpointListCmd.Flags().BoolVar(&noHeaders, "no-headers", false, "Do not print headers")
+	AddMultipleOutput(endpointListCmd)
 }
 
 func listEndpoint(w *tabwriter.Writer, ep *models.Endpoint, id string, label string) {
@@ -79,6 +80,13 @@ func listEndpoints() {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
 			endpointTitle, policyTitle, labelsIDTitle, labelsDesTitle, ipv6Title, ipv4Title, statusTitle)
 		fmt.Fprintf(w, "\t%s\t\t\t\t\t\t\n", enforcementTitle)
+	}
+
+	if len(dumpOutput) > 0 {
+		if err := OutputPrinter(eps); err != nil {
+			os.Exit(1)
+		}
+		return
 	}
 
 	for _, ep := range eps {

--- a/cilium/cmd/helpers.go
+++ b/cilium/cmd/helpers.go
@@ -15,13 +15,17 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/policy"
 
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/util/jsonpath"
 )
 
 func Fatalf(msg string, args ...interface{}) {
@@ -78,4 +82,58 @@ func requireServiceID(cmd *cobra.Command, args []string) {
 	if args[0] == "" {
 		Usagef(cmd, "Empty service id argument")
 	}
+}
+
+var dumpOutput string
+
+//AddMultipleOutput adds the -o|--output option to any cmd to export to json
+func AddMultipleOutput(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&dumpOutput, "output", "o", "", "json| jsonpath='{}'")
+}
+
+//OutputPrinter receives an interface and dump the data using the --output flag.
+//ATM only json or jsonpath. In the future yaml
+func OutputPrinter(data interface{}) error {
+	var re = regexp.MustCompile(`^jsonpath\=(.*)`)
+
+	if dumpOutput == "json" {
+		return dumpJSON(data, "")
+	}
+
+	if re.MatchString(dumpOutput) {
+		return dumpJSON(data, re.ReplaceAllString(dumpOutput, "$1"))
+	}
+
+	return fmt.Errorf("Couldn't found output printer")
+}
+
+// dumpJSON dump the data variable to the stdout as json.
+// If somethings fail, it'll return an error
+// If jsonPath is passed, it'll run the json query over data var.
+func dumpJSON(data interface{}, jsonPath string) error {
+
+	if len(jsonPath) == 0 {
+		result, err := json.Marshal(data)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Couldn't marshal to json: '%s'\n", err)
+			return err
+		}
+		fmt.Println(string(result))
+		return nil
+	}
+
+	parser := jsonpath.New("").AllowMissingKeys(true)
+	if err := parser.Parse(jsonPath); err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't parse jsonpath expression: '%s'\n", err)
+		return err
+	}
+
+	buf := new(bytes.Buffer)
+	if err := parser.Execute(buf, data); err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't parse jsonpath expression: '%s'\n", err)
+		return err
+
+	}
+	fmt.Println(buf.String())
+	return nil
 }

--- a/cilium/cmd/helpers_test.go
+++ b/cilium/cmd/helpers_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type CMDHelpersSuite struct{}
+
+var _ = Suite(&CMDHelpersSuite{})
+
+func (s *CMDHelpersSuite) TestDumpJSON(c *C) {
+	type sampleData struct {
+		ID   int
+		Name string
+	}
+
+	tt := sampleData{
+		ID:   1,
+		Name: "test",
+	}
+
+	err := dumpJSON(tt, "")
+	c.Assert(err, IsNil)
+
+	err = dumpJSON(tt, "{.Id}")
+	c.Assert(err, IsNil)
+
+	err = dumpJSON(tt, "{{.Id}}")
+	if err == nil {
+		c.Fatalf("Dumpjson jsonpath no error with invalid path '%s'", err)
+	}
+}

--- a/cilium/cmd/service_get.go
+++ b/cilium/cmd/service_get.go
@@ -38,7 +38,7 @@ var serviceGetCmd = &cobra.Command{
 
 		svc, err := client.GetServiceID(id)
 		if err != nil {
-			Fatalf("Cannot get service: %s\n", err)
+			Fatalf("Cannot get service '%v': %s\n", id, err)
 		}
 
 		slice := []string{}
@@ -48,6 +48,13 @@ var serviceGetCmd = &cobra.Command{
 			} else {
 				slice = append(slice, bea.String())
 			}
+		}
+
+		if len(dumpOutput) > 0 {
+			if err := OutputPrinter(slice); err != nil {
+				os.Exit(1)
+			}
+			return
 		}
 
 		if fea, err := types.NewL3n4AddrFromModel(svc.FrontendAddress); err != nil {
@@ -64,4 +71,5 @@ var serviceGetCmd = &cobra.Command{
 
 func init() {
 	serviceCmd.AddCommand(serviceGetCmd)
+	AddMultipleOutput(serviceGetCmd)
 }

--- a/cilium/cmd/service_list.go
+++ b/cilium/cmd/service_list.go
@@ -30,17 +30,16 @@ var serviceListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List services",
 	Run: func(cmd *cobra.Command, args []string) {
-		listServices()
+		listServices(cmd, args)
 	},
 }
 
 func init() {
 	serviceCmd.AddCommand(serviceListCmd)
-
+	AddMultipleOutput(serviceListCmd)
 }
 
-func listServices() {
-
+func listServices(cmd *cobra.Command, args []string) {
 	list, err := client.GetServices()
 	if err != nil {
 		Fatalf("Cannot get services list: %s", err)
@@ -90,6 +89,13 @@ func listServices() {
 	sort.Slice(svcs, func(i, j int) bool {
 		return svcs[i].ID <= svcs[j].ID
 	})
+
+	if len(dumpOutput) > 0 {
+		if err := OutputPrinter(svcs); err != nil {
+			os.Exit(1)
+		}
+		return
+	}
 
 	for _, service := range svcs {
 		var str string

--- a/pkg/maps/tunnel/tunnel.go
+++ b/pkg/maps/tunnel/tunnel.go
@@ -117,6 +117,9 @@ func dumpCallback(key bpf.MapKey, value bpf.MapValue) {
 }
 
 // DumpMap prints the content of the tunnel endpoint map to stdout
-func DumpMap() error {
-	return mapInstance.Dump(dumpParser, dumpCallback)
+func DumpMap(callback bpf.DumpCallback) error {
+	if callback == nil {
+		return mapInstance.Dump(dumpParser, dumpCallback)
+	}
+	return mapInstance.Dump(dumpParser, callback)
 }

--- a/tests/12-policy-import.sh
+++ b/tests/12-policy-import.sh
@@ -152,7 +152,7 @@ FOO_SEC_ID=$(cilium endpoint list | grep id.foo | awk '{ print $3}')
 EXPECTED_CONSUMER="1\n$FOO_SEC_ID"
 
 log "verify allowed consumers"
-DIFF=$(diff -Nru <(echo -e "$EXPECTED_CONSUMER") <(cilium endpoint get $BAR_ID | jq '.policy | .["allowed-consumers"] | .[]' | sort)) || true
+DIFF=$(diff -Nru <(echo -e "$EXPECTED_CONSUMER") <(cilium endpoint get $BAR_ID | jq '.[].policy | .["allowed-consumers"] | .[]' | sort)) || true
 if [[ "$DIFF" != "" ]]; then
   abort "$DIFF"
 fi
@@ -260,7 +260,7 @@ fi
 EXPECTED_CONSUMER="$FOO_SEC_ID"
 
 log "verify allowed consumers"
-DIFF=$(diff -Nru <(echo -e "$EXPECTED_CONSUMER") <(cilium endpoint get $BAR_ID | jq '.policy | .["allowed-consumers"] | .[]')) || true
+DIFF=$(diff -Nru <(echo -e "$EXPECTED_CONSUMER") <(cilium endpoint get $BAR_ID | jq '.[].policy | .["allowed-consumers"] | .[]')) || true
 if [[ "$DIFF" != "" ]]; then
   abort "$DIFF"
 fi

--- a/tests/20-identity-list.sh
+++ b/tests/20-identity-list.sh
@@ -58,7 +58,7 @@ function test_identity_list {
 
   echo "Endpoint security ID is: $ID"
 
-  local expected_response='Identities in use by endpoints: (Note: If labels have been provided as parameters, only matching identities will be displayed) {   "Payload": [     {       "id": '$ID',       "labels": [         "container:id.foo"       ]     }   ] }'
+  local expected_response='Identities in use by endpoints: (Note: If labels have been provided as parameters, only matching identities will be displayed) [   {     "id": '$ID',     "labels": [       "container:id.foo"     ]   } ]'
 
   echo "Response is $response"
 

--- a/vendor/k8s.io/client-go/third_party/forked/golang/template/exec.go
+++ b/vendor/k8s.io/client-go/third_party/forked/golang/template/exec.go
@@ -1,0 +1,94 @@
+//This package is copied from Go library text/template.
+//The original private functions indirect and printableValue
+//are exported as public functions.
+package template
+
+import (
+	"fmt"
+	"reflect"
+)
+
+var Indirect = indirect
+var PrintableValue = printableValue
+
+var (
+	errorType       = reflect.TypeOf((*error)(nil)).Elem()
+	fmtStringerType = reflect.TypeOf((*fmt.Stringer)(nil)).Elem()
+)
+
+// indirect returns the item at the end of indirection, and a bool to indicate if it's nil.
+// We indirect through pointers and empty interfaces (only) because
+// non-empty interfaces have methods we might need.
+func indirect(v reflect.Value) (rv reflect.Value, isNil bool) {
+	for ; v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface; v = v.Elem() {
+		if v.IsNil() {
+			return v, true
+		}
+		if v.Kind() == reflect.Interface && v.NumMethod() > 0 {
+			break
+		}
+	}
+	return v, false
+}
+
+// printableValue returns the, possibly indirected, interface value inside v that
+// is best for a call to formatted printer.
+func printableValue(v reflect.Value) (interface{}, bool) {
+	if v.Kind() == reflect.Ptr {
+		v, _ = indirect(v) // fmt.Fprint handles nil.
+	}
+	if !v.IsValid() {
+		return "<no value>", true
+	}
+
+	if !v.Type().Implements(errorType) && !v.Type().Implements(fmtStringerType) {
+		if v.CanAddr() && (reflect.PtrTo(v.Type()).Implements(errorType) || reflect.PtrTo(v.Type()).Implements(fmtStringerType)) {
+			v = v.Addr()
+		} else {
+			switch v.Kind() {
+			case reflect.Chan, reflect.Func:
+				return nil, false
+			}
+		}
+	}
+	return v.Interface(), true
+}
+
+// canBeNil reports whether an untyped nil can be assigned to the type. See reflect.Zero.
+func canBeNil(typ reflect.Type) bool {
+	switch typ.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return true
+	}
+	return false
+}
+
+// isTrue reports whether the value is 'true', in the sense of not the zero of its type,
+// and whether the value has a meaningful truth value.
+func isTrue(val reflect.Value) (truth, ok bool) {
+	if !val.IsValid() {
+		// Something like var x interface{}, never set. It's a form of nil.
+		return false, true
+	}
+	switch val.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		truth = val.Len() > 0
+	case reflect.Bool:
+		truth = val.Bool()
+	case reflect.Complex64, reflect.Complex128:
+		truth = val.Complex() != 0
+	case reflect.Chan, reflect.Func, reflect.Ptr, reflect.Interface:
+		truth = !val.IsNil()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		truth = val.Int() != 0
+	case reflect.Float32, reflect.Float64:
+		truth = val.Float() != 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		truth = val.Uint() != 0
+	case reflect.Struct:
+		truth = true // Struct values are always true.
+	default:
+		return
+	}
+	return truth, true
+}

--- a/vendor/k8s.io/client-go/third_party/forked/golang/template/funcs.go
+++ b/vendor/k8s.io/client-go/third_party/forked/golang/template/funcs.go
@@ -1,0 +1,599 @@
+//This package is copied from Go library text/template.
+//The original private functions eq, ge, gt, le, lt, and ne
+//are exported as public functions.
+package template
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"reflect"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+var Equal = eq
+var GreaterEqual = ge
+var Greater = gt
+var LessEqual = le
+var Less = lt
+var NotEqual = ne
+
+// FuncMap is the type of the map defining the mapping from names to functions.
+// Each function must have either a single return value, or two return values of
+// which the second has type error. In that case, if the second (error)
+// return value evaluates to non-nil during execution, execution terminates and
+// Execute returns that error.
+type FuncMap map[string]interface{}
+
+var builtins = FuncMap{
+	"and":      and,
+	"call":     call,
+	"html":     HTMLEscaper,
+	"index":    index,
+	"js":       JSEscaper,
+	"len":      length,
+	"not":      not,
+	"or":       or,
+	"print":    fmt.Sprint,
+	"printf":   fmt.Sprintf,
+	"println":  fmt.Sprintln,
+	"urlquery": URLQueryEscaper,
+
+	// Comparisons
+	"eq": eq, // ==
+	"ge": ge, // >=
+	"gt": gt, // >
+	"le": le, // <=
+	"lt": lt, // <
+	"ne": ne, // !=
+}
+
+var builtinFuncs = createValueFuncs(builtins)
+
+// createValueFuncs turns a FuncMap into a map[string]reflect.Value
+func createValueFuncs(funcMap FuncMap) map[string]reflect.Value {
+	m := make(map[string]reflect.Value)
+	addValueFuncs(m, funcMap)
+	return m
+}
+
+// addValueFuncs adds to values the functions in funcs, converting them to reflect.Values.
+func addValueFuncs(out map[string]reflect.Value, in FuncMap) {
+	for name, fn := range in {
+		v := reflect.ValueOf(fn)
+		if v.Kind() != reflect.Func {
+			panic("value for " + name + " not a function")
+		}
+		if !goodFunc(v.Type()) {
+			panic(fmt.Errorf("can't install method/function %q with %d results", name, v.Type().NumOut()))
+		}
+		out[name] = v
+	}
+}
+
+// AddFuncs adds to values the functions in funcs. It does no checking of the input -
+// call addValueFuncs first.
+func addFuncs(out, in FuncMap) {
+	for name, fn := range in {
+		out[name] = fn
+	}
+}
+
+// goodFunc checks that the function or method has the right result signature.
+func goodFunc(typ reflect.Type) bool {
+	// We allow functions with 1 result or 2 results where the second is an error.
+	switch {
+	case typ.NumOut() == 1:
+		return true
+	case typ.NumOut() == 2 && typ.Out(1) == errorType:
+		return true
+	}
+	return false
+}
+
+// findFunction looks for a function in the template, and global map.
+func findFunction(name string) (reflect.Value, bool) {
+	if fn := builtinFuncs[name]; fn.IsValid() {
+		return fn, true
+	}
+	return reflect.Value{}, false
+}
+
+// Indexing.
+
+// index returns the result of indexing its first argument by the following
+// arguments.  Thus "index x 1 2 3" is, in Go syntax, x[1][2][3]. Each
+// indexed item must be a map, slice, or array.
+func index(item interface{}, indices ...interface{}) (interface{}, error) {
+	v := reflect.ValueOf(item)
+	for _, i := range indices {
+		index := reflect.ValueOf(i)
+		var isNil bool
+		if v, isNil = indirect(v); isNil {
+			return nil, fmt.Errorf("index of nil pointer")
+		}
+		switch v.Kind() {
+		case reflect.Array, reflect.Slice, reflect.String:
+			var x int64
+			switch index.Kind() {
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+				x = index.Int()
+			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+				x = int64(index.Uint())
+			default:
+				return nil, fmt.Errorf("cannot index slice/array with type %s", index.Type())
+			}
+			if x < 0 || x >= int64(v.Len()) {
+				return nil, fmt.Errorf("index out of range: %d", x)
+			}
+			v = v.Index(int(x))
+		case reflect.Map:
+			if !index.IsValid() {
+				index = reflect.Zero(v.Type().Key())
+			}
+			if !index.Type().AssignableTo(v.Type().Key()) {
+				return nil, fmt.Errorf("%s is not index type for %s", index.Type(), v.Type())
+			}
+			if x := v.MapIndex(index); x.IsValid() {
+				v = x
+			} else {
+				v = reflect.Zero(v.Type().Elem())
+			}
+		default:
+			return nil, fmt.Errorf("can't index item of type %s", v.Type())
+		}
+	}
+	return v.Interface(), nil
+}
+
+// Length
+
+// length returns the length of the item, with an error if it has no defined length.
+func length(item interface{}) (int, error) {
+	v, isNil := indirect(reflect.ValueOf(item))
+	if isNil {
+		return 0, fmt.Errorf("len of nil pointer")
+	}
+	switch v.Kind() {
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len(), nil
+	}
+	return 0, fmt.Errorf("len of type %s", v.Type())
+}
+
+// Function invocation
+
+// call returns the result of evaluating the first argument as a function.
+// The function must return 1 result, or 2 results, the second of which is an error.
+func call(fn interface{}, args ...interface{}) (interface{}, error) {
+	v := reflect.ValueOf(fn)
+	typ := v.Type()
+	if typ.Kind() != reflect.Func {
+		return nil, fmt.Errorf("non-function of type %s", typ)
+	}
+	if !goodFunc(typ) {
+		return nil, fmt.Errorf("function called with %d args; should be 1 or 2", typ.NumOut())
+	}
+	numIn := typ.NumIn()
+	var dddType reflect.Type
+	if typ.IsVariadic() {
+		if len(args) < numIn-1 {
+			return nil, fmt.Errorf("wrong number of args: got %d want at least %d", len(args), numIn-1)
+		}
+		dddType = typ.In(numIn - 1).Elem()
+	} else {
+		if len(args) != numIn {
+			return nil, fmt.Errorf("wrong number of args: got %d want %d", len(args), numIn)
+		}
+	}
+	argv := make([]reflect.Value, len(args))
+	for i, arg := range args {
+		value := reflect.ValueOf(arg)
+		// Compute the expected type. Clumsy because of variadics.
+		var argType reflect.Type
+		if !typ.IsVariadic() || i < numIn-1 {
+			argType = typ.In(i)
+		} else {
+			argType = dddType
+		}
+		if !value.IsValid() && canBeNil(argType) {
+			value = reflect.Zero(argType)
+		}
+		if !value.Type().AssignableTo(argType) {
+			return nil, fmt.Errorf("arg %d has type %s; should be %s", i, value.Type(), argType)
+		}
+		argv[i] = value
+	}
+	result := v.Call(argv)
+	if len(result) == 2 && !result[1].IsNil() {
+		return result[0].Interface(), result[1].Interface().(error)
+	}
+	return result[0].Interface(), nil
+}
+
+// Boolean logic.
+
+func truth(a interface{}) bool {
+	t, _ := isTrue(reflect.ValueOf(a))
+	return t
+}
+
+// and computes the Boolean AND of its arguments, returning
+// the first false argument it encounters, or the last argument.
+func and(arg0 interface{}, args ...interface{}) interface{} {
+	if !truth(arg0) {
+		return arg0
+	}
+	for i := range args {
+		arg0 = args[i]
+		if !truth(arg0) {
+			break
+		}
+	}
+	return arg0
+}
+
+// or computes the Boolean OR of its arguments, returning
+// the first true argument it encounters, or the last argument.
+func or(arg0 interface{}, args ...interface{}) interface{} {
+	if truth(arg0) {
+		return arg0
+	}
+	for i := range args {
+		arg0 = args[i]
+		if truth(arg0) {
+			break
+		}
+	}
+	return arg0
+}
+
+// not returns the Boolean negation of its argument.
+func not(arg interface{}) (truth bool) {
+	truth, _ = isTrue(reflect.ValueOf(arg))
+	return !truth
+}
+
+// Comparison.
+
+// TODO: Perhaps allow comparison between signed and unsigned integers.
+
+var (
+	errBadComparisonType = errors.New("invalid type for comparison")
+	errBadComparison     = errors.New("incompatible types for comparison")
+	errNoComparison      = errors.New("missing argument for comparison")
+)
+
+type kind int
+
+const (
+	invalidKind kind = iota
+	boolKind
+	complexKind
+	intKind
+	floatKind
+	integerKind
+	stringKind
+	uintKind
+)
+
+func basicKind(v reflect.Value) (kind, error) {
+	switch v.Kind() {
+	case reflect.Bool:
+		return boolKind, nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return intKind, nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return uintKind, nil
+	case reflect.Float32, reflect.Float64:
+		return floatKind, nil
+	case reflect.Complex64, reflect.Complex128:
+		return complexKind, nil
+	case reflect.String:
+		return stringKind, nil
+	}
+	return invalidKind, errBadComparisonType
+}
+
+// eq evaluates the comparison a == b || a == c || ...
+func eq(arg1 interface{}, arg2 ...interface{}) (bool, error) {
+	v1 := reflect.ValueOf(arg1)
+	k1, err := basicKind(v1)
+	if err != nil {
+		return false, err
+	}
+	if len(arg2) == 0 {
+		return false, errNoComparison
+	}
+	for _, arg := range arg2 {
+		v2 := reflect.ValueOf(arg)
+		k2, err := basicKind(v2)
+		if err != nil {
+			return false, err
+		}
+		truth := false
+		if k1 != k2 {
+			// Special case: Can compare integer values regardless of type's sign.
+			switch {
+			case k1 == intKind && k2 == uintKind:
+				truth = v1.Int() >= 0 && uint64(v1.Int()) == v2.Uint()
+			case k1 == uintKind && k2 == intKind:
+				truth = v2.Int() >= 0 && v1.Uint() == uint64(v2.Int())
+			default:
+				return false, errBadComparison
+			}
+		} else {
+			switch k1 {
+			case boolKind:
+				truth = v1.Bool() == v2.Bool()
+			case complexKind:
+				truth = v1.Complex() == v2.Complex()
+			case floatKind:
+				truth = v1.Float() == v2.Float()
+			case intKind:
+				truth = v1.Int() == v2.Int()
+			case stringKind:
+				truth = v1.String() == v2.String()
+			case uintKind:
+				truth = v1.Uint() == v2.Uint()
+			default:
+				panic("invalid kind")
+			}
+		}
+		if truth {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ne evaluates the comparison a != b.
+func ne(arg1, arg2 interface{}) (bool, error) {
+	// != is the inverse of ==.
+	equal, err := eq(arg1, arg2)
+	return !equal, err
+}
+
+// lt evaluates the comparison a < b.
+func lt(arg1, arg2 interface{}) (bool, error) {
+	v1 := reflect.ValueOf(arg1)
+	k1, err := basicKind(v1)
+	if err != nil {
+		return false, err
+	}
+	v2 := reflect.ValueOf(arg2)
+	k2, err := basicKind(v2)
+	if err != nil {
+		return false, err
+	}
+	truth := false
+	if k1 != k2 {
+		// Special case: Can compare integer values regardless of type's sign.
+		switch {
+		case k1 == intKind && k2 == uintKind:
+			truth = v1.Int() < 0 || uint64(v1.Int()) < v2.Uint()
+		case k1 == uintKind && k2 == intKind:
+			truth = v2.Int() >= 0 && v1.Uint() < uint64(v2.Int())
+		default:
+			return false, errBadComparison
+		}
+	} else {
+		switch k1 {
+		case boolKind, complexKind:
+			return false, errBadComparisonType
+		case floatKind:
+			truth = v1.Float() < v2.Float()
+		case intKind:
+			truth = v1.Int() < v2.Int()
+		case stringKind:
+			truth = v1.String() < v2.String()
+		case uintKind:
+			truth = v1.Uint() < v2.Uint()
+		default:
+			panic("invalid kind")
+		}
+	}
+	return truth, nil
+}
+
+// le evaluates the comparison <= b.
+func le(arg1, arg2 interface{}) (bool, error) {
+	// <= is < or ==.
+	lessThan, err := lt(arg1, arg2)
+	if lessThan || err != nil {
+		return lessThan, err
+	}
+	return eq(arg1, arg2)
+}
+
+// gt evaluates the comparison a > b.
+func gt(arg1, arg2 interface{}) (bool, error) {
+	// > is the inverse of <=.
+	lessOrEqual, err := le(arg1, arg2)
+	if err != nil {
+		return false, err
+	}
+	return !lessOrEqual, nil
+}
+
+// ge evaluates the comparison a >= b.
+func ge(arg1, arg2 interface{}) (bool, error) {
+	// >= is the inverse of <.
+	lessThan, err := lt(arg1, arg2)
+	if err != nil {
+		return false, err
+	}
+	return !lessThan, nil
+}
+
+// HTML escaping.
+
+var (
+	htmlQuot = []byte("&#34;") // shorter than "&quot;"
+	htmlApos = []byte("&#39;") // shorter than "&apos;" and apos was not in HTML until HTML5
+	htmlAmp  = []byte("&amp;")
+	htmlLt   = []byte("&lt;")
+	htmlGt   = []byte("&gt;")
+)
+
+// HTMLEscape writes to w the escaped HTML equivalent of the plain text data b.
+func HTMLEscape(w io.Writer, b []byte) {
+	last := 0
+	for i, c := range b {
+		var html []byte
+		switch c {
+		case '"':
+			html = htmlQuot
+		case '\'':
+			html = htmlApos
+		case '&':
+			html = htmlAmp
+		case '<':
+			html = htmlLt
+		case '>':
+			html = htmlGt
+		default:
+			continue
+		}
+		w.Write(b[last:i])
+		w.Write(html)
+		last = i + 1
+	}
+	w.Write(b[last:])
+}
+
+// HTMLEscapeString returns the escaped HTML equivalent of the plain text data s.
+func HTMLEscapeString(s string) string {
+	// Avoid allocation if we can.
+	if strings.IndexAny(s, `'"&<>`) < 0 {
+		return s
+	}
+	var b bytes.Buffer
+	HTMLEscape(&b, []byte(s))
+	return b.String()
+}
+
+// HTMLEscaper returns the escaped HTML equivalent of the textual
+// representation of its arguments.
+func HTMLEscaper(args ...interface{}) string {
+	return HTMLEscapeString(evalArgs(args))
+}
+
+// JavaScript escaping.
+
+var (
+	jsLowUni = []byte(`\u00`)
+	hex      = []byte("0123456789ABCDEF")
+
+	jsBackslash = []byte(`\\`)
+	jsApos      = []byte(`\'`)
+	jsQuot      = []byte(`\"`)
+	jsLt        = []byte(`\x3C`)
+	jsGt        = []byte(`\x3E`)
+)
+
+// JSEscape writes to w the escaped JavaScript equivalent of the plain text data b.
+func JSEscape(w io.Writer, b []byte) {
+	last := 0
+	for i := 0; i < len(b); i++ {
+		c := b[i]
+
+		if !jsIsSpecial(rune(c)) {
+			// fast path: nothing to do
+			continue
+		}
+		w.Write(b[last:i])
+
+		if c < utf8.RuneSelf {
+			// Quotes, slashes and angle brackets get quoted.
+			// Control characters get written as \u00XX.
+			switch c {
+			case '\\':
+				w.Write(jsBackslash)
+			case '\'':
+				w.Write(jsApos)
+			case '"':
+				w.Write(jsQuot)
+			case '<':
+				w.Write(jsLt)
+			case '>':
+				w.Write(jsGt)
+			default:
+				w.Write(jsLowUni)
+				t, b := c>>4, c&0x0f
+				w.Write(hex[t : t+1])
+				w.Write(hex[b : b+1])
+			}
+		} else {
+			// Unicode rune.
+			r, size := utf8.DecodeRune(b[i:])
+			if unicode.IsPrint(r) {
+				w.Write(b[i : i+size])
+			} else {
+				fmt.Fprintf(w, "\\u%04X", r)
+			}
+			i += size - 1
+		}
+		last = i + 1
+	}
+	w.Write(b[last:])
+}
+
+// JSEscapeString returns the escaped JavaScript equivalent of the plain text data s.
+func JSEscapeString(s string) string {
+	// Avoid allocation if we can.
+	if strings.IndexFunc(s, jsIsSpecial) < 0 {
+		return s
+	}
+	var b bytes.Buffer
+	JSEscape(&b, []byte(s))
+	return b.String()
+}
+
+func jsIsSpecial(r rune) bool {
+	switch r {
+	case '\\', '\'', '"', '<', '>':
+		return true
+	}
+	return r < ' ' || utf8.RuneSelf <= r
+}
+
+// JSEscaper returns the escaped JavaScript equivalent of the textual
+// representation of its arguments.
+func JSEscaper(args ...interface{}) string {
+	return JSEscapeString(evalArgs(args))
+}
+
+// URLQueryEscaper returns the escaped value of the textual representation of
+// its arguments in a form suitable for embedding in a URL query.
+func URLQueryEscaper(args ...interface{}) string {
+	return url.QueryEscape(evalArgs(args))
+}
+
+// evalArgs formats the list of arguments into a string. It is therefore equivalent to
+//	fmt.Sprint(args...)
+// except that each argument is indirected (if a pointer), as required,
+// using the same rules as the default string evaluation during template
+// execution.
+func evalArgs(args []interface{}) string {
+	ok := false
+	var s string
+	// Fast path for simple common case.
+	if len(args) == 1 {
+		s, ok = args[0].(string)
+	}
+	if !ok {
+		for i, arg := range args {
+			a, ok := printableValue(reflect.ValueOf(arg))
+			if ok {
+				args[i] = a
+			} // else left fmt do its thing
+		}
+		s = fmt.Sprint(args...)
+	}
+	return s
+}

--- a/vendor/k8s.io/client-go/util/jsonpath/doc.go
+++ b/vendor/k8s.io/client-go/util/jsonpath/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// package jsonpath is a template engine using jsonpath syntax,
+// which can be seen at http://goessner.net/articles/JsonPath/.
+// In addition, it has {range} {end} function to iterate list and slice.
+package jsonpath // import "k8s.io/client-go/util/jsonpath"

--- a/vendor/k8s.io/client-go/util/jsonpath/jsonpath.go
+++ b/vendor/k8s.io/client-go/util/jsonpath/jsonpath.go
@@ -1,0 +1,509 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jsonpath
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+
+	"k8s.io/client-go/third_party/forked/golang/template"
+)
+
+type JSONPath struct {
+	name       string
+	parser     *Parser
+	stack      [][]reflect.Value //push and pop values in different scopes
+	cur        []reflect.Value   //current scope values
+	beginRange int
+	inRange    int
+	endRange   int
+
+	allowMissingKeys bool
+}
+
+func New(name string) *JSONPath {
+	return &JSONPath{
+		name:       name,
+		beginRange: 0,
+		inRange:    0,
+		endRange:   0,
+	}
+}
+
+// AllowMissingKeys allows a caller to specify whether they want an error if a field or map key
+// cannot be located, or simply an empty result. The receiver is returned for chaining.
+func (j *JSONPath) AllowMissingKeys(allow bool) *JSONPath {
+	j.allowMissingKeys = allow
+	return j
+}
+
+// Parse parse the given template, return error
+func (j *JSONPath) Parse(text string) (err error) {
+	j.parser, err = Parse(j.name, text)
+	return
+}
+
+// Execute bounds data into template and write the result
+func (j *JSONPath) Execute(wr io.Writer, data interface{}) error {
+	fullResults, err := j.FindResults(data)
+	if err != nil {
+		return err
+	}
+	for ix := range fullResults {
+		if err := j.PrintResults(wr, fullResults[ix]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (j *JSONPath) FindResults(data interface{}) ([][]reflect.Value, error) {
+	if j.parser == nil {
+		return nil, fmt.Errorf("%s is an incomplete jsonpath template", j.name)
+	}
+
+	j.cur = []reflect.Value{reflect.ValueOf(data)}
+	nodes := j.parser.Root.Nodes
+	fullResult := [][]reflect.Value{}
+	for i := 0; i < len(nodes); i++ {
+		node := nodes[i]
+		results, err := j.walk(j.cur, node)
+		if err != nil {
+			return nil, err
+		}
+
+		//encounter an end node, break the current block
+		if j.endRange > 0 && j.endRange <= j.inRange {
+			j.endRange -= 1
+			break
+		}
+		//encounter a range node, start a range loop
+		if j.beginRange > 0 {
+			j.beginRange -= 1
+			j.inRange += 1
+			for k, value := range results {
+				j.parser.Root.Nodes = nodes[i+1:]
+				if k == len(results)-1 {
+					j.inRange -= 1
+				}
+				nextResults, err := j.FindResults(value.Interface())
+				if err != nil {
+					return nil, err
+				}
+				fullResult = append(fullResult, nextResults...)
+			}
+			break
+		}
+		fullResult = append(fullResult, results)
+	}
+	return fullResult, nil
+}
+
+// PrintResults write the results into writer
+func (j *JSONPath) PrintResults(wr io.Writer, results []reflect.Value) error {
+	for i, r := range results {
+		text, err := j.evalToText(r)
+		if err != nil {
+			return err
+		}
+		if i != len(results)-1 {
+			text = append(text, ' ')
+		}
+		if _, err = wr.Write(text); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// walk visits tree rooted at the given node in DFS order
+func (j *JSONPath) walk(value []reflect.Value, node Node) ([]reflect.Value, error) {
+	switch node := node.(type) {
+	case *ListNode:
+		return j.evalList(value, node)
+	case *TextNode:
+		return []reflect.Value{reflect.ValueOf(node.Text)}, nil
+	case *FieldNode:
+		return j.evalField(value, node)
+	case *ArrayNode:
+		return j.evalArray(value, node)
+	case *FilterNode:
+		return j.evalFilter(value, node)
+	case *IntNode:
+		return j.evalInt(value, node)
+	case *BoolNode:
+		return j.evalBool(value, node)
+	case *FloatNode:
+		return j.evalFloat(value, node)
+	case *WildcardNode:
+		return j.evalWildcard(value, node)
+	case *RecursiveNode:
+		return j.evalRecursive(value, node)
+	case *UnionNode:
+		return j.evalUnion(value, node)
+	case *IdentifierNode:
+		return j.evalIdentifier(value, node)
+	default:
+		return value, fmt.Errorf("unexpected Node %v", node)
+	}
+}
+
+// evalInt evaluates IntNode
+func (j *JSONPath) evalInt(input []reflect.Value, node *IntNode) ([]reflect.Value, error) {
+	result := make([]reflect.Value, len(input))
+	for i := range input {
+		result[i] = reflect.ValueOf(node.Value)
+	}
+	return result, nil
+}
+
+// evalFloat evaluates FloatNode
+func (j *JSONPath) evalFloat(input []reflect.Value, node *FloatNode) ([]reflect.Value, error) {
+	result := make([]reflect.Value, len(input))
+	for i := range input {
+		result[i] = reflect.ValueOf(node.Value)
+	}
+	return result, nil
+}
+
+// evalBool evaluates BoolNode
+func (j *JSONPath) evalBool(input []reflect.Value, node *BoolNode) ([]reflect.Value, error) {
+	result := make([]reflect.Value, len(input))
+	for i := range input {
+		result[i] = reflect.ValueOf(node.Value)
+	}
+	return result, nil
+}
+
+// evalList evaluates ListNode
+func (j *JSONPath) evalList(value []reflect.Value, node *ListNode) ([]reflect.Value, error) {
+	var err error
+	curValue := value
+	for _, node := range node.Nodes {
+		curValue, err = j.walk(curValue, node)
+		if err != nil {
+			return curValue, err
+		}
+	}
+	return curValue, nil
+}
+
+// evalIdentifier evaluates IdentifierNode
+func (j *JSONPath) evalIdentifier(input []reflect.Value, node *IdentifierNode) ([]reflect.Value, error) {
+	results := []reflect.Value{}
+	switch node.Name {
+	case "range":
+		j.stack = append(j.stack, j.cur)
+		j.beginRange += 1
+		results = input
+	case "end":
+		if j.endRange < j.inRange { //inside a loop, break the current block
+			j.endRange += 1
+			break
+		}
+		// the loop is about to end, pop value and continue the following execution
+		if len(j.stack) > 0 {
+			j.cur, j.stack = j.stack[len(j.stack)-1], j.stack[:len(j.stack)-1]
+		} else {
+			return results, fmt.Errorf("not in range, nothing to end")
+		}
+	default:
+		return input, fmt.Errorf("unrecognized identifier %v", node.Name)
+	}
+	return results, nil
+}
+
+// evalArray evaluates ArrayNode
+func (j *JSONPath) evalArray(input []reflect.Value, node *ArrayNode) ([]reflect.Value, error) {
+	result := []reflect.Value{}
+	for _, value := range input {
+
+		value, isNil := template.Indirect(value)
+		if isNil {
+			continue
+		}
+		if value.Kind() != reflect.Array && value.Kind() != reflect.Slice {
+			return input, fmt.Errorf("%v is not array or slice", value.Type())
+		}
+		params := node.Params
+		if !params[0].Known {
+			params[0].Value = 0
+		}
+		if params[0].Value < 0 {
+			params[0].Value += value.Len()
+		}
+		if !params[1].Known {
+			params[1].Value = value.Len()
+		}
+
+		if params[1].Value < 0 {
+			params[1].Value += value.Len()
+		}
+
+		sliceLength := value.Len()
+		if params[1].Value != params[0].Value { // if you're requesting zero elements, allow it through.
+			if params[0].Value >= sliceLength {
+				return input, fmt.Errorf("array index out of bounds: index %d, length %d", params[0].Value, sliceLength)
+			}
+			if params[1].Value > sliceLength {
+				return input, fmt.Errorf("array index out of bounds: index %d, length %d", params[1].Value-1, sliceLength)
+			}
+		}
+
+		if !params[2].Known {
+			value = value.Slice(params[0].Value, params[1].Value)
+		} else {
+			value = value.Slice3(params[0].Value, params[1].Value, params[2].Value)
+		}
+		for i := 0; i < value.Len(); i++ {
+			result = append(result, value.Index(i))
+		}
+	}
+	return result, nil
+}
+
+// evalUnion evaluates UnionNode
+func (j *JSONPath) evalUnion(input []reflect.Value, node *UnionNode) ([]reflect.Value, error) {
+	result := []reflect.Value{}
+	for _, listNode := range node.Nodes {
+		temp, err := j.evalList(input, listNode)
+		if err != nil {
+			return input, err
+		}
+		result = append(result, temp...)
+	}
+	return result, nil
+}
+
+func (j *JSONPath) findFieldInValue(value *reflect.Value, node *FieldNode) (reflect.Value, error) {
+	t := value.Type()
+	var inlineValue *reflect.Value
+	for ix := 0; ix < t.NumField(); ix++ {
+		f := t.Field(ix)
+		jsonTag := f.Tag.Get("json")
+		parts := strings.Split(jsonTag, ",")
+		if len(parts) == 0 {
+			continue
+		}
+		if parts[0] == node.Value {
+			return value.Field(ix), nil
+		}
+		if len(parts[0]) == 0 {
+			val := value.Field(ix)
+			inlineValue = &val
+		}
+	}
+	if inlineValue != nil {
+		if inlineValue.Kind() == reflect.Struct {
+			// handle 'inline'
+			match, err := j.findFieldInValue(inlineValue, node)
+			if err != nil {
+				return reflect.Value{}, err
+			}
+			if match.IsValid() {
+				return match, nil
+			}
+		}
+	}
+	return value.FieldByName(node.Value), nil
+}
+
+// evalField evaluates field of struct or key of map.
+func (j *JSONPath) evalField(input []reflect.Value, node *FieldNode) ([]reflect.Value, error) {
+	results := []reflect.Value{}
+	// If there's no input, there's no output
+	if len(input) == 0 {
+		return results, nil
+	}
+	for _, value := range input {
+		var result reflect.Value
+		value, isNil := template.Indirect(value)
+		if isNil {
+			continue
+		}
+
+		if value.Kind() == reflect.Struct {
+			var err error
+			if result, err = j.findFieldInValue(&value, node); err != nil {
+				return nil, err
+			}
+		} else if value.Kind() == reflect.Map {
+			mapKeyType := value.Type().Key()
+			nodeValue := reflect.ValueOf(node.Value)
+			// node value type must be convertible to map key type
+			if !nodeValue.Type().ConvertibleTo(mapKeyType) {
+				return results, fmt.Errorf("%s is not convertible to %s", nodeValue, mapKeyType)
+			}
+			result = value.MapIndex(nodeValue.Convert(mapKeyType))
+		}
+		if result.IsValid() {
+			results = append(results, result)
+		}
+	}
+	if len(results) == 0 {
+		if j.allowMissingKeys {
+			return results, nil
+		}
+		return results, fmt.Errorf("%s is not found", node.Value)
+	}
+	return results, nil
+}
+
+// evalWildcard extract all contents of the given value
+func (j *JSONPath) evalWildcard(input []reflect.Value, node *WildcardNode) ([]reflect.Value, error) {
+	results := []reflect.Value{}
+	for _, value := range input {
+		value, isNil := template.Indirect(value)
+		if isNil {
+			continue
+		}
+
+		kind := value.Kind()
+		if kind == reflect.Struct {
+			for i := 0; i < value.NumField(); i++ {
+				results = append(results, value.Field(i))
+			}
+		} else if kind == reflect.Map {
+			for _, key := range value.MapKeys() {
+				results = append(results, value.MapIndex(key))
+			}
+		} else if kind == reflect.Array || kind == reflect.Slice || kind == reflect.String {
+			for i := 0; i < value.Len(); i++ {
+				results = append(results, value.Index(i))
+			}
+		}
+	}
+	return results, nil
+}
+
+// evalRecursive visit the given value recursively and push all of them to result
+func (j *JSONPath) evalRecursive(input []reflect.Value, node *RecursiveNode) ([]reflect.Value, error) {
+	result := []reflect.Value{}
+	for _, value := range input {
+		results := []reflect.Value{}
+		value, isNil := template.Indirect(value)
+		if isNil {
+			continue
+		}
+
+		kind := value.Kind()
+		if kind == reflect.Struct {
+			for i := 0; i < value.NumField(); i++ {
+				results = append(results, value.Field(i))
+			}
+		} else if kind == reflect.Map {
+			for _, key := range value.MapKeys() {
+				results = append(results, value.MapIndex(key))
+			}
+		} else if kind == reflect.Array || kind == reflect.Slice || kind == reflect.String {
+			for i := 0; i < value.Len(); i++ {
+				results = append(results, value.Index(i))
+			}
+		}
+		if len(results) != 0 {
+			result = append(result, value)
+			output, err := j.evalRecursive(results, node)
+			if err != nil {
+				return result, err
+			}
+			result = append(result, output...)
+		}
+	}
+	return result, nil
+}
+
+// evalFilter filter array according to FilterNode
+func (j *JSONPath) evalFilter(input []reflect.Value, node *FilterNode) ([]reflect.Value, error) {
+	results := []reflect.Value{}
+	for _, value := range input {
+		value, _ = template.Indirect(value)
+
+		if value.Kind() != reflect.Array && value.Kind() != reflect.Slice {
+			return input, fmt.Errorf("%v is not array or slice and cannot be filtered", value)
+		}
+		for i := 0; i < value.Len(); i++ {
+			temp := []reflect.Value{value.Index(i)}
+			lefts, err := j.evalList(temp, node.Left)
+
+			//case exists
+			if node.Operator == "exists" {
+				if len(lefts) > 0 {
+					results = append(results, value.Index(i))
+				}
+				continue
+			}
+
+			if err != nil {
+				return input, err
+			}
+
+			var left, right interface{}
+			if len(lefts) != 1 {
+				return input, fmt.Errorf("can only compare one element at a time")
+			}
+			left = lefts[0].Interface()
+
+			rights, err := j.evalList(temp, node.Right)
+			if err != nil {
+				return input, err
+			}
+			if len(rights) != 1 {
+				return input, fmt.Errorf("can only compare one element at a time")
+			}
+			right = rights[0].Interface()
+
+			pass := false
+			switch node.Operator {
+			case "<":
+				pass, err = template.Less(left, right)
+			case ">":
+				pass, err = template.Greater(left, right)
+			case "==":
+				pass, err = template.Equal(left, right)
+			case "!=":
+				pass, err = template.NotEqual(left, right)
+			case "<=":
+				pass, err = template.LessEqual(left, right)
+			case ">=":
+				pass, err = template.GreaterEqual(left, right)
+			default:
+				return results, fmt.Errorf("unrecognized filter operator %s", node.Operator)
+			}
+			if err != nil {
+				return results, err
+			}
+			if pass {
+				results = append(results, value.Index(i))
+			}
+		}
+	}
+	return results, nil
+}
+
+// evalToText translates reflect value to corresponding text
+func (j *JSONPath) evalToText(v reflect.Value) ([]byte, error) {
+	iface, ok := template.PrintableValue(v)
+	if !ok {
+		return nil, fmt.Errorf("can't print type %s", v.Type())
+	}
+	var buffer bytes.Buffer
+	fmt.Fprint(&buffer, iface)
+	return buffer.Bytes(), nil
+}

--- a/vendor/k8s.io/client-go/util/jsonpath/node.go
+++ b/vendor/k8s.io/client-go/util/jsonpath/node.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jsonpath
+
+import "fmt"
+
+// NodeType identifies the type of a parse tree node.
+type NodeType int
+
+// Type returns itself and provides an easy default implementation
+func (t NodeType) Type() NodeType {
+	return t
+}
+
+func (t NodeType) String() string {
+	return NodeTypeName[t]
+}
+
+const (
+	NodeText NodeType = iota
+	NodeArray
+	NodeList
+	NodeField
+	NodeIdentifier
+	NodeFilter
+	NodeInt
+	NodeFloat
+	NodeWildcard
+	NodeRecursive
+	NodeUnion
+	NodeBool
+)
+
+var NodeTypeName = map[NodeType]string{
+	NodeText:       "NodeText",
+	NodeArray:      "NodeArray",
+	NodeList:       "NodeList",
+	NodeField:      "NodeField",
+	NodeIdentifier: "NodeIdentifier",
+	NodeFilter:     "NodeFilter",
+	NodeInt:        "NodeInt",
+	NodeFloat:      "NodeFloat",
+	NodeWildcard:   "NodeWildcard",
+	NodeRecursive:  "NodeRecursive",
+	NodeUnion:      "NodeUnion",
+	NodeBool:       "NodeBool",
+}
+
+type Node interface {
+	Type() NodeType
+	String() string
+}
+
+// ListNode holds a sequence of nodes.
+type ListNode struct {
+	NodeType
+	Nodes []Node // The element nodes in lexical order.
+}
+
+func newList() *ListNode {
+	return &ListNode{NodeType: NodeList}
+}
+
+func (l *ListNode) append(n Node) {
+	l.Nodes = append(l.Nodes, n)
+}
+
+func (l *ListNode) String() string {
+	return fmt.Sprintf("%s", l.Type())
+}
+
+// TextNode holds plain text.
+type TextNode struct {
+	NodeType
+	Text string // The text; may span newlines.
+}
+
+func newText(text string) *TextNode {
+	return &TextNode{NodeType: NodeText, Text: text}
+}
+
+func (t *TextNode) String() string {
+	return fmt.Sprintf("%s: %s", t.Type(), t.Text)
+}
+
+// FieldNode holds field of struct
+type FieldNode struct {
+	NodeType
+	Value string
+}
+
+func newField(value string) *FieldNode {
+	return &FieldNode{NodeType: NodeField, Value: value}
+}
+
+func (f *FieldNode) String() string {
+	return fmt.Sprintf("%s: %s", f.Type(), f.Value)
+}
+
+// IdentifierNode holds an identifier
+type IdentifierNode struct {
+	NodeType
+	Name string
+}
+
+func newIdentifier(value string) *IdentifierNode {
+	return &IdentifierNode{
+		NodeType: NodeIdentifier,
+		Name:     value,
+	}
+}
+
+func (f *IdentifierNode) String() string {
+	return fmt.Sprintf("%s: %s", f.Type(), f.Name)
+}
+
+// ParamsEntry holds param information for ArrayNode
+type ParamsEntry struct {
+	Value int
+	Known bool //whether the value is known when parse it
+}
+
+// ArrayNode holds start, end, step information for array index selection
+type ArrayNode struct {
+	NodeType
+	Params [3]ParamsEntry //start, end, step
+}
+
+func newArray(params [3]ParamsEntry) *ArrayNode {
+	return &ArrayNode{
+		NodeType: NodeArray,
+		Params:   params,
+	}
+}
+
+func (a *ArrayNode) String() string {
+	return fmt.Sprintf("%s: %v", a.Type(), a.Params)
+}
+
+// FilterNode holds operand and operator information for filter
+type FilterNode struct {
+	NodeType
+	Left     *ListNode
+	Right    *ListNode
+	Operator string
+}
+
+func newFilter(left, right *ListNode, operator string) *FilterNode {
+	return &FilterNode{
+		NodeType: NodeFilter,
+		Left:     left,
+		Right:    right,
+		Operator: operator,
+	}
+}
+
+func (f *FilterNode) String() string {
+	return fmt.Sprintf("%s: %s %s %s", f.Type(), f.Left, f.Operator, f.Right)
+}
+
+// IntNode holds integer value
+type IntNode struct {
+	NodeType
+	Value int
+}
+
+func newInt(num int) *IntNode {
+	return &IntNode{NodeType: NodeInt, Value: num}
+}
+
+func (i *IntNode) String() string {
+	return fmt.Sprintf("%s: %d", i.Type(), i.Value)
+}
+
+// FloatNode holds float value
+type FloatNode struct {
+	NodeType
+	Value float64
+}
+
+func newFloat(num float64) *FloatNode {
+	return &FloatNode{NodeType: NodeFloat, Value: num}
+}
+
+func (i *FloatNode) String() string {
+	return fmt.Sprintf("%s: %f", i.Type(), i.Value)
+}
+
+// WildcardNode means a wildcard
+type WildcardNode struct {
+	NodeType
+}
+
+func newWildcard() *WildcardNode {
+	return &WildcardNode{NodeType: NodeWildcard}
+}
+
+func (i *WildcardNode) String() string {
+	return fmt.Sprintf("%s", i.Type())
+}
+
+// RecursiveNode means a recursive descent operator
+type RecursiveNode struct {
+	NodeType
+}
+
+func newRecursive() *RecursiveNode {
+	return &RecursiveNode{NodeType: NodeRecursive}
+}
+
+func (r *RecursiveNode) String() string {
+	return fmt.Sprintf("%s", r.Type())
+}
+
+// UnionNode is union of ListNode
+type UnionNode struct {
+	NodeType
+	Nodes []*ListNode
+}
+
+func newUnion(nodes []*ListNode) *UnionNode {
+	return &UnionNode{NodeType: NodeUnion, Nodes: nodes}
+}
+
+func (u *UnionNode) String() string {
+	return fmt.Sprintf("%s", u.Type())
+}
+
+// BoolNode holds bool value
+type BoolNode struct {
+	NodeType
+	Value bool
+}
+
+func newBool(value bool) *BoolNode {
+	return &BoolNode{NodeType: NodeBool, Value: value}
+}
+
+func (b *BoolNode) String() string {
+	return fmt.Sprintf("%s: %t", b.Type(), b.Value)
+}

--- a/vendor/k8s.io/client-go/util/jsonpath/parser.go
+++ b/vendor/k8s.io/client-go/util/jsonpath/parser.go
@@ -1,0 +1,449 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jsonpath
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const eof = -1
+
+const (
+	leftDelim  = "{"
+	rightDelim = "}"
+)
+
+type Parser struct {
+	Name  string
+	Root  *ListNode
+	input string
+	cur   *ListNode
+	pos   int
+	start int
+	width int
+}
+
+// Parse parsed the given text and return a node Parser.
+// If an error is encountered, parsing stops and an empty
+// Parser is returned with the error
+func Parse(name, text string) (*Parser, error) {
+	p := NewParser(name)
+	err := p.Parse(text)
+	if err != nil {
+		p = nil
+	}
+	return p, err
+}
+
+func NewParser(name string) *Parser {
+	return &Parser{
+		Name: name,
+	}
+}
+
+// parseAction parsed the expression inside delimiter
+func parseAction(name, text string) (*Parser, error) {
+	p, err := Parse(name, fmt.Sprintf("%s%s%s", leftDelim, text, rightDelim))
+	// when error happens, p will be nil, so we need to return here
+	if err != nil {
+		return p, err
+	}
+	p.Root = p.Root.Nodes[0].(*ListNode)
+	return p, nil
+}
+
+func (p *Parser) Parse(text string) error {
+	p.input = text
+	p.Root = newList()
+	p.pos = 0
+	return p.parseText(p.Root)
+}
+
+// consumeText return the parsed text since last cosumeText
+func (p *Parser) consumeText() string {
+	value := p.input[p.start:p.pos]
+	p.start = p.pos
+	return value
+}
+
+// next returns the next rune in the input.
+func (p *Parser) next() rune {
+	if int(p.pos) >= len(p.input) {
+		p.width = 0
+		return eof
+	}
+	r, w := utf8.DecodeRuneInString(p.input[p.pos:])
+	p.width = w
+	p.pos += p.width
+	return r
+}
+
+// peek returns but does not consume the next rune in the input.
+func (p *Parser) peek() rune {
+	r := p.next()
+	p.backup()
+	return r
+}
+
+// backup steps back one rune. Can only be called once per call of next.
+func (p *Parser) backup() {
+	p.pos -= p.width
+}
+
+func (p *Parser) parseText(cur *ListNode) error {
+	for {
+		if strings.HasPrefix(p.input[p.pos:], leftDelim) {
+			if p.pos > p.start {
+				cur.append(newText(p.consumeText()))
+			}
+			return p.parseLeftDelim(cur)
+		}
+		if p.next() == eof {
+			break
+		}
+	}
+	// Correctly reached EOF.
+	if p.pos > p.start {
+		cur.append(newText(p.consumeText()))
+	}
+	return nil
+}
+
+// parseLeftDelim scans the left delimiter, which is known to be present.
+func (p *Parser) parseLeftDelim(cur *ListNode) error {
+	p.pos += len(leftDelim)
+	p.consumeText()
+	newNode := newList()
+	cur.append(newNode)
+	cur = newNode
+	return p.parseInsideAction(cur)
+}
+
+func (p *Parser) parseInsideAction(cur *ListNode) error {
+	prefixMap := map[string]func(*ListNode) error{
+		rightDelim: p.parseRightDelim,
+		"[?(":      p.parseFilter,
+		"..":       p.parseRecursive,
+	}
+	for prefix, parseFunc := range prefixMap {
+		if strings.HasPrefix(p.input[p.pos:], prefix) {
+			return parseFunc(cur)
+		}
+	}
+
+	switch r := p.next(); {
+	case r == eof || isEndOfLine(r):
+		return fmt.Errorf("unclosed action")
+	case r == ' ':
+		p.consumeText()
+	case r == '@' || r == '$': //the current object, just pass it
+		p.consumeText()
+	case r == '[':
+		return p.parseArray(cur)
+	case r == '"':
+		return p.parseQuote(cur)
+	case r == '.':
+		return p.parseField(cur)
+	case r == '+' || r == '-' || unicode.IsDigit(r):
+		p.backup()
+		return p.parseNumber(cur)
+	case isAlphaNumeric(r):
+		p.backup()
+		return p.parseIdentifier(cur)
+	default:
+		return fmt.Errorf("unrecognized character in action: %#U", r)
+	}
+	return p.parseInsideAction(cur)
+}
+
+// parseRightDelim scans the right delimiter, which is known to be present.
+func (p *Parser) parseRightDelim(cur *ListNode) error {
+	p.pos += len(rightDelim)
+	p.consumeText()
+	cur = p.Root
+	return p.parseText(cur)
+}
+
+// parseIdentifier scans build-in keywords, like "range" "end"
+func (p *Parser) parseIdentifier(cur *ListNode) error {
+	var r rune
+	for {
+		r = p.next()
+		if isTerminator(r) {
+			p.backup()
+			break
+		}
+	}
+	value := p.consumeText()
+
+	if isBool(value) {
+		v, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("can not parse bool '%s': %s", value, err.Error())
+		}
+
+		cur.append(newBool(v))
+	} else {
+		cur.append(newIdentifier(value))
+	}
+
+	return p.parseInsideAction(cur)
+}
+
+// parseRecursive scans the recursive desent operator ..
+func (p *Parser) parseRecursive(cur *ListNode) error {
+	p.pos += len("..")
+	p.consumeText()
+	cur.append(newRecursive())
+	if r := p.peek(); isAlphaNumeric(r) {
+		return p.parseField(cur)
+	}
+	return p.parseInsideAction(cur)
+}
+
+// parseNumber scans number
+func (p *Parser) parseNumber(cur *ListNode) error {
+	r := p.peek()
+	if r == '+' || r == '-' {
+		r = p.next()
+	}
+	for {
+		r = p.next()
+		if r != '.' && !unicode.IsDigit(r) {
+			p.backup()
+			break
+		}
+	}
+	value := p.consumeText()
+	i, err := strconv.Atoi(value)
+	if err == nil {
+		cur.append(newInt(i))
+		return p.parseInsideAction(cur)
+	}
+	d, err := strconv.ParseFloat(value, 64)
+	if err == nil {
+		cur.append(newFloat(d))
+		return p.parseInsideAction(cur)
+	}
+	return fmt.Errorf("cannot parse number %s", value)
+}
+
+// parseArray scans array index selection
+func (p *Parser) parseArray(cur *ListNode) error {
+Loop:
+	for {
+		switch p.next() {
+		case eof, '\n':
+			return fmt.Errorf("unterminated array")
+		case ']':
+			break Loop
+		}
+	}
+	text := p.consumeText()
+	text = string(text[1 : len(text)-1])
+	if text == "*" {
+		text = ":"
+	}
+
+	//union operator
+	strs := strings.Split(text, ",")
+	if len(strs) > 1 {
+		union := []*ListNode{}
+		for _, str := range strs {
+			parser, err := parseAction("union", fmt.Sprintf("[%s]", strings.Trim(str, " ")))
+			if err != nil {
+				return err
+			}
+			union = append(union, parser.Root)
+		}
+		cur.append(newUnion(union))
+		return p.parseInsideAction(cur)
+	}
+
+	// dict key
+	reg := regexp.MustCompile(`^'([^']*)'$`)
+	value := reg.FindStringSubmatch(text)
+	if value != nil {
+		parser, err := parseAction("arraydict", fmt.Sprintf(".%s", value[1]))
+		if err != nil {
+			return err
+		}
+		for _, node := range parser.Root.Nodes {
+			cur.append(node)
+		}
+		return p.parseInsideAction(cur)
+	}
+
+	//slice operator
+	reg = regexp.MustCompile(`^(-?[\d]*)(:-?[\d]*)?(:[\d]*)?$`)
+	value = reg.FindStringSubmatch(text)
+	if value == nil {
+		return fmt.Errorf("invalid array index %s", text)
+	}
+	value = value[1:]
+	params := [3]ParamsEntry{}
+	for i := 0; i < 3; i++ {
+		if value[i] != "" {
+			if i > 0 {
+				value[i] = value[i][1:]
+			}
+			if i > 0 && value[i] == "" {
+				params[i].Known = false
+			} else {
+				var err error
+				params[i].Known = true
+				params[i].Value, err = strconv.Atoi(value[i])
+				if err != nil {
+					return fmt.Errorf("array index %s is not a number", value[i])
+				}
+			}
+		} else {
+			if i == 1 {
+				params[i].Known = true
+				params[i].Value = params[0].Value + 1
+			} else {
+				params[i].Known = false
+				params[i].Value = 0
+			}
+		}
+	}
+	cur.append(newArray(params))
+	return p.parseInsideAction(cur)
+}
+
+// parseFilter scans filter inside array selection
+func (p *Parser) parseFilter(cur *ListNode) error {
+	p.pos += len("[?(")
+	p.consumeText()
+Loop:
+	for {
+		switch p.next() {
+		case eof, '\n':
+			return fmt.Errorf("unterminated filter")
+		case ')':
+			break Loop
+		}
+	}
+	if p.next() != ']' {
+		return fmt.Errorf("unclosed array expect ]")
+	}
+	reg := regexp.MustCompile(`^([^!<>=]+)([!<>=]+)(.+?)$`)
+	text := p.consumeText()
+	text = string(text[:len(text)-2])
+	value := reg.FindStringSubmatch(text)
+	if value == nil {
+		parser, err := parseAction("text", text)
+		if err != nil {
+			return err
+		}
+		cur.append(newFilter(parser.Root, newList(), "exists"))
+	} else {
+		leftParser, err := parseAction("left", value[1])
+		if err != nil {
+			return err
+		}
+		rightParser, err := parseAction("right", value[3])
+		if err != nil {
+			return err
+		}
+		cur.append(newFilter(leftParser.Root, rightParser.Root, value[2]))
+	}
+	return p.parseInsideAction(cur)
+}
+
+// parseQuote unquotes string inside double quote
+func (p *Parser) parseQuote(cur *ListNode) error {
+Loop:
+	for {
+		switch p.next() {
+		case eof, '\n':
+			return fmt.Errorf("unterminated quoted string")
+		case '"':
+			break Loop
+		}
+	}
+	value := p.consumeText()
+	s, err := strconv.Unquote(value)
+	if err != nil {
+		return fmt.Errorf("unquote string %s error %v", value, err)
+	}
+	cur.append(newText(s))
+	return p.parseInsideAction(cur)
+}
+
+// parseField scans a field until a terminator
+func (p *Parser) parseField(cur *ListNode) error {
+	p.consumeText()
+	for p.advance() {
+	}
+	value := p.consumeText()
+	if value == "*" {
+		cur.append(newWildcard())
+	} else {
+		cur.append(newField(strings.Replace(value, "\\", "", -1)))
+	}
+	return p.parseInsideAction(cur)
+}
+
+// advance scans until next non-escaped terminator
+func (p *Parser) advance() bool {
+	r := p.next()
+	if r == '\\' {
+		p.next()
+	} else if isTerminator(r) {
+		p.backup()
+		return false
+	}
+	return true
+}
+
+// isTerminator reports whether the input is at valid termination character to appear after an identifier.
+func isTerminator(r rune) bool {
+	if isSpace(r) || isEndOfLine(r) {
+		return true
+	}
+	switch r {
+	case eof, '.', ',', '[', ']', '$', '@', '{', '}':
+		return true
+	}
+	return false
+}
+
+// isSpace reports whether r is a space character.
+func isSpace(r rune) bool {
+	return r == ' ' || r == '\t'
+}
+
+// isEndOfLine reports whether r is an end-of-line character.
+func isEndOfLine(r rune) bool {
+	return r == '\r' || r == '\n'
+}
+
+// isAlphaNumeric reports whether r is an alphabetic, digit, or underscore.
+func isAlphaNumeric(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+// isBool reports whether s is a boolean value.
+func isBool(s string) bool {
+	return s == "true" || s == "false"
+}


### PR DESCRIPTION
This commit updates some cmd commands, to support json output and
jsonpath queries. The example command output is the following:

```
$/home/ecoto# kubectl -n kube-system exec -ti cilium-fhcs4 -- cilium service list --json
[{"ID":1,"FrontendAddress":"10.96.0.10:53","BackendAddresses":["1 =\u003e 10.2.42.252:53"]},{"ID":2,"FrontendAddress":"10.96.0.1:443","BackendAddresses":["1 =\u003e 172.16.0.2:6443"]}]
$master:/home/ecoto# kubectl -n kube-system exec -ti cilium-fhcs4 -- cilium service list --jsonpath  '{[0].ID}'
1
```

- Two helpers functions were added:
    - AddJsonSupport: to enable both flags in the command definition.
    - DumpJson: function to dump the full json or execute the jsonPath query.
- Some cmd commands were refactoring to provide a consistent output to
  json and simple text.

- A new dependency was added: vendor/k8s.io/client-go/util/jsonpath/

This commit fixes #1448

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>