### PR TITLE
cni: Create destination directory if it does not exist

### DIFF
--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -9,6 +9,8 @@ MTU=${MTU:-1450}
 CNI_DIR=${CNI_DIR:-${HOST_PREFIX}/opt/cni}
 CILIUM_CNI_CONF=${CILIUM_CNI_CONF:-${HOST_PREFIX}/etc/cni/net.d/${CNI_CONF_NAME}}
 
+mkdir -p ${CNI_DIR}/bin
+
 # Install the CNI loopback driver if not installed already
 if [ ! -f ${CNI_DIR}/bin/loopback ]; then
 	echo "Installing loopback driver..."
@@ -21,7 +23,7 @@ cp /opt/cni/bin/cilium-cni ${CNI_DIR}/bin/
 if [ -f "${CILIUM_CNI_CONF}" ]; then
 	echo "Using existing ${CILIUM_CNI_CONF}..."
 else
-	echo "Installing new $CILIUM_CNI_CONF ..."
+	echo "Installing new ${CILIUM_CNI_CONF}..."
 	cat > ${CNI_CONF_NAME} <<EOF
 {
     "name": "cilium",
@@ -29,6 +31,7 @@ else
     "mtu": ${MTU}
 }
 EOF
+	mkdir -p $(dirname $CILIUM_CNI_CONF)
 
 	mv ${CNI_CONF_NAME} ${CILIUM_CNI_CONF}
 fi


### PR DESCRIPTION
Fixes installation if either the bin or conf directory does not exist
already.

Reported-by: Jon Davies
Signed-off-by: Thomas Graf <thomas@cilium.io>
