### PR TITLE
tests: dump gops output during runtime tests

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,7 @@ sudo pip install sphinx sphinxcontrib-httpdomain sphinxcontrib-openapi
 echo 'cd ~/go/src/github.com/cilium/cilium' >> /home/vagrant/.bashrc
 export GOPATH=/home/vagrant/go
 sudo -E /usr/local/go/bin/go get github.com/jteeuwen/go-bindata/...
+sudo -E /usr/local/go/bin/go get -u github.com/google/gops
 chown -R vagrant:vagrant $GOPATH
 curl -SsL https://github.com/cilium/bpf-map/releases/download/v1.0/bpf-map -o bpf-map
 chmod +x bpf-map


### PR DESCRIPTION
After each runtime test is ran, dump the output of the following commands to
the test's logs directory in a new directory, "profiling" for the cilium-agent:
    
* `gops stack`
* `gops memstats`
* `gops stats`

Also installs `gops` into the runtime test Vagrant image in the Vagrantfile.

Signed-off by: Ian Vernon <ian@cilium.io>

Partially address #1637 .