### PR TITLE
log: import correct log package into submodules

### DIFF
--- a/pkg/k8s/apis/cilium.io/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils.go
@@ -17,6 +17,7 @@ package ciliumio
 import (
 	"fmt"
 
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -33,7 +34,7 @@ const (
 
 var (
 	// log is the k8s package logger object.
-	log = logrus.WithField(logfields.LogSubsys, subsysK8s)
+	log = common.DefaultLogger.WithField(logfields.LogSubsys, subsysK8s)
 )
 
 // ExtractNamespace extracts the namespace of ObjectMeta.

--- a/pkg/k8s/apis/cilium.io/v1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1/types.go
@@ -19,11 +19,11 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/cilium/cilium/common"
 	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/policy/api"
 
-	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -34,7 +34,7 @@ const (
 
 var (
 	// log is the k8s package logger object.
-	log = logrus.WithField(logfields.LogSubsys, subsysK8s)
+	log = common.DefaultLogger.WithField(logfields.LogSubsys, subsysK8s)
 )
 
 // +genclient

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -19,11 +19,10 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/cilium/cilium/common"
 	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/policy/api"
-
-	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -34,7 +33,7 @@ const (
 
 var (
 	// log is the k8s package logger object.
-	log = logrus.WithField(logfields.LogSubsys, subsysK8s)
+	log = common.DefaultLogger.WithField(logfields.LogSubsys, subsysK8s)
 )
 
 // +genclient

--- a/pkg/k8s/logfields.go
+++ b/pkg/k8s/logfields.go
@@ -15,9 +15,8 @@
 package k8s
 
 import (
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/logfields"
-
-	"github.com/sirupsen/logrus"
 )
 
 // logging field definitions
@@ -34,5 +33,5 @@ const (
 
 var (
 	// log is the k8s package logger object.
-	log = logrus.WithField(logfields.LogSubsys, subsysK8s)
+	log = common.DefaultLogger.WithField(logfields.LogSubsys, subsysK8s)
 )

--- a/pkg/workloads/containerd/logfields.go
+++ b/pkg/workloads/containerd/logfields.go
@@ -15,9 +15,8 @@
 package containerd
 
 import (
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/logfields"
-
-	"github.com/sirupsen/logrus"
 )
 
 // logging field definitions
@@ -33,5 +32,5 @@ const (
 )
 
 var (
-	log = logrus.WithField(logfields.LogSubsys, fieldSubsys)
+	log = common.DefaultLogger.WithField(logfields.LogSubsys, fieldSubsys)
 )

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -25,13 +25,14 @@ import (
 	"strings"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/common/plugins"
 	"github.com/cilium/cilium/pkg/client"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logfields"
 
-	"github.com/cilium/cilium/pkg/labels"
 	"github.com/containernetworking/cni/pkg/ns"
 	"github.com/containernetworking/cni/pkg/skel"
 	cniTypes "github.com/containernetworking/cni/pkg/types"
@@ -42,7 +43,7 @@ import (
 )
 
 var (
-	log = logrus.New()
+	log = common.DefaultLogger
 )
 
 func init() {


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

In some packages the logrus package was being imported, this was causing some log messages to not showing up.

```release-note
Fix logging setup for submodules
```