### PR TITLE
Nightly: Increase the max job duration on Jenkins

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -7,7 +7,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 120, unit: 'MINUTES')
+        timeout(time: 240, unit: 'MINUTES')
         timestamps()
     }
 
@@ -35,7 +35,7 @@ pipeline {
             post {
                 always {
                     junit 'test/*.xml'
-                    sh 'cd test/; ./post_build_agent.sh || true'                    
+                    sh 'cd test/; ./post_build_agent.sh || true'
                     sh 'cd test/; K8S_VERSION=1.7 vagrant destroy -f'
                 }
             }


### PR DESCRIPTION
With the new PolicyGeneration tests a bigger timeout is needed to run
all the test on the platform.

Reference: https://jenkins.cilium.io/job/Cilium-Nightly-Tests/37/

