### PR TITLE
Isolate network policies by k8s namespace

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -30,7 +30,6 @@ import (
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	informer "github.com/cilium/cilium/pkg/k8s/client/informers/externalversions"
-	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -694,7 +693,7 @@ func (d *Daemon) updateK8sNetworkPolicyV1(oldk8sNP, newk8sNP *networkingv1.Netwo
 }
 
 func (d *Daemon) deleteK8sNetworkPolicyV1(k8sNP *networkingv1.NetworkPolicy) {
-	labels := labels.ParseSelectLabelArray(k8s.ExtractPolicyName(k8sNP))
+	labels := k8s.GetPolicyLabelsv1(k8sNP)
 
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.K8sNetworkPolicyName: k8sNP.ObjectMeta.Name,
@@ -747,7 +746,7 @@ func (d *Daemon) updateK8sNetworkPolicyV1beta1(oldk8sNP, newk8sNP *v1beta1.Netwo
 // deleteK8sNetworkPolicyV1beta1
 // FIXME remove when we drop support to k8s Network Policy extensions/v1beta1
 func (d *Daemon) deleteK8sNetworkPolicyV1beta1(k8sNP *v1beta1.NetworkPolicy) {
-	labels := labels.ParseSelectLabelArray(k8s.ExtractPolicyNameDeprecated(k8sNP))
+	labels := k8s.GetPolicyLabelsv1beta1(k8sNP)
 
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.K8sNetworkPolicyName: k8sNP.ObjectMeta.Name,

--- a/pkg/k8s/apis/cilium.io/const.go
+++ b/pkg/k8s/apis/cilium.io/const.go
@@ -20,8 +20,10 @@ import (
 
 const (
 	// PolicyLabelName is the name of the policy label which refers to the
-	// k8s policy name
+	// k8s policy name.
 	PolicyLabelName = "io.cilium.k8s-policy-name"
+	// PolicyLabelNamespace is the policy's namespace set in k8s.
+	PolicyLabelNamespace = "io.cilium.k8s-policy-namespace"
 	// PodNamespaceLabel is the label used in kubernetes containers to
 	// specify which namespace they belong to.
 	PodNamespaceLabel = types.KubernetesPodNamespaceLabel

--- a/pkg/k8s/apis/cilium.io/v1/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v1/types_test.go
@@ -16,7 +16,6 @@ package v1
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/comparator"
@@ -106,7 +105,7 @@ var (
 				ToCIDRSet: []api.CIDRRule{{Cidr: api.CIDR("10.0.0.0/8"), ExceptCIDRs: []api.CIDR{"10.96.0.0/12"}}},
 			},
 		},
-		Labels: labels.ParseLabelArray(fmt.Sprintf("%s=%s", k8sconst.PolicyLabelName, "rule1")),
+		Labels: k8sconst.GetPolicyLabels("default", "rule1"),
 	}
 
 	rawRule = []byte(`{

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -16,7 +16,6 @@ package v2
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/comparator"
@@ -106,7 +105,7 @@ var (
 				ToCIDRSet: []api.CIDRRule{{Cidr: api.CIDR("10.0.0.0/8"), ExceptCIDRs: []api.CIDR{"10.96.0.0/12"}}},
 			},
 		},
-		Labels: labels.ParseLabelArray(fmt.Sprintf("%s=%s", k8sconst.PolicyLabelName, "rule1")),
+		Labels: k8sconst.GetPolicyLabels("default", "rule1"),
 	}
 
 	rawRule = []byte(`{


### PR DESCRIPTION
**Summary of changes**:

Fixes: #1938 

```release-note
Enable multiple policies with the same name but on different namespaces to be enforced #1938
```