### PR TITLE
Miscellaneous logrus.WithFields fixups

### DIFF
--- a/common/plugins/add_endpoint.go
+++ b/common/plugins/add_endpoint.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/logfields"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -73,12 +74,12 @@ func SetupVeth(id string, mtu int, ep *models.EndpointChangeRequest) (*netlink.V
 	defer func() {
 		if err != nil {
 			if err = netlink.LinkDel(veth); err != nil {
-				log.Warningf("failed to clean up veth %q: %s", veth.Name, err)
+				log.WithError(err).WithField(logfields.Veth, veth.Name).Warn("failed to clean up veth")
 			}
 		}
 	}()
 
-	log.Debugf("Created veth pair %s <-> %s", lxcIfName, veth.PeerName)
+	log.WithField(logfields.VethPair, []string{veth.PeerName, lxcIfName}).Debug("Created veth pair")
 
 	// Disable reverse path filter on the host side veth peer to allow
 	// container addresses to be used as source address when the linux

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -250,7 +250,7 @@ func TriggerPolicyUpdates(owner endpoint.Owner) *sync.WaitGroup {
 		go func(ep *endpoint.Endpoint, wg *sync.WaitGroup) {
 			policyChanges, err := ep.TriggerPolicyUpdates(owner)
 			if err != nil {
-				log.Warningf("Error while handling policy updates for endpoint %s", err)
+				log.WithError(err).Warn("Error while handling policy updates for endpoint")
 				ep.LogStatus(endpoint.Policy, endpoint.Failure, err.Error())
 			} else {
 				ep.LogStatusOK(endpoint.Policy, "Policy regenerated")

--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -128,7 +128,7 @@ func ParseLabelPrefixCfg(prefixes []string, file string) error {
 
 	validLabelPrefixes = cfg
 
-	log.Infof("Valid label prefix configuration:")
+	log.Info("Valid label prefix configuration:")
 	for _, l := range validLabelPrefixes.LabelPrefixes {
 		log.Infof(" - %s", l)
 	}

--- a/pkg/node/manager.go
+++ b/pkg/node/manager.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
 
 	log "github.com/sirupsen/logrus"
@@ -59,7 +60,7 @@ func deleteNodeCIDR(ip *net.IPNet) {
 	}
 
 	if err := tunnel.DeleteTunnelEndpoint(ip.IP); err != nil {
-		log.Errorf("bpf: Unable to delete %s in tunnel endpoint map: %s", ip, err)
+		log.WithError(err).WithField(logfields.IPAddr, ip).Error("bpf: Unable to delete in tunnel endpoint map")
 	}
 }
 
@@ -69,7 +70,7 @@ func updateNodeCIDR(ip *net.IPNet, host net.IP) {
 	}
 
 	if err := tunnel.SetTunnelEndpoint(ip.IP, host); err != nil {
-		log.Errorf("bpf: Unable to update %s in tunnel endpoint map: %s", ip, err)
+		log.WithError(err).WithField(logfields.IPAddr, ip).Error("bpf: Unable to update in tunnel endpoint map")
 	}
 }
 
@@ -87,8 +88,11 @@ func UpdateNode(ni Identity, n *Node, routesTypes RouteType, ownAddr net.IP) {
 			deleteNodeCIDR(oldNode.IPv6AllocCIDR)
 		}
 		// FIXME if PodCIDR is empty retrieve the CIDR from the KVStore
-		log.Debugf("bpf: Setting tunnel endpoint %+v: %+v %+v",
-			n.GetNodeIP(false), n.IPv4AllocCIDR, n.IPv6AllocCIDR)
+		log.WithFields(log.Fields{
+			logfields.IPAddr:   n.GetNodeIP(false),
+			logfields.V4Prefix: n.IPv4AllocCIDR,
+			logfields.V6Prefix: n.IPv6AllocCIDR,
+		}).Debug("bpf: Setting tunnel endpoint")
 
 		nodeIP := n.GetNodeIP(false)
 		updateNodeCIDR(n.IPv4AllocCIDR, nodeIP)
@@ -108,8 +112,11 @@ func DeleteNode(ni Identity, routesTypes RouteType) {
 	mutex.Lock()
 	if n, ok := nodes[ni]; ok {
 		if (routesTypes & TunnelRoute) != 0 {
-			log.Debugf("bpf: Removing tunnel endpoint %+v: %+v %+v",
-				n.GetNodeIP(false), n.IPv4AllocCIDR, n.IPv6AllocCIDR)
+			log.WithFields(log.Fields{
+				logfields.IPAddr:   n.GetNodeIP(false),
+				logfields.V4Prefix: n.IPv4AllocCIDR,
+				logfields.V6Prefix: n.IPv6AllocCIDR,
+			}).Debug("bpf: Removing tunnel endpoint")
 
 			if n.IPv4AllocCIDR != nil {
 				err1 = tunnel.DeleteTunnelEndpoint(n.IPv4AllocCIDR.IP)
@@ -142,17 +149,17 @@ func DeleteNode(ni Identity, routesTypes RouteType) {
 // network interface that as ownAddr.
 func updateIPRoute(oldNode, n *Node, ownAddr net.IP) {
 	nodeIPv6 := n.GetNodeIP(true)
-	log.Debugf("iproute: Setting endpoint v6 route for %s via %s",
-		n.IPv6AllocCIDR, nodeIPv6)
+	scopedLog := log.WithField(logfields.V6Prefix, n.IPv6AllocCIDR)
+	scopedLog.WithField(logfields.IPAddr, nodeIPv6).Debug("iproute: Setting endpoint v6 route for prefix via IP")
 
 	nl, err := firstLinkWithv6(ownAddr)
 	if err != nil {
-		log.WithError(err).Errorf("iproute: Unable to get v6 interface with IP %s", ownAddr)
+		scopedLog.WithError(err).WithField(logfields.IPAddr, ownAddr).Error("iproute: Unable to get v6 interface with IP")
 		return
 	}
 	dev := nl.Attrs().Name
 	if dev == "" {
-		log.Errorf("iproute: Unable to get v6 interface for %s: empty interface name", ownAddr)
+		scopedLog.WithField(logfields.IPAddr, ownAddr).Error("iproute: Unable to get v6 interface for address: empty interface name")
 		return
 	}
 
@@ -165,7 +172,11 @@ func updateIPRoute(oldNode, n *Node, ownAddr net.IP) {
 
 			err = routeDel(oldNodeIPv6.String(), oldNode.IPv6AllocCIDR.String(), oldNode.dev)
 			if err != nil {
-				log.Warning(err)
+				log.WithError(err).WithFields(log.Fields{
+					logfields.IPAddr:   oldNodeIPv6,
+					logfields.V6Prefix: oldNode.IPv6AllocCIDR,
+					"device":           oldNode.dev,
+				}).Warn("Cannot delete old route during update")
 			}
 		}
 	} else {
@@ -175,7 +186,11 @@ func updateIPRoute(oldNode, n *Node, ownAddr net.IP) {
 	// Always re add
 	err = routeAdd(nodeIPv6.String(), n.IPv6AllocCIDR.String(), dev)
 	if err != nil {
-		log.Warning(err)
+		log.WithError(err).WithFields(log.Fields{
+			logfields.IPAddr:   nodeIPv6,
+			logfields.V6Prefix: n.IPv6AllocCIDR,
+			"device":           dev,
+		}).Warn("Cannot re-add route")
 		return
 	}
 }
@@ -187,7 +202,11 @@ func deleteIPRoute(node *Node) {
 
 	err := routeDel(oldNodeIPv6.String(), node.IPv6AllocCIDR.String(), node.dev)
 	if err != nil {
-		log.Warning(err)
+		log.WithError(err).WithFields(log.Fields{
+			logfields.IPAddr:   oldNodeIPv6,
+			logfields.V6Prefix: node.IPv6AllocCIDR,
+			"device":           node.dev,
+		}).Warn("Cannot delete route")
 	}
 }
 

--- a/pkg/nodeaddress/node_address.go
+++ b/pkg/nodeaddress/node_address.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/node"
 
 	log "github.com/sirupsen/logrus"
@@ -45,7 +46,7 @@ func makeIPv6HostIP() net.IP {
 	ipstr := "fc00::10CA:1"
 	ip := net.ParseIP(ipstr)
 	if ip == nil {
-		log.Fatalf("Unable to parse IP '%s'", ipstr)
+		log.WithField(logfields.IPAddr, ipstr).Fatal("Unable to parse IP")
 	}
 
 	return ip
@@ -142,11 +143,11 @@ func InitDefaultPrefix(device string) {
 			ip.To4()[3], DefaultIPv4PrefixLen)
 		_, ip4net, err := net.ParseCIDR(v4range)
 		if err != nil {
-			log.Panicf("BUG: Invalid default prefix '%s': %s", v4range, err)
+			log.WithError(err).WithField(logfields.V4Prefix, v4range).Panic("BUG: Invalid default IPv4 prefix")
 		}
 
 		ipv4AllocRange = ip4net
-		log.Infof("Automatically added IPv4 allocation %s", ipv4AllocRange)
+		log.WithField(logfields.V4Prefix, ipv4AllocRange).Info("Automatically generated IPv4 allocation range")
 	}
 
 	if ipv6AllocRange == nil {
@@ -158,11 +159,11 @@ func InitDefaultPrefix(device string) {
 
 		_, ip6net, err := net.ParseCIDR(v6range)
 		if err != nil {
-			log.Panicf("BUG: Invalid default prefix '%s': %s", v6range, err)
+			log.WithError(err).WithField(logfields.V6Prefix, v6range).Panic("BUG: Invalid default IPv6 prefix")
 		}
 
 		ipv6AllocRange = ip6net
-		log.Infof("Automatically added IPv6 allocation %s", ipv6AllocRange)
+		log.WithField(logfields.V6Prefix, ipv6AllocRange).Info("Automatically generated IPv6 allocation range")
 	}
 }
 
@@ -374,14 +375,15 @@ func GetNode() (node.Identity, *node.Node) {
 // UseNodeCIDR sets the ipv4-range and ipv6-range values values from the
 // addresses defined in the given node.
 func UseNodeCIDR(node *node.Node) error {
+	scopedLog := log.WithField(logfields.Node, node.Name)
 	if node.IPv4AllocCIDR != nil {
-		log.Infof("Retrieved %s for node %s. Using it for ipv4-range", node.IPv4AllocCIDR, node.Name)
+		scopedLog.WithField(logfields.V4Prefix, node.IPv4AllocCIDR).Info("Retrieved IPv4 allocation range for node. Using it for ipv4-range")
 		SetIPv4AllocRange(node.IPv4AllocCIDR)
 	}
 	if node.IPv6AllocCIDR != nil {
-		log.Infof("Retrieved %s for node %s. Using it for ipv6-range", node.IPv6AllocCIDR, node.Name)
+		scopedLog.WithField(logfields.V4Prefix, node.IPv6AllocCIDR).Info("Retrieved IPv6 allocation range for node. Using it for ipv6-range")
 		if err := SetIPv6NodeRange(node.IPv6AllocCIDR); err != nil {
-			log.Warningf("k8s: Can't use CIDR '%s' from kubernetes: %s", node.IPv6AllocCIDR, err)
+			scopedLog.WithError(err).WithField(logfields.V4Prefix, node.IPv6AllocCIDR).Warn("k8s: Can't use IPv6 CIDR range from kubernetes")
 		}
 	}
 
@@ -391,14 +393,15 @@ func UseNodeCIDR(node *node.Node) error {
 // UseNodeAddresses sets the local ipv4-node and ipv6-node values from the
 // addresses defined in the given node.
 func UseNodeAddresses(node *node.Node) error {
+	scopedLog := log.WithField(logfields.Node, node.Name)
 	nodeIP4 := node.GetNodeIP(false)
 	if nodeIP4 != nil {
-		log.Infof("Automatically retrieved %s for node %s. Using it for ipv4-node", nodeIP4, node.Name)
+		scopedLog.WithField(logfields.IPAddr, nodeIP4).Info("Automatically retrieved IP for node. Using it for ipv4-node")
 		SetExternalIPv4(nodeIP4)
 	}
 	nodeIP6 := node.GetNodeIP(true)
 	if nodeIP6 != nil {
-		log.Infof("Automatically retrieved %s for node %s. Using it for ipv6-node", nodeIP6, node.Name)
+		scopedLog.WithField(logfields.IPAddr, nodeIP6).Info("Automatically retrieved IP for node. Using it for ipv6-node")
 		SetIPv6(nodeIP6)
 	}
 

--- a/pkg/nodeaddress/nodename.go
+++ b/pkg/nodeaddress/nodename.go
@@ -17,6 +17,7 @@ package nodeaddress
 import (
 	"os"
 
+	"github.com/cilium/cilium/pkg/logfields"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -43,9 +44,9 @@ func GetName() string {
 
 func init() {
 	if h, err := os.Hostname(); err != nil {
-		log.Warningf("Unable to retrieve local hostname: %s", err)
+		log.WithError(err).Warn("Unable to retrieve local hostname")
 	} else {
-		log.Debugf("os.Hostname() returned: %s", h)
+		log.WithField(logfields.NodeName, h).Debug("os.Hostname() returned")
 		nodeName = h
 	}
 }

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -28,7 +28,7 @@ const apiAddress = "localhost:6060"
 func Enable() {
 	go func() {
 		if err := http.ListenAndServe(apiAddress, nil); err != nil {
-			log.WithError(err).Warning("Unable to serve pprof API")
+			log.WithError(err).Warn("Unable to serve pprof API")
 		}
 	}()
 }


### PR DESCRIPTION
This switches a bunch of log callsites to use logrus.WIthFields. These changes are not supposed to break anything and follow the same reasoning from https://github.com/cilium/cilium/pull/1801 The goal of these changes is to make debugging via logs easier by making our usage more consistent. Ideally, field names should be used the same way throughout the code and mean the same thing.

The most important things to review are whether the field names make sense in the context they're used, and whether we should introduce new ones to pkg/logfields/logfields.go. I'm also happy to incorporate better messages into this PR :)