### PR TITLE
pkg/bpf: fix concurrent access of Buffer structure

### DIFF
--- a/pkg/bpf/bpffs.go
+++ b/pkg/bpf/bpffs.go
@@ -15,13 +15,14 @@
 package bpf
 
 import (
-	"bytes"
 	"fmt"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/cilium/cilium/pkg/syncbytes"
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -130,8 +131,8 @@ func mountCmdPipe(cmds []*exec.Cmd) (mountCmdOutput, mountCmdStandardError []byt
 	}
 
 	// Total output of commands.
-	var output bytes.Buffer
-	var stderr bytes.Buffer
+	var output syncbytes.Buffer
+	var stderr syncbytes.Buffer
 
 	lastCmd := len(cmds) - 1
 	for i, cmd := range cmds[:lastCmd] {

--- a/pkg/syncbytes/buffer.go
+++ b/pkg/syncbytes/buffer.go
@@ -1,0 +1,52 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncbytes
+
+import (
+	"bytes"
+	"sync"
+)
+
+// Buffer is a golang's buffer wrapper that can be used concurrently.
+type Buffer struct {
+	b bytes.Buffer
+	m sync.RWMutex
+}
+
+// Read calls the Read method for the internal Buffer in a thread safe
+// environment.
+func (b *Buffer) Read(p []byte) (n int, err error) {
+	b.m.RLock()
+	defer b.m.RUnlock()
+	return b.b.Read(p)
+}
+
+// Write calls the Write method for the internal Buffer in a thread safe
+// environment.
+func (b *Buffer) Write(p []byte) (n int, err error) {
+	b.m.Lock()
+	defer b.m.Unlock()
+	return b.b.Write(p)
+}
+
+// Bytes returns a copy of the internal bytes Buffer that can be modified by the
+// caller.
+func (b *Buffer) Bytes() []byte {
+	b.m.RLock()
+	bcpy := make([]byte, len(b.b.Bytes()))
+	copy(bcpy, b.b.Bytes())
+	b.m.RUnlock()
+	return bcpy
+}


### PR DESCRIPTION
Since Golang doesn't provide thread-safe buffers, we need to make them
thread-safe in order for them be used in multiple exec.Cmd executions.

Signed-off-by: André Martins <andre@cilium.io>