### PR TITLE
Revert #2237 "agent: Allow state transition from waiting-for-identity..."

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -169,22 +169,24 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder 
 		return apierror.Error(PutEndpointIDFailedCode, err)
 	}
 
-	// Regenerate immediately if ready
+	// Regenerate immediately if ready or waiting for identity
 	ep.Mutex.Lock()
-	ready := false
+	build := false
 	state := ep.GetStateLocked()
 	reason := "Create endpoint from API PUT"
-	if state == endpoint.StateReady || state == endpoint.StateWaitingForIdentity {
+	// Note that the endpoint state can initially also be "creating", and the
+	// initial build will not be done yet in that case. A following PATCH
+	// request will be needed to change the state and trigger bpf build.
+	if state == endpoint.StateReady {
+		ep.SetStateLocked(endpoint.StateWaitingToRegenerate, reason)
+		build = true
+	} else if state == endpoint.StateWaitingForIdentity {
 		// state not changed if it is "waiting-for-identity",
 		// but we still trigger the initial build.
-		// Note that the endpoint state can initially also be "creating", and the
-		// initial build will not be done yet in that case. A following PATCH
-		// request will be needed to change the state and trigger bpf build.
-		ep.SetStateLocked(endpoint.StateWaitingToRegenerate, reason)
-		ready = true
+		build = true
 	}
 	ep.Mutex.Unlock()
-	if ready {
+	if build {
 		if err := ep.RegenerateWait(h.d, reason); err != nil {
 			ep.RemoveDirectory()
 			return apierror.Error(PatchEndpointIDFailedCode, err)

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -175,6 +175,8 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder 
 	state := ep.GetStateLocked()
 	reason := "Create endpoint from API PUT"
 	if state == endpoint.StateReady || state == endpoint.StateWaitingForIdentity {
+		// state not changed if it is "waiting-for-identity",
+		// but we still trigger the initial build.
 		// Note that the endpoint state can initially also be "creating", and the
 		// initial build will not be done yet in that case. A following PATCH
 		// request will be needed to change the state and trigger bpf build.

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1375,7 +1375,7 @@ func (e *Endpoint) SetStateLocked(toState, reason string) bool {
 		}
 	case StateWaitingForIdentity:
 		switch toState {
-		case StateReady, StateDisconnecting, StateWaitingToRegenerate:
+		case StateReady, StateDisconnecting:
 			goto OKState
 		}
 	case StateReady:

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -194,7 +194,7 @@ func (s *EndpointSuite) TestEndpointState(c *C) {
 	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, false)
 	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, true)
 	e.state = StateWaitingForIdentity
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, true)
+	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, false)
 	c.Assert(e.SetStateLocked(StateRegenerating, "test"), Equals, false)
 	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, true)
 	e.state = StateWaitingForIdentity


### PR DESCRIPTION
This reverts commit 8d5295d8ff16512aea7b8c4f8cbc59b208e85485.

There is no evidence from GH issue #2232 that the endpoint actually
had an identity. In the case where an endpoint lacks an identity, it
should remain in "waiting-for-identity" state as long as it takes for
the identity to be resolved.

Furthermore the change in the reverted commit would change endpoint's
state to "waiting-to-regenerate", to "regenerating" and then to
"ready" even in cases where the endpoint does not yet have an identity
and the endpoint is by definition not ready for normal operation.

We call endpoint.SetIdentity() whenever we set or change an endpoint's
identity. This method takes care of transitioning the endpoint away
from the "waiting-for-identity" state. The caller of SetIdentity() is
responsible for triggering endpoint regeneration before releasing the
endpoint's lock when needed. SetIdentity also logs the state
transition with comment "Set identity for this endpoint". The fact
that this transition was not seen in #2232 means that the endpoint
most likely did not have an identity set and was stuck in the
"waiting-for-identity" for a good reason. Another explanation would be
that we have missed a call to SetIdentity() in some call path taken
during the execution in #2232.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
