### PR TITLE
Using filepath.Join instead of path.Join in OS paths

### DIFF
--- a/pkg/bpf/bpffs.go
+++ b/pkg/bpf/bpffs.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -78,12 +78,12 @@ func GetMapPrefix() string {
 
 func MapPrefixPath() string {
 	once.Do(lockDown)
-	return path.Join(mapRoot, mapPrefix)
+	return filepath.Join(mapRoot, mapPrefix)
 }
 
 func MapPath(name string) string {
 	once.Do(lockDown)
-	return path.Join(mapRoot, mapPrefix, name)
+	return filepath.Join(mapRoot, mapPrefix, name)
 }
 
 var (

--- a/plugins/cilium-docker/main.go
+++ b/plugins/cilium-docker/main.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/plugins/cilium-docker/driver"
@@ -84,7 +84,7 @@ func initConfig() {
 
 	common.RequireRootPrivilege("cilium-docker")
 
-	driverSock = path.Join(pluginPath, "cilium.sock")
+	driverSock = filepath.Join(pluginPath, "cilium.sock")
 
 	if err := os.MkdirAll(pluginPath, 0755); err != nil && !os.IsExist(err) {
 		log.Fatalf("Could not create net plugin path directory: %s", err)


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>