### PR TITLE
Kafka: Initial base code for policy enforcement and api

### DIFF
--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -270,9 +270,9 @@ type PortRuleKafka struct {
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
 
-	// APIKey is a string matched against the key of a
-	// request, e.g. "Produce", "Fetch", "CreateTopic", "DeleteTopic", ...
-	//
+	// APIKey is a case-insensitive string matched against the key of a
+	// request, e.g. "produce", "fetch", "createtopic", "deletetopic", et al
+	// Reference: https://kafka.apache.org/protocol#protocol_api_keys
 	//
 	// If omitted or empty, all keys are allowed.
 	//
@@ -290,7 +290,7 @@ type PortRuleKafka struct {
 
 // KafkaAPIKeyMap is the map of all allowed kafka API keys
 // with the key values.
-// https://kafka.apache.org/protocol#protocol_api_keys
+// Reference: https://kafka.apache.org/protocol#protocol_api_keys
 var KafkaAPIKeyMap = map[string]int{
 	"produce":              0,
 	"fetch":                1,

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -274,7 +274,7 @@ type PortRuleKafka struct {
 	// request, e.g. "Produce", "Fetch", "CreateTopic", "DeleteTopic", ...
 	//
 	//
-	// If omitted or empty, all methods are allowed.
+	// If omitted or empty, all keys are allowed.
 	//
 	// +optional
 	APIKey string `json:"apiKey,omitempty"`

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -262,19 +262,19 @@ type PortRuleHTTP struct {
 // effect.
 //
 type PortRuleKafka struct {
-	// ApiVersion is an POSIX regex matched against the api version of the
+	// APIVersion is an POSIX regex matched against the api version of the
 	// Kafka message
-	ApiVersion string `json:"apiVersion,omitempty"`
+	APIVersion string `json:"apiVersion,omitempty"`
 
 	// Topic is an POSIX regex matched against the topic of the
 	// Kafka message.
 	Topic string `json:"topic,omitempty"`
 
-	// Method is an extended POSIX regex matched against the method of a
+	// APIKey is an extended POSIX regex matched against the key of a
 	// request, e.g. "Produce", "Fetch", "CreateTopic", "DeleteTopic", ...
 	//
 	// If omitted or empty, all methods are allowed.
 	//
 	// +optional
-	ApiKey string `json:"apikey,omitempty"`
+	APIKey string `json:"apikey,omitempty"`
 }

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -207,6 +207,10 @@ type L7Rules struct {
 	//
 	// +optional
 	HTTP []PortRuleHTTP `json:"http,omitempty"`
+	// Kafka specific rules.
+	//
+	// +optional
+	Kafka []PortRuleKafka `json:"kafka,omitempty"`
 }
 
 // PortRuleHTTP is a list of HTTP protocol constraints. All fields are
@@ -251,4 +255,26 @@ type PortRuleHTTP struct {
 	//
 	// +optional
 	Headers []string `json:"headers,omitempty"`
+}
+
+// PortRuleKafka is a list of Kafka protocol constraints. All fields are
+// optional, if all fields are empty or missing, the rule does not have any
+// effect.
+//
+type PortRuleKafka struct {
+	// ApiVersion is an POSIX regex matched against the api version of the
+	// Kafka message
+	ApiVersion string `json:"apiVersion,omitempty"`
+
+	// Topic is an POSIX regex matched against the topic of the
+	// Kafka message.
+	Topic string `json:"topic,omitempty"`
+
+	// Method is an extended POSIX regex matched against the method of a
+	// request, e.g. "Produce", "Fetch", "CreateTopic", "DeleteTopic", ...
+	//
+	// If omitted or empty, all methods are allowed.
+	//
+	// +optional
+	ApiKey string `json:"apikey,omitempty"`
 }

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -207,7 +207,8 @@ type L7Rules struct {
 	//
 	// +optional
 	HTTP []PortRuleHTTP `json:"http,omitempty"`
-	// Kafka specific rules.
+	// Kafka-specific rules.
+
 	//
 	// +optional
 	Kafka []PortRuleKafka `json:"kafka,omitempty"`
@@ -260,15 +261,13 @@ type PortRuleHTTP struct {
 // PortRuleKafka is a list of Kafka protocol constraints. All fields are
 // optional, if all fields are empty or missing, the rule does not have any
 // effect.
-//
 type PortRuleKafka struct {
 	// APIVersion is an POSIX regex matched against the api version of the
-	// Kafka message
+	// Kafka message. It is always "0" or a string representing a
+	// positive integer.
+	//
+	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
-
-	// Topic is an POSIX regex matched against the topic of the
-	// Kafka message.
-	Topic string `json:"topic,omitempty"`
 
 	// APIKey is an extended POSIX regex matched against the key of a
 	// request, e.g. "Produce", "Fetch", "CreateTopic", "DeleteTopic", ...
@@ -276,5 +275,12 @@ type PortRuleKafka struct {
 	// If omitted or empty, all methods are allowed.
 	//
 	// +optional
-	APIKey string `json:"apikey,omitempty"`
+	APIKey string `json:"apiKey,omitempty"`
+
+	// Topic is an POSIX regex matched against the topic of the
+	// Kafka message. Ignored if the matched request message type doesn't
+	// contain any topic.
+	//
+	// +optional
+	Topic string `json:"topic,omitempty"`
 }

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -267,6 +267,8 @@ type PortRuleKafka struct {
 	// Kafka message. It is always "0" or a string representing a
 	// positive integer.
 	//
+	// If omitted or empty, all versions are allowed.
+	//
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
 
@@ -282,7 +284,13 @@ type PortRuleKafka struct {
 	// Topic is a regex matched against the topic of the
 	// Kafka message. Ignored if the matched request message type doesn't
 	// contain any topic. Maximum size of Topic can be 249 characters as
-	// per Kafka spec and allowed characters are a-z, A-Z, 0-9, -, . and _
+	// per recent Kafka spec and allowed characters are
+	// a-z, A-Z, 0-9, -, . and _
+	// Older Kafka versions had longer topic lengths of 255, but in Kafka 0.10
+	// version the length was changed from 255 to 249. For compatibility
+	// reasons we are using 255
+	//
+	// If omitted or empty, all topics are allowed.
 	//
 	// +optional
 	Topic string `json:"topic,omitempty"`
@@ -292,45 +300,46 @@ type PortRuleKafka struct {
 // with the key values.
 // Reference: https://kafka.apache.org/protocol#protocol_api_keys
 var KafkaAPIKeyMap = map[string]int{
-	"produce":              0,
-	"fetch":                1,
-	"offsets":              2,
-	"metadata":             3,
-	"leaderandisr":         4,
-	"stopreplica":          5,
-	"updatemetadata":       6,
-	"controlledshutdown":   7,
-	"offsetcommit":         8,
-	"offsetfetch":          9,
-	"findcoordinator":      10,
-	"joingroup":            11,
-	"heartbeat":            12,
-	"leavegroup":           13,
-	"syncgroup":            14,
-	"describegroups":       15,
-	"listgroups":           16,
-	"saslhandshake":        17,
-	"apiversions":          18,
-	"createtopics":         19,
-	"deletetopics":         20,
-	"deleterecords":        21,
-	"initproducerid":       22,
-	"offsetforleaderepoch": 23,
-	"addpartitionstotxn":   24,
-	"addoffsetstotxn":      25,
-	"endtxn":               26,
-	"writetxnmarkers":      27,
-	"txnoffsetcommit":      28,
-	"describeacls":         29,
-	"createacls":           30,
-	"deleteacls":           31,
-	"describeconfigs":      32,
-	"alterconfigs":         33,
+	"produce":              0,  /* Produce */
+	"fetch":                1,  /* Fetch */
+	"offsets":              2,  /* Offsets */
+	"metadata":             3,  /* Metadata */
+	"leaderandisr":         4,  /* LeaderAndIsr */
+	"stopreplica":          5,  /* StopReplica */
+	"updatemetadata":       6,  /* UpdateMetadata */
+	"controlledshutdown":   7,  /* ControlledShutdown */
+	"offsetcommit":         8,  /* OffsetCommit */
+	"offsetfetch":          9,  /* OffsetFetch */
+	"findcoordinator":      10, /* FindCoordinator */
+	"joingroup":            11, /* JoinGroup */
+	"heartbeat":            12, /* Heartbeat */
+	"leavegroup":           13, /* LeaveGroup */
+	"syncgroup":            14, /* SyncGroup */
+	"describegroups":       15, /* DescribeGroups */
+	"listgroups":           16, /* ListGroups */
+	"saslhandshake":        17, /* SaslHandshake */
+	"apiversions":          18, /* ApiVersions */
+	"createtopics":         19, /* CreateTopics */
+	"deletetopics":         20, /* DeleteTopics */
+	"deleterecords":        21, /* DeleteRecords */
+	"initproducerid":       22, /* InitProducerId */
+	"offsetforleaderepoch": 23, /* OffsetForLeaderEpoch */
+	"addpartitionstotxn":   24, /* AddPartitionsToTxn */
+	"addoffsetstotxn":      25, /* AddOffsetsToTxn */
+	"endtxn":               26, /* EndTxn */
+	"writetxnmarkers":      27, /* WriteTxnMarkers */
+	"txnoffsetcommit":      28, /* TxnOffsetCommit */
+	"describeacls":         29, /* DescribeAcls */
+	"createacls":           30, /* CreateAcls */
+	"deleteacls":           31, /* DeleteAcls */
+	"describeconfigs":      32, /* DescribeConfigs */
+	"alterconfigs":         33, /* AlterConfigs */
 }
 
 // KafkaMaxTopicLen is the maximum character len of a topic.
 // Older Kafka versions had longer topic lengths of 255, in Kafka 0.10 version
-// the length was changed from 255 to 249. For compatibility using 255.
+// the length was changed from 255 to 249. For compatibility reasons we are
+// using 255
 const (
 	KafkaMaxTopicLen = 255
 )

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -288,6 +288,8 @@ type PortRuleKafka struct {
 	Topic string `json:"topic,omitempty"`
 }
 
+// KafkaProduceReq, KafkaFetchReq, KafkaCreateTopicsReq, KafkaDeleteTopicsReq
+// are the current supported list of messages for policy enforcement.
 const (
 	KafkaProduceReq      = "Produce"
 	KafkaFetchReq        = "Fetch"
@@ -295,8 +297,11 @@ const (
 	KafkaDeleteTopicsReq = "DeleteTopics"
 )
 
+// KafkaMaxTopicLen is the maximum character len of a topic.
 const (
 	KafkaMaxTopicLen = 249
 )
 
+// KafkaTopicValidChar is a one-time regex generation of all allowed characters
+// in kafka topic name.
 var KafkaTopicValidChar = regexp.MustCompile(`^[a-zA-Z0-9\\._\\-]+$`)

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -208,8 +208,8 @@ type L7Rules struct {
 	//
 	// +optional
 	HTTP []PortRuleHTTP `json:"http,omitempty"`
-	// Kafka-specific rules.
 
+	// Kafka-specific rules.
 	//
 	// +optional
 	Kafka []PortRuleKafka `json:"kafka,omitempty"`
@@ -288,18 +288,51 @@ type PortRuleKafka struct {
 	Topic string `json:"topic,omitempty"`
 }
 
-// KafkaProduceReq, KafkaFetchReq, KafkaCreateTopicsReq, KafkaDeleteTopicsReq
-// are the current supported list of messages for policy enforcement.
-const (
-	KafkaProduceReq      = "Produce"
-	KafkaFetchReq        = "Fetch"
-	KafkaCreateTopicsReq = "CreateTopics"
-	KafkaDeleteTopicsReq = "DeleteTopics"
-)
+// KafkaAPIKeyMap is the map of all allowed kafka API keys
+// with the key values.
+// https://kafka.apache.org/protocol#protocol_api_keys
+var KafkaAPIKeyMap = map[string]int{
+	"produce":              0,
+	"fetch":                1,
+	"offsets":              2,
+	"metadata":             3,
+	"leaderandisr":         4,
+	"stopreplica":          5,
+	"updatemetadata":       6,
+	"controlledshutdown":   7,
+	"offsetcommit":         8,
+	"offsetfetch":          9,
+	"findcoordinator":      10,
+	"joingroup":            11,
+	"heartbeat":            12,
+	"leavegroup":           13,
+	"syncgroup":            14,
+	"describegroups":       15,
+	"listgroups":           16,
+	"saslhandshake":        17,
+	"apiversions":          18,
+	"createtopics":         19,
+	"deletetopics":         20,
+	"deleterecords":        21,
+	"initproducerid":       22,
+	"offsetforleaderepoch": 23,
+	"addpartitionstotxn":   24,
+	"addoffsetstotxn":      25,
+	"endtxn":               26,
+	"writetxnmarkers":      27,
+	"txnoffsetcommit":      28,
+	"describeacls":         29,
+	"createacls":           30,
+	"deleteacls":           31,
+	"describeconfigs":      32,
+	"alterconfigs":         33,
+}
 
 // KafkaMaxTopicLen is the maximum character len of a topic.
+// Older Kafka versions had longer topic lengths of 255, in Kafka 0.10 version
+// the length was changed from 255 to 249. For compatibility using 255.
 const (
-	KafkaMaxTopicLen = 249
+	KafkaMaxTopicLen = 255
 )
 
 // KafkaTopicValidChar is a one-time regex generation of all allowed characters

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"github.com/cilium/cilium/pkg/labels"
+	"regexp"
 )
 
 // Rule is a policy rule which must be applied to all endpoints which match the
@@ -262,25 +263,40 @@ type PortRuleHTTP struct {
 // optional, if all fields are empty or missing, the rule does not have any
 // effect.
 type PortRuleKafka struct {
-	// APIVersion is an POSIX regex matched against the api version of the
+	// APIVersion is the version matched against the api version of the
 	// Kafka message. It is always "0" or a string representing a
 	// positive integer.
 	//
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
 
-	// APIKey is an extended POSIX regex matched against the key of a
+	// APIKey is a string matched against the key of a
 	// request, e.g. "Produce", "Fetch", "CreateTopic", "DeleteTopic", ...
+	//
 	//
 	// If omitted or empty, all methods are allowed.
 	//
 	// +optional
 	APIKey string `json:"apiKey,omitempty"`
 
-	// Topic is an POSIX regex matched against the topic of the
+	// Topic is a regex matched against the topic of the
 	// Kafka message. Ignored if the matched request message type doesn't
-	// contain any topic.
+	// contain any topic. Maximum size of Topic can be 249 characters as
+	// per Kafka spec and allowed characters are a-z, A-Z, 0-9, -, . and _
 	//
 	// +optional
 	Topic string `json:"topic,omitempty"`
 }
+
+const (
+	KafkaProduceReq      = "Produce"
+	KafkaFetchReq        = "Fetch"
+	KafkaCreateTopicsReq = "CreateTopics"
+	KafkaDeleteTopicsReq = "DeleteTopics"
+)
+
+const (
+	KafkaMaxTopicLen = 249
+)
+
+var KafkaTopicValidChar = regexp.MustCompile(`^[a-zA-Z0-9\\._\\-]+$`)

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -87,36 +87,30 @@ func (e EgressRule) Validate() error {
 // wildcard and prefix/suffix later on.
 func (kr PortRuleKafka) Validate() error {
 	if len(kr.APIKey) > 0 {
-		switch kr.APIKey {
-		case KafkaProduceReq:
-		case KafkaFetchReq:
-		case KafkaCreateTopicsReq:
-		case KafkaDeleteTopicsReq:
-		default:
-			return fmt.Errorf("Invalid Kafka APIKey :", kr.APIKey)
+		if _, ok := KafkaAPIKeyMap[strings.ToLower(kr.APIKey)]; ok == false {
+			return fmt.Errorf("invalid Kafka APIKey :%q", kr.APIKey)
 		}
 	}
 
 	if len(kr.APIVersion) > 0 {
-		switch kr.APIVersion {
-		case "0":
-		case "1":
-		case "2":
-		case "3":
-		default:
-			return fmt.Errorf("Invalid Kafka APIVersion :", kr.APIVersion)
+		_, err := strconv.ParseUint(kr.APIVersion, 10, 16)
+
+		if err != nil {
+			fmt.Errorf("invalid Kafka APIVersion :%q",
+				kr.APIVersion)
 		}
+
 	}
 
 	if len(kr.Topic) > 0 {
 		if len(kr.Topic) > KafkaMaxTopicLen {
-			return fmt.Errorf("Kafka Topic exceeds maximum len of ",
+			return fmt.Errorf("kafka topic exceeds maximum len of %d",
 				KafkaMaxTopicLen)
 		}
 		// This check allows suffix and prefix matching
 		// for topic.
 		if KafkaTopicValidChar.MatchString(kr.Topic) == false {
-			return fmt.Errorf("Invalid Kafka Topic name")
+			return fmt.Errorf("invalid Kafka Topic name")
 		}
 	}
 	return nil
@@ -125,7 +119,7 @@ func (kr PortRuleKafka) Validate() error {
 // Validate validates L7 rules
 func (pr *L7Rules) Validate() error {
 	if (pr.HTTP != nil) && (pr.Kafka != nil) {
-		return fmt.Errorf("multiple rules for the same port")
+		return fmt.Errorf("multiple L7 protocol rule types specified in single rule")
 	}
 
 	if pr.Kafka != nil {

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -96,7 +96,7 @@ func (kr PortRuleKafka) Validate() error {
 		_, err := strconv.ParseUint(kr.APIVersion, 10, 16)
 
 		if err != nil {
-			fmt.Errorf("invalid Kafka APIVersion :%q",
+			return fmt.Errorf("invalid Kafka APIVersion :%q",
 				kr.APIVersion)
 		}
 	}

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -93,6 +93,12 @@ func (pr PortRule) Validate() error {
 		}
 	}
 
+	// Validate L7 rules
+	if pr.Rules != nil {
+		if (pr.Rules.HTTP != nil) && (pr.Rules.Kafka != nil) {
+			return fmt.Errorf("multiple rules for the same port")
+		}
+	}
 	return nil
 }
 

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -99,7 +99,6 @@ func (kr PortRuleKafka) Validate() error {
 			fmt.Errorf("invalid Kafka APIVersion :%q",
 				kr.APIVersion)
 		}
-
 	}
 
 	if len(kr.Topic) > 0 {

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -82,6 +82,15 @@ func (e EgressRule) Validate() error {
 	return nil
 }
 
+// Validate validates L7 rules
+func (pr *L7Rules) Validate() error {
+	if (pr.HTTP != nil) && (pr.Kafka != nil) {
+		return fmt.Errorf("multiple rules for the same port")
+	}
+
+	return nil
+}
+
 // Validate validates a port policy rule
 func (pr PortRule) Validate() error {
 	if len(pr.Ports) > maxPorts {
@@ -95,8 +104,8 @@ func (pr PortRule) Validate() error {
 
 	// Validate L7 rules
 	if pr.Rules != nil {
-		if (pr.Rules.HTTP != nil) && (pr.Rules.Kafka != nil) {
-			return fmt.Errorf("multiple rules for the same port")
+		if err := pr.Rules.Validate(); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -29,7 +29,10 @@ type AuxRule struct {
 	L7Parser string `json:"l7Parser"`
 }
 
-const HttpStr = "http"
+// HTTPStr for proxy type http
+const HTTPStr = "http"
+
+// KafkaStr for proxy type kafka
 const KafkaStr = "kafka"
 
 type L4Filter struct {
@@ -52,7 +55,7 @@ type L4Filter struct {
 func FillPortRuleHTTP(httpRule []api.PortRuleHTTP) []AuxRule {
 	l7rules := []AuxRule{}
 	for _, h := range httpRule {
-		r := AuxRule{L7Parser: HttpStr}
+		r := AuxRule{L7Parser: HTTPStr}
 
 		if h.Path != "" {
 			r.Expr = "PathRegexp(\"" + h.Path + "\")"
@@ -150,7 +153,7 @@ func CreateL4Filter(rule api.PortRule, port api.PortProtocol, direction string, 
 		case rule.Rules.HTTP != nil:
 			l7rules := FillPortRuleHTTP(rule.Rules.HTTP)
 			if len(l7rules) > 0 {
-				l4.L7Parser = HttpStr
+				l4.L7Parser = HTTPStr
 				l4.L7Rules = l7rules
 			}
 		case rule.Rules.Kafka != nil:

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -132,7 +132,7 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	}
 
 	l7rules := []AuxRule{
-		{Expr: "PathRegexp(\"/\") && MethodRegexp(\"GET\")", L7Parser: HTTPStr},
+		{Expr: "PathRegexp(\"/\") && MethodRegexp(\"GET\")", L7Parser: string(ParserTypeHTTP)},
 	}
 
 	expected := NewL4Policy()

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -132,7 +132,7 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	}
 
 	l7rules := []AuxRule{
-		{Expr: "PathRegexp(\"/\") && MethodRegexp(\"GET\")"},
+		{Expr: "PathRegexp(\"/\") && MethodRegexp(\"GET\")", L7Parser: HTTPStr},
 	}
 
 	expected := NewL4Policy()

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -489,7 +489,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string,
 	}
 
 	switch l4.L7Parser {
-	case policy.HttpStr:
+	case policy.HTTPStr:
 	case policy.KafkaStr:
 		// TODO We need to remove this once Kakfa parser and router support is in.
 		log.Debug("MK in CreateOrUpdateRedirect l4.L7Parser:..returning", l4.L7Parser)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -488,9 +488,9 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string,
 		return nil, err
 	}
 
-	switch l4.L7Parser {
-	case policy.HTTPStr:
-	case policy.KafkaStr:
+	switch policy.L7ParserType(l4.L7Parser) {
+	case policy.ParserTypeHTTP:
+	case policy.ParserTypeKafka:
 		// TODO We need to remove this once Kakfa parser and router support is in.
 		log.Debug("Kafka Parser not supported yet")
 		return nil, fmt.Errorf("unsupported L7 protocol proxy:\"%s\"", l4.L7Parser)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -492,7 +492,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string,
 	case policy.HTTPStr:
 	case policy.KafkaStr:
 		// TODO We need to remove this once Kakfa parser and router support is in.
-		log.Debug("MK in CreateOrUpdateRedirect l4.L7Parser:..returning", l4.L7Parser)
+		log.Debug("Kafka Parser not supported yet")
 		return nil, fmt.Errorf("unsupported L7 protocol proxy:\"%s\"", l4.L7Parser)
 	default:
 		return nil, fmt.Errorf("unknown L7 protocol \"%s\"", l4.L7Parser)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -489,15 +488,14 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string,
 		return nil, err
 	}
 
-	if !(strings.ToLower(l4.L7Parser) == "http" ||
-		strings.ToLower(l4.L7Parser) == "kafka") {
-		return nil, fmt.Errorf("unknown L7 protocol \"%s\"", l4.L7Parser)
-	}
-
-	// TODO We need to remove this once Kakfa parser and router support is in.
-	if strings.ToLower(l4.L7Parser) == "kafka" {
+	switch l4.L7Parser {
+	case policy.HttpStr:
+	case policy.KafkaStr:
+		// TODO We need to remove this once Kakfa parser and router support is in.
 		log.Debug("MK in CreateOrUpdateRedirect l4.L7Parser:..returning", l4.L7Parser)
 		return nil, fmt.Errorf("unsupported L7 protocol proxy:\"%s\"", l4.L7Parser)
+	default:
+		return nil, fmt.Errorf("unknown L7 protocol \"%s\"", l4.L7Parser)
 	}
 
 	for _, r := range l4.L7Rules {


### PR DESCRIPTION
This is the initial piece of code which lays the foundation for supporting Kafka proxy.
This change specifically defines the policy enforcement rules for Kafka and checks
whether only a single rule is configured on a given port.

Fixes #1633
Signed-off by: Manali Bhutiyani manali@covalent.io