### PR TITLE
Makefile, bpf/Makefile: silence error messages in 'clean-tags' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ tests-consul:
 
 clean-tags:
 	-$(MAKE) -C bpf/ clean-tags
-	rm cscope.out cscope.in.out cscope.po.out cscope.files tags
+	-rm -f cscope.out cscope.in.out cscope.po.out cscope.files tags
 
 tags: $(GOLANG_SRCFILES) $(BPF_SRCFILES)
 	@$(MAKE) -C bpf/ tags

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -20,7 +20,7 @@ ifeq ("$(PKG_BUILD)","")
 all: $(BPF)
 
 clean-tags:
-	-rm cscope.out cscope.in.out cscope.po.out tags
+	-rm -f cscope.out cscope.in.out cscope.po.out tags
 
 tags: *.c $(LIB)
 	cscope -R -b -q


### PR DESCRIPTION
Silence the following error message which occur if the tag files don't
exists:

  make[1]: Entering directory '/home/vagrant/go/src/github.com/cilium/cilium/bpf'
  rm cscope.out cscope.in.out cscope.po.out tags
  rm: cannot remove 'cscope.out': No such file or directory
  rm: cannot remove 'cscope.in.out': No such file or directory
  rm: cannot remove 'cscope.po.out': No such file or directory
  rm: cannot remove 'tags': No such file or directory
  Makefile:23: recipe for target 'clean-tags' failed
  make[1]: [clean-tags] Error 1 (ignored)

Also ignore rm's exit status.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>