### PR TITLE
agent: Add --pprof flag to enable pprof API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,5 +148,29 @@ gofmt:
 precheck-gofmt:
 	tests/00-fmt.sh
 
+pprof-help:
+	@echo "Available pprof targets:"
+	@echo "  pprof-heap"
+	@echo "  pprof-profile"
+	@echo "  pprof-block"
+	@echo "  pprof-trace-5s"
+	@echo "  pprof-mutex"
+
+pprof-heap:
+	go tool pprof http://localhost:6060/debug/pprof/heap
+
+pprof-profile:
+	go tool pprof http://localhost:6060/debug/pprof/profile
+
+
+pprof-block:
+	go tool pprof http://localhost:6060/debug/pprof/block
+
+pprof-trace-5s:
+	curl http://localhost:6060/debug/pprof/trace?seconds=5
+
+pprof-mutex:
+	go tool pprof http://localhost:6060/debug/pprof/mutex
+
 .PHONY: force
 force :;

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -30,6 +30,7 @@ Documentation
 
 Other
 -----
+* Add new --pprof flag to serve the pprof API (1646_)
 * Update Sirupsen/logrus to sirupsen/logrus (1573_)
 
 

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/nodeaddress"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/pprof"
 	"github.com/cilium/cilium/pkg/version"
 
 	"github.com/go-openapi/loads"
@@ -333,6 +334,8 @@ func init() {
 		"trace-payloadlen", 128, "Length of payload to capture when tracing")
 	flags.Bool(
 		"version", false, "Print version information")
+	flags.Bool(
+		"pprof", false, "Enable serving the pprof debugging API")
 
 	viper.BindPFlags(flags)
 }
@@ -388,6 +391,10 @@ func initConfig() {
 	log.Info("|  _| | | | | |     |")
 	log.Info("|___|_|_|_|___|_|_|_|")
 	log.Infof("Cilium %s", version.Version)
+
+	if viper.GetBool("pprof") {
+		pprof.Enable()
+	}
 
 	if config.IPv4Disabled {
 		endpoint.IPv4Enabled = false

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -1,0 +1,34 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pprof enables use of pprof in Cilium
+package pprof
+
+import (
+	"net/http"
+	_ "net/http/pprof"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const apiAddress = "localhost:6060"
+
+// Enable runs an HTTP server to serve the pprof API
+func Enable() {
+	go func() {
+		if err := http.ListenAndServe(apiAddress, nil); err != nil {
+			log.WithError(err).Warning("Unable to serve pprof API")
+		}
+	}()
+}


### PR DESCRIPTION
Start agent with `--pprof`, then use Makefile targets:

```
$  make pprof-help
Available pprof targets:
  pprof-heap
  pprof-profile
  pprof-block
  pprof-trace-5s
  pprof-mutex
```

Signed-off-by: Thomas Graf <thomas@cilium.io>