### PR TITLE
Improve policy trace output

### DIFF
--- a/Documentation/policy.rst
+++ b/Documentation/policy.rst
@@ -782,7 +782,7 @@ endpoint with the label ``id.http`` on port 80:
     1 rules matched
     L4 ingress verdict: allowed
 
-    Verdict: ALLOWED
+    Final verdict: ALLOWED
 
 .. _NetworkPolicy: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 

--- a/Documentation/policy.rst
+++ b/Documentation/policy.rst
@@ -763,23 +763,28 @@ endpoint with the label ``id.http`` on port 80:
 
     $ cilium policy trace -s id.curl -d id.httpd --dport 80
     Tracing From: [container:id.curl] => To: [container:id.httpd] Ports: [80/any]
-    * Rule {"matchLabels":{"any:id.httpd":""}}: match
+    * Rule {"matchLabels":{"any:id.httpd":""}}: selected
         Allows from labels {"matchLabels":{"any:id.curl":""}}
           Found all required labels
             Rule restricts traffic to specific L4 destinations; deferring policy decision to L4 policy stage
-    1 rules matched
+    1/1 rules selected
+    Found no allow rule
     Label verdict: undecided
 
     Resolving egress port policy for [container:id.curl]
-    * Rule {"matchLabels":{"any:id.curl":""}}: match
+    * Rule {"matchLabels":{"any:id.curl":""}}: selected
       Allows Egress port [{80 tcp}]
-    1 rules matched
+        Found all required labels
+    1/1 rules selected
+    Found allow rule
     L4 egress verdict: allowed
 
     Resolving ingress port policy for [container:id.httpd]
-    * Rule {"matchLabels":{"any:id.httpd":""}}: match
+    * Rule {"matchLabels":{"any:id.httpd":""}}: selected
       Allows Ingress port [{80 tcp}]
-    1 rules matched
+        Found all required labels
+    1/1 rules selected
+    Found allow rule
     L4 ingress verdict: allowed
 
     Final verdict: ALLOWED

--- a/Documentation/policy.rst
+++ b/Documentation/policy.rst
@@ -763,7 +763,7 @@ endpoint with the label ``id.http`` on port 80:
 
     $ cilium policy trace -s id.curl -d id.httpd --dport 80
     Tracing From: [container:id.curl] => To: [container:id.httpd] Ports: [80/any]
-    * Rule 2 {"matchLabels":{"any:id.httpd":""}}: match
+    * Rule {"matchLabels":{"any:id.httpd":""}}: match
         Allows from labels {"matchLabels":{"any:id.curl":""}}
           Found all required labels
             Rule restricts traffic to specific L4 destinations; deferring policy decision to L4 policy stage
@@ -771,13 +771,13 @@ endpoint with the label ``id.http`` on port 80:
     Label verdict: undecided
 
     Resolving egress port policy for [container:id.curl]
-    * Rule 0 {"matchLabels":{"any:id.curl":""}}: match
+    * Rule {"matchLabels":{"any:id.curl":""}}: match
       Allows Egress port [{80 tcp}]
     1 rules matched
     L4 egress verdict: allowed
 
     Resolving ingress port policy for [container:id.httpd]
-    * Rule 2 {"matchLabels":{"any:id.httpd":""}}: match
+    * Rule {"matchLabels":{"any:id.httpd":""}}: match
       Allows Ingress port [{80 tcp}]
     1 rules matched
     L4 ingress verdict: allowed

