### PR TITLE
tests/helpers: remove ip6tables rules from runtime tests

### DIFF
--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -22,6 +22,9 @@ for bin in "../cilium/cilium" \
         fi
 done
 
+# Prevent Fedora rules in raw table from affecting the test.
+ip6tables -t raw -F || true
+
 function log {
   local save=$-
   set +u


### PR DESCRIPTION
Related-to: #1170 (cilium and iptables rpfilter interactions.)
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>