### PR TITLE
test/runtime: more netperf / super_netperf tests

### DIFF
--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -109,11 +109,20 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 		res = docker.ContainerExec(helpers.Client, helpers.Ping(serverIP.String()))
 		res.ExpectSuccess()
 
+		By(fmt.Sprintf("netperf to %s from %s (should succeed)", helpers.Server, helpers.Client))
+		cmd := fmt.Sprintf("netperf -c -C -H %s", serverIP)
+		res = docker.ContainerExec(helpers.Client, cmd)
+
 		// TODO: remove this hardcoding ; it is not clean. Have command wrappers that take maps of strings.
-		By(fmt.Sprintf("netperf to %s from %s IPv6", helpers.Server, helpers.Client))
-		cmd := fmt.Sprintf(
+		By(fmt.Sprintf("netperf to %s from %s IPv6 with -t TCP_SENDFILE", helpers.Server, helpers.Client))
+		cmd = fmt.Sprintf(
 			"netperf -c -C -t TCP_SENDFILE -H %s", serverIPv6)
 
+		res = docker.ContainerExec(helpers.Client, cmd)
+		res.ExpectSuccess()
+
+		By(fmt.Sprintf("super_netperf to %s from %s (should succeed)", helpers.Server, helpers.Client))
+		cmd = fmt.Sprintf("super_netperf 10 -c -C -t TCP_SENDFILE -H %s", serverIP)
 		res = docker.ContainerExec(helpers.Client, cmd)
 		res.ExpectSuccess()
 


### PR DESCRIPTION
**Summary of changes**:

Added a few more connectivity tests to acheive parity with tests/03-docker.sh

* Add a check of connectivity with netperf without -t TCP_SENDFILE
* Add a check of connectivity with super_netperf

Fixes: #2101 

Signed-off by: Ian Vernon <ian@cilium.io>

<!--  Thanks for contributing to Cilium!

If this is your first time contributing, then please see the following
guidelines for detailed instructions on how to contribute:
https://github.com/cilium/cilium/blob/master/CONTRIBUTING.md for detailed instructions 

-->

**How to test (optional)**:
```cd test;  ginkgo --focus="RuntimeConnectivityTest" -v -noColor```