### PR TITLE
Revert "tests: Disable tests temporarily to resolve CI build failures"

### DIFF
--- a/tests/21-ct-clean-up.sh
+++ b/tests/21-ct-clean-up.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# FIXME: Re-enable when bazel build disk size issues are resolved
-exit 0
-
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "${dir}/helpers.bash"
 # dir might have been overwritten by helpers.bash


### PR DESCRIPTION
This reverts commit db33c9340afaf726186dde57886586ac86b74b9b.

Fixes #2170