### PR TITLE
Ginkgo: Fix race condition when cilium is restarted

### DIFF
--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -170,8 +170,10 @@ var _ = Describe("RuntimeConntrackTest", func() {
 		logger = log.WithFields(logrus.Fields{"test": "RunConntrackTest"})
 		logger.Info("Starting")
 		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		vm.WaitUntilReady(100)
 		vm.NetworkCreate(helpers.CiliumDockerNetwork, "")
 		initialized = true
+
 	}
 
 	clientServerConnectivity := func() {

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -42,6 +42,7 @@ var _ = Describe("RuntimeKafka", func() {
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimeKafka"})
 		logger.Info("Starting")
 		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		vm.WaitUntilReady(100)
 		vm.NetworkCreate(helpers.CiliumDockerNetwork, "")
 		initialized = true
 	}


### PR DESCRIPTION
In the build 598, the KVStore test was executed just before
RuntimeConntrackTest. KVStore stops cilium for running it manually,
cilium starts correctly after the test, but it takes a bit to be ready
and test fail.

Added a `WaitUntilReady` on initializing functions to fix that problem.

https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/598/consoleFull

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>