### PR TITLE
Ginkgo - Add Combined output on k8st.Policies

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -200,13 +200,13 @@ var _ = Describe("K8sPolicyTest", func() {
 		trace := kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
 			"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 80",
 			appPods["app2"], appPods["app1"]))
-		trace.ExpectSuccess(trace.Output().String())
+		trace.ExpectSuccess(trace.CombineOutput().String())
 		Expect(trace.Output().String()).Should(ContainSubstring("Final verdict: ALLOWED"))
 
 		trace = kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
 			"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s",
 			appPods["app3"], appPods["app1"]))
-		trace.ExpectSuccess()
+		trace.ExpectSuccess(trace.CombineOutput().String())
 		Expect(trace.Output().String()).Should(ContainSubstring("Final verdict: DENIED"))
 
 		_, err = kubectl.Exec(


### PR DESCRIPTION
Added the stderr output on some asserts. Based on Jenkins error without
all the info:

```
/root/jenkins/workspace/Ginkgo-CI-Tests-Pipeline/src/github.com/cilium/cilium/test/k8sT/Policies.go:162

Expected
    <bool>: false
to be true
/root/jenkins/workspace/Ginkgo-CI-Tests-Pipeline/src/github.com/cilium/cilium/test/k8sT/Policies.go:203
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

