### PR TITLE
test/Vagrantfile: migrate to cilium-managed vagrant box

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure("2") do |config|
         end
 
         # server.vm.box = "bento/ubuntu-17.04"
-        server.vm.box = "eloycoto/cilium"
+        server.vm.box = "cilium/ginkgo"
         server.vm.hostname = "runtime"
         server.vm.synced_folder "../", "/src/"
 
@@ -41,7 +41,7 @@ Vagrant.configure("2") do |config|
             end
 
             # server.vm.box = "bento/ubuntu-17.04"
-            server.vm.box = "eloycoto/cilium"
+            server.vm.box = "cilium/ginkgo"
             server.vm.hostname = "k8s#{i}"
             server.vm.network "private_network",
                 ip: "192.168.36.1#{i}",


### PR DESCRIPTION
This migrates the Ginkgo test Vagrantfile to use a different VM, the scripts for provisioning of which are located at https://github.com/cilium/packer-ci-build . This ensures that the VM used in the Cilium build pipeline are controlled and managed by Cilium maintainers.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #1844 