### PR TITLE
test: use cilium/connectivity-container for Nightly tests

### DIFF
--- a/test/k8sT/manifests/client.yaml
+++ b/test/k8sT/manifests/client.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: app-frontend
-    image: byrnedo/alpine-curl
+    image: cilium/connectivity-container:v1.0
     command: [ "sleep" ]
     args:
       - "1000h"

--- a/test/k8sT/manifests/server.yaml
+++ b/test/k8sT/manifests/server.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   containers:
   - name: web
-    image: jojomi/lighttpd-static
+    image: cilium/connectivity-container:v1.0
     ports:
     - containerPort: 80
     volumeMounts:


### PR DESCRIPTION
Use cilium/connectivity-container, which is a small container based on code at
https://github.com/cilium/connectivity-container , which contains a small HTTP
server and curl packaged in for basic connectivity testing. It has a small
memory and CPU footprint, as well as is quick to download. This will allow for
scale testing of Cilium itself without the containers being used for testing
taking up too many resources.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #2118 

```release-note
use cilium/connectivity-container in nightly tests
```

**How to test (optional)**:
`cd test; K8S_VERSION=1.7 ginkgo --focus="Nightly*" -v -noColor`