### PR TITLE
common: deadlock detection during runtime tests

### DIFF
--- a/common/build.sh
+++ b/common/build.sh
@@ -9,4 +9,6 @@ popd > /dev/null
 cd "$P"
 go install ./... 2> /dev/null || true
 make clean
-make
+
+# Compile with deadlock detection during runtime tests. See GH-1654.
+LOCKDEBUG=1 make


### PR DESCRIPTION
Compile cilium with deadlock detection enabled during runtime tests to catch
deadlocks.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #1654 