### PR TITLE
daemon: start API earlier while restoring endpoints

### DIFF
--- a/api/v1/models/endpoint_state.go
+++ b/api/v1/models/endpoint_state.go
@@ -30,6 +30,8 @@ const (
 	EndpointStateWaitingToRegenerate EndpointState = "waiting-to-regenerate"
 	// EndpointStateRegenerating captures enum value "regenerating"
 	EndpointStateRegenerating EndpointState = "regenerating"
+	// EndpointStateRestoring captures enum value "restoring"
+	EndpointStateRestoring EndpointState = "restoring"
 	// EndpointStateReady captures enum value "ready"
 	EndpointStateReady EndpointState = "ready"
 	// EndpointStateDisconnecting captures enum value "disconnecting"
@@ -43,7 +45,7 @@ var endpointStateEnum []interface{}
 
 func init() {
 	var res []EndpointState
-	if err := json.Unmarshal([]byte(`["creating","waiting-for-identity","not-ready","waiting-to-regenerate","regenerating","ready","disconnecting","disconnected"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["creating","waiting-for-identity","not-ready","waiting-to-regenerate","regenerating","restoring","ready","disconnecting","disconnected"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -832,6 +832,7 @@ definitions:
       - not-ready
       - waiting-to-regenerate
       - regenerating
+      - restoring
       - ready
       - disconnecting
       - disconnected

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1235,6 +1235,7 @@ func init() {
         "not-ready",
         "waiting-to-regenerate",
         "regenerating",
+        "restoring",
         "ready",
         "disconnecting",
         "disconnected"

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -23,15 +23,12 @@ import (
 	"path/filepath"
 
 	"github.com/cilium/cilium/common/addressing"
-	"github.com/cilium/cilium/pkg/comparator"
 	e "github.com/cilium/cilium/pkg/endpoint"
-	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/policy"
-	"github.com/cilium/cilium/pkg/workloads/containerd"
 
 	. "gopkg.in/check.v1"
 )
@@ -171,30 +168,6 @@ func (ds *DaemonSuite) TestReadEPsFromDirNames(c *C) {
 	c.Assert(err, IsNil)
 	eps := readEPsFromDirNames(tmpDir, epsNames)
 	c.Assert(len(eps), Equals, len(epsWanted))
-}
-
-func (ds *DaemonSuite) TestCleanUpDockerDangling(c *C) {
-	epsWanted, epsMap := createEndpoints()
-
-	err := containerd.InitMock()
-	c.Assert(err, IsNil)
-
-	for _, ep := range epsWanted {
-		endpointmanager.Insert(ep)
-	}
-
-	ep, err := endpointmanager.Lookup(e.NewCiliumID(259))
-	c.Assert(err, IsNil)
-	c.Assert(ep, comparator.DeepEquals, epsMap[259])
-
-	ds.d.deleteNonFunctionalEndpoints()
-
-	// Since 259 doesn't exist in the list of docker network endpoint running,
-	// it will be removed from the list of endpoints
-
-	ep, err = endpointmanager.Lookup(e.NewCiliumID(259))
-	c.Assert(err, IsNil)
-	c.Assert(ep, IsNil)
 }
 
 func (ds *DaemonSuite) TestSyncLabels(c *C) {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -391,7 +391,9 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) error {
 	// it won't be regenerated.
 	// When building the initial drop policy in waiting-for-identity state
 	// the state remains unchanged
-	if e.GetStateLocked() != StateWaitingForIdentity && !e.BuilderSetStateLocked(StateRegenerating, "Regenerating Endpoint BPF: "+reason) {
+	if e.GetStateLocked() != StateWaitingForIdentity && e.GetStateLocked() != StateRestoring &&
+		!e.BuilderSetStateLocked(StateRegenerating, "Regenerating Endpoint BPF: "+reason) {
+
 		e.getLogger().WithField(logfields.EndpointState, e.state).Debug("Skipping build due to invalid state")
 		e.Mutex.Unlock()
 		return fmt.Errorf("Skipping build due to invalid state: %s", e.state)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -182,6 +182,9 @@ const (
 	// StateDisconnected is used to set the endpoint is disconnected.
 	StateDisconnected = string(models.EndpointStateDisconnected)
 
+	// StateRestoring is used to set the endpoint is being restored.
+	StateRestoring = string(models.EndpointStateRestoring)
+
 	// CallsMapName specifies the base prefix for EP specific call map.
 	CallsMapName = "cilium_calls_"
 	// PolicyGlobalMapName specifies the global tail call map for EP handle_policy() lookup.
@@ -859,7 +862,7 @@ func ParseEndpoint(strEp string) (*Endpoint, error) {
 		ep.Status = NewEndpointStatus()
 	}
 
-	ep.state = StateWaitingForIdentity
+	ep.state = StateRestoring
 
 	return &ep, nil
 }
@@ -1296,6 +1299,11 @@ func (e *Endpoint) SetStateLocked(toState, reason string) bool {
 		// from the regenerating state to
 		// waiting-to-regenerate state.
 		case StateDisconnecting, StateWaitingToRegenerate:
+			goto OKState
+		}
+	case StateRestoring:
+		switch toState {
+		case StateDisconnecting, StateRestoring, StateWaitingToRegenerate:
 			goto OKState
 		}
 	}


### PR DESCRIPTION
Daemon couldn't serve the API immediately as it would restore all
previous endpoints. That was a slow process due the lack of running
time-consuming operations on the background. For this reason, this
commit moves such operations to be executed on the background, leaving
the API in ready state almost immediately.

When restoring an endpoint there are steps that need to be done in this
particular order:
 1 - Parse endpoint for the lxc_config.h;
 2 - Check if the endpoint has its container running;
 3 - Allocate its IP addresses;
 4 - Set default endpoint options;
 5 - Synchronize endpoints' labels with the kv-store;
 6 - Regenerate endpoint.

The necessary steps that needed to be executed before the API is opened
are 1 to 4, which takes relatively less time than synchronizing the
labels with the kv-store or regenerating the endpoint. After step 4 is
executed for all endpoints, the API is opened.

To inform the user of such restore operations, a new endpoint state was
created designated by "restoring" which allows the user to verify which
endpoints are being in restoring state once cilium is started.

With this commit cilium takes around 3 to 4 seconds to have its API
available while restoring 30 endpoints.

Signed-off-by: André Martins <andre@cilium.io>


Fixes: #1914

```release-note
Start serving the cilium API almost immediately while restoring endpoints on the background.
```
