### PR TITLE
Ginkgo:  Fix issue with timeouts fix #2050

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -16,11 +16,10 @@ package helpers
 
 import (
 	"fmt"
-	"time"
 )
 
 var (
-	timeout     = 300 * time.Second
+	timeout     = 300 //WithTimeout helper translate it to seconds
 	basePath    = "/vagrant/"
 	networkName = "cilium-net"
 )

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -315,7 +315,7 @@ func (kub *Kubectl) CiliumNodesWait() (bool, error) {
 	}
 	err := WithTimeout(body, "k8s nodes does not have cilium metadata", &TimeoutConfig{Timeout: timeout})
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 	return true, nil
 }


### PR DESCRIPTION
helpers.timeout was set as time.Seconds and need to as a int.
Return error on kubectl.CiliumNodesWait

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
