### PR TITLE
bash command completion

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -11,7 +11,7 @@ Bug Fixes
 
 Features
 --------
-* Add here
+* Add bash code completion (1597_)
 
 Kubernetes
 ----------

--- a/cilium/cmd/bash_completion.go
+++ b/cilium/cmd/bash_completion.go
@@ -28,11 +28,11 @@ var bashCompletionCmd = &cobra.Command{
 	Hidden: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		out := new(bytes.Buffer)
-		RootCmd.GenBashCompletion(out)
+		rootCmd.GenBashCompletion(out)
 		fmt.Println(out.String())
 	},
 }
 
 func init() {
-	RootCmd.AddCommand(bashCompletionCmd)
+	rootCmd.AddCommand(bashCompletionCmd)
 }

--- a/cilium/cmd/bpf.go
+++ b/cilium/cmd/bpf.go
@@ -25,5 +25,5 @@ var bpfCmd = &cobra.Command{
 }
 
 func init() {
-	RootCmd.AddCommand(bpfCmd)
+	rootCmd.AddCommand(bpfCmd)
 }

--- a/cilium/cmd/config.go
+++ b/cilium/cmd/config.go
@@ -48,7 +48,7 @@ var configCmd = &cobra.Command{
 }
 
 func init() {
-	RootCmd.AddCommand(configCmd)
+	rootCmd.AddCommand(configCmd)
 	configCmd.Flags().BoolVarP(&listOptions, "list-options", "", false, "List available options")
 	configCmd.Flags().IntVarP(&numPages, "num-pages", "n", 0, "Number of pages for perf ring buffer. If 0, defaults to the Cilium daemon's configuration")
 }

--- a/cilium/cmd/endpoint.go
+++ b/cilium/cmd/endpoint.go
@@ -25,5 +25,5 @@ var endpointCmd = &cobra.Command{
 }
 
 func init() {
-	RootCmd.AddCommand(endpointCmd)
+	rootCmd.AddCommand(endpointCmd)
 }

--- a/cilium/cmd/identity.go
+++ b/cilium/cmd/identity.go
@@ -25,5 +25,5 @@ var identityCmd = &cobra.Command{
 }
 
 func init() {
-	RootCmd.AddCommand(identityCmd)
+	rootCmd.AddCommand(identityCmd)
 }

--- a/cilium/cmd/monitor.go
+++ b/cilium/cmd/monitor.go
@@ -76,7 +76,7 @@ func listEventTypes() []string {
 }
 
 func init() {
-	RootCmd.AddCommand(monitorCmd)
+	rootCmd.AddCommand(monitorCmd)
 	monitorCmd.Flags().BoolVar(&hex, "hex", false, "Do not dissect, print payload in HEX")
 	monitorCmd.Flags().StringVarP(&eventType, "type", "t", "", fmt.Sprintf("Filter by event types %v", listEventTypes()))
 	monitorCmd.Flags().Uint16Var(&fromSource, "from", 0, "Filter by source endpoint id")

--- a/cilium/cmd/policy.go
+++ b/cilium/cmd/policy.go
@@ -48,7 +48,7 @@ func init() {
 		ignoredMasks[i] = regexp.MustCompile(ignoredMasksSource[i])
 	}
 
-	RootCmd.AddCommand(policyCmd)
+	rootCmd.AddCommand(policyCmd)
 }
 
 func getContext(content []byte, offset int64) (int, string, int) {

--- a/cilium/cmd/root.go
+++ b/cilium/cmd/root.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	clientPkg "github.com/cilium/cilium/pkg/client"
@@ -31,35 +32,11 @@ var (
 	log     = logrus.New()
 )
 
-const (
-	bashCompletionFunc = `__cilium_endpoint()
-{
-    local cilium_output out
-    if cilium_output=$(cilium endpoint list --no-headers 2>/dev/null); then
-        out=($(echo "${cilium_output}" | awk '{print $1}'))
-        COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
-    fi
-}
-
-__custom_func() {
-    case ${last_command} in
-        cilium_endpoint_get | cilium_endpoint_config | cilium_endpoint_disconnect | cilium_endpoint_labels | cilium_endpoint_regenerate)
-            __cilium_endpoint
-            return
-            ;;
-        *)
-            ;;
-    esac
-}
-`
-)
-
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "cilium",
 	Short: "CLI",
 	Long:  `CLI for interacting with the local Cilium Agent`,
-	BashCompletionFunction: bashCompletionFunc,
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.
@@ -78,6 +55,7 @@ func init() {
 	flags.BoolP("debug", "D", false, "Enable debug messages")
 	flags.StringP("host", "H", "", "URI to server-side API")
 	viper.BindPFlags(flags)
+	rootCmd.AddCommand(newCmdCompletion(os.Stdout))
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -107,4 +85,69 @@ func initConfig() {
 	} else {
 		client = cl
 	}
+}
+
+const copyRightHeader = `
+# Copyright 2017 Authors of Cilium
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+`
+
+var (
+	completionExample = `
+# Installing bash completion on macOS using homebrew
+## If running Bash 3.2 included with macOS
+	brew install bash-completion
+## or, if running Bash 4.1+
+	brew install bash-completion@2
+## afterwards you only need to run
+	cilium completion bash > $(brew --prefix)/etc/bash_completion.d/cilium
+
+
+# Installing bash completion on Linux
+## Load the cilium completion code for bash into the current shell
+	source <(cilium completion bash)
+## Write bash completion code to a file and source if from .bash_profile
+	cilium completion bash > ~/.cilium/completion.bash.inc
+	printf "
+	  # Cilium shell completion
+	  source '$HOME/.cilium/completion.bash.inc'
+	  " >> $HOME/.bash_profile
+	source $HOME/.bash_profile`
+)
+
+func newCmdCompletion(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "completion [bash]",
+		Short:   "Output shell completion code for bash",
+		Long:    ``,
+		Example: completionExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			runCompletion(out, cmd, args)
+		},
+		ValidArgs: []string{"bash"},
+	}
+
+	return cmd
+}
+
+func runCompletion(out io.Writer, cmd *cobra.Command, args []string) error {
+	if len(args) > 1 {
+		return fmt.Errorf("Too many arguments. Expected only the shell type.")
+	}
+	if _, err := out.Write([]byte(copyRightHeader)); err != nil {
+		return err
+	}
+
+	return cmd.Parent().GenBashCompletion(out)
 }

