### PR TITLE
test/helpers: fix formatting of CmdRes exit code

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -60,9 +60,9 @@ func (res *CmdRes) GetStdErr() string {
 
 // SendToLog writes to `TestLogWriter` the debug message for the running command
 func (res *CmdRes) SendToLog() {
-	fmt.Fprintf(&config.TestLogWriter, "cmd: %q exitCode: %q \n %s\n",
+	fmt.Fprintf(&config.TestLogWriter, "cmd: %q exitCode: %d \n %s\n",
 		res.cmd,
-		res.exit,
+		res.GetExitCode(),
 		res.CombineOutput())
 }
 


### PR DESCRIPTION
Logs from tests had the following issue: " exitCode: %!q(bool=true)".
This changes the string formatting to use %d instead of %q for the
exit code value, which is an integer.

Signed-off by: Ian Vernon <ian@cilium.io>"

Fixes: #2425 
  