### PR TITLE
k8s: Reduce initial readinessProbe delay

### DIFF
--- a/examples/kubernetes/cilium.yaml
+++ b/examples/kubernetes/cilium.yaml
@@ -140,7 +140,10 @@ spec:
             command:
             - cilium
             - status
-          initialDelaySeconds: 180
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
           failureThreshold: 10
           periodSeconds: 10
         readinessProbe:
@@ -148,8 +151,8 @@ spec:
             command:
             - cilium
             - status
-          initialDelaySeconds: 180
-          periodSeconds: 15
+          initialDelaySeconds: 5
+          periodSeconds: 5
         volumeMounts:
           - name: bpf-maps
             mountPath: /sys/fs/bpf

--- a/examples/minikube/cilium-ds.yaml
+++ b/examples/minikube/cilium-ds.yaml
@@ -141,7 +141,10 @@ spec:
             command:
             - cilium
             - status
-          initialDelaySeconds: 180
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
           failureThreshold: 10
           periodSeconds: 10
         readinessProbe:
@@ -149,8 +152,8 @@ spec:
             command:
             - cilium
             - status
-          initialDelaySeconds: 180
-          periodSeconds: 15
+          initialDelaySeconds: 5
+          periodSeconds: 5
         volumeMounts:
           - name: bpf-maps
             mountPath: /sys/fs/bpf

--- a/test/k8sT/manifests/1.6/cilium_ds.yaml
+++ b/test/k8sT/manifests/1.6/cilium_ds.yaml
@@ -132,7 +132,7 @@ spec:
             command:
             - cilium
             - status
-          initialDelaySeconds: 30
+          initialDelaySeconds: 120
           failureThreshold: 10
           periodSeconds: 10
         readinessProbe:
@@ -140,8 +140,8 @@ spec:
             command:
             - cilium
             - status
-          initialDelaySeconds: 30
-          periodSeconds: 15
+          initialDelaySeconds: 5
+          periodSeconds: 5
         volumeMounts:
           - name: bpf-maps
             mountPath: /sys/fs/bpf

--- a/test/k8sT/manifests/1.6/cilium_ds_geneve.yaml
+++ b/test/k8sT/manifests/1.6/cilium_ds_geneve.yaml
@@ -132,7 +132,7 @@ spec:
             command:
             - cilium
             - status
-          initialDelaySeconds: 30
+          initialDelaySeconds: 120
           failureThreshold: 10
           periodSeconds: 10
         readinessProbe:
@@ -140,8 +140,8 @@ spec:
             command:
             - cilium
             - status
-          initialDelaySeconds: 30
-          periodSeconds: 15
+          initialDelaySeconds: 5
+          periodSeconds: 5
         volumeMounts:
           - name: bpf-maps
             mountPath: /sys/fs/bpf

--- a/test/k8sT/manifests/1.7/cilium_ds.yaml
+++ b/test/k8sT/manifests/1.7/cilium_ds.yaml
@@ -132,7 +132,7 @@ spec:
             command:
             - cilium
             - status
-          initialDelaySeconds: 30
+          initialDelaySeconds: 120
           failureThreshold: 10
           periodSeconds: 10
         readinessProbe:
@@ -140,8 +140,8 @@ spec:
             command:
             - cilium
             - status
-          initialDelaySeconds: 30
-          periodSeconds: 15
+          initialDelaySeconds: 5
+          periodSeconds: 5
         volumeMounts:
           - name: bpf-maps
             mountPath: /sys/fs/bpf

--- a/test/k8sT/manifests/1.7/cilium_ds_geneve.yaml
+++ b/test/k8sT/manifests/1.7/cilium_ds_geneve.yaml
@@ -132,7 +132,7 @@ spec:
             command:
             - cilium
             - status
-          initialDelaySeconds: 30
+          initialDelaySeconds: 120
           failureThreshold: 10
           periodSeconds: 10
         readinessProbe:
@@ -140,8 +140,8 @@ spec:
             command:
             - cilium
             - status
-          initialDelaySeconds: 30
-          periodSeconds: 15
+          initialDelaySeconds: 5
+          periodSeconds: 5
         volumeMounts:
           - name: bpf-maps
             mountPath: /sys/fs/bpf


### PR DESCRIPTION
Keep the initial liveness probe long to avoid endless kill & restart
cycles but reduce the readinessProbe delay to mark the pod as ready
earlier.

Signed-off-by: Thomas Graf <thomas@cilium.io>

``` release-note
Reduce the readinessProbe delay to mark the pod as ready earlier
```