### PR TITLE
add support for CIDR exceptions to CiliumNetworkPolicy

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -27,7 +27,7 @@ Features
 * Support L3-dependent L4 policies on ingress (1599_, 1496_, 1217_, 1064_, 789_)
 * Add new fields to Ingress and Egress rules for CiliumNetworkPolicy called
 FromCIDR and ToCIDR. These are lists of CIDR prefixes to whitelist along with
-a list of CIDR prefixes for each CIDR prefix to blacklist. (TODO_) 
+a list of CIDR prefixes for each CIDR prefix to blacklist. (1663_) 
 
 CI
 __
@@ -47,7 +47,7 @@ Documentation
 -------------
 
 * Policy enforcement mode documentation (1464_)
-* Updated L3 CIDR policy documentation (TODO_)
+* Updated L3 CIDR policy documentation (1663_)
 
 Other
 -----

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -25,6 +25,9 @@ Features
   the same as for Kubernetes environments; traffic is allowed by default until
   a rule selects an endpoint (1464_)
 * Support L3-dependent L4 policies on ingress (1599_, 1496_, 1217_, 1064_, 789_)
+* Add new fields to Ingress and Egress rules for CiliumNetworkPolicy called
+FromCIDR and ToCIDR. These are lists of CIDR prefixes to whitelist along with
+a list of CIDR prefixes for each CIDR prefix to blacklist. (TODO_) 
 
 CI
 __
@@ -44,6 +47,7 @@ Documentation
 -------------
 
 * Policy enforcement mode documentation (1464_)
+* Updated L3 CIDR policy documentation (TODO_)
 
 Other
 -----

