### PR TITLE
Pretty-print unit test assertions

### DIFF
--- a/common/addressing/ip_test.go
+++ b/common/addressing/ip_test.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/comparator"
 	. "gopkg.in/check.v1"
 )
 
@@ -37,8 +38,8 @@ func (s *AddressingSuite) TestCiliumIPv6(c *C) {
 	c.Assert(ip.ValidNodeIP(), Equals, false)
 	c.Assert(ip.EndpointID(), Equals, uint16(0))
 	c.Assert(ip.NodeID(), Equals, uint32(0))
-	c.Assert(ip.NodeIP(), DeepEquals, net.ParseIP("b007::"))
-	c.Assert(ip.HostIP(), DeepEquals, net.ParseIP("b007::ffff"))
+	c.Assert(ip.NodeIP(), comparator.DeepEquals, net.ParseIP("b007::"))
+	c.Assert(ip.HostIP(), comparator.DeepEquals, net.ParseIP("b007::ffff"))
 	ip2, _ := NewCiliumIPv6("")
 	// Lacking a better Equals method, checking if the stringified IP is consistent
 	c.Assert(ip.String() == ip2.String(), Equals, false)
@@ -53,7 +54,7 @@ func (s *AddressingSuite) TestCiliumIPv6(c *C) {
 	c.Assert(ip.EndpointID(), Equals, uint16(0))
 	c.Assert(ip.NodeID(), Equals, uint32(0xaaaabbbb))
 	c.Assert(ip.String(), Equals, "b007::aaaa:bbbb:0:0")
-	c.Assert(ip.NodeIP(), DeepEquals, net.ParseIP("b007::aaaa:bbbb:0:0"))
+	c.Assert(ip.NodeIP(), comparator.DeepEquals, net.ParseIP("b007::aaaa:bbbb:0:0"))
 }
 
 func (s *AddressingSuite) TestCiliumIPv4(c *C) {
@@ -80,7 +81,7 @@ func (s *AddressingSuite) TestCiliumIPv6NodeIP(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(ip.ValidContainerIP(), Equals, true)
 	c.Assert(ip.ValidNodeIP(), Equals, false)
-	c.Assert(ip.NodeIP(), DeepEquals, net.ParseIP("b007::aaaa:bbbb:0:0"))
+	c.Assert(ip.NodeIP(), comparator.DeepEquals, net.ParseIP("b007::aaaa:bbbb:0:0"))
 }
 
 func (s *AddressingSuite) TestCiliumIPv6Negative(c *C) {

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -17,37 +17,37 @@ package common
 import (
 	"testing"
 
-	. "gopkg.in/check.v1"
+	"gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.
 func Test(t *testing.T) {
-	TestingT(t)
+	check.TestingT(t)
 }
 
 type CommonSuite struct{}
 
-var _ = Suite(&CommonSuite{})
+var _ = check.Suite(&CommonSuite{})
 
-func (s *CommonSuite) TestGoArray2C(c *C) {
-	c.Assert(goArray2C([]byte{0, 0x01, 0x02, 0x03}), Equals, "0x0, 0x1, 0x2, 0x3")
-	c.Assert(goArray2C([]byte{0, 0xFF, 0xFF, 0xFF}), Equals, "0x0, 0xff, 0xff, 0xff")
-	c.Assert(goArray2C([]byte{0xa, 0xbc, 0xde, 0xf1}), Equals, "0xa, 0xbc, 0xde, 0xf1")
-	c.Assert(goArray2C([]byte{0}), Equals, "0x0")
-	c.Assert(goArray2C([]byte{}), Equals, "")
+func (s *CommonSuite) TestGoArray2C(c *check.C) {
+	c.Assert(goArray2C([]byte{0, 0x01, 0x02, 0x03}), check.Equals, "0x0, 0x1, 0x2, 0x3")
+	c.Assert(goArray2C([]byte{0, 0xFF, 0xFF, 0xFF}), check.Equals, "0x0, 0xff, 0xff, 0xff")
+	c.Assert(goArray2C([]byte{0xa, 0xbc, 0xde, 0xf1}), check.Equals, "0xa, 0xbc, 0xde, 0xf1")
+	c.Assert(goArray2C([]byte{0}), check.Equals, "0x0")
+	c.Assert(goArray2C([]byte{}), check.Equals, "")
 }
 
-func (s *CommonSuite) TestFmtDefineComma(c *C) {
-	c.Assert(FmtDefineComma("foo", []byte{1, 2, 3}), Equals, "#define foo 0x1, 0x2, 0x3\n")
-	c.Assert(FmtDefineComma("foo", []byte{}), Equals, "#define foo \n")
+func (s *CommonSuite) TestFmtDefineComma(c *check.C) {
+	c.Assert(FmtDefineComma("foo", []byte{1, 2, 3}), check.Equals, "#define foo 0x1, 0x2, 0x3\n")
+	c.Assert(FmtDefineComma("foo", []byte{}), check.Equals, "#define foo \n")
 }
 
-func (s *CommonSuite) TestFmtDefineAddress(c *C) {
-	c.Assert(FmtDefineAddress("foo", []byte{1, 2, 3}), Equals, "#define foo { .addr = { 0x1, 0x2, 0x3 } }\n")
-	c.Assert(FmtDefineAddress("foo", []byte{}), Equals, "#define foo { .addr = {  } }\n")
+func (s *CommonSuite) TestFmtDefineAddress(c *check.C) {
+	c.Assert(FmtDefineAddress("foo", []byte{1, 2, 3}), check.Equals, "#define foo { .addr = { 0x1, 0x2, 0x3 } }\n")
+	c.Assert(FmtDefineAddress("foo", []byte{}), check.Equals, "#define foo { .addr = {  } }\n")
 }
 
-func (s *CommonSuite) TestFmtDefineArray(c *C) {
-	c.Assert(FmtDefineArray("foo", []byte{1, 2, 3}), Equals, "#define foo { 0x1, 0x2, 0x3 }\n")
-	c.Assert(FmtDefineArray("foo", []byte{}), Equals, "#define foo {  }\n")
+func (s *CommonSuite) TestFmtDefineArray(c *check.C) {
+	c.Assert(FmtDefineArray("foo", []byte{1, 2, 3}), check.Equals, "#define foo { 0x1, 0x2, 0x3 }\n")
+	c.Assert(FmtDefineArray("foo", []byte{}), check.Equals, "#define foo {  }\n")
 }

--- a/daemon/labels_test.go
+++ b/daemon/labels_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/daemon/options"
+	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
@@ -134,7 +135,7 @@ func (ds *DaemonSuite) TestLabels(c *C) {
 	wantSecCtxLbls.ID = policy.MinimalNumericIdentity
 	wantSecCtxLbls.Labels = lbls
 	c.Assert(gotSecCtxLbl.ID, Equals, wantSecCtxLbls.ID)
-	c.Assert(gotSecCtxLbl.Labels, DeepEquals, wantSecCtxLbls.Labels)
+	c.Assert(gotSecCtxLbl.Labels, comparator.DeepEquals, wantSecCtxLbls.Labels)
 	c.Assert(gotSecCtxLbl.RefCount(), Equals, 3)
 
 	err = ds.d.DeleteIdentity(policy.MinimalNumericIdentity, "containerLabel1-1")
@@ -144,7 +145,7 @@ func (ds *DaemonSuite) TestLabels(c *C) {
 	wantSecCtxLbls.ID = policy.MinimalNumericIdentity
 	wantSecCtxLbls.Labels = lbls
 	c.Assert(gotSecCtxLbl.ID, Equals, wantSecCtxLbls.ID)
-	c.Assert(gotSecCtxLbl.Labels, DeepEquals, wantSecCtxLbls.Labels)
+	c.Assert(gotSecCtxLbl.Labels, comparator.DeepEquals, wantSecCtxLbls.Labels)
 	c.Assert(gotSecCtxLbl.RefCount(), Equals, 2)
 
 	gotSecCtxLbl, err = ds.d.LookupIdentity(policy.MinimalNumericIdentity + 1)
@@ -152,7 +153,7 @@ func (ds *DaemonSuite) TestLabels(c *C) {
 	wantSecCtxLbls.ID = policy.MinimalNumericIdentity + 1
 	wantSecCtxLbls.Labels = lbls2
 	c.Assert(gotSecCtxLbl.ID, Equals, wantSecCtxLbls.ID)
-	c.Assert(gotSecCtxLbl.Labels, DeepEquals, wantSecCtxLbls.Labels)
+	c.Assert(gotSecCtxLbl.Labels, comparator.DeepEquals, wantSecCtxLbls.Labels)
 	c.Assert(gotSecCtxLbl.RefCount(), Equals, 2)
 
 	err = ds.d.DeleteIdentity(policy.MinimalNumericIdentity, "containerLabel1-2")
@@ -162,7 +163,7 @@ func (ds *DaemonSuite) TestLabels(c *C) {
 	wantSecCtxLbls.ID = policy.MinimalNumericIdentity
 	wantSecCtxLbls.Labels = lbls
 	c.Assert(gotSecCtxLbl.ID, Equals, wantSecCtxLbls.ID)
-	c.Assert(gotSecCtxLbl.Labels, DeepEquals, wantSecCtxLbls.Labels)
+	c.Assert(gotSecCtxLbl.Labels, comparator.DeepEquals, wantSecCtxLbls.Labels)
 	c.Assert(gotSecCtxLbl.RefCount(), Equals, 1)
 
 	err = ds.d.DeleteIdentity(policy.MinimalNumericIdentity, "containerLabel1-3")
@@ -176,7 +177,7 @@ func (ds *DaemonSuite) TestLabels(c *C) {
 	c.Assert(err, IsNil)
 
 	err = ds.d.DeleteIdentity(policy.MinimalNumericIdentity, "containerLabel1-non-existent")
-	c.Assert(err, DeepEquals, errors.New("identity not found"))
+	c.Assert(err, comparator.DeepEquals, errors.New("identity not found"))
 	gotSecCtxLbl, err = ds.d.LookupIdentity(policy.MinimalNumericIdentity)
 	c.Assert(err, IsNil)
 	c.Assert(gotSecCtxLbl, Equals, emptySecCtxLblPtr)
@@ -190,7 +191,7 @@ func (ds *DaemonSuite) TestLabels(c *C) {
 	sha256sum := lbls2.SHA256Sum()
 	gotSecCtxLbl, err = LookupIdentityBySHA256(sha256sum)
 	c.Assert(err, IsNil)
-	c.Assert(gotSecCtxLbl, DeepEquals, secCtxLbl)
+	c.Assert(gotSecCtxLbl, comparator.DeepEquals, secCtxLbl)
 
 	err = ds.d.DeleteIdentityBySHA256(sha256sum, "containerLabel2-1")
 	c.Assert(err, IsNil)

--- a/daemon/services_test.go
+++ b/daemon/services_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/common/types"
+	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/kvstore"
 
 	. "gopkg.in/check.v1"
@@ -74,7 +75,7 @@ func (ds *DaemonSuite) TestServices(c *C) {
 	c.Assert(err, Equals, nil)
 	wantL3n4AddrID.ID = ffsIDu16
 	wantL3n4AddrID.L3n4Addr = l3n4Addr1
-	c.Assert(gotL3n4AddrID, DeepEquals, wantL3n4AddrID)
+	c.Assert(gotL3n4AddrID, comparator.DeepEquals, wantL3n4AddrID)
 
 	err = DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
@@ -86,7 +87,7 @@ func (ds *DaemonSuite) TestServices(c *C) {
 	c.Assert(err, Equals, nil)
 	wantL3n4AddrID.ID = types.ServiceID(common.FirstFreeServiceID + 1)
 	wantL3n4AddrID.L3n4Addr = l3n4Addr2
-	c.Assert(gotL3n4AddrID, DeepEquals, wantL3n4AddrID)
+	c.Assert(gotL3n4AddrID, comparator.DeepEquals, wantL3n4AddrID)
 
 	err = DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
@@ -107,7 +108,7 @@ func (ds *DaemonSuite) TestServices(c *C) {
 	sha256sum := l3n4Addr2.SHA256Sum()
 	gotL3n4AddrID, err = GetL3n4AddrIDBySHA256(sha256sum)
 	c.Assert(err, Equals, nil)
-	c.Assert(gotL3n4AddrID, DeepEquals, wantL3n4AddrID)
+	c.Assert(gotL3n4AddrID, comparator.DeepEquals, wantL3n4AddrID)
 
 	err = DeleteL3n4AddrIDBySHA256(sha256sum)
 	c.Assert(err, Equals, nil)

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	"github.com/cilium/cilium/common/addressing"
+	"github.com/cilium/cilium/pkg/comparator"
 	e "github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/labels"
@@ -184,7 +185,7 @@ func (ds *DaemonSuite) TestCleanUpDockerDangling(c *C) {
 
 	ep, err := endpointmanager.Lookup(e.NewCiliumID(259))
 	c.Assert(err, IsNil)
-	c.Assert(ep, DeepEquals, epsMap[259])
+	c.Assert(ep, comparator.DeepEquals, epsMap[259])
 
 	ds.d.deleteNonFunctionalEndpoints()
 

--- a/monitor/payload/monitor_payload_test.go
+++ b/monitor/payload/monitor_payload_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/comparator"
 	. "gopkg.in/check.v1"
 )
 
@@ -36,7 +37,7 @@ func (s *PayloadSuite) TestMeta_UnMarshalBinary(c *C) {
 	err = meta2.UnmarshalBinary(buf)
 	c.Assert(err, Equals, nil)
 
-	c.Assert(meta1, DeepEquals, meta2)
+	c.Assert(meta1, comparator.DeepEquals, meta2)
 }
 
 func (s *PayloadSuite) TestPayload_UnMarshalBinary(c *C) {
@@ -53,7 +54,7 @@ func (s *PayloadSuite) TestPayload_UnMarshalBinary(c *C) {
 	err = payload2.Decode(buf)
 	c.Assert(err, Equals, nil)
 
-	c.Assert(payload1, DeepEquals, payload2)
+	c.Assert(payload1, comparator.DeepEquals, payload2)
 }
 
 func (s *PayloadSuite) TestWriteReadMetaPayload(c *C) {
@@ -74,8 +75,8 @@ func (s *PayloadSuite) TestWriteReadMetaPayload(c *C) {
 	err = ReadMetaPayload(&buf, &meta2, &payload2)
 	c.Assert(err, Equals, nil)
 
-	c.Assert(meta1, DeepEquals, meta2)
-	c.Assert(payload1, DeepEquals, payload2)
+	c.Assert(meta1, comparator.DeepEquals, meta2)
+	c.Assert(payload1, comparator.DeepEquals, payload2)
 }
 
 func (s *PayloadSuite) BenchmarkWriteMetaPayload(c *C) {

--- a/pkg/comparator/checker.go
+++ b/pkg/comparator/checker.go
@@ -1,0 +1,60 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package comparator
+
+import (
+	"reflect"
+
+	"github.com/kr/pretty"
+	"github.com/pmezard/go-difflib/difflib"
+	"gopkg.in/check.v1"
+)
+
+type diffChecker struct {
+	*check.CheckerInfo
+}
+
+// DeepEquals is a GoCheck checker that does a diff between two objects and
+// pretty-prints any difference between the two. It can act as a substitute
+// for DeepEquals.
+var DeepEquals check.Checker = &diffChecker{
+	&check.CheckerInfo{Name: "Diff", Params: []string{"obtained", "expected"}},
+}
+
+// Check performs a diff between two objects provided as parameters, and
+// returns either true if the objects are identical, or false otherwise. If
+// it returns false, it also returns the unified diff between the expected
+// and obtained output.
+func (checker *diffChecker) Check(params []interface{}, names []string) (result bool, error string) {
+	if reflect.DeepEqual(params[0], params[1]) {
+		return true, ""
+	}
+
+	string0 := pretty.Sprintf("%# v", params[0])
+	string1 := pretty.Sprintf("%# v", params[1])
+	diff := difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string1),
+		B:        difflib.SplitLines(string0),
+		FromFile: names[1],
+		ToFile:   names[0],
+		Context:  32,
+	}
+
+	out, err := difflib.GetUnifiedDiffString(diff)
+	if err != nil {
+		return false, err.Error()
+	}
+	return false, "Unified diff:\n" + out
+}

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/common/addressing"
+	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/maps/policymap"
@@ -65,7 +66,7 @@ func (s *EndpointSuite) TestOrderEndpointAsc(c *C) {
 		{ID: 1000},
 	}
 	OrderEndpointAsc(eps)
-	c.Assert(eps, DeepEquals, epsWant)
+	c.Assert(eps, comparator.DeepEquals, epsWant)
 }
 
 func (s *EndpointSuite) TestDeepCopy(c *C) {
@@ -89,7 +90,7 @@ func (s *EndpointSuite) TestDeepCopy(c *C) {
 		Status:           NewEndpointStatus(),
 	}
 	cpy := epWant.DeepCopy()
-	c.Assert(cpy, DeepEquals, epWant)
+	c.Assert(cpy, comparator.DeepEquals, epWant)
 	epWant.SecLabel = &policy.Identity{
 		ID: 1,
 		Labels: labels.Labels{
@@ -118,9 +119,9 @@ func (s *EndpointSuite) TestDeepCopy(c *C) {
 	}
 	epWant.PolicyMap = &policymap.PolicyMap{}
 	cpy = epWant.DeepCopy()
-	c.Assert(*cpy.SecLabel, DeepEquals, *epWant.SecLabel)
-	c.Assert(cpy.Consumable, DeepEquals, epWant.Consumable)
-	c.Assert(*cpy.PolicyMap, DeepEquals, *epWant.PolicyMap)
+	c.Assert(*cpy.SecLabel, comparator.DeepEquals, *epWant.SecLabel)
+	c.Assert(cpy.Consumable, comparator.DeepEquals, epWant.Consumable)
+	c.Assert(*cpy.PolicyMap, comparator.DeepEquals, *epWant.PolicyMap)
 
 	epWant.Consumable.Labels = &policy.Identity{
 		ID: 1,
@@ -135,7 +136,7 @@ func (s *EndpointSuite) TestDeepCopy(c *C) {
 	epWant.PolicyMap = &policymap.PolicyMap{}
 	cpy = epWant.DeepCopy()
 
-	c.Assert(*cpy.Consumable.Labels, DeepEquals, *epWant.Consumable.Labels)
+	c.Assert(*cpy.Consumable.Labels, comparator.DeepEquals, *epWant.Consumable.Labels)
 
 	cpy.Consumable.Labels.Endpoints["1234"] = time.Now()
 	c.Assert(*cpy.Consumable.Labels, Not(DeepEquals), *epWant.Consumable.Labels)

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/nodeaddress"
 
 	. "gopkg.in/check.v1"
@@ -50,7 +51,7 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 					return &NodeInterfaceClient{
 						OnGet: func(name string, options metav1.GetOptions) (*v1.Node, error) {
 							c.Assert(name, Equals, "node1")
-							c.Assert(options, DeepEquals, metav1.GetOptions{})
+							c.Assert(options, comparator.DeepEquals, metav1.GetOptions{})
 							n1copy := v1.Node(node1)
 							return &n1copy, nil
 						},
@@ -59,7 +60,7 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 							n1copy := v1.Node(node1)
 							n1copy.Annotations[Annotationv4CIDRName] = "10.2.0.0/16"
 							n1copy.Annotations[Annotationv6CIDRName] = "beef:beef:beef:beef:aaaa:aaaa:1111:0/96"
-							c.Assert(n, DeepEquals, &n1copy)
+							c.Assert(n, comparator.DeepEquals, &n1copy)
 							return &n1copy, nil
 						},
 					}
@@ -109,7 +110,7 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 					return &NodeInterfaceClient{
 						OnGet: func(name string, options metav1.GetOptions) (*v1.Node, error) {
 							c.Assert(name, Equals, "node2")
-							c.Assert(options, DeepEquals, metav1.GetOptions{})
+							c.Assert(options, comparator.DeepEquals, metav1.GetOptions{})
 							n1copy := v1.Node(node2)
 							return &n1copy, nil
 						},
@@ -123,7 +124,7 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 							n1copy := v1.Node(node2)
 							n1copy.Annotations[Annotationv4CIDRName] = "10.2.0.0/16"
 							n1copy.Annotations[Annotationv6CIDRName] = "aaaa:aaaa:aaaa:aaaa:beef:beef::/96"
-							c.Assert(n, DeepEquals, &n1copy)
+							c.Assert(n, comparator.DeepEquals, &n1copy)
 							return &n1copy, nil
 						},
 					}

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -115,7 +116,7 @@ func (s *K8sSuite) TestParseNetworkPolicy(c *C) {
 	result, err := repo.ResolveL4Policy(&ctx)
 	c.Assert(result, Not(IsNil))
 	c.Assert(err, IsNil)
-	c.Assert(result, DeepEquals, &policy.L4Policy{
+	c.Assert(result, comparator.DeepEquals, &policy.L4Policy{
 		Ingress: policy.L4PolicyMap{
 			"80/TCP": policy.L4Filter{
 				Port: 80, Protocol: api.ProtoTCP,

--- a/pkg/k8s/network_policy_v1beta_test.go
+++ b/pkg/k8s/network_policy_v1beta_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -103,7 +104,7 @@ func (s *K8sSuite) TestParseNetworkPolicyDeprecated(c *C) {
 	result, err := repo.ResolveL4Policy(&ctx)
 	c.Assert(result, Not(IsNil))
 	c.Assert(err, IsNil)
-	c.Assert(result, DeepEquals, &policy.L4Policy{
+	c.Assert(result, comparator.DeepEquals, &policy.L4Policy{
 		Ingress: policy.L4PolicyMap{
 			"80/TCP": policy.L4Filter{
 				Port: 80, Protocol: api.ProtoTCP,

--- a/pkg/k8s/third_party_test.go
+++ b/pkg/k8s/third_party_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
 
@@ -220,19 +221,19 @@ func (s *K8sSuite) TestParseSpec(c *C) {
 	rules, err := expectedPolicyRule.Parse()
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
-	c.Assert(*rules[0], DeepEquals, expectedSpecRule)
+	c.Assert(*rules[0], comparator.DeepEquals, expectedSpecRule)
 
 	b, err := json.Marshal(expectedPolicyRule)
 	c.Assert(err, IsNil)
 	var expectedPolicyRuleUnmarshalled CiliumNetworkPolicy
 	err = json.Unmarshal(b, &expectedPolicyRuleUnmarshalled)
 	c.Assert(err, IsNil)
-	c.Assert(expectedPolicyRuleUnmarshalled, DeepEquals, *expectedPolicyRule)
+	c.Assert(expectedPolicyRuleUnmarshalled, comparator.DeepEquals, *expectedPolicyRule)
 
 	cnpl := CiliumNetworkPolicy{}
 	err = json.Unmarshal(ciliumRule, &cnpl)
 	c.Assert(err, IsNil)
-	c.Assert(cnpl, DeepEquals, *expectedPolicyRule)
+	c.Assert(cnpl, comparator.DeepEquals, *expectedPolicyRule)
 }
 
 func (s *K8sSuite) TestParseRules(c *C) {
@@ -259,7 +260,7 @@ func (s *K8sSuite) TestParseRules(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 2)
 	for i, rule := range rules {
-		c.Assert(rule, DeepEquals, expectedSpecRules[i])
+		c.Assert(rule, comparator.DeepEquals, expectedSpecRules[i])
 	}
 
 	b, err := json.Marshal(expectedPolicyRuleList)
@@ -267,10 +268,10 @@ func (s *K8sSuite) TestParseRules(c *C) {
 	var expectedPolicyRuleUnmarshalled CiliumNetworkPolicy
 	err = json.Unmarshal(b, &expectedPolicyRuleUnmarshalled)
 	c.Assert(err, IsNil)
-	c.Assert(expectedPolicyRuleUnmarshalled, DeepEquals, *expectedPolicyRuleList)
+	c.Assert(expectedPolicyRuleUnmarshalled, comparator.DeepEquals, *expectedPolicyRuleList)
 
 	cnpl := CiliumNetworkPolicy{}
 	err = json.Unmarshal(ciliumRuleList, &cnpl)
 	c.Assert(err, IsNil)
-	c.Assert(cnpl, DeepEquals, *expectedPolicyRuleList)
+	c.Assert(cnpl, comparator.DeepEquals, *expectedPolicyRuleList)
 }

--- a/pkg/kvstore/events_tests.go
+++ b/pkg/kvstore/events_tests.go
@@ -17,6 +17,7 @@ package kvstore
 import (
 	"time"
 
+	"github.com/cilium/cilium/pkg/comparator"
 	log "github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 )
@@ -39,11 +40,11 @@ func expectEvent(c *C, w *Watcher, typ EventType, key string, val []byte) {
 	select {
 	case event := <-w.Events:
 		c.Assert(event.Typ, Equals, typ)
-		c.Assert(event.Key, DeepEquals, key)
+		c.Assert(event.Key, comparator.DeepEquals, key)
 
 		// etcd does not provide the value of deleted keys
 		if backend == "consul" {
-			c.Assert(event.Value, DeepEquals, val)
+			c.Assert(event.Value, comparator.DeepEquals, val)
 		}
 	case <-time.After(30 * time.Second):
 		c.Fatal("timeout while waiting for kvstore watcher event")

--- a/pkg/labels/array_test.go
+++ b/pkg/labels/array_test.go
@@ -15,6 +15,8 @@
 package labels
 
 import (
+	"github.com/cilium/cilium/pkg/comparator"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -40,9 +42,9 @@ func (s *LabelsSuite) TestMatches(c *C) {
 }
 
 func (s *LabelsSuite) TestParse(c *C) {
-	c.Assert(ParseLabelArray(), DeepEquals, LabelArray{})
-	c.Assert(ParseLabelArray("magic"), DeepEquals, LabelArray{ParseLabel("magic")})
-	c.Assert(ParseLabelArray("a", "b", "c"), DeepEquals,
+	c.Assert(ParseLabelArray(), comparator.DeepEquals, LabelArray{})
+	c.Assert(ParseLabelArray("magic"), comparator.DeepEquals, LabelArray{ParseLabel("magic")})
+	c.Assert(ParseLabelArray("a", "b", "c"), comparator.DeepEquals,
 		LabelArray{ParseLabel("a"), ParseLabel("b"), ParseLabel("c")})
 }
 

--- a/pkg/labels/filter_test.go
+++ b/pkg/labels/filter_test.go
@@ -15,6 +15,8 @@
 package labels
 
 import (
+	"github.com/cilium/cilium/pkg/comparator"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -61,9 +63,9 @@ func (s *LabelsPrefCfgSuite) TestFilterLabels(c *C) {
 	allLabels["id.lizards.k8s"] = NewLabel("id.lizards.k8s", "web", LabelSourceK8s)
 	filtered, _ = dlpcfg.filterLabels(allLabels)
 	c.Assert(len(filtered), Equals, 3)
-	c.Assert(filtered, DeepEquals, wanted)
+	c.Assert(filtered, comparator.DeepEquals, wanted)
 
 	// Making sure we are deep copying the labels
 	allLabels["id.lizards"].Source = "I can change this and doesn't affect any one"
-	c.Assert(filtered, DeepEquals, wanted)
+	c.Assert(filtered, comparator.DeepEquals, wanted)
 }

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/comparator"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -55,7 +57,7 @@ func (s *LabelsSuite) TestSortMap(c *C) {
 	lblsString := strings.Join(lblsArray, ";")
 	lblsString += ";"
 	sortedMap := lbls.sortedList()
-	c.Assert(sortedMap, DeepEquals, []byte(lblsString))
+	c.Assert(sortedMap, comparator.DeepEquals, []byte(lblsString))
 }
 
 type lblTest struct {
@@ -73,7 +75,7 @@ func (s *LabelsSuite) TestMap2Labels(c *C) {
 		`//=/`:     "",
 		`%`:        `%ed`,
 	}, LabelSourceUnspec)
-	c.Assert(m, DeepEquals, lbls)
+	c.Assert(m, comparator.DeepEquals, lbls)
 }
 
 func (s *LabelsSuite) TestMergeLabels(c *C) {
@@ -90,7 +92,7 @@ func (s *LabelsSuite) TestMergeLabels(c *C) {
 	}
 	to.MergeLabels(from)
 	from["key1"].Value = "changed"
-	c.Assert(to, DeepEquals, want)
+	c.Assert(to, comparator.DeepEquals, want)
 }
 
 func (s *LabelsSuite) TestParseLabel(c *C) {
@@ -117,7 +119,7 @@ func (s *LabelsSuite) TestParseLabel(c *C) {
 	}
 	for _, test := range tests {
 		lbl := ParseLabel(test.str)
-		c.Assert(lbl, DeepEquals, test.out)
+		c.Assert(lbl, comparator.DeepEquals, test.out)
 	}
 }
 
@@ -145,7 +147,7 @@ func (s *LabelsSuite) TestParseSelectLabel(c *C) {
 	}
 	for _, test := range tests {
 		lbl := ParseSelectLabel(test.str)
-		c.Assert(lbl, DeepEquals, test.out)
+		c.Assert(lbl, comparator.DeepEquals, test.out)
 	}
 }
 
@@ -216,6 +218,6 @@ func (s *LabelsSuite) TestLabelParseKey(c *C) {
 	}
 	for _, test := range tests {
 		lbl := GetExtendedKeyFrom(test.str)
-		c.Assert(lbl, DeepEquals, test.out)
+		c.Assert(lbl, comparator.DeepEquals, test.out)
 	}
 }

--- a/pkg/mac/mac_test.go
+++ b/pkg/mac/mac_test.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/comparator"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -42,11 +44,11 @@ func (s *MACSuite) TestUnmarshalJSON(c *C) {
 	w := MAC([]byte{0x11, 0x12, 0x23, 0x34, 0x45, 0xAB})
 	d, err := json.Marshal(m)
 	c.Assert(err, IsNil)
-	c.Assert(d, DeepEquals, []byte(`"11:12:23:34:45:56"`))
+	c.Assert(d, comparator.DeepEquals, []byte(`"11:12:23:34:45:56"`))
 	var t MAC
 	err = json.Unmarshal([]byte(`"11:12:23:34:45:AB"`), &t)
 	c.Assert(err, IsNil)
-	c.Assert(t, DeepEquals, w)
+	c.Assert(t, comparator.DeepEquals, w)
 	err = json.Unmarshal([]byte(`"11:12:23:34:45:A"`), &t)
 	c.Assert(err, NotNil)
 
@@ -54,9 +56,9 @@ func (s *MACSuite) TestUnmarshalJSON(c *C) {
 	w = MAC([]byte{})
 	d, err = json.Marshal(m)
 	c.Assert(err, Equals, nil)
-	c.Assert(d, DeepEquals, []byte(`""`))
+	c.Assert(d, comparator.DeepEquals, []byte(`""`))
 	var t2 MAC
 	err = json.Unmarshal([]byte(`""`), &t2)
 	c.Assert(err, IsNil)
-	c.Assert(t2, DeepEquals, w)
+	c.Assert(t2, comparator.DeepEquals, w)
 }

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -15,6 +15,7 @@
 package policy
 
 import (
+	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
 
@@ -64,7 +65,7 @@ func (ds *PolicyTestSuite) TestAddSearchDelete(c *C) {
 
 	// rule3 should not be in there yet
 	repo.Mutex.RLock()
-	c.Assert(repo.SearchRLocked(lbls2), DeepEquals, api.Rules{})
+	c.Assert(repo.SearchRLocked(lbls2), comparator.DeepEquals, api.Rules{})
 	repo.Mutex.RUnlock()
 
 	// add rule3
@@ -75,8 +76,8 @@ func (ds *PolicyTestSuite) TestAddSearchDelete(c *C) {
 
 	// search rule1,rule2
 	repo.Mutex.RLock()
-	c.Assert(repo.SearchRLocked(lbls1), DeepEquals, api.Rules{&rule1, &rule2})
-	c.Assert(repo.SearchRLocked(lbls2), DeepEquals, api.Rules{&rule3})
+	c.Assert(repo.SearchRLocked(lbls1), comparator.DeepEquals, api.Rules{&rule1, &rule2})
+	c.Assert(repo.SearchRLocked(lbls2), comparator.DeepEquals, api.Rules{&rule3})
 	repo.Mutex.RUnlock()
 
 	// delete rule1, rule2
@@ -92,7 +93,7 @@ func (ds *PolicyTestSuite) TestAddSearchDelete(c *C) {
 
 	// rule3 can still be found
 	repo.Mutex.RLock()
-	c.Assert(repo.SearchRLocked(lbls2), DeepEquals, api.Rules{&rule3})
+	c.Assert(repo.SearchRLocked(lbls2), comparator.DeepEquals, api.Rules{&rule3})
 	repo.Mutex.RUnlock()
 
 	// delete rule3
@@ -103,7 +104,7 @@ func (ds *PolicyTestSuite) TestAddSearchDelete(c *C) {
 
 	// rule1 is gone
 	repo.Mutex.RLock()
-	c.Assert(repo.SearchRLocked(lbls2), DeepEquals, api.Rules{})
+	c.Assert(repo.SearchRLocked(lbls2), comparator.DeepEquals, api.Rules{})
 	repo.Mutex.RUnlock()
 }
 
@@ -326,10 +327,10 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 	}
 
 	c.Assert(len(l4policy.Ingress), Equals, 1)
-	c.Assert(*l4policy, DeepEquals, *expected)
+	c.Assert(*l4policy, comparator.DeepEquals, *expected)
 
 	// L4 from app3 has no rules
 	l4policy, err = repo.ResolveL4Policy(fromApp3)
 	c.Assert(len(l4policy.Ingress), Equals, 1)
-	c.Assert(*l4policy, DeepEquals, *expected)
+	c.Assert(*l4policy, comparator.DeepEquals, *expected)
 }

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -17,6 +17,7 @@ package policy
 import (
 	"net"
 
+	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
 
@@ -160,7 +161,7 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	res, err := rule1.resolveL4Policy(toBar, &state, NewL4Policy())
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
-	c.Assert(*res, DeepEquals, *expected)
+	c.Assert(*res, comparator.DeepEquals, *expected)
 	c.Assert(state.selectedRules, Equals, 1)
 
 	state = traceState{}
@@ -225,7 +226,7 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(len(res.Ingress), Equals, 1)
-	c.Assert(*res, DeepEquals, *expected)
+	c.Assert(*res, comparator.DeepEquals, *expected)
 	c.Assert(state.selectedRules, Equals, 1)
 
 	state = traceState{}
@@ -275,7 +276,7 @@ func (ds *PolicyTestSuite) TestMergeL4Policy(c *C) {
 	res, err := rule1.resolveL4Policy(toBar, &state, NewL4Policy())
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
-	c.Assert(*res, DeepEquals, *expected)
+	c.Assert(*res, comparator.DeepEquals, *expected)
 	c.Assert(state.selectedRules, Equals, 1)
 }
 
@@ -346,7 +347,7 @@ func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
 	res, err := rule1.resolveL4Policy(toBar, &state, NewL4Policy())
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
-	c.Assert(*res, DeepEquals, *expected)
+	c.Assert(*res, comparator.DeepEquals, *expected)
 	c.Assert(state.selectedRules, Equals, 1)
 
 	state = traceState{}
@@ -414,7 +415,7 @@ func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
 	res, err = rule2.resolveL4Policy(toBar, &state, NewL4Policy())
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
-	c.Assert(*res, DeepEquals, *expected)
+	c.Assert(*res, comparator.DeepEquals, *expected)
 	c.Assert(state.selectedRules, Equals, 1)
 
 	state = traceState{}
@@ -491,7 +492,7 @@ func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
 	res, err = rule3.resolveL4Policy(toBar, &state, NewL4Policy())
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
-	c.Assert(*res, DeepEquals, *expected)
+	c.Assert(*res, comparator.DeepEquals, *expected)
 	c.Assert(state.selectedRules, Equals, 1)
 }
 
@@ -553,7 +554,7 @@ func (ds *PolicyTestSuite) TestL3Policy(c *C) {
 	state := traceState{}
 	res := rule1.resolveL3Policy(toBar, &state, NewL3Policy())
 	c.Assert(res, Not(IsNil))
-	c.Assert(*res, DeepEquals, *expected)
+	c.Assert(*res, comparator.DeepEquals, *expected)
 	c.Assert(state.selectedRules, Equals, 1)
 
 	// Must be parsable, make sure Validate fails when not.

--- a/vendor.conf
+++ b/vendor.conf
@@ -61,6 +61,7 @@ github.com/pelletier/go-buffruneio df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d
 github.com/pelletier/go-toml 22139eb5469018e7374b3e7ef653de37ffb44f72
 github.com/philhofer/fwd 98c11a7a6ec829d672b03833c3d69a7fae1ca972
 github.com/pkg/errors v0.8.0
+github.com/pmezard/go-difflib v1.0.0
 github.com/sirupsen/logrus v1.0.3
 github.com/spf13/afero 9be650865eab0c12963d8753212f4f9c66cdcf12
 github.com/spf13/cast f820543c3592e283e311a60d2a600a664e39f6f7
@@ -92,3 +93,5 @@ github.com/sasha-s/go-deadlock master
 github.com/petermattis/goid 0ded85884ba5c4c9267fcd5a149061f7c3455eee
 github.com/google/gops 25312cafb9a191a6d377c480a4666beec3105e4a
 github.com/kardianos/osext ae77be60afb1dcacde03767a8c37337fad28ac14
+github.com/kr/text 7cafcd837844e784b526369c9bce262804aebc60
+github.com/kr/pretty cfb55aafdaf3ec08f0db22699ab822c50091b1c4

--- a/vendor/github.com/kr/pretty/License
+++ b/vendor/github.com/kr/pretty/License
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright 2012 Keith Rarick
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/kr/pretty/Readme
+++ b/vendor/github.com/kr/pretty/Readme
@@ -1,0 +1,9 @@
+package pretty
+
+    import "github.com/kr/pretty"
+
+    Package pretty provides pretty-printing for Go values.
+
+Documentation
+
+    http://godoc.org/github.com/kr/pretty

--- a/vendor/github.com/kr/pretty/diff.go
+++ b/vendor/github.com/kr/pretty/diff.go
@@ -1,0 +1,265 @@
+package pretty
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+)
+
+type sbuf []string
+
+func (p *sbuf) Printf(format string, a ...interface{}) {
+	s := fmt.Sprintf(format, a...)
+	*p = append(*p, s)
+}
+
+// Diff returns a slice where each element describes
+// a difference between a and b.
+func Diff(a, b interface{}) (desc []string) {
+	Pdiff((*sbuf)(&desc), a, b)
+	return desc
+}
+
+// wprintfer calls Fprintf on w for each Printf call
+// with a trailing newline.
+type wprintfer struct{ w io.Writer }
+
+func (p *wprintfer) Printf(format string, a ...interface{}) {
+	fmt.Fprintf(p.w, format+"\n", a...)
+}
+
+// Fdiff writes to w a description of the differences between a and b.
+func Fdiff(w io.Writer, a, b interface{}) {
+	Pdiff(&wprintfer{w}, a, b)
+}
+
+type Printfer interface {
+	Printf(format string, a ...interface{})
+}
+
+// Pdiff prints to p a description of the differences between a and b.
+// It calls Printf once for each difference, with no trailing newline.
+// The standard library log.Logger is a Printfer.
+func Pdiff(p Printfer, a, b interface{}) {
+	diffPrinter{w: p}.diff(reflect.ValueOf(a), reflect.ValueOf(b))
+}
+
+type Logfer interface {
+	Logf(format string, a ...interface{})
+}
+
+// logprintfer calls Fprintf on w for each Printf call
+// with a trailing newline.
+type logprintfer struct{ l Logfer }
+
+func (p *logprintfer) Printf(format string, a ...interface{}) {
+	p.l.Logf(format, a...)
+}
+
+// Ldiff prints to l a description of the differences between a and b.
+// It calls Logf once for each difference, with no trailing newline.
+// The standard library testing.T and testing.B are Logfers.
+func Ldiff(l Logfer, a, b interface{}) {
+	Pdiff(&logprintfer{l}, a, b)
+}
+
+type diffPrinter struct {
+	w Printfer
+	l string // label
+}
+
+func (w diffPrinter) printf(f string, a ...interface{}) {
+	var l string
+	if w.l != "" {
+		l = w.l + ": "
+	}
+	w.w.Printf(l+f, a...)
+}
+
+func (w diffPrinter) diff(av, bv reflect.Value) {
+	if !av.IsValid() && bv.IsValid() {
+		w.printf("nil != %# v", formatter{v: bv, quote: true})
+		return
+	}
+	if av.IsValid() && !bv.IsValid() {
+		w.printf("%# v != nil", formatter{v: av, quote: true})
+		return
+	}
+	if !av.IsValid() && !bv.IsValid() {
+		return
+	}
+
+	at := av.Type()
+	bt := bv.Type()
+	if at != bt {
+		w.printf("%v != %v", at, bt)
+		return
+	}
+
+	switch kind := at.Kind(); kind {
+	case reflect.Bool:
+		if a, b := av.Bool(), bv.Bool(); a != b {
+			w.printf("%v != %v", a, b)
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if a, b := av.Int(), bv.Int(); a != b {
+			w.printf("%d != %d", a, b)
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		if a, b := av.Uint(), bv.Uint(); a != b {
+			w.printf("%d != %d", a, b)
+		}
+	case reflect.Float32, reflect.Float64:
+		if a, b := av.Float(), bv.Float(); a != b {
+			w.printf("%v != %v", a, b)
+		}
+	case reflect.Complex64, reflect.Complex128:
+		if a, b := av.Complex(), bv.Complex(); a != b {
+			w.printf("%v != %v", a, b)
+		}
+	case reflect.Array:
+		n := av.Len()
+		for i := 0; i < n; i++ {
+			w.relabel(fmt.Sprintf("[%d]", i)).diff(av.Index(i), bv.Index(i))
+		}
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		if a, b := av.Pointer(), bv.Pointer(); a != b {
+			w.printf("%#x != %#x", a, b)
+		}
+	case reflect.Interface:
+		w.diff(av.Elem(), bv.Elem())
+	case reflect.Map:
+		ak, both, bk := keyDiff(av.MapKeys(), bv.MapKeys())
+		for _, k := range ak {
+			w := w.relabel(fmt.Sprintf("[%#v]", k))
+			w.printf("%q != (missing)", av.MapIndex(k))
+		}
+		for _, k := range both {
+			w := w.relabel(fmt.Sprintf("[%#v]", k))
+			w.diff(av.MapIndex(k), bv.MapIndex(k))
+		}
+		for _, k := range bk {
+			w := w.relabel(fmt.Sprintf("[%#v]", k))
+			w.printf("(missing) != %q", bv.MapIndex(k))
+		}
+	case reflect.Ptr:
+		switch {
+		case av.IsNil() && !bv.IsNil():
+			w.printf("nil != %# v", formatter{v: bv, quote: true})
+		case !av.IsNil() && bv.IsNil():
+			w.printf("%# v != nil", formatter{v: av, quote: true})
+		case !av.IsNil() && !bv.IsNil():
+			w.diff(av.Elem(), bv.Elem())
+		}
+	case reflect.Slice:
+		lenA := av.Len()
+		lenB := bv.Len()
+		if lenA != lenB {
+			w.printf("%s[%d] != %s[%d]", av.Type(), lenA, bv.Type(), lenB)
+			break
+		}
+		for i := 0; i < lenA; i++ {
+			w.relabel(fmt.Sprintf("[%d]", i)).diff(av.Index(i), bv.Index(i))
+		}
+	case reflect.String:
+		if a, b := av.String(), bv.String(); a != b {
+			w.printf("%q != %q", a, b)
+		}
+	case reflect.Struct:
+		for i := 0; i < av.NumField(); i++ {
+			w.relabel(at.Field(i).Name).diff(av.Field(i), bv.Field(i))
+		}
+	default:
+		panic("unknown reflect Kind: " + kind.String())
+	}
+}
+
+func (d diffPrinter) relabel(name string) (d1 diffPrinter) {
+	d1 = d
+	if d.l != "" && name[0] != '[' {
+		d1.l += "."
+	}
+	d1.l += name
+	return d1
+}
+
+// keyEqual compares a and b for equality.
+// Both a and b must be valid map keys.
+func keyEqual(av, bv reflect.Value) bool {
+	if !av.IsValid() && !bv.IsValid() {
+		return true
+	}
+	if !av.IsValid() || !bv.IsValid() || av.Type() != bv.Type() {
+		return false
+	}
+	switch kind := av.Kind(); kind {
+	case reflect.Bool:
+		a, b := av.Bool(), bv.Bool()
+		return a == b
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		a, b := av.Int(), bv.Int()
+		return a == b
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		a, b := av.Uint(), bv.Uint()
+		return a == b
+	case reflect.Float32, reflect.Float64:
+		a, b := av.Float(), bv.Float()
+		return a == b
+	case reflect.Complex64, reflect.Complex128:
+		a, b := av.Complex(), bv.Complex()
+		return a == b
+	case reflect.Array:
+		for i := 0; i < av.Len(); i++ {
+			if !keyEqual(av.Index(i), bv.Index(i)) {
+				return false
+			}
+		}
+		return true
+	case reflect.Chan, reflect.UnsafePointer, reflect.Ptr:
+		a, b := av.Pointer(), bv.Pointer()
+		return a == b
+	case reflect.Interface:
+		return keyEqual(av.Elem(), bv.Elem())
+	case reflect.String:
+		a, b := av.String(), bv.String()
+		return a == b
+	case reflect.Struct:
+		for i := 0; i < av.NumField(); i++ {
+			if !keyEqual(av.Field(i), bv.Field(i)) {
+				return false
+			}
+		}
+		return true
+	default:
+		panic("invalid map key type " + av.Type().String())
+	}
+}
+
+func keyDiff(a, b []reflect.Value) (ak, both, bk []reflect.Value) {
+	for _, av := range a {
+		inBoth := false
+		for _, bv := range b {
+			if keyEqual(av, bv) {
+				inBoth = true
+				both = append(both, av)
+				break
+			}
+		}
+		if !inBoth {
+			ak = append(ak, av)
+		}
+	}
+	for _, bv := range b {
+		inBoth := false
+		for _, av := range a {
+			if keyEqual(av, bv) {
+				inBoth = true
+				break
+			}
+		}
+		if !inBoth {
+			bk = append(bk, bv)
+		}
+	}
+	return
+}

--- a/vendor/github.com/kr/pretty/formatter.go
+++ b/vendor/github.com/kr/pretty/formatter.go
@@ -1,0 +1,328 @@
+package pretty
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"strconv"
+	"text/tabwriter"
+
+	"github.com/kr/text"
+)
+
+type formatter struct {
+	v     reflect.Value
+	force bool
+	quote bool
+}
+
+// Formatter makes a wrapper, f, that will format x as go source with line
+// breaks and tabs. Object f responds to the "%v" formatting verb when both the
+// "#" and " " (space) flags are set, for example:
+//
+//     fmt.Sprintf("%# v", Formatter(x))
+//
+// If one of these two flags is not set, or any other verb is used, f will
+// format x according to the usual rules of package fmt.
+// In particular, if x satisfies fmt.Formatter, then x.Format will be called.
+func Formatter(x interface{}) (f fmt.Formatter) {
+	return formatter{v: reflect.ValueOf(x), quote: true}
+}
+
+func (fo formatter) String() string {
+	return fmt.Sprint(fo.v.Interface()) // unwrap it
+}
+
+func (fo formatter) passThrough(f fmt.State, c rune) {
+	s := "%"
+	for i := 0; i < 128; i++ {
+		if f.Flag(i) {
+			s += string(i)
+		}
+	}
+	if w, ok := f.Width(); ok {
+		s += fmt.Sprintf("%d", w)
+	}
+	if p, ok := f.Precision(); ok {
+		s += fmt.Sprintf(".%d", p)
+	}
+	s += string(c)
+	fmt.Fprintf(f, s, fo.v.Interface())
+}
+
+func (fo formatter) Format(f fmt.State, c rune) {
+	if fo.force || c == 'v' && f.Flag('#') && f.Flag(' ') {
+		w := tabwriter.NewWriter(f, 4, 4, 1, ' ', 0)
+		p := &printer{tw: w, Writer: w, visited: make(map[visit]int)}
+		p.printValue(fo.v, true, fo.quote)
+		w.Flush()
+		return
+	}
+	fo.passThrough(f, c)
+}
+
+type printer struct {
+	io.Writer
+	tw      *tabwriter.Writer
+	visited map[visit]int
+	depth   int
+}
+
+func (p *printer) indent() *printer {
+	q := *p
+	q.tw = tabwriter.NewWriter(p.Writer, 4, 4, 1, ' ', 0)
+	q.Writer = text.NewIndentWriter(q.tw, []byte{'\t'})
+	return &q
+}
+
+func (p *printer) printInline(v reflect.Value, x interface{}, showType bool) {
+	if showType {
+		io.WriteString(p, v.Type().String())
+		fmt.Fprintf(p, "(%#v)", x)
+	} else {
+		fmt.Fprintf(p, "%#v", x)
+	}
+}
+
+// printValue must keep track of already-printed pointer values to avoid
+// infinite recursion.
+type visit struct {
+	v   uintptr
+	typ reflect.Type
+}
+
+func (p *printer) printValue(v reflect.Value, showType, quote bool) {
+	if p.depth > 10 {
+		io.WriteString(p, "!%v(DEPTH EXCEEDED)")
+		return
+	}
+
+	switch v.Kind() {
+	case reflect.Bool:
+		p.printInline(v, v.Bool(), showType)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		p.printInline(v, v.Int(), showType)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		p.printInline(v, v.Uint(), showType)
+	case reflect.Float32, reflect.Float64:
+		p.printInline(v, v.Float(), showType)
+	case reflect.Complex64, reflect.Complex128:
+		fmt.Fprintf(p, "%#v", v.Complex())
+	case reflect.String:
+		p.fmtString(v.String(), quote)
+	case reflect.Map:
+		t := v.Type()
+		if showType {
+			io.WriteString(p, t.String())
+		}
+		writeByte(p, '{')
+		if nonzero(v) {
+			expand := !canInline(v.Type())
+			pp := p
+			if expand {
+				writeByte(p, '\n')
+				pp = p.indent()
+			}
+			keys := v.MapKeys()
+			for i := 0; i < v.Len(); i++ {
+				showTypeInStruct := true
+				k := keys[i]
+				mv := v.MapIndex(k)
+				pp.printValue(k, false, true)
+				writeByte(pp, ':')
+				if expand {
+					writeByte(pp, '\t')
+				}
+				showTypeInStruct = t.Elem().Kind() == reflect.Interface
+				pp.printValue(mv, showTypeInStruct, true)
+				if expand {
+					io.WriteString(pp, ",\n")
+				} else if i < v.Len()-1 {
+					io.WriteString(pp, ", ")
+				}
+			}
+			if expand {
+				pp.tw.Flush()
+			}
+		}
+		writeByte(p, '}')
+	case reflect.Struct:
+		t := v.Type()
+		if v.CanAddr() {
+			addr := v.UnsafeAddr()
+			vis := visit{addr, t}
+			if vd, ok := p.visited[vis]; ok && vd < p.depth {
+				p.fmtString(t.String()+"{(CYCLIC REFERENCE)}", false)
+				break // don't print v again
+			}
+			p.visited[vis] = p.depth
+		}
+
+		if showType {
+			io.WriteString(p, t.String())
+		}
+		writeByte(p, '{')
+		if nonzero(v) {
+			expand := !canInline(v.Type())
+			pp := p
+			if expand {
+				writeByte(p, '\n')
+				pp = p.indent()
+			}
+			for i := 0; i < v.NumField(); i++ {
+				showTypeInStruct := true
+				if f := t.Field(i); f.Name != "" {
+					io.WriteString(pp, f.Name)
+					writeByte(pp, ':')
+					if expand {
+						writeByte(pp, '\t')
+					}
+					showTypeInStruct = labelType(f.Type)
+				}
+				pp.printValue(getField(v, i), showTypeInStruct, true)
+				if expand {
+					io.WriteString(pp, ",\n")
+				} else if i < v.NumField()-1 {
+					io.WriteString(pp, ", ")
+				}
+			}
+			if expand {
+				pp.tw.Flush()
+			}
+		}
+		writeByte(p, '}')
+	case reflect.Interface:
+		switch e := v.Elem(); {
+		case e.Kind() == reflect.Invalid:
+			io.WriteString(p, "nil")
+		case e.IsValid():
+			pp := *p
+			pp.depth++
+			pp.printValue(e, showType, true)
+		default:
+			io.WriteString(p, v.Type().String())
+			io.WriteString(p, "(nil)")
+		}
+	case reflect.Array, reflect.Slice:
+		t := v.Type()
+		if showType {
+			io.WriteString(p, t.String())
+		}
+		if v.Kind() == reflect.Slice && v.IsNil() && showType {
+			io.WriteString(p, "(nil)")
+			break
+		}
+		if v.Kind() == reflect.Slice && v.IsNil() {
+			io.WriteString(p, "nil")
+			break
+		}
+		writeByte(p, '{')
+		expand := !canInline(v.Type())
+		pp := p
+		if expand {
+			writeByte(p, '\n')
+			pp = p.indent()
+		}
+		for i := 0; i < v.Len(); i++ {
+			showTypeInSlice := t.Elem().Kind() == reflect.Interface
+			pp.printValue(v.Index(i), showTypeInSlice, true)
+			if expand {
+				io.WriteString(pp, ",\n")
+			} else if i < v.Len()-1 {
+				io.WriteString(pp, ", ")
+			}
+		}
+		if expand {
+			pp.tw.Flush()
+		}
+		writeByte(p, '}')
+	case reflect.Ptr:
+		e := v.Elem()
+		if !e.IsValid() {
+			writeByte(p, '(')
+			io.WriteString(p, v.Type().String())
+			io.WriteString(p, ")(nil)")
+		} else {
+			pp := *p
+			pp.depth++
+			writeByte(pp, '&')
+			pp.printValue(e, true, true)
+		}
+	case reflect.Chan:
+		x := v.Pointer()
+		if showType {
+			writeByte(p, '(')
+			io.WriteString(p, v.Type().String())
+			fmt.Fprintf(p, ")(%#v)", x)
+		} else {
+			fmt.Fprintf(p, "%#v", x)
+		}
+	case reflect.Func:
+		io.WriteString(p, v.Type().String())
+		io.WriteString(p, " {...}")
+	case reflect.UnsafePointer:
+		p.printInline(v, v.Pointer(), showType)
+	case reflect.Invalid:
+		io.WriteString(p, "nil")
+	}
+}
+
+func canInline(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Map:
+		return !canExpand(t.Elem())
+	case reflect.Struct:
+		for i := 0; i < t.NumField(); i++ {
+			if canExpand(t.Field(i).Type) {
+				return false
+			}
+		}
+		return true
+	case reflect.Interface:
+		return false
+	case reflect.Array, reflect.Slice:
+		return !canExpand(t.Elem())
+	case reflect.Ptr:
+		return false
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		return false
+	}
+	return true
+}
+
+func canExpand(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Map, reflect.Struct,
+		reflect.Interface, reflect.Array, reflect.Slice,
+		reflect.Ptr:
+		return true
+	}
+	return false
+}
+
+func labelType(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Interface, reflect.Struct:
+		return true
+	}
+	return false
+}
+
+func (p *printer) fmtString(s string, quote bool) {
+	if quote {
+		s = strconv.Quote(s)
+	}
+	io.WriteString(p, s)
+}
+
+func writeByte(w io.Writer, b byte) {
+	w.Write([]byte{b})
+}
+
+func getField(v reflect.Value, i int) reflect.Value {
+	val := v.Field(i)
+	if val.Kind() == reflect.Interface && !val.IsNil() {
+		val = val.Elem()
+	}
+	return val
+}

--- a/vendor/github.com/kr/pretty/pretty.go
+++ b/vendor/github.com/kr/pretty/pretty.go
@@ -1,0 +1,108 @@
+// Package pretty provides pretty-printing for Go values. This is
+// useful during debugging, to avoid wrapping long output lines in
+// the terminal.
+//
+// It provides a function, Formatter, that can be used with any
+// function that accepts a format string. It also provides
+// convenience wrappers for functions in packages fmt and log.
+package pretty
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"reflect"
+)
+
+// Errorf is a convenience wrapper for fmt.Errorf.
+//
+// Calling Errorf(f, x, y) is equivalent to
+// fmt.Errorf(f, Formatter(x), Formatter(y)).
+func Errorf(format string, a ...interface{}) error {
+	return fmt.Errorf(format, wrap(a, false)...)
+}
+
+// Fprintf is a convenience wrapper for fmt.Fprintf.
+//
+// Calling Fprintf(w, f, x, y) is equivalent to
+// fmt.Fprintf(w, f, Formatter(x), Formatter(y)).
+func Fprintf(w io.Writer, format string, a ...interface{}) (n int, error error) {
+	return fmt.Fprintf(w, format, wrap(a, false)...)
+}
+
+// Log is a convenience wrapper for log.Printf.
+//
+// Calling Log(x, y) is equivalent to
+// log.Print(Formatter(x), Formatter(y)), but each operand is
+// formatted with "%# v".
+func Log(a ...interface{}) {
+	log.Print(wrap(a, true)...)
+}
+
+// Logf is a convenience wrapper for log.Printf.
+//
+// Calling Logf(f, x, y) is equivalent to
+// log.Printf(f, Formatter(x), Formatter(y)).
+func Logf(format string, a ...interface{}) {
+	log.Printf(format, wrap(a, false)...)
+}
+
+// Logln is a convenience wrapper for log.Printf.
+//
+// Calling Logln(x, y) is equivalent to
+// log.Println(Formatter(x), Formatter(y)), but each operand is
+// formatted with "%# v".
+func Logln(a ...interface{}) {
+	log.Println(wrap(a, true)...)
+}
+
+// Print pretty-prints its operands and writes to standard output.
+//
+// Calling Print(x, y) is equivalent to
+// fmt.Print(Formatter(x), Formatter(y)), but each operand is
+// formatted with "%# v".
+func Print(a ...interface{}) (n int, errno error) {
+	return fmt.Print(wrap(a, true)...)
+}
+
+// Printf is a convenience wrapper for fmt.Printf.
+//
+// Calling Printf(f, x, y) is equivalent to
+// fmt.Printf(f, Formatter(x), Formatter(y)).
+func Printf(format string, a ...interface{}) (n int, errno error) {
+	return fmt.Printf(format, wrap(a, false)...)
+}
+
+// Println pretty-prints its operands and writes to standard output.
+//
+// Calling Print(x, y) is equivalent to
+// fmt.Println(Formatter(x), Formatter(y)), but each operand is
+// formatted with "%# v".
+func Println(a ...interface{}) (n int, errno error) {
+	return fmt.Println(wrap(a, true)...)
+}
+
+// Sprint is a convenience wrapper for fmt.Sprintf.
+//
+// Calling Sprint(x, y) is equivalent to
+// fmt.Sprint(Formatter(x), Formatter(y)), but each operand is
+// formatted with "%# v".
+func Sprint(a ...interface{}) string {
+	return fmt.Sprint(wrap(a, true)...)
+}
+
+// Sprintf is a convenience wrapper for fmt.Sprintf.
+//
+// Calling Sprintf(f, x, y) is equivalent to
+// fmt.Sprintf(f, Formatter(x), Formatter(y)).
+func Sprintf(format string, a ...interface{}) string {
+	return fmt.Sprintf(format, wrap(a, false)...)
+}
+
+func wrap(a []interface{}, force bool) []interface{} {
+	w := make([]interface{}, len(a))
+	for i, x := range a {
+		w[i] = formatter{v: reflect.ValueOf(x), force: force}
+	}
+	return w
+}

--- a/vendor/github.com/kr/pretty/zero.go
+++ b/vendor/github.com/kr/pretty/zero.go
@@ -1,0 +1,41 @@
+package pretty
+
+import (
+	"reflect"
+)
+
+func nonzero(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Bool:
+		return v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() != 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() != 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() != 0
+	case reflect.Complex64, reflect.Complex128:
+		return v.Complex() != complex(0, 0)
+	case reflect.String:
+		return v.String() != ""
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if nonzero(getField(v, i)) {
+				return true
+			}
+		}
+		return false
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if nonzero(v.Index(i)) {
+				return true
+			}
+		}
+		return false
+	case reflect.Map, reflect.Interface, reflect.Slice, reflect.Ptr, reflect.Chan, reflect.Func:
+		return !v.IsNil()
+	case reflect.UnsafePointer:
+		return v.Pointer() != 0
+	}
+	return true
+}

--- a/vendor/github.com/kr/text/License
+++ b/vendor/github.com/kr/text/License
@@ -1,0 +1,19 @@
+Copyright 2012 Keith Rarick
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/kr/text/Readme
+++ b/vendor/github.com/kr/text/Readme
@@ -1,0 +1,3 @@
+This is a Go package for manipulating paragraphs of text.
+
+See http://go.pkgdoc.org/github.com/kr/text for full documentation.

--- a/vendor/github.com/kr/text/doc.go
+++ b/vendor/github.com/kr/text/doc.go
@@ -1,0 +1,3 @@
+// Package text provides rudimentary functions for manipulating text in
+// paragraphs.
+package text

--- a/vendor/github.com/kr/text/indent.go
+++ b/vendor/github.com/kr/text/indent.go
@@ -1,0 +1,74 @@
+package text
+
+import (
+	"io"
+)
+
+// Indent inserts prefix at the beginning of each non-empty line of s. The
+// end-of-line marker is NL.
+func Indent(s, prefix string) string {
+	return string(IndentBytes([]byte(s), []byte(prefix)))
+}
+
+// IndentBytes inserts prefix at the beginning of each non-empty line of b.
+// The end-of-line marker is NL.
+func IndentBytes(b, prefix []byte) []byte {
+	var res []byte
+	bol := true
+	for _, c := range b {
+		if bol && c != '\n' {
+			res = append(res, prefix...)
+		}
+		res = append(res, c)
+		bol = c == '\n'
+	}
+	return res
+}
+
+// Writer indents each line of its input.
+type indentWriter struct {
+	w   io.Writer
+	bol bool
+	pre [][]byte
+	sel int
+	off int
+}
+
+// NewIndentWriter makes a new write filter that indents the input
+// lines. Each line is prefixed in order with the corresponding
+// element of pre. If there are more lines than elements, the last
+// element of pre is repeated for each subsequent line.
+func NewIndentWriter(w io.Writer, pre ...[]byte) io.Writer {
+	return &indentWriter{
+		w:   w,
+		pre: pre,
+		bol: true,
+	}
+}
+
+// The only errors returned are from the underlying indentWriter.
+func (w *indentWriter) Write(p []byte) (n int, err error) {
+	for _, c := range p {
+		if w.bol {
+			var i int
+			i, err = w.w.Write(w.pre[w.sel][w.off:])
+			w.off += i
+			if err != nil {
+				return n, err
+			}
+		}
+		_, err = w.w.Write([]byte{c})
+		if err != nil {
+			return n, err
+		}
+		n++
+		w.bol = c == '\n'
+		if w.bol {
+			w.off = 0
+			if w.sel < len(w.pre)-1 {
+				w.sel++
+			}
+		}
+	}
+	return n, nil
+}

--- a/vendor/github.com/kr/text/wrap.go
+++ b/vendor/github.com/kr/text/wrap.go
@@ -1,0 +1,86 @@
+package text
+
+import (
+	"bytes"
+	"math"
+)
+
+var (
+	nl = []byte{'\n'}
+	sp = []byte{' '}
+)
+
+const defaultPenalty = 1e5
+
+// Wrap wraps s into a paragraph of lines of length lim, with minimal
+// raggedness.
+func Wrap(s string, lim int) string {
+	return string(WrapBytes([]byte(s), lim))
+}
+
+// WrapBytes wraps b into a paragraph of lines of length lim, with minimal
+// raggedness.
+func WrapBytes(b []byte, lim int) []byte {
+	words := bytes.Split(bytes.Replace(bytes.TrimSpace(b), nl, sp, -1), sp)
+	var lines [][]byte
+	for _, line := range WrapWords(words, 1, lim, defaultPenalty) {
+		lines = append(lines, bytes.Join(line, sp))
+	}
+	return bytes.Join(lines, nl)
+}
+
+// WrapWords is the low-level line-breaking algorithm, useful if you need more
+// control over the details of the text wrapping process. For most uses, either
+// Wrap or WrapBytes will be sufficient and more convenient.
+//
+// WrapWords splits a list of words into lines with minimal "raggedness",
+// treating each byte as one unit, accounting for spc units between adjacent
+// words on each line, and attempting to limit lines to lim units. Raggedness
+// is the total error over all lines, where error is the square of the
+// difference of the length of the line and lim. Too-long lines (which only
+// happen when a single word is longer than lim units) have pen penalty units
+// added to the error.
+func WrapWords(words [][]byte, spc, lim, pen int) [][][]byte {
+	n := len(words)
+
+	length := make([][]int, n)
+	for i := 0; i < n; i++ {
+		length[i] = make([]int, n)
+		length[i][i] = len(words[i])
+		for j := i + 1; j < n; j++ {
+			length[i][j] = length[i][j-1] + spc + len(words[j])
+		}
+	}
+
+	nbrk := make([]int, n)
+	cost := make([]int, n)
+	for i := range cost {
+		cost[i] = math.MaxInt32
+	}
+	for i := n - 1; i >= 0; i-- {
+		if length[i][n-1] <= lim || i == n-1 {
+			cost[i] = 0
+			nbrk[i] = n
+		} else {
+			for j := i + 1; j < n; j++ {
+				d := lim - length[i][j-1]
+				c := d*d + cost[j]
+				if length[i][j-1] > lim {
+					c += pen // too-long lines get a worse penalty
+				}
+				if c < cost[i] {
+					cost[i] = c
+					nbrk[i] = j
+				}
+			}
+		}
+	}
+
+	var lines [][][]byte
+	i := 0
+	for i < n {
+		lines = append(lines, words[i:nbrk[i]])
+		i = nbrk[i]
+	}
+	return lines
+}

--- a/vendor/github.com/pmezard/go-difflib/LICENSE
+++ b/vendor/github.com/pmezard/go-difflib/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2013, Patrick Mezard
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+    The names of its contributors may not be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pmezard/go-difflib/README.md
+++ b/vendor/github.com/pmezard/go-difflib/README.md
@@ -1,0 +1,50 @@
+go-difflib
+==========
+
+[![Build Status](https://travis-ci.org/pmezard/go-difflib.png?branch=master)](https://travis-ci.org/pmezard/go-difflib)
+[![GoDoc](https://godoc.org/github.com/pmezard/go-difflib/difflib?status.svg)](https://godoc.org/github.com/pmezard/go-difflib/difflib)
+
+Go-difflib is a partial port of python 3 difflib package. Its main goal
+was to make unified and context diff available in pure Go, mostly for
+testing purposes.
+
+The following class and functions (and related tests) have be ported:
+
+* `SequenceMatcher`
+* `unified_diff()`
+* `context_diff()`
+
+## Installation
+
+```bash
+$ go get github.com/pmezard/go-difflib/difflib
+```
+
+### Quick Start
+
+Diffs are configured with Unified (or ContextDiff) structures, and can
+be output to an io.Writer or returned as a string.
+
+```Go
+diff := UnifiedDiff{
+    A:        difflib.SplitLines("foo\nbar\n"),
+    B:        difflib.SplitLines("foo\nbaz\n"),
+    FromFile: "Original",
+    ToFile:   "Current",
+    Context:  3,
+}
+text, _ := GetUnifiedDiffString(diff)
+fmt.Printf(text)
+```
+
+would output:
+
+```
+--- Original
++++ Current
+@@ -1,3 +1,3 @@
+ foo
+-bar
++baz
+```
+

--- a/vendor/github.com/pmezard/go-difflib/difflib/difflib.go
+++ b/vendor/github.com/pmezard/go-difflib/difflib/difflib.go
@@ -1,0 +1,772 @@
+// Package difflib is a partial port of Python difflib module.
+//
+// It provides tools to compare sequences of strings and generate textual diffs.
+//
+// The following class and functions have been ported:
+//
+// - SequenceMatcher
+//
+// - unified_diff
+//
+// - context_diff
+//
+// Getting unified diffs was the main goal of the port. Keep in mind this code
+// is mostly suitable to output text differences in a human friendly way, there
+// are no guarantees generated diffs are consumable by patch(1).
+package difflib
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func calculateRatio(matches, length int) float64 {
+	if length > 0 {
+		return 2.0 * float64(matches) / float64(length)
+	}
+	return 1.0
+}
+
+type Match struct {
+	A    int
+	B    int
+	Size int
+}
+
+type OpCode struct {
+	Tag byte
+	I1  int
+	I2  int
+	J1  int
+	J2  int
+}
+
+// SequenceMatcher compares sequence of strings. The basic
+// algorithm predates, and is a little fancier than, an algorithm
+// published in the late 1980's by Ratcliff and Obershelp under the
+// hyperbolic name "gestalt pattern matching".  The basic idea is to find
+// the longest contiguous matching subsequence that contains no "junk"
+// elements (R-O doesn't address junk).  The same idea is then applied
+// recursively to the pieces of the sequences to the left and to the right
+// of the matching subsequence.  This does not yield minimal edit
+// sequences, but does tend to yield matches that "look right" to people.
+//
+// SequenceMatcher tries to compute a "human-friendly diff" between two
+// sequences.  Unlike e.g. UNIX(tm) diff, the fundamental notion is the
+// longest *contiguous* & junk-free matching subsequence.  That's what
+// catches peoples' eyes.  The Windows(tm) windiff has another interesting
+// notion, pairing up elements that appear uniquely in each sequence.
+// That, and the method here, appear to yield more intuitive difference
+// reports than does diff.  This method appears to be the least vulnerable
+// to synching up on blocks of "junk lines", though (like blank lines in
+// ordinary text files, or maybe "<P>" lines in HTML files).  That may be
+// because this is the only method of the 3 that has a *concept* of
+// "junk" <wink>.
+//
+// Timing:  Basic R-O is cubic time worst case and quadratic time expected
+// case.  SequenceMatcher is quadratic time for the worst case and has
+// expected-case behavior dependent in a complicated way on how many
+// elements the sequences have in common; best case time is linear.
+type SequenceMatcher struct {
+	a              []string
+	b              []string
+	b2j            map[string][]int
+	IsJunk         func(string) bool
+	autoJunk       bool
+	bJunk          map[string]struct{}
+	matchingBlocks []Match
+	fullBCount     map[string]int
+	bPopular       map[string]struct{}
+	opCodes        []OpCode
+}
+
+func NewMatcher(a, b []string) *SequenceMatcher {
+	m := SequenceMatcher{autoJunk: true}
+	m.SetSeqs(a, b)
+	return &m
+}
+
+func NewMatcherWithJunk(a, b []string, autoJunk bool,
+	isJunk func(string) bool) *SequenceMatcher {
+
+	m := SequenceMatcher{IsJunk: isJunk, autoJunk: autoJunk}
+	m.SetSeqs(a, b)
+	return &m
+}
+
+// Set two sequences to be compared.
+func (m *SequenceMatcher) SetSeqs(a, b []string) {
+	m.SetSeq1(a)
+	m.SetSeq2(b)
+}
+
+// Set the first sequence to be compared. The second sequence to be compared is
+// not changed.
+//
+// SequenceMatcher computes and caches detailed information about the second
+// sequence, so if you want to compare one sequence S against many sequences,
+// use .SetSeq2(s) once and call .SetSeq1(x) repeatedly for each of the other
+// sequences.
+//
+// See also SetSeqs() and SetSeq2().
+func (m *SequenceMatcher) SetSeq1(a []string) {
+	if &a == &m.a {
+		return
+	}
+	m.a = a
+	m.matchingBlocks = nil
+	m.opCodes = nil
+}
+
+// Set the second sequence to be compared. The first sequence to be compared is
+// not changed.
+func (m *SequenceMatcher) SetSeq2(b []string) {
+	if &b == &m.b {
+		return
+	}
+	m.b = b
+	m.matchingBlocks = nil
+	m.opCodes = nil
+	m.fullBCount = nil
+	m.chainB()
+}
+
+func (m *SequenceMatcher) chainB() {
+	// Populate line -> index mapping
+	b2j := map[string][]int{}
+	for i, s := range m.b {
+		indices := b2j[s]
+		indices = append(indices, i)
+		b2j[s] = indices
+	}
+
+	// Purge junk elements
+	m.bJunk = map[string]struct{}{}
+	if m.IsJunk != nil {
+		junk := m.bJunk
+		for s, _ := range b2j {
+			if m.IsJunk(s) {
+				junk[s] = struct{}{}
+			}
+		}
+		for s, _ := range junk {
+			delete(b2j, s)
+		}
+	}
+
+	// Purge remaining popular elements
+	popular := map[string]struct{}{}
+	n := len(m.b)
+	if m.autoJunk && n >= 200 {
+		ntest := n/100 + 1
+		for s, indices := range b2j {
+			if len(indices) > ntest {
+				popular[s] = struct{}{}
+			}
+		}
+		for s, _ := range popular {
+			delete(b2j, s)
+		}
+	}
+	m.bPopular = popular
+	m.b2j = b2j
+}
+
+func (m *SequenceMatcher) isBJunk(s string) bool {
+	_, ok := m.bJunk[s]
+	return ok
+}
+
+// Find longest matching block in a[alo:ahi] and b[blo:bhi].
+//
+// If IsJunk is not defined:
+//
+// Return (i,j,k) such that a[i:i+k] is equal to b[j:j+k], where
+//     alo <= i <= i+k <= ahi
+//     blo <= j <= j+k <= bhi
+// and for all (i',j',k') meeting those conditions,
+//     k >= k'
+//     i <= i'
+//     and if i == i', j <= j'
+//
+// In other words, of all maximal matching blocks, return one that
+// starts earliest in a, and of all those maximal matching blocks that
+// start earliest in a, return the one that starts earliest in b.
+//
+// If IsJunk is defined, first the longest matching block is
+// determined as above, but with the additional restriction that no
+// junk element appears in the block.  Then that block is extended as
+// far as possible by matching (only) junk elements on both sides.  So
+// the resulting block never matches on junk except as identical junk
+// happens to be adjacent to an "interesting" match.
+//
+// If no blocks match, return (alo, blo, 0).
+func (m *SequenceMatcher) findLongestMatch(alo, ahi, blo, bhi int) Match {
+	// CAUTION:  stripping common prefix or suffix would be incorrect.
+	// E.g.,
+	//    ab
+	//    acab
+	// Longest matching block is "ab", but if common prefix is
+	// stripped, it's "a" (tied with "b").  UNIX(tm) diff does so
+	// strip, so ends up claiming that ab is changed to acab by
+	// inserting "ca" in the middle.  That's minimal but unintuitive:
+	// "it's obvious" that someone inserted "ac" at the front.
+	// Windiff ends up at the same place as diff, but by pairing up
+	// the unique 'b's and then matching the first two 'a's.
+	besti, bestj, bestsize := alo, blo, 0
+
+	// find longest junk-free match
+	// during an iteration of the loop, j2len[j] = length of longest
+	// junk-free match ending with a[i-1] and b[j]
+	j2len := map[int]int{}
+	for i := alo; i != ahi; i++ {
+		// look at all instances of a[i] in b; note that because
+		// b2j has no junk keys, the loop is skipped if a[i] is junk
+		newj2len := map[int]int{}
+		for _, j := range m.b2j[m.a[i]] {
+			// a[i] matches b[j]
+			if j < blo {
+				continue
+			}
+			if j >= bhi {
+				break
+			}
+			k := j2len[j-1] + 1
+			newj2len[j] = k
+			if k > bestsize {
+				besti, bestj, bestsize = i-k+1, j-k+1, k
+			}
+		}
+		j2len = newj2len
+	}
+
+	// Extend the best by non-junk elements on each end.  In particular,
+	// "popular" non-junk elements aren't in b2j, which greatly speeds
+	// the inner loop above, but also means "the best" match so far
+	// doesn't contain any junk *or* popular non-junk elements.
+	for besti > alo && bestj > blo && !m.isBJunk(m.b[bestj-1]) &&
+		m.a[besti-1] == m.b[bestj-1] {
+		besti, bestj, bestsize = besti-1, bestj-1, bestsize+1
+	}
+	for besti+bestsize < ahi && bestj+bestsize < bhi &&
+		!m.isBJunk(m.b[bestj+bestsize]) &&
+		m.a[besti+bestsize] == m.b[bestj+bestsize] {
+		bestsize += 1
+	}
+
+	// Now that we have a wholly interesting match (albeit possibly
+	// empty!), we may as well suck up the matching junk on each
+	// side of it too.  Can't think of a good reason not to, and it
+	// saves post-processing the (possibly considerable) expense of
+	// figuring out what to do with it.  In the case of an empty
+	// interesting match, this is clearly the right thing to do,
+	// because no other kind of match is possible in the regions.
+	for besti > alo && bestj > blo && m.isBJunk(m.b[bestj-1]) &&
+		m.a[besti-1] == m.b[bestj-1] {
+		besti, bestj, bestsize = besti-1, bestj-1, bestsize+1
+	}
+	for besti+bestsize < ahi && bestj+bestsize < bhi &&
+		m.isBJunk(m.b[bestj+bestsize]) &&
+		m.a[besti+bestsize] == m.b[bestj+bestsize] {
+		bestsize += 1
+	}
+
+	return Match{A: besti, B: bestj, Size: bestsize}
+}
+
+// Return list of triples describing matching subsequences.
+//
+// Each triple is of the form (i, j, n), and means that
+// a[i:i+n] == b[j:j+n].  The triples are monotonically increasing in
+// i and in j. It's also guaranteed that if (i, j, n) and (i', j', n') are
+// adjacent triples in the list, and the second is not the last triple in the
+// list, then i+n != i' or j+n != j'. IOW, adjacent triples never describe
+// adjacent equal blocks.
+//
+// The last triple is a dummy, (len(a), len(b), 0), and is the only
+// triple with n==0.
+func (m *SequenceMatcher) GetMatchingBlocks() []Match {
+	if m.matchingBlocks != nil {
+		return m.matchingBlocks
+	}
+
+	var matchBlocks func(alo, ahi, blo, bhi int, matched []Match) []Match
+	matchBlocks = func(alo, ahi, blo, bhi int, matched []Match) []Match {
+		match := m.findLongestMatch(alo, ahi, blo, bhi)
+		i, j, k := match.A, match.B, match.Size
+		if match.Size > 0 {
+			if alo < i && blo < j {
+				matched = matchBlocks(alo, i, blo, j, matched)
+			}
+			matched = append(matched, match)
+			if i+k < ahi && j+k < bhi {
+				matched = matchBlocks(i+k, ahi, j+k, bhi, matched)
+			}
+		}
+		return matched
+	}
+	matched := matchBlocks(0, len(m.a), 0, len(m.b), nil)
+
+	// It's possible that we have adjacent equal blocks in the
+	// matching_blocks list now.
+	nonAdjacent := []Match{}
+	i1, j1, k1 := 0, 0, 0
+	for _, b := range matched {
+		// Is this block adjacent to i1, j1, k1?
+		i2, j2, k2 := b.A, b.B, b.Size
+		if i1+k1 == i2 && j1+k1 == j2 {
+			// Yes, so collapse them -- this just increases the length of
+			// the first block by the length of the second, and the first
+			// block so lengthened remains the block to compare against.
+			k1 += k2
+		} else {
+			// Not adjacent.  Remember the first block (k1==0 means it's
+			// the dummy we started with), and make the second block the
+			// new block to compare against.
+			if k1 > 0 {
+				nonAdjacent = append(nonAdjacent, Match{i1, j1, k1})
+			}
+			i1, j1, k1 = i2, j2, k2
+		}
+	}
+	if k1 > 0 {
+		nonAdjacent = append(nonAdjacent, Match{i1, j1, k1})
+	}
+
+	nonAdjacent = append(nonAdjacent, Match{len(m.a), len(m.b), 0})
+	m.matchingBlocks = nonAdjacent
+	return m.matchingBlocks
+}
+
+// Return list of 5-tuples describing how to turn a into b.
+//
+// Each tuple is of the form (tag, i1, i2, j1, j2).  The first tuple
+// has i1 == j1 == 0, and remaining tuples have i1 == the i2 from the
+// tuple preceding it, and likewise for j1 == the previous j2.
+//
+// The tags are characters, with these meanings:
+//
+// 'r' (replace):  a[i1:i2] should be replaced by b[j1:j2]
+//
+// 'd' (delete):   a[i1:i2] should be deleted, j1==j2 in this case.
+//
+// 'i' (insert):   b[j1:j2] should be inserted at a[i1:i1], i1==i2 in this case.
+//
+// 'e' (equal):    a[i1:i2] == b[j1:j2]
+func (m *SequenceMatcher) GetOpCodes() []OpCode {
+	if m.opCodes != nil {
+		return m.opCodes
+	}
+	i, j := 0, 0
+	matching := m.GetMatchingBlocks()
+	opCodes := make([]OpCode, 0, len(matching))
+	for _, m := range matching {
+		//  invariant:  we've pumped out correct diffs to change
+		//  a[:i] into b[:j], and the next matching block is
+		//  a[ai:ai+size] == b[bj:bj+size]. So we need to pump
+		//  out a diff to change a[i:ai] into b[j:bj], pump out
+		//  the matching block, and move (i,j) beyond the match
+		ai, bj, size := m.A, m.B, m.Size
+		tag := byte(0)
+		if i < ai && j < bj {
+			tag = 'r'
+		} else if i < ai {
+			tag = 'd'
+		} else if j < bj {
+			tag = 'i'
+		}
+		if tag > 0 {
+			opCodes = append(opCodes, OpCode{tag, i, ai, j, bj})
+		}
+		i, j = ai+size, bj+size
+		// the list of matching blocks is terminated by a
+		// sentinel with size 0
+		if size > 0 {
+			opCodes = append(opCodes, OpCode{'e', ai, i, bj, j})
+		}
+	}
+	m.opCodes = opCodes
+	return m.opCodes
+}
+
+// Isolate change clusters by eliminating ranges with no changes.
+//
+// Return a generator of groups with up to n lines of context.
+// Each group is in the same format as returned by GetOpCodes().
+func (m *SequenceMatcher) GetGroupedOpCodes(n int) [][]OpCode {
+	if n < 0 {
+		n = 3
+	}
+	codes := m.GetOpCodes()
+	if len(codes) == 0 {
+		codes = []OpCode{OpCode{'e', 0, 1, 0, 1}}
+	}
+	// Fixup leading and trailing groups if they show no changes.
+	if codes[0].Tag == 'e' {
+		c := codes[0]
+		i1, i2, j1, j2 := c.I1, c.I2, c.J1, c.J2
+		codes[0] = OpCode{c.Tag, max(i1, i2-n), i2, max(j1, j2-n), j2}
+	}
+	if codes[len(codes)-1].Tag == 'e' {
+		c := codes[len(codes)-1]
+		i1, i2, j1, j2 := c.I1, c.I2, c.J1, c.J2
+		codes[len(codes)-1] = OpCode{c.Tag, i1, min(i2, i1+n), j1, min(j2, j1+n)}
+	}
+	nn := n + n
+	groups := [][]OpCode{}
+	group := []OpCode{}
+	for _, c := range codes {
+		i1, i2, j1, j2 := c.I1, c.I2, c.J1, c.J2
+		// End the current group and start a new one whenever
+		// there is a large range with no changes.
+		if c.Tag == 'e' && i2-i1 > nn {
+			group = append(group, OpCode{c.Tag, i1, min(i2, i1+n),
+				j1, min(j2, j1+n)})
+			groups = append(groups, group)
+			group = []OpCode{}
+			i1, j1 = max(i1, i2-n), max(j1, j2-n)
+		}
+		group = append(group, OpCode{c.Tag, i1, i2, j1, j2})
+	}
+	if len(group) > 0 && !(len(group) == 1 && group[0].Tag == 'e') {
+		groups = append(groups, group)
+	}
+	return groups
+}
+
+// Return a measure of the sequences' similarity (float in [0,1]).
+//
+// Where T is the total number of elements in both sequences, and
+// M is the number of matches, this is 2.0*M / T.
+// Note that this is 1 if the sequences are identical, and 0 if
+// they have nothing in common.
+//
+// .Ratio() is expensive to compute if you haven't already computed
+// .GetMatchingBlocks() or .GetOpCodes(), in which case you may
+// want to try .QuickRatio() or .RealQuickRation() first to get an
+// upper bound.
+func (m *SequenceMatcher) Ratio() float64 {
+	matches := 0
+	for _, m := range m.GetMatchingBlocks() {
+		matches += m.Size
+	}
+	return calculateRatio(matches, len(m.a)+len(m.b))
+}
+
+// Return an upper bound on ratio() relatively quickly.
+//
+// This isn't defined beyond that it is an upper bound on .Ratio(), and
+// is faster to compute.
+func (m *SequenceMatcher) QuickRatio() float64 {
+	// viewing a and b as multisets, set matches to the cardinality
+	// of their intersection; this counts the number of matches
+	// without regard to order, so is clearly an upper bound
+	if m.fullBCount == nil {
+		m.fullBCount = map[string]int{}
+		for _, s := range m.b {
+			m.fullBCount[s] = m.fullBCount[s] + 1
+		}
+	}
+
+	// avail[x] is the number of times x appears in 'b' less the
+	// number of times we've seen it in 'a' so far ... kinda
+	avail := map[string]int{}
+	matches := 0
+	for _, s := range m.a {
+		n, ok := avail[s]
+		if !ok {
+			n = m.fullBCount[s]
+		}
+		avail[s] = n - 1
+		if n > 0 {
+			matches += 1
+		}
+	}
+	return calculateRatio(matches, len(m.a)+len(m.b))
+}
+
+// Return an upper bound on ratio() very quickly.
+//
+// This isn't defined beyond that it is an upper bound on .Ratio(), and
+// is faster to compute than either .Ratio() or .QuickRatio().
+func (m *SequenceMatcher) RealQuickRatio() float64 {
+	la, lb := len(m.a), len(m.b)
+	return calculateRatio(min(la, lb), la+lb)
+}
+
+// Convert range to the "ed" format
+func formatRangeUnified(start, stop int) string {
+	// Per the diff spec at http://www.unix.org/single_unix_specification/
+	beginning := start + 1 // lines start numbering with one
+	length := stop - start
+	if length == 1 {
+		return fmt.Sprintf("%d", beginning)
+	}
+	if length == 0 {
+		beginning -= 1 // empty ranges begin at line just before the range
+	}
+	return fmt.Sprintf("%d,%d", beginning, length)
+}
+
+// Unified diff parameters
+type UnifiedDiff struct {
+	A        []string // First sequence lines
+	FromFile string   // First file name
+	FromDate string   // First file time
+	B        []string // Second sequence lines
+	ToFile   string   // Second file name
+	ToDate   string   // Second file time
+	Eol      string   // Headers end of line, defaults to LF
+	Context  int      // Number of context lines
+}
+
+// Compare two sequences of lines; generate the delta as a unified diff.
+//
+// Unified diffs are a compact way of showing line changes and a few
+// lines of context.  The number of context lines is set by 'n' which
+// defaults to three.
+//
+// By default, the diff control lines (those with ---, +++, or @@) are
+// created with a trailing newline.  This is helpful so that inputs
+// created from file.readlines() result in diffs that are suitable for
+// file.writelines() since both the inputs and outputs have trailing
+// newlines.
+//
+// For inputs that do not have trailing newlines, set the lineterm
+// argument to "" so that the output will be uniformly newline free.
+//
+// The unidiff format normally has a header for filenames and modification
+// times.  Any or all of these may be specified using strings for
+// 'fromfile', 'tofile', 'fromfiledate', and 'tofiledate'.
+// The modification times are normally expressed in the ISO 8601 format.
+func WriteUnifiedDiff(writer io.Writer, diff UnifiedDiff) error {
+	buf := bufio.NewWriter(writer)
+	defer buf.Flush()
+	wf := func(format string, args ...interface{}) error {
+		_, err := buf.WriteString(fmt.Sprintf(format, args...))
+		return err
+	}
+	ws := func(s string) error {
+		_, err := buf.WriteString(s)
+		return err
+	}
+
+	if len(diff.Eol) == 0 {
+		diff.Eol = "\n"
+	}
+
+	started := false
+	m := NewMatcher(diff.A, diff.B)
+	for _, g := range m.GetGroupedOpCodes(diff.Context) {
+		if !started {
+			started = true
+			fromDate := ""
+			if len(diff.FromDate) > 0 {
+				fromDate = "\t" + diff.FromDate
+			}
+			toDate := ""
+			if len(diff.ToDate) > 0 {
+				toDate = "\t" + diff.ToDate
+			}
+			if diff.FromFile != "" || diff.ToFile != "" {
+				err := wf("--- %s%s%s", diff.FromFile, fromDate, diff.Eol)
+				if err != nil {
+					return err
+				}
+				err = wf("+++ %s%s%s", diff.ToFile, toDate, diff.Eol)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		first, last := g[0], g[len(g)-1]
+		range1 := formatRangeUnified(first.I1, last.I2)
+		range2 := formatRangeUnified(first.J1, last.J2)
+		if err := wf("@@ -%s +%s @@%s", range1, range2, diff.Eol); err != nil {
+			return err
+		}
+		for _, c := range g {
+			i1, i2, j1, j2 := c.I1, c.I2, c.J1, c.J2
+			if c.Tag == 'e' {
+				for _, line := range diff.A[i1:i2] {
+					if err := ws(" " + line); err != nil {
+						return err
+					}
+				}
+				continue
+			}
+			if c.Tag == 'r' || c.Tag == 'd' {
+				for _, line := range diff.A[i1:i2] {
+					if err := ws("-" + line); err != nil {
+						return err
+					}
+				}
+			}
+			if c.Tag == 'r' || c.Tag == 'i' {
+				for _, line := range diff.B[j1:j2] {
+					if err := ws("+" + line); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// Like WriteUnifiedDiff but returns the diff a string.
+func GetUnifiedDiffString(diff UnifiedDiff) (string, error) {
+	w := &bytes.Buffer{}
+	err := WriteUnifiedDiff(w, diff)
+	return string(w.Bytes()), err
+}
+
+// Convert range to the "ed" format.
+func formatRangeContext(start, stop int) string {
+	// Per the diff spec at http://www.unix.org/single_unix_specification/
+	beginning := start + 1 // lines start numbering with one
+	length := stop - start
+	if length == 0 {
+		beginning -= 1 // empty ranges begin at line just before the range
+	}
+	if length <= 1 {
+		return fmt.Sprintf("%d", beginning)
+	}
+	return fmt.Sprintf("%d,%d", beginning, beginning+length-1)
+}
+
+type ContextDiff UnifiedDiff
+
+// Compare two sequences of lines; generate the delta as a context diff.
+//
+// Context diffs are a compact way of showing line changes and a few
+// lines of context. The number of context lines is set by diff.Context
+// which defaults to three.
+//
+// By default, the diff control lines (those with *** or ---) are
+// created with a trailing newline.
+//
+// For inputs that do not have trailing newlines, set the diff.Eol
+// argument to "" so that the output will be uniformly newline free.
+//
+// The context diff format normally has a header for filenames and
+// modification times.  Any or all of these may be specified using
+// strings for diff.FromFile, diff.ToFile, diff.FromDate, diff.ToDate.
+// The modification times are normally expressed in the ISO 8601 format.
+// If not specified, the strings default to blanks.
+func WriteContextDiff(writer io.Writer, diff ContextDiff) error {
+	buf := bufio.NewWriter(writer)
+	defer buf.Flush()
+	var diffErr error
+	wf := func(format string, args ...interface{}) {
+		_, err := buf.WriteString(fmt.Sprintf(format, args...))
+		if diffErr == nil && err != nil {
+			diffErr = err
+		}
+	}
+	ws := func(s string) {
+		_, err := buf.WriteString(s)
+		if diffErr == nil && err != nil {
+			diffErr = err
+		}
+	}
+
+	if len(diff.Eol) == 0 {
+		diff.Eol = "\n"
+	}
+
+	prefix := map[byte]string{
+		'i': "+ ",
+		'd': "- ",
+		'r': "! ",
+		'e': "  ",
+	}
+
+	started := false
+	m := NewMatcher(diff.A, diff.B)
+	for _, g := range m.GetGroupedOpCodes(diff.Context) {
+		if !started {
+			started = true
+			fromDate := ""
+			if len(diff.FromDate) > 0 {
+				fromDate = "\t" + diff.FromDate
+			}
+			toDate := ""
+			if len(diff.ToDate) > 0 {
+				toDate = "\t" + diff.ToDate
+			}
+			if diff.FromFile != "" || diff.ToFile != "" {
+				wf("*** %s%s%s", diff.FromFile, fromDate, diff.Eol)
+				wf("--- %s%s%s", diff.ToFile, toDate, diff.Eol)
+			}
+		}
+
+		first, last := g[0], g[len(g)-1]
+		ws("***************" + diff.Eol)
+
+		range1 := formatRangeContext(first.I1, last.I2)
+		wf("*** %s ****%s", range1, diff.Eol)
+		for _, c := range g {
+			if c.Tag == 'r' || c.Tag == 'd' {
+				for _, cc := range g {
+					if cc.Tag == 'i' {
+						continue
+					}
+					for _, line := range diff.A[cc.I1:cc.I2] {
+						ws(prefix[cc.Tag] + line)
+					}
+				}
+				break
+			}
+		}
+
+		range2 := formatRangeContext(first.J1, last.J2)
+		wf("--- %s ----%s", range2, diff.Eol)
+		for _, c := range g {
+			if c.Tag == 'r' || c.Tag == 'i' {
+				for _, cc := range g {
+					if cc.Tag == 'd' {
+						continue
+					}
+					for _, line := range diff.B[cc.J1:cc.J2] {
+						ws(prefix[cc.Tag] + line)
+					}
+				}
+				break
+			}
+		}
+	}
+	return diffErr
+}
+
+// Like WriteContextDiff but returns the diff a string.
+func GetContextDiffString(diff ContextDiff) (string, error) {
+	w := &bytes.Buffer{}
+	err := WriteContextDiff(w, diff)
+	return string(w.Bytes()), err
+}
+
+// Split a string on "\n" while preserving them. The output can be used
+// as input for UnifiedDiff and ContextDiff structures.
+func SplitLines(s string) []string {
+	lines := strings.SplitAfter(s, "\n")
+	lines[len(lines)-1] += "\n"
+	return lines
+}


### PR DESCRIPTION
This series implements a new gocheck checker to perform `DeepEquals`, but if the comparison fails it will print the differences more visually, with unified diff output. 

Here's an example:
```
----------------------------------------------------------------------                                                                                                                                               
FAIL: rule_test.go:238: PolicyTestSuite.TestMergeL4Policy                                                                                                                                                            
                                                                                                                                                                                                                     
rule_test.go:278:                                                                                                                                                                                                    
    c.Assert(*res, comparator.DeepEquals, *expected)
... obtained policy.L4Policy = policy.L4Policy{Ingress:policy.L4PolicyMap{"80/TCP":policy.L4Filter{Port:80, Protocol:"TCP", FromEndpoints:[]api.EndpointSelector{api.EndpointSelector{LabelSelector:(*v1.LabelSelect$
r)(0xc420499160)}, api.EndpointSelector{LabelSelector:(*v1.LabelSelector)(0xc4204991c0)}}, L7Parser:"", L7RedirectPort:0, L7RulesPerEp:policy.L7DataMap{}, Ingress:true}}, Egress:policy.L4PolicyMap{}}
... expected policy.L4Policy = policy.L4Policy{Ingress:policy.L4PolicyMap{"80/TCP":policy.L4Filter{Port:80, Protocol:"TCP", FromEndpoints:[]api.EndpointSelector(nil), L7Parser:"", L7RedirectPort:0, L7RulesPerEp:p$
licy.L7DataMap{}, Ingress:true}}, Egress:policy.L4PolicyMap{}}
... Unified diff:                                     
--- expected                                        
+++ obtained                    
@@ -1,16 +1,29 @@      
 policy.L4Policy{
     Ingress: {
         "80/TCP": {
-            Port:           80,
-            Protocol:       "TCP",
-            FromEndpoints:  nil,
+            Port:          80,
+            Protocol:      "TCP",
+            FromEndpoints: {
+                {
+                    LabelSelector: &v1.LabelSelector{
+                        MatchLabels:      {"any.foo":""},
+                        MatchExpressions: nil,
+                    },
+                },
+                {
+                    LabelSelector: &v1.LabelSelector{
+                        MatchLabels:      {"any.baz":""},
+                        MatchExpressions: nil,
+                    },
+                },
+            },
             L7Parser:       "",
             L7RedirectPort: 0,
             L7RulesPerEp:   {
             },
             Ingress: true,
         },
     },
     Egress: {
     },
 }



----------------------------------------------------------------------
```
