### PR TITLE
monitor: update Makefile dependencies in Makefile

### DIFF
--- a/monitor/Makefile
+++ b/monitor/Makefile
@@ -15,7 +15,7 @@
 include ../Makefile.defs
 
 TARGET=cilium-node-monitor
-SOURCES := $(shell find ../common . -name '*.go')
+SOURCES := $(shell find ../monitor ../common ../pkg ../api . -name '*.go')
 $(TARGET): $(SOURCES)
 	$(GO) build -i $(GOBUILD) -o $(TARGET)
 


### PR DESCRIPTION
The monitor uses a number of packages under pkg/ and autogenerated files
under api/ The Makefile reflects this and will cause a recompile when
these files are changed.

**How to test (optional)**:
I didn't test this but you would:
- change a file in pkg/bpf
- run make, note that it doesn't build
- apply this patch
- run make, note that it does build