### PR TITLE
Allow empty endpoint selector

### DIFF
--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -47,11 +47,6 @@ func (r *rule) sanitize() error {
 		return err
 	}
 
-	if len(r.EndpointSelector.MatchLabels) == 0 &&
-		len(r.EndpointSelector.MatchExpressions) == 0 {
-		return fmt.Errorf("empty EndpointSelector")
-	}
-
 	// resetting entity selector slices
 	r.fromEntities = []api.EndpointSelector{}
 	r.toEntities = []api.EndpointSelector{}

--- a/tests/12-policy-import.sh
+++ b/tests/12-policy-import.sh
@@ -97,19 +97,6 @@ cat <<EOF | cilium -D policy import -
 }]
 EOF
 
-set +e
-log "import policy without an endpointSelector. This should fail"
-cat <<EOF | cilium -D policy import -
-[{
-    "labels": ["key4"]
-}]
-EOF
-if [ $? -eq 0 ]; then 
-  cilium policy delete key4
-	abort "Agent accepted a CiliumNetworkPolicy without an endpointSelector"
-fi
-set -e
-
 log "retrieve policy by labels"
 cilium policy get key1
 cilium policy get key2


### PR DESCRIPTION
``` release-note
Allow for empty endpoint selector. This enables defining policy which applies to all endpoints.
```