### PR TITLE
Misc cleanups in pkg/node/manager

### DIFF
--- a/pkg/node/manager.go
+++ b/pkg/node/manager.go
@@ -265,7 +265,9 @@ func updateNodeCIDR(n *Node, ip *net.IPNet) {
 	}
 
 	if err := tunnel.SetTunnelEndpoint(ip.IP, n.GetNodeIP(false)); err != nil {
-		log.WithError(err).WithField(logfields.IPAddr, ip).Error("bpf: Unable to update in tunnel endpoint map")
+		log.WithError(err).WithFields(logrus.Fields{
+			logfields.IPAddr: ip,
+		}).Error("bpf: Unable to update in tunnel endpoint map")
 	}
 }
 
@@ -304,6 +306,8 @@ func UpdateNode(ni Identity, n *Node, routesTypes RouteType, ownAddr net.IP) {
 // reach that node.
 func DeleteNode(ni Identity, routesTypes RouteType) {
 	clusterConf.Lock()
+	defer clusterConf.Unlock()
+
 	if n, ok := clusterConf.nodes[ni]; ok {
 		if (routesTypes & TunnelRoute) != 0 {
 			log.WithFields(logrus.Fields{
@@ -321,7 +325,6 @@ func DeleteNode(ni Identity, routesTypes RouteType) {
 		delete(clusterConf.nodes, ni)
 		clusterConf.replaceHostRoutes()
 	}
-	clusterConf.Unlock()
 }
 
 // GetNodes returns a copy of all of the nodes as a map from Identity to Node.

--- a/pkg/node/manager.go
+++ b/pkg/node/manager.go
@@ -86,7 +86,9 @@ func deleteNodeCIDR(ip *net.IPNet) {
 	}
 
 	if err := tunnel.DeleteTunnelEndpoint(ip.IP); err != nil {
-		log.WithError(err).WithField(logfields.IPAddr, ip).Error("bpf: Unable to delete in tunnel endpoint map")
+		log.WithError(err).WithFields(logrus.Fields{
+			logfields.IPAddr: ip,
+		}).Debug("bpf: Unable to delete in tunnel endpoint map")
 	}
 }
 


### PR DESCRIPTION
Lower the failure to delete tunnel endpoints to debug level, as requested in #1915. While we're here, fix up some unlikely but inconsistent failure conditions, and reduce unnecessary host route checks when nothing is being changed.