### PR TITLE
Fix kafka rule merge

### DIFF
--- a/pkg/policy/api/utils.go
+++ b/pkg/policy/api/utils.go
@@ -79,6 +79,15 @@ func (l4 L4Proto) Validate() error {
 	return nil
 }
 
+// NumRules returns the total number of L7Rules configured in this PortRule
+func (r *PortRule) NumRules() int {
+	if r.Rules == nil {
+		return 0
+	}
+
+	return r.Rules.Len()
+}
+
 // ParseL4Proto parses a string as layer 4 protocol
 func ParseL4Proto(proto string) (L4Proto, error) {
 	if proto == "" {

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -144,8 +144,8 @@ func mergeL4Port(ctx *SearchContext, fromEndpoints []api.EndpointSelector, r api
 	for hash, newL7Rules := range l4Filter.L7RulesPerEp {
 		if ep, ok := v.L7RulesPerEp[hash]; ok {
 			switch {
-			case len(l4Filter.L7RulesPerEp[hash].HTTP) > 0:
-				if len(v.L7RulesPerEp[hash].Kafka) > 0 {
+			case len(newL7Rules.HTTP) > 0:
+				if len(ep.Kafka) > 0 {
 					ctx.PolicyTrace("   Merge conflict: mismatching L7 rule types.\n")
 					return 0, fmt.Errorf("Cannot merge conflicting L7 rule types")
 				}
@@ -155,8 +155,8 @@ func mergeL4Port(ctx *SearchContext, fromEndpoints []api.EndpointSelector, r api
 						ep.HTTP = append(ep.HTTP, newRule)
 					}
 				}
-			case len(l4Filter.L7RulesPerEp[hash].Kafka) > 0:
-				if len(v.L7RulesPerEp[hash].HTTP) > 0 {
+			case len(newL7Rules.Kafka) > 0:
+				if len(ep.HTTP) > 0 {
 					ctx.PolicyTrace("   Merge conflict: mismatching L7 rule types.\n")
 					return 0, fmt.Errorf("Cannot merge conflicting L7 rule types")
 				}

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -124,7 +124,7 @@ func mergeL4Port(ctx *SearchContext, fromEndpoints []api.EndpointSelector, r api
 		}
 	}
 
-	if adjustL4PolicyIfNeeded(fromEndpoints, &v) && len(r.Rules.HTTP) == 0 {
+	if adjustL4PolicyIfNeeded(fromEndpoints, &v) && r.NumRules() == 0 {
 		// skip this policy as it is already covered and it does not contain L7 rules
 		return 1, nil
 	}


### PR DESCRIPTION
The first portion of this branch is PR #1705 which can be ignored in this PR, the last two commits fix up another issue identified recently, which was that Kafka l7 rules for a specific set of labels could end up being ignored if the existing policy applied L7Rules for all endpoints.