### PR TITLE
Prepare for multiple proxies

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -131,12 +131,12 @@ func (d *Daemon) UpdateProxyRedirect(e *endpoint.Endpoint, l4 *policy.L4Filter) 
 	}
 
 	log.Debugf("Adding redirect %+v to endpoint %d", l4, e.ID)
-	r, err := d.l7Proxy.CreateOrUpdateRedirect(l4, e.ProxyID(l4), e)
+	r, err := d.l7Proxy.CreateOrUpdateRedirect(l4, e.ProxyID(l4), e, proxy.ProxyKindOxy)
 	if err != nil {
 		return 0, err
 	}
 
-	return r.ToPort, nil
+	return r.ToPort(), nil
 }
 
 // RemoveProxyRedirect removes a previously installed proxy redirect for an

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -116,8 +116,11 @@ func (d *Daemon) traceL4Egress(ctx policy.SearchContext, ports []*models.Port) a
 	ctx.EgressL4Only = true
 
 	ctx.PolicyTrace("\n")
-	policy := d.policy.ResolveL4Policy(&ctx)
-	verdict := policy.EgressCoversDPorts(ports)
+	policy, err := d.policy.ResolveL4Policy(&ctx)
+	verdict := api.Undecided
+	if err == nil {
+		verdict = policy.EgressCoversDPorts(ports)
+	}
 
 	if len(ports) == 0 {
 		ctx.PolicyTrace("L4 egress verdict: [no port context specified]\n")
@@ -133,8 +136,11 @@ func (d *Daemon) traceL4Ingress(ctx policy.SearchContext, ports []*models.Port) 
 	ctx.IngressL4Only = true
 
 	ctx.PolicyTrace("\n")
-	policy := d.policy.ResolveL4Policy(&ctx)
-	verdict := policy.IngressCoversDPorts(ports)
+	policy, err := d.policy.ResolveL4Policy(&ctx)
+	verdict := api.Undecided
+	if err == nil {
+		verdict = policy.IngressCoversDPorts(ports)
+	}
 
 	if len(ports) == 0 {
 		ctx.PolicyTrace("L4 ingress verdict: [no port context specified]\n")

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -161,8 +161,12 @@ func (e *Endpoint) regenerateConsumable(owner Owner) (bool, error) {
 
 	repo := owner.GetPolicyRepository()
 	repo.Mutex.Lock()
-	newL4policy := repo.ResolveL4Policy(&ctx)
+	newL4policy, err := repo.ResolveL4Policy(&ctx)
 	defer repo.Mutex.Unlock()
+
+	if err != nil {
+		return false, err
+	}
 
 	c.Mutex.Lock()
 	defer c.Mutex.Unlock()

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -95,12 +95,14 @@ func (s *K8sSuite) TestParseNetworkPolicy(c *C) {
 	repo.AddList(rules)
 	c.Assert(repo.CanReachRLocked(&ctx), Equals, api.Allowed)
 
-	result := repo.ResolveL4Policy(&ctx)
+	result, err := repo.ResolveL4Policy(&ctx)
+	c.Assert(result, Not(IsNil))
+	c.Assert(err, IsNil)
 	c.Assert(result, DeepEquals, &policy.L4Policy{
 		Ingress: policy.L4PolicyMap{
 			"80/tcp": policy.L4Filter{
 				Port: 80, Protocol: "tcp", L7Parser: "",
-				L7RedirectPort: 0, L7Rules: []policy.AuxRule(nil),
+				L7RedirectPort: 0, L7Rules: api.L7Rules{},
 				Ingress: true,
 			},
 		},
@@ -413,7 +415,9 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	// Should be DENY sense the traffic needs to come from
 	// namespace `user=bob` AND port 443.
 	c.Assert(repo.AllowsRLocked(&ctx), Equals, api.Allowed)
-	l4Policy := repo.ResolveL4Policy(&ctx)
+	l4Policy, err := repo.ResolveL4Policy(&ctx)
+	c.Assert(l4Policy, Not(IsNil))
+	c.Assert(err, IsNil)
 	l4Veridict := l4Policy.IngressCoversDPorts([]*models.Port{})
 	c.Assert(l4Veridict, Equals, api.Denied)
 

--- a/pkg/k8s/network_policy_v1beta_test.go
+++ b/pkg/k8s/network_policy_v1beta_test.go
@@ -87,12 +87,14 @@ func (s *K8sSuite) TestParseNetworkPolicyDeprecated(c *C) {
 	repo.AddList(rules)
 	c.Assert(repo.CanReachRLocked(&ctx), Equals, api.Allowed)
 
-	result := repo.ResolveL4Policy(&ctx)
+	result, err := repo.ResolveL4Policy(&ctx)
+	c.Assert(result, Not(IsNil))
+	c.Assert(err, IsNil)
 	c.Assert(result, DeepEquals, &policy.L4Policy{
 		Ingress: policy.L4PolicyMap{
 			"80/tcp": policy.L4Filter{
 				Port: 80, Protocol: "tcp", L7Parser: "",
-				L7RedirectPort: 0, L7Rules: []policy.AuxRule(nil),
+				L7RedirectPort: 0, L7Rules: api.L7Rules{},
 				Ingress: true,
 			},
 		},
@@ -405,7 +407,9 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 	// Should be DENY sense the traffic needs to come from
 	// namespace `user=bob` AND port 443.
 	c.Assert(repo.AllowsRLocked(&ctx), Equals, api.Allowed)
-	l4Policy := repo.ResolveL4Policy(&ctx)
+	l4Policy, err := repo.ResolveL4Policy(&ctx)
+	c.Assert(l4Policy, Not(IsNil))
+	c.Assert(err, IsNil)
 	l4Veridict := l4Policy.IngressCoversDPorts([]*models.Port{})
 	c.Assert(l4Veridict, Equals, api.Denied)
 

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -24,11 +24,6 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 )
 
-type AuxRule struct {
-	Expr     string `json:"expr"`
-	L7Parser string `json:"l7Parser"`
-}
-
 // L7ParserType is the type used to indicate what L7 parser to use and
 // defines all supported types of L7 parsers
 type L7ParserType string
@@ -46,105 +41,13 @@ type L4Filter struct {
 	// Protocol is the L4 protocol to allow or NONE
 	Protocol string
 	// L7Parser specifies the L7 protocol parser (optional)
-	L7Parser string
+	L7Parser L7ParserType
 	// L7RedirectPort is the L7 proxy port to redirect to (optional)
 	L7RedirectPort int
 	// L7Rules is a list of L7 rules which are passed to the L7 proxy (optional)
-	L7Rules []AuxRule
+	L7Rules api.L7Rules
 	// Ingress is true if filter applies at ingress
 	Ingress bool
-}
-
-// FillPortRuleHTTP fills in the http port rule fields
-// as a regex into a single string
-func FillPortRuleHTTP(httpRule []api.PortRuleHTTP) ([]AuxRule, string) {
-	l7rules := []AuxRule{}
-	l7Parser := ""
-	for _, h := range httpRule {
-		r := AuxRule{L7Parser: string(ParserTypeHTTP)}
-
-		if h.Path != "" {
-			r.Expr = "PathRegexp(\"" + h.Path + "\")"
-		}
-
-		if h.Method != "" {
-			if r.Expr != "" {
-				r.Expr += " && "
-			}
-			r.Expr += "MethodRegexp(\"" + h.Method + "\")"
-		}
-
-		if h.Host != "" {
-			if r.Expr != "" {
-				r.Expr += " && "
-			}
-			r.Expr += "HostRegexp(\"" + h.Host + "\")"
-		}
-
-		for _, hdr := range h.Headers {
-			s := strings.SplitN(hdr, " ", 2)
-			if r.Expr != "" {
-				r.Expr += " && "
-			}
-			r.Expr += "Header(\""
-			if len(s) == 2 {
-				// Remove ':' in "X-Key: true"
-				key := strings.TrimRight(s[0], ":")
-				r.Expr += key + "\",\"" + s[1]
-			} else {
-				r.Expr += s[0]
-			}
-			r.Expr += "\")"
-		}
-
-		if r.Expr != "" {
-			l7rules = append(l7rules, r)
-		}
-	}
-
-	if len(l7rules) > 0 {
-		l7Parser = string(ParserTypeHTTP)
-	}
-	return l7rules, l7Parser
-}
-
-// FillPortRuleKafka fills in the Kafka port rule fields
-// as a regex into a single string
-// TODO The string formed is likely not the final format, and will
-// evolve as more kafka keys are supported.
-func FillPortRuleKafka(kafkaRule []api.PortRuleKafka) ([]AuxRule, string) {
-	l7rules := []AuxRule{}
-	l7Parser := ""
-	for _, h := range kafkaRule {
-		r := AuxRule{L7Parser: string(ParserTypeKafka)}
-
-		if h.APIVersion != "" {
-			r.Expr = "ApiVersionRegexp(\"" + h.APIVersion + "\")"
-		}
-
-		if h.Topic != "" {
-			if r.Expr != "" {
-				r.Expr += " && "
-			}
-			r.Expr += "TopicRegexp(\"" + h.Topic + "\")"
-		}
-
-		if h.APIKey != "" {
-			if r.Expr != "" {
-				r.Expr += " && "
-			}
-			r.Expr += "ApiKeyRegexp(\"" + h.APIKey + "\")"
-		}
-
-		if r.Expr != "" {
-			l7rules = append(l7rules, r)
-		}
-	}
-
-	if len(l7rules) > 0 {
-		l7Parser = string(ParserTypeKafka)
-	}
-	return l7rules, l7Parser
 }
 
 // CreateL4Filter creates an L4Filter based on an api.PortRule and api.PortProtocol
@@ -163,12 +66,12 @@ func CreateL4Filter(rule api.PortRule, port api.PortProtocol, direction string, 
 	}
 
 	if rule.Rules != nil {
-		switch {
-		case rule.Rules.HTTP != nil:
-			l4.L7Rules, l4.L7Parser = FillPortRuleHTTP(rule.Rules.HTTP)
-		case rule.Rules.Kafka != nil:
-			l4.L7Rules, l4.L7Parser = FillPortRuleKafka(rule.Rules.Kafka)
+		if len(rule.Rules.HTTP) > 0 {
+			l4.L7Parser = ParserTypeHTTP
+		} else if len(rule.Rules.Kafka) > 0 {
+			l4.L7Parser = ParserTypeKafka
 		}
+		l4.L7Rules = *rule.Rules
 	}
 
 	return l4

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -66,9 +66,10 @@ func CreateL4Filter(rule api.PortRule, port api.PortProtocol, direction string, 
 	}
 
 	if rule.Rules != nil {
-		if len(rule.Rules.HTTP) > 0 {
+		switch {
+		case len(rule.Rules.HTTP) > 0:
 			l4.L7Parser = ParserTypeHTTP
-		} else if len(rule.Rules.Kafka) > 0 {
+		case len(rule.Rules.Kafka) > 0:
 			l4.L7Parser = ParserTypeKafka
 		}
 		l4.L7Rules = *rule.Rules

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -131,8 +131,8 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 		},
 	}
 
-	l7rules := []AuxRule{
-		{Expr: "PathRegexp(\"/\") && MethodRegexp(\"GET\")", L7Parser: string(ParserTypeHTTP)},
+	l7rules := api.L7Rules{
+		HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
 	}
 
 	expected := NewL4Policy()
@@ -142,13 +142,15 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	expected.Egress["3000/udp"] = L4Filter{Port: 3000, Protocol: "udp", Ingress: false}
 
 	state := traceState{}
-	res := rule1.resolveL4Policy(toBar, &state, NewL4Policy())
+	res, err := rule1.resolveL4Policy(toBar, &state, NewL4Policy())
+	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, DeepEquals, *expected)
 	c.Assert(state.selectedRules, Equals, 1)
 
 	state = traceState{}
-	c.Assert(rule1.resolveL4Policy(toFoo, &state, NewL4Policy()), IsNil)
+	res, err = rule1.resolveL4Policy(toFoo, &state, NewL4Policy())
+	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
 }
 

--- a/pkg/proxy/oxyproxy.go
+++ b/pkg/proxy/oxyproxy.go
@@ -1,0 +1,607 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/cilium/cilium/common/addressing"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/nodeaddress"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/proxy/accesslog"
+
+	"github.com/braintree/manners"
+	log "github.com/sirupsen/logrus"
+	"github.com/vulcand/oxy/forward"
+	"github.com/vulcand/route"
+)
+
+// OxyRedirect implements the Redirect interface for a l7 proxy
+type OxyRedirect struct {
+	mutex lock.RWMutex
+
+	id       string
+	fromPort uint16
+	toPort   uint16
+	epID     uint64
+	rules    []string
+	source   ProxySource
+	server   *manners.GracefulServer
+	router   route.Router
+	l4       policy.L4Filter // stale copy, ignore rules
+	nodeInfo accesslog.NodeAddressInfo
+}
+
+// ToPort returns the redirect port of an OxyRedirect
+func (r *OxyRedirect) ToPort() uint16 {
+	return r.toPort
+}
+
+func (r *OxyRedirect) updateRules(rules []string) {
+	for _, v := range r.rules {
+		r.router.RemoveRoute(v)
+	}
+
+	r.rules = make([]string, len(rules))
+	copy(r.rules, rules)
+
+	for _, v := range r.rules {
+		r.router.AddRoute(v, v)
+	}
+}
+
+func (r *OxyRedirect) localEndpointInfo(info *accesslog.EndpointInfo) {
+	r.source.RLock()
+	info.ID = r.epID
+	info.IPv4 = r.source.GetIPv4Address()
+	info.IPv6 = r.source.GetIPv6Address()
+	info.Labels = r.source.GetLabels()
+	info.LabelsSHA256 = r.source.GetLabelsSHA()
+	info.Identity = uint64(r.source.GetIdentity())
+	r.source.RUnlock()
+}
+
+// fillReservedIdentity resolves the labels of the specified identity if known
+// locally and fills in the following info member fields:
+//  - info.Identity
+//  - info.Labels
+//  - info.LabelsSHA256
+func (r *OxyRedirect) fillReservedIdentity(info *accesslog.EndpointInfo, id policy.NumericIdentity) {
+	info.Identity = uint64(id)
+
+	if c := policy.GetConsumableCache().Lookup(id); c != nil {
+		if c.Labels != nil {
+			info.Labels = c.Labels.Labels.GetModel()
+			info.LabelsSHA256 = c.Labels.GetLabelsSHA256()
+		}
+	}
+}
+
+// egressDestinationInfo returns the destination EndpointInfo for a flow
+// leaving the proxy at egress.
+func (r *OxyRedirect) egressDestinationInfo(ipstr string, info *accesslog.EndpointInfo) {
+	ip := net.ParseIP(ipstr)
+	if ip != nil {
+		if ip.To4() != nil {
+			info.IPv4 = ip.String()
+
+			if nodeaddress.IsHostIPv4(ip) {
+				r.fillReservedIdentity(info, policy.ReservedIdentityHost)
+				return
+			}
+
+			if nodeaddress.GetIPv4ClusterRange().Contains(ip) {
+				c := addressing.DeriveCiliumIPv4(ip)
+				ep := endpointmanager.LookupIPv4(c.String())
+				if ep != nil {
+					info.ID = uint64(ep.ID)
+					info.Labels = ep.GetLabels()
+					info.LabelsSHA256 = ep.GetLabelsSHA()
+					info.Identity = uint64(ep.GetIdentity())
+				} else {
+					r.fillReservedIdentity(info, policy.ReservedIdentityCluster)
+				}
+			} else {
+				r.fillReservedIdentity(info, policy.ReservedIdentityWorld)
+			}
+		} else {
+			info.IPv6 = ip.String()
+
+			if nodeaddress.IsHostIPv6(ip) {
+				r.fillReservedIdentity(info, policy.ReservedIdentityHost)
+				return
+			}
+
+			if nodeaddress.GetIPv6ClusterRange().Contains(ip) {
+				c := addressing.DeriveCiliumIPv6(ip)
+				id := c.EndpointID()
+				info.ID = uint64(id)
+
+				ep := endpointmanager.LookupCiliumID(id)
+				if ep != nil {
+					ep.RLock()
+					info.Labels = ep.GetLabels()
+					info.LabelsSHA256 = ep.GetLabelsSHA()
+					info.Identity = uint64(ep.GetIdentity())
+					ep.RUnlock()
+				} else {
+					r.fillReservedIdentity(info, policy.ReservedIdentityCluster)
+				}
+			} else {
+				r.fillReservedIdentity(info, policy.ReservedIdentityWorld)
+			}
+		}
+	}
+}
+
+// getInfoFromConsumable fills the accesslog.EndpointInfo fields, by fetching
+// the consumable from the consumable cache of endpoint using identity sent by
+// source. This is needed in ingress proxy while logging the source endpoint
+// info.  Since there will be 2 proxies on the same host, if both egress and
+// ingress policies are set, the ingress policy cannot determine the source
+// endpoint info based on ip address, as the ip address would be that of the
+// egress proxy i.e host.
+func (r *OxyRedirect) getInfoFromConsumable(ipstr string, info *accesslog.EndpointInfo, srcIdentity policy.NumericIdentity) {
+	ep := r.source
+	ip := net.ParseIP(ipstr)
+	if ip != nil {
+		if ip.To4() != nil {
+			info.IPv4 = ip.String()
+		} else {
+			info.IPv6 = ip.String()
+		}
+	}
+	secIdentity := ep.ResolveIdentity(srcIdentity)
+
+	if secIdentity != nil {
+		info.Labels = secIdentity.Labels.GetModel()
+		info.LabelsSHA256 = secIdentity.Labels.SHA256Sum()
+		info.Identity = uint64(srcIdentity)
+	}
+}
+
+func (r *OxyRedirect) getSourceInfo(req *http.Request, srcIdentity policy.NumericIdentity) (accesslog.EndpointInfo, accesslog.IPVersion) {
+	info := accesslog.EndpointInfo{}
+	version := accesslog.VersionIPv4
+	ipstr, port, err := net.SplitHostPort(req.RemoteAddr)
+	if err == nil {
+		p, err := strconv.ParseUint(port, 10, 16)
+		if err == nil {
+			info.Port = uint16(p)
+		}
+
+		ip := net.ParseIP(ipstr)
+		if ip != nil && ip.To4() == nil {
+			version = accesslog.VersionIPV6
+		}
+	}
+
+	// At egress, the local origin endpoint is the source
+	if !r.l4.Ingress {
+		r.localEndpointInfo(&info)
+	} else if err == nil {
+		if srcIdentity != 0 {
+			r.getInfoFromConsumable(ipstr, &info, srcIdentity)
+		} else {
+			// source security identity 0 is possible when somebody else other than the BPF datapath attempts to
+			// connect to the proxy.
+			// We should log no source information in that case, in the proxy log.
+			log.Warn("Missing security identity in source endpoint info")
+		}
+
+	}
+
+	return info, version
+}
+
+func (r *OxyRedirect) getDestinationInfo(dstIPPort string) accesslog.EndpointInfo {
+	info := accesslog.EndpointInfo{}
+	ipstr, port, err := net.SplitHostPort(dstIPPort)
+	if err == nil {
+		p, err := strconv.ParseUint(port, 10, 16)
+		if err == nil {
+			info.Port = uint16(p)
+		}
+	}
+
+	// At ingress the local origin endpoint is the source
+	if r.l4.Ingress {
+		r.localEndpointInfo(&info)
+	} else if err == nil {
+		r.egressDestinationInfo(ipstr, &info)
+	}
+
+	return info
+}
+
+func translateOxyPolicyRules(l4 *policy.L4Filter) ([]string, error) {
+	var l7rules []string
+
+	for _, h := range l4.L7Rules.HTTP {
+		var r string
+
+		if h.Path != "" {
+			r = "PathRegexp(\"" + h.Path + "\")"
+		}
+
+		if h.Method != "" {
+			if r != "" {
+				r += " && "
+			}
+			r += "MethodRegexp(\"" + h.Method + "\")"
+		}
+
+		if h.Host != "" {
+			if r != "" {
+				r += " && "
+			}
+			r += "HostRegexp(\"" + h.Host + "\")"
+		}
+
+		for _, hdr := range h.Headers {
+			s := strings.SplitN(hdr, " ", 2)
+			if r != "" {
+				r += " && "
+			}
+			r += "Header(\""
+			if len(s) == 2 {
+				// Remove ':' in "X-Key: true"
+				key := strings.TrimRight(s[0], ":")
+				r += key + "\",\"" + s[1]
+			} else {
+				r += s[0]
+			}
+			r += "\")"
+		}
+
+		if !route.IsValid(r) {
+			return nil, fmt.Errorf("invalid filter expression: %s", r)
+		}
+		l7rules = append(l7rules, r)
+	}
+
+	return l7rules, nil
+}
+
+func listenSocket(address string, mark int) (net.Listener, error) {
+	addr, err := net.ResolveTCPAddr("tcp", address)
+	if err != nil {
+		return nil, err
+	}
+
+	family := syscall.AF_INET
+	if addr.IP.To4() == nil {
+		family = syscall.AF_INET6
+	}
+
+	fd, err := syscall.Socket(family, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {
+		return nil, fmt.Errorf("unable to set SO_REUSEADDR socket option: %s", err)
+	}
+
+	setFdMark(fd, mark)
+
+	sockAddr, err := ipToSockaddr(family, addr.IP, addr.Port, addr.Zone)
+	if err != nil {
+		syscall.Close(fd)
+		return nil, err
+	}
+
+	if err := syscall.Bind(fd, sockAddr); err != nil {
+		syscall.Close(fd)
+		return nil, err
+	}
+
+	if err := syscall.Listen(fd, 128); err != nil {
+		syscall.Close(fd)
+		return nil, err
+	}
+
+	f := os.NewFile(uintptr(fd), addr.String())
+	defer f.Close()
+
+	return net.FileListener(f)
+}
+
+func lookupNewDest(req *http.Request, dport uint16) (uint32, string, error) {
+	ip, port, err := net.SplitHostPort(req.RemoteAddr)
+	if err != nil {
+		return 0, "", fmt.Errorf("invalid remote address: %s", err)
+	}
+
+	pIP := net.ParseIP(ip)
+	if pIP == nil {
+		return 0, "", fmt.Errorf("unable to parse IP %s", ip)
+	}
+
+	sport, err := strconv.ParseUint(port, 10, 16)
+	if err != nil {
+		return 0, "", fmt.Errorf("unable to parse port string: %s", err)
+	}
+
+	if pIP.To4() != nil {
+		key := &Proxy4Key{
+			SPort:   uint16(sport),
+			DPort:   dport,
+			Nexthdr: 6,
+		}
+
+		copy(key.SAddr[:], pIP.To4())
+
+		val, err := LookupEgress4(key)
+		if err != nil {
+			return 0, "", fmt.Errorf("Unable to find IPv4 proxy entry for %s: %s", key, err)
+		}
+
+		log.Debugf("Found IPv4 proxy entry: %+v", val)
+		return val.SourceIdentity, val.HostPort(), nil
+	}
+
+	key := &Proxy6Key{
+		SPort:   uint16(sport),
+		DPort:   dport,
+		Nexthdr: 6,
+	}
+
+	copy(key.SAddr[:], pIP.To16())
+
+	val, err := LookupEgress6(key)
+	if err != nil {
+		return 0, "", fmt.Errorf("Unable to find IPv6 proxy entry for %s: %s", key, err)
+	}
+
+	log.Debugf("Found IPv6 proxy entry: %+v", val)
+	return val.SourceIdentity, val.HostPort(), nil
+}
+
+func generateURL(req *http.Request, hostport string) *url.URL {
+	newURL := *req.URL
+	newURL.Scheme = "http"
+	newURL.Host = hostport
+
+	return &newURL
+}
+
+type proxyIdentity int
+
+const identityKey proxyIdentity = 0
+
+func newIdentityContext(ctx context.Context, id int) context.Context {
+	return context.WithValue(ctx, identityKey, id)
+}
+
+func identityFromContext(ctx context.Context) (int, bool) {
+	val, ok := ctx.Value(identityKey).(int)
+	return val, ok
+}
+
+func setFdMark(fd, mark int) {
+	log.WithFields(log.Fields{
+		fieldFd:     fd,
+		fieldMarker: mark,
+	}).Debug("Setting packet marker of socket")
+
+	err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_MARK, mark)
+	if err != nil {
+		log.WithFields(log.Fields{
+			fieldFd:     fd,
+			fieldMarker: mark,
+		}).WithError(err).Warning("Unable to set SO_MARK")
+	}
+}
+
+func setSocketMark(c net.Conn, mark int) {
+	if tc, ok := c.(*net.TCPConn); ok {
+		if f, err := tc.File(); err == nil {
+			defer f.Close()
+			setFdMark(int(f.Fd()), mark)
+		}
+	}
+}
+
+// createOxyRedirect creates a redirect with corresponding proxy
+// configuration. This will launch a proxy instance.
+func createOxyRedirect(l4 *policy.L4Filter, id string, source ProxySource, to uint16) (Redirect, error) {
+	if len(l4.L7Rules.Kafka) > 0 {
+		log.Debug("Kafka Parser not supported by Oxy proxy.")
+		return nil, fmt.Errorf("unsupported L7 protocol proxy: \"%s\"", l4.L7Parser)
+
+	}
+	if l4.L7Parser != policy.ParserTypeHTTP {
+		return nil, fmt.Errorf("unknown L7 protocol \"%s\"", l4.L7Parser)
+	}
+
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           ciliumDialer,
+		MaxIdleConns:          2048,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	fwd, err := forward.New(forward.RoundTripper(transport))
+	if err != nil {
+		return nil, err
+	}
+
+	l7rules, err := translateOxyPolicyRules(l4)
+	if err != nil {
+		return nil, err
+	}
+
+	redir := &OxyRedirect{
+		id:       id,
+		fromPort: uint16(l4.Port),
+		toPort:   to,
+		source:   source,
+		router:   route.New(),
+		l4:       *l4,
+		nodeInfo: accesslog.NodeAddressInfo{
+			IPv4: nodeaddress.GetExternalIPv4().String(),
+			IPv6: nodeaddress.GetIPv6().String(),
+		},
+	}
+
+	redir.epID = source.GetID()
+
+	redirect := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		record := &accesslog.LogRecord{
+			Request:           req,
+			Timestamp:         time.Now().UTC().Format(time.RFC3339Nano),
+			NodeAddressInfo:   redir.nodeInfo,
+			TransportProtocol: 6, // TCP's IANA-assigned protocol number
+		}
+
+		if redir.l4.Ingress {
+			record.ObservationPoint = accesslog.Ingress
+		} else {
+			record.ObservationPoint = accesslog.Egress
+		}
+
+		srcIdentity, dstIPPort, err := lookupNewDest(req, to)
+		if err != nil {
+			// FIXME: What do we do here long term?
+			log.Errorf("%s", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			record.Info = fmt.Sprintf("cannot generate url: %s", err)
+			accesslog.Log(record, accesslog.TypeRequest, accesslog.VerdictError, http.StatusBadRequest)
+			return
+		}
+
+		info, version := redir.getSourceInfo(req, policy.NumericIdentity(srcIdentity))
+		record.SourceEndpoint = info
+		record.IPVersion = version
+
+		if srcIdentity != 0 {
+			record.SourceEndpoint.Identity = uint64(srcIdentity)
+		}
+
+		record.DestinationEndpoint = redir.getDestinationInfo(dstIPPort)
+
+		// Validate access to L4/L7 resource
+		redir.mutex.Lock()
+		if len(redir.rules) > 0 {
+			rule, _ := redir.router.Route(req)
+			if rule == nil {
+				http.Error(w, "Access denied", http.StatusForbidden)
+				redir.mutex.Unlock()
+				accesslog.Log(record, accesslog.TypeRequest, accesslog.VerdictDenied, http.StatusForbidden)
+				return
+			}
+			ar := rule.(string)
+			log.Debugf("Allowing request based on rule %+v", ar)
+			record.Info = fmt.Sprintf("rule: %+v", ar)
+		} else {
+			log.Debugf("Allowing request as there are no rules")
+		}
+		redir.mutex.Unlock()
+
+		// Reconstruct original URL used for the request
+		req.URL = generateURL(req, dstIPPort)
+
+		// log valid request
+		accesslog.Log(record, accesslog.TypeRequest, accesslog.VerdictForwarded, http.StatusOK)
+
+		ctx := req.Context()
+		if ctx != nil {
+			marker := GetMagicMark(redir.l4.Ingress) | int(record.SourceEndpoint.Identity)
+			req = req.WithContext(newIdentityContext(ctx, marker))
+		}
+
+		fwd.ServeHTTP(w, req)
+
+		// log valid response
+		record.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
+		accesslog.Log(record, accesslog.TypeResponse, accesslog.VerdictForwarded, http.StatusOK)
+	})
+
+	redir.server = manners.NewWithServer(&http.Server{
+		Addr:    fmt.Sprintf("[::]:%d", to),
+		Handler: redirect,
+
+		// Set a large timeout for ReadTimeout. This timeout controls
+		// the time that can pass between accepting the connection and
+		// reading the entire request. The default 10 seconds is not
+		// long enough.
+		ReadTimeout: 120 * time.Second,
+	})
+
+	redir.updateRules(l7rules)
+
+	// The following code up until the go-routine is from manners/server.go:ListenAndServe()
+	// It was extracted in order to keep the listening on the TCP socket synchronous so that
+	// when policies are regenerated, the port is listening for connections before policy
+	// revisions get bumped for an endpoint.
+	addr := redir.server.Addr
+	if addr == "" {
+		addr = ":http"
+	}
+
+	marker := GetMagicMark(redir.l4.Ingress)
+
+	// As ingress proxy, all replies to incoming requests must have the
+	// identity of the endpoint we are proxying for
+	if redir.l4.Ingress {
+		marker |= int(source.GetIdentity())
+	}
+
+	// Listen needs to be in the synchronous part of this function to ensure that
+	// the proxy port is never refusing connections.
+	listener, err := listenSocket(addr, marker)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		err := redir.server.Serve(listener)
+		if err != nil {
+			log.Errorf("Unable to listen and serve proxy: %s", err)
+		}
+	}()
+
+	return redir, nil
+}
+
+// UpdateRules replaces old l7 rules of a redirect with new ones.
+func (r *OxyRedirect) UpdateRules(l4 *policy.L4Filter) error {
+	l7rules, err := translateOxyPolicyRules(l4)
+	if err == nil {
+		r.mutex.Lock()
+		r.updateRules(l7rules)
+		r.mutex.Unlock()
+	}
+	return err
+}
+
+// Close the redirect.
+func (r *OxyRedirect) Close() {
+	r.server.Close()
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -15,29 +15,16 @@
 package proxy
 
 import (
-	"context"
 	"fmt"
-	"net"
-	"net/http"
-	"net/url"
-	"os"
-	"strconv"
 	"sync"
-	"syscall"
 	"time"
 
-	"github.com/cilium/cilium/common/addressing"
-	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/nodeaddress"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 
-	"github.com/braintree/manners"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	"github.com/vulcand/oxy/forward"
-	"github.com/vulcand/route"
 )
 
 // Magic markers are attached to each packet. The upper 16 bits are used to
@@ -56,43 +43,31 @@ const (
 	fieldFd     = "fd"
 )
 
-type Redirect struct {
-	id       string
-	FromPort uint16
-	ToPort   uint16
-	epID     uint64
-	Rules    []policy.AuxRule
-	source   ProxySource
-	server   *manners.GracefulServer
-	router   route.Router
-	l4       policy.L4Filter // stale copy, ignore rules
-	nodeInfo accesslog.NodeAddressInfo
+// Supported proxy types
+const (
+	ProxyKindOxy   = "oxy"
+	ProxyKindEnvoy = "envoy"
+)
+
+// Redirect is the generic proxy redirect interface that each proxy redirect type must export
+type Redirect interface {
+	ToPort() uint16
+	UpdateRules(l4 *policy.L4Filter) error
+	Close()
 }
 
 // GetMagicMark returns the magic marker with which each packet must be marked.
 // The mark is different depending on whether the proxy is injected at ingress
 // or egress.
-func (r *Redirect) GetMagicMark() int {
-	if r.l4.Ingress {
+func GetMagicMark(isIngress bool) int {
+	if isIngress {
 		return magicMarkIngress
 	}
 
 	return magicMarkEgress
 }
 
-func (r *Redirect) updateRules(rules []policy.AuxRule) {
-	for _, v := range r.Rules {
-		r.router.RemoveRoute(v.Expr)
-	}
-
-	r.Rules = make([]policy.AuxRule, len(rules))
-	copy(r.Rules, rules)
-
-	for _, v := range r.Rules {
-		r.router.AddRoute(v.Expr, v)
-	}
-}
-
+// ProxySource returns information about the endpoint being proxied.
 type ProxySource interface {
 	GetID() uint64
 	RLock()
@@ -105,6 +80,7 @@ type ProxySource interface {
 	RUnlock()
 }
 
+// Proxy maintains state about redirects
 type Proxy struct {
 	// mutex is the lock required when modifying any proxy datastructure
 	mutex lock.RWMutex
@@ -122,20 +98,22 @@ type Proxy struct {
 
 	// allocatedPorts is a map of all allocated proxy ports pointing
 	// to the redirect rules attached to that port
-	allocatedPorts map[uint16]*Redirect
+	allocatedPorts map[uint16]Redirect
 
 	// redirects is a map of all redirect configurations indexed by
-	// the redirect identifier
-	redirects map[string]*Redirect
+	// the redirect identifier. Redirects may be implemented by different
+	// proxies.
+	redirects map[string]Redirect
 }
 
+// NewProxy creates a Proxy to keep track of redirects.
 func NewProxy(minPort uint16, maxPort uint16) *Proxy {
 	return &Proxy{
 		rangeMin:       minPort,
 		rangeMax:       maxPort,
 		nextPort:       minPort,
-		redirects:      make(map[string]*Redirect),
-		allocatedPorts: make(map[uint16]*Redirect),
+		redirects:      make(map[string]Redirect),
+		allocatedPorts: make(map[uint16]Redirect),
 	}
 }
 
@@ -159,352 +137,13 @@ func (p *Proxy) allocatePort() (uint16, error) {
 	}
 }
 
-func lookupNewDest(req *http.Request, dport uint16) (uint32, string, error) {
-	ip, port, err := net.SplitHostPort(req.RemoteAddr)
-	if err != nil {
-		return 0, "", fmt.Errorf("invalid remote address: %s", err)
-	}
-
-	pIP := net.ParseIP(ip)
-	if pIP == nil {
-		return 0, "", fmt.Errorf("unable to parse IP %s", ip)
-	}
-
-	sport, err := strconv.ParseUint(port, 10, 16)
-	if err != nil {
-		return 0, "", fmt.Errorf("unable to parse port string: %s", err)
-	}
-
-	if pIP.To4() != nil {
-		key := &Proxy4Key{
-			SPort:   uint16(sport),
-			DPort:   dport,
-			Nexthdr: 6,
-		}
-
-		copy(key.SAddr[:], pIP.To4())
-
-		val, err := LookupEgress4(key)
-		if err != nil {
-			return 0, "", fmt.Errorf("Unable to find IPv4 proxy entry for %s: %s", key, err)
-		}
-
-		log.Debugf("Found IPv4 proxy entry: %+v", val)
-		return val.SourceIdentity, val.HostPort(), nil
-	}
-
-	key := &Proxy6Key{
-		SPort:   uint16(sport),
-		DPort:   dport,
-		Nexthdr: 6,
-	}
-
-	copy(key.SAddr[:], pIP.To16())
-
-	val, err := LookupEgress6(key)
-	if err != nil {
-		return 0, "", fmt.Errorf("Unable to find IPv6 proxy entry for %s: %s", key, err)
-	}
-
-	log.Debugf("Found IPv6 proxy entry: %+v", val)
-	return val.SourceIdentity, val.HostPort(), nil
-}
-
-func generateURL(req *http.Request, hostport string) *url.URL {
-	newURL := *req.URL
-	newURL.Scheme = "http"
-	newURL.Host = hostport
-
-	return &newURL
-}
-
 var gcOnce sync.Once
-
-// Configuration is used to pass configuration into CreateOrUpdateRedirect
-type Configuration struct {
-}
-
-func (r *Redirect) localEndpointInfo(info *accesslog.EndpointInfo) {
-	r.source.RLock()
-	info.ID = r.epID
-	info.IPv4 = r.source.GetIPv4Address()
-	info.IPv6 = r.source.GetIPv6Address()
-	info.Labels = r.source.GetLabels()
-	info.LabelsSHA256 = r.source.GetLabelsSHA()
-	info.Identity = uint64(r.source.GetIdentity())
-	r.source.RUnlock()
-}
-
-// fillReservedIdentity resolves the labels of the specified identity if known
-// locally and fills in the following info member fields:
-//  - info.Identity
-//  - info.Labels
-//  - info.LabelsSHA256
-func (r *Redirect) fillReservedIdentity(info *accesslog.EndpointInfo, id policy.NumericIdentity) {
-	info.Identity = uint64(id)
-
-	if c := policy.GetConsumableCache().Lookup(id); c != nil {
-		if c.Labels != nil {
-			info.Labels = c.Labels.Labels.GetModel()
-			info.LabelsSHA256 = c.Labels.GetLabelsSHA256()
-		}
-	}
-}
-
-// egressDestinationInfo returns the destination EndpointInfo for a flow
-// leaving the proxy at egress.
-func (r *Redirect) egressDestinationInfo(ipstr string, info *accesslog.EndpointInfo) {
-	ip := net.ParseIP(ipstr)
-	if ip != nil {
-		if ip.To4() != nil {
-			info.IPv4 = ip.String()
-
-			if nodeaddress.IsHostIPv4(ip) {
-				r.fillReservedIdentity(info, policy.ReservedIdentityHost)
-				return
-			}
-
-			if nodeaddress.GetIPv4ClusterRange().Contains(ip) {
-				c := addressing.DeriveCiliumIPv4(ip)
-				ep := endpointmanager.LookupIPv4(c.String())
-				if ep != nil {
-					info.ID = uint64(ep.ID)
-					info.Labels = ep.GetLabels()
-					info.LabelsSHA256 = ep.GetLabelsSHA()
-					info.Identity = uint64(ep.GetIdentity())
-				} else {
-					r.fillReservedIdentity(info, policy.ReservedIdentityCluster)
-				}
-			} else {
-				r.fillReservedIdentity(info, policy.ReservedIdentityWorld)
-			}
-		} else {
-			info.IPv6 = ip.String()
-
-			if nodeaddress.IsHostIPv6(ip) {
-				r.fillReservedIdentity(info, policy.ReservedIdentityHost)
-				return
-			}
-
-			if nodeaddress.GetIPv6ClusterRange().Contains(ip) {
-				c := addressing.DeriveCiliumIPv6(ip)
-				id := c.EndpointID()
-				info.ID = uint64(id)
-
-				ep := endpointmanager.LookupCiliumID(id)
-				if ep != nil {
-					ep.RLock()
-					info.Labels = ep.GetLabels()
-					info.LabelsSHA256 = ep.GetLabelsSHA()
-					info.Identity = uint64(ep.GetIdentity())
-					ep.RUnlock()
-				} else {
-					r.fillReservedIdentity(info, policy.ReservedIdentityCluster)
-				}
-			} else {
-				r.fillReservedIdentity(info, policy.ReservedIdentityWorld)
-			}
-		}
-	}
-}
-
-// getInfoFromConsumable fills the accesslog.EndpointInfo fields, by fetching
-// the consumable from the consumable cache of endpoint using identity sent by
-// source. This is needed in ingress proxy while logging the source endpoint
-// info.  Since there will be 2 proxies on the same host, if both egress and
-// ingress policies are set, the ingress policy cannot determine the source
-// endpoint info based on ip address, as the ip address would be that of the
-// egress proxy i.e host.
-func (r *Redirect) getInfoFromConsumable(ipstr string, info *accesslog.EndpointInfo, srcIdentity policy.NumericIdentity) {
-	ep := r.source
-	ip := net.ParseIP(ipstr)
-	if ip != nil {
-		if ip.To4() != nil {
-			info.IPv4 = ip.String()
-		} else {
-			info.IPv6 = ip.String()
-		}
-	}
-	secIdentity := ep.ResolveIdentity(srcIdentity)
-
-	if secIdentity != nil {
-		info.Labels = secIdentity.Labels.GetModel()
-		info.LabelsSHA256 = secIdentity.Labels.SHA256Sum()
-		info.Identity = uint64(srcIdentity)
-	}
-}
-
-func (r *Redirect) getSourceInfo(req *http.Request, srcIdentity policy.NumericIdentity) (accesslog.EndpointInfo, accesslog.IPVersion) {
-	info := accesslog.EndpointInfo{}
-	version := accesslog.VersionIPv4
-	ipstr, port, err := net.SplitHostPort(req.RemoteAddr)
-	if err == nil {
-		p, err := strconv.ParseUint(port, 10, 16)
-		if err == nil {
-			info.Port = uint16(p)
-		}
-
-		ip := net.ParseIP(ipstr)
-		if ip != nil && ip.To4() == nil {
-			version = accesslog.VersionIPV6
-		}
-	}
-
-	// At egress, the local origin endpoint is the source
-	if !r.l4.Ingress {
-		r.localEndpointInfo(&info)
-	} else if err == nil {
-		if srcIdentity != 0 {
-			r.getInfoFromConsumable(ipstr, &info, srcIdentity)
-		} else {
-			// source security identity 0 is possible when somebody else other than the BPF datapath attempts to
-			// connect to the proxy.
-			// We should log no source information in that case, in the proxy log.
-			log.Warn("Missing security identity in source endpoint info")
-		}
-
-	}
-
-	return info, version
-}
-
-func (r *Redirect) getDestinationInfo(dstIPPort string) accesslog.EndpointInfo {
-	info := accesslog.EndpointInfo{}
-	ipstr, port, err := net.SplitHostPort(dstIPPort)
-	if err == nil {
-		p, err := strconv.ParseUint(port, 10, 16)
-		if err == nil {
-			info.Port = uint16(p)
-		}
-	}
-
-	// At ingress the local origin endpoint is the source
-	if r.l4.Ingress {
-		r.localEndpointInfo(&info)
-	} else if err == nil {
-		r.egressDestinationInfo(ipstr, &info)
-	}
-
-	return info
-}
-
-type proxyIdentity int
-
-const identityKey proxyIdentity = 0
-
-func newIdentityContext(ctx context.Context, id int) context.Context {
-	return context.WithValue(ctx, identityKey, id)
-}
-
-func identityFromContext(ctx context.Context) (int, bool) {
-	val, ok := ctx.Value(identityKey).(int)
-	return val, ok
-}
-
-func setFdMark(fd, mark int) {
-	log.WithFields(log.Fields{
-		fieldFd:     fd,
-		fieldMarker: mark,
-	}).Debug("Setting packet marker of socket")
-
-	err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_MARK, mark)
-	if err != nil {
-		log.WithFields(log.Fields{
-			fieldFd:     fd,
-			fieldMarker: mark,
-		}).WithError(err).Warning("Unable to set SO_MARK")
-	}
-}
-
-func setSocketMark(c net.Conn, mark int) {
-	if tc, ok := c.(*net.TCPConn); ok {
-		if f, err := tc.File(); err == nil {
-			defer f.Close()
-			setFdMark(int(f.Fd()), mark)
-		}
-	}
-}
-
-func listenSocket(address string, mark int) (net.Listener, error) {
-	addr, err := net.ResolveTCPAddr("tcp", address)
-	if err != nil {
-		return nil, err
-	}
-
-	family := syscall.AF_INET
-	if addr.IP.To4() == nil {
-		family = syscall.AF_INET6
-	}
-
-	fd, err := syscall.Socket(family, syscall.SOCK_STREAM, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {
-		return nil, fmt.Errorf("unable to set SO_REUSEADDR socket option: %s", err)
-	}
-
-	setFdMark(fd, mark)
-
-	sockAddr, err := ipToSockaddr(family, addr.IP, addr.Port, addr.Zone)
-	if err != nil {
-		syscall.Close(fd)
-		return nil, err
-	}
-
-	if err := syscall.Bind(fd, sockAddr); err != nil {
-		syscall.Close(fd)
-		return nil, err
-	}
-
-	if err := syscall.Listen(fd, 128); err != nil {
-		syscall.Close(fd)
-		return nil, err
-	}
-
-	f := os.NewFile(uintptr(fd), addr.String())
-	defer f.Close()
-
-	return net.FileListener(f)
-}
 
 // CreateOrUpdateRedirect creates or updates a L4 redirect with corresponding
 // proxy configuration. This will allocate a proxy port as required and launch
 // a proxy instance. If the redirect is already in place, only the rules will be
 // updated.
-func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string,
-	source ProxySource) (*Redirect, error) {
-	transport := &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
-		DialContext:           ciliumDialer,
-		MaxIdleConns:          2048,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-	}
-
-	fwd, err := forward.New(forward.RoundTripper(transport))
-	if err != nil {
-		return nil, err
-	}
-
-	switch policy.L7ParserType(l4.L7Parser) {
-	case policy.ParserTypeHTTP:
-	case policy.ParserTypeKafka:
-		// TODO We need to remove this once Kakfa parser and router support is in.
-		log.Debug("Kafka Parser not supported yet")
-		return nil, fmt.Errorf("unsupported L7 protocol proxy:\"%s\"", l4.L7Parser)
-	default:
-		return nil, fmt.Errorf("unknown L7 protocol \"%s\"", l4.L7Parser)
-	}
-
-	for _, r := range l4.L7Rules {
-		if !route.IsValid(r.Expr) {
-			return nil, fmt.Errorf("invalid filter expression: %s", r.Expr)
-		}
-	}
-
+func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, source ProxySource, kind string) (Redirect, error) {
 	gcOnce.Do(func() {
 		if lf := viper.GetString("access-log"); lf != "" {
 			if err := accesslog.OpenLogfile(lf); err != nil {
@@ -529,159 +168,42 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string,
 	})
 
 	p.mutex.Lock()
+	defer p.mutex.Unlock()
 
 	if r, ok := p.redirects[id]; ok {
-		r.updateRules(l4.L7Rules)
+		err := r.UpdateRules(l4)
+		if err != nil {
+			return nil, err
+		}
 		log.Debugf("updated existing proxy instance %+v", r)
-		p.mutex.Unlock()
 		return r, nil
 	}
 
 	to, err := p.allocatePort()
 	if err != nil {
-		p.mutex.Unlock()
 		return nil, err
 	}
 
-	redir := &Redirect{
-		id:       id,
-		FromPort: uint16(l4.Port),
-		ToPort:   to,
-		source:   source,
-		router:   route.New(),
-		l4:       *l4,
-		nodeInfo: accesslog.NodeAddressInfo{
-			IPv4: nodeaddress.GetExternalIPv4().String(),
-			IPv6: nodeaddress.GetIPv6().String(),
-		},
+	var redir Redirect
+	if kind == ProxyKindOxy {
+		redir, err = createOxyRedirect(l4, id, source, to)
+	} else {
+		return nil, fmt.Errorf("Unknown proxy kind: %s", kind)
+	}
+	if err != nil {
+		log.Errorf("Unable to create proxy of kind: %s: %s", kind, err)
+		return nil, err
 	}
 
-	redir.epID = source.GetID()
-
-	redirect := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		record := &accesslog.LogRecord{
-			Request:           req,
-			Timestamp:         time.Now().UTC().Format(time.RFC3339Nano),
-			NodeAddressInfo:   redir.nodeInfo,
-			TransportProtocol: 6, // TCP's IANA-assigned protocol number
-		}
-
-		if redir.l4.Ingress {
-			record.ObservationPoint = accesslog.Ingress
-		} else {
-			record.ObservationPoint = accesslog.Egress
-		}
-
-		srcIdentity, dstIPPort, err := lookupNewDest(req, to)
-		if err != nil {
-			// FIXME: What do we do here long term?
-			log.Errorf("%s", err)
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			record.Info = fmt.Sprintf("cannot generate url: %s", err)
-			accesslog.Log(record, accesslog.TypeRequest, accesslog.VerdictError, http.StatusBadRequest)
-			return
-		}
-
-		info, version := redir.getSourceInfo(req, policy.NumericIdentity(srcIdentity))
-		record.SourceEndpoint = info
-		record.IPVersion = version
-
-		if srcIdentity != 0 {
-			record.SourceEndpoint.Identity = uint64(srcIdentity)
-		}
-
-		record.DestinationEndpoint = redir.getDestinationInfo(dstIPPort)
-
-		// Validate access to L4/L7 resource
-		p.mutex.Lock()
-		if len(redir.Rules) > 0 {
-			rule, _ := redir.router.Route(req)
-			if rule == nil {
-				http.Error(w, "Access denied", http.StatusForbidden)
-				p.mutex.Unlock()
-				accesslog.Log(record, accesslog.TypeRequest, accesslog.VerdictDenied, http.StatusForbidden)
-				return
-			}
-			ar := rule.(policy.AuxRule)
-			log.Debugf("Allowing request based on rule %+v", ar)
-			record.Info = fmt.Sprintf("rule: %+v", ar)
-		} else {
-			log.Debugf("Allowing request as there are no rules")
-		}
-		p.mutex.Unlock()
-
-		// Reconstruct original URL used for the request
-		req.URL = generateURL(req, dstIPPort)
-
-		// log valid request
-		accesslog.Log(record, accesslog.TypeRequest, accesslog.VerdictForwarded, http.StatusOK)
-
-		ctx := req.Context()
-		if ctx != nil {
-			marker := redir.GetMagicMark() | int(record.SourceEndpoint.Identity)
-			req = req.WithContext(newIdentityContext(ctx, marker))
-		}
-
-		fwd.ServeHTTP(w, req)
-
-		// log valid response
-		record.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
-		accesslog.Log(record, accesslog.TypeResponse, accesslog.VerdictForwarded, http.StatusOK)
-	})
-
-	redir.server = manners.NewWithServer(&http.Server{
-		Addr:    fmt.Sprintf("[::]:%d", to),
-		Handler: redirect,
-
-		// Set a large timeout for ReadTimeout. This timeout controls
-		// the time that can pass between accepting the connection and
-		// reading the entire request. The default 10 seconds is not
-		// long enough.
-		ReadTimeout: 120 * time.Second,
-	})
-
-	redir.updateRules(l4.L7Rules)
 	p.allocatedPorts[to] = redir
 	p.redirects[id] = redir
 
-	p.mutex.Unlock()
-
-	log.Debugf("Created new proxy instance %+v", redir)
-
-	// The following code up until the go-routine is from manners/server.go:ListenAndServe()
-	// It was extracted in order to keep the listening on the TCP socket synchronous so that
-	// when policies are regenerated, the port is listening for connections before policy
-	// revisions get bumped for an endpoint.
-	addr := redir.server.Addr
-	if addr == "" {
-		addr = ":http"
-	}
-
-	marker := redir.GetMagicMark()
-
-	// As ingress proxy, all replies to incoming requests must have the
-	// identity of the endpoint we are proxying for
-	if redir.l4.Ingress {
-		marker |= int(source.GetIdentity())
-	}
-
-	// Listen needs to be in the synchronous part of this function to ensure that
-	// the proxy port is never refusing connections.
-	listener, err := listenSocket(addr, marker)
-	if err != nil {
-		return nil, err
-	}
-
-	go func() {
-		err := redir.server.Serve(listener)
-		if err != nil {
-			log.Errorf("Unable to listen and serve proxy: %s", err)
-		}
-	}()
+	log.Debugf("Created new %s proxy instance %+v", kind, redir)
 
 	return redir, nil
 }
 
+// RemoveRedirect removes an existing redirect.
 func (p *Proxy) RemoveRedirect(id string) error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
@@ -691,10 +213,11 @@ func (p *Proxy) RemoveRedirect(id string) error {
 	}
 
 	log.Debugf("removing proxy redirect %s", id)
-	r.server.Close()
+	toPort := r.ToPort()
+	r.Close()
 
-	delete(p.redirects, r.id)
-	delete(p.allocatedPorts, r.ToPort)
+	delete(p.redirects, id)
+	delete(p.allocatedPorts, toPort)
 
 	return nil
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -648,7 +648,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string,
 
 	log.Debugf("Created new proxy instance %+v", redir)
 
-	// The following code up until the go-routine is from manners/sever.go:ListenAndServe()
+	// The following code up until the go-routine is from manners/server.go:ListenAndServe()
 	// It was extracted in order to keep the listening on the TCP socket synchronous so that
 	// when policies are regenerated, the port is listening for connections before policy
 	// revisions get bumped for an endpoint.


### PR DESCRIPTION
Relocate L7 rule translation from policy package to proxy package and move all oxy code to a new file oxyproxy.go in preparation to supporting multiple kinds of proxies.

As part of this change the type policy.AuxRule is eliminated, and the api.L7Rules is used instead, so that the proxy specific code can translate the l7 rules.

With this change each redirection is implemented through an Redirect interface, each of which can be backed by different proxy implementations.

Policy code is changed to handle conflicts in L4 policy merges due to conflicting parser types, redirect port values and conflicting l7 rules.
