### PR TITLE
Documentation: add support for tabs via plugin

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -33,7 +33,8 @@ import re
 # ones.
 extensions = ['sphinx.ext.ifconfig',
     'sphinx.ext.githubpages',
-    'sphinxcontrib.openapi']
+    'sphinxcontrib.openapi',
+    'sphinx_tabs.tabs']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/Documentation/policy.rst
+++ b/Documentation/policy.rst
@@ -153,7 +153,19 @@ Example (Basic)
 This example shows to enable all endpoints with the label ``role=frontend`` to
 communicate with all endpoints with the label ``role=backend``:
 
-.. literalinclude:: ../examples/policies/l3.json
+.. only:: html
+
+   .. tabs::
+     .. group-tab:: JSON
+
+        .. literalinclude:: ../examples/policies/l3.json
+     .. group-tab:: YAML
+
+        .. literalinclude:: ../examples/policies/l3.yaml
+
+.. only:: epub or latex
+
+        .. literalinclude:: ../examples/policies/l3.json
 
 Example (Requires)
 ------------------

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -22,3 +22,4 @@ sphinxcontrib-openapi==0.3.1
 sphinxcontrib-websupport==1.0.1
 typing==3.6.2
 urllib3==1.22
+sphinx-tabs==1.1.5

--- a/examples/policies/l3.yaml
+++ b/examples/policies/l3.yaml
@@ -1,0 +1,12 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "l3-rule"
+spec:
+  endpointSelector:
+    matchLabels:
+      role: backend
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        role: frontend


### PR DESCRIPTION
This can be used to show a JSON and YAML example in the examples. It
works with`literalinclude` so the duplication is contained. We can pick
the name of the tabs and the content so we could also split on a specific
version of Kubernetes or Cilium so not just JSON / YAML.

Thomas mentioned the `only`[0] directive which makes it possible to only
add the tabs on HTML and then we can have a fallback to one of the
examples for PDF and EPUB. This does duplicate but is better IMO to
achieve good output on all formats.

Also tried converting one of the examples to CiliumNetworkPolicy.

[0]: http://www.sphinx-doc.org/en/stable/markup/misc.html#role-index

Suggested-by: Dan Wendlandt <danwent@gmail.com>
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>
