### PR TITLE
Ginkgo: Fix issues with cilium_ds manifest path

### DIFF
--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -33,8 +33,6 @@ var _ = Describe("NightlyK8sEpsMeasurement", func() {
 	var logger *logrus.Entry
 	var initialized bool
 
-	ciliumPath := fmt.Sprintf("%s/cilium_ds.yaml", kubectl.ManifestsPath())
-
 	initialize := func() {
 		if initialized == true {
 			return
@@ -43,7 +41,10 @@ var _ = Describe("NightlyK8sEpsMeasurement", func() {
 		logger.Info("Starting")
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+
+		ciliumPath := fmt.Sprintf("%s/cilium_ds.yaml", kubectl.ManifestsPath())
 		kubectl.Apply(ciliumPath)
+
 		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 		Expect(err).Should(BeNil())
 		initialized = true


### PR DESCRIPTION
kubectl.ManifestsPath() was called outside the initialize function, if
K8S_VERSION was not set by user, ManifestPath will not have the current
k8S_VERSION due ENV var was not set yet.

