### PR TITLE
Add ginkgo L4 policy tests

### DIFF
--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -424,7 +424,7 @@ var _ = Describe("RunPolicies", func() {
 			case "http6_private":
 				By(title("Client '%s' HttpReq to server '%s' private Ipv6"))
 				res := docker.ContainerExec(client, fmt.Sprintf(
-					"curl -s --fail --connect-timeout 3 http://%s:80/private", srvIP["IPv6"]))
+					"curl -s --fail --connect-timeout 3 http://[%s]:80/private", srvIP["IPv6"]))
 				ExpectWithOffset(1, res.WasSuccessful()).Should(assertFn(), fmt.Sprintf(
 					"Client '%s' can't curl to server '%s' private", client, srvIP["IPv6"]))
 			}

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -442,7 +442,7 @@ var _ = Describe("RunPolicies", func() {
 		// APP2 can't reach using TCP to HTTP2
 		connectivityTest([]string{"http", "http6"}, "app2", "httpd2", BeFalse)
 
-		// APP3 can reach using TCP HTTP2, but can't ping EGRESS
+		// APP3 can reach using TCP HTTP3, but can't ping EGRESS
 		connectivityTest([]string{"http", "http6"}, "app3", "httpd3", BeTrue)
 
 		By("Disabling all the policies. All should work")

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -390,12 +390,12 @@ var _ = Describe("RunPolicies", func() {
 			switch test {
 			case "ping":
 				By(title("Client '%s' pinging server '%s' IPv4"))
-				res := docker.ContainerExec(client, fmt.Sprintf("ping -c 4 %s", srvIP["IPv4"]))
+				res := docker.ContainerExec(client, fmt.Sprintf("ping -c 3 -W 2 %s", srvIP["IPv4"]))
 				ExpectWithOffset(1, res.WasSuccessful()).Should(assertFn(), fmt.Sprintf(
 					"Client '%s' can't ping to server '%s'", client, srvIP["IPv4"]))
 			case "ping6":
 				By(title("Client '%s' pinging server '%s' IPv6"))
-				res := docker.ContainerExec(client, fmt.Sprintf("ping6 -c 4 %s", srvIP["IPv6"]))
+				res := docker.ContainerExec(client, fmt.Sprintf("ping6 -c 3 -W 2 %s", srvIP["IPv6"]))
 				ExpectWithOffset(1, res.WasSuccessful()).Should(assertFn(), fmt.Sprintf(
 					"Client '%s' can't ping to server '%s'", client, srvIP["IPv6"]))
 			case "http":

--- a/test/runtime/manifests/Policies-l4-policy.json
+++ b/test/runtime/manifests/Policies-l4-policy.json
@@ -1,0 +1,27 @@
+[{
+    "endpointSelector": {
+        "matchLabels":{"id.httpd1":""}
+    },
+    "ingress": [{
+        "toPorts": [{
+            "ports": [
+                {"port": "80",   "protocol": "tcp"}
+            ]
+        }]
+    }]
+},
+{
+    "endpointSelector": {
+        "matchLabels":{"id.httpd2":""}
+    },
+    "ingress": [{
+        "fromEndpoints": [
+            {"matchLabels":{}}
+        ],
+        "toPorts": [{
+            "ports": [
+                {"port": "80",   "protocol": "tcp"}
+            ]
+        }]
+   }]
+}]


### PR DESCRIPTION
Perform some cleanups in the test/runtime/Policies ginkgo tests, then add a new category which tests the L4 policy behaviour.