### PR TITLE
add gops dependency and utilize it in Cilium agent

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cilium/cilium/pkg/workloads/containerd"
 
 	"github.com/go-openapi/loads"
+	gops "github.com/google/gops/agent"
 	go_version "github.com/hashicorp/go-version"
 	flags "github.com/jessevdk/go-flags"
 	log "github.com/sirupsen/logrus"
@@ -110,6 +111,14 @@ var RootCmd = &cobra.Command{
 }
 
 func main() {
+
+	// Open socket for using gops to get stacktraces of the agent.
+	if err := gops.Listen(gops.Options{}); err != nil {
+		errorString := fmt.Sprintf("unable to start gops: %s", err)
+		fmt.Println(errorString)
+		os.Exit(-1)
+	}
+
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)

--- a/vendor.conf
+++ b/vendor.conf
@@ -90,3 +90,5 @@ k8s.io/client-go v4.0.0
 k8s.io/kubernetes v1.5.1
 github.com/sasha-s/go-deadlock master
 github.com/petermattis/goid 0ded85884ba5c4c9267fcd5a149061f7c3455eee
+github.com/google/gops 25312cafb9a191a6d377c480a4666beec3105e4a
+github.com/kardianos/osext ae77be60afb1dcacde03767a8c37337fad28ac14

