### PR TITLE
daemon: Fix nil dereference from duplicate set of endpoint state

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -337,11 +337,12 @@ func (d *Daemon) deleteEndpoint(ep *endpoint.Endpoint) int {
 
 	// In case multiple delete requests have been enqueued, have all of them
 	// except the first return here.
-	if !ep.SetStateLocked(endpoint.StateDisconnecting, "Deleting endpoint") {
+	if ep.GetStateLocked() == endpoint.StateDisconnecting {
 		ep.Mutex.Unlock()
 		ep.BuildMutex.Unlock()
 		return 0
 	}
+	ep.SetStateLocked(endpoint.StateDisconnecting, "Deleting endpoint")
 
 	sha256sum := ep.OpLabels.IdentityLabels().SHA256Sum()
 	if err := d.DeleteIdentityBySHA256(sha256sum, ep.StringID()); err != nil {


### PR DESCRIPTION
If two state changes were queued up in quick succession, it's possible
for them to both attempt to set the state of the endpoint to
disconnecting. Unfortunately this now also involves modifying the
endpoint, so if the first update modified the state and deleted the
endpoint, then the second state would attempt to modify the state and
hit a nil dereference rather than exiting out early. Fix the issue.

```
panic: assignment to entry in nil map
goroutine 157 [running]:
github.com/cilium/cilium/pkg/endpoint.(*EndpointStatus).addStatusLog(0xc420057c80, 0xc420084a50)
        /home/vagrant/go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:748 +0x4f
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).logStatusLocked(0xc4202fe1e0, 0x0, 0x0, 0x1c5b63f, 0x11)
        /home/vagrant/go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:1125 +0x156
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).SetStateLocked(0xc4202fe1e0, 0x1c56ac0, 0xd, 0x1c5b63f, 0x11, 0xc420084a00)
        /home/vagrant/go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:1438 +0x134
main.(*Daemon).deleteEndpoint(0xc420010240, 0xc4202fe1e0, 0x1)
        /home/vagrant/go/src/github.com/cilium/cilium/daemon/endpoint.go:305 +0x10c
main.(*Daemon).SyncState.func1(0xc420060701, 0xc420010240, 0xc4202fe1e0, 0xc420060700, 0xc420060770)
        /home/vagrant/go/src/github.com/cilium/cilium/daemon/state.go:70 +0xa06
created by main.(*Daemon).SyncState
        /home/vagrant/go/src/github.com/cilium/cilium/daemon/state.go:66 +0x1e4
```

Closes: #2394
Fixes: 22d4ac1af112 ("pkg/endpoint: fix stuck state "restoring" when restoring endpoints")

Suggested-by: André Martins <andre@cilium.io>
Signed-off-by: Joe Stringer <joe@covalent.io>

```release-note
Fix an issue where cilium would crash if two endpoint disconnect endpoints for the same endpoint occurred in quick succession.
```