### PR TITLE
make endpointmanager's endpoints a private attribute

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1098,9 +1098,6 @@ func (d *Daemon) validateExistingMaps() error {
 }
 
 func (d *Daemon) collectStaleMapGarbage() {
-	endpointmanager.Mutex.RLock()
-	defer endpointmanager.Mutex.RUnlock()
-
 	walker := func(path string, _ os.FileInfo, _ error) error {
 		return d.staleMapWalker(path)
 	}
@@ -1126,28 +1123,17 @@ func (d *Daemon) removeStaleIDFromPolicyMap(id uint32) {
 	}
 }
 
-// call with endpointmanager.Mutex.RLocked
 func (d *Daemon) checkStaleMap(path string, filename string, id string) {
 	if tmp, err := strconv.ParseUint(id, 0, 16); err == nil {
-		if _, ok := endpointmanager.Endpoints[uint16(tmp)]; !ok {
+		if ep := endpointmanager.LookupCiliumID(uint16(tmp)); ep != nil {
 			d.removeStaleIDFromPolicyMap(uint32(tmp))
 			d.removeStaleMap(path)
 		}
 	}
 }
 
-// call with endpointmanager.Mutex.RLocked
 func (d *Daemon) checkStaleGlobalMap(path string, filename string) {
-	var globalCTinUse = false
-
-	for k := range endpointmanager.Endpoints {
-		e := endpointmanager.Endpoints[k]
-		if e.Consumable != nil &&
-			e.Opts.IsDisabled(endpoint.OptionConntrackLocal) {
-			globalCTinUse = true
-			break
-		}
-	}
+	globalCTinUse := endpointmanager.HasGlobalCT()
 
 	if !globalCTinUse &&
 		(filename == ctmap.MapName6Global ||
@@ -1156,7 +1142,6 @@ func (d *Daemon) checkStaleGlobalMap(path string, filename string) {
 	}
 }
 
-// call with endpointmanager.Mutex.RLocked
 func (d *Daemon) staleMapWalker(path string) error {
 	filename := filepath.Base(path)
 

--- a/daemon/logstash.go
+++ b/daemon/logstash.go
@@ -69,17 +69,17 @@ func (d *Daemon) EnableLogstash(LogstashAddr string, refreshTime int) {
 			timeToProcess1 := time.Now()
 
 			allPes := map[uint16][]policymap.PolicyEntryDump{}
-			endpointmanager.Mutex.RLock()
-			for _, ep := range endpointmanager.Endpoints {
+			eps := endpointmanager.GetEndpoints()
+			for _, ep := range eps {
 				ep.Mutex.RLock()
 				pes, err := ep.PolicyMap.DumpToSlice()
 				if err != nil {
+					ep.Mutex.RUnlock()
 					continue
 				}
 				allPes[ep.ID] = pes
 				ep.Mutex.RUnlock()
 			}
-			endpointmanager.Mutex.RUnlock()
 			lss := d.processStats(allPes)
 			for _, ls := range lss {
 				if err := json.NewEncoder(c).Encode(ls); err != nil {

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -52,7 +52,6 @@ func (d *Daemon) SyncState(dir string, clean bool) error {
 		return nil
 	}
 
-	endpointmanager.Mutex.Lock()
 	nEndpoints := len(possibleEPs)
 
 	// we need to signalize when the endpoints are restored, i.e., when the
@@ -123,7 +122,6 @@ func (d *Daemon) SyncState(dir string, clean bool) error {
 			epRegenerated <- true
 		}(ep, epRestored, epRegenerated)
 	}
-	endpointmanager.Mutex.Unlock()
 
 	go func() {
 		regenerated, total := 0, 0

--- a/daemon/status.go
+++ b/daemon/status.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
-	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -80,9 +79,6 @@ func NewGetHealthzHandler(d *Daemon) GetHealthzHandler {
 func checkLocks(d *Daemon) {
 	// Try to acquire a couple of global locks to have the status API fail
 	// in case of a deadlock on these locks
-
-	endpointmanager.Mutex.Lock()
-	endpointmanager.Mutex.Unlock()
 
 	d.conf.ConfigPatchMutex.Lock()
 	d.conf.ConfigPatchMutex.Unlock()

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1136,6 +1136,8 @@ func (e *Endpoint) Update(owner Owner, opts models.ConfigurationMap) error {
 // HasLabels returns whether endpoint e contains all labels l. Will return 'false'
 // if any label in l is not in the endpoint's labels.
 func (e *Endpoint) HasLabels(l pkgLabels.Labels) bool {
+	e.Mutex.RLock()
+	defer e.Mutex.RUnlock()
 	allEpLabels := e.OpLabels.AllLabels()
 
 	for _, v := range l {

--- a/pkg/endpointmanager/conntrack.go
+++ b/pkg/endpointmanager/conntrack.go
@@ -86,10 +86,8 @@ func EnableConntrackGC(ipv4, ipv6 bool) {
 		seenGlobal := false
 		sleepTime := time.Duration(GcInterval) * time.Second
 		for {
-			Mutex.RLock()
-
-			for k := range Endpoints {
-				e := Endpoints[k]
+			eps := GetEndpoints()
+			for _, e := range eps {
 				e.Mutex.RLock()
 
 				if e.Consumable == nil {
@@ -125,8 +123,6 @@ func EnableConntrackGC(ipv4, ipv6 bool) {
 					RunGC(e, isLocal, false, ctmap.NewGCFilterBy(ctmap.GCFilterByTime))
 				}
 			}
-
-			Mutex.RUnlock()
 			time.Sleep(sleepTime)
 			seenGlobal = false
 		}

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -27,39 +27,137 @@ import (
 var (
 	log = common.DefaultLogger
 
-	// Mutex protects Endpoints and endpointsAux
-	//
-	// Warning: This lock may not be taken while an individual endpoint
-	// lock is being held. If you require to hold both, then the global
-	// endpointmanager lock must always be acquired first.
-	Mutex lock.RWMutex
+	// mutex protects endpoints and endpointsAux
+	mutex lock.RWMutex
 
-	// Endpoints is the global list of endpoints indexed by ID. Mutex must
+	// endpoints is the global list of endpoints indexed by ID. mutex must
 	// be held to read and write.
-	//
-	// FIXME: This is currently exported, as more code moves from daemon
-	// into pkg/endpoint, we might be able to unexport this
-	Endpoints    = map[uint16]*endpoint.Endpoint{}
+	endpoints    = map[uint16]*endpoint.Endpoint{}
 	endpointsAux = map[string]*endpoint.Endpoint{}
 )
 
-// LookupCiliumIDLocked looks up endpoint by endpoint ID with Mutex held
-func LookupCiliumIDLocked(id uint16) *endpoint.Endpoint {
-	if ep, ok := Endpoints[id]; ok {
+// Insert inserts the endpoint into the global maps.
+// Must be called with ep.Mutex.RLock held.
+func Insert(ep *endpoint.Endpoint) {
+	mutex.Lock()
+	metrics.EndpointCount.Inc()
+	endpoints[ep.ID] = ep
+	updateReferences(ep)
+	mutex.Unlock()
+}
+
+// Lookup looks up the endpoint by prefix id
+func Lookup(id string) (*endpoint.Endpoint, error) {
+	mutex.RLock()
+	defer mutex.RUnlock()
+
+	prefix, eid, err := endpoint.ParseID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	switch prefix {
+	case endpoint.CiliumLocalIdPrefix:
+		n, err := endpoint.ParseCiliumID(id)
+		if err != nil {
+			return nil, err
+		}
+		return lookupCiliumID(uint16(n)), nil
+
+	case endpoint.CiliumGlobalIdPrefix:
+		return nil, fmt.Errorf("Unsupported id format for now")
+
+	case endpoint.ContainerIdPrefix:
+		return lookupDockerID(eid), nil
+
+	case endpoint.DockerEndpointPrefix:
+		return lookupDockerEndpoint(eid), nil
+
+	case endpoint.ContainerNamePrefix:
+		return lookupDockerContainerName(eid), nil
+
+	case endpoint.PodNamePrefix:
+		return lookupPodNameLocked(eid), nil
+
+	case endpoint.IPv4Prefix:
+		return lookupIPv4(eid), nil
+
+	default:
+		return nil, fmt.Errorf("Unknown endpoint prefix %s", prefix)
+	}
+}
+
+// LookupCiliumID looks up endpoint by endpoint ID
+func LookupCiliumID(id uint16) *endpoint.Endpoint {
+	mutex.RLock()
+	ep := lookupCiliumID(id)
+	mutex.RUnlock()
+	return ep
+}
+
+// LookupDockerID looks up endpoint by Docker ID
+func LookupDockerID(id string) *endpoint.Endpoint {
+	mutex.RLock()
+	ep := lookupDockerID(id)
+	mutex.RUnlock()
+	return ep
+}
+
+// LookupIPv4 looks up endpoint by IPv4 address
+func LookupIPv4(ipv4 string) *endpoint.Endpoint {
+	mutex.RLock()
+	ep := lookupIPv4(ipv4)
+	mutex.RUnlock()
+	return ep
+}
+
+// UpdateReferences makes an endpoint available by all possible reference
+// fields as available for this endpoint (containerID, IPv4 address, ...)
+// Must be called with ep.Mutex.RLock held.
+func UpdateReferences(ep *endpoint.Endpoint) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	updateReferences(ep)
+}
+
+// Remove removes the endpoint from the global maps.
+// Must be called with ep.Mutex.RLock held.
+func Remove(ep *endpoint.Endpoint) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	metrics.EndpointCount.Dec()
+	delete(endpoints, ep.ID)
+
+	if ep.DockerID != "" {
+		delete(endpointsAux, endpoint.NewID(endpoint.ContainerIdPrefix, ep.DockerID))
+	}
+
+	if ep.DockerEndpointID != "" {
+		delete(endpointsAux, endpoint.NewID(endpoint.DockerEndpointPrefix, ep.DockerEndpointID))
+	}
+
+	if ep.IPv4.String() != "" {
+		delete(endpointsAux, endpoint.NewID(endpoint.IPv4Prefix, ep.IPv4.String()))
+	}
+
+	if ep.ContainerName != "" {
+		delete(endpointsAux, endpoint.NewID(endpoint.ContainerNamePrefix, ep.ContainerName))
+	}
+
+	if ep.PodName != "" {
+		delete(endpointsAux, endpoint.NewID(endpoint.PodNamePrefix, ep.PodName))
+	}
+}
+
+// lookupCiliumID looks up endpoint by endpoint ID
+func lookupCiliumID(id uint16) *endpoint.Endpoint {
+	if ep, ok := endpoints[id]; ok {
 		return ep
 	}
 	return nil
 }
 
-// LookupCiliumID looks up endpoint by endpoint ID
-func LookupCiliumID(id uint16) *endpoint.Endpoint {
-	Mutex.Lock()
-	defer Mutex.Unlock()
-
-	return LookupCiliumIDLocked(id)
-}
-
-func lookupDockerEndpointLocked(id string) *endpoint.Endpoint {
+func lookupDockerEndpoint(id string) *endpoint.Endpoint {
 	if ep, ok := endpointsAux[endpoint.NewID(endpoint.DockerEndpointPrefix, id)]; ok {
 		return ep
 	}
@@ -73,39 +171,21 @@ func lookupPodNameLocked(name string) *endpoint.Endpoint {
 	return nil
 }
 
-func lookupDockerContainerNameLocked(name string) *endpoint.Endpoint {
+func lookupDockerContainerName(name string) *endpoint.Endpoint {
 	if ep, ok := endpointsAux[endpoint.NewID(endpoint.ContainerNamePrefix, name)]; ok {
 		return ep
 	}
 	return nil
 }
 
-// LookupDockerID looks up endpoint by Docker ID
-func LookupDockerID(id string) *endpoint.Endpoint {
-	Mutex.Lock()
-	defer Mutex.Unlock()
-
-	return LookupDockerIDLocked(id)
-}
-
-func lookupIPv4Locked(ipv4 string) *endpoint.Endpoint {
+func lookupIPv4(ipv4 string) *endpoint.Endpoint {
 	if ep, ok := endpointsAux[endpoint.NewID(endpoint.IPv4Prefix, ipv4)]; ok {
 		return ep
 	}
 	return nil
 }
 
-// LookupIPv4 looks up endpoint by IPv4 address
-func LookupIPv4(ipv4 string) *endpoint.Endpoint {
-	Mutex.Lock()
-	defer Mutex.Unlock()
-
-	return lookupIPv4Locked(ipv4)
-}
-
-// LookupDockerIDLocked is identical to LookupDockerID() but with
-// endpointmanager.Mutex already held
-func LookupDockerIDLocked(id string) *endpoint.Endpoint {
+func lookupDockerID(id string) *endpoint.Endpoint {
 	if ep, ok := endpointsAux[endpoint.NewID(endpoint.ContainerIdPrefix, id)]; ok {
 		return ep
 	}
@@ -114,12 +194,6 @@ func LookupDockerIDLocked(id string) *endpoint.Endpoint {
 
 func linkContainerID(ep *endpoint.Endpoint) {
 	endpointsAux[endpoint.NewID(endpoint.ContainerIdPrefix, ep.DockerID)] = ep
-}
-
-// LinkContainerID links an endpoint and makes it searchable by Docker ID.
-// Mutex must be held
-func LinkContainerID(ep *endpoint.Endpoint) {
-	linkContainerID(ep)
 }
 
 // UpdateReferences updates the mappings of various values to their corresponding
@@ -146,98 +220,6 @@ func updateReferences(ep *endpoint.Endpoint) {
 	}
 }
 
-// UpdateReferences makes an endpoint available by all possible reference
-// fields as available for this endpoint (containerID, IPv4 address, ...)
-func UpdateReferences(ep *endpoint.Endpoint) {
-	Mutex.Lock()
-	defer Mutex.Unlock()
-
-	updateReferences(ep)
-}
-
-// Insert inserts the endpoint into the global maps
-func Insert(ep *endpoint.Endpoint) {
-	Endpoints[ep.ID] = ep
-	metrics.EndpointCount.Inc()
-	updateReferences(ep)
-}
-
-// RemoveLocked is identical to Remove but with endpointmanager.Mutex already held
-func RemoveLocked(ep *endpoint.Endpoint) {
-	delete(Endpoints, ep.ID)
-	metrics.EndpointCount.Dec()
-
-	if ep.DockerID != "" {
-		delete(endpointsAux, endpoint.NewID(endpoint.ContainerIdPrefix, ep.DockerID))
-	}
-
-	if ep.DockerEndpointID != "" {
-		delete(endpointsAux, endpoint.NewID(endpoint.DockerEndpointPrefix, ep.DockerEndpointID))
-	}
-
-	if ep.IPv4.String() != "" {
-		delete(endpointsAux, endpoint.NewID(endpoint.IPv4Prefix, ep.IPv4.String()))
-	}
-
-	if ep.ContainerName != "" {
-		delete(endpointsAux, endpoint.NewID(endpoint.ContainerNamePrefix, ep.ContainerName))
-	}
-
-	if ep.PodName != "" {
-		delete(endpointsAux, endpoint.NewID(endpoint.PodNamePrefix, ep.PodName))
-	}
-}
-
-// Remove removes the endpoint from the global maps
-func Remove(ep *endpoint.Endpoint) {
-	Mutex.Lock()
-	RemoveLocked(ep)
-	Mutex.Unlock()
-}
-
-// Lookup looks up the endpoint by prefix id
-func Lookup(id string) (*endpoint.Endpoint, error) {
-	Mutex.RLock()
-	defer Mutex.RUnlock()
-
-	return LookupLocked(id)
-}
-
-// LookupLocked looks up the endpoint by prefix id with the Mutex already held
-func LookupLocked(id string) (*endpoint.Endpoint, error) {
-	prefix, eid, err := endpoint.ParseID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	switch prefix {
-	case endpoint.CiliumLocalIdPrefix:
-		n, _ := endpoint.ParseCiliumID(id)
-		return LookupCiliumIDLocked(uint16(n)), nil
-
-	case endpoint.CiliumGlobalIdPrefix:
-		return nil, fmt.Errorf("Unsupported id format for now")
-
-	case endpoint.ContainerIdPrefix:
-		return LookupDockerIDLocked(eid), nil
-
-	case endpoint.DockerEndpointPrefix:
-		return lookupDockerEndpointLocked(eid), nil
-
-	case endpoint.ContainerNamePrefix:
-		return lookupDockerContainerNameLocked(eid), nil
-
-	case endpoint.PodNamePrefix:
-		return lookupPodNameLocked(eid), nil
-
-	case endpoint.IPv4Prefix:
-		return lookupIPv4Locked(eid), nil
-
-	default:
-		return nil, fmt.Errorf("Unknown endpoint prefix %s", prefix)
-	}
-}
-
 // TriggerPolicyUpdates calls TriggerPolicyUpdatesLocked for each endpoint and
 // regenerates as required. During this process, the endpoint list is locked
 // and cannot be modified.
@@ -246,11 +228,10 @@ func LookupLocked(id string) (*endpoint.Endpoint, error) {
 func TriggerPolicyUpdates(owner endpoint.Owner) *sync.WaitGroup {
 	var wg sync.WaitGroup
 
-	Mutex.RLock()
+	eps := GetEndpoints()
+	wg.Add(len(eps))
 
-	wg.Add(len(Endpoints))
-
-	for k := range Endpoints {
+	for _, ep := range eps {
 		go func(ep *endpoint.Endpoint, wg *sync.WaitGroup) {
 			ep.Mutex.Lock()
 			policyChanges, ctCleaned, err := ep.TriggerPolicyUpdatesLocked(owner, nil)
@@ -276,10 +257,33 @@ func TriggerPolicyUpdates(owner endpoint.Owner) *sync.WaitGroup {
 				} // else policy changed, but can't regenerate => do not change status
 			}
 			wg.Done()
-		}(Endpoints[k], &wg)
+		}(ep, &wg)
 	}
 
-	Mutex.RUnlock()
-
 	return &wg
+}
+
+// HasGlobalCT returns true if the endpoints have a global CT, false otherwise.
+func HasGlobalCT() bool {
+	eps := GetEndpoints()
+	for _, e := range eps {
+		e.RLock()
+		globalCT := e.Consumable != nil && !e.Opts.IsEnabled(endpoint.OptionConntrackLocal)
+		e.RUnlock()
+		if globalCT {
+			return true
+		}
+	}
+	return false
+}
+
+// GetEndpoints returns a slice of all endpoints present in endpoint manager.
+func GetEndpoints() []*endpoint.Endpoint {
+	mutex.RLock()
+	eps := make([]*endpoint.Endpoint, 0, len(endpoints))
+	for _, ep := range endpoints {
+		eps = append(eps, ep)
+	}
+	mutex.RUnlock()
+	return eps
 }

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -176,10 +176,6 @@ func (bo *BoolOptions) IsEnabled(key string) bool {
 	return exists && set
 }
 
-func (bo *BoolOptions) IsDisabled(key string) bool {
-	return !bo.IsEnabled(key)
-}
-
 func (bo *BoolOptions) Set(key string, value bool) {
 	bo.optsMU.Lock()
 	bo.Opts[key] = value


### PR DESCRIPTION
endpointmanager: hide mutex in the package

This PR hides the endpointmanager internal mutex to be inaccessible
by outside of this package. This also fixes some data race conditions
that were triggered by misplaced lock / unlocks of this package.