### PR TITLE
monitor: made NodeMonitor thread safe

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1253,7 +1253,7 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 	defer d.conf.ConfigPatchMutex.Unlock()
 
 	if numPagesEntry, ok := params.Configuration.Mutable["MonitorNumPages"]; ok {
-		if d.nodeMonitor.Arg != numPagesEntry {
+		if d.nodeMonitor.GetArg() != numPagesEntry {
 			d.nodeMonitor.Restart(numPagesEntry)
 		}
 		if len(params.Configuration.Mutable) == 0 {


### PR DESCRIPTION
By not having a mutex to guarantee single access we could have
concurrent access in state and Arg of NodeMonitor struct.

Signed-off-by: André Martins <andre@cilium.io>