### PR TITLE
accesslog: Rename HTTP "header" field to "headers"

### DIFF
--- a/pkg/proxy/accesslog/log.go
+++ b/pkg/proxy/accesslog/log.go
@@ -109,7 +109,7 @@ func Log(l *LogRecord, typ FlowType, verdict FlowVerdict, code int) {
 		Method:   l.Request.Method,
 		URL:      l.Request.URL,
 		Protocol: l.Request.Proto,
-		Header:   l.Request.Header,
+		Headers:  l.Request.Header,
 	}
 
 	log.WithFields(log.Fields{

--- a/pkg/proxy/accesslog/record.go
+++ b/pkg/proxy/accesslog/record.go
@@ -195,8 +195,8 @@ type LogRecordHTTP struct {
 	// Protocol is the HTTP protocol in use
 	Protocol string
 
-	// Header is the HTTP header in use
-	Header http.Header
+	// Headers are all HTTP headers present in the request
+	Headers http.Header
 }
 
 // KafkaTopic contains the topic for requests


### PR DESCRIPTION
This has been confusing to users as the field holds all HTTP headers

Fixes: #1747 