### PR TITLE
nodeaddress: Use a IPv6 site local address as host address

### DIFF
--- a/pkg/nodeaddress/node_address.go
+++ b/pkg/nodeaddress/node_address.go
@@ -41,12 +41,13 @@ var (
 	ipv6AllocRange      *net.IPNet
 )
 
-func makeIPv6HostIP(ip net.IP) net.IP {
-	// Derive prefix::1 as the IPv6 host address
-	ip[12] = 0
-	ip[13] = 0
-	ip[14] = 0
-	ip[15] = 1
+func makeIPv6HostIP() net.IP {
+	ipstr := "fc00::10CA:1"
+	ip := net.ParseIP(ipstr)
+	if ip == nil {
+		log.Fatalf("Unable to parse IP '%s'", ipstr)
+	}
+
 	return ip
 }
 
@@ -229,7 +230,7 @@ func AutoComplete() error {
 	}
 
 	if ipv6Address == nil {
-		ipv6Address = makeIPv6HostIP(ipv6AllocRange.IP)
+		ipv6Address = makeIPv6HostIP()
 	}
 
 	return nil


### PR DESCRIPTION
This resolves an issue where running Cilium will configure a global
scope address for the system which causes getaddrinfo() to start
returning IPv6 addresses for DNS requests even though the system may not
have actual IPv6 connectivity.

Fixes: #267

Signed-off-by: Thomas Graf <thomas@cilium.io>