### PR TITLE
daemon: fix clang and kernel versions output

### DIFF
--- a/daemon/main_test.go
+++ b/daemon/main_test.go
@@ -1,0 +1,47 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	go_version "github.com/hashicorp/go-version"
+
+	. "gopkg.in/check.v1"
+)
+
+func (ds *DaemonSuite) TestParseKernelVersion(c *C) {
+	mustHaveVersion := func(v string) *go_version.Version {
+		ver, err := go_version.NewVersion(v)
+		c.Assert(err, IsNil)
+		return ver
+	}
+
+	var flagtests = []struct {
+		in  string
+		out *go_version.Version
+	}{
+		{"4.10.0", mustHaveVersion("4.10.0")},
+		{"4.10", mustHaveVersion("4.10.0")},
+		{"4.12.0+", mustHaveVersion("4.12.0")},
+		{"4.12.8", mustHaveVersion("4.12.8")},
+		{"4.14.0-rc7+", mustHaveVersion("4.14.0")},
+		{"4.9.17-040917-generic", mustHaveVersion("4.9.17")},
+		{"4.9.generic", mustHaveVersion("4.9.0")},
+	}
+	for _, tt := range flagtests {
+		s, err := parseKernelVersion(tt.in)
+		c.Assert(err, IsNil)
+		c.Assert(tt.out.Equal(s), Equals, true)
+	}
+}


### PR DESCRIPTION
Previously we were only priting the major.minor versions of clang and
the kernel. This commit will try to retrieve the kernel and clang patch
versions. On a worst case it will print the patch version "0"

Previously:
clang (3.8.0) and kernel (4.9.0) versions: OK!
Now:
clang (3.8.1) and kernel (4.9.17) versions: OK!

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Printing patch clang and kernel patch versions when starting cilium.
```

It is a fair assumption the kernel will have `major.minor.patch[-random-string]`?