### PR TITLE
pkg/kvstore: Consistently use logrus fields

### DIFF
--- a/pkg/kvstore/client.go
+++ b/pkg/kvstore/client.go
@@ -40,7 +40,7 @@ func initClient() error {
 			return err
 		}
 
-		log.Infof("Using consul as key-value store")
+		log.Info("Using consul as key-value store")
 		clientInstance = c
 
 	case Etcd:
@@ -53,7 +53,7 @@ func initClient() error {
 			return err
 		}
 
-		log.Infof("Using etcd as key-value store")
+		log.Info("Using etcd as key-value store")
 		clientInstance = c
 
 	default:

--- a/pkg/kvstore/config.go
+++ b/pkg/kvstore/config.go
@@ -66,11 +66,11 @@ func SetupDummy() {
 		etcdConfig.Endpoints = []string{"http://127.0.0.1:4002"}
 
 	default:
-		log.Panicf("Unknown kvstore backend: %s", backend)
+		log.WithField("backend", backend).Panic("Unknown kvstore backend")
 	}
 
 	if err := initClient(); err != nil {
-		log.WithError(err).Panicf("Unable to initialize kvstore client")
+		log.WithError(err).Panic("Unable to initialize kvstore client")
 	}
 }
 

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/common/types"
+	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 
 	consulAPI "github.com/hashicorp/consul/api"
@@ -85,7 +86,7 @@ func newConsulClient(config *consulAPI.Config) (KVClient, error) {
 	}
 
 	if err != nil {
-		log.WithError(err).Fatalf("Unable to contact consul server")
+		log.WithError(err).Fatal("Unable to contact consul server")
 	}
 	cc := &ConsulClient{c}
 	// Clean-up old services path
@@ -204,7 +205,7 @@ func (c *ConsulClient) GetMaxID(key string, firstID uint32) (uint32, error) {
 		if k == nil {
 			// Something is really wrong
 			errMsg := "Unable to retrieve last free ID because the key is always empty\n"
-			log.Errorf(errMsg)
+			log.Error(errMsg)
 			return 0, fmt.Errorf(errMsg)
 		}
 	}
@@ -229,7 +230,7 @@ func (c *ConsulClient) SetMaxID(key string, firstID, maxID uint32) error {
 		if k == nil {
 			// Something is really wrong
 			errMsg := "Unable to setting ID because the key is always empty\n"
-			log.Errorf(errMsg)
+			log.Error(errMsg)
 			return fmt.Errorf(errMsg)
 		}
 	}
@@ -283,7 +284,7 @@ func (c *ConsulClient) GASNewSecLabelID(basePath string, baseID uint32, pI *poli
 				return false, err
 			}
 			if consulLabels.RefCount() == 0 {
-				log.Infof("Recycling ID %d", *incID)
+				log.WithField(logfields.Identity, *incID).Info("Recycling ID")
 				return false, setID2Label(*incID)
 			}
 		}
@@ -351,7 +352,7 @@ func (c *ConsulClient) GASNewL3n4AddrID(basePath string, baseID uint32, lAddrID 
 				return false, err
 			}
 			if consulL3n4AddrID.ID == 0 {
-				log.Infof("Recycling Service ID %d", baseID)
+				log.WithField(logfields.Identity, baseID).Info("Recycling Service ID")
 				return false, setIDtoL3n4Addr(*incID)
 			}
 		}
