### PR TITLE
Fix issue with helpers.cons.timeout

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -16,12 +16,13 @@ package helpers
 
 import (
 	"fmt"
+	"time"
 )
 
 var (
-	timeout     = 300 //WithTimeout helper translate it to seconds
-	basePath    = "/vagrant/"
-	networkName = "cilium-net"
+	timeout     time.Duration = 300 //WithTimeout helper translate it to seconds
+	basePath                  = "/vagrant/"
+	networkName               = "cilium-net"
 )
 
 //GetFilePath returns the absolute path of the provided filename


### PR DESCRIPTION
Hi, 

Sorry, I made a typo in the PR 2054, the timeout accepts numbers but is not int, need to be `time.Duration`. 

Related issue: 
```
12:08:22 [K8s-1.7] Failed to compile test:
12:08:22 [K8s-1.7] 
12:08:22 [K8s-1.7] # github.com/cilium/cilium/test/helpers
12:08:22 [K8s-1.7] helpers/kubectl.go:266:77: cannot use timeout (type int) as type time.Duration in field value
12:08:22 [K8s-1.7] helpers/kubectl.go:316:92: cannot use timeout (type int) as type time.Duration in field value
12:08:22 [K8s-1.7] 
12:08:22 [K8s-1.7] Ginkgo ran 1 suite in 1.100577433s
12:08:22 [K8s-1.7] Test Suite Failed
12:08:22 [Runtime] Failed in branch Runtime
[Pipeline] [K8s-1.7] }
```

https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/170/console

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
