### PR TITLE
tests: adding more logs to 20-cidr-limit

### DIFF
--- a/tests/20-cidr-limit.sh
+++ b/tests/20-cidr-limit.sh
@@ -14,11 +14,16 @@ set +x # Reduce noise
 
 function cleanup() {
   gather_files 20-cidr-limit ${TEST_SUITE}
+  log "removing container id.server2"
   docker rm -f id.service2 2> /dev/null || true
+  log "deleting all policies from cilium"
   cilium policy delete --all 2> /dev/null || true
+  log "stopping cilium with systemctl"
   systemctl stop cilium
   wait_for_cilium_shutdown
+  log "running \"cilium cleanup -f\""
   log "cleanup: `cilium cleanup -f`"
+  log "starting cilium with systemctl"
   systemctl start cilium
 }
 

--- a/tests/20-cidr-limit.sh
+++ b/tests/20-cidr-limit.sh
@@ -10,7 +10,6 @@ LOGS_DIR="${dir}/cilium-files/${TEST_NAME}/logs"
 redirect_debug_logs ${LOGS_DIR}
 
 set -ex # Required for the linter
-set +x # Reduce noise
 
 function cleanup() {
   gather_files 20-cidr-limit ${TEST_SUITE}

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -1095,6 +1095,7 @@ function ping_success {
 } 
 
 function wait_for_cilium_shutdown {
+  log "waiting for cilium to shutdown"
   i=0
   while [[ -f /var/run/cilium/cilium.pid ]]; do
     micro_sleep
@@ -1104,4 +1105,5 @@ function wait_for_cilium_shutdown {
     fi
     ((i++))
   done
+  log "finished waiting for cilium to shutdown"
 }


### PR DESCRIPTION
Add more logs to 20-cidr-limit which has been failing sporadically in the build.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #2189