### PR TITLE
Issue #1472 Resolve reserved identities to labels and fetch source endpoint info using consumable cache instead of endpoints for proxy logs  #1472

### DIFF
--- a/daemon/labels.go
+++ b/daemon/labels.go
@@ -238,6 +238,7 @@ func (h *getIdentity) Handle(params GetIdentityParams) middleware.Responder {
 	identities := []*models.Identity{}
 	if params.Labels == nil {
 		// if labels is nil, return all identities from the kvstore
+		// This is in response to "identity list" command
 		outputList, err := kvstore.Client().ListPrefix(common.LabelIDKeyPath)
 		if err != nil {
 			return apierror.Error(GetIdentityIDInvalidStorageFormatCode, err)

--- a/pkg/bpf/bpffs.go
+++ b/pkg/bpf/bpffs.go
@@ -209,7 +209,7 @@ func mountFS() error {
 	}
 	if !isBpffs(mapRoot) {
 		// TODO currently on minikube this check is failing. Uncomment this log and remove the debug log,
-		// this once Issue 1475 is fixed.
+		// once Issue 1475 is fixed.
 		//log.Fatalf("BPF: '%s' is not mounted as BPF filesystem.", mapRoot)
 		log.Debugf("BPF: '%s' is not mounted as BPF filesystem.", mapRoot)
 	}

--- a/pkg/bpf/bpffs.go
+++ b/pkg/bpf/bpffs.go
@@ -208,8 +208,8 @@ func mountFS() error {
 
 	}
 	if !isBpffs(mapRoot) {
-		// TODO currently on minikube this check is failing. Uncomment this log and remove the debug log,
-		// once Issue 1475 is fixed.
+		// TODO currently on minikube isBpffs check is failing. We need to make the following log
+		// fatal again. This will be tracked in #Issue 1475
 		//log.Fatalf("BPF: '%s' is not mounted as BPF filesystem.", mapRoot)
 		log.Debugf("BPF: '%s' is not mounted as BPF filesystem.", mapRoot)
 	}

--- a/pkg/bpf/bpffs.go
+++ b/pkg/bpf/bpffs.go
@@ -208,7 +208,10 @@ func mountFS() error {
 
 	}
 	if !isBpffs(mapRoot) {
-		log.Fatalf("BPF: '%s' is not mounted as BPF filesystem.", mapRoot)
+		// TODO currently on minikube this check is failing. Uncomment this log and remove the debug log,
+		// this once Issue 1475 is fixed.
+		//log.Fatalf("BPF: '%s' is not mounted as BPF filesystem.", mapRoot)
+		log.Debugf("BPF: '%s' is not mounted as BPF filesystem.", mapRoot)
 	}
 	mountMutex.Lock()
 	for _, m := range delayedOpens {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -696,6 +696,10 @@ func (e *Endpoint) GetIdentity() policy.NumericIdentity {
 	return policy.InvalidIdentity
 }
 
+func (e *Endpoint) GetIdentityFromConsumable(srcIdentity policy.NumericIdentity) *policy.Identity {
+	return e.Consumable.GetIdentityFromConsumableCache(srcIdentity)
+}
+
 func (e *Endpoint) directoryPath() string {
 	return filepath.Join(".", fmt.Sprintf("%d", e.ID))
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -696,9 +696,9 @@ func (e *Endpoint) GetIdentity() policy.NumericIdentity {
 	return policy.InvalidIdentity
 }
 
-// GetIdentityFromConsumable fetches consumable from consumable cache, using security identity.
-func (e *Endpoint) GetIdentityFromConsumable(srcIdentity policy.NumericIdentity) *policy.Identity {
-	return e.Consumable.GetIdentityFromConsumableCache(srcIdentity)
+// ResolveIdentity fetches Consumable from consumable cache, using security identity as key.
+func (e *Endpoint) ResolveIdentity(srcIdentity policy.NumericIdentity) *policy.Identity {
+	return e.Consumable.ResolveIdentityFromCache(srcIdentity)
 }
 
 func (e *Endpoint) directoryPath() string {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -696,6 +696,7 @@ func (e *Endpoint) GetIdentity() policy.NumericIdentity {
 	return policy.InvalidIdentity
 }
 
+// GetIdentityFromConsumable fetches consumable from consumable cache, using security identity.
 func (e *Endpoint) GetIdentityFromConsumable(srcIdentity policy.NumericIdentity) *policy.Identity {
 	return e.Consumable.GetIdentityFromConsumableCache(srcIdentity)
 }

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -97,7 +97,7 @@ func NewConsumable(id NumericIdentity, lbls *Identity, cache *ConsumableCache) *
 // security identity, and returns labels for that identity.
 func (c *Consumable) GetIdentityFromConsumableCache(id NumericIdentity) *Identity {
 	cc := c.cache.Lookup(id)
-	if cc {
+	if cc != nil {
 		return cc.Labels
 	}
 	return nil

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -97,7 +97,10 @@ func NewConsumable(id NumericIdentity, lbls *Identity, cache *ConsumableCache) *
 // security identity, and returns labels for that identity.
 func (c *Consumable) GetIdentityFromConsumableCache(id NumericIdentity) *Identity {
 	cc := c.cache.Lookup(id)
-	return cc.Labels
+	if cc {
+		return cc.Labels
+	}
+	return nil
 }
 
 func (c *Consumable) DeepCopy() *Consumable {

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -53,7 +53,7 @@ func NewConsumer(id NumericIdentity) *Consumer {
 
 // Consumable is the entity that is being consumed by a Consumer.
 type Consumable struct {
-	// ID of the consumable
+	// ID of the consumable (same as security ID)
 	ID NumericIdentity `json:"id"`
 	// Mutex protects all variables from this structure below this line
 	Mutex sync.RWMutex
@@ -91,6 +91,11 @@ func NewConsumable(id NumericIdentity, lbls *Identity, cache *ConsumableCache) *
 	}
 
 	return consumable
+}
+
+func (c *Consumable) GetIdentityFromConsumableCache(id NumericIdentity) *Identity {
+	cc := c.cache.Lookup(id)
+	return cc.Labels
 }
 
 func (c *Consumable) DeepCopy() *Consumable {

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -93,9 +93,9 @@ func NewConsumable(id NumericIdentity, lbls *Identity, cache *ConsumableCache) *
 	return consumable
 }
 
-// GetIdentityFromConsumableCache fetches consumable from consumable cache using
-// security identity, and returns labels for that identity.
-func (c *Consumable) GetIdentityFromConsumableCache(id NumericIdentity) *Identity {
+// ResolveIdentityFromCache fetches Consumable from ConsumableCache using
+// security identity as key, and returns labels for that identity.
+func (c *Consumable) ResolveIdentityFromCache(id NumericIdentity) *Identity {
 	cc := c.cache.Lookup(id)
 	if cc != nil {
 		return cc.Labels

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -93,6 +93,8 @@ func NewConsumable(id NumericIdentity, lbls *Identity, cache *ConsumableCache) *
 	return consumable
 }
 
+// GetIdentityFromConsumableCache fetches consumable from consumable cache using
+// security identity, and returns labels for that identity.
 func (c *Consumable) GetIdentityFromConsumableCache(id NumericIdentity) *Identity {
 	cc := c.cache.Lookup(id)
 	return cc.Labels

--- a/pkg/policy/identity.go
+++ b/pkg/policy/identity.go
@@ -68,11 +68,12 @@ func (id NumericIdentity) Uint32() uint32 {
 type Identity struct {
 	// Identity's ID.
 	ID NumericIdentity `json:"id"`
-	// Endpoints that have this Identity where their value is the last time they were seen.
+	// Set of labels that belong to this Identity.
 	Labels labels.Labels `json:"labels"`
 	// SHA256 of labels.
 	LabelsSHA256 string `json:"labelsSHA256"`
-	// Set of labels that belong to this Identity.
+	// Endpoints that have this Identity where their value is the last time they were seen.
+	// Also, If an identity is no longer used (i.e. all endpoints have disassociated from it) we can recycle the identity.
 	Endpoints map[string]time.Time `json:"containers"`
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -99,6 +99,7 @@ type ProxySource interface {
 	GetLabels() []string
 	GetLabelsSHA() string
 	GetIdentity() policy.NumericIdentity
+	GetIdentityFromConsumable(policy.NumericIdentity) *policy.Identity
 	GetIPv4Address() string
 	GetIPv6Address() string
 	RUnlock()
@@ -269,10 +270,31 @@ func parseIPPort(ipstr string, info *accesslog.EndpointInfo) {
 	}
 }
 
-func (r *Redirect) getSourceInfo(req *http.Request) (accesslog.EndpointInfo, accesslog.IPVersion) {
+/*
+   This function fills the accesslog.EndpointInfo fields, by fetching the consumable from the consumable cache
+   of endpoint using identity sent by source. This is needed in ingress proxy while logging the source endpoint info.
+   Since there will be 2 proxies on the same host, if both egress and ingress policies are set, the ingress policy cannot determine the
+   source endpoint info based on ip adress, as the ip address would be that of the egress proxy i.e host.
+*/
+func fillInfoFromConsumable(ipstr string, info *accesslog.EndpointInfo, srcIdentity policy.NumericIdentity, ep ProxySource) {
+	ip := net.ParseIP(ipstr)
+	if ip != nil {
+		if ip.To4() != nil {
+			info.IPv4 = ip.String()
+		} else {
+			info.IPv6 = ip.String()
+		}
+	}
+	secLabel := ep.GetIdentityFromConsumable(srcIdentity)
+	//TODO check is secLabel == nil
+	info.Labels = secLabel.Labels.GetModel()
+	info.LabelsSHA256 = secLabel.Labels.SHA256Sum()
+	info.Identity = uint64(srcIdentity)
+}
+
+func (r *Redirect) getSourceInfo(req *http.Request, srcIdentity policy.NumericIdentity) (accesslog.EndpointInfo, accesslog.IPVersion) {
 	info := accesslog.EndpointInfo{}
 	version := accesslog.VersionIPv4
-
 	ipstr, port, err := net.SplitHostPort(req.RemoteAddr)
 	if err == nil {
 		p, err := strconv.ParseUint(port, 10, 16)
@@ -290,7 +312,10 @@ func (r *Redirect) getSourceInfo(req *http.Request) (accesslog.EndpointInfo, acc
 	if !r.l4.Ingress {
 		r.localEndpointInfo(&info)
 	} else if err == nil {
-		parseIPPort(ipstr, &info)
+		if srcIdentity != 0 { //TODO else? parseIPPort?
+			fillInfoFromConsumable(ipstr, &info, srcIdentity, r.source)
+		}
+
 	}
 
 	return info, version
@@ -298,7 +323,6 @@ func (r *Redirect) getSourceInfo(req *http.Request) (accesslog.EndpointInfo, acc
 
 func (r *Redirect) getDestinationInfo(dstIPPort string) accesslog.EndpointInfo {
 	info := accesslog.EndpointInfo{}
-
 	ipstr, port, err := net.SplitHostPort(dstIPPort)
 	if err == nil {
 		p, err := strconv.ParseUint(port, 10, 16)
@@ -488,10 +512,6 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, source Pr
 			TransportProtocol: 6, // TCP's IANA-assigned protocol number
 		}
 
-		info, version := redir.getSourceInfo(req)
-		record.SourceEndpoint = info
-		record.IPVersion = version
-
 		if redir.l4.Ingress {
 			record.ObservationPoint = accesslog.Ingress
 		} else {
@@ -507,6 +527,10 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, source Pr
 			accesslog.Log(record, accesslog.TypeRequest, accesslog.VerdictError, http.StatusBadRequest)
 			return
 		}
+
+		info, version := redir.getSourceInfo(req, policy.NumericIdentity(srcIdentity))
+		record.SourceEndpoint = info
+		record.IPVersion = version
 
 		if srcIdentity != 0 {
 			record.SourceEndpoint.Identity = uint64(srcIdentity)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -270,13 +270,13 @@ func parseIPPort(ipstr string, info *accesslog.EndpointInfo) {
 	}
 }
 
-/*
-   This function fills the accesslog.EndpointInfo fields, by fetching the consumable from the consumable cache
-   of endpoint using identity sent by source. This is needed in ingress proxy while logging the source endpoint info.
-   Since there will be 2 proxies on the same host, if both egress and ingress policies are set, the ingress policy cannot determine the
-   source endpoint info based on ip adress, as the ip address would be that of the egress proxy i.e host.
-*/
-func fillInfoFromConsumable(ipstr string, info *accesslog.EndpointInfo, srcIdentity policy.NumericIdentity, ep ProxySource) {
+//   This function fills the accesslog.EndpointInfo fields, by fetching the consumable from the consumable cache
+//   of endpoint using identity sent by source. This is needed in ingress proxy while logging the source endpoint info.
+//   Since there will be 2 proxies on the same host, if both egress and ingress policies are set, the ingress policy cannot determine the
+//   source endpoint info based on ip address, as the ip address would be that of the egress proxy i.e host.
+
+func (r *Redirect) getInfoFromConsumable(ipstr string, info *accesslog.EndpointInfo, srcIdentity policy.NumericIdentity) {
+	ep := r.source
 	ip := net.ParseIP(ipstr)
 	if ip != nil {
 		if ip.To4() != nil {
@@ -313,7 +313,7 @@ func (r *Redirect) getSourceInfo(req *http.Request, srcIdentity policy.NumericId
 		r.localEndpointInfo(&info)
 	} else if err == nil {
 		if srcIdentity != 0 { //TODO else? parseIPPort?
-			fillInfoFromConsumable(ipstr, &info, srcIdentity, r.source)
+			r.getInfoFromConsumable(ipstr, &info, srcIdentity)
 		}
 
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -286,10 +286,12 @@ func (r *Redirect) getInfoFromConsumable(ipstr string, info *accesslog.EndpointI
 		}
 	}
 	secLabel := ep.GetIdentityFromConsumable(srcIdentity)
-	//TODO check is secLabel == nil
-	info.Labels = secLabel.Labels.GetModel()
-	info.LabelsSHA256 = secLabel.Labels.SHA256Sum()
-	info.Identity = uint64(srcIdentity)
+
+	if secLabel != nil {
+		info.Labels = secLabel.Labels.GetModel()
+		info.LabelsSHA256 = secLabel.Labels.SHA256Sum()
+		info.Identity = uint64(srcIdentity)
+	}
 }
 
 func (r *Redirect) getSourceInfo(req *http.Request, srcIdentity policy.NumericIdentity) (accesslog.EndpointInfo, accesslog.IPVersion) {
@@ -312,8 +314,11 @@ func (r *Redirect) getSourceInfo(req *http.Request, srcIdentity policy.NumericId
 	if !r.l4.Ingress {
 		r.localEndpointInfo(&info)
 	} else if err == nil {
-		if srcIdentity != 0 { //TODO else? parseIPPort?
+		if srcIdentity != 0 {
 			r.getInfoFromConsumable(ipstr, &info, srcIdentity)
+		} else {
+			// logging warning for now.
+			log.Warn("Missing security identity in source endpoint info")
 		}
 
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -285,11 +285,11 @@ func (r *Redirect) getInfoFromConsumable(ipstr string, info *accesslog.EndpointI
 			info.IPv6 = ip.String()
 		}
 	}
-	secLabel := ep.ResolveIdentity(srcIdentity)
+	secIdentity := ep.ResolveIdentity(srcIdentity)
 
-	if secLabel != nil {
-		info.Labels = secLabel.Labels.GetModel()
-		info.LabelsSHA256 = secLabel.Labels.SHA256Sum()
+	if secIdentity != nil {
+		info.Labels = secIdentity.Labels.GetModel()
+		info.LabelsSHA256 = secIdentity.Labels.SHA256Sum()
 		info.Identity = uint64(srcIdentity)
 	}
 }


### PR DESCRIPTION
Today, the proxy access log contains IDs 1 (for host) or 2 (for world).
However, it does not contain the corresponding labels for those identities.
Given that these identities are constant, we can add their labels to the proxy access log.
Fixes #1472 

Additionally:

 For ingress proxy case
	Destination identity is fixed (proxy bound to destination endpoint)
 	Since source Identity is always available, we need to lookup by identity instead of source IP.

Signed-off by: Manali Bhutiyani manali@covalent.io