### PR TITLE
Makefile: add target for checking if pkg/lock or sync.Mutex is used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BPF_SRCFILES=$(shell find bpf/ -name *.[ch] -print)
 
 GOTEST_OPTS = -test.v -check.v
 
-all: precheck-gofmt build cmdref-check
+all: precheck-gofmt build cmdref-check lock-check
 	@echo "Build finished."
 
 build: $(SUBDIRS)
@@ -233,6 +233,9 @@ install-manpages:
 
 cmdref-check:
 	tests/00-check-cmdref.sh
+
+lock-check:
+	contrib/scripts/lock-check.sh
 
 .PHONY: force
 force :;

--- a/contrib/scripts/lock-check.sh
+++ b/contrib/scripts/lock-check.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Copyright 2017 Authors of Cilium
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Used to cause failure when pkg/lock is not used
+for l in sync.Mutex sync.RWMutex; do
+  if grep -r --exclude-dir={vendor,externalversions,lock,contrib} -i --include \*.go "$l" .; then
+    echo "Found $l usage. Please use pkg/lock instead to improve deadlock detection";
+    exit 1
+  fi
+done

--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -20,15 +20,15 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"sync"
 
 	"github.com/cilium/cilium/common"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 )
 
 var (
 	log                  = logging.DefaultLogger
-	validLabelPrefixesMU sync.RWMutex
+	validLabelPrefixesMU lock.RWMutex
 	validLabelPrefixes   *labelPrefixCfg // Label prefixes used to filter from all labels
 )
 

--- a/pkg/policy/prefilter.go
+++ b/pkg/policy/prefilter.go
@@ -20,10 +20,10 @@ import (
 	"net"
 	"os/exec"
 	"path"
-	"sync"
 	"syscall"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/maps/cidrmap"
 )
 
@@ -58,7 +58,7 @@ type PreFilter struct {
 	maps     preFilterMaps
 	config   preFilterConfig
 	revision int64
-	mutex    sync.RWMutex
+	mutex    lock.RWMutex
 }
 
 // WriteConfig dumps the configuration for the corresponding header file

--- a/pkg/proxy/server_test.go
+++ b/pkg/proxy/server_test.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"sync"
 	"time"
+
+	"github.com/cilium/cilium/pkg/lock"
 
 	"github.com/optiopay/kafka/proto"
 )
@@ -33,7 +34,7 @@ type RequestHandler func(request Serializable) (response Serializable)
 type Server struct {
 	Processed int
 
-	mu       sync.RWMutex
+	mu       lock.RWMutex
 	ln       net.Listener
 	clients  map[int64]net.Conn
 	handlers map[int16]RequestHandler

--- a/pkg/workloads/containerd/ignore.go
+++ b/pkg/workloads/containerd/ignore.go
@@ -15,11 +15,11 @@
 package containerd
 
 import (
-	"sync"
+	"github.com/cilium/cilium/pkg/lock"
 )
 
 var (
-	ignoredMutex      sync.RWMutex
+	ignoredMutex      lock.RWMutex
 	ignoredContainers = make(map[string]int)
 )
 


### PR DESCRIPTION
Makes the build fail if the lock package is not used.

Closes: #1702 (Add check to Makefile build to ensure that Cilium uses `pkg/lock` and not `sync.Mutex`)
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>