### PR TITLE
Ginkgo: redirects vagrant provision output to GinkgoWriter

### DIFF
--- a/test/helpers/vagrant.go
+++ b/test/helpers/vagrant.go
@@ -15,12 +15,13 @@
 package helpers
 
 import (
-	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
 
+	"github.com/onsi/ginkgo"
 	"github.com/sirupsen/logrus"
 )
 
@@ -52,19 +53,8 @@ func CreateVM(scope string) error {
 		return fmt.Errorf("error getting stderr: %s", err)
 	}
 
-	go func() {
-		in := bufio.NewScanner(stdout)
-		for in.Scan() {
-			log.Infof("stdout: %s", in.Text()) // write each line to your log
-		}
-	}()
-
-	go func() {
-		errIn := bufio.NewScanner(stderr)
-		for errIn.Scan() {
-			log.Infof("stderr: %s", errIn.Text())
-		}
-	}()
+	go io.Copy(ginkgo.GinkgoWriter, stderr)
+	go io.Copy(ginkgo.GinkgoWriter, stdout)
 
 	if err := cmd.Start(); err != nil {
 		log.WithFields(logrus.Fields{


### PR DESCRIPTION
At the moment the output of `vagrant provision` is not saved anywhere.
Logs are not written to logfile due that it's not part of any test (it's
running on BeforeSuite) with this change the output is always sent to
Ginkgo and can be retrieved from jenkins console.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>