### PR TITLE
Fix some data races on shutdown of cilium-health

### DIFF
--- a/pkg/health/server/prober.go
+++ b/pkg/health/server/prober.go
@@ -122,12 +122,6 @@ func (p *prober) getResults() []*models.NodeStatus {
 	return result
 }
 
-func (p *prober) getNodes() nodeMap {
-	p.RLock()
-	defer p.RUnlock()
-	return p.nodes
-}
-
 func isIPv4(ip string) bool {
 	netIP := net.ParseIP(ip)
 	return netIP != nil && !strings.Contains(ip, ":")

--- a/pkg/health/server/server.go
+++ b/pkg/health/server/server.go
@@ -152,7 +152,9 @@ func (s *Server) GetStatusResponse() *healthModels.HealthStatusResponse {
 	s.RLock()
 	defer s.RUnlock()
 	return &healthModels.HealthStatusResponse{
-		Local:     s.localStatus,
+		Local: &healthModels.SelfStatus{
+			Name: s.localStatus.Name,
+		},
 		Nodes:     s.connectivity,
 		Timestamp: s.lastProbe.Format(time.RFC3339),
 	}


### PR DESCRIPTION
This series also does some cleanup / simplification, removing a couple of goroutines from this code.

`Reported-by: André Martins <andre@cilium.io>`

Remaining tasks:
* [x] Fix referencing `p.nodes` in `runHTTPProbe()`
* [x] Ensure that `setNodes()` only makes the nodes list available after setting up the map.
* [x] Consolidate logic for choosing IPs to probe via ICMP/HTTP