### PR TITLE
l4: Fix policy trace for udp/tcp policies

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -7,7 +7,8 @@ HEAD
 
 Bug Fixes
 ---------
-* Add here
+* Fixed issue where L4 policy trace would incorrectly determine that traffic
+  would be rejected when the L4 policy specifies the protocol (1587_)
 
 Features
 --------

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -174,7 +174,7 @@ func (l4 L4PolicyMap) containsAllL4(l4Ports []*models.Port) api.Decision {
 				return api.Denied
 			}
 		default:
-			port := fmt.Sprintf("%s/%d", lwrProtocol, l4CtxIng.Port)
+			port := fmt.Sprintf("%d/%s", l4CtxIng.Port, lwrProtocol)
 			if _, match := l4[port]; !match {
 				return api.Denied
 			}

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -1,0 +1,94 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	//"encoding/json"
+	//"testing"
+
+	"github.com/cilium/cilium/api/v1/models"
+	//"github.com/cilium/cilium/pkg/labels"
+	//"github.com/cilium/cilium/pkg/maps/policymap"
+	"github.com/cilium/cilium/pkg/policy/api"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *PolicyTestSuite) testDPortCoverage(c *C, policy L4Policy,
+	covers func([]*models.Port) api.Decision) {
+
+	ports := []*models.Port{}
+	c.Assert(covers(ports), Equals, api.Denied)
+
+	// Policy should match all of the below ports.
+	ports = []*models.Port{
+		{
+			Port:     8080,
+			Protocol: "tcp",
+		},
+	}
+	c.Assert(covers(ports), Equals, api.Allowed)
+
+	// Adding another port outside the policy will now be denied.
+	ports = append(ports, &models.Port{Port: 8080, Protocol: "udp"})
+	c.Assert(covers(ports), Equals, api.Denied)
+
+	// Ports with protocol any should match the TCP policy above.
+	ports = []*models.Port{
+		{
+			Port:     8080,
+			Protocol: "any",
+		},
+	}
+	c.Assert(covers(ports), Equals, api.Allowed)
+}
+
+func (s *PolicyTestSuite) TestIngressCoversDPorts(c *C) {
+	policy := L4Policy{}
+
+	// Empty policy allows traffic
+	c.Assert(policy.IngressCoversDPorts([]*models.Port{}), Equals, api.Allowed)
+
+	// Non-empty policy denies traffic without a port specified
+	policy = L4Policy{
+		Ingress: L4PolicyMap{
+			"8080/tcp": {
+				Port:     8080,
+				Protocol: "tcp",
+				Ingress:  true,
+			},
+		},
+	}
+	s.testDPortCoverage(c, policy, policy.IngressCoversDPorts)
+}
+
+func (s *PolicyTestSuite) TestEgressCoversDPorts(c *C) {
+	policy := L4Policy{}
+
+	// Empty policy allows traffic
+	c.Assert(policy.EgressCoversDPorts([]*models.Port{}), Equals, api.Allowed)
+
+	// Non-empty policy denies traffic without a port specified
+	policy = L4Policy{
+		Egress: L4PolicyMap{
+			"8080/tcp": {
+				Port:     8080,
+				Protocol: "tcp",
+				Ingress:  false,
+			},
+		},
+	}
+	s.testDPortCoverage(c, policy, policy.EgressCoversDPorts)
+}

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -15,12 +15,7 @@
 package policy
 
 import (
-	//"encoding/json"
-	//"testing"
-
 	"github.com/cilium/cilium/api/v1/models"
-	//"github.com/cilium/cilium/pkg/labels"
-	//"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/policy/api"
 
 	. "gopkg.in/check.v1"


### PR DESCRIPTION
The L4Policy map is indexed by "port/proto", not "proto/port". Fix it,
and add some basic unit tests to validate the functionality.

Fixes: #1587
Signed-off-by: Joe Stringer <joe@covalent.io>