### PR TITLE
pkg/k8s: add client InClusterConfig option

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -73,6 +73,12 @@ const (
 
 // CreateConfig creates a rest.Config for a given endpoint using a kubeconfig file.
 func createConfig(endpoint, kubeCfgPath string) (*rest.Config, error) {
+	// If the endpoint and the kubeCfgPath are empty then we can try getting
+	// the rest.Config from the InClusterConfig
+	if endpoint == "" && kubeCfgPath == "" {
+		return rest.InClusterConfig()
+	}
+
 	if kubeCfgPath != "" {
 		return clientcmd.BuildConfigFromFlags("", kubeCfgPath)
 	}

--- a/pkg/k8s/config.go
+++ b/pkg/k8s/config.go
@@ -16,6 +16,7 @@
 package k8s
 
 import (
+	"os"
 	"strings"
 )
 
@@ -49,12 +50,17 @@ func Configure(apiServer, kubeconfigPath string) {
 	config.APIServer = apiServer
 	config.KubeconfigPath = kubeconfigPath
 
-	if IsEnabled() && !strings.HasPrefix(apiServer, "http") {
+	if IsEnabled() &&
+		config.APIServer != "" &&
+		!strings.HasPrefix(apiServer, "http") {
 		config.APIServer = "http://" + apiServer
 	}
 }
 
 // IsEnabled checks if Cilium is being used in tandem with Kubernetes.
 func IsEnabled() bool {
-	return config.APIServer != "" || config.KubeconfigPath != ""
+	return config.APIServer != "" ||
+		config.KubeconfigPath != "" ||
+		(os.Getenv("KUBERNETES_SERVICE_HOST") != "" &&
+			os.Getenv("KUBERNETES_SERVICE_PORT") != "")
 }


### PR DESCRIPTION
With InClusterConfig users will not need to specify kubeconfig nor mount
a volume in cilium daemonset to export k8s certificate authority file. The InClusterConfig will be
used by default if the user does not specify k8s-api-server IP nor
kubeconfig filepath.

Signed-off-by: André Martins <andre@cilium.io>