### PR TITLE
Policy regeneration improvements

### DIFF
--- a/api/v1/models/endpoint_state.go
+++ b/api/v1/models/endpoint_state.go
@@ -22,18 +22,20 @@ type EndpointState string
 const (
 	// EndpointStateCreating captures enum value "creating"
 	EndpointStateCreating EndpointState = "creating"
-	// EndpointStateDisconnecting captures enum value "disconnecting"
-	EndpointStateDisconnecting EndpointState = "disconnecting"
-	// EndpointStateDisconnected captures enum value "disconnected"
-	EndpointStateDisconnected EndpointState = "disconnected"
 	// EndpointStateWaitingForIdentity captures enum value "waiting-for-identity"
 	EndpointStateWaitingForIdentity EndpointState = "waiting-for-identity"
 	// EndpointStateNotReady captures enum value "not-ready"
 	EndpointStateNotReady EndpointState = "not-ready"
+	// EndpointStateWaitingToRegenerate captures enum value "waiting-to-regenerate"
+	EndpointStateWaitingToRegenerate EndpointState = "waiting-to-regenerate"
 	// EndpointStateRegenerating captures enum value "regenerating"
 	EndpointStateRegenerating EndpointState = "regenerating"
 	// EndpointStateReady captures enum value "ready"
 	EndpointStateReady EndpointState = "ready"
+	// EndpointStateDisconnecting captures enum value "disconnecting"
+	EndpointStateDisconnecting EndpointState = "disconnecting"
+	// EndpointStateDisconnected captures enum value "disconnected"
+	EndpointStateDisconnected EndpointState = "disconnected"
 )
 
 // for schema
