### PR TITLE
Ginkgo: Fix policy import without selector

### DIFF
--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -117,7 +117,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 		It("Handles missing required fields", func() {
 			By("Apply a policy with no endpointSelector without crashing")
 			_, err := vm.PolicyImport(vm.GetFullPath("no_endpointselector_policy.json"), helpers.HelperTimeout)
-			Expect(err).ShouldNot(BeNil())
+			Expect(err).Should(BeNil())
 		})
 
 		It("Default to Always without policy", func() {


### PR DESCRIPTION
From commit `ba018e3fb98e0b037d89d4d8c033846366e748b6` policies can be
without EndpointSelector, so the test shouldn't fail. Policy should be
added without problems.

Fix ginkgo build 593

https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/593/

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>