### PR TITLE
Documentation: k8s metrics examples and instructions

### DIFF
--- a/Documentation/gettingstarted.rst
+++ b/Documentation/gettingstarted.rst
@@ -508,6 +508,24 @@ L3/L4 and L7 network security policies.
 
 After this, you can re-run the `Getting Started Using Kubernetes`_ from Step 1.
 
+Extra:  Metrics
+===============
+
+To try out the metrics exported by cilium, simply install the example prometheus spec file:
+
+.. parsed-literal::
+
+   $ kubectl create -f \ |SCM_WEB|\/examples/kubernetes/prometheus.yaml
+
+
+This will create a barebones prometheus installation that you can use to
+inspect metrics from the agent. Navigate to the web ui with:
+
+::
+
+   $ minikube service prometheus -n prometheus
+
+
 ****************************
 Getting Started Using Docker
 ****************************

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -16,6 +16,7 @@ Welcome to Cilium's documentation!
    concepts
    install
    policy
+   metrics
    troubleshooting
    bpf
    api

--- a/Documentation/intro.rst
+++ b/Documentation/intro.rst
@@ -77,6 +77,8 @@ The remainder of this documentation is divided into the following sections:
 * :ref:`policy_guide` : Detailed walkthrough of the policy language structure
   and the supported formats.
 
+* :ref:`metrics` : Instructions for configuring metrics collection from Cilium.
+
 * :ref:`admin_guide` : Describes how to troubleshoot Cilium in different
   deployment modes.
 

--- a/Documentation/metrics.rst
+++ b/Documentation/metrics.rst
@@ -1,0 +1,104 @@
+.. _metrics:
+
+######################
+Cilium Runtime Metrics
+######################
+
+cilium-agent can be configured to serve `Prometheus <https://prometheus.io>`_
+metrics. Prometheus is a pluggable metrics collection and storage system and
+can act as a data source for `Grafana <https://grafana.com/>`_, a metrics
+visualisation system. Unlike some metrics collectors like statsd, Prometheus requires the
+collectors to pull metrics from each source.
+
+******************************
+Configuring Metrics Collection
+******************************
+
+cilium must be invoked with the ``--prometheus-serve-addr`` option (the
+`kubernetes example spec file <https://github.com/cilium/cilium/blob/master/examples/kubernetes/cilium.yaml>`_
+already does this). This is a ``IP:Port`` pair and passing no IP (i.e.
+``:9090``) will bind the server to all available interfaces (usually there is
+only one in a container).
+
+
+cilium as a kubernetes pod
+==========================
+The Prometheus reference configuration includes "jobs" to automatically collect pod metrics marked appropriately. Your cilium spec will need two labels:
+
+.. code-block:: yaml
+
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+
+*Note: the port can be configured to any value. Prometheus uses this label to
+discover the port.*
+
+An example of how to do this can be found in the cilium
+`kubernetes example spec file <https://github.com/cilium/cilium/blob/master/examples/kubernetes/cilium.yaml>`_
+
+To configure this automatic discovery and collecction, Prometheus itself requires a
+`kubernetes_sd_config <https://prometheus.io/docs/prometheus/latest/configuration/configuration/>`_
+configuration.
+This will use the kubernetes API server to discover pods, nodes etc. It also
+takes rules that match and filter pods on labels and annotations, and otherwise
+tag the metrics series.
+
+An example `promethues configuration file <https://github.com/cilium/cilium/blob/master/examples/kubernetes/cilium.yaml>`_
+can be found alongside the kubernetes cilium spec. The critical discovery section is:
+
+.. code-block:: yaml
+
+      - job_name: 'kubernetes-pods'
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_k8s_app]
+            action: keep
+            regex: cilium
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: (.+):(?:\d+);(\d+)
+            replacement: ${1}:${2}
+            target_label: __address__
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - action: labelmap
+            regex: __meta_kubernetes_pod_label_(.+)
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: kubernetes_namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: kubernetes_pod_name
+
+This job configures prometheus to do a number of things for all pods returned
+by the kubernetes API server:
+
+- find and keep all pods that have labels ``k8s-app=cilium`` and ``prometheus.io/scrape=true``
+- extract the IP and port of the pod from ``address`` and ``prometheus.io/port``
+- discover the metrics url path from the label ``prometheus.io/path`` and uses the default of ``/metrics`` when it isn't present
+- populate metrics tags for the kubernetes namespace and pod name derived from the pod labels
+
+cilium as a host-agent on a node
+================================
+Prometheus can use a number of more common service discovery schemes, such as
+consul and DNS, or a cloud provider API, such as AWS EC2, GCE or Azure.
+Relevant documentation can be found at the
+`Prometheus site <https://prometheus.io/docs/prometheus/latest/configuration/configuration/>`_.
+
+It is also possible to hard-code ``static-config`` sections that are simply an IP address and port:
+
+.. code-block:: yaml
+
+      - job_name: 'cilium-agent-nodes'
+        metrics_path: /metrics
+        static_configs:
+          - targets: ['192.168.33.11:9090']
+            labels:
+              node-id: i-0598c7d7d356eba47
+              node-az: a

