### PR TITLE
pkg/node: fix nil pointer access if no CIDR is allocated

### DIFF
--- a/pkg/node/manager.go
+++ b/pkg/node/manager.go
@@ -343,6 +343,9 @@ func GetNodes() map[Identity]Node {
 // updateIPRoute updates the IP routing entry for the given node n via the
 // network interface that as ownAddr.
 func updateIPRoute(oldNode, n *Node, ownAddr net.IP) {
+	if n.IPv6AllocCIDR == nil {
+		return
+	}
 	nodeIPv6 := n.GetNodeIP(true)
 	scopedLog := log.WithField(logfields.V6Prefix, n.IPv6AllocCIDR)
 	scopedLog.WithField(logfields.IPAddr, nodeIPv6).Debug("iproute: Setting endpoint v6 route for prefix via IP")


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x531f06]
goroutine 247 [running]:
net.networkNumberAndMask(0x0, 0xc420b2e420, 0x0, 0x0, 0x0, 0xffffffff, 0xffffffff)
 /usr/local/go/src/net/ip.go:445 +0x26
net.(*IPNet).String(0x0, 0x0, 0x0)
 /usr/local/go/src/net/ip.go:495 +0x40
github.com/cilium/cilium/pkg/node.updateIPRoute(0x0, 0xc420733040, 0xc4201b10ac, 0x10, 0xf54)
 /home/vagrant/go/src/github.com/cilium/cilium/pkg/node/manager.go:382 +0x28f
github.com/cilium/cilium/pkg/node.UpdateNode(0xc420c799c0, 0x11, 0xc420733040, 0x3, 0xc4201b10ac, 0x10, 0xf54)
 /home/vagrant/go/src/github.com/cilium/cilium/pkg/node/manager.go:298 +0x415
main.(*Daemon).addK8sNodeV1(0xc420010780, 0xc4200f2dc0)
 /home/vagrant/go/src/github.com/cilium/cilium/daemon/k8s_watcher.go:1665 +0xf2
main.(*Daemon).EnableK8sWatcher.func23.1(0x0, 0xc4205b6420)
 /home/vagrant/go/src/github.com/cilium/cilium/daemon/k8s_watcher.go:548 +0x33
github.com/cilium/cilium/pkg/serializer.(*functionQueue).run(0xc4202e63e0)
 /home/vagrant/go/src/github.com/cilium/cilium/pkg/serializer/func_queue.go:65 +0x70
created by github.com/cilium/cilium/pkg/serializer.NewFunctionQueue
 /home/vagrant/go/src/github.com/cilium/cilium/pkg/serializer/func_queue.go:45 +0xca
```
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Fix nil pointer when v6 CIDR was not set by kubernetes.
```