### PR TITLE
Daemon logrus.WithFields logs

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
@@ -120,7 +121,11 @@ func (d *Daemon) UpdateProxyRedirect(e *endpoint.Endpoint, l4 *policy.L4Filter) 
 		return 0, fmt.Errorf("can't redirect, proxy disabled")
 	}
 
-	log.Debugf("Adding redirect %+v to endpoint %d", l4, e.ID)
+	log.WithFields(log.Fields{
+		logfields.EndpointID: e.ID,
+		logfields.L4PolicyID: e.ProxyID(l4),
+		logfields.Object:     logfields.Repr(l4),
+	}).Debug("Adding redirect to endpoint")
 	r, err := d.l7Proxy.CreateOrUpdateRedirect(l4, e.ProxyID(l4), e, proxy.ProxyKindOxy)
 	if err != nil {
 		return 0, err
@@ -137,7 +142,11 @@ func (d *Daemon) RemoveProxyRedirect(e *endpoint.Endpoint, l4 *policy.L4Filter) 
 	}
 
 	id := e.ProxyID(l4)
-	log.Debugf("Removing redirect %s from endpoint %d", id, e.ID)
+	log.WithFields(log.Fields{
+		logfields.EndpointID: e.ID,
+		logfields.L4PolicyID: id,
+		logfields.Object:     l4,
+	}).Debug("Removing redirect to endpoint")
 	return d.l7Proxy.RemoveRedirect(id)
 }
 
