### PR TITLE
cmd: Fix policy trace --dport

### DIFF
--- a/cilium/cmd/policy_trace.go
+++ b/cilium/cmd/policy_trace.go
@@ -55,7 +55,7 @@ If multiple sources and / or destinations are provided, each source is tested wh
 
 		srcSlices := [][]string{}
 		dstSlices := [][]string{}
-		var srcSlice, dstSlice, dports []string
+		var srcSlice, dstSlice []string
 		var dPorts []*models.Port
 		var err error
 


### PR DESCRIPTION
The local variable was hiding the originally-parsed commandline
argument, which would cause L4 policy not to be traced even when you
specify "--dport" on the 'cilium policy trace' commandline.

Fixes: 31266bd17f50 ("cmd: policy trace src/dst eID, secid, k8s-pod options")
Signed-off-by: Joe Stringer <joe@covalent.io>