--- a/pkg/ip/doc.go
+++ b/pkg/ip/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ip is a library for performing manipulations on IPv4 and IPv6 addresses
+// and CIDR prefixes.
+package ip

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -1,0 +1,222 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ip
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"sort"
+)
+
+const (
+	ipv4BitLen = 8 * net.IPv4len
+	ipv6BitLen = 8 * net.IPv6len
+)
+
+// NetsByMask is used to sort a list of IP networks by the size of their masks.
+// Implements sort.Interface.
+type NetsByMask []*net.IPNet
+
+func (s NetsByMask) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s NetsByMask) Less(i, j int) bool {
+	iPrefixSize, _ := s[i].Mask.Size()
+	jPrefixSize, _ := s[j].Mask.Size()
+	if iPrefixSize == jPrefixSize {
+		byteArrComp := bytes.Compare(s[i].IP, s[j].IP)
+		if byteArrComp < 0 {
+			return true
+		}
+		return false
+	}
+	return iPrefixSize < jPrefixSize
+}
+
+func (s NetsByMask) Len() int {
+	return len(s)
+}
+
+// Assert that NetsByMask implements sort.Interface.
+var _ sort.Interface = NetsByMask{}
+
+// RemoveCIDRs removes the specified CIDRs from another set of CIDRs. If a CIDR to remove is not
+// contained within the CIDR, the CIDR to remove is ignored. A slice of CIDRs is
+// returned which contains the set of CIDRs provided minus the set of CIDRs which
+// were removed. Both input slices may be modified by calling this function.
+func RemoveCIDRs(allowCIDRs, removeCIDRs []*net.IPNet) ([]*net.IPNet, error) {
+
+	// Ensure that we iterate through the provided CIDRs in order of largest
+	// subnet first.
+	sort.Sort(NetsByMask(removeCIDRs))
+
+PreLoop:
+	// Remove CIDRs which are contained within CIDRs that we want to remove;
+	// such CIDRs are redundant.
+	for j, removeCIDR := range removeCIDRs {
+		for i, removeCIDR2 := range removeCIDRs {
+			if i == j {
+				continue
+			}
+			if removeCIDR.Contains(removeCIDR2.IP) {
+				removeCIDRs = append(removeCIDRs[:i], removeCIDRs[i+1:]...)
+				// Re-trigger loop since we have modified the slice we are iterating over.
+				goto PreLoop
+			}
+		}
+	}
+
+	for _, remove := range removeCIDRs {
+	Loop:
+		for i, allowCIDR := range allowCIDRs {
+
+			// Don't allow comparison of different address spaces.
+			if allowCIDR.IP.To4() != nil && remove.IP.To4() == nil ||
+				allowCIDR.IP.To4() == nil && remove.IP.To4() != nil {
+				return nil, fmt.Errorf("cannot mix IP addresses of different IP protocol versions")
+			}
+
+			// Only remove CIDR if it is contained in the subnet we are allowing.
+			if allowCIDR.Contains(remove.IP.Mask(remove.Mask)) {
+				nets, err := removeCIDR(allowCIDR, remove)
+				if err != nil {
+					return nil, err
+				}
+
+				// Remove CIDR that we have just processed and append new CIDRs
+				// that we computed from removing the CIDR to remove.
+				allowCIDRs = append(allowCIDRs[:i], allowCIDRs[i+1:]...)
+				allowCIDRs = append(allowCIDRs, nets...)
+				goto Loop
+			} else if remove.Contains(allowCIDR.IP.Mask(allowCIDR.Mask)) {
+				// If a CIDR that we want to remove contains a CIDR in the list
+				// that is allowed, then we can just remove the CIDR to allow.
+				allowCIDRs = append(allowCIDRs[:i], allowCIDRs[i+1:]...)
+				goto Loop
+			}
+		}
+	}
+
+	return allowCIDRs, nil
+}
+
+func getNetworkPrefix(ipNet *net.IPNet) *net.IP {
+	var mask net.IP
+
+	if ipNet.IP.To4() == nil {
+		mask = make(net.IP, net.IPv6len)
+		for i := 0; i < len(ipNet.Mask); i++ {
+			mask[net.IPv6len-i-1] = ipNet.IP[net.IPv6len-i-1] & ^ipNet.Mask[i]
+		}
+	} else {
+		mask = make(net.IP, net.IPv4len)
+		for i := 0; i < net.IPv4len; i++ {
+			mask[net.IPv4len-i-1] = ipNet.IP[net.IPv6len-i-1] & ^ipNet.Mask[i]
+		}
+	}
+
+	return &mask
+}
+
+func removeCIDR(allowCIDR, removeCIDR *net.IPNet) ([]*net.IPNet, error) {
+	var allows []*net.IPNet
+	var allowIsIpv4, removeIsIpv4 bool
+	var allowBitLen int
+
+	if allowCIDR.IP.To4() != nil {
+		allowIsIpv4 = true
+		allowBitLen = ipv4BitLen
+	} else {
+		allowBitLen = ipv6BitLen
+	}
+
+	if removeCIDR.IP.To4() != nil {
+		removeIsIpv4 = true
+	}
+
+	if removeIsIpv4 != allowIsIpv4 {
+		return nil, fmt.Errorf("cannot mix IP addresses of different IP protocol versions")
+	}
+
+	// Get size of each CIDR mask.
+	allowSize, _ := allowCIDR.Mask.Size()
+	removeSize, _ := removeCIDR.Mask.Size()
+
+	if allowSize >= removeSize {
+		return nil, fmt.Errorf("allow CIDR prefix must be a superset of " +
+			"remove CIDR prefix")
+	}
+
+	allowFirstIPMasked := allowCIDR.IP.Mask(allowCIDR.Mask)
+	removeFirstIPMasked := removeCIDR.IP.Mask(removeCIDR.Mask)
+
+	ipv4Ipv6Slice := []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff}
+
+	// Convert to IPv4 in IPv6 addresses if needed.
+	if allowIsIpv4 {
+		allowFirstIPMasked = append(ipv4Ipv6Slice, allowFirstIPMasked...)
+	}
+
+	if removeIsIpv4 {
+		removeFirstIPMasked = append(ipv4Ipv6Slice, removeFirstIPMasked...)
+	}
+
+	allowFirstIP := &allowFirstIPMasked
+	removeFirstIP := &removeFirstIPMasked
+
+	// Create CIDR prefixes with mask size of Y+1, Y+2 ... X where Y is the mask
+	// length of the CIDR prefix B from which we are excluding a CIDR prefix A
+	// with mask length X.
+	for i := (allowBitLen - allowSize - 1); i >= (allowBitLen - removeSize); i-- {
+		// The mask for each CIDR prefix is simply the ith bit flipped, and then
+		// zero'ing out all subsequent bits (the host identifier part of the
+		// prefix).
+		newMaskSize := allowBitLen - i
+		newIP := (*net.IP)(flipNthBit((*[]byte)(removeFirstIP), uint(i)))
+		for k := range *allowFirstIP {
+			(*newIP)[k] = (*allowFirstIP)[k] | (*newIP)[k]
+		}
+
+		newMask := net.CIDRMask(newMaskSize, allowBitLen)
+		newIPMasked := newIP.Mask(newMask)
+
+		newIPNet := net.IPNet{IP: newIPMasked, Mask: newMask}
+		allows = append(allows, &newIPNet)
+	}
+
+	return allows, nil
+}
+
+func getByteIndexOfBit(bit uint) uint {
+	return net.IPv6len - (bit / 8) - 1
+}
+
+func getNthBit(ip *net.IP, bitNum uint) uint8 {
+	byteNum := getByteIndexOfBit(bitNum)
+	bits := (*ip)[byteNum]
+	b := uint8(bits)
+	return b >> (bitNum % 8) & 1
+}
+
+func flipNthBit(ip *[]byte, bitNum uint) *[]byte {
+	ipCopy := make([]byte, len(*ip))
+	copy(ipCopy, *ip)
+	byteNum := getByteIndexOfBit(bitNum)
+	ipCopy[byteNum] = ipCopy[byteNum] ^ 1<<(bitNum%8)
+
+	return &ipCopy
+}

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -1,0 +1,170 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ip
+
+import (
+	"net"
+	"reflect"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+type IPTestSuite struct{}
+
+var _ = Suite(&IPTestSuite{})
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+func (s *IPTestSuite) TestFirstIP(c *C) {
+	// Test IPv4.
+	desiredIPv4_1 := net.IP{0xa, 0, 0, 0}
+	testNetv4_1 := net.IPNet{IP: net.ParseIP("10.0.0.5"), Mask: net.CIDRMask(8, 32)}
+	ipNetv4_1 := getNetworkPrefix(&testNetv4_1)
+	for k := range *ipNetv4_1 {
+		c.Assert(reflect.DeepEqual((*ipNetv4_1)[k], desiredIPv4_1[k]), Equals, true)
+	}
+	testNetv4_2 := net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(8, 32)}
+	ipNetv4_2 := getNetworkPrefix(&testNetv4_2)
+	for k := range *ipNetv4_2 {
+		c.Assert(reflect.DeepEqual((*ipNetv4_2)[k], desiredIPv4_1[k]), Equals, true)
+	}
+
+	// Test IPv6
+	desiredIPv6_1, testNetv6_1, _ := net.ParseCIDR("fd44:7089:ff32:712b::/64")
+
+	ipNetv6_1 := getNetworkPrefix(testNetv6_1)
+	for k := range *ipNetv6_1 {
+		c.Assert(reflect.DeepEqual((*ipNetv6_1)[k], desiredIPv6_1[k]), Equals, true)
+	}
+}
+
+func (s *IPTestSuite) testIPNetsEqual(created, expected []*net.IPNet, c *C) {
+	for index := range created {
+		c.Assert(created[index].String(), Equals, expected[index].String())
+		c.Assert(created[index].Mask.String(), Equals, expected[index].Mask.String())
+	}
+}
+
+func createIPNet(address string, maskSize int, bitLen int) *net.IPNet {
+	return &net.IPNet{IP: net.ParseIP(address), Mask: net.CIDRMask(maskSize, bitLen)}
+}
+
+func (s *IPTestSuite) TestRemoveCIDRs(c *C) {
+	allowCIDRs := []*net.IPNet{createIPNet("10.0.0.0", 8, int(ipv4BitLen))}
+	removeCIDRs := []*net.IPNet{createIPNet("10.96.0.0", 12, int(ipv4BitLen)),
+		createIPNet("10.112.0.0", 13, int(ipv4BitLen)),
+	}
+	expectedCIDRs := []*net.IPNet{createIPNet("10.128.0.0", 9, int(ipv4BitLen)),
+		createIPNet("10.0.0.0", 10, int(ipv4BitLen)),
+		createIPNet("10.64.0.0", 11, int(ipv4BitLen)),
+		createIPNet("10.120.0.0", 13, int(ipv4BitLen))}
+
+	allowedCIDRs, err := RemoveCIDRs(allowCIDRs, removeCIDRs)
+	c.Assert(err, IsNil)
+
+	s.testIPNetsEqual(allowedCIDRs, expectedCIDRs, c)
+
+	allowCIDRs = []*net.IPNet{createIPNet("10.0.0.0", 8, int(ipv4BitLen))}
+	removeCIDRs = []*net.IPNet{createIPNet("10.96.0.0", 12, int(ipv4BitLen)),
+		createIPNet("10.112.0.0", 13, int(ipv4BitLen)),
+		createIPNet("10.62.0.33", 32, int(ipv4BitLen)),
+		createIPNet("10.93.0.4", 30, int(ipv4BitLen)),
+		createIPNet("10.63.0.5", 13, int(ipv4BitLen)),
+	}
+
+	expectedCIDRs = []*net.IPNet{createIPNet("10.128.0.0", 9, int(ipv4BitLen)),
+		createIPNet("10.0.0.0", 11, int(ipv4BitLen)),
+		createIPNet("10.32.0.0", 12, int(ipv4BitLen)),
+		createIPNet("10.48.0.0", 13, int(ipv4BitLen)),
+		createIPNet("10.120.0.0", 13, int(ipv4BitLen)),
+		createIPNet("10.64.0.0", 12, int(ipv4BitLen)),
+		createIPNet("10.80.0.0", 13, int(ipv4BitLen)),
+		createIPNet("10.88.0.0", 14, int(ipv4BitLen)),
+		createIPNet("10.94.0.0", 15, int(ipv4BitLen)),
+		createIPNet("10.92.0.0", 16, int(ipv4BitLen)),
+		createIPNet("10.93.128.0", 17, int(ipv4BitLen)),
+		createIPNet("10.93.64.0", 18, int(ipv4BitLen)),
+		createIPNet("10.93.32.0", 19, int(ipv4BitLen)),
+		createIPNet("10.93.16.0", 20, int(ipv4BitLen)),
+		createIPNet("10.93.8.0", 21, int(ipv4BitLen)),
+		createIPNet("10.93.4.0", 22, int(ipv4BitLen)),
+		createIPNet("10.93.2.0", 23, int(ipv4BitLen)),
+		createIPNet("10.93.1.0", 24, int(ipv4BitLen)),
+		createIPNet("10.93.0.128", 25, int(ipv4BitLen)),
+		createIPNet("10.93.0.64", 26, int(ipv4BitLen)),
+		createIPNet("10.93.0.32", 27, int(ipv4BitLen)),
+		createIPNet("10.93.0.16", 28, int(ipv4BitLen)),
+		createIPNet("10.93.0.8", 29, int(ipv4BitLen)),
+		createIPNet("10.93.0.0", 30, int(ipv4BitLen)),
+	}
+
+	allowedCIDRs, err = RemoveCIDRs(allowCIDRs, removeCIDRs)
+	c.Assert(err, IsNil)
+	s.testIPNetsEqual(allowedCIDRs, expectedCIDRs, c)
+
+	// Cannot remove CIDRs that are of a different address family.
+	removeCIDRs = []*net.IPNet{createIPNet("fd44:7089:ff32:712b::", 66, int(ipv6BitLen))}
+	allowedCIDRs, err = RemoveCIDRs(allowCIDRs, removeCIDRs)
+	c.Assert(err, NotNil)
+
+	//IPv6 tests
+	allowCIDRs = []*net.IPNet{createIPNet("fd44:7089:ff32:712b:ff00::", 64, int(ipv6BitLen))}
+	allowedCIDRs, err = RemoveCIDRs(allowCIDRs, removeCIDRs)
+
+	c.Assert(err, IsNil)
+	expectedCIDRs = []*net.IPNet{createIPNet("fd44:7089:ff32:712b:8000::", 65, int(ipv6BitLen)),
+		createIPNet("fd44:7089:ff32:712b:4000::", 66, int(ipv6BitLen))}
+	s.testIPNetsEqual(allowedCIDRs, expectedCIDRs, c)
+
+}
+
+func (s *IPTestSuite) TestByteFunctions(c *C) {
+
+	//getByteIndexofBit
+	byteNum := getByteIndexOfBit(0)
+	c.Assert(byteNum, Equals, uint(15))
+	byteNum = getByteIndexOfBit(1)
+	c.Assert(byteNum, Equals, uint(15))
+	byteNum = getByteIndexOfBit(8)
+	c.Assert(byteNum, Equals, uint(14))
+	byteNum = getByteIndexOfBit(9)
+	c.Assert(byteNum, Equals, uint(14))
+
+	//getNthBit
+	testNet := net.IPNet{IP: net.ParseIP("10.96.0.0"), Mask: net.CIDRMask(12, int(ipv4BitLen))}
+	bit := getNthBit(&(testNet.IP), 20)
+	c.Assert(bit, Equals, uint8(0))
+	bit = getNthBit(&(testNet.IP), 22)
+	c.Assert(bit, Equals, uint8(1))
+
+	//flipNthBit
+	testBytes := []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0}
+	newBytes := flipNthBit(&testBytes, 10)
+	expectedBytes := []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0x0, 0x0, 0x4, 0x0}
+	for k := range expectedBytes {
+		c.Assert(reflect.DeepEqual(expectedBytes[k], (*newBytes)[k]), Equals, true)
+	}
+
+	newBytes = flipNthBit(&testBytes, 32)
+	expectedBytes = []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xfe, 0x0, 0x0, 0x0, 0x0}
+	for k := range expectedBytes {
+		c.Assert(reflect.DeepEqual(expectedBytes[k], (*newBytes)[k]), Equals, true)
+	}
+
+}

