### PR TITLE
Documentation: use VERSION file

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -61,12 +61,14 @@ author = u'Cilium Authors'
 # built documents.
 #
 # The short X.Y version.
-release = re.sub('^v', '', os.popen('git describe --tags').read().strip())
-# The full version, including alpha/beta/rc tags.
-version = release
+release = open("../VERSION", "r").read().strip()
 
-# The current branch
-branch = os.popen('git rev-parse --abbrev-ref HEAD').read().strip()
+# Asume the current branch is master but check with VERSION file.
+branch = "master"
+if not release.endswith(".90"):
+    semver = release.split(".")
+    branch = "v{}.{}".format(semver[0], semver[1])
+
 githubusercontent = 'https://raw.githubusercontent.com/cilium/cilium/'
 scm_web = githubusercontent + branch
 


### PR DESCRIPTION
If the release ends with the `.90` patch we know the branch should be
master. For everything else use the release format "v{major}.{minor}".

Closes: #1805 (Documentation website title includes outdated cilium version)
Suggested-by: Thomas Graf <thomas@cilium.io>
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>