### PR TITLE
K8s logrus.WithFields fixups

### DIFF
--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -19,9 +19,10 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/nodeaddress"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // Init initializes the Kubernetes package. It is required to call Configure()
@@ -43,7 +44,11 @@ func Init() error {
 
 		node := ParseNode(k8sNode)
 
-		log.Infof("Retrieved node's %s information from kubernetes", node.Name)
+		log.WithFields(logrus.Fields{
+			logfields.NodeName:         node.Name,
+			logfields.IPAddr + ".ipv4": node.GetNodeIP(false),
+			logfields.IPAddr + ".ipv6": node.GetNodeIP(true),
+		}).Info("Received own node information from API server")
 
 		if err := nodeaddress.UseNodeCIDR(node); err != nil {
 			return fmt.Errorf("unable to retrieve k8s node CIDR: %s", err)

--- a/pkg/k8s/logfields.go
+++ b/pkg/k8s/logfields.go
@@ -14,6 +14,12 @@
 
 package k8s
 
+import (
+	"github.com/cilium/cilium/pkg/logfields"
+
+	"github.com/sirupsen/logrus"
+)
+
 // logging field definitions
 const (
 	// fieldRetry is the current retry attempt
@@ -22,10 +28,11 @@ const (
 	// fieldMaxRetry is the maximum number of retries
 	fieldMaxRetry = "maxRetry"
 
-	// fieldNodeName is the Kubernetes node name where the agent is running on
-	fieldNodeName = "nodeName"
+	// subsysK8s is the value for logfields.LogSubsys
+	subsysK8s = "k8s"
+)
 
-	// fieldSubsys is set to subsysKubernetes on all Kubernetes logging messages
-	fieldSubsys      = "subsys"
-	subsysKubernetes = "kubernetes"
+var (
+	// log is the k8s package logger object.
+	log = logrus.WithField(logfields.LogSubsys, subsysK8s)
 )

--- a/pkg/logfields/logfields.go
+++ b/pkg/logfields/logfields.go
@@ -164,4 +164,7 @@ const (
 
 	// K8sIngressName is the name of a K8sIngress
 	K8sIngressName = "k8sIngressName"
+
+	// K8sAPIVersion is the version of the k8s API an object has
+	K8sAPIVersion = "k8sApiVersion"
 )

--- a/pkg/nodeaddress/node_address.go
+++ b/pkg/nodeaddress/node_address.go
@@ -383,7 +383,7 @@ func UseNodeCIDR(node *node.Node) error {
 	if node.IPv6AllocCIDR != nil {
 		scopedLog.WithField(logfields.V4Prefix, node.IPv6AllocCIDR).Info("Retrieved IPv6 allocation range for node. Using it for ipv6-range")
 		if err := SetIPv6NodeRange(node.IPv6AllocCIDR); err != nil {
-			scopedLog.WithError(err).WithField(logfields.V4Prefix, node.IPv6AllocCIDR).Warn("k8s: Can't use IPv6 CIDR range from kubernetes")
+			scopedLog.WithError(err).WithField(logfields.V4Prefix, node.IPv6AllocCIDR).Warn("k8s: Can't use IPv6 CIDR range from k8s")
 		}
 	}
 

--- a/pkg/workloads/containerd/watcher.go
+++ b/pkg/workloads/containerd/watcher.go
@@ -187,7 +187,7 @@ func fetchK8sLabels(dockerLbls map[string]string) (map[string]string, error) {
 	log.WithFields(logrus.Fields{
 		logfields.K8sNamespace: ns,
 		logfields.K8sPodName:   podName,
-	}).Debug("Connecting to kubernetes to retrieve labels for pod in ns")
+	}).Debug("Connecting to k8s to retrieve labels for pod in ns")
 
 	result, err := k8s.Client().CoreV1().Pods(ns).Get(podName, metav1.GetOptions{})
 	if err != nil {

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/common/plugins"
 	"github.com/cilium/cilium/pkg/client"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/logfields"
 
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/containernetworking/cni/pkg/ns"
@@ -148,7 +149,7 @@ func renameLink(curName, newName string) error {
 func releaseIP(client *client.Client, ip string) {
 	if ip != "" {
 		if err := client.IPAMReleaseIP(ip); err != nil {
-			log.Warningf("Unable to release IP %s: %s", ip, err)
+			log.WithError(err).WithField(logfields.IPAddr, ip).Warn("Unable to release IP")
 		}
 	}
 }
@@ -159,7 +160,11 @@ func releaseIPs(client *client.Client, addr *models.EndpointAddressing) {
 }
 
 func addIPConfigToLink(ip addressing.CiliumIP, routes []plugins.Route, link netlink.Link, ifName string) error {
-	log.Debugf("Configuring link %+v/%s with %s", link, ifName, ip.String())
+	log.WithFields(logrus.Fields{
+		logfields.IPAddr:    ip,
+		"netLink":           logfields.Repr(link),
+		logfields.Interface: ifName,
+	}).Debug("Configuring link")
 
 	addr := &netlink.Addr{IPNet: ip.EndpointPrefix()}
 	if err := netlink.AddrAdd(link, addr); err != nil {
@@ -171,7 +176,7 @@ func addIPConfigToLink(ip addressing.CiliumIP, routes []plugins.Route, link netl
 	sort.Sort(plugins.ByMask(routes))
 
 	for _, r := range routes {
-		log.Debugf("Adding route %+v", r)
+		log.WithField("route", logfields.Repr(r)).Debug("Adding route")
 		rt := &netlink.Route{
 			LinkIndex: link.Attrs().Index,
 			Scope:     netlink.SCOPE_UNIVERSE,
@@ -290,7 +295,7 @@ func prepareIP(ipAddr string, isIPv6 bool, state *CmdState) (*cniTypesVer.IPConf
 }
 
 func cmdAdd(args *skel.CmdArgs) error {
-	log.Debugf("ADD %s", args)
+	log.WithField("args", args).Debug("Processing CNI ADD request")
 
 	n, cniVersion, err := loadNetConf(args.StdinData)
 	if err != nil {
@@ -333,7 +338,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	defer func() {
 		if err != nil {
 			if err = netlink.LinkDel(veth); err != nil {
-				log.Warningf("failed to clean up and delete veth %q: %s", veth.Name, err)
+				log.WithError(err).WithField(logfields.Veth, veth.Name).Warn("failed to clean up and delete veth")
 			}
 		}
 	}()
@@ -407,9 +412,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 	if err = netNs.Do(func(_ ns.NetNS) error {
 		out, err := exec.Command("sysctl", "-w", "net.ipv6.conf.all.disable_ipv6=0").CombinedOutput()
 		if err != nil {
-			log.Warnf("Error while enabling IPv6 on all interfaces: %s", err)
+			log.WithError(err).Warn("Error while enabling IPv6 on all interfaces")
 		}
-		log.Debugf("Enabling IPv6 command output: %s", out)
+		log.WithField("output", out).Debug("Enabling IPv6 command output")
 		macAddrStr, err = configureIface(ipam, args.IfName, &state)
 		return err
 	}); err != nil {
@@ -430,7 +435,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 }
 
 func cmdDel(args *skel.CmdArgs) error {
-	log.Debugf("DEL %s", args)
+	log.WithField("args", args).Debug("Processing CNI DEL request")
 
 	client, err := client.NewDefaultClient()
 	if err != nil {
@@ -440,17 +445,17 @@ func cmdDel(args *skel.CmdArgs) error {
 	id := endpoint.NewID(endpoint.ContainerIdPrefix, args.ContainerID)
 	if ep, err := client.EndpointGet(id); err != nil {
 		// Ignore endpoints not found
-		log.Debugf("unable to find endpoint %s: %s", id, err)
+		log.WithError(err).WithField(logfields.EndpointID, id).Debug("Agent is not aware of endpoint")
 		return nil
 	} else if ep == nil {
-		log.Debugf("unable to find endpoint %s: %s", id, err)
+		log.WithError(err).WithField(logfields.EndpointID, id).Debug("Agent is not aware of endpoint")
 		return nil
 	} else {
 		releaseIPs(client, ep.Addressing)
 	}
 
 	if err := client.EndpointDelete(id); err != nil {
-		log.Warningf("Deletion of endpoint failed: %s", err)
+		log.WithError(err).Warn("Deletion of endpoint failed")
 	}
 
 	return ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {


### PR DESCRIPTION
This switches a bunch of log callsites to use logrus.WIthFields. These changes are not supposed to break anything and follow the same reasoning from https://github.com/cilium/cilium/pull/1801 The goal of these changes is to make debugging via logs easier by making our usage more consistent. Ideally, field names should be used the same way throughout the code and mean the same thing.

The most important things to review are whether the field names make sense in the context they're used, and whether we should introduce new ones to pkg/logfields/logfields.go. I'm also happy to incorporate better messages into this PR :)
I'm also not sure how to reconcile the k8s package's logfields.go file with the more global pkg/logfiles/logfiles.go. I opted to add to the global one in https://github.com/cilium/cilium/pull/1801 but it might make sense to incorporate them into pkg/k8s and export them for use by other packages. The current overlap is with daemon, mostly, in it's k8s_watcher.go.