### PR TITLE
Generalize access logging (rebased)

### DIFF
--- a/pkg/proxy/accesslog/log.go
+++ b/pkg/proxy/accesslog/log.go
@@ -17,12 +17,10 @@ package accesslog
 import (
 	"bufio"
 	"encoding/json"
-	"fmt"
 	"os"
 
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logfields"
-	"github.com/cilium/cilium/pkg/policy/api"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -54,14 +52,8 @@ const (
 	FieldKafkaCorrelationID = "kafkaCorrelationID"
 )
 
-// L7Type
-const (
-	L7TypeHTTP = iota
-	L7TypeKafka
-)
-
-// OpenLogfile opens a file for logging
-func OpenLogfile(lf string) error {
+// Called with lock held
+func openLogfileLocked(lf string) error {
 	var err error
 
 	if logFile, err = os.OpenFile(lf, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666); err != nil {
@@ -75,27 +67,47 @@ func OpenLogfile(lf string) error {
 	return nil
 }
 
-// CloseLogfile closes the logfile
-func CloseLogfile() {
+// OpenLogfile opens a file for logging
+func OpenLogfile(lf string) error {
+	logMutex.Lock()
+	defer logMutex.Unlock()
+
+	return openLogfileLocked(lf)
+}
+
+// Called with lock held.
+func closeLogfileLocked() {
 	log.WithField(FieldFilePath, logPath).Debug("Closed access log")
 
 	logBuf.Flush()
 	logFile.Close()
 }
 
+// CloseLogfile closes the log file.
+func CloseLogfile() {
+	logMutex.Lock()
+	defer logMutex.Unlock()
+
+	closeLogfileLocked()
+}
+
 // SetMetadata sets the metadata to include in each record
 func SetMetadata(md []string) {
+	logMutex.Lock()
+	defer logMutex.Unlock()
+
 	metadata = md
 }
 
+// Called with lock held.
 func logString(outStr string, retry bool) {
 	_, err := logBuf.WriteString(outStr + "\n")
 	if err != nil {
 		if retry {
 			log.WithError(err).WithField(FieldFilePath, logPath).Warn("Error encountered while writing to access log, retrying once...")
 
-			CloseLogfile()
-			OpenLogfile(logPath)
+			closeLogfileLocked()
+			openLogfileLocked(logPath)
 
 			// retry once
 			logString(outStr, false)
@@ -103,31 +115,20 @@ func logString(outStr string, retry bool) {
 	}
 }
 
-// LogHTTP logs a HTTP record to the logfile
-func LogHTTP(l *LogRecord, typ FlowType, verdict FlowVerdict, code int) {
-	l.HTTP = &LogRecordHTTP{
-		Code:     code,
-		Method:   l.HTTPRequest.Method,
-		URL:      l.HTTPRequest.URL,
-		Protocol: l.HTTPRequest.Proto,
-		Headers:  l.HTTPRequest.Header,
-	}
-	log.WithFields(log.Fields{
-		FieldType:     typ,
-		FieldVerdict:  verdict,
-		FieldCode:     code,
-		FieldMethod:   l.HTTPRequest.Method,
-		FieldURL:      l.HTTPRequest.URL,
-		FieldProtocol: l.HTTPRequest.Proto,
-		FieldHeader:   l.HTTPRequest.Header,
-		FieldFilePath: logPath,
-	}).Debug("Logging HTTP L7 flow record")
+// Log logs a record to the logfile and flushes the buffer
+func (l *LogRecord) Log() {
+	// Lock while writing access log so we serialize writes as we may have
+	// to reopen the logfile and parallel writes could fail because of that
+	logMutex.Lock()
+	defer logMutex.Unlock()
 
 	if logBuf == nil {
 		log.WithField(FieldFilePath,
 			logPath).Debug("Skipping writing to access log (write buffer nil)")
 		return
 	}
+
+	l.Metadata = metadata
 
 	b, err := json.Marshal(*l)
 	if err != nil {
@@ -135,81 +136,9 @@ func LogHTTP(l *LogRecord, typ FlowType, verdict FlowVerdict, code int) {
 	} else {
 		logString(string(b), true)
 	}
-}
 
-func apiKeyToString(apiKey int16) string {
-	if key, ok := api.KafkaReverseAPIKeyMap[apiKey]; ok {
-		return key
-	}
-	return fmt.Sprintf("%d", apiKey)
-}
-
-// LogKafka logs a Kafka record to the logfile
-func LogKafka(l *LogRecord, typ FlowType, verdict FlowVerdict, code int) {
-	apiKey := l.KafkaRequest.GetAPIKey()
-
-	l.Kafka = &LogRecordKafka{
-		ErrorCode:     code,
-		APIVersion:    l.KafkaRequest.GetVersion(),
-		APIKey:        apiKeyToString(apiKey),
-		CorrelationID: l.KafkaRequest.GetCorrelationID(),
-	}
-
-	log.WithFields(log.Fields{
-		FieldType:               typ,
-		FieldVerdict:            verdict,
-		FieldCode:               code,
-		FieldKafkaAPIKey:        apiKeyToString(apiKey),
-		FieldKafkaAPIVersion:    l.KafkaRequest.GetVersion(),
-		FieldKafkaCorrelationID: l.KafkaRequest.GetCorrelationID(),
-		FieldFilePath:           logPath,
-	}).Debug("Logging Kafka L7 flow record")
-
-	if logBuf == nil {
-		log.WithField(FieldFilePath,
-			logPath).Debug("Skipping writing to access log (write buffer nil)")
-		return
-	}
-
-	//
-	// Log multiple entries for multiple Kafka topics in a single
-	// request. GH #1815
-	//
-
-	topics := l.KafkaRequest.GetTopics()
-	for i := 0; i < len(topics); i++ {
-		l.Kafka.Topic.Topic = topics[i]
-		b, err := json.Marshal(*l)
-		if err != nil {
-			logString(err.Error(), true)
-		} else {
-			logString(string(b), true)
-		}
-	}
-}
-
-// Log logs a record to the logfile and flushes the buffer
-func Log(l *LogRecord, typ FlowType, verdict FlowVerdict, code int, L7type int) {
-	// Lock while writing access log so we serialize writes as we may have
-	// to reopen the logfile and parallel writes could fail because of that
-	logMutex.Lock()
-	defer logMutex.Unlock()
-
-	l.Type = typ
-	l.Verdict = verdict
-	l.Metadata = metadata
-
-	switch L7type {
-	case L7TypeHTTP:
-		LogHTTP(l, typ, verdict, code)
-	case L7TypeKafka:
-		LogKafka(l, typ, verdict, code)
-	}
-
-	if logBuf != nil {
-		if err := logBuf.Flush(); err != nil {
-			log.WithError(err).WithField(FieldFilePath,
-				logPath).Warn("Error encountered while flushing to access log")
-		}
+	if err := logBuf.Flush(); err != nil {
+		log.WithError(err).WithField(FieldFilePath,
+			logPath).Warn("Error encountered while flushing to access log")
 	}
 }

--- a/pkg/proxy/accesslog/record.go
+++ b/pkg/proxy/accesslog/record.go
@@ -17,8 +17,6 @@ package accesslog
 import (
 	"net/http"
 	"net/url"
-
-	"github.com/cilium/cilium/pkg/kafka"
 )
 
 // FlowType is the type to indicate the flow direction
@@ -178,12 +176,6 @@ type LogRecord struct {
 
 	// Kafka contains information for Kafka request/responses
 	Kafka *LogRecordKafka `json:"Kafka,omitempty"`
-
-	// Internal HTTP request
-	HTTPRequest *http.Request `json:"-"`
-
-	// Internal Kafka request
-	KafkaRequest *kafka.RequestMessage `json:"-"`
 }
 
 // LogRecordHTTP contains the HTTP specific portion of a log record

--- a/pkg/proxy/kafka.go
+++ b/pkg/proxy/kafka.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 
 	"github.com/optiopay/kafka/proto"
@@ -40,17 +41,20 @@ type kafkaRedirect struct {
 	// protects all fields of this struct
 	lock.RWMutex
 
-	conf     kafkaConfiguration
-	epID     uint64
-	ingress  bool
-	nodeInfo accesslog.NodeAddressInfo
-	rules    policy.L7DataMap
-	socket   *proxySocket
+	conf    kafkaConfiguration
+	epID    uint64
+	ingress bool
+	rules   policy.L7DataMap
+	socket  *proxySocket
 }
 
 // ToPort returns the redirect port of an OxyRedirect
 func (k *kafkaRedirect) ToPort() uint16 {
 	return k.conf.listenPort
+}
+
+func (k *kafkaRedirect) IsIngress() bool {
+	return k.ingress
 }
 
 type destLookupFunc func(remoteAddr string, dport uint16) (uint32, string, error)
@@ -71,10 +75,6 @@ func createKafkaRedirect(conf kafkaConfiguration) (Redirect, error) {
 		conf:    conf,
 		epID:    conf.source.GetID(),
 		ingress: conf.policy.Ingress,
-		nodeInfo: accesslog.NodeAddressInfo{
-			IPv4: node.GetExternalIPv4().String(),
-			IPv6: node.GetIPv6().String(),
-		},
 	}
 
 	if redir.conf.lookupNewDest == nil {
@@ -164,29 +164,90 @@ func (k *kafkaRedirect) getSource() ProxySource {
 	return k.conf.source
 }
 
-func (k *kafkaRedirect) handleRequest(pair *connectionPair, req *kafka.RequestMessage) {
-	scopedLog := log.WithField(fieldID, pair.String())
-	scopedLog.WithField(logfields.Request, req.String()).Debug("Handling Kafka request")
+func apiKeyToString(apiKey int16) string {
+	if key, ok := api.KafkaReverseAPIKeyMap[apiKey]; ok {
+		return key
+	}
+	return fmt.Sprintf("%d", apiKey)
+}
 
-	record := &accesslog.LogRecord{
-		KafkaRequest:      req,
-		Timestamp:         time.Now().UTC().Format(time.RFC3339Nano),
-		NodeAddressInfo:   k.nodeInfo,
-		TransportProtocol: 6, // TCP's IANA-assigned protocol number
+// kafkaLogRecord wraps an accesslog.LogRecord so that we can define methods with a receiver
+type kafkaLogRecord struct {
+	accesslog.LogRecord
+
+	req *kafka.RequestMessage
+}
+
+func (k *kafkaRedirect) newKafkaLogRecord(req *kafka.RequestMessage) *kafkaLogRecord {
+	record := &kafkaLogRecord{
+		req: req,
+		LogRecord: accesslog.LogRecord{
+			Kafka: &accesslog.LogRecordKafka{
+				APIVersion:    req.GetVersion(),
+				APIKey:        apiKeyToString(req.GetAPIKey()),
+				CorrelationID: req.GetCorrelationID(),
+			},
+			NodeAddressInfo: accesslog.NodeAddressInfo{
+				IPv4: node.GetExternalIPv4().String(),
+				IPv6: node.GetIPv6().String(),
+			},
+			TransportProtocol: 6, // TCP's IANA-assigned protocol number
+		},
 	}
 
-	if k.ingress {
+	if k.IsIngress() {
 		record.ObservationPoint = accesslog.Ingress
 	} else {
 		record.ObservationPoint = accesslog.Egress
 	}
 
+	return record
+}
+
+func (l *kafkaLogRecord) fillInfo(r Redirect, srcIPPort, dstIPPort string, srcIdentity uint32) {
+	fillInfo(r, &l.LogRecord, srcIPPort, dstIPPort, srcIdentity)
+}
+
+// log Kafka log records
+func (l *kafkaLogRecord) log(typ accesslog.FlowType, verdict accesslog.FlowVerdict, code int, info string) {
+	l.Type = typ
+	l.Verdict = verdict
+	l.Kafka.ErrorCode = code
+	l.Info = info
+	l.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
+
+	log.WithFields(log.Fields{
+		accesslog.FieldType:               l.Type,
+		accesslog.FieldVerdict:            l.Verdict,
+		accesslog.FieldCode:               l.Kafka.ErrorCode,
+		accesslog.FieldKafkaAPIKey:        l.Kafka.APIKey,
+		accesslog.FieldKafkaAPIVersion:    l.Kafka.APIVersion,
+		accesslog.FieldKafkaCorrelationID: l.Kafka.CorrelationID,
+	}).Debug("Logging Kafka L7 flow record")
+
+	//
+	// Log multiple entries for multiple Kafka topics in a single
+	// request. GH #1815
+	//
+
+	topics := l.req.GetTopics()
+	for i := 0; i < len(topics); i++ {
+		l.Kafka.Topic.Topic = topics[i]
+		l.Log()
+	}
+}
+
+func (k *kafkaRedirect) handleRequest(pair *connectionPair, req *kafka.RequestMessage) {
+	scopedLog := log.WithField(fieldID, pair.String())
+	scopedLog.WithField(logfields.Request, req.String()).Debug("Handling Kafka request")
+
+	record := k.newKafkaLogRecord(req)
+
 	addr := pair.rx.conn.RemoteAddr()
 	if addr == nil {
-		record.Info = fmt.Sprint("RemoteAddr() is nil")
-		scopedLog.Warn(record.Info)
-		accesslog.Log(record, accesslog.TypeRequest, accesslog.VerdictError,
-			kafka.ErrInvalidMessage, accesslog.L7TypeKafka)
+		info := fmt.Sprint("RemoteAddr() is nil")
+		scopedLog.Warn(info)
+		record.log(accesslog.TypeRequest, accesslog.VerdictError, kafka.ErrInvalidMessage, info)
 		return
 	}
 
@@ -196,36 +257,24 @@ func (k *kafkaRedirect) handleRequest(pair *connectionPair, req *kafka.RequestMe
 	if err != nil {
 		log.WithField("source",
 			addr.String()).WithError(err).Error("Unable lookup original destination")
-		record.Info = fmt.Sprintf("Unable lookup original destination: %s", err)
-		accesslog.Log(record, accesslog.TypeRequest, accesslog.VerdictError,
-			kafka.ErrInvalidMessage, accesslog.L7TypeKafka)
+		record.log(accesslog.TypeRequest, accesslog.VerdictError, kafka.ErrInvalidMessage,
+			fmt.Sprintf("Unable lookup original destination: %s", err))
 		return
 	}
 
-	info, version := getSourceInfo(addr.String(),
-		policy.NumericIdentity(srcIdentity), k.ingress, k)
-	record.SourceEndpoint = info
-	record.IPVersion = version
-
-	if srcIdentity != 0 {
-		record.SourceEndpoint.Identity = uint64(srcIdentity)
-	}
-
-	record.DestinationEndpoint = getDestinationInfo(dstIPPort, k.ingress, k)
+	record.fillInfo(k, addr.String(), dstIPPort, srcIdentity)
 
 	if !k.canAccess(req, policy.NumericIdentity(srcIdentity)) {
 		scopedLog.Debug("Kafka request is denied by policy")
 
-		record.Info = fmt.Sprint("Kafka request is denied by policy")
-		accesslog.Log(record, accesslog.TypeRequest, accesslog.VerdictDenied,
-			kafka.ErrTopicAuthorizationFailed, accesslog.L7TypeKafka)
+		record.log(accesslog.TypeRequest, accesslog.VerdictDenied,
+			kafka.ErrTopicAuthorizationFailed, fmt.Sprint("Kafka request is denied by policy"))
 
 		resp, err := req.CreateResponse(proto.ErrTopicAuthorizationFailed)
 		if err != nil {
 			scopedLog.WithError(err).Error("Unable to create response message")
-			record.Info = fmt.Sprintf("Unable to create response message: %s", err)
-			accesslog.Log(record, accesslog.TypeRequest, accesslog.VerdictError,
-				kafka.ErrInvalidMessage, accesslog.L7TypeKafka)
+			record.log(accesslog.TypeRequest, accesslog.VerdictError,
+				kafka.ErrInvalidMessage, fmt.Sprintf("Unable to create response message: %s", err))
 			return
 		}
 
@@ -260,9 +309,7 @@ func (k *kafkaRedirect) handleRequest(pair *connectionPair, req *kafka.RequestMe
 
 	scopedLog.Debug("Forwarding Kafka request")
 	// log valid request
-	record.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
-	accesslog.Log(record, accesslog.TypeRequest, accesslog.VerdictForwarded,
-		kafka.ErrNone, accesslog.L7TypeKafka)
+	record.log(accesslog.TypeRequest, accesslog.VerdictForwarded, kafka.ErrNone, "")
 
 	// Write the entire raw request onto the outgoing connection
 	pair.tx.Enqueue(req.GetRaw())
@@ -271,7 +318,7 @@ func (k *kafkaRedirect) handleRequest(pair *connectionPair, req *kafka.RequestMe
 type kafkaMessageHander func(pair *connectionPair, req *kafka.RequestMessage)
 
 func handleConnection(pair *connectionPair, c *proxyConnection,
-	record *accesslog.LogRecord, handler kafkaMessageHander) {
+	record *kafkaLogRecord, handler kafkaMessageHander) {
 	for {
 		req, err := kafka.ReadRequest(c.conn)
 		if err != nil {
@@ -281,9 +328,8 @@ func handleConnection(pair *connectionPair, c *proxyConnection,
 			}
 
 			if record != nil {
-				record.Info = fmt.Sprintf("Unable to parse Kafka request: %s", err)
-				accesslog.Log(record, accesslog.TypeRequest, accesslog.VerdictError,
-					kafka.ErrInvalidMessage, accesslog.L7TypeKafka)
+				record.log(accesslog.TypeRequest, accesslog.VerdictError,
+					kafka.ErrInvalidMessage, fmt.Sprintf("Unable to parse Kafka request: %s", err))
 			}
 
 			log.WithError(err).Error("Unable to parse Kafka request")
@@ -303,8 +349,7 @@ func (k *kafkaRedirect) handleRequestConnection(pair *connectionPair) {
 	handleConnection(pair, pair.rx, nil, k.handleRequest)
 }
 
-func (k *kafkaRedirect) handleResponseConnection(pair *connectionPair,
-	record *accesslog.LogRecord) {
+func (k *kafkaRedirect) handleResponseConnection(pair *connectionPair, record *kafkaLogRecord) {
 	log.WithFields(log.Fields{
 		"from": pair.tx,
 		"to":   pair.rx,
@@ -315,9 +360,7 @@ func (k *kafkaRedirect) handleResponseConnection(pair *connectionPair,
 	})
 
 	// log valid response
-	record.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
-	accesslog.Log(record, accesslog.TypeResponse, accesslog.VerdictForwarded,
-		kafka.ErrNone, accesslog.L7TypeKafka)
+	record.log(accesslog.TypeResponse, accesslog.VerdictForwarded, kafka.ErrNone, "")
 }
 
 // UpdateRules replaces old l7 rules of a redirect with new ones.

--- a/pkg/proxy/logrecord.go
+++ b/pkg/proxy/logrecord.go
@@ -1,0 +1,81 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/proxy/accesslog"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// HTTPLogRecord wraps an accesslog.LogRecord so that we can define methods with a receiver
+type HTTPLogRecord struct {
+	accesslog.LogRecord
+}
+
+func newHTTPLogRecord(r Redirect, method string, url *url.URL, proto string, headers http.Header) *HTTPLogRecord {
+	record := &HTTPLogRecord{
+		LogRecord: accesslog.LogRecord{
+			HTTP: &accesslog.LogRecordHTTP{
+				Method:   method,
+				URL:      url,
+				Protocol: proto,
+				Headers:  headers,
+			},
+			NodeAddressInfo: accesslog.NodeAddressInfo{
+				IPv4: node.GetExternalIPv4().String(),
+				IPv6: node.GetIPv6().String(),
+			},
+			TransportProtocol: 6, // TCP's IANA-assigned protocol number
+		},
+	}
+
+	if r.IsIngress() {
+		record.ObservationPoint = accesslog.Ingress
+	} else {
+		record.ObservationPoint = accesslog.Egress
+	}
+
+	return record
+}
+
+func (l *HTTPLogRecord) fillInfo(r Redirect, srcIPPort, dstIPPort string, srcIdentity uint32) {
+	fillInfo(r, &l.LogRecord, srcIPPort, dstIPPort, srcIdentity)
+}
+
+func (l *HTTPLogRecord) log(typ accesslog.FlowType, verdict accesslog.FlowVerdict, code int, info string) {
+	l.Type = typ
+	l.Verdict = verdict
+	l.HTTP.Code = code
+	l.Info = info
+	l.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
+
+	log.WithFields(log.Fields{
+		accesslog.FieldType:     l.Type,
+		accesslog.FieldVerdict:  l.Verdict,
+		accesslog.FieldCode:     l.HTTP.Code,
+		accesslog.FieldMethod:   l.HTTP.Method,
+		accesslog.FieldURL:      l.HTTP.URL,
+		accesslog.FieldProtocol: l.HTTP.Protocol,
+		accesslog.FieldHeader:   l.HTTP.Headers,
+	}).Debug("Logging HTTP L7 flow record")
+
+	l.Log()
+}

--- a/pkg/proxy/socket.go
+++ b/pkg/proxy/socket.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/http"
 	"os"
 	"strconv"
 	"sync/atomic"
@@ -307,10 +306,6 @@ func (p *connectionPair) queueClose() {
 
 func (p *connectionPair) CloseRx() {
 	p.rx.conn.Close()
-}
-
-func lookupNewDestFromHttp(req *http.Request, dport uint16) (uint32, string, error) {
-	return lookupNewDest(req.RemoteAddr, dport)
 }
 
 func lookupNewDest(remoteAddr string, dport uint16) (uint32, string, error) {


### PR DESCRIPTION
Refactor access logging internals from oxyproxy.go to accesslog/log.go, allowing for sharing most of the code with other proxy types.

Note that the (marked internal) http.Request has been removed from the access log message. This means that it is also removed from the json formatted output.
