### PR TITLE
policy: add PolicyTrace msg to AllowsRLocked() when L4 policies not evaluated

### DIFF
--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -229,6 +229,7 @@ func (p *Repository) AllowsRLocked(ctx *SearchContext) api.Decision {
 	decision := p.CanReachRLocked(ctx)
 	ctx.PolicyTrace("Label verdict: %s", decision.String())
 	if decision == api.Allowed {
+		ctx.PolicyTrace("L4 ingress & egress policies skipped")
 		return decision
 	}
 

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -410,6 +410,7 @@ func (ds *PolicyTestSuite) TestPolicyTrace(c *C) {
 1/1 rules selected
 Found allow rule
 Label verdict: allowed
+L4 ingress & egress policies skipped
 `
 	ctx := buildSearchCtx("foo", "bar", 0)
 	repo.checkTrace(c, ctx, expectedOut, api.Allowed)


### PR DESCRIPTION
When repository.AllowsRLocked() determines that traffic should be allowed purely
based on L3, it skips looking at l4 policies and the "cilium policy trace ..."
output doesn't print any indication that it is aware of the L4 policies or how
they might impact the policy decision.

Fixes: #1707

Signed-off-by: Erik Chang <gnahckire@gmail.com>