### PR TITLE
Vagrantfile: add box version to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -98,6 +98,7 @@ Vagrant.configure(2) do |config|
 
     config.vm.provider :libvirt do |libvirt|
         config.vm.box = "cilium/ubuntu-16.10"
+        config.vm.box_version = "2.0"
         libvirt.memory = ENV['VM_MEMORY'].to_i
         libvirt.cpus = ENV['VM_CPUS'].to_i
         config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/cilium/cilium", disabled: false
@@ -109,6 +110,7 @@ Vagrant.configure(2) do |config|
         vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
 
         config.vm.box = "cilium/ubuntu-16.10"
+        config.vm.box_version = "2.0"
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i
 


### PR DESCRIPTION
Add the version of the image used in the builds to the Vagrantfile. This will allow for testing of box updates in PRs without affecting what is used in other PRs.

Signed-off by: Ian Vernon <ian@cilium.io>