### PR TITLE
Jenkinsfile / test / tests: Ginkgo validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,12 @@ tests-ginkgo: tests-common-ginkgo
 
 tests-common-ginkgo: force
 	tests/00-fmt.sh
+	go vet $(GOFILES)
 	# Make the bindata to run the unittest
 	make -C daemon go-bindata
 	docker-compose -f test/docker-compose.yml -p $$JOB_BASE_NAME-$$BUILD_NUMBER run --rm test
 	# Remove the networks
 	docker-compose -f test/docker-compose.yml -p $$JOB_BASE_NAME-$$BUILD_NUMBER down
-	go vet $(GOFILES)
 
 tests-common: force
 	tests/00-fmt.sh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -117,7 +117,7 @@ Vagrant.configure(2) do |config|
             # Ignore contrib/packaging/docker/stage to prevent concurrent
             # problems when using rsync on multiple VMs
             config.vm.synced_folder '.', '/home/vagrant/go/src/github.com/cilium/cilium', type: "rsync",
-            rsync__exclude: "contrib/packaging/docker/stage"
+            rsync__exclude: ["contrib/packaging/docker/stage", "src"]
         end
     end
 

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -1,5 +1,7 @@
 pipeline {
-    agent none
+    agent {
+        label 'ginkgo'
+    }
     environment {
         PROJ_PATH = "src/github.com/cilium/cilium"
     }
@@ -11,15 +13,14 @@ pipeline {
 
     stages {
         stage('Checkout') {
-            agent any
             steps {
+                sh 'env'
                 sh 'rm -rf src; mkdir -p src/github.com/cilium'
                 sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
                 checkout scm
             }
         }
         stage('UnitTesting') {
-            agent any
             environment {
                 GOPATH="${WORKSPACE}"
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/"
@@ -29,7 +30,6 @@ pipeline {
             }
         }
         stage('BDD-Test') {
-            agent any
             environment {
                 GOPATH="${WORKSPACE}"
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -50,6 +50,8 @@ pipeline {
             post {
                 always {
                     junit 'test/*.xml'
+                    // Temporary workaround to test cleanup
+                    // rm -rf ${GOPATH}/src/github.com/cilium/cilium
                     sh 'cd test/; vagrant destroy -f'
                     sh 'cd test/; K8S_VERSION=1.6 vagrant destroy -f'
                 }

--- a/test/helpers/vagrant.go
+++ b/test/helpers/vagrant.go
@@ -53,12 +53,24 @@ func (vagrant *Vagrant) Create(scope string) error {
 	cmd := vagrant.getCmd(createCMD)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting stdout: %s", err)
 	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("error getting stderr: %s", err)
+	}
+
 	go func() {
 		in := bufio.NewScanner(stdout)
 		for in.Scan() {
-			log.Infof(in.Text()) // write each line to your log
+			log.Infof("stdout: %s", in.Text()) // write each line to your log
+		}
+	}()
+
+	go func() {
+		errIn := bufio.NewScanner(stderr)
+		for errIn.Scan() {
+			log.Infof("stderr: %s", errIn.Text())
 		}
 	}()
 

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -61,7 +61,7 @@ var _ = BeforeSuite(func() {
 	case "runtime":
 		err := vagrant.Create("runtime")
 		if err != nil {
-			Fail(fmt.Sprintf("Vagrant could not started correctly: %s", err))
+			Fail(fmt.Sprintf("Vagrant could not start correctly: %s", err))
 		}
 		cilium := helpers.CreateCilium("runtime", log.WithFields(
 			log.Fields{"testName": "BeforeSuite"}))

--- a/tests/00-fmt.sh
+++ b/tests/00-fmt.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-set -ex
+set -x
 
 diff="$(find . ! \( -path './contrib' -prune \) \
         ! \( -path './vendor' -prune \) \
@@ -8,6 +8,7 @@ diff="$(find . ! \( -path './contrib' -prune \) \
         ! -samefile ./daemon/bindata.go \
         -type f -name '*.go' -print0 \
                 | xargs -0 gofmt -d -l -s )"
+set -e
 
 if [ -n "$diff" ]; then
 	echo "Unformatted Go source code:"

--- a/tests/00-script-linter.sh
+++ b/tests/00-script-linter.sh
@@ -25,6 +25,7 @@ function check_flags_set
 {
   if grep -RL --include=\*.sh "set -.*e.*x" * | \
     grep -v "00-script-linter" | \
+    grep -v "00-fmt" | \
     grep -v "start.sh" | \
     grep -v "helpers.bash" | \
     grep -v "cilium-files" | \


### PR DESCRIPTION
This branch contains fixes that enable that the Ginkgo build framework functions appropriately on the Cilium Jenkins setup. Some other minor enhancements / test gaps were fixed, specifically running `go vet`, and outputting `stderr` of Vagrant commands.

The Jenkinsfile for the Ginkgo tests has been edited to run only on build slaves with the label 'ginkgo'; this is intentional.

Signed-off by: Ian Vernon <ian@cilium.io>