### PR TITLE
tests: only output last 200 lines of various logs

### DIFF
--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -144,8 +144,8 @@ function abort {
   monitor_stop
 
   echo "------------------------------------------------------------------------"
-  echo "                            Cilium logs"
-  journalctl --no-pager --since "${LAST_LOG_DATE}" -u cilium
+  echo "                            Cilium logs (last 200 lines)"
+  journalctl --no-pager --since "${LAST_LOG_DATE}" -u cilium | tail -n 200
   echo ""
   echo "------------------------------------------------------------------------"
 

--- a/tests/k8s/helpers.bash
+++ b/tests/k8s/helpers.bash
@@ -16,14 +16,14 @@ function abort {
 
 	cilium_id=$(docker ps -aql --filter=name=cilium-agent)
 	echo "------------------------------------------------------------------------"
-	echo "                            Cilium logs"
-	docker logs ${cilium_id}
+	echo "                            Cilium logs (last 200 lines)"
+	docker logs ${cilium_id} --tail 200
 	echo ""
 	echo "------------------------------------------------------------------------"
 
     echo "------------------------------------------------------------------------"
-    echo "                            L7 Proxy logs"
-    cat /var/lib/cilium/proxy.log
+    echo "                            L7 Proxy logs (last 200 lines)"
+    tail -n 200 /var/lib/cilium/proxy.log
 	echo ""
 	echo "------------------------------------------------------------------------"
 


### PR DESCRIPTION
This will help us avoid having disk fill up on Jenkins.

Signed-off by: Ian Vernon <ian@cilium.io>