@@ -402,7 +403,7 @@ func (c *ConsulClient) Watch(w *Watcher, list bool) {
 			log.WithFields(log.Fields{
 				fieldWatcher:      w,
 				fieldListAndWatch: list,
-			}).WithError(err).Debugf("Consul watcher failed, will retry")
+			}).WithError(err).Debug("Consul watcher failed, will retry")
 		}
 
 		if q != nil {
@@ -433,7 +434,7 @@ func (c *ConsulClient) Watch(w *Watcher, list bool) {
 						Value: newPair.Value,
 					}
 				} else {
-					log.Warning("consul: Previously unknown key %s received with CreateIndex(%d) != ModifyIndex(%d)",
+					log.Warnf("consul: Previously unknown key %s received with CreateIndex(%d) != ModifyIndex(%d); ignoring update",
 						newPair.Key, newPair.CreateIndex, newPair.ModifyIndex)
 				}
 			} else if oldPair.ModifyIndex != newPair.ModifyIndex {
@@ -485,10 +486,10 @@ func (c *ConsulClient) GetWatcher(key string, timeSleep time.Duration) <-chan []
 		for {
 			k, q, err = c.KV().Get(key, &qo)
 			if err != nil {
-				log.Errorf("Unable to retrieve last free Index: %s", err)
+				log.WithError(err).Error("Unable to retrieve last free Index")
 			}
 			if k == nil || q == nil {
-				log.Warning("Unable to retrieve last free Index, please start some containers with labels.")
+				log.Warn("Unable to retrieve last free Index, please start some containers with labels")
 				time.Sleep(curSeconds)
 				if curSeconds < timeSleep {
 					curSeconds += time.Second

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/common/types"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 
 	client "github.com/coreos/etcd/clientv3"
@@ -100,7 +101,7 @@ func newEtcdClient(config *client.Config, cfgPath string) (KVClient, error) {
 		lockPaths: map[string]*lock.Mutex{},
 	}
 	if err := ec.CheckMinVersion(15 * time.Second); err != nil {
-		log.Fatalf("%s", err)
+		log.WithError(err).Fatal("Error checking etcd min version")
 	}
 	// Clean-up old services path
 	ec.DeleteTree(common.ServicePathV1)
@@ -109,17 +110,15 @@ func newEtcdClient(config *client.Config, cfgPath string) (KVClient, error) {
 			<-ec.session.Done()
 			newSession, err := concurrency.NewSession(c)
 			if err != nil {
-				log.Warningf("Error while renewing etcd session %s", err)
+				log.WithError(err).Warn("Error while renewing etcd session")
 				time.Sleep(3 * time.Second)
 			} else {
 				ec.sessionMU.Lock()
 				ec.session = newSession
 				ec.sessionMU.Unlock()
-				log.WithFields(log.Fields{
-					fieldSession: newSession,
-				}).Debugf("Renewing session")
+				log.WithField(fieldSession, newSession).Debug("Renewing session")
 				if err := ec.CheckMinVersion(10 * time.Second); err != nil {
-					log.Fatalf("%s", err)
+					log.WithError(err).Fatal("Error checking etcd min version")
 				}
 			}
 		}
@@ -150,8 +149,8 @@ func (e *EtcdClient) CheckMinVersion(timeout time.Duration) error {
 	for _, ep := range eps {
 		v, err := getEPVersion(e.cli.Maintenance, ep, timeout)
 		if err != nil {
-			log.WithError(err).Debugf("Unable to check etcd min version")
-			log.WithError(err).Warningf("Checking version of etcd endpoint %q", ep)
+			log.WithError(err).Debug("Unable to check etcd min version")
+			log.WithError(err).WithField(fieldEtcdEndpoint, ep).Warn("Checking version of etcd endpoint")
 			errors = true
 			continue
 		}
@@ -161,13 +160,16 @@ func (e *EtcdClient) CheckMinVersion(timeout time.Duration) error {
 			return fmt.Errorf("Minimal etcd version not met in %q,"+
 				" required: %s, found: %s", ep, minEVersion.String(), v.String())
 		}
-		log.Infof("Version of etcd endpoint %q: %s OK!", ep, v.String())
+		log.WithFields(log.Fields{
+			fieldEtcdEndpoint: ep,
+			"version":         v,
+		}).Info("Version of etcd endpoint OK")
 	}
 	if len(eps) == 0 {
-		log.Warningf("Minimal etcd version unknown: No etcd endpoints available!")
+		log.Warn("Minimal etcd version unknown: No etcd endpoints available")
 	} else if errors {
-		log.Warningf("Unable to check etcd's cluster version."+
-			" Please make sure the minimal etcd version running on all endpoints is %s", minEVersion.String())
+		log.WithField("version.min", minEVersion).Warn("Unable to check etcd's cluster version." +
+			" Please make sure the minimal etcd version is running on all endpoints")
 	}
 	return nil
 }
@@ -278,9 +280,9 @@ func (e *EtcdClient) SetMaxID(key string, firstID, maxID uint32) error {
 		}
 		if k == nil {
 			// Something is really wrong
-			errMsg := "Unable to setting ID because the key is always empty\n"
-			log.Errorf(errMsg)
-			return fmt.Errorf(errMsg)
+			errMsg := "Unable to set ID because the key is always empty"
+			log.Error(errMsg)
+			return fmt.Errorf("%s\n", errMsg)
 		}
 	}
 	return e.SetValue(key, maxID)
@@ -324,7 +326,7 @@ func (e *EtcdClient) GASNewSecLabelID(basePath string, baseID uint32, pI *policy
 			return false, err
 		}
 		if consulLabels.RefCount() == 0 {
-			log.Infof("Recycling ID %d", *incID)
+			log.WithField(logfields.Identity, *incID).Info("Recycling ID")
 			return false, setID2Label(*incID)
 		}
 
@@ -387,7 +389,7 @@ func (e *EtcdClient) GASNewL3n4AddrID(basePath string, baseID uint32, lAddrID *t
 			return false, err
 		}
 		if consulL3n4AddrID.ID == 0 {
-			log.Infof("Recycling Service ID %d", *incID)
+			log.WithField(logfields.Identity, *incID).Info("Recycling Service ID")
 			return false, setIDtoL3n4Addr(*incID)
 		}
 
@@ -430,7 +432,7 @@ func (e *EtcdClient) Watch(w *Watcher, list bool) {
 				fieldRev:     lastRev,
 				fieldPrefix:  w.prefix,
 				fieldWatcher: w,
-			}).WithError(err).Warningf("unable to list keys before watching")
+			}).WithError(err).Warn("Unable to list keys before watching")
 			continue
 		}
 
