### PR TITLE
Documentation/Makefile: use relative path to cilium for cmdref

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -8,6 +8,7 @@ SPHINXPROJ    = Cilium
 SOURCEDIR     = .
 BUILDDIR      = _build
 CMDREFDIR     = cmdref
+CILIUMDIR     = ../cilium
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -37,7 +38,7 @@ render:
 cmdref:
 	# We don't know what changed so recreate the directory
 	-rm -rvf $(CMDREFDIR) && mkdir $(CMDREFDIR)
-	cilium cmdref -d $(CMDREFDIR)
+	${CILIUMDIR}/cilium cmdref -d $(CMDREFDIR)
 
 .PHONY: help Makefile check-requirements cmdref
 

--- a/tests/20-cidr-limit.sh
+++ b/tests/20-cidr-limit.sh
@@ -18,7 +18,7 @@ function cleanup() {
   cilium policy delete --all 2> /dev/null || true
   systemctl stop cilium
   wait_for_cilium_shutdown
-  cilium cleanup -f
+  log "cleanup: `cilium cleanup -f`"
   systemctl start cilium
 }
 


### PR DESCRIPTION
Closes: #2106 (Fix path to `cmdref`)
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>