### PR TITLE
daemon: delete double-remove of endpoint from endpointmanager

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -353,6 +353,10 @@ func (d *Daemon) deleteEndpoint(ep *endpoint.Endpoint) int {
 		}).Error("Error while deleting labels")
 	}
 
+	// Remove the endpoint before we clean up. This ensures it is no longer
+	// listed or queued for rebuilds.
+	endpointmanager.Remove(ep)
+
 	var errors int
 
 	// If dry mode is enabled, no changes to BPF maps are performed
@@ -394,7 +398,6 @@ func (d *Daemon) deleteEndpoint(ep *endpoint.Endpoint) int {
 		}
 	}
 
-	endpointmanager.Remove(ep)
 	if !d.conf.IPv4Disabled {
 		if err := ipam.ReleaseIP(ep.IPv4.IP()); err != nil {
 			scopedLog.WithError(err).WithField(logfields.IPAddr, ep.IPv4.IP()).Warn("Error while releasing IPv4")
@@ -410,8 +413,6 @@ func (d *Daemon) deleteEndpoint(ep *endpoint.Endpoint) int {
 	ep.LeaveLocked(d)
 	ep.Mutex.Unlock()
 	ep.BuildMutex.Unlock()
-
-	endpointmanager.Remove(ep)
 
 	return errors
 }


### PR DESCRIPTION
We were removing the endpoint twice. This seems unnecessary and caused
double counting in some instances, in particular it caused the endpoint count metric to go negative. I'll fix that metric to not be sensitive to things like this but I thought it wasn't ideal to do the double remove (it should be harmless nonetheless).

I'm not sure why we added the upper `Remove` in https://github.com/cilium/cilium/commit/0948bc0b3a6fe96a6bbc5ce56515ebef54f19208 and it seems like the remove call could/should happen before all the bookkeeping we do, or after all of it (where the one I deleted is).