### PR TITLE
[Ginkgo] Added resCmd.ExpectSuccess and ExpectFail helper functions

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/onsi/gomega"
 	"k8s.io/client-go/util/jsonpath"
 )
 
@@ -37,6 +38,20 @@ type CmdRes struct {
 //WasSuccessful returns true if the command was sucessful
 func (res *CmdRes) WasSuccessful() bool {
 	return res.exit
+}
+
+//ExpectFail make an assertion that checks command failed to execute
+//It accepts an optional parameter that can be used to annotate failure messages.
+func (res *CmdRes) ExpectFail(optionalDescription ...interface{}) bool {
+	return gomega.ExpectWithOffset(1, res.WasSuccessful()).Should(
+		gomega.BeFalse(), optionalDescription...)
+}
+
+//ExpectSucess make an assertion that checks command executes successfully
+//It accepts an optional parameter that can be used to annotate failure messages.
+func (res *CmdRes) ExpectSuccess(optionalDescription ...interface{}) bool {
+	return gomega.ExpectWithOffset(1, res.WasSuccessful()).Should(
+		gomega.BeTrue(), optionalDescription...)
 }
 
 //CountLines return the number of stdout lines

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -113,7 +113,7 @@ var _ = Describe("K8sPolicyTest", func() {
 		Expect(err).Should(BeNil())
 
 		status := kubectl.CiliumExec(ciliumPod, "cilium config PolicyEnforcement=default")
-		Expect(status.WasSuccessful()).Should(BeTrue())
+		status.ExpectSuccess()
 		helpers.Sleep(5)
 		kubectl.CiliumEndpointWait(ciliumPod)
 
@@ -136,7 +136,7 @@ var _ = Describe("K8sPolicyTest", func() {
 		By("Set PolicyEnforcement to always")
 
 		status = kubectl.CiliumExec(ciliumPod, "cilium config PolicyEnforcement=always")
-		Expect(status.WasSuccessful()).Should(BeTrue())
+		status.ExpectSuccess()
 		kubectl.CiliumEndpointWait(ciliumPod)
 
 		endpoints, err = kubectl.CiliumEndpointsListByTag(ciliumPod, podFilter)
@@ -148,7 +148,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 		By("Return PolicyEnforcement to default")
 		status = kubectl.CiliumExec(ciliumPod, "cilium config PolicyEnforcement=default")
-		Expect(status.WasSuccessful()).Should(BeTrue())
+		status.ExpectSuccess()
 		kubectl.CiliumEndpointWait(ciliumPod)
 
 		endpoints, err = kubectl.CiliumEndpointsListByTag(ciliumPod, podFilter)
@@ -170,7 +170,7 @@ var _ = Describe("K8sPolicyTest", func() {
 		Expect(err).Should(BeNil())
 
 		status := kubectl.CiliumExec(ciliumPod, "cilium config PolicyEnforcement=default")
-		Expect(status.WasSuccessful()).Should(BeTrue())
+		status.ExpectSuccess()
 		kubectl.CiliumEndpointWait(ciliumPod)
 
 		By("Testing L3/L4 rules")
@@ -200,14 +200,13 @@ var _ = Describe("K8sPolicyTest", func() {
 		trace := kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
 			"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 80",
 			appPods["app2"], appPods["app1"]))
-
-		Expect(trace.WasSuccessful()).Should(BeTrue(), trace.Output().String())
+		trace.ExpectSuccess(trace.Output().String())
 		Expect(trace.Output().String()).Should(ContainSubstring("Final verdict: ALLOWED"))
 
 		trace = kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
 			"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s",
 			appPods["app3"], appPods["app1"]))
-		Expect(trace.WasSuccessful()).Should(BeTrue())
+		trace.ExpectSuccess()
 		Expect(trace.Output().String()).Should(ContainSubstring("Final verdict: DENIED"))
 
 		_, err = kubectl.Exec(
@@ -220,7 +219,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 		eps = kubectl.CiliumEndpointPolicyVersion(ciliumPod)
 		status = kubectl.Delete(l3Policy)
-		Expect(status.WasSuccessful()).Should(BeTrue())
+		status.ExpectSuccess()
 		kubectl.CiliumEndpointWait(ciliumPod)
 
 		//Only 1 endpoint is affected by L7 rule
@@ -256,7 +255,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 		eps = kubectl.CiliumEndpointPolicyVersion(ciliumPod)
 		status = kubectl.Delete(l7Policy)
-		Expect(status.WasSuccessful()).Should(BeTrue())
+		status.ExpectSuccess()
 
 		//Only 1 endpoint is affected by L7 rule
 		err = waitUntilEndpointUpdates(ciliumPod, eps, 4)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -66,14 +66,14 @@ var _ = Describe("K8sServicesTest", func() {
 		Expect(govalidator.IsIP(svcIP.String())).Should(BeTrue())
 
 		status := kubectl.Node.Exec(fmt.Sprintf("curl http://%s/", svcIP))
-		Expect(status.WasSuccessful()).Should(BeTrue())
+		status.ExpectSuccess()
 
 		ciliumPod, err := kubectl.GetCiliumPodOnNode("kube-system", "k8s1")
 		Expect(err).Should(BeNil())
 
 		service := kubectl.CiliumExec(ciliumPod, "cilium service list")
 		Expect(service.Output()).Should(ContainSubstring(svcIP.String()))
-		Expect(service.WasSuccessful()).Should(BeTrue())
+		service.ExpectSuccess()
 
 	}, 300)
 
@@ -92,11 +92,11 @@ var _ = Describe("K8sServicesTest", func() {
 		Expect(govalidator.IsIP(svcIP.String())).Should(BeTrue())
 
 		status := kubectl.Node.Exec(fmt.Sprintf("curl http://%s/", svcIP))
-		Expect(status.WasSuccessful()).Should(BeTrue())
+		status.ExpectSuccess()
 
 		k8s2 := helpers.CreateKubectl("k8s2", logger)
 		status = k8s2.Node.Exec(fmt.Sprintf("curl http://%s/", svcIP))
-		Expect(status.WasSuccessful()).Should(BeTrue())
+		status.ExpectSuccess()
 	})
 
 	//TODO: Check service with IPV6

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -81,7 +81,7 @@ var _ = Describe("K8sTunnelTest", func() {
 			kubectl.CiliumReport("kube-system", ciliumPod, cmds)
 		}
 
-		Expect(status.WasSuccessful()).Should(BeTrue())
+		status.ExpectSuccess()
 		Expect(status.IntOutput()).Should(Equal(4))
 
 		By("Checking that BPF tunnels are working correctly")
@@ -109,7 +109,7 @@ var _ = Describe("K8sTunnelTest", func() {
 		//Check that cilium detects a
 		By("Checking that BPF tunnels are in place")
 		status := kubectl.CiliumExec(ciliumPod, "cilium bpf tunnel list | wc -l")
-		Expect(status.WasSuccessful()).Should(BeTrue())
+		status.ExpectSuccess()
 		if tunnels, _ := status.IntOutput(); tunnels != 4 {
 			cmds := []string{
 				"cilium bpf tunnel list",

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -45,7 +45,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 		docker.NetworkCreate(networkName, "")
 
 		res := cilium.PolicyEnforcementSet("default", false)
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 
 		initialized = true
 	}
@@ -70,7 +70,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 		BeforeEach(func() {
 			initialize()
 			res := cilium.PolicyEnforcementSet("default")
-			Expect(res.WasSuccessful()).Should(BeTrue())
+			res.ExpectSuccess()
 		})
 
 		It("Default values", func() {
@@ -99,7 +99,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			By("Setting to Always")
 
 			res := cilium.PolicyEnforcementSet("always", true)
-			Expect(res.WasSuccessful()).Should(BeTrue())
+			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -107,7 +107,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 
 			By("Setting to default from Always")
 			res = cilium.PolicyEnforcementSet("default", true)
-			Expect(res.WasSuccessful()).Should(BeTrue())
+			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -124,14 +124,14 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			//DEfault =APP with PolicyEnforcement
 
 			res := cilium.PolicyEnforcementSet("always", true)
-			Expect(res.WasSuccessful()).Should(BeTrue())
+			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
 			Expect(endPoints["enabled"]).To(Equal(1))
 
 			res = cilium.PolicyEnforcementSet("default", true)
-			Expect(res.WasSuccessful()).Should(BeTrue())
+			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -144,7 +144,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			Expect(endPoints["disabled"]).To(Equal(1))
 
 			res := cilium.PolicyEnforcementSet("never", true)
-			Expect(res.WasSuccessful()).Should(BeTrue())
+			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -165,14 +165,14 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			Expect(endPoints["enabled"]).To(Equal(1))
 
 			res := cilium.PolicyEnforcementSet("never", true)
-			Expect(res.WasSuccessful()).Should(BeTrue())
+			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
 			Expect(endPoints["enabled"]).To(Equal(0))
 
 			res = cilium.PolicyEnforcementSet("default", true)
-			Expect(res.WasSuccessful()).Should(BeTrue())
+			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -185,7 +185,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 		BeforeEach(func() {
 			initialize()
 			res := cilium.PolicyEnforcementSet("always", true)
-			Expect(res.WasSuccessful()).Should(BeTrue())
+			res.ExpectSuccess()
 		})
 
 		It("Container creation", func() {
@@ -219,14 +219,14 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			Expect(endPoints["disabled"]).To(Equal(0))
 
 			res := cilium.PolicyEnforcementSet("never", true)
-			Expect(res.WasSuccessful()).Should(BeTrue())
+			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
 			Expect(endPoints["enabled"]).To(Equal(0))
 
 			res = cilium.PolicyEnforcementSet("always", true)
-			Expect(res.WasSuccessful()).Should(BeTrue())
+			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -240,7 +240,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			Expect(endPoints["disabled"]).To(Equal(0))
 
 			res := cilium.PolicyEnforcementSet("never", true)
-			Expect(res.WasSuccessful()).Should(BeTrue())
+			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -248,7 +248,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			Expect(endPoints["disabled"]).To(Equal(1))
 
 			res = cilium.PolicyEnforcementSet("always", true)
-			Expect(res.WasSuccessful()).Should(BeTrue())
+			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -262,7 +262,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 		BeforeEach(func() {
 			initialize()
 			res := cilium.PolicyEnforcementSet("never")
-			Expect(res.WasSuccessful()).Should(BeTrue())
+			res.ExpectSuccess()
 		})
 
 		It("Container creation", func() {
@@ -296,7 +296,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			Expect(endPoints["disabled"]).To(Equal(1))
 
 			res := cilium.PolicyEnforcementSet("default", true)
-			Expect(res.WasSuccessful()).Should(BeTrue())
+			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -304,7 +304,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			Expect(endPoints["disabled"]).To(Equal(0))
 
 			res = cilium.PolicyEnforcementSet("never", true)
-			Expect(res.WasSuccessful()).Should(BeTrue())
+			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -319,7 +319,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			Expect(endPoints["disabled"]).To(Equal(1))
 
 			res := cilium.PolicyEnforcementSet("default", true)
-			Expect(res.WasSuccessful()).Should(BeTrue())
+			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -327,7 +327,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			Expect(endPoints["disabled"]).To(Equal(1))
 
 			res = cilium.PolicyEnforcementSet("never", true)
-			Expect(res.WasSuccessful()).Should(BeTrue())
+			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -356,7 +356,7 @@ var _ = Describe("RunPolicies", func() {
 
 		cilium.WaitUntilReady(100)
 		res := cilium.PolicyEnforcementSet("default", false)
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 		initialized = true
 
 	}
@@ -448,7 +448,7 @@ var _ = Describe("RunPolicies", func() {
 		By("Disabling all the policies. All should work")
 
 		status := cilium.Exec("policy delete --all")
-		Expect(status.WasSuccessful()).Should(BeTrue())
+		status.ExpectSuccess()
 		cilium.EndpointWaitUntilReady()
 
 		connectivityTest([]string{"ping", "ping6", "http", "http6"}, "app1", "httpd1", BeTrue)
@@ -537,7 +537,7 @@ var _ = Describe("RunPolicies", func() {
 
 		By("Disabling all the policies. All should work")
 		status := cilium.Exec("policy delete --all")
-		Expect(status.WasSuccessful()).Should(BeTrue())
+		status.ExpectSuccess()
 		cilium.EndpointWaitUntilReady()
 
 		connectivityTest([]string{"ping", "ping6", "http", "http6"}, "app1", "httpd1", BeTrue)
@@ -564,7 +564,7 @@ var _ = Describe("RunPolicies", func() {
 		By("Disabling all the policies. All should work")
 
 		status = cilium.Exec("policy delete --all")
-		Expect(status.WasSuccessful()).Should(BeTrue())
+		status.ExpectSuccess()
 		cilium.EndpointWaitUntilReady()
 
 		connectivityTest([]string{"ping", "ping6", "http", "http6"}, "app1", "httpd1", BeTrue)
@@ -645,29 +645,28 @@ var _ = Describe("RunPolicies", func() {
 		defer os.Remove("policy.json")
 		for _, v := range []string{"key1", "key2", "key3"} {
 			res := cilium.PolicyGet(v)
-			Expect(res.WasSuccessful()).Should(BeTrue(), fmt.Sprintf("Key %s can't get get", v))
+			res.ExpectSuccess(fmt.Sprintf("Key %s can't get get", v))
 		}
 
 		res := cilium.PolicyDel("key2")
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 
 		res = cilium.PolicyGet("key2")
-		Expect(res.WasSuccessful()).Should(BeFalse())
+		res.ExpectFail()
 
 		//Key1 and key3 should still exist. Test to delete it
 		for _, v := range []string{"key1", "key3"} {
 			res := cilium.PolicyGet(v)
-			Expect(res.WasSuccessful()).Should(BeTrue(), fmt.Sprintf(
-				"Key %s can't get get", v))
+			res.ExpectSuccess(fmt.Sprintf("Key %s can't get get", v))
 
 			res = cilium.PolicyDel(v)
-			Expect(res.WasSuccessful()).Should(BeTrue())
+			res.ExpectSuccess()
 		}
 		res = cilium.Exec("policy get")
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 
 		res = cilium.Exec("policy delete --all")
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 
 	})
 })

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -69,7 +69,7 @@ var _ = Describe("RuntimeChaosMonkey", func() {
 		http://localhost/v1beta/healthz/ | jq ".ipam.ipv4|length"`)
 
 		res := cilium.Node.Exec("sudo systemctl restart cilium")
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 
 		waitForCilium()
 
@@ -87,13 +87,12 @@ var _ = Describe("RuntimeChaosMonkey", func() {
 		_ = docker.Node.Exec("sudo ip link add lxc12345 type veth peer name tmp54321")
 
 		res := cilium.Node.Exec("sudo systemctl restart cilium")
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 
 		waitForCilium()
 
 		status := docker.Node.Exec("sudo ip link show lxc12345")
-		Expect(status.WasSuccessful()).Should(BeFalse(),
-			"leftover interface were not properly cleaned up")
+		status.ExpectFail("leftover interface were not properly cleaned up")
 
 		links, err := docker.Node.Exec("sudo ip link show | wc -l").IntOutput()
 		Expect(links).Should(Equal(originalLinks),

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -63,17 +63,18 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 
 		By("Client can ping to server IPV6")
 		res := docker.ContainerExec("client", fmt.Sprintf("ping6 -c 4 %s", serverIPv6))
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 
 		By("Client can ping to server Ipv4")
 		res = docker.ContainerExec("client", fmt.Sprintf("ping -c 5 %s", serverIP))
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 
 		By("Netperf to server from client IPv6")
 		cmd := fmt.Sprintf(
 			"netperf -c -C -t TCP_SENDFILE -H %s", serverIPv6)
 		res = docker.ContainerExec("client", cmd)
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
+
 	}, 300)
 
 	It("Test containers connectivity WITH policy", func() {
@@ -89,21 +90,21 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 
 		By("Client can ping to server IPV6")
 		res := docker.ContainerExec("client", fmt.Sprintf("ping6 -c 4 %s", serverIPv6))
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 
 		By("Client can ping to server Ipv4")
 		res = docker.ContainerExec("client", fmt.Sprintf("ping -c 5 %s", serverIP))
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 
 		By("Netperf to server from client IPv6")
 		cmd := fmt.Sprintf(
 			"netperf -c -C -t TCP_SENDFILE -H %s", serverIPv6)
 		res = docker.ContainerExec("client", cmd)
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 
 		By("Ping from host to server")
 		res = docker.Node.Exec(fmt.Sprintf("ping -c 4 %s", serverIP))
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 	}, 300)
 
 	It("Test containers NAT46 connectivity ", func() {
@@ -122,11 +123,11 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 
 		res := docker.ContainerExec("client", fmt.Sprintf(
 			"ping6 -c 4 ::FFFF:%s", server["IPv4"]))
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 
 		res = docker.ContainerExec("server", fmt.Sprintf(
 			"ping6 -c 4 ::FFFF:%s", client["IPv4"]))
-		Expect(res.WasSuccessful()).Should(BeFalse(), "Unexpected NAT46 access")
+		res.ExpectFail("Unexpected NAT46 access")
 	})
 })
 

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -46,7 +46,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		docker.NetworkCreate(networkName, "")
 
 		res := cilium.PolicyEnforcementSet("default", false)
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 
 		initialized = true
 	}
@@ -62,7 +62,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 	It("Cilium monitor verbose mode", func() {
 
 		res := cilium.Exec("config Debug=true DropNotification=true TraceNotification=true")
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 
 		ctx, cancel := context.WithCancel(context.Background())
 
@@ -88,7 +88,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		}
 
 		res := cilium.Exec("config Debug=true DropNotification=true TraceNotification=true")
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 		for k, v := range eventTypes {
 			By(fmt.Sprintf("Type %s", k))
 
@@ -107,7 +107,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 
 	It("cilium monitor check --from", func() {
 		res := cilium.Exec("config Debug=true DropNotification=true TraceNotification=true")
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 
 		docker.SampleContainersActions("create", networkName)
 		endpoints, err := cilium.GetEndpointsIds()
@@ -133,7 +133,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 
 		res := cilium.Exec(
 			"config Debug=true DropNotification=true TraceNotification=true PolicyEnforcement=always")
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 
 		docker.SampleContainersActions("create", networkName)
 		endpoints, err := cilium.GetEndpointsIds()
@@ -158,7 +158,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 
 		res := cilium.Exec(
 			"config Debug=true DropNotification=true TraceNotification=true PolicyEnforcement=always")
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 
 		docker.SampleContainersActions("create", networkName)
 		endpoints, err := cilium.GetEndpointsIds()
@@ -181,7 +181,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 
 		res := cilium.Exec(
 			"config Debug=true DropNotification=true TraceNotification=true PolicyEnforcement=default")
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		res.ExpectSuccess()
 
 		var monitorRes []*helpers.CmdRes
 


### PR DESCRIPTION
Hello! 

An improvement on the ginkgo tests, instead using a bunch of: 

```
Expect(status.WasSuccessful()).Should(BeTrue())
```

I added the assertion on the ResCMD helper, so it's easy to write tests. On the helper functions, I used ExpectWithOffset, so the fail will be in the parent function. 

Regards.  
