### PR TITLE
Fix L4Filter JSON marshalling

### DIFF
--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -46,20 +46,20 @@ const (
 
 type L4Filter struct {
 	// Port is the destination port to allow
-	Port int
+	Port int `json:"port"`
 	// Protocol is the L4 protocol to allow or NONE
-	Protocol api.L4Proto
+	Protocol api.L4Proto `json:"protocol"`
 	// FromEndpoints limit the source labels for allowing traffic. If
 	// FromEndpoints is empty, then it selects all endpoints.
 	FromEndpoints []api.EndpointSelector `json:"-"`
 	// L7Parser specifies the L7 protocol parser (optional)
-	L7Parser L7ParserType
+	L7Parser L7ParserType `json:"-"`
 	// L7RedirectPort is the L7 proxy port to redirect to (optional)
-	L7RedirectPort int
+	L7RedirectPort int `json:"l7-redirect-port,omitempty"`
 	// L7RulesPerEp is a list of L7 rules per endpoint passed to the L7 proxy (optional)
-	L7RulesPerEp L7DataMap
+	L7RulesPerEp L7DataMap `json:"l7-rules,omitempty"`
 	// Ingress is true if filter applies at ingress
-	Ingress bool
+	Ingress bool `json:"-"`
 }
 
 // GetRelevantRules returns the relevant rules based on the source and

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -33,6 +33,25 @@ var (
 // L7DataMap contains a map of L7 rules per endpoint where key is a hash of EndpointSelector
 type L7DataMap map[api.EndpointSelector]api.L7Rules
 
+func (l7 L7DataMap) MarshalJSON() ([]byte, error) {
+	var err error
+	rules := []byte{}
+
+	if len(l7) == 0 {
+		return []byte("{}"), nil
+	}
+
+	for _, v := range l7 {
+		b, err := json.MarshalIndent(v, "", "  ")
+		if err != nil {
+			b = []byte("\"L7DataMap error: " + err.Error() + "\"")
+		}
+		rules = append(rules, b...)
+	}
+
+	return rules, err
+}
+
 // L7ParserType is the type used to indicate what L7 parser to use and
 // defines all supported types of L7 parsers
 type L7ParserType string
@@ -154,7 +173,7 @@ func (l4 *L4Filter) IsRedirect() bool {
 func (l4 *L4Filter) MarshalIndent() string {
 	b, err := json.MarshalIndent(l4, "", "  ")
 	if err != nil {
-		return err.Error()
+		b = []byte("\"L4Filter error: " + err.Error() + "\"")
 	}
 	return string(b)
 }

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -16,8 +16,10 @@ package policy
 
 import (
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/kr/pretty"
 
 	. "gopkg.in/check.v1"
 )
@@ -115,4 +117,75 @@ func (s *PolicyTestSuite) TestCreateL4Filter(c *C) {
 			c.Assert(len(filter.L7RulesPerEp), Equals, 1)
 		}
 	}
+}
+
+func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
+	selector := api.NewESFromLabels(labels.ParseSelectLabel("foo"))
+
+	policy := L4Policy{
+		Egress: L4PolicyMap{
+			"8080/TCP": {
+				Port:     8080,
+				Protocol: api.ProtoTCP,
+				Ingress:  false,
+			},
+		},
+		Ingress: L4PolicyMap{
+			"80/TCP": {
+				Port: 80, Protocol: api.ProtoTCP,
+				FromEndpoints: []api.EndpointSelector{selector},
+				L7Parser:      "http",
+				L7RulesPerEp: L7DataMap{
+					selector: api.L7Rules{
+						HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
+					},
+				},
+				Ingress: true,
+			},
+			"8080/TCP": {
+				Port: 8080, Protocol: api.ProtoTCP,
+				FromEndpoints: []api.EndpointSelector{selector},
+				L7Parser:      "http",
+				L7RulesPerEp: L7DataMap{
+					selector: api.L7Rules{
+						HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
+					},
+				},
+				Ingress: true,
+			},
+		},
+	}
+
+	model := policy.GetModel()
+	c.Assert(model, NotNil)
+
+	expected := `[{
+  "port": 8080,
+  "protocol": "TCP"
+}]`
+	c.Assert(pretty.Sprintf("%+ v", model.Egress), comparator.DeepEquals, expected)
+	expected = `[{
+  "port": 80,
+  "protocol": "TCP",
+  "l7-rules": {
+    "http": [
+      {
+        "path": "/",
+        "method": "GET"
+      }
+    ]
+  }
+} {
+  "port": 8080,
+  "protocol": "TCP",
+  "l7-rules": {
+    "http": [
+      {
+        "path": "/",
+        "method": "GET"
+      }
+    ]
+  }
+}]`
+	c.Assert(pretty.Sprintf("%+ v", model.Ingress), comparator.DeepEquals, expected)
 }


### PR DESCRIPTION
@aanm pointed out that L4Filter JSON marshalling was borked, returning a JSON serialization error rather than actually serializing its contents. This series fixes that up and makes some other minor improvements to the serialization.