### PR TITLE
daemon: add l7-proxy option to specify which l7 proxy should be used

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -30,7 +30,6 @@ cilium-agent
   -e, --docker string                     Path to docker runtime socket (default "unix:///var/run/docker.sock")
       --enable-policy string              Enable policy enforcement (default "default")
       --enable-tracing                    Enable tracing while determining policy (debugging)
-      --envoy-proxy                       Use Envoy for HTTP proxy
       --ipv4-cluster-cidr-mask-size int   Mask size for the cluster wide CIDR (default 8)
       --ipv4-node string                  IPv4 address of node (default "auto")
       --ipv4-range string                 Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")
@@ -44,6 +43,7 @@ cilium-agent
       --keep-config                       When restoring state, keeps containers' configuration in place
       --kvstore string                    Key-value store type
       --kvstore-opt map                   Key-value store options (default map[])
+      --l7-proxy string                   L7 proxy: oxy or envoy (default "oxy")
       --label-prefix-file string          Valid label prefixes file path
       --labels stringSlice                List of label prefixes used to determine identity of an endpoint
       --lb string                         Enables load balancer mode where load balancer bpf program is attached to the given interface

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -87,6 +87,9 @@ type Config struct {
 
 	// Monitor contains the configuration for the node monitor.
 	Monitor *models.MonitorStatus
+
+	// proxyKind contains which proxy will be used.
+	proxyKind string
 }
 
 func NewConfig() *Config {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -62,7 +62,6 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/mattn/go-shellwords"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"github.com/vishvananda/netlink"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -125,13 +124,7 @@ func (d *Daemon) UpdateProxyRedirect(e *endpoint.Endpoint, l4 *policy.L4Filter) 
 		return 0, fmt.Errorf("can't redirect, proxy disabled")
 	}
 
-	// proxyKind only has an effects on newly created redirects
-	proxyKind := proxy.ProxyKindOxy
-	if viper.GetBool("envoy-proxy") {
-		proxyKind = proxy.ProxyKindEnvoy
-	}
-
-	r, err := d.l7Proxy.CreateOrUpdateRedirect(l4, e.ProxyID(l4), e, proxyKind)
+	r, err := d.l7Proxy.CreateOrUpdateRedirect(l4, e.ProxyID(l4), e)
 	if err != nil {
 		return 0, err
 	}
@@ -1077,7 +1070,7 @@ func NewDaemon(c *Config) (*Daemon, error) {
 	}
 
 	// FIXME: Make configurable
-	d.l7Proxy = proxy.NewProxy(10000, 20000)
+	d.l7Proxy = proxy.NewProxy(c.proxyKind, 10000, 20000)
 
 	if c.RestoreState {
 		if err := d.SyncState(d.conf.StateDir, true); err != nil {

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/pprof"
+	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/version"
 	"github.com/cilium/cilium/pkg/workloads/containerd"
 
@@ -343,9 +344,6 @@ func init() {
 	flags.String("enable-policy", endpoint.DefaultEnforcement, "Enable policy enforcement")
 	flags.BoolVar(&enableTracing,
 		"enable-tracing", false, "Enable tracing while determining policy (debugging)")
-	flags.BoolVar(&useEnvoy,
-		"envoy-proxy", false, "Use Envoy for HTTP proxy")
-	viper.BindEnv("envoy-proxy", "CILIUM_USE_ENVOY")
 	flags.StringVar(&v4Prefix,
 		"ipv4-range", AutoCIDR, "Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16")
 	flags.StringVar(&v6Prefix,
@@ -370,6 +368,8 @@ func init() {
 		"label-prefix-file", "", "Valid label prefixes file path")
 	flags.StringSliceVar(&validLabels,
 		"labels", []string{}, "List of label prefixes used to determine identity of an endpoint")
+	flags.StringVar(&config.proxyKind,
+		"l7-proxy", proxy.ProxyKindOxy, "L7 proxy: "+proxy.ProxyKindOxy+" or "+proxy.ProxyKindEnvoy)
 	flags.StringVar(&config.LBInterface,
 		"lb", "", "Enables load balancer mode where load balancer bpf program is attached to the given interface")
 	flags.StringVar(&config.LibDir,
@@ -485,6 +485,11 @@ func initEnv(cmd *cobra.Command) {
 
 	if viper.GetBool("pprof") {
 		pprof.Enable()
+	}
+
+	if viper.GetBool("envoy-proxy") {
+		log.Info("CILIUM_USE_ENVOY set, using envoy proxy")
+		config.proxyKind = proxy.ProxyKindEnvoy
 	}
 
 	if config.IPv4Disabled {


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

```release-note
add l7-proxy to specify which l7 proxy should be used
```
