### PR TITLE
Reject l3 dependent l7 when proxy is not able to enforce it

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -30,7 +30,6 @@ cilium-agent
   -e, --docker string                     Path to docker runtime socket (default "unix:///var/run/docker.sock")
       --enable-policy string              Enable policy enforcement (default "default")
       --enable-tracing                    Enable tracing while determining policy (debugging)
-      --envoy-proxy                       Use Envoy for HTTP proxy
       --ipv4-cluster-cidr-mask-size int   Mask size for the cluster wide CIDR (default 8)
       --ipv4-node string                  IPv4 address of node (default "auto")
       --ipv4-range string                 Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")
@@ -44,6 +43,7 @@ cilium-agent
       --keep-config                       When restoring state, keeps containers' configuration in place
       --kvstore string                    Key-value store type
       --kvstore-opt map                   Key-value store options (default map[])
+      --l7-proxy string                   L7 proxy: oxy or envoy (default "oxy")
       --label-prefix-file string          Valid label prefixes file path
       --labels stringSlice                List of label prefixes used to determine identity of an endpoint
       --lb string                         Enables load balancer mode where load balancer bpf program is attached to the given interface

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -87,6 +87,9 @@ type Config struct {
 
 	// Monitor contains the configuration for the node monitor.
 	Monitor *models.MonitorStatus
+
+	// proxyKind contains which proxy will be used.
+	proxyKind string
 }
 
 func NewConfig() *Config {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -62,7 +62,6 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/mattn/go-shellwords"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"github.com/vishvananda/netlink"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -125,13 +124,7 @@ func (d *Daemon) UpdateProxyRedirect(e *endpoint.Endpoint, l4 *policy.L4Filter) 
 		return 0, fmt.Errorf("can't redirect, proxy disabled")
 	}
 
-	// proxyKind only has an effects on newly created redirects
-	proxyKind := proxy.ProxyKindOxy
-	if viper.GetBool("envoy-proxy") {
-		proxyKind = proxy.ProxyKindEnvoy
-	}
-
-	r, err := d.l7Proxy.CreateOrUpdateRedirect(l4, e.ProxyID(l4), e, proxyKind)
+	r, err := d.l7Proxy.CreateOrUpdateRedirect(l4, e.ProxyID(l4), e)
 	if err != nil {
 		return 0, err
 	}
@@ -1077,7 +1070,7 @@ func NewDaemon(c *Config) (*Daemon, error) {
 	}
 
 	// FIXME: Make configurable
