### PR TITLE
Go deadlock update

### DIFF
--- a/pkg/lock/lock_test.go
+++ b/pkg/lock/lock_test.go
@@ -35,8 +35,6 @@ func (s *LockSuite) TestLock(c *C) {
 	lock1.Unlock()
 
 	lock1.RLock()
-	lock1.RLock()
-	lock1.RUnlock()
 	lock1.RUnlock()
 
 	var lock2 Mutex
@@ -50,8 +48,6 @@ func (s *LockSuite) TestDebugLock(c *C) {
 	lock1.Unlock()
 
 	lock1.RLock()
-	lock1.RLock()
-	lock1.RUnlock()
 	lock1.RUnlock()
 
 	var lock2 MutexDebug

--- a/pkg/option/option_test.go
+++ b/pkg/option/option_test.go
@@ -44,7 +44,9 @@ func (s *OptionSuite) TestGetFmtOpt(c *C) {
 			"test": &OptionTest,
 		},
 	}
+	o.optsMU.Lock()
 	c.Assert(o.getFmtOpt("test"), Equals, "#define TEST_DEFINE")
 	c.Assert(o.getFmtOpt("BAR"), Equals, "#undef BAR")
 	c.Assert(o.getFmtOpt("BAZ"), Equals, "#undef BAZ")
+	o.optsMU.Unlock()
 }

--- a/vendor/github.com/sasha-s/go-deadlock/Readme.md
+++ b/vendor/github.com/sasha-s/go-deadlock/Readme.md
@@ -40,6 +40,14 @@ B.Lock() // defer B.Unlock() or similar.
 ...
 A.Lock() // defer A.Unlock() or similar.
 ```
+
+Another common sources of deadlocs is duplicate take a lock in a goroutine:
+```
+A.Rlock() or lock()
+
+A.lock() or A.RLock()
+```
+
 This does not guarantee a deadlock (maybe the goroutines above can never be running at the same time), but it usually a design flaw at least.
 
 go-deadlock can detect such cases (unless you cross goroutine boundary - say lock A, then spawn a goroutine, block until it is singals, and lock B inside of the goroutine), even if the deadlock itself happens very infrequently and is painful to reproduce!


### PR DESCRIPTION
Updating the github.com/sasha-s/go-deadlock dependency to the current master with the vendor tool adds detection of duplicate locking. The diff on the README.md is like this:

```
 A.Lock() // defer A.Unlock() or similar.
+
+Another common sources of deadlocs is duplicate take a lock in a goroutine:
+
+A.Rlock() or lock()
+
+A.lock() or A.RLock()
+
+
 This does not guarantee a deadlock (maybe the goroutines above can never be running at the same time), but it usually a design flaw at least.
```
The problem is that we have seemed to assume it top be safe for the same goroutine to take an RLock twice. In reality, if another goroutine takes a write Lock on the same lock in between the two RLocks in the first goroutine, both of these goroutines will block forever (deadlock). This is due to go RW lock being "write preferred", meaning that after a write lock is blocking, all further read lock attempts block., and the first read lock will never be released.

Even the pkg/lock unit test fails with this updated go-deadlock, as it also assumes that taking a read lock twice in the same goroutine should succeed.

Fix this and a detected double RLock in the option package.

Fixes: #2205 
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
