### PR TITLE
Fixing a couple spelling errors.

### DIFF
--- a/pkg/node/node_address.go
+++ b/pkg/node/node_address.go
@@ -330,7 +330,7 @@ func UseNodeCIDR(node *Node) error {
 		SetIPv4AllocRange(node.IPv4AllocCIDR)
 	}
 	if node.IPv6AllocCIDR != nil {
-		scopedLog.WithField(logfields.V4Prefix, node.IPv6AllocCIDR).Info("Retrieved IPv6 allocation range for node. Using it for ipv6-range")
+		scopedLog.WithField(logfields.V6Prefix, node.IPv6AllocCIDR).Info("Retrieved IPv6 allocation range for node. Using it for ipv6-range")
 		if err := SetIPv6NodeRange(node.IPv6AllocCIDR); err != nil {
 			scopedLog.WithError(err).WithField(logfields.V4Prefix, node.IPv6AllocCIDR).Warn("k8s: Can't use IPv6 CIDR range from k8s")
 		}

--- a/pkg/workloads/containerd/watcher.go
+++ b/pkg/workloads/containerd/watcher.go
@@ -167,7 +167,7 @@ func getCiliumIPv6(networks map[string]*dNetwork.EndpointSettings) *addressing.C
 
 		ipv6gw := net.ParseIP(contNetwork.IPv6Gateway)
 		if !ipv6gw.Equal(node.GetIPv6Router()) {
-			scopedLog.WithField(logfields.Object, contNetwork).Debug("Skipping networt because of gateway mismatch")
+			scopedLog.WithField(logfields.Object, contNetwork).Debug("Skipping network because of gateway mismatch")
 			continue
 		}
 		ip, err := addressing.NewCiliumIPv6(contNetwork.GlobalIPv6Address)


### PR DESCRIPTION
**Summary of changes**: Changed logfield to show correct message. Fixed minor spelling error.

pkg/node/node_address.go was incorrectly using logfields.V4Prefix for both the IPv4 message and IPv6 message. This made it so the logs would log:

***INFO[0000] Retrieved IPv6 allocation range for node. Using it for ipv6-range  node=node2 v4Prefix="aaaa:aaaa:aaaa:aaaa:beef:beef::/96"***

Instead of:

***INFO[0000] Retrieved IPv6 allocation range for node. Using it for ipv6-range  node=node2 v6Prefix="aaaa:aaaa:aaaa:aaaa:beef:beef::/96"***

The second change was pkg/workloads/containerd/watcher.go had a string where network was misspelled. 

Signed-off-by: Nathan Taylor <ntaylor1781@gmail.com>