-	d.l7Proxy = proxy.NewProxy(10000, 20000)
+	d.l7Proxy = proxy.NewProxy(c.proxyKind, 10000, 20000)
 
 	if c.RestoreState {
 		if err := d.SyncState(d.conf.StateDir, true); err != nil {

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -47,7 +47,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/pprof"
-	"github.com/cilium/cilium/pkg/proxy"
+	proxyConst "github.com/cilium/cilium/pkg/proxy/constant"
 	"github.com/cilium/cilium/pkg/version"
 	"github.com/cilium/cilium/pkg/workloads/containerd"
 
@@ -369,7 +369,7 @@ func init() {
 	flags.StringSliceVar(&validLabels,
 		"labels", []string{}, "List of label prefixes used to determine identity of an endpoint")
 	flags.StringVar(&config.proxyKind,
-		"l7-proxy", proxy.ProxyKindOxy, "L7 proxy: "+proxy.ProxyKindOxy+" or "+proxy.ProxyKindEnvoy)
+		"l7-proxy", proxyConst.ProxyKindOxy, "L7 proxy: "+proxyConst.ProxyKindOxy+" or "+proxyConst.ProxyKindEnvoy)
 	flags.StringVar(&config.LBInterface,
 		"lb", "", "Enables load balancer mode where load balancer bpf program is attached to the given interface")
 	flags.StringVar(&config.LibDir,
@@ -489,7 +489,7 @@ func initEnv(cmd *cobra.Command) {
 
 	if os.Getenv("CILIUM_USE_ENVOY") != "" {
 		log.Info("CILIUM_USE_ENVOY set, using envoy proxy")
-		config.proxyKind = proxy.ProxyKindEnvoy
+		config.proxyKind = proxyConst.ProxyKindEnvoy
 	}
 
 	if config.IPv4Disabled {

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/pprof"
+	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/version"
 	"github.com/cilium/cilium/pkg/workloads/containerd"
 
@@ -343,9 +344,6 @@ func init() {
 	flags.String("enable-policy", endpoint.DefaultEnforcement, "Enable policy enforcement")
 	flags.BoolVar(&enableTracing,
 		"enable-tracing", false, "Enable tracing while determining policy (debugging)")
-	flags.BoolVar(&useEnvoy,
-		"envoy-proxy", false, "Use Envoy for HTTP proxy")
-	viper.BindEnv("envoy-proxy", "CILIUM_USE_ENVOY")
 	flags.StringVar(&v4Prefix,
 		"ipv4-range", AutoCIDR, "Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16")
 	flags.StringVar(&v6Prefix,
@@ -370,6 +368,8 @@ func init() {
 		"label-prefix-file", "", "Valid label prefixes file path")
 	flags.StringSliceVar(&validLabels,
 		"labels", []string{}, "List of label prefixes used to determine identity of an endpoint")
+	flags.StringVar(&config.proxyKind,
+		"l7-proxy", proxy.ProxyKindOxy, "L7 proxy: "+proxy.ProxyKindOxy+" or "+proxy.ProxyKindEnvoy)
 	flags.StringVar(&config.LBInterface,
 		"lb", "", "Enables load balancer mode where load balancer bpf program is attached to the given interface")
 	flags.StringVar(&config.LibDir,
@@ -485,6 +485,11 @@ func initEnv(cmd *cobra.Command) {
 
 	if viper.GetBool("pprof") {
 		pprof.Enable()
+	}
+
+	if os.Getenv("CILIUM_USE_ENVOY") != "" {
+		log.Info("CILIUM_USE_ENVOY set, using envoy proxy")
+		config.proxyKind = proxy.ProxyKindEnvoy
 	}
 
 	if config.IPv4Disabled {

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/proxy/constant"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/op/go-logging"
@@ -246,6 +247,13 @@ func (d *Daemon) PolicyAdd(rules api.Rules, opts *AddOptions) (uint64, error) {
 	for _, r := range rules {
 		if err := r.Sanitize(); err != nil {
 			return 0, apierror.Error(PutPolicyFailureCode, err)
+		}
+	}
+	switch l7 := rules.L7Type(); l7 {
+	case constant.ProxyKindEnvoy:
+		if daemonl7Kind := d.l7Proxy.GetKind(); daemonl7Kind == constant.ProxyKindOxy {
+			return 0, fmt.Errorf("Selected proxy %q is not able to enforce this rule. "+
+				"Please start cilium with a capable l7 proxy (e.g. %q)", daemonl7Kind, constant.ProxyKindEnvoy)
 		}
 	}
 

--- a/pkg/proxy/constant/const.go
+++ b/pkg/proxy/constant/const.go
@@ -1,0 +1,21 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constant
+
+// Supported proxy types
+const (
+	ProxyKindOxy   = "oxy"
+	ProxyKindEnvoy = "envoy"
+)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
+	"github.com/cilium/cilium/pkg/proxy/constant"
 
 	"github.com/spf13/viper"
 )
@@ -51,12 +52,6 @@ const (
 	fieldFd              = "fd"
 	fieldProxyRedirectID = "id"
 	fieldProxyKind       = "kind"
-)
-
-// Supported proxy types
-const (
-	ProxyKindOxy   = "oxy"
-	ProxyKindEnvoy = "envoy"
 )
 
 // Redirect is the generic proxy redirect interface that each proxy redirect
@@ -335,6 +330,10 @@ func fillEgressDestinationInfo(info *accesslog.EndpointInfo, ipstr string) {
 	}
 }
 
+func (p *Proxy) GetKind() string {
+	return p.proxyKind
+}
+
 // CreateOrUpdateRedirect creates or updates a L4 redirect with corresponding
 // proxy configuration. This will allocate a proxy port as required and launch
 // a proxy instance. If the redirect is already in place, only the rules will be
@@ -397,9 +396,9 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, source Pr
 			listenPort: to})
 	case policy.ParserTypeHTTP:
 		switch p.proxyKind {
-		case ProxyKindOxy:
+		case constant.ProxyKindOxy:
 			redir, err = createOxyRedirect(l4, id, source, to)
-		case ProxyKindEnvoy:
+		case constant.ProxyKindEnvoy:
 			redir, err = createEnvoyRedirect(l4, id, source, to)
 		default:
 			return nil, fmt.Errorf("Unknown proxy kind: %s", p.proxyKind)

--- a/tests/k8s/tests/deployments/bad-cnp/kafka-l7-policy-v1.yaml
+++ b/tests/k8s/tests/deployments/bad-cnp/kafka-l7-policy-v1.yaml
@@ -1,0 +1,22 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+description: "Policy to test l3-dependent-l7"
+metadata:
+  name: "l3-dependent-l7"
+spec:
+  endpointSelector:
+    matchLabels:
+      id: server
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        id: client
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+      rules:
+        kafka:
+        - apiKey: metadata
+        - topic: allowedTopic
+

--- a/tests/k8s/tests/deployments/bad-cnp/kafka-l7-policy-v2.yaml
+++ b/tests/k8s/tests/deployments/bad-cnp/kafka-l7-policy-v2.yaml
@@ -1,0 +1,22 @@
+apiVersion: "cilium.io/v1"
+kind: CiliumNetworkPolicy
+description: "Policy to test l3-dependent-l7"
+metadata:
+  name: "l3-dependent-l7"
+spec:
+  endpointSelector:
+    matchLabels:
+      id: server
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        id: client
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+      rules:
+        kafka:
+        - apiKey: metadata
+        - topic: allowedTopic
+


### PR DESCRIPTION
- Add new CLI flag to select with L7 proxy the daemon should use
- Reject L3-dependent L7 rules if the L7 proxy is not able to enforce it

Fixes: #2149

```release-note
Reject L3-dependent L7 rules if the L7 proxy is not able to enforce it
```
