### PR TITLE
Mark generated ToCIDR rules as such

### DIFF
--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -336,6 +336,10 @@ type CIDRRule struct {
 	//
 	// +optional
 	ExceptCIDRs []CIDR `json:"except,omitempty"`
+
+	// Generated indicates whether the rule was generated based on other rules
+	// or provided by user
+	Generated bool `json:"-"`
 }
 
 // L7Rules is a union of port level rule types. Mixing of different port


### PR DESCRIPTION
This change makes the user-provided CIDR egress rules safe from deleting
based on headless service/endpoint deletion.

fixes #1876
