### PR TITLE
tests: Use HTTP 1.1 instead of HTTP 1.0

### DIFF
--- a/tests/21-ct-clean-up-nc.py
+++ b/tests/21-ct-clean-up-nc.py
@@ -20,8 +20,8 @@ clientsocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 clientsocket.bind(('', localport))
 clientsocket.settimeout(timeout)
 clientsocket.connect((serverAddr, serverPort))
-clientsocket.send('GET '+httpPath+' HTTP/1.0\r\nHost: '+host+
-                  '\r\nUser-Agent: curl/7.38.0\r\nAccept: */*\r\n\r\n')
+clientsocket.send('GET '+httpPath+' HTTP/1.1\r\nHost: '+host+
+                  '\r\nConnection: close\r\nUser-Agent: curl/7.38.0\r\nAccept: */*\r\n\r\n')
 
 data = clientsocket.recv(4096)
 print(data)


### PR DESCRIPTION
Envoy does not support HTTP 1.0, so use HTTP 1.1 instead.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