@@ -41,7 +43,7 @@ var endpointStateEnum []interface{}
 
 func init() {
 	var res []EndpointState
-	if err := json.Unmarshal([]byte(`["creating","disconnecting","disconnected","waiting-for-identity","not-ready","regenerating","ready"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["creating","waiting-for-identity","not-ready","waiting-to-regenerate","regenerating","ready","disconnecting","disconnected"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -88,7 +88,7 @@ paths:
     put:
       summary: Create endpoint
       description: |
-        Updates an existing endpoint
+        Creates a new endpoint
       tags:
       - endpoint
       parameters:
@@ -813,12 +813,13 @@ definitions:
     type: string
     enum:
       - creating
-      - disconnecting
-      - disconnected
       - waiting-for-identity
       - not-ready
+      - waiting-to-regenerate
       - regenerating
       - ready
+      - disconnecting
+      - disconnected
   EndpointStatusChange:
     description: Indication of a change of status
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1206,12 +1206,13 @@ func init() {
       "type": "string",
       "enum": [
         "creating",
-        "disconnecting",
-        "disconnected",
         "waiting-for-identity",
         "not-ready",
+        "waiting-to-regenerate",
         "regenerating",
-        "ready"
+        "ready",
+        "disconnecting",
+        "disconnected"
       ]
     },
     "EndpointStatusChange": {

--- a/cilium/cmd/policy_wait.go
+++ b/cilium/cmd/policy_wait.go
@@ -19,6 +19,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/cilium/cilium/api/v1/models"
+
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +50,8 @@ var policyWaitCmd = &cobra.Command{
 			ready := 0
 
 			for _, ep := range eps {
-				if ep.Policy != nil && ep.PolicyRevision >= reqRevision {
+				if ep.Policy != nil && ep.PolicyRevision >= reqRevision &&
+					ep.State == models.EndpointStateReady {
 					ready++
 				}
 			}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1189,7 +1189,7 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 			if enforcement != oldEnforcementValue {
 				changes++
 				policy.SetPolicyEnabled(enforcement)
-				d.TriggerPolicyUpdates([]policy.NumericIdentity{})
+				d.TriggerPolicyUpdates()
 			}
 		default:
 			msg := fmt.Errorf("Invalid option for PolicyEnforcement %s", enforcement)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1138,6 +1138,8 @@ func mapValidateWalker(path string) error {
 }
 
 func changedOption(key string, value bool, data interface{}) {
+	d := data.(*Daemon)
+	d.policy.BumpRevision() // force policy recalculation
 }
 
 type patchConfig struct {
@@ -1189,7 +1191,7 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 			if enforcement != oldEnforcementValue {
 				changes++
 				policy.SetPolicyEnabled(enforcement)
-				d.TriggerPolicyUpdates()
+				d.TriggerPolicyUpdates(true)
 			}
 		default:
 			msg := fmt.Errorf("Invalid option for PolicyEnforcement %s", enforcement)

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -411,7 +411,6 @@ func (d *Daemon) EndpointUpdate(id string, opts models.ConfigurationMap) error {
 	}
 
 	if ep != nil {
-		invalidateCache()
 		if err := ep.Update(d, opts); err != nil {
 			switch err.(type) {
 			case endpoint.UpdateValidationError:
@@ -676,7 +675,7 @@ func (d *Daemon) EndpointLabelsUpdate(ep *endpoint.Endpoint, identityLabels, inf
 		ep.Regenerate(d)
 
 		// FIXME: Does this rebuild epID twice?
-		d.TriggerPolicyUpdates([]policy.NumericIdentity{identity.ID})
+		d.TriggerPolicyUpdates()
 	}
 
 	return nil

--- a/daemon/kvstore_watcher.go
+++ b/daemon/kvstore_watcher.go
@@ -43,7 +43,7 @@ func (d *Daemon) EnableKVStoreWatcher(maxSeconds time.Duration) {
 				if len(updates) != 0 {
 					d.setCachedMaxLabelID(updates[0])
 				}
-				d.TriggerPolicyUpdates()
+				d.TriggerPolicyUpdates(true)
 			}
 		}
 	}()

--- a/daemon/kvstore_watcher.go
+++ b/daemon/kvstore_watcher.go
@@ -43,7 +43,7 @@ func (d *Daemon) EnableKVStoreWatcher(maxSeconds time.Duration) {
 				if len(updates) != 0 {
 					d.setCachedMaxLabelID(updates[0])
 				}
-				d.TriggerPolicyUpdates(updates)
+				d.TriggerPolicyUpdates()
 			}
 		}
 	}()

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -60,41 +60,36 @@ func endpointCreator(id uint16, secID policy.NumericIdentity) *e.Endpoint {
 	strID := getStrID(id)
 	b := make([]byte, 2)
 	binary.LittleEndian.PutUint16(b, id)
-	ep := &e.Endpoint{
-		ID:       id,
-		DockerID: "",
-		// Random network ID and docker endpoint ID with 59 hex chars + 5 strID = 64 hex chars
-		DockerNetworkID:  "603e047d2268a57f5a5f93f7f9e1263e9207e348a06654bf64948def001" + strID,
-		DockerEndpointID: "93529fda8c401a071d21d6bd46fdf5499b9014dcb5a35f2e3efaa8d8002" + strID,
-		IfName:           "lxc" + strID,
-		LXCMAC:           mac.MAC([]byte{0x01, 0xff, 0xf2, 0x12, b[0], b[1]}),
-		IPv4:             addressing.DeriveCiliumIPv4(net.IP{0xc0, 0xa8, b[0], b[1]}),
-		IPv6:             addressing.DeriveCiliumIPv6(net.IP{0xbe, 0xef, 0xbe, 0xef, 0xbe, 0xef, 0xbe, 0xef, 0xaa, 0xaa, 0xaa, 0xaa, 0x00, 0x00, b[0], b[1]}),
-		IfIndex:          1,
-		NodeMAC:          mac.MAC([]byte{0x02, 0xff, 0xf2, 0x12, 0x0, 0x0}),
-		SecLabel: &policy.Identity{
+
+	ep := e.NewEndpointWithState(id, e.StateReady)
+	// Random network ID and docker endpoint ID with 59 hex chars + 5 strID = 64 hex chars
+	ep.DockerNetworkID = "603e047d2268a57f5a5f93f7f9e1263e9207e348a06654bf64948def001" + strID
+	ep.DockerEndpointID = "93529fda8c401a071d21d6bd46fdf5499b9014dcb5a35f2e3efaa8d8002" + strID
+	ep.IfName = "lxc" + strID
+	ep.LXCMAC = mac.MAC([]byte{0x01, 0xff, 0xf2, 0x12, b[0], b[1]})
+	ep.IPv4 = addressing.DeriveCiliumIPv4(net.IP{0xc0, 0xa8, b[0], b[1]})
+	ep.IPv6 = addressing.DeriveCiliumIPv6(net.IP{0xbe, 0xef, 0xbe, 0xef, 0xbe, 0xef, 0xbe, 0xef, 0xaa, 0xaa, 0xaa, 0xaa, 0x00, 0x00, b[0], b[1]})
+	ep.IfIndex = 1
+	ep.NodeMAC = mac.MAC([]byte{0x02, 0xff, 0xf2, 0x12, 0x0, 0x0})
+	ep.SecLabel = &policy.Identity{
+		ID: secID,
+		Labels: labels.Labels{
+			"foo" + strID: labels.NewLabel("foo"+strID, "", ""),
+		},
+	}
+	ep.Consumable = &policy.Consumable{
+		ID:        secID,
+		Iteration: 0,
+		Labels: &policy.Identity{
 			ID: secID,
 			Labels: labels.Labels{
 				"foo" + strID: labels.NewLabel("foo"+strID, "", ""),
 			},
 		},
-		PortMap: nil,
-		Consumable: &policy.Consumable{
-			ID:        secID,
-			Iteration: 0,
-			Labels: &policy.Identity{
-				ID: secID,
-				Labels: labels.Labels{
-					"foo" + strID: labels.NewLabel("foo"+strID, "", ""),
-				},
-			},
-			Maps:         map[int]*policymap.PolicyMap{},
-			Consumers:    map[string]*policy.Consumer{},
-			ReverseRules: map[policy.NumericIdentity]*policy.Consumer{},
-		},
+		Maps:         map[int]*policymap.PolicyMap{},
+		Consumers:    map[string]*policy.Consumer{},
+		ReverseRules: map[policy.NumericIdentity]*policy.Consumer{},
 	}
-	ep.SetDefaultOpts(nil)
-	ep.Status = e.NewEndpointStatus()
 	return ep
 }
 
@@ -154,7 +149,12 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 	epsNames := []string{}
 	for _, ep := range epsWanted {
 		os.MkdirAll(filepath.Join(baseDir, ep.StringID()), 777)
-		<-ep.Regenerate(ds)
+		ep.Mutex.Lock()
+		ready := ep.SetStateLocked(e.StateWaitingToRegenerate)
+		ep.Mutex.Unlock()
+		if ready {
+			<-ep.Regenerate(ds)
+		}
 		epsNames = append(epsNames, ep.StringID())
 	}
 	return epsNames, nil

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -409,42 +409,34 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string) error {
 	}
 
 	if e.L3Policy != nil {
-		if e.L3Policy.Ingress.IPv6Changed {
-			if e.L3Policy.Ingress.IPv6Count > 0 &&
-				e.L3Maps.ResetBpfMap(IPv6Ingress, e.IPv6IngressMapPathLocked()) == nil {
-				createdIPv6IngressMap = true
-				e.L3Policy.Ingress.PopulateBPF(e.L3Maps[IPv6Ingress])
-			} else {
-				e.L3Maps.DestroyBpfMap(IPv6Ingress, e.IPv6IngressMapPathLocked())
-			}
+		if e.L3Policy.Ingress.IPv6Count > 0 &&
+			e.L3Maps.ResetBpfMap(IPv6Ingress, e.IPv6IngressMapPathLocked()) == nil {
+			createdIPv6IngressMap = true
+			e.L3Policy.Ingress.PopulateBPF(e.L3Maps[IPv6Ingress])
+		} else {
+			e.L3Maps.DestroyBpfMap(IPv6Ingress, e.IPv6IngressMapPathLocked())
 		}
-		if e.L3Policy.Egress.IPv6Changed {
-			if e.L3Policy.Egress.IPv6Count > 0 &&
-				e.L3Maps.ResetBpfMap(IPv6Egress, e.IPv6EgressMapPathLocked()) == nil {
-				createdIPv6EgressMap = true
-				e.L3Policy.Egress.PopulateBPF(e.L3Maps[IPv6Egress])
-			} else {
-				e.L3Maps.DestroyBpfMap(IPv6Egress, e.IPv6EgressMapPathLocked())
-			}
+		if e.L3Policy.Egress.IPv6Count > 0 &&
+			e.L3Maps.ResetBpfMap(IPv6Egress, e.IPv6EgressMapPathLocked()) == nil {
+			createdIPv6EgressMap = true
+			e.L3Policy.Egress.PopulateBPF(e.L3Maps[IPv6Egress])
+		} else {
+			e.L3Maps.DestroyBpfMap(IPv6Egress, e.IPv6EgressMapPathLocked())
 		}
 
-		if e.L3Policy.Ingress.IPv4Changed {
-			if e.L3Policy.Ingress.IPv4Count > 0 &&
-				e.L3Maps.ResetBpfMap(IPv4Ingress, e.IPv4IngressMapPathLocked()) == nil {
-				createdIPv4IngressMap = true
-				e.L3Policy.Ingress.PopulateBPF(e.L3Maps[IPv4Ingress])
-			} else {
-				e.L3Maps.DestroyBpfMap(IPv4Ingress, e.IPv4IngressMapPathLocked())
-			}
+		if e.L3Policy.Ingress.IPv4Count > 0 &&
+			e.L3Maps.ResetBpfMap(IPv4Ingress, e.IPv4IngressMapPathLocked()) == nil {
+			createdIPv4IngressMap = true
+			e.L3Policy.Ingress.PopulateBPF(e.L3Maps[IPv4Ingress])
+		} else {
+			e.L3Maps.DestroyBpfMap(IPv4Ingress, e.IPv4IngressMapPathLocked())
 		}
-		if e.L3Policy.Egress.IPv4Changed {
-			if e.L3Policy.Egress.IPv4Count > 0 &&
-				e.L3Maps.ResetBpfMap(IPv4Egress, e.IPv4EgressMapPathLocked()) == nil {
-				createdIPv4EgressMap = true
-				e.L3Policy.Egress.PopulateBPF(e.L3Maps[IPv4Egress])
-			} else {
-				e.L3Maps.DestroyBpfMap(IPv4Egress, e.IPv4EgressMapPathLocked())
-			}
+		if e.L3Policy.Egress.IPv4Count > 0 &&
+			e.L3Maps.ResetBpfMap(IPv4Egress, e.IPv4EgressMapPathLocked()) == nil {
+			createdIPv4EgressMap = true
+			e.L3Policy.Egress.PopulateBPF(e.L3Maps[IPv4Egress])
+		} else {
+			e.L3Maps.DestroyBpfMap(IPv4Egress, e.IPv4EgressMapPathLocked())
 		}
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -652,67 +652,6 @@ func (e *EndpointStatus) String() string {
 	return e.CurrentStatus().String()
 }
 
-func (e *EndpointStatus) DeepCopy() *EndpointStatus {
-	cpy := NewEndpointStatus()
-	e.indexMU.RLock()
-	defer e.indexMU.RUnlock()
-	cpy.Index = e.Index
-	cpy.Log = statusLog{}
-	for _, v := range e.Log {
-		cpy.Log = append(cpy.Log, v)
-	}
-	return cpy
-}
-
-func (e *Endpoint) DeepCopy() *Endpoint {
-	e.Mutex.RLock()
-	defer e.Mutex.RUnlock()
-	cpy := &Endpoint{
-		ID:               e.ID,
-		DockerID:         e.DockerID,
-		ContainerName:    e.ContainerName,
-		DockerNetworkID:  e.DockerNetworkID,
-		DockerEndpointID: e.DockerEndpointID,
-		IfName:           e.IfName,
-		LXCMAC:           make(mac.MAC, len(e.LXCMAC)),
-		IPv6:             make(addressing.CiliumIPv6, len(e.IPv6)),
-		IfIndex:          e.IfIndex,
-		NodeMAC:          make(mac.MAC, len(e.NodeMAC)),
-		PortMap:          make([]PortMap, len(e.PortMap)),
-		Status:           NewEndpointStatus(),
-	}
-	copy(cpy.LXCMAC, e.LXCMAC)
-	copy(cpy.IPv6, e.IPv6)
-	copy(cpy.NodeMAC, e.NodeMAC)
-	copy(cpy.PortMap, e.PortMap)
-
-	if e.IPv4 != nil {
-		cpy.IPv4 = make(addressing.CiliumIPv4, len(e.IPv4))
-		copy(cpy.IPv4, e.IPv4)
-	}
-	if e.SecLabel != nil {
-		cpy.SecLabel = e.SecLabel.DeepCopy()
-	}
-	if e.Consumable != nil {
-		cpy.Consumable = e.Consumable.DeepCopy()
-	}
-	if e.PolicyMap != nil {
-		cpy.PolicyMap = e.PolicyMap.DeepCopy()
-	}
-	if e.L3Policy != nil {
-		cpy.L3Policy = e.L3Policy.DeepCopy()
-	}
-	cpy.L3Maps = e.L3Maps.DeepCopy()
-	if e.Opts != nil {
-		cpy.Opts = e.Opts.DeepCopy()
-	}
-	if e.Status != nil {
-		cpy.Status = e.Status.DeepCopy()
-	}
-
-	return cpy
-}
-
 // StringID returns the endpoint's ID in a string.
 func (e *Endpoint) StringID() string {
 	return strconv.Itoa(int(e.ID))

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -22,11 +22,6 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/comparator"
-	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/mac"
-	"github.com/cilium/cilium/pkg/maps/policymap"
-	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/policy"
 
 	. "gopkg.in/check.v1"
 )
@@ -67,79 +62,6 @@ func (s *EndpointSuite) TestOrderEndpointAsc(c *C) {
 	}
 	OrderEndpointAsc(eps)
 	c.Assert(eps, comparator.DeepEquals, epsWant)
-}
-
-func (s *EndpointSuite) TestDeepCopy(c *C) {
-	ipv4, err := addressing.NewCiliumIPv4("127.0.0.1")
-	c.Assert(err, IsNil)
-	ipv6, err := addressing.NewCiliumIPv6("::1")
-	c.Assert(err, IsNil)
-	epWant := &Endpoint{
-		ID:               12,
-		DockerID:         "123",
-		DockerNetworkID:  "1234",
-		DockerEndpointID: "12345",
-		IfName:           "lxcifname",
-		LXCMAC:           mac.MAC{1, 2, 3, 4, 5, 6},
-		IPv6:             ipv6,
-		IPv4:             ipv4,
-		IfIndex:          4,
-		NodeMAC:          mac.MAC{1, 2, 3, 4, 5, 6},
-		PortMap:          make([]PortMap, 2),
-		Opts:             option.NewBoolOptions(&EndpointOptionLibrary),
-		Status:           NewEndpointStatus(),
-	}
-	cpy := epWant.DeepCopy()
-	c.Assert(cpy, comparator.DeepEquals, epWant)
-	epWant.SecLabel = &policy.Identity{
-		ID: 1,
-		Labels: labels.Labels{
-			"io.cilium.kubernetes": labels.NewLabel("io.cilium.kubernetes", "", "cilium"),
-		},
-		Endpoints: map[string]time.Time{
-			"1234": time.Now(),
-		},
-	}
-	epWant.Consumable = &policy.Consumable{
-		ID:        123,
-		Iteration: 3,
-		Labels:    nil,
-		LabelArray: labels.LabelArray{
-			labels.NewLabel("io.cilium.kubernetes", "", "cilium"),
-		},
-		Maps: map[int]*policymap.PolicyMap{
-			0: {},
-		},
-		Consumers: map[string]*policy.Consumer{
-			"foo": policy.NewConsumer(12),
-		},
-		ReverseRules: map[policy.NumericIdentity]*policy.Consumer{
-			12: policy.NewConsumer(12),
-		},
-	}
-	epWant.PolicyMap = &policymap.PolicyMap{}
-	cpy = epWant.DeepCopy()
-	c.Assert(*cpy.SecLabel, comparator.DeepEquals, *epWant.SecLabel)
-	c.Assert(cpy.Consumable, comparator.DeepEquals, epWant.Consumable)
-	c.Assert(*cpy.PolicyMap, comparator.DeepEquals, *epWant.PolicyMap)
-
-	epWant.Consumable.Labels = &policy.Identity{
-		ID: 1,
-		Labels: labels.Labels{
-			"io.cilium.kubernetes": labels.NewLabel("io.cilium.kubernetes", "", "cilium"),
-		},
-		Endpoints: map[string]time.Time{
-			"1234": time.Now(),
-		},
-	}
-
-	epWant.PolicyMap = &policymap.PolicyMap{}
-	cpy = epWant.DeepCopy()
-
-	c.Assert(*cpy.Consumable.Labels, comparator.DeepEquals, *epWant.Consumable.Labels)
-
-	cpy.Consumable.Labels.Endpoints["1234"] = time.Now()
-	c.Assert(*cpy.Consumable.Labels, Not(DeepEquals), *epWant.Consumable.Labels)
 }
 
 func (s *EndpointSuite) TestEndpointStatus(c *C) {

--- a/pkg/endpoint/l3maps.go
+++ b/pkg/endpoint/l3maps.go
@@ -60,16 +60,6 @@ func (l3 *L3Maps) ResetBpfMap(mt L3MapType, path string) error {
 	return err
 }
 
-// DeepCopy duplicates the bpf map references, but the duplicates
-// refer to the same bpf maps.
-func (l3 *L3Maps) DeepCopy() L3Maps {
-	var cpy L3Maps
-	for i, v := range l3 {
-		cpy[i] = v.DeepCopy()
-	}
-	return cpy
-}
-
 // Close closes all bpf maps, but does not destroy them.
 func (l3 *L3Maps) Close() {
 	for _, v := range l3 {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -646,11 +646,7 @@ func (e *Endpoint) TriggerPolicyUpdatesLocked(owner Owner, opts models.Configura
 // Caller triggers policy regeneration if needed.
 // Called with e.Mutex Locked
 func (e *Endpoint) SetIdentity(owner Owner, id *policy.Identity) {
-	repo := owner.GetPolicyRepository()
 	cache := policy.GetConsumableCache()
-
-	repo.Mutex.Lock()
-	defer repo.Mutex.Unlock()
 
 	if e.Consumable != nil {
 		if e.SecLabel != nil && id.ID == e.Consumable.ID {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -18,8 +18,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -28,75 +30,38 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (e *Endpoint) checkEgressAccess(owner Owner, opts models.ConfigurationMap, dstID policy.NumericIdentity, opt string) {
-	var err error
-
+func (e *Endpoint) checkEgressAccess(owner Owner, dstLabels labels.LabelArray, opts models.ConfigurationMap, opt string) {
 	ctx := policy.SearchContext{
 		From: e.Consumable.LabelArray,
+		To:   dstLabels,
 	}
 
 	if owner.TracingEnabled() {
 		ctx.Trace = policy.TRACE_ENABLED
 	}
 
-	ctx.To, err = owner.GetCachedLabelList(dstID)
-	if err != nil {
-		e.getLogger().WithField(logfields.PolicyID, dstID).Warn("Unable to get label list for policy, access for endpoint may be restricted")
-		return
-	}
+	scopedLog := e.getLogger().WithFields(log.Fields{
+		logfields.Labels + ".from": ctx.From,
+		logfields.Labels + ".to":   ctx.To,
+	})
 
 	switch owner.GetPolicyRepository().AllowsLabelAccess(&ctx) {
 	case api.Allowed:
 		opts[opt] = "enabled"
+		scopedLog.Debug("checkEgressAccess: Enabled")
 	case api.Denied:
 		opts[opt] = "disabled"
+		scopedLog.Debug("checkEgressAccess: Disabled")
 	}
 }
 
 // allowConsumer must be called with global endpoint.Mutex held
-func (e *Endpoint) allowConsumer(owner Owner, id policy.NumericIdentity) {
+func (e *Endpoint) allowConsumer(owner Owner, id policy.NumericIdentity) bool {
 	cache := policy.GetConsumableCache()
 	if !e.Opts.IsEnabled(OptionConntrack) {
-		e.Consumable.AllowConsumerAndReverseLocked(cache, id)
-	} else {
-		e.Consumable.AllowConsumerLocked(cache, id)
+		return e.Consumable.AllowConsumerAndReverseLocked(cache, id)
 	}
-}
-
-func (e *Endpoint) evaluateConsumerSource(owner Owner, ctx *policy.SearchContext, srcID policy.NumericIdentity) error {
-	var err error
-
-	ctx.From, err = owner.GetCachedLabelList(srcID)
-	if err != nil {
-		return err
-	}
-
-	// Skip currently unused IDs
-	if ctx.From == nil || len(ctx.From) == 0 {
-		return nil
-	}
-
-	e.getLogger().WithFields(log.Fields{
-		logfields.PolicyID: srcID,
-		"ctx":              ctx,
-	}).Debug("Evaluating context for source PolicyID")
-
-	if owner.GetPolicyRepository().AllowsLabelAccess(ctx) == api.Allowed {
-		e.allowConsumer(owner, srcID)
-	}
-
-	return nil
-}
-
-func (e *Endpoint) invalidatePolicy() {
-	if e.Consumable != nil {
-		e.getLogger().Debug("Invalidated policy for endpoint")
-
-		// Resetting to 0 will trigger a regeneration on the next update
-		e.Consumable.Mutex.Lock()
-		e.Consumable.Iteration = 0
-		e.Consumable.Mutex.Unlock()
-	}
+	return e.Consumable.AllowConsumerLocked(cache, id)
 }
 
 // ProxyID returns a unique string to identify a proxy mapping
@@ -123,30 +88,21 @@ func (e *Endpoint) cleanUnusedRedirects(owner Owner, oldMap policy.L4PolicyMap, 
 
 		if v.IsRedirect() {
 			if err := owner.RemoveProxyRedirect(e, &v); err != nil {
-				e.getLogger().WithError(err).WithField("redirect", v).Warn("error while removing proxy redirect")
+				e.getLogger().WithError(err).WithField("redirect", v).Warn("Error while removing proxy redirect")
 			}
 
 		}
 	}
 }
 
-func getSecurityIdentities(owner Owner, selector *api.EndpointSelector) []policy.NumericIdentity {
+func getSecurityIdentities(labelsMap *LabelsMap, selector *api.EndpointSelector) []policy.NumericIdentity {
 	identities := []policy.NumericIdentity{}
-	maxID, err := owner.GetCachedMaxLabelID()
-	if err != nil {
-		return identities
-	}
-	for idx := policy.MinimalNumericIdentity; idx < maxID; idx++ {
-		labels, err := owner.GetCachedLabelList(idx)
-		if err != nil {
-			log.WithError(err).WithField(logfields.IdentityLabels, labels).Info("L4 Policy label lookup failed")
-		}
-
-		if labels != nil && selector.Matches(labels) {
+	for idx, labels := range *labelsMap {
+		if selector.Matches(labels) {
 			log.WithFields(log.Fields{
 				logfields.IdentityLabels: labels,
 				logfields.L4PolicyID:     idx,
-			}).Debug("L4 Policy matches.")
+			}).Debug("L4 Policy matches")
 			identities = append(identities, idx)
 		}
 	}
@@ -154,12 +110,12 @@ func getSecurityIdentities(owner Owner, selector *api.EndpointSelector) []policy
 	return identities
 }
 
-func (e *Endpoint) removeOldFilter(owner Owner, filter *policy.L4Filter) {
+func (e *Endpoint) removeOldFilter(labelsMap *LabelsMap, filter *policy.L4Filter) {
 	port := uint16(filter.Port)
 	proto := uint8(filter.U8Proto)
 
 	for _, sel := range filter.FromEndpoints {
-		for _, id := range getSecurityIdentities(owner, &sel) {
+		for _, id := range getSecurityIdentities(labelsMap, &sel) {
 			srcID := id.Uint32()
 			if err := e.PolicyMap.DeleteL4(srcID, port, proto); err != nil {
 				// This happens when the policy would add
@@ -172,19 +128,19 @@ func (e *Endpoint) removeOldFilter(owner Owner, filter *policy.L4Filter) {
 	}
 }
 
-func (e *Endpoint) applyNewFilter(owner Owner, filter *policy.L4Filter) int {
+func (e *Endpoint) applyNewFilter(labelsMap *LabelsMap, filter *policy.L4Filter) int {
 	port := uint16(filter.Port)
 	proto := uint8(filter.U8Proto)
 
 	errors := 0
 	for _, sel := range filter.FromEndpoints {
-		for _, id := range getSecurityIdentities(owner, &sel) {
+		for _, id := range getSecurityIdentities(labelsMap, &sel) {
 			srcID := id.Uint32()
 			if e.PolicyMap.L4Exists(srcID, port, proto) {
 				e.getLogger().WithField("l4Filter", filter).Debug("L4 filter exists")
 				continue
 			}
-			if err = e.PolicyMap.AllowL4(srcID, port, proto); err != nil {
+			if err := e.PolicyMap.AllowL4(srcID, port, proto); err != nil {
 				e.getLogger().WithError(err).Warn("Update of l4 policy map failed")
 				errors++
 			}
@@ -196,10 +152,10 @@ func (e *Endpoint) applyNewFilter(owner Owner, filter *policy.L4Filter) int {
 
 // Looks for mismatches between 'oldPolicy' and 'newPolicy', and fixes up
 // this Endpoint's BPF PolicyMap to reflect the new L3+L4 combined policy.
-func (e *Endpoint) applyL4PolicyLocked(owner Owner, oldPolicy *policy.L4Policy, newPolicy *policy.L4Policy) error {
+func (e *Endpoint) applyL4PolicyLocked(labelsMap *LabelsMap, oldPolicy *policy.L4Policy, newPolicy *policy.L4Policy) error {
 	if oldPolicy != nil {
 		for _, filter := range oldPolicy.Ingress {
-			e.removeOldFilter(owner, &filter)
+			e.removeOldFilter(labelsMap, &filter)
 		}
 	}
 
@@ -210,7 +166,7 @@ func (e *Endpoint) applyL4PolicyLocked(owner Owner, oldPolicy *policy.L4Policy, 
 	errors := 0
 
 	for _, filter := range newPolicy.Ingress {
-		errors += e.applyNewFilter(owner, &filter)
+		errors += e.applyNewFilter(labelsMap, &filter)
 	}
 
 	if errors > 0 {
@@ -219,91 +175,122 @@ func (e *Endpoint) applyL4PolicyLocked(owner Owner, oldPolicy *policy.L4Policy, 
 	return nil
 }
 
-// Must be called with global endpoint.Mutex held
-func (e *Endpoint) regenerateConsumable(owner Owner) (bool, error) {
-	c := e.Consumable
-
-	// Endpoints without a security label are not accessible
-	if c.ID == 0 {
-		e.getLogger().Warn("Endpoint lacks identity, skipping policy calculation")
-
-		return false, nil
-	}
-
-	cache := policy.GetConsumableCache()
-
-	// Skip if policy for this consumable is already valid
-	//if c.Iteration == cache.Iteration {
-	//	repo.Mutex.RUnlock()
-	//	e.getLogger().WithField("consumableID", c.ID).Debug("Reusing cached policy for consumable identity")
-	//	return false, nil
-	//}
-
+func getLabelsMap(owner Owner) (*LabelsMap, error) {
 	maxID, err := owner.GetCachedMaxLabelID()
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
-	c.Mutex.RLock()
+	labelsMap := LabelsMap{}
+
+	reservedIDs := policy.GetConsumableCache().GetReservedIDs()
+	var idx policy.NumericIdentity
+	for _, idx = range reservedIDs {
+		lbls, err := owner.GetCachedLabelList(idx)
+		if err != nil {
+			return nil, err
+		}
+		// Skip currently unused IDs
+		if lbls == nil || len(lbls) == 0 {
+			continue
+		}
+		labelsMap[idx] = lbls
+	}
+
+	for idx = policy.MinimalNumericIdentity; idx < maxID; idx++ {
+		lbls, err := owner.GetCachedLabelList(idx)
+		if err != nil {
+			return nil, err
+		}
+		// Skip currently unused IDs
+		if lbls == nil || len(lbls) == 0 {
+			continue
+		}
+		labelsMap[idx] = lbls
+	}
+
+	return &labelsMap, nil
+}
+
+// Must be called with global endpoint.Mutex held
+func (e *Endpoint) resolveL4Policy(owner Owner, repo *policy.Repository, c *policy.Consumable) error {
 	ctx := policy.SearchContext{
 		To: c.LabelArray,
 	}
-	c.Mutex.RUnlock()
-
 	if owner.TracingEnabled() {
 		ctx.Trace = policy.TRACE_ENABLED
 	}
 
-	repo := owner.GetPolicyRepository()
-	repo.Mutex.Lock()
-	newL4policy, err := repo.ResolveL4Policy(&ctx)
-	defer repo.Mutex.Unlock()
-
+	newL4Policy, err := repo.ResolveL4Policy(&ctx)
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	c.Mutex.Lock()
-	defer c.Mutex.Unlock()
+	if reflect.DeepEqual(c.L4Policy, newL4Policy) {
+		return nil
+	}
+
+	c.L4Policy = newL4Policy
+	return nil
+}
+
+// Must be called with global endpoint.Mutex held
+func (e *Endpoint) regenerateConsumable(owner Owner, labelsMap *LabelsMap, repo *policy.Repository, c *policy.Consumable) bool {
+	changed := false
+
 	// Mark all entries unused by denying them
 	for k := range c.Consumers {
 		c.Consumers[k].DeletionMark = true
 	}
 
-	if c.L4Policy != nil {
-		e.cleanUnusedRedirects(owner, c.L4Policy.Ingress, newL4policy.Ingress)
-		e.cleanUnusedRedirects(owner, c.L4Policy.Egress, newL4policy.Egress)
+	// L4 policy needs to be applied on two conditions
+	// 1. The L4 policy has changed
+	// 2. The set of applicable security identities has changed.
+	if e.L4Policy != c.L4Policy || e.LabelsMap != labelsMap {
+		// PolicyMap can't be created in dry mode.
+		if !owner.DryModeEnabled() {
+			// Update Endpoint's L4Policy
+			if e.L4Policy != nil {
+				e.cleanUnusedRedirects(owner, e.L4Policy.Ingress, c.L4Policy.Ingress)
+				e.cleanUnusedRedirects(owner, e.L4Policy.Egress, c.L4Policy.Egress)
+			}
+
+			err := e.applyL4PolicyLocked(labelsMap, e.L4Policy, c.L4Policy)
+			if err != nil {
+				// This should not happen, and we can't fail at this stage anyway.
+				e.getLogger().Fatal("L4 Policy application failed")
+			}
+		}
+		e.L4Policy = c.L4Policy // Reuse the common policy
+		e.LabelsMap = labelsMap // Remember the set of labels used
+		changed = true
 	}
 
-	err = e.applyL4PolicyLocked(owner, c.L4Policy, newL4policy)
-	if err != nil {
-		return false, err
-	}
-	c.L4Policy = newL4policy
-
-	if newL4policy.HasRedirect() || owner.AlwaysAllowLocalhost() {
-		e.allowConsumer(owner, policy.ReservedIdentityHost)
-	}
-
-	// Check access from reserved consumables first
-	reservedIDs := cache.GetReservedIDs()
-	for _, id := range reservedIDs {
-		if err := e.evaluateConsumerSource(owner, &ctx, id); err != nil {
-			// This should never really happen
-			// FIXME: clear policy because it is inconsistent
-			e.getLogger().WithError(err).Debug("Received error while evaluating policy")
+	if owner.AlwaysAllowLocalhost() || c.L4Policy.HasRedirect() {
+		if e.allowConsumer(owner, policy.ReservedIdentityHost) {
+			changed = true
 		}
 	}
 
-	// Iterate over all possible assigned search contexts
-	idx := policy.MinimalNumericIdentity
-	e.getLogger().WithField("range", []policy.NumericIdentity{idx, maxID}).Debug("Eval ID range")
-	for idx < maxID {
-		if err := e.evaluateConsumerSource(owner, &ctx, idx); err != nil {
-			// FIXME: clear policy because it is inconsistent
-			e.getLogger().WithError(err).Debug("Received error while evaluating policy")
+	ctx := policy.SearchContext{
+		To: c.LabelArray,
+	}
+	if owner.TracingEnabled() {
+		ctx.Trace = policy.TRACE_ENABLED
+	}
+
+	for srcID, srcLabels := range *labelsMap {
+		ctx.From = srcLabels
+		e.getLogger().WithFields(log.Fields{
+			logfields.PolicyID: srcID,
+			"ctx":              ctx,
+		}).Debug("Evaluating context for source PolicyID")
+
+		if repo.AllowsLabelAccess(&ctx) == api.Allowed {
+			if e.allowConsumer(owner, srcID) {
+				changed = true
+			}
 		}
-		idx++
 	}
 
 	// Garbage collect all unused entries
@@ -311,31 +298,23 @@ func (e *Endpoint) regenerateConsumable(owner Owner) (bool, error) {
 		if val.DeletionMark {
 			val.DeletionMark = false
 			c.BanConsumerLocked(val.ID)
+			changed = true
 		}
 	}
 
-	// Result is valid until cache iteration advances
-	c.Iteration = repo.GetRevision()
-
 	e.getLogger().WithFields(log.Fields{
-		"consumableID": c.ID,
-		"consumers":    logfields.Repr(c.Consumers),
-	}).Debug("new consumable with consumers")
+		logfields.Identity: c.ID,
+		"consumers":        logfields.Repr(c.Consumers),
+	}).Debug("New consumable with consumers")
 
-	// FIXME: Optimize this and only return true if L4 policy changed
-	return true, nil
+	return changed
 }
 
-// Must be called with global endpoint.Mutex held
-func (e *Endpoint) regenerateL3Policy(owner Owner) (bool, error) {
-	c := e.Consumable
+// Must be called with global repo.Mutrex, e.Mutex, and c.Mutex held
+func (e *Endpoint) regenerateL3Policy(owner Owner, repo *policy.Repository, revision uint64, c *policy.Consumable) (bool, error) {
 
-	repo := owner.GetPolicyRepository()
-	repo.Mutex.Lock() // Must be taken before c.Mutex
-	c.Mutex.RLock()
 	ctx := policy.SearchContext{
-		To:    c.LabelArray, // keep c.Mutex taken to protect this.
-		Trace: policy.TRACE_VERBOSE,
+		To: c.LabelArray, // keep c.Mutex taken to protect this.
 	}
 	if owner.TracingEnabled() {
 		ctx.Trace = policy.TRACE_ENABLED
@@ -344,58 +323,155 @@ func (e *Endpoint) regenerateL3Policy(owner Owner) (bool, error) {
 	// Perform the validation on the new policy
 	err := newL3policy.Validate()
 	valid := err == nil
-	repo.Mutex.Unlock()
-	c.Mutex.RUnlock()
 
 	if valid {
+		if reflect.DeepEqual(e.L3Policy, newL3policy) {
+			e.getLogger().Debug("No change in CIDR policy")
+			return false, nil
+		}
 		e.L3Policy = newL3policy
 	}
 
-	// FIXME: Optimize this and only return true if L3 policy changed
 	return valid, err
 }
 
-// regeneratePolicy returns whether the policy for the given endpoint should be
-// regenerated. Only called when e.Consumable != nil.
-func (e *Endpoint) regeneratePolicy(owner Owner) (bool, error) {
+// regeneratePolicy regenerates endpoint's policy if needed and returns
+// whether the BPF for the given endpoint should be regenerated. Only
+// called when e.Consumable != nil.
+//
+// In a typical workflow this is first called to regenerate the policy
+// (if needed), and second time when the BPF program is
+// regenerated. The second step is usually unnecessary and may be
+// optimized away by the revision checks.  However, if there has been
+// a further policy update between the first and second calls, the
+// second call will update the policy just before regenerating the BPF
+// programs to avoid needing to regenerate BPF programs aging right
+// after.
+//
+// Policy changes are tracked so that only endpoints affected by the
+// policy change need to have their BPF programs regenerated.
+//
+// Policy generation may fail, and in that case we exit before
+// actually changing the policy in any way, so that the last policy
+// remains fully in effect if the new policy can not be
+// implemented. This is done on a per endpoint-basis, however, and it is
+// possible that policy update succeeds for some endpoints, while it
+// fails for other endpoints.
+//
+// Must be called with endpoint mutex held.
+func (e *Endpoint) regeneratePolicy(owner Owner, opts models.ConfigurationMap) (bool, error) {
+	// Dry mode does not regenerate policy via bpf regeneration, so we let it pass
+	// through. Some bpf/redirect updates are skipped in that case.
+	//
+	// This can be cleaned up once we shift all bpf updates to regenerateBPF().
+	if e.PolicyMap == nil && !owner.DryModeEnabled() {
+		// First run always results in bpf generation
+		// L4 policy generation assumes e.PolicyMp to exist, but it is only created
+		// when bpf is generated for the first time. Until then we can't really compute
+		// the policy. Bpf generation calls us again after PolicyMap is created.
+		// In dry mode we are called with a nil PolicyMap.
+
+		// We still need to apply any options if given.
+		if opts != nil {
+			e.applyOptsLocked(opts)
+		}
+
+		return true, nil
+	}
+
 	e.getLogger().Debug("Starting regenerate...")
 
-	policyChanged, err := e.regenerateConsumable(owner)
+	// Collect label arrays before policy computation, as this can fail.
+	// GH-1128 should allow optimizing this away, but currently we can't
+	// reliably know if the KV-store has changed or not, so we must scan
+	// through it each time.
+	labelsMap, err := getLabelsMap(owner)
 	if err != nil {
+		e.getLogger().WithError(err).Debug("Received error while evaluating policy")
 		return false, err
 	}
-
-	l3PolicyChanged, err := e.regenerateL3Policy(owner)
-	if err != nil {
-		return false, err
-	}
-	if l3PolicyChanged {
-		policyChanged = true
+	if reflect.DeepEqual(e.LabelsMap, labelsMap) {
+		labelsMap = e.LabelsMap
 	}
 
-	opts := make(models.ConfigurationMap)
 	repo := owner.GetPolicyRepository()
 	repo.Mutex.RLock()
 	revision := repo.GetRevision()
-	e.Consumable.Mutex.RLock()
+	defer repo.Mutex.RUnlock()
 
-	e.checkEgressAccess(owner, opts, policy.ReservedIdentityHost, OptionAllowToHost)
-	e.checkEgressAccess(owner, opts, policy.ReservedIdentityWorld, OptionAllowToWorld)
+	// Recompute policy for this endpoint only if not already done for this revision.
+	if !e.forcePolicyCompute && e.nextPolicyRevision >= revision &&
+		labelsMap == e.LabelsMap && opts == nil {
 
-	if e.Consumable != nil && e.Consumable.L4Policy.RequiresConntrack() {
-		opts[OptionConntrack] = "enabled"
+		e.getLogger().WithFields(log.Fields{
+			"policyRevision.next": e.nextPolicyRevision,
+			"policyRevision.repo": revision,
+		}).Debug("Skipping policy recalculation")
+		// This revision already computed, but may still need to be applied to BPF
+		return e.nextPolicyRevision > e.policyRevision, nil
 	}
 
+	if opts == nil {
+		opts = make(models.ConfigurationMap)
+	}
+
+	c := e.Consumable
+
+	// We may update the consumable, serialize access between endpoints sharing it
+	c.Mutex.Lock()
+	defer c.Mutex.Unlock()
+
+	// Containers without a security label are not accessible
+	if c.ID == 0 {
+		e.getLogger().Warn("Endpoint lacks identity, skipping policy calculation")
+		return false, nil
+	}
+
+	// Skip L4 policy recomputation for this consumable if already valid.
+	// Rest of the policy computation still needs to be done for each endpoint
+	// separately even thought the consumable may be shared between them.
+	if c.Iteration != revision {
+		err = e.resolveL4Policy(owner, repo, c)
+		if err != nil {
+			return false, err
+		}
+		// Result is valid until cache iteration advances
+		c.Iteration = revision
+	} else {
+		e.getLogger().WithField(logfields.Identity, c.ID).Debug("Reusing cached L4 policy")
+	}
+
+	var policyChanged bool
+	if policyChanged, err = e.regenerateL3Policy(owner, repo, revision, c); err != nil {
+		return false, err
+	}
+
+	// no failures after this point
+
+	// Apply possible option changes before regenerating maps, as map regeneration
+	// depends on the conntrack options
+	if c.L4Policy != nil {
+		if c.L4Policy.RequiresConntrack() {
+			opts[OptionConntrack] = "enabled"
+		}
+	}
+
+	e.checkEgressAccess(owner, (*labelsMap)[policy.ReservedIdentityHost], opts, OptionAllowToHost)
+	e.checkEgressAccess(owner, (*labelsMap)[policy.ReservedIdentityWorld], opts, OptionAllowToWorld)
+
 	if owner.EnableEndpointPolicyEnforcement(e) {
+		e.getLogger().Info("Policy enabled")
 		opts[OptionPolicy] = "enabled"
 	} else {
+		e.getLogger().Info("Policy disabled")
 		opts[OptionPolicy] = "disabled"
 	}
 
-	e.Consumable.Mutex.RUnlock()
-	repo.Mutex.RUnlock()
-
 	optsChanged := e.applyOptsLocked(opts)
+
+	if e.regenerateConsumable(owner, labelsMap, repo, c) {
+		policyChanged = true
+	}
 
 	// If we are in this function, then policy has been calculated.
 	if !e.PolicyCalculated {
@@ -403,39 +479,43 @@ func (e *Endpoint) regeneratePolicy(owner Owner) (bool, error) {
 		e.PolicyCalculated = true
 		// Always trigger a regenerate after the first policy
 		// calculation has been performed
-		policyChanged = true
+		optsChanged = true
+	}
+
+	if e.forcePolicyCompute {
+		optsChanged = true           // Options were changed by the caller.
+		e.forcePolicyCompute = false // Policies just computed
+		e.getLogger().Info("Forced rebuild")
+	}
+
+	e.nextPolicyRevision = revision
+
+	// If no policy or options change occurred for this endpoint then the endpoint is
+	// already running the latest revision, otherwise we have to wait for
+	// the regeneration of the endpoint to complete.
+	if !policyChanged && !optsChanged {
+		e.policyRevision = revision
+		e.updateLogger()
 	}
 
 	e.getLogger().WithFields(log.Fields{
-		"policyChanged": policyChanged,
-		"optsChanged":   optsChanged,
+		"policyChanged":       policyChanged,
+		"optsChanged":         optsChanged,
+		"policyRevision.next": e.nextPolicyRevision,
 	}).Debug("Done regenerating")
 
-	// If no policy change occurred for this endpoint then the endpoint is
-	// already running the latest revision, otherwise we have to wait for
-	// the regeneration of the endpoint to complete.
-	if !policyChanged {
-		e.policyRevision = revision
-	} else {
-		e.nextPolicyRevision = revision
-	}
-
-	return policyChanged || optsChanged, nil
+	// Return true if need to regenerate BPF
+	return optsChanged || policyChanged || e.nextPolicyRevision > e.policyRevision, nil
 }
 
-// Called with e.Mutex locked
+// Called with e.Mutex UNlocked
 func (e *Endpoint) regenerate(owner Owner) error {
 	e.BuildMutex.Lock()
 	defer e.BuildMutex.Unlock()
 
-	// If endpoint was marked as disconnected then
-	// it won't be regenerated
-	if e.IsDisconnecting() {
-		e.getLogger().Debug("Endpoint disconnected, skipping build")
-		return fmt.Errorf("endpoint disconnected, skipping build")
-	}
-
+	e.Mutex.RLock()
 	e.getLogger().Debug("Regenerating endpoint...")
+	e.Mutex.RUnlock()
 
 	origDir := filepath.Join(owner.GetStateDir(), e.StringID())
 
@@ -448,19 +528,6 @@ func (e *Endpoint) regenerate(owner Owner) error {
 	if err := os.MkdirAll(tmpDir, 0777); err != nil {
 		return fmt.Errorf("Failed to create endpoint directory: %s", err)
 	}
-
-	e.Mutex.Lock()
-
-	if e.Consumable != nil {
-		// Regenerate policy and apply any options resulting in the
-		// policy change.
-		if _, err := e.regeneratePolicy(owner); err != nil {
-			e.Mutex.Unlock()
-			return fmt.Errorf("Unable to regenerate policy for '%s': %s",
-				e.PolicyMap.String(), err)
-		}
-	}
-	e.Mutex.Unlock()
 
 	if err := e.regenerateBPF(owner, tmpDir); err != nil {
 		os.RemoveAll(tmpDir)
@@ -491,12 +558,20 @@ func (e *Endpoint) regenerate(owner Owner) error {
 
 	os.RemoveAll(backupDir)
 
+	// Set to Ready, but only if no other changes are pending.
+	// State will remain as waiting-to-regenerate if further
+	// changes are needed. There should be an another regenerate
+	// queued for taking care of it.
+	e.Mutex.Lock()
+	e.BuilderSetStateLocked(StateReady)
 	e.getLogger().Info("Regenerated program of endpoint")
+	e.Mutex.Unlock()
 
 	return nil
 }
 
 // Regenerate forces the regeneration of endpoint programs & policy
+// Should only be called with e.state == StateWaitingToRegenerate
 func (e *Endpoint) Regenerate(owner Owner) <-chan bool {
 	newReq := &Request{
 		ID:           uint64(e.ID),
@@ -509,12 +584,6 @@ func (e *Endpoint) Regenerate(owner Owner) <-chan bool {
 		buildSuccess := true
 
 		e.Mutex.Lock()
-		// If endpoint was marked as disconnected then it won't be
-		// regenerated
-		if !e.IsDisconnectingLocked() {
-			e.State = StateRegenerating
-		}
-
 		// This must be accessed in a locked section, so we grab it here.
 		scopedLog := e.getLogger()
 		e.Mutex.Unlock()
@@ -533,7 +602,6 @@ func (e *Endpoint) Regenerate(owner Owner) <-chan bool {
 				e.LogStatus(BPF, Failure, err.Error())
 			} else {
 				buildSuccess = true
-				e.SetState(StateReady)
 				e.LogStatusOK(BPF, "Successfully regenerated endpoint program")
 			}
 
@@ -554,26 +622,29 @@ func (e *Endpoint) Regenerate(owner Owner) <-chan bool {
 	return newReq.ExternalDone
 }
 
-// TriggerPolicyUpdates indicates that a policy change is likely to
+// TriggerPolicyUpdatesLocked indicates that a policy change is likely to
 // affect this endpoint. Will update all required endpoint configuration and
-// state to reflect new policy and regenerate programs if required.
+// state to reflect new policy.
 //
-// Returns true if policy was changed and endpoints needs to be rebuilt
-func (e *Endpoint) TriggerPolicyUpdates(owner Owner) (bool, error) {
-	e.Mutex.Lock()
-	defer e.Mutex.Unlock()
+// Returns true if policy was changed and the endpoint needs to be rebuilt
+func (e *Endpoint) TriggerPolicyUpdatesLocked(owner Owner, opts models.ConfigurationMap) (bool, error) {
 	if e.Consumable == nil {
 		return false, nil
 	}
 
-	changed, err := e.regeneratePolicy(owner)
+	changed, err := e.regeneratePolicy(owner, opts)
 	if err != nil {
-		return changed, fmt.Errorf("%s: %s", e.StringID(), err)
+		return false, fmt.Errorf("%s: %s", e.StringID(), err)
 	}
 
-	return changed, err
+	e.getLogger().Debugf("TriggerPolicyUpdatesLocked: changed: %d", changed)
+
+	return changed, nil
 }
 
+// SetIdentity resets endpoint's policy identity to 'id'.
+// Caller triggers policy regeneration if needed.
+// Called with e.Mutex Locked
 func (e *Endpoint) SetIdentity(owner Owner, id *policy.Identity) {
 	repo := owner.GetPolicyRepository()
 	cache := policy.GetConsumableCache()
@@ -583,6 +654,8 @@ func (e *Endpoint) SetIdentity(owner Owner, id *policy.Identity) {
 
 	if e.Consumable != nil {
 		if e.SecLabel != nil && id.ID == e.Consumable.ID {
+			// Even if the numeric identity is the same, the order in which the
+			// labels are represented may change.
 			e.SecLabel = id
 			e.Consumable.Mutex.Lock()
 			e.Consumable.Labels = id
@@ -590,14 +663,19 @@ func (e *Endpoint) SetIdentity(owner Owner, id *policy.Identity) {
 			e.Consumable.Mutex.Unlock()
 			return
 		}
+		// TODO: This removes the consumable from the cache even if other endpoints
+		// would still point to it. Consumable should be removed from the cache
+		// only when no endpoint refers to it. Fix by implementing explicit reference
+		// counting via the cache?
 		cache.Remove(e.Consumable)
 	}
 	e.SecLabel = id
 	e.LabelsHash = e.SecLabel.Labels.SHA256Sum()
 	e.Consumable = cache.GetOrCreate(id.ID, id)
 
-	if e.State == StateWaitingForIdentity {
-		e.State = StateReady
+	// Sets endpoint state to ready if was waiting for identity
+	if e.GetStateLocked() == StateWaitingForIdentity {
+		e.SetStateLocked(StateReady)
 	}
 
 	// Annotate pod that this endpoint represents with its security identity

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -234,7 +234,7 @@ func LookupLocked(id string) (*endpoint.Endpoint, error) {
 	}
 }
 
-// TriggerPolicyUpdates calls TriggerPolicyUpdates for each endpoint and
+// TriggerPolicyUpdates calls TriggerPolicyUpdatesLocked for each endpoint and
 // regenerates as required. During this process, the endpoint list is locked
 // and cannot be modified.
 // Returns a waiting group that can be used to know when all the endpoints are
@@ -248,15 +248,24 @@ func TriggerPolicyUpdates(owner endpoint.Owner) *sync.WaitGroup {
 
 	for k := range Endpoints {
 		go func(ep *endpoint.Endpoint, wg *sync.WaitGroup) {
-			policyChanges, err := ep.TriggerPolicyUpdates(owner)
+			ep.Mutex.Lock()
+			policyChanges, err := ep.TriggerPolicyUpdatesLocked(owner, nil)
+			if err == nil && policyChanges {
+				// Regenerate only if state transition succeeds
+				policyChanges = ep.SetStateLocked(endpoint.StateWaitingToRegenerate)
+			}
+			ep.Mutex.Unlock()
+
 			if err != nil {
 				log.WithError(err).Warn("Error while handling policy updates for endpoint")
 				ep.LogStatus(endpoint.Policy, endpoint.Failure, err.Error())
 			} else {
-				ep.LogStatusOK(endpoint.Policy, "Policy regenerated")
-			}
-			if policyChanges {
-				<-ep.Regenerate(owner)
+				if policyChanges {
+					<-ep.Regenerate(owner)
+					ep.LogStatusOK(endpoint.Policy, "Policy regenerated")
+				} else {
+					ep.LogStatusOK(endpoint.Policy, "Policy regeneration skipped")
+				}
 			}
 			wg.Done()
 		}(Endpoints[k], &wg)

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -120,7 +120,7 @@ func (s *K8sSuite) TestParseNetworkPolicy(c *C) {
 	c.Assert(result, comparator.DeepEquals, &policy.L4Policy{
 		Ingress: policy.L4PolicyMap{
 			"80/TCP": policy.L4Filter{
-				Port: 80, Protocol: api.ProtoTCP,
+				Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 				FromEndpoints:  []api.EndpointSelector{epSelector},
 				L7Parser:       "",
 				L7RedirectPort: 0, L7RulesPerEp: policy.L7DataMap{},

--- a/pkg/k8s/network_policy_v1beta_test.go
+++ b/pkg/k8s/network_policy_v1beta_test.go
@@ -108,7 +108,7 @@ func (s *K8sSuite) TestParseNetworkPolicyDeprecated(c *C) {
 	c.Assert(result, comparator.DeepEquals, &policy.L4Policy{
 		Ingress: policy.L4PolicyMap{
 			"80/TCP": policy.L4Filter{
-				Port: 80, Protocol: api.ProtoTCP,
+				Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 				FromEndpoints:  []api.EndpointSelector{epSelector},
 				L7Parser:       "",
 				L7RedirectPort: 0, L7RulesPerEp: policy.L7DataMap{},

--- a/pkg/logfields/logfields.go
+++ b/pkg/logfields/logfields.go
@@ -29,6 +29,9 @@ const (
 	// EndpointID is the numeric endpoint identifier
 	EndpointID = "endpointID"
 
+	// EndpointState is the current endpoint state
+	EndpointState = "endpointState"
+
 	// ContainerID is the container identifier
 	ContainerID = "containerID"
 

--- a/pkg/maps/cidrmap/cidrmap.go
+++ b/pkg/maps/cidrmap/cidrmap.go
@@ -37,20 +37,6 @@ type CIDRMap struct {
 	Prefixlen uint32
 }
 
-// DeepCopy duplicates CIDRMap 'cm', but both copies refer to the same map.
-func (cm *CIDRMap) DeepCopy() *CIDRMap {
-	if cm == nil {
-		return nil
-	}
-
-	return &CIDRMap{
-		path:      cm.path,
-		Fd:        cm.Fd,
-		AddrSize:  cm.AddrSize,
-		Prefixlen: cm.Prefixlen,
-	}
-}
-
 const (
 	MAX_KEYS           = 1024
 	LPM_MAP_VALUE_SIZE = 1

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -32,13 +32,6 @@ type PolicyMap struct {
 	Fd   int
 }
 
-func (pm *PolicyMap) DeepCopy() *PolicyMap {
-	return &PolicyMap{
-		path: pm.path,
-		Fd:   pm.Fd,
-	}
-}
-
 const (
 	MAX_KEYS = 1024
 )

--- a/pkg/policy/api/utils.go
+++ b/pkg/policy/api/utils.go
@@ -63,7 +63,7 @@ func (k *PortRuleKafka) Exists(rules L7Rules) bool {
 	return false
 }
 
-// Equal returns true if both HTTP rules are equal
+// Equal returns true if both rules are equal
 func (k *PortRuleKafka) Equal(o PortRuleKafka) bool {
 	return k.APIVersion == o.APIVersion && k.APIKey == o.APIKey && k.Topic == o.Topic
 }

--- a/pkg/policy/cache.go
+++ b/pkg/policy/cache.go
@@ -26,8 +26,7 @@ type ConsumableCache struct {
 	cacheMU lock.RWMutex // Protects the `cache` map
 	cache   map[NumericIdentity]*Consumable
 	// List of consumables representing the reserved identities
-	reserved  []*Consumable
-	iteration int
+	reserved []*Consumable
 }
 
 // GetConsumableCache returns the consumable cache. The cache is a list of all
@@ -39,9 +38,8 @@ func GetConsumableCache() *ConsumableCache {
 
 func newConsumableCache() *ConsumableCache {
 	return &ConsumableCache{
-		cache:     map[NumericIdentity]*Consumable{},
-		reserved:  make([]*Consumable, 0),
-		iteration: 1,
+		cache:    map[NumericIdentity]*Consumable{},
+		reserved: make([]*Consumable, 0),
 	}
 }
 
@@ -101,24 +99,6 @@ func (c *ConsumableCache) GetConsumables() map[NumericIdentity][]NumericIdentity
 	}
 	c.cacheMU.RUnlock()
 	return consumables
-}
-
-// GetIteration returns the current iteration of the ConsumableCache.
-func (c *ConsumableCache) GetIteration() int {
-	c.cacheMU.RLock()
-	defer c.cacheMU.RUnlock()
-	return c.iteration
-}
-
-// IncrementIteration increments by 1 the current iteration of the
-// ConsumableCache.
-func (c *ConsumableCache) IncrementIteration() {
-	c.cacheMU.Lock()
-	c.iteration++
-	if c.iteration == 0 {
-		c.iteration = 1
-	}
-	c.cacheMU.Unlock()
 }
 
 // ConsumablesInANotInB returns a map of consumables numeric identity mapped to

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -33,18 +33,6 @@ type Consumer struct {
 	Decision     api.Decision
 }
 
-func (c *Consumer) DeepCopy() *Consumer {
-	cpy := &Consumer{
-		ID:           c.ID,
-		DeletionMark: c.DeletionMark,
-		Decision:     c.Decision,
-	}
-	if c.Reverse != nil {
-		cpy.Reverse = c.Reverse.DeepCopy()
-	}
-	return cpy
-}
-
 func (c *Consumer) StringID() string {
 	return c.ID.String()
 }
@@ -105,37 +93,6 @@ func (c *Consumable) ResolveIdentityFromCache(id NumericIdentity) *Identity {
 		return cc.Labels
 	}
 	return nil
-}
-
-func (c *Consumable) DeepCopy() *Consumable {
-	c.Mutex.RLock()
-	cpy := &Consumable{
-		ID:           c.ID,
-		Iteration:    c.Iteration,
-		LabelArray:   make(labels.LabelArray, len(c.LabelArray)),
-		Maps:         make(map[int]*policymap.PolicyMap, len(c.Maps)),
-		Consumers:    make(map[string]*Consumer, len(c.Consumers)),
-		ReverseRules: make(map[NumericIdentity]*Consumer, len(c.ReverseRules)),
-		cache:        c.cache,
-	}
-	copy(cpy.LabelArray, c.LabelArray)
-	if c.Labels != nil {
-		cpy.Labels = c.Labels.DeepCopy()
-	}
-	if c.L4Policy != nil {
-		cpy.L4Policy = c.L4Policy.DeepCopy()
-	}
-	for k, v := range c.Maps {
-		cpy.Maps[k] = v.DeepCopy()
-	}
-	for k, v := range c.Consumers {
-		cpy.Consumers[k] = v.DeepCopy()
-	}
-	for k, v := range c.ReverseRules {
-		cpy.ReverseRules[k] = v.DeepCopy()
-	}
-	c.Mutex.RUnlock()
-	return cpy
 }
 
 func (c *Consumable) AddMap(m *policymap.PolicyMap) {

--- a/pkg/policy/identity.go
+++ b/pkg/policy/identity.go
@@ -128,18 +128,6 @@ func (id *Identity) GetModel() *models.Identity {
 	return ret
 }
 
-func (id *Identity) DeepCopy() *Identity {
-	cpy := &Identity{
-		ID:        id.ID,
-		Labels:    id.Labels.DeepCopy(),
-		Endpoints: make(map[string]time.Time, len(id.Endpoints)),
-	}
-	for k, v := range id.Endpoints {
-		cpy.Endpoints[k] = v
-	}
-	return cpy
-}
-
 func NewIdentity() *Identity {
 	return &Identity{
 		Endpoints: make(map[string]time.Time),

--- a/pkg/policy/l3.go
+++ b/pkg/policy/l3.go
@@ -32,11 +32,9 @@ import (
 // L3PolicyMap does no locking internally, so the user is responsible for synchronizing
 // between multiple threads when applicable.
 type L3PolicyMap struct {
-	Map         map[string]net.IPNet // Allowed L3 prefixes
-	IPv6Changed bool
-	IPv6Count   int // Count of IPv6 prefixes in 'Map'
-	IPv4Changed bool
-	IPv4Count   int // Count of IPv4 prefixes in 'Map'
+	Map       map[string]net.IPNet // Allowed L3 prefixes
+	IPv6Count int                  // Count of IPv6 prefixes in 'Map'
+	IPv4Count int                  // Count of IPv4 prefixes in 'Map'
 }
 
 // Insert places 'cidr' in to map 'm'. Returns `1` if `cidr` is added
@@ -69,10 +67,8 @@ func (m *L3PolicyMap) Insert(cidr string) int {
 		m.Map[key] = *ipnet
 		if ipnet.IP.To4() == nil {
 			m.IPv6Count++
-			m.IPv6Changed = true
 		} else {
 			m.IPv4Count++
-			m.IPv4Changed = true
 		}
 		return 1
 	}

--- a/pkg/policy/l3.go
+++ b/pkg/policy/l3.go
@@ -119,21 +119,6 @@ func (m *L3PolicyMap) PopulateBPF(cidrmap *cidrmap.CIDRMap) error {
 	return nil
 }
 
-// DeepCopy makes a duplicate of 'm'.
-func (m L3PolicyMap) DeepCopy() L3PolicyMap {
-	cpy := L3PolicyMap{
-		Map:         make(map[string]net.IPNet, len(m.Map)),
-		IPv6Changed: m.IPv6Changed,
-		IPv6Count:   m.IPv6Count,
-		IPv4Changed: m.IPv4Changed,
-		IPv4Count:   m.IPv4Count,
-	}
-	for k, v := range m.Map {
-		cpy.Map[k] = v
-	}
-	return cpy
-}
-
 // L3Policy contains L3 policy maps for ingress and egress.
 type L3Policy struct {
 	Ingress L3PolicyMap
@@ -145,14 +130,6 @@ func NewL3Policy() *L3Policy {
 	return &L3Policy{
 		Ingress: L3PolicyMap{Map: make(map[string]net.IPNet)},
 		Egress:  L3PolicyMap{Map: make(map[string]net.IPNet)},
-	}
-}
-
-// DeepCopy duplicates 'l3'.
-func (l3 *L3Policy) DeepCopy() *L3Policy {
-	return &L3Policy{
-		Ingress: l3.Ingress.DeepCopy(),
-		Egress:  l3.Egress.DeepCopy(),
 	}
 }
 

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -345,20 +345,3 @@ func (l4 *L4Policy) GetModel() *models.L4Policy {
 		Egress:  egress,
 	}
 }
-
-func (l4 *L4Policy) DeepCopy() *L4Policy {
-	cpy := &L4Policy{
-		Ingress: make(L4PolicyMap, len(l4.Ingress)),
-		Egress:  make(L4PolicyMap, len(l4.Egress)),
-	}
-
-	for k, v := range l4.Ingress {
-		cpy.Ingress[k] = v
-	}
-
-	for k, v := range l4.Egress {
-		cpy.Egress[k] = v
-	}
-
-	return cpy
-}

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -169,7 +169,7 @@ func CreateL4Filter(fromEndpoints []api.EndpointSelector, rule api.PortRule, por
 		l4.Ingress = true
 	}
 
-	if rule.Rules != nil {
+	if protocol == api.ProtoTCP && rule.Rules != nil {
 		switch {
 		case len(rule.Rules.HTTP) > 0:
 			l4.L7Parser = ParserTypeHTTP

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 var (
@@ -87,6 +88,8 @@ type L4Filter struct {
 	Port int `json:"port"`
 	// Protocol is the L4 protocol to allow or NONE
 	Protocol api.L4Proto `json:"protocol"`
+	// U8Proto is the Protocol in numeric format, or 0 for NONE
+	U8Proto u8proto.U8proto `json:"-"`
 	// FromEndpoints limit the source labels for allowing traffic. If
 	// FromEndpoints is empty, then it selects all endpoints.
 	FromEndpoints []api.EndpointSelector `json:"-"`
@@ -156,10 +159,13 @@ func CreateL4Filter(fromEndpoints []api.EndpointSelector, rule api.PortRule, por
 
 	// already validated via PortRule.Validate()
 	p, _ := strconv.ParseUint(port.Port, 0, 16)
+	// already validated via L4Proto.Validate()
+	u8p, _ := u8proto.ParseProtocol(string(protocol))
 
 	l4 := L4Filter{
 		Port:           int(p),
 		Protocol:       protocol,
+		U8Proto:        u8p,
 		L7RedirectPort: rule.RedirectPort,
 		L7RulesPerEp:   make(L7DataMap),
 		FromEndpoints:  fromEndpoints,

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -405,3 +405,10 @@ func (p *Repository) TranslateRules(translator Translator) error {
 	}
 	return nil
 }
+
+// BumpRevision allows forcing policy regeneration
+func (p *Repository) BumpRevision() {
+	p.Mutex.Lock()
+	defer p.Mutex.Unlock()
+	p.revision++
+}

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -316,7 +316,7 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 
 	expected := NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port: 80, Protocol: api.ProtoTCP,
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		FromEndpoints: selectorFromApp2DupList,
 		L7Parser:      "http",
 		L7RulesPerEp: L7DataMap{

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -543,21 +543,17 @@ func (ds *PolicyTestSuite) TestL3Policy(c *C) {
 	expected.Ingress.Map["10.0.1.0/24"] = net.IPNet{IP: []byte{10, 0, 1, 0}, Mask: []byte{255, 255, 255, 0}}
 	expected.Ingress.Map["192.168.2.0/24"] = net.IPNet{IP: []byte{192, 168, 2, 0}, Mask: []byte{255, 255, 255, 0}}
 	expected.Ingress.Map["10.0.3.1/32"] = net.IPNet{IP: []byte{10, 0, 3, 1}, Mask: []byte{255, 255, 255, 255}}
-	expected.Ingress.IPv4Changed = true
 	expected.Ingress.IPv4Count = 3
 	expected.Ingress.Map["2001:db8::/48"] = net.IPNet{IP: []byte{0x20, 1, 0xd, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, Mask: []byte{255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}
 	expected.Ingress.Map["2001:db9::/128"] = net.IPNet{IP: []byte{0x20, 1, 0xd, 0xb9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, Mask: []byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255}}
-	expected.Ingress.IPv6Changed = true
 	expected.Ingress.IPv6Count = 2
 	expected.Egress.Map["10.1.0.0/16"] = net.IPNet{IP: []byte{10, 1, 0, 0}, Mask: []byte{255, 255, 0, 0}}
 	expected.Egress.Map["10.128.0.0/9"] = net.IPNet{IP: []byte{10, 128, 0, 0}, Mask: []byte{255, 128, 0, 0}}
 	expected.Egress.Map["10.0.0.0/10"] = net.IPNet{IP: []byte{10, 0, 0, 0}, Mask: []byte{255, 192, 0, 0}}
 	expected.Egress.Map["10.64.0.0/11"] = net.IPNet{IP: []byte{10, 64, 0, 0}, Mask: []byte{255, 224, 0, 0}}
 	expected.Egress.Map["10.112.0.0/12"] = net.IPNet{IP: []byte{10, 112, 0, 0}, Mask: []byte{255, 240, 0, 0}}
-	expected.Egress.IPv4Changed = true
 	expected.Egress.IPv4Count = 5
 	expected.Egress.Map["2001:dbf::/64"] = net.IPNet{IP: []byte{0x20, 1, 0xd, 0xbf, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, Mask: []byte{255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0}}
-	expected.Egress.IPv6Changed = true
 	expected.Egress.IPv6Count = 1
 
 	toBar := &SearchContext{To: labels.ParseSelectLabelArray("bar")}

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -146,19 +146,19 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 
 	expected := NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port: 80, Protocol: api.ProtoTCP, FromEndpoints: nil,
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: nil,
 		L7Parser: "http", L7RulesPerEp: l7map, Ingress: true,
 	}
 	expected.Ingress["8080/TCP"] = L4Filter{
-		Port: 8080, Protocol: api.ProtoTCP, FromEndpoints: nil,
+		Port: 8080, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: nil,
 		L7Parser: "http", L7RulesPerEp: l7map, Ingress: true,
 	}
 	expected.Egress["3000/TCP"] = L4Filter{
-		Port: 3000, Protocol: api.ProtoTCP, Ingress: false,
+		Port: 3000, Protocol: api.ProtoTCP, U8Proto: 6, Ingress: false,
 		L7RulesPerEp: L7DataMap{},
 	}
 	expected.Egress["3000/UDP"] = L4Filter{
-		Port: 3000, Protocol: api.ProtoUDP, Ingress: false,
+		Port: 3000, Protocol: api.ProtoUDP, U8Proto: 17, Ingress: false,
 		L7RulesPerEp: L7DataMap{},
 	}
 
@@ -217,15 +217,15 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 
 	expected = NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port: 80, Protocol: api.ProtoTCP, FromEndpoints: nil,
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: nil,
 		L7Parser: "http", L7RulesPerEp: l7map, Ingress: true,
 	}
 	expected.Egress["3000/TCP"] = L4Filter{
-		Port: 3000, Protocol: api.ProtoTCP, Ingress: false,
+		Port: 3000, Protocol: api.ProtoTCP, U8Proto: 6, Ingress: false,
 		L7RulesPerEp: L7DataMap{},
 	}
 	expected.Egress["3000/UDP"] = L4Filter{
-		Port: 3000, Protocol: api.ProtoUDP, Ingress: false,
+		Port: 3000, Protocol: api.ProtoUDP, U8Proto: 17, Ingress: false,
 		L7RulesPerEp: L7DataMap{},
 	}
 
@@ -278,7 +278,7 @@ func (ds *PolicyTestSuite) TestMergeL4Policy(c *C) {
 	mergedES := []api.EndpointSelector{fooSelector, bazSelector}
 	expected := NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port: 80, Protocol: api.ProtoTCP, FromEndpoints: mergedES,
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: mergedES,
 		L7Parser: "", L7RulesPerEp: L7DataMap{}, Ingress: true,
 	}
 
@@ -348,7 +348,7 @@ func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
 
 	expected := NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port: 80, Protocol: api.ProtoTCP, FromEndpoints: nil,
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: nil,
 		L7Parser: "http", L7RulesPerEp: l7map, Ingress: true,
 	}
 
@@ -416,7 +416,7 @@ func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
 
 	expected = NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port: 80, Protocol: api.ProtoTCP, FromEndpoints: nil,
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: nil,
 		L7Parser: "kafka", L7RulesPerEp: l7map, Ingress: true,
 	}
 
@@ -493,7 +493,7 @@ func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
 	}
 	expected = NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port: 80, Protocol: api.ProtoTCP, FromEndpoints: nil,
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: nil,
 		L7Parser: "kafka", L7RulesPerEp: l7map, Ingress: true,
 	}
 

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -321,7 +321,7 @@ func (driver *driver) createEndpoint(w http.ResponseWriter, r *http.Request) {
 
 	endpoint := &models.EndpointChangeRequest{
 		ID:               int64(ip6.EndpointID()),
-		State:            models.EndpointStateDisconnected,
+		State:            models.EndpointStateCreating,
 		DockerEndpointID: create.EndpointID,
 		DockerNetworkID:  create.NetworkID,
 		Addressing: &models.EndpointAddressing{
@@ -396,8 +396,8 @@ func (driver *driver) joinEndpoint(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.WithField(logfields.Object, old).Debug("Existing endpoint")
-	if old.State != models.EndpointStateDisconnected {
-		sendError(w, "Error: endpoint not in disconnected state", http.StatusBadRequest)
+	if old.State != models.EndpointStateCreating {
+		sendError(w, "Error: endpoint not in creating state", http.StatusBadRequest)
 		return
 	}
 

--- a/tests/01-ct.sh
+++ b/tests/01-ct.sh
@@ -129,8 +129,6 @@ cat <<EOF | policy_import_and_wait -
 }]
 EOF
 
-wait_for_endpoints 6
-
 function connectivity_test() {
   local TIMEOUT="5"
   local DROP_TIMEOUT="2"

--- a/tests/08-nat46.sh
+++ b/tests/08-nat46.sh
@@ -74,19 +74,20 @@ EOF
 log "updating client endpoint configuration: NAT46=true"
 cilium endpoint config ${CLIENT_ID} NAT46=true
 
-function connectivity_test64() {
-  log "beginning connectivity_test64"
+function connectivity_test46() {
+  log "beginning connectivity_test46"
   # ICMPv4 echo request from client to server should succeed
   monitor_clear
-  log "pinging NAT64 address of client from host (should work)" 
+  log "pinging NAT46 address of server from client (should work)" 
   docker exec -i client ping6 -c 10 ::FFFF:$SERVER_IP4 || {
-    abort "Error: Could not ping nat64 address of client from host"
+    abort "Error: Could not ping nat46 address of server from client"
   }
-  log "finished connectivity_test64"
+  log "finished connectivity_test46"
 }
 
-connectivity_test64
+connectivity_test46
 log "deleting all policies from Cilium"
 cilium -D policy delete --all
 
 test_succeeded "${TEST_NAME}"
+

--- a/tests/10-proxy.sh
+++ b/tests/10-proxy.sh
@@ -33,6 +33,12 @@ SVC_IP4="2.2.2.2"
 cleanup
 logs_clear
 
+function no_service_init {
+  cilium service delete --all
+  SERVER_IP=$SERVER1_IP;
+  SERVER_IP4=$SERVER1_IP4;
+}
+
 function service_init {
   log "beginning service init"
   cilium service update --rev --frontend "$SVC_IP4:80" --id 2233 \
@@ -284,15 +290,19 @@ function proxy_test {
   log "finished proxy test"
 }
 
-for service in "none" "lb"; do
-  for policy in "egress" "ingress" "egress_and_ingress" "many_egress" "many_ingress"; do
-    for state in "false" "true"; do
-      log "+----------------------------------------------------------------------+"
-      log "Testing with Policy=$policy, Conntrack=$state, Service=$service"
-      cilium config ConntrackLocal=$state
-      wait_for_cilium_ep_gen
-      proxy_init
+proxy_init
+for state in "false" "true"; do
+  cilium config ConntrackLocal=$state
 
+  for service in "none" "lb"; do
+    case $service in
+      "none")
+        no_service_init;;
+      "lb")
+        service_init;;
+    esac
+
+    for policy in "egress" "ingress" "egress_and_ingress" "many_egress" "many_ingress"; do
       case $policy in
         "many_egress")
           policy_many_egress;;
@@ -306,26 +316,22 @@ for service in "none" "lb"; do
           policy_egress_and_ingress;;
       esac
 
-
-      case $service in
-        "none")
-          ;;
-        "lb")
-          service_init;;
-      esac
+      log "+----------------------------------------------------------------------+"
+      log "Testing with Policy=$policy, Service=$service, Conntrack=$state"
+      log "+----------------------------------------------------------------------+"
 
       wait_for_cilium_ep_gen
-      cilium endpoint list
+
       proxy_test
-      log "deleting all services from Cilium"
-      cilium service delete --all
-      log "deleting all policies from Cilium"
-      cilium policy delete --all 2> /dev/null || true
-      log "removing containers"
-      docker rm -f server1 server2 client 2> /dev/null || true
-      wait_for_cilium_ep_gen
     done
   done
 done
+
+log "deleting all services from Cilium"
+cilium service delete --all
+log "deleting all policies from Cilium"
+cilium policy delete --all 2> /dev/null || true
+log "removing containers"
+docker rm -f server1 server2 client 2> /dev/null || true
 
 test_succeeded "${TEST_NAME}"

--- a/tests/11-getting-started.sh
+++ b/tests/11-getting-started.sh
@@ -64,8 +64,6 @@ cat <<EOF | policy_import_and_wait -
 }]
 EOF
 
-wait_for_endpoints 1
-
 monitor_clear
 log "pinging service1 from service3"
 docker run --rm -i --net ${TEST_NET} -l "id.service3" --cap-add NET_ADMIN ${DEMO_CONTAINER} ping -c 10 ${HTTPD_CONTAINER_NAME} && {
@@ -118,8 +116,6 @@ cat <<EOF | policy_import_and_wait -
     }]
 }]
 EOF
-
-wait_for_cilium_ep_gen
 
 monitor_clear
 log "performing HTTP GET on ${HTTPD_CONTAINER_NAME}/public from service2 (expected: 200)"

--- a/tests/14-policy-enforcement-docker.sh
+++ b/tests/14-policy-enforcement-docker.sh
@@ -180,14 +180,12 @@ check_endpoints_policy_enabled ${NUM_ENDPOINTS}
 # Policy enforcement should be 'true' for all endpoints.
 log " Test 10: always mode: check that each endpoint has policy enforcement enabled after policy is removed  "
 policy_delete_and_wait "--all"
-wait_for_endpoints ${NUM_ENDPOINTS}
 check_endpoints_policy_enabled ${NUM_ENDPOINTS}
 
 # Test 11: always mode, import policy.
 # All endpoints should have policy enforcement enabled.
 log " Test 11: always mode: check that each endpoint has policy enforcement enabled after policy is imported "
 import_sample_policy
-wait_for_endpoints ${NUM_ENDPOINTS}
 check_endpoints_policy_enabled ${NUM_ENDPOINTS}
 
 # Test 12: always --> never mode, policy imported.
@@ -201,7 +199,6 @@ check_endpoints_policy_disabled ${NUM_ENDPOINTS}
 # All endpoints should have policy enforcement disabled.
 log " Test 13: never mode: check that each endpoint has policy disabled when policy is deleted "
 policy_delete_and_wait "--all"
-wait_for_endpoints ${NUM_ENDPOINTS}
 check_endpoints_policy_disabled ${NUM_ENDPOINTS}
 
 # Test 14: never --> always, no policy imported.

--- a/tests/16-cidr-ingress-policy.sh
+++ b/tests/16-cidr-ingress-policy.sh
@@ -23,7 +23,7 @@ IPV4_OTHERNET=99.11.0.0/16
 IPV6_HOST=fdff::ff
 
 TIMEOUT="14"
-DROP_TIMEOUT="10"
+DROP_TIMEOUT="14"
 
 log "IPV4HOST: ${IPV4_HOST}"
 log "IPV4_OTHERHOST: ${IPV4_OTHERHOST}"
@@ -70,7 +70,7 @@ log "IPV4_PREFIX: ${IPV4_PREFIX}"
 log "IPV4_PREFIX_EXCEPT: ${IPV4_PREFIX_EXCEPT}"
 
 function test_cidr_except {
-  policy_delete_and_wait "--all"
+  cilium policy delete --all
   cat <<EOF | policy_import_and_wait -
 [{
     "endpointSelector": {"matchLabels":{"${ID_SERVICE1}":""}},
@@ -95,7 +95,7 @@ EOF
   log "output of cilium endpoint list -o json"
   cilium endpoint list -o json | python -m json.tool
 
-  policy_delete_and_wait "--all"
+  cilium policy delete --all
 }
 
 cilium config PolicyEnforcement=always
@@ -106,7 +106,6 @@ log "running: ip addr add dev lo ${IPV6_HOST}/128"
 ip addr add dev lo ${IPV6_HOST}/128
 
 policy_delete_and_wait "--all"
-wait_for_cilium_ep_gen
 
 log "listing all endpoints"
 cilium endpoint list
@@ -121,7 +120,7 @@ docker run --rm -i --net ${TEST_NET} -l "${ID_SERVICE2}" --cap-add NET_ADMIN ${D
 set -e
 
 log "importing L3 CIDR policy for IPv4 egress"
-policy_delete_and_wait "--all"
+cilium policy delete --all
 cat <<EOF | policy_import_and_wait -
 [{
     "endpointSelector": {"matchLabels":{"${ID_SERVICE2}":""}},
@@ -153,7 +152,6 @@ docker run --rm -i --net ${TEST_NET} -l "${ID_SERVICE2}" --cap-add NET_ADMIN ${D
 set -e
 
 log "importing L3 CIDR policy for IPv6 egress"
-policy_delete_and_wait "--all"
 cat <<EOF | policy_import_and_wait -
 [{
     "endpointSelector": {"matchLabels":{"${ID_SERVICE2}":""}},
@@ -173,7 +171,7 @@ docker run --rm -i --net ${TEST_NET} -l "${ID_SERVICE2}" --cap-add NET_ADMIN ${D
 }
 
 log "importing policy"
-policy_delete_and_wait "--all"
+cilium policy delete --all
 cat <<EOF | policy_import_and_wait -
 [{
     "endpointSelector": {"matchLabels":{"${ID_SERVICE1}":""}},
@@ -216,7 +214,7 @@ set -e
 log "creating cidr_aware_policy.json with matching prefixes"
 echo "IPv6 prefix: $IPV6_PREFIX"
 echo "IPv4 prefix: $IPV4_PREFIX"
-policy_delete_and_wait "--all"
+cilium policy delete --all
 cat <<EOF | policy_import_and_wait -
 [{
     "endpointSelector": {"matchLabels":{"${ID_SERVICE1}":""}},
@@ -247,7 +245,7 @@ docker run --rm -i --net ${TEST_NET} -l "${ID_SERVICE3}" --cap-add NET_ADMIN ${D
 }
 
 log "creating cidr_aware_policy.json with non-matching prefix"
-policy_delete_and_wait "--all"
+cilium policy delete --all
 cat <<EOF | policy_import_and_wait -
 [{
     "endpointSelector": {"matchLabels":{"${ID_SERVICE1}":""}},
@@ -278,8 +276,6 @@ docker run --rm -i --net ${TEST_NET} -l "${ID_SERVICE3}" --cap-add NET_ADMIN ${D
   abort "Error: Unexpected success pinging ${HTTPD_CONTAINER_NAME} from service3"
 }
 set -e
-
-policy_delete_and_wait "--all"
 
 test_cidr_except
 

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -296,10 +296,10 @@ function wait_for_cilium_ep_gen {
     log "mode is K8s"
     NAMESPACE=$2
     POD=$3
-    CMD="kubectl exec -n ${NAMESPACE} ${POD} -- cilium endpoint list | grep -c regenerating"
+    CMD="kubectl exec -n ${NAMESPACE} ${POD} -- cilium endpoint list | grep -c regenerat"
     INFO_CMD="kubectl exec -n ${NAMESPACE} ${POD} -- cilium endpoint list"
   else
-    CMD="cilium endpoint list | grep -c regenerating"
+    CMD="cilium endpoint list | grep -c regenerat"
     INFO_CMD="cilium endpoint list"
   fi
 

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -133,6 +133,13 @@ function abort {
   echo ""
   echo "------------------------------------------------------------------------"
 
+  if [ ! -z "$DEBUG" ]; then
+    cilium status
+    cilium endpoint list
+    cilium policy get
+    read -n 1 -p "Press any key to continue..."
+  fi
+
   monitor_dump
   monitor_stop
 

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -307,49 +307,31 @@ function wait_for_cilium_ep_gen {
   local MAX_MINS="2"
   local ERROR_OUTPUT="Timeout while waiting for endpoints to regenerate"
  
-  # Track the amount of times the command has succeeded in a row. 
-  local check_cmd_iter=0 
-  # Need to have a timeout that tracks total number of iterations so tests can exit.
-  local total_cmd_iter=0
   local sleep_time=1
  
-  while [[ "$check_cmd_iter" -lt "10" ]]; do    
-    if [[ "$total_cmd_iter" -gt $((${MAX_MINS}*60/$sleep_time)) ]]; then
+  local iter=0
+  local found
+  found=$(eval "$CMD")
+
+  while [[ "$found" -ne "$NUM_DESIRED" ]]; do
+    log "$found endpoints are still regenerating; want $NUM_DESIRED"
+    if [[ $((iter++)) -gt $((${MAX_MINS}*60/$sleep_time)) ]]; then
       echo ""
-      log "$ERROR_OUTPUT"
+      log "${ERROR_OUTPUT}"
       exit 1
+    else
+      overwrite $iter '
+        log "still within time limit for waiting for endpoints to be in 'ready' state; sleeping and checking again"
+        log "output of ${INFO_CMD}"
+        eval "$INFO_CMD"
+        echo -n " [$found/$NUM_DESIRED]"
+        log "sleeping for $sleep_time"
+      '
+      sleep $sleep_time
     fi
-
-    local iter=0
-    local found
-    found=$(eval "$CMD")
-
-    while [[ "$found" -ne "$NUM_DESIRED" ]]; do
-      log "$found endpoints are still regenerating; want $NUM_DESIRED"
-      if [[ $((iter++)) -gt $((${MAX_MINS}*60/$sleep_time)) ]]; then
-        echo ""
-        log "${ERROR_OUTPUT}"
-        exit 1
-      else
-        overwrite $total_cmd_iter '
-          log "still within time limit for waiting for endpoints to be in 'ready' state; sleeping and checking again"
-          log "output of ${INFO_CMD}"
-          eval "$INFO_CMD"
-          echo -n " [$found/$NUM_DESIRED]"
-          # If command fails and iter is non-zero, reset iter back to zero.
-          log "setting command counter to zero"
-          log "sleeping for $sleep_time"
-        '
-        check_cmd_iter=0; \
-        sleep $sleep_time
-      fi
-      log "evaluating $CMD"
-      found=$(eval "${CMD}")
-      log "found: $found"
-    done
-    check_cmd_iter=$(expr $check_cmd_iter + 1)
-    total_cmd_iter=$(expr $total_cmd_iter + 1)
-    sleep .25
+    log "evaluating $CMD"
+    found=$(eval "${CMD}")
+    log "found: $found"
   done
   set -e 
   restore_flag $save "e"


### PR DESCRIPTION
Restructure policy regeneration code to keep track if the policy actually changed or not and also restructure the proxy test to reuse the same containers throughout all 20 test variations.

Together these changes reduce the 10-proxy.sh runtime on a 6-CPU/8GB Linux 4.13 VM from 20 to 4.3 minutes.
