### PR TITLE
Ginkgo: Fix mount issue on Ginkgo VMs

### DIFF
--- a/Documentation/kubernetes/install.rst
+++ b/Documentation/kubernetes/install.rst
@@ -50,9 +50,9 @@ filesystem to be automatically mounted when the node boots.
 If you are using systemd to manage the kubelet, another option is to add a
 mountd systemd service on all hosts:
 
-Due to how systemd mounts <link rel="this SO article for example"
-href="https://unix.stackexchange.com/questions/283442/systemd-mount-fails-where-setting-doesnt-match-unit-name">
-This string must be reflected in the unit filename.
+Due to how systemd `mounts
+<https://unix.stackexchange.com/questions/283442/systemd-mount-fails-where-setting-doesnt-match-unit-name>`__
+filesystems, the mount point path must be reflected in the unit filename.
 
 .. code:: bash
 
@@ -63,7 +63,7 @@ This string must be reflected in the unit filename.
         DefaultDependencies=no
         Before=local-fs.target umount.target
         After=swap.target
-        
+
         [Mount]
         What=bpffs
         Where=/sys/fs/bpf

--- a/contrib/systemd/sys-fs-bpf.mount
+++ b/contrib/systemd/sys-fs-bpf.mount
@@ -9,3 +9,6 @@ After=swap.target
 What=bpffs
 Where=/sys/fs/bpf
 Type=bpf
+
+[Install]
+WantedBy=multi-user.target

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -5,6 +5,10 @@ HOST=$(hostname)
 TOKEN="258062.5d84c017c9b2796c"
 CILIUM_CONFIG_DIR="/opt/cilium"
 ETCD_VERSION="v3.1.0"
+SRC_FOLDER="/src/"
+SYSTEMD_SERVICES="$SRC_FOLDER/contrib/systemd/"
+MOUNT_SYSTEMD="sys-fs-bpf.mount"
+
 NODE=$1
 IP=$2
 K8S_VERSION=$3
@@ -45,7 +49,9 @@ apt-get install --allow-downgrades -y \
 
 sudo mkdir -p ${CILIUM_CONFIG_DIR}
 
-sudo mount bpffs /sys/fs/bpf -t bpf
+sudo cp "$SYSTEMD_SERVICES/$MOUNT_SYSTEMD" /etc/systemd/system/
+sudo systemctl enable $MOUNT_SYSTEMD
+sudo systemctl restart $MOUNT_SYSTEMD
 sudo rm -rfv /var/lib/kubelet
 
 #check hostname to know if is kubernetes or runtime test


### PR DESCRIPTION
- Updated mount systemd to have a proper install section and avoid the
error message on `systemctl enable`

- Updated k8s provision file to add systemd mount. It fix when you reboot
any k8s server and didn't mount correctly the `/sys/fs/bpf`

Fix #2066

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
