### PR TITLE
pkg/endpoint: Consistently use logrus fields

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -67,14 +67,15 @@ func (d *Daemon) SyncState(dir string, clean bool) error {
 	}
 
 	for _, ep := range possibleEPs {
+		ep.Mutex.Lock()
 		log.WithField(logfields.EndpointID, ep.ID).Debug("Restoring endpoint")
 
 		if err := d.syncLabels(ep); err != nil {
 			log.WithError(err).WithField(logfields.EndpointID, ep.ID).Warn("Unable to restore endpoint")
+			ep.Mutex.Unlock()
 			continue
 		}
 
-		ep.Mutex.Lock()
 		if d.conf.KeepConfig {
 			ep.SetDefaultOpts(nil)
 		} else {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -309,6 +309,7 @@ func (e *Endpoint) runInit(libdir, rundir, epdir, debug string) error {
 	e.Mutex.RLock()
 	args := []string{libdir, rundir, epdir, e.IfName, debug}
 	prog := filepath.Join(libdir, "join_ep.sh")
+	scopedLog := e.getLogger() // must be called with e.Mutex held
 	e.Mutex.RUnlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), ExecTimeout)
@@ -317,7 +318,7 @@ func (e *Endpoint) runInit(libdir, rundir, epdir, debug string) error {
 	out, err := exec.CommandContext(ctx, prog, args...).CombinedOutput()
 
 	cmd := fmt.Sprintf("%s %s", prog, strings.Join(args, " "))
-	scopedLog := e.log().WithField("cmd", cmd)
+	scopedLog = scopedLog.WithField("cmd", cmd)
 	if ctx.Err() == context.DeadlineExceeded {
 		scopedLog.Error("Command execution failed: Timeout")
 		return ctx.Err()

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -20,18 +20,22 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (e *Endpoint) log() *log.Entry {
-	return log.WithFields(log.Fields{
-		logfields.EndpointID:  e.ID,
-		logfields.ContainerID: e.DockerID,
-		// REVIEW Is this a valid association?
-		"iteration": e.getIteration(),
-	})
+// logger returns a logrus object with EndpointID, ContainerID and the Endpoint
+// revision fields.
+// Note: You must host Endpoint.Mutex
+func (e *Endpoint) getLogger() *log.Entry {
+	if e.logger == nil {
+		e.updateLogger()
+	}
+	return e.logger
 }
 
-func (e *Endpoint) getIteration() uint64 {
-	if e.Consumable == nil {
-		return 0
-	}
-	return e.Consumable.Iteration
+// updateLogger
+// Note: You must hold Endpoint.Mutex
+func (e *Endpoint) updateLogger() {
+	e.logger = log.WithFields(log.Fields{
+		logfields.EndpointID:  e.ID,
+		logfields.ContainerID: e.DockerID,
+		"policyRevision":      e.policyRevision,
+	})
 }

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -1,0 +1,37 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"github.com/cilium/cilium/pkg/logfields"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func (e *Endpoint) log() *log.Entry {
+	return log.WithFields(log.Fields{
+		logfields.EndpointID:  e.ID,
+		logfields.ContainerID: e.DockerID,
+		// REVIEW Is this a valid association?
+		"iteration": e.getIteration(),
+	})
+}
+
+func (e *Endpoint) getIteration() uint64 {
+	if e.Consumable == nil {
+		return 0
+	}
+	return e.Consumable.Iteration
+}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -398,7 +398,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner) (bool, error) {
 	e.Consumable.Mutex.RUnlock()
 	repo.Mutex.RUnlock()
 
-	optsChanged := e.ApplyOptsLocked(opts)
+	optsChanged := e.applyOptsLocked(opts)
 
 	// If we are in this function, then policy has been calculated.
 	if !e.PolicyCalculated {


### PR DESCRIPTION
This switches a bunch of log callsites to use logrus.WIthFields. These changes are not supposed to break anything and follow the same reasoning from https://github.com/cilium/cilium/pull/1801 The goal of these changes is to make debugging via logs easier by making our usage more consistent. Ideally, field names should be used the same way throughout the code and mean the same thing.

The most important things to review are whether the field names make sense in the context they're used, and whether we should introduce new ones to pkg/logfields/logfields.go. I'm also happy to incorporate better messages into this PR :)
I might have been too aggressive by making a logger method bound to endpoint. I'm not sure if the fields reported are always appropriate, but they seemed to be. In particular, I'm not sure if Iteration is relevant, and if I'm reporting it correctly in any case.