### PR TITLE
debugdetection pkg added

### DIFF
--- a/pkg/debugdetection/debugdetection.go
+++ b/pkg/debugdetection/debugdetection.go
@@ -12,16 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package logfields
+package debugdetection
 
 import (
-	"fmt"
+	"os"
 
-	// Initialize logrus package with debug log level if needed
-	_ "github.com/cilium/cilium/pkg/debugdetection"
+	log "github.com/sirupsen/logrus"
+	flag "github.com/spf13/pflag"
 )
 
-// Repr formats an object with the Printf %+v formatter
-func Repr(s interface{}) string {
-	return fmt.Sprintf("%+v", s)
+func init() {
+	flags := flag.NewFlagSet("init-debug", flag.ContinueOnError)
+	debug := flags.Bool("debug", false, "")
+	flags.Parse(os.Args)
+
+	if *debug {
+		log.SetLevel(log.DebugLevel)
+	}
 }


### PR DESCRIPTION
This package makes a very simple check in os.Args slice for `--debug`
value. If it's there, it sets logrus debug level to `logrus.Debug`.

This change makes all packages that initiate before daemon main package
able to have debug output in their init functions.

fixes #1762