### PR TITLE
[Ginkgo] Fix issue with vagrant user

### DIFF
--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -29,5 +29,6 @@ else
         systemctl enable $service || echo "service $service failed"
         systemctl restart $service || echo "service $service failed to restart"
     done
+    echo "running \"sudo adduser vagrant cilium\" "
+    sudo adduser vagrant cilium
 fi
-sudo adduser vagrant cilium


### PR DESCRIPTION
On Kubernetes boxes cilium group doesn't exits, so it was failing in
case of kubernetes test.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>