### PR TITLE
policy/l4: Fix merging of L7 rules

### DIFF
--- a/Documentation/gettingstarted.rst
+++ b/Documentation/gettingstarted.rst
@@ -515,7 +515,7 @@ and ``cilium`` CLI:
                 "ports": [
                   {
                     "port": "80",
-                    "protocol": "tcp"
+                    "protocol": "TCP"
                   }
                 ]
               }
@@ -712,7 +712,7 @@ We can achieve that with the following Cilium policy:
                 {"matchLabels":{"id":"app2"}}
             ],
             "toPorts": [{
-                    "ports": [{"port": "80", "protocol": "tcp"}]
+                    "ports": [{"port": "80", "protocol": "TCP"}]
             }]
         }]
     }]
@@ -813,7 +813,7 @@ The following Cilium policy file achieves this goal:
                 {"matchLabels":{"id":"app2"}}
             ],
             "toPorts": [{
-                "ports": [{"port": "80", "protocol": "tcp"}],
+                "ports": [{"port": "80", "protocol": "TCP"}],
                 "rules": {
                     "HTTP": [{
                         "method": "GET",
@@ -1090,7 +1090,7 @@ Apply an L3/L4 policy only allowing the *goodclient* to access the *web-server*.
                 {"matchLabels":{"id":"goodclient"}}
             ],
             "toPorts": [{
-                    "ports": [{"port": "8181", "protocol": "tcp"}]
+                    "ports": [{"port": "8181", "protocol": "TCP"}]
             }]
         }]
     }]
@@ -1164,7 +1164,7 @@ Now, apply an L7 Policy that only allows access for the *goodclient* to the */pu
                 {"matchLabels":{"id":"goodclient"}}
             ],
             "toPorts": [{
-                "ports": [{"port": "8181", "protocol": "tcp"}],
+                "ports": [{"port": "8181", "protocol": "TCP"}],
                 "rules": {
                     "HTTP": [{
                         "method": "GET",

--- a/Documentation/policy.rst
+++ b/Documentation/policy.rst
@@ -387,7 +387,7 @@ The ``toPorts`` field takes a ``PortProtocol`` structure which is defined as fol
                 Port string `json:"port"`
 
                 // Protocol is the L4 protocol. If omitted or empty, any protocol
-                // matches. Accepted values: "tcp", "udp", ""/"any"
+                // matches. Accepted values: "TCP", "UDP", ""/"ANY"
                 //
                 // Matching on ICMP is not supported.
                 //
@@ -408,7 +408,7 @@ only be able to emit packets using TCP on port 80::
             "endpointSelector": {"matchLabels":{"app":"myService"}},
             "egress": [{
                 "toPorts": [
-                    {"port": "80", "protocol": "tcp"}
+                    {"port": "80", "protocol": "TCP"}
                 ]
             }]
         }
@@ -427,7 +427,7 @@ communicate using using TCP on port 80::
                   {"matchLabels":{"role":"frontend"}}
                 ],
                 "toPorts": [
-                    {"port": "80", "protocol": "tcp"}
+                    {"port": "80", "protocol": "TCP"}
                 ]
             }]
         }
@@ -449,7 +449,7 @@ endpoint that is communicating over TCP on port 80::
                 ]
               }, {
                 "toPorts": [
-                    {"port": "80", "protocol": "tcp"}
+                    {"port": "80", "protocol": "TCP"}
                 ]
             }]
         }
