### PR TITLE
Vagrant: Allow parallel Envoy build.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -179,7 +179,8 @@ Vagrant.configure(2) do |config|
                    privileged: true,
                    path: k8sinstall
            end
-           script = "#{ENV['CILIUM_TEMP']}/cilium-master.sh"
+           script = "#{ENV['CILIUM_TEMP']}/"
+           script += ENV['CILIUM_USE_ENVOY'] ? "cilium-master-envoy.sh" : "cilium-master.sh"
            cm.vm.provision "config-install", type: "shell", privileged: true, run: "always", path: script
            # In k8s mode cilium needs etcd in order to run which was started in
            # the first part of the script. The 2nd part will install the

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -401,7 +401,11 @@ EOF
 function create_master(){
     split_ipv4 ipv4_array "${MASTER_IPV4}"
     get_cilium_node_addr master_cilium_ipv6 "${MASTER_IPV4}"
-    output_file="${dir}/cilium-master.sh"
+    if test ${CILIUM_USE_ENVOY}; then
+	output_file="${dir}/cilium-master-envoy.sh"
+    else
+	output_file="${dir}/cilium-master.sh"
+    fi
     write_netcfg_header "${MASTER_IPV6}" "${MASTER_IPV6}" "${output_file}"
 
     if [ -n "${NWORKERS}" ]; then


### PR DESCRIPTION
Currently the parallel builds of Cilium in Jenkins write on top of
each other's config files causing cilium to try to use Envoy when it
is not built.

Fixes: #2117
Reported-by: Ian Vernon <ian@covalent.io>
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
