### PR TITLE
cilium: change default error message when checking agent status

### DIFF
--- a/cilium/cmd/status.go
+++ b/cilium/cmd/status.go
@@ -20,6 +20,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/cilium/cilium/api/v1/models"
+	pkg "github.com/cilium/cilium/pkg/client"
 
 	"github.com/spf13/cobra"
 )
@@ -39,7 +40,7 @@ func init() {
 
 func statusDaemon(cmd *cobra.Command, args []string) {
 	if resp, err := client.Daemon.GetHealthz(nil); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: Unable to reach out daemon: %s\n", err)
+		fmt.Fprintf(os.Stderr, "%s\n", pkg.Hint(err))
 		os.Exit(1)
 	} else {
 		sr := resp.Payload

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -89,3 +89,15 @@ func NewClient(host string) (*Client, error) {
 		clientapi.DefaultSchemes, httpClient)
 	return &Client{*clientapi.New(clientTrans, strfmt.Default)}, nil
 }
+
+// Hint tries to improve the error message displayed to the user.
+func Hint(err error) error {
+	if err == nil {
+		return err
+	}
+	e, _ := url.PathUnescape(err.Error())
+	if strings.Contains(err.Error(), defaults.SockPath) {
+		return fmt.Errorf("%s\nIs the agent running?", e)
+	}
+	return fmt.Errorf("%s", e)
+}

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -23,7 +23,7 @@ import (
 func (c *Client) ConfigGet() (*models.DaemonConfigurationResponse, error) {
 	resp, err := c.Daemon.GetConfig(nil)
 	if err != nil {
-		return nil, err
+		return nil, Hint(err)
 	}
 	return resp.Payload, nil
 }
@@ -32,5 +32,5 @@ func (c *Client) ConfigGet() (*models.DaemonConfigurationResponse, error) {
 func (c *Client) ConfigPatch(cfg models.Configuration) error {
 	params := daemon.NewPatchConfigParams().WithConfiguration(&cfg)
 	_, err := c.Daemon.PatchConfig(params)
-	return err
+	return Hint(err)
 }

--- a/pkg/client/endpoint.go
+++ b/pkg/client/endpoint.go
@@ -24,7 +24,7 @@ import (
 func (c *Client) EndpointList() ([]*models.Endpoint, error) {
 	resp, err := c.Endpoint.GetEndpoint(nil)
 	if err != nil {
-		return nil, err
+		return nil, Hint(err)
 	}
 	return resp.Payload, nil
 }
@@ -34,6 +34,9 @@ func (c *Client) EndpointGet(id string) (*models.Endpoint, error) {
 	params := endpoint.NewGetEndpointIDParams().WithID(id)
 	resp, err := c.Endpoint.GetEndpointID(params)
 	if err != nil {
+		/* Since plugins rely on checking the error type, we don't wrap this
+		 * with Hint(...)
+		 */
 		return nil, err
 	}
 	return resp.Payload, nil
@@ -44,21 +47,21 @@ func (c *Client) EndpointCreate(ep *models.EndpointChangeRequest) error {
 	id := pkgEndpoint.NewCiliumID(ep.ID)
 	params := endpoint.NewPutEndpointIDParams().WithID(id).WithEndpoint(ep)
 	_, err := c.Endpoint.PutEndpointID(params)
-	return err
+	return Hint(err)
 }
 
 // EndpointPatch modifies the endpoint
 func (c *Client) EndpointPatch(id string, ep *models.EndpointChangeRequest) error {
 	params := endpoint.NewPatchEndpointIDParams().WithID(id).WithEndpoint(ep)
 	_, err := c.Endpoint.PatchEndpointID(params)
-	return err
+	return Hint(err)
 }
 
 // EndpointDelete deletes endpoint
 func (c *Client) EndpointDelete(id string) error {
 	params := endpoint.NewDeleteEndpointIDParams().WithID(id)
 	_, _, err := c.Endpoint.DeleteEndpointID(params)
-	return err
+	return Hint(err)
 }
 
 // EndpointConfigGet returns endpoint configuration
@@ -66,7 +69,7 @@ func (c *Client) EndpointConfigGet(id string) (*models.Configuration, error) {
 	params := endpoint.NewGetEndpointIDConfigParams().WithID(id)
 	resp, err := c.Endpoint.GetEndpointIDConfig(params)
 	if err != nil {
-		return nil, err
+		return nil, Hint(err)
 	}
 	return resp.Payload, nil
 }
@@ -79,7 +82,7 @@ func (c *Client) EndpointConfigPatch(id string, cfg models.ConfigurationMap) err
 	}
 
 	_, err := c.Endpoint.PatchEndpointIDConfig(params)
-	return err
+	return Hint(err)
 }
 
 // EndpointLabelsGet returns endpoint label configuration
@@ -87,7 +90,7 @@ func (c *Client) EndpointLabelsGet(id string) (*models.LabelConfiguration, error
 	params := endpoint.NewGetEndpointIDLabelsParams().WithID(id)
 	resp, err := c.Endpoint.GetEndpointIDLabels(params)
 	if err != nil {
-		return nil, err
+		return nil, Hint(err)
 	}
 	return resp.Payload, nil
 }
@@ -96,5 +99,5 @@ func (c *Client) EndpointLabelsGet(id string) (*models.LabelConfiguration, error
 func (c *Client) EndpointLabelsPut(id string, cfg *models.LabelConfigurationModifier) error {
 	params := endpoint.NewPutEndpointIDLabelsParams().WithID(id)
 	_, err := c.Endpoint.PutEndpointIDLabels(params.WithConfiguration(cfg))
-	return err
+	return Hint(err)
 }

--- a/pkg/client/identity.go
+++ b/pkg/client/identity.go
@@ -25,7 +25,7 @@ func (c *Client) IdentityGet(id string) (*models.Identity, error) {
 
 	resp, err := c.Policy.GetIdentityID(params)
 	if err != nil {
-		return nil, err
+		return nil, Hint(err)
 	}
 	return resp.Payload, nil
 }

--- a/pkg/client/ipam.go
+++ b/pkg/client/ipam.go
@@ -34,7 +34,7 @@ func (c *Client) IPAMAllocate(family string) (*models.IPAM, error) {
 
 	resp, err := c.IPAM.PostIPAM(params)
 	if err != nil {
-		return nil, err
+		return nil, Hint(err)
 	}
 	return resp.Payload, nil
 }
@@ -43,12 +43,12 @@ func (c *Client) IPAMAllocate(family string) (*models.IPAM, error) {
 func (c *Client) IPAMAllocateIP(ip string) error {
 	params := ipam.NewPostIPAMIPParams().WithIP(ip)
 	_, err := c.IPAM.PostIPAMIP(params)
-	return err
+	return Hint(err)
 }
 
 // IPAMReleaseIP releases a IP address back to the pool.
 func (c *Client) IPAMReleaseIP(ip string) error {
 	params := ipam.NewDeleteIPAMIPParams().WithIP(ip)
 	_, err := c.IPAM.DeleteIPAMIP(params)
-	return err
+	return Hint(err)
 }

--- a/pkg/client/policy.go
+++ b/pkg/client/policy.go
@@ -24,7 +24,7 @@ func (c *Client) PolicyPut(policyJSON string) (*models.Policy, error) {
 	params := policy.NewPutPolicyParams().WithPolicy(&policyJSON)
 	resp, err := c.Policy.PutPolicy(params)
 	if err != nil {
-		return nil, err
+		return nil, Hint(err)
 	}
 	return resp.Payload, nil
 }
@@ -34,7 +34,7 @@ func (c *Client) PolicyGet(labels []string) (*models.Policy, error) {
 	params := policy.NewGetPolicyParams().WithLabels(labels)
 	resp, err := c.Policy.GetPolicy(params)
 	if err != nil {
-		return nil, err
+		return nil, Hint(err)
 	}
 	return resp.Payload, nil
 }
@@ -44,9 +44,9 @@ func (c *Client) PolicyDelete(labels []string) (*models.Policy, error) {
 	params := policy.NewDeletePolicyParams().WithLabels(labels)
 	resp, err := c.Policy.DeletePolicy(params)
 	if err != nil {
-		return nil, err
+		return nil, Hint(err)
 	}
-	return resp.Payload, err
+	return resp.Payload, Hint(err)
 }
 
 // PolicyResolveGet resolves policy for a context with source and destination identity.
@@ -54,7 +54,7 @@ func (c *Client) PolicyResolveGet(context *models.IdentityContext) (*models.Poli
 	params := policy.NewGetPolicyResolveParams().WithIdentityContext(context)
 	resp, err := c.Policy.GetPolicyResolve(params)
 	if err != nil {
-		return nil, err
+		return nil, Hint(err)
 	}
 	return resp.Payload, nil
 }

--- a/pkg/client/service.go
+++ b/pkg/client/service.go
@@ -23,7 +23,7 @@ import (
 func (c *Client) GetServices() ([]*models.Service, error) {
 	resp, err := c.Service.GetService(nil)
 	if err != nil {
-		return nil, err
+		return nil, Hint(err)
 	}
 	return resp.Payload, nil
 }
@@ -33,7 +33,7 @@ func (c *Client) GetServiceID(id int64) (*models.Service, error) {
 	params := service.NewGetServiceIDParams().WithID(id)
 	resp, err := c.Service.GetServiceID(params)
 	if err != nil {
-		return nil, err
+		return nil, Hint(err)
 	}
 	return resp.Payload, nil
 }
@@ -43,12 +43,12 @@ func (c *Client) PutServiceID(id int64, svc *models.Service) (bool, error) {
 	svc.ID = id
 	params := service.NewPutServiceIDParams().WithID(id).WithConfig(svc)
 	_, created, err := c.Service.PutServiceID(params)
-	return created != nil, err
+	return created != nil, Hint(err)
 }
 
 // DeleteServiceID deletes a service by ID.
 func (c *Client) DeleteServiceID(id int64) error {
 	params := service.NewDeleteServiceIDParams().WithID(id)
 	_, err := c.Service.DeleteServiceID(params)
-	return err
+	return Hint(err)
 }


### PR DESCRIPTION
cilium: change default client error messages
    
When the agent is down the new output looks something like this
    
            Cannot connect to the Cilium Agent at unix:///var/run/cilium/cilium.sock. Is the agent running?
    
It might differ a little depending on what the prefix is. Also the error
strings are now unescaped so output with `%` should not show up.
    
Closes: #1522 (Improve error message if UDS does not exist)
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>
