### PR TITLE
Documentation: override the font and frame for parsed literal

### DIFF
--- a/Documentation/_static/parsed-literal.css
+++ b/Documentation/_static/parsed-literal.css
@@ -1,0 +1,10 @@
+pre.literal-block {
+  white-space: pre;
+  margin: 0 !important;
+  padding: 12px 12px !important;
+  font-family: Consolas,"Andale Mono WT","Andale Mono","Lucida Console","Lucida Sans Typewriter","DejaVu Sans Mono","Bitstream Vera Sans Mono","Liberation Mono","Nimbus Mono L",Monaco,"Courier New",Courier,monospace;
+  font-size: 12px;
+  display: block;
+  overflow: auto;
+  color: #404040;
+}

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -113,8 +113,7 @@ html_theme_path = ["_themes", ]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['images']
-
+html_static_path = ['images', '_static']
 
 # -- Options for HTMLHelp output ------------------------------------------
 
@@ -177,3 +176,6 @@ http_strict_mode = False
 
 # Try as hard as possible to find references
 default_role = 'any'
+
+def setup(app):
+    app.add_stylesheet('parsed-literal.css')


### PR DESCRIPTION
This makes the snippets using a variable URL look the same
as regular snippets.

Closes: #1784 (docs: make snippets / examples have a consistent look)

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>
