### PR TITLE
test: change import path for k8s API

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/api/core/v1"
 )
 
 var _ = Describe("K8sServicesTest", func() {


### PR DESCRIPTION
Signed-off by: Ian Vernon <ian@cilium.io>

After the updating of dependencies in the Cilium repository, the Ginkgo tests have been failing due to a change in the imports that was not made accordingly.

Example failed build: https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/152/execution/node/45/log/