### PR TITLE
test: rework test for endpoint regeneration

### DIFF
--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -73,7 +73,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 		initialize()
 		cilium.PolicyDelAll()
 		docker.ContainerCreate("app", "cilium/demo-httpd", helpers.CiliumDockerNetwork, "-l id.app")
-		cilium.EndpointWaitUntilReady()
+		cilium.WaitEndpointsReady()
 	})
 
 	AfterEach(func() {
@@ -300,7 +300,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
 			docker.ContainerCreate("new", "cilium/demo-httpd", helpers.CiliumDockerNetwork, "-l id.new")
-			cilium.EndpointWaitUntilReady()
+			cilium.WaitEndpointsReady()
 			endPoints, err = cilium.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Enabled]).To(Equal(0))
@@ -391,7 +391,7 @@ var _ = Describe("RuntimePolicies", func() {
 		initialize()
 		cilium.PolicyDelAll()
 		docker.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
-		cilium.EndpointWaitUntilReady()
+		cilium.WaitEndpointsReady()
 	})
 
 	AfterEach(func() {
@@ -482,7 +482,7 @@ var _ = Describe("RuntimePolicies", func() {
 		status := cilium.PolicyDelAll()
 		status.ExpectSuccess()
 
-		cilium.EndpointWaitUntilReady()
+		cilium.WaitEndpointsReady()
 
 		connectivityTest(allRequests, helpers.App1, helpers.Httpd1, BeTrue)
 		connectivityTest(allRequests, helpers.App2, helpers.Httpd1, BeTrue)
@@ -563,7 +563,7 @@ var _ = Describe("RuntimePolicies", func() {
 
 		status := cilium.PolicyDelAll()
 		Expect(status.WasSuccessful()).Should(BeTrue())
-		cilium.EndpointWaitUntilReady()
+		cilium.WaitEndpointsReady()
 
 		for _, app := range []string{helpers.App1, helpers.App2} {
 			connectivityTest(allRequests, app, helpers.Httpd1, BeTrue)
@@ -594,7 +594,7 @@ var _ = Describe("RuntimePolicies", func() {
 
 		status := cilium.PolicyDelAll()
 		status.ExpectSuccess()
-		cilium.EndpointWaitUntilReady()
+		cilium.WaitEndpointsReady()
 
 		connectivityTest(allRequests, helpers.App1, helpers.Httpd1, BeTrue)
 		connectivityTest(allRequests, helpers.App2, helpers.Httpd1, BeTrue)
@@ -622,7 +622,7 @@ var _ = Describe("RuntimePolicies", func() {
 
 		status = cilium.PolicyDelAll()
 		status.ExpectSuccess()
-		cilium.EndpointWaitUntilReady()
+		cilium.WaitEndpointsReady()
 
 		connectivityTest(allRequests, helpers.App1, helpers.Httpd1, BeTrue)
 		connectivityTest(allRequests, helpers.App2, helpers.Httpd1, BeTrue)

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -44,7 +44,7 @@ var _ = Describe("RuntimeChaos", func() {
 		err := cilium.WaitUntilReady(100)
 		Expect(err).Should(BeNil())
 
-		status := cilium.EndpointWaitUntilReady()
+		status := cilium.WaitEndpointsReady()
 		Expect(status).Should(BeTrue())
 
 	}
@@ -54,7 +54,7 @@ var _ = Describe("RuntimeChaos", func() {
 		docker.ContainerCreate(helpers.Client, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
 		docker.ContainerCreate(helpers.Server, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.server")
 
-		areEndpointsReady := cilium.EndpointWaitUntilReady()
+		areEndpointsReady := cilium.WaitEndpointsReady()
 		Expect(areEndpointsReady).Should(BeTrue())
 	})
 

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -34,7 +34,7 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 		docker.ContainerCreate(helpers.Client, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
 		docker.ContainerCreate(helpers.Server, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.server")
 		cilium.PolicyDelAll()
-		cilium.EndpointWaitUntilReady()
+		cilium.WaitEndpointsReady()
 		err := helpers.WithTimeout(func() bool {
 			if data, _ := cilium.GetEndpointsNames(); len(data) < 2 {
 				logger.Info("Waiting for endpoints to be ready")

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -79,7 +79,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 		docker.Node.Exec("sudo systemctl restart cilium-docker")
 		helpers.Sleep(2)
 		containers(helpers.Create)
-		cilium.EndpointWaitUntilReady()
+		cilium.WaitEndpointsReady()
 		eps, err := cilium.GetEndpointsNames()
 		Expect(err).Should(BeNil())
 		Expect(len(eps)).To(Equal(1))
@@ -97,7 +97,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 		docker.Node.Exec("sudo systemctl restart cilium-docker")
 		helpers.Sleep(2)
 		containers(helpers.Create)
-		cilium.EndpointWaitUntilReady()
+		cilium.WaitEndpointsReady()
 
 		eps, err := cilium.GetEndpointsNames()
 		Expect(err).Should(BeNil())

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -199,7 +199,7 @@ var _ = Describe("RuntimeLB", func() {
 		Expect(err).Should(BeNil())
 
 		containers(helpers.Create)
-		cilium.EndpointWaitUntilReady()
+		cilium.WaitEndpointsReady()
 
 		httpd1, err := docker.ContainerInspectNet(helpers.Httpd1)
 		Expect(err).Should(BeNil())

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -152,7 +152,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		docker.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
 		endpoints, err := cilium.GetEndpointsIds()
 		Expect(err).Should(BeNil())
-		cilium.EndpointWaitUntilReady()
+		cilium.WaitEndpointsReady()
 		ctx, cancel := context.WithCancel(context.Background())
 		res = docker.Node.ExecContext(ctx, fmt.Sprintf(
 			"cilium monitor --type drop -v --to %s", endpoints[helpers.Httpd1]))
@@ -181,7 +181,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		res = docker.Node.ExecContext(ctx, fmt.Sprintf(
 			"cilium monitor -v --type drop --related-to %s", endpoints[helpers.Httpd1]))
-		cilium.EndpointWaitUntilReady()
+		cilium.WaitEndpointsReady()
 		docker.ContainerExec(helpers.App1, helpers.CurlFail("http://httpd1/public"))
 
 		helpers.Sleep(2)


### PR DESCRIPTION
* The check for endpoint regeneration was broken due to recent changes in the
endpoint status API. Refactor this function so that it that waits for all
endpoints to be in 'ready' state until a
certain number of retries are exceeded.
* Add a function that waits until a specific endpoint is regenerated as well.
* Add a function that returns the status log for a specified endpoint.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #2047 
