### PR TITLE
k8s: Treat unavailability of own node resource as warning

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1042,7 +1042,7 @@ func NewDaemon(c *Config) (*Daemon, error) {
 		err := k8s.AnnotateNodeCIDR(k8s.Client(), node.GetName(),
 			node.GetIPv4AllocRange(), node.GetIPv6NodeRange())
 		if err != nil {
-			log.WithError(err).Fatal("Cannot annotate node CIDR range data")
+			log.WithError(err).Warning("Cannot annotate k8s node with CIDR range")
 		}
 	}
 

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -39,7 +39,8 @@ func Init() error {
 
 		k8sNode, err := GetNode(Client(), nodeName)
 		if err != nil {
-			return fmt.Errorf("unable to retrieve k8s node information: %s", err)
+			log.WithError(err).Warning("Unable to retrieve k8s node information, skipping...")
+			return nil
 		}
 
 		n := ParseNode(k8sNode)


### PR DESCRIPTION
This allows running the agent on a node that is not a k8s node but has
access to the k8s apiserver.

Fixes: #2375

Signed-off-by: Thomas Graf <thomas@cilium.io>