### PR TITLE
pkg/monitor: consistently use logrus fields

### DIFF
--- a/monitor/launch/launcher.go
+++ b/monitor/launch/launcher.go
@@ -42,7 +42,7 @@ func (nm *NodeMonitor) Run() {
 		cmd := exec.Command(targetName, nm.GetArg())
 		stdout, _ := cmd.StdoutPipe()
 		if err := cmd.Start(); err != nil {
-			log.Errorf("cmd.Start(): %s", err)
+			log.WithError(err).Error("cmd.Start()")
 		}
 
 		nm.setProcess(cmd.Process)
@@ -69,7 +69,7 @@ func (nm *NodeMonitor) Restart(arg string) {
 		return
 	}
 	if err := nm.process.Kill(); err != nil {
-		log.Errorf("process.Kill(): %s", err)
+		log.WithError(err).Error("process.Kill()")
 	}
 	nm.process = nil
 }

--- a/monitor/launch/launcher.go
+++ b/monitor/launch/launcher.go
@@ -17,6 +17,7 @@ package launch
 import (
 	"bufio"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 
@@ -42,7 +43,8 @@ func (nm *NodeMonitor) Run() {
 		cmd := exec.Command(targetName, nm.GetArg())
 		stdout, _ := cmd.StdoutPipe()
 		if err := cmd.Start(); err != nil {
-			log.WithError(err).Error("cmd.Start()")
+			cmdStr := fmt.Sprintf("%s %s", targetName, nm.GetArg())
+			log.WithError(err).WithField("cmd", cmdStr).Error("cmd.Start()")
 		}
 
 		nm.setProcess(cmd.Process)
@@ -69,7 +71,7 @@ func (nm *NodeMonitor) Restart(arg string) {
 		return
 	}
 	if err := nm.process.Kill(); err != nil {
-		log.WithError(err).Error("process.Kill()")
+		log.WithError(err).WithField("pid", nm.process.Pid).Error("process.Kill()")
 	}
 	nm.process = nil
 }

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -50,7 +50,7 @@ func (m *Monitor) Run(npages int) {
 
 	me, err := bpf.NewPerCpuEvents(c)
 	if err != nil {
-		log.Errorf("Error while starting monitor: %s", err)
+		log.WithError(err).Error("Error while starting monitor")
 		return
 	}
 	monitorEvents = me
@@ -72,14 +72,14 @@ func (m *Monitor) Run(npages int) {
 	for {
 		todo, err := monitorEvents.Poll(pollTimeout)
 		if err != nil {
-			log.Errorf("Error Poll %s", err)
+			log.WithError(err).Error("Error in Poll")
 			if err == syscall.EBADF {
 				break
 			}
 		}
 		if todo > 0 {
 			if err := monitorEvents.ReadAll(m.receiveEvent, m.lostEvent); err != nil {
-				log.Warningf("Error received while reading from perf buffer: %s", err)
+				log.WithError(err).Warn("Error received while reading from perf buffer")
 			}
 		}
 	}
@@ -112,7 +112,7 @@ func (m *Monitor) handleConnection(server net.Listener) {
 
 		mutex.Lock()
 		listeners.PushBack(conn)
-		log.Infof("New monitor connected. len(listeners) = %d", listeners.Len())
+		log.WithField("count.listener", listeners.Len()).Info("New monitor connected.")
 		mutex.Unlock()
 	}
 }
@@ -128,12 +128,12 @@ func (m *Monitor) send(pl payload.Payload) {
 
 	payloadBuf, err := pl.Encode()
 	if err != nil {
-		log.Fatal("payload encode: ", err)
+		log.WithError(err).Fatal("payload encode")
 	}
 	meta := &payload.Meta{Size: uint32(len(payloadBuf))}
 	metaBuf, err := meta.MarshalBinary()
 	if err != nil {
-		log.Fatal("meta encode: ", err)
+		log.WithError(err).Fatal("meta encode")
 	}
 	var next *list.Element
 	for e := listeners.Front(); e != nil; e = next {


### PR DESCRIPTION
This switches a bunch of log callsites to use logrus.WIthFields. These changes are not supposed to break anything and follow the same reasoning from https://github.com/cilium/cilium/pull/1801 The goal of these changes is to make debugging via logs easier by making our usage more consistent. Ideally, field names should be used the same way throughout the code and mean the same thing.

The most important things to review are whether the field names make sense in the context they're used, and whether we should introduce new ones to pkg/logfields/logfields.go. I'm also happy to incorporate better messages into this PR :)