### PR TITLE
[Ginkgo] Report  on Fail

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -117,27 +117,32 @@ const (
 	PingCount          = 5
 	CurlConnectTimeout = 5
 
-	DefaultNamespace                     = "default"
-	KubeSystemNamespace                  = "kube-system"
-	testResultsPath                      = "test_results/"
-	testResultsPath                      = "test_results/"
-	runDir                               = "/var/run/cilium"
-	libDir                               = "/var/lib/cilium"
-	agentDaemon                          = "cilium-agent"
-	daemonName                           = "cilium"
-	dockerDaemonName                     = "cilium-docker"
-	timeout                time.Duration = 300 //WithTimeout helper translate it to seconds
-	basePath                             = "/vagrant/"
-	networkName                          = "cilium-net"
-	testResultsPath                      = "test_results/"
-	runDir                               = "/var/run/cilium"
-	libDir                               = "/var/lib/cilium"
-	agentDaemon                          = "cilium-agent"
-	daemonName                           = "cilium"
-	ciliumDockerDaemonName               = "cilium-docker"
+	DefaultNamespace    = "default"
+	KubeSystemNamespace = "kube-system"
+
+	TestResultsPath = "test_results/"
+	RunDir          = "/var/run/cilium"
+	LibDir          = "/var/lib/cilium"
+
+	DaemonName             = "cilium"
+	CiliumDockerDaemonName = "cilium-docker"
+	AgentDaemon            = "cilium-agent"
 )
 
 var ciliumCLICommands = map[string]string{
+	"cilium endpoint list -o json":   "endpoint_list_txt",
+	"cilium service list -o json":    "service_list.txt",
+	"cilium config":                  "config.txt",
+	"sudo cilium bpf lb list":        "bpf_lb_list.txt",
+	"sudo cilium bpf ct list global": "bpf_ct_list.txt",
+	"sudo cilium bpf tunnel list":    "bpf_tunnel_list.txt",
+	"cilium policy get":              "policy_get.txt",
+	"cilium status":                  "status.txt",
+}
+
+// ciliumKubCLICommands these commands are the same as `ciliumCLICommands` but
+// it'll run inside a container and it does not have sudo support
+var ciliumKubCLICommands = map[string]string{
 	"cilium endpoint list -o json": "endpoint_list_txt",
 	"cilium service list -o json":  "service_list.txt",
 	"cilium config":                "config.txt",

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -117,18 +117,27 @@ const (
 	PingCount          = 5
 	CurlConnectTimeout = 5
 
-	DefaultNamespace    = "default"
-	KubeSystemNamespace = "kube-system"
-	testResultsPath     = "test_results/"
-	testResultsPath     = "test_results/"
-	runDir              = "/var/run/cilium"
-	libDir              = "/var/lib/cilium"
-	agentDaemon         = "cilium-agent"
-	daemonName          = "cilium"
-	dockerDaemonName    = "cilium-docker"
+	DefaultNamespace                     = "default"
+	KubeSystemNamespace                  = "kube-system"
+	testResultsPath                      = "test_results/"
+	testResultsPath                      = "test_results/"
+	runDir                               = "/var/run/cilium"
+	libDir                               = "/var/lib/cilium"
+	agentDaemon                          = "cilium-agent"
+	daemonName                           = "cilium"
+	dockerDaemonName                     = "cilium-docker"
+	timeout                time.Duration = 300 //WithTimeout helper translate it to seconds
+	basePath                             = "/vagrant/"
+	networkName                          = "cilium-net"
+	testResultsPath                      = "test_results/"
+	runDir                               = "/var/run/cilium"
+	libDir                               = "/var/lib/cilium"
+	agentDaemon                          = "cilium-agent"
+	daemonName                           = "cilium"
+	ciliumDockerDaemonName               = "cilium-docker"
 )
 
-var reportCommands = map[string]string{
+var ciliumCLICommands = map[string]string{
 	"cilium endpoint list -o json": "endpoint_list_txt",
 	"cilium service list -o json":  "service_list.txt",
 	"cilium config":                "config.txt",

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -119,6 +119,7 @@ const (
 
 	DefaultNamespace    = "default"
 	KubeSystemNamespace = "kube-system"
+	testResultsPath     = "test_results/"
 )
 
 //GetFilePath returns the absolute path of the provided filename

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -120,7 +120,24 @@ const (
 	DefaultNamespace    = "default"
 	KubeSystemNamespace = "kube-system"
 	testResultsPath     = "test_results/"
+	testResultsPath     = "test_results/"
+	runDir              = "/var/run/cilium"
+	libDir              = "/var/lib/cilium"
+	agentDaemon         = "cilium-agent"
+	daemonName          = "cilium"
+	dockerDaemonName    = "cilium-docker"
 )
+
+var reportCommands = map[string]string{
+	"cilium endpoint list -o json": "endpoint_list_txt",
+	"cilium service list -o json":  "service_list.txt",
+	"cilium config":                "config.txt",
+	"cilium bpf lb list":           "bpf_lb_list.txt",
+	"cilium bpf ct list global":    "bpf_ct_list.txt",
+	"cilium bpf tunnel list":       "bpf_tunnel_list.txt",
+	"cilium policy get":            "policy_get.txt",
+	"cilium status":                "status.txt",
+}
 
 //GetFilePath returns the absolute path of the provided filename
 func GetFilePath(filename string) string {

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -142,7 +142,7 @@ func Fail(description string, callerSkip ...int) {
 
 // ReportDirectory creates and returns the directory path to export all report
 // commands that need to be run in the that a test has failed.
-// If dir can not be created it'll return an error
+// If the directory cannot be created it'll return an error
 func ReportDirectory() (string, error) {
 	testDesc := ginkgo.CurrentGinkgoTestDescription()
 	testPath := fmt.Sprintf("%s%s/",
@@ -151,23 +151,22 @@ func ReportDirectory() (string, error) {
 	if _, err := os.Stat(testPath); err == nil {
 		return testPath, nil
 	}
-	err := os.MkdirAll(testPath, 0777)
+	err := os.MkdirAll(testPath, os.ModePerm)
 	return testPath, err
 }
 
-//reportMap saves the output of the commands in the filename to which they map
-//to in reportCmds
-// Function needs the directory path where the files are going to be written and
-// a node. instance to execute the commands
+// reportMap saves the output of the given commands to the specified filename.
+// Function needs a directory path where the files are going to be written and
+// a *Node instance to execute the commands
 func reportMap(path string, reportCmds map[string]string, node *Node) {
 	for cmd, logfile := range reportCmds {
 		res := node.Exec(cmd)
 		err := ioutil.WriteFile(
 			fmt.Sprintf("%s/%s", path, logfile),
 			res.CombineOutput().Bytes(),
-			0777)
+			os.ModePerm)
 		if err != nil {
-			log.WithError(err).Errorf("Cannot create test results for command '%s'", cmd)
+			log.WithError(err).Errorf("cannot create test results for command '%s'", cmd)
 		}
 	}
 }

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -141,7 +141,7 @@ func Fail(description string, callerSkip ...int) {
 }
 
 // ReportDirectory creates and returns the directory path to export all report
-// commands that need to be run in case of fail.
+// commands that need to be run in the that a test has failed.
 // If dir can not be created it'll return an error
 func ReportDirectory() (string, error) {
 	testDesc := ginkgo.CurrentGinkgoTestDescription()
@@ -155,8 +155,10 @@ func ReportDirectory() (string, error) {
 	return testPath, err
 }
 
-//reportMap get a path, a map with command and output file and a node instance,
-//run the commands and save the output in the defined file
+//reportMap saves the output of the commands in the filename to which they map
+//to in reportCmds
+// Function needs the directory path where the files are going to be written and
+// a node. instance to execute the commands
 func reportMap(path string, reportCmds map[string]string, node *Node) {
 	for cmd, logfile := range reportCmds {
 		res := node.Exec(cmd)
@@ -165,7 +167,7 @@ func reportMap(path string, reportCmds map[string]string, node *Node) {
 			res.CombineOutput().Bytes(),
 			0777)
 		if err != nil {
-			log.Errorf("Can not create test results for command '%s' err='%s'", cmd, err)
+			log.WithError(err).Errorf("Cannot create test results for command '%s'", cmd)
 		}
 	}
 }

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -141,12 +141,12 @@ func Fail(description string, callerSkip ...int) {
 }
 
 // ReportDirectory creates and returns the directory path to export all report
-// commands that need to be run in the that a test has failed.
+// commands that need to be run in the case that a test has failed.
 // If the directory cannot be created it'll return an error
 func ReportDirectory() (string, error) {
 	testDesc := ginkgo.CurrentGinkgoTestDescription()
 	testPath := fmt.Sprintf("%s%s/",
-		testResultsPath,
+		TestResultsPath,
 		strings.Replace(testDesc.FullTestText, " ", "", -1))
 	if _, err := os.Stat(testPath); err == nil {
 		return testPath, nil
@@ -157,8 +157,13 @@ func ReportDirectory() (string, error) {
 
 // reportMap saves the output of the given commands to the specified filename.
 // Function needs a directory path where the files are going to be written and
-// a *Node instance to execute the commands
-func reportMap(path string, reportCmds map[string]string, node *Node) {
+// a *SSHMeta instance to execute the commands
+func reportMap(path string, reportCmds map[string]string, node *SSHMeta) {
+	if node == nil {
+		log.Errorf("cannot execute reportMap due invalid node instance")
+		return
+	}
+
 	for cmd, logfile := range reportCmds {
 		res := node.Exec(cmd)
 		err := ioutil.WriteFile(

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -68,6 +68,11 @@ var _ = Describe("RuntimeMonitorTest", func() {
 	})
 
 	AfterEach(func() {
+
+		if CurrentGinkgoTestDescription().Failed {
+			cilium.ReportFailed()
+		}
+
 		docker.SampleContainersActions(helpers.Delete, helpers.CiliumDockerNetwork)
 	})
 

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -154,6 +154,8 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
+
+	var destroy bool = true
 	if !helpers.IsRunningOnJenkins() {
 		log.Infof("AfterSuite: not running on Jenkins; leaving VMs running for debugging")
 		return

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -154,8 +154,6 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-
-	var destroy bool = true
 	if !helpers.IsRunningOnJenkins() {
 		log.Infof("AfterSuite: not running on Jenkins; leaving VMs running for debugging")
 		return


### PR DESCRIPTION
Hello, 


First POC of the work related to task #2026, mainly I created two new helpers functions `cilium.ReportFailedFull` and `kubectl.ReportFailedFull`. Both functions dump all cilium related information to the test name directory. My proposal is: 

- In case of a fail, report it with a custom command (`cilium.ReportFailed`), that info will be stored into the GinkgoWriter and show in the JUnit xml output. It'll be the fast error checking 
-  ReportFailed function calls ReportFailedFull func, and the files will be generated for deep inspection in case of Junit output is not enough.
