### PR TITLE
Misc cleanup and possible flake fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ BPF_SRCFILES=$(shell find bpf/ -name *.[ch] -print)
 GOTEST_OPTS = -test.v -check.v
 
 all: precheck-gofmt build cmdref-check
+	@echo "Build finished."
 
 build: $(SUBDIRS)
 

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -214,6 +214,10 @@ func copySystemInfo(cmdDir string) {
 			}
 			k8sCommands = append(k8sCommands, podPrefix(pod, cmd))
 		}
+
+		// Check for previous logs of the pod
+		cmd := fmt.Sprintf("kubectl -n %s logs --previous -p %s", k8sNamespace, pod)
+		k8sCommands = append(k8sCommands, cmd)
 	}
 
 	runAll(k8sCommands, cmdDir)

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -44,6 +44,7 @@ func main() {
 			scopedLog.WithError(err).Fatal("Cannot set default permissions on socket")
 		}
 	}
+	log.Infof("Serving cilium node monitor at unix://%s", defaults.MonitorSockPath)
 
 	m := Monitor{}
 	go m.handleConnection(server)

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -42,7 +42,6 @@ type Monitor struct {
 
 // Run starts monitoring.
 func (m *Monitor) Run(npages int) {
-	log.Info("Starting monitoring traffic")
 	c := bpf.DefaultPerfEventConfig()
 	c.NumPages = npages
 

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -80,7 +80,7 @@ func (s *SSHMeta) EndpointGet(id string) *models.Endpoint {
 	res := s.ExecCilium(endpointGetCmd)
 	err := res.Unmarshal(&data)
 	if err != nil {
-		s.logger.WithError(err).Errorf("EndpointGet fail %d", id)
+		s.logger.WithError(err).Errorf("EndpointGet fail %s", id)
 		return nil
 	}
 	if len(data) > 0 {

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -186,7 +186,7 @@ var _ = Describe("RuntimeConntrackTest", func() {
 		By(fmt.Sprintf("%s pinging %s IPv6", helpers.Client, helpers.Server))
 		res := vm.ContainerExec(helpers.Client, helpers.Ping6(srvIP[helpers.IPv6]))
 		Expect(res.WasSuccessful()).Should(BeTrue(), fmt.Sprintf(
-			fmt.Sprintf("%s cannot ping to % %s", helpers.Client, helpers.Server, srvIP[helpers.IPv6])))
+			fmt.Sprintf("%s cannot ping to %s %s", helpers.Client, helpers.Server, srvIP[helpers.IPv6])))
 
 		By(fmt.Sprintf("%s pinging %s IPv4", helpers.Client, helpers.Server))
 		res = vm.ContainerExec(helpers.Client, helpers.Ping(srvIP[helpers.IPv4]))

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -1103,15 +1103,18 @@ function ping_success {
 }
 
 function wait_for_cilium_shutdown {
+  local save=$-
+  set +e
   log "waiting for cilium to shutdown"
   i=0
-  while [[ -f /var/run/cilium/cilium.pid ]]; do
+  while pgrep cilium-agent; do
     micro_sleep
-    if [[ ${i} -ge 120 ]]; then
+    if [[ ${i} -ge 240 ]]; then
       log "Timeout while waiting for Cilium to shutdown"
       exit 1
     fi
     ((i++))
   done
   log "finished waiting for cilium to shutdown"
+  restore_flag $save "e"
 }


### PR DESCRIPTION
- Change monitor log
- Print finished after building
- add log from the previous instance of a pod
- fix format issue detected by `go vet`
- try fixing a test flake

Will trigger four builds of this PR to see if the test flake shows up again.