### PR TITLE
Jenkins: add Jenkinsfile.nightly for nightly jobs

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -1,0 +1,44 @@
+pipeline {
+    agent {
+        label 'nightly'
+    }
+    environment {
+        PROJ_PATH = "src/github.com/cilium/cilium"
+    }
+
+    options {
+        timeout(time: 120, unit: 'MINUTES')
+        timestamps()
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                sh 'env'
+                sh 'rm -rf src; mkdir -p src/github.com/cilium'
+                sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
+                checkout scm
+            }
+        }
+        stage('Nightly-Tests') {
+            environment {
+                GOPATH="${WORKSPACE}"
+                TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
+            }
+            steps {
+                parallel(
+                    "Nightly":{
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.7 ginkgo --focus="Nightly*" -v -noColor'
+                    },
+                )
+            }
+            post {
+                always {
+                    junit 'test/*.xml'
+                    sh 'cd test/; ./post_build_agent.sh || true'                    
+                    sh 'cd test/; K8S_VERSION=1.7 vagrant destroy -f'
+                }
+            }
+        }
+    }
+}

--- a/test/ginkgo-ext/scope.go
+++ b/test/ginkgo-ext/scope.go
@@ -31,6 +31,9 @@ func GetScope() string {
 		return helpers.Runtime
 	case strings.HasPrefix(focusString, helpers.K8s):
 		return helpers.K8s
+	case strings.Contains(focusString, "nightly"):
+		// Nightly tests run in a Kubernetes environment.
+		return helpers.K8s
 	default:
 		return helpers.Runtime
 	}


### PR DESCRIPTION
**Summary of changes**:

Add a new Jenkinsfile which will be used to run tests written in Ginkgo prefixed with "Nightly".

Signed-off by: Ian Vernon <ian@cilium.io>


**How to test (optional)**:

```cd test; K8S_VERSION=1.7 ginkgo --focus="Nightly*" -v -noColor```