@@ -564,7 +564,7 @@ While communicating on this port, the only API endpoints allowed will be ``GET
             "ingress": [{
                 "toPorts": [{
                     "ports": [
-                        {"port": "80", "protocol": "tcp"}
+                        {"port": "80", "protocol": "TCP"}
                     ],
                     "rules": {
                         "HTTP": [

--- a/api/v1/models/port.go
+++ b/api/v1/models/port.go
@@ -50,7 +50,7 @@ var portTypeProtocolPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["tcp","udp","any"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["TCP","UDP","ANY"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -59,12 +59,12 @@ func init() {
 }
 
 const (
-	// PortProtocolTCP captures enum value "tcp"
-	PortProtocolTCP string = "tcp"
-	// PortProtocolUDP captures enum value "udp"
-	PortProtocolUDP string = "udp"
-	// PortProtocolAny captures enum value "any"
-	PortProtocolAny string = "any"
+	// PortProtocolTCP captures enum value "TCP"
+	PortProtocolTCP string = "TCP"
+	// PortProtocolUDP captures enum value "UDP"
+	PortProtocolUDP string = "UDP"
+	// PortProtocolANY captures enum value "ANY"
+	PortProtocolANY string = "ANY"
 )
 
 // prop value enum

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1126,9 +1126,9 @@ definitions:
         description: Layer 4 protocol
         type: string
         enum:
-          - tcp
-          - udp
-          - any
+          - TCP
+          - UDP
+          - ANY
       port:
         description: Layer 4 port number
         type: integer

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1494,9 +1494,9 @@ func init() {
           "description": "Layer 4 protocol",
           "type": "string",
           "enum": [
-            "tcp",
-            "udp",
-            "any"
+            "TCP",
+            "UDP",
+            "ANY"
           ]
         }
       }

--- a/cilium/cmd/policy_import.go
+++ b/cilium/cmd/policy_import.go
@@ -44,7 +44,7 @@ var policyImportCmd = &cobra.Command{
 			}
 
 			for _, r := range ruleList {
-				if err := r.Validate(); err != nil {
+				if err := r.Sanitize(); err != nil {
 					Fatalf("%s", err)
 				}
 			}

--- a/cilium/cmd/policy_trace.go
+++ b/cilium/cmd/policy_trace.go
@@ -269,11 +269,11 @@ func parseL4PortsSlice(slice []string) ([]*models.Port, error) {
 		var protoStr string
 		switch len(vSplit) {
 		case 1:
-			protoStr = models.PortProtocolAny
+			protoStr = models.PortProtocolANY
 		case 2:
-			protoStr = strings.ToLower(vSplit[1])
+			protoStr = strings.ToUpper(vSplit[1])
 			switch protoStr {
-			case models.PortProtocolTCP, models.PortProtocolUDP, models.PortProtocolAny:
+			case models.PortProtocolTCP, models.PortProtocolUDP, models.PortProtocolANY:
 			default:
 				return nil, fmt.Errorf("invalid protocol %q", protoStr)
 			}

--- a/cilium/cmd/policy_validate.go
+++ b/cilium/cmd/policy_validate.go
@@ -32,7 +32,7 @@ var policyValidateCmd = &cobra.Command{
 			Fatalf("Validation of policy has failed: %s\n", err)
 		} else {
 			for _, r := range ruleList {
-				if err := r.Validate(); err != nil {
+				if err := r.Sanitize(); err != nil {
 					Fatalf("Validation of policy has failed: %s\n", err)
 				}
 			}

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -242,7 +242,7 @@ func (d *Daemon) PolicyAdd(rules api.Rules, opts *AddOptions) (uint64, error) {
 	log.Debugf("Policy Add Request: %+v", rules)
 
 	for _, r := range rules {
-		if err := r.Validate(); err != nil {
+		if err := r.Sanitize(); err != nil {
 			return 0, apierror.Error(PutPolicyFailureCode, err)
 		}
 	}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -52,7 +52,7 @@ func (e *Endpoint) writeL4Map(fw *bufio.Writer, owner Owner, m policy.L4PolicyMa
 
 	for _, l4 := range m {
 		// Represents struct l4_allow in bpf/lib/l4.h
-		protoNum, err := u8proto.ParseProtocol(l4.Protocol)
+		protoNum, err := u8proto.ParseProtocol(string(l4.Protocol))
 		if err != nil {
 			return fmt.Errorf("invalid protocol %s", l4.Protocol)
 		}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -150,7 +150,7 @@ func getSecurityIdentities(owner Owner, selector *api.EndpointSelector) []policy
 
 func (e *Endpoint) removeOldFilter(owner Owner, filter *policy.L4Filter) int {
 	port := uint16(filter.Port)
-	proto, err := u8proto.ParseProtocol(filter.Protocol)
+	proto, err := u8proto.ParseProtocol(string(filter.Protocol))
 	if err != nil {
 		log.Warningf("Parse policy protocol failed: %s", err)
 		return 1
@@ -171,7 +171,7 @@ func (e *Endpoint) removeOldFilter(owner Owner, filter *policy.L4Filter) int {
 
 func (e *Endpoint) applyNewFilter(owner Owner, filter *policy.L4Filter) int {
 	port := uint16(filter.Port)
-	proto, err := u8proto.ParseProtocol(filter.Protocol)
+	proto, err := u8proto.ParseProtocol(string(filter.Protocol))
 	if err != nil {
 		log.Warningf("Parse policy protocol failed: %s", err)
 		return 1

--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -16,7 +16,6 @@ package k8s
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
@@ -126,7 +125,7 @@ func ParseNetworkPolicy(np *networkingv1.NetworkPolicy) (api.Rules, error) {
 		Ingress:          ingresses,
 	}
 
-	if err := rule.Validate(); err != nil {
+	if err := rule.Sanitize(); err != nil {
 		return nil, err
 	}
 
@@ -142,9 +141,9 @@ func parsePorts(ports []networkingv1.NetworkPolicyPort) []api.PortRule {
 			continue
 		}
 
-		protocol := "tcp"
+		protocol := api.ProtoTCP
 		if port.Protocol != nil {
-			protocol = strings.ToLower(string(*port.Protocol))
+			protocol, _ = api.ParseL4Proto(string(*port.Protocol))
 		}
 
 		portStr := ""

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -117,8 +117,8 @@ func (s *K8sSuite) TestParseNetworkPolicy(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(result, DeepEquals, &policy.L4Policy{
 		Ingress: policy.L4PolicyMap{
-			"80/tcp": policy.L4Filter{
-				Port: 80, Protocol: "tcp",
+			"80/TCP": policy.L4Filter{
+				Port: 80, Protocol: api.ProtoTCP,
 				FromEndpoints:  []api.EndpointSelector{epSelector},
 				L7Parser:       "",
 				L7RedirectPort: 0, L7RulesPerEp: policy.L7DataMap{},
@@ -409,7 +409,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 		DPorts: []*models.Port{
 			{
 				Port:     6379,
-				Protocol: "tcp",
+				Protocol: models.PortProtocolTCP,
 			},
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -535,7 +535,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 		DPorts: []*models.Port{
 			{
 				Port:     443,
-				Protocol: "tcp",
+				Protocol: models.PortProtocolTCP,
 			},
 		},
 		To: labels.LabelArray{
@@ -614,7 +614,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 		DPorts: []*models.Port{
 			{
 				Port:     443,
-				Protocol: "tcp",
+				Protocol: models.PortProtocolTCP,
 			},
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -730,7 +730,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 		},
 		DPorts: []*models.Port{
 			{
-				Protocol: "udp",
+				Protocol: models.PortProtocolUDP,
 				Port:     8080,
 			},
 		},
@@ -751,7 +751,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 		DPorts: []*models.Port{
 			{
 				Port:     443,
-				Protocol: "tcp",
+				Protocol: models.PortProtocolTCP,
 			},
 		},
 		To: labels.LabelArray{
@@ -770,7 +770,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 		},
 		DPorts: []*models.Port{
 			{
-				Protocol: "udp",
+				Protocol: models.PortProtocolUDP,
 				Port:     8080,
 			},
 		},
@@ -883,7 +883,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 		DPorts: []*models.Port{
 			{
 				Port:     8080,
-				Protocol: "udp",
+				Protocol: models.PortProtocolUDP,
 			},
 		},
 		To: labels.LabelArray{
@@ -920,7 +920,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 		DPorts: []*models.Port{
 			{
 				Port:     8080,
-				Protocol: "udp",
+				Protocol: models.PortProtocolUDP,
 			},
 		},
 		To: labels.LabelArray{
@@ -941,7 +941,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 		DPorts: []*models.Port{
 			{
 				Port:     8080,
-				Protocol: "udp",
+				Protocol: models.PortProtocolUDP,
 			},
 		},
 		To: labels.LabelArray{

--- a/pkg/k8s/network_policy_v1beta.go
+++ b/pkg/k8s/network_policy_v1beta.go
@@ -18,7 +18,6 @@ package k8s
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
@@ -93,9 +92,9 @@ func ParseNetworkPolicyDeprecated(np *v1beta1.NetworkPolicy) (api.Rules, error) 
 					continue
 				}
 
-				protocol := "tcp"
+				protocol := api.ProtoTCP
 				if port.Protocol != nil {
-					protocol = strings.ToLower(string(*port.Protocol))
+					protocol, _ = api.ParseL4Proto(string(*port.Protocol))
 				}
 
 				portStr := ""
@@ -128,7 +127,7 @@ func ParseNetworkPolicyDeprecated(np *v1beta1.NetworkPolicy) (api.Rules, error) 
 		Ingress:          ingresses,
 	}
 
-	if err := rule.Validate(); err != nil {
+	if err := rule.Sanitize(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/k8s/network_policy_v1beta_test.go
+++ b/pkg/k8s/network_policy_v1beta_test.go
@@ -105,8 +105,8 @@ func (s *K8sSuite) TestParseNetworkPolicyDeprecated(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(result, DeepEquals, &policy.L4Policy{
 		Ingress: policy.L4PolicyMap{
-			"80/tcp": policy.L4Filter{
-				Port: 80, Protocol: "tcp",
+			"80/TCP": policy.L4Filter{
+				Port: 80, Protocol: api.ProtoTCP,
 				FromEndpoints:  []api.EndpointSelector{epSelector},
 				L7Parser:       "",
 				L7RedirectPort: 0, L7RulesPerEp: policy.L7DataMap{},
@@ -353,7 +353,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 		DPorts: []*models.Port{
 			{
 				Port:     6379,
-				Protocol: "tcp",
+				Protocol: models.PortProtocolTCP,
 			},
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -436,7 +436,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 		DPorts: []*models.Port{
 			{
 				Port:     443,
-				Protocol: "tcp",
+				Protocol: models.PortProtocolTCP,
 			},
 		},
 		To: labels.LabelArray{
@@ -515,7 +515,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 		DPorts: []*models.Port{
 			{
 				Port:     443,
-				Protocol: "tcp",
+				Protocol: models.PortProtocolTCP,
 			},
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -587,7 +587,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 		},
 		DPorts: []*models.Port{
 			{
-				Protocol: "udp",
+				Protocol: models.PortProtocolUDP,
 				Port:     8080,
 			},
 		},
@@ -608,7 +608,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 		DPorts: []*models.Port{
 			{
 				Port:     443,
-				Protocol: "tcp",
+				Protocol: models.PortProtocolTCP,
 			},
 		},
 		To: labels.LabelArray{
@@ -720,7 +720,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 		DPorts: []*models.Port{
 			{
 				Port:     8080,
-				Protocol: "udp",
+				Protocol: models.PortProtocolUDP,
 			},
 		},
 		To: labels.LabelArray{
@@ -757,7 +757,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 		DPorts: []*models.Port{
 			{
 				Port:     8080,
-				Protocol: "udp",
+				Protocol: models.PortProtocolUDP,
 			},
 		},
 		To: labels.LabelArray{
@@ -778,7 +778,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 		DPorts: []*models.Port{
 			{
 				Port:     8080,
-				Protocol: "udp",
+				Protocol: models.PortProtocolUDP,
 			},
 		},
 		To: labels.LabelArray{

--- a/pkg/k8s/third_party.go
+++ b/pkg/k8s/third_party.go
@@ -198,7 +198,7 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 	retRules := api.Rules{}
 
 	if r.Spec != nil {
-		if err := r.Spec.Validate(); err != nil {
+		if err := r.Spec.Sanitize(); err != nil {
 			return nil, fmt.Errorf("Invalid spec: %s", err)
 
 		}
@@ -207,7 +207,7 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 	}
 	if r.Specs != nil {
 		for _, rule := range r.Specs {
-			if err := rule.Validate(); err != nil {
+			if err := rule.Sanitize(); err != nil {
 				return nil, fmt.Errorf("Invalid specs: %s", err)
 
 			}

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -241,6 +241,15 @@ type EgressRule struct {
 // Example: 192.0.2.1/32
 type CIDR string
 
+// L4Proto is a layer 4 protocol name
+type L4Proto string
+
+const (
+	ProtoTCP L4Proto = "TCP"
+	ProtoUDP L4Proto = "UDP"
+	ProtoAny L4Proto = "ANY"
+)
+
 // PortProtocol specifies an L4 port with an optional transport protocol
 type PortProtocol struct {
 	// Port is an L4 port number. For now the string will be strictly
@@ -249,12 +258,12 @@ type PortProtocol struct {
 	Port string `json:"port"`
 
 	// Protocol is the L4 protocol. If omitted or empty, any protocol
-	// matches. Accepted values: "tcp", "udp", ""/"any"
+	// matches. Accepted values: "TCP", "UDP", ""/"ANY"
 	//
 	// Matching on ICMP is not supported.
 	//
 	// +optional
-	Protocol string `json:"protocol,omitempty"`
+	Protocol L4Proto `json:"protocol,omitempty"`
 }
 
 // PortRule is a list of ports/protocol combinations with optional Layer 7

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -317,11 +317,6 @@ type L7Rules struct {
 	Kafka []PortRuleKafka `json:"kafka,omitempty"`
 }
 
-// Len returns the total number of rules inside `L7Rules`.
-func (rules *L7Rules) Len() int {
-	return len(rules.HTTP) + len(rules.Kafka)
-}
-
 // PortRuleHTTP is a list of HTTP protocol constraints. All fields are
 // optional, if all fields are empty or missing, the rule does not have any
 // effect.

--- a/pkg/policy/api/utils.go
+++ b/pkg/policy/api/utils.go
@@ -14,6 +14,11 @@
 
 package api
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Len returns the total number of rules inside `L7Rules`.
 func (rules *L7Rules) Len() int {
 	return len(rules.HTTP) + len(rules.Kafka)
@@ -61,4 +66,25 @@ func (k *PortRuleKafka) Exists(rules L7Rules) bool {
 // Equal returns true if both HTTP rules are equal
 func (k *PortRuleKafka) Equal(o PortRuleKafka) bool {
 	return k.APIVersion == o.APIVersion && k.APIKey == o.APIKey && k.Topic == o.Topic
+}
+
+// Validate returns an error if the layer 4 protocol is not valid
+func (l4 L4Proto) Validate() error {
+	switch l4 {
+	case ProtoAny, ProtoTCP, ProtoUDP:
+	default:
+		return fmt.Errorf("invalid protocol %q, must be { tcp | udp | any }", l4)
+	}
+
+	return nil
+}
+
+// ParseL4Proto parses a string as layer 4 protocol
+func ParseL4Proto(proto string) (L4Proto, error) {
+	if proto == "" {
+		return ProtoAny, nil
+	}
+
+	p := L4Proto(strings.ToUpper(proto))
+	return p, p.Validate()
 }

--- a/pkg/policy/api/utils.go
+++ b/pkg/policy/api/utils.go
@@ -1,0 +1,64 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+// Len returns the total number of rules inside `L7Rules`.
+func (rules *L7Rules) Len() int {
+	return len(rules.HTTP) + len(rules.Kafka)
+}
+
+// Exists returns true if the HTTP rule already exists in the list of rules
+func (h *PortRuleHTTP) Exists(rules L7Rules) bool {
+	for _, existingRule := range rules.HTTP {
+		if h.Equal(existingRule) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Equal returns true if both HTTP rules are equal
+func (h *PortRuleHTTP) Equal(o PortRuleHTTP) bool {
+	if h.Path != o.Path ||
+		h.Method != o.Method ||
+		h.Host != o.Host ||
+		len(h.Headers) != len(o.Headers) {
+		return false
+	}
+
+	for i, value := range h.Headers {
+		if o.Headers[i] != value {
+			return false
+		}
+	}
+	return true
+}
+
+// Exists returns true if the HTTP rule already exists in the list of rules
+func (k *PortRuleKafka) Exists(rules L7Rules) bool {
+	for _, existingRule := range rules.Kafka {
+		if k.Equal(existingRule) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Equal returns true if both HTTP rules are equal
+func (k *PortRuleKafka) Equal(o PortRuleKafka) bool {
+	return k.APIVersion == o.APIVersion && k.APIKey == o.APIKey && k.Topic == o.Topic
+}

--- a/pkg/policy/api/utils_test.go
+++ b/pkg/policy/api/utils_test.go
@@ -64,3 +64,28 @@ func (s *PolicyAPITestSuite) TestKafkaEqual(c *C) {
 	c.Assert(rule2.Exists(rules), Equals, true)
 	c.Assert(rule3.Exists(rules), Equals, false)
 }
+
+func (s *PolicyAPITestSuite) TestValidateL4Proto(c *C) {
+	c.Assert(L4Proto("TCP").Validate(), IsNil)
+	c.Assert(L4Proto("UDP").Validate(), IsNil)
+	c.Assert(L4Proto("ANY").Validate(), IsNil)
+	c.Assert(L4Proto("TCP2").Validate(), Not(IsNil))
+	c.Assert(L4Proto("t").Validate(), Not(IsNil))
+}
+
+func (s *PolicyAPITestSuite) TestParseL4Proto(c *C) {
+	p, err := ParseL4Proto("tcp")
+	c.Assert(p, Equals, ProtoTCP)
+	c.Assert(err, IsNil)
+
+	p, err = ParseL4Proto("Any")
+	c.Assert(p, Equals, ProtoAny)
+	c.Assert(err, IsNil)
+
+	p, err = ParseL4Proto("")
+	c.Assert(p, Equals, ProtoAny)
+	c.Assert(err, IsNil)
+
+	_, err = ParseL4Proto("foo2")
+	c.Assert(err, Not(IsNil))
+}

--- a/pkg/policy/api/utils_test.go
+++ b/pkg/policy/api/utils_test.go
@@ -1,0 +1,66 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type PolicyAPITestSuite struct{}
+
+var _ = Suite(&PolicyAPITestSuite{})
+
+func (s *PolicyAPITestSuite) TestHTTPEqual(c *C) {
+	rule1 := PortRuleHTTP{Path: "/foo$", Method: "GET", Headers: []string{"X-Test: Foo"}}
+	rule2 := PortRuleHTTP{Path: "/bar$", Method: "GET", Headers: []string{"X-Test: Foo"}}
+	rule3 := PortRuleHTTP{Path: "/foo$", Method: "GET", Headers: []string{"X-Test: Bar"}}
+
+	c.Assert(rule1.Equal(rule1), Equals, true)
+	c.Assert(rule1.Equal(rule2), Equals, false)
+	c.Assert(rule1.Equal(rule3), Equals, false)
+
+	rules := L7Rules{
+		HTTP: []PortRuleHTTP{rule1, rule2},
+	}
+
+	c.Assert(rule1.Exists(rules), Equals, true)
+	c.Assert(rule2.Exists(rules), Equals, true)
+	c.Assert(rule3.Exists(rules), Equals, false)
+}
+
+func (s *PolicyAPITestSuite) TestKafkaEqual(c *C) {
+	rule1 := PortRuleKafka{APIVersion: "1", APIKey: "foo", Topic: "topic1"}
+	rule2 := PortRuleKafka{APIVersion: "1", APIKey: "bar", Topic: "topic1"}
+	rule3 := PortRuleKafka{APIVersion: "1", APIKey: "foo", Topic: "topic2"}
+
+	c.Assert(rule1.Equal(rule1), Equals, true)
+	c.Assert(rule1.Equal(rule2), Equals, false)
+	c.Assert(rule1.Equal(rule3), Equals, false)
+
+	rules := L7Rules{
+		Kafka: []PortRuleKafka{rule1, rule2},
+	}
+
+	c.Assert(rule1.Exists(rules), Equals, true)
+	c.Assert(rule2.Exists(rules), Equals, true)
+	c.Assert(rule3.Exists(rules), Equals, false)
+}

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -49,7 +49,7 @@ type L4Filter struct {
 	// Port is the destination port to allow
 	Port int
 	// Protocol is the L4 protocol to allow or NONE
-	Protocol string
+	Protocol api.L4Proto
 	// FromEndpoints limit the source labels for allowing traffic. If
 	// FromEndpoints is empty, then it selects all endpoints.
 	FromEndpoints []api.EndpointSelector `json:"-"`
@@ -96,7 +96,7 @@ func (dm L7DataMap) addRulesForEndpoints(rules api.L7Rules,
 // This L4Filter will only apply to endpoints covered by `fromEndpoints`.
 // `rule` allows a series of L7 rules to be associated with this L4Filter.
 func CreateL4Filter(fromEndpoints []api.EndpointSelector, rule api.PortRule, port api.PortProtocol,
-	direction string, protocol string) L4Filter {
+	direction string, protocol api.L4Proto) L4Filter {
 
 	// already validated via PortRule.Validate()
 	p, _ := strconv.ParseUint(port.Port, 0, 16)
@@ -205,15 +205,15 @@ func (l4 L4PolicyMap) containsAllL3L4(labels labels.LabelArray, ports []*models.
 	}
 
 	for _, l4CtxIng := range ports {
-		lwrProtocol := strings.ToLower(l4CtxIng.Protocol)
+		lwrProtocol := l4CtxIng.Protocol
 		switch lwrProtocol {
-		case "", models.PortProtocolAny:
-			tcpPort := fmt.Sprintf("%d/tcp", l4CtxIng.Port)
+		case "", models.PortProtocolANY:
+			tcpPort := fmt.Sprintf("%d/TCP", l4CtxIng.Port)
 			tcpFilter, tcpmatch := l4[tcpPort]
 			if tcpmatch {
 				tcpmatch = tcpFilter.matchesLabels(labels)
 			}
-			udpPort := fmt.Sprintf("%d/udp", l4CtxIng.Port)
+			udpPort := fmt.Sprintf("%d/UDP", l4CtxIng.Port)
 			udpFilter, udpmatch := l4[udpPort]
 			if udpmatch {
 				udpmatch = udpFilter.matchesLabels(labels)

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -32,20 +32,20 @@ func (s *PolicyTestSuite) testDPortCoverage(c *C, policy L4Policy,
 	ports = []*models.Port{
 		{
 			Port:     8080,
-			Protocol: "tcp",
+			Protocol: models.PortProtocolTCP,
 		},
 	}
 	c.Assert(covers(ports), Equals, api.Allowed)
 
 	// Adding another port outside the policy will now be denied.
-	ports = append(ports, &models.Port{Port: 8080, Protocol: "udp"})
+	ports = append(ports, &models.Port{Port: 8080, Protocol: models.PortProtocolUDP})
 	c.Assert(covers(ports), Equals, api.Denied)
 
 	// Ports with protocol any should match the TCP policy above.
 	ports = []*models.Port{
 		{
 			Port:     8080,
-			Protocol: "any",
+			Protocol: models.PortProtocolANY,
 		},
 	}
 	c.Assert(covers(ports), Equals, api.Allowed)
@@ -60,9 +60,9 @@ func (s *PolicyTestSuite) TestIngressCoversDPorts(c *C) {
 	// Non-empty policy denies traffic without a port specified
 	policy = L4Policy{
 		Ingress: L4PolicyMap{
-			"8080/tcp": {
+			"8080/TCP": {
 				Port:     8080,
-				Protocol: "tcp",
+				Protocol: api.ProtoTCP,
 				Ingress:  true,
 			},
 		},
@@ -79,9 +79,9 @@ func (s *PolicyTestSuite) TestEgressCoversDPorts(c *C) {
 	// Non-empty policy denies traffic without a port specified
 	policy = L4Policy{
 		Egress: L4PolicyMap{
-			"8080/tcp": {
+			"8080/TCP": {
 				Port:     8080,
-				Protocol: "tcp",
+				Protocol: api.ProtoTCP,
 				Ingress:  false,
 			},
 		},
@@ -90,7 +90,7 @@ func (s *PolicyTestSuite) TestEgressCoversDPorts(c *C) {
 }
 
 func (s *PolicyTestSuite) TestCreateL4Filter(c *C) {
-	tuple := api.PortProtocol{Port: "80", Protocol: "tcp"}
+	tuple := api.PortProtocol{Port: "80", Protocol: api.ProtoTCP}
 	portrule := api.PortRule{
 		Ports: []api.PortProtocol{tuple},
 		Rules: &api.L7Rules{

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -250,7 +250,7 @@ func (p *Repository) Add(r api.Rule) (uint64, error) {
 	defer p.Mutex.Unlock()
 
 	realRule := &rule{Rule: r}
-	if err := realRule.validate(); err != nil {
+	if err := realRule.sanitize(); err != nil {
 		return p.revision, err
 	}
 
@@ -267,7 +267,7 @@ func (p *Repository) AddListLocked(rules api.Rules) (uint64, error) {
 	newList := make([]*rule, len(rules))
 	for i := range rules {
 		newList[i] = &rule{Rule: *rules[i]}
-		if err := newList[i].validate(); err != nil {
+		if err := newList[i].sanitize(); err != nil {
 			return p.revision, err
 		}
 	}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -20,6 +20,8 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/policy/api"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // Repository is a list of policy rules which in combination form the security
@@ -157,6 +159,9 @@ func (p *Repository) allowsL4Egress(searchCtx *SearchContext) api.Decision {
 
 	ctx.PolicyTrace("\n")
 	policy, err := p.ResolveL4Policy(&ctx)
+	if err != nil {
+		log.WithError(err).Warning("Evaluation error while resolving L4 egress policy")
+	}
 	verdict := api.Undecided
 	if err == nil && len(policy.Egress) > 0 {
 		verdict = policy.EgressCoversDPorts(ctx.DPorts)
@@ -176,6 +181,9 @@ func (p *Repository) allowsL4Ingress(ctx *SearchContext) api.Decision {
 
 	ctx.PolicyTrace("\n")
 	policy, err := p.ResolveL4Policy(ctx)
+	if err != nil {
+		log.WithError(err).Warning("Evaluation error while resolving L4 ingress policy")
+	}
 	verdict := api.Undecided
 	if err == nil && len(policy.Ingress) > 0 {
 		verdict = policy.IngressCoversContext(ctx)

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -238,7 +238,7 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 				FromEndpoints: selectorFromApp2,
 				ToPorts: []api.PortRule{{
 					Ports: []api.PortProtocol{
-						{Port: "80", Protocol: "tcp"},
+						{Port: "80", Protocol: api.ProtoTCP},
 					},
 				}},
 			},
@@ -253,7 +253,7 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 				FromEndpoints: selectorFromApp2,
 				ToPorts: []api.PortRule{{
 					Ports: []api.PortProtocol{
-						{Port: "80", Protocol: "tcp"},
+						{Port: "80", Protocol: api.ProtoTCP},
 					},
 					Rules: &api.L7Rules{
 						HTTP: []api.PortRuleHTTP{
@@ -273,7 +273,7 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 				FromEndpoints: selectorFromApp2,
 				ToPorts: []api.PortRule{{
 					Ports: []api.PortProtocol{
-						{Port: "80", Protocol: "tcp"},
+						{Port: "80", Protocol: api.ProtoTCP},
 					},
 					Rules: &api.L7Rules{
 						HTTP: []api.PortRuleHTTP{
@@ -297,8 +297,8 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 	c.Assert(err, IsNil)
 
 	expected := NewL4Policy()
-	expected.Ingress["80/tcp"] = L4Filter{
-		Port: 80, Protocol: "tcp",
+	expected.Ingress["80/TCP"] = L4Filter{
+		Port: 80, Protocol: api.ProtoTCP,
 		FromEndpoints: selectorFromApp2,
 		L7Parser:      "http",
 		L7RulesPerEp: L7DataMap{

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -145,13 +145,23 @@ func mergeL4Port(ctx *SearchContext, fromEndpoints []api.EndpointSelector, r api
 					ctx.PolicyTrace("   Merge conflict: mismatching L7 rule types.\n")
 					return 0, fmt.Errorf("Cannot merge conflicting L7 rule types")
 				}
-				ep.HTTP = append(ep.HTTP, newL7Rules.HTTP...)
+
+				for _, newRule := range newL7Rules.HTTP {
+					if !newRule.Exists(ep) {
+						ep.HTTP = append(ep.HTTP, newRule)
+					}
+				}
 			case len(l4Filter.L7RulesPerEp[hash].Kafka) > 0:
 				if len(v.L7RulesPerEp[hash].HTTP) > 0 {
 					ctx.PolicyTrace("   Merge conflict: mismatching L7 rule types.\n")
 					return 0, fmt.Errorf("Cannot merge conflicting L7 rule types")
 				}
-				ep.Kafka = append(ep.Kafka, newL7Rules.Kafka...)
+
+				for _, newRule := range newL7Rules.Kafka {
+					if !newRule.Exists(ep) {
+						ep.Kafka = append(ep.Kafka, newRule)
+					}
+				}
 			default:
 				ctx.PolicyTrace("   No L7 rules to merge.\n")
 			}

--- a/tests/k8s/tests/00-gsg-test.sh
+++ b/tests/k8s/tests/00-gsg-test.sh
@@ -124,10 +124,8 @@ log "creating L7-aware policy"
 # FIXME Remove workaround once we drop k8s 1.6 support
 # Only test the new network policy with k8s >= 1.7
 if [[ "${k8s_version}" != 1.6.* ]]; then
-    k8s_apply_policy $NAMESPACE delete "${MINIKUBE}/l3_l4_policy.yaml"
     k8s_apply_policy $NAMESPACE create "${MINIKUBE}/l3_l4_l7_policy.yaml"
 else
-    k8s_apply_policy $NAMESPACE delete "${MINIKUBE}/l3_l4_policy_deprecated.yaml"
     k8s_apply_policy $NAMESPACE create "${MINIKUBE}/l3_l4_l7_policy_deprecated.yaml"
 fi
 


### PR DESCRIPTION
* Allow merging L4 rules with no L7 rules, no parser and no redirect
  port with other L4 rules

* Correctly write back the copy of rules into the hashtable of per
  endpoint rules

Signed-off-by: Thomas Graf <thomas@cilium.io>