### PR TITLE
policy_wait: Add timeouts for total time and when an endpoint failed

### DIFF
--- a/Documentation/cmdref/cilium_policy_wait.md
+++ b/Documentation/cmdref/cilium_policy_wait.md
@@ -16,7 +16,9 @@ cilium policy wait <revision>
 ### Options
 
 ```
-      --sleep-time int   Sleep interval between checks (seconds) (default 1)
+      --fail-wait-time int   Wait time after which command fails if endpoint regeration fails (seconds) (default 60)
+      --max-wait-time int    Wait time after which command fails (seconds) (default 360)
+      --sleep-time int       Sleep interval between checks (seconds) (default 1)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
cilium policy wait waits indefinitely if endpoint policy regeneration
fails. Add a timeout both for total time waited and for when an
endpoint regeneration fails. These default to 120 and 10 seconds,
respectively.

Fixes: #2070
Reported-by: Ian Vernon <ian@covalent.io>
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
