### PR TITLE
logging: Stop using default logrus logger

### DIFF
--- a/common/plugins/add_endpoint.go
+++ b/common/plugins/add_endpoint.go
@@ -19,11 +19,13 @@ import (
 	"os/exec"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/logfields"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
+
+var log = common.DefaultLogger
 
 const (
 	// hostInterfacePrefix is the Host interface prefix.

--- a/common/types/loadbalancer.go
+++ b/common/types/loadbalancer.go
@@ -21,11 +21,14 @@ import (
 	"strings"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logfields"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
+
+var log = common.DefaultLogger
 
 const (
 	NONE = L4Type("NONE")
@@ -106,7 +109,7 @@ type LoadBalancer struct {
 
 // AddService adds a service to list of loadbalancers and returns true if created.
 func (lb *LoadBalancer) AddService(svc LBSVC) bool {
-	scopedLog := log.WithFields(log.Fields{
+	scopedLog := log.WithFields(logrus.Fields{
 		logfields.ServiceName: svc.FE.String(),
 		logfields.SHA:         svc.Sha256,
 	})
@@ -125,7 +128,7 @@ func (lb *LoadBalancer) AddService(svc LBSVC) bool {
 
 // DeleteService deletes svc from lb's SVCMap and SVCMapID.
 func (lb *LoadBalancer) DeleteService(svc *LBSVC) {
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.ServiceName: svc.FE.String(),
 		logfields.SHA:         svc.Sha256,
 	}).Debug("deleting service from loadbalancer")
@@ -434,7 +437,7 @@ func (l *L3n4AddrID) IsIPv6() bool {
 // remaining be elements will be kept on the same index and, in case the new array is
 // larger than the number of backends, some elements will be empty.
 func (svcs SVCMap) AddFEnBE(fe *L3n4AddrID, be *LBBackEnd, beIndex int) *LBSVC {
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"frontend":     fe,
 		"backend":      be,
 		"backendIndex": beIndex,

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -60,7 +60,7 @@ import (
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/mattn/go-shellwords"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/vishvananda/netlink"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -145,7 +145,7 @@ func (d *Daemon) RemoveProxyRedirect(e *endpoint.Endpoint, l4 *policy.L4Filter) 
 	}
 
 	id := e.ProxyID(l4)
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.EndpointID: e.ID,
 		logfields.L4PolicyID: id,
 		logfields.Object:     l4,
@@ -270,7 +270,7 @@ func (d *Daemon) AnnotateEndpoint(e *endpoint.Endpoint, annotationKey, annotatio
 			// Endpoint's PodName is in the format namespace:pod-name
 			split := strings.Split(e.PodName, ":")
 			if len(split) < 2 {
-				log.WithFields(log.Fields{
+				log.WithFields(logrus.Fields{
 					logfields.EndpointID:            e.ID,
 					logfields.K8sPodName:            e.PodName,
 					logfields.K8sIdentityAnnotation: common.CiliumIdentityAnnotation,
@@ -278,7 +278,7 @@ func (d *Daemon) AnnotateEndpoint(e *endpoint.Endpoint, annotationKey, annotatio
 				return
 			}
 
-			scopedLog := log.WithFields(log.Fields{
+			scopedLog := log.WithFields(logrus.Fields{
 				logfields.EndpointID:            e.ID,
 				logfields.K8sNamespace:          split[0],
 				logfields.K8sPodName:            split[1],

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -33,7 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 
 	"github.com/go-openapi/runtime/middleware"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type getEndpoint struct {
@@ -197,7 +197,7 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder 
 		endpointmanager.Mutex.Lock()
 		if errLabelsAdd != nil {
 			// XXX: Why should the endpoint remain in this case?
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				logfields.EndpointID:              params.ID,
 				logfields.IdentityLabels:          logfields.Repr(add),
 				logfields.IdentityLabels + ".bad": errLabelsAdd,
@@ -345,7 +345,7 @@ func (d *Daemon) deleteEndpoint(ep *endpoint.Endpoint) int {
 
 	sha256sum := ep.OpLabels.IdentityLabels().SHA256Sum()
 	if err := d.DeleteIdentityBySHA256(sha256sum, ep.StringID()); err != nil {
-		log.WithError(err).WithFields(log.Fields{
+		log.WithError(err).WithFields(logrus.Fields{
 			logfields.SHA:            sha256sum,
 			logfields.IdentityLabels: ep.OpLabels.IdentityLabels(),
 		}).Error("Error while deleting labels")
@@ -648,7 +648,7 @@ func (d *Daemon) UpdateSecLabels(id string, add, del labels.Labels) middleware.R
 	if ep.GetStateLocked() == endpoint.StateDisconnected {
 		ep.Mutex.Unlock()
 		if err := d.DeleteIdentity(identity.ID, ep.StringID()); err != nil {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				logfields.EndpointID: ep.StringID(),
 				logfields.Identity:   identity.ID,
 			}).WithError(err).Warn("Unable to release temporary identity")
@@ -706,7 +706,7 @@ func (h *putEndpointIDLabels) Handle(params PutEndpointIDLabelsParams) middlewar
 //  - trigger endpoint regeneration if required
 //  - trigger policy regeneration if required
 func (d *Daemon) EndpointLabelsUpdate(ep *endpoint.Endpoint, identityLabels, infoLabels labels.Labels) error {
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.ContainerID:    ep.GetShortContainerID(),
 		logfields.EndpointID:     ep.StringID(),
 		logfields.IdentityLabels: identityLabels.String(),
@@ -734,7 +734,7 @@ func (d *Daemon) EndpointLabelsUpdate(ep *endpoint.Endpoint, identityLabels, inf
 	if ep.GetStateLocked() == endpoint.StateDisconnected {
 		ep.Mutex.Unlock()
 		if err := d.DeleteIdentity(identity.ID, ep.StringID()); err != nil {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				logfields.EndpointID: ep.StringID(),
 				logfields.Identity:   identity.ID,
 			}).WithError(err).Warn("Unable to release temporary identity")

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -37,7 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/serializer"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
@@ -663,7 +663,7 @@ func (d *Daemon) addK8sNetworkPolicyV1(k8sNP *networkingv1.NetworkPolicy) {
 	scopedLog := log.WithField(logfields.K8sAPIVersion, k8sNP.TypeMeta.APIVersion)
 	rules, err := k8s.ParseNetworkPolicy(k8sNP)
 	if err != nil {
-		scopedLog.WithError(err).WithFields(log.Fields{
+		scopedLog.WithError(err).WithFields(logrus.Fields{
 			logfields.CiliumNetworkPolicy: logfields.Repr(k8sNP),
 		}).Error("Error while parsing k8s kubernetes NetworkPolicy")
 		return
@@ -672,7 +672,7 @@ func (d *Daemon) addK8sNetworkPolicyV1(k8sNP *networkingv1.NetworkPolicy) {
 
 	opts := AddOptions{Replace: true}
 	if _, err := d.PolicyAdd(rules, &opts); err != nil {
-		scopedLog.WithError(err).WithFields(log.Fields{
+		scopedLog.WithError(err).WithFields(logrus.Fields{
 			logfields.CiliumNetworkPolicy: logfields.Repr(rules),
 		}).Error("Unable to add NetworkPolicy rules to policy repository")
 		return
@@ -682,7 +682,7 @@ func (d *Daemon) addK8sNetworkPolicyV1(k8sNP *networkingv1.NetworkPolicy) {
 }
 
 func (d *Daemon) updateK8sNetworkPolicyV1(oldk8sNP, newk8sNP *networkingv1.NetworkPolicy) {
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.K8sAPIVersion:                 oldk8sNP.TypeMeta.APIVersion,
 		logfields.K8sNetworkPolicyName + ".old": oldk8sNP.ObjectMeta.Name,
 		logfields.K8sNamespace + ".old":         oldk8sNP.ObjectMeta.Namespace,
@@ -696,7 +696,7 @@ func (d *Daemon) updateK8sNetworkPolicyV1(oldk8sNP, newk8sNP *networkingv1.Netwo
 func (d *Daemon) deleteK8sNetworkPolicyV1(k8sNP *networkingv1.NetworkPolicy) {
 	labels := labels.ParseSelectLabelArray(k8s.ExtractPolicyName(k8sNP))
 
-	scopedLog := log.WithFields(log.Fields{
+	scopedLog := log.WithFields(logrus.Fields{
 		logfields.K8sNetworkPolicyName: k8sNP.ObjectMeta.Name,
 		logfields.K8sNamespace:         k8sNP.ObjectMeta.Namespace,
 		logfields.K8sAPIVersion:        k8sNP.TypeMeta.APIVersion,
@@ -733,7 +733,7 @@ func (d *Daemon) addK8sNetworkPolicyV1beta1(k8sNP *v1beta1.NetworkPolicy) {
 // updateK8sNetworkPolicyV1beta1
 // FIXME remove when we drop support to k8s Network Policy extensions/v1beta1
 func (d *Daemon) updateK8sNetworkPolicyV1beta1(oldk8sNP, newk8sNP *v1beta1.NetworkPolicy) {
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.K8sAPIVersion:                 oldk8sNP.TypeMeta.APIVersion,
 		logfields.K8sNetworkPolicyName + ".old": oldk8sNP.ObjectMeta.Name,
 		logfields.K8sNamespace + ".old":         oldk8sNP.ObjectMeta.Namespace,
@@ -749,7 +749,7 @@ func (d *Daemon) updateK8sNetworkPolicyV1beta1(oldk8sNP, newk8sNP *v1beta1.Netwo
 func (d *Daemon) deleteK8sNetworkPolicyV1beta1(k8sNP *v1beta1.NetworkPolicy) {
 	labels := labels.ParseSelectLabelArray(k8s.ExtractPolicyNameDeprecated(k8sNP))
 
-	scopedLog := log.WithFields(log.Fields{
+	scopedLog := log.WithFields(logrus.Fields{
 		logfields.K8sNetworkPolicyName: k8sNP.ObjectMeta.Name,
 		logfields.K8sNamespace:         k8sNP.ObjectMeta.Namespace,
 		logfields.K8sAPIVersion:        k8sNP.TypeMeta.APIVersion,
@@ -764,7 +764,7 @@ func (d *Daemon) deleteK8sNetworkPolicyV1beta1(k8sNP *v1beta1.NetworkPolicy) {
 }
 
 func (d *Daemon) addK8sServiceV1(svc *v1.Service) {
-	scopedLog := log.WithFields(log.Fields{
+	scopedLog := log.WithFields(logrus.Fields{
 		logfields.K8sSvcName:    svc.ObjectMeta.Name,
 		logfields.K8sNamespace:  svc.ObjectMeta.Namespace,
 		logfields.K8sAPIVersion: svc.TypeMeta.APIVersion,
@@ -824,7 +824,7 @@ func (d *Daemon) addK8sServiceV1(svc *v1.Service) {
 }
 
 func (d *Daemon) updateK8sServiceV1(oldSvc, newSvc *v1.Service) {
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.K8sAPIVersion:         oldSvc.TypeMeta.APIVersion,
 		logfields.K8sSvcName + ".old":   oldSvc.ObjectMeta.Name,
 		logfields.K8sNamespace + ".old": oldSvc.ObjectMeta.Namespace,
@@ -838,7 +838,7 @@ func (d *Daemon) updateK8sServiceV1(oldSvc, newSvc *v1.Service) {
 }
 
 func (d *Daemon) deleteK8sServiceV1(svc *v1.Service) {
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.K8sSvcName:    svc.ObjectMeta.Name,
 		logfields.K8sNamespace:  svc.ObjectMeta.Namespace,
 		logfields.K8sAPIVersion: svc.TypeMeta.APIVersion,
@@ -855,7 +855,7 @@ func (d *Daemon) deleteK8sServiceV1(svc *v1.Service) {
 }
 
 func (d *Daemon) addK8sEndpointV1(ep *v1.Endpoints) {
-	scopedLog := log.WithFields(log.Fields{
+	scopedLog := log.WithFields(logrus.Fields{
 		logfields.K8sEndpointName: ep.ObjectMeta.Name,
 		logfields.K8sNamespace:    ep.ObjectMeta.Namespace,
 		logfields.K8sAPIVersion:   ep.TypeMeta.APIVersion,
@@ -909,7 +909,7 @@ func (d *Daemon) addK8sEndpointV1(ep *v1.Endpoints) {
 func (d *Daemon) updateK8sEndpointV1(oldEP, newEP *v1.Endpoints) {
 	// TODO only print debug message if the difference between the old endpoint
 	// and the new endpoint are important to us.
-	//log.WithFields(log.Fields{
+	//log.WithFields(logrus.Fields{
 	//	logfields.K8sAPIVersion:            oldEP.TypeMeta.APIVersion,
 	//	logfields.K8sEndpointName + ".old": oldEP.ObjectMeta.Name,
 	//	logfields.K8sNamespace + ".old":    oldEP.ObjectMeta.Namespace,
@@ -921,7 +921,7 @@ func (d *Daemon) updateK8sEndpointV1(oldEP, newEP *v1.Endpoints) {
 }
 
 func (d *Daemon) deleteK8sEndpointV1(ep *v1.Endpoints) {
-	scopedLog := log.WithFields(log.Fields{
+	scopedLog := log.WithFields(logrus.Fields{
 		logfields.K8sEndpointName: ep.ObjectMeta.Name,
 		logfields.K8sNamespace:    ep.ObjectMeta.Namespace,
 		logfields.K8sAPIVersion:   ep.TypeMeta.APIVersion,
@@ -1001,7 +1001,7 @@ func (d *Daemon) delK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 		return err
 	}
 
-	scopedLog := log.WithFields(log.Fields{
+	scopedLog := log.WithFields(logrus.Fields{
 		logfields.K8sSvcName:   svc.ServiceName,
 		logfields.K8sNamespace: svc.Namespace,
 	})
@@ -1050,7 +1050,7 @@ func (d *Daemon) addK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 		return nil
 	}
 
-	scopedLog := log.WithFields(log.Fields{
+	scopedLog := log.WithFields(logrus.Fields{
 		logfields.K8sSvcName:   svc.ServiceName,
 		logfields.K8sNamespace: svc.Namespace,
 	})
@@ -1073,7 +1073,7 @@ func (d *Daemon) addK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 		if fePort.ID == 0 {
 			feAddr, err := types.NewL3n4Addr(fePort.Protocol, svcInfo.FEIP, fePort.Port)
 			if err != nil {
-				scopedLog.WithError(err).WithFields(log.Fields{
+				scopedLog.WithError(err).WithFields(logrus.Fields{
 					logfields.ServiceID: fePortName,
 					logfields.IPAddr:    svcInfo.FEIP,
 					logfields.Port:      fePort.Port,
@@ -1083,7 +1083,7 @@ func (d *Daemon) addK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 			}
 			feAddrID, err := PutL3n4Addr(*feAddr, 0)
 			if err != nil {
-				scopedLog.WithError(err).WithFields(log.Fields{
+				scopedLog.WithError(err).WithFields(logrus.Fields{
 					logfields.ServiceID: fePortName,
 					logfields.IPAddr:    svcInfo.FEIP,
 					logfields.Port:      fePort.Port,
@@ -1091,7 +1091,7 @@ func (d *Daemon) addK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 				}).Error("Error while getting a new service ID. Ignoring service...")
 				continue
 			}
-			scopedLog.WithFields(log.Fields{
+			scopedLog.WithFields(logrus.Fields{
 				logfields.ServiceName: fePortName,
 				logfields.ServiceID:   feAddrID.ID,
 				logfields.Object:      logfields.Repr(svc),
@@ -1113,7 +1113,7 @@ func (d *Daemon) addK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 
 		fe, err := types.NewL3n4AddrID(fePort.Protocol, svcInfo.FEIP, fePort.Port, fePort.ID)
 		if err != nil {
-			scopedLog.WithError(err).WithFields(log.Fields{
+			scopedLog.WithError(err).WithFields(logrus.Fields{
 				logfields.IPAddr: svcInfo.FEIP,
 				logfields.Port:   svcInfo.Ports,
 			}).Error("Error while creating a New L3n4AddrID. Ignoring service...")
@@ -1141,7 +1141,7 @@ func (d *Daemon) syncLB(newSN, modSN, delSN *types.K8sServiceNamespace) {
 		}
 
 		if err := d.delK8sSVCs(delSN, svc, endpoint); err != nil {
-			log.WithError(err).WithFields(log.Fields{
+			log.WithError(err).WithFields(logrus.Fields{
 				logfields.K8sSvcName:   delSN.ServiceName,
 				logfields.K8sNamespace: delSN.Namespace,
 			}).Error("Unable to delete k8s service")
@@ -1164,7 +1164,7 @@ func (d *Daemon) syncLB(newSN, modSN, delSN *types.K8sServiceNamespace) {
 		}
 
 		if err := d.addK8sSVCs(addSN, svcInfo, endpoint); err != nil {
-			log.WithError(err).WithFields(log.Fields{
+			log.WithError(err).WithFields(logrus.Fields{
 				logfields.K8sSvcName:   addSN.ServiceName,
 				logfields.K8sNamespace: addSN.Namespace,
 			}).Error("Unable to add k8s service")
@@ -1190,7 +1190,7 @@ func (d *Daemon) addIngressV1beta1(ingress *v1beta1.Ingress) {
 		// Add operations don't matter to non-LB nodes.
 		return
 	}
-	scopedLog := log.WithFields(log.Fields{
+	scopedLog := log.WithFields(logrus.Fields{
 		logfields.K8sIngressName: ingress.ObjectMeta.Name,
 		logfields.K8sAPIVersion:  ingress.TypeMeta.APIVersion,
 		logfields.K8sNamespace:   ingress.ObjectMeta.Namespace,
@@ -1250,7 +1250,7 @@ func (d *Daemon) addIngressV1beta1(ingress *v1beta1.Ingress) {
 
 	_, err = k8s.Client().ExtensionsV1beta1().Ingresses(dpyCopyIngress.ObjectMeta.Namespace).UpdateStatus(dpyCopyIngress)
 	if err != nil {
-		scopedLog.WithError(err).WithFields(log.Fields{
+		scopedLog.WithError(err).WithFields(logrus.Fields{
 			logfields.K8sIngress: dpyCopyIngress,
 		}).Error("Unable to update status of ingress")
 		return
@@ -1258,7 +1258,7 @@ func (d *Daemon) addIngressV1beta1(ingress *v1beta1.Ingress) {
 }
 
 func (d *Daemon) updateIngressV1beta1(oldIngress, newIngress *v1beta1.Ingress) {
-	scopedLog := log.WithFields(log.Fields{
+	scopedLog := log.WithFields(logrus.Fields{
 		logfields.K8sIngressName + ".old": oldIngress.ObjectMeta.Name,
 		logfields.K8sAPIVersion + ".old":  oldIngress.TypeMeta.APIVersion,
 		logfields.K8sNamespace + ".old":   oldIngress.ObjectMeta.Namespace,
@@ -1292,12 +1292,12 @@ func (d *Daemon) updateIngressV1beta1(oldIngress, newIngress *v1beta1.Ingress) {
 				scopedLog.WithError(err).Error("Error while getting a new service ID. Ignoring ingress...")
 				continue
 			}
-			scopedLog.WithFields(log.Fields{
+			scopedLog.WithFields(logrus.Fields{
 				logfields.ServiceID: feAddrID.ID,
 			}).Debug("Got service ID for ingress")
 
 			if err := d.RevNATAdd(feAddrID.ID, feAddrID.L3n4Addr); err != nil {
-				scopedLog.WithError(err).WithFields(log.Fields{
+				scopedLog.WithError(err).WithFields(logrus.Fields{
 					logfields.ServiceID: feAddrID.ID,
 					logfields.IPAddr:    feAddrID.L3n4Addr.IP,
 					logfields.Port:      feAddrID.L3n4Addr.Port,
@@ -1317,7 +1317,7 @@ func (d *Daemon) updateIngressV1beta1(oldIngress, newIngress *v1beta1.Ingress) {
 }
 
 func (d *Daemon) deleteIngressV1beta1(ingress *v1beta1.Ingress) {
-	scopedLog := log.WithFields(log.Fields{
+	scopedLog := log.WithFields(logrus.Fields{
 		logfields.K8sIngressName: ingress.ObjectMeta.Name,
 		logfields.K8sAPIVersion:  ingress.TypeMeta.APIVersion,
 		logfields.K8sNamespace:   ingress.ObjectMeta.Namespace,
@@ -1352,7 +1352,7 @@ func (d *Daemon) deleteIngressV1beta1(ingress *v1beta1.Ingress) {
 			svc := d.svcGetBySHA256Sum(feAddr.SHA256Sum())
 			if svc != nil {
 				if err := d.RevNATDelete(svc.FE.ID); err != nil {
-					scopedLog.WithError(err).WithFields(log.Fields{
+					scopedLog.WithError(err).WithFields(logrus.Fields{
 						logfields.ServiceID: svc.FE.ID,
 					}).Error("Error while removing RevNAT for ingress")
 				}
@@ -1438,7 +1438,7 @@ func (d *Daemon) syncExternalLB(newSN, modSN, delSN *types.K8sServiceNamespace) 
 
 // Deprecated: use addCiliumNetworkPolicyV2
 func (d *Daemon) addCiliumNetworkPolicyV1(ciliumV1Store cache.Store, cnp *cilium_v1.CiliumNetworkPolicy) {
-	scopedLog := log.WithFields(log.Fields{
+	scopedLog := log.WithFields(logrus.Fields{
 		logfields.CiliumNetworkPolicyName: cnp.ObjectMeta.Name,
 		logfields.K8sAPIVersion:           cnp.TypeMeta.APIVersion,
 		logfields.K8sNamespace:            cnp.ObjectMeta.Namespace,
@@ -1480,7 +1480,7 @@ func (d *Daemon) addCiliumNetworkPolicyV1(ciliumV1Store cache.Store, cnp *cilium
 
 // Deprecated: use deleteCiliumNetworkPolicyV2
 func (d *Daemon) deleteCiliumNetworkPolicyV1(cnp *cilium_v1.CiliumNetworkPolicy) {
-	scopedLog := log.WithFields(log.Fields{
+	scopedLog := log.WithFields(logrus.Fields{
 		logfields.CiliumNetworkPolicyName: cnp.ObjectMeta.Name,
 		logfields.K8sAPIVersion:           cnp.TypeMeta.APIVersion,
 		logfields.K8sNamespace:            cnp.ObjectMeta.Namespace,
@@ -1529,7 +1529,7 @@ func (d *Daemon) updateCiliumNetworkPolicyV1(ciliumV1Store cache.Store,
 		return
 	}
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.K8sAPIVersion:                    oldCNP.TypeMeta.APIVersion,
 		logfields.CiliumNetworkPolicyName + ".old": oldCNP.ObjectMeta.Name,
 		logfields.K8sNamespace + ".old":            oldCNP.ObjectMeta.Namespace,
@@ -1542,7 +1542,7 @@ func (d *Daemon) updateCiliumNetworkPolicyV1(ciliumV1Store cache.Store,
 }
 
 func (d *Daemon) addCiliumNetworkPolicyV2(ciliumV2Store cache.Store, cnp *cilium_v2.CiliumNetworkPolicy) {
-	scopedLog := log.WithFields(log.Fields{
+	scopedLog := log.WithFields(logrus.Fields{
 		logfields.CiliumNetworkPolicyName: cnp.ObjectMeta.Name,
 		logfields.K8sAPIVersion:           cnp.TypeMeta.APIVersion,
 		logfields.K8sNamespace:            cnp.ObjectMeta.Namespace,
@@ -1583,7 +1583,7 @@ func (d *Daemon) addCiliumNetworkPolicyV2(ciliumV2Store cache.Store, cnp *cilium
 }
 
 func (d *Daemon) deleteCiliumNetworkPolicyV2(cnp *cilium_v2.CiliumNetworkPolicy) {
-	scopedLog := log.WithFields(log.Fields{
+	scopedLog := log.WithFields(logrus.Fields{
 		logfields.CiliumNetworkPolicyName: cnp.ObjectMeta.Name,
 		logfields.K8sAPIVersion:           cnp.TypeMeta.APIVersion,
 		logfields.K8sNamespace:            cnp.ObjectMeta.Namespace,
@@ -1630,7 +1630,7 @@ func (d *Daemon) updateCiliumNetworkPolicyV2(ciliumV2Store cache.Store,
 		return
 	}
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.K8sAPIVersion:                    oldRuleCpy.TypeMeta.APIVersion,
 		logfields.CiliumNetworkPolicyName + ".old": oldRuleCpy.ObjectMeta.Name,
 		logfields.K8sNamespace + ".old":            oldRuleCpy.ObjectMeta.Namespace,
@@ -1661,7 +1661,7 @@ func (d *Daemon) addK8sNodeV1(k8sNode *v1.Node) {
 
 	node.UpdateNode(ni, n, routeTypes, ownAddr)
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.K8sNodeID:     ni,
 		logfields.K8sAPIVersion: k8sNode.TypeMeta.APIVersion,
 		logfields.Node:          logfields.Repr(n),
@@ -1693,7 +1693,7 @@ func (d *Daemon) updateK8sNodeV1(_, k8sNode *v1.Node) {
 
 	node.UpdateNode(ni, newNode, routeTypes, ownAddr)
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.K8sNodeID:     ni,
 		logfields.K8sAPIVersion: k8sNode.TypeMeta.APIVersion,
 		logfields.Node:          logfields.Repr(newNode),
@@ -1705,7 +1705,7 @@ func (d *Daemon) deleteK8sNodeV1(k8sNode *v1.Node) {
 
 	node.DeleteNode(ni, node.TunnelRoute|node.DirectRoute)
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.K8sNodeID:     ni,
 		logfields.K8sAPIVersion: k8sNode.TypeMeta.APIVersion,
 	}).Debug("Removed node")

--- a/daemon/kvstore_watcher.go
+++ b/daemon/kvstore_watcher.go
@@ -21,8 +21,6 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/policy"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // EnableKVStoreWatcher watches for kvstore changes in the common.LastFreeIDKeyPath key.

--- a/daemon/labels.go
+++ b/daemon/labels.go
@@ -33,7 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 
 	"github.com/go-openapi/runtime/middleware"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func updateSecLabelIDRef(id policy.Identity) error {
@@ -54,7 +54,7 @@ func gasNewSecLabelID(id *policy.Identity) error {
 func (d *Daemon) CreateOrUpdateIdentity(lbls labels.Labels, epid string) (*policy.Identity, bool, error) {
 	clusterEndpointID := node.GetExternalIPv4().String() + ":" + epid
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.EndpointID:     epid,
 		logfields.IdentityLabels: lbls.String(),
 	}).Debug("Associating endpoint with identity")
@@ -104,7 +104,7 @@ func (d *Daemon) CreateOrUpdateIdentity(lbls labels.Labels, epid string) (*polic
 	// K/V store operations
 
 	if isNew {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			logfields.EndpointID:     epid,
 			logfields.IdentityLabels: lbls.String(),
 		}).Debug("Creating new identity")
@@ -113,7 +113,7 @@ func (d *Daemon) CreateOrUpdateIdentity(lbls labels.Labels, epid string) (*polic
 			return nil, false, err
 		}
 	} else {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			logfields.EndpointID:     epid,
 			logfields.Identity:       identity.StringID(),
 			logfields.IdentityLabels: lbls.String(),
@@ -136,7 +136,7 @@ func (d *Daemon) CreateOrUpdateIdentity(lbls labels.Labels, epid string) (*polic
 func (d *Daemon) updateEndpointIdentity(epID, oldLabelsHash string, opLabels *labels.OpLabels) (*policy.Identity, string, error) {
 	lbls := opLabels.IdentityLabels()
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.EndpointID:     epID,
 		logfields.IdentityLabels: lbls,
 	}).Debug("Resolving identity for endpoint")
@@ -149,14 +149,14 @@ func (d *Daemon) updateEndpointIdentity(epID, oldLabelsHash string, opLabels *la
 
 	if newLabelsHash != oldLabelsHash {
 		if err := d.DeleteIdentityBySHA256(oldLabelsHash, epID); err != nil {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"oldIdentityHash":    oldLabelsHash,
 				logfields.EndpointID: epID,
 			}).WithError(err).Warn("Unable to delete old identity of endpoint")
 		}
 	}
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.EndpointID:     epID,
 		logfields.IdentityLabels: lbls,
 		logfields.Identity:       identity.StringID(),
@@ -352,7 +352,7 @@ func (d *Daemon) DeleteIdentityBySHA256(sha256Sum string, epid string) error {
 		return err
 	}
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.EndpointID:     epid,
 		logfields.IdentityLabels: dbSecCtxLbls.ID,
 		"count":                  dbSecCtxLbls.RefCount(),

--- a/daemon/logstash.go
+++ b/daemon/logstash.go
@@ -25,8 +25,6 @@ import (
 	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/policy"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // LogstashStat is used to collect stats from the policy dumps.

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -54,7 +54,7 @@ import (
 	gops "github.com/google/gops/agent"
 	go_version "github.com/hashicorp/go-version"
 	flags "github.com/jessevdk/go-flags"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -69,6 +69,8 @@ var (
 
 var (
 	config = NewConfig()
+
+	log = common.DefaultLogger
 
 	// Arguments variables keep in alphabetical order
 
@@ -473,7 +475,7 @@ func initConfig() {
 		node.EnableIPv4 = false
 	}
 
-	scopedLog := log.WithFields(log.Fields{
+	scopedLog := log.WithFields(logrus.Fields{
 		logfields.Path + ".RunDir": config.RunDir,
 		logfields.Path + ".LibDir": config.LibDir,
 	})

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/op/go-logging"
-	log "github.com/sirupsen/logrus"
 )
 
 // GetCachedLabelList returns the cached labels for the given identity.

--- a/daemon/services.go
+++ b/daemon/services.go
@@ -23,8 +23,6 @@ import (
 	"github.com/cilium/cilium/common/types"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/logfields"
-
-	log "github.com/sirupsen/logrus"
 )
 
 func updateL3n4AddrIDRef(id types.ServiceID, l3n4AddrID types.L3n4AddrID) error {

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/workloads/containerd"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // SyncState syncs cilium state against the containers running in the host. dir is the
@@ -140,7 +140,7 @@ func (d *Daemon) SyncState(dir string, clean bool) error {
 		}
 		close(epRegenerated)
 
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"count.regenerated": regenerated,
 			"count.total":       total,
 		}).Info("Finish regenerating all restored endpoints")
@@ -158,7 +158,7 @@ func (d *Daemon) SyncState(dir string, clean bool) error {
 		}
 		close(epRestored)
 
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"count.restored": nEPsRestored,
 			"count.total":    nEndpoints,
 		}).Info("Finish restoring endpoints")
@@ -198,7 +198,7 @@ func readEPsFromDirNames(basePath string, eptsDirNames []string) []*endpoint.End
 	for _, epID := range eptsDirNames {
 		epDir := filepath.Join(basePath, epID)
 		readDir := func() string {
-			scopedLog := log.WithFields(log.Fields{
+			scopedLog := log.WithFields(logrus.Fields{
 				logfields.EndpointID: epID,
 				logfields.Path:       filepath.Join(epDir, common.CHeaderFileName),
 			})
@@ -221,7 +221,7 @@ func readEPsFromDirNames(basePath string, eptsDirNames []string) []*endpoint.End
 			cHeaderFile = readDir()
 		}
 
-		scopedLog := log.WithFields(log.Fields{
+		scopedLog := log.WithFields(logrus.Fields{
 			logfields.EndpointID: epID,
 			logfields.Path:       cHeaderFile,
 		})
@@ -274,7 +274,7 @@ func (d *Daemon) syncLabels(ep *endpoint.Endpoint) error {
 	}
 
 	if labels.ID != ep.SecLabel.ID {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			logfields.EndpointID:              ep.ID,
 			logfields.IdentityLabels + ".old": ep.SecLabel.ID,
 			logfields.IdentityLabels + ".new": labels.ID,

--- a/monitor/launch/launcher.go
+++ b/monitor/launch/launcher.go
@@ -22,10 +22,11 @@ import (
 	"os/exec"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/lock"
-
-	log "github.com/sirupsen/logrus"
 )
+
+var log = common.DefaultLogger
 
 const targetName = "cilium-node-monitor"
 

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -23,9 +23,9 @@ import (
 	"github.com/cilium/cilium/daemon/defaults"
 	"github.com/cilium/cilium/pkg/apisocket"
 	"github.com/cilium/cilium/pkg/logfields"
-
-	log "github.com/sirupsen/logrus"
 )
+
+var log = common.DefaultLogger
 
 const targetName = "cilium-node-monitor"
 

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -26,8 +26,6 @@ import (
 	"github.com/cilium/cilium/monitor/payload"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/lock"
-
-	log "github.com/sirupsen/logrus"
 )
 
 const pollTimeout = 5000

--- a/pkg/apisocket/apisocket.go
+++ b/pkg/apisocket/apisocket.go
@@ -22,10 +22,13 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/logfields"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
+
+var log = common.DefaultLogger
 
 // GetGroupIDByName returns the group ID for the given grpName.
 func GetGroupIDByName(grpName string) (int, error) {
@@ -56,7 +59,7 @@ func GetGroupIDByName(grpName string) (int, error) {
 func SetDefaultPermissions(socketPath string) error {
 	gid, err := GetGroupIDByName(CiliumGroupName)
 	if err != nil {
-		log.WithError(err).WithFields(log.Fields{
+		log.WithError(err).WithFields(logrus.Fields{
 			logfields.Path: socketPath,
 			"group":        CiliumGroupName,
 		}).Info("Group not found")

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -24,9 +24,12 @@ import (
 	"path/filepath"
 	"unsafe"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/cilium/cilium/common"
+
 	"golang.org/x/sys/unix"
 )
+
+var log = common.DefaultLogger
 
 const (
 	// BPF map type constants. Must match enum bpf_map_type from linux/bpf.h

--- a/pkg/bpf/bpffs.go
+++ b/pkg/bpf/bpffs.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/syncbytes"
 
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 

--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logfields"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -247,7 +247,7 @@ func (m *Map) migrate(fd int) (bool, error) {
 	mismatch := false
 
 	if info.MapType != m.MapType {
-		scopedLog.WithFields(log.Fields{
+		scopedLog.WithFields(logrus.Fields{
 			"old": info.MapType,
 			"new": m.MapType,
 		}).Info("Map type mismatch for BPF map")
@@ -255,7 +255,7 @@ func (m *Map) migrate(fd int) (bool, error) {
 	}
 
 	if info.KeySize != m.KeySize {
-		scopedLog.WithFields(log.Fields{
+		scopedLog.WithFields(logrus.Fields{
 			"old": info.KeySize,
 			"new": m.KeySize,
 		}).Info("Key-size mismatch for BPF map")
@@ -263,7 +263,7 @@ func (m *Map) migrate(fd int) (bool, error) {
 	}
 
 	if info.ValueSize != m.ValueSize {
-		scopedLog.WithFields(log.Fields{
+		scopedLog.WithFields(logrus.Fields{
 			"old": info.ValueSize,
 			"new": m.ValueSize,
 		}).Info("Value-size mismatch for BPF map")
@@ -271,7 +271,7 @@ func (m *Map) migrate(fd int) (bool, error) {
 	}
 
 	if info.MaxEntries != m.MaxEntries {
-		scopedLog.WithFields(log.Fields{
+		scopedLog.WithFields(logrus.Fields{
 			"old": info.MaxEntries,
 			"new": m.MaxEntries,
 		}).Info("Max entries mismatch for BPF map")
@@ -279,7 +279,7 @@ func (m *Map) migrate(fd int) (bool, error) {
 	}
 
 	if info.Flags != m.Flags {
-		scopedLog.WithFields(log.Fields{
+		scopedLog.WithFields(logrus.Fields{
 			"old": info.Flags,
 			"new": m.Flags,
 		}).Info("Flags mismatch for BPF map")

--- a/pkg/debugdetection/debugdetection.go
+++ b/pkg/debugdetection/debugdetection.go
@@ -18,9 +18,13 @@ import (
 	"io/ioutil"
 	"os"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/cilium/cilium/common"
+
+	"github.com/sirupsen/logrus"
 	flag "github.com/spf13/pflag"
 )
+
+var log = common.DefaultLogger
 
 func init() {
 	flags := flag.NewFlagSet("init-debug", flag.ContinueOnError)
@@ -31,6 +35,6 @@ func init() {
 	flags.Parse(os.Args)
 
 	if *debug {
-		log.SetLevel(log.DebugLevel)
+		log.SetLevel(logrus.DebugLevel)
 	}
 }

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -41,8 +41,6 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/u8proto"
 	"github.com/cilium/cilium/pkg/version"
-
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -41,7 +41,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -326,7 +326,7 @@ type Endpoint struct {
 
 	// logger is a logrus object with fields set to report an endpoints information.
 	// You must hold Endpoint.Mutex to read or write it (but not to log with it).
-	logger *log.Entry
+	logger *logrus.Entry
 }
 
 // NewEndpointWithState creates a new endpoint useful for testing purposes
@@ -1311,7 +1311,7 @@ func (e *Endpoint) SetStateLocked(toState, reason string) bool {
 	}
 	if toState != fromState {
 		_, fileName, fileLine, _ := runtime.Caller(1)
-		e.getLogger().WithFields(log.Fields{
+		e.getLogger().WithFields(logrus.Fields{
 			logfields.EndpointState + ".from": fromState,
 			logfields.EndpointState + ".to":   toState,
 			"file": fileName,

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -15,15 +15,18 @@
 package endpoint
 
 import (
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/logfields"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
+
+var log = common.DefaultLogger
 
 // logger returns a logrus object with EndpointID, ContainerID and the Endpoint
 // revision fields.
 // Note: You must host Endpoint.Mutex
-func (e *Endpoint) getLogger() *log.Entry {
+func (e *Endpoint) getLogger() *logrus.Entry {
 	if e.logger == nil {
 		e.updateLogger()
 	}
@@ -33,7 +36,7 @@ func (e *Endpoint) getLogger() *log.Entry {
 // updateLogger
 // Note: You must hold Endpoint.Mutex
 func (e *Endpoint) updateLogger() {
-	e.logger = log.WithFields(log.Fields{
+	e.logger = log.WithFields(logrus.Fields{
 		logfields.EndpointID:  e.ID,
 		logfields.ContainerID: e.DockerID,
 		"policyRevision":      e.policyRevision,

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"sync"
 )
 
@@ -44,7 +44,7 @@ func (e *Endpoint) checkEgressAccess(owner Owner, dstLabels labels.LabelArray, o
 		ctx.Trace = policy.TRACE_ENABLED
 	}
 
-	scopedLog := e.getLogger().WithFields(log.Fields{
+	scopedLog := e.getLogger().WithFields(logrus.Fields{
 		logfields.Labels + ".from": ctx.From,
 		logfields.Labels + ".to":   ctx.To,
 	})
@@ -103,7 +103,7 @@ func getSecurityIdentities(labelsMap *LabelsMap, selector *api.EndpointSelector)
 	identities := []policy.NumericIdentity{}
 	for idx, labels := range *labelsMap {
 		if selector.Matches(labels) {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				logfields.IdentityLabels: labels,
 				logfields.L4PolicyID:     idx,
 			}).Debug("L4 Policy matches")
@@ -366,7 +366,7 @@ func (e *Endpoint) regenerateConsumable(owner Owner, labelsMap *LabelsMap,
 
 	for srcID, srcLabels := range *labelsMap {
 		ctx.From = srcLabels
-		e.getLogger().WithFields(log.Fields{
+		e.getLogger().WithFields(logrus.Fields{
 			logfields.PolicyID: srcID,
 			"ctx":              ctx,
 		}).Debug("Evaluating context for source PolicyID")
@@ -399,7 +399,7 @@ func (e *Endpoint) regenerateConsumable(owner Owner, labelsMap *LabelsMap,
 		}
 	}
 
-	e.getLogger().WithFields(log.Fields{
+	e.getLogger().WithFields(logrus.Fields{
 		logfields.Identity: c.ID,
 		"consumers":        logfields.Repr(c.Consumers),
 	}).Debug("New consumable with consumers")
@@ -499,7 +499,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner, opts models.ConfigurationMap) (
 	if !e.forcePolicyCompute && e.nextPolicyRevision >= revision &&
 		labelsMap == e.LabelsMap && opts == nil {
 
-		e.getLogger().WithFields(log.Fields{
+		e.getLogger().WithFields(logrus.Fields{
 			"policyRevision.next": e.nextPolicyRevision,
 			"policyRevision.repo": revision,
 		}).Debug("Skipping policy recalculation")
@@ -595,7 +595,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner, opts models.ConfigurationMap) (
 		e.updateLogger()
 	}
 
-	e.getLogger().WithFields(log.Fields{
+	e.getLogger().WithFields(logrus.Fields{
 		"policyChanged":       policyChanged,
 		"optsChanged":         optsChanged,
 		"policyRevision.next": e.nextPolicyRevision,
@@ -655,7 +655,7 @@ func (e *Endpoint) regenerate(owner Owner, reason string) (retErr error) {
 		os.RemoveAll(tmpDir)
 
 		if err2 := os.Rename(backupDir, origDir); err2 != nil {
-			e.getLogger().WithFields(log.Fields{
+			e.getLogger().WithFields(logrus.Fields{
 				logfields.Path: backupDir,
 			}).Warn("Restoring directory for endpoint failed, endpoint " +
 				"is in inconsistent state. Keeping stale directory.")
@@ -798,7 +798,7 @@ func (e *Endpoint) SetIdentity(owner Owner, id *policy.Identity) {
 	// Annotate pod that this endpoint represents with its security identity
 	go owner.AnnotateEndpoint(e, common.CiliumIdentityAnnotation, e.SecLabel.ID.String())
 	e.Consumable.Mutex.RLock()
-	e.getLogger().WithFields(log.Fields{
+	e.getLogger().WithFields(logrus.Fields{
 		logfields.Identity: id,
 		"consumable":       e.Consumable,
 	}).Debug("Set identity and consumable of EP")

--- a/pkg/endpointmanager/conntrack.go
+++ b/pkg/endpointmanager/conntrack.go
@@ -26,7 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/policy"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -72,7 +72,7 @@ func RunGC(e *endpoint.Endpoint, isLocal, isIPv6 bool, filter *ctmap.GCFilter) {
 	deleted := ctmap.GC(m, mapType, filter)
 
 	if deleted > 0 {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			logfields.Path:  file,
 			"ctFilter.type": filter.TypeString(),
 			"count":         deleted,

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -18,14 +18,15 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/metrics"
-
-	log "github.com/sirupsen/logrus"
 )
 
 var (
+	log = common.DefaultLogger
+
 	// Mutex protects Endpoints and endpointsAux
 	//
 	// Warning: This lock may not be taken while an individual endpoint

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -12,12 +12,13 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/policy"
 
 	"github.com/golang/protobuf/proto"
-
-	log "github.com/sirupsen/logrus"
 )
+
+var log = common.DefaultLogger
 
 // Envoy manages a running Envoy proxy instance via the
 // ListenerDiscoveryService and RouteDiscoveryService gRPC APIs.

--- a/pkg/envoy/envoy_test.go
+++ b/pkg/envoy/envoy_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	. "gopkg.in/check.v1"
 )
@@ -29,7 +29,7 @@ func (t *testRedirect) Log(pblog *HttpLogEntry) {
 }
 
 func (s *EnvoySuite) TestEnvoy(c *C) {
-	log.SetLevel(log.DebugLevel)
+	log.SetLevel(logrus.DebugLevel)
 
 	if os.Getenv("CILIUM_USE_ENVOY") == "" {
 		c.Skip("skipping test; CILIUM_USE_ENVOY not set")

--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -19,7 +19,6 @@ import (
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"

--- a/pkg/envoy/streamctrl.go
+++ b/pkg/envoy/streamctrl.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/lock"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // StreamControlCtx holds the state of a gRPC stream server instance we need to know about.

--- a/pkg/ipam/init.go
+++ b/pkg/ipam/init.go
@@ -18,17 +18,19 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/node"
 
 	cniTypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/plugins/ipam/host-local/backend/allocator"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 )
 
 var (
+	log      = common.DefaultLogger
 	ipamConf *Config
 )
 
@@ -72,7 +74,7 @@ func reserveLocalRoutes(ipam *Config) {
 		log.WithField("route", logfields.Repr(r)).Debug("Considering route")
 
 		if allocRange.Contains(r.Dst.IP) {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"route":            r.Dst,
 				logfields.V4Prefix: allocRange,
 			}).Info("Marking local route as no-alloc in node allocation prefix")

--- a/pkg/kafka/logfields.go
+++ b/pkg/kafka/logfields.go
@@ -14,6 +14,10 @@
 
 package kafka
 
+import "github.com/cilium/cilium/common"
+
+var log = common.DefaultLogger
+
 const (
 	fieldRequest = "request.kafka"
 	fieldRule    = "rule.kafka"

--- a/pkg/kafka/policy.go
+++ b/pkg/kafka/policy.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 
 	"github.com/optiopay/kafka/proto"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func produceTopicContained(neededTopic string, topics []proto.ProduceReqTopic) bool {
@@ -182,7 +182,7 @@ func (req *RequestMessage) ruleMatches(rule api.PortRuleKafka) bool {
 		return false
 	}
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		fieldRequest: req.String(),
 		fieldRule:    rule,
 	}).Debug("Matching Kafka rule")
@@ -204,7 +204,7 @@ func (req *RequestMessage) ruleMatches(rule api.PortRuleKafka) bool {
 	}
 
 	if req.request == nil {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			fieldRequest: req.String(),
 			fieldRule:    rule,
 		}).Debug("Unparseable kafka message, denying...")

--- a/pkg/kafka/request.go
+++ b/pkg/kafka/request.go
@@ -22,7 +22,7 @@ import (
 	"io"
 
 	"github.com/optiopay/kafka/proto"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // RequestMessage represents a Kafka request message
@@ -204,7 +204,7 @@ func ReadRequest(reader io.Reader) (*RequestMessage, error) {
 	}
 
 	if err != nil {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			fieldRequest: req.String(),
 		}).WithError(err).Debug("Ignoring Kafka message due to parse error")
 	}

--- a/pkg/kvstore/client.go
+++ b/pkg/kvstore/client.go
@@ -14,11 +14,7 @@
 
 package kvstore
 
-import (
-	"fmt"
-
-	log "github.com/sirupsen/logrus"
-)
+import "fmt"
 
 var (
 	clientInstance KVClient

--- a/pkg/kvstore/config.go
+++ b/pkg/kvstore/config.go
@@ -23,7 +23,6 @@ import (
 
 	etcdAPI "github.com/coreos/etcd/clientv3"
 	consulAPI "github.com/hashicorp/consul/api"
-	log "github.com/sirupsen/logrus"
 )
 
 // Supported key-value store types.

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 
 	consulAPI "github.com/hashicorp/consul/api"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -115,7 +115,7 @@ retry:
 
 	ch, err := lockKey.Lock(nil)
 	if ch == nil && err == nil {
-		trace("Acquiring lock timed out", nil, log.Fields{fieldKey: path})
+		trace("Acquiring lock timed out", nil, logrus.Fields{fieldKey: path})
 		goto retry
 	}
 
@@ -400,7 +400,7 @@ func (c *ConsulClient) Watch(w *Watcher, list bool) {
 		if err != nil {
 			// in case of error, sleep for 15 seconds before retrying
 			sleepTime = 15 * time.Second
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				fieldWatcher:      w,
 				fieldListAndWatch: list,
 			}).WithError(err).Debug("Consul watcher failed, will retry")

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -33,7 +33,7 @@ import (
 	clientyaml "github.com/coreos/etcd/clientv3/yaml"
 	"github.com/coreos/etcd/mvcc/mvccpb"
 	"github.com/hashicorp/go-version"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	ctx "golang.org/x/net/context"
 )
 
@@ -160,7 +160,7 @@ func (e *EtcdClient) CheckMinVersion(timeout time.Duration) error {
 			return fmt.Errorf("Minimal etcd version not met in %q,"+
 				" required: %s, found: %s", ep, minEVersion.String(), v.String())
 		}
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			fieldEtcdEndpoint: ep,
 			"version":         v,
 		}).Info("Version of etcd endpoint OK")
@@ -428,7 +428,7 @@ func (e *EtcdClient) Watch(w *Watcher, list bool) {
 		res, err := e.cli.Get(ctx.Background(), w.prefix, client.WithPrefix(),
 			client.WithRev(lastRev), client.WithSerializable())
 		if err != nil {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				fieldRev:     lastRev,
 				fieldPrefix:  w.prefix,
 				fieldWatcher: w,
@@ -471,7 +471,7 @@ func (e *EtcdClient) Watch(w *Watcher, list bool) {
 				lastRev = r.Header.Revision
 
 				if err := r.Err(); err != nil {
-					log.WithFields(log.Fields{
+					log.WithFields(logrus.Fields{
 						fieldRev:     lastRev,
 						fieldWatcher: w,
 					}).WithError(err).Warn("etcd watcher received error")

--- a/pkg/kvstore/events.go
+++ b/pkg/kvstore/events.go
@@ -17,7 +17,7 @@ package kvstore
 import (
 	"sync"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // EventType defines the type of watch event that occurred
@@ -92,7 +92,7 @@ func watch(name, prefix string, chanSize int, list bool) *Watcher {
 		stopWatch: make(stopChan, 0),
 	}
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		fieldWatcher:      w,
 		fieldListAndWatch: list,
 	}).Debug("Starting watcher...")

--- a/pkg/kvstore/events_tests.go
+++ b/pkg/kvstore/events_tests.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/comparator"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 )
 
@@ -31,7 +31,7 @@ func (s *KvstoreSuite) SetUpTest(c *C) {
 }
 
 func expectEvent(c *C, w *Watcher, typ EventType, key string, val []byte) {
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"type":  typ,
 		"key":   key,
 		"value": string(val),

--- a/pkg/kvstore/keepalive.go
+++ b/pkg/kvstore/keepalive.go
@@ -17,7 +17,7 @@ package kvstore
 import (
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -38,14 +38,14 @@ var (
 // CreateLease creates a new lease with the given ttl
 func CreateLease(ttl time.Duration) (interface{}, error) {
 	lease, err := Client().CreateLease(ttl)
-	trace("CreateLease", err, log.Fields{fieldTTL: ttl, fieldLease: lease})
+	trace("CreateLease", err, logrus.Fields{fieldTTL: ttl, fieldLease: lease})
 	return lease, err
 }
 
 // KeepAlive keeps a lease created with CreateLease alive
 func KeepAlive(lease interface{}) error {
 	err := Client().KeepAlive(lease)
-	trace("KeepAlive", err, log.Fields{fieldLease: lease})
+	trace("KeepAlive", err, logrus.Fields{fieldLease: lease})
 	return err
 }
 

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cilium/cilium/common/types"
 	"github.com/cilium/cilium/pkg/policy"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type KVClient interface {
@@ -80,49 +80,49 @@ type KVClient interface {
 // Get returns value of key
 func Get(key string) ([]byte, error) {
 	v, err := Client().Get(key)
-	trace("Get", err, log.Fields{fieldKey: key, fieldValue: string(v)})
+	trace("Get", err, logrus.Fields{fieldKey: key, fieldValue: string(v)})
 	return v, err
 }
 
 // GetPrefix returns the first key which matches the prefix
 func GetPrefix(prefix string) ([]byte, error) {
 	v, err := Client().GetPrefix(prefix)
-	trace("GetPrefix", err, log.Fields{fieldPrefix: prefix, fieldValue: string(v)})
+	trace("GetPrefix", err, logrus.Fields{fieldPrefix: prefix, fieldValue: string(v)})
 	return v, err
 }
 
 // ListPrefix returns the list of keys matching the prefix
 func ListPrefix(prefix string) (KeyValuePairs, error) {
 	v, err := Client().ListPrefix(prefix)
-	trace("ListPrefix", err, log.Fields{fieldPrefix: prefix, fieldNumEntries: len(v)})
+	trace("ListPrefix", err, logrus.Fields{fieldPrefix: prefix, fieldNumEntries: len(v)})
 	return v, err
 }
 
 // CreateOnly atomically creates a key or fails if it already exists
 func CreateOnly(key string, value []byte, lease bool) error {
 	err := Client().CreateOnly(key, value, lease)
-	trace("CreateOnly", err, log.Fields{fieldKey: key, fieldValue: string(value), fieldAttachLease: lease})
+	trace("CreateOnly", err, logrus.Fields{fieldKey: key, fieldValue: string(value), fieldAttachLease: lease})
 	return err
 }
 
 // Set sets the value of a key
 func Set(key string, value []byte) error {
 	err := Client().Set(key, value)
-	trace("Set", err, log.Fields{fieldKey: key, fieldValue: string(value)})
+	trace("Set", err, logrus.Fields{fieldKey: key, fieldValue: string(value)})
 	return err
 }
 
 // Delete deletes a key
 func Delete(key string) error {
 	err := Client().Delete(key)
-	trace("Delete", err, log.Fields{fieldKey: key})
+	trace("Delete", err, logrus.Fields{fieldKey: key})
 	return err
 }
 
 // DeleteTree deletes all keys matching a prefix
 func DeleteTree(prefix string) error {
 	err := Client().DeleteTree(prefix)
-	trace("DeleteTree", err, log.Fields{fieldPrefix: prefix})
+	trace("DeleteTree", err, logrus.Fields{fieldPrefix: prefix})
 	return err
 }
 

--- a/pkg/kvstore/lock.go
+++ b/pkg/kvstore/lock.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/lock"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type kvLocker interface {
@@ -50,7 +50,7 @@ func LockPath(path string) (*Lock, error) {
 	}
 	lockPathsMU.Unlock()
 
-	trace("Creating lock", nil, log.Fields{fieldKey: path})
+	trace("Creating lock", nil, logrus.Fields{fieldKey: path})
 
 	// Take the local lock as both etcd and consul protect per client
 	lockPaths[path].Lock()
@@ -61,7 +61,7 @@ func LockPath(path string) (*Lock, error) {
 		return nil, fmt.Errorf("Error while locking path %s: %s", path, err)
 	}
 
-	trace("Successful lock", nil, log.Fields{fieldKey: path})
+	trace("Successful lock", nil, logrus.Fields{fieldKey: path})
 	return &Lock{lock: lock, path: path}, nil
 }
 
@@ -71,7 +71,7 @@ func (l *Lock) Unlock() error {
 
 	lockPaths[l.path].Unlock()
 	if err == nil {
-		trace("Unlocked", nil, log.Fields{fieldKey: l.path})
+		trace("Unlocked", nil, logrus.Fields{fieldKey: l.path})
 	}
 	return err
 }

--- a/pkg/kvstore/logfields.go
+++ b/pkg/kvstore/logfields.go
@@ -14,6 +14,10 @@
 
 package kvstore
 
+import "github.com/cilium/cilium/common"
+
+var log = common.DefaultLogger
+
 const (
 	// name of watcher
 	fieldWatcher = "watcher"

--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -23,11 +23,10 @@ import (
 	"sync"
 
 	"github.com/cilium/cilium/common"
-
-	log "github.com/sirupsen/logrus"
 )
 
 var (
+	log                  = common.DefaultLogger
 	validLabelPrefixesMU sync.RWMutex
 	validLabelPrefixes   *labelPrefixCfg // Label prefixes used to filter from all labels
 )

--- a/pkg/maps/cidrmap/cidrmap.go
+++ b/pkg/maps/cidrmap/cidrmap.go
@@ -19,11 +19,14 @@ import (
 	"net"
 	"unsafe"
 
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/logfields"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
+
+var log = common.DefaultLogger
 
 const (
 	MapName = "cilium_cidr_"
@@ -170,7 +173,7 @@ func OpenMapElems(path string, prefixlen int, prefixdyn bool, maxelem uint32) (*
 
 	m := &CIDRMap{path: path, Fd: fd, AddrSize: bytes, Prefixlen: uint32(prefix)}
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.Path: path,
 		"fd":           fd,
 	}).Debug("Created CIDR map")

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -21,12 +21,13 @@ import (
 	"net"
 	"unsafe"
 
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/policy"
-
-	log "github.com/sirupsen/logrus"
 )
+
+var log = common.DefaultLogger
 
 const (
 	MapName6       = "cilium_ct6_"

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -19,12 +19,15 @@ import (
 	"net"
 	"unsafe"
 
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/common/types"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/logfields"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
+
+var log = common.DefaultLogger
 
 const (
 	// Maximum number of entries in each hashtable
@@ -118,7 +121,7 @@ type RRSeqValue struct {
 func (s RRSeqValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(&s) }
 
 func UpdateService(key ServiceKey, value ServiceValue) error {
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"frontend": key,
 		"backend":  value,
 	}).Debug("adding frontend for backend to BPF maps")
@@ -208,7 +211,7 @@ type RevNatValue interface {
 }
 
 func UpdateRevNat(key RevNatKey, value RevNatValue) error {
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.BPFMapKey:   key,
 		logfields.BPFMapValue: value,
 	}).Debug("adding revNat to lbmap")
@@ -387,7 +390,7 @@ func L3n4Addr2ServiceKey(l3n4Addr types.L3n4AddrID) ServiceKey {
 
 // LBSVC2ServiceKeynValue transforms the SVC Cilium type into a bpf SVC type.
 func LBSVC2ServiceKeynValue(svc types.LBSVC) (ServiceKey, []ServiceValue, error) {
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"lbFrontend": svc.FE.String(),
 		"lbBackend":  svc.BES,
 	}).Debug("converting Cilium load-balancer service (frontend -> backend(s)) into BPF service")
@@ -406,12 +409,12 @@ func LBSVC2ServiceKeynValue(svc types.LBSVC) (ServiceKey, []ServiceValue, error)
 		beValue.SetWeight(be.Weight)
 
 		besValues = append(besValues, beValue)
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"lbFrontend": fe,
 			"lbBackend":  beValue,
 		}).Debug("associating frontend -> backend")
 	}
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"lbFrontend":        svc.FE.String(),
 		"lbBackend":         svc.BES,
 		logfields.ServiceID: fe,
@@ -457,7 +460,7 @@ func ServiceKeynValue2FEnBE(svcKey ServiceKey, svcValue ServiceValue) (*types.L3
 		beWeight uint16
 	)
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.ServiceID: svcKey,
 		logfields.Object:    logfields.Repr(svcValue),
 	}).Debug("converting ServiceKey and ServiceValue to frontend and backend")

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -22,12 +22,13 @@ import (
 	"strings"
 	"unsafe"
 
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/logfields"
-
-	log "github.com/sirupsen/logrus"
 )
+
+var log = common.DefaultLogger
 
 const (
 	MapName = "cilium_lxc"

--- a/pkg/node/manager.go
+++ b/pkg/node/manager.go
@@ -21,13 +21,16 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
+
+var log = common.DefaultLogger
 
 // RouteType represents the route type to be configured when adding the node
 // routes
@@ -278,7 +281,7 @@ func UpdateNode(ni Identity, n *Node, routesTypes RouteType, ownAddr net.IP) {
 			deleteNodeCIDR(oldNode.IPv6AllocCIDR)
 		}
 		// FIXME if PodCIDR is empty retrieve the CIDR from the KVStore
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			logfields.IPAddr:   n.GetNodeIP(false),
 			logfields.V4Prefix: n.IPv4AllocCIDR,
 			logfields.V6Prefix: n.IPv6AllocCIDR,
@@ -302,7 +305,7 @@ func DeleteNode(ni Identity, routesTypes RouteType) {
 	clusterConf.Lock()
 	if n, ok := clusterConf.nodes[ni]; ok {
 		if (routesTypes & TunnelRoute) != 0 {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				logfields.IPAddr:   n.GetNodeIP(false),
 				logfields.V4Prefix: n.IPv4AllocCIDR,
 				logfields.V6Prefix: n.IPv6AllocCIDR,
@@ -362,7 +365,7 @@ func updateIPRoute(oldNode, n *Node, ownAddr net.IP) {
 
 			err = routeDel(oldNodeIPv6.String(), oldNode.IPv6AllocCIDR.String(), oldNode.dev)
 			if err != nil {
-				log.WithError(err).WithFields(log.Fields{
+				log.WithError(err).WithFields(logrus.Fields{
 					logfields.IPAddr:   oldNodeIPv6,
 					logfields.V6Prefix: oldNode.IPv6AllocCIDR,
 					"device":           oldNode.dev,
@@ -376,7 +379,7 @@ func updateIPRoute(oldNode, n *Node, ownAddr net.IP) {
 	// Always re add
 	err = routeAdd(nodeIPv6.String(), n.IPv6AllocCIDR.String(), dev)
 	if err != nil {
-		log.WithError(err).WithFields(log.Fields{
+		log.WithError(err).WithFields(logrus.Fields{
 			logfields.IPAddr:   nodeIPv6,
 			logfields.V6Prefix: n.IPv6AllocCIDR,
 			"device":           dev,
@@ -392,7 +395,7 @@ func deleteIPRoute(node *Node) {
 
 	err := routeDel(oldNodeIPv6.String(), node.IPv6AllocCIDR.String(), node.dev)
 	if err != nil {
-		log.WithError(err).WithFields(log.Fields{
+		log.WithError(err).WithFields(logrus.Fields{
 			logfields.IPAddr:   oldNodeIPv6,
 			logfields.V6Prefix: node.IPv6AllocCIDR,
 			"device":           node.dev,

--- a/pkg/node/node_address.go
+++ b/pkg/node/node_address.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/logfields"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )

--- a/pkg/node/nodename.go
+++ b/pkg/node/nodename.go
@@ -18,7 +18,6 @@ import (
 	"os"
 
 	"github.com/cilium/cilium/pkg/logfields"
-	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -18,14 +18,16 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logfields"
 
 	"github.com/mitchellh/hashstructure"
-	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sLbls "k8s.io/apimachinery/pkg/labels"
 )
+
+var log = common.DefaultLogger
 
 // EndpointSelector is a wrapper for k8s LabelSelector.
 type EndpointSelector struct {

--- a/pkg/policy/config.go
+++ b/pkg/policy/config.go
@@ -15,10 +15,12 @@
 package policy
 
 import (
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/lock"
 )
 
 var (
+	log          = common.DefaultLogger
 	mutex        lock.RWMutex // Protects enablePolicy
 	enablePolicy string       // Whether policy enforcement is enabled.
 )

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/policy/api"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // Consumer is the entity that consumes a Consumable. It identifies a source
@@ -107,7 +107,7 @@ func (c *Consumable) AddMap(m *policymap.PolicyMap) {
 		return
 	}
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"policymap":  m,
 		"consumable": c,
 	}).Debug("Adding policy map to consumable")
@@ -160,7 +160,7 @@ func (c *Consumable) RemoveMap(m *policymap.PolicyMap) {
 	if m != nil {
 		c.Mutex.Lock()
 		delete(c.Maps, m.Fd)
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"policymap":  m,
 			"consumable": c,
 			"count":      len(c.Maps),
@@ -188,7 +188,7 @@ func (c *Consumable) addToMaps(id NumericIdentity) {
 			continue
 		}
 
-		scopedLog := log.WithFields(log.Fields{
+		scopedLog := log.WithFields(logrus.Fields{
 			"policymap":        m,
 			logfields.Identity: id,
 		})
@@ -206,7 +206,7 @@ func (c *Consumable) wasLastRule(id NumericIdentity) bool {
 
 func (c *Consumable) removeFromMaps(id NumericIdentity) {
 	for _, m := range c.Maps {
-		scopedLog := log.WithFields(log.Fields{
+		scopedLog := log.WithFields(logrus.Fields{
 			"policymap":        m,
 			logfields.Identity: id,
 		})
@@ -224,7 +224,7 @@ func (c *Consumable) removeFromMaps(id NumericIdentity) {
 func (c *Consumable) AllowConsumerLocked(cache *ConsumableCache, id NumericIdentity) bool {
 	consumer := c.getConsumer(id)
 	if consumer == nil {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			logfields.Identity: id,
 			"consumable":       logfields.Repr(c),
 		}).Debug("New consumer Identity for consumable")
@@ -241,14 +241,14 @@ func (c *Consumable) AllowConsumerLocked(cache *ConsumableCache, id NumericIdent
 // Must be called with Consumable mutex Locked.
 // returns true if changed, false if not
 func (c *Consumable) AllowConsumerAndReverseLocked(cache *ConsumableCache, id NumericIdentity) bool {
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.Identity + ".from": id,
 		logfields.Identity + ".to":   c.ID,
 	}).Debug("Allowing direction")
 	changed := c.AllowConsumerLocked(cache, id)
 
 	if reverse := cache.Lookup(id); reverse != nil {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			logfields.Identity + ".from": c.ID,
 			logfields.Identity + ".to":   id,
 		}).Debug("Allowing reverse direction")
@@ -258,7 +258,7 @@ func (c *Consumable) AllowConsumerAndReverseLocked(cache *ConsumableCache, id Nu
 			return true
 		}
 	}
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		logfields.Identity + ".from": c.ID,
 		logfields.Identity + ".to":   id,
 	}).Warn("Allowed a consumer which can't be found in the reverse direction")

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 
 	"github.com/op/go-logging"
-	log "github.com/sirupsen/logrus"
 )
 
 type Tracing int

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -21,8 +21,6 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/policy/api"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // Repository is a list of policy rules which in combination form the security

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/policy/api"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type rule struct {
@@ -86,7 +86,7 @@ func (r *rule) sanitize() error {
 func (policy *L4Filter) addFromEndpoints(fromEndpoints []api.EndpointSelector) bool {
 
 	if len(policy.FromEndpoints) == 0 && len(fromEndpoints) > 0 {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			logfields.EndpointSelector: fromEndpoints,
 			"policy":                   policy,
 		}).Debug("skipping L4 filter as the endpoints are already covered.")

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -19,8 +19,10 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/cilium/cilium/common"
 )
+
+var log = common.DefaultLogger
 
 const apiAddress = "localhost:6060"
 

--- a/pkg/proxy/accesslog/log.go
+++ b/pkg/proxy/accesslog/log.go
@@ -17,14 +17,17 @@ package accesslog
 import (
 	"encoding/json"
 
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logfields"
 
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 var (
+	// the agent-level logrus logger
+	log = common.DefaultLogger
+
 	logMutex lock.Mutex
 	logger   *lumberjack.Logger
 	logPath  string
@@ -100,8 +103,8 @@ func logString(outStr string, retry bool) {
 	output := []byte(outStr + "\n")
 	_, err := logger.Write(output)
 	if err != nil {
-		log.WithField(FieldFilePath,
-			logPath).Errorf("Error writing to access file %+v", err)
+		log.WithError(err).WithField(FieldFilePath, logPath).
+			Errorf("Error writing to access file")
 	}
 }
 
@@ -113,8 +116,8 @@ func (l *LogRecord) Log() {
 	defer logMutex.Unlock()
 
 	if logger == nil {
-		log.WithField(FieldFilePath,
-			logPath).Debug("Skipping writing to access log (logger nil)")
+		log.WithField(FieldFilePath, logPath).
+			Debug("Skipping writing to access log (logger nil)")
 		return
 	}
 

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 

--- a/pkg/proxy/kafka.go
+++ b/pkg/proxy/kafka.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 
 	"github.com/optiopay/kafka/proto"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -132,7 +132,7 @@ func (k *kafkaRedirect) canAccess(req *kafka.RequestMessage, numIdentity policy.
 	if numIdentity != 0 {
 		identity = k.conf.source.ResolveIdentity(numIdentity)
 		if identity == nil {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				logfields.Request:  req.String(),
 				logfields.Identity: numIdentity,
 			}).Warn("Unable to resolve identity to labels")
@@ -151,7 +151,7 @@ func (k *kafkaRedirect) canAccess(req *kafka.RequestMessage, numIdentity policy.
 	if err != nil {
 		log.WithError(err).WithField(logfields.Request, req.String()).Debug("Error marshalling kafka rules to apply")
 	} else {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			logfields.Request: req.String(),
 			"rule":            string(b),
 		}).Debug("Applying rule")
@@ -216,7 +216,7 @@ func (l *kafkaLogRecord) log(typ accesslog.FlowType, verdict accesslog.FlowVerdi
 	l.Info = info
 	l.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		accesslog.FieldType:               l.Type,
 		accesslog.FieldVerdict:            l.Verdict,
 		accesslog.FieldCode:               l.Kafka.ErrorCode,
@@ -288,14 +288,14 @@ func (k *kafkaRedirect) handleRequest(pair *connectionPair, req *kafka.RequestMe
 			marker = GetMagicMark(k.ingress) | int(srcIdentity)
 		}
 
-		scopedLog.WithFields(log.Fields{
+		scopedLog.WithFields(logrus.Fields{
 			"marker":      marker,
 			"destination": dstIPPort,
 		}).Debug("Dialing original destination")
 
 		txConn, err := ciliumDialer(marker, addr.Network(), dstIPPort)
 		if err != nil {
-			scopedLog.WithError(err).WithFields(log.Fields{
+			scopedLog.WithError(err).WithFields(logrus.Fields{
 				"origNetwork": addr.Network(),
 				"origDest":    dstIPPort,
 			}).Error("Unable to dial original destination")
@@ -366,7 +366,7 @@ func handleResponse(pair *connectionPair, c *proxyConnection,
 }
 
 func (k *kafkaRedirect) handleRequestConnection(pair *connectionPair) {
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"from": pair.rx,
 		"to":   pair.tx,
 	}).Debug("Proxying request Kafka connection")
@@ -376,7 +376,7 @@ func (k *kafkaRedirect) handleRequestConnection(pair *connectionPair) {
 
 func (k *kafkaRedirect) handleResponseConnection(pair *connectionPair,
 	record *kafkaLogRecord) {
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"from": pair.tx,
 		"to":   pair.rx,
 	}).Debug("Proxying response Kafka connection")

--- a/pkg/proxy/kafka_test.go
+++ b/pkg/proxy/kafka_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/optiopay/kafka"
 	"github.com/optiopay/kafka/proto"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 )
 
@@ -60,8 +60,8 @@ func newTestBrokerConf(clientID string) kafka.BrokerConf {
 
 type loggerMap struct{}
 
-func fields(args ...interface{}) log.Fields {
-	fields := log.Fields{}
+func fields(args ...interface{}) logrus.Fields {
+	fields := logrus.Fields{}
 	for i := 0; i+1 < len(args); i += 2 {
 		fields[args[i].(string)] = args[i+1]
 	}
@@ -162,15 +162,17 @@ func (m *metadataTester) Handler() RequestHandler {
 }
 
 func (k *proxyTestSuite) TestKafkaRedirect(c *C) {
-	oldLevel := log.GetLevel()
+	// this isn't thread safe but there is no function to get it
+	// SetLevel is atomic, however.
+	oldLevel := log.Level
 	defer log.SetLevel(oldLevel)
-	log.SetLevel(log.DebugLevel)
+	log.SetLevel(logrus.DebugLevel)
 
 	server := NewServer()
 	server.Start()
 	defer server.Close()
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"address": server.Address(),
 	}).Debug("Started kafka server")
 
@@ -208,7 +210,7 @@ func (k *proxyTestSuite) TestKafkaRedirect(c *C) {
 	c.Assert(err, IsNil)
 	defer redir.Close()
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"address": proxyAddress,
 	}).Debug("Started kafka proxy")
 

--- a/pkg/proxy/logrecord.go
+++ b/pkg/proxy/logrecord.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // HTTPLogRecord wraps an accesslog.LogRecord so that we can define methods with a receiver
@@ -66,7 +66,7 @@ func (l *HTTPLogRecord) logStamped(typ accesslog.FlowType, verdict accesslog.Flo
 	l.HTTP.Code = code
 	l.Info = info
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		accesslog.FieldType:     l.Type,
 		accesslog.FieldVerdict:  l.Verdict,
 		accesslog.FieldCode:     l.HTTP.Code,

--- a/pkg/proxy/oxyproxy.go
+++ b/pkg/proxy/oxyproxy.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 
 	"github.com/braintree/manners"
-	log "github.com/sirupsen/logrus"
 	"github.com/vulcand/oxy/forward"
 	"github.com/vulcand/route"
 )

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/lock"
@@ -29,9 +30,10 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
+
+var log = common.DefaultLogger
 
 // Magic markers are attached to each packet. The upper 16 bits are used to
 // identify packets which have gone through the proxy and to determine whether

--- a/pkg/proxy/socket.go
+++ b/pkg/proxy/socket.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/logfields"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -145,7 +145,7 @@ func newProxyConnection(rx bool, queueClose func()) *proxyConnection {
 // connection
 func (c *proxyConnection) SetConnection(conn net.Conn) {
 	if c.conn != nil {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			fieldConn: c,
 		}).Panic("Established connection is already associated")
 	}
@@ -229,7 +229,7 @@ func (c *proxyConnection) direction() string {
 
 // Enqueue queues a message to be written to the socket
 func (c *proxyConnection) Enqueue(msg []byte) {
-	scopedLog := log.WithFields(log.Fields{
+	scopedLog := log.WithFields(logrus.Fields{
 		fieldConn: c,
 		fieldSize: len(msg),
 	})
@@ -373,7 +373,7 @@ func identityFromContext(ctx context.Context) (int, bool) {
 }
 
 func setFdMark(fd, mark int) {
-	scopedLog := log.WithFields(log.Fields{
+	scopedLog := log.WithFields(logrus.Fields{
 		fieldFd:     fd,
 		fieldMarker: mark,
 	})

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/client/endpoint"
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/common/plugins"
 	"github.com/cilium/cilium/pkg/client"
@@ -32,9 +33,11 @@ import (
 	"github.com/docker/libnetwork/drivers/remote/api"
 	lnTypes "github.com/docker/libnetwork/types"
 	"github.com/gorilla/mux"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
+
+var log = common.DefaultLogger
 
 const (
 	// ContainerInterfacePrefix is the container's internal interface name prefix.
@@ -173,7 +176,7 @@ func notFound(w http.ResponseWriter, r *http.Request) {
 }
 
 func sendError(w http.ResponseWriter, msg string, code int) {
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"code": code,
 		"msg":  msg,
 	}).Error("Sending error")

--- a/plugins/cilium-docker/driver/ipam.go
+++ b/plugins/cilium-docker/driver/ipam.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cilium/cilium/pkg/logfields"
 
 	"github.com/docker/libnetwork/ipams/remote/api"
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/plugins/cilium-docker/main.go
+++ b/plugins/cilium-docker/main.go
@@ -22,11 +22,12 @@ import (
 	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/plugins/cilium-docker/driver"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 var (
+	log        = common.DefaultLogger
 	pluginPath string
 	driverSock string
 	debug      bool
@@ -77,9 +78,9 @@ func init() {
 
 func initConfig() {
 	if debug {
-		log.SetLevel(log.DebugLevel)
+		log.SetLevel(logrus.DebugLevel)
 	} else {
-		log.SetLevel(log.InfoLevel)
+		log.SetLevel(logrus.InfoLevel)
 	}
 
 	common.RequireRootPrivilege("cilium-docker")

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -25,9 +25,12 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/common"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
+
+var log = common.DefaultLogger
 
 const (
 	// MaxRetries is the number of times that a loop should iterate until a
@@ -123,7 +126,7 @@ func (c *Cilium) EndpointStatusLog(id string) *models.EndpointStatusLog {
 	res := c.Exec(endpointLogCmd)
 	err := res.Unmarshal(&epStatusLog)
 	if err != nil {
-		c.logger.WithFields(log.Fields{"endpointID": id}).WithError(err).Errorf("unable to get endpoint status log")
+		c.logger.WithFields(logrus.Fields{"endpointID": id}).WithError(err).Errorf("unable to get endpoint status log")
 		return nil
 	}
 
@@ -134,7 +137,7 @@ func (c *Cilium) EndpointStatusLog(id string) *models.EndpointStatusLog {
 // endpoint with the specified ID to be in "ready" state. Returns false if
 // no such endpoint corresponds to the given id or if MaxRetries are exceeded.
 func (c *Cilium) WaitEndpointRegenerated(id string) bool {
-	logger := c.logger.WithFields(log.Fields{
+	logger := c.logger.WithFields(logrus.Fields{
 		"functionName": "WaitEndpointRegenerated",
 		"id":           id,
 	})
@@ -151,7 +154,7 @@ func (c *Cilium) WaitEndpointRegenerated(id string) bool {
 
 	for ; epState != desiredState && counter < MaxRetries; counter++ {
 
-		logger.WithFields(log.Fields{
+		logger.WithFields(logrus.Fields{
 			"endpointState": epState,
 		}).Info("endpoint not ready")
 
@@ -177,7 +180,7 @@ func (c *Cilium) WaitEndpointRegenerated(id string) bool {
 // not be in any regenerating or waiting-to-generate state. Returns true if
 // all endpoints regenerate before MaxRetries are exceeded, false otherwise.
 func (c *Cilium) WaitEndpointsReady() bool {
-	logger := c.logger.WithFields(log.Fields{"functionName": "WaitEndpointsReady"})
+	logger := c.logger.WithFields(logrus.Fields{"functionName": "WaitEndpointsReady"})
 
 	numDesired := 0
 	counter := 0
@@ -196,7 +199,7 @@ func (c *Cilium) WaitEndpointsReady() bool {
 	}
 	for numDesired != numEndpointsRegenerating {
 
-		logger.WithFields(log.Fields{
+		logger.WithFields(logrus.Fields{
 			"regenerating": numEndpointsRegenerating,
 		}).Info("endpoints are still regenerating")
 
@@ -228,7 +231,7 @@ func (c *Cilium) EndpointSetConfig(id, option, value string) bool {
 	// For now use `grep` with an extra space to ensure that we only match
 	// on specified option.
 	// TODO: for consistency, all fields should be constants if they are reused.
-	logger := c.logger.WithFields(log.Fields{"endpointID": id})
+	logger := c.logger.WithFields(logrus.Fields{"endpointID": id})
 	res := c.Exec(fmt.Sprintf(
 		"endpoint config %s | grep '%s ' | awk '{print $2}'", id, option))
 

--- a/test/helpers/docker.go
+++ b/test/helpers/docker.go
@@ -17,8 +17,6 @@ package helpers
 import (
 	"bytes"
 	"fmt"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // Docker is utilized to run docker-specific commands on its SSHMeta. Informational

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/asaskevich/govalidator"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/api/v1/models"
 )
@@ -186,7 +186,7 @@ func (kub *Kubectl) WaitforPods(namespace string, filter string, timeout time.Du
 		if valid == true {
 			return true
 		}
-		kub.logCxt.WithFields(log.Fields{
+		kub.logCxt.WithFields(logrus.Fields{
 			"namespace": namespace,
 			"filter":    filter,
 			"data":      data,
@@ -290,7 +290,7 @@ func (kub *Kubectl) CiliumEndpointWait(pod string) bool {
 		if invalid == 0 {
 			return true
 		}
-		kub.logCxt.WithFields(log.Fields{
+		kub.logCxt.WithFields(logrus.Fields{
 			"pod":     pod,
 			"valid":   valid,
 			"invalid": invalid,
@@ -550,7 +550,7 @@ func (kub *Kubectl) GetCiliumPodOnNode(namespace string, node string) (string, e
 
 // TestConnectivityPodService runs HTTP connectivity test from pod to ClusterIP service
 func (kub *Kubectl) TestConnectivityPodService(from, to string) *CmdRes {
-	kub.logCxt.WithFields(log.Fields{
+	kub.logCxt.WithFields(logrus.Fields{
 		"from": from,
 		"to":   to,
 	}).Info("Testing connectivity")

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // SSHMeta contains metadata to SSH into a remote location to run tests

--- a/test/helpers/runtime.go
+++ b/test/helpers/runtime.go
@@ -14,10 +14,6 @@
 
 package helpers
 
-import (
-	log "github.com/sirupsen/logrus"
-)
-
 //CreateNewRuntimeHelper returns Docker and Cilium helpers for running the
 //runtime tests on the provided VM target and using logger log .
 func CreateNewRuntimeHelper(target string, log *log.Entry) (*Docker, *Cilium) {

--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/kevinburke/ssh_config"
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 )

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/cilium/cilium/test/config"
 	"github.com/onsi/ginkgo"
-	log "github.com/sirupsen/logrus"
 )
 
 // IsRunningOnJenkins detects if the currently running Ginkgo application is

--- a/test/helpers/vagrant.go
+++ b/test/helpers/vagrant.go
@@ -21,7 +21,7 @@ import (
 	"os/exec"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 //Vagrant helper struct
@@ -77,7 +77,7 @@ func (vagrant *Vagrant) Create(scope string) error {
 	}()
 
 	if err := cmd.Start(); err != nil {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"command": createCMD,
 			"err":     err,
 		}).Fatalf("Create error on start")

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -24,7 +24,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("NightlyK8sEpsMeasurement", func() {
@@ -39,7 +39,7 @@ var _ = Describe("NightlyK8sEpsMeasurement", func() {
 		if initialized == true {
 			return
 		}
-		logger = log.WithFields(log.Fields{"testName": "NightlyK8sEpsMeasurement"})
+		logger = log.WithFields(logrus.Fields{"testName": "NightlyK8sEpsMeasurement"})
 		logger.Info("Starting")
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
@@ -80,7 +80,7 @@ var _ = Describe("NightlyK8sEpsMeasurement", func() {
 			Expect(pods).Should(BeTrue())
 			Expect(err).Should(BeNil())
 		})
-		log.WithFields(log.Fields{"pod creation time": waitForPodsTime}).Info("")
+		log.WithFields(logrus.Fields{"pod creation time": waitForPodsTime}).Info("")
 
 		ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
 		Expect(err).Should(BeNil())
@@ -103,7 +103,7 @@ var _ = Describe("NightlyK8sEpsMeasurement", func() {
 
 			}, 300*time.Second, 3*time.Second).Should(BeTrue())
 		})
-		log.WithFields(log.Fields{"endpoint creation time": runtime}).Info("")
+		log.WithFields(logrus.Fields{"endpoint creation time": runtime}).Info("")
 
 	}, 1)
 

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -20,7 +20,7 @@ import (
 	"github.com/cilium/cilium/test/helpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("K8sPolicyTest", func() {
@@ -38,7 +38,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			return
 		}
 
-		logger = log.WithFields(log.Fields{"testName": "K8sPolicyTest"})
+		logger = log.WithFields(logrus.Fields{"testName": "K8sPolicyTest"})
 		logger.Info("Starting")
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		podFilter = "k8s:zgroup=testapp"

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -24,7 +24,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 )
 
@@ -38,7 +38,7 @@ var _ = Describe("K8sServicesTest", func() {
 		if initialized == true {
 			return
 		}
-		logger = log.WithFields(log.Fields{"testName": "K8sServiceTest"})
+		logger = log.WithFields(logrus.Fields{"testName": "K8sServiceTest"})
 		logger.Info("Starting")
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("K8sTunnelTest", func() {
@@ -36,7 +36,7 @@ var _ = Describe("K8sTunnelTest", func() {
 		if initialized == true {
 			return
 		}
-		logger = log.WithFields(log.Fields{"testName": "K8sTunnelTest"})
+		logger = log.WithFields(logrus.Fields{"testName": "K8sTunnelTest"})
 		logger.Info("Starting")
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)

--- a/test/k8sT/log.go
+++ b/test/k8sT/log.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2017 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,24 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package kvstore
+package k8sTest
 
-import (
-	"strings"
+import "github.com/cilium/cilium/common"
 
-	"github.com/sirupsen/logrus"
-)
-
-var (
-	// Debug enables kvstore tracing messages
-	//
-	// Debugging can be enabled at compile with:
-	// -ldflags "-X "github.com/cilium/cilium/pkg/kvstore".Debug=true"
-	Debug string
-)
-
-func trace(format string, err error, fields logrus.Fields, a ...interface{}) {
-	if strings.ToLower(Debug) == "true" {
-		log.WithError(err).WithFields(fields).Debugf(format)
-	}
-}
+var log = common.DefaultLogger

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -19,7 +19,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("RuntimeChaos", func() {
@@ -33,7 +33,7 @@ var _ = Describe("RuntimeChaos", func() {
 		if initialized == true {
 			return
 		}
-		logger = log.WithFields(log.Fields{"testName": "RuntimeChaos"})
+		logger = log.WithFields(logrus.Fields{"testName": "RuntimeChaos"})
 		logger.Info("Starting")
 		docker, cilium = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 		docker.NetworkCreate(helpers.CiliumDockerNetwork, "")

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -7,7 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("RuntimeConnectivityTest", func() {
@@ -21,7 +21,7 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 		if initialized == true {
 			return
 		}
-		logger = log.WithFields(log.Fields{"test": "RuntimeConnectivityTest"})
+		logger = log.WithFields(logrus.Fields{"test": "RuntimeConnectivityTest"})
 		logger.Info("Starting")
 		docker, cilium = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 		cilium.WaitUntilReady(100)
@@ -169,7 +169,7 @@ var _ = Describe("RuntimeConntrackTest", func() {
 		if initialized == true {
 			return
 		}
-		logger = log.WithFields(log.Fields{"test": "RunConntrackTest"})
+		logger = log.WithFields(logrus.Fields{"test": "RunConntrackTest"})
 		logger.Info("Starting")
 		docker, cilium = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 		docker.NetworkCreate(helpers.CiliumDockerNetwork, "")

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -22,7 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("RuntimeKafka", func() {
@@ -40,7 +40,7 @@ var _ = Describe("RuntimeKafka", func() {
 		if initialized == true {
 			return
 		}
-		logger = log.WithFields(log.Fields{"testName": "RuntimeKafka"})
+		logger = log.WithFields(logrus.Fields{"testName": "RuntimeKafka"})
 		logger.Info("Starting")
 		docker, cilium = helpers.CreateNewRuntimeHelper("runtime", logger)
 		docker.NetworkCreate(helpers.CiliumDockerNetwork, "")

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -21,7 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("RuntimeKVStoreTest", func() {
@@ -35,7 +35,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 		if initialized == true {
 			return
 		}
-		logger = log.WithFields(log.Fields{"testName": "RuntimeKVStoreTest"})
+		logger = log.WithFields(logrus.Fields{"testName": "RuntimeKVStoreTest"})
 		logger.Info("Starting")
 		docker, cilium = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 		logger.Info("done creating Cilium and Docker helpers")

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -22,7 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("RuntimeLB", func() {
@@ -36,7 +36,7 @@ var _ = Describe("RuntimeLB", func() {
 		if initialized == true {
 			return
 		}
-		logger = log.WithFields(log.Fields{"test": "RuntimeLB"})
+		logger = log.WithFields(logrus.Fields{"test": "RuntimeLB"})
 		logger.Info("Starting")
 		docker, cilium = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 		cilium.WaitUntilReady(100)

--- a/test/runtime/log.go
+++ b/test/runtime/log.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2017 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,24 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package kvstore
+package RuntimeTest
 
-import (
-	"strings"
+import "github.com/cilium/cilium/common"
 
-	"github.com/sirupsen/logrus"
-)
-
-var (
-	// Debug enables kvstore tracing messages
-	//
-	// Debugging can be enabled at compile with:
-	// -ldflags "-X "github.com/cilium/cilium/pkg/kvstore".Debug=true"
-	Debug string
-)
-
-func trace(format string, err error, fields logrus.Fields, a ...interface{}) {
-	if strings.ToLower(Debug) == "true" {
-		log.WithError(err).WithFields(fields).Debugf(format)
-	}
-}
+var log = common.DefaultLogger

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -23,7 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -51,7 +51,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		if initialized == true {
 			return
 		}
-		logger = log.WithFields(log.Fields{"testName": "RuntimeMonitorTest"})
+		logger = log.WithFields(logrus.Fields{"testName": "RuntimeMonitorTest"})
 		logger.Info("Starting")
 		docker, cilium = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 		cilium.WaitUntilReady(100)

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -29,7 +29,7 @@ import (
 	ginkgoext "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 	gops "github.com/google/gops/agent"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -127,7 +127,7 @@ var _ = BeforeSuite(func() {
 			Fail(fmt.Sprintf("error starting VM %q: %s", helpers.Runtime, err))
 		}
 		cilium := helpers.CreateCilium(helpers.Runtime, log.WithFields(
-			log.Fields{"testName": "BeforeSuite"}))
+			logrus.Fields{"testName": "BeforeSuite"}))
 		err = cilium.SetUp()
 		if err != nil {
 			Fail(fmt.Sprintf("cilium was unable to be set up correctly: %s", err))


### PR DESCRIPTION
This is needed because other libraries log to the logrus global logger.
When we run in debug, which we do while testing, these messages are also
printed. This is filling up logs during CI and breaking things. I'm hoping this will suppress this excess and our CI will be more stable.


Fixes: #2088 

**How to test (optional)**:
Hopefully a CI build passes without a million GB of logs