### PR TITLE
Mark cilium pod as CriticalPod in the DaemonSet

### DIFF
--- a/examples/kubernetes/cilium.yaml
+++ b/examples/kubernetes/cilium.yaml
@@ -75,6 +75,11 @@ spec:
         k8s-app: cilium
         kubernetes.io/cluster-service: "true"
       annotations:
+        # This annotation plus the CriticalAddonsOnly toleration makes
+        # cilium to be a critical pod in the cluster, which ensures cilium
+        # gets priority scheduling.
+        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: >-
           [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
     spec:
@@ -194,6 +199,9 @@ spec:
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
+      # Mark cilium's pod as critical for rescheduling
+      - key: CriticalAddonsOnly
+        operator: "Exists"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/test/k8sT/manifests/1.6/cilium_ds.yaml
+++ b/test/k8sT/manifests/1.6/cilium_ds.yaml
@@ -91,6 +91,12 @@ spec:
       labels:
         k8s-app: cilium
         kubernetes.io/cluster-service: "true"
+      annotations:
+        # This annotation plus the CriticalAddonsOnly toleration makes
+        # cilium to be a critical pod in the cluster, which ensures cilium
+        # gets priority scheduling.
+        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
       - image: k8s1:5000/cilium/cilium-dev:latest
@@ -185,3 +191,6 @@ spec:
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
+      # Mark cilium's pod as critical for rescheduling
+      - key: CriticalAddonsOnly
+        operator: "Exists"

--- a/test/k8sT/manifests/1.6/cilium_ds_geneve.yaml
+++ b/test/k8sT/manifests/1.6/cilium_ds_geneve.yaml
@@ -91,6 +91,12 @@ spec:
       labels:
         k8s-app: cilium
         kubernetes.io/cluster-service: "true"
+      annotations:
+        # This annotation plus the CriticalAddonsOnly toleration makes
+        # cilium to be a critical pod in the cluster, which ensures cilium
+        # gets priority scheduling.
+        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
       - image: k8s1:5000/cilium/cilium-dev:latest
@@ -185,3 +191,6 @@ spec:
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
+      # Mark cilium's pod as critical for rescheduling
+      - key: CriticalAddonsOnly
+        operator: "Exists"

--- a/test/k8sT/manifests/1.7/cilium_ds.yaml
+++ b/test/k8sT/manifests/1.7/cilium_ds.yaml
@@ -91,6 +91,12 @@ spec:
       labels:
         k8s-app: cilium
         kubernetes.io/cluster-service: "true"
+      annotations:
+        # This annotation plus the CriticalAddonsOnly toleration makes
+        # cilium to be a critical pod in the cluster, which ensures cilium
+        # gets priority scheduling.
+        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
       - image: k8s1:5000/cilium/cilium-dev:latest
@@ -185,3 +191,6 @@ spec:
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
+        # Mark cilium's pod as critical for rescheduling
+      - key: CriticalAddonsOnly
+        operator: "Exists"

--- a/test/k8sT/manifests/1.7/cilium_ds_geneve.yaml
+++ b/test/k8sT/manifests/1.7/cilium_ds_geneve.yaml
@@ -91,6 +91,12 @@ spec:
       labels:
         k8s-app: cilium
         kubernetes.io/cluster-service: "true"
+      annotations:
+        # This annotation plus the CriticalAddonsOnly toleration makes
+        # cilium to be a critical pod in the cluster, which ensures cilium
+        # gets priority scheduling.
+        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
       - image: k8s1:5000/cilium/cilium-dev:latest
@@ -185,3 +191,6 @@ spec:
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
+      # Mark cilium's pod as critical for rescheduling
+      - key: CriticalAddonsOnly
+        operator: "Exists"

--- a/tests/k8s/cluster/cilium/cilium-lb-ds.yaml.sed
+++ b/tests/k8s/cluster/cilium/cilium-lb-ds.yaml.sed
@@ -9,6 +9,13 @@ spec:
       labels:
         k8s-app: cilium
         kubernetes.io/cluster-service: "true"
+      annotations:
+       # This annotation plus the CriticalAddonsOnly toleration makes
+       # cilium to be a critical pod in the cluster, which ensures cilium
+       # gets priority scheduling.
+       # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+
     spec:
       serviceAccountName: cilium
       containers:
@@ -86,3 +93,7 @@ spec:
         - name: etc-cni-netd
           hostPath:
               path: /etc/cni/net.d
+      tolerations:
+      # Mark cilium's pod as critical for rescheduling
+      - key: CriticalAddonsOnly
+        operator: "Exists"


### PR DESCRIPTION
We experienced the cilium pod getting evicted away due to nodefs pressure.
We should mark the pod as critical (the requirement for it is to run
in the kube-system namespace) as cilium is required for the
operating of all other pods on the node.

Fixes #1428

Signed-off-by: Manali Bhutiyani <manali@covalent.io>


```release-note
Mark cilium pod as CriticalPod in the DaemonSet
```