### PR TITLE
daemon: Improve locking around k8sUsedGroups map

### DIFF
--- a/daemon/status.go
+++ b/daemon/status.go
@@ -61,12 +61,7 @@ func (d *Daemon) getK8sStatus() *models.K8sStatus {
 		}
 	}
 
-	d.k8sAPIGroups.Range(func(key string, value bool) bool {
-		if value {
-			k8sStatus.K8sAPIVersions = append(k8sStatus.K8sAPIVersions, key)
-		}
-		return true
-	})
+	k8sStatus.K8sAPIVersions = d.k8sAPIGroups.getGroups()
 
 	return k8sStatus
 }


### PR DESCRIPTION
This map is rarely accesed after it is declared, but there was a race
in the Range function because it did not use the lock on the object.
This change refactors that function to be simpler and uses the lock
library we use elsewhere in the code.

**How to test (optional)**:
Run cilium in race detection mode (see https://github.com/cilium/cilium/pull/2125/files#diff-dd772f9afa82bb62b55fc15ee2bba157 for what Makefile changes to make).
e.g. Run `make tests`, `make runtime-tests` and/or some more specific way to
exercise the new behavior(s).
Note: [The runtime testsuite will modify the host it runs on.](http://cilium.readthedocs.io/en/latest/contributing/#testsuite)
