### PR TITLE
Fix typo in copyright header of main.go

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016- 2017Authors of Cilium
+// Copyright 2016-2017 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>