### PR TITLE
pkg/policy: Consistently use logrus fields

### DIFF
--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -17,6 +17,7 @@ package policy
 import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/policy/api"
 
@@ -149,21 +150,24 @@ func (c *Consumable) AddMap(m *policymap.PolicyMap) {
 		return
 	}
 
-	log.Debugf("Adding map %v to consumable %v", m, c)
+	log.WithFields(log.Fields{
+		"policymap":  m,
+		"consumable": c,
+	}).Debug("Adding policy map to consumable")
 	c.Maps[m.Fd] = m
 
 	// Populate the new map with the already established consumers of
 	// this consumable
 	for _, c := range c.Consumers {
 		if err := m.AllowConsumer(c.ID.Uint32()); err != nil {
-			log.Warningf("Update of policy map failed: %s", err)
+			log.WithError(err).Warn("Update of policy map failed")
 		}
 	}
 }
 
 func (c *Consumable) deleteReverseRule(consumable NumericIdentity, consumer NumericIdentity) {
 	if c.cache == nil {
-		log.Errorf("Consumable without cache association: %+v", consumer)
+		log.WithField("consumer", consumer).Error("Consumable without cache association")
 		return
 	}
 
@@ -199,7 +203,11 @@ func (c *Consumable) RemoveMap(m *policymap.PolicyMap) {
 	if m != nil {
 		c.Mutex.Lock()
 		delete(c.Maps, m.Fd)
-		log.Debugf("Removing map %v from consumable %v, new len %d", m, c, len(c.Maps))
+		log.WithFields(log.Fields{
+			"policymap":  m,
+			"consumable": c,
+			"count":      len(c.Maps),
+		}).Debug("Removing map from consumable")
 
 		// If the last map of the consumable is gone the consumable is no longer
 		// needed and should be removed from the cache and all cross references
@@ -223,9 +231,14 @@ func (c *Consumable) addToMaps(id NumericIdentity) {
 			continue
 		}
 
-		log.Debugf("Updating policy BPF map %s: allowing %d", m.String(), id)
+		scopedLog := log.WithFields(log.Fields{
+			"policymap":        m,
+			logfields.Identity: id,
+		})
+
+		scopedLog.Debug("Updating policy BPF map: allowing Identity")
 		if err := m.AllowConsumer(id.Uint32()); err != nil {
-			log.Warningf("Update of policy map failed: %s", err)
+			scopedLog.WithError(err).Warn("Update of policy map failed")
 		}
 	}
 }
@@ -236,9 +249,14 @@ func (c *Consumable) wasLastRule(id NumericIdentity) bool {
 
 func (c *Consumable) removeFromMaps(id NumericIdentity) {
 	for _, m := range c.Maps {
-		log.Debugf("Updating policy BPF map %s: denying %d", m.String(), id)
+		scopedLog := log.WithFields(log.Fields{
+			"policymap":        m,
+			logfields.Identity: id,
+		})
+
+		scopedLog.Debug("Updating policy BPF map: denying Identity")
 		if err := m.DeleteConsumer(id.Uint32()); err != nil {
-			log.Warningf("Update of policy map failed: %s", err)
+			scopedLog.WithError(err).Warn("Update of policy map failed")
 		}
 	}
 }
@@ -247,7 +265,10 @@ func (c *Consumable) removeFromMaps(id NumericIdentity) {
 // consumers map. Must be called with Consumable mutex Locked.
 func (c *Consumable) AllowConsumerLocked(cache *ConsumableCache, id NumericIdentity) {
 	if consumer := c.getConsumer(id); consumer == nil {
-		log.Debugf("New consumer %d for consumable %+v", id, c)
+		log.WithFields(log.Fields{
+			logfields.Identity: id,
+			"consumable":       logfields.Repr(c),
+		}).Debug("New consumer Identity for consumable")
 		c.addToMaps(id)
 		c.Consumers[id.StringID()] = NewConsumer(id)
 	} else {
@@ -259,17 +280,26 @@ func (c *Consumable) AllowConsumerLocked(cache *ConsumableCache, id NumericIdent
 // consumers map and the given consumable to the given consumer's consumers map.
 // Must be called with Consumable mutex Locked.
 func (c *Consumable) AllowConsumerAndReverseLocked(cache *ConsumableCache, id NumericIdentity) {
-	log.Debugf("Allowing direction %d -> %d", id, c.ID)
+	log.WithFields(log.Fields{
+		logfields.Identity + ".from": id,
+		logfields.Identity + ".to":   c.ID,
+	}).Debug("Allowing direction")
 	c.AllowConsumerLocked(cache, id)
 
 	if reverse := cache.Lookup(id); reverse != nil {
-		log.Debugf("Allowing reverse direction %d -> %d", c.ID, id)
+		log.WithFields(log.Fields{
+			logfields.Identity + ".from": c.ID,
+			logfields.Identity + ".to":   id,
+		}).Debug("Allowing reverse direction")
 		if _, ok := reverse.ReverseRules[c.ID]; !ok {
 			reverse.addToMaps(c.ID)
 			reverse.ReverseRules[c.ID] = NewConsumer(c.ID)
 		}
 	} else {
-		log.Warningf("Allowed a consumer %d->%d which can't be found in the reverse direction", c.ID, id)
+		log.WithFields(log.Fields{
+			logfields.Identity + ".from": c.ID,
+			logfields.Identity + ".to":   id,
+		}).Warn("Allowed a consumer which can't be found in the reverse direction")
 	}
 }
 
@@ -277,7 +307,7 @@ func (c *Consumable) AllowConsumerAndReverseLocked(cache *ConsumableCache, id Nu
 // map. Must be called with the Consumable mutex locked.
 func (c *Consumable) BanConsumerLocked(id NumericIdentity) {
 	if consumer, ok := c.Consumers[id.StringID()]; ok {
-		log.Debugf("Removing consumer %v", consumer)
+		log.WithField("consumer", logfields.Repr(consumer)).Debug("Removing consumer")
 		delete(c.Consumers, id.StringID())
 
 		if c.wasLastRule(id) {

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -183,7 +183,7 @@ func (p *Repository) allowsL4Egress(searchCtx *SearchContext) api.Decision {
 
 	policy, err := p.ResolveL4Policy(&ctx)
 	if err != nil {
-		log.WithError(err).Warning("Evaluation error while resolving L4 egress policy")
+		log.WithError(err).Warn("Evaluation error while resolving L4 egress policy")
 	}
 	verdict := api.Undecided
 	if err == nil && len(policy.Egress) > 0 {
@@ -204,7 +204,7 @@ func (p *Repository) allowsL4Ingress(ctx *SearchContext) api.Decision {
 
 	policy, err := p.ResolveL4Policy(ctx)
 	if err != nil {
-		log.WithError(err).Warning("Evaluation error while resolving L4 ingress policy")
+		log.WithError(err).Warn("Evaluation error while resolving L4 ingress policy")
 	}
 	verdict := api.Undecided
 	if err == nil && len(policy.Ingress) > 0 {

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -19,7 +19,9 @@ import (
 	"net"
 
 	"github.com/cilium/cilium/pkg/ip"
+	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/policy/api"
+
 	log "github.com/sirupsen/logrus"
 )
 
@@ -84,7 +86,10 @@ func (r *rule) sanitize() error {
 func (policy *L4Filter) addFromEndpoints(fromEndpoints []api.EndpointSelector) bool {
 
 	if len(policy.FromEndpoints) == 0 && len(fromEndpoints) > 0 {
-		log.Debugf("skipping L4 filter %s as the endpoints %s are already covered.", policy, fromEndpoints)
+		log.WithFields(log.Fields{
+			logfields.EndpointSelector: fromEndpoints,
+			"policy":                   policy,
+		}).Debug("skipping L4 filter as the endpoints are already covered.")
 		return true
 	}
 


### PR DESCRIPTION
This switches a bunch of log callsites to use logrus.WIthFields. These changes are not supposed to break anything and follow the same reasoning from https://github.com/cilium/cilium/pull/1801 The goal of these changes is to make debugging via logs easier by making our usage more consistent. Ideally, field names should be used the same way throughout the code and mean the same thing.

The most important things to review are whether the field names make sense in the context they're used, and whether we should introduce new ones to pkg/logfields/logfields.go. I'm also happy to incorporate better messages into this PR :)