### PR TITLE
Restart CiliumRulesCtl after unparsable policy

### DIFF
--- a/examples/minikube/malformed_policy.yaml
+++ b/examples/minikube/malformed_policy.yaml
@@ -1,0 +1,14 @@
+
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+description: "A rule that will break your policy watcher"
+metadata:
+  name: "badrule"
+spec:
+  podSelector:
+    matchLabels:
+      id: app3
+  egress:
+    toCIDR:
+      podSelector:
+        ip: 8.8.8.8/32


### PR DESCRIPTION
k8s.io/apimachinery/pkg/watch/streamwatcher.go receive function loops
until a decode error occurs. This causes the controller to stop
receiving new events.

Decode error can be triggerred by malformed policy manifest.

This change expands k8s error handling in k8s watcher to detect whether
decode error occurred, tries to close running CiliumRulesController
gracefully by sending information to its stop channel and closing the
channel. Then a new identical controller is created and it can be
restarted in the same way.

Signed-off-by: Maciej Kwiek <maciej@covalent.io>

fixes #1323

Note: when the invalid policy is in the system, the watcher keeps restarting and is unable to handle any valid policies created.