--- a/pkg/k8s/third_party.go
+++ b/pkg/k8s/third_party.go
@@ -146,6 +146,11 @@ func parseToCilium(namespace, name string, r *api.Rule) *api.Rule {
 				copy(retRule.Ingress[i].FromCIDR, ing.FromCIDR)
 			}
 
+			if ing.FromCIDRSet != nil {
+				retRule.Ingress[i].FromCIDRSet = make([]api.CIDRRule, len(ing.FromCIDRSet))
+				copy(retRule.Ingress[i].FromCIDRSet, ing.FromCIDRSet)
+			}
+
 			if ing.FromRequires != nil {
 				retRule.Ingress[i].FromRequires = make([]api.EndpointSelector, len(ing.FromRequires))
 				for j, ep := range ing.FromRequires {

--- a/pkg/k8s/third_party_test.go
+++ b/pkg/k8s/third_party_test.go
@@ -54,7 +54,8 @@ var (
 					},
 				},
 			}, {
-				ToCIDR: []api.CIDR{"10.0.0.1"},
+				ToCIDR:    []api.CIDR{"10.0.0.1"},
+				ToCIDRSet: []api.CIDRRule{{Cidr: api.CIDR("10.0.0.0/8"), ExceptCIDRs: []api.CIDR{"10.96.0.0/12"}}},
 			},
 		},
 	}
