### PR TITLE
tests: Skip contrib/ for go vet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include Makefile.defs
 
 SUBDIRS = plugins bpf cilium daemon monitor
-GOFILES ?= $(shell go list ./... | grep -v /vendor/)
+GOFILES ?= $(shell go list ./... | grep -v /vendor/ | grep -v /contrib/)
 GOLANGVERSION = $(shell go version 2>/dev/null | grep -Eo '(go[0-9].[0-9])')
 GOLANG_SRCFILES=$(shell for pkg in $GOFILES; do find $(pkg) -name *.go -print; done | grep -v /vendor/)
 BPF_SRCFILES=$(shell find bpf/ -name *.[ch] -print)

--- a/tests/00-fmt.sh
+++ b/tests/00-fmt.sh
@@ -2,7 +2,12 @@
 
 set -ex
 
-diff="$(find . ! \( -path './vendor' -prune \) ! \( -path './.git' -prune \) ! -samefile ./daemon/bindata.go -type f -name '*.go' -print0 | xargs -0 gofmt -d -l -s )"
+diff="$(find . ! \( -path './contrib' -prune \) \
+        ! \( -path './vendor' -prune \) \
+        ! \( -path './.git' -prune \) \
+        ! -samefile ./daemon/bindata.go \
+        -type f -name '*.go' -print0 \
+                | xargs -0 gofmt -d -l -s )"
 
 if [ -n "$diff" ]; then
 	echo "Unformatted Go source code:"


### PR DESCRIPTION
The contrib/ directory sometimes interferes with the formatting checks
that are invoked by running "make tests", remove them from the .go file
locators.

Signed-off-by: Joe Stringer <joe@covalent.io>