### PR TITLE
tests: Disable flaky CIDR limit test until fixed

### DIFF
--- a/tests/20-cidr-limit.sh
+++ b/tests/20-cidr-limit.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# GH-1686 Re-enable when fixed
+exit 0
+
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "${dir}/helpers.bash"
 # dir might have been overwritten by helpers.bash


### PR DESCRIPTION
Signed-off-by: Thomas Graf <thomas@cilium.io>