### PR TITLE
Ginkgo - Add service recovery on restart test

### DIFF
--- a/cilium/cmd/service_get.go
+++ b/cilium/cmd/service_get.go
@@ -51,7 +51,7 @@ var serviceGetCmd = &cobra.Command{
 		}
 
 		if len(dumpOutput) > 0 {
-			if err := OutputPrinter(slice); err != nil {
+			if err := OutputPrinter(svc); err != nil {
 				os.Exit(1)
 			}
 			return

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -409,16 +409,32 @@ func (c *Cilium) ServiceAdd(id int, frontend string, backends []string, rev int)
 	return c.Exec(cmd)
 }
 
+// ServiceDel is a wrapper around `cilium service delete <id>`. It returns the
+// result of deleting said service.
+func (c *Cilium) ServiceDel(id int) *CmdRes {
+	return c.Exec(fmt.Sprintf("service delete '%d'", id))
+}
+
+// ServiceList returns the output of  `cilium service list`
+func (c *Cilium) ServiceList() *CmdRes {
+	return c.Exec("service list -o json")
+}
+
 // ServiceGet is a wrapper around `cilium service get <id>`. It returns the
 // result of retrieving said service.
 func (c *Cilium) ServiceGet(id int) *CmdRes {
 	return c.Exec(fmt.Sprintf("service get '%d'", id))
 }
 
-// ServiceDel is a wrapper around `cilium service delete <id>`. It returns the
-// result of deleting said service.
-func (c *Cilium) ServiceDel(id int) *CmdRes {
-	return c.Exec(fmt.Sprintf("service delete '%d'", id))
+// ServiceGetIds returns an array with the IDs of all Cilium services. Returns
+// an error if the IDs cannot be retrieved
+func (c *Cilium) ServiceGetIds() ([]string, error) {
+	filter := `{range [*]}{@.ID}{end}`
+	res, err := c.ServiceList().Filter(filter)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(res.String(), "\n"), nil
 }
 
 // SetUp sets up Cilium as a systemd service with a hardcoded set of options. It

--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -158,9 +158,9 @@ func (res *CmdRes) Output() *bytes.Buffer {
 	return res.stdout
 }
 
-//ExpectEqual makes an assertion that compare cmdRes.Output().String() and the
-//given parameter.  It accepts an optional parameter that can be used to
-//annotate failure messages.
+// ExpectEqual asserts whether cmdRes.Output().String() and expected are equal.
+// It accepts an optional parameter that can be used to annotate failure
+// messages.
 func (res *CmdRes) ExpectEqual(expected string, optionalDescription ...interface{}) bool {
 	return gomega.ExpectWithOffset(1, res.Output().String()).Should(
 		gomega.Equal(expected), optionalDescription...)

--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -158,6 +158,14 @@ func (res *CmdRes) Output() *bytes.Buffer {
 	return res.stdout
 }
 
+//ExpectEqual makes an assertion that compare cmdRes.Output().String() and the
+//given parameter.  It accepts an optional parameter that can be used to
+//annotate failure messages.
+func (res *CmdRes) ExpectEqual(expected string, optionalDescription ...interface{}) bool {
+	return gomega.ExpectWithOffset(1, res.Output().String()).Should(
+		gomega.Equal(expected), optionalDescription...)
+}
+
 // Reset resets res's stdout buffer to be empty.
 func (res *CmdRes) Reset() {
 	res.stdout.Reset()


### PR DESCRIPTION
- Ported `tests/06-lb.sh:test_svc_restore_functionality` test to ginkgo
- Added `cilium.ServiceList` and `cilium.ServiceGetIds` helpers
functions.

Fix #2049

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