--- a/cilium/cmd/root.go
+++ b/cilium/cmd/root.go
@@ -54,8 +54,8 @@ __custom_func() {
 `
 )
 
-// RootCmd represents the base command when called without any subcommands
-var RootCmd = &cobra.Command{
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
 	Use:   "cilium",
 	Short: "CLI",
 	Long:  `CLI for interacting with the local Cilium Agent`,
@@ -65,7 +65,7 @@ var RootCmd = &cobra.Command{
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
+	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}
@@ -73,7 +73,7 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	flags := RootCmd.PersistentFlags()
+	flags := rootCmd.PersistentFlags()
 	flags.StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cilium.yaml)")
 	flags.BoolP("debug", "D", false, "Enable debug messages")
 	flags.StringP("host", "H", "", "URI to server-side API")

--- a/cilium/cmd/service.go
+++ b/cilium/cmd/service.go
@@ -25,5 +25,5 @@ var serviceCmd = &cobra.Command{
 }
 
 func init() {
-	RootCmd.AddCommand(serviceCmd)
+	rootCmd.AddCommand(serviceCmd)
 }

--- a/cilium/cmd/status.go
+++ b/cilium/cmd/status.go
@@ -35,7 +35,7 @@ var statusCmd = &cobra.Command{
 }
 
 func init() {
-	RootCmd.AddCommand(statusCmd)
+	rootCmd.AddCommand(statusCmd)
 }
 
 func statusDaemon(cmd *cobra.Command, args []string) {

--- a/cilium/cmd/version.go
+++ b/cilium/cmd/version.go
@@ -31,5 +31,5 @@ var versionCmd = &cobra.Command{
 }
 
 func init() {
-	RootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(versionCmd)
 }


### PR DESCRIPTION
Add bash command completion
```
# Installing bash completion on macOS using homebrew
## If running Bash 3.2 included with macOS
        brew install bash-completion
## or, if running Bash 4.1+
        brew install bash-completion@2
## afterwards you only need to run
        cilium completion bash > $(brew --prefix)/etc/bash_completion.d/cilium


# Installing bash completion on Linux
## Load the cilium completion code for bash into the current shell
        source <(cilium completion bash)
## Write bash completion code to a file and source if from .bash_profile
        cilium completion bash > ~/.cilium/completion.bash.inc
        printf "
          # Cilium shell completion
          source '$HOME/.cilium/completion.bash.inc'
          " >> $HOME/.bash_profile
        source $HOME/.bash_profile
```

Fixes #1214 