--- a/cilium/cmd/policy_trace.go
+++ b/cilium/cmd/policy_trace.go
@@ -170,7 +170,7 @@ If multiple sources and / or destinations are provided, each source is tested wh
 				} else if scr != nil && scr.Payload != nil {
 					fmt.Println("----------------------------------------------------------------")
 					fmt.Printf("%s\n", scr.Payload.Log)
-					fmt.Printf("Verdict: %s\n", strings.ToUpper(scr.Payload.Verdict))
+					fmt.Printf("Final verdict: %s\n", strings.ToUpper(scr.Payload.Verdict))
 				}
 			}
 		}

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -132,8 +132,8 @@ func (h *getPolicyResolve) Handle(params GetPolicyResolveParams) middleware.Resp
 		if !(d.policy.GetRulesMatching(labels.NewSelectLabelArrayFromModel(params.IdentityContext.From), true) ||
 			d.policy.GetRulesMatching(labels.NewSelectLabelArrayFromModel(params.IdentityContext.To), true)) {
 			policyEnforcementMsg = "Policy enforcement is disabled because " +
-				"no rules in the policy repository match either of the provided " +
-				"sets of labels."
+				"no rules in the policy repository match any endpoint selector " +
+				"from the provided destination sets of labels."
 			isPolicyEnforcementEnabled = false
 		}
 	}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -58,13 +58,15 @@ func (p *Repository) CanReachRLocked(ctx *SearchContext) api.Decision {
 	decision := api.Undecided
 	state := traceState{}
 
+loop:
 	for i, r := range p.rules {
 		state.ruleID = i
 		switch r.canReach(ctx, &state) {
 		// The rule contained a constraint which was not met, this
 		// connection is not allowed
 		case api.Denied:
-			return api.Denied
+			decision = api.Denied
+			break loop
 
 		// The rule allowed the connection but a later rule may impose
 		// additional constraints, so we store the decision but allow

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -330,7 +330,8 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 	c.Assert(*l4policy, comparator.DeepEquals, *expected)
 
 	// L4 from app3 has no rules
+	expected = NewL4Policy()
 	l4policy, err = repo.ResolveL4Policy(fromApp3)
-	c.Assert(len(l4policy.Ingress), Equals, 1)
+	c.Assert(len(l4policy.Ingress), Equals, 0)
 	c.Assert(*l4policy, comparator.DeepEquals, *expected)
 }

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -15,10 +15,14 @@
 package policy
 
 import (
+	"bytes"
+
+	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
 
+	"github.com/op/go-logging"
 	. "gopkg.in/check.v1"
 )
 
@@ -334,4 +338,255 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 	l4policy, err = repo.ResolveL4Policy(fromApp3)
 	c.Assert(len(l4policy.Ingress), Equals, 0)
 	c.Assert(*l4policy, comparator.DeepEquals, *expected)
+}
+
+func buildSearchCtx(from, to string, port uint16) *SearchContext {
+	var ports []*models.Port
+	if port != 0 {
+		ports = []*models.Port{{Port: port}}
+	}
+	return &SearchContext{
+		From:   labels.ParseSelectLabelArray(from),
+		To:     labels.ParseSelectLabelArray(to),
+		DPorts: ports,
+		Trace:  TRACE_ENABLED,
+	}
+}
+
+func buildRule(from, to, port string) api.Rule {
+	reservedES := api.NewESFromLabels(labels.ParseSelectLabel("reserved:host"))
+	fromES := api.NewESFromLabels(labels.ParseSelectLabel(from))
+	toES := api.NewESFromLabels(labels.ParseSelectLabel(to))
+
+	ports := []api.PortRule{}
+	if port != "" {
+		ports = []api.PortRule{
+			{Ports: []api.PortProtocol{{Port: port}}},
+		}
+	}
+	return api.Rule{
+		EndpointSelector: toES,
+		Ingress: []api.IngressRule{
+			{
+				FromEndpoints: []api.EndpointSelector{
+					reservedES,
+					fromES,
+				},
+				ToPorts: ports,
+			},
+		},
+	}
+}
+
+func (repo *Repository) checkTrace(c *C, ctx *SearchContext, trace string,
+	expectedVerdict api.Decision) {
+
+	buffer := new(bytes.Buffer)
+	ctx.Logging = logging.NewLogBackend(buffer, "", 0)
+
+	repo.Mutex.RLock()
+	verdict := repo.AllowsRLocked(ctx)
+	repo.Mutex.RUnlock()
+	c.Assert(verdict, Equals, expectedVerdict)
+
+	expectedOut := "Tracing " + ctx.String() + trace
+	c.Assert(buffer.String(), comparator.DeepEquals, expectedOut)
+}
+
+func (ds *PolicyTestSuite) TestPolicyTrace(c *C) {
+	repo := NewPolicyRepository()
+
+	// Add rules to allow foo=>bar
+	l3rule := buildRule("foo", "bar", "")
+	rules := api.Rules{&l3rule}
+	_, err := repo.AddList(rules)
+	c.Assert(err, IsNil)
+
+	// foo=>bar is OK
+	expectedOut := `
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    Allows from labels {"matchLabels":{"reserved:host":""}}
+      Labels [any:foo] not found
+    Allows from labels {"matchLabels":{"any:foo":""}}
+      Found all required labels
++       No L4 restrictions
+1/1 rules selected
+Found allow rule
+Label verdict: allowed
+`
+	ctx := buildSearchCtx("foo", "bar", 0)
+	repo.checkTrace(c, ctx, expectedOut, api.Allowed)
+
+	// foo=>bar:80 is OK
+	ctx = buildSearchCtx("foo", "bar", 80)
+	repo.checkTrace(c, ctx, expectedOut, api.Allowed)
+
+	// bar=>foo is Denied
+	ctx = buildSearchCtx("bar", "foo", 0)
+	expectedOut = `
+0/1 rules selected
+Found no allow rule
+Label verdict: undecided
+`
+	repo.checkTrace(c, ctx, expectedOut, api.Denied)
+
+	// bar=>foo:80 is Denied, also checks L4 policy
+	ctx = buildSearchCtx("bar", "foo", 80)
+	expectedOut += `
+Resolving egress port policy for [any:bar]
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No L4 rules
+1/1 rules selected
+Found no allow rule
+L4 egress verdict: undecided
+
+Resolving ingress port policy for [any:foo]
+0/1 rules selected
+Found no allow rule
+L4 ingress verdict: undecided
+`
+	repo.checkTrace(c, ctx, expectedOut, api.Denied)
+
+	// Now, add extra rules to allow specifically baz=>bar on port 80
+	l4rule := buildRule("baz", "bar", "80")
+	_, err = repo.Add(l4rule)
+	c.Assert(err, IsNil)
+
+	// baz=>bar:80 is OK
+	ctx = buildSearchCtx("baz", "bar", 80)
+	expectedOut = `
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    Allows from labels {"matchLabels":{"reserved:host":""}}
+      Labels [any:baz] not found
+    Allows from labels {"matchLabels":{"any:foo":""}}
+      Labels [any:baz] not found
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    Allows from labels {"matchLabels":{"reserved:host":""}}
+      Labels [any:baz] not found
+    Allows from labels {"matchLabels":{"any:baz":""}}
+      Found all required labels
+        Rule restricts traffic to specific L4 destinations; deferring policy decision to L4 policy stage
+2/2 rules selected
+Found no allow rule
+Label verdict: undecided
+
+Resolving egress port policy for [any:baz]
+0/2 rules selected
+Found no allow rule
+L4 egress verdict: undecided
+
+Resolving ingress port policy for [any:bar]
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No L4 rules
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    Allows Ingress port [{80 ANY}] from endpoints [{"matchLabels":{"reserved:host":""}} {"matchLabels":{"any:baz":""}}]
+      Found all required labels
+2/2 rules selected
+Found allow rule
+L4 ingress verdict: allowed
+`
+	repo.checkTrace(c, ctx, expectedOut, api.Allowed)
+
+	// bar=>bar:80 is Denied
+	ctx = buildSearchCtx("bar", "bar", 80)
+	expectedOut = `
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    Allows from labels {"matchLabels":{"reserved:host":""}}
+      Labels [any:bar] not found
+    Allows from labels {"matchLabels":{"any:foo":""}}
+      Labels [any:bar] not found
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    Allows from labels {"matchLabels":{"reserved:host":""}}
+      Labels [any:bar] not found
+    Allows from labels {"matchLabels":{"any:baz":""}}
+      Labels [any:bar] not found
+2/2 rules selected
+Found no allow rule
+Label verdict: undecided
+
+Resolving egress port policy for [any:bar]
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No L4 rules
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No L4 rules
+2/2 rules selected
+Found no allow rule
+L4 egress verdict: undecided
+
+Resolving ingress port policy for [any:bar]
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    No L4 rules
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    Allows Ingress port [{80 ANY}] from endpoints [{"matchLabels":{"reserved:host":""}} {"matchLabels":{"any:baz":""}}]
+      Labels [any:bar] not found
+2/2 rules selected
+Found no allow rule
+L4 ingress verdict: undecided
+`
+	repo.checkTrace(c, ctx, expectedOut, api.Denied)
+
+	// Test that FromRequires "baz" drops "foo" traffic
+	l3rule = api.Rule{
+		EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("bar")),
+		Ingress: []api.IngressRule{{
+			FromRequires: []api.EndpointSelector{
+				api.NewESFromLabels(labels.ParseSelectLabel("baz")),
+			},
+		}},
+	}
+	_, err = repo.Add(l3rule)
+	c.Assert(err, IsNil)
+
+	// foo=>bar is now denied due to the FromRequires
+	ctx = buildSearchCtx("foo", "bar", 0)
+	expectedOut = `
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    Allows from labels {"matchLabels":{"reserved:host":""}}
+      Labels [any:foo] not found
+    Allows from labels {"matchLabels":{"any:foo":""}}
+      Found all required labels
++       No L4 restrictions
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    Allows from labels {"matchLabels":{"reserved:host":""}}
+      Labels [any:foo] not found
+    Allows from labels {"matchLabels":{"any:baz":""}}
+      Labels [any:foo] not found
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    Requires from labels {"matchLabels":{"any:baz":""}}
+-     Labels [any:foo] not found
+3/3 rules selected
+Found unsatisfied FromRequires constraint
+Label verdict: denied
+`
+	repo.checkTrace(c, ctx, expectedOut, api.Denied)
+
+	// baz=>bar is only denied because of the L4 policy
+	ctx = buildSearchCtx("baz", "bar", 0)
+	expectedOut = `
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    Allows from labels {"matchLabels":{"reserved:host":""}}
+      Labels [any:baz] not found
+    Allows from labels {"matchLabels":{"any:foo":""}}
+      Labels [any:baz] not found
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    Allows from labels {"matchLabels":{"reserved:host":""}}
+      Labels [any:baz] not found
+    Allows from labels {"matchLabels":{"any:baz":""}}
+      Found all required labels
+        Rule restricts traffic to specific L4 destinations; deferring policy decision to L4 policy stage
+* Rule {"matchLabels":{"any:bar":""}}: selected
+    Requires from labels {"matchLabels":{"any:baz":""}}
++     Found all required labels
+3/3 rules selected
+Found no allow rule
+Label verdict: undecided
+`
+	repo.checkTrace(c, ctx, expectedOut, api.Denied)
+
+	// Should still be allowed with the new FromRequires constraint
+	ctx = buildSearchCtx("baz", "bar", 80)
+	repo.Mutex.RLock()
+	verdict := repo.AllowsRLocked(ctx)
+	repo.Mutex.RUnlock()
+	c.Assert(verdict, Equals, api.Allowed)
 }

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -192,6 +192,21 @@ func mergeL4(ctx *SearchContext, dir string, fromEndpoints []api.EndpointSelecto
 			}
 		}
 
