### PR TITLE
daemon: parse CNP rules before checking equality

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1136,6 +1136,21 @@ func (d *Daemon) updateCiliumNetworkPolicy(oldObj interface{}, newObj interface{
 		log.WithField(logfields.Object, logfields.Repr(newObj)).Warn("Received unknown object, expected a CiliumNetworkPolicy object")
 		return
 	}
+
+	// Parse rules before checking whether they are equal. When rules are parsed,
+	// fields are sanitized and changed. Since Parse() is called on a pointer
+	// to a rule, the oldRule, which is cached locally, is modified, while the
+	// newRule is not modified yet. See GH-1885.
+	_, err := oldRule.Parse()
+	if err != nil {
+		log.WithError(err).WithField(logfields.Object, logfields.Repr(oldRule)).Warn("Error parsing old CiliumNetworkPolicy rule")
+	}
+
+	_, err = newRules.Parse()
+	if err != nil {
+		log.WithError(err).WithField(logfields.Object, logfields.Repr(newRules)).Warn("Error parsing new CiliumNetworkPolicy rule")
+	}
+
 	// Since we are updating the status map from all nodes we need to prevent
 	// deletion and addition of all rules in cilium.
 	if oldRule.SpecEquals(newRules) {


### PR DESCRIPTION
An issue was observed where creation and deletion of CiliumNetworkPolicy objects kept occurring in the case where a CiliumNetworkPolicy with a Kafka rule was imported via Kubernetes. This kept occurring because when a CiliumNetworkPolicy object is updated in Kubernetes, calls to `daemon/k8s_watcher.go:updateCiliumNetworkPolicy` checked if the provided old / new CiliumNetworkPolicy objects were equal. The old and new objects were not equal due to the fact that parsing is performed upon CiliumNetworkPolicy pointers. These rule pointers are updated when they are parsed. The pointers to the rules are cached locally by the Kubernetes watcher. Thus the rules that are parsed into Kubernetes which are provided into `daemon/k8s_watcher.go:updateCiliumNetworkPolicy` upon future updates are the modified copies of the rules that were parsed previously. The provided old rule was modified due to being parsed, while the new rule was not. These modified copies were not truly equal, and thus did not cause `daemon/k8s_watcher.go:updateCiliumNetworkPolicy` to return:

```
// Since we are updating the status map from all nodes we need to prevent
// deletion and addition of all rules in cilium.
if oldRule.SpecEquals(newRules) {
	return
}

d.deleteCiliumNetworkPolicy(oldObj)
d.addCiliumNetworkPolicy(newObj)
```

and instead kept triggering deletions and updates of CiliumNetworkPolicies. 
This commit simply parses the rules before checking whether they are equal or not to normalize them. This is a workaround fix. The correct fix is to DeepCopy the old / new objects before they are modified, which #1885 covers.

Signed-off by: Ian Vernon <ian@cilium.io>