### PR TITLE
Jenkinsfile: restrict concurrent builds per branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ pipeline {
     options {
         timeout(time: 120, unit: 'MINUTES')
         timestamps()
+        disableConcurrentBuilds()
     }
     stages {
         stage ('Tests') {


### PR DESCRIPTION
This change will restrict the number of concurrent builds per job on Jenkins (per pull-request / master), meaning that if multiple pushes are done to the same PR, they will be queued until the build currently running for that job / pull-request has finished. 

Signed-off by: Ian Vernon <ian@cilium.io>
