### PR TITLE
Ginkgo - Fix issue with Load Balancer test

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -492,6 +492,27 @@ func (c *Cilium) ServiceGet(id int) *CmdRes {
 	return c.Exec(fmt.Sprintf("service get '%d' -o json", id))
 }
 
+// ServiceGetFrontendAddress returns a string with the frontend address and
+// port. It returns an error if the ID cannot be retrieved.
+func (c *Cilium) ServiceGetFrontendAddress(id int) (string, error) {
+
+	var svc *models.Service
+	res := c.ServiceGet(id)
+	if !res.WasSuccessful() {
+		return "", fmt.Errorf("Cannot get service id %d: %s", id, res.CombineOutput())
+	}
+
+	err := res.Unmarshal(&svc)
+	if err != nil {
+		return "", err
+	}
+
+	frontendAddress := net.JoinHostPort(
+		svc.FrontendAddress.IP,
+		fmt.Sprintf("%d", svc.FrontendAddress.Port))
+	return frontendAddress, nil
+}
+
 // ServiceGetIds returns an array with the IDs of all Cilium services. Returns
 // an error if the IDs cannot be retrieved
 func (c *Cilium) ServiceGetIds() ([]string, error) {

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -89,13 +89,15 @@ var _ = Describe("RuntimeLB", func() {
 		result = cilium.ServiceGet(1)
 		result.ExpectSuccess("Service cannot be retrieved correctly")
 
-		Expect(result.Output()).Should(ContainSubstring("[::1]:90"), fmt.Sprintf(
-			"No service backends added correctly %q", result.Output()))
+		frontendAddress, err := cilium.ServiceGetFrontendAddress(1)
+		Expect(err).Should(BeNil())
+		Expect(frontendAddress).Should(ContainSubstring("[::]:80"),
+			"No service backends added correctly %q", result.Output())
+
 		helpers.Sleep(5)
 		//TODO: This need to be with Wait,Timeout
 		//Checking that bpf lb list is working correctly
 		result = cilium.Exec("bpf lb list")
-
 		result.ExpectSuccess("service cannot be retrieved correctly")
 
 		Expect(result.Output()).Should(ContainSubstring("[::1]:90"), fmt.Sprintf(


### PR DESCRIPTION
Hello! 

Fix the issue with the current ginkgo builds. 

Current issue: 
```
/root/jenkins/workspace/Ginkgo-CI-Tests-Pipeline/src/github.com/cilium/cilium/test/runtime/lb.go:82
No service backends added correctly "{\"backend-addresses\":[{\"ip\":\"::1\",\"port\":90},{\"ip\":\"::2\",\"port\":91}],\"frontend-address\":{\"ip\":\"::\",\"port\":80,\"protocol\":\"TCP\"},\"id\":1}\n"
```

Problem introduced by me in the PR 2059