### PR TITLE
Ginkgo: Using box version on Vagrantfile

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -5,6 +5,10 @@ $BUILD_NUMBER = ENV['BUILD_NUMBER'] || "0"
 $JOB_NAME = ENV['JOB_BASE_NAME'] || "LOCAL"
 $K8S_VERSION = ENV['K8S_VERSION'] || "1.7"
 
+
+$SERVER_BOX= "cilium/ginkgo"
+$SERVER_VERSION= "0.0.2"
+
 ENV["VAGRANT_DEFAULT_PROVIDER"] = "virtualbox"
 Vagrant.configure("2") do |config|
 
@@ -16,8 +20,8 @@ Vagrant.configure("2") do |config|
             vb.linked_clone = true
         end
 
-        # server.vm.box = "bento/ubuntu-17.04"
-        server.vm.box = "cilium/ginkgo"
+        server.vm.box =  "#{$SERVER_BOX}"
+        server.vm.box_version = "#{$SERVER_VERSION}"
         server.vm.hostname = "runtime"
         server.vm.synced_folder "../", "/src/"
 
@@ -40,8 +44,8 @@ Vagrant.configure("2") do |config|
                 vb.linked_clone = true
             end
 
-            # server.vm.box = "bento/ubuntu-17.04"
-            server.vm.box = "cilium/ginkgo"
+            server.vm.box =  "#{$SERVER_BOX}"
+            server.vm.box_version = "#{$SERVER_VERSION}"
             server.vm.hostname = "k8s#{i}"
             server.vm.network "private_network",
                 ip: "192.168.36.1#{i}",


### PR DESCRIPTION
Updated the Vagrantfile to reflect the version of the vagrant box that
is needed to run the test.

Refactor the box name to a variable

Fix #2045 