### PR TITLE
Add script to display output of state of processes on Jenkins agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,7 @@ pipeline {
     }
     post {
         always {
+            sh './test/post_build_agent.sh || true'
             sh './tests/copy_files || true'
             archiveArtifacts artifacts: "cilium-files-runtime-${JOB_BASE_NAME}-${BUILD_NUMBER}.tar.gz", allowEmptyArchive: true
             sh './tests/k8s/copy_files || true'

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -52,6 +52,7 @@ pipeline {
                     junit 'test/*.xml'
                     // Temporary workaround to test cleanup
                     // rm -rf ${GOPATH}/src/github.com/cilium/cilium
+                    sh 'cd test/; ./post_build_agent.sh || true'                    
                     sh 'cd test/; vagrant destroy -f'
                     sh 'cd test/; K8S_VERSION=1.6 vagrant destroy -f'
                 }

--- a/test/post_build_agent.sh
+++ b/test/post_build_agent.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "output of following commands are ran on the Jenkins agent itself"
+echo "output of: \"ps -ef | grep -i vbox\" "
+ps -ef | grep -i vbox
+
+echo "output of: \"ps -ef | grep -i vagrant\" "
+ps -ef | grep -i vagrant
+
+echo "output of: \"VBoxManage list runningvms\" "
+VBoxManage list runningvms
+
+echo "output of: \"VBoxManage list intnets\" "
+VBoxManage list intnets


### PR DESCRIPTION
Run a script as part of the post build actions in both the Ginkgo / Bash-script based builds to give information about state of the nodes. This is done in hopes of providing debugging information in case Vagrant / VirtualBox misbehaves.

Signed-off by: Ian Vernon <ian@cilium.io>