### PR TITLE
k8s: fix missing deep copy when updating status

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1419,7 +1419,7 @@ func (d *Daemon) updateCiliumNetworkPolicyV1(ciliumV1Store cache.Store,
 	}
 
 	newRuleCpy := newRules.DeepCopy()
-	_, err = newRules.Parse()
+	_, err = newRuleCpy.Parse()
 	if err != nil {
 		log.WithError(err).WithField(logfields.Object, logfields.Repr(newRuleCpy)).
 			Warn("Error parsing new CiliumNetworkPolicy rule")
@@ -1552,7 +1552,7 @@ func (d *Daemon) updateCiliumNetworkPolicyV2(ciliumV2Store cache.Store,
 	}
 
 	newRuleCpy := newRules.DeepCopy()
-	_, err = newRules.Parse()
+	_, err = newRuleCpy.Parse()
 	if err != nil {
 		log.WithError(err).WithField(logfields.Object, logfields.Repr(newRuleCpy)).
 			Warn("Error parsing new CiliumNetworkPolicy rule")


### PR DESCRIPTION
Fix Parse() invocation on wrong variable that was causing
spec.DeepEquals to always return false.

Signed-off-by: André Martins <andre@cilium.io>
