### PR TITLE
tests: wait for endpoint deletion when checking stale map removal

### DIFF
--- a/tests/17-cilium_policy-id-remove.sh
+++ b/tests/17-cilium_policy-id-remove.sh
@@ -51,14 +51,19 @@ for ep in $known_endpoints; do
   fi
 done
 
-log "before removal: `cilium endpoint list`"
-log "`docker ps`"
+log "before removal"
+log "endpoint list: `cilium endpoint list`"
+log "docker: `docker ps`"
 
 log "removing containerA and containerB"
 docker rm -f containerA containerB
 
-log "after removal: `cilium endpoint list`"
-log "`docker ps`"
+log "after removal"
+log "endpoint list: `cilium endpoint list`"
+log "docker: `docker ps`"
+
+# In the unlikely case endpoint deletion should take longer than expected, wait.
+wait_for_endpoints_deletion
 
 # There should only be one cilium_policy file after the containers are gone.
 # Ignoring the reserved files.

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -158,6 +158,20 @@ function wait_for_endpoints {
   restore_flag $save "e"
 }
 
+function wait_for_endpoints_deletion {
+  local save=$-
+  set +e
+  local NUM_DESIRED="2" # When no endpoints are present there should be two lines only.
+  local CMD="cilium endpoint list | wc -l || true"
+  local INFO_CMD="cilium endpoint list"
+  local MAX_MINS="2"
+  local ERROR_OUTPUT="Timeout while waiting for endpoint removal"
+  log "waiting for up to ${MAX_MINS} mins for all endpoints to be removed"
+  wait_for_desired_state "$NUM_DESIRED" "$CMD" "$INFO_CMD" "$MAX_MINS" "$ERROR_OUTPUT"
+  log "done waiting"
+  restore_flag $save "e"
+}
+
 function k8s_num_ready {
   local save=$-
   set +e


### PR DESCRIPTION
Tested this by applying the below diff

	diff --git a/daemon/endpoint.go b/daemon/endpoint.go
	index 506ee6e41807..4bb5a410698a 100644
	--- a/daemon/endpoint.go
	+++ b/daemon/endpoint.go
	@@ -17,6 +17,7 @@ package main
	 import (
	        "os"
	        "sync"
	+       "time"

	        "github.com/cilium/cilium/api/v1/models"
	        . "github.com/cilium/cilium/api/v1/server/restapi/endpoint"
	@@ -296,6 +297,9 @@ func (d *Daemon) deleteEndpoint(ep *endpoint.Endpoint) int {
	        ep.Mutex.Lock()
	        defer ep.Mutex.Unlock()
	        ep.LeaveLocked(d)
	+       log.Infof("Delaying deleteEndpoint")
	+       time.Sleep(100 * time.Second)
	+       log.Infof("Delay over deleteEndpoint")

	        sha256sum := ep.OpLabels.IdentityLabels().SHA256Sum()
	        if err := d.DeleteIdentityBySHA256(sha256sum, ep.StringID()); err != nil {

Also split up the log lines for easier distinction between cilium and
docker output.

Related-to: #1542 (Test flake 17-cilium_policy-id-remove.sh)
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>