### PR TITLE
vendor.conf: remove unused entry github/opencontainers/runc

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -56,7 +56,6 @@ github.com/mattn/go-shellwords 9858af9cca4c73576f0b8c6609a396eb0878023c
 github.com/mitchellh/hashstructure 2bca23e0e452137f789efbc8610126fd8b94f73b
 github.com/mitchellh/mapstructure bfdb1a85537d60bc7e954e600c250219ea497417
 github.com/op/go-logging 0882c9abce533ab4afbab5677fcef7434dd36d5a
-github.com/opencontainers/runc 4f601205d475e1995472d81b3787b197008c5dd7
 github.com/pborman/uuid 14801136da1260ea57627a3af55873f59f9ee1ea
 github.com/pelletier/go-buffruneio df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d
 github.com/pelletier/go-toml 22139eb5469018e7374b3e7ef653de37ffb44f72


### PR DESCRIPTION
This fixes the following warning when running vndr:

WARNING: package github.com/opencontainers/runc is unused, consider removing it from vendor.conf

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>