### PR TITLE
Bpf logrus.WithFields fixups

### DIFF
--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -23,6 +23,7 @@ import (
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logfields"
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -242,41 +243,52 @@ func (m *Map) migrate(fd int) (bool, error) {
 		return false, nil
 	}
 
+	scopedLog := log.WithField(logfields.Path, m.path)
 	mismatch := false
 
 	if info.MapType != m.MapType {
-		log.Infof("Map type mismatch for BPF map %s: old: %d new: %d",
-			m.path, info.MapType, m.MapType)
+		scopedLog.WithFields(log.Fields{
+			"old": info.MapType,
+			"new": m.MapType,
+		}).Info("Map type mismatch for BPF map")
 		mismatch = true
 	}
 
 	if info.KeySize != m.KeySize {
-		log.Infof("Key-size mismatch for BPF map %s: old: %d new: %d",
-			m.path, info.KeySize, m.KeySize)
+		scopedLog.WithFields(log.Fields{
+			"old": info.KeySize,
+			"new": m.KeySize,
+		}).Info("Key-size mismatch for BPF map")
 		mismatch = true
 	}
 
 	if info.ValueSize != m.ValueSize {
-		log.Infof("Value-size mismatch for BPF map %s: old: %d new: %d",
-			m.path, info.ValueSize, m.ValueSize)
+		scopedLog.WithFields(log.Fields{
+			"old": info.ValueSize,
+			"new": m.ValueSize,
+		}).Info("Value-size mismatch for BPF map")
 		mismatch = true
 	}
 
 	if info.MaxEntries != m.MaxEntries {
-		log.Infof("Max entries mismatch for BPF map %s: old: %d new: %d",
-			m.path, info.MaxEntries, m.MaxEntries)
+		scopedLog.WithFields(log.Fields{
+			"old": info.MaxEntries,
+			"new": m.MaxEntries,
+		}).Info("Max entries mismatch for BPF map")
 		mismatch = true
 	}
 
 	if info.Flags != m.Flags {
-		log.Infof("Flags mismatch for BPF map %s: old: %d new: %d",
-			m.path, info.Flags, m.Flags)
+		scopedLog.WithFields(log.Fields{
+			"old": info.Flags,
+			"new": m.Flags,
+		}).Info("Flags mismatch for BPF map")
 		mismatch = true
 	}
 	if mismatch {
 		b, err := m.containsEntries()
 		if err == nil && !b {
-			log.Infof("Safely removing empty map %s so it can be recreated", m.path)
+			scopedLog.Info("Safely removing empty map so it can be recreated")
 			os.Remove(m.path)
 			return true, nil
 		}

--- a/pkg/maps/cidrmap/cidrmap.go
+++ b/pkg/maps/cidrmap/cidrmap.go
@@ -20,6 +20,7 @@ import (
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/logfields"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -177,13 +178,16 @@ func OpenMapElems(path string, prefixlen int, prefixdyn bool, maxelem uint32) (*
 	)
 
 	if err != nil {
-		log.Debugf("Kernel does not support CIDR maps, using inline bpf tables instead.")
+		log.Debug("Kernel does not support CIDR maps, using inline bpf tables instead.")
 		return nil, false, err
 	}
 
 	m := &CIDRMap{path: path, Fd: fd, AddrSize: bytes, Prefixlen: uint32(prefix)}
 
-	log.Debugf("Created CIDR map %s (fd: %d)", path, fd)
+	log.WithFields(log.Fields{
+		logfields.Path: path,
+		"fd":           fd,
+	}).Debug("Created CIDR map")
 
 	return m, isNewMap, nil
 }

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -225,7 +225,7 @@ func doGC6(m *bpf.Map, filter *GCFilter) int {
 		nextKeyValid := m.GetNextKey(&nextKey, &tmpKey)
 		entryMap, err := m.Lookup(&nextKey)
 		if err != nil {
-			log.Errorf("error during map Lookup: %s", err)
+			log.WithError(err).Error("error during map Lookup")
 			break
 		}
 
@@ -237,7 +237,7 @@ func doGC6(m *bpf.Map, filter *GCFilter) int {
 			entry.lifetime < filter.Time {
 
 			del = true
-			//log.Debugf("Deleting entry %v since it timeout", entry)
+			//log.WithField(logfields.Object, logfields.Repr(entry)).Debug("Deleting IPv4 entry since it timeout")
 		}
 		if filter.fType&GCFilterByID != 0 &&
 			// In CT's entries, saddr is the packet's receiver,
@@ -249,15 +249,17 @@ func doGC6(m *bpf.Map, filter *GCFilter) int {
 			if _, ok := filter.IDsToRm[entry.src_sec_id]; ok {
 
 				del = true
-				//log.Debugf("Deleting entry since ID %d is no "+
-				//	"longer being consumed by %s", entry.src_sec_id, filter.IP)
+				//log.WithFields(log.Fields{
+				//	logfields.IPAddr:   filter.IP,
+				//	logfields.Identity: entry.src_sec_id,
+				//}).Debug("Deleting IPv6 entry since ID is no longer being consumed by filter")
 			}
 		}
 
 		if del {
 			err := m.Delete(&nextKey)
 			if err != nil {
-				log.Debugf("error during Delete: %s", err)
+				log.WithError(err).Debug("error during Delete")
 			} else {
 				deleted++
 			}
@@ -290,7 +292,7 @@ func doGC4(m *bpf.Map, filter *GCFilter) int {
 		nextKeyValid := m.GetNextKey(&nextKey, &tmpKey)
 		entryMap, err := m.Lookup(&nextKey)
 		if err != nil {
-			log.Errorf("error during map Lookup: %s", err)
+			log.WithError(err).Error("error during map Lookup")
 			break
 		}
 
@@ -302,7 +304,7 @@ func doGC4(m *bpf.Map, filter *GCFilter) int {
 			entry.lifetime < filter.Time {
 
 			del = true
-			//log.Debugf("Deleting entry %v since it timeout", entry)
+			//log.WithField(logfields.Object, logfields.Repr(entry)).Debug("Deleting IPv6 entry since it timeout")
 		}
 		if filter.fType&GCFilterByID != 0 &&
 			// In CT's entries, saddr is the packet's receiver,
@@ -314,15 +316,17 @@ func doGC4(m *bpf.Map, filter *GCFilter) int {
 			if _, ok := filter.IDsToRm[entry.src_sec_id]; ok {
 
 				del = true
-				//log.Debugf("Deleting entry since ID %d is no "+
-				//	"longer being consumed by %s", entry.src_sec_id, filter.IP)
+				//log.WithFields(log.Fields{
+				//	logfields.IPAddr:   filter.IP,
+				//	logfields.Identity: entry.src_sec_id,
+				//}).Debug("Deleting IPv4 entry since ID is no longer being consumed by filter")
 			}
 		}
 
 		if del {
 			err := m.Delete(&nextKey)
 			if err != nil {
-				log.Debugf("error during Delete: %s", err)
+				log.WithError(err).Debug("error during Delete")
 			} else {
 				deleted++
 			}

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cilium/cilium/common/types"
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/logfields"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -117,7 +118,10 @@ type RRSeqValue struct {
 func (s RRSeqValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(&s) }
 
 func UpdateService(key ServiceKey, value ServiceValue) error {
-	log.Debugf("adding frontend: %s for backend: %s to BPF maps", key, value)
+	log.WithFields(log.Fields{
+		"frontend": key,
+		"backend":  value,
+	}).Debug("adding frontend for backend to BPF maps")
 	if key.GetBackend() != 0 && value.RevNatKey().GetKey() == 0 {
 		return fmt.Errorf("invalid RevNat ID (0) in the Service Value")
 	}
@@ -204,7 +208,10 @@ type RevNatValue interface {
 }
 
 func UpdateRevNat(key RevNatKey, value RevNatValue) error {
-	log.Debugf("adding revNat key: %s --> value: %s", key, value)
+	log.WithFields(log.Fields{
+		logfields.BPFMapKey:   key,
+		logfields.BPFMapValue: value,
+	}).Debug("adding revNat to lbmap")
 	if key.GetKey() == 0 {
 		return fmt.Errorf("invalid RevNat ID (0)")
 	}
@@ -216,12 +223,13 @@ func UpdateRevNat(key RevNatKey, value RevNatValue) error {
 }
 
 func DeleteRevNat(key RevNatKey) error {
-	log.Debugf("deleting RevNatKey: %s", key.String())
+	log.WithField(logfields.BPFMapKey, key).Debug("deleting RevNatKey")
 	return key.Map().Delete(key.ToNetwork())
 }
 
 func LookupRevNat(key RevNatKey) (RevNatValue, error) {
 	var revnat RevNatValue
+	log.WithField(logfields.BPFMapKey, key).Debug("lookup RevNatKey")
 
 	val, err := key.Map().Lookup(key.ToNetwork())
 	if err != nil {
@@ -370,7 +378,7 @@ func AddSVC2BPFMap(fe ServiceKey, besValues []ServiceValue, addRevNAT bool, revN
 // L3n4Addr2ServiceKey converts the given l3n4Addr to a ServiceKey with the slave ID
 // set to 0.
 func L3n4Addr2ServiceKey(l3n4Addr types.L3n4AddrID) ServiceKey {
-	log.Debugf("converting L3n4Addr %s to ServiceKey", l3n4Addr.String())
+	log.WithField(logfields.L3n4AddrID, l3n4Addr).Debug("converting L3n4Addr to ServiceKey")
 	if l3n4Addr.IsIPv6() {
 		return NewService6Key(l3n4Addr.IP, l3n4Addr.Port, 0)
 	}
@@ -379,8 +387,10 @@ func L3n4Addr2ServiceKey(l3n4Addr types.L3n4AddrID) ServiceKey {
 
 // LBSVC2ServiceKeynValue transforms the SVC Cilium type into a bpf SVC type.
 func LBSVC2ServiceKeynValue(svc types.LBSVC) (ServiceKey, []ServiceValue, error) {
-	log.Debugf("converting Cilium load-balancer service (frontend: %s, "+
-		"backend(s): %v) into BPF service", svc.FE.String(), svc.BES)
+	log.WithFields(log.Fields{
+		"lbFrontend": svc.FE.String(),
+		"lbBackend":  svc.BES,
+	}).Debug("converting Cilium load-balancer service (frontend -> backend(s)) into BPF service")
 	fe := L3n4Addr2ServiceKey(svc.FE)
 
 	// Create a list of ServiceValues so we know everything is safe to put in the lb
@@ -396,11 +406,17 @@ func LBSVC2ServiceKeynValue(svc types.LBSVC) (ServiceKey, []ServiceValue, error)
 		beValue.SetWeight(be.Weight)
 
 		besValues = append(besValues, beValue)
-		log.Debugf("associating frontend: %s --> backend: %s", fe, beValue)
+		log.WithFields(log.Fields{
+			"lbFrontend": fe,
+			"lbBackend":  beValue,
+		}).Debug("associating frontend -> backend")
 	}
-	log.Debugf("converted LBSVC (frontend: %s, backend(s): %v), to "+
-		"ServiceKey: %s, ServiceValue(s): %v", svc.FE.String(), svc.BES, fe.String(),
-		besValues)
+	log.WithFields(log.Fields{
+		"lbFrontend":        svc.FE.String(),
+		"lbBackend":         svc.BES,
+		logfields.ServiceID: fe,
+		logfields.Object:    logfields.Repr(besValues),
+	}).Debug("converted LBSVC (frontend -> backend(s)), to Service Key and Value")
 	return fe, besValues, nil
 }
 
@@ -414,7 +430,7 @@ func L3n4Addr2RevNatKeynValue(svcID types.ServiceID, feL3n4Addr types.L3n4Addr) 
 
 // ServiceKey2L3n4Addr converts the given svcKey to a L3n4Addr.
 func ServiceKey2L3n4Addr(svcKey ServiceKey) (*types.L3n4Addr, error) {
-	log.Debugf("creating L3n4Addr for ServiceKey %s", svcKey)
+	log.WithField(logfields.ServiceID, svcKey).Debug("creating L3n4Addr for ServiceKey")
 	var (
 		feIP   net.IP
 		fePort uint16
@@ -441,7 +457,10 @@ func ServiceKeynValue2FEnBE(svcKey ServiceKey, svcValue ServiceValue) (*types.L3
 		beWeight uint16
 	)
 
-	log.Debugf("converting ServiceKey %s and ServiceValue %s to frontend and backend", svcKey, svcValue)
+	log.WithFields(log.Fields{
+		logfields.ServiceID: svcKey,
+		logfields.Object:    logfields.Repr(svcValue),
+	}).Debug("converting ServiceKey and ServiceValue to frontend and backend")
 
 	if svcKey.IsIPv6() {
 		svc6Val := svcValue.(*Service6Value)

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/common/types"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/logfields"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -211,7 +212,7 @@ func DeleteElement(f EndpointFrontend) int {
 	errors := 0
 	for _, k := range f.GetBPFKeys() {
 		if err := mapInstance.Delete(k); err != nil {
-			log.Warningf("Unable to delete endpoint %s in BPF map: %s", k, err)
+			log.WithError(err).WithField(logfields.BPFMapKey, k).Warn("Unable to delete endpoint in BPF map")
 			errors++
 		}
 	}


### PR DESCRIPTION
This switches a bunch of log callsites to use logrus.WIthFields. These changes are not supposed to break anything and follow the same reasoning from https://github.com/cilium/cilium/pull/1801 The goal of these changes is to make debugging via logs easier by making our usage more consistent. Ideally, field names should be used the same way throughout the code and mean the same thing.

The most important things to review are whether the field names make sense in the context they're used, and whether we should introduce new ones to pkg/logfields/logfields.go. I'm also happy to incorporate better messages into this PR :)