### PR TITLE
[WIP] Define new "ingressVisibility" rule type

### DIFF
--- a/api/v1/models/l4_policy.go
+++ b/api/v1/models/l4_policy.go
@@ -22,11 +22,16 @@ type L4Policy struct {
 
 	// List of L4 ingress rules
 	Ingress []string `json:"ingress"`
+
+	// List of L4 ingress visibility rules
+	IngressVisibility []string `json:"ingress-visibility"`
 }
 
 /* polymorph L4Policy egress false */
 
 /* polymorph L4Policy ingress false */
+
+/* polymorph L4Policy ingress-visibility false */
 
 // Validate validates this l4 policy
 func (m *L4Policy) Validate(formats strfmt.Registry) error {
@@ -38,6 +43,11 @@ func (m *L4Policy) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateIngress(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateIngressVisibility(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -60,6 +70,15 @@ func (m *L4Policy) validateEgress(formats strfmt.Registry) error {
 func (m *L4Policy) validateIngress(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.Ingress) { // not required
+		return nil
+	}
+
+	return nil
+}
+
+func (m *L4Policy) validateIngressVisibility(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.IngressVisibility) { // not required
 		return nil
 	}
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -869,6 +869,11 @@ definitions:
         type: array
         items:
           type: string
+      ingress-visibility:
+        description: List of L4 ingress visibility rules
+        type: array
+        items:
+          type: string
   CIDRPolicy:
     description: CIDR endpoint policy
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1354,6 +1354,13 @@ func init() {
           "items": {
             "type": "string"
           }
+        },
+        "ingress-visibility": {
+          "description": "List of L4 ingress visibility rules",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -80,7 +80,7 @@ func (d *Daemon) TriggerPolicyUpdates(added []policy.NumericIdentity) *sync.Wait
 	return endpointmanager.TriggerPolicyUpdates(d)
 }
 
-// UpdateEndpointPolicyEnforcement returns whether policy enforcement needs to be
+// EnableEndpointPolicyEnforcement returns whether policy enforcement needs to be
 // enabled for the specified endpoint.
 //
 // Must be called with e.Consumable.Mutex and d.GetPolicyRepository().Mutex held.

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -52,6 +52,11 @@ func (e *Endpoint) writeL4Map(fw *bufio.Writer, owner Owner, m policy.L4PolicyMa
 	index := 0
 
 	for _, l4 := range m {
+		// Ignore L4 filters that match any port.
+		if l4.MatchesAnyPort() {
+			continue
+		}
+
 		// Represents struct l4_allow in bpf/lib/l4.h
 		protoNum, err := u8proto.ParseProtocol(string(l4.Protocol))
 		if err != nil {

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -126,7 +126,8 @@ func (s *K8sSuite) TestParseNetworkPolicy(c *C) {
 				Ingress: true,
 			},
 		},
-		Egress: policy.L4PolicyMap{},
+		Egress:            policy.L4PolicyMap{},
+		IngressVisibility: policy.L7VisibilityMap{},
 	})
 
 	ctx.To = labels.LabelArray{
@@ -134,7 +135,7 @@ func (s *K8sSuite) TestParseNetworkPolicy(c *C) {
 	}
 
 	// ctx.To needs to have all labels from the policy in order to be accepted
-	c.Assert(repo.CanReachRLocked(&ctx), Not(Equals), api.Allowed)
+	c.Assert(repo.CanReachRLocked(ctx), Not(Equals), api.Allowed)
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
@@ -147,7 +148,7 @@ func (s *K8sSuite) TestParseNetworkPolicy(c *C) {
 		Trace: policy.TRACE_VERBOSE,
 	}
 	// ctx.From also needs to have all labels from the policy in order to be accepted
-	c.Assert(repo.CanReachRLocked(&ctx), Not(Equals), api.Allowed)
+	c.Assert(repo.CanReachRLocked(ctx), Not(Equals), api.Allowed)
 }
 
 func (s *K8sSuite) TestParseNetworkPolicyUnknownProto(c *C) {
@@ -206,7 +207,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEmptyFrom(c *C) {
 
 	repo := policy.NewPolicyRepository()
 	repo.AddList(rules)
-	c.Assert(repo.CanReachRLocked(&ctx), Equals, api.Allowed)
+	c.Assert(repo.CanReachRLocked(ctx), Equals, api.Allowed)
 
 	// Empty From rules, all sources should be allowed
 	netPolicy2 := &networkingv1.NetworkPolicy{
@@ -230,7 +231,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEmptyFrom(c *C) {
 	c.Assert(len(rules), Equals, 1)
 	repo = policy.NewPolicyRepository()
 	repo.AddList(rules)
-	c.Assert(repo.CanReachRLocked(&ctx), Equals, api.Allowed)
+	c.Assert(repo.CanReachRLocked(ctx), Equals, api.Allowed)
 }
 
 func (s *K8sSuite) TestParseNetworkPolicyDenyAll(c *C) {

--- a/pkg/k8s/network_policy_v1beta_test.go
+++ b/pkg/k8s/network_policy_v1beta_test.go
@@ -114,7 +114,8 @@ func (s *K8sSuite) TestParseNetworkPolicyDeprecated(c *C) {
 				Ingress: true,
 			},
 		},
-		Egress: policy.L4PolicyMap{},
+		Egress:            policy.L4PolicyMap{},
+		IngressVisibility: policy.L7VisibilityMap{},
 	})
 
 	ctx.To = labels.LabelArray{
@@ -122,7 +123,7 @@ func (s *K8sSuite) TestParseNetworkPolicyDeprecated(c *C) {
 	}
 
 	// ctx.To needs to have all labels from the policy in order to be accepted
-	c.Assert(repo.CanReachRLocked(&ctx), Not(Equals), api.Allowed)
+	c.Assert(repo.CanReachRLocked(ctx), Not(Equals), api.Allowed)
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
@@ -135,7 +136,7 @@ func (s *K8sSuite) TestParseNetworkPolicyDeprecated(c *C) {
 		Trace: policy.TRACE_VERBOSE,
 	}
 	// ctx.From also needs to have all labels from the policy in order to be accepted
-	c.Assert(repo.CanReachRLocked(&ctx), Not(Equals), api.Allowed)
+	c.Assert(repo.CanReachRLocked(ctx), Not(Equals), api.Allowed)
 }
 
 func (s *K8sSuite) TestParseNetworkPolicyUnknownProtoDeprecated(c *C) {
@@ -194,7 +195,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEmptyFromDeprecated(c *C) {
 
 	repo := policy.NewPolicyRepository()
 	repo.AddList(rules)
-	c.Assert(repo.CanReachRLocked(&ctx), Equals, api.Allowed)
+	c.Assert(repo.CanReachRLocked(ctx), Equals, api.Allowed)
 
 	// Empty From rules, all sources should be allowed
 	netPolicy2 := &v1beta1.NetworkPolicy{
@@ -218,7 +219,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEmptyFromDeprecated(c *C) {
 	c.Assert(len(rules), Equals, 1)
 	repo = policy.NewPolicyRepository()
 	repo.AddList(rules)
-	c.Assert(repo.CanReachRLocked(&ctx), Equals, api.Allowed)
+	c.Assert(repo.CanReachRLocked(ctx), Equals, api.Allowed)
 }
 
 func (s *K8sSuite) TestParseNetworkPolicyDenyAllDeprecated(c *C) {

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -79,9 +79,7 @@ func (key *policyKey) String() string {
 }
 
 func (pm *PolicyMap) AllowConsumer(id uint32) error {
-	key := policyKey{Identity: id}
-	entry := PolicyEntry{Action: 1}
-	return bpf.UpdateElement(pm.Fd, unsafe.Pointer(&key), unsafe.Pointer(&entry), 0)
+	return pm.AllowL4(id, 0, 0)
 }
 
 // AllowL4 pushes an entry into the PolicyMap to allow source identity `id`
@@ -93,9 +91,7 @@ func (pm *PolicyMap) AllowL4(id uint32, dport uint16, proto uint8) error {
 }
 
 func (pm *PolicyMap) ConsumerExists(id uint32) bool {
-	key := policyKey{Identity: id}
-	var entry PolicyEntry
-	return bpf.LookupElement(pm.Fd, unsafe.Pointer(&key), unsafe.Pointer(&entry)) == nil
+	return pm.L4Exists(id, 0, 0)
 }
 
 // L4Exists determines whether PolicyMap currently contains an entry that
@@ -108,8 +104,7 @@ func (pm *PolicyMap) L4Exists(id uint32, dport uint16, proto uint8) bool {
 }
 
 func (pm *PolicyMap) DeleteConsumer(id uint32) error {
-	key := policyKey{Identity: id}
-	return bpf.DeleteElement(pm.Fd, unsafe.Pointer(&key))
+	return pm.DeleteL4(id, 0, 0)
 }
 
 // DeleteL4 removes an entry from the PolicyMap for source identity `id`

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -324,7 +324,7 @@ type IngressVisibilityRule struct {
 	// ports. Case insensitive. Accepted values: "http", "kafka".
 	//
 	// +optional
-	L7Protocol L7ParserType `json:"l7protocol,omitempty"`
+	L7Protocol L7ParserType `json:"l7Protocol,omitempty"`
 }
 
 // PortRule is a list of ports/protocol combinations with optional Layer 7
@@ -374,7 +374,7 @@ type CIDRRule struct {
 
 // L7Rules is a union of port level rule types. Mixing of different port
 // level rule types is disallowed, so exactly one of the following must be set.
-// If none is specified, then no additional port-level rules are applied.
+// If none are specified, then no additional port-level rules are applied.
 type L7Rules struct {
 	// HTTP-specific rules.
 	//

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -285,7 +285,7 @@ type PortProtocol struct {
 	Port string `json:"port"`
 
 	// Protocol is the L4 protocol. If omitted or empty, any protocol
-	// matches. Accepted values: "TCP", "UDP", ""/"ANY"
+	// matches. Case insensitive. Accepted values: "TCP", "UDP", ""/"ANY".
 	//
 	// Matching on ICMP is not supported.
 	//

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -43,9 +43,8 @@ func (n EndpointSelector) String() string {
 	if n.LabelSelector != nil {
 		j, _ := n.MarshalJSON()
 		return string(j)
-	} else {
-		return "{}"
 	}
+	return "{}"
 }
 
 // Hash return hash of the internal json structure that represents the endpoint selector

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -40,8 +40,12 @@ func (n *EndpointSelector) LabelSelectorString() string {
 
 // String returns a string representation of EndpointSelector.
 func (n EndpointSelector) String() string {
-	j, _ := n.MarshalJSON()
-	return string(j)
+	if n.LabelSelector != nil {
+		j, _ := n.MarshalJSON()
+		return string(j)
+	} else {
+		return "{}"
+	}
 }
 
 // Hash return hash of the internal json structure that represents the endpoint selector

--- a/pkg/policy/api/utils.go
+++ b/pkg/policy/api/utils.go
@@ -68,12 +68,23 @@ func (k *PortRuleKafka) Equal(o PortRuleKafka) bool {
 	return k.APIVersion == o.APIVersion && k.APIKey == o.APIKey && k.Topic == o.Topic
 }
 
-// Validate returns an error if the layer 4 protocol is not valid
+// Validate returns an error if the Layer-4 protocol is not valid
 func (l4 L4Proto) Validate() error {
 	switch l4 {
 	case ProtoAny, ProtoTCP, ProtoUDP:
 	default:
-		return fmt.Errorf("invalid protocol %q, must be { TCP | UDP | ANY }", l4)
+		return fmt.Errorf("invalid L4 protocol %q, must be { TCP | UDP | ANY }", l4)
+	}
+
+	return nil
+}
+
+// Validate returns an error if the Layer-7 protocol is not valid
+func (l7 L7ParserType) Validate() error {
+	switch l7 {
+	case ParserTypeHTTP, ParserTypeKafka:
+	default:
+		return fmt.Errorf("invalid L7 protocol %q, must be { http | kafka }", l7)
 	}
 
 	return nil
@@ -88,12 +99,18 @@ func (r *PortRule) NumRules() int {
 	return r.Rules.Len()
 }
 
-// ParseL4Proto parses a string as layer 4 protocol
+// ParseL4Proto parses a string as Layer-4 protocol
 func ParseL4Proto(proto string) (L4Proto, error) {
 	if proto == "" {
 		return ProtoAny, nil
 	}
 
 	p := L4Proto(strings.ToUpper(proto))
+	return p, p.Validate()
+}
+
+// ParseL7ParserType parses a string as Layer-7 parser type
+func ParseL7ParserType(l7Parser string) (L7ParserType, error) {
+	p := L7ParserType(strings.ToLower(l7Parser))
 	return p, p.Validate()
 }

--- a/pkg/policy/api/utils.go
+++ b/pkg/policy/api/utils.go
@@ -73,7 +73,7 @@ func (l4 L4Proto) Validate() error {
 	switch l4 {
 	case ProtoAny, ProtoTCP, ProtoUDP:
 	default:
-		return fmt.Errorf("invalid protocol %q, must be { tcp | udp | any }", l4)
+		return fmt.Errorf("invalid protocol %q, must be { TCP | UDP | ANY }", l4)
 	}
 
 	return nil

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -142,14 +142,14 @@ func (dm L7DataMap) addRulesForEndpoints(rules api.L7Rules, fromEndpoints []api.
 // This L4Filter will only apply to endpoints covered by `fromEndpoints`.
 // `rule` allows a series of L7 rules to be associated with this L4Filter.
 func CreateL4Filter(fromEndpoints []api.EndpointSelector, rule api.PortRule, port api.PortProtocol,
-	direction string, protocol api.L4Proto) L4Filter {
+	direction string) L4Filter {
 
 	// already validated via PortRule.Validate()
 	p, _ := strconv.ParseUint(port.Port, 0, 16)
 
 	l4 := L4Filter{
 		Port:           int(p),
-		Protocol:       protocol,
+		Protocol:       port.Protocol,
 		L7RedirectPort: rule.RedirectPort,
 		L7RulesPerEp:   make(L7DataMap),
 		FromEndpoints:  fromEndpoints,

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -72,9 +72,9 @@ type L4Filter struct {
 	// L7Parser specifies the L7 protocol parser (optional)
 	L7Parser api.L7ParserType `json:"-"`
 	// L7RedirectPort is the L7 proxy port to redirect to (optional)
-	L7RedirectPort int `json:"l7-redirect-port,omitempty"`
+	L7RedirectPort int `json:"l7RedirectPort,omitempty"`
 	// L7RulesPerEp is a list of L7 rules per endpoint passed to the L7 proxy (optional)
-	L7RulesPerEp L7DataMap `json:"l7-rules,omitempty"`
+	L7RulesPerEp L7DataMap `json:"l7Rules,omitempty"`
 	// Ingress is true if filter applies at ingress
 	Ingress bool `json:"-"`
 }

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -213,11 +213,11 @@ type L4PolicyMap map[string]L4Filter
 // L7VisibilityRule is an active ingress visibility rule.
 type L7VisibilityRule struct {
 	// Port is the destination L4 port to redirect to L7 for access logging.
-	Port int
+	Port uint16 `json:"port"`
 	// Protocol is the port's L4 protocol.
-	Protocol api.L4Proto
-	// L7Parser specifies the L7 protocol parser.
-	L7Parser api.L7ParserType
+	Protocol api.L4Proto `json:"protocol"`
+	// L7Protocol specifies the L7 protocol parser.
+	L7Protocol api.L7ParserType `json:"l7Protocol"`
 }
 
 // MarshalIndent returns the `L7VisibilityRule` in indented JSON string.
@@ -265,7 +265,7 @@ func (l4 L4PolicyMap) containsAllL3L4(labels labels.LabelArray, ports []*models.
 	}
 
 	// Check any rule that accepts any port.
-	anyPortFilter, match := l4["0/ANY"]
+	anyPortFilter, match := l4[fmt.Sprintf("%d/%s", 0, api.ProtoAny)]
 	if match && anyPortFilter.matchesLabels(labels) {
 		return api.Allowed
 	}
@@ -274,12 +274,12 @@ func (l4 L4PolicyMap) containsAllL3L4(labels labels.LabelArray, ports []*models.
 		lwrProtocol := l4CtxIng.Protocol
 		switch lwrProtocol {
 		case "", models.PortProtocolANY:
-			tcpPort := fmt.Sprintf("%d/TCP", l4CtxIng.Port)
+			tcpPort := fmt.Sprintf("%d/%s", l4CtxIng.Port, api.ProtoTCP)
 			tcpFilter, tcpmatch := l4[tcpPort]
 			if tcpmatch {
 				tcpmatch = tcpFilter.matchesLabels(labels)
 			}
-			udpPort := fmt.Sprintf("%d/UDP", l4CtxIng.Port)
+			udpPort := fmt.Sprintf("%d/%s", l4CtxIng.Port, api.ProtoUDP)
 			udpFilter, udpmatch := l4[udpPort]
 			if udpmatch {
 				udpmatch = udpFilter.matchesLabels(labels)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -61,17 +61,6 @@ func (l7 L7DataMap) MarshalJSON() ([]byte, error) {
 	return buffer.Bytes(), err
 }
 
-// L7ParserType is the type used to indicate what L7 parser to use and
-// defines all supported types of L7 parsers
-type L7ParserType string
-
-const (
-	// ParserTypeHTTP specifies a HTTP parser type
-	ParserTypeHTTP L7ParserType = "http"
-	// ParserTypeKafka specifies a Kafka parser type
-	ParserTypeKafka L7ParserType = "kafka"
-)
-
 type L4Filter struct {
 	// Port is the destination port to allow
 	Port int `json:"port"`
@@ -81,7 +70,7 @@ type L4Filter struct {
 	// FromEndpoints is empty, then it selects all endpoints.
 	FromEndpoints []api.EndpointSelector `json:"-"`
 	// L7Parser specifies the L7 protocol parser (optional)
-	L7Parser L7ParserType `json:"-"`
+	L7Parser api.L7ParserType `json:"-"`
 	// L7RedirectPort is the L7 proxy port to redirect to (optional)
 	L7RedirectPort int `json:"l7-redirect-port,omitempty"`
 	// L7RulesPerEp is a list of L7 rules per endpoint passed to the L7 proxy (optional)
@@ -162,9 +151,9 @@ func CreateL4Filter(fromEndpoints []api.EndpointSelector, rule api.PortRule, por
 	if rule.Rules != nil {
 		switch {
 		case len(rule.Rules.HTTP) > 0:
-			l4.L7Parser = ParserTypeHTTP
+			l4.L7Parser = api.ParserTypeHTTP
 		case len(rule.Rules.Kafka) > 0:
-			l4.L7Parser = ParserTypeKafka
+			l4.L7Parser = api.ParserTypeKafka
 		}
 
 		l4.L7RulesPerEp.addRulesForEndpoints(*rule.Rules, fromEndpoints)

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -114,8 +114,7 @@ func (s *PolicyTestSuite) TestCreateL4Filter(c *C) {
 			// Regardless of ingress/egress, we should end up with
 			// a single L7 rule whether the selector is wildcarded
 			// or if it is based on specific labels.
-			filter := CreateL4Filter(eps, portrule, tuple,
-				direction, tuple.Protocol)
+			filter := CreateL4Filter(eps, portrule, tuple, direction)
 			c.Assert(len(filter.L7RulesPerEp), Equals, 1)
 		}
 	}

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -179,7 +179,7 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
 	expected = `[{
   "port": 80,
   "protocol": "TCP",
-  "l7-rules": [
+  "l7Rules": [
     {
       "any.foo=": {
         "http": [
@@ -194,7 +194,7 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
 } {
   "port": 8080,
   "protocol": "TCP",
-  "l7-rules": [
+  "l7Rules": [
     {
       "any.foo=": {
         "http": [

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -72,14 +72,18 @@ func (state *traceState) trace(p *Repository, ctx *SearchContext) {
 // CanReachRLocked evaluates the policy repository for the provided search
 // context and returns the verdict or api.Undecided if no rule matches. The
 // policy repository mutex must be held.
-func (p *Repository) CanReachRLocked(ctx *SearchContext) api.Decision {
+func (p *Repository) CanReachRLocked(ctx SearchContext) api.Decision {
 	decision := api.Undecided
 	state := traceState{}
+
+	ctx.IngressL4Only = true
+
+	// TODO: Refactor canReach and this method to avoid multiple loops over p.rules below.
 
 loop:
 	for i, r := range p.rules {
 		state.ruleID = i
-		switch r.canReach(ctx, &state) {
+		switch r.canReach(&ctx, &state) {
 		// The rule contained a constraint which was not met, this
 		// connection is not allowed
 		case api.Denied:
@@ -93,8 +97,23 @@ loop:
 			decision = api.Allowed
 		}
 	}
+	state.trace(p, &ctx)
 
-	state.trace(p, ctx)
+	if decision == api.Undecided {
+		ctx.PolicyTrace("\nResolving L4 policy for matching on labels\n")
+		// The calls to rule.canReach above check canReachEntities, FromEntities, etc.
+		// But that's NOT sufficient to determine reachability because resolving the L4 policy
+		// may result in the synthesis of new rules that may allow broader reachability.
+		policy, err := p.ResolveL4Policy(&ctx)
+		if err != nil {
+			log.WithError(err).Warning("Evaluation error while resolving L4 ingress policy")
+		}
+		if err == nil && len(policy.Ingress) > 0 {
+			ctx2 := ctx
+			ctx2.DPorts = nil
+			decision = policy.IngressCoversContext(&ctx2)
+		}
+	}
 
 	return decision
 }
@@ -110,7 +129,7 @@ func (p *Repository) AllowsLabelAccess(ctx *SearchContext) api.Decision {
 	if len(p.rules) == 0 {
 		ctx.PolicyTrace("  No rules found\n")
 	} else {
-		if p.CanReachRLocked(ctx) == api.Allowed {
+		if p.CanReachRLocked(*ctx) == api.Allowed {
 			decision = api.Allowed
 		}
 	}
@@ -141,7 +160,6 @@ func (p *Repository) ResolveL4Policy(ctx *SearchContext) (*L4Policy, error) {
 	}
 
 	state := traceState{}
-	curRuleID := state.ruleID
 	for _, r := range p.rules {
 		found, err := r.resolveL4Policy(ctx, &state, result)
 		if err != nil {
@@ -154,13 +172,19 @@ func (p *Repository) ResolveL4Policy(ctx *SearchContext) (*L4Policy, error) {
 	}
 
 	ctx.PolicyTrace("Resolving ingress visibility rules for %+v\n", ctx.To)
-	state.ruleID = curRuleID
 	for _, r := range p.rules {
-		_, err := r.resolveIngressVisibility(ctx, &state, result)
+		err := r.resolveIngressVisibility(ctx, &state, result)
 		if err != nil {
 			return nil, err
 		}
-		state.ruleID++
+	}
+
+	// Empty the rules that were not requested.
+	if ctx.EgressL4Only {
+		result.Ingress = make(L4PolicyMap)
+	}
+	if ctx.IngressL4Only {
+		result.Egress = make(L4PolicyMap)
 	}
 
 	ctx.PolicyTrace("%d rules matched\n", state.selectedRules)
@@ -187,8 +211,7 @@ func (p *Repository) ResolveL3Policy(ctx *SearchContext) *L3Policy {
 	return result
 }
 
-func (p *Repository) allowsL4Egress(searchCtx *SearchContext) api.Decision {
-	ctx := *searchCtx
+func (p *Repository) allowsL4Egress(ctx SearchContext) api.Decision {
 	ctx.To = ctx.From
 	ctx.From = labels.LabelArray{}
 	ctx.EgressL4Only = true
@@ -211,16 +234,16 @@ func (p *Repository) allowsL4Egress(searchCtx *SearchContext) api.Decision {
 	return verdict
 }
 
-func (p *Repository) allowsL4Ingress(ctx *SearchContext) api.Decision {
+func (p *Repository) allowsL4Ingress(ctx SearchContext) api.Decision {
 	ctx.IngressL4Only = true
 
-	policy, err := p.ResolveL4Policy(ctx)
+	policy, err := p.ResolveL4Policy(&ctx)
 	if err != nil {
 		log.WithError(err).Warn("Evaluation error while resolving L4 ingress policy")
 	}
 	verdict := api.Undecided
 	if err == nil && len(policy.Ingress) > 0 {
-		verdict = policy.IngressCoversContext(ctx)
+		verdict = policy.IngressCoversContext(&ctx)
 	}
 
 	if len(ctx.DPorts) == 0 {
@@ -238,24 +261,23 @@ func (p *Repository) allowsL4Ingress(ctx *SearchContext) api.Decision {
 // held.
 func (p *Repository) AllowsRLocked(ctx *SearchContext) api.Decision {
 	ctx.PolicyTrace("Tracing %s\n", ctx.String())
-	decision := p.CanReachRLocked(ctx)
+	decision := p.CanReachRLocked(*ctx)
 	ctx.PolicyTrace("Label verdict: %s", decision.String())
 	if decision == api.Allowed {
 		return decision
 	}
 
-	// We only report the overall decision as L4 inclusive if a port has
-	// been specified
-	if len(ctx.DPorts) != 0 {
-		l4Egress := p.allowsL4Egress(ctx)
-		l4Ingress := p.allowsL4Ingress(ctx)
+	ctx.PolicyTrace("\nResolving L4 policy for matching on ports\n")
 
-		// Explicit deny should deny; Allow+Undecided should allow
-		if l4Egress == api.Denied || l4Ingress == api.Denied {
-			decision = api.Denied
-		} else if l4Egress == api.Allowed || l4Ingress == api.Allowed {
-			decision = api.Allowed
-		}
+	// TODO: Avoid resolving the L4 policy twice, once in each of the following calls.
+	l4Egress := p.allowsL4Egress(*ctx)
+	l4Ingress := p.allowsL4Ingress(*ctx)
+
+	// Explicit deny should deny; Allow+Undecided should allow
+	if l4Egress == api.Denied || l4Ingress == api.Denied {
+		decision = api.Denied
+	} else if l4Egress == api.Allowed || l4Ingress == api.Allowed {
+		decision = api.Allowed
 	}
 
 	if decision != api.Allowed {

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -141,6 +141,7 @@ func (p *Repository) ResolveL4Policy(ctx *SearchContext) (*L4Policy, error) {
 	}
 
 	state := traceState{}
+	curRuleID := state.ruleID
 	for _, r := range p.rules {
 		found, err := r.resolveL4Policy(ctx, &state, result)
 		if err != nil {
@@ -152,6 +153,17 @@ func (p *Repository) ResolveL4Policy(ctx *SearchContext) (*L4Policy, error) {
 		}
 	}
 
+	ctx.PolicyTrace("Resolving ingress visibility rules for %+v\n", ctx.To)
+	state.ruleID = curRuleID
+	for _, r := range p.rules {
+		_, err := r.resolveIngressVisibility(ctx, &state, result)
+		if err != nil {
+			return nil, err
+		}
+		state.ruleID++
+	}
+
+	ctx.PolicyTrace("%d rules matched\n", state.selectedRules)
 	state.trace(p, ctx)
 	return result, nil
 }

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -433,11 +433,17 @@ Label verdict: undecided
 Resolving egress port policy for [any:bar]
 * Rule {"matchLabels":{"any:bar":""}}: selected
     No L4 rules
+Resolving ingress visibility rules for [any:bar]
+* Rule 0 {"matchLabels":{"any:bar":""}}: match
+    No active ingress visibility rules
+1 rules matched
 1/1 rules selected
 Found no allow rule
 L4 egress verdict: undecided
 
 Resolving ingress port policy for [any:foo]
+Resolving ingress visibility rules for [any:foo]
+0 rules matched
 0/1 rules selected
 Found no allow rule
 L4 ingress verdict: undecided
@@ -468,6 +474,8 @@ Found no allow rule
 Label verdict: undecided
 
 Resolving egress port policy for [any:baz]
+Resolving ingress visibility rules for [any:baz]
+0 rules matched
 0/2 rules selected
 Found no allow rule
 L4 egress verdict: undecided
@@ -478,6 +486,12 @@ Resolving ingress port policy for [any:bar]
 * Rule {"matchLabels":{"any:bar":""}}: selected
     Allows Ingress port [{80 ANY}] from endpoints [{"matchLabels":{"reserved:host":""}} {"matchLabels":{"any:baz":""}}]
       Found all required labels
+Resolving ingress visibility rules for [any:bar]
+* Rule 0 {"matchLabels":{"any:bar":""}}: match
+    No active ingress visibility rules
+* Rule 1 {"matchLabels":{"any:bar":""}}: match
+    No active ingress visibility rules
+2 rules matched
 2/2 rules selected
 Found allow rule
 L4 ingress verdict: allowed
@@ -506,6 +520,12 @@ Resolving egress port policy for [any:bar]
     No L4 rules
 * Rule {"matchLabels":{"any:bar":""}}: selected
     No L4 rules
+Resolving ingress visibility rules for [any:bar]
+* Rule 0 {"matchLabels":{"any:bar":""}}: match
+    No active ingress visibility rules
+* Rule 1 {"matchLabels":{"any:bar":""}}: match
+    No active ingress visibility rules
+2 rules matched
 2/2 rules selected
 Found no allow rule
 L4 egress verdict: undecided
@@ -516,6 +536,12 @@ Resolving ingress port policy for [any:bar]
 * Rule {"matchLabels":{"any:bar":""}}: selected
     Allows Ingress port [{80 ANY}] from endpoints [{"matchLabels":{"reserved:host":""}} {"matchLabels":{"any:baz":""}}]
       Labels [any:bar] not found
+Resolving ingress visibility rules for [any:bar]
+* Rule 0 {"matchLabels":{"any:bar":""}}: match
+    No active ingress visibility rules
+* Rule 1 {"matchLabels":{"any:bar":""}}: match
+    No active ingress visibility rules
+2 rules matched
 2/2 rules selected
 Found no allow rule
 L4 ingress verdict: undecided

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -115,7 +115,7 @@ func (ds *PolicyTestSuite) TestAddSearchDelete(c *C) {
 func (ds *PolicyTestSuite) TestCanReach(c *C) {
 	repo := NewPolicyRepository()
 
-	fooToBar := &SearchContext{
+	fooToBar := SearchContext{
 		From: labels.ParseSelectLabelArray("foo"),
 		To:   labels.ParseSelectLabelArray("bar"),
 	}
@@ -124,7 +124,7 @@ func (ds *PolicyTestSuite) TestCanReach(c *C) {
 	// no rules loaded: CanReach => undecided
 	c.Assert(repo.CanReachRLocked(fooToBar), Equals, api.Undecided)
 	// no rules loaded: Allows() => denied
-	c.Assert(repo.AllowsRLocked(fooToBar), Equals, api.Denied)
+	c.Assert(repo.AllowsRLocked(&fooToBar), Equals, api.Denied)
 	repo.Mutex.RUnlock()
 
 	tag1 := labels.LabelArray{labels.ParseLabel("tag1")}
@@ -173,7 +173,7 @@ func (ds *PolicyTestSuite) TestCanReach(c *C) {
 	c.Assert(err, IsNil)
 
 	// foo=>bar is OK
-	c.Assert(repo.AllowsRLocked(fooToBar), Equals, api.Allowed)
+	c.Assert(repo.AllowsRLocked(&fooToBar), Equals, api.Allowed)
 
 	// foo=>bar2 is OK
 	c.Assert(repo.AllowsRLocked(&SearchContext{
@@ -209,13 +209,13 @@ func (ds *PolicyTestSuite) TestCanReach(c *C) {
 func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 	repo := NewPolicyRepository()
 
-	fromApp2 := &SearchContext{
+	fromApp2 := SearchContext{
 		From:  labels.ParseSelectLabelArray("id=app2"),
 		To:    labels.ParseSelectLabelArray("id=app1"),
 		Trace: TRACE_VERBOSE,
 	}
 
-	fromApp3 := &SearchContext{
+	fromApp3 := SearchContext{
 		From: labels.ParseSelectLabelArray("id=app3"),
 		To:   labels.ParseSelectLabelArray("id=app1"),
 	}
@@ -226,8 +226,8 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 	c.Assert(repo.CanReachRLocked(fromApp3), Equals, api.Undecided)
 
 	// no rules loaded: Allows() => denied
-	c.Assert(repo.AllowsLabelAccess(fromApp2), Equals, api.Denied)
-	c.Assert(repo.AllowsLabelAccess(fromApp3), Equals, api.Denied)
+	c.Assert(repo.AllowsLabelAccess(&fromApp2), Equals, api.Denied)
+	c.Assert(repo.AllowsLabelAccess(&fromApp3), Equals, api.Denied)
 	repo.Mutex.RUnlock()
 
 	selectorFromApp2 := []api.EndpointSelector{
@@ -295,7 +295,7 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 	defer repo.Mutex.RUnlock()
 
 	// L4 from app2 is restricted
-	l4policy, err := repo.ResolveL4Policy(fromApp2)
+	l4policy, err := repo.ResolveL4Policy(&fromApp2)
 	c.Assert(err, IsNil)
 
 	// Due to the lack of a set structure for L4Filter.FromEndpoints,
@@ -330,10 +330,10 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 	c.Assert(len(l4policy.Ingress), Equals, 1)
 	c.Assert(*l4policy, comparator.DeepEquals, *expected)
 
-	// L4 from app3 has no rules
-	expected = NewL4Policy()
-	l4policy, err = repo.ResolveL4Policy(fromApp3)
-	c.Assert(len(l4policy.Ingress), Equals, 0)
+	// L4 from app3 has no rules matching it, but the policy still contains the
+	// exact same rules.
+	l4policy, err = repo.ResolveL4Policy(&fromApp3)
+	c.Assert(len(l4policy.Ingress), Equals, 1)
 	c.Assert(*l4policy, comparator.DeepEquals, *expected)
 }
 
@@ -423,18 +423,60 @@ Label verdict: allowed
 	expectedOut = `
 0/1 rules selected
 Found no allow rule
+
+Resolving L4 policy for matching on labels
+
+Resolving ingress port policy for [any:foo]
+Resolving ingress visibility rules for [any:foo]
+0 rules matched
+0/1 rules selected
+Found no allow rule
 Label verdict: undecided
+
+Resolving L4 policy for matching on ports
+
+Resolving egress port policy for [any:bar]
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No Egress L4 rules
+Resolving ingress visibility rules for [any:bar]
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No active ingress visibility rules
+1 rules matched
+1/1 rules selected
+Found no allow rule
+L4 egress verdict: [no port context specified]
+
+Resolving ingress port policy for [any:foo]
+Resolving ingress visibility rules for [any:foo]
+0 rules matched
+0/1 rules selected
+Found no allow rule
+L4 ingress verdict: [no port context specified]
 `
 	repo.checkTrace(c, ctx, expectedOut, api.Denied)
 
 	// bar=>foo:80 is Denied, also checks L4 policy
 	ctx = buildSearchCtx("bar", "foo", 80)
-	expectedOut += `
+	expectedOut = `
+0/1 rules selected
+Found no allow rule
+
+Resolving L4 policy for matching on labels
+
+Resolving ingress port policy for [any:foo]
+Resolving ingress visibility rules for [any:foo]
+0 rules matched
+0/1 rules selected
+Found no allow rule
+Label verdict: undecided
+
+Resolving L4 policy for matching on ports
+
 Resolving egress port policy for [any:bar]
 * Rule {"matchLabels":{"any:bar":""}}: selected
-    No L4 rules
+    No Egress L4 rules
 Resolving ingress visibility rules for [any:bar]
-* Rule 0 {"matchLabels":{"any:bar":""}}: match
+* Rule {"matchLabels":{"any:bar":""}}: selected
     No active ingress visibility rules
 1 rules matched
 1/1 rules selected
@@ -471,7 +513,27 @@ L4 ingress verdict: undecided
         Rule restricts traffic to specific L4 destinations; deferring policy decision to L4 policy stage
 2/2 rules selected
 Found no allow rule
-Label verdict: undecided
+
+Resolving L4 policy for matching on labels
+
+Resolving ingress port policy for [any:bar]
+* Rule {"matchLabels":{"any:bar":""}}: selected
+  Allows Ingress any port from endpoints [{"matchLabels":{"reserved:host":""}} {"matchLabels":{"any:foo":""}}]
+      Labels [any:baz] not found
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    Allows Ingress port [{80 ANY}] from endpoints [{"matchLabels":{"reserved:host":""}} {"matchLabels":{"any:baz":""}}]
+      Found all required labels
+Resolving ingress visibility rules for [any:bar]
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No active ingress visibility rules
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No active ingress visibility rules
+2 rules matched
+2/2 rules selected
+Found allow rule
+Label verdict: denied
+
+Resolving L4 policy for matching on ports
 
 Resolving egress port policy for [any:baz]
 Resolving ingress visibility rules for [any:baz]
@@ -482,14 +544,15 @@ L4 egress verdict: undecided
 
 Resolving ingress port policy for [any:bar]
 * Rule {"matchLabels":{"any:bar":""}}: selected
-    No L4 rules
+  Allows Ingress any port from endpoints [{"matchLabels":{"reserved:host":""}} {"matchLabels":{"any:foo":""}}]
+      Labels [any:baz] not found
 * Rule {"matchLabels":{"any:bar":""}}: selected
     Allows Ingress port [{80 ANY}] from endpoints [{"matchLabels":{"reserved:host":""}} {"matchLabels":{"any:baz":""}}]
       Found all required labels
 Resolving ingress visibility rules for [any:bar]
-* Rule 0 {"matchLabels":{"any:bar":""}}: match
+* Rule {"matchLabels":{"any:bar":""}}: selected
     No active ingress visibility rules
-* Rule 1 {"matchLabels":{"any:bar":""}}: match
+* Rule {"matchLabels":{"any:bar":""}}: selected
     No active ingress visibility rules
 2 rules matched
 2/2 rules selected
@@ -513,17 +576,37 @@ L4 ingress verdict: allowed
       Labels [any:bar] not found
 2/2 rules selected
 Found no allow rule
-Label verdict: undecided
+
+Resolving L4 policy for matching on labels
+
+Resolving ingress port policy for [any:bar]
+* Rule {"matchLabels":{"any:bar":""}}: selected
+  Allows Ingress any port from endpoints [{"matchLabels":{"reserved:host":""}} {"matchLabels":{"any:foo":""}}]
+      Labels [any:bar] not found
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    Allows Ingress port [{80 ANY}] from endpoints [{"matchLabels":{"reserved:host":""}} {"matchLabels":{"any:baz":""}}]
+      Labels [any:bar] not found
+Resolving ingress visibility rules for [any:bar]
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No active ingress visibility rules
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No active ingress visibility rules
+2 rules matched
+2/2 rules selected
+Found allow rule
+Label verdict: denied
+
+Resolving L4 policy for matching on ports
 
 Resolving egress port policy for [any:bar]
 * Rule {"matchLabels":{"any:bar":""}}: selected
-    No L4 rules
+    No Egress L4 rules
 * Rule {"matchLabels":{"any:bar":""}}: selected
-    No L4 rules
+    No Egress L4 rules
 Resolving ingress visibility rules for [any:bar]
-* Rule 0 {"matchLabels":{"any:bar":""}}: match
+* Rule {"matchLabels":{"any:bar":""}}: selected
     No active ingress visibility rules
-* Rule 1 {"matchLabels":{"any:bar":""}}: match
+* Rule {"matchLabels":{"any:bar":""}}: selected
     No active ingress visibility rules
 2 rules matched
 2/2 rules selected
@@ -532,19 +615,20 @@ L4 egress verdict: undecided
 
 Resolving ingress port policy for [any:bar]
 * Rule {"matchLabels":{"any:bar":""}}: selected
-    No L4 rules
+  Allows Ingress any port from endpoints [{"matchLabels":{"reserved:host":""}} {"matchLabels":{"any:foo":""}}]
+      Labels [any:bar] not found
 * Rule {"matchLabels":{"any:bar":""}}: selected
     Allows Ingress port [{80 ANY}] from endpoints [{"matchLabels":{"reserved:host":""}} {"matchLabels":{"any:baz":""}}]
       Labels [any:bar] not found
 Resolving ingress visibility rules for [any:bar]
-* Rule 0 {"matchLabels":{"any:bar":""}}: match
+* Rule {"matchLabels":{"any:bar":""}}: selected
     No active ingress visibility rules
-* Rule 1 {"matchLabels":{"any:bar":""}}: match
+* Rule {"matchLabels":{"any:bar":""}}: selected
     No active ingress visibility rules
 2 rules matched
 2/2 rules selected
-Found no allow rule
-L4 ingress verdict: undecided
+Found allow rule
+L4 ingress verdict: denied
 `
 	repo.checkTrace(c, ctx, expectedOut, api.Denied)
 
@@ -580,6 +664,37 @@ L4 ingress verdict: undecided
 3/3 rules selected
 Found unsatisfied FromRequires constraint
 Label verdict: denied
+
+Resolving L4 policy for matching on ports
+
+Resolving egress port policy for [any:foo]
+Resolving ingress visibility rules for [any:foo]
+0 rules matched
+0/3 rules selected
+Found no allow rule
+L4 egress verdict: [no port context specified]
+
+Resolving ingress port policy for [any:bar]
+* Rule {"matchLabels":{"any:bar":""}}: selected
+  Allows Ingress any port from endpoints [{"matchLabels":{"reserved:host":""}} {"matchLabels":{"any:foo":""}}]
+      Found all required labels
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    Allows Ingress port [{80 ANY}] from endpoints [{"matchLabels":{"reserved:host":""}} {"matchLabels":{"any:baz":""}}]
+      Labels [any:foo] not found
+* Rule {"matchLabels":{"any:bar":""}}: selected
+  Allows Ingress any port
+      Labels [any:foo] not found
+Resolving ingress visibility rules for [any:bar]
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No active ingress visibility rules
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No active ingress visibility rules
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No active ingress visibility rules
+3 rules matched
+3/3 rules selected
+Found allow rule
+L4 ingress verdict: [no port context specified]
 `
 	repo.checkTrace(c, ctx, expectedOut, api.Denied)
 
@@ -602,7 +717,61 @@ Label verdict: denied
 +     Found all required labels
 3/3 rules selected
 Found no allow rule
-Label verdict: undecided
+
+Resolving L4 policy for matching on labels
+
+Resolving ingress port policy for [any:bar]
+* Rule {"matchLabels":{"any:bar":""}}: selected
+  Allows Ingress any port from endpoints [{"matchLabels":{"reserved:host":""}} {"matchLabels":{"any:foo":""}}]
+      Labels [any:baz] not found
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    Allows Ingress port [{80 ANY}] from endpoints [{"matchLabels":{"reserved:host":""}} {"matchLabels":{"any:baz":""}}]
+      Found all required labels
+* Rule {"matchLabels":{"any:bar":""}}: selected
+  Allows Ingress any port
+      Labels [any:baz] not found
+Resolving ingress visibility rules for [any:bar]
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No active ingress visibility rules
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No active ingress visibility rules
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No active ingress visibility rules
+3 rules matched
+3/3 rules selected
+Found allow rule
+Label verdict: denied
+
+Resolving L4 policy for matching on ports
+
+Resolving egress port policy for [any:baz]
+Resolving ingress visibility rules for [any:baz]
+0 rules matched
+0/3 rules selected
+Found no allow rule
+L4 egress verdict: [no port context specified]
+
+Resolving ingress port policy for [any:bar]
+* Rule {"matchLabels":{"any:bar":""}}: selected
+  Allows Ingress any port from endpoints [{"matchLabels":{"reserved:host":""}} {"matchLabels":{"any:foo":""}}]
+      Labels [any:baz] not found
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    Allows Ingress port [{80 ANY}] from endpoints [{"matchLabels":{"reserved:host":""}} {"matchLabels":{"any:baz":""}}]
+      Found all required labels
+* Rule {"matchLabels":{"any:bar":""}}: selected
+  Allows Ingress any port
+      Labels [any:baz] not found
+Resolving ingress visibility rules for [any:bar]
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No active ingress visibility rules
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No active ingress visibility rules
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No active ingress visibility rules
+3 rules matched
+3/3 rules selected
+Found allow rule
+L4 ingress verdict: [no port context specified]
 `
 	repo.checkTrace(c, ctx, expectedOut, api.Denied)
 

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -188,9 +188,9 @@ func mergeIngressVisibilityPort(ctx *SearchContext, p api.PortProtocol, l7Parser
 
 	// Report as active visibility rule.
 	visMap[key] = L7VisibilityRule{
-		Port:     int(l4Port),
-		Protocol: p.Protocol,
-		L7Parser: l7Parser,
+		Port:       uint16(l4Port),
+		Protocol:   p.Protocol,
+		L7Protocol: l7Parser,
 	}
 
 	resMap[key] = v
@@ -371,6 +371,8 @@ func mergeL4(ctx *SearchContext, dir string, fromEndpoints []api.EndpointSelecto
 	return found, nil
 }
 
+// mergeIngressVisibility merges visibility rules into the given maps.
+// Returns the number of ingress rules that have been created as a result of the merge.
 func mergeIngressVisibility(ctx *SearchContext, rule api.IngressVisibilityRule, resMap L4PolicyMap, visMap L7VisibilityMap,
 	defaultAllow bool) (int, error) {
 	found := 0
@@ -468,7 +470,7 @@ func (r *rule) resolveL4Policy(ctx *SearchContext, state *traceState, result *L4
 }
 
 // allowAllRule is a L4 rule that allows all ingress & egress L4 traffic.
-var allowAllRule rule = rule{
+var allowAllRule = rule{
 	Rule: api.Rule{
 		EndpointSelector: api.NewESFromLabels(),
 		Ingress: []api.IngressRule{

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -104,15 +104,15 @@ func (policy *L4Filter) addFromEndpoints(fromEndpoints []api.EndpointSelector) b
 }
 
 func mergeL4Port(ctx *SearchContext, fromEndpoints []api.EndpointSelector, r api.PortRule, p api.PortProtocol,
-	dir string, proto api.L4Proto, resMap L4PolicyMap) (int, error) {
+	dir string, resMap L4PolicyMap) (int, error) {
 
-	key := p.Port + "/" + string(proto)
+	key := p.Port + "/" + string(p.Protocol)
 	v, ok := resMap[key]
 	if !ok {
-		resMap[key] = CreateL4Filter(fromEndpoints, r, p, dir, proto)
+		resMap[key] = CreateL4Filter(fromEndpoints, r, p, dir)
 		return 1, nil
 	}
-	l4Filter := CreateL4Filter(fromEndpoints, r, p, dir, proto)
+	l4Filter := CreateL4Filter(fromEndpoints, r, p, dir)
 	if l4Filter.L7Parser != "" {
 		if v.L7Parser == "" {
 			v.L7Parser = l4Filter.L7Parser
@@ -220,19 +220,19 @@ func mergeL4(ctx *SearchContext, dir string, fromEndpoints []api.EndpointSelecto
 		for _, p := range r.Ports {
 			var cnt int
 			if p.Protocol != api.ProtoAny {
-				cnt, err = mergeL4Port(ctx, fromEndpoints, r, p, dir, p.Protocol, resMap)
+				cnt, err = mergeL4Port(ctx, fromEndpoints, r, p, dir, resMap)
 				if err != nil {
 					return found, err
 				}
 				found += cnt
 			} else {
-				cnt, err = mergeL4Port(ctx, fromEndpoints, r, p, dir, api.ProtoTCP, resMap)
+				cnt, err = mergeL4Port(ctx, fromEndpoints, r, api.PortProtocol{Port: p.Port, Protocol: api.ProtoTCP}, dir, resMap)
 				if err != nil {
 					return found, err
 				}
 				found += cnt
 
-				cnt, err = mergeL4Port(ctx, fromEndpoints, r, p, dir, api.ProtoUDP, resMap)
+				cnt, err = mergeL4Port(ctx, fromEndpoints, r, api.PortProtocol{Port: p.Port, Protocol: api.ProtoUDP}, dir, resMap)
 				if err != nil {
 					return found, err
 				}

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -485,7 +485,6 @@ func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
 	barRules := api.L7Rules{
 		Kafka: []api.PortRuleKafka{{Topic: "bar"}},
 	}
-
 	// The l3-dependent l7 rules are not merged together.
 	l7map = L7DataMap{
 		fooSelector[0]:           fooRules,

--- a/pkg/proxy/kafka.go
+++ b/pkg/proxy/kafka.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/nodeaddress"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 
 	"github.com/optiopay/kafka/proto"
@@ -261,7 +262,7 @@ func (k *kafkaRedirect) handleResponseConnection(pair *connectionPair) {
 
 // UpdateRules replaces old l7 rules of a redirect with new ones.
 func (k *kafkaRedirect) UpdateRules(l4 *policy.L4Filter) error {
-	if l4.L7Parser != policy.ParserTypeKafka {
+	if l4.L7Parser != api.ParserTypeKafka {
 		return fmt.Errorf("invalid type %q, must be of type ParserTypeKafka", l4.L7Parser)
 	}
 

--- a/pkg/proxy/kafka_test.go
+++ b/pkg/proxy/kafka_test.go
@@ -187,7 +187,7 @@ func (k *proxyTestSuite) TestKafkaRedirect(c *C) {
 		policy: &policy.L4Filter{
 			Port:           serverPort,
 			Protocol:       api.ProtoTCP,
-			L7Parser:       policy.ParserTypeKafka,
+			L7Parser:       api.ParserTypeKafka,
 			L7RedirectPort: proxyPort,
 			L7RulesPerEp: policy.L7DataMap{
 				policy.WildcardEndpointSelector: api.L7Rules{

--- a/pkg/proxy/oxyproxy.go
+++ b/pkg/proxy/oxyproxy.go
@@ -316,7 +316,7 @@ func createOxyRedirect(l4 *policy.L4Filter, id string, source ProxySource, to ui
 		}
 	}
 
-	if l4.L7Parser != policy.ParserTypeHTTP {
+	if l4.L7Parser != api.ParserTypeHTTP {
 		return nil, fmt.Errorf("unknown L7 protocol \"%s\"", l4.L7Parser)
 	}
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 
 	log "github.com/sirupsen/logrus"
@@ -193,14 +194,14 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, source Pr
 	var redir Redirect
 
 	switch l4.L7Parser {
-	case policy.ParserTypeKafka:
+	case api.ParserTypeKafka:
 		redir, err = createKafkaRedirect(kafkaConfiguration{
 			policy:     l4,
 			id:         id,
 			source:     source,
 			listenPort: to})
 		scopedLog.WithField(logfields.Object, logfields.Repr(redir)).Debug("Created new kafka proxy instance")
-	case policy.ParserTypeHTTP:
+	case api.ParserTypeHTTP:
 		switch kind {
 		case ProxyKindOxy:
 			redir, err = createOxyRedirect(l4, id, source, to)

--- a/tests/21-visibility.sh
+++ b/tests/21-visibility.sh
@@ -253,9 +253,9 @@ function assert_visibility_rule_active() {
   local expected_response=`cat <<EOF
 [
   {
-    "Port": 80,
-    "Protocol": "TCP",
-    "L7Parser": "http"
+    "port": 80,
+    "protocol": "TCP",
+    "l7Protocol": "http"
   }
 ]
 EOF`

--- a/tests/21-visibility.sh
+++ b/tests/21-visibility.sh
@@ -1,0 +1,728 @@
+#!/bin/bash
+
+# Tests to validate visibility rules.
+
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source "${dir}/helpers.bash"
+# dir might have been overwritten by helpers.bash
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+TEST_NAME=$(get_filename_without_extension $0)
+LOGS_DIR="${dir}/cilium-files/${TEST_NAME}/logs"
+redirect_debug_logs ${LOGS_DIR}
+
+set -ex
+
+function start_container {
+  create_cilium_docker_network
+  docker run -dt --net=$TEST_NET --name foo -l id.foo tgraf/netperf
+}
+
+function policy_allow_none() {
+  log "importing policy with no ingress rule"
+  cilium policy delete --all
+  policy_import_and_wait - <<EOF
+[{
+    "endpointSelector": {"matchLabels":{"id.foo":""}},
+    "ingressVisibility": [{
+	"toPorts": [{"port": "80", "protocol": "tcp"}],
+	"l7Protocol": "http"
+    }]
+}]
+EOF
+}
+
+function policy_allow_all() {
+  log "importing policy with one ingress rule allowing from all endpoints"
+  cilium policy delete --all
+  policy_import_and_wait - <<EOF
+[{
+    "endpointSelector": {"matchLabels":{"id.foo":""}},
+    "ingress": [{
+        "fromEndpoints": [{"matchLabels":{}}]
+    }]
+},{
+    "endpointSelector": {"matchLabels":{"id.foo":""}},
+    "ingressVisibility": [{
+	"toPorts": [{"port": "80", "protocol": "tcp"}],
+	"l7Protocol": "http"
+    }]
+}]
+EOF
+}
+
+function policy_allow_all_to_port() {
+  log "importing policy with one ingress rule allowing from all endpoints to port 80"
+  cilium policy delete --all
+  policy_import_and_wait - <<EOF
+[{
+    "endpointSelector": {"matchLabels":{"id.foo":""}},
+    "ingress": [{
+        "fromEndpoints": [{"matchLabels":{}}],
+	"toPorts": [{
+	    "ports": [{"port": "80", "protocol": "tcp"}]
+	}]
+    }]
+},{
+    "endpointSelector": {"matchLabels":{"id.foo":""}},
+    "ingressVisibility": [{
+	"toPorts": [{"port": "80", "protocol": "tcp"}],
+	"l7Protocol": "http"
+    }]
+}]
+EOF
+}
+
+function policy_allow_all_to_port_http() {
+  log "importing policy with one ingress rule allowing from all endpoints to port 80 & HTTP"
+  cilium policy delete --all
+  policy_import_and_wait - <<EOF
+[{
+    "endpointSelector": {"matchLabels":{"id.foo":""}},
+    "ingress": [{
+        "fromEndpoints": [{"matchLabels":{}}],
+	"toPorts": [{
+	    "ports": [{"port": "80", "protocol": "tcp"}],
+	    "rules": {
+                "http": [{
+		    "method": "GET",
+		    "path": "/public"
+                }]
+	    }
+	}]
+    }]
+},{
+    "endpointSelector": {"matchLabels":{"id.foo":""}},
+    "ingressVisibility": [{
+	"toPorts": [{"port": "80", "protocol": "tcp"}],
+	"l7Protocol": "http"
+    }]
+}]
+EOF
+}
+
+function policy_allow_all_to_another_port() {
+  log "importing policy with one ingress rule allowing from all endpoints to port 1234"
+  cilium policy delete --all
+  policy_import_and_wait - <<EOF
+[{
+    "endpointSelector": {"matchLabels":{"id.foo":""}},
+    "ingress": [{
+        "fromEndpoints": [{"matchLabels":{}}],
+	"toPorts": [{
+	    "ports": [{"port": "1234", "protocol": "tcp"}]
+	}]
+    }]
+},{
+    "endpointSelector": {"matchLabels":{"id.foo":""}},
+    "ingressVisibility": [{
+	"toPorts": [{"port": "80", "protocol": "tcp"}],
+	"l7Protocol": "http"
+    }]
+}]
+EOF
+}
+
+function policy_allow_from_bar() {
+  log "importing policy with one ingress rule allowing from id.bar"
+  cilium policy delete --all
+  policy_import_and_wait - <<EOF
+[{
+    "endpointSelector": {"matchLabels":{"id.foo":""}},
+    "ingress": [{
+        "fromEndpoints": [{"matchLabels":{"id.bar":""}}]
+    }]
+},{
+    "endpointSelector": {"matchLabels":{"id.foo":""}},
+    "ingressVisibility": [{
+	"toPorts": [{"port": "80", "protocol": "tcp"}],
+	"l7Protocol": "http"
+    }]
+}]
+EOF
+}
+
+function policy_allow_from_bar_to_port() {
+  log "importing policy with one ingress rule allowing from id.bar to port 80"
+  cilium policy delete --all
+  policy_import_and_wait - <<EOF
+[{
+    "endpointSelector": {"matchLabels":{"id.foo":""}},
+    "ingress": [{
+        "fromEndpoints": [{"matchLabels":{"id.bar":""}}],
+	"toPorts": [{
+	    "ports": [{"port": "80", "protocol": "tcp"}]
+	}]
+    }]
+},{
+    "endpointSelector": {"matchLabels":{"id.foo":""}},
+    "ingressVisibility": [{
+	"toPorts": [{"port": "80", "protocol": "tcp"}],
+	"l7Protocol": "http"
+    }]
+}]
+EOF
+}
+
+function policy_allow_from_bar_to_port_http() {
+  log "importing policy with one ingress rule allowing from id.bar to port 80 & HTTP"
+  cilium policy delete --all
+  policy_import_and_wait - <<EOF
+[{
+    "endpointSelector": {"matchLabels":{"id.foo":""}},
+    "ingress": [{
+        "fromEndpoints": [{"matchLabels":{"id.bar":""}}],
+	"toPorts": [{
+	    "ports": [{"port": "80", "protocol": "tcp"}],
+	    "rules": {
+                "http": [{
+		    "method": "GET",
+		    "path": "/public"
+                }]
+	    }
+	}]
+    }]
+},{
+    "endpointSelector": {"matchLabels":{"id.foo":""}},
+    "ingressVisibility": [{
+	"toPorts": [{"port": "80", "protocol": "tcp"}],
+	"l7Protocol": "http"
+    }]
+}]
+EOF
+}
+
+function cilium_endpoint_get_policy_enabled() {
+  cilium endpoint get $* -o json | jq '.[0]."policy-enabled"'
+}
+
+function cilium_endpoint_get_policy_l4() {
+  cilium endpoint get $* -o json | jq '.[0].policy.l4'
+}
+
+function cilium_endpoint_get_policy_l4_ingress() {
+  cilium endpoint get $* -o json | jq '[.[0].policy.l4.ingress[] | fromjson] | sort'
+}
+
+function cilium_endpoint_get_policy_l4_egress() {
+  cilium endpoint get $* -o json | jq '[.[0].policy.l4.egress[] | fromjson] | sort'
+}
+
+function cilium_endpoint_get_policy_l4_ingress_visibility() {
+  cilium endpoint get $* -o json | jq '[.[0].policy.l4."ingress-visibility"[] | fromjson] | sort'
+}
+
+function assert_l4_ingress_equals() {
+  log "testing the L4 ingress policy"
+  local expected_response=`cat`
+  local response=`cilium_endpoint_get_policy_l4_ingress -l container:id.foo`
+  if [ "$response" != "$expected_response" ]; then
+    abort "Expected: ${expected_response}; Got: ${response}; L4 policy: `cilium_endpoint_get_policy_l4 -l container:id.foo`"
+  fi
+}
+
+function assert_policy_enabled() {
+  log "testing that policy is enabled"
+  local expected_response="true"
+  local response=`cilium_endpoint_get_policy_enabled -l container:id.foo`
+  if [ "$response" != "$expected_response" ]; then
+    abort "Expected: ${expected_response}; Got: ${response}"
+  fi
+}
+
+function assert_policy_disabled() {
+  log "testing that policy is disabled"
+  local expected_response="false"
+  local response=`cilium_endpoint_get_policy_enabled -l container:id.foo`
+  if [ "$response" != "$expected_response" ]; then
+    abort "Expected: ${expected_response}; Got: ${response}"
+  fi
+}
+
+function assert_visibility_rule_inactive() {
+  log "testing that visibility rule is inactive"
+  local expected_response="[]"
+  local response=`cilium_endpoint_get_policy_l4_ingress_visibility -l container:id.foo`
+  if [ "$response" != "$expected_response" ]; then
+    abort "Expected: ${expected_response}; Got: ${response}; L4 policy: `cilium_endpoint_get_policy_l4 -l container:id.foo`"
+  fi
+}
+
+function assert_visibility_rule_active() {
+  log "testing that visibility rule is active"
+  local expected_response=`cat <<EOF
+[
+  {
+    "Port": 80,
+    "Protocol": "TCP",
+    "L7Parser": "http"
+  }
+]
+EOF`
+  local response=`cilium_endpoint_get_policy_l4_ingress_visibility -l container:id.foo`
+  if [ "$response" != "$expected_response" ]; then
+    abort "Expected: ${expected_response}; Got: ${response}; L4 policy: `cilium_endpoint_get_policy_l4 -l container:id.foo`"
+  fi
+}
+
+function assert_port80_allowed_from_bar() {
+  log "testing that id.bar has access to port 80"
+  local expected_response="ALLOWED"
+  local trace=`cilium policy trace -s any:id.bar -d container:id.foo --dport 80/tcp`
+  local response=`echo "$trace" | sed -n -e 's/^Final verdict: \(.*\)$/\1/p'`
+  if [ "$response" != "$expected_response" ]; then
+    abort "Expected: ${expected_response}; Got: ${response}; Trace: ${trace}"
+  fi
+}
+
+function assert_port80_denied_from_bar() {
+  log "testing that id.bar is denied access to port 80"
+  local expected_response="DENIED"
+  local trace=`cilium policy trace -s any:id.bar -d container:id.foo --dport 80/tcp`
+  local response=`echo "$trace" | sed -n -e 's/^Final verdict: \(.*\)$/\1/p'`
+  if [ "$response" != "$expected_response" ]; then
+    abort "Expected: ${expected_response}; Got: ${response}; Trace: ${trace}"
+  fi
+}
+
+function assert_port80_allowed_from_other() {
+  log "testing that id.other has access to port 80"
+  local expected_response="ALLOWED"
+  local trace=`cilium policy trace -s any:id.other -d container:id.foo --dport 80/tcp`
+  local response=`echo "$trace" | sed -n -e 's/^Final verdict: \(.*\)$/\1/p'`
+  if [ "$response" != "$expected_response" ]; then
+    abort "Expected: ${expected_response}; Got: ${response}; Trace: ${trace}"
+  fi
+}
+
+function assert_port80_denied_from_other() {
+  log "testing that id.other is denied access to port 80"
+  local expected_response="DENIED"
+  local trace=`cilium policy trace -s any:id.other -d container:id.foo --dport 80/tcp`
+  local response=`echo "$trace" | sed -n -e 's/^Final verdict: \(.*\)$/\1/p'`
+  if [ "$response" != "$expected_response" ]; then
+    abort "Expected: ${expected_response}; Got: ${response}; Trace: ${trace}"
+  fi
+}
+
+function test_policy_enforcement_never() {
+  cilium config PolicyEnforcement=never
+
+  policy_allow_none
+  assert_policy_disabled
+
+  policy_allow_all
+  assert_policy_disabled
+
+  policy_allow_all_to_port
+  assert_policy_disabled
+
+  policy_allow_all_to_port_http
+  assert_policy_disabled
+
+  policy_allow_all_to_another_port
+  assert_policy_disabled
+
+  policy_allow_from_bar
+  assert_policy_disabled
+
+  policy_allow_from_bar_to_port
+  assert_policy_disabled
+
+  policy_allow_from_bar_to_port_http
+  assert_policy_disabled
+}
+
+function test_policy_enforcement_always() {
+  cilium config PolicyEnforcement=always
+
+  policy_allow_none
+  assert_policy_enabled
+  assert_visibility_rule_inactive
+  assert_port80_denied_from_bar
+  assert_port80_denied_from_other
+  echo "[]" | assert_l4_ingress_equals
+
+  policy_allow_all
+  assert_policy_enabled
+  assert_visibility_rule_active
+  assert_port80_allowed_from_bar
+  assert_port80_allowed_from_other
+  assert_l4_ingress_equals <<EOF
+[
+  {
+    "port": 80,
+    "protocol": "TCP",
+    "l7Rules": [
+      {
+        "<none>": {
+          "http": [
+            {}
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "port": 0,
+    "protocol": "ANY"
+  }
+]
+EOF
+
+  policy_allow_all_to_port
+  assert_policy_enabled
+  assert_visibility_rule_active
+  assert_port80_allowed_from_bar
+  assert_port80_allowed_from_other
+  assert_l4_ingress_equals <<EOF
+[
+  {
+    "port": 80,
+    "protocol": "TCP",
+    "l7Rules": [
+      {
+        "<none>": {
+          "http": [
+            {}
+          ]
+        }
+      }
+    ]
+  }
+]
+EOF
+
+  policy_allow_all_to_port_http
+  assert_policy_enabled
+  assert_visibility_rule_inactive
+  assert_port80_allowed_from_bar
+  assert_port80_allowed_from_other
+  assert_l4_ingress_equals <<EOF
+[
+  {
+    "port": 80,
+    "protocol": "TCP",
+    "l7Rules": [
+      {
+        "<none>": {
+          "http": [
+            {
+              "path": "/public",
+              "method": "GET"
+            }
+          ]
+        }
+      }
+    ]
+  }
+]
+EOF
+
+  policy_allow_all_to_another_port
+  assert_policy_enabled
+  assert_visibility_rule_inactive
+  assert_port80_denied_from_bar
+  assert_port80_denied_from_other
+  assert_l4_ingress_equals <<EOF
+[
+  {
+    "port": 1234,
+    "protocol": "TCP"
+  }
+]
+EOF
+
+  policy_allow_from_bar
+  assert_policy_enabled
+  assert_visibility_rule_active
+  assert_port80_allowed_from_bar
+  assert_port80_denied_from_other
+  assert_l4_ingress_equals <<EOF
+[
+  {
+    "port": 80,
+    "protocol": "TCP",
+    "l7Rules": [
+      {
+        "any.id.bar=": {
+          "http": [
+            {}
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "port": 0,
+    "protocol": "ANY"
+  }
+]
+EOF
+
+  policy_allow_from_bar_to_port
+  assert_policy_enabled
+  assert_visibility_rule_active
+  assert_port80_allowed_from_bar
+  assert_port80_denied_from_other
+  assert_l4_ingress_equals <<EOF
+[
+  {
+    "port": 80,
+    "protocol": "TCP",
+    "l7Rules": [
+      {
+        "any.id.bar=": {
+          "http": [
+            {}
+          ]
+        }
+      }
+    ]
+  }
+]
+EOF
+
+  policy_allow_from_bar_to_port_http
+  assert_policy_enabled
+  assert_visibility_rule_inactive
+  assert_port80_allowed_from_bar
+  assert_port80_denied_from_other
+  assert_l4_ingress_equals <<EOF
+[
+  {
+    "port": 80,
+    "protocol": "TCP",
+    "l7Rules": [
+      {
+        "any.id.bar=": {
+          "http": [
+            {
+              "path": "/public",
+              "method": "GET"
+            }
+          ]
+        }
+      }
+    ]
+  }
+]
+EOF
+}
+
+function test_policy_enforcement_default() {
+  cilium config PolicyEnforcement=default
+
+  policy_allow_none
+  assert_policy_enabled
+  assert_visibility_rule_active
+  assert_port80_allowed_from_bar
+  assert_port80_allowed_from_other
+  assert_l4_ingress_equals <<EOF
+[
+  {
+    "port": 80,
+    "protocol": "TCP",
+    "l7Rules": [
+      {
+        "<none>": {
+          "http": [
+            {}
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "port": 0,
+    "protocol": "ANY"
+  }
+]
+EOF
+
+  policy_allow_all
+  assert_policy_enabled
+  assert_visibility_rule_active
+  assert_port80_allowed_from_bar
+  assert_port80_allowed_from_other
+  assert_l4_ingress_equals <<EOF
+[
+  {
+    "port": 80,
+    "protocol": "TCP",
+    "l7Rules": [
+      {
+        "<none>": {
+          "http": [
+            {}
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "port": 0,
+    "protocol": "ANY"
+  }
+]
+EOF
+
+  policy_allow_all_to_port
+  assert_policy_enabled
+  assert_visibility_rule_active
+  assert_port80_allowed_from_bar
+  assert_port80_allowed_from_other
+  assert_l4_ingress_equals <<EOF
+[
+  {
+    "port": 80,
+    "protocol": "TCP",
+    "l7Rules": [
+      {
+        "<none>": {
+          "http": [
+            {}
+          ]
+        }
+      }
+    ]
+  }
+]
+EOF
+
+  policy_allow_all_to_port_http
+  assert_policy_enabled
+  assert_visibility_rule_inactive
+  assert_port80_allowed_from_bar
+  assert_port80_allowed_from_other
+  assert_l4_ingress_equals <<EOF
+[
+  {
+    "port": 80,
+    "protocol": "TCP",
+    "l7Rules": [
+      {
+        "<none>": {
+          "http": [
+            {
+              "path": "/public",
+              "method": "GET"
+            }
+          ]
+        }
+      }
+    ]
+  }
+]
+EOF
+
+  policy_allow_all_to_another_port
+  assert_policy_enabled
+  assert_visibility_rule_inactive
+  assert_port80_denied_from_bar
+  assert_port80_denied_from_other
+  assert_l4_ingress_equals <<EOF
+[
+  {
+    "port": 1234,
+    "protocol": "TCP"
+  }
+]
+EOF
+
+  policy_allow_from_bar
+  assert_policy_enabled
+  assert_visibility_rule_active
+  assert_port80_allowed_from_bar
+  assert_port80_denied_from_other
+  assert_l4_ingress_equals <<EOF
+[
+  {
+    "port": 80,
+    "protocol": "TCP",
+    "l7Rules": [
+      {
+        "any.id.bar=": {
+          "http": [
+            {}
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "port": 0,
+    "protocol": "ANY"
+  }
+]
+EOF
+
+  policy_allow_from_bar_to_port
+  assert_policy_enabled
+  assert_visibility_rule_active
+  assert_port80_allowed_from_bar
+  assert_port80_denied_from_other
+  assert_l4_ingress_equals <<EOF
+[
+  {
+    "port": 80,
+    "protocol": "TCP",
+    "l7Rules": [
+      {
+        "any.id.bar=": {
+          "http": [
+            {}
+          ]
+        }
+      }
+    ]
+  }
+]
+EOF
+
+  policy_allow_from_bar_to_port_http
+  assert_policy_enabled
+  assert_visibility_rule_inactive
+  assert_port80_allowed_from_bar
+  assert_port80_denied_from_other
+  assert_l4_ingress_equals <<EOF
+[
+  {
+    "port": 80,
+    "protocol": "TCP",
+    "l7Rules": [
+      {
+        "any.id.bar=": {
+          "http": [
+            {
+              "path": "/public",
+              "method": "GET"
+            }
+          ]
+        }
+      }
+    ]
+  }
+]
+EOF
+}
+
+function cleanup {
+  gather_files ${TEST_NAME} ${TEST_SUITE}
+  cilium policy delete --all 2> /dev/null || true
+  cilium config PolicyEnforcement=default
+  docker rm -f foo 2> /dev/null || true
+}
+
+trap cleanup EXIT
+
+cleanup
+logs_clear
+
+start_container
+
+test_policy_enforcement_never
+test_policy_enforcement_always
+test_policy_enforcement_default
+
+test_succeeded "${TEST_NAME}"


### PR DESCRIPTION
Define a new "ingressVisibility" rule type to forward ingress traffic to
L4 ports through the L7 proxy for access logging.
    
Compute the list of all active ingress visibility rules for each
L4 port, and report them in the endpoint policy API.

```release-note
Introduce ingressVisibility policy rule type to forward ingress traffic to L4 ports at L7 for access logging
```

Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/1540)
<!-- Reviewable:end -->
