### PR TITLE
tests: redirect ip6tables cmd line to dev null

### DIFF
--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -24,7 +24,7 @@ for bin in "../cilium/cilium" \
 done
 
 # Prevent Fedora rules in raw table from affecting the test.
-ip6tables -t raw -F || true
+ip6tables -t raw -F 2> /dev/null || true
 
 function log {
   local save=$-


### PR DESCRIPTION
Closes: #1721 (Silence ip6tables output if ip6tables is not supported by kernel)
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>