### PR TITLE
l4: Fix l7rules ordering test failure

### DIFF
--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -172,3 +172,16 @@ func (n *EndpointSelector) Matches(lblsToMatch k8sLbls.Labels) bool {
 
 	return lbSelector.Matches(lblsToMatch)
 }
+
+// EndpointSelectorSlice is a slice of EndpointSelectors that can be sorted.
+type EndpointSelectorSlice []EndpointSelector
+
+func (s EndpointSelectorSlice) Len() int      { return len(s) }
+func (s EndpointSelectorSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+func (s EndpointSelectorSlice) Less(i, j int) bool {
+	strI := s[i].LabelSelectorString()
+	strJ := s[j].LabelSelectorString()
+
+	return strings.Compare(strI, strJ) < 0
+}

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -52,10 +52,10 @@ func (l7 L7DataMap) MarshalJSON() ([]byte, error) {
 	var err error
 	buffer := bytes.NewBufferString("[")
 	for _, es := range selectors {
-		buffer.WriteString("\n  {    \n    \"")
+		buffer.WriteString("{\"")
 		buffer.WriteString(es.LabelSelectorString())
-		buffer.WriteString("\": ")
-		b, err := json.MarshalIndent(l7[es], "    ", "  ")
+		buffer.WriteString("\":")
+		b, err := json.Marshal(l7[es])
 		if err == nil {
 			buffer.Write(b)
 		} else {
@@ -63,10 +63,10 @@ func (l7 L7DataMap) MarshalJSON() ([]byte, error) {
 			buffer.WriteString(err.Error())
 			buffer.WriteString("\"")
 		}
-		buffer.WriteString("\n  },")
+		buffer.WriteString("},")
 	}
 	buffer.Truncate(buffer.Len() - 1) // Drop the final ","
-	buffer.WriteString("\n]")
+	buffer.WriteString("]")
 
 	return buffer.Bytes(), err
 }

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -197,6 +197,16 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
   "protocol": "TCP",
   "l7-rules": [
     {
+      "\u003cnone\u003e": {
+        "http": [
+          {
+            "path": "/",
+            "method": "GET"
+          }
+        ]
+      }
+    },
+    {
       "any.foo=": {
         "http": [
           {
@@ -205,16 +215,6 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
           },
           {
             "path": "/bar",
-            "method": "GET"
-          }
-        ]
-      }
-    },
-    {
-      "\u003cnone\u003e": {
-        "http": [
-          {
-            "path": "/",
             "method": "GET"
           }
         ]


### PR DESCRIPTION
This patch fixes issue #1902 reported on GitHub where the ordering of
l7rules formatted to JSON is unreliable. We don't serialize the
L7DataMap to JSON very frequently, so solve this by sorting the
endpointselectors before assembling the JSON.

Fixes: #1902 
Reported-by: Ian Vernon <ian@cilium.io>
Signed-off-by: Joe Stringer <joe@covalent.io>