### PR TITLE
Use latest created cilium-agent in k8s tests

### DIFF
--- a/tests/k8s/helpers.bash
+++ b/tests/k8s/helpers.bash
@@ -14,7 +14,7 @@ function abort {
 	echo ""
 	echo "------------------------------------------------------------------------"
 
-	cilium_id=$(docker ps -aq --filter=name=cilium-agent)
+	cilium_id=$(docker ps -aql --filter=name=cilium-agent)
 	echo "------------------------------------------------------------------------"
 	echo "                            Cilium logs"
 	docker logs ${cilium_id}

--- a/tests/k8s/tests/01-guestbook-test.sh
+++ b/tests/k8s/tests/01-guestbook-test.sh
@@ -92,7 +92,7 @@ else
     k8s_nodes_policy_status 2 default guestbook-web-deprecated
 fi
 
-cilium_id=$(docker ps -aq --filter=name=cilium-agent)
+cilium_id=$(docker ps -aql --filter=name=cilium-agent)
 
 # Set redis on master to force inter-node communication
 node_selector="k8s-1"

--- a/tests/k8s/tests/02-cnp-specs.sh
+++ b/tests/k8s/tests/02-cnp-specs.sh
@@ -125,7 +125,7 @@ kubectl exec -t ${productpage_v1} wget -- --tries=5 ratings:9080
 
 if [ $? -ne 0 ]; then abort "Error: could not connect from productpage-v1 to ratings:9080 service" ; fi
 
-cilium_id=$(docker ps -aq --filter=name=cilium-agent)
+cilium_id=$(docker ps -aql --filter=name=cilium-agent)
 
 # Install cilium policies
 # FIXME Remove workaround once we drop k8s 1.6 support

--- a/tests/k8s/tests/03-l7-stresstest.sh
+++ b/tests/k8s/tests/03-l7-stresstest.sh
@@ -96,7 +96,7 @@ if [ ${code} -ne 200 ]; then abort "Error: unable to connect between frontend an
 kubectl exec -n qa -i ${frontend_pod} -- wrk -t20 -c1000 -d60 "http://${backend_svc_ip}:80/"
 kubectl exec -n qa -i ${frontend_pod} -- ab -r -n 1000000 -c 200 -s 60 -v 1 "http://${backend_svc_ip}:80/"
 
-cilium_id=$(docker ps -aq --filter=name=cilium-agent)
+cilium_id=$(docker ps -aql --filter=name=cilium-agent)
 
 # FIXME Remove workaround once we drop k8s 1.6 support
 # This cilium network policy v2 will work in k8s >= 1.7.x with CRD and v1 with


### PR DESCRIPTION
CI failed if there were more than one `cilium-agent` docker containers
running. This change ensures that tests are run on the newest one.