### PR TITLE
pkg/policy: replace apiKeyInt and apiVersionInt with pointers

### DIFF
--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -457,16 +457,11 @@ type PortRuleKafka struct {
 	// via the API.
 
 	// apiKeyInt is the integer representation of APIKey
-	apiKeyInt int16
+	apiKeyInt *int16
 
 	// apiVersionInt is the integer representation of APIVersion
-	apiVersionInt int16
+	apiVersionInt *int16
 }
-
-const (
-	apiKeyWildcard     int16 = -1
-	apiVersionWildcard int16 = -1
-)
 
 // KafkaAPIKeyMap is the map of all allowed kafka API keys
 // with the key values.
@@ -569,19 +564,19 @@ var KafkaTopicValidChar = regexp.MustCompile(`^[a-zA-Z0-9\\._\\-]+$`)
 // GetAPIKey returns the APIKey as integer or the bool set to true if any API
 // key is allowed
 func (kr *PortRuleKafka) GetAPIKey() (int16, bool) {
-	if kr.apiKeyInt == apiKeyWildcard {
+	if kr.apiKeyInt == nil {
 		return 0, true
 	}
 
-	return kr.apiKeyInt, false
+	return *kr.apiKeyInt, false
 }
 
 // GetAPIVersion returns the APIVersion as integer or the bool set to true if
 // any API version is allowed
 func (kr *PortRuleKafka) GetAPIVersion() (int16, bool) {
-	if kr.apiVersionInt == apiVersionWildcard {
+	if kr.apiVersionInt == nil {
 		return 0, true
 	}
 
-	return kr.apiVersionInt, false
+	return *kr.apiVersionInt, false
 }

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -117,9 +117,7 @@ func (kr *PortRuleKafka) Sanitize() error {
 		if !ok {
 			return fmt.Errorf("invalid Kafka APIKey :%q", kr.APIKey)
 		}
-		kr.apiKeyInt = n
-	} else {
-		kr.apiKeyInt = apiKeyWildcard
+		kr.apiKeyInt = &n
 	}
 
 	if len(kr.APIVersion) > 0 {
@@ -128,9 +126,8 @@ func (kr *PortRuleKafka) Sanitize() error {
 			return fmt.Errorf("invalid Kafka APIVersion :%q",
 				kr.APIVersion)
 		}
-		kr.apiVersionInt = int16(n)
-	} else {
-		kr.apiVersionInt = apiVersionWildcard
+		n16 := int16(n)
+		kr.apiVersionInt = &n16
 	}
 
 	if len(kr.Topic) > 0 {


### PR DESCRIPTION
When the user creates a CNP rule in kubernetes, without specifying the
kafka API Version nor the APIKey, the
pkg/policy/api/rule.go:PortRuleKafka.apiKeyInt and
pkg/policy/api/rule.go:PortRuleKafka.apiVersionInt will be set with 0 as
it is the default value for private attributes.

As we were doing CiliumNetworkPolicy.Parse(), after receiving the CNP,
we were internally setting apiKeyInt and apiVersionInt with -1 since they
were not initialized.

Unfortunately this was causing the CiliumNetworkPolicy.SpecEquals method
to always return false.

To solve this problem, this replaces the apiKeyInt and the apiVersionInt
with a *int16, instead of a int16. This way, when we receive the CNP
rule from kubernetes the values will be nil, and internally we will also
use it as nil since they were not initialized.

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Fixed infinite loop when importing CNP to kubernetes with an empty kafka version
```
