### PR TITLE
pkg/k8s: add policy enforcement from any namespace

### DIFF
--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -118,6 +118,20 @@ func (n EndpointSelector) HasKeyPrefix(prefix string) bool {
 	return false
 }
 
+// HasKey checks if the endpoint selector contains the given key in
+// its MatchLabels map or in its MatchExpressions slice.
+func (n EndpointSelector) HasKey(key string) bool {
+	if _, ok := n.MatchLabels[key]; ok {
+		return true
+	}
+	for _, v := range n.MatchExpressions {
+		if v.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
 // NewWildcardEndpointSelector returns a selector that matches on all endpoints
 func NewWildcardEndpointSelector() EndpointSelector {
 	return EndpointSelector{&metav1.LabelSelector{MatchLabels: map[string]string{}}}

--- a/tests/k8s/tests/deployments/l7-stresstest/policies/cnp-any-namespace-deprecated.yaml
+++ b/tests/k8s/tests/deployments/l7-stresstest/policies/cnp-any-namespace-deprecated.yaml
@@ -1,0 +1,24 @@
+apiVersion: "cilium.io/v1"
+kind: CiliumNetworkPolicy
+description: "Policy to stress test L7 proxy"
+metadata:
+  name: "l7-stresstest-deprecated"
+  namespace: "development"
+spec:
+  endpointSelector:
+    matchLabels:
+      id: server
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        id: client
+      matchExpressions:
+      - {key: 'k8s:io.kubernetes.pod.namespace', operator: Exists}
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+      rules:
+        http:
+        - method: "GET"
+          path: "/$"

--- a/tests/k8s/tests/deployments/l7-stresstest/policies/cnp-any-namespace.yaml
+++ b/tests/k8s/tests/deployments/l7-stresstest/policies/cnp-any-namespace.yaml
@@ -1,0 +1,24 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+description: "Policy to stress test L7 proxy"
+metadata:
+  name: "l7-stresstest"
+  namespace: "development"
+spec:
+  endpointSelector:
+    matchLabels:
+      id: server
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        id: client
+      matchExpressions:
+      - {key: 'k8s:io.kubernetes.pod.namespace', operator: Exists}
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+      rules:
+        http:
+        - method: "GET"
+          path: "/$"


### PR DESCRIPTION
Add ability to enforce policy from any namespace using:
```
  matchExpressions:
  - {key: 'k8s:io.kubernetes.pod.namespace', operator: Exists}
```
on the cilium network policy

Fixes: #1957

```release-note
Enabled policy enforcement on cilium network policy from any namespace
```