### PR TITLE
Improve ginkgo test failure readability.

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -320,11 +320,7 @@ func (c *Cilium) ReportFailed(commands ...string) {
 	wr := c.logCxt.Logger.Out
 	fmt.Fprint(wr, "StackTrace Begin\n")
 
-	//FIXME: Ginkgo PR383 add here --since option
-	res := c.Node.Exec("sudo journalctl --no-pager -u cilium")
-	fmt.Fprint(wr, res.Output())
-
-	res = c.Node.Exec("sudo cilium endpoint list")
+	res := c.Node.Exec("sudo cilium endpoint list")
 	fmt.Fprint(wr, res.Output())
 
 	for _, cmd := range commands {
@@ -332,6 +328,10 @@ func (c *Cilium) ReportFailed(commands ...string) {
 		res = c.Node.Exec(fmt.Sprintf("%s", cmd))
 		fmt.Fprint(wr, res.Output())
 	}
+	//FIXME: Ginkgo Issue 383: add here "--since" option
+	logCmd := "sudo journalctl --no-pager -u cilium"
+	fmt.Fprintf(wr, "Logs can be gathered by running '%s' in vagrant\n", logCmd)
+	fmt.Fprint(wr, "Consider debugging the live environment using \"ginkgo -- -cilium.holdEnvironment\"\n")
 	fmt.Fprint(wr, "StackTrace Ends\n")
 }
 


### PR DESCRIPTION
Split out from original patch in #1975 so that this change could be independently reviewed and debated.

One of the pain points for developers using the runtime testsuites is that the directly relevant information about the failure is split in half, with a giant Cilium log in the middle, eg:

```
------------------------------
• Failure [33.489 seconds]
RunPolicies
/home/joe/work/src/github.com/cilium/cilium/test/runtime/Policies.go:340
  L4Policy Checks [It]
  /home/joe/work/src/github.com/cilium/cilium/test/runtime/Policies.go:524

  Client 'app1' can't ping to server '10.15.13.37'
  Expected
      <bool>: false
  to be true

  /home/joe/work/src/github.com/cilium/cilium/test/runtime/Policies.go:529
------------------------------
level=info msg=Starting test=RunPolicies
level=info msg="Docker: set target to 'runtime'" test=RunPolicies
level=info msg="Cilium: set target to 'runtime'" test=RunPolicies
level=info msg="Cilium status is true" test=RunPolicies
level=info msg="Endpoints are not ready valid='4' invalid='2'" EndpointWaitReady= test=RunPolicies
level=info msg="PolicyImport: /vagrant//runtime/manifests/Policies-l4-policy.json and current policy revision is '7'" test=RunPolicies
level=info msg="PolicyImport: finished '/vagrant//runtime/manifests/Policies-l4-policy.json' with revision '8'" test=RunPolicies
STEP: Client 'app1' pinging server 'httpd1' IPv4
StackTrace Begin

*** Cilium log ***

ENDPOINT   POLICY        IDENTITY   LABELS (source:key[=value])   IPv6            IPv4            STATUS
           ENFORCEMENT 
3978       Disabled      274        container:id.app2             f00d::a0f:0:0:f8a    10.15.251.95    ready
4314       Disabled      278        container:id.app3             f00d::a0f:0:0:10da   10.15.25.58     ready
15124      Disabled      279        container:id.httpd3           f00d::a0f:0:0:3b14   10.15.195.213   ready
                                    container:id.service1 
25729      Disabled      275        container:id.app1             f00d::a0f:0:0:6481   10.15.101.61    ready
48896      Enabled       276        container:id.httpd1           f00d::a0f:0:0:bf00   10.15.13.37     ready
                                    container:id.service1 
60670      Enabled       277        container:id.httpd2           f00d::a0f:0:0:ecfe   10.15.167.158   ready
                                    container:id.service1 
StackTrace Ends
SSSSSSSS

Summarizing 1 Failure:

[Fail] RunPolicies [It] L4Policy Checks 
/home/joe/work/src/github.com/cilium/cilium/test/runtime/Policies.go:529

Ran 1 of 41 Specs in 33.491 seconds
FAIL! -- 0 Passed | 1 Failed | 0 Pending | 40 Skipped --- FAIL: TestTest (33.49s)
FAIL

Ginkgo ran 1 suite in 35.326556304s
Test Suite Failed
```

When running the ginkgo tests locally, the Cilium logs get in the way of seeing the actual error, for example `Expected <bool> false to be true`. In a lot of cases, the error itself may be revealing enough so that the developer working on the test can understand what the problem is without looking through the Cilium logs. Furthermore, when running locally, it's much easier for a developer to open the Cilium log separately in an editor that allows better search, highlight, etc. capabilities.

There is currently a ginkgo PR open (https://github.com/onsi/ginkgo/pull/383) to allow us to restrict the length of these Cilium logs to only those since the beginning of the current testrun (or, a particular point in time). This will independently be useful to allow us to filter out irrelevant logs from previous test runs. However, even with this kind of functionality, if we continue to print the logs directly to the terminal upon failure, then it is still possible for the Cilium logs to be very long, in which case we still have the developer pain point described above.

The proposed patch here replaces the printout of the actual log with a pointer about how to get the logs. It could be extended so that when running in a Jenkins environment, it gives different instructions (perhaps even with a link to the relevant path to fetch the logs, for example).