### PR TITLE
Kafka: producing messages denied by policy crashes Cilium agent

### DIFF
--- a/pkg/kafka/request.go
+++ b/pkg/kafka/request.go
@@ -207,6 +207,7 @@ func ReadRequest(reader io.Reader) (*RequestMessage, error) {
 		log.WithFields(logrus.Fields{
 			fieldRequest: req.String(),
 		}).WithError(err).Debug("Ignoring Kafka message due to parse error")
+		return nil, err
 	}
 	return req, nil
 }


### PR DESCRIPTION
We were incorrectly not returning error if we fail to parse a kafka request. This was causing a
null dereference panic of the cilium daemon.

Fixes issue #2255

Signed-off-by: Manali Bhutiyani manali@covalent.io

```release-note
      Kafka: producing messages denied by policy crashes Cilium agent
```
