### PR TITLE
misc: remove harmless warning and improve auto-generation of author file

### DIFF
--- a/.AUTHORS.aux
+++ b/.AUTHORS.aux
@@ -1,8 +1,0 @@
-
-The following additional people are mentioned in commit logs as having provided
-helpful bug reports, suggestions or have otherwise provided value to the
-project:
-
-Brenden Blanco        bblanco@plumgrid.com
-Salvatore Orlando     salv.orlando@gmail.com
-Tomás Senart          tsenart@gmail.com

--- a/.authors.aux
+++ b/.authors.aux
@@ -1,0 +1,8 @@
+
+The following additional people are mentioned in commit logs as having provided
+helpful bug reports, suggestions or have otherwise provided value to the
+project:
+
+Brenden Blanco                          bblanco@plumgrid.com
+Salvatore Orlando                       salv.orlando@gmail.com
+Tomás Senart                            tsenart@gmail.com

--- a/.mailmap
+++ b/.mailmap
@@ -5,3 +5,5 @@ Florian Koch <f0@users.noreply.github.com>
 Madhu Challa <challa@gmail.com>
 Peiqi Shi <uestc.shi@gmail.com>
 Craig Box <craig.box@gmail.com>
+Matthew Gumport <me@gum.pt>
+Daniel Qian <qsj.daniel@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,57 +1,60 @@
 The following people, in alphabetical order, have either authored or signed
 off on commits in the Cilium repository:
 
-Alban Crequy <alban@kinvolk.io>
-Alexander Alemayhu <alexander@alemayhu.com>
-Alexei Starovoitov <alexei.starovoitov@gmail.com>
-Amre Shakimov <amre@covalent.io>
-André Martins <andre@cilium.io>
-Ashwin Paranjpe <ashwinp.work@gmail.com>
-Craig Box <craig.box@gmail.com>
-Cynthia Thomas <techcet@users.noreply.github.com>
-Daniel Borkmann <daniel@iogearbox.net>
-Daniel Dao <dqminh89@gmail.com>
-Dan Wendlandt <dan@covalent.io>
-Dom Del Nano <ddelnano@gmail.com>
-Eloy Coto <eloy.coto@gmail.com>
-Faiyaz Ahmed <faiyaza@gmail.com>
-Florian Koch <f0@users.noreply.github.com>
-Fred Hsu <fredlhsu@gmail.com>
-Gianluca Arbezzano <gianarb92@gmail.com>
-Ian Vernon <ian@covalent.io>
-Ivar Lazzaro <ivarlazzaro@gmail.com>
-Jan-Erik Rediger <janerik@fnordig.de>
-Jarno Rajahalme <jarno@covalent.io>
-Joe Stringer <joe@covalent.io>
-John Fastabend <john.fastabend@gmail.com>
-Jonathan Davies <jpds@protonmail.com>
-Jon Davies <jpds@protonmail.com>
-Katarzyna Borkmann <kasia@iogearbox.net>
-Maciej Kwiek <maciej.iai@gmail.com>
-Madhu Challa <madhu@cilium.io>
-Manali Bhutiyani <manali@covalent.io>
-Marcin Skarbek <git@skarbek.name>
-Michi Mutsuzaki <michi@covalent.io>
-Peiqi Shi <uestc.shi@gmail.com>
-Raghu Gyambavantha <raghug@bld-ml-loan4.olympus.f5net.com>
-Ray Bejjani <raybejjani@users.noreply.github.com>
-Romain Lenglet <romain@covalent.io>
-Ross Guarino <rssguar@gmail.com>
-Russell Bryant <russell@russellbryant.net>
-Sergey Generalov <sergey@genbit.ru>
-shijunqian <qsj.daniel@gmail.com>
-Simon Pasquier <spasquier@mirantis.com>
-Steven Ceuppens <steven.ceuppens@icloud.com>
-Thomas Bachman <tbachman@yahoo.com>
-Thomas Graf <thomas@cilium.io>
-Tobias Klauser <tklauser@distanz.ch>
-Tony Lambiris <tony@criticalstack.com>
-Trevor Roberts Jr <Trevor.Roberts.Jr@gmail.com>
+Alban Crequy                            alban@kinvolk.io
+Alexander Alemayhu                      alexander@alemayhu.com
+Alexei Starovoitov                      alexei.starovoitov@gmail.com
+Amre Shakimov                           amre@covalent.io
+André Martins                           andre@cilium.io
+Ashwin Paranjpe                         ashwinp.work@gmail.com
+Craig Box                               craig.box@gmail.com
+Cynthia Thomas                          techcet@users.noreply.github.com
+Daniel Borkmann                         daniel@iogearbox.net
+Daniel Dao                              dqminh89@gmail.com
+Daniel Qian                             qsj.daniel@gmail.com
+Dan Wendlandt                           dan@covalent.io
+Dom Del Nano                            ddelnano@gmail.com
+Eloy Coto                               eloy.coto@gmail.com
+Erik Chang                              erik.chang@nordstrom.com
+Faiyaz Ahmed                            faiyaza@gmail.com
+Florian Koch                            f0@users.noreply.github.com
+Fred Hsu                                fredlhsu@gmail.com
+Fulvio Risso                            fulvio.risso@polito.it
+Gianluca Arbezzano                      gianarb92@gmail.com
+Ian Vernon                              ian@covalent.io
+Ivar Lazzaro                            ivarlazzaro@gmail.com
+Jan-Erik Rediger                        janerik@fnordig.de
+Jarno Rajahalme                         jarno@covalent.io
+Joe Stringer                            joe@covalent.io
+John Fastabend                          john.fastabend@gmail.com
+Jonathan Davies                         jpds@protonmail.com
+Jon Davies                              jpds@protonmail.com
+Katarzyna Borkmann                      kasia@iogearbox.net
+Maciej Kwiek                            maciej.iai@gmail.com
+Madhu Challa                            madhu@cilium.io
+Manali Bhutiyani                        manali@covalent.io
+Marcin Skarbek                          git@skarbek.name
+Matthew Gumport                         me@gum.pt
+Michi Mutsuzaki                         michi@covalent.io
+Peiqi Shi                               uestc.shi@gmail.com
+Raghu Gyambavantha                      raghug@bld-ml-loan4.olympus.f5net.com
+Ray Bejjani                             ray@covalent.io
+Romain Lenglet                          romain@covalent.io
+Ross Guarino                            rssguar@gmail.com
+Russell Bryant                          russell@russellbryant.net
+Sergey Generalov                        sergey@genbit.ru
+Simon Pasquier                          spasquier@mirantis.com
+Steven Ceuppens                         steven.ceuppens@icloud.com
+Thomas Bachman                          tbachman@yahoo.com
+Thomas Graf                             thomas@cilium.io
+Tobias Klauser                          tklauser@distanz.ch
+Tony Lambiris                           tony@criticalstack.com
+Trevor Roberts Jr                       Trevor.Roberts.Jr@gmail.com
 
 The following additional people are mentioned in commit logs as having provided
 helpful bug reports, suggestions or have otherwise provided value to the
 project:
 
