### PR TITLE
Jenkinsfile: fail build fast if one parallel stage fails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
                      },
                     "Runtime Tests with Envoy": {
                          // Make sure that VMs from prior runs are cleaned up in case something went wrong in a prior build.
-                         sh 'vagrant destroy -f || true'
+                         sh 'CILIUM_USE_ENVOY=1 vagrant destroy -f || true'
                          sh 'CILIUM_USE_ENVOY=1 ./contrib/vagrant/start.sh'
                      },
                     "K8s multi node Tests": {
@@ -45,6 +45,7 @@ pipeline {
             sh 'rm -rf ${WORKSPACE}/cilium-files*${JOB_BASE_NAME}-${BUILD_NUMBER}* ${WORKSPACE}/tests/cilium-files ${WORKSPACE}/tests/k8s/tests/cilium-files'
             sh 'ls'
             sh 'vagrant destroy -f'
+            sh 'CILIUM_USE_ENVOY=1 vagrant destroy -f'
             sh 'cd ./tests/k8s && vagrant destroy -f'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,8 @@ pipeline {
                     "K8s multi node Tests": {
                          sh 'cd ./tests/k8s && vagrant destroy -f || true'
                          sh './tests/k8s/start.sh'
-                    }
+                    },
+                    failFast: true
                 )
             }
         }


### PR DESCRIPTION
* Set `failFast` option to `true` in the Jenkinsfile so that if any stage in the build fails, all stages terminate and post-build actions are ran immediately. This will increase throughput for jobs on Jenkins.
* Destroy envoy stage VM as part of post-build actions. I found this while making sure that setting `failFast` did not cause any regressions by leaving VMs up and running on Jenkins. This was occurring because there was no invocation of `vagrant destroy -f` with `CILIUM_USE_ENVOY=1` in the Jenkinsfile.

Signed-off by: Ian Vernon <ian@cilium.io>


Fixes:  #2248

```release-note
fail all stages in build if any stage fails in Jenkins
```
