### PR TITLE
test: fix sending to nil channel

### DIFF
--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -109,8 +109,9 @@ var _ = BeforeSuite(func() {
 		return
 	}
 
-	progressChan := goReportVagrantStatus()
-	defer func() { progressChan <- err == nil }()
+	if progressChan := goReportVagrantStatus(); progressChan != nil {
+		defer func() { progressChan <- err == nil }()
+	}
 
 	switch ginkgoext.GetScope() {
 	case "runtime":


### PR DESCRIPTION
If goReportVagrantStatus() returns a nil channel, don't send to it as this blocks infinitely.
    
Signed-off by: Ian Vernon <ian@cilium.io>