### PR TITLE
cmd: fixing cilium endpoint list output

### DIFF
--- a/cilium/cmd/endpoint_list.go
+++ b/cilium/cmd/endpoint_list.go
@@ -126,7 +126,7 @@ func printEndpointList(w *tabwriter.Writer, eps []*models.Endpoint) {
 					listEndpoint(w, ep, id, lbl)
 					first = false
 				} else {
-					fmt.Fprintf(w, "\t\t\t%s\t\t\t\t\n", lbl)
+					fmt.Fprintf(w, "\t\t\t\t%s\t\t\t\t\n", lbl)
 				}
 			}
 		}


### PR DESCRIPTION
Fixing output of cilium endpoint list an endpoint with multi labels

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Fix output of cilium endpoint list for endpoints using multiple labels.
```