### PR TITLE
Docker logrus.WithFields fixups

### DIFF
--- a/pkg/workloads/containerd/logfields.go
+++ b/pkg/workloads/containerd/logfields.go
@@ -1,0 +1,37 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containerd
+
+import (
+	"github.com/cilium/cilium/pkg/logfields"
+
+	"github.com/sirupsen/logrus"
+)
+
+// logging field definitions
+const (
+	// fieldRetry is the current retry attempt
+	fieldRetry = "retry"
+
+	// fieldMaxRetry is the maximum number of retries
+	fieldMaxRetry = "maxRetry"
+
+	// fieldSubsys is the value for logfields.LogSubsys
+	fieldSubsys = "containerd-watcher"
+)
+
+var (
+	log = logrus.WithField(logfields.LogSubsys, fieldSubsys)
+)

--- a/pkg/workloads/containerd/watcher_state.go
+++ b/pkg/workloads/containerd/watcher_state.go
@@ -22,7 +22,7 @@ import (
 
 	dTypes "github.com/docker/engine-api/types"
 	dTypesEvents "github.com/docker/engine-api/types/events"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	ctx "golang.org/x/net/context"
 )
 
@@ -96,7 +96,7 @@ func (ws *watcherState) syncWithRuntime() {
 
 	cList, err := dockerClient.ContainerList(ctx.Background(), dTypes.ContainerListOptions{All: false})
 	if err != nil {
-		log.Errorf("Failed to retrieve the container list %s", err)
+		log.WithError(err).Error("Failed to retrieve the container list")
 		return
 	}
 	for _, cont := range cList {
@@ -105,7 +105,7 @@ func (ws *watcherState) syncWithRuntime() {
 		}
 
 		if alreadyHandled := ws.handlingContainerID(cont.ID); !alreadyHandled {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				logfields.ContainerID: shortContainerID(cont.ID),
 			}).Debug("Found unwatched container")
 

--- a/plugins/cilium-docker/driver/ipam.go
+++ b/plugins/cilium-docker/driver/ipam.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/cilium/cilium/pkg/client"
+	"github.com/cilium/cilium/pkg/logfields"
 
 	"github.com/docker/libnetwork/ipams/remote/api"
 	log "github.com/sirupsen/logrus"
@@ -33,7 +34,7 @@ const (
 func (driver *driver) ipamCapabilities(w http.ResponseWriter, r *http.Request) {
 	err := json.NewEncoder(w).Encode(&api.GetCapabilityResponse{})
 	if err != nil {
-		log.Fatalf("capabilities encode: %s", err)
+		log.WithError(err).Fatal("capabilities encode")
 		sendError(w, "encode error", http.StatusInternalServerError)
 		return
 	}
@@ -41,14 +42,14 @@ func (driver *driver) ipamCapabilities(w http.ResponseWriter, r *http.Request) {
 }
 
 func (driver *driver) getDefaultAddressSpaces(w http.ResponseWriter, r *http.Request) {
-	log.Debugf("GetDefaultAddressSpaces Called")
+	log.Debug("GetDefaultAddressSpaces Called")
 
 	resp := &api.GetAddressSpacesResponse{
 		LocalDefaultAddressSpace:  "CiliumLocal",
 		GlobalDefaultAddressSpace: "CiliumGlobal",
 	}
 
-	log.Debugf("Get Default Address Spaces response: %+v", resp)
+	log.WithField(logfields.Response, logfields.Repr(resp)).Debug("Get Default Address Spaces response")
 	objectResponse(w, resp)
 }
 
@@ -81,9 +82,9 @@ func (driver *driver) requestPool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Debugf("Request Pool request: %+v", &req)
+	log.WithField(logfields.Request, logfields.Repr(&req)).Debug("Request Pool request")
 	resp := driver.getPoolResponse(&req)
-	log.Debugf("Request Pool response: %+v", resp)
+	log.WithField(logfields.Response, logfields.Repr(resp)).Debug("Request Pool response")
 	objectResponse(w, resp)
 }
 
@@ -94,7 +95,7 @@ func (driver *driver) releasePool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Debugf("Release Pool request: %+v", &release)
+	log.WithField(logfields.Request, logfields.Repr(&release)).Debug("Release Pool request")
 
 	emptyResponse(w)
 }
@@ -106,7 +107,7 @@ func (driver *driver) requestAddress(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Debugf("Request Address request: %+v", &request)
+	log.WithField(logfields.Request, logfields.Repr(&request)).Debug("Request Address request")
 
 	family := client.AddressFamilyIPv6 // Default
 	switch request.PoolID {
@@ -141,7 +142,7 @@ func (driver *driver) requestAddress(w http.ResponseWriter, r *http.Request) {
 		resp.Address = addr.IPV4 + "/32"
 	}
 
-	log.Debugf("Request Address response: %+v", resp)
+	log.WithField(logfields.Response, logfields.Repr(resp)).Debug("Request Address response")
 	objectResponse(w, resp)
 }
 
@@ -152,7 +153,7 @@ func (driver *driver) releaseAddress(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Debugf("Release Address request: %+v", release)
+	log.WithField(logfields.Request, logfields.Repr(&release)).Debug("Release Address request")
 	if err := driver.client.IPAMReleaseIP(release.Address); err != nil {
 		sendError(w, fmt.Sprintf("Could not release IP address: %s", err), http.StatusBadRequest)
 		return

--- a/plugins/cilium-docker/main.go
+++ b/plugins/cilium-docker/main.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 
 	"github.com/cilium/cilium/common"
+	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/plugins/cilium-docker/driver"
 
 	"github.com/sirupsen/logrus"
@@ -49,9 +50,9 @@ connected to a Docker network of type "cilium".`,
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		if d, err := driver.NewDriver(ciliumAPI); err != nil {
-			log.Fatalf("Unable to create cilium-net driver: %s", err)
+			log.WithError(err).Fatal("Unable to create cilium-net driver")
 		} else {
-			log.Infof("Listening for events from Docker on %s", driverSock)
+			log.WithField(logfields.Path, driverSock).Info("Listening for events from Docker")
 			if err := d.Listen(driverSock); err != nil {
 				log.Fatal(err)
 			}
@@ -87,11 +88,11 @@ func initConfig() {
 	driverSock = filepath.Join(pluginPath, "cilium.sock")
 
 	if err := os.MkdirAll(pluginPath, 0755); err != nil && !os.IsExist(err) {
-		log.Fatalf("Could not create net plugin path directory: %s", err)
+		log.WithError(err).Fatal("Could not create net plugin path directory")
 	}
 
 	if _, err := os.Stat(driverSock); err == nil {
-		log.Debugf("socket file %s already exists, unlinking the old file handle.", driverSock)
+		log.WithField(logfields.Path, driverSock).Debug("socket file already exists, unlinking the old file handle.")
 		os.RemoveAll(driverSock)
 	}
 }


### PR DESCRIPTION
This switches a bunch of log callsites to use logrus.WIthFields. These changes are not supposed to break anything and follow the same reasoning from https://github.com/cilium/cilium/pull/1801 The goal of these changes is to make debugging via logs easier by making our usage more consistent. Ideally, field names should be used the same way throughout the code and mean the same thing.

The most important things to review are whether the field names make sense in the context they're used, and whether we should introduce new ones to pkg/logfields/logfields.go. I'm also happy to incorporate better messages into this PR :)

I've included the containerd watcher here, despite it being owned by janitors, since it's related.