### PR TITLE
pkg: fixed monitor output for conntrack messages

### DIFF
--- a/pkg/bpfdebug/debug.go
+++ b/pkg/bpfdebug/debug.go
@@ -159,8 +159,8 @@ func ctInfo(arg1 uint32, arg2 uint32) string {
 }
 
 func ctLookup4Info1(n *DebugMsg) string {
-	return fmt.Sprintf("src=%s:%d dst=%s:%d", ip4Str(n.Arg2),
-		n.Arg3&0xFFFF, ip4Str(n.Arg1), n.Arg3>>16)
+	return fmt.Sprintf("src=%s:%d dst=%s:%d", ip4Str(n.Arg1),
+		n.Arg3&0xFFFF, ip4Str(n.Arg2), n.Arg3>>16)
 }
 
 func ctLookup4Info2(n *DebugMsg) string {


### PR DESCRIPTION
Fixed swapped src dst IPs on Conntrack related messages on the
monitor's output:

before fix:
CPU 00: MARK 0xb140dcc2 FROM 29140 DEBUG: Conntrack lookup 1/2: src=10.15.71.108:58582 dst=10.15.22.134:85

after fix:
CPU 00: MARK 0xb140dcc2 FROM 29140 DEBUG: Conntrack lookup 1/2: src=10.15.22.134:58582 dst=10.15.71.108:85

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Fix swapped src dst IPs on Conntrack related messages on the monitor's output
```