### PR TITLE
tests/k8s/Vagrantfile: bump K8s VM ram to 3 GB

### DIFF
--- a/tests/k8s/Vagrantfile
+++ b/tests/k8s/Vagrantfile
@@ -89,7 +89,7 @@ Vagrant.configure(2) do |config|
 		# Do not inherit DNS server from host, use proxy
 		vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
 		vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
-
+                vb.memory = 3072
                 config.vm.synced_folder '../../', '/home/vagrant/go/src/github.com/cilium/cilium'
             end
 

--- a/tests/k8s/Vagrantfile
+++ b/tests/k8s/Vagrantfile
@@ -86,9 +86,9 @@ Vagrant.configure(2) do |config|
             s.vm.provision "ssh_accept_env", type: "shell", privileged: true, inline: $install_sshd_env
 
             s.vm.provider "virtualbox" do |vb|
-		# Do not inherit DNS server from host, use proxy
-		vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
-		vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+                # Do not inherit DNS server from host, use proxy
+                vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+                vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
                 vb.memory = 3072
                 config.vm.synced_folder '../../', '/home/vagrant/go/src/github.com/cilium/cilium'
             end


### PR DESCRIPTION
There have been Jenkins builds which fail due to thrashing in the K8s build.
The VMs currently only have 1 GB of RAM, which is not enough for running
Kubernetes, etcd, and Cilium as well as application pods.

Signed-off by: Ian Vernon <ian@cilium.io>