### PR TITLE
Ginkgo: Added PolicyGeneration on Nightly tests

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -30,16 +30,22 @@ import (
 
 // CmdRes contains a variety of data which results from running a command.
 type CmdRes struct {
-	cmd    string        // Command to run
-	params []string      // Parameters to provide to command
-	stdout *bytes.Buffer // Stdout from running cmd
-	stderr *bytes.Buffer // Stderr from running cmd
-	exit   bool          // Whether command successfully executed
+	cmd      string        // Command to run
+	params   []string      // Parameters to provide to command
+	stdout   *bytes.Buffer // Stdout from running cmd
+	stderr   *bytes.Buffer // Stderr from running cmd
+	exit     bool          // Whether command successfully executed
+	exitcode int           // The exitcode result from command execution
 }
 
 // GetCmd returns res's cmd.
 func (res *CmdRes) GetCmd() string {
 	return res.cmd
+}
+
+// GetExitCode returns res's exitcode.
+func (res *CmdRes) GetExitCode() int {
+	return res.exitcode
 }
 
 // GetStdOut returns the contents of the stdout buffer of res as a string.

--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -35,7 +35,7 @@ type CmdRes struct {
 	stdout   *bytes.Buffer // Stdout from running cmd
 	stderr   *bytes.Buffer // Stderr from running cmd
 	exit     bool          // Whether command successfully executed
-	exitcode int           // The exitcode result from command execution
+	exitcode int           // The exit code of cmd
 }
 
 // GetCmd returns res's cmd.

--- a/test/helpers/docker.go
+++ b/test/helpers/docker.go
@@ -100,6 +100,10 @@ func (s *SSHMeta) NetworkGet(name string) *CmdRes {
 	return s.ExecWithSudo(fmt.Sprintf("docker network inspect %s", name))
 }
 
+func (s *SSHMeta) execCmd(cmd string) *CmdRes {
+	return s.ExecWithSudo(cmd)
+}
+
 // SampleContainersActions creates or deletes various containers used for
 // testing Cilium and adds said containers to the provided Docker network.
 func (s *SSHMeta) SampleContainersActions(mode string, networkName string) {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -137,6 +137,9 @@ func (kub *Kubectl) GetServiceHostPort(namespace string, service string) (string
 	if err != nil {
 		return "", 0, err
 	}
+	if len(data.Spec.Ports) == 0 {
+		return "", 0, fmt.Errorf("Service %q does not have ports defined", service)
+	}
 	return data.Spec.ClusterIP, int(data.Spec.Ports[0].Port), nil
 }
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -81,8 +81,8 @@ func (kub *Kubectl) ExecPodCmd(namespace string, pod string, cmd string) (string
 	command := fmt.Sprintf("%s exec -n %s %s -- %s", kubectl, namespace, pod, cmd)
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-	exit, _ := kub.Execute(command, stdout, stderr)
-	if exit == false {
+	err := kub.Execute(command, stdout, stderr)
+	if err != nil {
 		// TODO: Return CmdRes here
 		// Return the string is not fired on the assertion :\ Need to check
 		kub.logger.Errorf(
@@ -112,11 +112,11 @@ func (kub *Kubectl) GetPodNames(namespace string, label string) ([]string, error
 	stdout := new(bytes.Buffer)
 	filter := "-o jsonpath='{.items[*].metadata.name}'"
 
-	exit, _ := kub.Execute(
+	err := kub.Execute(
 		fmt.Sprintf("%s -n %s get pods -l %s %s", kubectl, namespace, label, filter),
 		stdout, nil)
 
-	if exit == false {
+	if err != nil {
 		return nil, fmt.Errorf(
 			"could not find pods in namespace %q with label %q", namespace, label)
 	}

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -78,7 +78,7 @@ func GetVagrantSSHMeta(vmName string) *SSHMeta {
 // Execute executes cmd on the provided node and stores the stdout / stderr of
 // the command in the provided buffers. Returns false if the command failed
 // during its execution.
-func (s *SSHMeta) Execute(cmd string, stdout io.Writer, stderr io.Writer) (bool, error) {
+func (s *SSHMeta) Execute(cmd string, stdout io.Writer, stderr io.Writer) error {
 	if stdout == nil {
 		stdout = os.Stdout
 	}
@@ -94,11 +94,7 @@ func (s *SSHMeta) Execute(cmd string, stdout io.Writer, stderr io.Writer) (bool,
 		Stderr: stderr,
 	}
 	err := s.sshClient.RunCommand(command)
-	if err != nil {
-		log.WithError(err).Debugf("error while running command: %s", cmd)
-		return false, err
-	}
-	return true, nil
+	return err
 }
 
 // ExecWithSudo returns the result of executing the provided cmd via SSH using
@@ -112,7 +108,11 @@ func (s *SSHMeta) ExecWithSudo(cmd string) *CmdRes {
 func (s *SSHMeta) Exec(cmd string) *CmdRes {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-	exit, err := s.Execute(cmd, stdout, stderr)
+	exit := true
+	err := s.Execute(cmd, stdout, stderr)
+	if err != nil {
+		exit = false
+	}
 	res := CmdRes{
 		cmd:    cmd,
 		stdout: stdout,

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
 )
 
 // SSHMeta contains metadata to SSH into a remote location to run tests
@@ -77,7 +78,7 @@ func GetVagrantSSHMeta(vmName string) *SSHMeta {
 // Execute executes cmd on the provided node and stores the stdout / stderr of
 // the command in the provided buffers. Returns false if the command failed
 // during its execution.
-func (s *SSHMeta) Execute(cmd string, stdout io.Writer, stderr io.Writer) bool {
+func (s *SSHMeta) Execute(cmd string, stdout io.Writer, stderr io.Writer) (bool, error) {
 	if stdout == nil {
 		stdout = os.Stdout
 	}
@@ -95,9 +96,9 @@ func (s *SSHMeta) Execute(cmd string, stdout io.Writer, stderr io.Writer) bool {
 	err := s.sshClient.RunCommand(command)
 	if err != nil {
 		log.WithError(err).Debugf("error while running command: %s", cmd)
-		return false
+		return false, err
 	}
-	return true
+	return true, nil
 }
 
 // ExecWithSudo returns the result of executing the provided cmd via SSH using
@@ -111,17 +112,20 @@ func (s *SSHMeta) ExecWithSudo(cmd string) *CmdRes {
 func (s *SSHMeta) Exec(cmd string) *CmdRes {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-
-	exit := s.Execute(cmd, stdout, stderr)
-
-	res := &CmdRes{
+	exit, err := s.Execute(cmd, stdout, stderr)
+	res := CmdRes{
 		cmd:    cmd,
 		stdout: stdout,
 		stderr: stderr,
 		exit:   exit,
 	}
+	// Set the exitCode if the error is an ExitError
+	if exiterr, ok := err.(*ssh.ExitError); ok {
+		res.exitcode = exiterr.Waitmsg.ExitStatus()
+	}
+
 	res.SendToLog()
-	return res
+	return &res
 }
 
 // GetCopy returns a copy of SSHMeta, useful for parallel requests

--- a/test/helpers/policygen/actions.go
+++ b/test/helpers/policygen/actions.go
@@ -10,7 +10,7 @@ import (
 // HTTPAction runs a helpers.CurlFail from specified pod to a specified target.
 // It needs a `helpers.Kubectl` instance to run the comamnd in the pod. It
 // returns a ResultType struct.
-func HTTPAction(srcPod string, target string, kub *helpers.Kubectl) *ResultType {
+func HTTPAction(srcPod string, target string, kub *helpers.Kubectl) ResultType {
 	command := fmt.Sprintf("%s exec -n %s %s -- %s",
 		"kubectl", helpers.DefaultNamespace,
 		srcPod, helpers.CurlFail(target))
@@ -18,23 +18,23 @@ func HTTPAction(srcPod string, target string, kub *helpers.Kubectl) *ResultType 
 	log.Infof("Executing HTTPAction '%s'", command)
 	res := kub.Exec(command)
 	if res.WasSuccessful() {
-		return &ResultOK
+		return ResultOK
 	}
 	// Curl exitcodes are described in https://curl.haxx.se/libcurl/c/libcurl-errors.html
 	switch exitCode := res.GetExitCode(); exitCode {
 	case 28: //CURLE_OPERATION_TIMEDOUT (28)
-		return &ResultTimeout
+		return ResultTimeout
 	case 22: //CURLE_HTTP_RETURNED_ERROR
-		return &ResultAuth
+		return ResultAuth
 	default:
-		log.Infof("HTTPAction returns exitcode '%d' and it's not handle", exitCode)
-		return &ResultOK
+		log.Infof("HTTPAction returns exitcode '%d' and it's not handled", exitCode)
+		return ResultOK
 	}
-	return nil
+	return ResultType{}
 }
 
 // HTTPActionPrivate runs a CurlAction to private http target using destTargetDetails
-func HTTPActionPrivate(srcPod string, dest *TargetDetails, kub *helpers.Kubectl) *ResultType {
+func HTTPActionPrivate(srcPod string, dest TargetDetails, kub *helpers.Kubectl) ResultType {
 	return HTTPAction(
 		srcPod,
 		fmt.Sprintf("http://%s/private", dest),
@@ -42,7 +42,7 @@ func HTTPActionPrivate(srcPod string, dest *TargetDetails, kub *helpers.Kubectl)
 }
 
 // HTTPActionPublic runs a CurlAction to public http target using destTargetDetails
-func HTTPActionPublic(srcPod string, dest *TargetDetails, kub *helpers.Kubectl) *ResultType {
+func HTTPActionPublic(srcPod string, dest TargetDetails, kub *helpers.Kubectl) ResultType {
 	return HTTPAction(
 		srcPod,
 		fmt.Sprintf("http://%s/public", dest),
@@ -50,20 +50,20 @@ func HTTPActionPublic(srcPod string, dest *TargetDetails, kub *helpers.Kubectl) 
 }
 
 // NetPerfAction TODO make this function
-func NetPerfAction(srcPod string, dest *TargetDetails, kub *helpers.Kubectl) *ResultType {
-	return nil
+func NetPerfAction(srcPod string, dest TargetDetails, kub *helpers.Kubectl) ResultType {
+	return ResultType{}
 }
 
 // PingAction executes a ping from the `srcPod` to the destination Target using
 // Kubectl object. It will return a ResultType based on the exitCode
-func PingAction(srcPod string, dest *TargetDetails, kub *helpers.Kubectl) *ResultType {
+func PingAction(srcPod string, dest TargetDetails, kub *helpers.Kubectl) ResultType {
 	command := fmt.Sprintf("%s exec -n %s %s -- %s",
 		"kubectl", helpers.DefaultNamespace,
 		srcPod, helpers.Ping(dest.IP))
 
 	res := kub.Exec(command)
 	if res.WasSuccessful() {
-		return &ResultOK
+		return ResultOK
 	}
-	return &ResultTimeout
+	return ResultTimeout
 }

--- a/test/helpers/policygen/actions.go
+++ b/test/helpers/policygen/actions.go
@@ -1,0 +1,69 @@
+package policygen
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/test/helpers"
+	log "github.com/sirupsen/logrus"
+)
+
+// HTTPAction runs a helpers.CurlFail from specified pod to a specified target.
+// It needs a `helpers.Kubectl` instance to run the comamnd in the pod. It
+// returns a ResultType struct.
+func HTTPAction(srcPod string, target string, kub *helpers.Kubectl) *ResultType {
+	command := fmt.Sprintf("%s exec -n %s %s -- %s",
+		"kubectl", helpers.DefaultNamespace,
+		srcPod, helpers.CurlFail(target))
+
+	log.Infof("Executing HTTPAction '%s'", command)
+	res := kub.Exec(command)
+	if res.WasSuccessful() {
+		return &ResultOK
+	}
+	// Curl exitcodes are described in https://curl.haxx.se/libcurl/c/libcurl-errors.html
+	switch exitCode := res.GetExitCode(); exitCode {
+	case 28: //CURLE_OPERATION_TIMEDOUT (28)
+		return &ResultTimeout
+	case 22: //CURLE_HTTP_RETURNED_ERROR
+		return &ResultAuth
+	default:
+		log.Infof("HTTPAction returns exitcode '%d' and it's not handle", exitCode)
+		return &ResultOK
+	}
+	return nil
+}
+
+// HTTPActionPrivate runs a CurlAction to private http target using destTargetDetails
+func HTTPActionPrivate(srcPod string, dest *TargetDetails, kub *helpers.Kubectl) *ResultType {
+	return HTTPAction(
+		srcPod,
+		fmt.Sprintf("http://%s/private", dest),
+		kub)
+}
+
+// HTTPActionPublic runs a CurlAction to public http target using destTargetDetails
+func HTTPActionPublic(srcPod string, dest *TargetDetails, kub *helpers.Kubectl) *ResultType {
+	return HTTPAction(
+		srcPod,
+		fmt.Sprintf("http://%s/public", dest),
+		kub)
+}
+
+// NetPerfAction TODO make this function
+func NetPerfAction(srcPod string, dest *TargetDetails, kub *helpers.Kubectl) *ResultType {
+	return nil
+}
+
+// PingAction executes a ping from the `srcPod` to the destination Target using
+// Kubectl object. It will return a ResultType based on the exitCode
+func PingAction(srcPod string, dest *TargetDetails, kub *helpers.Kubectl) *ResultType {
+	command := fmt.Sprintf("%s exec -n %s %s -- %s",
+		"kubectl", helpers.DefaultNamespace,
+		srcPod, helpers.Ping(dest.IP))
+
+	res := kub.Exec(command)
+	if res.WasSuccessful() {
+		return &ResultOK
+	}
+	return &ResultTimeout
+}

--- a/test/helpers/policygen/const.go
+++ b/test/helpers/policygen/const.go
@@ -7,11 +7,10 @@ import (
 )
 
 var (
-	ConnTests        = []string{Ping, HTTP, HTTPPrivate}
-	ConnTestsResults = []ResultType{
+	ConnTests              = []string{Ping, HTTP, HTTPPrivate}
+	ConnTestsFailedResults = []ResultType{
 		ResultTimeout,
 		ResultAuth,
-		ResultOK,
 	}
 	ConnTestsActions = map[string]func(srcPod string, dest *TargetDetails, kub *helpers.Kubectl) *ResultType{
 		Ping:        PingAction,

--- a/test/helpers/policygen/const.go
+++ b/test/helpers/policygen/const.go
@@ -1,3 +1,16 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package policygen
 
 import (
@@ -46,9 +59,9 @@ var (
 	}
 
 	DestinationsTypes = []Target{
-		Target{Kind: service},
-		Target{Kind: nodePort},
-		Target{Kind: direct},
+		{Kind: service},
+		{Kind: nodePort},
+		{Kind: direct},
 	}
 
 	NodePortStart = 10000

--- a/test/helpers/policygen/const.go
+++ b/test/helpers/policygen/const.go
@@ -12,7 +12,7 @@ var (
 		ResultTimeout,
 		ResultAuth,
 	}
-	ConnTestsActions = map[string]func(srcPod string, dest *TargetDetails, kub *helpers.Kubectl) *ResultType{
+	ConnTestsActions = map[string]func(srcPod string, dest TargetDetails, kub *helpers.Kubectl) ResultType{
 		Ping:        PingAction,
 		HTTP:        HTTPActionPublic,
 		HTTPPrivate: HTTPActionPrivate,

--- a/test/helpers/policygen/const.go
+++ b/test/helpers/policygen/const.go
@@ -1,0 +1,77 @@
+package policygen
+
+import (
+	"time"
+
+	"github.com/cilium/cilium/test/helpers"
+)
+
+var (
+	ConnTests        = []string{Ping, HTTP, HTTPPrivate}
+	ConnTestsResults = []ResultType{
+		ResultTimeout,
+		ResultAuth,
+		ResultOK,
+	}
+	ConnTestsActions = map[string]func(srcPod string, dest *TargetDetails, kub *helpers.Kubectl) *ResultType{
+		Ping:        PingAction,
+		HTTP:        HTTPActionPublic,
+		HTTPPrivate: HTTPActionPrivate,
+	}
+
+	ConnResultAllOK = ConnTestSpec{
+		HTTP:        ResultOK,
+		HTTPPrivate: ResultOK,
+		Ping:        ResultOK,
+		UDP:         ResultOK,
+	}
+
+	ConnResultAllTimeout = ConnTestSpec{
+		HTTP:        ResultTimeout,
+		HTTPPrivate: ResultTimeout,
+		Ping:        ResultTimeout,
+		UDP:         ResultTimeout,
+	}
+	ConnResultOnlyHTTP = ConnTestSpec{
+		HTTP:        ResultOK,
+		HTTPPrivate: ResultOK,
+		Ping:        ResultTimeout,
+		UDP:         ResultTimeout,
+	}
+
+	ConnResultOnlyHTTPPrivate = ConnTestSpec{
+		HTTP:        ResultAuth,
+		HTTPPrivate: ResultOK,
+		Ping:        ResultTimeout,
+		UDP:         ResultTimeout,
+	}
+
+	DestinationsTypes = []Target{
+		Target{Kind: service},
+		Target{Kind: nodePort},
+		Target{Kind: direct},
+	}
+
+	NodePortStart = 10000
+
+	ResultTimeout = ResultType{"timeout", false}
+	ResultAuth    = ResultType{"reply", false}
+	ResultOK      = ResultType{"reply", true}
+)
+
+const (
+	ingress = "ingress"
+	egress  = "egress"
+	toPorts = "ToPorts"
+
+	HTTP        = "HTTP"
+	HTTPPrivate = "HTTPPrivate"
+	Ping        = "Ping"
+	UDP         = "UDP"
+
+	service  = "service"
+	nodePort = "NodePort"
+	direct   = "Direct"
+
+	destroyDelay time.Duration = 30 * time.Minute
+)

--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -1,0 +1,641 @@
+package policygen
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"net"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cilium/cilium/test/helpers"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+)
+
+// ConnTestSpec Connectivy Test Specification. This is a struct to use in
+// PolicyTest to determine the result of the TestCase.
+type ConnTestSpec struct {
+	HTTP        ResultType
+	HTTPPrivate ResultType
+	Ping        ResultType
+	UDP         ResultType
+}
+
+// GetField method to retrieve the value of any type of the struct.
+// It is used by `TestSpec` to created expected results
+func (conn *ConnTestSpec) GetField(field string) ResultType {
+	r := reflect.ValueOf(conn)
+	f := reflect.Indirect(r).FieldByName(field)
+	return (f.Interface()).(ResultType)
+}
+
+// PolicyTest is utilized to decribe a new TestCase
+// It needs a described name, the kind of the test (Egrees or Ingress) and the
+// expected result of `ConnTestSpec`
+// Template field is used to render the cilium network policy.
+type PolicyTest struct {
+	name     string
+	kind     string //Egress/ingress
+	tests    ConnTestSpec
+	template map[string]string
+}
+
+// SetTemplate renders the template field from the PolicyTest struct using go
+// templates. The result will be stored in the result parameter, the spec
+// parameters is needed to retrieve the source and destination pods and pass
+// the information to the go template.
+func (pol *PolicyTest) SetTemplate(result *map[string]interface{}, spec *TestSpec) error {
+	getTemplate := func(tmpl string) (*bytes.Buffer, error) {
+		t, err := template.New("").Parse(tmpl)
+		if err != nil {
+			return nil, err
+		}
+		content := new(bytes.Buffer)
+		err = t.Execute(content, spec)
+		if err != nil {
+			return nil, err
+		}
+		return content, nil
+	}
+
+	for k, v := range pol.template {
+
+		tmpl, err := getTemplate(v)
+		if err != nil {
+			return err
+		}
+		var data interface{}
+		err = json.Unmarshal(tmpl.Bytes(), &data)
+		if err != nil {
+			return err
+		}
+		(*result)[k] = data
+	}
+	return nil
+}
+
+// ResultType each connectivity test needs to have an expected result. This
+// result is defined in ResultType. Some ResultTypes s are defined under
+// policygen.const
+type ResultType struct {
+	kind    string // Timeout, reply
+	success bool   // If the cmd exec is valid or not.
+}
+
+// String returns the the ResultType in humman readable format
+func (res ResultType) String() string {
+	return fmt.Sprintf("kind: %s sucess: %t", res.kind, res.success)
+}
+
+// PolicyTestSuite  helper struct to store all different policies types
+type PolicyTestSuite struct {
+	l3Checks []PolicyTest
+	l4Checks []PolicyTest
+	l7Checks []PolicyTest
+}
+
+// Target struct to define the destination that wee need to use for the
+// testcase
+type Target struct {
+	Kind       string // serviceL3, serviceL4, NodePort, Direct
+	PortNumber int
+}
+
+// SetPortNumber returns a non used host(Kubernetes node) port to set in the
+// NodePort Service configuration.
+func (t *Target) SetPortNumber() int {
+	NodePortStart++
+	t.PortNumber = NodePortStart
+	return t.PortNumber
+}
+
+// GetTarget returns a `TargetDetails` struct with the IP and Port to  be able
+// to execute the actions for the test spec. It needs the `TestSpec` parameter
+// to be able to retrieve the service name. It'll return an error if the
+// service is not defined or cannot be retrieved. This function only returns
+// the first port mapped in the service, it'll not work with multiple ports.
+func (t *Target) GetTarget(spec *TestSpec) (*TargetDetails, error) {
+
+	switch t.Kind {
+	case nodePort, service:
+		host, port, err := spec.Kub.GetServiceHostPort(helpers.DefaultNamespace, t.GetServiceName(spec))
+		if err != nil {
+			return nil, err
+		}
+		return &TargetDetails{
+			Port: port,
+			IP:   host,
+		}, nil
+	case direct:
+		filter := `{.status.podIP}{"="}{.spec.containers[0].ports[0].containerPort}`
+		res, err := spec.Kub.Get(helpers.DefaultNamespace, fmt.Sprintf("pod %s", spec.DestPod)).Filter(filter)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get pod '%s' info: %s", spec.DestPod, err)
+		}
+		vals := strings.Split(res.String(), "=")
+		port, err := strconv.Atoi(vals[1])
+		if err != nil {
+			return nil, fmt.Errorf("cannot get pod '%s' port: %s", spec.DestPod, err)
+		}
+		return &TargetDetails{
+			Port: port,
+			IP:   vals[0],
+		}, nil
+	}
+	return nil, fmt.Errorf("Not Implemented yet")
+}
+
+// GetServiceName returns an string with the service name using the spec
+// parameter
+func (t *Target) GetServiceName(spec *TestSpec) string {
+	return fmt.Sprintf("%s-%s", strings.ToLower(t.Kind), spec.Prefix)
+}
+
+//GetManifestName returns the manifest filename for the target using the spec
+//parameter
+func (t *Target) GetManifestName(spec *TestSpec) string {
+	return fmt.Sprintf("%s_%s_manifest.json", spec.Prefix, strings.ToLower(t.Kind))
+}
+
+// GetManifestPath returns the manifest path for the target using the spec
+// parameter
+func (t *Target) GetManifestPath(spec *TestSpec) string {
+	return fmt.Sprintf("%s/%s", helpers.BasePath, t.GetManifestName(spec))
+}
+
+// CreateApplyManifest it creates the manifest for the type of the target and
+// applied it in kubernetes. It will fail if the service manifest cannot be
+// created correctly or applied to kubernetes
+func (t *Target) CreateApplyManifest(spec *TestSpec) error {
+	manifestPath := t.GetManifestPath(spec)
+	getTemplate := func(tmpl string) (*bytes.Buffer, error) {
+		metadata := map[string]interface{}{
+			"spec":       spec,
+			"target":     t,
+			"targetName": t.GetServiceName(spec),
+		}
+		t, err := template.New("").Parse(tmpl)
+		if err != nil {
+			return nil, err
+		}
+		content := new(bytes.Buffer)
+		err = t.Execute(content, metadata)
+		if err != nil {
+			return nil, err
+		}
+		return content, nil
+	}
+
+	switch t.Kind {
+	case service:
+		service := `{
+		"apiVersion": "v1",
+		"kind": "Service",
+		"metadata": {
+			"name": "{{ .targetName }}"
+		},
+		"spec": {
+			"ports": [
+				{ "port": 80 }
+			],
+			"selector": {
+				"id": "{{ .spec.DestPod }}"
+			}
+		}}`
+		data, err := getTemplate(service)
+		if err != nil {
+			return fmt.Errorf("cannot render template: %s", err)
+		}
+		err = helpers.RenderTemplateToFile(t.GetManifestName(spec), data.String(), os.ModePerm)
+		if err != nil {
+			return err
+		}
+	case nodePort:
+		t.SetPortNumber()
+		nodePort := `
+		{
+		  "apiVersion": "v1",
+		  "kind": "Service",
+		  "metadata": {
+			"name": "{{ .targetName }}"
+		  },
+		  "spec": {
+			"type": "NodePort",
+			"ports": [
+			  {
+				"targetPort": 80,
+				"port": {{ .target.PortNumber }},
+				"protocol": "TCP"
+			  }
+			],
+			"selector": {
+			  "id": "{{ .spec.DestPod }}"
+			}
+		  }
+		}`
+
+		data, err := getTemplate(nodePort)
+		if err != nil {
+			return fmt.Errorf("cannot render template: %s", err)
+		}
+
+		err = helpers.RenderTemplateToFile(t.GetManifestName(spec), data.String(), os.ModePerm)
+		if err != nil {
+			return err
+		}
+	case direct:
+		return nil
+	}
+	res := spec.Kub.Apply(manifestPath)
+	if !res.WasSuccessful() {
+		return fmt.Errorf("%s", res.CombineOutput())
+	}
+	return nil
+}
+
+// TargetDetails helper struct to store the IP and Port
+type TargetDetails struct {
+	Port int
+	IP   string
+}
+
+// String combines host and port into a network address of the
+// form "host:port" or, if host contains a colon or a percent sign,
+// "[host]:port".
+func (target TargetDetails) String() string {
+	return net.JoinHostPort(target.IP, fmt.Sprintf("%d", target.Port))
+}
+
+// TestSpec struct is where a new test specification is defined. It contains
+// three different rules (l3,l4,l7) and a destination and source pod in which
+// test will run. Each testSpec has a prefix, that is a label that is used to
+// group all resources created by the TestSpec. Each test is going to be
+// executed using a type of Destination that is defined under Target struct.
+// This struct needs a `*helpers.Kubectl` to run the needed commands
+type TestSpec struct {
+	l3          PolicyTest
+	l4          PolicyTest
+	l7          PolicyTest
+	SrcPod      string
+	DestPod     string
+	Prefix      string
+	Destination Target
+	Kub         *helpers.Kubectl
+}
+
+// String: return the testSpec definition on human readable format
+func (t TestSpec) String() string {
+	return fmt.Sprintf("L3:%s L4:%s L7:%s Destination:%s",
+		t.l3.name, t.l4.name, t.l7.name, t.Destination.Kind)
+}
+
+// RunTest is the method that runs all the `TestSpec` methods and makes the
+// needed assertions for Ginkgo tests. This method will create pods manifest,
+// wait for pods to be ready, apply a new cilium network policy and create a
+// new Destination (Service, NodePort) if it's needed. When all of this happen
+// it'll execute the `connectivityTest` and validated that it is the expected
+// result.
+func (t *TestSpec) RunTest(kub *helpers.Kubectl) {
+	defer func() { go t.Destroy(destroyDelay) }()
+	t.Kub = kub
+	err := t.CreateManifests()
+	gomega.Expect(err).To(gomega.BeNil(), "cannot create pods manifest for %s", t.Prefix)
+
+	manifest, err := t.ApplyManifest()
+	gomega.Expect(err).To(gomega.BeNil(), "cannot apply pods manifest for %s", t.Prefix)
+	log.WithField("prefix", t.Prefix).Infof("Manifest '%s' is created correctly", manifest)
+
+	err = t.NetworkPolicyApply()
+	gomega.Expect(err).To(gomega.BeNil(), "cannot apply network policy for %s", t.Prefix)
+
+	err = t.Destination.CreateApplyManifest(t)
+	gomega.Expect(err).To(gomega.BeNil(), "cannot apply destination for %s", t.Prefix)
+
+	err = t.ExecTest()
+	gomega.Expect(err).To(gomega.BeNil(), "cannot execute test for %s", t.Prefix)
+}
+
+// Destroy will delete all the pods, cnp and Destinations that was created by
+// `TestSpec`. It needs a delay parameter that means that it'll delete it after
+// the specified time. (This is to keep the Nightly test under consider load)
+func (t *TestSpec) Destroy(delay time.Duration) error {
+	manifestToDestroy := []string{
+		t.GetManifestsPath(),
+		fmt.Sprintf("%s/%s", helpers.BasePath, t.NetworkPolicyName()),
+		fmt.Sprintf("%s", t.Destination.GetManifestPath(t)),
+	}
+
+	done := time.After(delay)
+
+	for {
+		select {
+		case <-done:
+			for _, manifest := range manifestToDestroy {
+				t.Kub.Delete(manifest)
+			}
+		}
+	}
+}
+
+// GetManifestName returns an string with the `TestSpec` manifest name
+func (t *TestSpec) GetManifestName() string {
+	return fmt.Sprintf("%s_manifest.yaml", t.Prefix)
+}
+
+// GetManifestsPath returns the `TestSpec` manifest path
+func (t *TestSpec) GetManifestsPath() string {
+	return fmt.Sprintf("%s/%s", helpers.BasePath, t.GetManifestName())
+}
+
+// CreateManifests creates a new pod manifest. It will set a random prefix for
+// the `TestCase` and it creates two new pods (srcPod and DestPod). It will
+// return an error in case that the manifest cannot be created.
+func (t *TestSpec) CreateManifests() error {
+	t.Prefix = helpers.MakeUID()
+	t.SrcPod = fmt.Sprintf("%s-%s", t.Prefix, helpers.MakeUID())
+	t.DestPod = fmt.Sprintf("%s-%s", t.Prefix, helpers.MakeUID())
+
+	manifest := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: %[2]s
+  labels:
+    id: %[2]s
+    zgroup: %[1]s
+spec:
+  containers:
+  - name: app-frontend
+    image: byrnedo/alpine-curl
+    command: [ "sleep" ]
+    args:
+      - "1000h"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: %[3]s
+  labels:
+    id: %[3]s
+    zgroup: %[1]s
+spec:
+  containers:
+  - name: web
+    image: cilium/demo-httpd
+    ports:
+      - containerPort: 80`
+
+	err := helpers.RenderTemplateToFile(
+		t.GetManifestName(),
+		fmt.Sprintf(manifest, t.Prefix, t.SrcPod, t.DestPod),
+		os.ModePerm)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// ApplyManifest applies a new deployment manifest into the kubernetes cluster.
+// It'll return an error if the manifest cannot be applied correctly
+func (t *TestSpec) ApplyManifest() (string, error) {
+	err := t.CreateManifests()
+	if err != nil {
+		return "", err
+	}
+	res := t.Kub.Apply(t.GetManifestsPath())
+	if !res.WasSuccessful() {
+		return "", fmt.Errorf("%s", res.CombineOutput())
+	}
+	status, err := t.Kub.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l zgroup=%s", t.Prefix), 300)
+	if err != nil || !status {
+		return "", err
+	}
+	return t.GetManifestName(), nil
+}
+
+// GetPodMetadata returns a map with the pod name and the IP for the pods used
+// by the `TestSpec`. It will return an error in case that the pod info cannot
+// be retrieved correctly.
+func (t *TestSpec) GetPodMetadata() (map[string]string, error) {
+	result := make(map[string]string)
+	filter := `{range .items[*]}{@.metadata.name}{"="}{@.status.podIP}{"\n"}{end}`
+
+	res := t.Kub.Get(helpers.DefaultNamespace, fmt.Sprintf("pods -l zgroup=%s", t.Prefix))
+	data, err := res.Filter(filter)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, line := range strings.Split(data.String(), "\n") {
+		vals := strings.Split(line, "=")
+		if len(vals) == 2 {
+			result[vals[0]] = vals[1]
+		}
+	}
+	return result, nil
+}
+
+// NetworkPolicyCreate returns a network policy based on the `TestSpec` l3,l4
+// and l7 rules. It will return an error if any of the `PolicyTest` set
+// Template fails or if spec cannot be dump as string
+func (t *TestSpec) NetworkPolicyCreate() (string, error) {
+
+	type rule map[string]interface{}
+
+	type endpointSelector struct {
+		Matchlabels map[string]string `json:"matchlabels"`
+	}
+
+	type Spec struct {
+		EndpointSelector endpointSelector
+		Ingress          []rule
+		Egress           []rule
+	}
+	specs := []Spec{}
+	var err error
+
+	ingressMap := map[string]interface{}{}
+	l4ingress := map[string]interface{}{}
+	egressMap := map[string]interface{}{}
+	l4egress := map[string]interface{}{}
+
+	metadata := []byte(`
+	{
+	  "apiVersion": "cilium.io/v2",
+	  "kind": "CiliumNetworkPolicy",
+	  "metadata": {
+		"name": "%[1]s",
+		"test": "%[3]s"
+	  },
+	  "specs": %[2]s}`)
+
+	//Create template
+	switch kind := t.l3.kind; kind {
+	case ingress:
+		err = t.l3.SetTemplate(&ingressMap, t)
+	case egress:
+		err = t.l3.SetTemplate(&egressMap, t)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	switch kind := t.l4.kind; kind {
+	case ingress:
+		err = t.l4.SetTemplate(&l4ingress, t)
+	case egress:
+		err = t.l4.SetTemplate(&l4egress, t)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	switch kind := t.l7.kind; kind {
+	case ingress:
+		err = t.l7.SetTemplate(&l4ingress, t)
+	case egress:
+		err = t.l7.SetTemplate(&l4egress, t)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	if len(l4ingress) > 0 {
+		ingressMap[toPorts] = []rule{l4ingress}
+	}
+
+	if len(l4egress) > 0 {
+		egressMap[toPorts] = []rule{l4egress}
+	}
+
+	if len(ingressMap) > 0 {
+		specs = append(specs, Spec{
+			EndpointSelector: endpointSelector{
+				Matchlabels: map[string]string{
+					"id": t.DestPod},
+			},
+			Ingress: []rule{ingressMap},
+		})
+	}
+
+	if len(egressMap) > 0 {
+		specs = append(specs, Spec{
+			EndpointSelector: endpointSelector{
+				Matchlabels: map[string]string{
+					"id": t.SrcPod},
+			},
+			Egress: []rule{egressMap},
+		})
+	}
+
+	if len(specs) == 0 {
+		return "", nil
+	}
+
+	jsonOutput, err := json.Marshal(specs)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(string(metadata), t.Prefix, jsonOutput, t), nil
+}
+
+// NetworkPolicyName returns the name of the NetworkPolicy
+func (t *TestSpec) NetworkPolicyName() string {
+	return fmt.Sprintf("%s_policy.json", t.Prefix)
+}
+
+// NetworkPolicyApply applies the cilium network policy in kubernetes and wait
+// until all  pods updates their status. It'll return an error if pods did not
+// update the state or policy cannot be applied
+func (t *TestSpec) NetworkPolicyApply() error {
+	policy, err := t.NetworkPolicyCreate()
+	if err != nil {
+		return fmt.Errorf("Network policy cannot be created prefix=%s: %s", t.Prefix, err)
+	}
+
+	if policy == "" {
+		//This only happens on L3:No Policy L4:No Policy L7:No Policy
+		log.Info("No policy so do not import it")
+		return nil
+	}
+
+	err = ioutil.WriteFile(t.NetworkPolicyName(), []byte(policy), os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("Network policy cannot be written prefix=%s: %s", t.Prefix, err)
+	}
+
+	_, err = t.Kub.CiliumImportPolicy(
+		helpers.KubeSystemNamespace,
+		fmt.Sprintf("%s/%s", helpers.BasePath, t.NetworkPolicyName()),
+		helpers.HelperTimeout)
+
+	if err != nil {
+		return fmt.Errorf("Network policy cannot be imported prefix=%s: %s", t.Prefix, err)
+	}
+	return nil
+}
+
+// GetConnectivyTest returns and array with the expected results of the given
+// connectivy test kind
+func (t *TestSpec) GetConnectivyTest(kind string) []ResultType {
+	return []ResultType{
+		t.l3.tests.GetField(kind),
+		t.l4.tests.GetField(kind),
+		t.l7.tests.GetField(kind)}
+
+}
+
+// GetTestExpects returns a map with the connTestType and the exepected result
+// based on the `testExpect`
+func (t *TestSpec) GetTestExpects() map[string]ResultType {
+	DetermineStatus := func(testType string) ResultType {
+		connTest := t.GetConnectivyTest(testType)
+		for _, kind := range ConnTestsResults {
+			for _, test := range connTest {
+				if test == kind {
+					return kind
+				}
+			}
+		}
+		return ResultOK
+	}
+
+	result := map[string]ResultType{}
+	for _, connTestType := range ConnTests {
+		result[connTestType] = DetermineStatus(connTestType)
+	}
+
+	return result
+}
+
+// ExecTest runs the connectivyTest for the expected `PolicyTest`. It will
+// assert using gomega.
+func (t *TestSpec) ExecTest() error {
+	testFailMessage := func(kind string) string {
+		return fmt.Sprintf("Type %s from %s to %s did not work", kind, t.SrcPod, t.DestPod)
+	}
+	for connType, expectResult := range t.GetTestExpects() {
+		if connType == Ping && (t.Destination.Kind == service || t.Destination.Kind == nodePort) {
+			continue
+		}
+		ginkgo.By(fmt.Sprintf("Checking %s", connType))
+		fn := ConnTestsActions[connType]
+		target, err := t.Destination.GetTarget(t)
+		if err != nil {
+			return fmt.Errorf("cannot get target in '%s': %s", t.Prefix, err)
+		}
+		result := fn(t.SrcPod, target, t.Kub)
+		gomega.Expect(result).To(gomega.Equal(&expectResult), testFailMessage(connType))
+	}
+	return nil
+}

--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -66,7 +66,11 @@ func (pol *PolicyTest) SetTemplate(result *map[string]interface{}, spec *TestSpe
 	}
 
 	for k, v := range pol.template {
-
+		// If any key was already set we do not need to overwrite it.
+		// This is in use on L7 when a port is always needed
+		if _, ok := (*result)[k]; ok {
+			continue
+		}
 		tmpl, err := getTemplate(v)
 		if err != nil {
 			return err

--- a/test/helpers/policygen/policygen.go
+++ b/test/helpers/policygen/policygen.go
@@ -1,8 +1,8 @@
 package policygen
 
 var policiesTestSuite = PolicyTestSuite{
-	l3Checks: []PolicyTest{
-		PolicyTest{
+	l3Checks: []PolicyTestKind{
+		PolicyTestKind{
 			name:  "No Policy",
 			kind:  ingress,
 			tests: ConnResultAllOK,
@@ -10,7 +10,7 @@ var policiesTestSuite = PolicyTestSuite{
 				"FromEndpoints": `[{}]`,
 			},
 		},
-		PolicyTest{
+		PolicyTestKind{
 			name:  "Ingress Label",
 			kind:  ingress,
 			tests: ConnResultAllOK,
@@ -18,7 +18,7 @@ var policiesTestSuite = PolicyTestSuite{
 				"FromEndpoints": `[{"matchLabels": { "id": "{{.SrcPod}}"}}]`,
 			},
 		},
-		PolicyTest{
+		PolicyTestKind{
 			name:  "Ingress Label Invalid",
 			kind:  ingress,
 			tests: ConnResultAllTimeout,
@@ -27,14 +27,14 @@ var policiesTestSuite = PolicyTestSuite{
 			},
 		},
 	},
-	l4Checks: []PolicyTest{
-		PolicyTest{
+	l4Checks: []PolicyTestKind{
+		PolicyTestKind{
 			name:     "No Policy",
 			kind:     ingress,
 			tests:    ConnResultAllOK,
 			template: map[string]string{},
 		},
-		PolicyTest{
+		PolicyTestKind{
 			name:  "Ingress Port 80 No protocol",
 			kind:  ingress,
 			tests: ConnResultOnlyHTTP,
@@ -42,7 +42,7 @@ var policiesTestSuite = PolicyTestSuite{
 				"Ports": `[{"port": "80"}]`,
 			},
 		},
-		PolicyTest{
+		PolicyTestKind{
 			name:  "Ingress Port 80 TCP",
 			kind:  ingress,
 			tests: ConnResultOnlyHTTP,
@@ -50,7 +50,7 @@ var policiesTestSuite = PolicyTestSuite{
 				"Ports": `[{"port": "80", "protocol": "TCP"}]`,
 			},
 		},
-		PolicyTest{
+		PolicyTestKind{
 			name:  "Ingress Port 80 UDP",
 			kind:  ingress,
 			tests: ConnResultAllTimeout,
@@ -59,14 +59,14 @@ var policiesTestSuite = PolicyTestSuite{
 			},
 		},
 	},
-	l7Checks: []PolicyTest{
-		PolicyTest{
+	l7Checks: []PolicyTestKind{
+		PolicyTestKind{
 			name:     "No Policy",
 			kind:     ingress,
 			tests:    ConnResultAllOK,
 			template: map[string]string{},
 		},
-		PolicyTest{
+		PolicyTestKind{
 			name:  "Ingress policy /private/",
 			kind:  ingress,
 			tests: ConnResultOnlyHTTPPrivate,
@@ -75,7 +75,7 @@ var policiesTestSuite = PolicyTestSuite{
 				"Ports": `[{"port": "80", "protocol": "TCP"}]`,
 			},
 		},
-		PolicyTest{
+		PolicyTestKind{
 			name:  "Egress policy to /private/",
 			kind:  egress,
 			tests: ConnResultOnlyHTTPPrivate,

--- a/test/helpers/policygen/policygen.go
+++ b/test/helpers/policygen/policygen.go
@@ -1,8 +1,21 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package policygen
 
 var policiesTestSuite = PolicyTestSuite{
 	l3Checks: []PolicyTestKind{
-		PolicyTestKind{
+		{
 			name:  "No Policy",
 			kind:  ingress,
 			tests: ConnResultAllOK,
@@ -10,7 +23,7 @@ var policiesTestSuite = PolicyTestSuite{
 				"FromEndpoints": `[{}]`,
 			},
 		},
-		PolicyTestKind{
+		{
 			name:  "Ingress Label",
 			kind:  ingress,
 			tests: ConnResultAllOK,
@@ -18,7 +31,7 @@ var policiesTestSuite = PolicyTestSuite{
 				"FromEndpoints": `[{"matchLabels": { "id": "{{.SrcPod}}"}}]`,
 			},
 		},
-		PolicyTestKind{
+		{
 			name:  "Ingress Label Invalid",
 			kind:  ingress,
 			tests: ConnResultAllTimeout,
@@ -28,13 +41,13 @@ var policiesTestSuite = PolicyTestSuite{
 		},
 	},
 	l4Checks: []PolicyTestKind{
-		PolicyTestKind{
+		{
 			name:     "No Policy",
 			kind:     ingress,
 			tests:    ConnResultAllOK,
 			template: map[string]string{},
 		},
-		PolicyTestKind{
+		{
 			name:  "Ingress Port 80 No protocol",
 			kind:  ingress,
 			tests: ConnResultOnlyHTTP,
@@ -42,7 +55,7 @@ var policiesTestSuite = PolicyTestSuite{
 				"Ports": `[{"port": "80"}]`,
 			},
 		},
-		PolicyTestKind{
+		{
 			name:  "Ingress Port 80 TCP",
 			kind:  ingress,
 			tests: ConnResultOnlyHTTP,
@@ -50,7 +63,7 @@ var policiesTestSuite = PolicyTestSuite{
 				"Ports": `[{"port": "80", "protocol": "TCP"}]`,
 			},
 		},
-		PolicyTestKind{
+		{
 			name:  "Ingress Port 80 UDP",
 			kind:  ingress,
 			tests: ConnResultAllTimeout,
@@ -60,13 +73,13 @@ var policiesTestSuite = PolicyTestSuite{
 		},
 	},
 	l7Checks: []PolicyTestKind{
-		PolicyTestKind{
+		{
 			name:     "No Policy",
 			kind:     ingress,
 			tests:    ConnResultAllOK,
 			template: map[string]string{},
 		},
-		PolicyTestKind{
+		{
 			name:  "Ingress policy /private/",
 			kind:  ingress,
 			tests: ConnResultOnlyHTTPPrivate,
@@ -75,7 +88,7 @@ var policiesTestSuite = PolicyTestSuite{
 				"Ports": `[{"port": "80", "protocol": "TCP"}]`,
 			},
 		},
-		PolicyTestKind{
+		{
 			name:  "Egress policy to /private/",
 			kind:  egress,
 			tests: ConnResultOnlyHTTPPrivate,
@@ -87,8 +100,8 @@ var policiesTestSuite = PolicyTestSuite{
 	},
 }
 
-// GeneratedTestSpec retuns a `TestSpec` array with all the policies
-// possibilities
+// GeneratedTestSpec returns a `TestSpec` array with all the policies
+// possibilities based on all combinations of `policiesTestSuite`
 func GeneratedTestSpec() []TestSpec {
 	var testSpecs = []TestSpec{}
 	for _, l3 := range policiesTestSuite.l3Checks {

--- a/test/helpers/policygen/policygen.go
+++ b/test/helpers/policygen/policygen.go
@@ -72,6 +72,7 @@ var policiesTestSuite = PolicyTestSuite{
 			tests: ConnResultOnlyHTTPPrivate,
 			template: map[string]string{
 				"Rules": `{"http": [{"method": "GET", "path": "/private"}]}`,
+				"Ports": `[{"port": "80", "protocol": "TCP"}]`,
 			},
 		},
 		PolicyTest{
@@ -80,6 +81,7 @@ var policiesTestSuite = PolicyTestSuite{
 			tests: ConnResultOnlyHTTPPrivate,
 			template: map[string]string{
 				"Rules": `{"http": [{"method": "GET", "path": "/private"}]}`,
+				"Ports": `[{"port": "80", "protocol": "TCP"}]`,
 			},
 		},
 	},

--- a/test/helpers/policygen/policygen.go
+++ b/test/helpers/policygen/policygen.go
@@ -1,0 +1,107 @@
+package policygen
+
+var policiesTestSuite = PolicyTestSuite{
+	l3Checks: []PolicyTest{
+		PolicyTest{
+			name:  "No Policy",
+			kind:  ingress,
+			tests: ConnResultAllOK,
+			template: map[string]string{
+				"FromEndpoints": `[{}]`,
+			},
+		},
+		PolicyTest{
+			name:  "Ingress Label",
+			kind:  ingress,
+			tests: ConnResultAllOK,
+			template: map[string]string{
+				"FromEndpoints": `[{"matchLabels": { "id": "{{.SrcPod}}"}}]`,
+			},
+		},
+		PolicyTest{
+			name:  "Ingress Label Invalid",
+			kind:  ingress,
+			tests: ConnResultAllTimeout,
+			template: map[string]string{
+				"FromEndpoints": `[{"matchLabels": { "id": "{{.SrcPod}}Invalid"}}]`,
+			},
+		},
+	},
+	l4Checks: []PolicyTest{
+		PolicyTest{
+			name:     "No Policy",
+			kind:     ingress,
+			tests:    ConnResultAllOK,
+			template: map[string]string{},
+		},
+		PolicyTest{
+			name:  "Ingress Port 80 No protocol",
+			kind:  ingress,
+			tests: ConnResultOnlyHTTP,
+			template: map[string]string{
+				"Ports": `[{"port": "80"}]`,
+			},
+		},
+		PolicyTest{
+			name:  "Ingress Port 80 TCP",
+			kind:  ingress,
+			tests: ConnResultOnlyHTTP,
+			template: map[string]string{
+				"Ports": `[{"port": "80", "protocol": "TCP"}]`,
+			},
+		},
+		PolicyTest{
+			name:  "Ingress Port 80 UDP",
+			kind:  ingress,
+			tests: ConnResultAllTimeout,
+			template: map[string]string{
+				"Ports": `[{"port": "80", "protocol": "UDP"}]`,
+			},
+		},
+	},
+	l7Checks: []PolicyTest{
+		PolicyTest{
+			name:     "No Policy",
+			kind:     ingress,
+			tests:    ConnResultAllOK,
+			template: map[string]string{},
+		},
+		PolicyTest{
+			name:  "Ingress policy /private/",
+			kind:  ingress,
+			tests: ConnResultOnlyHTTPPrivate,
+			template: map[string]string{
+				"Rules": `{"http": [{"method": "GET", "path": "/private"}]}`,
+			},
+		},
+		PolicyTest{
+			name:  "Egress policy to /private/",
+			kind:  egress,
+			tests: ConnResultOnlyHTTPPrivate,
+			template: map[string]string{
+				"Rules": `{"http": [{"method": "GET", "path": "/private"}]}`,
+			},
+		},
+	},
+}
+
+// GeneratedTestSpec retuns a `TestSpec` array with all the policies
+// possibilities
+func GeneratedTestSpec() []TestSpec {
+	var testSpecs = []TestSpec{}
+	for _, l3 := range policiesTestSuite.l3Checks {
+		for _, l4 := range policiesTestSuite.l4Checks {
+			for _, l7 := range policiesTestSuite.l7Checks {
+				for _, dst := range DestinationsTypes {
+					testSpecs = append(testSpecs, TestSpec{
+						l3:          l3,
+						l4:          l4,
+						l7:          l7,
+						Destination: dst,
+					})
+				}
+			}
+		}
+	}
+	return testSpecs
+}

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"html/template"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"strings"
 	"syscall"
@@ -62,6 +63,11 @@ func CountValues(key string, data []string) (int, int) {
 		}
 	}
 	return result, len(data)
+}
+
+// MakeUID returns a randomly generated string.
+func MakeUID() string {
+	return fmt.Sprintf("%08x", rand.Uint32())
 }
 
 // RenderTemplateToFile renders a text/template string into a target filename

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -1,0 +1,78 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sTest
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/test/helpers"
+	"github.com/cilium/cilium/test/helpers/policygen"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+var _ = Describe("NightlyK8sPolicies", func() {
+
+	var kubectl *helpers.Kubectl
+	var logger *logrus.Entry
+	var initialized bool
+
+	ciliumPath := fmt.Sprintf("%s/cilium_ds.yaml", kubectl.ManifestsPath())
+
+	initialize := func() {
+		if initialized == true {
+			return
+		}
+
+		logger = log.WithFields(logrus.Fields{"testName": "NightlyK8sPolicies"})
+		logger.Info("Starting")
+
+		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+		kubectl.Apply(ciliumPath)
+		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
+		Expect(err).Should(BeNil())
+		initialized = true
+	}
+
+	BeforeEach(func() {
+		initialize()
+	})
+
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, "k8s1")
+			kubectl.CiliumReport("kube-system", ciliumPod, []string{
+				"cilium policy get",
+				"cilium endpoint list",
+				"cilium service list"})
+		}
+	})
+
+	Context("PolicyEnforcement default", func() {
+		createTests := func() {
+			testSpecs := policygen.GeneratedTestSpec()
+			for _, test := range testSpecs {
+				func(testSpec policygen.TestSpec) {
+					It(fmt.Sprintf("%s", testSpec), func() {
+						testSpec.RunTest(kubectl)
+					})
+				}(test)
+			}
+		}
+		createTests()
+	})
+})

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -31,8 +31,6 @@ var _ = Describe("NightlyK8sPolicies", func() {
 	var logger *logrus.Entry
 	var initialized bool
 
-	ciliumPath := fmt.Sprintf("%s/cilium_ds.yaml", kubectl.ManifestsPath())
-
 	initialize := func() {
 		if initialized == true {
 			return
@@ -42,6 +40,7 @@ var _ = Describe("NightlyK8sPolicies", func() {
 		logger.Info("Starting")
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+		ciliumPath := fmt.Sprintf("%s/cilium_ds.yaml", kubectl.ManifestsPath())
 		kubectl.Apply(ciliumPath)
 		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 		Expect(err).Should(BeNil())


### PR DESCRIPTION
This issue covers a few test cases for issue #2029, not all yet, but I'll provide more test cases this week. 

Summary: 

- Added a new policy generation tool under helpers/policygen folder.
- Added exitCode on CMDRes
- Added Kubectl.GetServiceHostPort method.
- Added NightlyK8sPolicies test

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>