-Brenden Blanco        bblanco@plumgrid.com
-Salvatore Orlando     salv.orlando@gmail.com
-Tomás Senart          tsenart@gmail.com
+Brenden Blanco                          bblanco@plumgrid.com
+Salvatore Orlando                       salv.orlando@gmail.com
+Tomás Senart                            tsenart@gmail.com

--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ update-authors:
 	@echo "off on commits in the Cilium repository:" >> AUTHORS
 	@echo "" >> AUTHORS
 	@contrib/scripts/extract_authors.sh >> AUTHORS
-	@cat .AUTHORS.aux >> AUTHORS
+	@cat .authors.aux >> AUTHORS
 
 docs-container:
 	docker build -t cilium/docs-builder -f Documentation/Dockerfile .

--- a/contrib/scripts/extract_authors.sh
+++ b/contrib/scripts/extract_authors.sh
@@ -3,8 +3,14 @@
 function extract_authors() {
 	authors=$(git shortlog --summary | awk '{$1=""; print $0}' | sed -e 's/^ //')
 	IFS=$'\n'
+	pad=$(printf '%0.1s' " "{1..60})
+	padlen=40
 	for i in $authors; do
-		git log --use-mailmap --author="$i" | grep Author | head -1 | sed -e 's/Author: //'
+		name=$(git log --use-mailmap --author="$i" --format="%aN" | head -1)
+		mail=$(git log --use-mailmap --author="$i" --format="%aE" | head -1)
+		printf '%s' "$name"
+		printf '%*.*s' 0 $((padlen - ${#name})) "$pad"
+		printf '%s\n' "$mail"
 	done
 }
 

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -49,11 +49,9 @@ func main() {
 	go m.handleConnection(server)
 	npages := 64
 	if len(os.Args) > 1 {
-		v, err := strconv.Atoi(os.Args[1])
+		v, _ := strconv.Atoi(os.Args[1])
 		if v > 0 {
 			npages = v
-		} else {
-			log.WithError(err).Info("Cannot parse number of pages with strconv")
 		}
 	}
 	m.Run(npages)


### PR DESCRIPTION
Two minor cleanups, one to get the authors file in shape which I had lying around for longer time locally, and another minor one for removing an error message in the log that I am running into and got confused, but given the issue is harmless lets just remove it.