### PR TITLE
Ginkgo: Added Nightly endpoint loads tests

### DIFF
--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -686,7 +686,7 @@ func (t *TestSpec) ExecTest() error {
 // TestSpecsGroup is a group of different TestSpec
 type TestSpecsGroup []*TestSpec
 
-// CreateAndApplyManifests creates all the pods manifests and applies those
+// CreateAndApplyManifests creates all of the pods manifests and applies those
 // manifest to the given kubernetes instance.
 func (tg TestSpecsGroup) CreateAndApplyManifests(kub *helpers.Kubectl) {
 	completeManifest := "/tmp/data.yaml"
@@ -703,7 +703,7 @@ func (tg TestSpecsGroup) CreateAndApplyManifests(kub *helpers.Kubectl) {
 }
 
 // CreateAndApplyCNP creates all Cilium Network Policies and it applies those
-// policies to the given kunernetes instance.
+// manifests to the given Kubernetes instance.
 func (tg TestSpecsGroup) CreateAndApplyCNP(kub *helpers.Kubectl) {
 	for _, test := range tg {
 		// TODO: Should be any better way to do this

--- a/test/helpers/policygen/policygen.go
+++ b/test/helpers/policygen/policygen.go
@@ -120,3 +120,37 @@ func GeneratedTestSpec() []TestSpec {
 	}
 	return testSpecs
 }
+
+// GetBasicTestSpec returns a very simple TestSpec with a L4 and L7 policy that
+// allow traffic only to /private/
+func GetBasicTestSpec() TestSpec {
+	return TestSpec{
+		l3: PolicyTestKind{
+			name:  "No Policy",
+			kind:  ingress,
+			tests: ConnResultAllOK,
+			template: map[string]string{
+				"FromEndpoints": `[{}]`,
+			},
+		},
+		l4: PolicyTestKind{
+
+			name:  "Ingress Port 80 TCP",
+			kind:  ingress,
+			tests: ConnResultOnlyHTTP,
+			template: map[string]string{
+				"Ports": `[{"port": "80", "protocol": "TCP"}]`,
+			},
+		},
+		l7: PolicyTestKind{
+			name:  "Ingress policy /private/",
+			kind:  ingress,
+			tests: ConnResultOnlyHTTPPrivate,
+			template: map[string]string{
+				"Rules": `{"http": [{"method": "GET", "path": "/private"}]}`,
+				"Ports": `[{"port": "80", "protocol": "TCP"}]`,
+			},
+		},
+		Destination: DestinationsTypes[0],
+	}
+}

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -66,8 +66,8 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 
 	AfterEach(func() {
 		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, "k8s1")
-			kubectl.CiliumReport("kube-system", ciliumPod, []string{
+			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
+			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
 				"cilium service list",
 				"cilium endpoint list"})
 		}
@@ -174,21 +174,13 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 		podsCreated := 0
 
 		AfterEach(func() {
-			if CurrentGinkgoTestDescription().Failed {
-				ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, "k8s1")
-				kubectl.CiliumReport("kube-system", ciliumPod, []string{
-					"cilium service list",
-					"cilium endpoint list",
-					"cilium policy get"})
-			}
-
 			kubectl.Exec(fmt.Sprintf(
-				"%s delete --all pods,svc,cnp -n%s", helpers.KubectlCmd, helpers.DefaultNamespace))
+				"%s delete --all pods,svc,cnp -n %s", helpers.KubectlCmd, helpers.DefaultNamespace))
 		})
 
-		Measure(fmt.Sprintf("Applying policies to %d pods in bunch of %d", numPods, bunchPods), func(b Benchmarker) {
+		Measure(fmt.Sprintf("Applying policies to %d pods in a group of %d", numPods, bunchPods), func(b Benchmarker) {
 			testDef := func() {
-				logger.Errorf("Create %d new pods, total created are %d", numPods, podsCreated)
+				logger.Errorf("Creating %d new pods, total created are %d", numPods, podsCreated)
 				testSpecGroup := policygen.TestSpecsGroup{}
 				for i := 0; i < bunchPods; i++ {
 					testSpec := policygen.GetBasicTestSpec()


### PR DESCRIPTION
Created a new Nightly test to measure how long takes to load a few
endpoints and apply policies to them. After load the endpoints, some
basic connectivity tests will run.

Related to the task #2029

Example output: 

```
• [MEASUREMENT]                                            
NightlyK8sEpsMeasurement                                   
/home/ecoto/.go/src/github.com/cilium/cilium/test/k8sT/Nightly.go:210         
  Nightly Policies                                         
  /home/ecoto/.go/src/github.com/cilium/cilium/test/k8sT/Nightly.go:209       
    Applying policies to 4 pods in bunch of 2              
    /home/ecoto/.go/src/github.com/cilium/cilium/test/k8sT/Nightly.go:208     
                                                           
    Ran 1 samples:                                         
    Runtime:                                               
      Fastest Time: 0.596s                                                    
      Slowest Time: 0.683s                                 
      Average Time: 0.639s ± 0.043s                        
    Endpoint Creation in seconds:                          
      Smallest: 0.596        
       Largest: 0.683        
       Average: 0.639 ± 0.043
    policy:                  
      Fastest Time: 49.118s  
      Slowest Time: 87.867s  
      Average Time: 68.492s ± 19.375s                      
    Policy Creation in seconds:                            
      Smallest: 49.118       
       Largest: 87.867       
       Average: 68.492 ± 19.375                            
    connTest:                
      Fastest Time: 3.299s   
      Slowest Time: 6.247s   
      Average Time: 4.773s ± 1.474s                        
    Connectivity test in seconds:                          
      Smallest: 3.299        
       Largest: 6.247        
       Average: 4.773 ± 1.474
------------------------------                             
SSSSSSSSSSSS                 
Ran 1 of 158 Specs in 210.151 seconds                      
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 157 Skipped PASS                
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

