### PR TITLE
Documentation: move remaining inlined policies to examples

### DIFF
--- a/Documentation/gettingstarted_kafka.rst
+++ b/Documentation/gettingstarted_kafka.rst
@@ -288,40 +288,7 @@ from producing to *empire-announce* or consuming from *deathstar-plans*.
 Here is the *CiliumNetworkPolicy* rule that limits access of pods with label *app=empire-outpost* to
 only consume on topic *empire-announce*:
 
-::
-
-  apiVersion: "cilium.io/v2"
-  kind: CiliumNetworkPolicy
-  description: "enable outposts to consume empire-announce"
-  metadata:
-    name: "rule2"
-  spec:
-    endpointSelector:
-      matchLabels:
-        app: kafka
-    ingress:
-    - fromEndpoints:
-      - matchLabels:
-          app: empire-outpost
-      toPorts:
-      - ports:
-        - port: "9092"
-          protocol: TCP
-        rules:
-          kafka:
-          - apiKey: "fetch"
-            topic: "empire-announce"
-          - apiKey: "apiversions"
-          - apiKey: "metadata"
-          - apiKey: "findcoordinator"
-          - apiKey: "joingroup"
-          - apiKey: "leavegroup"
-          - apiKey: "syncgroup"
-          - apiKey: "offsets"
-          - apiKey: "offsetcommit"
-          - apiKey: "offsetfetch"
-          - apiKey: "heartbeat"
-
+.. literalinclude:: ../examples/policies/getting-started/kafka.yaml
 
 A *CiliumNetworkPolicy* contains a list of rules that define allowed requests, meaning that requests
 that do not match any rules are denied as invalid.

--- a/Documentation/policy.rst
+++ b/Documentation/policy.rst
@@ -683,29 +683,8 @@ Example (Single Rule)
 The following example allows all prod-labeled pods to access ``/public`` HTTP
 endpoint on service-labeled.
 
-.. code:: yaml
+.. literalinclude:: ../examples/policies/l7.yaml
 
-    apiVersion: "cilium.io/v2"
-    kind: CiliumNetworkPolicy
-    description: "L7 policy for accessing /public address on service endpoints"
-    metadata:
-      name: "rule1"
-    spec:
-      endpointSelector:
-        matchLabels:
-          app: service
-      ingress:
-      - fromEndpoints:
-        - matchLabels:
-            env: prod
-        toPorts:
-        - ports:
-          - port: "80"
-            protocol: TCP
-          rules:
-            http:
-            - method: "GET"
-              path: "/public"
 
 Example (Multiple Rules)
 ------------------------
@@ -713,40 +692,8 @@ Example (Multiple Rules)
 This example builds on previous example to show how to define multiple policy specs
 in single rule. Added spec allows production pods to POST requests to ``external-service.org``.
 
-.. code:: yaml
+.. literalinclude:: ../examples/policies/l7_multi.yaml
 
-    apiVersion: "cilium.io/v2"
-    kind: CiliumNetworkPolicy
-    metadata:
-      name: "fancyrule"
-    specs:
-      - endpointSelector:
-          matchLabels:
-            app: service
-        ingress:
-        - fromEndpoints:
-          - matchLabels:
-              env: prod
-          toPorts:
-          - ports:
-            - port: "80"
-              protocol: TCP
-            rules:
-              http:
-              - method: "GET"
-                path: "/public"
-      - endpointSelector:
-          matchLabels:
-            env: prod
-        egress:
-        - toPorts:
-          - ports:
-            - port: "80"
-              protocol: TCP
-            rules:
-              http:
-              - method: "POST"
-                host: "^external-service.org$"
 
 ***********************
 Policy Enforcement Mode

--- a/examples/policies/getting-started/kafka.yaml
+++ b/examples/policies/getting-started/kafka.yaml
@@ -1,0 +1,31 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+description: "enable outposts to consume empire-announce"
+metadata:
+  name: "rule2"
+spec:
+  endpointSelector:
+    matchLabels:
+      app: kafka
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        app: empire-outpost
+    toPorts:
+    - ports:
+      - port: "9092"
+        protocol: TCP
+      rules:
+        kafka:
+        - apiKey: "fetch"
+          topic: "empire-announce"
+        - apiKey: "apiversions"
+        - apiKey: "metadata"
+        - apiKey: "findcoordinator"
+        - apiKey: "joingroup"
+        - apiKey: "leavegroup"
+        - apiKey: "syncgroup"
+        - apiKey: "offsets"
+        - apiKey: "offsetcommit"
+        - apiKey: "offsetfetch"
+        - apiKey: "heartbeat"

--- a/examples/policies/l7.yaml
+++ b/examples/policies/l7.yaml
@@ -1,0 +1,21 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+description: "L7 policy for accessing /public address on service endpoints"
+metadata:
+  name: "rule1"
+spec:
+  endpointSelector:
+    matchLabels:
+      app: service
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        env: prod
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+      rules:
+        http:
+        - method: "GET"
+          path: "/public"

--- a/examples/policies/l7_multi.yaml
+++ b/examples/policies/l7_multi.yaml
@@ -1,0 +1,32 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "fancyrule"
+specs:
+  - endpointSelector:
+      matchLabels:
+        app: service
+    ingress:
+    - fromEndpoints:
+      - matchLabels:
+          env: prod
+      toPorts:
+      - ports:
+        - port: "80"
+          protocol: TCP
+        rules:
+          http:
+          - method: "GET"
+            path: "/public"
+  - endpointSelector:
+      matchLabels:
+        env: prod
+    egress:
+    - toPorts:
+      - ports:
+        - port: "80"
+          protocol: TCP
+        rules:
+          http:
+          - method: "POST"
+            host: "^external-service.org$"


### PR DESCRIPTION
Related: #1845 (Validate example policies in Cilium documentation)
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>