### PR TITLE
add internal queue for kubernetes watcher updates

### DIFF
--- a/pkg/serializer/func_queue.go
+++ b/pkg/serializer/func_queue.go
@@ -1,0 +1,94 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serializer
+
+var (
+	// NoRetry always returns false independently of the number of retries.
+	NoRetry = func(int) bool { return false }
+)
+
+// WaitFunc will be invoked each time a queued function has returned an error.
+// nRetries will be set to the number of consecutive execution failures that
+// have occurred so far. The WaitFunc must return true if execution must be
+// retried or false if the function must be returned from the queue.
+type WaitFunc func(nRetries int) bool
+
+type queuedFunction struct {
+	f        func() error
+	waitFunc WaitFunc
+}
+
+type functionQueue struct {
+	queue  chan queuedFunction
+	stopCh chan struct{}
+}
+
+// NewFunctionQueue returns a functionQueue that will be used to execute
+// functions in the same order they are enqueued.
+func NewFunctionQueue(queueSize uint) *functionQueue {
+	fq := &functionQueue{
+		queue:  make(chan queuedFunction, queueSize),
+		stopCh: make(chan struct{}),
+	}
+	go fq.run()
+	return fq
+}
+
+// run starts the functionQueue internal worker. It will be stopped once
+// `stopCh` is closed or receives a value.
+func (fq *functionQueue) run() {
+	for {
+		select {
+		case <-fq.stopCh:
+			return
+		case f := <-fq.queue:
+			retries := 0
+			for {
+				select {
+				case <-fq.stopCh:
+					return
+				default:
+				}
+				retries++
+				if err := f.f(); err != nil {
+					if !f.waitFunc(retries) {
+						break
+					}
+				} else {
+					break
+				}
+			}
+		}
+	}
+}
+
+// Stop stops the function queue from processing the functions on the queue.
+// If there are functions in the queue waiting for them to be processed, they
+// won't be executed.
+func (fq *functionQueue) Stop() {
+	close(fq.stopCh)
+}
+
+// Enqueue enqueues the receiving function `f` to be executed by the function
+// queue. Depending on the size of the function queue and the amount
+// of functions queued, this function can block until the function queue
+// is ready to receive more requests.
+// If `f` returns an error, `waitFunc` will be executed and, depending on the
+// return value of `waitFunc`, `f` will be executed again or not.
+// The return value of `f` will not be logged and it's up to the caller to log
+// it properly.
+func (fq *functionQueue) Enqueue(f func() error, waitFunc WaitFunc) {
+	fq.queue <- queuedFunction{f: f, waitFunc: waitFunc}
+}

--- a/pkg/serializer/func_queue_test.go
+++ b/pkg/serializer/func_queue_test.go
@@ -1,0 +1,63 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serializer
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type SerializerSuite struct{}
+
+var _ = Suite(&SerializerSuite{})
+
+func (s *SerializerSuite) TestFuncSerializer(c *C) {
+	stopTest := make(chan struct{})
+	nRetriesExecuted := 0
+	nRetriesExpected := 3
+
+	f := func() error {
+		nRetriesExecuted++
+		return errors.New("Failed")
+	}
+
+	wf := func(nRetries int) bool {
+		if nRetries >= nRetriesExpected {
+			close(stopTest)
+			return false
+		}
+		return true
+	}
+
+	fs := NewFunctionQueue(1)
+
+	fs.Enqueue(f, wf)
+
+	select {
+	case <-stopTest:
+	case <-time.NewTimer(5 * time.Second).C:
+		c.Fatalf("FuncSerializer failed to execute")
+	}
+
+	c.Assert(nRetriesExecuted, Equals, nRetriesExpected)
+}


### PR DESCRIPTION
**Summary of changes**:

Created a function serializer that will execute the functions the same order as they were received. This will allow us to retry those same functions in case of a failure.

Fixes: #1966 

```release-note
Add internal queue for k8s watcher updates #1966
```