### PR TITLE
Fix for maintainer label

### DIFF
--- a/contrib/packaging/rpm/cfg/Dockerfile
+++ b/contrib/packaging/rpm/cfg/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:25
 
-LABEL "Maintainer: Marcin Skarbek <marcin@skarbek.name>"
+LABEL maintainer "Marcin Skarbek <marcin@skarbek.name>"
 
 RUN echo "deltarpm=0" >> /etc/dnf/dnf.conf &&\
     curl -o /etc/yum.repos.d/mskarbek-golang-for-cilium-fedora-25.repo https://copr.fedorainfracloud.org/coprs/mskarbek/golang-for-cilium/repo/fedora-25/mskarbek-golang-for-cilium-fedora-25.repo &&\


### PR DESCRIPTION
Trivial fix, currently running `make build-rpm` errors out with the following:
```
make -C ./contrib/packaging/rpm
ls -d ./* | grep -vE Makefile\|cfg | xargs rm -f -rf
ls -d ./cfg/* | grep -vE Dockerfile\|create-rpm.sh\|cilium.spec.envsubst | xargs rm -f -rf
Sending build context to Docker daemon  8.625MB
Step 1/5 : FROM fedora:25
25: Pulling from library/fedora
351efb9803b9: Pull complete 
Digest: sha256:b81261b520b89755b4ab522be6110081ddfeb02c99f0f3c343da435af0064e41
Status: Downloaded newer image for fedora:25
 ---> 2e646412cd0b
failed to process "\"Maintainer:": unexpected end of statement while looking for matching double-quote
make[1]: *** [Makefile:11: build] Error 1
```