### PR TITLE
Jenkinsfile: boot VMs in serial order before parallel test stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,27 +8,26 @@ pipeline {
         disableConcurrentBuilds()
     }
     stages {
+        stage('Boot VMs') {
+            steps {
+                sh './tests/start_vms'
+            }
+        }
         stage ('Tests') {
             environment {
                 MEMORY = '4096'
                 RUN_TEST_SUITE = '1'
             }
-            steps {
-     		           
+            steps { 
                 parallel(
                     "Print Environment": { sh 'env' },
                     "Runtime Tests": {
-                         // Make sure that VMs from prior runs are cleaned up in case something went wrong in a prior build.
-                         sh 'vagrant destroy -f || true'
-                         sh './contrib/vagrant/start.sh'
+                         sh 'PROVISION=1 ./contrib/vagrant/start.sh'
                      },
                     "Runtime Tests with Envoy": {
-                         // Make sure that VMs from prior runs are cleaned up in case something went wrong in a prior build.
-                         sh 'CILIUM_USE_ENVOY=1 vagrant destroy -f || true'
-                         sh 'CILIUM_USE_ENVOY=1 ./contrib/vagrant/start.sh'
+                         sh 'CILIUM_USE_ENVOY=1 PROVISION=1 ./contrib/vagrant/start.sh'
                      },
                     "K8s multi node Tests": {
-                         sh 'cd ./tests/k8s && vagrant destroy -f || true'
                          sh './tests/k8s/start.sh'
                     },
                     failFast: true

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -596,6 +596,11 @@ cd "${dir}/../.."
 
 if [ -n "${RELOAD}" ]; then
     vagrant reload
+elif [ -n "${NO_PROVISION}" ]; then
+    vagrant up --no-provision
+elif [ -n "${PROVISION}" ]; then
+    vagrant provision
 else
     vagrant up
 fi
+

--- a/tests/00-script-linter.sh
+++ b/tests/00-script-linter.sh
@@ -33,6 +33,7 @@ function check_flags_set
     grep -v "cilium-files" | \
     grep -v ".diff" | \
     grep -v ".yaml" | \
+    grep -v "start_vms" | \
     grep -v ".json" ; then
     echo "Please make sure that all tests contain 'set -ex'"
     exit 1

--- a/tests/k8s/start.sh
+++ b/tests/k8s/start.sh
@@ -4,5 +4,5 @@ set -e
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 cd "${dir}"
-VAGRANT_DEFAULT_PROVIDER=virtualbox vagrant up --provider=virtualbox
+VAGRANT_DEFAULT_PROVIDER=virtualbox vagrant provision
 make k8s-multi-node-tests

--- a/tests/start_vms
+++ b/tests/start_vms
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+# This script must be launched with Jenkins only. 
+cd ${WORKSPACE}
+
+echo "Destroying runtime test VM if it's already running"
+vagrant destroy -f
+
+echo "Starting runtime test VM"
+NO_PROVISION=1 ./contrib/vagrant/start.sh
+
+echo "Destroying Envoy runtime test VM if it's already running"
+CILIUM_USE_ENVOY=1 vagrant destroy -f
+
+echo "Starting Envoy runtime test VM"
+NO_PROVISION=1 CILIUM_USE_ENVOY=1 ./contrib/vagrant/start.sh
+
+
+cd tests/k8s
+
+echo "Destorying K8s VMs if they are already running"
+vagrant destroy -f
+
+echo "Starting K8s VMs"
+VAGRANT_DEFAULT_PROVIDER=virtualbox vagrant up --provider=virtualbox --no-provision


### PR DESCRIPTION
#2172 references an issue that has been occurring sporadically on the Jenkins instances. The issue is that when multiple VMs are booted simultaneously, VirtualBox fails to launch the VMs. This PR boots the VMs in a separate stage in serial order for the build. It adds about 3 minutes to the length of the build. The provisioning scripts (installing of Cilium, installation of K8s, etc.) are then done in parallel steps as is currently done. 

Signed-off by: Ian Vernon <ian@cilium.io>