### PR TITLE
Issue #1923 Handle Kafka responses correctly

### DIFF
--- a/pkg/kafka/response.go
+++ b/pkg/kafka/response.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/optiopay/kafka/proto"
+	"io"
 )
 
 // ResponseMessage represents a Kafka response message.
@@ -39,6 +40,25 @@ func (res *ResponseMessage) String() string {
 		return err.Error()
 	}
 	return string(b)
+}
+
+// ReadResponse will read a Kafka response from an io.Reader and return the
+// message or an error.
+func ReadResponse(reader io.Reader) (*ResponseMessage, error) {
+	rsp := &ResponseMessage{}
+	var err error
+
+	_, rsp.rawMsg, err = proto.ReadResp(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(rsp.rawMsg) < 6 {
+		return nil,
+			fmt.Errorf("unexpected end of response (length < 6 bytes)")
+	}
+
+	return rsp, nil
 }
 
 func createProduceResponse(req *proto.ProduceReq, err error) (*ResponseMessage, error) {

--- a/pkg/proxy/kafka.go
+++ b/pkg/proxy/kafka.go
@@ -315,10 +315,11 @@ func (k *kafkaRedirect) handleRequest(pair *connectionPair, req *kafka.RequestMe
 	pair.tx.Enqueue(req.GetRaw())
 }
 
-type kafkaMessageHander func(pair *connectionPair, req *kafka.RequestMessage)
+type kafkaReqMessageHander func(pair *connectionPair, req *kafka.RequestMessage)
+type kafkaRespMessageHander func(pair *connectionPair, req *kafka.ResponseMessage)
 
-func handleConnection(pair *connectionPair, c *proxyConnection,
-	record *kafkaLogRecord, handler kafkaMessageHander) {
+func handleRequest(pair *connectionPair, c *proxyConnection,
+	record *kafkaLogRecord, handler kafkaReqMessageHander) {
 	for {
 		req, err := kafka.ReadRequest(c.conn)
 		if err != nil {
@@ -340,23 +341,49 @@ func handleConnection(pair *connectionPair, c *proxyConnection,
 	}
 }
 
+func handleResponse(pair *connectionPair, c *proxyConnection,
+	record *kafkaLogRecord, handler kafkaRespMessageHander) {
+	for {
+		rsp, err := kafka.ReadResponse(c.conn)
+		if err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				c.Close()
+				return
+			}
+
+			if record != nil {
+				record.log(accesslog.TypeResponse, accesslog.VerdictError,
+					kafka.ErrInvalidMessage,
+					fmt.Sprintf("Unable to parse Kafka response: %s", err))
+			}
+
+			log.WithError(err).Error("Unable to parse Kafka response")
+			continue
+		} else {
+			handler(pair, rsp)
+		}
+	}
+}
+
 func (k *kafkaRedirect) handleRequestConnection(pair *connectionPair) {
 	log.WithFields(log.Fields{
 		"from": pair.rx,
 		"to":   pair.tx,
 	}).Debug("Proxying request Kafka connection")
 
-	handleConnection(pair, pair.rx, nil, k.handleRequest)
+	handleRequest(pair, pair.rx, nil, k.handleRequest)
 }
 
-func (k *kafkaRedirect) handleResponseConnection(pair *connectionPair, record *kafkaLogRecord) {
+func (k *kafkaRedirect) handleResponseConnection(pair *connectionPair,
+	record *kafkaLogRecord) {
 	log.WithFields(log.Fields{
 		"from": pair.tx,
 		"to":   pair.rx,
 	}).Debug("Proxying response Kafka connection")
 
-	handleConnection(pair, pair.tx, record, func(pair *connectionPair, req *kafka.RequestMessage) {
-		pair.rx.Enqueue(req.GetRaw())
+	handleResponse(pair, pair.tx, record, func(pair *connectionPair,
+		rsp *kafka.ResponseMessage) {
+		pair.rx.Enqueue(rsp.GetRaw())
 	})
 
 	// log valid response


### PR DESCRIPTION
This change handles Kafka responses correctly and parses them as per Kafka Response message and
not request message.

Addresses issue #1923

```release-note
Handle Kafka responses correctly
```
Signed-off by: Manali Bhutiyani manali@covalent.io