### PR TITLE
pkg/bpf: free up allocated memory for state on poll false positives

### DIFF
--- a/pkg/bpf/perf.go
+++ b/pkg/bpf/perf.go
@@ -305,6 +305,7 @@ func (e *PerfEvent) Disable() error {
 func (e *PerfEvent) Read(receive ReceiveFunc, lostFn LostFunc) {
 	buf := make([]byte, 256)
 	state := C.malloc(C.size_t(unsafe.Sizeof(C.struct_read_state{})))
+	defer C.free(state)
 
 	// Prepare for reading and check if events are available
 	available := C.perf_event_read_init(C.int(e.npages), C.int(e.pagesize),
@@ -341,7 +342,6 @@ func (e *PerfEvent) Read(receive ReceiveFunc, lostFn LostFunc) {
 
 	// Move ring buffer tail pointer
 	C.perf_event_read_finish(unsafe.Pointer(&e.data[0]), unsafe.Pointer(state))
-	C.free(state)
 }
 
 func (e *PerfEvent) Close() {


### PR DESCRIPTION
Have not measured how often this happens, but we should still free.

Related-to: #1807 (cilium leaks memory when running inside a container)
Fixes: 9bd565261ac7 (bpf: manually handle the perf read state memory allocation, 2017-08-12)
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>