### PR TITLE
pkg/bpf: avoid leaking C strings

### DIFF
--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -14,6 +14,7 @@
 
 package bpf
 
+// #include <stdlib.h>
 import "C"
 
 import (
@@ -217,6 +218,7 @@ type bpfAttrObjOp struct {
 // ObjPin stores the map's fd in pathname.
 func ObjPin(fd int, pathname string) error {
 	pathStr := C.CString(pathname)
+	defer C.free(unsafe.Pointer(pathStr))
 	uba := bpfAttrObjOp{
 		pathname: uint64(uintptr(unsafe.Pointer(pathStr))),
 		fd:       uint32(fd),
@@ -239,6 +241,7 @@ func ObjPin(fd int, pathname string) error {
 // ObjGet reads the pathname and returns the map's fd read.
 func ObjGet(pathname string) (int, error) {
 	pathStr := C.CString(pathname)
+	defer C.free(unsafe.Pointer(pathStr))
 	uba := bpfAttrObjOp{
 		pathname: uint64(uintptr(unsafe.Pointer(pathStr))),
 	}


### PR DESCRIPTION
C strings created using C.CString are allocated in the C heap using
malloc. It is the callers responsibility to free them. See
https://golang.org/cmd/cgo/#hdr-Go_references_to_C for details.

Avoid leaking C strings in bpf.ObjPin and bpf.ObjGet by calling C.free
accordingly.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>