### PR TITLE
CLI logrus.WithFields fixups

### DIFF
--- a/cilium/cmd/endpoint_labels.go
+++ b/cilium/cmd/endpoint_labels.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logfields"
 
 	"github.com/spf13/cobra"
 )
@@ -71,7 +72,7 @@ func init() {
 }
 
 func printEndpointLabels(lbls *labels.OpLabels) {
-	log.Debugf("All Labels %#v", *lbls)
+	log.WithField(logfields.Labels, logfields.Repr(*lbls)).Debug("All Labels")
 	w := tabwriter.NewWriter(os.Stdout, 2, 0, 3, ' ', 0)
 
 	for _, v := range lbls.IdentityLabels() {

--- a/cilium/cmd/helpers.go
+++ b/cilium/cmd/helpers.go
@@ -28,11 +28,16 @@ import (
 	"k8s.io/client-go/util/jsonpath"
 )
 
+// Fatalf prints the Printf formatted message to stderr and exits the program
+// Note: os.Exit(1) is not recoverable
 func Fatalf(msg string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, "Error: %s\n", fmt.Sprintf(msg, args...))
 	os.Exit(1)
 }
 
+// Usagef prints the Printf formatted message to stderr, prints usage help and
+// exits the program
+// Note: os.Exit(1) is not recoverable
 func Usagef(cmd *cobra.Command, msg string, args ...interface{}) {
 	txt := fmt.Sprintf(msg, args...)
 	fmt.Fprintf(os.Stderr, "Error: %s\n\n", txt)

--- a/cilium/cmd/policy.go
+++ b/cilium/cmd/policy.go
@@ -25,8 +25,10 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/policy/api"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -109,7 +111,7 @@ func handleUnmarshalError(f string, content []byte, err error) error {
 func ignoredFile(name string) bool {
 	for i := range ignoredMasks {
 		if ignoredMasks[i].MatchString(name) {
-			log.Debugf("Ignoring file %s", name)
+			logrus.WithField(logfields.Path, name).Debug("Ignoring file")
 			return true
 		}
 	}
@@ -120,7 +122,7 @@ func ignoredFile(name string) bool {
 func loadPolicyFile(path string) (api.Rules, error) {
 	var content []byte
 	var err error
-	log.Debugf("Loading file %s", path)
+	logrus.WithField(logfields.Path, path).Debug("Loading file")
 
 	if path == "-" {
 		content, err = ioutil.ReadAll(bufio.NewReader(os.Stdin))
@@ -142,7 +144,7 @@ func loadPolicyFile(path string) (api.Rules, error) {
 }
 
 func loadPolicy(name string) (api.Rules, error) {
-	log.Debugf("Entering directory %s...", name)
+	logrus.WithField(logfields.Path, name).Debug("Entering directory")
 
 	if name == "-" {
 		return loadPolicyFile(name)
@@ -174,7 +176,7 @@ func loadPolicy(name string) (api.Rules, error) {
 	}
 	result = append(result, ruleList...)
 
-	log.Debugf("Leaving directory %s...", name)
+	logrus.WithField(logfields.Path, name).Debug("Leaving directory")
 
 	return result, nil
 }

--- a/cilium/cmd/policy_import.go
+++ b/cilium/cmd/policy_import.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/spf13/cobra"
 )
 
@@ -35,7 +36,7 @@ var policyImportCmd = &cobra.Command{
 		if ruleList, err := loadPolicy(path); err != nil {
 			Fatalf("Cannot parse policy %s: %s\n", path, err)
 		} else {
-			log.Debugf("Constructed policy object for import %+v", ruleList)
+			log.WithField("rule", logfields.Repr(ruleList)).Debug("Constructed policy object for import")
 
 			// Ignore request if no policies have been found
 			if len(ruleList) == 0 {

--- a/cilium/cmd/service_delete.go
+++ b/cilium/cmd/service_delete.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/spf13/cobra"
 )
 
@@ -36,7 +37,7 @@ var serviceDeleteCmd = &cobra.Command{
 
 			for _, svc := range list {
 				if err := client.DeleteServiceID(svc.ID); err != nil {
-					log.Errorf("Cannot delete service %d: %s", svc.ID, err)
+					log.WithError(err).WithField(logfields.ServiceID, svc.ID).Error("Cannot delete service")
 				}
 			}
 


### PR DESCRIPTION
This switches a bunch of log callsites to use logrus.WIthFields. These changes are not supposed to break anything and follow the same reasoning from https://github.com/cilium/cilium/pull/1801 The goal of these changes is to make debugging via logs easier by making our usage more consistent. Ideally, field names should be used the same way throughout the code and mean the same thing.

The most important things to review are whether the field names make sense in the context they're used, and whether we should introduce new ones to pkg/logfields/logfields.go. I'm also happy to incorporate better messages into this PR :)