### PR TITLE
Tl/fix rpm package build

### DIFF
--- a/contrib/packaging/rpm/.gitignore
+++ b/contrib/packaging/rpm/.gitignore
@@ -2,3 +2,4 @@ cilium*
 version*
 output
 env
+!cilium.spec.envsubst

--- a/contrib/packaging/rpm/cilium.spec.envsubst
+++ b/contrib/packaging/rpm/cilium.spec.envsubst
@@ -41,12 +41,12 @@ export PKG_BUILD=1
 cd %{name}-%{commit0}/src/github.com/cilium/%{name}
 %make_install
 
-mkdir -p "%{buildroot}%{_usr}/lib/systemd/system"
+mkdir -p "%{buildroot}%{_prefix}/lib/systemd/system"
 mkdir -p "%{buildroot}%{_sysconfdir}/sysconfig"
 
-cp contrib/systemd/*.service "%{buildroot}%{_usr}/lib/systemd/system"
-cp contrib/systemd/*.mount "%{buildroot}%{_usr}/lib/systemd/system"
-chmod 644 %{buildroot}%{_usr}/lib/systemd/system/*
+cp contrib/systemd/*.service "%{buildroot}%{_prefix}/lib/systemd/system"
+cp contrib/systemd/*.mount "%{buildroot}%{_prefix}/lib/systemd/system"
+chmod 644 %{buildroot}%{_prefix}/lib/systemd/system/*
 
 cp contrib/systemd/cilium "%{buildroot}%{_sysconfdir}/sysconfig"
 chmod 644 "%{buildroot}%{_sysconfdir}/sysconfig/cilium"

--- a/contrib/packaging/rpm/cilium.spec.envsubst
+++ b/contrib/packaging/rpm/cilium.spec.envsubst
@@ -69,7 +69,7 @@ chmod 644 "%{buildroot}%{_sysconfdir}/sysconfig/cilium"
 %{_bindir}/cilium-health
 
 %changelog
-* Wed Dev 20 2017 Tony Lambiris <tony@criticalstack.com> - 0.13.90-0.git${SHORTCOMMIT}
+* Wed Dec 20 2017 Tony Lambiris <tony@criticalstack.com> - 0.13.90-0.git${SHORTCOMMIT}
 - Added cilium-bugtool, cilium-bugtool and sys-fs-bpf.mount to %files
 
 * Thu Mar 23 2017 Marcin Skarbek <rpm@skarbek.name> - 0.1.0-0.git${SHORTCOMMIT}

--- a/contrib/packaging/rpm/cilium.spec.envsubst
+++ b/contrib/packaging/rpm/cilium.spec.envsubst
@@ -1,0 +1,79 @@
+%global commit0 ${COMMIT}
+%global shortcommit0 %(c=%{commit0}; echo ${c:0:7})
+
+Name:          cilium
+Version:       ${VERSION}
+Release:       0.git%{shortcommit0}%{?dist}
+Summary:       BPF & XDP for containers
+License:       Apache
+URL:           https://github/cilium/cilium
+ExclusiveArch: x86_64
+Source0:       https://github.com/cilium/%{name}/archive/%{commit0}.tar.gz#/%{name}-%{shortcommit0}.tar.gz
+BuildRequires: golang, go-bindata, glibc-devel(x86-32)
+Requires:      docker-engine >= 1.12, glibc-devel(x86-32), iproute >= 4.10, clang
+%{?fc25:Requires: clang >= 3.8, clang < 3.9}
+
+%description
+Cilium provides fast in-kernel networking and security policy enforcement
+for containers based on eBPF programs generated on the fly. It is an
+experimental project aiming at enabling emerging kernel technologies such
+as BPF and XDP for containers.
+
+%pre
+getent group cilium >/dev/null || groupadd -f -r cilium
+exit 0
+
+%prep
+mkdir -p %{name}-%{commit0}/src/github.com/cilium/%{name}
+tar zxf %{SOURCE0} --strip-components=1 -C %{name}-%{commit0}/src/github.com/cilium/%{name}
+echo "%{version}-0.git%{shortcommit0}" > %{name}-%{commit0}/src/github.com/cilium/%{name}/VERSION
+
+%build
+export GOPATH=$(pwd)/%{name}-%{commit0}
+export PKG_BUILD=1
+cd %{name}-%{commit0}/src/github.com/cilium/%{name}
+%{__make} -C daemon apply-bindata
+%{__make} build
+
+%install
+export GOPATH=$(pwd)/%{name}-%{commit0}
+export PKG_BUILD=1
+cd %{name}-%{commit0}/src/github.com/cilium/%{name}
+%make_install
+
+mkdir -p "%{buildroot}%{_usr}/lib/systemd/system"
+mkdir -p "%{buildroot}%{_sysconfdir}/sysconfig"
+
+cp contrib/systemd/*.service "%{buildroot}%{_usr}/lib/systemd/system"
+cp contrib/systemd/*.mount "%{buildroot}%{_usr}/lib/systemd/system"
+chmod 644 %{buildroot}%{_usr}/lib/systemd/system/*
+
+cp contrib/systemd/cilium "%{buildroot}%{_sysconfdir}/sysconfig"
+chmod 644 "%{buildroot}%{_sysconfdir}/sysconfig/cilium"
+
+%files
+%{_sysconfdir}/bash_completion.d/cilium
+%{_sysconfdir}/cni/net.d/10-cilium-cni.conf
+%{_sysconfdir}/sysconfig/cilium
+%{_prefix}/lib/systemd/system/cilium-consul.service
+%{_prefix}/lib/systemd/system/cilium-docker.service
+%{_prefix}/lib/systemd/system/cilium-etcd.service
+%{_prefix}/lib/systemd/system/cilium.service
+%{_prefix}/lib/systemd/system/sys-fs-bpf.mount
+/opt/cni/bin/cilium-cni
+%{_bindir}/cilium
+%{_bindir}/cilium-agent
+%{_bindir}/cilium-docker
+%{_bindir}/cilium-node-monitor
+%{_bindir}/cilium-bugtool
+%{_bindir}/cilium-health
+
+%changelog
+* Wed Dev 20 2017 Tony Lambiris <tony@criticalstack.com> - 0.13.90-0.git${SHORTCOMMIT}
+- Added cilium-bugtool, cilium-bugtool and sys-fs-bpf.mount to %files
+
+* Thu Mar 23 2017 Marcin Skarbek <rpm@skarbek.name> - 0.1.0-0.git${SHORTCOMMIT}
+- Updated spec file
+
+* Wed Oct 12 2016 Andre Martins <andre@cilium.io> - 0.1.0-0
+- Initial version of the package


### PR DESCRIPTION
Not sure when it happened, but it looks like `cilium.spec.envsubst` used to live in the cfg directory that no longer appears to exist. This brights the spec file template back, adds it to the end of `.gitignore` and also adds new binaries and sys-fs-bpf.mount to the `%files` directive. In addition, I added a new make target in the spec:
```
%{__make} -C daemon apply-bindata
```
This fixes an issue I was getting during my testing of this PR:
```
bindata.go: FAILED
sha1sum: WARNING: 1 computed checksum did NOT match
########################################################################

                  ERROR: bindata.go is out of date.

 This can happen for two reasons:
 1. You are using a go-bindata binary compiled with a different version
    of golang (not 1.9). If so, please up/downgrade.

 2. You have made changes to the bpf/ directory. Please run the
    following command to update the SHA in daemon/bpf.sha:

    $ make -C daemon apply-bindata
```

It looks as if this PR will also get you closer to closing out https://github.com/cilium/cilium/issues/1529

```release-note
Tl/fix rpm package build
```
  
  