@@ -87,8 +88,10 @@ var (
 						Rules: &api.L7Rules{HTTP: []api.PortRuleHTTP{{Path: "/public", Method: "GET"}}},
 					},
 				},
-			}, {
-				ToCIDR: []api.CIDR{"10.0.0.1"},
+			},
+			{
+				ToCIDR:    []api.CIDR{"10.0.0.1"},
+				ToCIDRSet: []api.CIDRRule{{Cidr: api.CIDR("10.0.0.0/8"), ExceptCIDRs: []api.CIDR{"10.96.0.0/12"}}},
 			},
 		},
 		Labels: labels.ParseLabelArray(fmt.Sprintf("%s=%s", PolicyLabelName, "rule1")),
@@ -166,7 +169,15 @@ var (
             },{
                 "toCIDR": [
                     "10.0.0.1"
-                ]
+                ],
+				"toCIDRSet": [
+					{
+						"cidr": "10.0.0.0/8",
+						"except": [
+							"10.96.0.0/12"
+						]
+					}
+				]
             }
         ]
     }`)


### PR DESCRIPTION
As part of [Kubernetes 1.8 NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/#the-networkpolicy-resource), ipBlock has been added as a field for ingress / egress rules:

> ipBlock: ipBlock describes a particular CIDR that is allowed to the pods matched by a NetworkPolicySpec’s podSelector. The except entry is a slice of CIDRs that should not be included within an IP Block. Except values will be rejected if they are outside the CIDR range.

Add support for similar 'except' entries in CiliumNetworkPolicy for CIDR. In order to not change the existing API, which just takes a set of CIDRs, a new field has been added for both ingress and egress rules, `fromCIDR` and `toCIDR`, which are comprised of a list of `CIDRule`. A CIDRRule is a CIDR from which traffic is allowed, and a list of exceptions to not allow traffic from, much like the `IPBlock` construct in Kubernetes. Such a policy with this new functionality looks like the following:

```
...
 "egress": [
            {
                "toPorts": [
                    {
                        "ports": [
                            {
                                "port": "80",
                                "protocol": "TCP"
                            }
                        ],
                        "rules": {
                            "http": [
                                {
                                    "path": "/public",
                                    "method": "GET"
                                }
                            ]
                        }
                    }
                ],
                "toCIDR": [
                    "10.0.0.1"
                ],
				"toCIDRSet": [
					{
						"cidr": "10.0.0.0/8",
						"except": [
							"10.96.0.0/12"
						]
					}
				]
            }
        ]
...
```

A new library to do manipulations on CIDRs / IPs was added to calculate the resultant set of CIDRs that allow traffic based on the removal of 'except' from the CIDR to/from which traffic is allowed.

There are still a number of things I want to address before this is merged, but I am putting this out as an RFC. The edges are a bit rough - please confirm that the API design is appropriate.

- [x] Add IPv6 Unit tests
- [x] Add runtime tests
- [x] Policy doc updates (will do once API is approved).

Signed-off by: Ian Vernon <ian@cilium.io>