### PR TITLE
test: refactor node code and some helper functions

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -38,30 +38,6 @@ const (
 	MaxRetries = 30
 )
 
-// Cilium is utilized to run cilium-specific commands on its SSHMeta. Informational
-// output about the result of commands and the state of the node is stored in its
-// associated logger.
-type Cilium struct {
-	Node *SSHMeta
-
-	logger *logrus.Entry
-}
-
-// CreateCilium returns a Cilium object containing the SSHMeta of the provided vmName,
-// as well as the provided logger.
-func CreateCilium(vmName string, log *logrus.Entry) *Cilium {
-	log.Infof("Cilium: set vmName to '%s'", vmName)
-	node := GetVagrantSSHMetadata(vmName)
-	if node == nil {
-		return nil
-	}
-
-	return &Cilium{
-		Node:   node,
-		logger: log,
-	}
-}
-
 // BpfLBList returns the output of `cilium bpf lb list -o json` as a map
 // Key will be the frontend address and the value is an array with all backend
 // addresses

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -65,10 +65,10 @@ func CreateCilium(vmName string, log *logrus.Entry) *Cilium {
 // BpfLBList returns the output of `cilium bpf lb list -o json` as a map
 // Key will be the frontend address and the value is an array with all backend
 // addresses
-func (c *Cilium) BpfLBList() (map[string][]string, error) {
+func (s *SSHMeta) BpfLBList() (map[string][]string, error) {
 	var result map[string][]string
 
-	res := c.Exec("bpf lb list -o json")
+	res := s.ExecCilium("bpf lb list -o json")
 	if !res.WasSuccessful() {
 		return nil, fmt.Errorf("cannot get bpf lb list: %s", res.CombineOutput())
 	}
@@ -79,12 +79,12 @@ func (c *Cilium) BpfLBList() (map[string][]string, error) {
 	return result, nil
 }
 
-// Exec runs a Cilium CLI command and returns the resultant cmdRes.
-func (c *Cilium) Exec(cmd string) *CmdRes {
+// ExecCilium runs a Cilium CLI command and returns the resultant cmdRes.
+func (s *SSHMeta) ExecCilium(cmd string) *CmdRes {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	command := fmt.Sprintf("cilium %s", cmd)
-	exit := c.Node.ExecWithSudo(command, stdout, stderr)
+	exit := s.ExecWithSudo(command, stdout, stderr)
 	return &CmdRes{
 		cmd:    command,
 		stdout: stdout,
@@ -95,16 +95,16 @@ func (c *Cilium) Exec(cmd string) *CmdRes {
 
 // EndpointGet returns the output of `cilium endpoint get` for the provided
 // endpoint ID.
-func (c *Cilium) EndpointGet(id string) *models.Endpoint {
+func (s *SSHMeta) EndpointGet(id string) *models.Endpoint {
 	if id == "" {
 		return nil
 	}
 	var data []models.Endpoint
 	endpointGetCmd := fmt.Sprintf("endpoint get %s", id)
-	res := c.Exec(endpointGetCmd)
+	res := s.ExecCilium(endpointGetCmd)
 	err := res.Unmarshal(&data)
 	if err != nil {
-		c.logger.WithError(err).Errorf("EndpointGet fail %d", id)
+		s.logger.WithError(err).Errorf("EndpointGet fail %d", id)
 		return nil
 	}
 	if len(data) > 0 {
@@ -115,7 +115,7 @@ func (c *Cilium) EndpointGet(id string) *models.Endpoint {
 
 // EndpointStatusLog returns the status log API model for the specified endpoint.
 // Returns nil if no endpoint corresponds to the provided ID.
-func (c *Cilium) EndpointStatusLog(id string) *models.EndpointStatusLog {
+func (s *SSHMeta) EndpointStatusLog(id string) *models.EndpointStatusLog {
 	if id == "" {
 		return nil
 	}
@@ -123,21 +123,20 @@ func (c *Cilium) EndpointStatusLog(id string) *models.EndpointStatusLog {
 	var epStatusLog models.EndpointStatusLog
 
 	endpointLogCmd := fmt.Sprintf("endpoint log %s", id)
-	res := c.Exec(endpointLogCmd)
+	res := s.ExecCilium(endpointLogCmd)
 	err := res.Unmarshal(&epStatusLog)
 	if err != nil {
-		c.logger.WithFields(logrus.Fields{"endpointID": id}).WithError(err).Errorf("unable to get endpoint status log")
+		s.logger.WithFields(logrus.Fields{"endpointID": id}).WithError(err).Errorf("unable to get endpoint status log")
 		return nil
 	}
-
 	return &epStatusLog
 }
 
 // WaitEndpointRegenerated attempts up until MaxRetries are exceeded for the
 // endpoint with the specified ID to be in "ready" state. Returns false if
 // no such endpoint corresponds to the given id or if MaxRetries are exceeded.
-func (c *Cilium) WaitEndpointRegenerated(id string) bool {
-	logger := c.logger.WithFields(logrus.Fields{
+func (s *SSHMeta) WaitEndpointRegenerated(id string) bool {
+	logger := s.logger.WithFields(logrus.Fields{
 		"functionName": "WaitEndpointRegenerated",
 		"id":           id,
 	})
@@ -145,7 +144,7 @@ func (c *Cilium) WaitEndpointRegenerated(id string) bool {
 	counter := 0
 	desiredState := models.EndpointStateReady
 
-	endpoint := c.EndpointGet(id)
+	endpoint := s.EndpointGet(id)
 	if endpoint == nil {
 		return false
 	}
@@ -161,7 +160,7 @@ func (c *Cilium) WaitEndpointRegenerated(id string) bool {
 		logger.Infof("still within retry limit for waiting for endpoint to be in %s state; sleeping and checking again", desiredState)
 		Sleep(1)
 
-		endpoint = c.EndpointGet(id)
+		endpoint = s.EndpointGet(id)
 		if endpoint == nil {
 			return false
 		}
@@ -179,15 +178,15 @@ func (c *Cilium) WaitEndpointRegenerated(id string) bool {
 // WaitEndpointsReady waits up until MaxRetries times for all endpoints to
 // not be in any regenerating or waiting-to-generate state. Returns true if
 // all endpoints regenerate before MaxRetries are exceeded, false otherwise.
-func (c *Cilium) WaitEndpointsReady() bool {
-	logger := c.logger.WithFields(logrus.Fields{"functionName": "WaitEndpointsReady"})
+func (s *SSHMeta) WaitEndpointsReady() bool {
+	logger := s.logger.WithFields(logrus.Fields{"functionName": "WaitEndpointsReady"})
 
 	numDesired := 0
 	counter := 0
 
 	cmdString := "cilium endpoint list | grep -c regenerat"
 	infoCmd := "cilium endpoint list"
-	res := c.Node.Exec(cmdString)
+	res := s.Exec(cmdString)
 	logger.Infof("string output of cmd: %s", res.stdout.String())
 	numEndpointsRegenerating, err := strconv.Atoi(strings.TrimSuffix(res.stdout.String(), "\n"))
 
@@ -208,10 +207,10 @@ func (c *Cilium) WaitEndpointsReady() bool {
 			return false
 		}
 
-		res := c.Node.Exec(infoCmd)
+		res := s.Exec(infoCmd)
 		logger.Infof("still within retry limit for waiting for endpoints to be in \"ready\" state; sleeping and checking again")
 		Sleep(1)
-		res = c.Node.Exec(cmdString)
+		res = s.Exec(cmdString)
 		numEndpointsRegenerating, err = strconv.Atoi(strings.TrimSuffix(res.stdout.String(), "\n"))
 		if err != nil {
 			numEndpointsRegenerating = -1
@@ -226,13 +225,13 @@ func (c *Cilium) WaitEndpointsReady() bool {
 // value for the endpoint with the endpoint ID id. It returns true if the
 // configuration update command returned successfully and if the endpoint
 // was able to regenerate successfully, false otherwise.
-func (c *Cilium) EndpointSetConfig(id, option, value string) bool {
+func (s *SSHMeta) EndpointSetConfig(id, option, value string) bool {
 	// TODO: GH-1725.
 	// For now use `grep` with an extra space to ensure that we only match
 	// on specified option.
 	// TODO: for consistency, all fields should be constants if they are reused.
-	logger := c.logger.WithFields(logrus.Fields{"endpointID": id})
-	res := c.Exec(fmt.Sprintf(
+	logger := s.logger.WithFields(logrus.Fields{"endpointID": id})
+	res := s.ExecCilium(fmt.Sprintf(
 		"endpoint config %s | grep '%s ' | awk '{print $2}'", id, option))
 
 	if res.SingleOut() == value {
@@ -240,30 +239,35 @@ func (c *Cilium) EndpointSetConfig(id, option, value string) bool {
 		return res.WasSuccessful()
 	}
 
+	before := s.EndpointGet(id)
+	if before == nil {
+		return false
+	}
+
 	configCmd := fmt.Sprintf("endpoint config %s %s=%s", id, option, value)
-	data := c.Exec(configCmd)
+	data := s.ExecCilium(configCmd)
 	if !data.WasSuccessful() {
 		logger.Errorf("cannot set endpoint configuration %s=%s", option, value)
 		return false
 	}
 
-	return c.WaitEndpointRegenerated(id)
+	return s.WaitEndpointRegenerated(id)
 }
 
 // GetEndpoints returns the CmdRes resulting from executing
 // `cilium endpoint list -o json`.
-func (c *Cilium) GetEndpoints() *CmdRes {
-	return c.Exec("endpoint list -o json")
+func (s *SSHMeta) GetEndpoints() *CmdRes {
+	return s.ExecCilium("endpoint list -o json")
 }
 
 // GetEndpointsIds returns a mapping of a Docker container name to to its
 // corresponding endpoint ID, and an error if the list of endpoints cannot be
 // retrieved via the Cilium CLI.
-func (c *Cilium) GetEndpointsIds() (map[string]string, error) {
+func (s *SSHMeta) GetEndpointsIds() (map[string]string, error) {
 	// cilium endpoint list -o jsonpath='{range [*]}{@.container-name}{"="}{@.id}{"\n"}{end}'
 	filter := `{range [*]}{@.container-name}{"="}{@.id}{"\n"}{end}`
 	cmd := fmt.Sprintf("endpoint list -o jsonpath='%s'", filter)
-	endpoints := c.Exec(cmd)
+	endpoints := s.ExecCilium(cmd)
 	if !endpoints.WasSuccessful() {
 		return nil, fmt.Errorf("%q failed: %s", cmd, endpoints.CombineOutput())
 	}
@@ -273,9 +277,9 @@ func (c *Cilium) GetEndpointsIds() (map[string]string, error) {
 // GetEndpointsIdentityIds returns a mapping of a Docker container name to it's
 // corresponding endpoint's security identity, it will return an error if the list
 // of endpoints cannot be retrieved via the Cilium CLI.
-func (c *Cilium) GetEndpointsIdentityIds() (map[string]string, error) {
+func (s *SSHMeta) GetEndpointsIdentityIds() (map[string]string, error) {
 	filter := `{range [*]}{@.container-name}{"="}{@.identity.id}{"\n"}{end}`
-	endpoints := c.Exec(fmt.Sprintf("endpoint list -o jsonpath='%s'", filter))
+	endpoints := s.ExecCilium(fmt.Sprintf("endpoint list -o jsonpath='%s'", filter))
 	if !endpoints.WasSuccessful() {
 		return nil, fmt.Errorf("cannot get endpoint list: %s", endpoints.CombineOutput())
 	}
@@ -283,8 +287,8 @@ func (c *Cilium) GetEndpointsIdentityIds() (map[string]string, error) {
 }
 
 // GetEndpointsNames returns the container-name field of each Cilium endpoint.
-func (c *Cilium) GetEndpointsNames() ([]string, error) {
-	data := c.GetEndpoints()
+func (s *SSHMeta) GetEndpointsNames() ([]string, error) {
+	data := s.GetEndpoints()
 	if data.WasSuccessful() == false {
 		return nil, fmt.Errorf("`cilium endpoint get` was not successful")
 	}
@@ -299,27 +303,27 @@ func (c *Cilium) GetEndpointsNames() ([]string, error) {
 // ManifestsPath returns the path of the directory where manifests (YAMLs
 // containing policies, DaemonSets, etc.) are stored for the runtime tests.
 // TODO: this can just be a constant; there's no need to have a function.
-func (c *Cilium) ManifestsPath() string {
+func (s *SSHMeta) ManifestsPath() string {
 	return fmt.Sprintf("%s/runtime/manifests/", BasePath)
 }
 
 // GetFullPath returns the path of file name prepended with the absolute path
 // where manifests (YAMLs containing policies, DaemonSets, etc.) are stored.
-func (c *Cilium) GetFullPath(name string) string {
-	return fmt.Sprintf("%s%s", c.ManifestsPath(), name)
+func (s *SSHMeta) GetFullPath(name string) string {
+	return fmt.Sprintf("%s%s", s.ManifestsPath(), name)
 }
 
 // PolicyEndpointsSummary returns the count of whether policy enforcement is
 // enabled, disabled, and the total number of endpoints, and an error if the
 // Cilium endpoint metadata cannot be retrieved via the API.
-func (c *Cilium) PolicyEndpointsSummary() (map[string]int, error) {
+func (s *SSHMeta) PolicyEndpointsSummary() (map[string]int, error) {
 	result := map[string]int{
 		Enabled:  0,
 		Disabled: 0,
 		Total:    0,
 	}
 
-	endpoints, err := c.GetEndpoints().Filter("{ [*].policy-enabled }")
+	endpoints, err := s.GetEndpoints().Filter("{ [*].policy-enabled }")
 	if err != nil {
 		return result, fmt.Errorf("cannot get endpoints")
 	}
@@ -331,116 +335,116 @@ func (c *Cilium) PolicyEndpointsSummary() (map[string]int, error) {
 
 // SetPolicyEnforcement sets the PolicyEnforcement configuration value for the
 // Cilium agent to the provided status.
-func (c *Cilium) SetPolicyEnforcement(status string, waitReady ...bool) *CmdRes {
+func (s *SSHMeta) SetPolicyEnforcement(status string, waitReady ...bool) *CmdRes {
 	// We check before setting PolicyEnforcement; if we do not, EndpointWait
 	// will fail due to the status of the endpoints not changing.
 	log.Infof("setting PolicyEnforcement=%s", status)
-	res := c.Exec(fmt.Sprintf("config | grep %s | awk '{print $2}'", PolicyEnforcement))
+	res := s.ExecCilium(fmt.Sprintf("config | grep %s | awk '{print $2}'", PolicyEnforcement))
 	if res.SingleOut() == status {
 		return res
 	}
-	res = c.Exec(fmt.Sprintf("config %s=%s", PolicyEnforcement, status))
+	res = s.ExecCilium(fmt.Sprintf("config %s=%s", PolicyEnforcement, status))
 	if len(waitReady) > 0 && waitReady[0] {
-		c.WaitEndpointsReady()
+		s.WaitEndpointsReady()
 	}
 	return res
 }
 
 // PolicyDelAll deletes all policy rules currently imported into Cilium.
-func (c *Cilium) PolicyDelAll() *CmdRes {
-	return c.PolicyDel("--all")
+func (s *SSHMeta) PolicyDelAll() *CmdRes {
+	return s.PolicyDel("--all")
 }
 
 // PolicyDel deletes the policy with the given ID from Cilium.
-func (c *Cilium) PolicyDel(id string) *CmdRes {
-	return c.Exec(fmt.Sprintf("policy delete %s", id))
+func (s *SSHMeta) PolicyDel(id string) *CmdRes {
+	return s.ExecCilium(fmt.Sprintf("policy delete %s", id))
 }
 
 // PolicyGet runs `cilium policy get <id>`, where id is the name of a specific
 // policy imported into Cilium. It returns the resultant CmdRes from running
 // the aforementioned command.
-func (c *Cilium) PolicyGet(id string) *CmdRes {
-	return c.Exec(fmt.Sprintf("policy get %s", id))
+func (s *SSHMeta) PolicyGet(id string) *CmdRes {
+	return s.ExecCilium(fmt.Sprintf("policy get %s", id))
 }
 
 // PolicyGetAll gets all policies that are imported in the Cilium agent.
-func (c *Cilium) PolicyGetAll() *CmdRes {
-	return c.Exec("policy get")
+func (s *SSHMeta) PolicyGetAll() *CmdRes {
+	return s.ExecCilium("policy get")
 
 }
 
 // PolicyGetRevision retrieves the current policy revision number in the Cilium
 // agent.
-func (c *Cilium) PolicyGetRevision() (int, error) {
+func (s *SSHMeta) PolicyGetRevision() (int, error) {
 	//FIXME GH-1725
-	rev := c.Exec("policy get | grep Revision| awk '{print $2}'")
+	rev := s.ExecCilium("policy get | grep Revision| awk '{print $2}'")
 	return rev.IntOutput()
 }
 
 // PolicyImport imports a new policy into Cilium and waits until the policy
 // revision number increments.
-func (c *Cilium) PolicyImport(path string, timeout time.Duration) (int, error) {
-	revision, err := c.PolicyGetRevision()
+func (s *SSHMeta) PolicyImport(path string, timeout time.Duration) (int, error) {
+	revision, err := s.PolicyGetRevision()
 	if err != nil {
 		return -1, fmt.Errorf("cannot get policy revision: %s", err)
 	}
-	c.logger.Infof("PolicyImport: %s and current policy revision is '%d'", path, revision)
-	res := c.Exec(fmt.Sprintf("policy import %s", path))
+	s.logger.Infof("PolicyImport: %s and current policy revision is '%d'", path, revision)
+	res := s.ExecCilium(fmt.Sprintf("policy import %s", path))
 	if res.WasSuccessful() == false {
-		c.logger.Errorf("could not import policy: %s", res.CombineOutput())
+		s.logger.Errorf("could not import policy: %s", res.CombineOutput())
 		return -1, fmt.Errorf("could not import policy %s", path)
 	}
 	body := func() bool {
-		currentRev, _ := c.PolicyGetRevision()
+		currentRev, _ := s.PolicyGetRevision()
 		if currentRev > revision {
-			c.PolicyWait(currentRev)
+			s.PolicyWait(currentRev)
 			return true
 		}
-		c.logger.Infof("PolicyImport: current revision %d same as %d", currentRev, revision)
+		s.logger.Infof("PolicyImport: current revision %d same as %d", currentRev, revision)
 		return false
 	}
 	err = WithTimeout(body, "could not import policy revision", &TimeoutConfig{Timeout: timeout})
 	if err != nil {
 		return -1, err
 	}
-	revision, err = c.PolicyGetRevision()
-	c.logger.Infof("PolicyImport: finished %q with revision '%d'", path, revision)
+	revision, err = s.PolicyGetRevision()
+	s.logger.Infof("PolicyImport: finished %q with revision '%d'", path, revision)
 	return revision, err
 }
 
 // PolicyWait executes `cilium policy wait`, which waits until all endpoints are
 // updated to the given policy revision.
-func (c *Cilium) PolicyWait(revisionNum int) *CmdRes {
-	return c.Exec(fmt.Sprintf("policy wait %d", revisionNum))
+func (s *SSHMeta) PolicyWait(revisionNum int) *CmdRes {
+	return s.ExecCilium(fmt.Sprintf("policy wait %d", revisionNum))
 }
 
 // ReportFailed gathers relevant Cilium runtime data and logs for debugging
 // purposes.
-func (c *Cilium) ReportFailed(commands ...string) {
-	wr := c.logger.Logger.Out
+func (s *SSHMeta) ReportFailed(commands ...string) {
+	wr := s.logger.Logger.Out
 	fmt.Fprint(wr, "StackTrace Begin\n")
 
 	//FIXME: Ginkgo PR383 add here --since option
-	res := c.Node.Exec("sudo journalctl --no-pager -u cilium")
+	res := s.Exec("sudo journalctl --no-pager -u cilium")
 	fmt.Fprint(wr, res.Output())
 
 	fmt.Fprint(wr, "\n")
-	res = c.Exec("endpoint list")
+	res = s.ExecCilium("endpoint list")
 	fmt.Fprint(wr, res.Output())
 
 	for _, cmd := range commands {
 		fmt.Fprintf(wr, "\nOutput of command '%s': \n", cmd)
-		res = c.Node.Exec(fmt.Sprintf("%s", cmd))
+		res = s.Exec(fmt.Sprintf("%s", cmd))
 		fmt.Fprint(wr, res.Output())
 	}
 	fmt.Fprint(wr, "StackTrace Ends\n")
-	c.ReportDump()
-	c.GatherLogs()
+	s.ReportDump()
+	s.GatherLogs()
 }
 
 // ReportDump runs a variety of commands and writes the results to
 // testResultsPath
-func (c *Cilium) ReportDump() {
+func (s *SSHMeta) ReportDump() {
 
 	reportEndpointsCommands := map[string]string{
 		"cilium endpoint get %s":         "endpoint_%s.txt",
@@ -449,21 +453,21 @@ func (c *Cilium) ReportDump() {
 
 	testPath, err := ReportDirectory()
 	if err != nil {
-		c.logger.WithError(err).Errorf(
+		s.logger.WithError(err).Errorf(
 			"cannot create test results path '%s'", testPath)
 		return
 	}
-	reportMap(testPath, ciliumCLICommands, c.Node)
+	reportMap(testPath, ciliumCLICommands, s)
 
 	// Endpoint specific information:
-	eps, err := c.GetEndpointsIds()
+	eps, err := s.GetEndpointsIds()
 	if err != nil {
-		c.logger.Errorf("cannot get endpoint ids")
+		s.logger.Errorf("cannot get endpoint ids")
 	}
 	for _, ep := range eps {
 		for cmd, logfile := range reportEndpointsCommands {
 			command := fmt.Sprintf(cmd, ep)
-			res := c.Node.Exec(command)
+			res := s.Exec(command)
 
 			err = ioutil.WriteFile(
 				fmt.Sprintf("%s/%s", testPath, fmt.Sprintf(logfile, ep)),
@@ -471,30 +475,30 @@ func (c *Cilium) ReportDump() {
 				os.ModePerm)
 
 			if err != nil {
-				c.logger.WithError(err).Errorf("cannot create test results for '%s'", command)
+				s.logger.WithError(err).Errorf("cannot create test results for '%s'", command)
 			}
 		}
 	}
 
-	eps, err = c.GetEndpointsIdentityIds()
+	eps, err = s.GetEndpointsIdentityIds()
 	if err != nil {
-		c.logger.WithError(err).Error("cannot get endpoint identity ids")
+		s.logger.WithError(err).Error("cannot get endpoint identity ids")
 	}
 	for _, ep := range eps {
-		res := c.Node.Exec(fmt.Sprintf("cilium identity get %s", ep))
+		res := s.Exec(fmt.Sprintf("cilium identity get %s", ep))
 		err = ioutil.WriteFile(
 			fmt.Sprintf("%s/%s", testPath, fmt.Sprintf("identity_%s.txt", ep)),
 			res.CombineOutput().Bytes(),
 			os.ModePerm)
 		if err != nil {
-			c.logger.WithError(err).Errorf("cannot create test results for identity get")
+			s.logger.WithError(err).Errorf("cannot create test results for identity get")
 		}
 	}
 }
 
 // GatherLogs dumps Cilium, Cilium Docker, key-value store logs, and gops output
 // to the directory testResultsPath
-func (c *Cilium) GatherLogs() {
+func (s *SSHMeta) GatherLogs() {
 	ciliumLogCommands := map[string]string{
 		fmt.Sprintf("sudo journalctl -xe -u %s --no-pager", DaemonName):            "cilium.log",
 		fmt.Sprintf("sudo journalctl -xe -u %s--no-pager", CiliumDockerDaemonName): "cilium-docker.log",
@@ -506,11 +510,11 @@ func (c *Cilium) GatherLogs() {
 
 	testPath, err := ReportDirectory()
 	if err != nil {
-		c.logger.WithError(err).Errorf(
+		s.logger.WithError(err).Errorf(
 			"cannot create test results path '%s'", testPath)
 		return
 	}
-	reportMap(testPath, ciliumLogCommands, c.Node)
+	reportMap(testPath, ciliumLogCommands, s)
 
 	ciliumBPFStateCommands := []string{
 		fmt.Sprintf("sudo cp -r %s %s/%s/lib", RunDir, BasePath, testPath),
@@ -518,33 +522,27 @@ func (c *Cilium) GatherLogs() {
 	}
 
 	for _, cmd := range ciliumBPFStateCommands {
-		res := c.Node.Exec(cmd)
+		res := s.Exec(cmd)
 		if !res.WasSuccessful() {
-			c.logger.Errorf("cannot gather files for cmd '%s': %s", cmd, res.CombineOutput())
+			s.logger.Errorf("cannot gather files for cmd '%s': %s", cmd, res.CombineOutput())
 		}
 	}
 }
 
 // ServiceAdd creates a new Cilium service with the provided ID, frontend,
 // backends, and revNAT number. Returns the result of creating said service.
-func (c *Cilium) ServiceAdd(id int, frontend string, backends []string, rev int) *CmdRes {
+func (s *SSHMeta) ServiceAdd(id int, frontend string, backends []string, rev int) *CmdRes {
 	cmd := fmt.Sprintf(
 		"service update --frontend '%s' --backends '%s' --id '%d' --rev '%d'",
 		frontend, strings.Join(backends, ","), id, rev)
-	return c.Exec(cmd)
-}
-
-// ServiceDel is a wrapper around `cilium service delete <id>`. It returns the
-// result of deleting said service.
-func (c *Cilium) ServiceDel(id int) *CmdRes {
-	return c.Exec(fmt.Sprintf("service delete '%d'", id))
+	return s.ExecCilium(cmd)
 }
 
 // ServiceIsSynced checks that the Cilium service with the specified id has its
 // metadata match that of the load balancer BPF maps
-func (c *Cilium) ServiceIsSynced(id int) (bool, error) {
+func (s *SSHMeta) ServiceIsSynced(id int) (bool, error) {
 	var svc *models.Service
-	svcRes := c.ServiceGet(id)
+	svcRes := s.ServiceGet(id)
 	if !svcRes.WasSuccessful() {
 		return false, fmt.Errorf("cannot get service id %d: %s", id, svcRes.CombineOutput())
 	}
@@ -553,7 +551,7 @@ func (c *Cilium) ServiceIsSynced(id int) (bool, error) {
 		return false, err
 	}
 
-	bpfLB, err := c.BpfLBList()
+	bpfLB, err := s.BpfLBList()
 	if err != nil {
 		return false, err
 	}
@@ -589,22 +587,22 @@ func (c *Cilium) ServiceIsSynced(id int) (bool, error) {
 }
 
 // ServiceList returns the output of  `cilium service list`
-func (c *Cilium) ServiceList() *CmdRes {
-	return c.Exec("service list -o json")
+func (s *SSHMeta) ServiceList() *CmdRes {
+	return s.ExecCilium("service list -o json")
 }
 
 // ServiceGet is a wrapper around `cilium service get <id>`. It returns the
 // result of retrieving said service.
-func (c *Cilium) ServiceGet(id int) *CmdRes {
-	return c.Exec(fmt.Sprintf("service get '%d' -o json", id))
+func (s *SSHMeta) ServiceGet(id int) *CmdRes {
+	return s.ExecCilium(fmt.Sprintf("service get '%d' -o json", id))
 }
 
 // ServiceGetFrontendAddress returns a string with the frontend address and
 // port. It returns an error if the ID cannot be retrieved.
-func (c *Cilium) ServiceGetFrontendAddress(id int) (string, error) {
+func (s *SSHMeta) ServiceGetFrontendAddress(id int) (string, error) {
 
 	var svc *models.Service
-	res := c.ServiceGet(id)
+	res := s.ServiceGet(id)
 	if !res.WasSuccessful() {
 		return "", fmt.Errorf("Cannot get service id %d: %s", id, res.CombineOutput())
 	}
@@ -622,18 +620,24 @@ func (c *Cilium) ServiceGetFrontendAddress(id int) (string, error) {
 
 // ServiceGetIds returns an array with the IDs of all Cilium services. Returns
 // an error if the IDs cannot be retrieved
-func (c *Cilium) ServiceGetIds() ([]string, error) {
+func (s *SSHMeta) ServiceGetIds() ([]string, error) {
 	filter := `{range [*]}{@.ID}{end}`
-	res, err := c.ServiceList().Filter(filter)
+	res, err := s.ServiceList().Filter(filter)
 	if err != nil {
 		return nil, err
 	}
 	return strings.Split(res.String(), "\n"), nil
 }
 
-// SetUp sets up Cilium as a systemd service with a hardcoded set of options. It
+// ServiceDel is a wrapper around `cilium service delete <id>`. It returns the
+// result of deleting said service.
+func (s *SSHMeta) ServiceDel(id int) *CmdRes {
+	return s.ExecCilium(fmt.Sprintf("service delete '%d'", id))
+}
+
+// SetUpCilium sets up Cilium as a systemd service with a hardcoded set of options. It
 // returns an error if any of the operations needed to start Cilium fails.
-func (c *Cilium) SetUp() error {
+func (s *SSHMeta) SetUpCilium() error {
 	template := `
 PATH=/usr/lib/llvm-3.8/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
 CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug
@@ -645,11 +649,11 @@ INITSYSTEM=SYSTEMD`
 	}
 	defer os.Remove("cilium")
 
-	res := c.Node.Exec("sudo cp /vagrant/cilium /etc/sysconfig/cilium")
+	res := s.Exec("sudo cp /vagrant/cilium /etc/sysconfig/cilium")
 	if !res.WasSuccessful() {
 		return fmt.Errorf("%s", res.CombineOutput())
 	}
-	res = c.Node.Exec("sudo systemctl restart cilium")
+	res = s.Exec("sudo systemctl restart cilium")
 	if !res.WasSuccessful() {
 		return fmt.Errorf("%s", res.CombineOutput())
 	}
@@ -659,11 +663,11 @@ INITSYSTEM=SYSTEMD`
 // WaitUntilReady waits until the output of `cilium status` returns with code
 // zero. Returns an error if the output of `cilium status` returns a nonzero
 // return code after the specified timeout duration has elapsed.
-func (c *Cilium) WaitUntilReady(timeout time.Duration) error {
+func (s *SSHMeta) WaitUntilReady(timeout time.Duration) error {
 
 	body := func() bool {
-		res := c.Exec("status")
-		c.logger.Infof("Cilium status is %t", res.WasSuccessful())
+		res := s.ExecCilium("status")
+		s.logger.Infof("Cilium status is %t", res.WasSuccessful())
 		return res.WasSuccessful()
 	}
 	err := WithTimeout(body, "Cilium is not ready", &TimeoutConfig{Timeout: timeout})

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -311,7 +311,7 @@ func (s *SSHMeta) PolicyEndpointsSummary() (map[string]int, error) {
 
 // SetPolicyEnforcement sets the PolicyEnforcement configuration value for the
 // Cilium agent to the provided status.
-func (s *SSHMeta) SetPolicyEnforcement(status string, waitReady ...bool) *CmdRes {
+func (s *SSHMeta) SetPolicyEnforcement(status string) *CmdRes {
 	// We check before setting PolicyEnforcement; if we do not, EndpointWait
 	// will fail due to the status of the endpoints not changing.
 	log.Infof("setting PolicyEnforcement=%s", status)
@@ -319,11 +319,7 @@ func (s *SSHMeta) SetPolicyEnforcement(status string, waitReady ...bool) *CmdRes
 	if res.SingleOut() == status {
 		return res
 	}
-	res = s.ExecCilium(fmt.Sprintf("config %s=%s", PolicyEnforcement, status))
-	if len(waitReady) > 0 && waitReady[0] {
-		s.WaitEndpointsReady()
-	}
-	return res
+	return s.ExecCilium(fmt.Sprintf("config %s=%s", PolicyEnforcement, status))
 }
 
 // PolicyDelAll deletes all policy rules currently imported into Cilium.

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -397,7 +397,7 @@ func (s *SSHMeta) ReportFailed(commands ...string) {
 	fmt.Fprint(wr, "StackTrace Begin\n")
 
 	//FIXME: Ginkgo PR383 add here --since option
-	res := s.Exec("sudo journalctl --no-pager -u cilium")
+	res := s.Exec("sudo journalctl --no-pager -u cilium | tail -n 50")
 	fmt.Fprint(wr, res.Output())
 
 	fmt.Fprint(wr, "\n")

--- a/test/helpers/docker.go
+++ b/test/helpers/docker.go
@@ -19,29 +19,6 @@ import (
 	"fmt"
 )
 
-// Docker is utilized to run docker-specific commands on its SSHMeta. Informational
-// output about the result of commands and the state of the node is stored in its
-// associated logCxt.
-type Docker struct {
-	Node *SSHMeta
-}
-
-// CreateDocker returns a Docker object containing the SSHMeta of the provided vmName.
-// TODO - I don't understand why we need separate Cilium vs. Docker constructs.
-// The contents are exactly the same. Why not just declare a single type that we name
-// accordingly?
-func CreateDocker(target string) *Docker {
-	log.Infof("Docker: set target to '%s'", target)
-	node := GetVagrantSSHMetadata(target)
-	if node == nil {
-		return nil
-	}
-
-	return &Docker{
-		Node: node,
-	}
-}
-
 // ContainerExec executes cmd in the container with the provided name.
 func (s *SSHMeta) ContainerExec(name string, cmd string) *CmdRes {
 	return s.execCmd(fmt.Sprintf("docker exec -i %s %s", name, cmd))

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -50,7 +50,7 @@ type Kubectl struct {
 
 // CreateKubectl initializes a Kubectl helper with the provided vmName and log
 func CreateKubectl(vmName string, log *logrus.Entry) *Kubectl {
-	node := GetVagrantSSHMetadata(vmName)
+	node := GetVagrantSSHMeta(vmName)
 	if node == nil {
 		return nil
 	}

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -46,11 +46,10 @@ func (s *SSHMeta) String() string {
 
 }
 
-// GetVagrantSSHMetadata returns a SSHMeta initialized based on the provided
+// GetVagrantSSHMeta returns a SSHMeta initialized based on the provided
 // SSH-config target.
-func GetVagrantSSHMetadata(vmName string) *SSHMeta {
-	var vagrant Vagrant
-	config, err := vagrant.GetVagrantSSHMetadata(vmName)
+func GetVagrantSSHMeta(vmName string) *SSHMeta {
+	config, err := GetVagrantSSHMetadata(vmName)
 	if err != nil {
 		return nil
 	}

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/sirupsen/logrus"
 )
 
 // SSHMeta contains metadata to SSH into a remote location to run tests
@@ -28,6 +30,7 @@ type SSHMeta struct {
 	env       []string
 	rawConfig []byte
 	nodeName  string
+	logger    *logrus.Entry
 }
 
 // CreateSSHMeta returns an SSHMeta with the specified host, port, and user, as

--- a/test/helpers/runtime.go
+++ b/test/helpers/runtime.go
@@ -20,10 +20,10 @@ import (
 
 //CreateNewRuntimeHelper returns Docker and Cilium helpers for running the
 //runtime tests on the provided VM target and using logger log .
-func CreateNewRuntimeHelper(target string, log *logrus.Entry) (*Docker, *Cilium) {
+func CreateNewRuntimeHelper(target string, log *logrus.Entry) (*SSHMeta, *Cilium) {
 	log.Infof("creating docker")
 	docker := CreateDocker(target)
 	log.Infof("creating cilium")
 	cilium := CreateCilium(target, log)
-	return docker, cilium
+	return docker.Node, cilium
 }

--- a/test/helpers/runtime.go
+++ b/test/helpers/runtime.go
@@ -20,10 +20,11 @@ import (
 
 //CreateNewRuntimeHelper returns Docker and Cilium helpers for running the
 //runtime tests on the provided VM target and using logger log .
-func CreateNewRuntimeHelper(target string, log *logrus.Entry) (*SSHMeta, *Cilium) {
-	log.Infof("creating docker")
-	docker := CreateDocker(target)
-	log.Infof("creating cilium")
-	cilium := CreateCilium(target, log)
-	return docker.Node, cilium
+func CreateNewRuntimeHelper(target string, log *logrus.Entry) *SSHMeta {
+	node := GetVagrantSSHMetadata(target)
+	if node == nil {
+		return nil
+	}
+	node.logger = log
+	return node
 }

--- a/test/helpers/runtime.go
+++ b/test/helpers/runtime.go
@@ -22,7 +22,7 @@ import (
 //runtime tests on the provided VM target and using logger log .
 func CreateNewRuntimeHelper(target string, log *logrus.Entry) (*Docker, *Cilium) {
 	log.Infof("creating docker")
-	docker := CreateDocker(target, log)
+	docker := CreateDocker(target)
 	log.Infof("creating cilium")
 	cilium := CreateCilium(target, log)
 	return docker, cilium

--- a/test/helpers/runtime.go
+++ b/test/helpers/runtime.go
@@ -21,7 +21,8 @@ import (
 //CreateNewRuntimeHelper returns Docker and Cilium helpers for running the
 //runtime tests on the provided VM target and using logger log .
 func CreateNewRuntimeHelper(target string, log *logrus.Entry) *SSHMeta {
-	node := GetVagrantSSHMetadata(target)
+	node := GetVagrantSSHMeta(target)
+
 	if node == nil {
 		return nil
 	}

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -212,11 +212,11 @@ var _ = Describe("K8sPolicyTest", func() {
 		trace.ExpectSuccess(trace.CombineOutput().String())
 		Expect(trace.Output().String()).Should(ContainSubstring("Final verdict: DENIED"))
 
-		_, err = kubectl.Exec(
+		_, err = kubectl.ExecPodCmd(
 			helpers.DefaultNamespace, appPods[helpers.App2], fmt.Sprintf("curl http://%s/public", clusterIP))
 		Expect(err).Should(BeNil())
 
-		_, err = kubectl.Exec(
+		_, err = kubectl.ExecPodCmd(
 			helpers.DefaultNamespace, appPods[helpers.App3], fmt.Sprintf("curl --fail -s http://%s/public", clusterIP))
 		Expect(err).Should(HaveOccurred())
 
@@ -240,19 +240,19 @@ var _ = Describe("K8sPolicyTest", func() {
 
 		appPods = getAppPods()
 
-		_, err = kubectl.Exec(
+		_, err = kubectl.ExecPodCmd(
 			helpers.DefaultNamespace, appPods[helpers.App2], fmt.Sprintf("curl http://%s/public", clusterIP))
 		Expect(err).Should(BeNil())
 
-		msg, err := kubectl.Exec(
+		msg, err := kubectl.ExecPodCmd(
 			helpers.DefaultNamespace, appPods[helpers.App2], fmt.Sprintf("curl --fail -s http://%s/private", clusterIP))
 		Expect(err).Should(HaveOccurred(), msg)
 
-		_, err = kubectl.Exec(
+		_, err = kubectl.ExecPodCmd(
 			helpers.DefaultNamespace, appPods[helpers.App3], fmt.Sprintf("curl --fail -s http://%s/public", clusterIP))
 		Expect(err).Should(HaveOccurred())
 
-		msg, err = kubectl.Exec(
+		msg, err = kubectl.ExecPodCmd(
 			helpers.DefaultNamespace, appPods[helpers.App3], fmt.Sprintf("curl --fail -s http://%s/private", clusterIP))
 		Expect(err).Should(HaveOccurred(), msg)
 
@@ -264,7 +264,7 @@ var _ = Describe("K8sPolicyTest", func() {
 		err = waitUntilEndpointUpdates(ciliumPod, eps, 4)
 		Expect(err).Should(BeNil())
 
-		_, err = kubectl.Exec(
+		_, err = kubectl.ExecPodCmd(
 			helpers.DefaultNamespace, appPods[helpers.App3], fmt.Sprintf("curl --fail -s http://%s/public", clusterIP))
 		Expect(err).Should(BeNil())
 	}, 500)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -72,7 +72,7 @@ var _ = Describe("K8sServicesTest", func() {
 		// two nodes
 		for _, pod := range pods {
 			for i := 1; i <= 10; i++ {
-				_, err := kubectl.Exec(helpers.DefaultNamespace, pod, fmt.Sprintf("curl --connect-timeout 5 %s", url))
+				_, err := kubectl.ExecPodCmd(helpers.DefaultNamespace, pod, fmt.Sprintf("curl --connect-timeout 5 %s", url))
 				ExpectWithOffset(1, err).Should(BeNil(), "Pod '%s' can not connect to service '%s'", pod, url)
 			}
 		}
@@ -101,7 +101,7 @@ var _ = Describe("K8sServicesTest", func() {
 		Expect(err).Should(BeNil())
 		Expect(govalidator.IsIP(svcIP.String())).Should(BeTrue())
 
-		status := kubectl.Node.Exec(fmt.Sprintf("curl http://%s/", svcIP))
+		status := kubectl.Exec(fmt.Sprintf("curl http://%s/", svcIP))
 		status.ExpectSuccess()
 
 		ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -41,7 +41,7 @@ var _ = Describe("K8sTunnelTest", func() {
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		demoDSPath = fmt.Sprintf("%s/demo_ds.yaml", kubectl.ManifestsPath())
-		kubectl.Node.Exec("kubectl -n kube-system delete ds cilium")
+		kubectl.Exec("kubectl -n kube-system delete ds cilium")
 		// Expect(res.Correct()).Should(BeTrue())
 
 		waitToDeleteCilium(kubectl, logger)
@@ -136,7 +136,7 @@ func isNodeNetworkingWorking(kubectl *helpers.Kubectl, filter string) bool {
 		helpers.DefaultNamespace,
 		fmt.Sprintf("pod %s -o json", pods[1])).Filter("{.status.podIP}")
 	Expect(err).Should(BeNil())
-	_, err = kubectl.Exec(helpers.DefaultNamespace, pods[0], helpers.Ping(podIP.String()))
+	_, err = kubectl.ExecPodCmd(helpers.DefaultNamespace, pods[0], helpers.Ping(podIP.String()))
 	if err != nil {
 		return false
 	}

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -50,7 +50,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 
 	var initialized bool
 	var logger *logrus.Entry
-	var docker *helpers.Docker
+	var docker *helpers.SSHMeta
 	var cilium *helpers.Cilium
 
 	initialize := func() {
@@ -368,7 +368,7 @@ var _ = Describe("RuntimePolicies", func() {
 
 	var initialized bool
 	var logger *logrus.Entry
-	var docker *helpers.Docker
+	var docker *helpers.SSHMeta
 	var cilium *helpers.Cilium
 
 	initialize := func() {

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -62,8 +62,11 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 		vm.WaitUntilReady(100)
 		vm.NetworkCreate(helpers.CiliumDockerNetwork, "")
 
-		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault, false)
+		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
 		res.ExpectSuccess()
+
+		areEndpointsReady := vm.WaitEndpointsReady()
+		Expect(areEndpointsReady).Should(BeTrue())
 
 		initialized = true
 	}
@@ -89,6 +92,9 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			initialize()
 			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
 			res.ExpectSuccess()
+
+			areEndpointsReady := vm.WaitEndpointsReady()
+			Expect(areEndpointsReady).Should(BeTrue())
 		})
 
 		It("Default values", func() {
@@ -122,16 +128,22 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 
 			By("Setting to Always")
 
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways, true)
+			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways)
 			res.ExpectSuccess()
+
+			areEndpointsReady := vm.WaitEndpointsReady()
+			Expect(areEndpointsReady).Should(BeTrue())
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 
 			By("Setting to default from Always")
-			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault, true)
+			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
 			res.ExpectSuccess()
+
+			areEndpointsReady = vm.WaitEndpointsReady()
+			Expect(areEndpointsReady).Should(BeTrue())
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -147,15 +159,21 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 			//DEfault =APP with PolicyEnforcement
 
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways, true)
+			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways)
 			res.ExpectSuccess()
+
+			areEndpointsReady := vm.WaitEndpointsReady()
+			Expect(areEndpointsReady).Should(BeTrue())
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 
-			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault, true)
+			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
 			res.ExpectSuccess()
+
+			areEndpointsReady = vm.WaitEndpointsReady()
+			Expect(areEndpointsReady).Should(BeTrue())
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -167,8 +185,11 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementNever, true)
+			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementNever)
 			res.ExpectSuccess()
+
+			areEndpointsReady := vm.WaitEndpointsReady()
+			Expect(areEndpointsReady).Should(BeTrue())
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -188,15 +209,21 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementNever, true)
+			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementNever)
 			res.ExpectSuccess()
+
+			areEndpointsReady := vm.WaitEndpointsReady()
+			Expect(areEndpointsReady).Should(BeTrue())
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Enabled]).To(Equal(0))
 
-			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault, true)
+			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
 			res.ExpectSuccess()
+
+			areEndpointsReady = vm.WaitEndpointsReady()
+			Expect(areEndpointsReady).Should(BeTrue())
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -209,8 +236,11 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 		BeforeEach(func() {
 			initialize()
 
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways, true)
+			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways)
 			res.ExpectSuccess()
+
+			areEndpointsReady := vm.WaitEndpointsReady()
+			Expect(areEndpointsReady).Should(BeTrue())
 		})
 
 		It("Container creation", func() {
@@ -243,15 +273,21 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 			Expect(endPoints[helpers.Disabled]).To(Equal(0))
 
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementNever, true)
+			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementNever)
 			res.ExpectSuccess()
+
+			areEndpointsReady := vm.WaitEndpointsReady()
+			Expect(areEndpointsReady).Should(BeTrue())
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Enabled]).To(Equal(0))
 
-			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways, true)
+			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways)
 			res.ExpectSuccess()
+
+			areEndpointsReady = vm.WaitEndpointsReady()
+			Expect(areEndpointsReady).Should(BeTrue())
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -264,16 +300,22 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 			Expect(endPoints[helpers.Disabled]).To(Equal(0))
 
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementNever, true)
+			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementNever)
 			res.ExpectSuccess()
+
+			areEndpointsReady := vm.WaitEndpointsReady()
+			Expect(areEndpointsReady).Should(BeTrue())
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Enabled]).To(Equal(0))
 			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
-			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways, true)
+			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways)
 			res.ExpectSuccess()
+
+			areEndpointsReady = vm.WaitEndpointsReady()
+			Expect(areEndpointsReady).Should(BeTrue())
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -322,16 +364,22 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			Expect(endPoints[helpers.Enabled]).To(Equal(0))
 			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault, true)
+			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
 			res.ExpectSuccess()
+
+			areEndpointsReady := vm.WaitEndpointsReady()
+			Expect(areEndpointsReady).Should(BeTrue())
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 			Expect(endPoints[helpers.Disabled]).To(Equal(0))
 
-			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementNever, true)
+			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementNever)
 			res.ExpectSuccess()
+
+			areEndpointsReady = vm.WaitEndpointsReady()
+			Expect(areEndpointsReady).Should(BeTrue())
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -345,16 +393,22 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 			Expect(endPoints[helpers.Enabled]).To(Equal(0))
 			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault, true)
+			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
 			res.ExpectSuccess()
+
+			areEndpointsReady := vm.WaitEndpointsReady()
+			Expect(areEndpointsReady).Should(BeTrue())
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Enabled]).To(Equal(0))
 			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
-			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementNever, true)
+			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementNever)
 			res.ExpectSuccess()
+
+			areEndpointsReady = vm.WaitEndpointsReady()
+			Expect(areEndpointsReady).Should(BeTrue())
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -380,8 +434,12 @@ var _ = Describe("RuntimePolicies", func() {
 		vm.NetworkCreate(helpers.CiliumDockerNetwork, "")
 
 		vm.WaitUntilReady(100)
-		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault, false)
+		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
 		res.ExpectSuccess()
+
+		areEndpointsReady := vm.WaitEndpointsReady()
+		Expect(areEndpointsReady).Should(BeTrue())
+
 		initialized = true
 
 	}

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -25,7 +25,8 @@ import (
 var _ = Describe("RuntimeChaos", func() {
 
 	var initialized bool
-	var docker *helpers.Docker
+
+	var docker *helpers.SSHMeta
 	var cilium *helpers.Cilium
 
 	initialize := func() {
@@ -83,20 +84,20 @@ var _ = Describe("RuntimeChaos", func() {
 	}, 300)
 
 	It("removing leftover Cilium interfaces", func() {
-		originalLinks, err := docker.Node.Exec("sudo ip link show | wc -l").IntOutput()
+		originalLinks, err := docker.Exec("sudo ip link show | wc -l").IntOutput()
 		Expect(err).Should(BeNil())
 
-		_ = docker.Node.Exec("sudo ip link add lxc12345 type veth peer name tmp54321")
+		_ = docker.Exec("sudo ip link add lxc12345 type veth peer name tmp54321")
 
 		res := cilium.Node.Exec("sudo systemctl restart cilium")
 		res.ExpectSuccess()
 
 		waitForCilium()
 
-		status := docker.Node.Exec("sudo ip link show lxc12345")
+		status := docker.Exec("sudo ip link show lxc12345")
 		status.ExpectFail("leftover interface were not properly cleaned up")
 
-		links, err := docker.Node.Exec("sudo ip link show | wc -l").IntOutput()
+		links, err := docker.Exec("sudo ip link show | wc -l").IntOutput()
 		Expect(links).Should(Equal(originalLinks),
 			"Some network interfaces were accidentally removed!")
 	}, 300)

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -14,7 +14,8 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 
 	var initialized bool
 	var logger *logrus.Entry
-	var docker *helpers.Docker
+	var docker *helpers.SSHMeta
+
 	var cilium *helpers.Cilium
 
 	initialize := func() {
@@ -127,7 +128,7 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 		res.ExpectSuccess()
 
 		By(fmt.Sprintf("ping from %s to %s", helpers.Host, helpers.Server))
-		res = docker.Node.Exec(helpers.Ping(serverIP.String()))
+		res = docker.Exec(helpers.Ping(serverIP.String()))
 		res.ExpectSuccess()
 	}, 300)
 
@@ -161,8 +162,9 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 var _ = Describe("RuntimeConntrackTest", func() {
 
 	var initialized bool
+
 	var logger *logrus.Entry
-	var docker *helpers.Docker
+	var docker *helpers.SSHMeta
 	var cilium *helpers.Cilium
 
 	initialize := func() {
@@ -228,11 +230,11 @@ var _ = Describe("RuntimeConntrackTest", func() {
 			"%s cannot netperf to %s %s", helpers.Client, helpers.Server, srvIP[helpers.IPv4]))
 
 		By(fmt.Sprintf("ping from %s to %s IPv6", helpers.Host, helpers.Server))
-		res = docker.Node.Exec(helpers.Ping6(srvIP[helpers.IPv6]))
+		res = docker.Exec(helpers.Ping6(srvIP[helpers.IPv6]))
 		Expect(res.WasSuccessful()).Should(BeTrue(), fmt.Sprintf("%s cannot ping %s", helpers.Host, helpers.Server))
 
 		By(fmt.Sprintf("ping from %s to %s IPv4", helpers.Host, helpers.Server))
-		res = docker.Node.Exec(helpers.Ping(srvIP[helpers.IPv4]))
+		res = docker.Exec(helpers.Ping(srvIP[helpers.IPv4]))
 		Expect(res.WasSuccessful()).Should(BeTrue(), fmt.Sprintf("%s cannot ping %s", helpers.Host, helpers.Server))
 
 		By(fmt.Sprintf("ping from %s to %s IPv6", helpers.Server, helpers.Client))

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -28,7 +28,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 
 	var initialized bool
 	var logger *logrus.Entry
-	var docker *helpers.Docker
+	var docker *helpers.SSHMeta
 	var cilium *helpers.Cilium
 
 	initialize := func() {
@@ -54,7 +54,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 
 	BeforeEach(func() {
 		initialize()
-		docker.Node.Exec("sudo systemctl stop cilium")
+		docker.Exec("sudo systemctl stop cilium")
 	}, 150)
 
 	AfterEach(func() {
@@ -64,7 +64,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 				"sudo cilium endpoint list")
 		}
 		containers(helpers.Delete)
-		docker.Node.Exec("sudo systemctl start cilium")
+		docker.Exec("sudo systemctl start cilium")
 	})
 
 	It("Consul KVStore", func() {
@@ -76,7 +76,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 		err := cilium.WaitUntilReady(150)
 		Expect(err).Should(BeNil())
 
-		docker.Node.Exec("sudo systemctl restart cilium-docker")
+		docker.Exec("sudo systemctl restart cilium-docker")
 		helpers.Sleep(2)
 		containers(helpers.Create)
 		cilium.WaitEndpointsReady()
@@ -94,7 +94,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 		err := cilium.WaitUntilReady(150)
 		Expect(err).Should(BeNil())
 
-		docker.Node.Exec("sudo systemctl restart cilium-docker")
+		docker.Exec("sudo systemctl restart cilium-docker")
 		helpers.Sleep(2)
 		containers(helpers.Create)
 		cilium.WaitEndpointsReady()

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -29,7 +29,7 @@ var _ = Describe("RuntimeLB", func() {
 
 	var initialized bool
 	var logger *logrus.Entry
-	var docker *helpers.Docker
+	var docker *helpers.SSHMeta
 	var cilium *helpers.Cilium
 
 	initialize := func() {
@@ -145,7 +145,7 @@ var _ = Describe("RuntimeLB", func() {
 	}, 500)
 
 	It("Service L3 tests", func() {
-		err := createInterface(docker.Node)
+		err := createInterface(docker)
 		if err != nil {
 			log.Errorf("error creating interface: %s", err)
 		}
@@ -194,7 +194,7 @@ var _ = Describe("RuntimeLB", func() {
 	}, 500)
 
 	It("Service L4 tests", func() {
-		err := createInterface(docker.Node)
+		err := createInterface(docker)
 		if err != nil {
 			log.Errorf("error creating interface: %s", err)
 		}

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -56,8 +56,11 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		vm.WaitUntilReady(100)
 		vm.NetworkCreate(helpers.CiliumDockerNetwork, "")
 
-		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault, false)
+		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
 		res.ExpectSuccess()
+
+		areEndpointsReady := vm.WaitEndpointsReady()
+		Expect(areEndpointsReady).Should(BeTrue())
 
 		initialized = true
 	}

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -44,7 +44,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 
 	var initialized bool
 	var logger *logrus.Entry
-	var docker *helpers.Docker
+	var docker *helpers.SSHMeta
 	var cilium *helpers.Cilium
 
 	initialize := func() {
@@ -84,7 +84,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
 
-		res = docker.Node.ExecContext(ctx, "cilium monitor -v")
+		res = docker.ExecContext(ctx, "cilium monitor -v")
 		docker.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
 		helpers.Sleep(5)
 		cancel()
@@ -112,7 +112,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 			By(fmt.Sprintf("Type %s", k))
 
 			ctx, cancel := context.WithCancel(context.Background())
-			res := docker.Node.ExecContext(ctx, fmt.Sprintf("cilium monitor --type %s -v", k))
+			res := docker.ExecContext(ctx, fmt.Sprintf("cilium monitor --type %s -v", k))
 			docker.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
 			docker.ContainerExec(helpers.App1, helpers.Ping(helpers.Httpd1))
 			helpers.Sleep(5)
@@ -133,7 +133,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		Expect(err).Should(BeNil())
 
 		ctx, cancel := context.WithCancel(context.Background())
-		res = docker.Node.ExecContext(ctx, fmt.Sprintf(
+		res = docker.ExecContext(ctx, fmt.Sprintf(
 			"cilium monitor --type debug --from %s -v", endpoints[helpers.App1]))
 		docker.ContainerExec(helpers.App1, helpers.Ping(helpers.Httpd1))
 		helpers.Sleep(5)
@@ -159,7 +159,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		Expect(err).Should(BeNil())
 		cilium.WaitEndpointsReady()
 		ctx, cancel := context.WithCancel(context.Background())
-		res = docker.Node.ExecContext(ctx, fmt.Sprintf(
+		res = docker.ExecContext(ctx, fmt.Sprintf(
 			"cilium monitor --type drop -v --to %s", endpoints[helpers.Httpd1]))
 
 		docker.ContainerExec(helpers.App1, helpers.Ping(helpers.Httpd1))
@@ -184,7 +184,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		Expect(err).Should(BeNil())
 
 		ctx, cancel := context.WithCancel(context.Background())
-		res = docker.Node.ExecContext(ctx, fmt.Sprintf(
+		res = docker.ExecContext(ctx, fmt.Sprintf(
 			"cilium monitor -v --type drop --related-to %s", endpoints[helpers.Httpd1]))
 		cilium.WaitEndpointsReady()
 		docker.ContainerExec(helpers.App1, helpers.CurlFail("http://httpd1/public"))
@@ -213,7 +213,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		ctx, cancelfn := context.WithCancel(context.Background())
 
 		for i := 1; i <= 3; i++ {
-			monitorRes = append(monitorRes, docker.Node.ExecContext(ctx, "cilium monitor"))
+			monitorRes = append(monitorRes, docker.ExecContext(ctx, "cilium monitor"))
 		}
 
 		docker.ContainerExec(helpers.Client, helpers.Ping(helpers.Server))

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -35,7 +35,6 @@ import (
 
 var (
 	log             = common.DefaultLogger
-	vagrant         helpers.Vagrant
 	DefaultSettings = map[string]string{
 		"K8S_VERSION": "1.7",
 	}
@@ -124,7 +123,7 @@ var _ = BeforeSuite(func() {
 
 	switch ginkgoext.GetScope() {
 	case helpers.Runtime:
-		err = vagrant.Create(helpers.Runtime)
+		err = helpers.CreateVM(helpers.Runtime)
 		if err != nil {
 			Fail(fmt.Sprintf("error starting VM %q: %s", helpers.Runtime, err))
 		}
@@ -145,11 +144,14 @@ var _ = BeforeSuite(func() {
 		// Wait until compilation finished, and pull cilium image on k8s2
 
 		// Name for K8s VMs depends on K8s version that is running.
-		err = vagrant.Create(helpers.K8s1VMName())
+
+		err = helpers.CreateVM(helpers.K8s1VMName())
 		if err != nil {
 			Fail(fmt.Sprintf("error starting VM %q: %s", helpers.K8s1VMName(), err))
 		}
-		err = vagrant.Create(helpers.K8s2VMName())
+
+		err = helpers.CreateVM(helpers.K8s2VMName())
+
 		if err != nil {
 			Fail(fmt.Sprintf("error starting VM %q: %s", helpers.K8s2VMName(), err))
 		}
@@ -167,10 +169,10 @@ var _ = AfterSuite(func() {
 	log.Infof("cleaning up VMs started for %s tests", scope)
 	switch scope {
 	case helpers.Runtime:
-		vagrant.Destroy(helpers.Runtime)
+		helpers.DestroyVM(helpers.Runtime)
 	case helpers.K8s:
-		vagrant.Destroy(helpers.K8s1VMName())
-		vagrant.Destroy(helpers.K8s2VMName())
+		helpers.DestroyVM(helpers.K8s1VMName())
+		helpers.DestroyVM(helpers.K8s2VMName())
 	}
 	return
 })

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -128,9 +128,11 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			Fail(fmt.Sprintf("error starting VM %q: %s", helpers.Runtime, err))
 		}
-		cilium := helpers.CreateCilium(helpers.Runtime, log.WithFields(
+
+		vm := helpers.CreateNewRuntimeHelper(helpers.Runtime, log.WithFields(
 			logrus.Fields{"testName": "BeforeSuite"}))
-		err = cilium.SetUp()
+		err = vm.SetUpCilium()
+
 		if err != nil {
 			Fail(fmt.Sprintf("cilium was unable to be set up correctly: %s", err))
 		}


### PR DESCRIPTION
* Get rid of the Cilium and Docker structures and use SSHMeta instead for runtime tests
* Put a logger directly in the SSHMeta itself
* Get rid of Vagrant object and just use functions with no receiver.
* Refactor PolicyEnforcement configuration functions in the daemon and wait for endpoints to be ready outside of the function. This was done as I think we should only utilize "Expect" in a test itself, and not in a helper function. 

Signed-off by: Ian Vernon <ian@cilium.io>