+		l3match := false
+		if ctx.From != nil && fromEndpoints != nil {
+			for _, labels := range fromEndpoints {
+				if labels.Matches(ctx.From) {
+					l3match = true
+					break
+				}
+			}
+			if l3match == false {
+				ctx.PolicyTrace("      Labels %s not found", ctx.From)
+				continue
+			}
+		}
+		ctx.PolicyTrace("      Found all required labels")
+
 		for _, p := range r.Ports {
 			var cnt int
 			if p.Protocol != api.ProtoAny {

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -221,12 +221,12 @@ func mergeL4(ctx *SearchContext, dir string, fromEndpoints []api.EndpointSelecto
 
 func (r *rule) resolveL4Policy(ctx *SearchContext, state *traceState, result *L4Policy) (*L4Policy, error) {
 	if !r.EndpointSelector.Matches(ctx.To) {
-		ctx.PolicyTraceVerbose("  Rule %d %s: no match\n", state.ruleID, r)
+		ctx.PolicyTraceVerbose("  Rule %s: no match\n", r)
 		return nil, nil
 	}
 
 	state.selectedRules++
-	ctx.PolicyTrace("* Rule %d %s: match\n", state.ruleID, r)
+	ctx.PolicyTrace("* Rule %s: match\n", r)
 	found := 0
 
 	if !ctx.EgressL4Only {
@@ -296,12 +296,12 @@ func computeResultantCIDRSet(cidrs []api.CIDRRule) []api.CIDR {
 
 func (r *rule) resolveL3Policy(ctx *SearchContext, state *traceState, result *L3Policy) *L3Policy {
 	if !r.EndpointSelector.Matches(ctx.To) {
-		ctx.PolicyTraceVerbose("  Rule %d %s: no match\n", state.ruleID, r)
+		ctx.PolicyTraceVerbose("  Rule %s: no match\n", r)
 		return nil
 	}
 
 	state.selectedRules++
-	ctx.PolicyTrace("* Rule %d %s: match\n", state.ruleID, r)
+	ctx.PolicyTrace("* Rule %s: match\n", r)
 	found := 0
 
 	for _, r := range r.Ingress {
@@ -336,16 +336,16 @@ func (r *rule) canReach(ctx *SearchContext, state *traceState) api.Decision {
 
 	if !r.EndpointSelector.Matches(ctx.To) {
 		if entitiesDecision == api.Undecided {
-			ctx.PolicyTraceVerbose("  Rule %d %s: no match for %+v\n", state.ruleID, r, ctx.To)
+			ctx.PolicyTraceVerbose("  Rule %s: no match for %+v\n", r, ctx.To)
 		} else {
 			state.selectedRules++
-			ctx.PolicyTrace("* Rule %d %s: match\n", state.ruleID, r)
+			ctx.PolicyTrace("* Rule %s: match\n", r)
 		}
 		return entitiesDecision
 	}
 
 	state.selectedRules++
-	ctx.PolicyTrace("* Rule %d %s: match\n", state.ruleID, r)
+	ctx.PolicyTrace("* Rule %s: match\n", r)
 
 	for _, r := range r.Ingress {
 		for _, sel := range r.FromRequires {

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -53,9 +53,11 @@ func (ds *PolicyTestSuite) TestRuleCanReach(c *C) {
 	state := traceState{}
 	c.Assert(rule1.canReach(fooFoo2ToBar, &state), Equals, api.Allowed)
 	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 1)
 	state = traceState{}
 	c.Assert(rule1.canReach(fooToBar, &traceState{}), Equals, api.Undecided)
 	c.Assert(state.selectedRules, Equals, 0)
+	c.Assert(state.matchedRules, Equals, 0)
 
 	// selector: bar
 	// allow: foo
@@ -88,14 +90,17 @@ func (ds *PolicyTestSuite) TestRuleCanReach(c *C) {
 	state = traceState{}
 	c.Assert(rule2.canReach(fooToBar, &state), Equals, api.Denied)
 	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
 	c.Assert(rule2.canReach(bazToBar, &state), Equals, api.Undecided)
 	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
 	c.Assert(rule2.canReach(fooBazToBar, &state), Equals, api.Allowed)
 	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 1)
 }
 
 func (ds *PolicyTestSuite) TestL4Policy(c *C) {
@@ -163,11 +168,14 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
 	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 0)
 
+	// Foo isn't selected in the rule1's policy.
 	state = traceState{}
 	res, err = rule1.resolveL4Policy(toFoo, &state, NewL4Policy())
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
+	c.Assert(state.matchedRules, Equals, 0)
 
 	// This rule actually overlaps with the existing ingress "http" rule,
 	// so we'd expect it to merge.
@@ -228,11 +236,13 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	c.Assert(len(res.Ingress), Equals, 1)
 	c.Assert(*res, comparator.DeepEquals, *expected)
 	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
 	res, err = rule2.resolveL4Policy(toFoo, &state, NewL4Policy())
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
+	c.Assert(state.matchedRules, Equals, 0)
 }
 
 func (ds *PolicyTestSuite) TestMergeL4Policy(c *C) {
@@ -278,6 +288,7 @@ func (ds *PolicyTestSuite) TestMergeL4Policy(c *C) {
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
 	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 0)
 }
 
 func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
@@ -349,11 +360,13 @@ func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
 	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
 	res, err = rule1.resolveL4Policy(toFoo, &state, NewL4Policy())
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
+	c.Assert(state.matchedRules, Equals, 0)
 
 	rule2 := &rule{
 		Rule: api.Rule{
@@ -417,11 +430,13 @@ func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
 	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
 	res, err = rule2.resolveL4Policy(toFoo, &state, NewL4Policy())
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
+	c.Assert(state.matchedRules, Equals, 0)
 
 	// Resolve rule1's policy, then try to add rule2.
 	res, err = rule1.resolveL4Policy(toBar, &state, NewL4Policy())
@@ -494,6 +509,7 @@ func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
 	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 0)
 }
 
 func (ds *PolicyTestSuite) TestL3Policy(c *C) {
@@ -556,6 +572,7 @@ func (ds *PolicyTestSuite) TestL3Policy(c *C) {
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
 	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 0)
 
 	// Must be parsable, make sure Validate fails when not.
 	err = api.Rule{
@@ -645,9 +662,11 @@ func (ds *PolicyTestSuite) TestRuleCanReachFromEntity(c *C) {
 	state := traceState{}
 	c.Assert(rule1.canReach(fromWorld, &state), Equals, api.Allowed)
 	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 1)
 	state = traceState{}
 	c.Assert(rule1.canReach(notFromWorld, &traceState{}), Equals, api.Undecided)
 	c.Assert(state.selectedRules, Equals, 0)
+	c.Assert(state.matchedRules, Equals, 0)
 }
 
 func (ds *PolicyTestSuite) TestRuleCanReachEntity(c *C) {
@@ -677,9 +696,11 @@ func (ds *PolicyTestSuite) TestRuleCanReachEntity(c *C) {
 	state := traceState{}
 	c.Assert(rule1.canReach(toWorld, &state), Equals, api.Allowed)
 	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 1)
 	state = traceState{}
 	c.Assert(rule1.canReach(notToWorld, &traceState{}), Equals, api.Undecided)
 	c.Assert(state.selectedRules, Equals, 0)
+	c.Assert(state.matchedRules, Equals, 0)
 }
 
 func (ds *PolicyTestSuite) TestPolicyEntityValidationEgress(c *C) {

--- a/tests/12-policy-import.sh
+++ b/tests/12-policy-import.sh
@@ -11,8 +11,8 @@ redirect_debug_logs ${LOGS_DIR}
 
 set -ex
 
-DENIED="Label verdict: denied"
-ALLOWED="Label verdict: allowed"
+DENIED="Final verdict: DENIED"
+ALLOWED="Final verdict: ALLOWED"
 
 
 function test_policy_trace_policy_disabled {
@@ -23,7 +23,7 @@ function test_policy_trace_policy_disabled {
   log "verify verbose trace for expected output using endpoint IDs "
   local TRACE_OUTPUT=$(cilium policy trace --src-endpoint $FOO_ID --dst-endpoint $BAR_ID -v)
   log "Trace output: ${TRACE_OUTPUT}"
-  local DIFF=$(diff -Nru <(echo "$ALLOWED") <(cilium policy trace --src-endpoint $FOO_ID --dst-endpoint $BAR_ID -v | grep "Label verdict:")) || true
+  local DIFF=$(diff -Nru <(echo "$ALLOWED") <(cilium policy trace --src-endpoint $FOO_ID --dst-endpoint $BAR_ID -v | grep "Final verdict:")) || true
   if [[ "$DIFF" != "" ]]; then
     abort "DIFF: $DIFF"
   fi
@@ -151,7 +151,7 @@ Tracing From: [any:id.foo] => To: [any:id.bar]
 1 rules matched
 Label verdict: allowed
 
-Verdict: ALLOWED
+Final verdict: ALLOWED
 
 EOF
 
@@ -204,7 +204,7 @@ Tracing From: [any:id.foo] => To: [any:id.bar]
 1 rules matched
 Label verdict: allowed
 
-Verdict: ALLOWED
+Final verdict: ALLOWED
 
 EOF
 
@@ -225,7 +225,7 @@ Tracing From: [any:id.foo] => To: [any:id.bar]
 1 rules matched
 Label verdict: allowed
 
-Verdict: ALLOWED
+Final verdict: ALLOWED
 
 EOF
 
@@ -255,20 +255,20 @@ Tracing From: [container:id.foo, container:id.teamA] => To: [container:id.bar, c
 2 rules matched
 Label verdict: allowed
 
-Verdict: ALLOWED
+Final verdict: ALLOWED
 
 EOF
 
 
 log "verify verbose trace for expected output using security identities"
-DIFF=$(diff -Nru <(echo "$ALLOWED") <(cilium policy trace --src-identity $FOO_SEC_ID --dst-identity $BAR_SEC_ID -v | grep "Label verdict:")) || true
+DIFF=$(diff -Nru <(echo "$ALLOWED") <(cilium policy trace --src-identity $FOO_SEC_ID --dst-identity $BAR_SEC_ID -v | grep "Final verdict:")) || true
 if [[ "$DIFF" != "" ]]; then
   abort "DIFF: $DIFF"
 fi
 
 log "verify verbose trace for expected output using endpoint IDs"
 TRACE_OUTPUT=$(cilium policy trace --src-endpoint $FOO_ID --dst-endpoint $BAR_ID -v)
-DIFF=$(diff -Nru <(echo "$ALLOWED") <(cilium policy trace --src-endpoint $FOO_ID --dst-endpoint $BAR_ID -v | grep "Label verdict:")) || true
+DIFF=$(diff -Nru <(echo "$ALLOWED") <(cilium policy trace --src-endpoint $FOO_ID --dst-endpoint $BAR_ID -v | grep "Final verdict:")) || true
 if [[ "$DIFF" != "" ]]; then
   abort "DIFF: $DIFF"
 fi

--- a/tests/12-policy-import.sh
+++ b/tests/12-policy-import.sh
@@ -142,13 +142,14 @@ EOF
 read -d '' EXPECTED_POLICY <<"EOF" || true
 ----------------------------------------------------------------
 Tracing From: [any:id.foo] => To: [any:id.bar]
-* Rule {"matchLabels":{"any:id.bar":""}}: match
+* Rule {"matchLabels":{"any:id.bar":""}}: selected
     Allows from labels {"matchLabels":{"reserved:host":""}}
       Labels [any:id.foo] not found
     Allows from labels {"matchLabels":{"any:id.foo":""}}
       Found all required labels
-+       No L4 restrictions; allowing
-1 rules matched
++       No L4 restrictions
+1/1 rules selected
+Found allow rule
 Label verdict: allowed
 
 Final verdict: ALLOWED
@@ -197,11 +198,12 @@ EOF
 read -d '' EXPECTED_POLICY <<"EOF" || true
 ----------------------------------------------------------------
 Tracing From: [any:id.foo] => To: [any:id.bar]
-* Rule {"matchLabels":{"any:id.bar":""}}: match
+* Rule {"matchLabels":{"any:id.bar":""}}: selected
     Allows from labels {"matchLabels":{"any:id.foo":""}}
       Found all required labels
-+       No L4 restrictions; allowing
-1 rules matched
++       No L4 restrictions
+1/2 rules selected
+Found allow rule
 Label verdict: allowed
 
 Final verdict: ALLOWED
@@ -217,12 +219,13 @@ fi
 read -d '' EXPECTED_POLICY <<"EOF" || true
 ----------------------------------------------------------------
 Tracing From: [any:id.foo] => To: [any:id.bar]
-* Rule {"matchLabels":{"any:id.bar":""}}: match
+* Rule {"matchLabels":{"any:id.bar":""}}: selected
     Allows from labels {"matchLabels":{"any:id.foo":""}}
       Found all required labels
-+       No L4 restrictions; allowing
-  Rule {"matchLabels":{"any:id.teamA":""}}: no match for [any:id.bar]
-1 rules matched
++       No L4 restrictions
+  Rule {"matchLabels":{"any:id.teamA":""}}: did not select [any:id.bar]
+1/2 rules selected
+Found allow rule
 Label verdict: allowed
 
 Final verdict: ALLOWED
@@ -244,15 +247,16 @@ BAR_SEC_ID=$(cilium endpoint list | grep id.bar | awk '{print $3}')
 read -d '' EXPECTED_POLICY <<"EOF" || true
 ----------------------------------------------------------------
 Tracing From: [container:id.foo, container:id.teamA] => To: [container:id.bar, container:id.teamA]
-* Rule {"matchLabels":{"any:id.bar":""}}: match
+* Rule {"matchLabels":{"any:id.bar":""}}: selected
     Allows from labels {"matchLabels":{"any:id.foo":""}}
       Found all required labels
-+       No L4 restrictions; allowing
-* Rule {"matchLabels":{"any:id.teamA":""}}: match
++       No L4 restrictions
+* Rule {"matchLabels":{"any:id.teamA":""}}: selected
     Requires from labels {"matchLabels":{"any:id.teamA":""}}
       Found all required labels
-+       No L4 restrictions; allowing
-2 rules matched
++       No L4 restrictions
+2/2 rules selected
+Found allow rule
 Label verdict: allowed
 
 Final verdict: ALLOWED

--- a/tests/12-policy-import.sh
+++ b/tests/12-policy-import.sh
@@ -142,7 +142,7 @@ EOF
 read -d '' EXPECTED_POLICY <<"EOF" || true
 ----------------------------------------------------------------
 Tracing From: [any:id.foo] => To: [any:id.bar]
-* Rule 0 {"matchLabels":{"any:id.bar":""}}: match
+* Rule {"matchLabels":{"any:id.bar":""}}: match
     Allows from labels {"matchLabels":{"reserved:host":""}}
       Labels [any:id.foo] not found
     Allows from labels {"matchLabels":{"any:id.foo":""}}
@@ -197,7 +197,7 @@ EOF
 read -d '' EXPECTED_POLICY <<"EOF" || true
 ----------------------------------------------------------------
 Tracing From: [any:id.foo] => To: [any:id.bar]
-* Rule 0 {"matchLabels":{"any:id.bar":""}}: match
+* Rule {"matchLabels":{"any:id.bar":""}}: match
     Allows from labels {"matchLabels":{"any:id.foo":""}}
       Found all required labels
 +       No L4 restrictions; allowing
@@ -217,11 +217,11 @@ fi
 read -d '' EXPECTED_POLICY <<"EOF" || true
 ----------------------------------------------------------------
 Tracing From: [any:id.foo] => To: [any:id.bar]
-* Rule 0 {"matchLabels":{"any:id.bar":""}}: match
+* Rule {"matchLabels":{"any:id.bar":""}}: match
     Allows from labels {"matchLabels":{"any:id.foo":""}}
       Found all required labels
 +       No L4 restrictions; allowing
-  Rule 1 {"matchLabels":{"any:id.teamA":""}}: no match for [any:id.bar]
+  Rule {"matchLabels":{"any:id.teamA":""}}: no match for [any:id.bar]
 1 rules matched
 Label verdict: allowed
 
@@ -244,11 +244,11 @@ BAR_SEC_ID=$(cilium endpoint list | grep id.bar | awk '{print $3}')
 read -d '' EXPECTED_POLICY <<"EOF" || true
 ----------------------------------------------------------------
 Tracing From: [container:id.foo, container:id.teamA] => To: [container:id.bar, container:id.teamA]
-* Rule 0 {"matchLabels":{"any:id.bar":""}}: match
+* Rule {"matchLabels":{"any:id.bar":""}}: match
     Allows from labels {"matchLabels":{"any:id.foo":""}}
       Found all required labels
 +       No L4 restrictions; allowing
-* Rule 1 {"matchLabels":{"any:id.teamA":""}}: match
+* Rule {"matchLabels":{"any:id.teamA":""}}: match
     Requires from labels {"matchLabels":{"any:id.teamA":""}}
       Found all required labels
 +       No L4 restrictions; allowing

--- a/tests/k8s/tests/00-gsg-test.sh
+++ b/tests/k8s/tests/00-gsg-test.sh
@@ -19,8 +19,8 @@ set -ex
 
 NAMESPACE="kube-system"
 GOPATH="/home/vagrant/go"
-DENIED="Verdict: DENIED"
-ALLOWED="Verdict: ALLOWED"
+DENIED="Final verdict: DENIED"
+ALLOWED="Final verdict: ALLOWED"
 
 log "running test: $TEST_NAME"
 
@@ -97,7 +97,7 @@ if [[ "${RETURN//$'\n'}" != "200" ]]; then
 fi
 
 log "confirming that \`cilium policy trace\` shows that app2 can reach app1"
-diff_timeout "echo $ALLOWED" "kubectl exec -n kube-system $CILIUM_POD_1 --  cilium policy trace --src-k8s-pod default:$APP2_POD --dst-k8s-pod default:$APP1_POD --dport 80 -v | grep \"Verdict:\""
+diff_timeout "echo $ALLOWED" "kubectl exec -n kube-system $CILIUM_POD_1 --  cilium policy trace --src-k8s-pod default:$APP2_POD --dst-k8s-pod default:$APP1_POD --dport 80 -v | grep \"Final verdict:\""
 
 log "testing that app3 cannot reach app 1 (expected behavior: cannot reach)"
 RETURN=$(kubectl exec $APP3_POD -- curl --connect-timeout 15 -s --output /dev/stderr -w '%{http_code}' -XGET $SVC_IP || true)
@@ -106,7 +106,7 @@ if [[ "${RETURN//$'\n'}" != "000" ]]; then
 fi
 
 log "confirming that \`cilium policy trace\` shows that app3 cannot reach app1"
-diff_timeout "echo $DENIED" "kubectl exec -n kube-system $CILIUM_POD_1 --  cilium policy trace --src-k8s-pod default:$APP3_POD --dst-k8s-pod default:$APP1_POD -v | grep \"Verdict:\""
+diff_timeout "echo $DENIED" "kubectl exec -n kube-system $CILIUM_POD_1 --  cilium policy trace --src-k8s-pod default:$APP3_POD --dst-k8s-pod default:$APP1_POD -v | grep \"Final verdict:\""
 
 log "performing HTTP GET on ${SVC_IP}/public from app2"
 RETURN=$(kubectl exec $APP2_POD -- curl -s --output /dev/stderr -w '%{http_code}' http://${SVC_IP}/public || true)


### PR DESCRIPTION
This PR takes a stab at improving policy trace output to address #1610, and converts the current runtime tests of its output into a few simple unit tests.

Below is an example of the updated output from the Documentation when we have one L3-dependent L4 rule:
```
$ cilium policy trace -s id.curl -d id.httpd --dport 80
Tracing From: [container:id.curl] => To: [container:id.httpd] Ports: [80/any]
* Rule {"matchLabels":{"any:id.httpd":""}}: selected
    Allows from labels {"matchLabels":{"any:id.curl":""}}
      Found all required labels
        Rule restricts traffic to specific L4 destinations; deferring policy decision to L4 policy stage
1/1 rules selected
Found no allow rule
Label verdict: undecided

Resolving egress port policy for [container:id.curl]
* Rule {"matchLabels":{"any:id.curl":""}}: selected
  Allows Egress port [{80 tcp}]
    Found all required labels
1/1 rules selected
Found allow rule
L4 egress verdict: allowed

Resolving ingress port policy for [container:id.httpd]
* Rule {"matchLabels":{"any:id.httpd":""}}: selected
  Allows Ingress port [{80 tcp}]
    Found all required labels
1/1 rules selected
Found allow rule
L4 ingress verdict: allowed

Final verdict: ALLOWED
```

