### PR TITLE
Streamline ginkgo developer debugging

### DIFF
--- a/test/config/config.go
+++ b/test/config/config.go
@@ -18,7 +18,8 @@ import "flag"
 
 // CiliumTestConfigType holds all of the configurable elements of the testsuite
 type CiliumTestConfigType struct {
-	Reprovision bool
+	Reprovision     bool
+	HoldEnvironment bool
 }
 
 // CiliumTestConfig holds the global configuration of commandline flags
@@ -29,4 +30,6 @@ var CiliumTestConfig = CiliumTestConfigType{}
 func (c *CiliumTestConfigType) ParseFlags() {
 	flag.BoolVar(&c.Reprovision, "cilium.provision", true,
 		"Provision Vagrant boxes and Cilium before running test")
+	flag.BoolVar(&c.HoldEnvironment, "cilium.holdEnvironment", false,
+		"On failure, hold the environment in its current state")
 }

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -1,0 +1,32 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "flag"
+
+// CiliumTestConfigType holds all of the configurable elements of the testsuite
+type CiliumTestConfigType struct {
+	Reprovision bool
+}
+
+// CiliumTestConfig holds the global configuration of commandline flags
+// in the ginkgo-based testing environment.
+var CiliumTestConfig = CiliumTestConfigType{}
+
+// ParseFlags parses commandline flags relevant to testing.
+func (c *CiliumTestConfigType) ParseFlags() {
+	flag.BoolVar(&c.Reprovision, "cilium.provision", true,
+		"Provision Vagrant boxes and Cilium before running test")
+}

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -52,7 +52,11 @@ func init() {
 }
 
 func TestTest(t *testing.T) {
-	RegisterFailHandler(Fail)
+	if config.CiliumTestConfig.HoldEnvironment {
+		RegisterFailHandler(helpers.Fail)
+	} else {
+		RegisterFailHandler(Fail)
+	}
 	junitReporter := reporters.NewJUnitReporter(fmt.Sprintf(
 		"%s.xml", ginkgoext.GetScopeWithVersion()))
 	RunSpecsWithDefaultAndCustomReporters(

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -15,7 +15,6 @@
 package ciliumTest
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"time"
@@ -27,6 +26,7 @@ import (
 
 	"testing"
 
+	"github.com/cilium/cilium/test/config"
 	ginkgoext "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 	log "github.com/sirupsen/logrus"
@@ -36,10 +36,7 @@ var DefaultSettings map[string]string = map[string]string{
 	"K8S_VERSION": "1.7",
 }
 
-var (
-	vagrant     helpers.Vagrant
-	reprovision bool
-)
+var vagrant helpers.Vagrant
 
 func init() {
 	log.SetOutput(GinkgoWriter)
@@ -51,9 +48,7 @@ func init() {
 	for k, v := range DefaultSettings {
 		getOrSetEnvVar(k, v)
 	}
-
-	flag.BoolVar(&reprovision, "cilium.provision", true,
-		"Provision Vagrant boxes and Cilium before running test")
+	config.CiliumTestConfig.ParseFlags()
 }
 
 func TestTest(t *testing.T) {
@@ -103,7 +98,7 @@ func goReportVagrantStatus() chan bool {
 var _ = BeforeSuite(func() {
 	var err error
 
-	if !reprovision {
+	if !config.CiliumTestConfig.Reprovision {
 		// The developer has explicitly told us that they don't care
 		// about updating Cilium inside the guest, so skip setup below.
 		return


### PR DESCRIPTION
Perform some cleanups and streamline the experience for developers running the new ginkgo testing framework.

* new `ginkgo -- -cilium.holdEnvironment` flag which holds the vagrant environment on failure for debugging purposes
* Don't always print the cilium log on failure, instead point out how to get to it