### PR TITLE
set pipe fail option in K8s tests

### DIFF
--- a/tests/k8s/run-tests.bash
+++ b/tests/k8s/run-tests.bash
@@ -67,9 +67,9 @@ function run_tests(){
 
 
     # Run non IP version specific tests
-    vmssh ${node2} 'set -e; for test in /home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/tests/*.sh; do file=$(basename $test); filename="${file%.*}"; mkdir -p /home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/tests/cilium-files/$filename;  $test | tee /home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/tests/cilium-files/"${filename}"/output.txt; done'
+    vmssh ${node2} 'set -e; set -o pipefail; for test in /home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/tests/*.sh; do file=$(basename $test); filename="${file%.*}"; mkdir -p /home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/tests/cilium-files/$filename;  $test | tee /home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/tests/cilium-files/"${filename}"/output.txt; done'
     # Run ipv4 tests
-    vmssh ${node2} 'set -e; for test in /home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/tests/ipv4/*.sh; do file=$(basename $test); filename="${file%.*}"; mkdir -p /home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/tests/cilium-files/$filename; $test | tee /home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/tests/cilium-files/"${filename}"/output.txt; done'
+    vmssh ${node2} 'set -e; set -o pipefail; for test in /home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/tests/ipv4/*.sh; do file=$(basename $test); filename="${file%.*}"; mkdir -p /home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/tests/cilium-files/$filename; $test | tee /home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/tests/cilium-files/"${filename}"/output.txt; done'
 
     # Run IPv6 tests
 

--- a/tests/k8s/tests/001-policy-enforcement.sh
+++ b/tests/k8s/tests/001-policy-enforcement.sh
@@ -295,9 +295,13 @@ check_endpoints_policy_disabled ${NUM_ENDPOINTS} ${CILIUM_POD_1}
 # Test 18: check policy enforcement after malformed policy is created and deleted
 # All endpoints should have policy enforcement enabled
 log " Test 18: check policy enforcement after malformed policy is created and deleted. All endpoints should have policy enforcement enabled"
+set +e
 kubectl create -f "${MINIKUBE}/malformed_policy.yaml"
+set -e
 wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}
+set +e
 kubectl delete -f "${MINIKUBE}/malformed_policy.yaml"
+set -e
 wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}
 import_policy
 wait_for_k8s_endpoints ${NAMESPACE} ${CILIUM_POD_1} ${NUM_ENDPOINTS} ${POD_FILTER}


### PR DESCRIPTION
commit 75b7d94be3e37158ec07e8edd079af98c7d9c69a introduced a regression because it piped the debug output of the tests to `tee`, which masks the return code of the test running for the K8s tests. This means that a test could fail, but the end result of piping to `tee` has a return code of zero, meaning the build thinks the tests passed just fine. This is a serious regression in the CI. Before running the tests, `set -o pipefail` which will cause the error code to get propagated up to the calling script from the tests.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #1626 