### PR TITLE
pkg/proxy: Consistently use logrus fields

### DIFF
--- a/pkg/proxy/kafka_test.go
+++ b/pkg/proxy/kafka_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 
@@ -231,7 +232,7 @@ func (k *proxyTestSuite) TestKafkaRedirect(c *C) {
 	// Start handling allowedTopic produce requests
 	server.Handle(ProduceRequest, func(request Serializable) Serializable {
 		req := request.(*proto.ProduceReq)
-		log.Debugf("Handling req %+v", req)
+		log.WithField(logfields.Request, logfields.Repr(req)).Debug("Handling req")
 		return &proto.ProduceResp{
 			CorrelationID: req.CorrelationID,
 			Topics: []proto.ProduceRespTopic{

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 
@@ -38,9 +39,11 @@ const (
 
 // field names used while logging
 const (
-	fieldMarker = "marker"
-	fieldSocket = "socket"
-	fieldFd     = "fd"
+	fieldMarker          = "marker"
+	fieldSocket          = "socket"
+	fieldFd              = "fd"
+	fieldProxyRedirectID = "id"
+	fieldProxyKind       = "kind"
 )
 
 // Supported proxy types
@@ -144,12 +147,15 @@ var gcOnce sync.Once
 // a proxy instance. If the redirect is already in place, only the rules will be
 // updated.
 func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, source ProxySource, kind string) (Redirect, error) {
+	scopedLog := log.WithFields(log.Fields{
+		fieldProxyRedirectID: id,
+		fieldProxyKind:       kind,
+	})
+
 	gcOnce.Do(func() {
 		if lf := viper.GetString("access-log"); lf != "" {
 			if err := accesslog.OpenLogfile(lf); err != nil {
-				log.WithFields(log.Fields{
-					accesslog.FieldFilePath: lf,
-				}).WithError(err).Warning("Cannot open L7 access log")
+				scopedLog.WithError(err).WithField(accesslog.FieldFilePath, lf).Warn("Cannot open L7 access log")
 			}
 		}
 
@@ -161,7 +167,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, source Pr
 			for {
 				time.Sleep(time.Duration(10) * time.Second)
 				if deleted := GC(); deleted > 0 {
-					log.Debugf("Evicted %d entries from proxy table", deleted)
+					scopedLog.WithField("count", deleted).Debug("Evicted entries from proxy table")
 				}
 			}
 		}()
@@ -175,7 +181,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, source Pr
 		if err != nil {
 			return nil, err
 		}
-		log.Debugf("updated existing proxy instance %+v", r)
+		scopedLog.WithField(logfields.Object, logfields.Repr(r)).Debug("updated existing proxy instance")
 		return r, nil
 	}
 
@@ -193,7 +199,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, source Pr
 			id:         id,
 			source:     source,
 			listenPort: to})
-		log.Debugf("Created new kafka proxy instance %+v", redir)
+		scopedLog.WithField(logfields.Object, logfields.Repr(redir)).Debug("Created new kafka proxy instance")
 	case policy.ParserTypeHTTP:
 		switch kind {
 		case ProxyKindOxy:
@@ -202,10 +208,10 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, source Pr
 			return nil, fmt.Errorf("Unknown proxy kind: %s", kind)
 		}
 
-		log.Debugf("Created new %s proxy instance %+v", kind, redir)
+		scopedLog.WithField(logfields.Object, logfields.Repr(redir)).Debug("Created new proxy instance")
 	}
 	if err != nil {
-		log.Errorf("Unable to create proxy of kind: %s: %s", kind, err)
+		scopedLog.WithError(err).Error("Unable to create proxy of kind")
 		return nil, err
 	}
 
@@ -224,7 +230,7 @@ func (p *Proxy) RemoveRedirect(id string) error {
 		return fmt.Errorf("unable to find redirect %s", id)
 	}
 
-	log.Debugf("removing proxy redirect %s", id)
+	log.WithField(fieldProxyRedirectID, id).Debug("removing proxy redirect")
 	toPort := r.ToPort()
 	r.Close()
 


### PR DESCRIPTION
This switches a bunch of log callsites to use logrus.WIthFields. These changes are not supposed to break anything and follow the same reasoning from https://github.com/cilium/cilium/pull/1801 The goal of these changes is to make debugging via logs easier by making our usage more consistent. Ideally, field names should be used the same way throughout the code and mean the same thing.

The most important things to review are whether the field names make sense in the context they're used, and whether we should introduce new ones to pkg/logfields/logfields.go. I'm also happy to incorporate better messages into this PR :)