@@ -171,7 +180,7 @@ func (d *Daemon) RemoveFromEndpointQueue(epID uint64) {
 // StartEndpointBuilders creates `nRoutines` go routines that listen on the
 // `d.buildEndpointChan` for new endpoints.
 func (d *Daemon) StartEndpointBuilders(nRoutines int) {
-	log.Debugf("Creating %d worker threads", nRoutines)
+	log.WithField("count", nRoutines).Debug("Creating worker threads")
 	for w := 0; w < nRoutines; w++ {
 		go func() {
 			for e := range d.buildEndpointChan {
@@ -257,15 +266,25 @@ func (d *Daemon) AnnotateEndpoint(e *endpoint.Endpoint, annotationKey, annotatio
 		for {
 			// Endpoint's PodName is in the format namespace:pod-name
 			split := strings.Split(e.PodName, ":")
-
 			if len(split) < 2 {
-				log.Errorf("k8s: unable to update pod %s with annotation %q: namespace and pod name should be delimited by %q", e.PodName, common.CiliumIdentityAnnotation, ":")
+				log.WithFields(log.Fields{
+					logfields.EndpointID:            e.ID,
+					logfields.K8sPodName:            e.PodName,
+					logfields.K8sIdentityAnnotation: common.CiliumIdentityAnnotation,
+				}).Error("k8s: unable to update pod with annotation: namespace and pod name should be delimited by :")
 				return
 			}
 
+			scopedLog := log.WithFields(log.Fields{
+				logfields.EndpointID:            e.ID,
+				logfields.K8sNamespace:          split[0],
+				logfields.K8sPodName:            split[1],
+				logfields.K8sIdentityAnnotation: common.CiliumIdentityAnnotation,
+			})
+
 			pod, err := k8s.Client().CoreV1().Pods(split[0]).Get(split[1], meta_v1.GetOptions{})
 			if err != nil {
-				log.Errorf("error getting pod for endpoint %d with namespace %s and pod name %s: %s", e.ID, split[0], split[1], err)
+				scopedLog.WithError(err).Error("error getting pod for endpoint")
 				return
 			}
 
@@ -275,10 +294,12 @@ func (d *Daemon) AnnotateEndpoint(e *endpoint.Endpoint, annotationKey, annotatio
 			pod.Annotations[annotationKey] = annotationValue
 			pod, err = k8s.Client().CoreV1().Pods(split[0]).Update(pod)
 			if err == nil {
-				log.Debugf("added %s annotation to endpoint %d / pod %s:%s", common.CiliumIdentityAnnotation, e.ID, split[0], split[1])
+				scopedLog.Debug("added annotation to endpoint / pods")
 				break
 			}
-			log.Warningf("k8s: unable to update  endpoint %d / pod %s:%s with %q annotation: %s, retrying...", e.ID, split[0], split[1], common.CiliumIdentityAnnotation, err)
+
+			scopedLog.Warn("k8s: unable to update  endpoint / pod  with annotation, retrying...")
+
 			if n < 30 {
 				n++
 			}
@@ -291,7 +312,7 @@ func (d *Daemon) writeNetdevHeader(dir string) error {
 
 	headerPath := filepath.Join(dir, common.NetdevHeaderFileName)
 
-	log.Debugf("writing configuration to %s", headerPath)
+	log.WithField(logfields.Path, headerPath).Debug("writing configuration")
 
 	f, err := os.Create(headerPath)
 	if err != nil {
@@ -318,7 +339,7 @@ func (d *Daemon) fmtPolicyEnforcement() string {
 // Must be called with d.conf.EnablePolicyMU locked.
 func (d *Daemon) writePreFilterHeader(dir string) error {
 	headerPath := filepath.Join(dir, common.PreFilterHeaderFileName)
-	log.Debugf("writing configuration to %s", headerPath)
+	log.WithField(logfields.Path, headerPath).Debug("writing configuration")
 	f, err := os.Create(headerPath)
 	if err != nil {
 		return fmt.Errorf("failed to open file %s for writing: %s", headerPath, err)
@@ -379,17 +400,18 @@ func runProg(prog string, args []string, quiet bool) error {
 	defer cancel()
 	out, err := exec.CommandContext(ctx, prog, args...).CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
-		log.Errorf("Command execution failed: Timeout for %s %s", prog, args)
+		cmd := fmt.Sprintf("%s %s", prog, strings.Join(args, " "))
+		log.WithField("cmd", cmd).Error("Command execution failed: Timeout")
 		return fmt.Errorf("Command execution failed: Timeout for %s %s", prog, args)
 	}
 	if err != nil {
 		if !quiet {
-			log.Warningf("Command execution %s %s failed: %s", prog,
-				strings.Join(args, " "), err)
+			cmd := fmt.Sprintf("%s %s", prog, strings.Join(args, " "))
+			log.WithError(err).WithField("cmd", cmd).Error("Command execution failed")
 
 			scanner := bufio.NewScanner(bytes.NewReader(out))
 			for scanner.Scan() {
-				log.Warning(scanner.Text())
+				log.Warn(scanner.Text())
 			}
 		}
 	}
@@ -416,7 +438,7 @@ func getFeedRule(name, args string) []string {
 	}
 	argsList, err := shellwords.Parse(args)
 	if err != nil {
-		log.WithError(err).Fatalf("Unable to parse rule '%s' into argument slice", args)
+		log.WithError(err).WithField(logfields.Object, args).Fatal("Unable to parse rule into argument slice")
 	}
 	return append(argsList, ruleTail...)
 }
@@ -433,34 +455,36 @@ func removeCiliumRules(table string) {
 	defer cancel()
 	out, err := exec.CommandContext(ctx, prog, args...).CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
-		log.Errorf("Command execution failed: Timeout for %s %s", prog, args)
+		cmd := fmt.Sprintf("%s %s", prog, strings.Join(args, " "))
+		log.WithField("cmd", cmd).Error("Command execution failed: Timeout")
 		return
 	}
 	if err != nil {
-		log.Warningf("Command execution %s %s failed: %s", prog,
-			strings.Join(args, " "), err)
+		cmd := fmt.Sprintf("%s %s", prog, strings.Join(args, " "))
+		log.WithError(err).WithField("cmd", cmd).Warn("Command execution failed")
 		return
 	}
 
 	scanner := bufio.NewScanner(bytes.NewReader(out))
 	for scanner.Scan() {
 		rule := scanner.Text()
-		log.Debugf("Considering to remove iptables rule '%s'", rule)
+		log.WithField(logfields.Object, logfields.Repr(rule)).Debug("Considering removing iptables rule")
+
 		if strings.Contains(strings.ToLower(rule), "cilium") &&
 			(strings.HasPrefix(rule, "-A") || strings.HasPrefix(rule, "-I")) {
 			// From: -A POSTROUTING -m comment [...]
 			// To:   -D POSTROUTING -m comment [...]
 			ruleAsArgs, err := shellwords.Parse(strings.Replace(rule, "-A", "-D", 1))
 			if err != nil {
-				log.WithError(err).Warningf("Unable to parse iptables rule '%s' into slice. Leaving rule behind.")
+				log.WithError(err).WithField(logfields.Object, rule).Warn("Unable to parse iptables rule into slice. Leaving rule behind.")
 				continue
 			}
 
 			deleteRule := append([]string{"-t", table}, ruleAsArgs...)
-			log.Debugf("Removing iptables rule '%v'", deleteRule)
+			log.WithField(logfields.Object, logfields.Repr(deleteRule)).Debug("Removing iptables rule")
 			err = runProg("iptables", deleteRule, true)
 			if err != nil {
-				log.WithError(err).Warningf("Unable to delete Cilium iptables rule '%s'", rule)
+				log.WithError(err).WithField(logfields.Object, rule).Warn("Unable to delete Cilium iptables rule")
 			}
 		}
 	}
@@ -571,24 +595,25 @@ func (d *Daemon) compileBase() error {
 	defer d.compilationMutex.Unlock()
 
 	if err := d.writeNetdevHeader("./"); err != nil {
-		log.Warningf("Unable to write netdev header: %s", err)
+		log.WithError(err).Warn("Unable to write netdev header")
 		return err
 	}
 
+	scopedLog := log.WithField(logfields.XDPDevice, d.conf.DevicePreFilter)
 	if d.conf.DevicePreFilter != "undefined" {
 		if err := policy.ProbePreFilter(d.conf.DevicePreFilter, d.conf.ModePreFilter); err != nil {
-			log.Warningf("Turning off prefilter for %s: %s", d.conf.DevicePreFilter, err)
+			scopedLog.WithError(err).Warn("Turning off prefilter")
 			d.conf.DevicePreFilter = "undefined"
 		}
 	}
 	if d.conf.DevicePreFilter != "undefined" {
 		if d.preFilter, ret = policy.NewPreFilter(); ret != nil {
-			log.Warningf("Unable to init prefilter: %s", ret)
+			scopedLog.WithError(ret).Warn("Unable to init prefilter")
 			return ret
 		}
 
 		if err := d.writePreFilterHeader("./"); err != nil {
-			log.Warningf("Unable to write prefilter header: %s", err)
+			scopedLog.WithError(err).Warn("Unable to write prefilter header")
 			return err
 		}
 
@@ -607,7 +632,7 @@ func (d *Daemon) compileBase() error {
 	if d.conf.Device != "undefined" {
 		_, err := netlink.LinkByName(d.conf.Device)
 		if err != nil {
-			log.Warningf("Link %s does not exist: %s", d.conf.Device, err)
+			log.WithError(err).WithField("device", d.conf.Device).Warn("Link does not exist")
 			return err
 		}
 
@@ -651,16 +676,17 @@ func (d *Daemon) compileBase() error {
 	defer cancel()
 	out, err := exec.CommandContext(ctx, prog, args...).CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
-		log.Errorf("Command execution failed: Timeout for %s %s", prog, args)
+		cmd := fmt.Sprintf("%s %s", prog, strings.Join(args, " "))
+		log.WithField("cmd", cmd).Error("Command execution failed: Timeout")
 		return fmt.Errorf("Command execution failed: Timeout for %s %s", prog, args)
 	}
 	if err != nil {
-		log.Warningf("Command execution %s %s failed: %s", prog,
-			strings.Join(args, " "), err)
+		cmd := fmt.Sprintf("%s %s", prog, strings.Join(args, " "))
+		log.WithField("cmd", cmd).Error("Command execution failed")
 
 		scanner := bufio.NewScanner(bytes.NewReader(out))
 		for scanner.Scan() {
-			log.Warning(scanner.Text())
+			log.Warn(scanner.Text())
 		}
 		return err
 	}
@@ -687,17 +713,17 @@ func (d *Daemon) compileBase() error {
 func (d *Daemon) init() error {
 	globalsDir := filepath.Join(d.conf.StateDir, "globals")
 	if err := os.MkdirAll(globalsDir, defaults.RuntimePathRights); err != nil {
-		log.Fatalf("Could not create runtime directory %s: %s", globalsDir, err)
+		log.WithError(err).WithField(logfields.Path, globalsDir).Fatal("Could not create runtime directory")
 	}
 
 	if err := os.Chdir(d.conf.StateDir); err != nil {
-		log.Fatalf("Could not change to runtime directory %s: \"%s\"",
-			d.conf.StateDir, err)
+		log.WithError(err).WithField(logfields.Path, d.conf.StateDir).Fatal("Could not change to runtime directory")
 	}
 
-	f, err := os.Create("./globals/node_config.h")
+	nodeConfigPath := "./globals/node_config.h"
+	f, err := os.Create(nodeConfigPath)
 	if err != nil {
-		log.Warningf("Failed to create node configuration file: %s", err)
+		log.WithError(err).WithField(logfields.Path, nodeConfigPath).Fatal("Failed to create node configuration file")
 		return err
 
 	}
@@ -761,7 +787,7 @@ func (d *Daemon) init() error {
 	if !d.DryModeEnabled() {
 		// Validate existing map paths before attempting BPF compile.
 		if err = d.validateExistingMaps(); err != nil {
-			log.Errorf("Error while validating maps: %s", err)
+			log.WithError(err).Error("Error while validating maps")
 			return err
 		}
 
@@ -776,7 +802,7 @@ func (d *Daemon) init() error {
 			nodeaddress.GetIPv6Router(),
 		}
 		for _, ip := range localIPs {
-			log.Debugf("Adding %v as local ip to endpoint map", ip)
+			log.WithField(logfields.IPAddr, ip).Debug("Adding local ip to endpoint map")
 			if err := lxcmap.AddHostEntry(ip); err != nil {
 				return fmt.Errorf("Unable to add host entry to endpoint map: %s", err)
 			}
@@ -804,7 +830,7 @@ func (d *Daemon) init() error {
 		}
 		// Clean all lb entries
 		if !d.conf.RestoreState {
-			log.Debugf("cleaning up all BPF LB maps")
+			log.Debug("cleaning up all BPF LB maps")
 
 			d.loadBalancer.BPFMapMU.Lock()
 			defer d.loadBalancer.BPFMapMU.Unlock()
@@ -864,7 +890,7 @@ func NewDaemon(c *Config) (*Daemon, error) {
 	// Clear previous leftovers before listening for new requests
 	err := d.clearCiliumVeths()
 	if err != nil {
-		log.Debugf("Unable to clean leftover veths: %s", err)
+		log.WithError(err).Debug("Unable to clean leftover veths")
 	}
 
 	// Create at least 4 worker threads or the same amount as there are
@@ -881,7 +907,7 @@ func NewDaemon(c *Config) (*Daemon, error) {
 		// specific mode, always allow localhost to reach local
 		// endpoints.
 		if d.conf.AllowLocalhost == AllowLocalhostAuto {
-			log.Infof("k8s mode: Allowing localhost to reach local endpoints")
+			log.Info("k8s mode: Allowing localhost to reach local endpoints")
 			config.alwaysAllowLocalhost = true
 		}
 	}
@@ -902,7 +928,7 @@ func NewDaemon(c *Config) (*Daemon, error) {
 	if v4Prefix != AutoCIDR {
 		_, net, err := net.ParseCIDR(v4Prefix)
 		if err != nil {
-			log.Fatalf("Invalid IPv4 allocation prefix '%s': %s", v4Prefix, err)
+			log.WithError(err).WithField(logfields.V4Prefix, v4Prefix).Fatal("Invalid IPv4 allocation prefix")
 		}
 		nodeaddress.SetIPv4AllocRange(net)
 	}
@@ -910,30 +936,30 @@ func NewDaemon(c *Config) (*Daemon, error) {
 	if v4ServicePrefix != AutoCIDR {
 		_, _, err := net.ParseCIDR(v4ServicePrefix)
 		if err != nil {
-			log.Fatalf("Invalid IPv4 service prefix '%s': %s", v4ServicePrefix, err)
+			log.WithError(err).WithField(logfields.V4Prefix, v4ServicePrefix).Fatal("Invalid IPv4 service prefix")
 		}
 	}
 
 	if v6Prefix != AutoCIDR {
 		_, net, err := net.ParseCIDR(v6Prefix)
 		if err != nil {
-			log.Fatalf("Invalid IPv6 allocation prefix '%s': %s", v6Prefix, err)
+			log.WithError(err).WithField(logfields.V6Prefix, v6ServicePrefix).Fatal("Invalid IPv6 allocation prefix")
 		}
 
 		if err := nodeaddress.SetIPv6NodeRange(net); err != nil {
-			log.Fatalf("Invalid per node IPv6 allocation prefix '%s': %s", net, err)
+			log.WithError(err).WithField(logfields.V6Prefix, net).Fatal("Invalid per node IPv6 allocation prefix")
 		}
 	}
 
 	if v6ServicePrefix != AutoCIDR {
 		_, _, err := net.ParseCIDR(v6ServicePrefix)
 		if err != nil {
-			log.Fatalf("Invalid IPv6 service prefix '%s': %s", v6ServicePrefix, err)
+			log.WithError(err).WithField(logfields.V6Prefix, v6ServicePrefix).Fatal("Invalid IPv6 service prefix")
 		}
 	}
 
 	if err := nodeaddress.AutoComplete(); err != nil {
-		log.Fatalf("%s", err)
+		log.WithError(err).Fatal("Cannot autocomplete node IPv6 address")
 	}
 
 	// Populate list of nodes with local node entry
@@ -945,19 +971,20 @@ func NewDaemon(c *Config) (*Daemon, error) {
 			nodeaddress.GetIPv4AllocRange(),
 			nodeaddress.GetIPv6NodeRange())
 		if err != nil {
-			log.Fatalf("Unable to get k8s node: %s", err)
+			log.WithError(err).Fatal("Cannot annotate node CIDR range data")
 		}
 	}
 
 	// Set up ipam conf after init() because we might be running d.conf.KVStoreIPv4Registration
 	if err = ipam.Init(); err != nil {
-		log.Fatal(err.Error())
+		log.WithError(err).Fatal("IPAM init failed")
 	}
 
 	if err := nodeaddress.ValidatePostInit(); err != nil {
-		log.Fatalf("%s", err)
+		log.WithError(err).Fatal("postinit failed")
 	}
 
+	// REVIEW should these be changed? they seem intended for humans
 	log.Infof("Local node-name: %s", nodeaddress.GetName())
 	log.Infof("Node-IPv6: %s", nodeaddress.GetIPv6())
 	log.Infof("External-Node IPv4: %s", nodeaddress.GetExternalIPv4())
@@ -979,7 +1006,7 @@ func NewDaemon(c *Config) (*Daemon, error) {
 	}
 
 	if err = d.init(); err != nil {
-		log.Errorf("Error while initializing daemon: %s", err)
+		log.WithError(err).Error("Error while initializing daemon")
 		return nil, err
 	}
 
@@ -988,10 +1015,10 @@ func NewDaemon(c *Config) (*Daemon, error) {
 
 	if c.RestoreState {
 		if err := d.SyncState(d.conf.StateDir, true); err != nil {
-			log.Warningf("Error while recovering endpoints: %s", err)
+			log.WithError(err).Warn("Error while recovering endpoints")
 		}
 		if err := d.SyncLBMap(); err != nil {
-			log.Warningf("Error while recovering endpoints: %s", err)
+			log.WithError(err).Warn("Error while recovering endpoints")
 		}
 	} else {
 		// We need to read all docker containers so we know we won't
@@ -1022,15 +1049,15 @@ func (d *Daemon) collectStaleMapGarbage() {
 	}
 
 	if err := filepath.Walk(bpf.MapPrefixPath(), walker); err != nil {
-		log.Warningf("Error while scanning for stale maps: %s", err)
+		log.WithError(err).Warn("Error while scanning for stale maps")
 	}
 }
 
 func (d *Daemon) removeStaleMap(path string) {
 	if err := os.RemoveAll(path); err != nil {
-		log.Warningf("Error while deleting stale map file %s: %s", path, err)
+		log.WithError(err).WithField(logfields.Path, path).Warn("Error while deleting stale map file")
 	} else {
-		log.Infof("Removed stale bpf map %s", path)
+		log.WithField(logfields.Path, path).Info("Removed stale bpf map")
 	}
 }
 
@@ -1109,7 +1136,7 @@ func mapValidateWalker(path string) error {
 			case err != nil:
 				return err
 			case !valid:
-				log.Infof("Removing mismatched map %s", filename)
+				log.WithField(logfields.Path, filename).Info("Removing mismatched map")
 				if err := os.Remove(path); err != nil {
 					return err
 				}
@@ -1132,7 +1159,7 @@ func NewPatchConfigHandler(d *Daemon) PatchConfigHandler {
 }
 
 func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
-	log.Debugf("PATCH /config request: %+v", params)
+	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PATCH /config request")
 
 	d := h.daemon
 
@@ -1160,7 +1187,7 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 
 	// Only update if value provided for PolicyEnforcement.
 	if enforcement != "" {
-		log.Debugf("configuration request to change PolicyEnforcement for daemon")
+		log.Debug("configuration request to change PolicyEnforcement for daemon")
 		switch enforcement {
 		case endpoint.NeverEnforce, endpoint.DefaultEnforcement, endpoint.AlwaysEnforce:
 
@@ -1176,22 +1203,22 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 			}
 		default:
 			msg := fmt.Errorf("Invalid option for PolicyEnforcement %s", enforcement)
-			log.Warningf("%s", msg)
+			log.Warn(msg)
 			return apierror.Error(PatchConfigFailureCode, msg)
 		}
-		log.Debugf("finished configuring PolicyEnforcement for daemon")
+		log.Debug("finished configuring PolicyEnforcement for daemon")
 	}
 
 	changes += d.conf.Opts.Apply(params.Configuration.Mutable, changedOption, d)
 
-	log.Debugf("Applied %d changes to daemon's configuration", changes)
+	log.WithField("count", changes).Debug("Applied changes to daemon's configuration")
 
 	// Only recompile if configuration has changed.
 	if changes > 0 {
-		log.Debugf("daemon configuration has changed; recompiling base programs")
+		log.Debug("daemon configuration has changed; recompiling base programs")
 		if err := d.compileBase(); err != nil {
+			log.WithError(err).Warn("Invalid option for PolicyEnforcement")
 			msg := fmt.Errorf("Unable to recompile base programs: %s", err)
-			log.Warningf("%s", msg)
 			return apierror.Error(PatchConfigFailureCode, msg)
 		}
 	}
@@ -1223,7 +1250,7 @@ func NewGetConfigHandler(d *Daemon) GetConfigHandler {
 }
 
 func (h *getConfig) Handle(params GetConfigParams) middleware.Responder {
-	log.Debugf("GET /config request: %+v", params)
+	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /config request")
 
 	d := h.daemon
 

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -43,7 +43,7 @@ func NewGetEndpointHandler(d *Daemon) GetEndpointHandler {
 }
 
 func (h *getEndpoint) Handle(params GetEndpointParams) middleware.Responder {
-	log.Debugf("GET /endpoint request: %+v", params)
+	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /endpoint request")
 
 	var wg sync.WaitGroup
 
@@ -101,7 +101,7 @@ func NewGetEndpointIDHandler(d *Daemon) GetEndpointIDHandler {
 }
 
 func (h *getEndpointID) Handle(params GetEndpointIDParams) middleware.Responder {
-	log.Debugf("GET /endpoint/{id} request: %+v", params.ID)
+	log.WithField(logfields.EndpointID, params.ID).Debug("GET /endpoint/{id} request")
 
 	ep, err := endpointmanager.Lookup(params.ID)
 
@@ -123,7 +123,7 @@ func NewPutEndpointIDHandler(d *Daemon) PutEndpointIDHandler {
 }
 
 func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder {
-	log.Debugf("PUT /endpoint/{id} request: %+v", params)
+	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PUT /endpoint/{id} request")
 
 	epTemplate := params.Endpoint
 	if n, err := endpoint.ParseCiliumID(params.ID); err != nil {
@@ -157,7 +157,7 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder 
 	}
 
 	if err := ep.CreateDirectory(); err != nil {
-		log.Warningf("Aborting endpoint join: %s", err)
+		log.WithError(err).Warn("Aborting endpoint join")
 		return apierror.Error(PutEndpointIDFailedCode, err)
 	}
 
@@ -175,7 +175,11 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder 
 		errLabelsAdd := h.d.UpdateSecLabels(params.ID, add, labels.Labels{})
 		endpointmanager.Mutex.Lock()
 		if errLabelsAdd != nil {
-			log.Errorf("Could not add labels %v while creating an ep %s due to %s", add, params.ID, errLabelsAdd)
+			log.WithFields(log.Fields{
+				logfields.EndpointID:              params.ID,
+				logfields.IdentityLabels:          logfields.Repr(add),
+				logfields.IdentityLabels + ".bad": errLabelsAdd,
+			}).Error("Could not add labels while creating an ep due to bad labels")
 			return errLabelsAdd
 		}
 	}
@@ -193,7 +197,7 @@ func NewPatchEndpointIDHandler(d *Daemon) PatchEndpointIDHandler {
 }
 
 func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Responder {
-	log.Debugf("PATCH /endpoint/{id} %+v", params)
+	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PATCH /endpoint/{id} request")
 
 	epTemplate := params.Endpoint
 
@@ -280,6 +284,8 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 }
 
 func (d *Daemon) deleteEndpoint(ep *endpoint.Endpoint) int {
+	scopedLog := log.WithField(logfields.EndpointID, ep.ID)
+
 	// Wait for existing builds to complete and prevent further builds
 	ep.BuildMutex.Lock()
 	defer ep.BuildMutex.Unlock()
@@ -298,8 +304,10 @@ func (d *Daemon) deleteEndpoint(ep *endpoint.Endpoint) int {
 
 	sha256sum := ep.OpLabels.IdentityLabels().SHA256Sum()
 	if err := d.DeleteIdentityBySHA256(sha256sum, ep.StringID()); err != nil {
-		log.Errorf("Error while deleting labels (SHA256SUM:%s) %+v: %s",
-			sha256sum, ep.OpLabels.IdentityLabels(), err)
+		log.WithError(err).WithFields(log.Fields{
+			logfields.SHA:            sha256sum,
+			logfields.IdentityLabels: ep.OpLabels.IdentityLabels(),
+		}).Error("Error while deleting labels")
 	}
 
 	var errors int
@@ -314,44 +322,44 @@ func (d *Daemon) deleteEndpoint(ep *endpoint.Endpoint) int {
 
 		// Remove policy BPF map
 		if err := os.RemoveAll(ep.PolicyMapPathLocked()); err != nil {
-			log.Warningf("Unable to remove policy map file (%s): %s", ep.PolicyMapPathLocked(), err)
+			scopedLog.WithError(err).WithField(logfields.Path, ep.PolicyMapPathLocked()).Warn("Unable to remove policy map file")
 			errors++
 		}
 
 		// Remove calls BPF map
 		if err := os.RemoveAll(ep.CallsMapPathLocked()); err != nil {
-			log.Warningf("Unable to remove calls map file (%s): %s", ep.CallsMapPathLocked(), err)
+			scopedLog.WithError(err).WithField(logfields.Path, ep.CallsMapPathLocked()).Warn("Unable to remove calls map file")
 			errors++
 		}
 
 		// Remove IPv6 connection tracking map
 		if err := os.RemoveAll(ep.Ct6MapPathLocked()); err != nil {
-			log.Warningf("Unable to remove IPv6 CT map file (%s): %s", ep.Ct6MapPathLocked(), err)
+			scopedLog.WithError(err).WithField(logfields.Path, ep.Ct6MapPathLocked()).Warn("Unable to remove IPv6 CT map file")
 			errors++
 		}
 
 		// Remove IPv4 connection tracking map
 		if err := os.RemoveAll(ep.Ct4MapPathLocked()); err != nil {
-			log.Warningf("Unable to remove IPv4 CT map file (%s): %s", ep.Ct4MapPathLocked(), err)
+			scopedLog.WithError(err).WithField(logfields.Path, ep.Ct4MapPathLocked()).Warn("Unable to remove IPv4 CT map file")
 			errors++
 		}
 
 		// Remove handle_policy() tail call entry for EP
-		if ep.RemoveFromGlobalPolicyMap() != nil {
-			log.Warningf("Unable to remove EP from global policy map!")
+		if err := ep.RemoveFromGlobalPolicyMap(); err != nil {
+			scopedLog.WithError(err).Warn("Unable to remove EP from global policy map!")
 			errors++
 		}
 	}
 
 	if !d.conf.IPv4Disabled {
 		if err := ipam.ReleaseIP(ep.IPv4.IP()); err != nil {
-			log.Warningf("error while releasing IPv4 %s: %s", ep.IPv4.IP(), err)
+			scopedLog.WithError(err).WithField(logfields.IPAddr, ep.IPv4.IP()).Warn("Error while releasing IPv4")
 			errors++
 		}
 	}
 
 	if err := ipam.ReleaseIP(ep.IPv6.IP()); err != nil {
-		log.Warningf("error while releasing IPv6 %s: %s", ep.IPv6.IP(), err)
+		scopedLog.WithError(err).WithField(logfields.IPAddr, ep.IPv6.IP()).Warn("Error while releasing IPv6")
 		errors++
 	}
 
@@ -382,7 +390,7 @@ func NewDeleteEndpointIDHandler(d *Daemon) DeleteEndpointIDHandler {
 }
 
 func (h *deleteEndpointID) Handle(params DeleteEndpointIDParams) middleware.Responder {
-	log.Debugf("DELETE /endpoint/{id} %+v", params)
+	log.WithField(logfields.Params, logfields.Repr(params)).Debug("DELETE /endpoint/{id} request")
 
 	d := h.daemon
 	if nerr, err := d.DeleteEndpoint(params.ID); err != nil {
@@ -431,7 +439,7 @@ func NewPatchEndpointIDConfigHandler(d *Daemon) PatchEndpointIDConfigHandler {
 }
 
 func (h *patchEndpointIDConfig) Handle(params PatchEndpointIDConfigParams) middleware.Responder {
-	log.Debugf("PATCH /endpoint/{id}/config %+v", params)
+	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PATCH /endpoint/{id}/config request")
 
 	d := h.daemon
 	if err := d.EndpointUpdate(params.ID, params.Configuration); err != nil {
@@ -453,7 +461,7 @@ func NewGetEndpointIDConfigHandler(d *Daemon) GetEndpointIDConfigHandler {
 }
 
 func (h *getEndpointIDConfig) Handle(params GetEndpointIDConfigParams) middleware.Responder {
-	log.Debugf("GET /endpoint/{id}/config %+v", params)
+	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /endpoint/{id}/config")
 
 	ep, err := endpointmanager.Lookup(params.ID)
 	if err != nil {
@@ -474,7 +482,7 @@ func NewGetEndpointIDLabelsHandler(d *Daemon) GetEndpointIDLabelsHandler {
 }
 
 func (h *getEndpointIDLabels) Handle(params GetEndpointIDLabelsParams) middleware.Responder {
-	log.Debugf("GET /endpoint/{id}/labels %+v", params)
+	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /endpoint/{id}/labels")
 
 	ep, err := endpointmanager.Lookup(params.ID)
 	if err != nil {
@@ -574,7 +582,7 @@ func (d *Daemon) UpdateSecLabels(id string, add, del labels.Labels) middleware.R
 			log.WithFields(log.Fields{
 				logfields.EndpointID: ep.StringID(),
 				logfields.Identity:   identity.ID,
-			}).WithError(err).Warningf("Unable to release temporary identity")
+			}).WithError(err).Warn("Unable to release temporary identity")
 		}
 		return NewPutEndpointIDLabelsNotFound()
 	}
@@ -600,7 +608,7 @@ func NewPutEndpointIDLabelsHandler(d *Daemon) PutEndpointIDLabelsHandler {
 func (h *putEndpointIDLabels) Handle(params PutEndpointIDLabelsParams) middleware.Responder {
 	d := h.daemon
 
-	log.Debugf("PUT /endpoint/{id}/labels %+v", params)
+	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PUT /endpoint/{id}/labels request")
 
 	mod := params.Configuration
 	add := labels.NewLabelsFromModel(mod.Add)
@@ -654,7 +662,7 @@ func (d *Daemon) EndpointLabelsUpdate(ep *endpoint.Endpoint, identityLabels, inf
 			log.WithFields(log.Fields{
 				logfields.EndpointID: ep.StringID(),
 				logfields.Identity:   identity.ID,
-			}).WithError(err).Warningf("Unable to release temporary identity")
+			}).WithError(err).Warn("Unable to release temporary identity")
 		}
 
 		return fmt.Errorf("Endpoint is disconnected, aborting label update handler")

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/nodeaddress"
 
@@ -85,17 +86,17 @@ func k8sErrorHandler(e error) {
 		} else {
 			if strings.Contains(errstr, "Failed to list *v1.NetworkPolicy: the server could not find the requested resource") {
 				k8sErrMsgMU.Unlock()
-				log.Warningf("Consider upgrading kubernetes to >=1.7 to enforce NetworkPolicy version 1")
+				log.Warn("Consider upgrading kubernetes to >=1.7 to enforce NetworkPolicy version 1")
 				stopPolicyController <- struct{}{}
 			} else if strings.Contains(errstr, "Failed to list *k8s.CiliumNetworkPolicy: the server could not find the requested resource") {
 				k8sErrMsg[errstr] = time.NewTimer(k8sErrLogTimeout)
 				k8sErrMsgMU.Unlock()
-				log.Warningf("Detected conflicting TPR and CRD, please migrate all ThirdPartyResource to CustomResourceDefinition! More info: https://cilium.link/migrate-tpr")
-				log.Warningf("Due to conflicting TPR and CRD rules, CiliumNetworkPolicy enforcement can't be guaranteed!")
+				log.Warn("Detected conflicting TPR and CRD, please migrate all ThirdPartyResource to CustomResourceDefinition! More info: https://cilium.link/migrate-tpr")
+				log.Warn("Due to conflicting TPR and CRD rules, CiliumNetworkPolicy enforcement can't be guaranteed!")
 			} else if strings.Contains(errstr, "Unable to decode an event from the watch stream: unable to decode watch event") || strings.Contains(errstr, "Failed to list *k8s.CiliumNetworkPolicy: only encoded map or array can be decoded into a struct") {
 				k8sErrMsg[errstr] = time.NewTimer(k8sErrLogTimeout)
 				k8sErrMsgMU.Unlock()
-				log.Warningf("Unable to decode an event from watch, restarting cilium policy rules controller")
+				log.Warn("Unable to decode an event from watch, restarting cilium policy rules controller")
 				restartCiliumRulesController <- struct{}{}
 			}
 		}
@@ -103,14 +104,14 @@ func k8sErrorHandler(e error) {
 		k8sErrMsgMU.Unlock()
 		select {
 		case <-t.C:
-			log.Error(e)
+			log.WithError(e).Error("k8sError")
 			t.Reset(k8sErrLogTimeout)
 		default:
 		}
 		return
 	}
 	// Still log other error messages
-	log.Error(e)
+	log.WithError(e).Error("k8sError")
 }
 
 // EnableK8sWatcher watches for policy, services and endpoint changes on the Kubernetes
@@ -134,7 +135,7 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 	if err := k8s.CreateCustomResourceDefinitions(apiextensionsclientset); errors.IsNotFound(err) {
 		// If CRD was not found it means we are running in k8s <1.7
 		// then we should set up TPR instead
-		log.Debugf("Detected k8s <1.7, using TPR instead of CRD")
+		log.Debug("Detected k8s <1.7, using TPR instead of CRD")
 		if err := k8s.CreateThirdPartyResourcesDefinitions(k8s.Client()); err != nil {
 			return fmt.Errorf("Unable to create third party resource: %s", err)
 		}
@@ -269,42 +270,55 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 func (d *Daemon) addK8sNetworkPolicy(obj interface{}) {
 	k8sNP, ok := obj.(*networkingv1.NetworkPolicy)
 	if !ok {
-		log.Errorf("Ignoring invalid k8s NetworkPolicy addition")
+		log.Error("Ignoring invalid k8s NetworkPolicy addition")
 		return
 	}
 	rules, err := k8s.ParseNetworkPolicy(k8sNP)
 	if err != nil {
-		log.Errorf("Error while parsing kubernetes network policy %+v: %s", obj, err)
+		log.WithError(err).WithField(logfields.Object, logfields.Repr(obj)).Error("Error while parsing kubernetes network policy")
 		return
 	}
+
+	scopedLog := log.WithFields(log.Fields{
+		logfields.K8sNetworkPolicyName: k8sNP.Name,
+		logfields.K8sNetworkPolicy:     logfields.Repr(k8sNP),
+	})
 
 	opts := AddOptions{Replace: true}
 	if _, err := d.PolicyAdd(rules, &opts); err != nil {
-		log.Errorf("Error while adding kubernetes network policy %+v: %s", rules, err)
+		scopedLog.WithError(err).WithField(logfields.Object, logfields.Repr(rules)).Error("Error while adding kubernetes network policy")
 		return
 	}
 
-	log.Infof("Kubernetes network policy '%s' successfully add", k8sNP.Name)
+	scopedLog.Info("Kubernetes network policy successfully added")
 }
 
 func (d *Daemon) updateK8sNetworkPolicy(oldObj interface{}, newObj interface{}) {
-	log.Debugf("Modified policy %+v->%+v", oldObj, newObj)
+	log.WithFields(log.Fields{
+		"obj.old": logfields.Repr(oldObj),
+		"obj.new": logfields.Repr(newObj),
+	}).Debug("Modified policy")
+
 	d.addK8sNetworkPolicy(newObj)
 }
 
 func (d *Daemon) deleteK8sNetworkPolicy(obj interface{}) {
 	k8sNP, ok := obj.(*networkingv1.NetworkPolicy)
 	if !ok {
-		log.Errorf("Ignoring invalid k8s NetworkPolicy deletion")
+		log.Error("Ignoring invalid k8s NetworkPolicy deletion")
 		return
 	}
 
 	labels := labels.ParseSelectLabelArray(k8s.ExtractPolicyName(k8sNP))
 
+	scopedLog := log.WithFields(log.Fields{
+		logfields.K8sNetworkPolicyName: k8sNP.Name,
+		logfields.Labels:               logfields.Repr(labels),
+	})
 	if _, err := d.PolicyDelete(labels); err != nil {
-		log.Errorf("Error while deleting kubernetes network policy %+v: %s", labels, err)
+		scopedLog.WithError(err).Error("Error while deleting kubernetes network policy")
 	} else {
-		log.Infof("Kubernetes network policy '%s' successfully removed", k8sNP.Name)
+		scopedLog.Info("Kubernetes network policy successfully removed")
 	}
 }
 
@@ -312,27 +326,33 @@ func (d *Daemon) deleteK8sNetworkPolicy(obj interface{}) {
 func (d *Daemon) addK8sNetworkPolicyDeprecated(obj interface{}) {
 	k8sNP, ok := obj.(*v1beta1.NetworkPolicy)
 	if !ok {
-		log.Errorf("Ignoring invalid k8s v1beta1 NetworkPolicy addition")
+		log.Error("Ignoring invalid k8s v1beta1 NetworkPolicy addition")
 		return
 	}
 	rules, err := k8s.ParseNetworkPolicyDeprecated(k8sNP)
 	if err != nil {
-		log.Errorf("Error while parsing kubernetes v1beta1 network policy %+v: %s", obj, err)
+		log.WithError(err).WithField(logfields.Object, logfields.Repr(obj)).Error("Error while parsing kubernetes v1beta1 network policy")
 		return
 	}
+
+	scopedLog := log.WithField(logfields.K8sNetworkPolicyName, k8sNP.Name)
 
 	opts := AddOptions{Replace: true}
 	if _, err := d.PolicyAdd(rules, &opts); err != nil {
-		log.Errorf("Error while adding kubernetes v1beta1 network policy %+v: %s", rules, err)
+		scopedLog.WithField(logfields.Object, logfields.Repr(rules)).Error("Error while parsing kubernetes v1beta1 network policy")
 		return
 	}
 
-	log.Infof("Kubernetes v1beta1 network policy '%s' successfully added", k8sNP.Name)
+	scopedLog.Info("Kubernetes v1beta1 network policy successfully added")
 }
 
 // updateK8sNetworkPolicyDeprecated FIXME remove in k8s 1.8
 func (d *Daemon) updateK8sNetworkPolicyDeprecated(oldObj interface{}, newObj interface{}) {
-	log.Debugf("Modified v1beta1 policy %+v->%+v", oldObj, newObj)
+	log.WithFields(log.Fields{
+		"obj.old": oldObj,
+		"obj.new": newObj,
+	}).Debug("Modified v1beta1 policy")
+
 	d.addK8sNetworkPolicyDeprecated(newObj)
 }
 
@@ -340,17 +360,23 @@ func (d *Daemon) updateK8sNetworkPolicyDeprecated(oldObj interface{}, newObj int
 func (d *Daemon) deleteK8sNetworkPolicyDeprecated(obj interface{}) {
 	k8sNP, ok := obj.(*v1beta1.NetworkPolicy)
 	if !ok {
-		log.Errorf("Ignoring invalid k8s v1beta1.NetworkPolicy deletion")
+		log.Error("Ignoring invalid k8s v1beta1.NetworkPolicy deletion")
 		return
 	}
 
 	labels := labels.ParseSelectLabelArray(k8s.ExtractPolicyNameDeprecated(k8sNP))
 
+	scopedLog := log.WithFields(log.Fields{
+		logfields.K8sNetworkPolicyName: k8sNP.Name,
+		logfields.Labels:               logfields.Repr(labels),
+	})
+
 	if _, err := d.PolicyDelete(labels); err != nil {
-		log.Errorf("Error while deleting v1beta1 kubernetes network policy %+v: %s", labels, err)
-	} else {
-		log.Infof("Kubernetes v1beta1 network policy '%s' successfully removed", k8sNP.Name)
+		scopedLog.WithError(err).Error("Error while deleting v1beta1 kubernetes network policy")
+		return
 	}
+
+	scopedLog.Info("Kubernetes v1beta1 network policy successfully removed")
 }
 
 func (d *Daemon) serviceAddFn(obj interface{}) {
@@ -358,6 +384,12 @@ func (d *Daemon) serviceAddFn(obj interface{}) {
 	if !ok {
 		return
 	}
+
+	scopedLog := log.WithFields(log.Fields{
+		logfields.K8sSvcName:   svc.Name,
+		logfields.K8sNamespace: svc.Namespace,
+		logfields.K8sSvcType:   svc.Spec.Type,
+	})
 
 	switch svc.Spec.Type {
 	case v1.ServiceTypeClusterIP, v1.ServiceTypeNodePort, v1.ServiceTypeLoadBalancer:
@@ -368,14 +400,12 @@ func (d *Daemon) serviceAddFn(obj interface{}) {
 		return
 
 	default:
-		log.Warningf("Ignoring k8s service %s/%s, reason unsupported type %s",
-			svc.Namespace, svc.Name, svc.Spec.Type)
+		scopedLog.Warn("Ignoring k8s service: unsupported type")
 		return
 	}
 
 	if strings.ToLower(svc.Spec.ClusterIP) == "none" || svc.Spec.ClusterIP == "" {
-		log.Infof("Ignoring k8s service %s/%s, reason: headless",
-			svc.Namespace, svc.Name, svc.Spec.Type)
+		scopedLog.Info("Ignoring k8s service: headless")
 		return
 	}
 
@@ -393,7 +423,7 @@ func (d *Daemon) serviceAddFn(obj interface{}) {
 	for _, port := range svc.Spec.Ports {
 		p, err := types.NewFEPort(types.L4Type(port.Protocol), uint16(port.Port))
 		if err != nil {
-			log.Errorf("Unable to add service port %v: %s", port, err)
+			scopedLog.WithError(err).WithField("port", port).Error("Unable to add service port")
 			continue
 		}
 		if _, ok := newSI.Ports[types.FEPortName(port.Name)]; !ok {
@@ -414,7 +444,7 @@ func (d *Daemon) serviceModFn(_ interface{}, newObj interface{}) {
 	if !ok {
 		return
 	}
-	log.Debugf("Service %+v", newSvc)
+	log.WithField(logfields.Object, logfields.Repr(newSvc)).Debug("Service ModFn")
 
 	d.serviceAddFn(newObj)
 }
@@ -424,7 +454,10 @@ func (d *Daemon) serviceDelFn(obj interface{}) {
 	if !ok {
 		return
 	}
-	log.Debugf("Service %+v", svc)
+	log.WithFields(log.Fields{
+		logfields.K8sSvcName:   svc.Name,
+		logfields.K8sNamespace: svc.Namespace,
+	}).Debug("Deleting k8s service")
 
 	svcns := &types.K8sServiceNamespace{
 		Service:   svc.Name,
@@ -442,6 +475,11 @@ func (d *Daemon) endpointAddFn(obj interface{}) {
 		return
 	}
 
+	scopedLog := log.WithFields(log.Fields{
+		logfields.K8sEndpointName: ep.Name,
+		logfields.K8sNamespace:    ep.Namespace,
+	})
+
 	svcns := types.K8sServiceNamespace{
 		Service:   ep.Name,
 		Namespace: ep.Namespace,
@@ -456,7 +494,7 @@ func (d *Daemon) endpointAddFn(obj interface{}) {
 		for _, port := range sub.Ports {
 			lbPort, err := types.NewL4Addr(types.L4Type(port.Protocol), uint16(port.Port))
 			if err != nil {
-				log.Errorf("Error while creating a new LB Port: %s", err)
+				scopedLog.WithError(err).Error("Error while creating a new LB Port")
 				continue
 			}
 			newSvcEP.Ports[types.FEPortName(port.Name)] = lbPort
@@ -472,7 +510,7 @@ func (d *Daemon) endpointAddFn(obj interface{}) {
 
 	if d.conf.IsLBEnabled() {
 		if err := d.syncExternalLB(&svcns, nil, nil); err != nil {
-			log.Errorf("Unable to add endpoints on ingress service %s: %s", svcns, err)
+			scopedLog.WithError(err).Error("Unable to add endpoints on ingress service")
 			return
 		}
 	}
@@ -493,6 +531,11 @@ func (d *Daemon) endpointDelFn(obj interface{}) {
 		return
 	}
 
+	scopedLog := log.WithFields(log.Fields{
+		logfields.K8sEndpointName: ep.Name,
+		logfields.K8sNamespace:    ep.Namespace,
+	})
+
 	svcns := &types.K8sServiceNamespace{
 		Service:   ep.Name,
 		Namespace: ep.Namespace,
@@ -504,7 +547,7 @@ func (d *Daemon) endpointDelFn(obj interface{}) {
 	d.syncLB(nil, nil, svcns)
 	if d.conf.IsLBEnabled() {
 		if err := d.syncExternalLB(nil, nil, svcns); err != nil {
-			log.Errorf("Unable to remove endpoints on ingress service %s: %s", svcns, err)
+			scopedLog.WithError(err).Error("Unable to remove endpoints on ingress service")
 			return
 		}
 	}
@@ -551,6 +594,11 @@ func (d *Daemon) delK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 		return err
 	}
 
+	scopedLog := log.WithFields(log.Fields{
+		logfields.K8sSvcName:   svc.Service,
+		logfields.K8sNamespace: svc.Namespace,
+	})
+
 	repPorts := getUniqPorts(svcInfo.Ports)
 
 	for _, svcPort := range svcInfo.Ports {
@@ -561,32 +609,38 @@ func (d *Daemon) delK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 
 		if svcPort.ID != 0 {
 			if err := DeleteL3n4AddrIDByUUID(uint32(svcPort.ID)); err != nil {
-				log.Warningf("Error while cleaning service ID: %s", err)
+				scopedLog.WithError(err).Warn("Error while cleaning service ID")
 			}
 		}
 
 		fe, err := types.NewL3n4Addr(svcPort.Protocol, svcInfo.FEIP, svcPort.Port)
 		if err != nil {
-			log.Errorf("Error while creating a New L3n4AddrID: %s. Ignoring service %v...", err, svcInfo)
+			scopedLog.WithError(err).Error("Error while creating a New L3n4AddrID. Ignoring service")
 			continue
 		}
 
 		if err := d.svcDeleteByFrontend(fe); err != nil {
-			log.Warningf("Error deleting service %+v, %s", fe, err)
+			scopedLog.WithError(err).WithField(logfields.Object, logfields.Repr(fe)).Warn("Error deleting service by frontend")
+
 		} else {
-			log.Debugf("# cilium lb delete-service %s %d 0", svcInfo.FEIP, svcPort.Port)
+			scopedLog.Debugf("# cilium lb delete-service %s %d 0", svcInfo.FEIP, svcPort.Port)
 		}
 
 		if err := d.RevNATDelete(svcPort.ID); err != nil {
-			log.Warningf("Error deleting reverse NAT %+v, %s", svcPort.ID, err)
+			scopedLog.WithError(err).WithField(logfields.ServiceID, svcPort.ID).Warn("Error deleting reverse NAT")
 		} else {
-			log.Debugf("# cilium lb delete-rev-nat %d", svcPort.ID)
+			scopedLog.Debugf("# cilium lb delete-rev-nat %d", svcPort.ID)
 		}
 	}
 	return nil
 }
 
 func (d *Daemon) addK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sServiceInfo, se *types.K8sServiceEndpoint) error {
+	scopedLog := log.WithFields(log.Fields{
+		logfields.K8sSvcName:   svc.Service,
+		logfields.K8sNamespace: svc.Namespace,
+	})
+
 	isSvcIPv4 := svcInfo.FEIP.To4() != nil
 	if err := areIPsConsistent(!d.conf.IPv4Disabled, isSvcIPv4, svc, se); err != nil {
 		return err
@@ -605,15 +659,29 @@ func (d *Daemon) addK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 		if fePort.ID == 0 {
 			feAddr, err := types.NewL3n4Addr(fePort.Protocol, svcInfo.FEIP, fePort.Port)
 			if err != nil {
-				log.Errorf("Error while creating a new L3n4Addr: %s. Ignoring service...", err)
+				scopedLog.WithError(err).WithFields(log.Fields{
+					logfields.ServiceID: fePortName,
+					logfields.IPAddr:    svcInfo.FEIP,
+					logfields.Port:      fePort.Port,
+					logfields.Protocol:  fePort.Protocol,
+				}).Error("Error while creating a new L3n4Addr. Ignoring service...")
 				continue
 			}
 			feAddrID, err := PutL3n4Addr(*feAddr, 0)
 			if err != nil {
-				log.Errorf("Error while getting a new service ID: %s. Ignoring service %v...", err, feAddr)
+				scopedLog.WithError(err).WithFields(log.Fields{
+					logfields.ServiceID: fePortName,
+					logfields.IPAddr:    svcInfo.FEIP,
+					logfields.Port:      fePort.Port,
+					logfields.Protocol:  fePort.Protocol,
+				}).Error("Error while getting a new service ID. Ignoring service...")
 				continue
 			}
-			log.Debugf("Got feAddr ID %d for service %+v", feAddrID.ID, svc)
+			scopedLog.WithFields(log.Fields{
+				logfields.ServiceName: fePortName,
+				logfields.ServiceID:   feAddrID.ID,
+				logfields.Object:      logfields.Repr(svc),
+			}).Debug("Got feAddr ID for service")
 			fePort.ID = feAddrID.ID
 		}
 
@@ -631,11 +699,14 @@ func (d *Daemon) addK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 
 		fe, err := types.NewL3n4AddrID(fePort.Protocol, svcInfo.FEIP, fePort.Port, fePort.ID)
 		if err != nil {
-			log.Errorf("Error while creating a New L3n4AddrID: %s. Ignoring service %v...", err, svcInfo)
+			scopedLog.WithError(err).WithFields(log.Fields{
+				logfields.IPAddr: svcInfo.FEIP,
+				logfields.Port:   svcInfo.Ports,
+			}).Error("Error while creating a New L3n4AddrID. Ignoring service...")
 			continue
 		}
 		if _, err := d.svcAdd(*fe, besValues, true); err != nil {
-			log.Errorf("Error while inserting service in LB map: %s", err)
+			scopedLog.WithError(err).Error("Error while inserting service in LB map")
 		}
 	}
 	return nil
@@ -656,7 +727,10 @@ func (d *Daemon) syncLB(newSN, modSN, delSN *types.K8sServiceNamespace) {
 		}
 
 		if err := d.delK8sSVCs(delSN, svc, endpoint); err != nil {
-			log.Errorf("Unable to delete k8s service: %s", err)
+			log.WithError(err).WithFields(log.Fields{
+				logfields.K8sSvcName:   delSN.Service,
+				logfields.K8sNamespace: delSN.Namespace,
+			}).Error("Unable to delete k8s service")
 			return
 		}
 
@@ -676,7 +750,10 @@ func (d *Daemon) syncLB(newSN, modSN, delSN *types.K8sServiceNamespace) {
 		}
 
 		if err := d.addK8sSVCs(addSN, svcInfo, endpoint); err != nil {
-			log.Errorf("Unable to add K8s service: %s", err)
+			log.WithError(err).WithFields(log.Fields{
+				logfields.K8sSvcName:   addSN.Service,
+				logfields.K8sNamespace: addSN.Namespace,
+			}).Error("Unable to add k8s service")
 		}
 	}
 
@@ -708,6 +785,11 @@ func (d *Daemon) ingressAddFn(obj interface{}) {
 		// We only support Single Service Ingress for now
 		return
 	}
+
+	scopedLog := log.WithFields(log.Fields{
+		logfields.K8sSvcName:   ingress.Spec.Backend.ServiceName,
+		logfields.K8sNamespace: ingress.Namespace,
+	})
 
 	svcName := types.K8sServiceNamespace{
 		Service:   ingress.Spec.Backend.ServiceName,
@@ -742,7 +824,7 @@ func (d *Daemon) ingressAddFn(obj interface{}) {
 	err = syncIngress(ingressSvcInfo)
 	d.loadBalancer.K8sMU.Unlock()
 	if err != nil {
-		log.Errorf("%s", err)
+		scopedLog.WithError(err).Error("Error in syncIngress")
 		return
 	}
 
@@ -756,7 +838,9 @@ func (d *Daemon) ingressAddFn(obj interface{}) {
 
 	_, err = k8s.Client().Extensions().Ingresses(ingress.Namespace).UpdateStatus(ingress)
 	if err != nil {
-		log.Errorf("Unable to update status of ingress %s: %s", ingress.Name, err)
+		scopedLog.WithError(err).WithFields(log.Fields{
+			logfields.K8sIngress: ingress,
+		}).Error("Unable to update status of ingress")
 		return
 	}
 }
@@ -770,6 +854,11 @@ func (d *Daemon) ingressModFn(oldObj interface{}, newObj interface{}) {
 	if !ok {
 		return
 	}
+
+	scopedLog := log.WithFields(log.Fields{
+		logfields.K8sNetworkPolicyName: newIngress.Name,
+		logfields.K8sNamespace:         newIngress.Namespace,
+	})
 
 	if oldIngress.Spec.Backend == nil || newIngress.Spec.Backend == nil {
 		// We only support Single Service Ingress for now
@@ -787,18 +876,25 @@ func (d *Daemon) ingressModFn(oldObj interface{}, newObj interface{}) {
 			}
 			feAddr, err := types.NewL3n4Addr(types.TCP, ingressIP, uint16(port))
 			if err != nil {
-				log.Errorf("Error while creating a new L3n4Addr: %s. Ignoring ingress %s/%s...", err, newIngress.Namespace, newIngress.Name)
+				scopedLog.WithError(err).Error("Error while creating a new L3n4Addr. Ignoring ingress...")
 				continue
 			}
 			feAddrID, err := PutL3n4Addr(*feAddr, 0)
 			if err != nil {
-				log.Errorf("Error while getting a new service ID: %s. Ignoring ingress %s/%s...", err, newIngress.Namespace, newIngress.Name)
+				scopedLog.WithError(err).Error("Error while getting a new service ID. Ignoring ingress...")
 				continue
 			}
-			log.Debugf("Got service ID %d for ingress %s/%s", feAddrID.ID, newIngress.Namespace, newIngress.Name)
+			scopedLog.WithFields(log.Fields{
+				logfields.ServiceID: feAddrID.ID,
+			}).Debug("Got service ID for ingress")
 
 			if err := d.RevNATAdd(feAddrID.ID, feAddrID.L3n4Addr); err != nil {
-				log.Errorf("Unable to add reverse NAT ID for ingress %s/%s: %s", newIngress.Namespace, newIngress.Name, err)
+				scopedLog.WithError(err).WithFields(log.Fields{
+					logfields.ServiceID: feAddrID.ID,
+					logfields.IPAddr:    feAddrID.L3n4Addr.IP,
+					logfields.Port:      feAddrID.L3n4Addr.Port,
+					logfields.Protocol:  feAddrID.L3n4Addr.Protocol,
+				}).Error("Unable to add reverse NAT ID for ingress")
 			}
 		}
 		return
@@ -823,6 +919,12 @@ func (d *Daemon) ingressDelFn(obj interface{}) {
 		return
 	}
 
+	scopedLog := log.WithFields(log.Fields{
+		logfields.K8sIngressName: ing.Name,
+		logfields.K8sSvcName:     ing.Spec.Backend.ServiceName,
+		logfields.K8sNamespace:   ing.Namespace,
+	})
+
 	svcName := types.K8sServiceNamespace{
 		Service:   ing.Spec.Backend.ServiceName,
 		Namespace: ing.Namespace,
@@ -838,7 +940,7 @@ func (d *Daemon) ingressDelFn(obj interface{}) {
 			}
 			feAddr, err := types.NewL3n4Addr(types.TCP, ingressIP, uint16(port))
 			if err != nil {
-				log.Errorf("Error while creating a new L3n4Addr: %s. Ignoring ingress %s/%s...", err, ing.Namespace, ing.Name)
+				scopedLog.WithError(err).Error("Error while creating a new L3n4Addr. Ignoring ingress...")
 				continue
 			}
 			// This is the only way that we can get the service's ID
@@ -846,7 +948,9 @@ func (d *Daemon) ingressDelFn(obj interface{}) {
 			svc := d.svcGetBySHA256Sum(feAddr.SHA256Sum())
 			if svc != nil {
 				if err := d.RevNATDelete(svc.FE.ID); err != nil {
-					log.Errorf("Error while removing RevNAT for ID %d for ingress %s/%s: %s", svc.FE.ID, ing.Namespace, ing.Name, err)
+					scopedLog.WithError(err).WithFields(log.Fields{
+						logfields.ServiceID: svc.FE.ID,
+					}).Error("Error while removing RevNAT for ingress")
 				}
 			}
 		}
@@ -869,7 +973,7 @@ func (d *Daemon) ingressDelFn(obj interface{}) {
 
 	err := d.delK8sSVCs(svcName, ingressSvcInfo, k8sEP)
 	if err != nil {
-		log.Errorf("Unable to delete K8s ingress: %s", err)
+		scopedLog.WithError(err).Error("Unable to delete K8s ingress")
 		return
 	}
 	delete(d.loadBalancer.K8sIngress, svcName)
@@ -931,11 +1035,11 @@ func (d *Daemon) syncExternalLB(newSN, modSN, delSN *types.K8sServiceNamespace) 
 func (d *Daemon) addCiliumNetworkPolicy(obj interface{}) {
 	rule, ok := obj.(*k8s.CiliumNetworkPolicy)
 	if !ok {
-		log.Warningf("Received unknown object %+v, expected a CiliumNetworkPolicy object", obj)
+		log.WithField(logfields.Object, logfields.Repr(obj)).Warn("Received unknown object, expected a CiliumNetworkPolicy object")
 		return
 	}
 
-	log.Debugf("Adding CiliumNetworkPolicy %+v", rule)
+	log.WithField(logfields.CiliumNetworkPolicy, logfields.Repr(rule)).Debug("Adding CiliumNetworkPolicy")
 
 	rules, err := rule.Parse()
 	if err == nil {
@@ -951,13 +1055,17 @@ func (d *Daemon) addCiliumNetworkPolicy(obj interface{}) {
 			Error:       fmt.Sprintf("%s", err),
 			LastUpdated: time.Now(),
 		}
-		log.Warningf("Unable to add CiliumNetworkPolicy %s: err: '%s'. err != nil: '%t'. a nil object: '%s'", rule.Metadata.Name, err, err != nil, nil)
+		log.WithError(err).WithFields(log.Fields{
+			logfields.CiliumNetworkPolicyName: rule.Metadata.Name,
+		}).Warnf("Unable to add CiliumNetworkPolicy. err != nil: '%t'. a nil object: '%s'", err != nil, nil)
 	} else {
 		cnpns = k8s.CiliumNetworkPolicyNodeStatus{
 			OK:          true,
 			LastUpdated: time.Now(),
 		}
-		log.Infof("Imported CiliumNetworkPolicy %s", rule.Metadata.Name)
+		log.WithError(err).WithFields(log.Fields{
+			logfields.CiliumNetworkPolicyName: rule.Metadata.Name,
+		}).Info("Imported CiliumNetworkPolicy")
 	}
 
 	go k8s.UpdateCNPStatus(cnpClient, k8s.BackOffLoopTimeout, ciliumRulesStore, rule, cnpns)
@@ -966,11 +1074,14 @@ func (d *Daemon) addCiliumNetworkPolicy(obj interface{}) {
 func (d *Daemon) deleteCiliumNetworkPolicy(obj interface{}) {
 	rule, ok := obj.(*k8s.CiliumNetworkPolicy)
 	if !ok {
-		log.Warningf("Received unknown object %+v, expected a CiliumNetworkPolicy object", obj)
+		log.WithField(logfields.Object, logfields.Repr(obj)).Warn("Received unknown object, expected a CiliumNetworkPolicy object")
 		return
 	}
 
-	log.Debugf("Deleting CiliumNetworkPolicy %+v", rule)
+	scopedLog := log.WithFields(log.Fields{
+		logfields.CiliumNetworkPolicyName: rule.Metadata.Name,
+	})
+	scopedLog.WithField(logfields.CiliumNetworkPolicy, logfields.Repr(rule)).Debug("Deleting CiliumNetworkPolicy")
 
 	rules, err := rule.Parse()
 	if err == nil {
@@ -980,21 +1091,21 @@ func (d *Daemon) deleteCiliumNetworkPolicy(obj interface{}) {
 	}
 
 	if err != nil {
-		log.Warningf("Unable to delete CiliumNetworkPolicy %s: %s", rule.Metadata.Name, err)
+		scopedLog.WithError(err).Warn("Unable to delete CiliumNetworkPolicy")
 	} else {
-		log.Infof("Deleted CiliumNetworkPolicy %s", rule.Metadata.Name)
+		scopedLog.Info("Deleted CiliumNetworkPolicy")
 	}
 }
 
 func (d *Daemon) updateCiliumNetworkPolicy(oldObj interface{}, newObj interface{}) {
 	oldRule, ok := oldObj.(*k8s.CiliumNetworkPolicy)
 	if !ok {
-		log.Warningf("Received unknown object %+v, expected a CiliumNetworkPolicy object", oldObj)
+		log.WithField(logfields.Object, logfields.Repr(oldObj)).Warn("Received unknown object, expected a CiliumNetworkPolicy object")
 		return
 	}
 	newRules, ok := newObj.(*k8s.CiliumNetworkPolicy)
 	if !ok {
-		log.Warningf("Received unknown object %+v, expected a CiliumNetworkPolicy object", newObj)
+		log.WithField(logfields.Object, logfields.Repr(newObj)).Warn("Received unknown object, expected a CiliumNetworkPolicy object")
 		return
 	}
 	// Since we are updating the status map from all nodes we need to prevent
@@ -1010,7 +1121,7 @@ func (d *Daemon) updateCiliumNetworkPolicy(oldObj interface{}, newObj interface{
 func (d *Daemon) nodesAddFn(obj interface{}) {
 	k8sNode, ok := obj.(*v1.Node)
 	if !ok {
-		log.Warningf("Invalid objected, expected v1.Node, got %+v", obj)
+		log.WithField(logfields.Object, logfields.Repr(obj)).Warn("Invalid objected, expected v1.Node")
 		return
 	}
 	ni := node.Identity{Name: k8sNode.Name}
@@ -1031,13 +1142,16 @@ func (d *Daemon) nodesAddFn(obj interface{}) {
 
 	node.UpdateNode(ni, n, routeTypes, ownAddr)
 
-	log.Debugf("Added node %s: %+v", ni, n)
+	log.WithFields(log.Fields{
+		logfields.K8sNodeID: ni,
+		logfields.Node:      logfields.Repr(n),
+	}).Debug("Added node")
 }
 
 func (d *Daemon) nodesModFn(oldObj interface{}, newObj interface{}) {
 	k8sNode, ok := newObj.(*v1.Node)
 	if !ok {
-		log.Warningf("Invalid objected, expected v1.Node, got %+v", newObj)
+		log.WithField(logfields.Object, logfields.Repr(newObj)).Warn("Invalid objected, expected v1.Node")
 		return
 	}
 
@@ -1065,13 +1179,16 @@ func (d *Daemon) nodesModFn(oldObj interface{}, newObj interface{}) {
 
 	node.UpdateNode(ni, newNode, routeTypes, ownAddr)
 
-	log.Debugf("k8s: Updated node %s to %+v", ni, newNode)
+	log.WithFields(log.Fields{
+		logfields.K8sNodeID: ni,
+		logfields.Node:      logfields.Repr(newNode),
+	}).Debug("k8s: Updated node")
 }
 
 func (d *Daemon) nodesDelFn(obj interface{}) {
 	k8sNode, ok := obj.(*v1.Node)
 	if !ok {
-		log.Warningf("Invalid objected, expected v1.Node, got %+v", obj)
+		log.WithField(logfields.Object, logfields.Repr(obj)).Warn("Invalid objected, expected v1.Node")
 		return
 	}
 
@@ -1079,5 +1196,5 @@ func (d *Daemon) nodesDelFn(obj interface{}) {
 
 	node.DeleteNode(ni, node.TunnelRoute|node.DirectRoute)
 
-	log.Debugf("k8s: Removed node %s", ni)
+	log.WithField(logfields.K8sNodeID, ni).Debug("k8s: Removed node")
 }

--- a/daemon/kvstore_watcher.go
+++ b/daemon/kvstore_watcher.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 
 	log "github.com/sirupsen/logrus"
@@ -36,7 +37,7 @@ func (d *Daemon) EnableKVStoreWatcher(maxSeconds time.Duration) {
 			select {
 			case updates, updateOk := <-ch:
 				if !updateOk {
-					log.Debugf("Watcher for %s closed, reacquiring it", common.LastFreeLabelIDKeyPath)
+					log.WithField(logfields.Path, common.LastFreeLabelIDKeyPath).Debug("Watcher for path closed, reacquiring it")
 					ch = kvstore.Client().GetWatcher(common.LastFreeLabelIDKeyPath, maxSeconds)
 				}
 				if len(updates) != 0 {

--- a/daemon/labels.go
+++ b/daemon/labels.go
@@ -151,7 +151,7 @@ func (d *Daemon) updateEndpointIdentity(epID, oldLabelsHash string, opLabels *la
 			log.WithFields(log.Fields{
 				"oldIdentityHash":    oldLabelsHash,
 				logfields.EndpointID: epID,
-			}).WithError(err).Warning("Unable to delete old identity of endpoint")
+			}).WithError(err).Warn("Unable to delete old identity of endpoint")
 		}
 	}
 
@@ -227,7 +227,7 @@ func NewGetIdentityHandler(d *Daemon) GetIdentityHandler {
 }
 
 func (h *getIdentity) Handle(params GetIdentityParams) middleware.Responder {
-	log.Debugf("GET /identity request: %+v", params)
+	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /identity request")
 
 	identities := []*models.Identity{}
 	if params.Labels == nil {
@@ -348,7 +348,11 @@ func (d *Daemon) DeleteIdentityBySHA256(sha256Sum string, epid string) error {
 		return err
 	}
 
-	log.Debugf("Decremented label %d ref-count to %d", dbSecCtxLbls.ID, dbSecCtxLbls.RefCount())
+	log.WithFields(log.Fields{
+		logfields.EndpointID:     epid,
+		logfields.IdentityLabels: dbSecCtxLbls.ID,
+		"count":                  dbSecCtxLbls.RefCount(),
+	}).Debug("Decremented label ref-count")
 
 	return kvstore.Client().SetValue(lblPath, dbSecCtxLbls)
 }

--- a/daemon/logstash.go
+++ b/daemon/logstash.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/policy"
 
@@ -41,17 +42,19 @@ type LogstashStat struct {
 func newLogstashClient(addr string) net.Conn {
 	i := 3
 	for {
+		scopedLog := log.WithField(logfields.IPAddr, addr)
+
 		c, err := net.Dial("tcp", addr)
 		if err != nil {
 			if i >= 0 {
-				log.Errorf("Error while connecting to Logstash address %s: %s", addr, err)
+				scopedLog.WithError(err).Error("Error while connecting to Logstash address")
 				if i == 0 {
-					log.Info("Mutting Logstash connection errors but still retrying...")
+					scopedLog.Info("Muting Logstash connection errors but still retrying...")
 				}
 				i--
 			}
 		} else {
-			log.Infof("Connection to Logstash %s successfully made", addr)
+			scopedLog.Info("Connection to Logstash successfully made")
 			return c
 		}
 		time.Sleep(10 * time.Second)
@@ -82,7 +85,7 @@ func (d *Daemon) EnableLogstash(LogstashAddr string, refreshTime int) {
 			lss := d.processStats(allPes)
 			for _, ls := range lss {
 				if err := json.NewEncoder(c).Encode(ls); err != nil {
-					log.Errorf("Error while sending data to Logstash: %s", err)
+					log.WithError(err).Error("Error while sending data to Logstash")
 					timeToProcess2 := time.Now()
 					time.Sleep(time.Second*time.Duration(refreshTime) - timeToProcess2.Sub(timeToProcess1))
 					return

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/nodeaddress"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
@@ -128,7 +129,7 @@ func main() {
 func getKernelVersion() (*go_version.Version, error) {
 	verOut, err := exec.Command("uname", "-r").CombinedOutput()
 	if err != nil {
-		log.Fatalf("kernel version: NOT OK: %s", err)
+		log.WithError(err).Fatal("kernel version: NOT OK")
 	}
 	verStrs := strings.Split(string(verOut), ".")
 	if len(verStrs) < 2 {
@@ -140,7 +141,7 @@ func getKernelVersion() (*go_version.Version, error) {
 func getClangVersion(filePath string) (*go_version.Version, error) {
 	verOut, err := exec.Command(filePath, "--version").CombinedOutput()
 	if err != nil {
-		log.Fatalf("clang version: NOT OK: %s", err)
+		log.WithError(err).Fatal("clang version: NOT OK")
 	}
 	res := regexp.MustCompile(`(clang version )([^ ]*)`).FindStringSubmatch(string(verOut))
 	if len(res) != 3 {
@@ -164,7 +165,7 @@ func checkBPFLogs(logType string, fatal bool) {
 	} else if err == nil {
 		bpfFeaturesLog, err := ioutil.ReadFile(bpfLogPath)
 		if err != nil {
-			log.Fatalf("%s check: NOT OK. Unable to read %q: %s", logType, bpfLogPath, err)
+			log.WithError(err).WithField(logfields.Path, bpfLogPath).Fatalf("%s check: NOT OK. Unable to read", logType)
 		}
 		printer := log.Debugf
 		if fatal {
@@ -181,14 +182,14 @@ func checkBPFLogs(logType string, fatal bool) {
 			log.Fatalf("%s check failed.", logType)
 		}
 	} else {
-		log.Fatalf("%s check: NOT OK. Unable to read %q: %s", logType, bpfLogPath, err)
+		log.WithError(err).WithField(logfields.Path, bpfLogPath).Fatalf("%s check: NOT OK. Unable to read", logType)
 	}
 }
 
 func checkMinRequirements() {
 	kernelVersion, err := getKernelVersion()
 	if err != nil {
-		log.Fatalf("kernel version: NOT OK: %s", err)
+		log.WithError(err).Fatal("kernel version: NOT OK")
 	}
 	if !minKernelVer.Check(kernelVersion) {
 		log.Fatalf("kernel version: NOT OK: minimal supported kernel "+
@@ -196,11 +197,11 @@ func checkMinRequirements() {
 	}
 
 	if filePath, err := exec.LookPath("clang"); err != nil {
-		log.Fatalf("clang: NOT OK: %s", err)
+		log.WithError(err).Fatal("clang: NOT OK")
 	} else {
 		clangVersion, err := getClangVersion(filePath)
 		if err != nil {
-			log.Fatalf("clang version: NOT OK: %s", err)
+			log.WithError(err).Fatal("clang: NOT OK")
 		}
 		if !minClangVer.Check(clangVersion) {
 			log.Fatalf("clang version: NOT OK: minimal supported clang "+
@@ -216,12 +217,12 @@ func checkMinRequirements() {
 	}
 
 	if filePath, err := exec.LookPath("llc"); err != nil {
-		log.Fatalf("llc: NOT OK: %s", err)
+		log.WithError(err).Fatal("llc: NOT OK")
 	} else {
 		lccVersion, err := exec.Command(filePath, "--version").CombinedOutput()
 		if err == nil {
 			if strings.Contains(strings.ToLower(string(lccVersion)), "debug") {
-				log.Warningf("llc version was compiled in debug mode, expect higher latency!")
+				log.Warn("llc version was compiled in debug mode, expect higher latency!")
 			}
 		}
 		// /usr/include/gnu/stubs-32.h is installed by 'glibc-devel.i686' in fedora
@@ -239,18 +240,17 @@ func checkMinRequirements() {
 
 	globalsDir := filepath.Join(config.StateDir, "globals")
 	if err := os.MkdirAll(globalsDir, defaults.StateDirRights); err != nil {
-		log.Fatalf("Could not create runtime directory %q: %s", globalsDir, err)
+		log.WithError(err).WithField(logfields.Path, globalsDir).Fatal("Could not create runtime directory")
 	}
 	if err := os.Chdir(config.LibDir); err != nil {
-		log.Fatalf("Could not change to runtime directory %q: %s",
-			config.LibDir, err)
+		log.WithError(err).WithField(logfields.Path, config.LibDir).Fatal("Could not change to runtime directory")
 	}
 	probeScript := filepath.Join(config.BpfDir, "run_probes.sh")
 	if err := exec.Command(probeScript, config.BpfDir, config.StateDir).Run(); err != nil {
-		log.Fatalf("BPF Verifier: NOT OK. Unable to run checker for bpf_features: %s", err)
+		log.WithError(err).Fatal("BPF Verifier: NOT OK. Unable to run checker for bpf_features")
 	}
 	if _, err := os.Stat(filepath.Join(globalsDir, "bpf_features.h")); os.IsNotExist(err) {
-		log.Fatalf("BPF Verifier: NOT OK. Unable to read bpf_features.h: %s", err)
+		log.WithError(err).WithField(logfields.Path, globalsDir).Fatal("BPF Verifier: NOT OK. Unable to read bpf_features.h")
 	}
 
 	checkBPFLogs("bpf_requirements", true)
@@ -416,26 +416,33 @@ func initConfig() {
 		nodeaddress.EnableIPv4 = false
 	}
 
+	scopedLog := log.WithFields(log.Fields{
+		logfields.Path + ".RunDir": config.RunDir,
+		logfields.Path + ".LibDir": config.LibDir,
+	})
+
 	config.BpfDir = filepath.Join(config.LibDir, defaults.BpfDir)
+	scopedLog = scopedLog.WithField(logfields.Path+".BPFDir", defaults.BpfDir)
 	if err := os.MkdirAll(config.RunDir, defaults.RuntimePathRights); err != nil {
-		log.Fatalf("Could not create runtime directory %q: %s", config.RunDir, err)
+		scopedLog.WithError(err).Fatal("Could not create runtime directory")
 	}
 
 	config.StateDir = filepath.Join(config.RunDir, defaults.StateDir)
+	scopedLog = scopedLog.WithField(logfields.Path+".StateDir", config.StateDir)
 	if err := os.MkdirAll(config.StateDir, defaults.StateDirRights); err != nil {
-		log.Fatalf("Could not create state directory %q: %s", config.StateDir, err)
+		scopedLog.WithError(err).Fatal("Could not create state directory")
 	}
 
 	if err := os.MkdirAll(config.LibDir, defaults.RuntimePathRights); err != nil {
-		log.Fatalf("Could not create library directory %q: %s", config.LibDir, err)
+		scopedLog.WithError(err).Fatal("Could not create library directory")
 	}
 	if !config.KeepTemplates {
 		if err := RestoreAssets(config.LibDir, defaults.BpfDir); err != nil {
-			log.Fatalf("Unable to restore agent assets: %s", err)
+			scopedLog.WithError(err).Fatal("Unable to restore agent assets")
 		}
 		// Restore permissions of executable files
 		if err := RestoreExecPermissions(config.LibDir, `.*\.sh`); err != nil {
-			log.Fatalf("Unable to restore agent assets: %s", err)
+			scopedLog.WithError(err).Fatal("Unable to restore agent assets")
 		}
 	}
 	checkMinRequirements()
@@ -466,13 +473,14 @@ func initConfig() {
 func initEnv() {
 	common.SetupLogging(loggers, logOpts, "cilium-agent", viper.GetBool("debug"))
 
+	scopedLog := log.WithField(logfields.Path, socketPath)
 	socketDir := path.Dir(socketPath)
 	if err := os.MkdirAll(socketDir, defaults.RuntimePathRights); err != nil {
-		log.Fatalf("Cannot mkdir directory %q for cilium socket: %s", socketDir, err)
+		scopedLog.WithError(err).Fatal("Cannot mkdir directory for cilium socket")
 	}
 
 	if err := os.Remove(socketPath); !os.IsNotExist(err) && err != nil {
-		log.Fatalf("Cannot remove existing Cilium sock %q: %s", socketPath, err)
+		scopedLog.WithError(err).Fatal("Cannot remove existing Cilium sock")
 	}
 
 	// The standard operation is to mount the BPF filesystem to the
@@ -502,16 +510,16 @@ func initEnv() {
 	policy.SetPolicyEnabled(strings.ToLower(viper.GetString("enable-policy")))
 
 	if err := kvstore.Setup(kvStore, kvStoreOpts); err != nil {
-		log.Fatalf("Unable to setup kvstore: %s", err)
+		log.WithError(err).Fatal("Unable to setup kvstore")
 	}
 
 	if err := labels.ParseLabelPrefixCfg(validLabels, labelPrefixFile); err != nil {
-		log.Fatalf("%s", err)
+		log.WithError(err).Fatal("Unable to parse Label prefix configuration")
 	}
 
 	_, r, err := net.ParseCIDR(nat46prefix)
 	if err != nil {
-		log.Fatalf("Invalid NAT46 prefix %s: %s", nat46prefix, err)
+		log.WithError(err).WithField(logfields.V6Prefix, nat46prefix).Fatal("Invalid NAT46 prefix")
 	}
 
 	config.NAT46Prefix = r
@@ -524,10 +532,10 @@ func initEnv() {
 
 	if v6Address != "auto" {
 		if ip := net.ParseIP(v6Address); ip == nil {
-			log.Fatalf("Invalid IPv6 node address '%s'", v6Address)
+			log.WithField(logfields.IPAddr, v6Address).Fatal("Invalid IPv6 node address")
 		} else {
 			if !ip.IsGlobalUnicast() {
-				log.Fatalf("Invalid IPv6 node address '%s': not a global unicast address", ip)
+				log.WithField(logfields.IPAddr, ip).Fatal("Invalid IPv6 node address: not a global unicast address")
 			}
 
 			nodeaddress.SetIPv6(ip)
@@ -536,7 +544,7 @@ func initEnv() {
 
 	if v4Address != "auto" {
 		if ip := net.ParseIP(v4Address); ip == nil {
-			log.Fatalf("Invalid IPv4 node address '%s'", v4Address)
+			log.WithField(logfields.IPAddr, v4Address).Fatal("Invalid IPv4 node address")
 		} else {
 			nodeaddress.SetExternalIPv4(ip)
 		}
@@ -548,12 +556,12 @@ func initEnv() {
 func runDaemon() {
 	d, err := NewDaemon(config)
 	if err != nil {
-		log.Fatalf("Error while creating daemon: %s", err)
+		log.WithError(err).Fatal("Error while creating daemon")
 		return
 	}
 
 	if err := d.PolicyInit(); err != nil {
-		log.Fatalf("Unable to initialize policy: %s", err)
+		log.WithError(err).Fatal("Unable to initialize policy")
 	}
 
 	endpointmanager.EnableConntrackGC(!d.conf.IPv4Disabled, true)
@@ -572,12 +580,12 @@ func runDaemon() {
 	d.EnableKVStoreWatcher(30 * time.Second)
 
 	if err := d.EnableK8sWatcher(5 * time.Minute); err != nil {
-		log.Warningf("Error while enabling k8s watcher %s", err)
+		log.WithError(err).Warn("Error while enabling k8s watcher")
 	}
 
 	swaggerSpec, err := loads.Analyzed(server.SwaggerJSON, "")
 	if err != nil {
-		log.Fatal(err)
+		log.WithError(err).Fatal("Cannot load swagger spec")
 	}
 
 	api := restapi.NewCiliumAPI(swaggerSpec)
@@ -646,6 +654,6 @@ func runDaemon() {
 	server.ConfigureAPI()
 
 	if err := server.Serve(); err != nil {
-		log.Fatal(err)
+		log.WithError(err).Fatal("Error returned from non-returning Serve() call")
 	}
 }

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -69,10 +70,10 @@ func invalidateCache() {
 // Returns a waiting group which signalizes when all endpoints are regenerated.
 func (d *Daemon) TriggerPolicyUpdates(added []policy.NumericIdentity) *sync.WaitGroup {
 	if len(added) == 0 {
-		log.Debugf("Full policy recalculation triggered")
+		log.Debug("Full policy recalculation triggered")
 		invalidateCache()
 	} else {
-		log.Debugf("Partial policy recalculation triggered: %d", added)
+		log.WithField(logfields.PolicyID, logfields.Repr(added)).Debug("Partial policy recalculation triggered")
 		// FIXME: Invalidate only cache that is affected
 		invalidateCache()
 	}
@@ -110,7 +111,7 @@ func NewGetPolicyResolveHandler(d *Daemon) GetPolicyResolveHandler {
 }
 
 func (h *getPolicyResolve) Handle(params GetPolicyResolveParams) middleware.Responder {
-	log.Debugf("GET /policy/resolve request: %+v", params)
+	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /policy/resolve request")
 
 	d := h.daemon
 
@@ -221,8 +222,8 @@ func (d *Daemon) policyAdd(rules api.Rules, opts *AddOptions) (uint64, error) {
 		// Restore old rules
 		if len(oldRules) > 0 {
 			if rev, err2 := d.policy.AddListLocked(oldRules); err2 != nil {
-				log.Errorf("Error while restoring old rules after adding of new rules failed: %s", err2)
-				log.Errorf("--- INCONSISTENT STATE OF POLICY ---")
+				log.WithError(err2).Error("Error while restoring old rules after adding of new rules failed")
+				log.Error("--- INCONSISTENT STATE OF POLICY ---")
 				return rev, err
 			}
 		}
@@ -239,7 +240,7 @@ func (d *Daemon) policyAdd(rules api.Rules, opts *AddOptions) (uint64, error) {
 // pods which are selected. Eventual changes in policy rules are propagated to
 // all locally managed endpoints.
 func (d *Daemon) PolicyAdd(rules api.Rules, opts *AddOptions) (uint64, error) {
-	log.Debugf("Policy Add Request: %+v", rules)
+	log.WithField(logfields.CiliumNetworkPolicy, logfields.Repr(rules)).Debug("Policy Add Request")
 
 	for _, r := range rules {
 		if err := r.Sanitize(); err != nil {
@@ -263,7 +264,7 @@ func (d *Daemon) PolicyAdd(rules api.Rules, opts *AddOptions) (uint64, error) {
 // rule from the node. If the path's node becomes ruleless it is removed from
 // the tree.
 func (d *Daemon) PolicyDelete(labels labels.LabelArray) (uint64, error) {
-	log.Debugf("Policy Delete Request: %+v", labels)
+	log.WithField(logfields.IdentityLabels, logfields.Repr(labels)).Debug("Policy Delete Request")
 
 	// An error is only returned if a label filter was provided and then
 	// not found A deletion request for all policy entries if no policied
@@ -313,7 +314,10 @@ func (d *Daemon) PolicyDelete(labels labels.LabelArray) (uint64, error) {
 					idsToKeep[consumer.Uint32()] = true
 				}
 				if len(idsToKeep) != 0 {
-					log.Debugf("Removing entries of EP %d: %+v", ep.ID, idsToKeep)
+					log.WithFields(log.Fields{
+						logfields.EndpointID:           ep.ID,
+						logfields.EndpointID + ".keep": logfields.Repr(idsToKeep),
+					}).Debug("Removing entries of EP")
 					endpointmanager.RmCTEntriesOf(!d.conf.IPv4Disabled, ep, idsToKeep)
 				}
 			}
@@ -406,7 +410,7 @@ func (h *getPolicy) Handle(params GetPolicyParams) middleware.Responder {
 
 func (d *Daemon) PolicyInit() error {
 	for k, v := range policy.ReservedIdentities {
-		log.Debugf("creating policy for %s", k)
+		log.WithField(logfields.Identity, k).Debug("creating policy for identity")
 		key := v.String()
 		lbl := labels.NewLabel(
 			key, "", labels.LabelSourceReserved,

--- a/daemon/services.go
+++ b/daemon/services.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/common/types"
 	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/logfields"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -49,7 +50,7 @@ func gasNewL3n4AddrID(l3n4AddrID *types.L3n4AddrID, baseID uint32) error {
 // created for the given l3n4Addr. If baseID is different than 0, it tries to acquire that
 // ID to the l3n4Addr.
 func PutL3n4Addr(l3n4Addr types.L3n4Addr, baseID uint32) (*types.L3n4AddrID, error) {
-	log.Debugf("Resolving service %+v", l3n4Addr)
+	log.WithField(logfields.L3n4Addr, logfields.Repr(l3n4Addr)).Debug("Resolving service")
 
 	// Retrieve unique SHA256Sum for service
 	sha256Sum := l3n4Addr.SHA256Sum()
@@ -91,7 +92,7 @@ func getL3n4AddrID(keyPath string) (*types.L3n4AddrID, error) {
 		return nil, err
 	}
 	if rmsg == nil {
-		log.Debugf("no value mapped to key %s in KVStore", keyPath)
+		log.WithField("key", keyPath).Debug("no value mapped to key in KVStore")
 		return nil, nil
 	}
 
@@ -105,7 +106,8 @@ func getL3n4AddrID(keyPath string) (*types.L3n4AddrID, error) {
 // GetL3n4AddrID returns the L3n4AddrID that belongs to the given id.
 func GetL3n4AddrID(id uint32) (*types.L3n4AddrID, error) {
 	strID := strconv.FormatUint(uint64(id), 10)
-	log.Debugf("getting L3n4AddrID for ID %s", strID)
+	log.WithField(logfields.L3n4AddrID, strID).Debug("getting L3n4AddrID for ID")
+
 	return getL3n4AddrID(path.Join(common.ServiceIDKeyPath, strID))
 }
 
@@ -116,7 +118,7 @@ func GetL3n4AddrIDBySHA256(sha256sum string) (*types.L3n4AddrID, error) {
 
 // DeleteL3n4AddrIDByUUID deletes the L3n4AddrID belonging to the given id from the kvstore.
 func DeleteL3n4AddrIDByUUID(id uint32) error {
-	log.Debugf("deleting L3n4Addr %d", id)
+	log.WithField(logfields.L3n4AddrID, id).Debug("deleting L3n4Addr by ID")
 	l3n4AddrID, err := GetL3n4AddrID(id)
 	if err != nil {
 		return err
@@ -131,7 +133,7 @@ func DeleteL3n4AddrIDByUUID(id uint32) error {
 // DeleteL3n4AddrIDBySHA256 deletes the L3n4AddrID from the kvstore corresponding to the service's
 // sha256Sum.
 func DeleteL3n4AddrIDBySHA256(sha256Sum string) error {
-	log.Debugf("deleting L3n4AddrID with SHA256 %s", sha256Sum)
+	log.WithField(logfields.SHA, sha256Sum).Debug("deleting L3n4AddrID with SHA256")
 	if sha256Sum == "" {
 		return nil
 	}

--- a/pkg/logfields/helpers.go
+++ b/pkg/logfields/helpers.go
@@ -1,0 +1,22 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logfields
+
+import "fmt"
+
+// Repr formats an object with the Printf %+v formatter
+func Repr(s interface{}) string {
+	return fmt.Sprintf("%+v", s)
+}

--- a/pkg/logfields/logfields.go
+++ b/pkg/logfields/logfields.go
@@ -130,4 +130,39 @@ const (
 	// Response is a response object received by us, reported in debug or error.
 	// It is often paired with logfields.Repr to render the object.
 	Response = "resp"
+
+	// K8s specific
+
+	// K8sNodeID is the k8s ID of a K8sNode
+	K8sNodeID = "k8sNodeID"
+
+	// K8sPodName is the name of a k8s pod
+	K8sPodName = "k8sPodName"
+
+	// K8sSvcName is the name of a K8s service
+	K8sSvcName = "k8sSvcName"
+
+	// K8sSvcType is the k8s service type (e.g. NodePort, Loadbalancer etc.)
+	K8sSvcType = "k8sSvcType"
+
+	// K8sEndpointName is the k8s name for a k8s Endpoint (not a cilium Endpoint)
+	K8sEndpointName = "k8sEndpointName"
+
+	// K8sNamespace is the namespace something belongs to
+	K8sNamespace = "k8sNamespace"
+
+	// K8sIdentityAnnotation is a k8s non-identifying annotations on k8s objects
+	K8sIdentityAnnotation = "k8sIdentityAnnotation"
+
+	// K8sNetworkPolicy is a k8s NetworkPolicy object (not a CiliumNetworkObject, above).
+	K8sNetworkPolicy = "k8sNetworkPolicy"
+
+	// K8sNetworkPolicyName is the name of a K8sPolicyObject
+	K8sNetworkPolicyName = "k8sNetworkPolicyName"
+
+	// K8sIngress is a k8s Ingress service object
+	K8sIngress = "k8sIngress"
+
+	// K8sIngressName is the name of a K8sIngress
+	K8sIngressName = "k8sIngressName"
 )

--- a/pkg/logfields/logfields.go
+++ b/pkg/logfields/logfields.go
@@ -18,6 +18,16 @@ package logfields
 import "github.com/cilium/cilium/pkg/proxy/accesslog"
 
 const (
+
+	// LogSubsys is the field denoting the subsystem when logging
+	LogSubsys = "subsys"
+
+	// Node is a host machine in the cluster, running cilium
+	Node = "node"
+
+	// NodeName is a human readable name for the node
+	NodeName = "nodeName"
+
 	// EndpointID is the numeric endpoint identifier
 	EndpointID = "endpointID"
 
@@ -27,10 +37,97 @@ const (
 	// IdentityLabels are the labels relevant for the security identity
 	IdentityLabels = "identityLabels"
 
+	// Labels are any label, they may not be relevant to the security identity.
+	Labels = "labels"
+
 	// Identity is the identifier of a security identity
 	Identity = "identity"
+
+	// PolicyID is the identifier of a L3, L4 or L7 Policy. Ideally the .NumericIdentity
+	PolicyID = "policyID"
+
+	// L3PolicyID is the identifier of a L3 Policy
+	L3PolicyID = "policyID.L3"
+
+	// L4PolicyID is the identifier of a L4 Policy
+	L4PolicyID = "PolicyID.L4"
+
+	// IPAddr is an IPV4 or IPv6 address
+	IPAddr = "ipAddr"
+
+	// L3n4Addr is a L3 (IP) + L4 (port and protocol) address object.
+	L3n4Addr = "l3n4Addr"
+
+	// L3n4AddrID is the allocated ID for a L3n4Addr object
+	L3n4AddrID = "l3n4AddrID"
+
+	// Port is a L4 port
+	Port = "port"
+
+	// Protocol is the L4 protocol
+	Protocol = "protocol"
+
+	// V4Prefix is a IPv4 subnet/CIDR prefix
+	V4Prefix = "v4Prefix"
+
+	// V6Prefix is a IPv6 subnet/CIDR prefix
+	V6Prefix = "v6Prefix"
+
+	// Interface is an interface id/name on the system
+	Interface = "interface"
+
+	// Veth is a veth object or ID
+	Veth = "veth"
+
+	// VethPair is a tuple of Veth that are paired
+	VethPair = "vethPair"
+
+	// SHA is a sha of something
+	SHA = "sha"
+
+	// ServiceName is the orchestration framework name for a service
+	ServiceName = "serviceName"
+
+	// ServiceID is the orchestration unique ID of a service
+	ServiceID = "serviceID"
+
+	// CiliumNetworkPolicy is a cilium specific NetworkPolicy
+	CiliumNetworkPolicy = "ciliumNetworkPolicy"
+
+	// CiliumNetworkPolicyName is the name of a CiliumNetworkPolicy
+	CiliumNetworkPolicyName = "ciliumNetworkPolicyName"
+
+	// BPFMapKey is a key from a BPF map
+	BPFMapKey = "bpfMapKey"
+
+	// BPFMapValue is a value from a BPF map
+	BPFMapValue = "bpfMapValue"
+
+	// XDPDevice is the device name
+	XDPDevice = "xdpDevice"
+
+	// EndpointLabelSelector is a selector for Endpoints by label
+	EndpointLabelSelector = "EndpointLabelSelector"
+
+	// EndpointSelector is a selector for Endpoints
+	EndpointSelector = "EndpointSelector"
 
 	// Path is a filesystem path. It can be a file or directory.
 	// Note: we follow what accesslog sets to be consistent.
 	Path = accesslog.FieldFilePath
+
+	// Object is used when "%+v" printing Go objects for debug or error handling.
+	// It is often paired with logfields.Repr to render the object.
+	Object = "obj"
+
+	// Request is a request object received by us, reported in debug or error.
+	// It is often paired with logfields.Repr to render the object.
+	Request = "req"
+
+	// Params are the parameters of a request, reported in debug or error.
+	Params = "params"
+
+	// Response is a response object received by us, reported in debug or error.
+	// It is often paired with logfields.Repr to render the object.
+	Response = "resp"
 )

--- a/pkg/logfields/logfields.go
+++ b/pkg/logfields/logfields.go
@@ -15,6 +15,8 @@
 // Package logfields defines common logging fields which are used across packages
 package logfields
 
+import "github.com/cilium/cilium/pkg/proxy/accesslog"
+
 const (
 	// EndpointID is the numeric endpoint identifier
 	EndpointID = "endpointID"
@@ -27,4 +29,8 @@ const (
 
 	// Identity is the identifier of a security identity
 	Identity = "identity"
+
+	// Path is a filesystem path. It can be a file or directory.
+	// Note: we follow what accesslog sets to be consistent.
+	Path = accesslog.FieldFilePath
 )


### PR DESCRIPTION
This is a focused subset of https://github.com/cilium/cilium/pull/1710. I've gone through the daemon package and attempted to normalise our log usage. In particular, we're using logrus' `.WithFields` functions to create messages like
```
time="2017-10-19T07:35:29-07:00" level=debug msg="Trying to associate container with existing endpoint" containerID=dad59d1fd1 containerName=/cilium-consul endpointID=0 identityLabels=
```

I still have some more work to do but I wanted to start getting real feedback on my approach. Things to consider:
- How aggressive should we be about using a shared label in messages? I've tried to do that in anything above Debug. Debug is more of a free-for-all
- I tried to keep the logs as one-liners, because they were expanding to 3 lines each an took up a lot of space. This isn't possible with multi-fields logs, but I created intermediate log objects that captures the relevant fields for that function/section. I named then `scopedLog` but I'd like a better name.
- I added a logfields.Repr function that does "+%v" formatting. I'm not sure if it's clear, or if I should have tried something else to replace "+%v" strings. Many were in Debug, but some were not. logrus calls `.String()` on objects passed to it (ie it checks for the Stringer interface) so it will not retain the current behaviour.
- The K8s* fields are an open question. Some packages, like pkg/k8s, have their own field definitions but they are intended for internal use. In this case, daemon uses some fields that could be exported by pkg/k8s. We don't have subsystem fields yet (that's for another set of PRs ;) ) so I've also included a prefix to make them clear.
- I've left REVIEW comments in certain places with more specific questions

I followed some guidelines when doing this:
- Don't use *f versions of functions (e.g. Errorf) unless we have formatting expansions
- If reporting an error, WithError should be first
- If reporting one field, us WithField and keep it on one line
- If we will log a number of messages in a section/function, create an intermediate log object with the fields
- Fields that appear in levels above Debug should use a consistent name with a consistent meaning (so, IPAddr is an IP address... not an IP:Port combo or an object).

Partially addresses https://github.com/cilium/cilium/issues/1692

CC @cilium/team I'll be making more PRs by code owner but this PR represents the general trend. Feedback appreciated!