@@ -472,7 +474,7 @@ func (e *EtcdClient) Watch(w *Watcher, list bool) {
 					log.WithFields(log.Fields{
 						fieldRev:     lastRev,
 						fieldWatcher: w,
-					}).WithError(err).Warningf("etcd watcher received error")
+					}).WithError(err).Warn("etcd watcher received error")
 					continue
 				}
 
@@ -507,7 +509,7 @@ func (e *EtcdClient) GetWatcher(key string, timeSleep time.Duration) <-chan []po
 		for {
 			w := <-e.cli.Watch(ctx.Background(), key, client.WithRev(lastRevision))
 			if w.Err() != nil {
-				log.Warning("Unable to watch key %s, retrying...", key)
+				log.WithField(fieldKey, key).Warn("Unable to watch key, retrying...")
 				time.Sleep(curSeconds)
 				if curSeconds < timeSleep {
 					curSeconds += time.Second

--- a/pkg/kvstore/events.go
+++ b/pkg/kvstore/events.go
@@ -95,7 +95,7 @@ func watch(name, prefix string, chanSize int, list bool) *Watcher {
 	log.WithFields(log.Fields{
 		fieldWatcher:      w,
 		fieldListAndWatch: list,
-	}).Debugf("Starting watcher...")
+	}).Debug("Starting watcher...")
 
 	go func() {
 		// Signal termination of watcher routine
@@ -139,9 +139,7 @@ func (w *Watcher) Stop() {
 
 	close(w.Events)
 
-	log.WithFields(log.Fields{
-		fieldWatcher: w,
-	}).Debugf("Stopped watcher...")
+	log.WithField(fieldWatcher, w).Debug("Stopped watcher...")
 
 	w.stopped = true
 }

--- a/pkg/kvstore/events_tests.go
+++ b/pkg/kvstore/events_tests.go
@@ -35,7 +35,7 @@ func expectEvent(c *C, w *Watcher, typ EventType, key string, val []byte) {
 		"type":  typ,
 		"key":   key,
 		"value": string(val),
-	}).Debugf("Expecting event")
+	}).Debug("Expecting event")
 
 	select {
 	case event := <-w.Events:

--- a/pkg/kvstore/keepalive.go
+++ b/pkg/kvstore/keepalive.go
@@ -54,7 +54,7 @@ func startKeepalive() {
 		sleepTime := KeepAliveInterval
 		for {
 			if err := KeepAlive(leaseInstance); err != nil {
-				log.WithError(err).Warningf("Unable to keep lease alive")
+				log.WithError(err).Warn("Unable to keep lease alive")
 				sleepTime = RetryInterval
 			}
 			time.Sleep(sleepTime)

--- a/pkg/kvstore/logfields.go
+++ b/pkg/kvstore/logfields.go
@@ -47,4 +47,7 @@ const (
 
 	// fieldTTL is the TTL of a lease
 	fieldTTL = "ttl"
+
+	// fieldEtcdEndpoint is the etcd endpoint we talk to
+	fieldEtcdEndpoint = "etcdEndpoint"
 )


### PR DESCRIPTION
This switches a bunch of log callsites to use logrus.WIthFields. These changes are not supposed to break anything and follow the same reasoning from https://github.com/cilium/cilium/pull/1801 The goal of these changes is to make debugging via logs easier by making our usage more consistent. Ideally, field names should be used the same way throughout the code and mean the same thing.

The most important things to review are whether the field names make sense in the context they're used, and whether we should introduce new ones to pkg/logfields/logfields.go. I'm also happy to incorporate better messages into this PR :)