### PR TITLE
cmd/identity: fix segfault when listing identities

### DIFF
--- a/cilium/cmd/identity_list.go
+++ b/cilium/cmd/identity_list.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	identityApi "github.com/cilium/cilium/api/v1/client/policy"
+	pkg "github.com/cilium/cilium/pkg/client"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/spf13/cobra"
 )
@@ -59,7 +60,11 @@ func listIdentities(args []string) {
 
 	identities, err := client.Policy.GetIdentity(params)
 	if err != nil {
-		Fatalf("Cannot get identities for given labels %v. err: %s\n", params.Labels, err.Error())
+		if params != nil {
+			Fatalf("Cannot get identities for given labels %v. err: %s\n", params.Labels, err.Error())
+		} else {
+			Fatalf("Cannot get identities. err: %s", pkg.Hint(err))
+		}
 	}
 	result["identities"] = identities.Payload
 


### PR DESCRIPTION
In the case the agent is down and we are checking for the identities list.  The
error formatting output would try accessing the parameter labels which is nil
and we get the below crasher.

	panic: runtime error: invalid memory address or nil pointer dereference
	[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x15e0def]

	goroutine 1 [running]:
	github.com/cilium/cilium/cilium/cmd.listIdentities(0x2bdbc30, 0x0, 0x0)
	        /home/scanf/opt/og/src/github.com/cilium/cilium/cilium/cmd/identity_list.go:62 +0x74f
	github.com/cilium/cilium/cilium/cmd.glob..func16(0x26141a0, 0x2bdbc30, 0x0, 0x0)
	        /home/scanf/opt/og/src/github.com/cilium/cilium/cilium/cmd/identity_list.go:32 +0x3f
	github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).execute(0x26141a0, 0x2bdbc30, 0x0, 0x0, 0x26141a0, 0x2bdbc30)
	        /home/scanf/opt/og/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:648 +0x231
	github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x26110c0, 0xc42006c058, 0x0, 0x1)
	        /home/scanf/opt/og/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:735 +0x339
	github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).Execute(0x26110c0, 0x1769680, 0xc4216b04b0)
	        /home/scanf/opt/og/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:693 +0x2b
	github.com/cilium/cilium/cilium/cmd.Execute()
	        /home/scanf/opt/og/src/github.com/cilium/cilium/cilium/cmd/root.go:68 +0x31
	main.main()
	        /home/scanf/opt/og/src/github.com/cilium/cilium/cilium/main.go:20 +0x20

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>