### PR TITLE
tests/k8s: Run docker registry before docker build

### DIFF
--- a/tests/k8s/Vagrantfile
+++ b/tests/k8s/Vagrantfile
@@ -7,11 +7,11 @@ Vagrant.require_version ">= 1.8.3"
 $build_docker_image = <<SCRIPT
 certs_dir="/home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/cluster/certs"
 cd /home/vagrant/go/src/github.com/cilium/cilium/
-make docker-image-dev
 docker run -d -p 5000:5000 --name registry -v ${certs_dir}:/certs \
         -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/kubernetes.pem \
         -e REGISTRY_HTTP_TLS_KEY=/certs/kubernetes-key.pem \
         registry:2
+make docker-image-dev
 docker tag cilium:${DOCKER_IMAGE_TAG} localhost:5000/cilium:${DOCKER_IMAGE_TAG}
 docker push localhost:5000/cilium:${DOCKER_IMAGE_TAG}
 SCRIPT


### PR DESCRIPTION
By running the docker image for the registry earlier in the vagrant
provision, it makes the later steps less likely to fail due to being
unable to find the docker registry.

Fixes: #1635

Signed-off-by: Joe Stringer <joe@covalent.io>