### PR TITLE
Fix `cilium bpf policy list` to print l4 ports

### DIFF
--- a/Documentation/cmdref/cilium_bpf_policy_add.md
+++ b/Documentation/cmdref/cilium_bpf_policy_add.md
@@ -10,7 +10,7 @@ Add/update policy entry
 Add/update policy entry
 
 ```
-cilium bpf policy add <endpoint id> <identity>
+cilium bpf policy add <endpoint id> <identity> [port/proto]
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium_bpf_policy_delete.md
+++ b/Documentation/cmdref/cilium_bpf_policy_delete.md
@@ -10,7 +10,7 @@ Delete a policy entry
 Delete a policy entry
 
 ```
-cilium bpf policy delete <endpoint id> <identity>
+cilium bpf policy delete <endpoint id> <identity> [port/proto]
 ```
 
 ### Options inherited from parent commands

--- a/cilium/cmd/bpf_policy_delete.go
+++ b/cilium/cmd/bpf_policy_delete.go
@@ -22,7 +22,7 @@ import (
 
 // bpfPolicyDeleteCmd represents the bpf_policy_delete command
 var bpfPolicyDeleteCmd = &cobra.Command{
-	Use:    "delete <endpoint id> <identity>",
+	Use:    "delete <endpoint id> <identity> [port/proto]",
 	Short:  "Delete a policy entry",
 	PreRun: requireEndpointID,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cilium/cmd/bpf_policy_list.go
+++ b/cilium/cmd/bpf_policy_list.go
@@ -34,9 +34,10 @@ var printIDs bool
 
 // bpfPolicyListCmd represents the bpf_policy_list command
 var bpfPolicyListCmd = &cobra.Command{
-	Use:    "list",
-	Short:  "List contents of a policy BPF map",
-	PreRun: requireEndpointID,
+	Use:     "list",
+	Aliases: []string{"get"},
+	Short:   "List contents of a policy BPF map",
+	PreRun:  requireEndpointID,
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf policy list")
 		listMap(cmd, args)

--- a/cilium/cmd/bpf_policy_list.go
+++ b/cilium/cmd/bpf_policy_list.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"text/tabwriter"
@@ -70,10 +71,16 @@ func listMap(cmd *cobra.Command, args []string) {
 	if err != nil {
 		Fatalf("Error while opening bpf Map: %s\n", err)
 	}
-	labelsID := map[policy.NumericIdentity]*policy.Identity{}
 
 	w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
+	formatMap(w, statsMap)
+	w.Flush()
+	if len(statsMap) == 0 {
+		fmt.Printf("Policy stats empty. Perhaps the policy enforcement is disabled?\n")
+	}
+}
 
+func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 	const (
 		labelsIDTitle  = "IDENTITY"
 		labelsDesTitle = "LABELS (source:key[=value])"
@@ -82,6 +89,7 @@ func listMap(cmd *cobra.Command, args []string) {
 		packetsTitle   = "PACKETS"
 	)
 
+	labelsID := map[policy.NumericIdentity]*policy.Identity{}
 	for _, stat := range statsMap {
 		if !printIDs {
 			id := policy.NumericIdentity(stat.Key.Identity)
@@ -118,9 +126,5 @@ func listMap(cmd *cobra.Command, args []string) {
 		} else {
 			fmt.Fprintf(w, "%d\t%s\t%d\t%d\t\n", id, act.String(), stat.Bytes, stat.Packets)
 		}
-	}
-	w.Flush()
-	if len(statsMap) == 0 {
-		fmt.Printf("Policy stats empty. Perhaps the policy enforcement is disabled?\n")
 	}
 }

--- a/cilium/cmd/bpf_policy_list.go
+++ b/cilium/cmd/bpf_policy_list.go
@@ -72,6 +72,9 @@ func listMap(cmd *cobra.Command, args []string) {
 		Fatalf("Error while opening bpf Map: %s\n", err)
 	}
 
+	if handleJSON(statsMap) {
+		return
+	}
 	w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
 	formatMap(w, statsMap)
 	w.Flush()

--- a/cilium/cmd/helpers.go
+++ b/cilium/cmd/helpers.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"k8s.io/client-go/util/jsonpath"
 )
 
@@ -119,7 +120,7 @@ func OutputPrinter(data interface{}) error {
 func dumpJSON(data interface{}, jsonPath string) error {
 
 	if len(jsonPath) == 0 {
-		result, err := json.Marshal(data)
+		result, err := json.MarshalIndent(data, "", "  ")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Couldn't marshal to json: '%s'\n", err)
 			return err
@@ -142,6 +143,21 @@ func dumpJSON(data interface{}, jsonPath string) error {
 	}
 	fmt.Println(buf.String())
 	return nil
+}
+
+// handleJSON checks if the "--json" flag was specified, and formats the object
+// provided to the console (or fails if this cannot be done).
+//
+// Returns true if the output has been printed, false otherwise.
+func handleJSON(data interface{}) bool {
+	if viper.GetBool("json") {
+		if err := dumpJSON(data, ""); err != nil {
+			os.Exit(1)
+		} else {
+			return true
+		}
+	}
+	return false
 }
 
 // Search 'result' for strings with escaped JSON inside, and expand the JSON.

--- a/pkg/u8proto/u8proto.go
+++ b/pkg/u8proto/u8proto.go
@@ -27,7 +27,7 @@ var protoNames = map[int]string{
 	58: "ICMPv6",
 }
 
-var protoIDs = map[string]U8proto{
+var ProtoIDs = map[string]U8proto{
 	"icmp":   1,
 	"tcp":    6,
 	"udp":    17,
@@ -46,7 +46,7 @@ func (p *U8proto) String() string {
 }
 
 func ParseProtocol(proto string) (U8proto, error) {
-	if u, ok := protoIDs[strings.ToLower(proto)]; ok {
+	if u, ok := ProtoIDs[strings.ToLower(proto)]; ok {
 		return u, nil
 	}
 	return 0, fmt.Errorf("unknown protocol '%s'", proto)


### PR DESCRIPTION
Fixes: #1941 

Tasks:
* [x] Also add support for dumping `--json`
* [x] Print protocol
* [x] Fix `bpf policy add/delete` to support l4port/proto