### PR TITLE
.gitignore: Ignore Emacs backup files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ outgoing
 
 man/
 
+# Bazel symlinks
 bazel-*
 
 test/tmp.yaml
+
+# Emacs backup files
+*~


### PR DESCRIPTION
Not sure how I did not see these earlier but we should ignore files
ending in '~' that Emacs sometimes leaves around.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
