### PR TITLE
Golint fixes, removed dead code

### DIFF
--- a/pkg/apierror/doc.go
+++ b/pkg/apierror/doc.go
@@ -1,3 +1,3 @@
-/*Package API Error representation
+/*Package apierror representation
  */
 package apierror

--- a/pkg/bpf/perf.go
+++ b/pkg/bpf/perf.go
@@ -458,7 +458,7 @@ func NewPerCpuEvents(config *PerfEventConfig) (*PerCpuEvents, error) {
 		}
 		e.event[event.Fd] = event
 
-		if err := e.poll.AddFD(event.Fd, unix.EPOLLIN); err != nil {
+		if err = e.poll.AddFD(event.Fd, unix.EPOLLIN); err != nil {
 			return nil, err
 		}
 

--- a/pkg/bpfdebug/debug.go
+++ b/pkg/bpfdebug/debug.go
@@ -413,7 +413,7 @@ func (n *DebugCapture) DumpInfo(data []byte) {
 
 }
 
-// Dump prints the captured packet in human readable format
+// DumpVerbose prints the captured packet in human readable format
 func (n *DebugCapture) DumpVerbose(dissect bool, data []byte, prefix string) {
 	fmt.Printf("%s MARK %#x FROM %d DEBUG: %d bytes ", prefix, n.Hash, n.Source, n.Len)
 	switch n.SubType {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -98,13 +98,13 @@ func (e *Endpoint) writeL4Policy(fw *bufio.Writer, owner Owner) error {
 		return nil
 	}
 
-	policy := e.Consumable.L4Policy
+	l4policy := e.Consumable.L4Policy
 
-	if err := e.writeL4Map(fw, owner, policy.Ingress, "CFG_L4_INGRESS"); err != nil {
+	if err := e.writeL4Map(fw, owner, l4policy.Ingress, "CFG_L4_INGRESS"); err != nil {
 		return err
 	}
 
-	if err := e.writeL4Map(fw, owner, policy.Egress, "CFG_L4_EGRESS"); err != nil {
+	if err := e.writeL4Map(fw, owner, l4policy.Egress, "CFG_L4_EGRESS"); err != nil {
 		return err
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -958,20 +958,20 @@ func (e *Endpoint) CallsMapPathLocked() string {
 	return CallsMapPath(int(e.ID))
 }
 
+// Ct6MapPath returns the path to IPv6 connection tracking map of endpoint.
 func Ct6MapPath(id int) string {
 	return bpf.MapPath(ctmap.MapName6 + strconv.Itoa(id))
 }
 
-// Ct6MapPath returns the path to IPv6 connection tracking map of endpoint.
 func (e *Endpoint) Ct6MapPathLocked() string {
 	return Ct6MapPath(int(e.ID))
 }
 
+// Ct4MapPath returns the path to IPv4 connection tracking map of endpoint.
 func Ct4MapPath(id int) string {
 	return bpf.MapPath(ctmap.MapName4 + strconv.Itoa(id))
 }
 
-// Ct4MapPath returns the path to IPv4 connection tracking map of endpoint.
 func (e *Endpoint) Ct4MapPathLocked() string {
 	return Ct4MapPath(int(e.ID))
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -124,9 +124,8 @@ var (
 		Verify: func(key string, val bool) error {
 			if !IPv4Enabled {
 				return fmt.Errorf("NAT46 requires IPv4 to be enabled")
-			} else {
-				return nil
 			}
+			return nil
 		},
 	}
 

--- a/pkg/geneve/geneve.go
+++ b/pkg/geneve/geneve.go
@@ -76,7 +76,7 @@ func ReadOpts(filePath string) (geneveOpts []GeneveTlv, rawData []byte, err erro
 			return nil, nil, fmt.Errorf("Geneve tlv %d validation failed %x %x %x", tlvCount, geneveTlv.optClass, geneveTlv.optType, geneveTlv.optLen)
 		}
 
-		tlvCount += 1
+		tlvCount++
 	}
 	return geneveOpts, rawData, nil
 }

--- a/pkg/kvstore/config.go
+++ b/pkg/kvstore/config.go
@@ -128,7 +128,7 @@ func Setup(selectedBackend string, opts map[string]string) error {
 			}
 
 		case "":
-			err = fmt.Errorf("kvstore not configured. Please specify --kvstore. See http://cilium.link/err-kvstore for details.")
+			err = fmt.Errorf("kvstore not configured. Please specify --kvstore. See http://cilium.link/err-kvstore for details")
 			return
 
 		default:

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -39,7 +39,7 @@ const (
 	MaxLockRetries = 10
 )
 
-// / ConsulOpts is the set of supported options for Consul configuration.
+// ConsulOpts is the set of supported options for Consul configuration.
 var ConsulOpts = map[string]bool{
 	cAddr: true,
 }

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -293,7 +293,7 @@ func (c *ConsulClient) GASNewSecLabelID(basePath string, baseID uint32, pI *poli
 			*incID = policy.MinimalNumericIdentity.Uint32()
 		}
 		if firstID == *incID {
-			return false, fmt.Errorf("reached maximum set of labels available.")
+			return false, fmt.Errorf("reached maximum set of labels available")
 		}
 		return true, nil
 	}
@@ -361,7 +361,7 @@ func (c *ConsulClient) GASNewL3n4AddrID(basePath string, baseID uint32, lAddrID 
 			*incID = common.FirstFreeServiceID
 		}
 		if firstID == *incID {
-			return false, fmt.Errorf("reached maximum set of serviceIDs available.")
+			return false, fmt.Errorf("reached maximum set of serviceIDs available")
 		}
 		// Only retry if we have incremented the service ID
 		return true, nil

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -249,12 +249,12 @@ func (e *EtcdClient) GetMaxID(key string, firstID uint32) (uint32, error) {
 		case err != nil:
 			return 0, err
 		case value == nil:
-			if err := e.InitializeFreeID(key, firstID); err != nil {
+			if err = e.InitializeFreeID(key, firstID); err != nil {
 				return 0, err
 			}
 			attempts--
 		case err == nil:
-			if err := json.Unmarshal(value, &freeID); err != nil {
+			if err = json.Unmarshal(value, &freeID); err != nil {
 				return 0, err
 			}
 			return freeID, nil

--- a/pkg/kvstore/events_tests.go
+++ b/pkg/kvstore/events_tests.go
@@ -31,12 +31,6 @@ func (s *KvstoreSuite) SetUpTest(c *C) {
 	SetupDummy()
 }
 
-func drainEvents(w *Watcher) {
-	for len(w.Events) > 0 {
-		<-w.Events
-	}
-}
-
 func expectEvent(c *C, w *Watcher, typ EventType, key string, val []byte) {
 	log.WithFields(log.Fields{
 		"type":  typ,

--- a/pkg/kvstore/logfields.go
+++ b/pkg/kvstore/logfields.go
@@ -24,9 +24,6 @@ const (
 	// fieldListAndWatch is true when ListAndWatch is used instead of Watch
 	fieldListAndWatch = "list"
 
-	// fieldTrace is true when the message is a kvstore trace message
-	fieldTrace = "trace"
-
 	// fieldSession refers to a connection/session with the kvstore
 	fieldSession = "session"
 

--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -102,7 +102,7 @@ func parseLabelPrefix(label string) (*LabelPrefix, error) {
 func ParseLabelPrefixCfg(prefixes []string, file string) (*LabelPrefixCfg, error) {
 	cfg, err := readLabelPrefixCfgFrom(file)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to read label prefix file: %s\n", err)
+		return nil, fmt.Errorf("Unable to read label prefix file: %s", err)
 	}
 
 	for _, label := range prefixes {

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -173,11 +173,11 @@ func Service4DumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue, err
 	svcVal := Service4Value{}
 
 	if err := binary.Read(keyBuf, byteorder.Native, &svcKey); err != nil {
-		return nil, nil, fmt.Errorf("Unable to convert key: %s\n", err)
+		return nil, nil, fmt.Errorf("Unable to convert key: %s", err)
 	}
 
 	if err := binary.Read(valueBuf, byteorder.Native, &svcVal); err != nil {
-		return nil, nil, fmt.Errorf("Unable to convert key: %s\n", err)
+		return nil, nil, fmt.Errorf("Unable to convert key: %s", err)
 	}
 
 	return svcKey.ToNetwork(), svcVal.ToNetwork(), nil
@@ -190,11 +190,11 @@ func Service4RRSeqDumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue
 	svcVal := RRSeqValue{}
 
 	if err := binary.Read(keyBuf, byteorder.Native, &svcKey); err != nil {
-		return nil, nil, fmt.Errorf("Unable to convert key: %s\n", err)
+		return nil, nil, fmt.Errorf("Unable to convert key: %s", err)
 	}
 
 	if err := binary.Read(valueBuf, byteorder.Native, &svcVal); err != nil {
-		return nil, nil, fmt.Errorf("Unable to convert value: %s\n", err)
+		return nil, nil, fmt.Errorf("Unable to convert value: %s", err)
 	}
 
 	return svcKey.ToNetwork(), &svcVal, nil
@@ -258,12 +258,12 @@ func RevNat4DumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue, erro
 	valueBuf := bytes.NewBuffer(value)
 
 	if err := binary.Read(keyBuf, byteorder.Native, &ukey); err != nil {
-		return nil, nil, fmt.Errorf("Unable to convert key: %s\n", err)
+		return nil, nil, fmt.Errorf("Unable to convert key: %s", err)
 	}
 	revKey := NewRevNat4Key(ukey)
 
 	if err := binary.Read(valueBuf, byteorder.Native, &revNat); err != nil {
-		return nil, nil, fmt.Errorf("Unable to convert value: %s\n", err)
+		return nil, nil, fmt.Errorf("Unable to convert value: %s", err)
 	}
 
 	return revKey.ToNetwork(), revNat.ToNetwork(), nil

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -166,11 +166,11 @@ func Service6DumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue, err
 	svcVal := Service6Value{}
 
 	if err := binary.Read(keyBuf, byteorder.Native, &svcKey); err != nil {
-		return nil, nil, fmt.Errorf("Unable to convert key: %s\n", err)
+		return nil, nil, fmt.Errorf("Unable to convert key: %s", err)
 	}
 
 	if err := binary.Read(valueBuf, byteorder.Native, &svcVal); err != nil {
-		return nil, nil, fmt.Errorf("Unable to convert value: %s\n", err)
+		return nil, nil, fmt.Errorf("Unable to convert value: %s", err)
 	}
 
 	return svcKey.ToNetwork(), svcVal.ToNetwork(), nil
@@ -183,11 +183,11 @@ func Service6RRSeqDumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue
 	svcVal := RRSeqValue{}
 
 	if err := binary.Read(keyBuf, byteorder.Native, &svcKey); err != nil {
-		return nil, nil, fmt.Errorf("Unable to convert key: %s\n", err)
+		return nil, nil, fmt.Errorf("Unable to convert key: %s", err)
 	}
 
 	if err := binary.Read(valueBuf, byteorder.Native, &svcVal); err != nil {
-		return nil, nil, fmt.Errorf("Unable to convert key: %s\n", err)
+		return nil, nil, fmt.Errorf("Unable to convert key: %s", err)
 	}
 
 	return svcKey.ToNetwork(), svcVal, nil
@@ -248,12 +248,12 @@ func RevNat6DumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue, erro
 	valueBuf := bytes.NewBuffer(value)
 
 	if err := binary.Read(keyBuf, byteorder.Native, &ukey); err != nil {
-		return nil, nil, fmt.Errorf("Unable to convert key: %s\n", err)
+		return nil, nil, fmt.Errorf("Unable to convert key: %s", err)
 	}
 	revKey := NewRevNat6Key(ukey)
 
 	if err := binary.Read(valueBuf, byteorder.Native, &revNat); err != nil {
-		return nil, nil, fmt.Errorf("Unable to convert value: %s\n", err)
+		return nil, nil, fmt.Errorf("Unable to convert value: %s", err)
 	}
 
 	return revKey.ToNetwork(), revNat.ToNetwork(), nil

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -320,7 +320,7 @@ func AddSVC2BPFMap(fe ServiceKey, besValues []ServiceValue, addRevNAT bool, revN
 		if be.GetWeight() != 0 {
 			nNonZeroWeights++
 		}
-		if err := UpdateService(fe, be); err != nil {
+		if err = UpdateService(fe, be); err != nil {
 			return fmt.Errorf("unable to update service %+v with the value %+v: %s", fe, be, err)
 		}
 		nSvcs++

--- a/pkg/maps/tunnel/tunnel.go
+++ b/pkg/maps/tunnel/tunnel.go
@@ -101,11 +101,11 @@ func dumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue, error) {
 	k, v := tunnelEndpoint{}, tunnelEndpoint{}
 
 	if err := binary.Read(bytes.NewBuffer(key), byteorder.Native, &k); err != nil {
-		return nil, nil, fmt.Errorf("Unable to convert key: %s\n", err)
+		return nil, nil, fmt.Errorf("Unable to convert key: %s", err)
 	}
 
 	if err := binary.Read(bytes.NewBuffer(value), byteorder.Native, &v); err != nil {
-		return nil, nil, fmt.Errorf("Unable to convert key: %s\n", err)
+		return nil, nil, fmt.Errorf("Unable to convert key: %s", err)
 	}
 
 	return k, v, nil

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -124,7 +124,7 @@ func (cidr CIDR) Validate() error {
 		// Returns the prefix length as zero if the mask is not continuous.
 		ones, _ := ipnet.Mask.Size()
 		if ones == 0 {
-			return fmt.Errorf("Mask length can not be zero.")
+			return fmt.Errorf("Mask length can not be zero")
 		}
 	} else {
 		// Try to parse as a fully masked IP or an IP subnetwork

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -542,11 +542,10 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, source Pr
 				p.mutex.Unlock()
 				accesslog.Log(record, accesslog.TypeRequest, accesslog.VerdictDenied, http.StatusForbidden)
 				return
-			} else {
-				ar := rule.(policy.AuxRule)
-				log.Debugf("Allowing request based on rule %+v", ar)
-				record.Info = fmt.Sprintf("rule: %+v", ar)
 			}
+			ar := rule.(policy.AuxRule)
+			log.Debugf("Allowing request based on rule %+v", ar)
+			record.Info = fmt.Sprintf("rule: %+v", ar)
 		}
 		p.mutex.Unlock()
 
@@ -625,16 +624,16 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, source Pr
 func (p *Proxy) RemoveRedirect(id string) error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
-
-	if r, ok := p.redirects[id]; !ok {
+	r, ok := p.redirects[id]
+	if !ok {
 		return fmt.Errorf("unable to find redirect %s", id)
-	} else {
-		log.Debugf("removing proxy redirect %s", id)
-		r.server.Close()
-
-		delete(p.redirects, r.id)
-		delete(p.allocatedPorts, r.ToPort)
 	}
+
+	log.Debugf("removing proxy redirect %s", id)
+	r.server.Close()
+
+	delete(p.redirects, r.id)
+	delete(p.allocatedPorts, r.ToPort)
 
 	return nil
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -390,7 +390,7 @@ func listenSocket(address string, mark int) (net.Listener, error) {
 		return nil, err
 	}
 
-	if err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {
+	if err = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {
 		return nil, fmt.Errorf("unable to set SO_REUSEADDR socket option: %s", err)
 	}
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -210,11 +210,11 @@ func lookupNewDest(req *http.Request, dport uint16) (uint32, string, error) {
 }
 
 func generateURL(req *http.Request, hostport string) *url.URL {
-	newUrl := *req.URL
-	newUrl.Scheme = "http"
-	newUrl.Host = hostport
+	newURL := *req.URL
+	newURL.Scheme = "http"
+	newURL.Host = hostport
 
-	return &newUrl
+	return &newURL
 }
 
 var gcOnce sync.Once

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -352,28 +352,6 @@ func setSocketMark(c net.Conn, mark int) {
 	}
 }
 
-func getSocketMark(c net.Conn) int {
-	if tc, ok := c.(*net.TCPConn); ok {
-		if f, err := tc.File(); err == nil {
-			defer f.Close()
-			fd := int(f.Fd())
-
-			val, err := syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_MARK)
-			if err != nil {
-				log.WithFields(log.Fields{
-					fieldSocket: tc,
-				}).WithError(err).Warning("Unable to retrieve SO_MARK")
-
-				return 0
-			}
-
-			return val
-		}
-	}
-
-	return 0
-}
-
 func listenSocket(address string, mark int) (net.Listener, error) {
 	addr, err := net.ResolveTCPAddr("tcp", address)
 	if err != nil {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -317,7 +317,9 @@ func (r *Redirect) getDestinationInfo(dstIPPort string) accesslog.EndpointInfo {
 	return info
 }
 
-const identityKey int = 0
+type proxyIdentity int
+
+const identityKey proxyIdentity = 0
 
 func newIdentityContext(ctx context.Context, id int) context.Context {
 	return context.WithValue(ctx, identityKey, id)

--- a/pkg/proxy/proxy6map.go
+++ b/pkg/proxy/proxy6map.go
@@ -135,30 +135,6 @@ func Dump6(cb bpf.DumpCallback) error {
 	return proxy6Map.Dump(proxy6DumpParser, cb)
 }
 
-func doGc6(interval uint16, key unsafe.Pointer, nextKey unsafe.Pointer, deleted *int) bool {
-	var entry Proxy6Value
-
-	err := bpf.GetNextKey(proxy6Map.GetFd(), key, nextKey)
-	if err != nil {
-		return false
-	}
-
-	err = bpf.LookupElement(proxy6Map.GetFd(), nextKey, unsafe.Pointer(&entry))
-	if err != nil {
-		return false
-	}
-
-	if entry.Lifetime <= interval {
-		bpf.DeleteElement(proxy6Map.GetFd(), nextKey)
-		(*deleted)++
-	} else {
-		entry.Lifetime -= interval
-		bpf.UpdateElement(proxy6Map.GetFd(), nextKey, unsafe.Pointer(&entry), 0)
-	}
-
-	return true
-}
-
 func GC6() int {
 	deleted := 0
 

--- a/pkg/proxy/proxy6map.go
+++ b/pkg/proxy/proxy6map.go
@@ -117,11 +117,11 @@ func proxy6DumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue, error
 	v := Proxy6Value{}
 
 	if err := binary.Read(keyBuf, byteorder.Native, &k); err != nil {
-		return nil, nil, fmt.Errorf("Unable to convert key: %s\n", err)
+		return nil, nil, fmt.Errorf("Unable to convert key: %s", err)
 	}
 
 	if err := binary.Read(valueBuf, byteorder.Native, &v); err != nil {
-		return nil, nil, fmt.Errorf("Unable to convert key: %s\n", err)
+		return nil, nil, fmt.Errorf("Unable to convert key: %s", err)
 	}
 
 	return k.ToNetwork(), v.ToNetwork(), nil

--- a/pkg/proxy/proxy6map.go
+++ b/pkg/proxy/proxy6map.go
@@ -35,6 +35,7 @@ type Proxy6Key struct {
 	Pad     uint8
 }
 
+// HostPort returns host port for provided proxy key
 func (k *Proxy6Key) HostPort() string {
 	portStr := strconv.FormatUint(uint64(k.SPort), 10)
 	return net.JoinHostPort(k.SAddr.IP().String(), portStr)

--- a/pkg/proxy/proxy6map.go
+++ b/pkg/proxy/proxy6map.go
@@ -47,9 +47,9 @@ type Proxy6Value struct {
 	SourceIdentity uint32
 }
 
-func (p *Proxy6Value) HostPort() string {
-	portStr := strconv.FormatUint(uint64(p.OrigDPort), 10)
-	return net.JoinHostPort(p.OrigDAddr.IP().String(), portStr)
+func (v *Proxy6Value) HostPort() string {
+	portStr := strconv.FormatUint(uint64(v.OrigDPort), 10)
+	return net.JoinHostPort(v.OrigDAddr.IP().String(), portStr)
 }
 
 var (
@@ -89,8 +89,8 @@ func (v *Proxy6Value) GetValuePtr() unsafe.Pointer {
 }
 
 // ToNetwork converts Proxy6Value to network byte order.
-func (p *Proxy6Value) ToNetwork() *Proxy6Value {
-	n := *p
+func (v *Proxy6Value) ToNetwork() *Proxy6Value {
+	n := *v
 	n.OrigDPort = byteorder.HostToNetwork(n.OrigDPort).(uint16)
 	return &n
 }

--- a/pkg/proxy/proxymap.go
+++ b/pkg/proxy/proxymap.go
@@ -47,9 +47,9 @@ type Proxy4Value struct {
 	SourceIdentity uint32
 }
 
-func (p *Proxy4Value) HostPort() string {
-	portStr := strconv.FormatUint(uint64(p.OrigDPort), 10)
-	return net.JoinHostPort(p.OrigDAddr.IP().String(), portStr)
+func (v *Proxy4Value) HostPort() string {
+	portStr := strconv.FormatUint(uint64(v.OrigDPort), 10)
+	return net.JoinHostPort(v.OrigDAddr.IP().String(), portStr)
 }
 
 var (
@@ -89,8 +89,8 @@ func (v *Proxy4Value) GetValuePtr() unsafe.Pointer {
 }
 
 // ToNetwork converts Proxy4Value to network byte order.
-func (p *Proxy4Value) ToNetwork() *Proxy4Value {
-	n := *p
+func (v *Proxy4Value) ToNetwork() *Proxy4Value {
+	n := *v
 	n.OrigDPort = byteorder.HostToNetwork(n.OrigDPort).(uint16)
 	return &n
 }

--- a/pkg/proxy/proxymap.go
+++ b/pkg/proxy/proxymap.go
@@ -117,11 +117,11 @@ func proxy4DumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue, error
 	v := Proxy4Value{}
 
 	if err := binary.Read(keyBuf, byteorder.Native, &k); err != nil {
-		return nil, nil, fmt.Errorf("Unable to convert key: %s\n", err)
+		return nil, nil, fmt.Errorf("Unable to convert key: %s", err)
 	}
 
 	if err := binary.Read(valueBuf, byteorder.Native, &v); err != nil {
-		return nil, nil, fmt.Errorf("Unable to convert key: %s\n", err)
+		return nil, nil, fmt.Errorf("Unable to convert key: %s", err)
 	}
 
 	return k.ToNetwork(), v.ToNetwork(), nil

--- a/pkg/proxy/proxymap.go
+++ b/pkg/proxy/proxymap.go
@@ -35,6 +35,7 @@ type Proxy4Key struct {
 	Pad     uint8
 }
 
+// HostPort returns host port for provided proxy key
 func (k *Proxy4Key) HostPort() string {
 	portStr := strconv.FormatUint(uint64(k.SPort), 10)
 	return net.JoinHostPort(k.SAddr.IP().String(), portStr)


### PR DESCRIPTION
Fixed golint fixes that seemed fixable.
Fixed several shadowed occurences.
Fixed comment format
Fixed error formatting (removed punctuation and newlines from the end of
error messages)
Capitalised abbreviations in local variable names (didn't touch exported
types)
Removed dead code occurences
Changed receiver identifiers to be consistent in proxy package

Signed-off-by: Maciej Kwiek <maciej@covalent.io>

related: #153