### PR TITLE
pkg/endpoint: fix PolicyID which was returning endpoint ID

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -758,7 +758,11 @@ func (e *Endpoint) String() string {
 // PolicyID returns an identifier for the endpoint's policy. Must be called
 // with the endpoint's lock held.
 func (e *Endpoint) PolicyID() string {
-	return fmt.Sprintf("Policy ID %d", e.ID)
+	pid := uint32(0)
+	if e.SecLabel != nil {
+		pid = e.SecLabel.ID.Uint32()
+	}
+	return fmt.Sprintf("Policy ID %d", pid)
 }
 
 // optionChanged is a callback used with pkg/option to apply the options to an

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -240,3 +240,16 @@ func (s *EndpointSuite) TestEndpointStatus(c *C) {
 	eps.addStatusLog(sts)
 	c.Assert(eps.String(), Equals, "OK")
 }
+
+func (s *EndpointSuite) TestEndpointPolicyID(c *C) {
+	ep := &Endpoint{
+		ID: 12,
+	}
+	c.Assert(ep.PolicyID(), Equals, "Policy ID 0")
+
+	id := policy.NewIdentity()
+	id.ID = 55
+	ep.SecLabel = id
+
+	c.Assert(ep.PolicyID(), Equals, "Policy ID 55")
+}


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

Should we use the output of `endpoint.GetIdentity()` instead?