### PR TITLE
Documentation: make it easier to build docs locally

### DIFF
--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -1,0 +1,17 @@
+# Container for making it easier to build the documentation via Docker.
+FROM ubuntu:16.04
+ENV DOCS_DIR=/srv/Documentation
+ENV API_DIR=/srv/api
+
+WORKDIR $DOCS_DIR
+ADD Documentation $DOCS_DIR
+ADD api $API_DIR
+
+RUN apt-get update && \
+      apt-get install -y git make python-sphinx python-pip \
+      # PDF dependencies use a lot of space, left here for others.
+      # latexmk texlive-latex-extra
+      && apt-get clean && \
+      pip install --upgrade pip && \
+      pip install -r $DOCS_DIR/requirements.txt && \
+      rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -26,6 +26,16 @@ check-requirements:
 	  echo "Run pip install sphinx-rtd-theme";  \
 	  exit 1)
 
+docs-container:
+	docker build -t cilium/docs-builder -f Documentation/Dockerfile .
+
+render:
+	-docker rm -f docs-cilium >/dev/null
+	cd .. && \
+	docker run -ti -v $$(pwd):/srv/ cilium/docs-builder /bin/bash -c 'make html' && \
+	docker run -dit --name docs-cilium -p 8080:80 -v $$(pwd)/Documentation/_build/html/:/usr/local/apache2/htdocs/ httpd:2.4
+	@echo "$$(tput setaf 2)Running at http://localhost:8080$$(tput sgr0)"
+
 .PHONY: help Makefile check-requirements
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -81,7 +81,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '_themes/**/*.rst']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -167,5 +167,4 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
-
-
+http_strict_mode = False

--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -231,6 +231,24 @@ Whenever making changes to Cilium documentation you should check that you did no
 After this you can browse the updated docs as HTML starting at
 ``Documentation\_build\html\index.html``.
 
+Alternatively you can use a Docker container to build the pages.
+
+::
+
+    $ docker run -ti -v $(pwd):/srv/ cilium/docs-builder /bin/bash -c 'make html'
+
+This behave similarly to running the ``make`` command above so the path to the
+build is the same.
+
+There is also a separate target for building and starting a web server with
+your document changes.
+
+::
+
+    $ make render
+
+Now the documentation page should be browsable on http://localhost:8080
+
 Debugging datapath code
 ~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Adding a Dockerfile to the documentation directory. This container
should include all of the necessary dependencies to build the HTML
documents. To reduce the image size decided to skip PDF documents for
now. Might revisit this in the future.

Also add examples to the contributor section on how to build docs via
the new image.

Closes: #1791 (docs: provide a Dockerfile for producing the PDF and HTML formats)