### PR TITLE
Nightly: Fix issues with egress Nodeport

### DIFF
--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -218,6 +218,8 @@ func (t *Target) CreateApplyManifest(spec *TestSpec) error {
 
 	switch t.Kind {
 	case service:
+		// As default services are listen on port 80.
+		t.PortNumber = 80
 		service := `{
 		"apiVersion": "v1",
 		"kind": "Service",
@@ -226,7 +228,7 @@ func (t *Target) CreateApplyManifest(spec *TestSpec) error {
 		},
 		"spec": {
 			"ports": [
-				{ "port": 80 }
+				{ "port": {{ .target.PortNumber }} }
 			],
 			"selector": {
 				"id": "{{ .spec.DestPod }}"
@@ -331,11 +333,11 @@ func (t *TestSpec) RunTest(kub *helpers.Kubectl) {
 	gomega.Expect(err).To(gomega.BeNil(), "cannot apply pods manifest for %s", t.Prefix)
 	log.WithField("prefix", t.Prefix).Infof("Manifest '%s' is created correctly", manifest)
 
-	err = t.NetworkPolicyApply()
-	gomega.Expect(err).To(gomega.BeNil(), "cannot apply network policy for %s", t.Prefix)
-
 	err = t.Destination.CreateApplyManifest(t)
 	gomega.Expect(err).To(gomega.BeNil(), "cannot apply destination for %s", t.Prefix)
+
+	err = t.NetworkPolicyApply()
+	gomega.Expect(err).To(gomega.BeNil(), "cannot apply network policy for %s", t.Prefix)
 
 	err = t.ExecTest()
 	gomega.Expect(err).To(gomega.BeNil(), "cannot execute test for %s", t.Prefix)

--- a/test/helpers/policygen/policygen.go
+++ b/test/helpers/policygen/policygen.go
@@ -94,7 +94,7 @@ var policiesTestSuite = PolicyTestSuite{
 			tests: ConnResultOnlyHTTPPrivate,
 			template: map[string]string{
 				"Rules": `{"http": [{"method": "GET", "path": "/private"}]}`,
-				"Ports": `[{"port": "80", "protocol": "TCP"}]`,
+				"Ports": `[{"port": "{{ .Destination.PortNumber }}", "protocol": "TCP"}]`,
 			},
 		},
 	},


### PR DESCRIPTION
When the test is an egress policy, the NodePort service was trying to
reach port 80 instead of the correct one. This change updates the
policies to the right port.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>