### PR TITLE
Vagrantfile: update box to version 2.7 for VirtualBox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -129,7 +129,7 @@ Vagrant.configure(2) do |config|
         vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
 
         config.vm.box = "cilium/ubuntu-16.10"
-	config.vm.box_version = "2.5"
+	config.vm.box_version = "2.7"
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i
 


### PR DESCRIPTION
Use new VM image that contains all of the Docker images used for testing packaged in.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #2011 

```release-note
Use version 2.7 of developer box, which contains commonly-used Docker images for tests pre-packaged
```
