### PR TITLE
docs: updating gsg with bootstrapper localkube

### DIFF
--- a/Documentation/gettingstarted/minikube_intro.rst
+++ b/Documentation/gettingstarted/minikube_intro.rst
@@ -10,11 +10,12 @@ Step 0: Install kubectl & minikube
 <https://github.com/kubernetes/minikube/releases>`_.
 
 Then, boot a minikube cluster with the Container Network Interface (CNI)
-network plugin enabled:
+network plugin enabled plus the ``localkube`` bootstrapper since it contains
+``etcd`` >= ``3.1.0`` required by cilium.
 
 ::
 
-    $ minikube start --network-plugin=cni
+    $ minikube start --network-plugin=cni --bootstrapper=localkube
 
 After minikube has finished  setting up your new Kubernetes cluster, you can
 check the status of the cluster by running ``kubectl get cs``:


### PR DESCRIPTION
Since minikube can have multiple bootstrappers, we need to specify the
ideal bootstrapper for cilium. For now, only localkube will provide
the minimal etcd version required for cilium.

Signed-off-by: André Martins <andre@cilium.io>
