### PR TITLE
Ginkgo: Fix issue with Jenkinsfile

### DIFF
--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -29,7 +29,9 @@ pipeline {
                 sh "cd ${TESTDIR}; make tests-ginkgo"
             }
             post {
-                sh "cd ${TESTDIR}; make clean-ginkgo-tests || true"
+                always {
+                    sh "cd ${TESTDIR}; make clean-ginkgo-tests || true"
+                }
             }
         }
         stage('BDD-Test') {
@@ -61,7 +63,6 @@ pipeline {
                     sh 'cd test/; K8S_VERSION=1.6 vagrant destroy -f'
                     sh 'cd test/; ./archive_test_results.sh || true'
                     archiveArtifacts artifacts: "test_results_${JOB_BASE_NAME}_${BUILD_NUMBER}.tar", allowEmptyArchive: true
-                    
                 }
             }
         }


### PR DESCRIPTION
Issue introduced by commit `945d84b35d03898fefbcf4dc9a51ac65e49711f9`

Current error message:

```
Obtained ginkgo.Jenkinsfile from git https://github.com/cilium/cilium.git
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: 32: The post section can only contain build condition names with code blocks. Valid condition names are [always, changed, aborted, failure, success, unstable, notBuilt] @ line 32, column 17.
                   sh "cd ${TESTDIR}; make clean-ginkgo-tests || true"
                   ^

WorkflowScript: 31: post can not be empty @ line 31, column 13.
               post {
```

Build ID: https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/556/console

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>