### PR TITLE
Vagrantfile: bumping vagrant box to 2.5

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -129,7 +129,7 @@ Vagrant.configure(2) do |config|
         vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
 
         config.vm.box = "cilium/ubuntu-16.10"
-        config.vm.box_version = "2.4"
+	config.vm.box_version = "2.5"
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i
 


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

This updates vagrant box to version 2.5.

Version 2.4 contained envoy dependencies build with root user, this version contains envoy dependencies build with vagrant user.