### PR TITLE
bpf: Double timeout on building BPF programs

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -44,7 +44,7 @@ import (
 
 const (
 	// ExecTimeout is the execution timeout to use in join_ep.sh executions
-	ExecTimeout = 30 * time.Second
+	ExecTimeout = 60 * time.Second
 )
 
 func (e *Endpoint) writeL4Map(fw *bufio.Writer, owner Owner, m policy.L4PolicyMap, config string) error {


### PR DESCRIPTION
When a system is slow, or otherwise overloaded, the builds may take
longer. There isn't a fixed number however, so we are trying to be
forgiving.

Fixes https://github.com/cilium/cilium/issues/1653

I kept this simple, but it might be useful to have a backoff that goes up with timeouts, so we "discover" the optimum balance.