### PR TITLE
Fix running ginkgo k8s tests locally

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -22,14 +22,6 @@ import (
 var (
 	// HelperTimeout is a predefined timeout value for commands.
 	HelperTimeout time.Duration = 300 // WithTimeout helper translates it to seconds
-
-	// K8s1VMName is the name of the Kubernetes master node when running
-	// Kubernetes tests.
-	K8s1VMName = fmt.Sprintf("k8s1-%s", GetCurrentK8SEnv())
-
-	// K8s2VMName is the name of the Kubernetes worker node when running
-	// Kubernetes tests.
-	K8s2VMName = fmt.Sprintf("k8s2-%s", GetCurrentK8SEnv())
 )
 
 const (
@@ -163,4 +155,14 @@ var ciliumKubCLICommands = map[string]string{
 //GetFilePath returns the absolute path of the provided filename
 func GetFilePath(filename string) string {
 	return fmt.Sprintf("%s%s", BasePath, filename)
+}
+
+// K8s1VMName is the name of the Kubernetes master node when running K8s tests.
+func K8s1VMName() string {
+	return fmt.Sprintf("k8s1-%s", GetCurrentK8SEnv())
+}
+
+// K8s2VMName is the name of the Kubernetes worker node when running K8s tests.
+func K8s2VMName() string {
+	return fmt.Sprintf("k8s2-%s", GetCurrentK8SEnv())
 }

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -42,7 +42,7 @@ var _ = Describe("NightlyK8sEpsMeasurement", func() {
 		logger = log.WithFields(log.Fields{"testName": "NightlyK8sEpsMeasurement"})
 		logger.Info("Starting")
 
-		kubectl = helpers.CreateKubectl(helpers.K8s1VMName, logger)
+		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		kubectl.Apply(ciliumPath)
 		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 		Expect(err).Should(BeNil())

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -40,7 +40,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 		logger = log.WithFields(log.Fields{"testName": "K8sPolicyTest"})
 		logger.Info("Starting")
-		kubectl = helpers.CreateKubectl(helpers.K8s1VMName, logger)
+		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		podFilter = "k8s:zgroup=testapp"
 
 		//Manifest paths

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -41,7 +41,7 @@ var _ = Describe("K8sServicesTest", func() {
 		logger = log.WithFields(log.Fields{"testName": "K8sServiceTest"})
 		logger.Info("Starting")
 
-		kubectl = helpers.CreateKubectl(helpers.K8s1VMName, logger)
+		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		path := fmt.Sprintf("%s/cilium_ds.yaml", kubectl.ManifestsPath())
 		kubectl.Apply(path)
 		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -39,7 +39,7 @@ var _ = Describe("K8sTunnelTest", func() {
 		logger = log.WithFields(log.Fields{"testName": "K8sTunnelTest"})
 		logger.Info("Starting")
 
-		kubectl = helpers.CreateKubectl(helpers.K8s1VMName, logger)
+		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		demoDSPath = fmt.Sprintf("%s/demo_ds.yaml", kubectl.ManifestsPath())
 		kubectl.Node.Exec("kubectl -n kube-system delete ds cilium")
 		// Expect(res.Correct()).Should(BeTrue())

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -141,13 +141,13 @@ var _ = BeforeSuite(func() {
 		// Wait until compilation finished, and pull cilium image on k8s2
 
 		// Name for K8s VMs depends on K8s version that is running.
-		err = vagrant.Create(helpers.K8s1VMName)
+		err = vagrant.Create(helpers.K8s1VMName())
 		if err != nil {
-			Fail(fmt.Sprintf("error starting VM %q: %s", helpers.K8s1VMName, err))
+			Fail(fmt.Sprintf("error starting VM %q: %s", helpers.K8s1VMName(), err))
 		}
-		err = vagrant.Create(helpers.K8s2VMName)
+		err = vagrant.Create(helpers.K8s2VMName())
 		if err != nil {
-			Fail(fmt.Sprintf("error starting VM %q: %s", helpers.K8s2VMName, err))
+			Fail(fmt.Sprintf("error starting VM %q: %s", helpers.K8s2VMName(), err))
 		}
 	}
 	return
@@ -165,8 +165,8 @@ var _ = AfterSuite(func() {
 	case helpers.Runtime:
 		vagrant.Destroy(helpers.Runtime)
 	case helpers.K8s:
-		vagrant.Destroy(helpers.K8s1VMName)
-		vagrant.Destroy(helpers.K8s2VMName)
+		vagrant.Destroy(helpers.K8s1VMName())
+		vagrant.Destroy(helpers.K8s2VMName())
 	}
 	return
 })


### PR DESCRIPTION
When running the ginkgo k8s tests locally, they fail to spin up the VMs,
so the tests fail. The reason is that K8S_VERSION is not set locally,
and the logic to default to k8s 1.7 was broken in commit d4f5005326a9
because the VM names were converted into variables initialized at
program startup, rather than after the ginkgo init() function is called.

This commit fixes the issue by changing the constant k8s VM names into
functions which evaluate when they are invoked, rather than on startup.

Fixes: #2151
Fixes: d4f5005326a9 ("test/helpers: add constants for use throughout tests")

Signed-off-by: Joe Stringer <joe@covalent.io>