### PR TITLE
significantly reduce hardcoding in Ginkgo Tests

### DIFF
--- a/test/ginkgo-ext/scope.go
+++ b/test/ginkgo-ext/scope.go
@@ -28,11 +28,11 @@ func GetScope() string {
 	focusString := strings.ToLower(config.GinkgoConfig.FocusString)
 	switch {
 	case strings.HasPrefix(focusString, "run"):
-		return "runtime"
-	case strings.HasPrefix(focusString, "k8s"):
-		return "k8s"
+		return helpers.Runtime
+	case strings.HasPrefix(focusString, helpers.K8s):
+		return helpers.K8s
 	default:
-		return "runtime"
+		return helpers.Runtime
 	}
 }
 
@@ -40,7 +40,7 @@ func GetScope() string {
 // k8s, then return k8s scope along with the version of k8s that is running.
 func GetScopeWithVersion() string {
 	result := GetScope()
-	if result != "k8s" {
+	if result != helpers.K8s {
 		return result
 	}
 	return fmt.Sprintf("%s-%s", result, helpers.GetCurrentK8SEnv())

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -180,7 +180,8 @@ func (c *Cilium) EndpointWaitUntilReady(validation ...bool) bool {
 			}
 			if len(validation) > 0 && validation[0] {
 				// If the endpoint's latest statest message does not contain "Policy regeneration skipped", then it must be regenerating; wait until length of status message array changes.
-				if originalVal, _ := epsStatus[eps.ID]; !(len(eps.Status) > 0 && eps.Status[0].Message == "Policy regeneration skipped") && len(eps.Status) <= originalVal {
+				originalVal, _ := epsStatus[eps.ID]
+				if !(len(eps.Status) > 0 && eps.Status[0].Message == "Policy regeneration skipped") && len(eps.Status) <= originalVal {
 					logger.Infof("endpoint %d not regenerated", eps.ID)
 					return false
 				}

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -231,7 +231,7 @@ func (c *Cilium) GetEndpointsNames() ([]string, error) {
 
 //ManifestsPath returns the manifest path
 func (c *Cilium) ManifestsPath() string {
-	return fmt.Sprintf("%s/runtime/manifests/", basePath)
+	return fmt.Sprintf("%s/runtime/manifests/", BasePath)
 }
 
 //GetFullPath returns the valid path for a file

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -77,7 +77,7 @@ func (c *Cilium) EndpointGet(id string) *models.Endpoint {
 	var data []models.Endpoint
 	endpointGetCmd := fmt.Sprintf("endpoint get %s", id)
 	res := c.Exec(endpointGetCmd)
-	err := res.UnMarshal(&data)
+	err := res.Unmarshal(&data)
 	if err != nil {
 		c.logger.Errorf("EndpointGet fail %d: %s", id, err)
 		return nil
@@ -150,7 +150,7 @@ func (c *Cilium) EndpointWaitUntilReady(validation ...bool) bool {
 
 	var data []models.Endpoint
 
-	if err := c.GetEndpoints().UnMarshal(&data); err != nil {
+	if err := c.GetEndpoints().Unmarshal(&data); err != nil {
 		if EndpointWaitUntilReadyRetry > MaxRetries {
 			logger.Errorf("%d retries exceeded to get endpoints: %s", MaxRetries, err)
 			return false
@@ -167,7 +167,7 @@ func (c *Cilium) EndpointWaitUntilReady(validation ...bool) bool {
 	body := func() bool {
 		var data []models.Endpoint
 
-		if err := c.GetEndpoints().UnMarshal(&data); err != nil {
+		if err := c.GetEndpoints().Unmarshal(&data); err != nil {
 			logger.Info("cannot get endpoints: %s", err)
 			return false
 		}

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -30,29 +30,31 @@ const (
 	MaxRetries = 30
 )
 
-//Cilium struct helper. Struct that has a Node and logCxt with all relevant
-//functions across cilium actions
+// Cilium is utilized to run cilium-specific commands on its SSHMeta. Informational
+// output about the result of commands and the state of the node is stored in its
+// associated logger.
 type Cilium struct {
-	Node *Node
+	Node *SSHMeta
 
-	logCxt *log.Entry
+	logger *log.Entry
 }
 
-//CreateCilium returns a Cilium struct
-func CreateCilium(target string, log *log.Entry) *Cilium {
-	log.Infof("Cilium: set target to '%s'", target)
-	node := CreateNodeFromTarget(target)
+// CreateCilium returns a Cilium object containing the SSHMeta of the provided vmName,
+// as well as the provided logger.
+func CreateCilium(vmName string, log *log.Entry) *Cilium {
+	log.Infof("Cilium: set vmName to '%s'", vmName)
+	node := GetVagrantSSHMetadata(vmName)
 	if node == nil {
 		return nil
 	}
 
 	return &Cilium{
 		Node:   node,
-		logCxt: log,
+		logger: log,
 	}
 }
 
-//Exec runs a Cilium command and returns the resultant cmdRes.
+// Exec runs a Cilium CLI command and returns the resultant cmdRes.
 func (c *Cilium) Exec(cmd string) *CmdRes {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
@@ -66,13 +68,14 @@ func (c *Cilium) Exec(cmd string) *CmdRes {
 	}
 }
 
-//EndpointGet returns the output of cilium endpoint get for the provided endpoint ID
+// EndpointGet returns the output of `cilium endpoint get` for the provided
+// endpoint ID.
 func (c *Cilium) EndpointGet(id string) *models.Endpoint {
 
 	var data []models.Endpoint
 	err := c.Exec(fmt.Sprintf("endpoint get %s", id)).UnMarshal(&data)
 	if err != nil {
-		c.logCxt.Errorf("EndpointGet fail %d: %s", id, err)
+		c.logger.Errorf("EndpointGet fail %d: %s", id, err)
 		return nil
 	}
 	if len(data) > 0 {
@@ -81,12 +84,14 @@ func (c *Cilium) EndpointGet(id string) *models.Endpoint {
 	return nil
 }
 
-//EndpointSetConfig sets the provided configuration option to the provided
-//value for the endpoint with the provided id.
+// EndpointSetConfig sets the provided configuration option to the provided
+// value for the endpoint with the provided id.
 func (c *Cilium) EndpointSetConfig(id, option, value string) bool {
-	// on grep we use an space, so we are sure that only match the key that we want.
-
-	logger := c.logCxt.WithFields(log.Fields{"EndpointId": id})
+	// TODO: GH-1725.
+	// For now use `grep` with an extra space to ensure that we only match
+	// on specified option.
+	// TODO: for consistency, all fields should be constants if they are reused.
+	logger := c.logger.WithFields(log.Fields{"EndpointId": id})
 	res := c.Exec(fmt.Sprintf(
 		"endpoint config %s | grep '%s ' | awk '{print $2}'", id, option))
 
@@ -100,7 +105,7 @@ func (c *Cilium) EndpointSetConfig(id, option, value string) bool {
 	}
 	data := c.Exec(fmt.Sprintf("endpoint config %s %s=%s", id, option, value))
 	if !data.WasSuccessful() {
-		logger.Errorf("Can't set endoint config %s=%s", option, value)
+		logger.Errorf("cannot set endpoint configuration %s=%s", option, value)
 		return false
 	}
 	err := WithTimeout(func() bool {
@@ -108,11 +113,11 @@ func (c *Cilium) EndpointSetConfig(id, option, value string) bool {
 		if len(status.Status) > len(before.Status) {
 			return true
 		}
-		logger.Info("Endpoint is not regenerated")
+		logger.Info("endpoint not regenerated")
 		return false
-	}, "Endpoint is not regenerated", &TimeoutConfig{Timeout: 100})
+	}, "endpoint not regenerated", &TimeoutConfig{Timeout: 100})
 	if err != nil {
-		logger.Errorf("Endpoint set failed:%s", err)
+		logger.Errorf("endpoint configuration update failed:%s", err)
 		return false
 	}
 	return true
@@ -120,10 +125,11 @@ func (c *Cilium) EndpointSetConfig(id, option, value string) bool {
 
 var EndpointWaitUntilReadyRetry int = 0 //List how many retries EndpointWaitUntilReady should have
 
-//EndpointWaitUntilReady This function wait until all the endpoints are in the ready status
+//EndpointWaitUntilReady waits until all of the endpoints that Cilium manages
+// are in 'ready' state.
 func (c *Cilium) EndpointWaitUntilReady(validation ...bool) bool {
 
-	logger := c.logCxt.WithFields(log.Fields{"EndpointWaitReady": ""})
+	logger := c.logger.WithFields(log.Fields{"EndpointWaitReady": ""})
 
 	getEpsStatus := func(data []models.Endpoint) map[int64]int {
 		result := make(map[int64]int)
@@ -136,11 +142,12 @@ func (c *Cilium) EndpointWaitUntilReady(validation ...bool) bool {
 	var data []models.Endpoint
 
 	if err := c.GetEndpoints().UnMarshal(&data); err != nil {
-		logger.Info("Can't get endpoints: %s", err)
 		if EndpointWaitUntilReadyRetry > MaxRetries {
-			logger.Errorf("Can not get endpoints, die :%s", err)
+			logger.Errorf("%d retries exceeded to get endpoints: %s", MaxRetries, err)
 			return false
 		}
+		logger.Infof("cannot get endpoints: %s", err)
+		logger.Infof("sleeping 5 seconds and trying again to get endpoints")
 		EndpointWaitUntilReadyRetry++
 		Sleep(5)
 		return c.EndpointWaitUntilReady(validation...)
@@ -152,7 +159,7 @@ func (c *Cilium) EndpointWaitUntilReady(validation ...bool) bool {
 		var data []models.Endpoint
 
 		if err := c.GetEndpoints().UnMarshal(&data); err != nil {
-			logger.Info("Can't get endpoints: %s", err)
+			logger.Info("cannot get endpoints: %s", err)
 			return false
 		}
 		var valid, invalid int
@@ -163,8 +170,9 @@ func (c *Cilium) EndpointWaitUntilReady(validation ...bool) bool {
 				valid++
 			}
 			if len(validation) > 0 && validation[0] {
-				if originalVal, _ := epsStatus[eps.ID]; len(eps.Status) <= originalVal {
-					logger.Infof("Endpoint '%d' is not regenerated", eps.ID)
+				// If the endpoint's latest statest message does not contain "Policy regeneration skipped", then it must be regenerating; wait until length of status message array changes.
+				if originalVal, _ := epsStatus[eps.ID]; !(len(eps.Status) > 0 && eps.Status[0].Message == "Policy regeneration skipped") && len(eps.Status) <= originalVal {
+					logger.Infof("endpoint %d not regenerated", eps.ID)
 					return false
 				}
 			}
@@ -173,17 +181,22 @@ func (c *Cilium) EndpointWaitUntilReady(validation ...bool) bool {
 		if invalid == 0 {
 			return true
 		}
-		logger.Infof("Endpoints are not ready valid='%d' invalid='%d'", valid, invalid)
+
+		logger.WithFields(log.Fields{
+			"valid":   valid,
+			"invalid": invalid,
+		}).Info("endpoints not ready")
+
 		return false
 	}
-	err := WithTimeout(body, "Endpoints are not ready", &TimeoutConfig{Timeout: 300})
+	err := WithTimeout(body, "endpoints not ready", &TimeoutConfig{Timeout: 300})
 	if err != nil {
 		return false
 	}
 	return true
 }
 
-//GetEndpoints Return the output of cilium endpoint list -o json
+// GetEndpoints returns the output of `cilium endpoint list -o json`.
 func (c *Cilium) GetEndpoints() *CmdRes {
 	return c.Exec("endpoint list -o json")
 }
@@ -194,9 +207,10 @@ func (c *Cilium) GetEndpoints() *CmdRes {
 func (c *Cilium) GetEndpointsIds() (map[string]string, error) {
 	// cilium endpoint list -o jsonpath='{range [*]}{@.container-name}{"="}{@.id}{"\n"}{end}'
 	filter := `{range [*]}{@.container-name}{"="}{@.id}{"\n"}{end}`
-	endpoints := c.Exec(fmt.Sprintf("endpoint list -o jsonpath='%s'", filter))
+	cmd := fmt.Sprintf("endpoint list -o jsonpath='%s'", filter)
+	endpoints := c.Exec(cmd)
 	if !endpoints.WasSuccessful() {
-		return nil, fmt.Errorf("Can't get endpoint list: %s", endpoints.CombineOutput())
+		return nil, fmt.Errorf("%q failed: %s", cmd, endpoints.CombineOutput())
 	}
 	return endpoints.KVOutput(), nil
 }
@@ -205,7 +219,7 @@ func (c *Cilium) GetEndpointsIds() (map[string]string, error) {
 func (c *Cilium) GetEndpointsNames() ([]string, error) {
 	data := c.GetEndpoints()
 	if data.WasSuccessful() == false {
-		return nil, fmt.Errorf("Could't get endpoints")
+		return nil, fmt.Errorf("`cilium endpoint get` was not successful")
 	}
 	result, err := data.Filter("{ [*].container-name }")
 	if err != nil {
@@ -230,35 +244,41 @@ func (c *Cilium) GetFullPath(name string) string {
 //Cilium endpoint metadata cannot be retrieved via the API.
 func (c *Cilium) PolicyEndpointsSummary() (map[string]int, error) {
 	result := map[string]int{
-		"enabled":  0,
-		"disabled": 0,
-		"total":    0,
+		Enabled:  0,
+		Disabled: 0,
+		Total:    0,
 	}
 
 	endpoints, err := c.GetEndpoints().Filter("{ [*].policy-enabled }")
 	if err != nil {
-		return result, fmt.Errorf("Can't get the endpoints")
+		return result, fmt.Errorf("cannot get endpoints")
 	}
 	status := strings.Split(endpoints.String(), " ")
-	result["enabled"], result["total"] = CountValues("true", status)
-	result["disabled"], result["total"] = CountValues("false", status)
+	result[Enabled], result[Total] = CountValues("true", status)
+	result[Disabled], result[Total] = CountValues("false", status)
 	return result, nil
 }
 
-//PolicyEnforcementSet sets the PolicyEnforcement configuration value for the
-//Cilium agent to the provided status.
-func (c *Cilium) PolicyEnforcementSet(status string, waitReady ...bool) *CmdRes {
+// SetPolicyEnforcement sets the PolicyEnforcement configuration value for the
+// Cilium agent to the provided status.
+func (c *Cilium) SetPolicyEnforcement(status string, waitReady ...bool) *CmdRes {
 	// We check before setting PolicyEnforcement; if we do not, EndpointWait
 	// will fail due to the status of the endpoints not changing.
-	res := c.Exec("config | grep PolicyEnforcement | awk '{print $2}'")
+	log.Infof("setting PolicyEnforcement=%s", status)
+	res := c.Exec(fmt.Sprintf("config | grep %s | awk '{print $2}'", PolicyEnforcement))
 	if res.SingleOut() == status {
 		return res
 	}
-	res = c.Exec(fmt.Sprintf("config PolicyEnforcement=%s", status))
+	res = c.Exec(fmt.Sprintf("config %s=%s", PolicyEnforcement, status))
 	if len(waitReady) > 0 && waitReady[0] {
 		c.EndpointWaitUntilReady(true)
 	}
 	return res
+}
+
+// PolicyDelAll deletes all policy rules currently imported into Cilium.
+func (c *Cilium) PolicyDelAll() *CmdRes {
+	return c.PolicyDel("--all")
 }
 
 //PolicyDel delete a policy with the given ID
@@ -266,9 +286,17 @@ func (c *Cilium) PolicyDel(id string) *CmdRes {
 	return c.Exec(fmt.Sprintf("policy delete %s", id))
 }
 
-//PolicyGet return the policy value
+//PolicyGet runs `cilium policy get <id>`, where id is the name of a specific
+// policy imported into Cilium. It returns the resultant CmdRes from running
+// the aforementioned command.
 func (c *Cilium) PolicyGet(id string) *CmdRes {
 	return c.Exec(fmt.Sprintf("policy get %s", id))
+}
+
+// PolicyGetAll gets all policies that are imported in the Cilium agent.
+func (c *Cilium) PolicyGetAll() *CmdRes {
+	return c.Exec("policy get")
+
 }
 
 //PolicyGetRevision Get the current Policy revision
@@ -283,13 +311,13 @@ func (c *Cilium) PolicyGetRevision() (int, error) {
 func (c *Cilium) PolicyImport(path string, timeout time.Duration) (int, error) {
 	revision, err := c.PolicyGetRevision()
 	if err != nil {
-		return -1, fmt.Errorf("Can't get policy revision: %s", err)
+		return -1, fmt.Errorf("cannot get policy revision: %s", err)
 	}
-	c.logCxt.Infof("PolicyImport: %s and current policy revision is '%d'", path, revision)
+	c.logger.Infof("PolicyImport: %s and current policy revision is '%d'", path, revision)
 	res := c.Exec(fmt.Sprintf("policy import %s", path))
 	if res.WasSuccessful() == false {
-		c.logCxt.Errorf("Could not import policy: %s", res.CombineOutput())
-		return -1, fmt.Errorf("Could not import policy %s", path)
+		c.logger.Errorf("could not import policy: %s", res.CombineOutput())
+		return -1, fmt.Errorf("could not import policy %s", path)
 	}
 	body := func() bool {
 		currentRev, _ := c.PolicyGetRevision()
@@ -297,15 +325,15 @@ func (c *Cilium) PolicyImport(path string, timeout time.Duration) (int, error) {
 			c.PolicyWait(currentRev)
 			return true
 		}
-		c.logCxt.Infof("PolicyImport: current revision %d same as %d", currentRev, revision)
+		c.logger.Infof("PolicyImport: current revision %d same as %d", currentRev, revision)
 		return false
 	}
-	err = WithTimeout(body, "Could not import policy revision", &TimeoutConfig{Timeout: timeout})
+	err = WithTimeout(body, "could not import policy revision", &TimeoutConfig{Timeout: timeout})
 	if err != nil {
 		return -1, err
 	}
 	revision, err = c.PolicyGetRevision()
-	c.logCxt.Infof("PolicyImport: finished '%s' with revision '%d'", path, revision)
+	c.logger.Infof("PolicyImport: finished %q with revision '%d'", path, revision)
 	return revision, err
 }
 
@@ -317,18 +345,19 @@ func (c *Cilium) PolicyWait(revisionNum int) *CmdRes {
 
 //ReportFailed gathers relevant Cilium runtime data and logs for debugging purposes
 func (c *Cilium) ReportFailed(commands ...string) {
-	wr := c.logCxt.Logger.Out
+	wr := c.logger.Logger.Out
 	fmt.Fprint(wr, "StackTrace Begin\n")
 
 	//FIXME: Ginkgo PR383 add here --since option
 	res := c.Node.Exec("sudo journalctl --no-pager -u cilium")
 	fmt.Fprint(wr, res.Output())
 
-	res = c.Node.Exec("sudo cilium endpoint list")
+	fmt.Fprint(wr, "\n")
+	res = c.Exec("endpoint list")
 	fmt.Fprint(wr, res.Output())
 
 	for _, cmd := range commands {
-		fmt.Fprintf(wr, "Command '%s': \n", cmd)
+		fmt.Fprintf(wr, "\nOutput of command '%s': \n", cmd)
 		res = c.Node.Exec(fmt.Sprintf("%s", cmd))
 		fmt.Fprint(wr, res.Output())
 	}
@@ -353,7 +382,8 @@ func (c *Cilium) ServiceDel(id int) *CmdRes {
 	return c.Exec(fmt.Sprintf("service delete '%d'", id))
 }
 
-//SetUp setup cilium config
+// SetUp sets up Cilium as a systemd service with a hardcoded set of options. It
+// returns an error if any of the operations needed to start Cilium fails.
 func (c *Cilium) SetUp() error {
 	template := `
 PATH=/usr/lib/llvm-3.8/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
@@ -383,8 +413,8 @@ INITSYSTEM=SYSTEMD`
 func (c *Cilium) WaitUntilReady(timeout time.Duration) error {
 
 	body := func() bool {
-		res := c.Node.Exec("sudo cilium status")
-		c.logCxt.Infof("Cilium status is %t", res.WasSuccessful())
+		res := c.Exec("status")
+		c.logger.Infof("Cilium status is %t", res.WasSuccessful())
 		return res.WasSuccessful()
 	}
 	err := WithTimeout(body, "Cilium is not ready", &TimeoutConfig{Timeout: timeout})

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -156,7 +156,7 @@ func (c *Cilium) EndpointWaitUntilReady(validation ...bool) bool {
 			return false
 		}
 		logger.Infof("cannot get endpoints: %s", err)
-		logger.Infof("sleeping 5 seconds and trying again to get endpoints")
+		logger.Info("sleeping 5 seconds and trying again to get endpoints")
 		EndpointWaitUntilReadyRetry++
 		Sleep(5)
 		return c.EndpointWaitUntilReady(validation...)
@@ -168,7 +168,7 @@ func (c *Cilium) EndpointWaitUntilReady(validation ...bool) bool {
 		var data []models.Endpoint
 
 		if err := c.GetEndpoints().Unmarshal(&data); err != nil {
-			logger.Info("cannot get endpoints: %s", err)
+			logger.Infof("cannot get endpoints: %s", err)
 			return false
 		}
 		var valid, invalid int

--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -164,8 +164,8 @@ func (res *CmdRes) SingleOut() string {
 	return strings.Replace(res.stdout.String(), "\n", "", -1)
 }
 
-// UnMarshal unmarshals res's stdout into data
-func (res *CmdRes) UnMarshal(data interface{}) error {
+// Unmarshal unmarshals res's stdout into data
+func (res *CmdRes) Unmarshal(data interface{}) error {
 	err := json.Unmarshal(res.stdout.Bytes(), &data)
 	return err
 }

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	timeout time.Duration = 300
+	timeout time.Duration = 300 // WithTimeout helper translates it to seconds
 
 	// K8s1VMName is the name of the Kubernetes master node when running
 	// Kubernetes tests.
@@ -32,7 +32,9 @@ var (
 )
 
 const (
-	basePath = "/vagrant/"
+	// BasePath is the path in the Vagrant VMs to which the test directory
+	// is mounted
+	BasePath = "/vagrant/"
 
 	// VM / Test suite constants.
 	K8s     = "k8s"
@@ -120,5 +122,5 @@ const (
 
 //GetFilePath returns the absolute path of the provided filename
 func GetFilePath(filename string) string {
-	return fmt.Sprintf("%s%s", basePath, filename)
+	return fmt.Sprintf("%s%s", BasePath, filename)
 }

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -20,7 +20,8 @@ import (
 )
 
 var (
-	timeout time.Duration = 300 // WithTimeout helper translates it to seconds
+	// HelperTimeout is a predefined timeout value for commands.
+	HelperTimeout time.Duration = 300 // WithTimeout helper translates it to seconds
 
 	// K8s1VMName is the name of the Kubernetes master node when running
 	// Kubernetes tests.

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -20,9 +20,102 @@ import (
 )
 
 var (
-	timeout     time.Duration = 300 //WithTimeout helper translate it to seconds
-	basePath                  = "/vagrant/"
-	networkName               = "cilium-net"
+	timeout time.Duration = 300
+
+	// K8s1VMName is the name of the Kubernetes master node when running
+	// Kubernetes tests.
+	K8s1VMName = fmt.Sprintf("k8s1-%s", GetCurrentK8SEnv())
+
+	// K8s2VMName is the name of the Kubernetes worker node when running
+	// Kubernetes tests.
+	K8s2VMName = fmt.Sprintf("k8s2-%s", GetCurrentK8SEnv())
+)
+
+const (
+	basePath = "/vagrant/"
+
+	// VM / Test suite constants.
+	K8s     = "k8s"
+	K8s1    = "k8s1"
+	K8s2    = "k8s2"
+	Runtime = "runtime"
+
+	Enabled  = "enabled"
+	Disabled = "disabled"
+	Total    = "total"
+
+	// PolicyEnforcement represents the PolicyEnforcement configuration option
+	// for the Cilium agent.
+	PolicyEnforcement = "PolicyEnforcement"
+
+	// PolicyEnforcementDefault represents the default PolicyEnforcement mode
+	// for Cilium.
+	PolicyEnforcementDefault = "default"
+
+	// PolicyEnforcementAlways represents the PolicyEnforcement mode
+	// for Cilium in which traffic is denied by default even when no policy
+	// is imported.
+	PolicyEnforcementAlways = "always"
+
+	// PolicyEnforcementNever represents the PolicyEnforcement mode
+	// for Cilium in which traffic is always allowed even if there is a policy
+	// selecting endpoints.
+	PolicyEnforcementNever = "never"
+
+	// Docker Image names
+
+	// CiliumDockerNetwork is the name of the Docker network which Cilium manages.
+	CiliumDockerNetwork = "cilium-net"
+
+	// NetperfImage is the Docker image used for performance testing
+	NetperfImage = "tgraf/netperf"
+
+	// HttpdImage is the image used for starting an HTTP server.
+	HttpdImage = "cilium/demo-httpd"
+
+	// Names of commonly used containers in tests.
+
+	Httpd1 = "httpd1"
+	Httpd2 = "httpd2"
+	Httpd3 = "httpd3"
+	App1   = "app1"
+	App2   = "app2"
+	App3   = "app3"
+	Client = "client"
+	Server = "server"
+	Host   = "host"
+
+	// Container lifecycle actions.
+	Create = "create"
+	Delete = "delete"
+
+	// IP Address families.
+	IPv4 = "IPv4"
+	IPv6 = "IPv6"
+
+	// Configuration options for endpoints. Copied from endpoint/endpoint.go
+	// TODO: these should be converted into types for use in configuration
+	// functions instead of using basic strings.
+
+	OptionAllowToHost         = "AllowToHost"
+	OptionAllowToWorld        = "AllowToWorld"
+	OptionConntrackAccounting = "ConntrackAccounting"
+	OptionConntrackLocal      = "ConntrackLocal"
+	OptionConntrack           = "Conntrack"
+	OptionDebug               = "Debug"
+	OptionDropNotify          = "DropNotification"
+	OptionTraceNotify         = "TraceNotification"
+	OptionNAT46               = "NAT46"
+	OptionPolicy              = "Policy"
+
+	OptionDisabled = "Disabled"
+	OptionEnabled  = "Enabled"
+
+	PingCount          = 5
+	CurlConnectTimeout = 5
+
+	DefaultNamespace    = "default"
+	KubeSystemNamespace = "kube-system"
 )
 
 //GetFilePath returns the absolute path of the provided filename

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -266,7 +266,7 @@ func (kub *Kubectl) CiliumEndpointWait(pod string) bool {
 		return false
 	}
 
-	err := WithTimeout(body, "cannot retrieve endpoints", &TimeoutConfig{Timeout: timeout})
+	err := WithTimeout(body, "cannot retrieve endpoints", &TimeoutConfig{Timeout: HelperTimeout})
 	if err != nil {
 		return false
 	}
@@ -297,7 +297,7 @@ func (kub *Kubectl) CiliumExec(pod string, cmd string) *CmdRes {
 
 //CiliumNodesWait When a new cilium DS is set, the status can be ok but tunnels
 //are not in place yet. Checking the `kubectl get nodes` we can know if cilium
-//added the node correctly. In case of timeout will return an error
+//added the node correctly. If the command times out, will return an error
 func (kub *Kubectl) CiliumNodesWait() (bool, error) {
 	body := func() bool {
 		filter := `{range .items[*]}{@.metadata.name}{"="}{@.metadata.annotations.io\.cilium\.network\.ipv4-pod-cidr}{"\n"}{end}`
@@ -316,7 +316,7 @@ func (kub *Kubectl) CiliumNodesWait() (bool, error) {
 		}
 		return true
 	}
-	err := WithTimeout(body, "Kubernetes node does not have cilium metadata", &TimeoutConfig{Timeout: timeout})
+	err := WithTimeout(body, "Kubernetes node does not have cilium metadata", &TimeoutConfig{Timeout: HelperTimeout})
 	if err != nil {
 		return false, err
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -130,7 +130,7 @@ func (kub *Kubectl) Logs(namespace string, pod string) *CmdRes {
 
 //ManifestsPath returns the manifests path for the k8s version
 func (kub *Kubectl) ManifestsPath() string {
-	return fmt.Sprintf("%s/k8sT/manifests/%s", basePath, GetCurrentK8SEnv())
+	return fmt.Sprintf("%s/k8sT/manifests/%s", BasePath, GetCurrentK8SEnv())
 }
 
 //NodeCleanMetadata delete all cilium metadata info to all nodes

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -234,7 +234,7 @@ func (kub *Kubectl) CiliumEndpointsListByLabel(pod, label string) (EndpointMap, 
 	var data []models.Endpoint
 	eps := kub.CiliumEndpointsList(pod)
 
-	err := eps.UnMarshal(&data)
+	err := eps.Unmarshal(&data)
 	if err != nil {
 		return nil, err
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -34,23 +34,22 @@ const (
 	// Annotationv6CIDRName is the annotation name used to store the IPv6
 	// pod CIDR in the node's annotations. From pkg/k8s
 	Annotationv6CIDRName = "io.cilium.network.ipv6-pod-cidr"
+	kubectl              = "kubectl"
 )
 
-//GetCurrentK8SEnv returns the value of K8S_VERSION from the OS environment
+// GetCurrentK8SEnv returns the value of K8S_VERSION from the OS environment
 func GetCurrentK8SEnv() string { return os.Getenv("K8S_VERSION") }
 
-//Kubectl kubectl command helper to connect to Kubectl instance
+// Kubectl kubectl command helper to connect to Kubectl instance
 type Kubectl struct {
-	Node *Node //helpers.Node struct to connect to ssh
+	Node *SSHMeta //helpers.SSHMeta struct to connect to ssh
 
 	logCxt *log.Entry //log context with test fields
 }
 
-// CreateKubectl initializes a Kubectl helper with the provided target and log
-func CreateKubectl(target string, log *log.Entry) *Kubectl {
-	versionTarget := fmt.Sprintf("%s-%s", target, GetCurrentK8SEnv())
-	log.Infof("Kubectl: Set target to '%s'", versionTarget)
-	node := CreateNodeFromTarget(versionTarget)
+// CreateKubectl initializes a Kubectl helper with the provided vmName and log
+func CreateKubectl(vmName string, log *log.Entry) *Kubectl {
+	node := GetVagrantSSHMetadata(vmName)
 	if node == nil {
 		return nil
 	}
@@ -61,9 +60,9 @@ func CreateKubectl(target string, log *log.Entry) *Kubectl {
 	}
 }
 
-//Exec runs the provided command in a pod running in a specific namespace
+// Exec runs the provided command in a pod running in a specific namespace
 func (kub *Kubectl) Exec(namespace string, pod string, cmd string) (string, error) {
-	command := fmt.Sprintf("kubectl exec -n %s %s -- %s", namespace, pod, cmd)
+	command := fmt.Sprintf("%s exec -n %s %s -- %s", kubectl, namespace, pod, cmd)
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	exit := kub.Node.Execute(command, stdout, stderr)
@@ -81,12 +80,13 @@ func (kub *Kubectl) Exec(namespace string, pod string, cmd string) (string, erro
 // Get retrieves the provided Kubernetes objects from the specified namespace
 func (kub *Kubectl) Get(namespace string, command string) *CmdRes {
 	return kub.Node.Exec(fmt.Sprintf(
-		"kubectl -n %s get %s -o json", namespace, command))
+		"%s -n %s get %s -o json", kubectl, namespace, command))
 }
 
-//GetPods return all the pods for a namespace. Kubectl options/filter can be passed
+// GetPods gets all of the pods in the given namespace that match the provided
+// filter.
 func (kub *Kubectl) GetPods(namespace string, filter string) *CmdRes {
-	return kub.Node.Exec(fmt.Sprintf("kubectl -n %s get pods %s -o json", namespace, filter))
+	return kub.Node.Exec(fmt.Sprintf("%s -n %s get pods %s -o json", kubectl, namespace, filter))
 }
 
 //GetPodNames returns the names of all of the pods that are labelled with label
@@ -96,12 +96,12 @@ func (kub *Kubectl) GetPodNames(namespace string, label string) ([]string, error
 	stdout := new(bytes.Buffer)
 	filter := "-o jsonpath='{.items[*].metadata.name}'"
 	exit := kub.Node.Execute(
-		fmt.Sprintf("kubectl -n %s get pods -l %s %s", namespace, label, filter),
+		fmt.Sprintf("%s -n %s get pods -l %s %s", kubectl, namespace, label, filter),
 		stdout, nil)
 
 	if exit == false {
 		return nil, fmt.Errorf(
-			"Pods couldn't be found on namespace '%s' with label %s", namespace, label)
+			"could not find pods in namespace %q with label %q", namespace, label)
 	}
 
 	out := strings.Trim(stdout.String(), "\n")
@@ -118,7 +118,7 @@ func (kub *Kubectl) Logs(namespace string, pod string) *CmdRes {
 	stderr := new(bytes.Buffer)
 
 	exit := kub.Node.Execute(
-		fmt.Sprintf("kubectl -n %s logs %s", namespace, pod),
+		fmt.Sprintf("%s -n %s logs %s", kubectl, namespace, pod),
 		stdout, stderr)
 	return &CmdRes{
 		cmd:    "",
@@ -140,13 +140,13 @@ func (kub *Kubectl) NodeCleanMetadata() error {
 		Annotationv6CIDRName,
 	}
 
-	data := kub.Node.Exec("kubectl get nodes -o jsonpath='{.items[*].metadata.name}'")
+	data := kub.Node.Exec(fmt.Sprintf("%s get nodes -o jsonpath='{.items[*].metadata.name}'", kubectl))
 	if !data.WasSuccessful() {
-		return fmt.Errorf("Could not get nodes: %s", data.CombineOutput())
+		return fmt.Errorf("could not get nodes via %s: %s", kubectl, data.CombineOutput())
 	}
 	for _, node := range strings.Split(data.Output().String(), " ") {
 		for _, label := range metadata {
-			kub.Node.Exec(fmt.Sprintf("kubectl annotate nodes %s %s", node, label))
+			kub.Node.Exec(fmt.Sprintf("%s annotate nodes %s %s", kubectl, node, label))
 		}
 	}
 	return nil
@@ -158,7 +158,7 @@ func (kub *Kubectl) WaitforPods(namespace string, filter string, timeout time.Du
 		var jsonPath = "{.items[*].status.containerStatuses[*].ready}"
 		data, err := kub.GetPods(namespace, filter).Filter(jsonPath)
 		if err != nil {
-			kub.logCxt.Errorf("Could not get pods: %s", err)
+			kub.logCxt.Errorf("could not get pods: %s", err)
 			return false
 		}
 
@@ -180,7 +180,7 @@ func (kub *Kubectl) WaitforPods(namespace string, filter string, timeout time.Du
 		}).Info("WaitforPods: pods are not ready")
 		return false
 	}
-	err := WithTimeout(body, "Could not get Pods", &TimeoutConfig{Timeout: timeout})
+	err := WithTimeout(body, "could not get Pods", &TimeoutConfig{Timeout: timeout})
 	if err != nil {
 		return false, err
 	}
@@ -188,30 +188,33 @@ func (kub *Kubectl) WaitforPods(namespace string, filter string, timeout time.Du
 }
 
 //Apply applies the Kubernetes manifest located at path filepath
-func (kub *Kubectl) Apply(filepath string) *CmdRes {
+func (kub *Kubectl) Apply(filePath string) *CmdRes {
+	kub.logCxt.Debugf("applying %s", filePath)
 	return kub.Node.Exec(
-		fmt.Sprintf("kubectl apply -f  %s", filepath))
+		fmt.Sprintf("%s apply -f  %s", kubectl, filePath))
 }
 
 //Delete Deletes the Kubernetes manifest at path filepath.
-func (kub *Kubectl) Delete(filepath string) *CmdRes {
+func (kub *Kubectl) Delete(filePath string) *CmdRes {
+	kub.logCxt.Debugf("deleting %s", filePath)
 	return kub.Node.Exec(
-		fmt.Sprintf("kubectl delete -f  %s", filepath))
+		fmt.Sprintf("%s delete -f  %s", kubectl, filePath))
 }
 
-//GetCiliumPods returns a list of all Cilium pods in the specified namespace,
-//and an error if the Cilium pods were not able to be retrieved.
+// GetCiliumPods returns a list of all Cilium pods in the specified namespace,
+// and an error if the Cilium pods were not able to be retrieved.
 func (kub *Kubectl) GetCiliumPods(namespace string) ([]string, error) {
 	return kub.GetPodNames(namespace, "k8s-app=cilium")
 }
 
-//CiliumEndpointsList return the list of cilium endpoint list
+// CiliumEndpointsList returns the result of `cilium endpoint list` from the
+// specified pod.
 func (kub *Kubectl) CiliumEndpointsList(pod string) *CmdRes {
 	return kub.CiliumExec(pod, "cilium endpoint list -o json")
 }
 
-//CiliumEndpointsListByTag return the list of endpoints filter by a tag
-func (kub *Kubectl) CiliumEndpointsListByTag(pod, tag string) (EndPointMap, error) {
+// CiliumEndpointsListByLabel returns a list of endpoints
+func (kub *Kubectl) CiliumEndpointsListByLabel(pod, label string) (EndPointMap, error) {
 	result := make(EndPointMap)
 	var data []models.Endpoint
 	eps := kub.CiliumEndpointsList(pod)
@@ -222,8 +225,8 @@ func (kub *Kubectl) CiliumEndpointsListByTag(pod, tag string) (EndPointMap, erro
 	}
 
 	for _, ep := range data {
-		for _, label := range ep.Labels.OrchestrationIdentity {
-			if tag == label {
+		for _, orchLabel := range ep.Labels.OrchestrationIdentity {
+			if label == orchLabel {
 				result[ep.ContainerName] = ep
 				break
 			}
@@ -263,7 +266,7 @@ func (kub *Kubectl) CiliumEndpointWait(pod string) bool {
 		return false
 	}
 
-	err := WithTimeout(body, "Can't retrieve endpoints", &TimeoutConfig{Timeout: timeout})
+	err := WithTimeout(body, "cannot retrieve endpoints", &TimeoutConfig{Timeout: timeout})
 	if err != nil {
 		return false
 	}
@@ -288,7 +291,7 @@ func (kub *Kubectl) CiliumEndpointPolicyVersion(pod string) map[string]int64 {
 
 //CiliumExec runs cmd in the specified Cilium pod
 func (kub *Kubectl) CiliumExec(pod string, cmd string) *CmdRes {
-	cmd = fmt.Sprintf("kubectl exec -n kube-system %s -- %s", pod, cmd)
+	cmd = fmt.Sprintf("%s exec -n kube-system %s -- %s", kubectl, pod, cmd)
 	return kub.Node.Exec(cmd)
 }
 
@@ -299,21 +302,21 @@ func (kub *Kubectl) CiliumNodesWait() (bool, error) {
 	body := func() bool {
 		filter := `{range .items[*]}{@.metadata.name}{"="}{@.metadata.annotations.io\.cilium\.network\.ipv4-pod-cidr}{"\n"}{end}`
 		data := kub.Node.Exec(fmt.Sprintf(
-			"kubectl get nodes -o jsonpath='%s'", filter))
+			"%s get nodes -o jsonpath='%s'", kubectl, filter))
 		if !data.WasSuccessful() {
 			return false
 		}
 		result := data.KVOutput()
 		for k, v := range result {
 			if v == "" {
-				kub.logCxt.Infof("K8s node '%s' does not have cilium metadata", k)
+				kub.logCxt.Infof("Kubernetes node %q does not have Cilium metadata", k)
 				return false
 			}
-			kub.logCxt.Infof("K8s node '%s' ipv4 addr '%s'", k, v)
+			kub.logCxt.Infof("Kubernetes node %q IPv4 address: %q", k, v)
 		}
 		return true
 	}
-	err := WithTimeout(body, "k8s nodes does not have cilium metadata", &TimeoutConfig{Timeout: timeout})
+	err := WithTimeout(body, "Kubernetes node does not have cilium metadata", &TimeoutConfig{Timeout: timeout})
 	if err != nil {
 		return false, err
 	}
@@ -356,12 +359,12 @@ func (kub *Kubectl) CiliumImportPolicy(namespace string, filepath string, timeou
 			return "", err
 		}
 		revisions[v] = revi
-		kub.logCxt.Infof("CiliumImportPolicy: pod '%s' has revision %v", v, revi)
+		kub.logCxt.Infof("CiliumImportPolicy: pod %q has revision %v", v, revi)
 	}
 
-	kub.logCxt.Infof("CiliumImportPolicy: path='%s' with revision '%d'", filepath, revision)
+	kub.logCxt.Infof("CiliumImportPolicy: path=%q with revision %q", filepath, revision)
 	if status := kub.Apply(filepath); !status.WasSuccessful() {
-		return "", fmt.Errorf("Can't apply the policy '%s'", filepath)
+		return "", fmt.Errorf("cannot apply policy %q", filepath)
 	}
 
 	body := func() bool {
@@ -411,11 +414,11 @@ func (kub *Kubectl) CiliumReport(namespace string, pod string, commands []string
 	data := kub.Logs(namespace, pod)
 	fmt.Fprintln(wr, data.Output())
 
-	data = kub.Node.Exec("kubectl get pods -o wide")
+	data = kub.Node.Exec(fmt.Sprintf("%s get pods -o wide", kubectl))
 	fmt.Fprintln(wr, data.Output())
 
 	for _, cmd := range commands {
-		command := fmt.Sprintf("kubectl exec -n %s %s -- %s", namespace, pod, cmd)
+		command := fmt.Sprintf("%s exec -n %s %s -- %s", kubectl, namespace, pod, cmd)
 		out := kub.Node.Exec(command)
 		fmt.Fprintln(wr, out.CombineOutput())
 	}
@@ -430,7 +433,7 @@ func (kub *Kubectl) GetCiliumPodOnNode(namespace string, node string) (string, e
 		"-o jsonpath='{.items[?(@.spec.nodeName == \"%s\")].metadata.name}'", node)
 
 	res := kub.Node.Exec(fmt.Sprintf(
-		"kubectl -n %s get pods -l k8s-app=cilium %s", namespace, filter))
+		"%s -n %s get pods -l k8s-app=cilium %s", kubectl, namespace, filter))
 	if !res.WasSuccessful() {
 		return "", fmt.Errorf("Cilium pod not found on node '%s'", node)
 	}
@@ -445,15 +448,15 @@ type EndPointMap map[string]models.Endpoint
 //enforcement enabled and disabled.
 func (epMap *EndPointMap) GetPolicyStatus() map[string]int {
 	result := map[string]int{
-		"enabled":  0,
-		"disabled": 0,
+		Enabled:  0,
+		Disabled: 0,
 	}
 
 	for _, ep := range *epMap {
 		if *ep.PolicyEnabled == true {
-			result["enabled"]++
+			result[Enabled]++
 		} else {
-			result["disabled"]++
+			result[Disabled]++
 		}
 	}
 	return result

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -18,9 +18,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"os"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // SSHMeta contains metadata to SSH into a remote location to run tests

--- a/test/helpers/runtime.go
+++ b/test/helpers/runtime.go
@@ -21,5 +21,9 @@ import (
 //CreateNewRuntimeHelper returns Docker and Cilium helpers for running the
 //runtime tests on the provided VM target and using logger log .
 func CreateNewRuntimeHelper(target string, log *log.Entry) (*Docker, *Cilium) {
-	return CreateDocker(target, log), CreateCilium(target, log)
+	log.Infof("creating docker")
+	docker := CreateDocker(target, log)
+	log.Infof("creating cilium")
+	cilium := CreateCilium(target, log)
+	return docker, cilium
 }

--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -31,8 +31,11 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 )
 
-//SSHCommand struct to send commands over SSHClient
+// SSHCommand stores the data associated with executing a command.
+// TODO: this is poorly named in that it's not related to a command only
+// ran over SSH - rename this.
 type SSHCommand struct {
+	// TODO: path is not a clear name - rename to something more clear.
 	Path   string
 	Env    []string
 	Stdin  io.Reader
@@ -40,7 +43,8 @@ type SSHCommand struct {
 	Stderr io.Writer
 }
 
-//SSHClient struct to store the configuration for a specific vagrant box
+// SSHClient stores the information needed to SSH into a remote location for
+// running tests.
 type SSHClient struct {
 	Config *ssh.ClientConfig // ssh client configuration information.
 	Host   string            // Ip/Host from the target virtualserver
@@ -49,7 +53,7 @@ type SSHClient struct {
 	// subprocesses, TCP port/streamlocal forwarding and tunneled dialing.
 }
 
-//SSHConfig contains metadata for an SSH session with a Vagrant VM .
+// SSHConfig contains metadata for an SSH session with a Vagrant VM.
 type SSHConfig struct {
 	target       string
 	host         string

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -38,7 +38,7 @@ func IsRunningOnJenkins() bool {
 	for _, varName := range env {
 		if val := os.Getenv(varName); val == "" {
 			result = false
-			log.Infof("Variable '%s' is not present, it is not running on jenkins", varName)
+			log.Infof("build is not running on Jenkins; environment variable %q is not set", varName)
 		}
 	}
 	return result

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -1,0 +1,54 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import "fmt"
+
+// PerfTest represents a type of test to run when running `netperf`.
+type PerfTest string
+
+const (
+	// TCP_RR represents a netperf test for TCP Request/Response performance.
+	// For more information, consult : http://www.cs.kent.edu/~farrell/dist/ref/Netperf.html
+	TCP_RR = PerfTest("TCP_RR")
+
+	// UDP_RR represents a netperf test for UDP Request/Response performance.
+	// For more information, consult : http://www.cs.kent.edu/~farrell/dist/ref/Netperf.html
+	UDP_RR = PerfTest("UDP_RR")
+)
+
+// Ping returns the string representing the ping command to ping the specified
+// endpoint.
+func Ping(endpoint string) string {
+	return fmt.Sprintf("ping -c %d %s", PingCount, endpoint)
+}
+
+// Ping6 returns the string representing the ping6 command to ping6 the
+// specified endpoint.
+func Ping6(endpoint string) string {
+	return fmt.Sprintf("ping6 -c %d %s", PingCount, endpoint)
+}
+
+// CurlFail returns the string representing the curl command with `-s` and `--fail`
+// options enabled to curl the specified endpoint.
+func CurlFail(endpoint string) string {
+	return fmt.Sprintf("curl -s --fail --connect-timeout %d %s", CurlConnectTimeout, endpoint)
+}
+
+// Netperf returns the string representing the netperf command to use when testing
+// connectivity between endpoints.
+func Netperf(endpoint string, perfTest PerfTest) string {
+	return fmt.Sprintf("netperf -l 3 -t %s -H %s", perfTest, endpoint)
+}

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -32,6 +32,7 @@ const (
 // Ping returns the string representing the ping command to ping the specified
 // endpoint.
 func Ping(endpoint string) string {
+	// TODO: add W -2 ?
 	return fmt.Sprintf("ping -c %d %s", PingCount, endpoint)
 }
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -140,7 +140,7 @@ var _ = Describe("K8sServicesTest", func() {
 		waitPodsDs()
 
 		var data v1.Service
-		err := kubectl.Get("default", "service test-nodeport").UnMarshal(&data)
+		err := kubectl.Get("default", "service test-nodeport").Unmarshal(&data)
 		Expect(err).Should(BeNil(), "Can not retrieve service")
 		url := fmt.Sprintf("http://%s",
 			net.JoinHostPort(data.Spec.ClusterIP, fmt.Sprintf("%d", data.Spec.Ports[0].Port)))

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -26,10 +26,29 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	// Commands
+	ping         = "ping"
+	ping6        = "ping6"
+	http         = "http"
+	http6        = "http6"
+	httpPrivate  = "http_private"
+	http6Private = "http6_private"
+
+	// Policy files
+	policyJSON         = "policy.json"
+	invalidJSON        = "invalid.json"
+	sampleJSON         = "sample_policy.json"
+	ingressJSON        = "ingress.json"
+	egressJSON         = "egress.json"
+	multL7PoliciesJSON = "Policies-l7-multiple.json"
+	policiesL7JSON     = "Policies-l7-simple.json"
+	policiesL3JSON     = "Policies-l3-policy.json"
+)
+
 var _ = Describe("RuntimePolicyEnforcement", func() {
 
 	var initialized bool
-	var networkName string = "cilium-net"
 	var logger *log.Entry
 	var docker *helpers.Docker
 	var cilium *helpers.Cilium
@@ -40,11 +59,11 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 		}
 		logger = log.WithFields(log.Fields{"testName": "RuntimePolicyEnforcement"})
 		logger.Info("Starting")
-		docker, cilium = helpers.CreateNewRuntimeHelper("runtime", logger)
+		docker, cilium = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 		cilium.WaitUntilReady(100)
-		docker.NetworkCreate(networkName, "")
+		docker.NetworkCreate(helpers.CiliumDockerNetwork, "")
 
-		res := cilium.PolicyEnforcementSet("default", false)
+		res := cilium.SetPolicyEnforcement(helpers.PolicyEnforcementDefault, false)
 		res.ExpectSuccess()
 
 		initialized = true
@@ -52,8 +71,8 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 
 	BeforeEach(func() {
 		initialize()
-		docker.ContainerCreate("app", "cilium/demo-httpd", networkName, "-l id.app")
-		cilium.Exec("policy delete --all")
+		cilium.PolicyDelAll()
+		docker.ContainerCreate("app", "cilium/demo-httpd", helpers.CiliumDockerNetwork, "-l id.app")
 		cilium.EndpointWaitUntilReady()
 	})
 
@@ -69,7 +88,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 
 		BeforeEach(func() {
 			initialize()
-			res := cilium.PolicyEnforcementSet("default")
+			res := cilium.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
 			res.ExpectSuccess()
 		})
 
@@ -78,16 +97,16 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			By("Policy Enforcement should be disabled for containers", func() {
 				endPoints, err := cilium.PolicyEndpointsSummary()
 				Expect(err).Should(BeNil())
-				Expect(endPoints["disabled"]).To(Equal(1))
+				Expect(endPoints[helpers.Disabled]).To(Equal(1))
 			})
 
 			By("Apply a new sample policy")
-			_, err := cilium.PolicyImport(cilium.GetFullPath("sample_policy.json"), 300)
+			_, err := cilium.PolicyImport(cilium.GetFullPath(sampleJSON), 300)
 			Expect(err).Should(BeNil())
 
 			endPoints, err := cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 		})
 
 		It("Handles missing required fields", func() {
@@ -100,89 +119,89 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			By("Check no policy enforcement")
 			endPoints, err := cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["disabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
 			By("Setting to Always")
 
-			res := cilium.PolicyEnforcementSet("always", true)
+			res := cilium.SetPolicyEnforcement(helpers.PolicyEnforcementAlways, true)
 			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 
 			By("Setting to default from Always")
-			res = cilium.PolicyEnforcementSet("default", true)
+			res = cilium.SetPolicyEnforcement(helpers.PolicyEnforcementDefault, true)
 			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["disabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 		})
 
 		It("Default to Always with policy", func() {
-			_, err := cilium.PolicyImport(cilium.GetFullPath("sample_policy.json"), 300)
+			_, err := cilium.PolicyImport(cilium.GetFullPath(sampleJSON), 300)
 			Expect(err).Should(BeNil())
 
 			endPoints, err := cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 			//DEfault =APP with PolicyEnforcement
 
-			res := cilium.PolicyEnforcementSet("always", true)
+			res := cilium.SetPolicyEnforcement(helpers.PolicyEnforcementAlways, true)
 			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 
-			res = cilium.PolicyEnforcementSet("default", true)
+			res = cilium.SetPolicyEnforcement(helpers.PolicyEnforcementDefault, true)
 			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 		})
 
 		It("Default to Never without policy", func() {
 			endPoints, err := cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["disabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
-			res := cilium.PolicyEnforcementSet("never", true)
+			res := cilium.SetPolicyEnforcement(helpers.PolicyEnforcementNever, true)
 			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["disabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["disabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 		})
 
 		It("Default to Never with policy", func() {
 
-			_, err := cilium.PolicyImport(cilium.GetFullPath("sample_policy.json"), 300)
+			_, err := cilium.PolicyImport(cilium.GetFullPath(sampleJSON), 300)
 			Expect(err).Should(BeNil())
 
 			endPoints, err := cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 
-			res := cilium.PolicyEnforcementSet("never", true)
+			res := cilium.SetPolicyEnforcement(helpers.PolicyEnforcementNever, true)
 			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(0))
+			Expect(endPoints[helpers.Enabled]).To(Equal(0))
 
-			res = cilium.PolicyEnforcementSet("default", true)
+			res = cilium.SetPolicyEnforcement(helpers.PolicyEnforcementDefault, true)
 			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 		})
 	})
 
@@ -190,7 +209,8 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 		//The test Always to Default is already tested in from default-always
 		BeforeEach(func() {
 			initialize()
-			res := cilium.PolicyEnforcementSet("always", true)
+
+			res := cilium.SetPolicyEnforcement(helpers.PolicyEnforcementAlways, true)
 			res.ExpectSuccess()
 		})
 
@@ -198,67 +218,67 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			//Check default containers are in place.
 			endPoints, err := cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(1))
-			Expect(endPoints["disabled"]).To(Equal(0))
+			Expect(endPoints[helpers.Enabled]).To(Equal(1))
+			Expect(endPoints[helpers.Disabled]).To(Equal(0))
 
 			By("Create a new container")
-			docker.ContainerCreate("new", "cilium/demo-httpd", networkName, "-l id.new")
+			docker.ContainerCreate("new", "cilium/demo-httpd", helpers.CiliumDockerNetwork, "-l id.new")
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(2))
-			Expect(endPoints["disabled"]).To(Equal(0))
+			Expect(endPoints[helpers.Enabled]).To(Equal(2))
+			Expect(endPoints[helpers.Disabled]).To(Equal(0))
 			docker.ContainerRm("new")
 		}, 300)
 
 		It("Always to Never with policy", func() {
 			endPoints, err := cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(1))
-			Expect(endPoints["disabled"]).To(Equal(0))
+			Expect(endPoints[helpers.Enabled]).To(Equal(1))
+			Expect(endPoints[helpers.Disabled]).To(Equal(0))
 
-			_, err = cilium.PolicyImport(cilium.GetFullPath("sample_policy.json"), 300)
+			_, err = cilium.PolicyImport(cilium.GetFullPath(sampleJSON), 300)
 			Expect(err).Should(BeNil())
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(1))
-			Expect(endPoints["disabled"]).To(Equal(0))
+			Expect(endPoints[helpers.Enabled]).To(Equal(1))
+			Expect(endPoints[helpers.Disabled]).To(Equal(0))
 
-			res := cilium.PolicyEnforcementSet("never", true)
+			res := cilium.SetPolicyEnforcement(helpers.PolicyEnforcementNever, true)
 			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(0))
+			Expect(endPoints[helpers.Enabled]).To(Equal(0))
 
-			res = cilium.PolicyEnforcementSet("always", true)
+			res = cilium.SetPolicyEnforcement(helpers.PolicyEnforcementAlways, true)
 			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 		})
 
 		It("Always to Never without policy", func() {
 			endPoints, err := cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(1))
-			Expect(endPoints["disabled"]).To(Equal(0))
+			Expect(endPoints[helpers.Enabled]).To(Equal(1))
+			Expect(endPoints[helpers.Disabled]).To(Equal(0))
 
-			res := cilium.PolicyEnforcementSet("never", true)
+			res := cilium.SetPolicyEnforcement(helpers.PolicyEnforcementNever, true)
 			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(0))
-			Expect(endPoints["disabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Enabled]).To(Equal(0))
+			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
-			res = cilium.PolicyEnforcementSet("always", true)
+			res = cilium.SetPolicyEnforcement(helpers.PolicyEnforcementAlways, true)
 			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 		})
 
 	})
@@ -267,7 +287,8 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 		//The test Always to Default is already tested in from default-always
 		BeforeEach(func() {
 			initialize()
-			res := cilium.PolicyEnforcementSet("never")
+
+			res := cilium.SetPolicyEnforcement(helpers.PolicyEnforcementNever)
 			res.ExpectSuccess()
 		})
 
@@ -275,70 +296,70 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			//Check default containers are in place.
 			endPoints, err := cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(0))
-			Expect(endPoints["disabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Enabled]).To(Equal(0))
+			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
-			docker.ContainerCreate("new", "cilium/demo-httpd", networkName, "-l id.new")
+			docker.ContainerCreate("new", "cilium/demo-httpd", helpers.CiliumDockerNetwork, "-l id.new")
 			cilium.EndpointWaitUntilReady()
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(0))
-			Expect(endPoints["disabled"]).To(Equal(2))
+			Expect(endPoints[helpers.Enabled]).To(Equal(0))
+			Expect(endPoints[helpers.Disabled]).To(Equal(2))
 			docker.ContainerRm("new")
 		}, 300)
 
 		It("Never to default with policy", func() {
 			endPoints, err := cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(0))
-			Expect(endPoints["disabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Enabled]).To(Equal(0))
+			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
-			_, err = cilium.PolicyImport(cilium.GetFullPath("sample_policy.json"), 300)
+			_, err = cilium.PolicyImport(cilium.GetFullPath(sampleJSON), 300)
 			Expect(err).Should(BeNil())
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(0))
-			Expect(endPoints["disabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Enabled]).To(Equal(0))
+			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
-			res := cilium.PolicyEnforcementSet("default", true)
+			res := cilium.SetPolicyEnforcement(helpers.PolicyEnforcementDefault, true)
 			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(1))
-			Expect(endPoints["disabled"]).To(Equal(0))
+			Expect(endPoints[helpers.Enabled]).To(Equal(1))
+			Expect(endPoints[helpers.Disabled]).To(Equal(0))
 
-			res = cilium.PolicyEnforcementSet("never", true)
+			res = cilium.SetPolicyEnforcement(helpers.PolicyEnforcementNever, true)
 			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(0))
-			Expect(endPoints["disabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Enabled]).To(Equal(0))
+			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 		})
 
 		It("Never to default without policy", func() {
 			endPoints, err := cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(0))
-			Expect(endPoints["disabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Enabled]).To(Equal(0))
+			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
-			res := cilium.PolicyEnforcementSet("default", true)
+			res := cilium.SetPolicyEnforcement(helpers.PolicyEnforcementDefault, true)
 			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(0))
-			Expect(endPoints["disabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Enabled]).To(Equal(0))
+			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
-			res = cilium.PolicyEnforcementSet("never", true)
+			res = cilium.SetPolicyEnforcement(helpers.PolicyEnforcementNever, true)
 			res.ExpectSuccess()
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
-			Expect(endPoints["enabled"]).To(Equal(0))
-			Expect(endPoints["disabled"]).To(Equal(1))
+			Expect(endPoints[helpers.Enabled]).To(Equal(0))
+			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 		})
 	})
 })
@@ -346,7 +367,6 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 var _ = Describe("RuntimePolicies", func() {
 
 	var initialized bool
-	var networkName string = "cilium-net"
 	var logger *log.Entry
 	var docker *helpers.Docker
 	var cilium *helpers.Cilium
@@ -357,11 +377,11 @@ var _ = Describe("RuntimePolicies", func() {
 		}
 		logger = log.WithFields(log.Fields{"test": "RunPolicies"})
 		logger.Info("Starting")
-		docker, cilium = helpers.CreateNewRuntimeHelper("runtime", logger)
-		docker.NetworkCreate(networkName, "")
+		docker, cilium = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		docker.NetworkCreate(helpers.CiliumDockerNetwork, "")
 
 		cilium.WaitUntilReady(100)
-		res := cilium.PolicyEnforcementSet("default", false)
+		res := cilium.SetPolicyEnforcement(helpers.PolicyEnforcementDefault, false)
 		res.ExpectSuccess()
 		initialized = true
 
@@ -369,8 +389,8 @@ var _ = Describe("RuntimePolicies", func() {
 
 	BeforeEach(func() {
 		initialize()
-		cilium.Exec("policy delete --all")
-		docker.SampleContainersActions("create", networkName)
+		cilium.PolicyDelAll()
+		docker.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
 		cilium.EndpointWaitUntilReady()
 	})
 
@@ -378,12 +398,12 @@ var _ = Describe("RuntimePolicies", func() {
 		if CurrentGinkgoTestDescription().Failed {
 			cilium.ReportFailed()
 		}
-		docker.SampleContainersActions("delete", networkName)
+		docker.SampleContainersActions(helpers.Delete, helpers.CiliumDockerNetwork)
 	})
 
-	pingRequests := []string{"ping", "ping6"}
-	httpRequestsPublic := []string{"http", "http6"}
-	httpRequestsPrivate := []string{"http_private", "http6_private"}
+	pingRequests := []string{ping, ping6}
+	httpRequestsPublic := []string{http, http6}
+	httpRequestsPrivate := []string{httpPrivate, http6Private}
 	httpRequests := append(httpRequestsPublic, httpRequestsPrivate...)
 	allRequests := append(pingRequests, httpRequests...)
 	connectivityTest := func(tests []string, client, server string, assertFn func() types.GomegaMatcher) {
@@ -392,82 +412,84 @@ var _ = Describe("RuntimePolicies", func() {
 		}
 		_, err := docker.ContainerInspectNet(client)
 		Expect(err).Should(BeNil(), fmt.Sprintf(
-			"Couldn't get container '%s' client meta", client))
+			"could not get container %q (client) meta", client))
 
 		srvIP, err := docker.ContainerInspectNet(server)
 		Expect(err).Should(BeNil(), fmt.Sprintf(
-			"Couldn't get container '%s' server meta", server))
+			"could not get container %q (server) meta", server))
 		for _, test := range tests {
 			switch test {
-			case "ping":
-				By(title("Client '%s' pinging server '%s' IPv4"))
-				res := docker.ContainerExec(client, fmt.Sprintf("ping -c 3 -W 2 %s", srvIP["IPv4"]))
+			case ping:
+				By(title("Client %q pinging server %q IPv4"))
+				res := docker.ContainerExec(client, helpers.Ping(srvIP[helpers.IPv4]))
 				ExpectWithOffset(1, res.WasSuccessful()).Should(assertFn(), fmt.Sprintf(
-					"Client '%s' can't ping to server '%s'", client, srvIP["IPv4"]))
-			case "ping6":
-				By(title("Client '%s' pinging server '%s' IPv6"))
-				res := docker.ContainerExec(client, fmt.Sprintf("ping6 -c 3 -W 2 %s", srvIP["IPv6"]))
+					"Client %q can't ping to server %q", client, srvIP[helpers.IPv4]))
+			case ping6:
+
+				By(title("Client %q pinging server %q IPv6"))
+				res := docker.ContainerExec(client, helpers.Ping6(srvIP[helpers.IPv6]))
 				ExpectWithOffset(1, res.WasSuccessful()).Should(assertFn(), fmt.Sprintf(
-					"Client '%s' can't ping to server '%s'", client, srvIP["IPv6"]))
-			case "http":
+					"Client %q can't ping to server %q", client, srvIP[helpers.IPv6]))
+			case http:
 				By(title("Client '%s' HttpReq to server '%s' Ipv4"))
-				res := docker.ContainerExec(client, fmt.Sprintf(
-					"curl -s --fail --connect-timeout 3 http://%s:80/public", srvIP["IPv4"]))
+				res := docker.ContainerExec(client, helpers.CurlFail(fmt.Sprintf(
+					"http://%s:80/public", srvIP[helpers.IPv4])))
 				ExpectWithOffset(1, res.WasSuccessful()).Should(assertFn(), fmt.Sprintf(
-					"Client '%s' can't curl to server '%s'", client, srvIP["IPv4"]))
-			case "http6":
-				By(title("Client '%s' HttpReq to server '%s' IPv6"))
-				res := docker.ContainerExec(client, fmt.Sprintf(
-					"curl -s --fail --connect-timeout 3 http://[%s]:80/public", srvIP["IPv6"]))
+					"Client %q can't curl to server %q", client, srvIP[helpers.IPv4]))
+			case http6:
+				By(title("Client %q HttpReq to server %q IPv6"))
+				res := docker.ContainerExec(client, helpers.CurlFail(fmt.Sprintf(
+					"http://[%s]:80/public", srvIP[helpers.IPv6])))
 				ExpectWithOffset(1, res.WasSuccessful()).Should(assertFn(), fmt.Sprintf(
-					"Client '%s' can't curl to server '%s'", client, srvIP["IPv6"]))
-			case "http_private":
-				By(title("Client '%s' HttpReq to server '%s' private Ipv4"))
-				res := docker.ContainerExec(client, fmt.Sprintf(
-					"curl -s --fail --connect-timeout 3 http://%s:80/private", srvIP["IPv4"]))
+					"Client %q can't curl to server %q", client, srvIP[helpers.IPv6]))
+			case httpPrivate:
+				By(title("Client %q HttpReq to server %q private Ipv4"))
+				res := docker.ContainerExec(client, helpers.CurlFail(fmt.Sprintf(
+					"http://%s:80/private", srvIP[helpers.IPv4])))
 				ExpectWithOffset(1, res.WasSuccessful()).Should(assertFn(), fmt.Sprintf(
-					"Client '%s' can't curl to server '%s' private", client, srvIP["IPv4"]))
-			case "http6_private":
-				By(title("Client '%s' HttpReq to server '%s' private Ipv6"))
-				res := docker.ContainerExec(client, fmt.Sprintf(
-					"curl -s --fail --connect-timeout 3 http://[%s]:80/private", srvIP["IPv6"]))
+					"Client %q can't curl to server %q private", client, srvIP[helpers.IPv4]))
+			case http6Private:
+				By(title("Client %q HttpReq to server %q private Ipv6"))
+				res := docker.ContainerExec(client, helpers.CurlFail(fmt.Sprintf(
+					"http://[%s]:80/private", srvIP[helpers.IPv6])))
 				ExpectWithOffset(1, res.WasSuccessful()).Should(assertFn(), fmt.Sprintf(
-					"Client '%s' can't curl to server '%s' private", client, srvIP["IPv6"]))
+					"Client %q can't curl to server %q private", client, srvIP[helpers.IPv6]))
 			}
 		}
 	}
 
 	It("L3/L4 Checks", func() {
-		_, err := cilium.PolicyImport(cilium.GetFullPath("Policies-l3-policy.json"), 300)
+		_, err := cilium.PolicyImport(cilium.GetFullPath(policiesL3JSON), 300)
 		Expect(err).Should(BeNil())
 
 		//APP1 can connect to all Httpd1
-		connectivityTest(allRequests, "app1", "httpd1", BeTrue)
+		connectivityTest(allRequests, helpers.App1, helpers.Httpd1, BeTrue)
 
 		//APP2 can't connect to Httpd1
-		connectivityTest([]string{"http"}, "app2", "httpd1", BeFalse)
+		connectivityTest([]string{http}, helpers.App2, helpers.Httpd1, BeFalse)
 
 		// APP1 can reach using TCP HTTP2
-		connectivityTest(httpRequestsPublic, "app1", "httpd2", BeTrue)
+		connectivityTest(httpRequestsPublic, helpers.App1, helpers.Httpd2, BeTrue)
 
 		// APP2 can't reach using TCP to HTTP2
-		connectivityTest(httpRequestsPublic, "app2", "httpd2", BeFalse)
+		connectivityTest(httpRequestsPublic, helpers.App2, helpers.Httpd2, BeFalse)
 
 		// APP3 can reach using TCP HTTP3, but can't ping EGRESS
-		connectivityTest(httpRequestsPublic, "app3", "httpd3", BeTrue)
+		connectivityTest(httpRequestsPublic, helpers.App3, helpers.Httpd3, BeTrue)
 
 		By("Disabling all the policies. All should work")
 
-		status := cilium.Exec("policy delete --all")
+		status := cilium.PolicyDelAll()
 		status.ExpectSuccess()
+
 		cilium.EndpointWaitUntilReady()
 
-		connectivityTest(allRequests, "app1", "httpd1", BeTrue)
-		connectivityTest(allRequests, "app2", "httpd1", BeTrue)
+		connectivityTest(allRequests, helpers.App1, helpers.Httpd1, BeTrue)
+		connectivityTest(allRequests, helpers.App2, helpers.Httpd1, BeTrue)
 
 		By("Ingress CIDR")
 
-		app1, err := docker.ContainerInspectNet("app1")
+		app1, err := docker.ContainerInspectNet(helpers.App1)
 		Expect(err).Should(BeNil())
 
 		script := fmt.Sprintf(`
@@ -482,22 +504,22 @@ var _ = Describe("RuntimePolicies", func() {
 				{"fromCIDR":
 					[ "%s/32", "%s" ]}
 			]
-		}]`, app1["IPv4"], app1["IPv6"])
+		}]`, app1[helpers.IPv4], app1[helpers.IPv6])
 
-		err = helpers.RenderTemplateToFile("ingress.json", script, 0777)
+		err = helpers.RenderTemplateToFile(ingressJSON, script, 0777)
 		Expect(err).Should(BeNil())
 
-		path := helpers.GetFilePath("ingress.json")
+		path := helpers.GetFilePath(ingressJSON)
 		_, err = cilium.PolicyImport(path, 300)
 		Expect(err).Should(BeNil())
-		defer os.Remove("ingress.json")
+		defer os.Remove(ingressJSON)
 
-		connectivityTest(httpRequests, "app1", "httpd1", BeTrue)
-		connectivityTest(httpRequests, "app2", "httpd1", BeFalse)
+		connectivityTest(httpRequestsPublic, helpers.App1, helpers.Httpd1, BeTrue)
+		connectivityTest(httpRequestsPublic, helpers.App2, helpers.Httpd1, BeFalse)
 
 		By("Egress CIDR")
 
-		httpd1, err := docker.ContainerInspectNet("httpd1")
+		httpd1, err := docker.ContainerInspectNet(helpers.Httpd1)
 		Expect(err).Should(BeNil())
 
 		script = fmt.Sprintf(`
@@ -515,105 +537,107 @@ var _ = Describe("RuntimePolicies", func() {
 			 "egress": [{
 				"toCIDR": [ "%s/32", "%s" ]
 			 }]
-		}]`, "app1", httpd1["IPv4"], httpd1["IPv6"])
-		err = helpers.RenderTemplateToFile("egress.json", script, 0777)
+		}]`, helpers.App1, httpd1[helpers.IPv4], httpd1[helpers.IPv6])
+		err = helpers.RenderTemplateToFile(egressJSON, script, 0777)
 		Expect(err).Should(BeNil())
-		path = helpers.GetFilePath("egress.json")
-		defer os.Remove("egress.json")
+		path = helpers.GetFilePath(egressJSON)
+		defer os.Remove(egressJSON)
 		_, err = cilium.PolicyImport(path, 300)
 		Expect(err).Should(BeNil())
 
-		connectivityTest(httpRequestsPublic, "app1", "httpd1", BeTrue)
-		connectivityTest(httpRequestsPublic, "app2", "httpd1", BeFalse)
+		connectivityTest(httpRequestsPublic, helpers.App1, helpers.Httpd1, BeTrue)
+		connectivityTest(httpRequestsPublic, helpers.App2, helpers.Httpd1, BeFalse)
 	})
 
 	It("L4Policy Checks", func() {
 		_, err := cilium.PolicyImport(cilium.GetFullPath("Policies-l4-policy.json"), 300)
 		Expect(err).Should(BeNil())
 
-		for _, app := range []string{"app1", "app2"} {
-			connectivityTest(allRequests, app, "httpd1", BeFalse)
-			connectivityTest(pingRequests, app, "httpd2", BeFalse)
-			connectivityTest(httpRequestsPublic, app, "httpd2", BeTrue)
+		for _, app := range []string{helpers.App1, helpers.App2} {
+			connectivityTest(allRequests, app, helpers.Httpd1, BeFalse)
+			connectivityTest(pingRequests, app, helpers.Httpd2, BeFalse)
+			connectivityTest(httpRequestsPublic, app, helpers.Httpd2, BeTrue)
 		}
 
 		By("Disabling all the policies. All should work")
 
-		status := cilium.Exec("policy delete --all")
+		status := cilium.PolicyDelAll()
 		Expect(status.WasSuccessful()).Should(BeTrue())
 		cilium.EndpointWaitUntilReady()
 
-		for _, app := range []string{"app1", "app2"} {
-			connectivityTest(allRequests, app, "httpd1", BeTrue)
-			connectivityTest(allRequests, app, "httpd2", BeTrue)
+		for _, app := range []string{helpers.App1, helpers.App2} {
+			connectivityTest(allRequests, app, helpers.Httpd1, BeTrue)
+			connectivityTest(allRequests, app, helpers.Httpd2, BeTrue)
 		}
 	})
 
 	It("L7 Checks", func() {
 
-		_, err := cilium.PolicyImport(cilium.GetFullPath("Policies-l7-simple.json"), 300)
+		_, err := cilium.PolicyImport(cilium.GetFullPath(policiesL7JSON), 300)
 		Expect(err).Should(BeNil())
 
 		By("Simple Ingress")
-		//APP1 can connnect to public, but no to private
-		connectivityTest(httpRequestsPublic, "app1", "httpd1", BeTrue)
-		connectivityTest(httpRequestsPrivate, "app1", "httpd1", BeFalse)
+		//APP1 can connect to public, but no to private
+		connectivityTest(httpRequestsPublic, helpers.App1, helpers.Httpd1, BeTrue)
+		connectivityTest(httpRequestsPrivate, helpers.App1, helpers.Httpd1, BeFalse)
 
 		//App2 can't connect
-		connectivityTest(httpRequestsPublic, "app2", "httpd1", BeFalse)
+		connectivityTest(httpRequestsPublic, helpers.App2, helpers.Httpd1, BeFalse)
 
 		By("Simple Egress")
 
 		//APP2 can connnect to public, but no to private
-		connectivityTest(httpRequestsPublic, "app2", "httpd2", BeTrue)
-		connectivityTest(httpRequestsPrivate, "app2", "httpd2", BeFalse)
+		connectivityTest(httpRequestsPublic, helpers.App2, helpers.Httpd2, BeTrue)
+		connectivityTest(httpRequestsPrivate, helpers.App2, helpers.Httpd2, BeFalse)
 
 		By("Disabling all the policies. All should work")
-		status := cilium.Exec("policy delete --all")
+
+		status := cilium.PolicyDelAll()
 		status.ExpectSuccess()
 		cilium.EndpointWaitUntilReady()
 
-		connectivityTest(allRequests, "app1", "httpd1", BeTrue)
-		connectivityTest(allRequests, "app2", "httpd1", BeTrue)
+		connectivityTest(allRequests, helpers.App1, helpers.Httpd1, BeTrue)
+		connectivityTest(allRequests, helpers.App2, helpers.Httpd1, BeTrue)
 
 		By("Multiple Ingress")
 
-		cilium.Exec("policy delete --all")
-		_, err = cilium.PolicyImport(cilium.GetFullPath("Policies-l7-multiple.json"), 300)
+		cilium.PolicyDelAll()
+		_, err = cilium.PolicyImport(cilium.GetFullPath(multL7PoliciesJSON), 300)
 		Expect(err).Should(BeNil())
 
 		//APP1 can connnect to public, but no to private
-		connectivityTest(httpRequestsPublic, "app1", "httpd1", BeTrue)
-		connectivityTest(httpRequestsPrivate, "app1", "httpd1", BeFalse)
+
+		connectivityTest(httpRequestsPublic, helpers.App1, helpers.Httpd1, BeTrue)
+		connectivityTest(httpRequestsPrivate, helpers.App1, helpers.Httpd1, BeFalse)
 
 		//App2 can't connect
-		connectivityTest(httpRequestsPublic, "app2", "httpd1", BeFalse)
+		connectivityTest(httpRequestsPublic, helpers.App2, helpers.Httpd1, BeFalse)
 
 		By("Multiple Egress")
-		//APP2 can connnect to public, but no to private
-		connectivityTest(httpRequestsPublic, "app2", "httpd2", BeTrue)
-		connectivityTest(httpRequestsPrivate, "app2", "httpd2", BeFalse)
+		// app2 can connect to /public, but not to /private
+		connectivityTest(httpRequestsPublic, helpers.App2, helpers.Httpd2, BeTrue)
+		connectivityTest(httpRequestsPrivate, helpers.App2, helpers.Httpd2, BeFalse)
 
 		By("Disabling all the policies. All should work")
 
-		status = cilium.Exec("policy delete --all")
+		status = cilium.PolicyDelAll()
 		status.ExpectSuccess()
 		cilium.EndpointWaitUntilReady()
 
-		connectivityTest(allRequests, "app1", "httpd1", BeTrue)
-		connectivityTest(allRequests, "app2", "httpd1", BeTrue)
+		connectivityTest(allRequests, helpers.App1, helpers.Httpd1, BeTrue)
+		connectivityTest(allRequests, helpers.App2, helpers.Httpd1, BeTrue)
 	})
 
 	It("Invalid Policies", func() {
 
 		testInvalidPolicy := func(data string) {
-			err := helpers.RenderTemplateToFile("invalid.json", data, 0777)
+			err := helpers.RenderTemplateToFile(invalidJSON, data, 0777)
 			Expect(err).Should(BeNil())
 
-			path := helpers.GetFilePath("invalid.json")
+			path := helpers.GetFilePath(invalidJSON)
 			_, err = cilium.PolicyImport(path, 300)
 			Expect(err).Should(HaveOccurred())
-			defer os.Remove("invalid.json")
+			defer os.Remove(invalidJSON)
 		}
 		By("Invalid Json")
 
@@ -624,7 +648,7 @@ var _ = Describe("RuntimePolicies", func() {
 			},`)
 		testInvalidPolicy(script)
 
-		By("Test maximun tcp ports")
+		By("Test maximum tcp ports")
 		var ports string
 		for i := 0; i < 50; i++ {
 			ports += fmt.Sprintf(`{"port": "%d", "protocol": "tcp"}`, i)
@@ -669,16 +693,16 @@ var _ = Describe("RuntimePolicies", func() {
 			"labels": ["key3"]
 		}]`
 
-		err := helpers.RenderTemplateToFile("policy.json", policy, 0777)
+		err := helpers.RenderTemplateToFile(policyJSON, policy, 0777)
 		Expect(err).Should(BeNil())
 
-		path := helpers.GetFilePath("policy.json")
+		path := helpers.GetFilePath(policyJSON)
 		_, err = cilium.PolicyImport(path, 300)
 		Expect(err).Should(BeNil())
-		defer os.Remove("policy.json")
+		defer os.Remove(policyJSON)
 		for _, v := range []string{"key1", "key2", "key3"} {
 			res := cilium.PolicyGet(v)
-			res.ExpectSuccess(fmt.Sprintf("Key %s can't get get", v))
+			res.ExpectSuccess(fmt.Sprintf("cannot get key %q", v))
 		}
 
 		res := cilium.PolicyDel("key2")
@@ -695,10 +719,11 @@ var _ = Describe("RuntimePolicies", func() {
 			res = cilium.PolicyDel(v)
 			res.ExpectSuccess()
 		}
-		res = cilium.Exec("policy get")
+
+		res = cilium.PolicyGetAll()
 		res.ExpectSuccess()
 
-		res = cilium.Exec("policy delete --all")
+		res = cilium.PolicyDelAll()
 		res.ExpectSuccess()
 
 	})

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -101,7 +101,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			})
 
 			By("Apply a new sample policy")
-			_, err := cilium.PolicyImport(cilium.GetFullPath(sampleJSON), 300)
+			_, err := cilium.PolicyImport(cilium.GetFullPath(sampleJSON), helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
 			endPoints, err := cilium.PolicyEndpointsSummary()
@@ -111,7 +111,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 
 		It("Handles missing required fields", func() {
 			By("Apply a policy with no endpointSelector without crashing")
-			_, err := cilium.PolicyImport(cilium.GetFullPath("no_endpointselector_policy.json"), 300)
+			_, err := cilium.PolicyImport(cilium.GetFullPath("no_endpointselector_policy.json"), helpers.HelperTimeout)
 			Expect(err).ShouldNot(BeNil())
 		})
 
@@ -140,7 +140,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 		})
 
 		It("Default to Always with policy", func() {
-			_, err := cilium.PolicyImport(cilium.GetFullPath(sampleJSON), 300)
+			_, err := cilium.PolicyImport(cilium.GetFullPath(sampleJSON), helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
 			endPoints, err := cilium.PolicyEndpointsSummary()
@@ -182,7 +182,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 
 		It("Default to Never with policy", func() {
 
-			_, err := cilium.PolicyImport(cilium.GetFullPath(sampleJSON), 300)
+			_, err := cilium.PolicyImport(cilium.GetFullPath(sampleJSON), helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
 			endPoints, err := cilium.PolicyEndpointsSummary()
@@ -236,7 +236,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 			Expect(endPoints[helpers.Disabled]).To(Equal(0))
 
-			_, err = cilium.PolicyImport(cilium.GetFullPath(sampleJSON), 300)
+			_, err = cilium.PolicyImport(cilium.GetFullPath(sampleJSON), helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
@@ -314,7 +314,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			Expect(endPoints[helpers.Enabled]).To(Equal(0))
 			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
-			_, err = cilium.PolicyImport(cilium.GetFullPath(sampleJSON), 300)
+			_, err = cilium.PolicyImport(cilium.GetFullPath(sampleJSON), helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
 			endPoints, err = cilium.PolicyEndpointsSummary()
@@ -459,7 +459,7 @@ var _ = Describe("RuntimePolicies", func() {
 	}
 
 	It("L3/L4 Checks", func() {
-		_, err := cilium.PolicyImport(cilium.GetFullPath(policiesL3JSON), 300)
+		_, err := cilium.PolicyImport(cilium.GetFullPath(policiesL3JSON), helpers.HelperTimeout)
 		Expect(err).Should(BeNil())
 
 		//APP1 can connect to all Httpd1
@@ -510,7 +510,7 @@ var _ = Describe("RuntimePolicies", func() {
 		Expect(err).Should(BeNil())
 
 		path := helpers.GetFilePath(ingressJSON)
-		_, err = cilium.PolicyImport(path, 300)
+		_, err = cilium.PolicyImport(path, helpers.HelperTimeout)
 		Expect(err).Should(BeNil())
 		defer os.Remove(ingressJSON)
 
@@ -542,7 +542,7 @@ var _ = Describe("RuntimePolicies", func() {
 		Expect(err).Should(BeNil())
 		path = helpers.GetFilePath(egressJSON)
 		defer os.Remove(egressJSON)
-		_, err = cilium.PolicyImport(path, 300)
+		_, err = cilium.PolicyImport(path, helpers.HelperTimeout)
 		Expect(err).Should(BeNil())
 
 		connectivityTest(httpRequestsPublic, helpers.App1, helpers.Httpd1, BeTrue)
@@ -550,7 +550,7 @@ var _ = Describe("RuntimePolicies", func() {
 	})
 
 	It("L4Policy Checks", func() {
-		_, err := cilium.PolicyImport(cilium.GetFullPath("Policies-l4-policy.json"), 300)
+		_, err := cilium.PolicyImport(cilium.GetFullPath("Policies-l4-policy.json"), helpers.HelperTimeout)
 		Expect(err).Should(BeNil())
 
 		for _, app := range []string{helpers.App1, helpers.App2} {
@@ -573,7 +573,7 @@ var _ = Describe("RuntimePolicies", func() {
 
 	It("L7 Checks", func() {
 
-		_, err := cilium.PolicyImport(cilium.GetFullPath(policiesL7JSON), 300)
+		_, err := cilium.PolicyImport(cilium.GetFullPath(policiesL7JSON), helpers.HelperTimeout)
 		Expect(err).Should(BeNil())
 
 		By("Simple Ingress")
@@ -602,7 +602,7 @@ var _ = Describe("RuntimePolicies", func() {
 		By("Multiple Ingress")
 
 		cilium.PolicyDelAll()
-		_, err = cilium.PolicyImport(cilium.GetFullPath(multL7PoliciesJSON), 300)
+		_, err = cilium.PolicyImport(cilium.GetFullPath(multL7PoliciesJSON), helpers.HelperTimeout)
 		Expect(err).Should(BeNil())
 
 		//APP1 can connnect to public, but no to private
@@ -635,7 +635,7 @@ var _ = Describe("RuntimePolicies", func() {
 			Expect(err).Should(BeNil())
 
 			path := helpers.GetFilePath(invalidJSON)
-			_, err = cilium.PolicyImport(path, 300)
+			_, err = cilium.PolicyImport(path, helpers.HelperTimeout)
 			Expect(err).Should(HaveOccurred())
 			defer os.Remove(invalidJSON)
 		}
@@ -697,7 +697,7 @@ var _ = Describe("RuntimePolicies", func() {
 		Expect(err).Should(BeNil())
 
 		path := helpers.GetFilePath(policyJSON)
-		_, err = cilium.PolicyImport(path, 300)
+		_, err = cilium.PolicyImport(path, helpers.HelperTimeout)
 		Expect(err).Should(BeNil())
 		defer os.Remove(policyJSON)
 		for _, v := range []string{"key1", "key2", "key3"} {

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -22,11 +22,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var _ = Describe("RuntimeChaosMonkey", func() {
+var _ = Describe("RuntimeChaos", func() {
 
 	var initialized bool
-	var networkName string = "cilium-net"
-	var netperfImage string = "tgraf/netperf"
 	var logger *log.Entry
 	var docker *helpers.Docker
 	var cilium *helpers.Cilium
@@ -35,10 +33,10 @@ var _ = Describe("RuntimeChaosMonkey", func() {
 		if initialized == true {
 			return
 		}
-		logger = log.WithFields(log.Fields{"testName": "RuntimeChaosMonkey"})
+		logger = log.WithFields(log.Fields{"testName": "RuntimeChaos"})
 		logger.Info("Starting")
-		docker, cilium = helpers.CreateNewRuntimeHelper("runtime", logger)
-		docker.NetworkCreate(networkName, "")
+		docker, cilium = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		docker.NetworkCreate(helpers.CiliumDockerNetwork, "")
 		initialized = true
 	}
 
@@ -53,8 +51,8 @@ var _ = Describe("RuntimeChaosMonkey", func() {
 
 	BeforeEach(func() {
 		initialize()
-		docker.ContainerCreate("client", netperfImage, networkName, "-l id.client")
-		docker.ContainerCreate("server", netperfImage, networkName, "-l id.server")
+		docker.ContainerCreate(helpers.Client, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
+		docker.ContainerCreate(helpers.Server, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.server")
 
 		areEndpointsReady := cilium.EndpointWaitUntilReady()
 		Expect(areEndpointsReady).Should(BeTrue())
@@ -64,8 +62,8 @@ var _ = Describe("RuntimeChaosMonkey", func() {
 		if CurrentGinkgoTestDescription().Failed {
 			cilium.ReportFailed()
 		}
-		docker.ContainerRm("client")
-		docker.ContainerRm("server")
+		docker.ContainerRm(helpers.Client)
+		docker.ContainerRm(helpers.Server)
 	})
 
 	It("Endpoint recovery on restart", func() {

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -13,9 +13,6 @@ import (
 var _ = Describe("RuntimeConnectivityTest", func() {
 
 	var initialized bool
-	var networkName string = "cilium-net"
-
-	var netperfImage string = "tgraf/netperf"
 	var logger *log.Entry
 	var docker *helpers.Docker
 	var cilium *helpers.Cilium
@@ -26,17 +23,17 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 		}
 		logger = log.WithFields(log.Fields{"test": "RuntimeConnectivityTest"})
 		logger.Info("Starting")
-		docker, cilium = helpers.CreateNewRuntimeHelper("runtime", logger)
+		docker, cilium = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 		cilium.WaitUntilReady(100)
-		docker.NetworkCreate(networkName, "")
+		docker.NetworkCreate(helpers.CiliumDockerNetwork, "")
 		initialized = true
 	}
 
 	BeforeEach(func() {
 		initialize()
-		docker.ContainerCreate("client", netperfImage, networkName, "-l id.client")
-		docker.ContainerCreate("server", netperfImage, networkName, "-l id.server")
-		cilium.Exec("policy delete --all")
+		docker.ContainerCreate(helpers.Client, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
+		docker.ContainerCreate(helpers.Server, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.server")
+		cilium.PolicyDelAll()
 		cilium.EndpointWaitUntilReady()
 		err := helpers.WithTimeout(func() bool {
 			if data, _ := cilium.GetEndpointsNames(); len(data) < 2 {
@@ -48,95 +45,113 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 		Expect(err).Should(BeNil())
 	}, 150)
 
+	removeContainer := func(containerName string) {
+		By(fmt.Sprintf("removing container %s", containerName))
+		res := docker.ContainerRm(containerName)
+		Expect(res.WasSuccessful()).Should(BeTrue())
+	}
+
 	AfterEach(func() {
-		docker.ContainerRm("client")
-		docker.ContainerRm("server")
+		removeContainer(helpers.Client)
+		removeContainer(helpers.Server)
 		return
 	})
 
-	It("Test containers connectivity without policy", func() {
-		serverData := docker.ContainerInspect("server")
-		serverIP, err := serverData.Filter("{[0].NetworkSettings.Networks.cilium-net.IPAddress}")
-		Expect(err).Should(BeNil())
-		serverIPv6, err := serverData.Filter("{[0].NetworkSettings.Networks.cilium-net.GlobalIPv6Address}")
+	It("Test connectivity between containers without policies imported", func() {
+		// TODO: this code is duplicated in the next "It" in this file. refactor it into a function.
+		// See if we can make the "Filter" strings for getting IPv4 and IPv6 addresses into constants.
+		By(fmt.Sprintf("inspecting container %s", helpers.Server))
+		serverData := docker.ContainerInspect(helpers.Server)
+		serverIP, err := serverData.Filter(fmt.Sprintf("{[0].NetworkSettings.Networks.%s.IPAddress}", helpers.CiliumDockerNetwork))
 		Expect(err).Should(BeNil())
 
-		By("Client can ping to server IPV6")
-		res := docker.ContainerExec("client", fmt.Sprintf("ping6 -c 4 %s", serverIPv6))
+		By(fmt.Sprintf("serverIP: %s", serverIP))
+		serverIPv6, err := serverData.Filter(fmt.Sprintf("{[0].NetworkSettings.Networks.%s.GlobalIPv6Address}", helpers.CiliumDockerNetwork))
+		By(fmt.Sprintf("serverIPv6: %s", serverIPv6))
+		Expect(err).Should(BeNil())
+
+		By(fmt.Sprintf("checking %s can ping to %s IPv6", helpers.Client, helpers.Server))
+		res := docker.ContainerExec(helpers.Client, helpers.Ping6(serverIPv6.String()))
 		res.ExpectSuccess()
 
-		By("Client can ping to server Ipv4")
-		res = docker.ContainerExec("client", fmt.Sprintf("ping -c 5 %s", serverIP))
+		By(fmt.Sprintf("checking %s can ping to %s IPv4", helpers.Client, helpers.Server))
+		res = docker.ContainerExec(helpers.Client, helpers.Ping(serverIP.String()))
 		res.ExpectSuccess()
 
-		By("Netperf to server from client IPv6")
+		// TODO: remove this hardcoding ; it is not clean. Have command wrappers that take maps of strings.
+		By(fmt.Sprintf("netperf to %s from %s IPv6", helpers.Server, helpers.Client))
 		cmd := fmt.Sprintf(
 			"netperf -c -C -t TCP_SENDFILE -H %s", serverIPv6)
-		res = docker.ContainerExec("client", cmd)
-		res.ExpectSuccess()
 
+		res = docker.ContainerExec(helpers.Client, cmd)
+		res.ExpectSuccess()
 	}, 300)
 
-	It("Test containers connectivity WITH policy", func() {
-		policyID, _ := cilium.PolicyImport(
+	It("Test connectivity between containers with policy imported", func() {
+		policyID, err := cilium.PolicyImport(
 			fmt.Sprintf("%s/test.policy", cilium.ManifestsPath()), 150)
+		Expect(err).Should(BeNil())
 		logger.Debug("New policy created with id '%d'", policyID)
 
-		serverData := docker.ContainerInspect("server")
-		serverIP, err := serverData.Filter("{[0].NetworkSettings.Networks.cilium-net.IPAddress}")
+		serverData := docker.ContainerInspect(helpers.Server)
+		serverIP, err := serverData.Filter(fmt.Sprintf("{[0].NetworkSettings.Networks.%s.IPAddress}", helpers.CiliumDockerNetwork))
 		Expect(err).Should(BeNil())
-		serverIPv6, err := serverData.Filter("{[0].NetworkSettings.Networks.cilium-net.GlobalIPv6Address}")
+		By(fmt.Sprintf("serverIP: %s", serverIP))
+		serverIPv6, err := serverData.Filter(fmt.Sprintf("{[0].NetworkSettings.Networks.%s.GlobalIPv6Address}", helpers.CiliumDockerNetwork))
+		By(fmt.Sprintf("serverIPv6: %s", serverIPv6))
 		Expect(err).Should(BeNil())
 
-		By("Client can ping to server IPV6")
-		res := docker.ContainerExec("client", fmt.Sprintf("ping6 -c 4 %s", serverIPv6))
+		By(fmt.Sprintf("%s can ping to %s IPV6", helpers.Client, helpers.Server))
+		res := docker.ContainerExec(helpers.Client, helpers.Ping6(serverIPv6.String()))
 		res.ExpectSuccess()
 
-		By("Client can ping to server Ipv4")
-		res = docker.ContainerExec("client", fmt.Sprintf("ping -c 5 %s", serverIP))
+		By(fmt.Sprintf("%s can ping to %s IPv4", helpers.Client, helpers.Server))
+		res = docker.ContainerExec(helpers.Client, helpers.Ping(serverIP.String()))
 		res.ExpectSuccess()
 
-		By("Netperf to server from client IPv6")
+		// TODO: remove this hardcoding ; it is not clean. Have command wrappers that take maps of strings.
+		By(fmt.Sprintf("netperf to %s from %s IPv6", helpers.Server, helpers.Client))
 		cmd := fmt.Sprintf(
 			"netperf -c -C -t TCP_SENDFILE -H %s", serverIPv6)
-		res = docker.ContainerExec("client", cmd)
+
+		res = docker.ContainerExec(helpers.Client, cmd)
 		res.ExpectSuccess()
 
-		By("Ping from host to server")
-		res = docker.Node.Exec(fmt.Sprintf("ping -c 4 %s", serverIP))
+		By(fmt.Sprintf("ping from %s to %s", helpers.Host, helpers.Server))
+		res = docker.Node.Exec(helpers.Ping(serverIP.String()))
 		res.ExpectSuccess()
 	}, 300)
 
-	It("Test containers NAT46 connectivity ", func() {
+	It("Test NAT46 connectivity between containers", func() {
 
 		endpoints, err := cilium.GetEndpointsIds()
-		Expect(err).Should(BeNil(), "Couldn't get endpoints IDS")
+		Expect(err).Should(BeNil(), "could not get endpoint IDs")
 
-		server, err := docker.ContainerInspectNet("server")
+		server, err := docker.ContainerInspectNet(helpers.Server)
 		Expect(err).Should(BeNil())
+		By(fmt.Sprintf("server: %s", server))
 
-		client, err := docker.ContainerInspectNet("client")
+		client, err := docker.ContainerInspectNet(helpers.Client)
 		Expect(err).Should(BeNil())
+		By(fmt.Sprintf("client: %s", client))
 
-		status := cilium.EndpointSetConfig(endpoints["client"], "NAT46", "Enabled")
+		status := cilium.EndpointSetConfig(endpoints[helpers.Client], "NAT46", helpers.OptionEnabled)
 		Expect(status).Should(BeTrue())
 
-		res := docker.ContainerExec("client", fmt.Sprintf(
-			"ping6 -c 4 ::FFFF:%s", server["IPv4"]))
+		res := docker.ContainerExec(helpers.Client, helpers.Ping6(fmt.Sprintf(
+			"::FFFF:%s", server[helpers.IPv4])))
+
 		res.ExpectSuccess()
 
-		res = docker.ContainerExec("server", fmt.Sprintf(
-			"ping6 -c 4 ::FFFF:%s", client["IPv4"]))
-		res.ExpectFail("Unexpected NAT46 access")
+		res = docker.ContainerExec(helpers.Server,
+			helpers.Ping6(fmt.Sprintf("::FFFF:%s", client[helpers.IPv4])))
+		res.ExpectFail(fmt.Sprintf("unexpectedly succeeded pinging IPv6 %s from %s", client[helpers.IPv4], helpers.Server))
 	})
 })
 
 var _ = Describe("RuntimeConntrackTest", func() {
 
 	var initialized bool
-	var networkName string = "cilium-net"
-
-	var netperfImage string = "tgraf/netperf"
 	var logger *log.Entry
 	var docker *helpers.Docker
 	var cilium *helpers.Cilium
@@ -147,86 +162,87 @@ var _ = Describe("RuntimeConntrackTest", func() {
 		}
 		logger = log.WithFields(log.Fields{"test": "RunConntrackTest"})
 		logger.Info("Starting")
-		docker, cilium = helpers.CreateNewRuntimeHelper("runtime", logger)
-		docker.NetworkCreate(networkName, "")
+		docker, cilium = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		docker.NetworkCreate(helpers.CiliumDockerNetwork, "")
 		initialized = true
 	}
 
 	clientServerConnectivity := func() {
-		cliIP, err := docker.ContainerInspectNet("client")
-		Expect(err).Should(BeNil(), "Couldn't get container client Meta")
+		cliIP, err := docker.ContainerInspectNet(helpers.Client)
+		Expect(err).Should(BeNil(), fmt.Sprintf("could not get metadata for container %q", helpers.Client))
+		By(fmt.Sprintf("cliIP: %s", cliIP))
 
-		srvIP, err := docker.ContainerInspectNet("server")
-		Expect(err).Should(BeNil(), "Couldn't get container server Meta")
+		srvIP, err := docker.ContainerInspectNet(helpers.Server)
+		Expect(err).Should(BeNil(), fmt.Sprintf("could not get metadata for container %q", helpers.Server))
+		By(fmt.Sprintf("srvIP: %s", srvIP))
 
-		By("Client pinging server IPv6")
-		res := docker.ContainerExec("client", fmt.Sprintf("ping6 -c 4 %s", srvIP["IPv6"]))
+		By(fmt.Sprintf("%s pinging %s IPv6", helpers.Client, helpers.Server))
+		res := docker.ContainerExec(helpers.Client, helpers.Ping6(srvIP[helpers.IPv6]))
 		Expect(res.WasSuccessful()).Should(BeTrue(), fmt.Sprintf(
-			"Client can't ping to server %s", srvIP["IPv6"]))
+			fmt.Sprintf("%s cannot ping to % %s", helpers.Client, helpers.Server, srvIP[helpers.IPv6])))
 
-		By("Client pinging server IPv4")
-		res = docker.ContainerExec("client", fmt.Sprintf("ping -c 4 %s", srvIP["IPv4"]))
+		By(fmt.Sprintf("%s pinging %s IPv4", helpers.Client, helpers.Server))
+		res = docker.ContainerExec(helpers.Client, helpers.Ping(srvIP[helpers.IPv4]))
 		Expect(res.WasSuccessful()).Should(BeTrue(), fmt.Sprintf(
-			"Client can't ping to server %s", srvIP["IPv4"]))
+			"%s cannot ping server %s", helpers.Client, srvIP[helpers.IPv4]))
 
-		By("Client netcat to port 777 IPv6")
-		res = docker.ContainerExec("client", fmt.Sprintf("nc -w 4 %s 777", srvIP["IPv6"]))
+		// TODO: remove this hardcoding ; it is not clean. Have command wrappers that take maps of strings.
+		By(fmt.Sprintf("%s netcat to port 777 IPv6", helpers.Client))
+		res = docker.ContainerExec(helpers.Client, fmt.Sprintf("nc -w 4 %s 777", srvIP[helpers.IPv6]))
 		Expect(res.WasSuccessful()).Should(BeFalse(), fmt.Sprintf(
-			"Client can connect to %s:777. Should fail", srvIP["IPv6"]))
+			"%s can connect to %s:777. Should fail", helpers.Client, srvIP[helpers.IPv6]))
 
-		By("Client netcat to port 777 IPv4")
-		res = docker.ContainerExec("client", fmt.Sprintf("nc -w 4 %s 777", srvIP["IPv4"]))
+		// TODO: remove this hardcoding ; it is not clean. Have command wrappers that take maps of strings.
+		By(fmt.Sprintf("%s netcat to port 777 IPv4", helpers.Client))
+		res = docker.ContainerExec(helpers.Client, fmt.Sprintf("nc -w 4 %s 777", srvIP[helpers.IPv4]))
 		Expect(res.WasSuccessful()).Should(BeFalse(), fmt.Sprintf(
-			"Client can connect to %s:777. Should fail", srvIP["IPv4"]))
+			"%s can connect to %s:777; should fail", helpers.Client, srvIP[helpers.IPv4]))
 
-		By("Client netperf to server IPv6")
-		res = docker.ContainerExec("client", fmt.Sprintf(
-			"netperf -l 3 -t TCP_RR -H %s", srvIP["IPv6"]))
+		By(fmt.Sprintf("%s netperf to %s IPv6", helpers.Client, helpers.Server))
+		res = docker.ContainerExec(helpers.Client, helpers.Netperf(srvIP[helpers.IPv6], helpers.TCP_RR))
 		Expect(res.WasSuccessful()).Should(BeTrue(), fmt.Sprintf(
-			"Client can't netperf to server %s", srvIP["IPv6"]))
+			"%s cannot netperf to %s %s", helpers.Client, helpers.Server, srvIP[helpers.IPv6]))
 
-		By("Client netperf to server IPv4")
-		res = docker.ContainerExec("client", fmt.Sprintf(
-			"netperf -l 3 -t TCP_RR -H %s", srvIP["IPv4"]))
+		By(fmt.Sprintf("%s netperf to %s IPv4", helpers.Client, helpers.Server))
+		res = docker.ContainerExec(helpers.Client, helpers.Netperf(srvIP[helpers.IPv4], helpers.TCP_RR))
 		Expect(res.WasSuccessful()).Should(BeTrue(), fmt.Sprintf(
-			"Client can't netperf to server %s", srvIP["IPv4"]))
+			"%s cannot netperf to %s %s", helpers.Client, helpers.Server, srvIP[helpers.IPv4]))
 
-		By("Client UDP netperf to server IPv6")
-		res = docker.ContainerExec("client", fmt.Sprintf(
-			"netperf -l 3 -t UDP_RR -H %s", srvIP["IPv6"]))
+		By(fmt.Sprintf("%s UDP netperf to %s IPv6", helpers.Client, helpers.Server))
+		res = docker.ContainerExec(helpers.Client, helpers.Netperf(srvIP[helpers.IPv6], helpers.UDP_RR))
 		Expect(res.WasSuccessful()).Should(BeTrue(), fmt.Sprintf(
-			"Client can't netperf to server %s", srvIP["IPv6"]))
+			"%s cannot netperf to %s %s", helpers.Client, helpers.Server, srvIP[helpers.IPv6]))
 
-		By("Client UDP netperf to server IPv4")
-		res = docker.ContainerExec("client", fmt.Sprintf(
-			"netperf -l 3 -t UDP_RR -H %s", srvIP["IPv4"]))
+		By(fmt.Sprintf("%s UDP netperf to %s IPv4", helpers.Client, helpers.Server))
+		res = docker.ContainerExec(helpers.Client, helpers.Netperf(srvIP[helpers.IPv4], helpers.UDP_RR))
 		Expect(res.WasSuccessful()).Should(BeTrue(), fmt.Sprintf(
-			"Client can't netperf to server %s", srvIP["IPv4"]))
+			"%s cannot netperf to %s %s", helpers.Client, helpers.Server, srvIP[helpers.IPv4]))
 
-		By("Ping from host to server IPv6")
-		res = docker.Node.Exec(fmt.Sprintf("ping6 -c 4 %s", srvIP["IPv6"]))
-		Expect(res.WasSuccessful()).Should(BeTrue(), "Host Can't ping to server")
+		By(fmt.Sprintf("ping from %s to %s IPv6", helpers.Host, helpers.Server))
+		res = docker.Node.Exec(helpers.Ping6(srvIP[helpers.IPv6]))
+		Expect(res.WasSuccessful()).Should(BeTrue(), fmt.Sprintf("%s cannot ping %s", helpers.Host, helpers.Server))
 
-		By("Ping from host to server IPv4")
-		res = docker.Node.Exec(fmt.Sprintf("ping -c 4 %s", srvIP["IPv4"]))
-		Expect(res.WasSuccessful()).Should(BeTrue(), "Host can't ping to server")
+		By(fmt.Sprintf("ping from %s to %s IPv4", helpers.Host, helpers.Server))
+		res = docker.Node.Exec(helpers.Ping(srvIP[helpers.IPv4]))
+		Expect(res.WasSuccessful()).Should(BeTrue(), fmt.Sprintf("%s cannot ping %s", helpers.Host, helpers.Server))
 
-		By("Ping from server to client IPv6")
-		res = docker.ContainerExec("server", fmt.Sprintf("ping6 -c 4 %s", cliIP["IPv6"]))
+		By(fmt.Sprintf("ping from %s to %s IPv6", helpers.Server, helpers.Client))
+		res = docker.ContainerExec(helpers.Server, helpers.Ping6(cliIP[helpers.IPv6]))
 		Expect(res.WasSuccessful()).Should(BeTrue(), fmt.Sprintf(
-			"Server can't ping to client %s", cliIP["IPv6"]))
+			"%s cannot ping to %s %s", helpers.Server, helpers.Client, cliIP[helpers.IPv6]))
 
-		By("Ping from server to client IPv4")
-		res = docker.ContainerExec("server", fmt.Sprintf("ping -c 4 %s", cliIP["IPv4"]))
+		By(fmt.Sprintf("ping from %s to %s IPv4", helpers.Server, helpers.Client))
+		res = docker.ContainerExec(helpers.Server, helpers.Ping(cliIP[helpers.IPv4]))
 		Expect(res.WasSuccessful()).Should(BeTrue(), fmt.Sprintf(
-			"Server can't ping to client %s", cliIP["IPv4"]))
+			"%s cannot ping to %s %s", helpers.Server, helpers.Client, cliIP[helpers.IPv4]))
 	}
 
 	BeforeEach(func() {
 		initialize()
-		docker.ContainerCreate("client", netperfImage, networkName, "-l id.client")
-		docker.ContainerCreate("server", netperfImage, networkName, "-l id.server")
-		cilium.Exec("policy delete --all")
+		// TODO: provide map[string]string instead of one string representing KV pair.
+		docker.ContainerCreate(helpers.Client, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
+		docker.ContainerCreate(helpers.Server, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.server")
+		cilium.PolicyDelAll()
 	})
 
 	AfterEach(func() {
@@ -234,44 +250,44 @@ var _ = Describe("RuntimeConntrackTest", func() {
 			cilium.ReportFailed()
 		}
 
-		docker.ContainerRm("server")
-		docker.ContainerRm("client")
+		docker.ContainerRm(helpers.Server)
+		docker.ContainerRm(helpers.Client)
 	})
 	It("Conntrack disabled", func() {
 		endpoints, err := cilium.GetEndpointsIds()
-		Expect(err).Should(BeNil(), "Couldn't get endpoints IDS")
+		Expect(err).Should(BeNil(), "could not get endpoints IDs")
 
-		status := cilium.EndpointSetConfig(endpoints["server"], "Conntrack", "Disabled")
-		Expect(status).Should(BeTrue(), "Couldn't set conntrack=false on endpoint 'server'")
+		status := cilium.EndpointSetConfig(endpoints[helpers.Server], helpers.OptionConntrack, helpers.OptionDisabled)
+		Expect(status).Should(BeTrue(), fmt.Sprintf("could not set %s=%s on endpoint %q", helpers.OptionConntrack, helpers.OptionDisabled, helpers.Server))
 
-		status = cilium.EndpointSetConfig(endpoints["client"], "Conntrack", "Disabled")
-		Expect(status).Should(BeTrue(), "Couldn't set conntrack=false on endpoint 'client'")
+		status = cilium.EndpointSetConfig(endpoints[helpers.Client], helpers.OptionConntrack, helpers.OptionDisabled)
+		Expect(status).Should(BeTrue(), fmt.Sprintf("could not set %s=%s on endpoint %q", helpers.OptionConntrack, helpers.OptionDisabled, helpers.Client))
 
 		clientServerConnectivity()
 	})
 
 	It("ConntrackLocal disabled", func() {
 		endpoints, err := cilium.GetEndpointsIds()
-		Expect(err).Should(BeNil(), "Couldn't get endpoints IDS")
+		Expect(err).Should(BeNil(), "could not get endpoint IDs")
 
-		status := cilium.EndpointSetConfig(endpoints["server"], "ConntrackLocal", "Disabled")
-		Expect(status).Should(BeTrue(), "Couldn't set conntrack=false on endpoint 'server'")
+		status := cilium.EndpointSetConfig(endpoints[helpers.Server], helpers.OptionConntrackLocal, helpers.OptionDisabled)
+		Expect(status).Should(BeTrue(), fmt.Sprintf("could not set %s=%s on endpoint %q", helpers.OptionConntrackLocal, helpers.OptionDisabled, helpers.Server))
 
-		status = cilium.EndpointSetConfig(endpoints["client"], "ConntrackLocal", "Disabled")
-		Expect(status).Should(BeTrue(), "Couldn't set conntrack=false on endpoint 'client'")
+		status = cilium.EndpointSetConfig(endpoints[helpers.Client], helpers.OptionConntrackLocal, helpers.OptionDisabled)
+		Expect(status).Should(BeTrue(), fmt.Sprintf("could not set %s=%s on endpoint %q", helpers.OptionConntrackLocal, helpers.OptionDisabled, helpers.Client))
 
 		clientServerConnectivity()
 	})
 
 	It("ConntrackLocal Enabled", func() {
 		endpoints, err := cilium.GetEndpointsIds()
-		Expect(err).Should(BeNil(), "Couldn't get endpoints IDS")
+		Expect(err).Should(BeNil(), "could not get endpoint IDs")
 
-		status := cilium.EndpointSetConfig(endpoints["server"], "ConntrackLocal", "Enabled")
-		Expect(status).Should(BeTrue(), "Couldn't set conntrack=false on endpoint 'server'")
+		status := cilium.EndpointSetConfig(endpoints[helpers.Server], helpers.OptionConntrackLocal, helpers.OptionEnabled)
+		Expect(status).Should(BeTrue(), fmt.Sprintf("could not set %s=%s on endpoint %q", helpers.OptionConntrackLocal, helpers.OptionEnabled, helpers.Server))
 
-		status = cilium.EndpointSetConfig(endpoints["client"], "ConntrackLocal", "Enabled")
-		Expect(status).Should(BeTrue(), "Couldn't set conntrack=false on endpoint 'client'")
+		status = cilium.EndpointSetConfig(endpoints[helpers.Client], helpers.OptionConntrackLocal, helpers.OptionEnabled)
+		Expect(status).Should(BeTrue(), fmt.Sprintf("could not set %s=%s on endpoint %q", helpers.OptionConntrackLocal, helpers.OptionEnabled, helpers.Client))
 
 		clientServerConnectivity()
 	})

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -28,7 +28,6 @@ import (
 var _ = Describe("RuntimeLB", func() {
 
 	var initialized bool
-	var networkName string = "cilium-net"
 	var logger *log.Entry
 	var docker *helpers.Docker
 	var cilium *helpers.Cilium
@@ -39,26 +38,27 @@ var _ = Describe("RuntimeLB", func() {
 		}
 		logger = log.WithFields(log.Fields{"test": "RuntimeLB"})
 		logger.Info("Starting")
-		docker, cilium = helpers.CreateNewRuntimeHelper("runtime", logger)
+		docker, cilium = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 		cilium.WaitUntilReady(100)
-		docker.NetworkCreate(networkName, "")
+		docker.NetworkCreate(helpers.CiliumDockerNetwork, "")
 		initialized = true
 	}
 
+	// TODO: rename this function; its name is not clear.
 	containers := func(mode string) {
-		var images map[string]string = map[string]string{
-			"httpd1": "cilium/demo-httpd",
-			"httpd2": "cilium/demo-httpd",
-			"httpd3": "cilium/demo-httpd",
-			"client": "tgraf/netperf",
+		images := map[string]string{
+			helpers.Httpd1: helpers.HttpdImage,
+			helpers.Httpd2: helpers.HttpdImage,
+			helpers.Httpd3: helpers.HttpdImage,
+			helpers.Client: helpers.NetperfImage,
 		}
 
 		switch mode {
-		case "create":
+		case helpers.Create:
 			for k, v := range images {
-				docker.ContainerCreate(k, v, networkName, fmt.Sprintf("-l id.%s", k))
+				docker.ContainerCreate(k, v, helpers.CiliumDockerNetwork, fmt.Sprintf("-l id.%s", k))
 			}
-		case "delete":
+		case helpers.Delete:
 			for k := range images {
 				docker.ContainerRm(k)
 			}
@@ -76,26 +76,30 @@ var _ = Describe("RuntimeLB", func() {
 				"sudo cilium service list",
 				"sudo cilium endpoint list")
 		}
-		containers("delete")
+		containers(helpers.Delete)
 	}, 500)
 
 	It("Service Simple tests", func() {
 
 		By("Creating a valid service")
 		result := cilium.ServiceAdd(1, "[::]:80", []string{"[::1]:90", "[::2]:91"}, 2)
+
 		result.ExpectSuccess("Service can't be added in cilium")
 
 		result = cilium.ServiceGet(1)
-		result.ExpectSuccess("Service can't be retrieved correctly")
+		result.ExpectSuccess("Service cannot be retrieved correctly")
+
 		Expect(result.Output()).Should(ContainSubstring("[::1]:90"), fmt.Sprintf(
-			"No service backends added correctly '%s'", result.Output()))
+			"No service backends added correctly %q", result.Output()))
 		helpers.Sleep(5)
 		//TODO: This need to be with Wait,Timeout
 		//Checking that bpf lb list is working correctly
 		result = cilium.Exec("bpf lb list")
-		result.ExpectSuccess("Service can't be retrieved correctly")
+
+		result.ExpectSuccess("service cannot be retrieved correctly")
+
 		Expect(result.Output()).Should(ContainSubstring("[::1]:90"), fmt.Sprintf(
-			"No service backends added correctly '%s'", result.Output()))
+			"No service backends added correctly %q", result.Output()))
 
 		By("Service ID 0")
 		result = cilium.ServiceAdd(0, "[::]:10000", []string{"[::1]:90", "[::2]:91"}, 2)
@@ -115,18 +119,20 @@ var _ = Describe("RuntimeLB", func() {
 		result.ExpectFail("Service with duplicated FE can be added in cilium")
 
 		result = cilium.ServiceGet(10)
-		result.ExpectFail("Service was added and it shouldn't")
+		result.ExpectFail("service was added; addition of said service should have failed")
 
 		//Deleting service ID=1
 		result = cilium.ServiceDel(1)
-		result.ExpectSuccess("Service can't be deleted")
+		result.ExpectSuccess("Service cannot be deleted")
 
 		By("IPv4 testing")
 		result = cilium.ServiceAdd(1, "127.0.0.1:80", []string{"127.0.0.1:90", "127.0.0.1:91"}, 2)
-		result.ExpectSuccess("Service can't be added in cilium")
+
+		Expect(result.WasSuccessful()).Should(BeTrue(),
+			"Service cannot be added in cilium")
 
 		result = cilium.ServiceGet(1)
-		result.ExpectSuccess("Service can't be retrieved correctly")
+		result.ExpectSuccess("Service cannot be retrieved correctly")
 
 		By("Duplicating service FE address IPv4")
 		result = cilium.ServiceAdd(20, "127.0.0.1:80", []string{"127.0.0.1:90", "127.0.0.1:91"}, 2)
@@ -138,23 +144,23 @@ var _ = Describe("RuntimeLB", func() {
 
 	It("Service L3 tests", func() {
 		createInterface(docker.Node)
-		containers("create")
+		containers(helpers.Create)
 
-		httpd1, err := docker.ContainerInspectNet("httpd1")
+		httpd1, err := docker.ContainerInspectNet(helpers.Httpd1)
 		Expect(err).Should(BeNil())
 
-		httpd2, err := docker.ContainerInspectNet("httpd2")
+		httpd2, err := docker.ContainerInspectNet(helpers.Httpd2)
 		Expect(err).Should(BeNil())
 
 		//Create all the services
 
 		cilium.ServiceAdd(1, "2.2.2.2:0", []string{
-			fmt.Sprintf("%s:0", httpd1["IPv4"]),
-			fmt.Sprintf("%s:0", httpd2["IPv4"])}, 2)
+			fmt.Sprintf("%s:0", httpd1[helpers.IPv4]),
+			fmt.Sprintf("%s:0", httpd2[helpers.IPv4])}, 2)
 
 		cilium.ServiceAdd(2, "[f00d::1:1]:0", []string{
-			fmt.Sprintf("[%s]:0", httpd1["IPv6"]),
-			fmt.Sprintf("[%s]:0", httpd2["IPv6"])}, 100)
+			fmt.Sprintf("[%s]:0", httpd1[helpers.IPv6]),
+			fmt.Sprintf("[%s]:0", httpd2[helpers.IPv6])}, 100)
 
 		cilium.ServiceAdd(11, "3.3.3.3:0", []string{
 			fmt.Sprintf("%s:0", "10.0.2.15")}, 100)
@@ -163,65 +169,68 @@ var _ = Describe("RuntimeLB", func() {
 			fmt.Sprintf("[%s]:0", "fd02:1:1:1:1:1:1:1")}, 100)
 
 		By("Cilium L3 service with Ipv4")
-		status := docker.ContainerExec("client", "ping -c 4 2.2.2.2")
+
+		status := docker.ContainerExec(helpers.Client, helpers.Ping("2.2.2.2"))
 		status.ExpectSuccess("L3 Proxy is not working IPv4")
 
 		By("Cilium L3 service with Ipv6")
-		status = docker.ContainerExec("client", "ping6 -c 4 f00d::1:1")
+		status = docker.ContainerExec(helpers.Client, helpers.Ping6("f00d::1:1"))
 		status.ExpectSuccess("L3 Proxy is not working IPv6")
 
 		By("Cilium L3 service with Ipv4 Reverse")
-		status = docker.ContainerExec("client", "ping -c 4 3.3.3.3")
+		status = docker.ContainerExec(helpers.Client, helpers.Ping("3.3.3.3"))
 		status.ExpectSuccess("L3 Proxy is not working IPv6")
 
 		By("Cilium L3 service with Ipv6 Reverse")
-		status = docker.ContainerExec("client", "ping6 -c 4 f00d::1:2")
+		status = docker.ContainerExec(helpers.Client, helpers.Ping("f00d::1:2"))
 		status.ExpectSuccess("L3 Proxy is not working IPv6")
 	}, 500)
 
 	It("Service L4 tests", func() {
-		// createInterface(docker.Node)
+		// createInterface(docker.SSHMeta)
 
-		containers("create")
+		containers(helpers.Create)
 		cilium.EndpointWaitUntilReady()
 
-		httpd1, err := docker.ContainerInspectNet("httpd1")
+		httpd1, err := docker.ContainerInspectNet(helpers.Httpd1)
 		Expect(err).Should(BeNil())
 
-		httpd2, err := docker.ContainerInspectNet("httpd2")
+		httpd2, err := docker.ContainerInspectNet(helpers.Httpd2)
 		Expect(err).Should(BeNil())
 
 		By("Valid IPV4 nat")
 		status := cilium.ServiceAdd(1, "2.2.2.2:80", []string{
-			fmt.Sprintf("%s:80", httpd1["IPv4"]),
-			fmt.Sprintf("%s:80", httpd2["IPv4"])}, 2)
-		status.ExpectSuccess("L4 service can't be created")
+			fmt.Sprintf("%s:80", httpd1[helpers.IPv4]),
+			fmt.Sprintf("%s:80", httpd2[helpers.IPv4])}, 2)
+		status.ExpectSuccess("L4 service cannot be created")
 
 		status = docker.ContainerExec(
-			"client",
-			"curl -s --fail --connect-timeout 4 http://2.2.2.2:80/public")
+			helpers.Client,
+			helpers.CurlFail("http://2.2.2.2:80/public"))
 		status.ExpectSuccess("L3 Proxy is not working IPv4")
 
 		By("Valid IPV6 nat")
 		status = cilium.ServiceAdd(2, "[f00d::1:1]:80", []string{
-			fmt.Sprintf("[%s]:80", httpd1["IPv6"]),
-			fmt.Sprintf("[%s]:80", httpd2["IPv6"])}, 2)
-		status.ExpectSuccess("L4 service can't be created")
+
+			fmt.Sprintf("[%s]:80", httpd1[helpers.IPv6]),
+			fmt.Sprintf("[%s]:80", httpd2[helpers.IPv6])}, 2)
+		status.ExpectSuccess("L4 service cannot be created")
 
 		status = docker.ContainerExec(
-			"client",
-			"curl -s --fail --connect-timeout 4 http://2.2.2.2:80/public")
+			helpers.Client,
+			helpers.CurlFail("http://2.2.2.2:80/public"))
 		status.ExpectSuccess("L3 Proxy is not working IPv6")
 
 		By("L3 redirect to L4")
 		status = cilium.ServiceAdd(3, "2.2.2.2:0", []string{
-			fmt.Sprintf("%s:80", httpd1["IPv4"]),
-			fmt.Sprintf("%s:80", httpd2["IPv4"])}, 2)
+
+			fmt.Sprintf("%s:80", httpd1[helpers.IPv4]),
+			fmt.Sprintf("%s:80", httpd2[helpers.IPv4])}, 2)
 		status.ExpectFail("Service created with invalid data")
 	}, 500)
 })
 
-func createInterface(node *helpers.Node) error {
+func createInterface(node *helpers.SSHMeta) error {
 
 	script := `
 #!/bin/bash

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -26,11 +26,23 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	// MonitorDropNotification represents the DropNotification configuration
+	// value for the Cilium monitor
+	MonitorDropNotification = "DropNotification"
+
+	// MonitorTraceNotification represents the TraceNotification configuration
+	// value for the Cilium monitor
+	MonitorTraceNotification = "TraceNotification"
+
+	// MonitorDebug represents the Debug configuration  value for
+	// the Cilium monitor
+	MonitorDebug = "Debug"
+)
+
 var _ = Describe("RuntimeMonitorTest", func() {
 
 	var initialized bool
-	var networkName string = "cilium-net"
-	var netperfImage string = "tgraf/netperf"
 	var logger *log.Entry
 	var docker *helpers.Docker
 	var cilium *helpers.Cilium
@@ -41,11 +53,11 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		}
 		logger = log.WithFields(log.Fields{"testName": "RuntimeMonitorTest"})
 		logger.Info("Starting")
-		docker, cilium = helpers.CreateNewRuntimeHelper("runtime", logger)
+		docker, cilium = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 		cilium.WaitUntilReady(100)
-		docker.NetworkCreate(networkName, "")
+		docker.NetworkCreate(helpers.CiliumDockerNetwork, "")
 
-		res := cilium.PolicyEnforcementSet("default", false)
+		res := cilium.SetPolicyEnforcement(helpers.PolicyEnforcementDefault, false)
 		res.ExpectSuccess()
 
 		initialized = true
@@ -56,18 +68,19 @@ var _ = Describe("RuntimeMonitorTest", func() {
 	})
 
 	AfterEach(func() {
-		docker.SampleContainersActions("delete", networkName)
+		docker.SampleContainersActions(helpers.Delete, helpers.CiliumDockerNetwork)
 	})
 
 	It("Cilium monitor verbose mode", func() {
 
-		res := cilium.Exec("config Debug=true DropNotification=true TraceNotification=true")
+		res := cilium.Exec(fmt.Sprintf("config %s=true %s=true %s=true",
+			MonitorDebug, MonitorDropNotification, MonitorTraceNotification))
 		res.ExpectSuccess()
 
 		ctx, cancel := context.WithCancel(context.Background())
 
 		res = docker.Node.ExecContext(ctx, "cilium monitor -v")
-		docker.SampleContainersActions("create", networkName)
+		docker.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
 		helpers.Sleep(5)
 		cancel()
 		endpoints, err := cilium.GetEndpointsIds()
@@ -75,7 +88,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 
 		for k, v := range endpoints {
 			filter := fmt.Sprintf("FROM %s DEBUG:", v)
-			docker.ContainerExec(k, "ping -c 1 httpd1")
+			docker.ContainerExec(k, helpers.Ping(helpers.Httpd1))
 			Expect(res.Output().String()).Should(ContainSubstring(filter))
 		}
 	})
@@ -87,109 +100,110 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			"capture": "DEBUG:",
 		}
 
-		res := cilium.Exec("config Debug=true DropNotification=true TraceNotification=true")
+		res := cilium.Exec(fmt.Sprintf("config %s=true %s=true %s=true",
+			MonitorDebug, MonitorDropNotification, MonitorTraceNotification))
 		res.ExpectSuccess()
 		for k, v := range eventTypes {
 			By(fmt.Sprintf("Type %s", k))
 
 			ctx, cancel := context.WithCancel(context.Background())
 			res := docker.Node.ExecContext(ctx, fmt.Sprintf("cilium monitor --type %s -v", k))
-			docker.SampleContainersActions("create", networkName)
-			docker.ContainerExec("app1", "ping -c 4 httpd1")
+			docker.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
+			docker.ContainerExec(helpers.App1, helpers.Ping(helpers.Httpd1))
 			helpers.Sleep(5)
 			cancel()
 
 			Expect(res.CountLines()).Should(BeNumerically(">", 3))
 			Expect(res.Output().String()).Should(ContainSubstring(v))
-			docker.SampleContainersActions("delete", networkName)
+			docker.SampleContainersActions(helpers.Delete, helpers.CiliumDockerNetwork)
 		}
 	})
 
 	It("cilium monitor check --from", func() {
-		res := cilium.Exec("config Debug=true DropNotification=true TraceNotification=true")
+		res := cilium.Exec(fmt.Sprintf("config %s=true %s=true %s=true", MonitorDebug, MonitorDropNotification, MonitorTraceNotification))
 		res.ExpectSuccess()
 
-		docker.SampleContainersActions("create", networkName)
+		docker.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
 		endpoints, err := cilium.GetEndpointsIds()
 		Expect(err).Should(BeNil())
 
 		ctx, cancel := context.WithCancel(context.Background())
 		res = docker.Node.ExecContext(ctx, fmt.Sprintf(
-			"cilium monitor --type debug --from %s -v", endpoints["app1"]))
-		docker.ContainerExec("app1", "ping -c 5 httpd1")
+			"cilium monitor --type debug --from %s -v", endpoints[helpers.App1]))
+		docker.ContainerExec(helpers.App1, helpers.Ping(helpers.Httpd1))
 		helpers.Sleep(5)
 		cancel()
 
 		Expect(res.CountLines()).Should(BeNumerically(">", 3))
-		filter := fmt.Sprintf("FROM %s DEBUG:", endpoints["app1"])
+		filter := fmt.Sprintf("FROM %s DEBUG:", endpoints[helpers.App1])
 		Expect(res.Output().String()).Should(ContainSubstring(filter))
 
-		//Debug mode shouldn't have DROP lines
+		//MonitorDebug mode shouldn't have DROP lines
 		Expect(res.Output().String()).ShouldNot(ContainSubstring("DROP"))
 
 	})
 
 	It("cilium monitor check --to", func() {
 
-		res := cilium.Exec(
-			"config Debug=true DropNotification=true TraceNotification=true PolicyEnforcement=always")
+		res := cilium.Exec(fmt.Sprintf(
+			"config %s=true %s=true %s=true %s=always", MonitorDebug, MonitorDropNotification, MonitorTraceNotification, helpers.PolicyEnforcement))
 		res.ExpectSuccess()
 
-		docker.SampleContainersActions("create", networkName)
+		docker.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
 		endpoints, err := cilium.GetEndpointsIds()
 		Expect(err).Should(BeNil())
 		cilium.EndpointWaitUntilReady()
 		ctx, cancel := context.WithCancel(context.Background())
 		res = docker.Node.ExecContext(ctx, fmt.Sprintf(
-			"cilium monitor --type drop -v --to %s", endpoints["httpd1"]))
+			"cilium monitor --type drop -v --to %s", endpoints[helpers.Httpd1]))
 
-		docker.ContainerExec("app1", "ping -c 5 httpd1")
-		docker.ContainerExec("app2", "ping -c 5 httpd1")
+		docker.ContainerExec(helpers.App1, helpers.Ping(helpers.Httpd1))
+		docker.ContainerExec(helpers.App2, helpers.Ping(helpers.Httpd1))
 		helpers.Sleep(5)
 		cancel()
 
 		Expect(res.CountLines()).Should(BeNumerically(">", 3))
-		filter := fmt.Sprintf("FROM %s DROP:", endpoints["httpd1"])
+		filter := fmt.Sprintf("FROM %s DROP:", endpoints[helpers.Httpd1])
 		Expect(res.Output().String()).Should(ContainSubstring(filter))
 
 	})
 
 	It("cilium monitor check --related-to", func() {
 
-		res := cilium.Exec(
-			"config Debug=true DropNotification=true TraceNotification=true PolicyEnforcement=always")
+		res := cilium.Exec(fmt.Sprintf(
+			"config %s=true %s=true %s=true %s=always", MonitorDebug, MonitorDropNotification, MonitorTraceNotification, helpers.PolicyEnforcement))
 		res.ExpectSuccess()
 
-		docker.SampleContainersActions("create", networkName)
+		docker.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
 		endpoints, err := cilium.GetEndpointsIds()
 		Expect(err).Should(BeNil())
 
 		ctx, cancel := context.WithCancel(context.Background())
 		res = docker.Node.ExecContext(ctx, fmt.Sprintf(
-			"cilium monitor -v --type drop --related-to %s", endpoints["httpd1"]))
+			"cilium monitor -v --type drop --related-to %s", endpoints[helpers.Httpd1]))
 		cilium.EndpointWaitUntilReady()
-		docker.ContainerExec("app1", "curl -s --fail --connect-timeout 3 http://httpd1/public")
+		docker.ContainerExec(helpers.App1, helpers.CurlFail("http://httpd1/public"))
 
 		helpers.Sleep(2)
 		cancel()
 		Expect(res.CountLines()).Should(BeNumerically(">=", 3))
-		filter := fmt.Sprintf("FROM %s DROP:", endpoints["httpd1"])
+		filter := fmt.Sprintf("FROM %s DROP:", endpoints[helpers.Httpd1])
 		Expect(res.Output().String()).Should(ContainSubstring(filter))
 	})
 
-	It("multiple monitor", func() {
+	It("multiple monitors", func() {
 
-		res := cilium.Exec(
-			"config Debug=true DropNotification=true TraceNotification=true PolicyEnforcement=default")
+		res := cilium.Exec(fmt.Sprintf(
+			"config %s=true %s=true %s=true %s=default", MonitorDebug, MonitorDropNotification, MonitorTraceNotification, helpers.PolicyEnforcement))
 		res.ExpectSuccess()
 
 		var monitorRes []*helpers.CmdRes
 
-		docker.ContainerCreate("client", netperfImage, networkName, "-l id.client")
-		docker.ContainerCreate("server", netperfImage, networkName, "-l id.server")
+		docker.ContainerCreate(helpers.Client, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
+		docker.ContainerCreate(helpers.Server, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.server")
 
-		defer docker.ContainerRm("client")
-		defer docker.ContainerRm("server")
+		defer docker.ContainerRm(helpers.Client)
+		defer docker.ContainerRm(helpers.Server)
 
 		ctx, cancelfn := context.WithCancel(context.Background())
 
@@ -197,7 +211,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			monitorRes = append(monitorRes, docker.Node.ExecContext(ctx, "cilium monitor"))
 		}
 
-		docker.ContainerExec("client", "ping -c 5 server")
+		docker.ContainerExec(helpers.Client, helpers.Ping(helpers.Server))
 		cancelfn()
 
 		Expect(monitorRes[0].CountLines()).Should(BeNumerically(">", 2))

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -17,6 +17,7 @@ package ciliumTest
 import (
 	"fmt"
 	"os"
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -24,21 +25,29 @@ import (
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 
-	"testing"
-
 	"github.com/cilium/cilium/test/config"
 	ginkgoext "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
+	gops "github.com/google/gops/agent"
 	log "github.com/sirupsen/logrus"
 )
 
-var DefaultSettings map[string]string = map[string]string{
-	"K8S_VERSION": "1.7",
-}
-
-var vagrant helpers.Vagrant
+var (
+	vagrant         helpers.Vagrant
+	DefaultSettings = map[string]string{
+		"K8S_VERSION": "1.7",
+	}
+)
 
 func init() {
+
+	// Open socket for using gops to get stacktraces in case the tests deadlock.
+	if err := gops.Listen(gops.Options{}); err != nil {
+		errorString := fmt.Sprintf("unable to start gops: %s", err)
+		fmt.Println(errorString)
+		os.Exit(-1)
+	}
+
 	log.SetOutput(GinkgoWriter)
 	log.SetLevel(log.DebugLevel)
 	log.SetFormatter(&log.TextFormatter{
@@ -76,7 +85,6 @@ func goReportVagrantStatus() chan bool {
 		iter := 0
 		for {
 			var out string
-
 			select {
 			case ok := <-exit:
 				if ok {
@@ -113,31 +121,33 @@ var _ = BeforeSuite(func() {
 	}
 
 	switch ginkgoext.GetScope() {
-	case "runtime":
-		err = vagrant.Create("runtime")
+	case helpers.Runtime:
+		err = vagrant.Create(helpers.Runtime)
 		if err != nil {
-			Fail(fmt.Sprintf("Vagrant could not start correctly: %s", err))
+			Fail(fmt.Sprintf("error starting VM %q: %s", helpers.Runtime, err))
 		}
-		cilium := helpers.CreateCilium("runtime", log.WithFields(
+		cilium := helpers.CreateCilium(helpers.Runtime, log.WithFields(
 			log.Fields{"testName": "BeforeSuite"}))
 		err = cilium.SetUp()
 		if err != nil {
-			Fail(fmt.Sprintf("Vagrant could not setup cilium correctly: %s", err))
+			Fail(fmt.Sprintf("cilium was unable to be set up correctly: %s", err))
 		}
 
-	case "k8s":
+	case helpers.K8s:
 		//FIXME: This should be:
 		// Start k8s1 and provision kubernetes.
 		// When finish, start to build cilium in background
 		// Start k8s2
 		// Wait until compilation finished, and pull cilium image on k8s2
-		err = vagrant.Create(fmt.Sprintf("k8s1-%s", helpers.GetCurrentK8SEnv()))
+
+		// Name for K8s VMs depends on K8s version that is running.
+		err = vagrant.Create(helpers.K8s1VMName)
 		if err != nil {
-			Fail(fmt.Sprintf("Vagrant k8s1 could not started correctly: %s", err))
+			Fail(fmt.Sprintf("error starting VM %q: %s", helpers.K8s1VMName, err))
 		}
-		err = vagrant.Create(fmt.Sprintf("k8s2-%s", helpers.GetCurrentK8SEnv()))
+		err = vagrant.Create(helpers.K8s2VMName)
 		if err != nil {
-			Fail(fmt.Sprintf("Vagrant k8s2 could not started correctly: %s", err))
+			Fail(fmt.Sprintf("error starting VM %q: %s", helpers.K8s2VMName, err))
 		}
 	}
 	return
@@ -145,25 +155,25 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	if !helpers.IsRunningOnJenkins() {
-		log.Infof("AfterSuite: is dev env, keep templates as it is")
+		log.Infof("AfterSuite: not running on Jenkins; leaving VMs running for debugging")
 		return
 	}
 
 	scope := ginkgoext.GetScope()
-	log.Infof("Running After Suite flag for scope='%s'", scope)
+	log.Infof("cleaning up VMs started for %s tests", scope)
 	switch scope {
-	case "runtime":
-		vagrant.Destroy("runtime")
-	case "k8s":
-		vagrant.Destroy(fmt.Sprintf("k8s1-%s", helpers.GetCurrentK8SEnv()))
-		vagrant.Destroy(fmt.Sprintf("k8s2-%s", helpers.GetCurrentK8SEnv()))
+	case helpers.Runtime:
+		vagrant.Destroy(helpers.Runtime)
+	case helpers.K8s:
+		vagrant.Destroy(helpers.K8s1VMName)
+		vagrant.Destroy(helpers.K8s2VMName)
 	}
 	return
 })
 
 func getOrSetEnvVar(key, value string) {
 	if val := os.Getenv(key); val == "" {
-		log.Infof("Init: Env var '%s' was not set, set default value '%s'", key, value)
+		log.Infof("environment variable %q was not set; setting to default value %q", key, value)
 		os.Setenv(key, value)
 	}
 }


### PR DESCRIPTION
This PR seeks to minimize the amount of hardcoding of commonly used strings in the Ginkgo tests. It also adds some more helper functions and wrappers around commonly used commands.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #2068 
Fixes: #2067 
Fixes: #2070 