### PR TITLE
Ginkgo CI: don't run Nightly tests as part of K8s tests

### DIFF
--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -45,10 +45,10 @@ pipeline {
                         sh 'cd ${TESTDIR}; ginkgo --focus="Runtime*" -v -noColor'
                     },
                     "K8s-1.7":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.7 ginkgo --focus="K8s*" -v -noColor'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.7 ginkgo --focus=" K8s*" -v -noColor'
                     },
                     "K8s-1.6":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.6 ginkgo --focus="K8s*" -v -noColor'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.6 ginkgo --focus=" K8s*" -v -noColor'
                     },
                     failFast: true
                 )

--- a/test/ginkgo-ext/scope.go
+++ b/test/ginkgo-ext/scope.go
@@ -25,7 +25,7 @@ import (
 
 // GetScope returns the scope for the currently running test.
 func GetScope() string {
-	focusString := strings.ToLower(config.GinkgoConfig.FocusString)
+	focusString := strings.TrimSpace(strings.ToLower(config.GinkgoConfig.FocusString))
 	switch {
 	case strings.HasPrefix(focusString, "run"):
 		return helpers.Runtime


### PR DESCRIPTION
Any test containing the string "K8s" in its Describe was running. Since the Nightly tests
contain the string "K8s", but do not start with "K8s", ensure that only tests prefixed
with "K8s" run during PRs.

Fixes: #2191 

**How to test (optional)**:
`cd test; K8S_VERSION=1.7 ginkgo --focus=" K8s*" -v -noColor`

Only tests prefixed with 'K8s' and not with the string 'K8s' within their `Describe` should run.