### PR TITLE
Revisiting k8s_watcher.go and refactored CRD to its own package

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1239,9 +1239,9 @@ func (d *Daemon) addCiliumNetworkPolicy(obj interface{}) {
 	ruleCpy := rule.DeepCopy()
 
 	scopedLog := log.WithFields(log.Fields{
-		logfields.CiliumNetworkPolicyName: ruleCpy.Metadata.Name,
+		logfields.CiliumNetworkPolicyName: ruleCpy.ObjectMeta.Name,
 		logfields.K8sAPIVersion:           ruleCpy.TypeMeta.APIVersion,
-		logfields.K8sNamespace:            ruleCpy.Metadata.Namespace,
+		logfields.K8sNamespace:            ruleCpy.ObjectMeta.Namespace,
 	})
 
 	scopedLog.Debug("Adding CiliumNetworkPolicy")
@@ -1283,9 +1283,9 @@ func (d *Daemon) deleteCiliumNetworkPolicy(obj interface{}) {
 	ruleCpy := rule.DeepCopy()
 
 	scopedLog := log.WithFields(log.Fields{
-		logfields.CiliumNetworkPolicyName: ruleCpy.Metadata.Name,
+		logfields.CiliumNetworkPolicyName: ruleCpy.ObjectMeta.Name,
 		logfields.K8sAPIVersion:           ruleCpy.TypeMeta.APIVersion,
-		logfields.K8sNamespace:            ruleCpy.Metadata.Namespace,
+		logfields.K8sNamespace:            ruleCpy.ObjectMeta.Namespace,
 	})
 
 	scopedLog.Debug("Deleting CiliumNetworkPolicy")
@@ -1343,10 +1343,10 @@ func (d *Daemon) updateCiliumNetworkPolicy(oldObj interface{}, newObj interface{
 
 	log.WithFields(log.Fields{
 		logfields.K8sAPIVersion:                    oldRule.TypeMeta.APIVersion,
-		logfields.CiliumNetworkPolicyName + ".old": oldRule.Metadata.Name,
-		logfields.K8sNamespace + ".old":            oldRule.Metadata.Namespace,
-		logfields.CiliumNetworkPolicyName + ".new": newRules.Metadata.Name,
-		logfields.K8sNamespace + ".new":            newRules.Metadata.Namespace,
+		logfields.CiliumNetworkPolicyName + ".old": oldRule.ObjectMeta.Name,
+		logfields.K8sNamespace + ".old":            oldRule.ObjectMeta.Namespace,
+		logfields.CiliumNetworkPolicyName + ".new": newRules.ObjectMeta.Name,
+		logfields.K8sNamespace + ".new":            newRules.ObjectMeta.Namespace,
 	}).Debug("Modified CiliumNetworkPolicy")
 
 	d.deleteCiliumNetworkPolicy(oldObj)

--- a/pkg/k8s/apis/cilium.io/const.go
+++ b/pkg/k8s/apis/cilium.io/const.go
@@ -1,0 +1,28 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ciliumio
+
+import (
+	"k8s.io/kubernetes/pkg/kubelet/types"
+)
+
+const (
+	// PolicyLabelName is the name of the policy label which refers to the
+	// k8s policy name
+	PolicyLabelName = "io.cilium.k8s-policy-name"
+	// PodNamespaceLabel is the label used in kubernetes containers to
+	// specify which namespace they belong to.
+	PodNamespaceLabel = types.KubernetesPodNamespaceLabel
+)

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -1,0 +1,20 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ciliumio
+
+const (
+	// GroupName is the group name of the cilium network policy
+	GroupName = "cilium.io"
+)

--- a/pkg/k8s/apis/cilium.io/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils.go
@@ -1,0 +1,29 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ciliumio
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+// ExtractNamespace extracts the namespace of ObjectMeta.
+func ExtractNamespace(np *metav1.ObjectMeta) string {
+	if np.Namespace == "" {
+		return v1.NamespaceDefault
+	}
+
+	return np.Namespace
+}

--- a/pkg/k8s/apis/cilium.io/v2/doc.go
+++ b/pkg/k8s/apis/cilium.io/v2/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +k8s:deepcopy-gen=package,register
+
+// Package v2 is the v2 version of the API.
+// +groupName=cilium.io
+package v2

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -1,0 +1,55 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+)
+
+// SchemeGroupVersion is group version used to register these objects
+var SchemeGroupVersion = schema.GroupVersion{Group: k8sconst.GroupName, Version: "v2"}
+
+// Resource takes an unqualified resource and returns a Group qualified GroupResource
+func Resource(resource string) schema.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}
+
+var (
+	SchemeBuilder runtime.SchemeBuilder
+	// localSchemeBuilder and AddToScheme will stay in k8s.io/kubernetes.
+	localSchemeBuilder = &SchemeBuilder
+	AddToScheme        = localSchemeBuilder.AddToScheme
+)
+
+func init() {
+	// We only register manually written functions here. The registration of the
+	// generated functions takes place in the generated files. The separation
+	// makes the code compile even when the generated files are missing.
+	localSchemeBuilder.Register(addKnownTypes)
+}
+
+// Adds the list of known types to api.Scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&CiliumNetworkPolicy{},
+		&CiliumNetworkPolicyList{},
+	)
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -42,9 +42,8 @@ var (
 // CiliumNetworkPolicy is a Kubernetes third-party resource with an extended version
 // of NetworkPolicy
 type CiliumNetworkPolicy struct {
-	metav1.TypeMeta `json:",inline"`
-	// +optional
-	Metadata metav1.ObjectMeta `json:"metadata"`
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata"`
 
 	// Spec is the desired Cilium specific rule specification.
 	Spec *api.Rule `json:"spec,omitempty"`
@@ -99,7 +98,7 @@ func (r *CiliumNetworkPolicy) GetObjectKind() schema.ObjectKind {
 
 // GetObjectMeta returns the metadata of the object
 func (r *CiliumNetworkPolicy) GetObjectMeta() metav1.Object {
-	return &r.Metadata
+	return &r.ObjectMeta
 }
 
 // parseToCilium returns an api.Rule with all the labels parsed into cilium
@@ -202,12 +201,12 @@ func parseToCilium(namespace, name string, r *api.Rule) *api.Rule {
 // Parse parses a CiliumNetworkPolicy and returns a list of cilium policy
 // rules.
 func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
-	if r.Metadata.Name == "" {
+	if r.ObjectMeta.Name == "" {
 		return nil, fmt.Errorf("CiliumNetworkPolicy must have name")
 	}
 
-	namespace := k8sconst.ExtractNamespace(&r.Metadata)
-	name := r.Metadata.Name
+	namespace := k8sconst.ExtractNamespace(&r.ObjectMeta)
+	name := r.ObjectMeta.Name
 
 	retRules := api.Rules{}
 
@@ -243,8 +242,7 @@ func (cnp *CiliumNetworkPolicy) DeepCopy() *CiliumNetworkPolicy {
 // CiliumNetworkPolicyList is a list of CiliumNetworkPolicy objects
 type CiliumNetworkPolicyList struct {
 	metav1.TypeMeta `json:",inline"`
-	// +optional
-	Metadata metav1.ListMeta `json:"metadata"`
+	metav1.ListMeta `json:"metadata"`
 
 	// Items is a list of CiliumNetworkPolicy
 	Items []CiliumNetworkPolicy `json:"items"`
@@ -257,5 +255,5 @@ func (r *CiliumNetworkPolicyList) GetObjectKind() schema.ObjectKind {
 
 // GetListMeta returns the metadata of the object
 func (r *CiliumNetworkPolicyList) GetListMeta() metav1.List {
-	return &r.Metadata
+	return &r.ListMeta
 }

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -218,7 +218,7 @@ func (s *CiliumV2Suite) TestParseSpec(c *C) {
 	apiRule.EndpointSelector = es
 
 	expectedPolicyRule := &CiliumNetworkPolicy{
-		Metadata: metav1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "rule1",
 		},
 		Spec: &apiRule,
@@ -254,7 +254,7 @@ func (s *CiliumV2Suite) TestParseRules(c *C) {
 	apiRule.EndpointSelector = es
 
 	expectedPolicyRuleList := &CiliumNetworkPolicy{
-		Metadata: metav1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "rule1",
 		},
 		Specs: api.Rules{&apiRule, &apiRule},

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -292,9 +292,9 @@ func CreateCRDClient(cfg *rest.Config) (CNPCliInterface, error) {
 // api-server and respective error.
 func (c *cnpClient) Update(cnp *v2.CiliumNetworkPolicy) (*v2.CiliumNetworkPolicy, error) {
 	var res v2.CiliumNetworkPolicy
-	ns := k8sconst.ExtractNamespace(&cnp.Metadata)
+	ns := k8sconst.ExtractNamespace(&cnp.ObjectMeta)
 	err := c.RESTClient.Put().Resource(CustomResourceDefinitionPluralName).
-		Namespace(ns).Name(cnp.Metadata.Name).
+		Namespace(ns).Name(cnp.ObjectMeta.Name).
 		Body(cnp).Do().Into(&res)
 	return &res, err
 }
@@ -303,7 +303,7 @@ func (c *cnpClient) Update(cnp *v2.CiliumNetworkPolicy) (*v2.CiliumNetworkPolicy
 // api-server and respective error.
 func (c *cnpClient) Create(cnp *v2.CiliumNetworkPolicy) (*v2.CiliumNetworkPolicy, error) {
 	var res v2.CiliumNetworkPolicy
-	ns := k8sconst.ExtractNamespace(&cnp.Metadata)
+	ns := k8sconst.ExtractNamespace(&cnp.ObjectMeta)
 	err := c.RESTClient.Post().Resource(CustomResourceDefinitionPluralName).
 		Namespace(ns).
 		Body(cnp).Do().Into(&res)
@@ -459,8 +459,8 @@ func UpdateCNPStatus(cnpClient CNPCliInterface, timeout time.Duration,
 	rule.SetPolicyStatus(node.GetName(), cnpns)
 	_, err := cnpClient.Update(rule)
 	if err != nil {
-		ns := k8sconst.ExtractNamespace(&rule.Metadata)
-		name := rule.Metadata.GetObjectMeta().GetName()
+		ns := k8sconst.ExtractNamespace(&rule.ObjectMeta)
+		name := rule.ObjectMeta.Name
 		scopedLog := log.WithFields(logrus.Fields{
 			logfields.K8sNamespace:            ns,
 			logfields.CiliumNetworkPolicyName: name,
@@ -487,7 +487,7 @@ func UpdateCNPStatus(cnpClient CNPCliInterface, timeout time.Duration,
 				}).Warn("Received object of unknown type from API server, expecting v2.CiliumNetworkPolicy")
 				return
 			}
-			if serverRule.Metadata.UID != rule.Metadata.UID &&
+			if serverRule.ObjectMeta.UID != rule.ObjectMeta.UID &&
 				serverRule.SpecEquals(rule) {
 				// Although the policy was found this means it was deleted,
 				// and re-added with the same name.

--- a/pkg/k8s/const.go
+++ b/pkg/k8s/const.go
@@ -15,11 +15,18 @@
 package k8s
 
 import (
-	"k8s.io/kubernetes/pkg/kubelet/types"
 	"time"
 )
 
 const (
+	// BackOffLoopTimeout is the default duration when trying to reach the
+	// kube-apiserver.
+	BackOffLoopTimeout = 2 * time.Minute
+
+	// maxUpdateRetries is the maximum number of update retries when
+	// updating k8s resources
+	maxUpdateRetries = 30
+
 	// AnnotationName is an optional annotation to the NetworkPolicy
 	// resource which specifies the name of the policy node to which all
 	// rules should be applied to.
@@ -35,22 +42,7 @@ const (
 	// EnvNodeNameSpec is the environment label used by Kubernetes to
 	// specify the node's name.
 	EnvNodeNameSpec = "K8S_NODE_NAME"
-
-	// PolicyLabelName is the name of the policy label which refers to the
-	// k8s policy name
-	PolicyLabelName = "io.cilium.k8s-policy-name"
-	// PodNamespaceLabel is the label used in kubernetes containers to
-	// specify which namespace they belong to.
-	PodNamespaceLabel = types.KubernetesPodNamespaceLabel
 	// PodNamespaceMetaLabels is the label used to store the labels of the
 	// kubernetes namespace's labels.
 	PodNamespaceMetaLabels = "ns-labels"
-
-	// BackOffLoopTimeout is the default duration when trying to reach the
-	// kube-apiserver.
-	BackOffLoopTimeout = 2 * time.Minute
-
-	// maxUpdateRetries is the maximum number of update retries when
-	// updating k8s resources
-	maxUpdateRetries = 30
 )

--- a/pkg/k8s/deepcopy.go
+++ b/pkg/k8s/deepcopy.go
@@ -1,0 +1,26 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+// DeepCopyv1beta1Ingress returns a DeepCopy of the given ingress.
+// Deprecated
+func DeepCopyv1beta1Ingress(ing *v1beta1.Ingress) *v1beta1.Ingress {
+	// FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME
+	return ing
+}

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/comparator"
+	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -79,7 +80,7 @@ func (s *K8sSuite) TestParseNetworkPolicy(c *C) {
 	c.Assert(err, IsNil)
 
 	fromEndpoints := labels.LabelArray{
-		labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+		labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 		labels.NewLabel("foo3", "bar3", labels.LabelSourceK8s),
 		labels.NewLabel("foo4", "bar4", labels.LabelSourceK8s),
 	}
@@ -87,7 +88,7 @@ func (s *K8sSuite) TestParseNetworkPolicy(c *C) {
 	ctx := policy.SearchContext{
 		From: fromEndpoints,
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo1", "bar1", labels.LabelSourceK8s),
 			labels.NewLabel("foo2", "bar2", labels.LabelSourceK8s),
 		},
@@ -194,11 +195,11 @@ func (s *K8sSuite) TestParseNetworkPolicyEmptyFrom(c *C) {
 
 	ctx := policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo0", "bar0", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo1", "bar1", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -249,11 +250,11 @@ func (s *K8sSuite) TestParseNetworkPolicyDenyAll(c *C) {
 
 	ctx := policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo0", "bar0", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo1", "bar1", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -374,7 +375,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	repo.AddList(rules)
 	ctx := policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
@@ -387,7 +388,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
@@ -400,11 +401,11 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			labels.NewLabel("role", "backend", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
@@ -508,11 +509,11 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	repo.AddList(rules)
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -530,7 +531,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
@@ -540,7 +541,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -577,11 +578,11 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	repo.AddList(rules)
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "backend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -591,11 +592,11 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "backend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -605,11 +606,11 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "backend", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
@@ -726,7 +727,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
@@ -736,7 +737,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -746,7 +747,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
@@ -756,7 +757,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -766,7 +767,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "alice", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
@@ -776,7 +777,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -871,7 +872,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
 			// doesn't matter the namespace.
-			labels.NewLabel(PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			// component==redis is in the policy
 			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "component"), "redis", labels.LabelSourceK8s),
 			// tier==cache is in the policy
@@ -889,7 +890,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 		},
 		To: labels.LabelArray{
 			// Namespace needs to be in `expressions` since the policy is being enforced for that namespace.
-			labels.NewLabel(PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
 			// component==redis is in the policy.
 			labels.NewLabel("component", "redis", labels.LabelSourceK8s),
 			// tier==cache is in the policy
@@ -902,7 +903,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx.To = labels.LabelArray{
 		// Namespace needs to be in `expressions` since the policy is being enforced for that namespace.
-		labels.NewLabel(PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+		labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 		// component==redis is in the policy.
 		labels.NewLabel("component", "redis", labels.LabelSourceK8s),
 		// tier==cache is in the policy
@@ -925,7 +926,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
 			labels.NewLabel("component", "redis", labels.LabelSourceK8s),
 			labels.NewLabel("tier", "cache", labels.LabelSourceK8s),
 		},
@@ -946,7 +947,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
 			labels.NewLabel("component", "redis", labels.LabelSourceK8s),
 			labels.NewLabel("tier", "cache", labels.LabelSourceK8s),
 		},

--- a/pkg/k8s/network_policy_v1beta.go
+++ b/pkg/k8s/network_policy_v1beta.go
@@ -19,6 +19,7 @@ package k8s
 import (
 	"fmt"
 
+	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -33,14 +34,14 @@ func ExtractPolicyNameDeprecated(np *v1beta1.NetworkPolicy) string {
 		policyName = np.Name
 	}
 
-	return fmt.Sprintf("%s=%s", PolicyLabelName, policyName)
+	return fmt.Sprintf("%s=%s", k8sconst.PolicyLabelName, policyName)
 }
 
 // ParseNetworkPolicyDeprecated parses a k8s NetworkPolicy and returns a list of
 // Cilium policy rules that can be added
 func ParseNetworkPolicyDeprecated(np *v1beta1.NetworkPolicy) (api.Rules, error) {
 	ingresses := []api.IngressRule{}
-	namespace := ExtractNamespace(&np.ObjectMeta)
+	namespace := k8sconst.ExtractNamespace(&np.ObjectMeta)
 	for _, iRule := range np.Spec.Ingress {
 		// Based on NetworkPolicyIngressRule docs:
 		//   From []NetworkPolicyPeer
@@ -62,7 +63,7 @@ func ParseNetworkPolicyDeprecated(np *v1beta1.NetworkPolicy) (api.Rules, error) 
 					// The PodSelector should only reflect to the same namespace
 					// the policy is being stored, thus we add the namespace to
 					// the MatchLabels map.
-					rule.PodSelector.MatchLabels[PodNamespaceLabel] = namespace
+					rule.PodSelector.MatchLabels[k8sconst.PodNamespaceLabel] = namespace
 					ingress.FromEndpoints = append(ingress.FromEndpoints,
 						api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, rule.PodSelector))
 				} else if rule.NamespaceSelector != nil {
@@ -119,7 +120,7 @@ func ParseNetworkPolicyDeprecated(np *v1beta1.NetworkPolicy) (api.Rules, error) 
 	if np.Spec.PodSelector.MatchLabels == nil {
 		np.Spec.PodSelector.MatchLabels = map[string]string{}
 	}
-	np.Spec.PodSelector.MatchLabels[PodNamespaceLabel] = namespace
+	np.Spec.PodSelector.MatchLabels[k8sconst.PodNamespaceLabel] = namespace
 
 	rule := &api.Rule{
 		EndpointSelector: api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, &np.Spec.PodSelector),

--- a/pkg/k8s/network_policy_v1beta_test.go
+++ b/pkg/k8s/network_policy_v1beta_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/comparator"
+	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -72,14 +73,14 @@ func (s *K8sSuite) TestParseNetworkPolicyDeprecated(c *C) {
 	c.Assert(len(rules), Equals, 1)
 
 	fromEndpoints := labels.LabelArray{
-		labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+		labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 		labels.NewLabel("foo3", "bar3", labels.LabelSourceK8s),
 		labels.NewLabel("foo4", "bar4", labels.LabelSourceK8s),
 	}
 	ctx := policy.SearchContext{
 		From: fromEndpoints,
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo1", "bar1", labels.LabelSourceK8s),
 			labels.NewLabel("foo2", "bar2", labels.LabelSourceK8s),
 		},
@@ -182,11 +183,11 @@ func (s *K8sSuite) TestParseNetworkPolicyEmptyFromDeprecated(c *C) {
 
 	ctx := policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo0", "bar0", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo1", "bar1", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -237,11 +238,11 @@ func (s *K8sSuite) TestParseNetworkPolicyDenyAllDeprecated(c *C) {
 
 	ctx := policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo0", "bar0", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo1", "bar1", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -318,7 +319,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 	repo.AddList(rules)
 	ctx := policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
@@ -331,7 +332,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
@@ -344,11 +345,11 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			labels.NewLabel("role", "backend", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
@@ -410,11 +411,11 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 	repo.AddList(rules)
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -431,7 +432,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
@@ -441,7 +442,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -478,11 +479,11 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 	repo.AddList(rules)
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "backend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -492,11 +493,11 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "backend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -506,11 +507,11 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "backend", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
@@ -583,7 +584,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
@@ -593,7 +594,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -603,7 +604,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
@@ -613,7 +614,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -708,7 +709,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
 			// doesn't matter the namespace.
-			labels.NewLabel(PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			// component==redis is in the policy
 			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "component"), "redis", labels.LabelSourceK8s),
 			// tier==cache is in the policy
@@ -726,7 +727,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 		},
 		To: labels.LabelArray{
 			// Namespace needs to be in `expressions` since the policy is being enforced for that namespace.
-			labels.NewLabel(PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
 			// component==redis is in the policy.
 			labels.NewLabel("component", "redis", labels.LabelSourceK8s),
 			// tier==cache is in the policy
@@ -739,7 +740,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 
 	ctx.To = labels.LabelArray{
 		// Namespace needs to be in `expressions` since the policy is being enforced for that namespace.
-		labels.NewLabel(PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+		labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 		// component==redis is in the policy.
 		labels.NewLabel("component", "redis", labels.LabelSourceK8s),
 		// tier==cache is in the policy
@@ -762,7 +763,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
 			labels.NewLabel("component", "redis", labels.LabelSourceK8s),
 			labels.NewLabel("tier", "cache", labels.LabelSourceK8s),
 		},
@@ -783,7 +784,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
+			labels.NewLabel(k8sconst.PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
 			labels.NewLabel("component", "redis", labels.LabelSourceK8s),
 			labels.NewLabel("tier", "cache", labels.LabelSourceK8s),
 		},

--- a/pkg/k8s/third_party.go
+++ b/pkg/k8s/third_party.go
@@ -222,6 +222,13 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 	return retRules, nil
 }
 
+// DeepCopy will return the same receiver of the DeepCopy function.
+// Deprecated
+func (cnp *CiliumNetworkPolicy) DeepCopy() *CiliumNetworkPolicy {
+	// FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME
+	return cnp
+}
+
 // CiliumNetworkPolicyList is a list of CiliumNetworkPolicy objects
 type CiliumNetworkPolicyList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/workloads/containerd/watcher.go
+++ b/pkg/workloads/containerd/watcher.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/k8s"
+	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/node"
@@ -197,7 +198,7 @@ func fetchK8sLabels(dockerLbls map[string]string) (map[string]string, error) {
 	if k8sLabels == nil {
 		return nil, nil
 	}
-	k8sLabels[k8s.PodNamespaceLabel] = ns
+	k8sLabels[k8sconst.PodNamespaceLabel] = ns
 	return k8sLabels, nil
 }
 


### PR DESCRIPTION
This PR was supposed to have a DeepCopy implementation of all the methods that are being used by cilium from the kubernetes watcher. Although, it end up being a clean up and some code refactoring. The actual PR with the DeepCopy implementation will be created on a follow up PR as well the FIXMEs on the 2 DeepCopy functions created.