### PR TITLE
Ginkgo: Fix issue with virtual machines dns

### DIFF
--- a/test/provision/dns.sh
+++ b/test/provision/dns.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script update the dns servers to use google ones.
+set -e
+
+cat <<EOF > /etc/resolv.conf
+nameserver 8.8.8.8
+nameserver 8.8.4.4
+EOF
+

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -4,6 +4,7 @@ set -e
 HOST=$(hostname)
 TOKEN="258062.5d84c017c9b2796c"
 CILIUM_CONFIG_DIR="/opt/cilium"
+PROVISIONSRC="/tmp/provision/"
 ETCD_VERSION="v3.1.0"
 NODE=$1
 IP=$2
@@ -16,6 +17,8 @@ if [[ -f  "/etc/provision_finished" ]]; then
     /tmp/provision/compile.sh
     exit 0
 fi
+
+$PROVISIONSRC/dns.sh
 
 cat <<EOF > /etc/hosts
 127.0.0.1       localhost
@@ -65,7 +68,7 @@ if [[ "${HOST}" == "k8s1" ]]; then
     kubectl taint nodes --all node-role.kubernetes.io/master-
 
     sudo systemctl start etcd
-    /tmp/provision/compile.sh
+    $PROVISIONSRC/compile.sh
 else
     kubeadm join --token=$TOKEN 192.168.36.11:6443
     cp /etc/kubernetes/kubelet.conf ${CILIUM_CONFIG_DIR}/kubeconfig

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -2,11 +2,12 @@
 set -e
 
 HOST=$(hostname)
+PROVISIONSRC="/tmp/provision/"
 
+$PROVISIONSRC/dns.sh
 sudo adduser vagrant docker
 
 export GOPATH=/go/
 go get -u github.com/jteeuwen/go-bindata/...
 ln -sf /go/bin/* /usr/local/bin/
-/tmp/provision/compile.sh
-
+$PROVISIONSRC/compile.sh


### PR DESCRIPTION
Added as default dns server the google servers. As default virtualbox
uses the gateway as dns and sometimes it fails.

Fix #2188