### PR TITLE
logging: Fix possible circular import dependency with accesslog

### DIFF
--- a/pkg/logfields/logfields.go
+++ b/pkg/logfields/logfields.go
@@ -15,8 +15,6 @@
 // Package logfields defines common logging fields which are used across packages
 package logfields
 
-import "github.com/cilium/cilium/pkg/proxy/accesslog"
-
 const (
 
 	// LogSubsys is the field denoting the subsystem when logging
@@ -113,8 +111,9 @@ const (
 	EndpointSelector = "EndpointSelector"
 
 	// Path is a filesystem path. It can be a file or directory.
-	// Note: we follow what accesslog sets to be consistent.
-	Path = accesslog.FieldFilePath
+	// Note: pkg/proxy/accesslog points to this variable so be careful when
+	// changing the value
+	Path = "file-path"
 
 	// Object is used when "%+v" printing Go objects for debug or error handling.
 	// It is often paired with logfields.Repr to render the object.

--- a/pkg/proxy/accesslog/log.go
+++ b/pkg/proxy/accesslog/log.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logfields"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -41,7 +42,7 @@ const (
 	FieldURL      = "url"
 	FieldProtocol = "protocol"
 	FieldHeader   = "header"
-	FieldFilePath = "file-path"
+	FieldFilePath = logfields.Path
 )
 
 // OpenLogfile opens a file for logging


### PR DESCRIPTION
logfields is intended to be a terminal import dependency. `accesslog` might not be, and this can cause a circular dependency in imports.

@tgraf @manalibhutiyani I think I overheard you talking about this. If it's blocking you, and you approve it, feel free to merge it over the weekend.