### PR TITLE
metrics: Correctly read endpoint_count metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -57,12 +57,9 @@ var (
 
 	// Endpoint
 
-	// EndpointCount is the number of managed endpoints
-	EndpointCount = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: Namespace,
-		Name:      "endpoint_count",
-		Help:      "Number of endpoints managed by this agent",
-	})
+	// EndpointCount is a function used to collect this metric.
+	// It must be thread-safe.
+	EndpointCount prometheus.GaugeFunc
 
 	// EndpointCountRegenerating is the number of endpoints currently regenerating
 	EndpointCountRegenerating = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -135,21 +132,27 @@ var (
 )
 
 func init() {
-	registry.MustRegister(prometheus.NewProcessCollector(os.Getpid(), Namespace))
+	MustRegister(prometheus.NewProcessCollector(os.Getpid(), Namespace))
 	// TODO: Figure out how to put this into a Namespace
-	//registry.MustRegister(prometheus.NewGoCollector())
+	//MustRegister(prometheus.NewGoCollector())
 
-	registry.MustRegister(EndpointCount)
-	registry.MustRegister(EndpointCountRegenerating)
-	registry.MustRegister(EndpointRegenerationCount)
+	MustRegister(EndpointCountRegenerating)
+	MustRegister(EndpointRegenerationCount)
 
-	registry.MustRegister(PolicyCount)
-	registry.MustRegister(PolicyRevision)
-	registry.MustRegister(PolicyImportErrors)
+	MustRegister(PolicyCount)
+	MustRegister(PolicyRevision)
+	MustRegister(PolicyImportErrors)
 
-	registry.MustRegister(EventTSK8s)
-	registry.MustRegister(EventTSContainerd)
-	registry.MustRegister(EventTSAPI)
+	MustRegister(EventTSK8s)
+	MustRegister(EventTSContainerd)
+	MustRegister(EventTSAPI)
+}
+
+// MustRegister adds the collector to the registry, exposing this metric to
+// prometheus scrapes.
+// It will panic on error.
+func MustRegister(c prometheus.Collector) {
+	registry.MustRegister(c)
 }
 
 // Enable begins serving prometheus metrics on the address passed in. Addresses


### PR DESCRIPTION
We previously incremented and decremented a gauge when we added and
removed endpoints. Unfortunately, the Insert/Delete functions for
endpoints were called gratuitiously and would result in double counting,
often pushing the count negative! This change collectes the count at the
time of a metrics read and should more correctly reflect the
point-in-time count.

I'm not sure if there is a better way to do this; metrics is a terminal import package and so it can't  call into endpointmanager to use `GetEndpoints`. This change makes where the endpoints are declared a little less clear and consistent :(

```release-note
Corrected a bug in the endpoint_count metric where it double counted endpoint removals.
```

**How to test (optional)**:
I was running in a dev VM, modified to have the CLI option `--prometheus-serve-addr=:9090` in /etc/sysconfig/cilium
kubectl create -f examples/minikube/demo.yaml
kubectl delete -f examples/minikube/demo.yaml
curl -s localhost:9090/metrics | grep endpoint_count