### PR TITLE
tests/00-fmt: trim git directory from find

### DIFF
--- a/tests/00-fmt.sh
+++ b/tests/00-fmt.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-diff="$(find . ! \( -path './vendor' -prune \) ! -samefile ./daemon/bindata.go -type f -name '*.go' -print0 | xargs -0 gofmt -d -l -s )"
+diff="$(find . ! \( -path './vendor' -prune \) ! \( -path './.git' -prune \) ! -samefile ./daemon/bindata.go -type f -name '*.go' -print0 | xargs -0 gofmt -d -l -s )"
 
 if [ -n "$diff" ]; then
 	echo "Unformatted Go source code:"


### PR DESCRIPTION
Fixes a failure seen on some machines.

	tests/00-fmt.sh
	+ find . ! ( -path ./vendor -prune ) ! -samefile ./daemon/bindata.go -type f -name *.go -print0
	+ xargs -0 gofmt -d -l -s
	./.git/logs/refs/remotes/origin/events-godoc.go:1:1: expected 'package', found 'EOF'
	./.git/logs/refs/remotes/origin/gofmt-tree-test.go:1:1: expected 'package', found 'EOF'
	./.git/logs/refs/remotes/origin/gofmt-pkg-events-doc.go:1:1: expected 'package', found 'EOF'
	./.git/logs/refs/remotes/origin/fix-warn-pkg-events-events.go:1:1: expected 'package', found 'EOF'
	+ diff=
	Makefile:134: recipe for target 'precheck-gofmt' failed
	make: *** [precheck-gofmt] Error 123

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>