### PR TITLE
Fix monitor permissions

### DIFF
--- a/api/v1/server.gotmpl
+++ b/api/v1/server.gotmpl
@@ -281,19 +281,9 @@ func (s *Server) Serve() (err error) {
 		configureServer(domainSocket, "unix")
 
 		if os.Getuid() == 0 {
-			socketPath := string(s.SocketPath)
-			gid, err := common.GetGroupIDByName(common.CiliumGroupName)
+		    err := apisocket.SetDefaultPermissions(string(s.SocketPath))
 			if err != nil {
-				s.Logf("Group %s not found: %s", common.CiliumGroupName, err)
-			} else {
-				if err := os.Chown(socketPath, 0, gid); err != nil {
-					return fmt.Errorf("failed while setting up %s's group ID"+
-						" in %q: %s", common.CiliumGroupName, socketPath, err)
-				}
-			}
-			if err := os.Chmod(socketPath, 0660); err != nil {
-				return fmt.Errorf("failed while setting up %s's file"+
-					" permissions in %q: %s", common.CiliumGroupName, socketPath, err)
+				return err
 			}
 		}
 

--- a/cilium/cmd/monitor.go
+++ b/cilium/cmd/monitor.go
@@ -24,7 +24,6 @@ import (
 	"os/signal"
 	"time"
 
-	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/daemon/defaults"
 	"github.com/cilium/cilium/monitor/payload"
 	"github.com/cilium/cilium/pkg/bpf"
@@ -251,8 +250,6 @@ func setupSigHandler() {
 }
 
 func runMonitor() {
-	// Privileged access is required for reading from the monitor socket.
-	common.RequireRootPrivilege("cilium monitor")
 	setVerbosity()
 	setupSigHandler()
 	if resp, err := client.Daemon.GetHealthz(nil); err == nil {

--- a/common/const.go
+++ b/common/const.go
@@ -45,10 +45,6 @@ const (
 
 	// PathDelimiter is the delimiter used in the labels paths.
 	PathDelimiter = "."
-	// GroupFilePath is the unix group file path.
-	GroupFilePath = "/etc/group"
-	// CiliumGroupName is the cilium's unix group name.
-	CiliumGroupName = "cilium"
 
 	// CHeaderFileName is the name of the C header file for BPF programs for a
 	// particular endpoint.

--- a/common/utils.go
+++ b/common/utils.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 )
 
@@ -57,30 +56,6 @@ func FmtDefineAddress(name string, addr []byte) string {
 // fmt.Print(FmtDefineArray("foo", []byte{1, 2, 3})) // "#define foo { 0x1, 0x2, 0x3 }\n"
 func FmtDefineArray(name string, array []byte) string {
 	return fmt.Sprintf("#define %s { %s }\n", name, goArray2C(array))
-}
-
-// GetGroupIDByName returns the group ID for the given grpName.
-func GetGroupIDByName(grpName string) (int, error) {
-	f, err := os.Open(GroupFilePath)
-	if err != nil {
-		return -1, err
-	}
-	defer f.Close()
-	br := bufio.NewReader(f)
-	for {
-		s, err := br.ReadString('\n')
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return -1, err
-		}
-		p := strings.Split(s, ":")
-		if len(p) >= 3 && p[0] == grpName {
-			return strconv.Atoi(p[2])
-		}
-	}
-	return -1, fmt.Errorf("group %q not found", grpName)
 }
 
 // FindEPConfigCHeader returns the full path of the file that is the CHeaderFileName from

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/daemon/defaults"
+	"github.com/cilium/cilium/pkg/apisocket"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -33,6 +34,13 @@ func main() {
 	server, err := net.Listen("unix", defaults.MonitorSockPath)
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	if os.Getuid() == 0 {
+		err := apisocket.SetDefaultPermissions(defaults.MonitorSockPath)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	m := Monitor{}

--- a/pkg/apisocket/apisocket.go
+++ b/pkg/apisocket/apisocket.go
@@ -1,0 +1,69 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apisocket
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// GetGroupIDByName returns the group ID for the given grpName.
+func GetGroupIDByName(grpName string) (int, error) {
+	f, err := os.Open(GroupFilePath)
+	if err != nil {
+		return -1, err
+	}
+	defer f.Close()
+	br := bufio.NewReader(f)
+	for {
+		s, err := br.ReadString('\n')
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return -1, err
+		}
+		p := strings.Split(s, ":")
+		if len(p) >= 3 && p[0] == grpName {
+			return strconv.Atoi(p[2])
+		}
+	}
+	return -1, fmt.Errorf("group %q not found", grpName)
+}
+
+// SetDefaultPermissions sets the given socket to with cilium's default
+// group and mode permissions. Group `CiliumGroupName` and mode `0660`
+func SetDefaultPermissions(socketPath string) error {
+	gid, err := GetGroupIDByName(CiliumGroupName)
+	if err != nil {
+		log.Infof("Group %s not found: %s", CiliumGroupName, err)
+	} else {
+		if err := os.Chown(socketPath, 0, gid); err != nil {
+			return fmt.Errorf("failed while setting up %s's group ID"+
+				" in %q: %s", CiliumGroupName, socketPath, err)
+		}
+	}
+	if err := os.Chmod(socketPath, SocketFileMode); err != nil {
+		return fmt.Errorf("failed while setting up %s's file"+
+			" permissions in %q: %s", CiliumGroupName, socketPath, err)
+	}
+	return nil
+}

--- a/pkg/apisocket/const.go
+++ b/pkg/apisocket/const.go
@@ -1,0 +1,26 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apisocket
+
+import "os"
+
+const (
+	// GroupFilePath is the unix group file path.
+	GroupFilePath = "/etc/group"
+	// CiliumGroupName is the cilium's unix group name.
+	CiliumGroupName = "cilium"
+	// SocketFileMode is the default file mode for the sockets.
+	SocketFileMode os.FileMode = 0660
+)


### PR DESCRIPTION
Changed monitor's group to be the same as cilium agent. So now users will be able to run the monitor without running with root user.
```
$ ls -la /var/run/cilium/
srw-rw----  1 root cilium   0 Sep 18 01:32 cilium.sock
srw-rw----  1 root cilium   0 Sep 18 01:32 monitor.sock
```