### PR TITLE
Debug toggle on cilium-agent and endpoints control debug logging

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
@@ -1275,8 +1276,11 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 
 	log.WithField("count", changes).Debug("Applied changes to daemon's configuration")
 
-	// Only recompile if configuration has changed.
 	if changes > 0 {
+		// Set the debug toggle (this can be a no-op)
+		logging.ToggleDebugLogs(d.DebugEnabled())
+
+		// Only recompile if configuration has changed.
 		log.Debug("daemon configuration has changed; recompiling base programs")
 		if err := d.compileBase(); err != nil {
 			log.WithError(err).Warn("Invalid option for PolicyEnforcement")

--- a/daemon/defaults/defaults.go
+++ b/daemon/defaults/defaults.go
@@ -14,6 +14,8 @@
 
 package defaults
 
+import "github.com/sirupsen/logrus"
+
 const (
 	// RuntimePath is the default path to the runtime directory
 	RuntimePath = "/var/run/cilium"
@@ -45,4 +47,8 @@ const (
 
 	// PidFilePath is the path to the pid file for the agent.
 	PidFilePath = RuntimePath + "/cilium.pid"
+
+	// DefaultLogLevel is the alternative we provide to Debug
+	// We set this in pkg/logging.
+	DefaultLogLevel = logrus.InfoLevel
 )

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -576,9 +576,8 @@ func initEnv(cmd *cobra.Command) {
 
 	bpf.MountFS()
 
-	if viper.GetBool("debug") {
-		config.Opts.Set(endpoint.OptionDebug, true)
-	}
+	logging.DefaultLogLevel = defaults.DefaultLogLevel
+	config.Opts.Set(endpoint.OptionDebug, viper.GetBool("debug"))
 
 	autoIPv6NodeRoutes = viper.GetBool("auto-ipv6-node-routes")
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1493,7 +1493,6 @@ func (e *Endpoint) bumpPolicyRevision(revision uint64) {
 	e.Mutex.Lock()
 	if revision > e.policyRevision {
 		e.policyRevision = revision
-		e.updateLogger()
 	}
 	e.Mutex.Unlock()
 }

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -176,6 +176,7 @@ func (s *EndpointSuite) TestEndpointState(c *C) {
 		Status: NewEndpointStatus(),
 	}
 	e.Mutex.Lock()
+	e.SetDefaultOpts(nil)
 	defer e.Mutex.Unlock()
 
 	e.state = StateCreating

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -25,18 +25,47 @@ var log = logging.DefaultLogger
 
 // logger returns a logrus object with EndpointID, ContainerID and the Endpoint
 // revision fields.
-// Note: You must host Endpoint.Mutex
+// Note: You must hold Endpoint.Mutex
 func (e *Endpoint) getLogger() *logrus.Entry {
-	if e.logger == nil {
-		e.updateLogger()
-	}
+	e.updateLogger()
 	return e.logger
 }
 
-// updateLogger
+// updateLogger creates a logger instance specific to this endpoint. It will
+// create a custom Debug logger for this endpoint when the option on it is set.
 // Note: You must hold Endpoint.Mutex
 func (e *Endpoint) updateLogger() {
-	e.logger = log.WithFields(logrus.Fields{
+	// We need to update if
+	// - e.logger is nil (this happens on the first ever call to updateLogger via
+	//   getLogger above). This clause has to come first to guard the others.
+	// - If any of EndpointID, ContainerID or policyRevision are different on the
+	//   endpoint from the logger.
+	// - The debug option on the endpoint is true, and the logger is not debug,
+	//   or vice versa.
+	shouldUpdate := e.logger == nil ||
+		e.logger.Data[logfields.EndpointID] != e.ID ||
+		e.logger.Data[logfields.ContainerID] != e.DockerID ||
+		e.logger.Data["policyRevision"] != e.policyRevision
+
+	// do nothing if we do not need an update
+	if !shouldUpdate {
+		return
+	}
+
+	// default to using the log var set above
+	baseLogger := log
+
+	// If this endpoint is set to debug ensure it will print debug by giving it
+	// an independent logger
+	if e.Opts.IsEnabled("Debug") {
+		baseLogger = logrus.New()
+		baseLogger.SetLevel(logrus.DebugLevel)
+	}
+
+	// update the logger object.
+	// Note: endpoint.Mutex protects the reference but not the logger objects. We
+	// cannot update the old object directly as that could be racey.
+	e.logger = baseLogger.WithFields(logrus.Fields{
 		logfields.EndpointID:  e.ID,
 		logfields.ContainerID: e.DockerID,
 		"policyRevision":      e.policyRevision,

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -45,7 +45,8 @@ func (e *Endpoint) updateLogger() {
 	shouldUpdate := e.logger == nil ||
 		e.logger.Data[logfields.EndpointID] != e.ID ||
 		e.logger.Data[logfields.ContainerID] != e.DockerID ||
-		e.logger.Data["policyRevision"] != e.policyRevision
+		e.logger.Data["policyRevision"] != e.policyRevision ||
+		e.Opts.IsEnabled("Debug") != (e.logger.Level == logrus.DebugLevel)
 
 	// do nothing if we do not need an update
 	if !shouldUpdate {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -635,7 +635,6 @@ func (e *Endpoint) regeneratePolicy(owner Owner, opts models.ConfigurationMap) (
 	// the regeneration of the endpoint to complete.
 	if !policyChanged && !optsChanged {
 		e.policyRevision = revision
-		e.updateLogger()
 	}
 
 	e.getLogger().WithFields(logrus.Fields{

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -49,6 +49,9 @@ var (
 	// default to avoid external dependencies from writing out unexpectedly
 	DefaultLogger = logrus.New()
 
+	// DefaultLogLevel is the alternative we provide to Debug
+	DefaultLogLevel = logrus.InfoLevel
+
 	// syslogOpts is the set of supported options for syslog configuration.
 	syslogOpts = map[string]bool{
 		"syslog.level": true,
@@ -113,11 +116,8 @@ func SetupLogging(loggers []string, logOpts map[string]string, tag string, debug
 		logrus.SetOutput(os.Stdout)
 	}
 
-	if debug {
-		DefaultLogger.SetLevel(logrus.DebugLevel)
-	} else {
-		DefaultLogger.SetLevel(logrus.InfoLevel)
-	}
+	SetLogLevel(DefaultLogLevel)
+	ToggleDebugLogs(debug)
 
 	// always suppress the default logger so libraries don't print things
 	logrus.SetLevel(logrus.PanicLevel)
@@ -157,6 +157,26 @@ func SetupLogging(loggers []string, logOpts map[string]string, tag string, debug
 		}
 	}
 	return nil
+}
+
+// SetLogLevel sets the log level on DefaultLogger. This logger is, by
+// convention, the base logger for package specific ones thus setting the level
+// here impacts the default logging behaviour.
+// This function is thread-safe when logging, reading DefaultLogger.Level is
+// not protected this way, however.
+func SetLogLevel(level logrus.Level) {
+	DefaultLogger.SetLevel(level)
+}
+
+// ToggleDebugLogs switches on or off debugging logs. It will select
+// DefaultLogLevel when turning debug off.
+// It is thread-safe.
+func ToggleDebugLogs(debug bool) {
+	if debug {
+		SetLogLevel(logrus.DebugLevel)
+	} else {
+		SetLogLevel(DefaultLogLevel)
+	}
 }
 
 // setupSyslog sets up and configures syslog with the provided options in


### PR DESCRIPTION
Note: This PR is based on https://github.com/cilium/cilium/pull/2322 and can't be merged before that one is merged.

We can configure debug at the agent level via the API or at start time. The API toggle will now change the log level globally in addition to what it did before. We can also set Debug on specific endpoints (this changed the BPF program, I think) and this now also changes the debug logging for just this endpoint. In the case where the agent has debug globally, the outcome is a noop. In the case where the agent has debug disabled endpoint functions will now begin logging debug messages.

Fixes: https://github.com/cilium/cilium/issues/2311

```release-note
Debug logging at the agent level, or on specific endpoints, can be toggled with their respective Debug config
```

**How to test (optional)**:
- run cilium-agent without --debug
- `cilium endpoint config 123  debug=true`
- see debug logs
- `cilium config debug=false`
- see no debug logs