### PR TITLE
Bugtool enhancement and small fixes

### DIFF
--- a/Documentation/cmdref/cilium_bugtool.md
+++ b/Documentation/cmdref/cilium_bugtool.md
@@ -21,7 +21,7 @@ cilium bugtool
       --k8s-namespace string   Kubernetes namespace for Cilium pod (default "kube-system")
   -p, --port int               Port to use for the HTTP server, (default 4444) (default 4444)
       --serve                  Start HTTP server to serve static files
-  -t, --tmp string             Path to store extracted files (default "/tmp/")
+  -t, --tmp string             Path to store extracted files (default "/tmp")
 ```
 
 ### Options inherited from parent commands

--- a/bugtool/cmd/ethool_darwin.go
+++ b/bugtool/cmd/ethool_darwin.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build darwin
 
 package cmd

--- a/bugtool/cmd/ethool_linux.go
+++ b/bugtool/cmd/ethool_linux.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build linux
 
 package cmd

--- a/bugtool/cmd/helper.go
+++ b/bugtool/cmd/helper.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/daemon/defaults"
@@ -61,7 +62,7 @@ var (
 func init() {
 	BugtoolRootCmd.Flags().BoolVar(&serve, "serve", false, "Start HTTP server to serve static files")
 	BugtoolRootCmd.Flags().IntVarP(&port, "port", "p", 4444, "Port to use for the HTTP server, (default 4444)")
-	BugtoolRootCmd.Flags().StringVarP(&dumpPath, "tmp", "t", "/tmp/", "Path to store extracted files")
+	BugtoolRootCmd.Flags().StringVarP(&dumpPath, "tmp", "t", "/tmp", "Path to store extracted files")
 	BugtoolRootCmd.Flags().StringVarP(&host, "host", "H", "", "URI to server-side API")
 	BugtoolRootCmd.Flags().StringVarP(&k8sNamespace, "k8s-namespace", "", "kube-system", "Kubernetes namespace for Cilium pod")
 	BugtoolRootCmd.Flags().StringVarP(&k8sLabel, "k8s-label", "", "k8s-app=cilium", "Kubernetes label for Cilium pod")
@@ -82,7 +83,9 @@ func runTool() {
 
 	defer printDisclaimer()
 	// Prevent collision with other directories
-	dbgDir, err := ioutil.TempDir(dumpPath, "cilium-bugtool-")
+	nowStr := time.Now().Format("20060102-150405.999-0700-MST")
+	prefix := fmt.Sprintf("cilium-bugtool-%s-", nowStr)
+	dbgDir, err := ioutil.TempDir(dumpPath, prefix)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create debug directory %s\n", err)
 		os.Exit(1)

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -70,7 +70,12 @@ func init() {
 func runTool() {
 	// Search for a Cilium pod and if one is found prefix all of the
 	// commands to use the pod(s).
-	k8sPods, _ = getCiliumPods(k8sNamespace, k8sLabel)
+	var err error
+	k8sPods, err = getCiliumPods(k8sNamespace, k8sLabel)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to retrieve cilium logs from kubernetes, skipping... %s\n", err)
+	}
+
 	if len(k8sPods) == 0 {
 		common.RequireRootPrivilege("bugtool")
 	}


### PR DESCRIPTION
**Summary of changes**:

- Add missing copyright headers
- Add 5 second timeout for all commands executed
- Lift root permissions for kubernetes commands
- Add timestamp to the generated tar file
- Compress base directory instead of uppermost directory