### PR TITLE
agent: Masquerade traffic from host to agent with ExternalIP

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -598,10 +598,10 @@ func (d *Daemon) installMasqRule() error {
 	if err := runProg("iptables", []string{
 		"-t", "nat",
 		"-A", ciliumPostNatChain,
-		"!", "-s", nodeaddress.GetInternalIPv4().String(),
+		"!", "-s", nodeaddress.GetExternalIPv4().String(),
 		"-o", "cilium_host",
 		"-m", "comment", "--comment", "cilium host->cluster masquerade",
-		"-j", "MASQUERADE"}, false); err != nil {
+		"-j", "SNAT", "--to-source", nodeaddress.GetExternalIPv4().String()}, false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This ensures that packets which are later routed over the overlay to
other nodes can properly respond to the traffic.

Signed-off-by: Thomas Graf <thomas@cilium.io>