### PR TITLE
Documentation: backwards compatible prometheus example

### DIFF
--- a/Documentation/gettingstarted/minikube.rst
+++ b/Documentation/gettingstarted/minikube.rst
@@ -466,10 +466,12 @@ To try out the metrics exported by cilium, simply install the example prometheus
 .. parsed-literal::
 
    $ kubectl create -f \ |SCM_WEB|\/examples/kubernetes/prometheus.yaml
+   $ kubectl replace --force -f \ |SCM_WEB|\/examples/kubernetes/cilium.yaml
 
 
 This will create a barebones prometheus installation that you can use to
-inspect metrics from the agent. Navigate to the web ui with:
+inspect metrics from the agent, then restart cilium so it can consume the new
+prometheus configuration. Navigate to the web ui with:
 
 ::
 

--- a/examples/kubernetes/cilium.yaml
+++ b/examples/kubernetes/cilium.yaml
@@ -25,10 +25,6 @@ data:
   # If you want to run cilium in debug mode change this value to true
   debug: "false"
   disable-ipv4: "false"
-
-  # Allow prometheus to scrape on this addr:port. Not specifying an address
-  # will bind to all available interfaces inthe container.
-  prometheus-serve-addr: ":9090"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret
@@ -131,10 +127,13 @@ spec:
               configMapKeyRef:
                 name: cilium-config
                 key: disable-ipv4
-          - name: "PROMETHEUS_SERVE_ADDR"
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+          - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-config
+                name: cilium-metrics-config
+                optional: true
                 key: prometheus-serve-addr
         livenessProbe:
           exec:

--- a/examples/kubernetes/prometheus.yaml
+++ b/examples/kubernetes/prometheus.yaml
@@ -157,3 +157,15 @@ kind: ServiceAccount
 metadata:
   name: prometheus-k8s
   namespace: prometheus
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cilium-metrics-config
+  namespace: kube-system
+data:
+  # Allow prometheus to scrape on this addr:port. Not specifying an address
+  # will bind to all available interfaces in the container.
+  # Note that this only enables the HTTP server. prometheus must be separately
+  # configured. If you wish to turn this off, set this variable to be empty.
+  prometheus-serve-addr: ":9090"


### PR DESCRIPTION
The prometheus option , --prometheus-serve-addr, is not available in
earlier ciliums and causes older container images to break when using
the newer spec. We now split this configuration into an optional
ConfigMap that is only loaded when a user creates the example prometheus
specs. This should avoid breaking all older versions and, in the case
where a user loads the new config with an older cilium image, the
cause-effect of errors is more tightly bound.

Fixes: https://github.com/cilium/cilium/issues/2229

**How to test (optional)**:
I tested by loading an image with the new cilium and setting `updatePolicy: Never`. I then followed the new instructions. I also tested backwards compatibility by installing cilium with the `v0.12` image (which doesn't have the prometheus option).