### PR TITLE
pkg/k8s: properly detecting if a node is not found in k8s

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -401,20 +401,18 @@ func AnnotateNodeCIDR(c kubernetes.Interface, nodeName string, v4CIDR, v6CIDR *n
 		fieldSubsys:   subsysKubernetes,
 	}).Debugf("Updating node annotations with node CIDRs: IPv4=%s IPv6=%s", v4CIDR, v6CIDR)
 
-	go func(c kubernetes.Interface, v4CIDR, v6CIDR *net.IPNet) {
+	go func(c kubernetes.Interface, nodeName string, v4CIDR, v6CIDR *net.IPNet) {
 		var node *v1.Node
 		var err error
 
 		for n := 1; n <= maxUpdateRetries; n++ {
-			if node == nil {
-				node, err = GetNode(c, nodeName)
-				if node == nil {
+			node, err = GetNode(c, nodeName)
+			if err == nil {
+				node, err = updateNodeAnnotation(c, node, v4CIDR, v6CIDR)
+			} else {
+				if errors.IsNotFound(err) {
 					err = ErrNilNode
 				}
-			}
-
-			if node != nil {
-				node, err = updateNodeAnnotation(c, node, v4CIDR, v6CIDR)
 			}
 
 			if err != nil {
@@ -430,7 +428,7 @@ func AnnotateNodeCIDR(c kubernetes.Interface, nodeName string, v4CIDR, v6CIDR *n
 
 			time.Sleep(time.Duration(n) * time.Second)
 		}
-	}(c, v4CIDR, v6CIDR)
+	}(c, nodeName, v4CIDR, v6CIDR)
 
 	return nil
 }


### PR DESCRIPTION
If cilium is running in k8s mode in a node that is not registered in
k8s. Cilium would hide the proper error message to the user. If the node
is not found, cilium will keep retrying until it reaches the maxRetries
defined.

Signed-off-by: André Martins <andre@cilium.io>