### PR TITLE
Issue 1606: Kafka : Define access log record format

### DIFF
--- a/pkg/proxy/accesslog/record.go
+++ b/pkg/proxy/accesslog/record.go
@@ -174,6 +174,9 @@ type LogRecord struct {
 	// HTTP contains information for HTTP request/responses
 	HTTP *LogRecordHTTP `json:"HTTP,omitempty"`
 
+	// Kafka contains information for Kafka request/responses
+	Kafka *LogRecordKafka `json:"Kafka,omitempty"`
+
 	// Internal
 	Request *http.Request `json:"-"`
 }
@@ -196,21 +199,21 @@ type LogRecordHTTP struct {
 	Header http.Header
 }
 
-
-
 // LogRecordKafka contains the kafka specific portion of a log record
-// Reference: https://kafka.apache.org/protocol#protocol_api_keys
+
 type LogRecordKafka struct {
 	// Version of the kafka api used
-	version int
+	apiVersion int
 
-	// Kafka ApiKey -> produce/fetch/createTopic/deleteTopic
-	apiKey int
+	// Kafka ApiKey
+	// Reference: https://kafka.apache.org/protocol#protocol_api_keys
+	apiKey int16
 
-	// Topics of the request/response, can be a single topic for message type
+	// correlation_id is a user-supplied integer value that will be passed
+	// back with the response
+	correlation_id int32
+
+	// Topics of the request, can be a single topic for message type
 	// produce/createTopic or a list of topics (fetch/deleteTopic)
 	topics []string
-
-	// number of topics/partitions. Should be one for produce/createTopic.
-	numTopics int32
 }

--- a/pkg/proxy/accesslog/record.go
+++ b/pkg/proxy/accesslog/record.go
@@ -199,7 +199,8 @@ type LogRecordHTTP struct {
 	Header http.Header
 }
 
-type Topic struct {
+// KafkaTopic contains the topic for requests
+type KafkaTopic struct {
 	Topic string `json:"Topic,omitempty"`
 }
 
@@ -220,5 +221,5 @@ type LogRecordKafka struct {
 	// produce/createTopic or a list of topics (fetch/deleteTopic).
 	// Note that this list can be empty since not all messages use
 	// Topic. example: LeaveGroup, Heartbeat
-	Topics []Topic
+	Topics []KafkaTopic
 }

--- a/pkg/proxy/accesslog/record.go
+++ b/pkg/proxy/accesslog/record.go
@@ -201,16 +201,16 @@ type LogRecordHTTP struct {
 
 // LogRecordKafka contains the kafka specific portion of a log record
 type LogRecordKafka struct {
-	// ApiVersion of the kafka api used
-	ApiVersion int
+	// APIVersion of the kafka api used
+	APIVersion int
 
-	// ApiKey for Kafka message
+	// APIKey for Kafka message
 	// Reference: https://kafka.apache.org/protocol#protocol_api_keys
-	ApiKey int16
+	APIKey int16
 
-	// CorrelationId is a user-supplied integer value that will be passed
+	// CorrelationID is a user-supplied integer value that will be passed
 	// back with the response
-	CorrelationId int32
+	CorrelationID int32
 
 	// Topics of the request, can be a single topic for message type
 	// produce/createTopic or a list of topics (fetch/deleteTopic).

--- a/pkg/proxy/accesslog/record.go
+++ b/pkg/proxy/accesslog/record.go
@@ -199,6 +199,10 @@ type LogRecordHTTP struct {
 	Header http.Header
 }
 
+type Topic struct {
+	Topic string `json:"Topic,omitempty"`
+}
+
 // LogRecordKafka contains the kafka specific portion of a log record
 type LogRecordKafka struct {
 	// APIVersion of the kafka api used
@@ -216,5 +220,5 @@ type LogRecordKafka struct {
 	// produce/createTopic or a list of topics (fetch/deleteTopic).
 	// Note that this list can be empty since not all messages use
 	// Topic. example: LeaveGroup, Heartbeat
-	Topics []string `json:"Topics,omitempty"`
+	Topics []Topic
 }

--- a/pkg/proxy/accesslog/record.go
+++ b/pkg/proxy/accesslog/record.go
@@ -200,20 +200,21 @@ type LogRecordHTTP struct {
 }
 
 // LogRecordKafka contains the kafka specific portion of a log record
-
 type LogRecordKafka struct {
-	// Version of the kafka api used
-	apiVersion int
+	// ApiVersion of the kafka api used
+	ApiVersion int
 
-	// Kafka ApiKey
+	// ApiKey for Kafka message
 	// Reference: https://kafka.apache.org/protocol#protocol_api_keys
-	apiKey int16
+	ApiKey int16
 
-	// correlation_id is a user-supplied integer value that will be passed
+	// CorrelationId is a user-supplied integer value that will be passed
 	// back with the response
-	correlation_id int32
+	CorrelationId int32
 
 	// Topics of the request, can be a single topic for message type
-	// produce/createTopic or a list of topics (fetch/deleteTopic)
-	topics []string
+	// produce/createTopic or a list of topics (fetch/deleteTopic).
+	// Note that this list can be empty since not all messages use
+	// Topic. example: LeaveGroup, Heartbeat
+	Topics []string `json:"Topics,omitempty"`
 }

--- a/pkg/proxy/accesslog/record.go
+++ b/pkg/proxy/accesslog/record.go
@@ -204,9 +204,9 @@ type KafkaTopic struct {
 	Topic string `json:"Topic,omitempty"`
 }
 
-// LogRecordKafka contains the kafka specific portion of a log record
+// LogRecordKafka contains the Kafka-specific portion of a log record
 type LogRecordKafka struct {
-	// APIVersion of the kafka api used
+	// APIVersion of the Kafka api used
 	APIVersion int
 
 	// APIKey for Kafka message

--- a/pkg/proxy/accesslog/record.go
+++ b/pkg/proxy/accesslog/record.go
@@ -195,3 +195,22 @@ type LogRecordHTTP struct {
 	// Header is the HTTP header in use
 	Header http.Header
 }
+
+
+
+// LogRecordKafka contains the kafka specific portion of a log record
+// Reference: https://kafka.apache.org/protocol#protocol_api_keys
+type LogRecordKafka struct {
+	// Version of the kafka api used
+	version int
+
+	// Kafka ApiKey -> produce/fetch/createTopic/deleteTopic
+	apiKey int
+
+	// Topics of the request/response, can be a single topic for message type
+	// produce/createTopic or a list of topics (fetch/deleteTopic)
+	topics []string
+
+	// number of topics/partitions. Should be one for produce/createTopic.
+	numTopics int32
+}


### PR DESCRIPTION
Fixes #1606. This sets the base to decouple others to start working on the access record for kafka.

Signed-off by: Manali Bhutiyani manali@covalent.io