--- a/examples/kubernetes/cilium.yaml
+++ b/examples/kubernetes/cilium.yaml
@@ -25,6 +25,10 @@ data:
   # If you want to run cilium in debug mode change this value to true
   debug: "false"
   disable-ipv4: "false"
+
+  # Allow prometheus to scrape on this addr:port. Not specifying an address
+  # will bind to all available interfaces inthe container.
+  prometheus-serve-addr: ":9090"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret
@@ -82,6 +86,8 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: >-
           [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
       containers:
@@ -98,6 +104,10 @@ spec:
           - "--kvstore-opt"
           - "etcd.config=/var/lib/etcd-config/etcd.config"
           - "--disable-ipv4=$(DISABLE_IPV4)"
+          - "--prometheus-serve-addr=$(PROMETHEUS_SERVE_ADDR)"
+        ports:
+          - name: prometheus
+            containerPort: 9090
         lifecycle:
           postStart:
             exec:
@@ -122,6 +132,11 @@ spec:
               configMapKeyRef:
                 name: cilium-config
                 key: disable-ipv4
+          - name: "PROMETHEUS_SERVE_ADDR"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: prometheus-serve-addr
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/prometheus.yaml
+++ b/examples/kubernetes/prometheus.yaml
@@ -1,0 +1,159 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prometheus
+
+# The prometheus service, deployment and config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: prometheus
+  labels:
+    app: prometheus
+    component: core
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  type: NodePort
+  ports:
+    - port: 9090
+      protocol: TCP
+      name: webui
+  selector:
+    app: prometheus
+    component: core
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: prometheus-core
+  namespace: prometheus
+  labels:
+    app: prometheus
+    component: core
+spec:
+  replicas: 1
+  template:
+    metadata:
+      name: prometheus-main
+      labels:
+        app: prometheus
+        component: core
+    spec:
+      serviceAccountName: prometheus-k8s
+      containers:
+      - name: prometheus
+        image: prom/prometheus:v1.7.0
+        args:
+          - '-storage.local.retention=12h'
+          - '-storage.local.memory-chunks=500000'
+          - '-config.file=/etc/prometheus/prometheus.yaml'
+        ports:
+        - name: webui
+          containerPort: 9090
+        resources:
+          requests:
+            cpu: 500m
+            memory: 500M
+          limits:
+            cpu: 500m
+            memory: 500M
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/prometheus
+      volumes:
+      - name: config-volume
+        configMap:
+          name: prometheus-core
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-core
+  namespace: prometheus
+data:
+  prometheus.yaml: |
+    global:
+      scrape_interval: 10s
+      scrape_timeout: 10s
+      evaluation_interval: 10s
+
+    scrape_configs:
+      # https://github.com/prometheus/prometheus/blob/release-2.0/documentation/examples/prometheus-kubernetes.yml#L239-L273
+      - job_name: 'kubernetes-pods'
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_k8s_app]
+            action: keep
+            regex: cilium
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: (.+):(?:\d+);(\d+)
+            replacement: ${1}:${2}
+            target_label: __address__
+          - action: labelmap
+            regex: __meta_kubernetes_pod_label_(.+)
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: kubernetes_namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: kubernetes_pod_name
+          - source_labels: [__meta_kubernetes_pod_container_port_number]
+            action: keep
+            regex: 9\d{3}
+
+# Authorization related objects
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: prometheus
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-k8s
+  namespace: prometheus


### PR DESCRIPTION
cilium-agent can serve metrics to prometheus. This is now exposed in our
examples, along with a minimal prometheus k8s spec to illustrate it. We
detail this in a new docs page about metrics.

Signed-off-by: Ray Bejjani <ray@covalent.io>

Fixes: #1935 

```release-note
kubernetes examples support prometheus metrics scraping (along with sample prometheus configuration)
```

**How to test (optional)**:
make -C Documentation render to see the docs.
Otherwise, test by following the instructions in kubernetes quick start. They are:
```
kubectl create -f examples/kubernetes/cilium.yaml
kubectl create -f examples/kubernetes/prometheus.yaml
minikube service -n prometheus prometheus
```
