### PR TITLE
daemon: bug fix for out of sync with kvstore

### DIFF
--- a/daemon/docker_watcher.go
+++ b/daemon/docker_watcher.go
@@ -302,10 +302,16 @@ func (d *Daemon) handleCreateContainer(id string, retry bool) {
 			return
 		}
 		ep.LabelsHash = newHash
+		epIdty := ep.GetIdentity()
 		ep.Mutex.Unlock()
 
 		// Since no orchLabels were modified we can safely return here
-		if ok && !orchLabelsModified {
+		if ok && !orchLabelsModified &&
+			// The kvstore can change the identity for a particular set of
+			// labels. We need to update the new identity and regenerate the
+			// bpf program as soon we know about it.
+			((identity == nil && epIdty == policy.InvalidIdentity) ||
+				(identity.ID == epIdty)) {
 			return
 		}
 


### PR DESCRIPTION
On a multi node environment, cilium could get out of sync with the
identities localy stored and the kvstore.

Steps to reproduce the issue:
1 - Have 2 nodes running with cilium

2 - Set a container running with the same set of labels on each node.
    `docker run -ti -d --net cilium --label id.server busybox sleep 999s`

3 - Check with `cilium endpoint list` they have the same identity
```
$ cilium endpoint list
ENDPOINT   POLICY        IDENTITY   LABELS (source:key[=value])  IPv6             IPv4            STATUS
           ENFORCEMENT
3978       Disabled      443        container:id.server          fd02::1:0:f8a    10.12.251.95    ready
```

4 - Disconnect one of the nodes from the network, without stopping
cilium.

5 - On the other node, stop / remove the container running.

6 - Wait at least 120 seconds (kvstore label timeout to be considered
unused)

7 - Start the container with the exact same labels and check the
identity is different than before.

8 - Reconnect the disconnected node from step 4.

9 - Both nodes have 2 different identities for the same set of labels.

This commit fixes the out of sync issue by comparing if the identity
stored in the kvstore differs from the container's identity. Once cilium
is reconnected with the kvstore, it can take up to 30 seconds to detect
the new identity

Signed-off-by: André Martins <andre@cilium.io>

Fixes #1518