### PR TITLE
Improve Ginkgo test output

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -288,7 +288,6 @@ func (c *Cilium) PolicyImport(path string, timeout time.Duration) (int, error) {
 	c.logCxt.Infof("PolicyImport: %s and current policy revision is '%d'", path, revision)
 	res := c.Exec(fmt.Sprintf("policy import %s", path))
 	if res.WasSuccessful() == false {
-		fmt.Println(res.Output())
 		c.logCxt.Errorf("Could not import policy: %s", res.CombineOutput())
 		return -1, fmt.Errorf("Could not import policy %s", path)
 	}

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -80,10 +80,8 @@ func (node *Node) Execute(cmd string, stdout io.Writer, stderr io.Writer) bool {
 		Stdout: stdout,
 		Stderr: stderr,
 	}
-	result, err := node.sshClient.RunCommand(command)
-	stdout.Write(result)
+	err := node.sshClient.RunCommand(command)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error running command '%s': %s\n", command.Path, err)
 		return false
 	}
 	return true

--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -183,8 +183,7 @@ func (client *SSHClient) RunCommandContext(ctx context.Context, cmd *SSHCommand)
 			session.Close()
 		}
 	}()
-	err = session.Run(cmd.Path)
-	return nil
+	return session.Run(cmd.Path)
 }
 
 func (client *SSHClient) newSession() (*ssh.Session, error) {

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -102,8 +102,8 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 		Expect(res.WasSuccessful()).Should(BeTrue())
 
 		By("Ping from host to server")
-		ping := docker.Node.Execute(fmt.Sprintf("ping -c 4 %s", serverIP), nil, nil)
-		Expect(ping).Should(BeTrue())
+		res = docker.Node.Exec(fmt.Sprintf("ping -c 4 %s", serverIP))
+		Expect(res.WasSuccessful()).Should(BeTrue())
 	}, 300)
 
 	It("Test containers NAT46 connectivity ", func() {
@@ -203,12 +203,12 @@ var _ = Describe("RunConntrackTest", func() {
 			"Client can't netperf to server %s", srvIP["IPv4"]))
 
 		By("Ping from host to server IPv6")
-		ping := docker.Node.Execute(fmt.Sprintf("ping6 -c 4 %s", srvIP["IPv6"]), nil, nil)
-		Expect(ping).Should(BeTrue(), "Host Can't ping to server")
+		res = docker.Node.Exec(fmt.Sprintf("ping6 -c 4 %s", srvIP["IPv6"]))
+		Expect(res.WasSuccessful()).Should(BeTrue(), "Host Can't ping to server")
 
 		By("Ping from host to server IPv4")
-		ping = docker.Node.Execute(fmt.Sprintf("ping -c 4 %s", srvIP["IPv4"]), nil, nil)
-		Expect(ping).Should(BeTrue(), "Host can't ping to server")
+		res = docker.Node.Exec(fmt.Sprintf("ping -c 4 %s", srvIP["IPv4"]))
+		Expect(res.WasSuccessful()).Should(BeTrue(), "Host can't ping to server")
 
 		By("Ping from server to client IPv6")
 		res = docker.ContainerExec("server", fmt.Sprintf("ping6 -c 4 %s", cliIP["IPv6"]))


### PR DESCRIPTION
Pick a few of the low-hanging fruit from the introduction of Ginkgo testing.

* Don't print local node ping output to the terminal while running the test
* Redirect stdout, stderr from SSH sessions to log buffers consistently
* Ensure that stdout, stderr are finished being populated from SSH sessions when RunCommand returns
* Share more code in common SSH execution paths
* Add `-- -cilium.provision` flag to skip provisioning VMs and building Cilium
* Add simple progress indication to show new developers that ginkgo is running vagrant provision