### PR TITLE
test/runtime: fix Describe text for runtime tests

### DIFF
--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -343,7 +343,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 	})
 })
 
-var _ = Describe("RunPolicies", func() {
+var _ = Describe("RuntimePolicies", func() {
 
 	var initialized bool
 	var networkName string = "cilium-net"

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -131,7 +131,7 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 	})
 })
 
-var _ = Describe("RunConntrackTest", func() {
+var _ = Describe("RuntimeConntrackTest", func() {
 
 	var initialized bool
 	var networkName string = "cilium-net"


### PR DESCRIPTION
Some runtime tests were only prefixed with "Run" and not "Runtime", which meant
that the command to run the runtime tests in ginkgo.Jenkinsfile,
--focus="Runtime*", did not pick up the tests prefixed with "Run".

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #2077