### PR TITLE
Ginkgo: Fix var initialization

### DIFF
--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -32,6 +32,7 @@ var _ = Describe("NightlyK8sEpsMeasurement", func() {
 	var kubectl *helpers.Kubectl
 	var logger *logrus.Entry
 	var initialized bool
+	var ciliumPath string
 
 	initialize := func() {
 		if initialized == true {


### PR DESCRIPTION
Issue in the current master branch on all ginkgo test, introduced in commit
e024f7f341f96515f7687a48d132082267c3848a

Error:
```
10:09:27 [K8s-1.6] k8sT/Nightly.go:149:27: undefined: ciliumPath
10:09:27 [K8s-1.6] k8sT/Nightly.go:152:25: undefined: ciliumPath
```
Build ID: https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/521/

Sorry for this, I think that I messed around in one rebase. My apologies