### PR TITLE
Ginkgo: ensuring docker containers are removed on jenkins.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ tests-common-ginkgo: force
 	# Remove the networks
 	docker-compose -f test/docker-compose.yml -p $$JOB_BASE_NAME-$$BUILD_NUMBER down
 
+clean-ginkgo-tests:
+	docker-compose -f test/docker-compose.yml -p $$JOB_BASE_NAME-$$BUILD_NUMBER down
+	docker-compose -f test/docker-compose.yml -p $$JOB_BASE_NAME-$$BUILD_NUMBER rm
+
 tests-common: force
 	tests/00-fmt.sh
 	go vet $(GOFILES)

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -28,6 +28,9 @@ pipeline {
             steps {
                 sh "cd ${TESTDIR}; make tests-ginkgo"
             }
+            post {
+                sh "cd ${TESTDIR}; make clean-ginkgo-tests || true"
+            }
         }
         stage('BDD-Test') {
             environment {
@@ -53,7 +56,7 @@ pipeline {
                     junit 'test/*.xml'
                     // Temporary workaround to test cleanup
                     // rm -rf ${GOPATH}/src/github.com/cilium/cilium
-                    sh 'cd test/; ./post_build_agent.sh || true'                    
+                    sh 'cd test/; ./post_build_agent.sh || true'
                     sh 'cd test/; vagrant destroy -f'
                     sh 'cd test/; K8S_VERSION=1.6 vagrant destroy -f'
                 }


### PR DESCRIPTION
Add a `clean-ginkgo-tests` target on Makefile to remove the docker
containers in any situation.

Fix #2009

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