--- a/vendor/github.com/google/gops/LICENSE
+++ b/vendor/github.com/google/gops/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2016 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/google/gops/README.md
+++ b/vendor/github.com/google/gops/README.md
@@ -1,0 +1,157 @@
+# gops
+
+[![Build status](https://circleci.com/gh/google/gops/tree/master.svg?style=shield&circle-token=2637dc1e57d5407ae250480a86a2e553a7d20482)](https://circleci.com/gh/google/gops)
+[![GoDoc](https://godoc.org/github.com/google/gops?status.svg)](https://godoc.org/github.com/google/gops)
+
+gops is a command to list and diagnose Go processes currently running on your system.
+
+```sh
+$ gops
+983   980    uplink-soecks go1.9 (/usr/local/bin/uplink-soecks)
+52697 52695  gops          go1.9 (/Users/jbd/bin/gops)
+4132  4130   foops*        go1.9 (/Users/jbd/bin/foops)
+51130 51128  gocode        go1.9 (/Users/jbd/bin/gocode)
+```
+
+## Installation
+
+```sh
+$ go get -u github.com/google/gops
+```
+
+## Diagnostics
+
+For processes that starts the diagnostics agent, gops can report
+additional information such as the current stack trace, Go version, memory
+stats, etc.
+
+In order to start the diagnostics agent, see the [hello example](https://github.com/google/gops/blob/master/examples/hello/main.go).
+
+``` go
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/google/gops/agent"
+)
+
+func main() {
+	if err := agent.Listen(nil); err != nil {
+		log.Fatal(err)
+	}
+	time.Sleep(time.Hour)
+}
+```
+
+### Manual
+
+It is possible to use gops tool both in local and remote mode.
+
+Local mode requires that you start the target binary as the same user that runs gops binary.
+To use gops in a remote mode you need to know target's agent address.
+
+In Local mode use process's PID as a target; in Remote mode target is a `host:port` combination.
+
+#### 0. Listing all processes running locally
+
+To print all go processes, run `gops` without arguments:
+
+```sh
+$ gops
+983   980    uplink-soecks go1.9 (/usr/local/bin/uplink-soecks)
+52697 52695  gops          go1.9 (/Users/jbd/bin/gops)
+4132  4130   foops*        go1.9 (/Users/jbd/bin/foops)
+51130 51128  gocode        go1.9 (/Users/jbd/bin/gocode)
+```
+
+The output displays:
+* PID
+* PPID
+* name of the program
+* Go version used to build the program,
+* Location of the associated program
+
+Note that processes running the agent are marked with `*` next to the PID (e.g. `4132*`).
+
+#### $ gops stack (\<pid\>|\<addr\>)
+
+In order to print the current stack trace from a target program, run the following command:
+
+
+```sh
+$ gops stack (<pid>|<addr>)
+gops stack 85709
+goroutine 8 [running]:
+runtime/pprof.writeGoroutineStacks(0x13c7bc0, 0xc42000e008, 0xc420ec8520, 0xc420ec8520)
+	/Users/jbd/go/src/runtime/pprof/pprof.go:603 +0x79
+runtime/pprof.writeGoroutine(0x13c7bc0, 0xc42000e008, 0x2, 0xc428f1c048, 0xc420ec8608)
+	/Users/jbd/go/src/runtime/pprof/pprof.go:592 +0x44
+runtime/pprof.(*Profile).WriteTo(0x13eeda0, 0x13c7bc0, 0xc42000e008, 0x2, 0xc42000e008, 0x0)
+	/Users/jbd/go/src/runtime/pprof/pprof.go:302 +0x3b5
+github.com/google/gops/agent.handle(0x13cd560, 0xc42000e008, 0xc420186000, 0x1, 0x1, 0x0, 0x0)
+	/Users/jbd/src/github.com/google/gops/agent/agent.go:150 +0x1b3
+github.com/google/gops/agent.listen()
+	/Users/jbd/src/github.com/google/gops/agent/agent.go:113 +0x2b2
+created by github.com/google/gops/agent.Listen
+	/Users/jbd/src/github.com/google/gops/agent/agent.go:94 +0x480
+# ...
+```
+
+#### $ gops memstats (\<pid\>|\<addr\>)
+
+To print the current memory stats, run the following command:
+
+```sh
+$ gops memstats (<pid>|<addr>)
+```
+
+
+#### $ gops gc (\<pid\>|\<addr\>)
+
+If you want to force run garbage collection on the target program, run `gc`.
+It will block until the GC is completed.
+
+
+#### $ gops version (\<pid\>|\<addr\>)
+
+gops reports the Go version the target program is built with, if you run the following:
+
+```sh
+$ gops version (<pid>|<addr>)
+devel +6a3c6c0 Sat Jan 14 05:57:07 2017 +0000
+```
+
+#### $ gops stats (\<pid\>|\<addr\>)
+
+To print the runtime statistics such as number of goroutines and `GOMAXPROCS`.
+
+#### Profiling
+
+
+##### Pprof
+
+gops supports CPU and heap pprof profiles. After reading either heap or CPU profile,
+it shells out to the `go tool pprof` and let you interatively examine the profiles.
+
+To enter the CPU profile, run:
+
+```sh
+$ gops pprof-cpu (<pid>|<addr>)
+```
+
+To enter the heap profile, run:
+
+```sh
+$ gops pprof-heap (<pid>|<addr>)
+```
+
+##### Execution trace
+
+gops allows you to start the runtime tracer for 5 seconds and examine the results.
+
+```sh
+$ gops trace (<pid>|<addr>)
+```
+

--- a/vendor/github.com/google/gops/agent/agent.go
+++ b/vendor/github.com/google/gops/agent/agent.go
@@ -1,0 +1,235 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package agent provides hooks programs can register to retrieve
+// diagnostics data by using gops.
+package agent
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+	gosignal "os/signal"
+	"runtime"
+	"runtime/pprof"
+	"runtime/trace"
+	"strconv"
+	"sync"
+	"time"
+
+	"bufio"
+
+	"github.com/google/gops/internal"
+	"github.com/google/gops/signal"
+	"github.com/kardianos/osext"
+)
+
+const defaultAddr = "127.0.0.1:0"
+
+var (
+	mu       sync.Mutex
+	portfile string
+	listener net.Listener
+
+	units = []string{" bytes", "KB", "MB", "GB", "TB", "PB"}
+)
+
+// Options allows configuring the started agent.
+type Options struct {
+	// Addr is the host:port the agent will be listening at.
+	// Optional.
+	Addr string
+
+	// ShutdownCleanup automatically cleans up resources if the
+	// running process receives an interrupt. Otherwise, users
+	// can call Close before shutting down.
+	// Optional.
+	ShutdownCleanup bool
+}
+
+// Listen starts the gops agent on a host process. Once agent started, users
+// can use the advanced gops features. The agent will listen to Interrupt
+// signals and exit the process, if you need to perform further work on the
+// Interrupt signal use the options parameter to configure the agent
+// accordingly.
+//
+// Note: The agent exposes an endpoint via a TCP connection that can be used by
+// any program on the system. Review your security requirements before starting
+// the agent.
+func Listen(opts Options) error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if portfile != "" {
+		return fmt.Errorf("gops: agent already listening at: %v", listener.Addr())
+	}
+
+	gopsdir, err := internal.ConfigDir()
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(gopsdir, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	if opts.ShutdownCleanup {
+		gracefulShutdown()
+	}
+
+	addr := opts.Addr
+	if addr == "" {
+		addr = defaultAddr
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	listener = ln
+	port := listener.Addr().(*net.TCPAddr).Port
+	portfile = fmt.Sprintf("%s/%d", gopsdir, os.Getpid())
+	err = ioutil.WriteFile(portfile, []byte(strconv.Itoa(port)), os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	go listen()
+	return nil
+}
+
+func listen() {
+	buf := make([]byte, 1)
+	for {
+		fd, err := listener.Accept()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "gops: %v", err)
+			if netErr, ok := err.(net.Error); ok && !netErr.Temporary() {
+				break
+			}
+			continue
+		}
+		if _, err := fd.Read(buf); err != nil {
+			fmt.Fprintf(os.Stderr, "gops: %v", err)
+			continue
+		}
+		if err := handle(fd, buf); err != nil {
+			fmt.Fprintf(os.Stderr, "gops: %v", err)
+			continue
+		}
+		fd.Close()
+	}
+}
+
+func gracefulShutdown() {
+	c := make(chan os.Signal, 1)
+	gosignal.Notify(c, os.Interrupt)
+	go func() {
+		// cleanup the socket on shutdown.
+		<-c
+		Close()
+		os.Exit(1)
+	}()
+}
+
+// Close closes the agent, removing temporary files and closing the TCP listener.
+// If no agent is listening, Close does nothing.
+func Close() {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if portfile != "" {
+		os.Remove(portfile)
+		portfile = ""
+	}
+	if listener != nil {
+		listener.Close()
+	}
+}
+
+func formatBytes(val uint64) string {
+	var i int
+	var target uint64
+	for i = range units {
+		target = 1 << uint(10*(i+1))
+		if val < target {
+			break
+		}
+	}
+	if i > 0 {
+		return fmt.Sprintf("%0.2f%s (%d bytes)", float64(val)/(float64(target)/1024), units[i], val)
+	}
+	return fmt.Sprintf("%d bytes", val)
+}
+
+func handle(conn io.Writer, msg []byte) error {
+	switch msg[0] {
+	case signal.StackTrace:
+		return pprof.Lookup("goroutine").WriteTo(conn, 2)
+	case signal.GC:
+		runtime.GC()
+		_, err := conn.Write([]byte("ok"))
+		return err
+	case signal.MemStats:
+		var s runtime.MemStats
+		runtime.ReadMemStats(&s)
+		fmt.Fprintf(conn, "alloc: %v\n", formatBytes(s.Alloc))
+		fmt.Fprintf(conn, "total-alloc: %v\n", formatBytes(s.TotalAlloc))
+		fmt.Fprintf(conn, "sys: %v\n", formatBytes(s.Sys))
+		fmt.Fprintf(conn, "lookups: %v\n", s.Lookups)
+		fmt.Fprintf(conn, "mallocs: %v\n", s.Mallocs)
+		fmt.Fprintf(conn, "frees: %v\n", s.Frees)
+		fmt.Fprintf(conn, "heap-alloc: %v\n", formatBytes(s.HeapAlloc))
+		fmt.Fprintf(conn, "heap-sys: %v\n", formatBytes(s.HeapSys))
+		fmt.Fprintf(conn, "heap-idle: %v\n", formatBytes(s.HeapIdle))
+		fmt.Fprintf(conn, "heap-in-use: %v\n", formatBytes(s.HeapInuse))
+		fmt.Fprintf(conn, "heap-released: %v\n", formatBytes(s.HeapReleased))
+		fmt.Fprintf(conn, "heap-objects: %v\n", s.HeapObjects)
+		fmt.Fprintf(conn, "stack-in-use: %v\n", formatBytes(s.StackInuse))
+		fmt.Fprintf(conn, "stack-sys: %v\n", formatBytes(s.StackSys))
+		fmt.Fprintf(conn, "next-gc: when heap-alloc >= %v\n", formatBytes(s.NextGC))
+		lastGC := "-"
+		if s.LastGC != 0 {
+			lastGC = fmt.Sprint(time.Unix(0, int64(s.LastGC)))
+		}
+		fmt.Fprintf(conn, "last-gc: %v\n", lastGC)
+		fmt.Fprintf(conn, "gc-pause: %v\n", time.Duration(s.PauseTotalNs))
+		fmt.Fprintf(conn, "num-gc: %v\n", s.NumGC)
+		fmt.Fprintf(conn, "enable-gc: %v\n", s.EnableGC)
+		fmt.Fprintf(conn, "debug-gc: %v\n", s.DebugGC)
+	case signal.Version:
+		fmt.Fprintf(conn, "%v\n", runtime.Version())
+	case signal.HeapProfile:
+		pprof.WriteHeapProfile(conn)
+	case signal.CPUProfile:
+		if err := pprof.StartCPUProfile(conn); err != nil {
+			return err
+		}
+		time.Sleep(30 * time.Second)
+		pprof.StopCPUProfile()
+	case signal.Stats:
+		fmt.Fprintf(conn, "goroutines: %v\n", runtime.NumGoroutine())
+		fmt.Fprintf(conn, "OS threads: %v\n", pprof.Lookup("threadcreate").Count())
+		fmt.Fprintf(conn, "GOMAXPROCS: %v\n", runtime.GOMAXPROCS(0))
+		fmt.Fprintf(conn, "num CPU: %v\n", runtime.NumCPU())
+	case signal.BinaryDump:
+		path, err := osext.Executable()
+		if err != nil {
+			return err
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		_, err = bufio.NewReader(f).WriteTo(conn)
+		return err
+	case signal.Trace:
+		trace.Start(conn)
+		time.Sleep(5 * time.Second)
+		trace.Stop()
+	}
+	return nil
+}

--- a/vendor/github.com/google/gops/internal/internal.go
+++ b/vendor/github.com/google/gops/internal/internal.go
@@ -1,0 +1,56 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func ConfigDir() (string, error) {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(os.Getenv("APPDATA"), "gops"), nil
+	}
+	homeDir := guessUnixHomeDir()
+	if homeDir == "" {
+		return "", errors.New("unable to get current user home directory: os/user lookup failed; $HOME is empty")
+	}
+	return filepath.Join(homeDir, ".config", "gops"), nil
+}
+
+func guessUnixHomeDir() string {
+	usr, err := user.Current()
+	if err == nil {
+		return usr.HomeDir
+	}
+	return os.Getenv("HOME")
+}
+
+func PIDFile(pid int) (string, error) {
+	gopsdir, err := ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/%d", gopsdir, pid), nil
+}
+
+func GetPort(pid int) (string, error) {
+	portfile, err := PIDFile(pid)
+	if err != nil {
+		return "", err
+	}
+	b, err := ioutil.ReadFile(portfile)
+	if err != nil {
+		return "", err
+	}
+	port := strings.TrimSpace(string(b))
+	return port, nil
+}

--- a/vendor/github.com/google/gops/signal/signal.go
+++ b/vendor/github.com/google/gops/signal/signal.go
@@ -1,0 +1,35 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package signal contains signals used to communicate to the gops agents.
+package signal
+
+const (
+	// StackTrace represents a command to print stack trace.
+	StackTrace = byte(0x1)
+
+	// GC runs the garbage collector.
+	GC = byte(0x2)
+
+	// MemStats reports memory stats.
+	MemStats = byte(0x3)
+
+	// Version prints the Go version.
+	Version = byte(0x4)
+
+	// HeapProfile starts `go tool pprof` with the current memory profile.
+	HeapProfile = byte(0x5)
+
+	// CPUProfile starts `go tool pprof` with the current CPU profile
+	CPUProfile = byte(0x6)
+
+	// Stats returns Go runtime statistics such as number of goroutines, GOMAXPROCS, and NumCPU.
+	Stats = byte(0x7)
+
+	// Trace starts the Go execution tracer, waits 5 seconds and launches the trace tool.
+	Trace = byte(0x8)
+
+	// BinaryDump returns running binary file.
+	BinaryDump = byte(0x9)
+)

--- a/vendor/github.com/kardianos/osext/LICENSE
+++ b/vendor/github.com/kardianos/osext/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/kardianos/osext/README.md
+++ b/vendor/github.com/kardianos/osext/README.md
@@ -1,0 +1,21 @@
+### Extensions to the "os" package.
+
+[![GoDoc](https://godoc.org/github.com/kardianos/osext?status.svg)](https://godoc.org/github.com/kardianos/osext)
+
+## Find the current Executable and ExecutableFolder.
+
+As of go1.8 the Executable function may be found in `os`. The Executable function
+in the std lib `os` package is used if available.
+
+There is sometimes utility in finding the current executable file
+that is running. This can be used for upgrading the current executable
+or finding resources located relative to the executable file. Both
+working directory and the os.Args[0] value are arbitrary and cannot
+be relied on; os.Args[0] can be "faked".
+
+Multi-platform and supports:
+ * Linux
+ * OS X
+ * Windows
+ * Plan 9
+ * BSDs.

--- a/vendor/github.com/kardianos/osext/osext.go
+++ b/vendor/github.com/kardianos/osext/osext.go
@@ -1,0 +1,33 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Extensions to the standard "os" package.
+package osext // import "github.com/kardianos/osext"
+
+import "path/filepath"
+
+var cx, ce = executableClean()
+
+func executableClean() (string, error) {
+	p, err := executable()
+	return filepath.Clean(p), err
+}
+
+// Executable returns an absolute path that can be used to
+// re-invoke the current program.
+// It may not be valid after the current program exits.
+func Executable() (string, error) {
+	return cx, ce
+}
+
+// Returns same path as Executable, returns just the folder
+// path. Excludes the executable name and any trailing slash.
+func ExecutableFolder() (string, error) {
+	p, err := Executable()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Dir(p), nil
+}

--- a/vendor/github.com/kardianos/osext/osext_go18.go
+++ b/vendor/github.com/kardianos/osext/osext_go18.go
@@ -1,0 +1,9 @@
+//+build go1.8,!openbsd
+
+package osext
+
+import "os"
+
+func executable() (string, error) {
+	return os.Executable()
+}

--- a/vendor/github.com/kardianos/osext/osext_plan9.go
+++ b/vendor/github.com/kardianos/osext/osext_plan9.go
@@ -1,0 +1,22 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//+build !go1.8
+
+package osext
+
+import (
+	"os"
+	"strconv"
+	"syscall"
+)
+
+func executable() (string, error) {
+	f, err := os.Open("/proc/" + strconv.Itoa(os.Getpid()) + "/text")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	return syscall.Fd2path(int(f.Fd()))
+}

--- a/vendor/github.com/kardianos/osext/osext_procfs.go
+++ b/vendor/github.com/kardianos/osext/osext_procfs.go
@@ -1,0 +1,36 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.8,android !go1.8,linux !go1.8,netbsd !go1.8,solaris !go1.8,dragonfly
+
+package osext
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+)
+
+func executable() (string, error) {
+	switch runtime.GOOS {
+	case "linux", "android":
+		const deletedTag = " (deleted)"
+		execpath, err := os.Readlink("/proc/self/exe")
+		if err != nil {
+			return execpath, err
+		}
+		execpath = strings.TrimSuffix(execpath, deletedTag)
+		execpath = strings.TrimPrefix(execpath, deletedTag)
+		return execpath, nil
+	case "netbsd":
+		return os.Readlink("/proc/curproc/exe")
+	case "dragonfly":
+		return os.Readlink("/proc/curproc/file")
+	case "solaris":
+		return os.Readlink(fmt.Sprintf("/proc/%d/path/a.out", os.Getpid()))
+	}
+	return "", errors.New("ExecPath not implemented for " + runtime.GOOS)
+}

--- a/vendor/github.com/kardianos/osext/osext_sysctl.go
+++ b/vendor/github.com/kardianos/osext/osext_sysctl.go
@@ -1,0 +1,126 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.8,darwin !go1.8,freebsd openbsd
+
+package osext
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"unsafe"
+)
+
+var initCwd, initCwdErr = os.Getwd()
+
+func executable() (string, error) {
+	var mib [4]int32
+	switch runtime.GOOS {
+	case "freebsd":
+		mib = [4]int32{1 /* CTL_KERN */, 14 /* KERN_PROC */, 12 /* KERN_PROC_PATHNAME */, -1}
+	case "darwin":
+		mib = [4]int32{1 /* CTL_KERN */, 38 /* KERN_PROCARGS */, int32(os.Getpid()), -1}
+	case "openbsd":
+		mib = [4]int32{1 /* CTL_KERN */, 55 /* KERN_PROC_ARGS */, int32(os.Getpid()), 1 /* KERN_PROC_ARGV */}
+	}
+
+	n := uintptr(0)
+	// Get length.
+	_, _, errNum := syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 4, 0, uintptr(unsafe.Pointer(&n)), 0, 0)
+	if errNum != 0 {
+		return "", errNum
+	}
+	if n == 0 { // This shouldn't happen.
+		return "", nil
+	}
+	buf := make([]byte, n)
+	_, _, errNum = syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 4, uintptr(unsafe.Pointer(&buf[0])), uintptr(unsafe.Pointer(&n)), 0, 0)
+	if errNum != 0 {
+		return "", errNum
+	}
+	if n == 0 { // This shouldn't happen.
+		return "", nil
+	}
+
+	var execPath string
+	switch runtime.GOOS {
+	case "openbsd":
+		// buf now contains **argv, with pointers to each of the C-style
+		// NULL terminated arguments.
+		var args []string
+		argv := uintptr(unsafe.Pointer(&buf[0]))
+	Loop:
+		for {
+			argp := *(**[1 << 20]byte)(unsafe.Pointer(argv))
+			if argp == nil {
+				break
+			}
+			for i := 0; uintptr(i) < n; i++ {
+				// we don't want the full arguments list
+				if string(argp[i]) == " " {
+					break Loop
+				}
+				if argp[i] != 0 {
+					continue
+				}
+				args = append(args, string(argp[:i]))
+				n -= uintptr(i)
+				break
+			}
+			if n < unsafe.Sizeof(argv) {
+				break
+			}
+			argv += unsafe.Sizeof(argv)
+			n -= unsafe.Sizeof(argv)
+		}
+		execPath = args[0]
+		// There is no canonical way to get an executable path on
+		// OpenBSD, so check PATH in case we are called directly
+		if execPath[0] != '/' && execPath[0] != '.' {
+			execIsInPath, err := exec.LookPath(execPath)
+			if err == nil {
+				execPath = execIsInPath
+			}
+		}
+	default:
+		for i, v := range buf {
+			if v == 0 {
+				buf = buf[:i]
+				break
+			}
+		}
+		execPath = string(buf)
+	}
+
+	var err error
+	// execPath will not be empty due to above checks.
+	// Try to get the absolute path if the execPath is not rooted.
+	if execPath[0] != '/' {
+		execPath, err = getAbs(execPath)
+		if err != nil {
+			return execPath, err
+		}
+	}
+	// For darwin KERN_PROCARGS may return the path to a symlink rather than the
+	// actual executable.
+	if runtime.GOOS == "darwin" {
+		if execPath, err = filepath.EvalSymlinks(execPath); err != nil {
+			return execPath, err
+		}
+	}
+	return execPath, nil
+}
+
+func getAbs(execPath string) (string, error) {
+	if initCwdErr != nil {
+		return execPath, initCwdErr
+	}
+	// The execPath may begin with a "../" or a "./" so clean it first.
+	// Join the two paths, trailing and starting slashes undetermined, so use
+	// the generic Join function.
+	return filepath.Join(initCwd, filepath.Clean(execPath)), nil
+}

--- a/vendor/github.com/kardianos/osext/osext_windows.go
+++ b/vendor/github.com/kardianos/osext/osext_windows.go
@@ -1,0 +1,36 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//+build !go1.8
+
+package osext
+
+import (
+	"syscall"
+	"unicode/utf16"
+	"unsafe"
+)
+
+var (
+	kernel                = syscall.MustLoadDLL("kernel32.dll")
+	getModuleFileNameProc = kernel.MustFindProc("GetModuleFileNameW")
+)
+
+// GetModuleFileName() with hModule = NULL
+func executable() (exePath string, err error) {
+	return getModuleFileName()
+}
+
+func getModuleFileName() (string, error) {
+	var n uint32
+	b := make([]uint16, syscall.MAX_PATH)
+	size := uint32(len(b))
+
+	r0, _, e1 := getModuleFileNameProc.Call(0, uintptr(unsafe.Pointer(&b[0])), uintptr(size))
+	n = uint32(r0)
+	if n == 0 {
+		return "", e1
+	}
+	return string(utf16.Decode(b[0:n])), nil
+}


### PR DESCRIPTION
Add support for getting stack traces of the Cilium agent with gops, a profiling tool from Google.

Partially address #1637 

Signed-off by: Ian Vernon <ian@cilium.io>