### PR TITLE
daemon: Simplify API metrics collection

### DIFF
--- a/api/v1/server/configure_cilium.go
+++ b/api/v1/server/configure_cilium.go
@@ -11,6 +11,7 @@ import (
 	graceful "github.com/tylerb/graceful"
 
 	"github.com/cilium/cilium/api/v1/server/restapi"
+	"github.com/cilium/cilium/pkg/metrics"
 )
 
 // This file is safe to edit. Once it exists it will not be overwritten
@@ -61,5 +62,8 @@ func setupMiddlewares(handler http.Handler) http.Handler {
 // The middleware configuration happens before anything, this middleware also applies to serving the swagger.json document.
 // So this is a good place to plug in a panic handling middleware, logging and metrics
 func setupGlobalMiddleware(handler http.Handler) http.Handler {
-	return handler
+	return &metrics.APIEventTSHelper{
+		Next:    handler,
+		TSGauge: metrics.EventTSAPI,
+	}
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -52,7 +52,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
-	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy"
@@ -1221,7 +1220,6 @@ func NewPatchConfigHandler(d *Daemon) PatchConfigHandler {
 }
 
 func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PATCH /config request")
 
 	d := h.daemon
@@ -1303,7 +1301,6 @@ func NewGetConfigHandler(d *Daemon) GetConfigHandler {
 }
 
 func (h *getConfig) Handle(params GetConfigParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /config request")
 
 	d := h.daemon

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"sync"
-	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/endpoint"
@@ -30,7 +29,6 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
-	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/policy"
 
 	"github.com/go-openapi/runtime/middleware"
@@ -46,7 +44,6 @@ func NewGetEndpointHandler(d *Daemon) GetEndpointHandler {
 }
 
 func (h *getEndpoint) Handle(params GetEndpointParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /endpoint request")
 	resEPs := getEndpointList(params)
 
@@ -109,7 +106,6 @@ func NewGetEndpointIDHandler(d *Daemon) GetEndpointIDHandler {
 }
 
 func (h *getEndpointID) Handle(params GetEndpointIDParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
 	log.WithField(logfields.EndpointID, params.ID).Debug("GET /endpoint/{id} request")
 
 	ep, err := endpointmanager.Lookup(params.ID)
@@ -132,7 +128,6 @@ func NewPutEndpointIDHandler(d *Daemon) PutEndpointIDHandler {
 }
 
 func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PUT /endpoint/{id} request")
 
 	epTemplate := params.Endpoint
@@ -221,7 +216,6 @@ func NewPatchEndpointIDHandler(d *Daemon) PatchEndpointIDHandler {
 }
 
 func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PATCH /endpoint/{id} request")
 
 	epTemplate := params.Endpoint
@@ -435,7 +429,6 @@ func NewDeleteEndpointIDHandler(d *Daemon) DeleteEndpointIDHandler {
 }
 
 func (h *deleteEndpointID) Handle(params DeleteEndpointIDParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("DELETE /endpoint/{id} request")
 
 	d := h.daemon
@@ -486,7 +479,6 @@ func NewPatchEndpointIDConfigHandler(d *Daemon) PatchEndpointIDConfigHandler {
 }
 
 func (h *patchEndpointIDConfig) Handle(params PatchEndpointIDConfigParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PATCH /endpoint/{id}/config request")
 
 	d := h.daemon
@@ -509,7 +501,6 @@ func NewGetEndpointIDConfigHandler(d *Daemon) GetEndpointIDConfigHandler {
 }
 
 func (h *getEndpointIDConfig) Handle(params GetEndpointIDConfigParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /endpoint/{id}/config")
 
 	ep, err := endpointmanager.Lookup(params.ID)
@@ -531,7 +522,6 @@ func NewGetEndpointIDLabelsHandler(d *Daemon) GetEndpointIDLabelsHandler {
 }
 
 func (h *getEndpointIDLabels) Handle(params GetEndpointIDLabelsParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /endpoint/{id}/labels")
 
 	ep, err := endpointmanager.Lookup(params.ID)
@@ -563,7 +553,6 @@ func NewGetEndpointIDLogHandler(d *Daemon) GetEndpointIDLogHandler {
 }
 
 func (h *getEndpointIDLog) Handle(params GetEndpointIDLogParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
 	log.WithField(logfields.EndpointID, params.ID).Debug("GET /endpoint/{id}/log request")
 
 	ep, err := endpointmanager.Lookup(params.ID)
@@ -708,7 +697,6 @@ func NewPutEndpointIDLabelsHandler(d *Daemon) PutEndpointIDLabelsHandler {
 }
 
 func (h *putEndpointIDLabels) Handle(params PutEndpointIDLabelsParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PUT /endpoint/{id}/labels request")
 
 	d := h.daemon

--- a/daemon/labels.go
+++ b/daemon/labels.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logfields"
-	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/policy"
 
@@ -228,7 +227,6 @@ func NewGetIdentityHandler(d *Daemon) GetIdentityHandler {
 }
 
 func (h *getIdentity) Handle(params GetIdentityParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /identity request")
 
 	identities := []*models.Identity{}
@@ -269,8 +267,6 @@ func NewGetIdentityIDHandler(d *Daemon) GetIdentityIDHandler {
 }
 
 func (h *getIdentityID) Handle(params GetIdentityIDParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
-
 	d := h.daemon
 
 	nid, err := policy.ParseNumericIdentity(params.ID)

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"time"
 
 	. "github.com/cilium/cilium/api/v1/server/restapi/service"
 	"github.com/cilium/cilium/common/types"
@@ -24,7 +23,6 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/logfields"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
-	"github.com/cilium/cilium/pkg/metrics"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/sirupsen/logrus"
@@ -145,7 +143,6 @@ func NewPutServiceIDHandler(d *Daemon) PutServiceIDHandler {
 }
 
 func (h *putServiceID) Handle(params PutServiceIDParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PUT /service/{id} request")
 
 	f, err := types.NewL3n4AddrFromModel(params.Config.FrontendAddress)
@@ -194,7 +191,6 @@ func NewDeleteServiceIDHandler(d *Daemon) DeleteServiceIDHandler {
 }
 
 func (h *deleteServiceID) Handle(params DeleteServiceIDParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("DELETE /service/{id} request")
 
 	d := h.d
@@ -301,7 +297,6 @@ func NewGetServiceIDHandler(d *Daemon) GetServiceIDHandler {
 }
 
 func (h *getServiceID) Handle(params GetServiceIDParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /service/{id} request")
 
 	d := h.daemon
@@ -346,7 +341,6 @@ func NewGetServiceHandler(d *Daemon) GetServiceHandler {
 }
 
 func (h *getService) Handle(params GetServiceParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /service request")
 	list := h.d.GetServiceList()
 	return NewGetServiceOK().WithPayload(list)

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/policy"
@@ -109,7 +108,6 @@ func NewGetPolicyResolveHandler(d *Daemon) GetPolicyResolveHandler {
 }
 
 func (h *getPolicyResolve) Handle(params GetPolicyResolveParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /policy/resolve request")
 
 	d := h.daemon
@@ -291,8 +289,6 @@ func newDeletePolicyHandler(d *Daemon) DeletePolicyHandler {
 }
 
 func (h *deletePolicy) Handle(params DeletePolicyParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
-
 	d := h.daemon
 	lbls := labels.ParseSelectLabelArrayFromArray(params.Labels)
 	rev, err := d.PolicyDelete(lbls)
@@ -317,8 +313,6 @@ func newPutPolicyHandler(d *Daemon) PutPolicyHandler {
 }
 
 func (h *putPolicy) Handle(params PutPolicyParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
-
 	d := h.daemon
 
 	var rules api.Rules
@@ -347,8 +341,6 @@ func newGetPolicyHandler(d *Daemon) GetPolicyHandler {
 }
 
 func (h *getPolicy) Handle(params GetPolicyParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
-
 	d := h.daemon
 	d.policy.Mutex.RLock()
 	defer d.policy.Mutex.RUnlock()

--- a/daemon/prefilter.go
+++ b/daemon/prefilter.go
@@ -17,12 +17,10 @@ package main
 import (
 	"fmt"
 	"net"
-	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/prefilter"
 	"github.com/cilium/cilium/pkg/apierror"
-	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/go-openapi/runtime/middleware"
 )
 
@@ -36,8 +34,6 @@ func NewGetPrefilterHandler(d *Daemon) GetPrefilterHandler {
 }
 
 func (h *getPrefilter) Handle(params GetPrefilterParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
-
 	var list []string
 	var revision int64
 	if h.d.preFilter == nil {
@@ -62,8 +58,6 @@ func NewPutPrefilterHandler(d *Daemon) PutPrefilterHandler {
 }
 
 func (h *putPrefilter) Handle(params PutPrefilterParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
-
 	var list []net.IPNet
 	cl := params.CidrList
 	if h.d.preFilter == nil {
@@ -95,8 +89,6 @@ func NewDeletePrefilterHandler(d *Daemon) DeletePrefilterHandler {
 }
 
 func (h *deletePrefilter) Handle(params DeletePrefilterParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
-
 	var list []net.IPNet
 	cl := params.CidrList
 	if h.d.preFilter == nil {

--- a/daemon/status.go
+++ b/daemon/status.go
@@ -16,13 +16,11 @@ package main
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/kvstore"
-	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/workloads/containerd"
 
@@ -104,8 +102,6 @@ func (h *getHealthz) getNodeStatus() *models.ClusterStatus {
 }
 
 func (h *getHealthz) Handle(params GetHealthzParams) middleware.Responder {
-	metrics.SetTSValue(metrics.EventTSAPI, time.Now())
-
 	d := h.daemon
 	sr := h.getStatus(d)
 	return NewGetHealthzOK().WithPayload(&sr)

--- a/pkg/metrics/middleware.go
+++ b/pkg/metrics/middleware.go
@@ -1,0 +1,37 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// APIEventTSHelper is intended to be a global middleware to track metrics
+// around API calls.
+// It records the timestamp of an API call in the provided gauge.
+type APIEventTSHelper struct {
+	Next    http.Handler
+	TSGauge prometheus.Gauge
+}
+
+// ServeHTTP implements the http.Handler interface. It records the timestamp
+// this API call began at, then chains to the next handler.
+func (m *APIEventTSHelper) ServeHTTP(r http.ResponseWriter, req *http.Request) {
+	SetTSValue(m.TSGauge, time.Now())
+	m.Next.ServeHTTP(r, req)
+}


### PR DESCRIPTION
We collect API timestamps at a global middleware layer. This simplifies
where we need to add code to collect this metric, avoiding adding code
at each API handler. In the future this can also be used to track API
timings.

Special thanks to aanm for the suggestion (and most of the code, actually).

**How to test (optional)**:
- build the daemon
- execute with `--prometheus-serve-addr=:9090`
- curl localhost:9090/metrics | grep cilium_event
- note that the API timestamp updates correctly (as before). You may need to create a request with `cilium status`