### PR TITLE
agent: Allow state transition from waiting-for-identity to regenerate

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -175,8 +175,6 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder 
 	state := ep.GetStateLocked()
 	reason := "Create endpoint from API PUT"
 	if state == endpoint.StateReady || state == endpoint.StateWaitingForIdentity {
-		// state not changed if it is "waiting-for-identity",
-		// but we still trigger the initial build.
 		// Note that the endpoint state can initially also be "creating", and the
 		// initial build will not be done yet in that case. A following PATCH
 		// request will be needed to change the state and trigger bpf build.

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1375,7 +1375,7 @@ func (e *Endpoint) SetStateLocked(toState, reason string) bool {
 		}
 	case StateWaitingForIdentity:
 		switch toState {
-		case StateReady, StateDisconnecting:
+		case StateReady, StateDisconnecting, StateWaitingToRegenerate:
 			goto OKState
 		}
 	case StateReady:

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -194,7 +194,7 @@ func (s *EndpointSuite) TestEndpointState(c *C) {
 	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, false)
 	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, true)
 	e.state = StateWaitingForIdentity
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, false)
+	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, true)
 	c.Assert(e.SetStateLocked(StateRegenerating, "test"), Equals, false)
 	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, true)
 	e.state = StateWaitingForIdentity


### PR DESCRIPTION
This state transition can happen when the identity is the last piece of
information to be resolved before the initial endpoint build can occur.

Fixes: #2232

Signed-off-by: Thomas Graf <thomas@cilium.io>

```release-note
Fix bug when endpoint does not get out of WaitingForIdentity state
```