### PR TITLE
Ginkgo: Fix issues with Kafka test

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -304,8 +304,15 @@ func (s *SSHMeta) PolicyEndpointsSummary() (map[string]int, error) {
 		return result, fmt.Errorf("cannot get endpoints")
 	}
 	status := strings.Split(endpoints.String(), " ")
-	result[Enabled], result[Total] = CountValues("true", status)
-	result[Disabled], result[Total] = CountValues("false", status)
+	for _, kind := range status {
+		switch kind {
+		case OptionIngress, OptionEgress:
+			result[Enabled]++
+		case OptionNone:
+			result[Disabled]++
+		}
+		result[Total]++
+	}
 	return result, nil
 }
 

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -106,9 +106,11 @@ const (
 	OptionNAT46               = "NAT46"
 	OptionIngressPolicy       = "IngressPolicy"
 	OptionEgressPolicy        = "EgressPolicy"
-
-	OptionDisabled = "Disabled"
-	OptionEnabled  = "Enabled"
+	OptionIngress             = "ingress"
+	OptionEgress              = "egress"
+	OptionNone                = "none"
+	OptionDisabled            = "Disabled"
+	OptionEnabled             = "Enabled"
 
 	PingCount          = 5
 	CurlConnectTimeout = 5

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -41,7 +41,7 @@ var _ = Describe("RuntimeKafka", func() {
 		}
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimeKafka"})
 		logger.Info("Starting")
-		vm := helpers.CreateNewRuntimeHelper("runtime", logger)
+		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 		vm.NetworkCreate(helpers.CiliumDockerNetwork, "")
 		initialized = true
 	}


### PR DESCRIPTION
Due to the last changes in the `cilium endpoint list` and the changes in the Docker&Cilium helpers at the moment the Jenkins Ginkgo CI is failing due to a panic exception. 

This code fixes the panic.
 
Regards