### PR TITLE
pkg/kvstore: fix nil pointer access

### DIFF
--- a/pkg/kvstore/lock.go
+++ b/pkg/kvstore/lock.go
@@ -75,7 +75,7 @@ func LockPath(path string) (l *Lock, err error) {
 		if err != nil {
 			lockPathsMU.Lock()
 			if ll.decRefCount() == 0 {
-				delete(lockPaths, l.path)
+				delete(lockPaths, path)
 			}
 			lockPathsMU.Unlock()
 		}


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Fix nil pointer access when unable to reach the KVStore
```
