### PR TITLE
Api logrus.WithFields fixups

### DIFF
--- a/pkg/apisocket/apisocket.go
+++ b/pkg/apisocket/apisocket.go
@@ -22,6 +22,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cilium/cilium/pkg/logfields"
+
 	log "github.com/sirupsen/logrus"
 )
 
@@ -54,7 +56,10 @@ func GetGroupIDByName(grpName string) (int, error) {
 func SetDefaultPermissions(socketPath string) error {
 	gid, err := GetGroupIDByName(CiliumGroupName)
 	if err != nil {
-		log.Infof("Group %s not found: %s", CiliumGroupName, err)
+		log.WithError(err).WithFields(log.Fields{
+			logfields.Path: socketPath,
+			"group":        CiliumGroupName,
+		}).Info("Group not found")
 	} else {
 		if err := os.Chown(socketPath, 0, gid); err != nil {
 			return fmt.Errorf("failed while setting up %s's group ID"+

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -19,15 +19,12 @@ import (
 	"strings"
 
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logfields"
 
 	"github.com/mitchellh/hashstructure"
-	"github.com/op/go-logging"
+	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sLbls "k8s.io/apimachinery/pkg/labels"
-)
-
-var (
-	log = logging.MustGetLogger("cilium-policy")
 )
 
 // EndpointSelector is a wrapper for k8s LabelSelector.
@@ -149,10 +146,10 @@ func NewESFromK8sLabelSelector(srcPrefix string, ls *metav1.LabelSelector) Endpo
 func (n *EndpointSelector) Matches(lblsToMatch k8sLbls.Labels) bool {
 	lbSelector, err := metav1.LabelSelectorAsSelector(n.LabelSelector)
 	if err != nil {
-		// FIXME: Omit this error or through it to the caller?
+		// FIXME: Omit this error or throw it to the caller?
 		// We are doing the verification in the ParseEndpointSelector but
 		// don't make sure the user can modify the current labels.
-		log.Errorf("unable the match selector %+v in selector: %s", n, err)
+		log.WithError(err).WithField(logfields.EndpointLabelSelector, logfields.Repr(n)).Error("unable to match label selector in selector")
 		return false
 	}
 

--- a/pkg/proxy/accesslog/log.go
+++ b/pkg/proxy/accesslog/log.go
@@ -53,9 +53,7 @@ func OpenLogfile(lf string) error {
 	}
 
 	logPath = lf
-	log.WithFields(log.Fields{
-		FieldFilePath: logPath,
-	}).Debug("Opened access log")
+	log.WithField(FieldFilePath, logPath).Debug("Opened access log")
 
 	logBuf = bufio.NewWriter(logFile)
 	return nil
@@ -63,9 +61,7 @@ func OpenLogfile(lf string) error {
 
 // CloseLogfile closes the logfile
 func CloseLogfile() {
-	log.WithFields(log.Fields{
-		FieldFilePath: logPath,
-	}).Debug("Closed access log")
+	log.WithField(FieldFilePath, logPath).Debug("Closed access log")
 
 	logBuf.Flush()
 	logFile.Close()
@@ -80,9 +76,7 @@ func logString(outStr string, retry bool) {
 	_, err := logBuf.WriteString(outStr + "\n")
 	if err != nil {
 		if retry {
-			log.WithFields(log.Fields{
-				FieldFilePath: logPath,
-			}).WithError(err).Warning("Error encountered while writing to access log, retrying once...")
+			log.WithError(err).WithField(FieldFilePath, logPath).Warn("Error encountered while writing to access log, retrying once...")
 
 			CloseLogfile()
 			OpenLogfile(logPath)
@@ -124,9 +118,7 @@ func Log(l *LogRecord, typ FlowType, verdict FlowVerdict, code int) {
 	}).Debug("Logging L7 flow record")
 
 	if logBuf == nil {
-		log.WithFields(log.Fields{
-			FieldFilePath: logPath,
-		}).Debug("Skipping writing to access log (write buffer nil)")
+		log.WithField(FieldFilePath, logPath).Debug("Skipping writing to access log (write buffer nil)")
 		return
 	}
 
@@ -138,8 +130,6 @@ func Log(l *LogRecord, typ FlowType, verdict FlowVerdict, code int) {
 	}
 
 	if err := logBuf.Flush(); err != nil {
-		log.WithFields(log.Fields{
-			FieldFilePath: logPath,
-		}).WithError(err).Warning("Error encountered while flushing to access log")
+		log.WithError(err).WithField(FieldFilePath, logPath).Warn("Error encountered while flushing to access log")
 	}
 }


### PR DESCRIPTION
This switches a bunch of log callsites to use logrus.WIthFields. These changes are not supposed to break anything and follow the same reasoning from https://github.com/cilium/cilium/pull/1801 The goal of these changes is to make debugging via logs easier by making our usage more consistent. Ideally, field names should be used the same way throughout the code and mean the same thing.

The most important things to review are whether the field names make sense in the context they're used, and whether we should introduce new ones to pkg/logfields/logfields.go. I'm also happy to incorporate better messages into this PR :)
I'm not sure if the go-logging sublogger I replaced is a breaking change. I tried to retain the "cilium-policy" labelling but I'm not sure what it was for to begin with (I'm hoping it was a human readable thing, and not a strict output formatting issue).