### PR TITLE
containerd watcher resyncs on missed events better

### DIFF
--- a/pkg/workloads/containerd/watcher.go
+++ b/pkg/workloads/containerd/watcher.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/cilium/cilium/common/addressing"
@@ -31,7 +30,6 @@ import (
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/nodeaddress"
 	"github.com/cilium/cilium/pkg/workloads"
@@ -53,36 +51,6 @@ const (
 	eventQueueBufferSize = 100
 )
 
-// containerEvents holds per-container queues for events
-type containerEvents struct {
-	lock.Mutex
-	events map[string]chan dTypesEvents.Message
-}
-
-func (ce *containerEvents) enqueueByContainerID(e dTypesEvents.Message) {
-	ce.Lock()
-	defer ce.Unlock()
-
-	if _, found := ce.events[e.Actor.ID]; !found {
-		q := make(chan dTypesEvents.Message, eventQueueBufferSize)
-		ce.events[e.Actor.ID] = q
-		go processContainerEvents(e.Actor.ID, q)
-	}
-	ce.events[e.Actor.ID] <- e
-}
-
-func (ce *containerEvents) reapEmpty() {
-	ce.Lock()
-	defer ce.Unlock()
-
-	for id, q := range ce.events {
-		if len(q) == 0 {
-			close(q)
-			delete(ce.events, id)
-		}
-	}
-}
-
 func shortContainerID(id string) string {
 	return id[:10]
 }
@@ -90,9 +58,9 @@ func shortContainerID(id string) string {
 // EnableEventListener watches for docker events. Performs the plumbing for the
 // containers started or dead.
 func EnableEventListener() error {
-	eventQueue := containerEvents{events: make(map[string]chan dTypesEvents.Message)}
 	since := time.Now()
-	syncWithRuntime()
+	ws := newWatcherState(eventQueueBufferSize)
+	ws.syncWithRuntime()
 
 	eo := dTypes.EventsOptions{Since: strconv.FormatInt(since.Unix(), 10)}
 	r, err := dockerClient.Events(ctx.Background(), eo)
@@ -100,59 +68,26 @@ func EnableEventListener() error {
 		return err
 	}
 
-	go listenForDockerEvents(&eventQueue, r)
+	go listenForDockerEvents(ws, r)
 
 	// start a go routine which periodically synchronizes containers
 	// managed by the local container runtime and checks if any of them
 	// need to be managed by Cilium. This is a fall back mechanism in case
 	// an event notification has been lost.
-	go func() {
+	go func(state *watcherState) {
 		for {
 			time.Sleep(syncRateDocker)
-			syncWithRuntime()
 
-			log.Debug("Reaping empty event queues")
-			eventQueue.reapEmpty()
+			state.reapEmpty()
+			state.syncWithRuntime()
 		}
-	}()
+	}(ws)
 
 	log.Debugf("Started to listen for containerd events")
-
 	return nil
 }
 
-// syncWithRuntime is used by the daemon to synchronize changes between Docker and
-// Cilium. This includes identities, labels, etc.
-func syncWithRuntime() {
-	var wg sync.WaitGroup
-
-	// FIXME GH-1662: Must be synchronize with event handler
-
-	cList, err := dockerClient.ContainerList(ctx.Background(), dTypes.ContainerListOptions{All: false})
-	if err != nil {
-		log.Errorf("Failed to retrieve the container list %s", err)
-	}
-	for _, cont := range cList {
-		if ignoredContainer(cont.ID) {
-			continue
-		}
-
-		wg.Add(1)
-		go func(wg *sync.WaitGroup, id string) {
-			log.WithFields(log.Fields{
-				logfields.ContainerID: shortContainerID(id),
-			}).Debug("Periodic synchronization of container")
-
-			handleCreateContainer(id, false)
-			wg.Done()
-		}(&wg, cont.ID)
-	}
-
-	// Wait for all spawned go routines handling container creations to exit
-	wg.Wait()
-}
-
-func listenForDockerEvents(eventQueue *containerEvents, reader io.ReadCloser) {
+func listenForDockerEvents(ws *watcherState, reader io.ReadCloser) {
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		var e dTypesEvents.Message
@@ -165,7 +100,7 @@ func listenForDockerEvents(eventQueue *containerEvents, reader io.ReadCloser) {
 				"event":               e.Status,
 				logfields.ContainerID: shortContainerID(e.ID),
 			}).Debug("Queueing container event")
-			eventQueue.enqueueByContainerID(e)
+			ws.enqueueByContainerID(e.ID, &e)
 		}
 	}
 
@@ -174,7 +109,7 @@ func listenForDockerEvents(eventQueue *containerEvents, reader io.ReadCloser) {
 	}
 }
 
