### PR TITLE
V0.12 backport for : Mark cilium pod as CriticalPod in the DaemonSet

### DIFF
--- a/examples/kubernetes/cilium.yaml
+++ b/examples/kubernetes/cilium.yaml
@@ -75,6 +75,11 @@ spec:
         k8s-app: cilium
         kubernetes.io/cluster-service: "true"
       annotations:
+        # This annotation plus the CriticalAddonsOnly toleration makes
+        # cilium to be a critical pod in the cluster, which ensures cilium
+        # gets priority scheduling.
+        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: >-
           [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
     spec:
@@ -194,6 +199,9 @@ spec:
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
+      # Mark cilium's pod as critical for rescheduling
+      - key: CriticalAddonsOnly
+        operator: "Exists"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/tests/k8s/cluster/cilium/cilium-lb-ds.yaml.sed
+++ b/tests/k8s/cluster/cilium/cilium-lb-ds.yaml.sed
@@ -9,6 +9,13 @@ spec:
       labels:
         k8s-app: cilium
         kubernetes.io/cluster-service: "true"
+      annotations:
+       # This annotation plus the CriticalAddonsOnly toleration makes
+       # cilium to be a critical pod in the cluster, which ensures cilium
+       # gets priority scheduling.
+       # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+
     spec:
       serviceAccountName: cilium
       containers:
@@ -86,3 +93,7 @@ spec:
         - name: etc-cni-netd
           hostPath:
               path: /etc/cni/net.d
+      tolerations:
+      # Mark cilium's pod as critical for rescheduling
+      - key: CriticalAddonsOnly
+        operator: "Exists"


### PR DESCRIPTION
We experienced the cilium pod getting evicted away due to nodefs pressure.
We should mark the pod as critical (the requirement for it is to run
in the kube-system namespace) as cilium is required for the
operating of all other pods on the node.

Addresses Issue #1428

Backports: 552cf142d695da25a4b8bce9ab1c847a232d8707

Signed-off-by: Manali Bhutiyani <manali@covalent.io>