### PR TITLE
L7DataMap JSON Serialization followup

### DIFF
--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -32,6 +32,12 @@ type EndpointSelector struct {
 	*metav1.LabelSelector
 }
 
+// LabelSelectorString returns a user-friendly string representation of
+// EndpointSelector.
+func (n *EndpointSelector) LabelSelectorString() string {
+	return metav1.FormatLabelSelector(n.LabelSelector)
+}
+
 // String returns a string representation of EndpointSelector.
 func (n EndpointSelector) String() string {
 	j, _ := n.MarshalJSON()

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -15,6 +15,8 @@
 package policy
 
 import (
+	"sort"
+
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/labels"
@@ -187,5 +189,8 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
     ]
   }
 }]`
-	c.Assert(pretty.Sprintf("%+ v", model.Ingress), comparator.DeepEquals, expected)
+	var result sort.StringSlice
+	result = model.Ingress
+	result.Sort()
+	c.Assert(pretty.Sprintf("%+ v", result), comparator.DeepEquals, expected)
 }


### PR DESCRIPTION
The first commit of this series fixes up an intermittent unit test failure due to L7DataMap entry ordering.

The second commit fixes up key serialization to JSON for the L7DataMap. 