-func processContainerEvents(containerID string, events chan dTypesEvents.Message) {
+func processContainerEvents(events chan dTypesEvents.Message) {
 	for m := range events {
 		if m.ID != "" {
 			log.WithFields(log.Fields{

--- a/pkg/workloads/containerd/watcher_state.go
+++ b/pkg/workloads/containerd/watcher_state.go
@@ -1,0 +1,123 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containerd
+
+import (
+	"sync"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logfields"
+
+	dTypes "github.com/docker/engine-api/types"
+	dTypesEvents "github.com/docker/engine-api/types/events"
+	log "github.com/sirupsen/logrus"
+	ctx "golang.org/x/net/context"
+)
+
+// watcherState holds global close flag, per-container queues for events and
+// ignore toggles
+type watcherState struct {
+	lock.Mutex
+
+	eventQueueBufferSize int
+	events               map[string]chan dTypesEvents.Message
+}
+
+func newWatcherState(eventQueueBufferSize int) *watcherState {
+	return &watcherState{
+		eventQueueBufferSize: eventQueueBufferSize,
+		events:               make(map[string]chan dTypesEvents.Message),
+	}
+}
+
+// enqueueByContainerID starts a handler for this container, if needed, and
+// enqueues a copy of the event if it is non-nil. Passing in a nil event will
+// only start the handler. These handlers can be reaped via
+// watcherState.reapEmpty.
+// This parallelism is desirable to respond to events faster; each event might
+// require talking to an outside daemon (docker) and a single noisy container
+// might starve others.
+func (ws *watcherState) enqueueByContainerID(containerID string, e *dTypesEvents.Message) {
+	ws.Lock()
+	defer ws.Unlock()
+
+	if _, found := ws.events[containerID]; !found {
+		q := make(chan dTypesEvents.Message, eventQueueBufferSize)
+		ws.events[containerID] = q
+		go processContainerEvents(q)
+	}
+
+	if e != nil {
+		ws.events[containerID] <- *e
+	}
+}
+
+// handlingContainerID returns whether there is a goroutine already consuming
+// events for this id
+func (ws *watcherState) handlingContainerID(id string) bool {
+	ws.Lock()
+	defer ws.Unlock()
+
+	_, handled := ws.events[id]
+	return handled
+}
+
+// reapEmpty deletes empty queues from the map. This also causes the handler
+// goroutines to exit. It is expected to be called periodically to avoid the
+// map growing over time.
+func (ws *watcherState) reapEmpty() {
+	ws.Lock()
+	defer ws.Unlock()
+
+	for id, q := range ws.events {
+		if len(q) == 0 {
+			close(q)
+			delete(ws.events, id)
+		}
+	}
+}
+
+// syncWithRuntime is used by the daemon to synchronize changes between Docker and
+// Cilium. This includes identities, labels, etc.
+func (ws *watcherState) syncWithRuntime() {
+	var wg sync.WaitGroup
+
+	cList, err := dockerClient.ContainerList(ctx.Background(), dTypes.ContainerListOptions{All: false})
+	if err != nil {
+		log.Errorf("Failed to retrieve the container list %s", err)
+		return
+	}
+	for _, cont := range cList {
+		if ignoredContainer(cont.ID) {
+			continue
+		}
+
+		if alreadyHandled := ws.handlingContainerID(cont.ID); !alreadyHandled {
+			log.WithFields(log.Fields{
+				logfields.ContainerID: shortContainerID(cont.ID),
+			}).Debug("Found unwatched container")
+
+			wg.Add(1)
+			go func(wg *sync.WaitGroup, id string) {
+				defer wg.Done()
+				ws.enqueueByContainerID(id, nil) // ensure a handler is running for future events
+				handleCreateContainer(id, false)
+			}(&wg, cont.ID)
+		}
+	}
+
+	// Wait for all spawned go routines handling container creations to exit
+	wg.Wait()
+}


### PR DESCRIPTION
Resync the whole state and restart listening for events at the resync timestamp.

If we have missed events for a container, in particular the create event, we are potentially out of sync. We now detect this and trigger a state rebuild with attached handlers and event listeners. We rely on the ignore map to represent containers we have seen (and want to ignore). Containers are in the ignore map unless we have not seen them, or are handling their start event.

A few notes that are worth mentioning for review:
1- We still have a race between syncWithRuntime and the ignore map in the case where are handling a `start` event (the container is removed from the ignore map during `handleCreateEvent`). This shouldn't matter since we end up with the new, correct, state anyway.
2- We rely on how we use the ignore map pretty heavily
3- Should we remove a container from the ignore map on a `die` event? I didn't do it since we ignore running containers on daemon start in order to reserve IPs for them. It seemed better to not change the current behaviour with ignore, and have it continue to reflect that ignored set of containers.
4- I began adding a test for this but the mock setup was becoming bigger than the changes I've made, and I'm not sure whether I can test more than "can we detect we are out of sync"