### PR TITLE
pkg/nodeaddress: give preference to k8s IP allocation

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -885,6 +885,17 @@ func NewDaemon(c *Config) (*Daemon, error) {
 			config.alwaysAllowLocalhost = true
 		}
 	}
+	// If the device has been specified, the IPv4AllocPrefix and the
+	// IPv6AllocPrefix were already allocated before the k8s.Init().
+	//
+	// If the device hasn't been specified, k8s.Init() allocated the
+	// IPv4AllocPrefix and the IPv6AllocPrefix from k8s node annotations.
+	//
+	// Then, we will calculate the IPv4 or IPv6 alloc prefix based on the IPv6
+	// or IPv4 alloc prefix, respectively, retrieved by k8s node annotations.
+	if config.Device == "undefined" {
+		nodeaddress.InitDefaultPrefix("")
+	}
 
 	nodeaddress.SetIPv4ClusterCidrMaskSize(v4ClusterCidrMaskSize)
 

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -32,6 +32,7 @@ type IPAMSuite struct{}
 var _ = Suite(&IPAMSuite{})
 
 func (s *IPAMSuite) TestLock(c *C) {
+	nodeaddress.InitDefaultPrefix("")
 	err := Init()
 	c.Assert(err, IsNil)
 

--- a/pkg/nodeaddress/node_address_test.go
+++ b/pkg/nodeaddress/node_address_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func (s *NodeAddressSuite) TestMaskCheck(c *C) {
+	InitDefaultPrefix("")
 	SetIPv4ClusterCidrMaskSize(24)
 
 	_, cidr, _ := net.ParseCIDR("1.1.1.1/16")


### PR DESCRIPTION
When using cilium with k8s, we should prioritize k8s pod CIDR for the
node CIDR allocation. Otherwise cilium might use the same PodCIDR on 2
different nodes, such as:

(The IPv6 pod cidr was automatically derived from the 1st global scope
interface where on this case the global scope interface had the same IP
private IP address)

```
$ kubectl get nodes -o json | grep -i CIDR
"io.cilium.network.ipv4-pod-cidr": "10.0.0.0/16",
"io.cilium.network.ipv6-pod-cidr": "f00d::a00:20f:0:0/96",
"podCIDR": "10.0.0.0/16"
"io.cilium.network.ipv4-pod-cidr": "10.1.0.0/16",
"io.cilium.network.ipv6-pod-cidr": "f00d::a00:20f:0:0/96",
"podCIDR": "10.1.0.0/16"
```

Or in case the podCIDR was an IPv6 address:

```
$ kubectl get nodes -o json | grep -i CIDR
"io.cilium.network.ipv4-pod-cidr": "10.15.0.0/16",
"io.cilium.network.ipv6-pod-cidr": "fd02::/96",
"podCIDR": "fd02::/96"
"io.cilium.network.ipv4-pod-cidr": "10.15.0.0/16",
"io.cilium.network.ipv6-pod-cidr": "fd02::1:0:0/96",
"podCIDR": "fd02::1:0:0/96"
```

This commit derives the IPv6 pod CIDR from the IPv4 pod CIDR and
vice-versa and gives priority to the podCIDR set by kubernetes if the
user runs cilium in non-overlay mode.

Signed-off-by: André Martins <andre@cilium.io>