### PR TITLE
Deadlock check after runtime and k8s tests

### DIFF
--- a/tests/999-deadlock-check.sh
+++ b/tests/999-deadlock-check.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source "${dir}/helpers.bash"
+# dir might have been overwritten by helpers.bash
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+TEST_NAME=$(get_filename_without_extension $0)
+LOGS_DIR="${dir}/cilium-files/${TEST_NAME}/logs"
+redirect_debug_logs ${LOGS_DIR}
+
+set -ex
+
+log "Checking for deadlocks in cilium service log"
+if journalctl -u cilium | grep -i -B 5 -A 5 deadlock; then
+	abort "Deadlock during test run detected, check the log above for context"
+fi
+
+test_succeeded "${TEST_NAME}"

--- a/tests/k8s/run-tests.bash
+++ b/tests/k8s/run-tests.bash
@@ -71,6 +71,8 @@ function run_tests(){
     # Run ipv4 tests
     vmssh ${node2} 'set -e; set -o pipefail; for test in /home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/tests/ipv4/*.sh; do file=$(basename $test); filename="${file%.*}"; mkdir -p /home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/tests/cilium-files/$filename; $test | tee /home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/tests/cilium-files/"${filename}"/output.txt; done'
 
+    # Check for deadlocks on node1 cilium pods
+    vmssh ${node1} 'set -e; set -o pipefail; for test in /home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/tests/999*.sh; do file=$(basename $test); filename="${file%.*}"; mkdir -p /home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/tests/cilium-files/$filename;  $test | tee /home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/tests/cilium-files/"${filename}"/output.txt; done'
     # Run IPv6 tests
 
     # Reinstall everything with IPv6 addresses

--- a/tests/k8s/tests/999-deadlock-check.sh
+++ b/tests/k8s/tests/999-deadlock-check.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source "${dir}/../helpers.bash"
+# dir might have been overwritten by helpers.bash
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+source "${dir}/../cluster/env.bash"
+
+TEST_NAME=$(get_filename_without_extension $0)
+LOGS_DIR="${dir}/cilium-files/${TEST_NAME}/logs"
+redirect_debug_logs ${LOGS_DIR}
+
+set -ex
+
+log "Checking for deadlocks in k8s cilium log"
+if docker ps -a | grep cilium-agent | awk '{print $1}' | xargs -n1 docker logs | grep -i -B 5 -A 5 deadlock; then
+	abort "Deadlock during test run detected, check the log above for context"
+fi
+
+test_succeeded "${TEST_NAME}"


### PR DESCRIPTION
All cilium-agent logs are checked for `deadlock` word.