### PR TITLE
docs: move docs-container target to top level Makefile

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -26,9 +26,6 @@ check-requirements:
 	  echo "Run pip install sphinx-rtd-theme";  \
 	  exit 1)
 
-docs-container:
-	docker build -t cilium/docs-builder -f Documentation/Dockerfile .
-
 render:
 	-docker rm -f docs-cilium >/dev/null
 	cd .. && \

--- a/Makefile
+++ b/Makefile
@@ -205,5 +205,8 @@ update-authors:
 	@contrib/scripts/extract_authors.sh >> AUTHORS
 	@cat .AUTHORS.aux >> AUTHORS
 
+docs-container:
+	docker build -t cilium/docs-builder -f Documentation/Dockerfile .
+
 .PHONY: force
 force :;


### PR DESCRIPTION
Related: #1791 (docs: provide a Dockerfile for producing the PDF and HTML formats)
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>