### PR TITLE
Ginkgo CI: failure during Kafka Policy Ingress test

### DIFF
--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -43,6 +43,8 @@ var _ = Describe("RuntimeKafka", func() {
 		logger.Info("Starting")
 		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 		vm.WaitUntilReady(100)
+		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
+		res.ExpectSuccess()
 		vm.NetworkCreate(helpers.CiliumDockerNetwork, "")
 		initialized = true
 	}


### PR DESCRIPTION
The issue is that ginkgo tests need to set cilium policy to default
and not "never". This causes "cilium endpoint get" to return
policy = none instead of ingress.

Fixes Issue:  #2418
Signed-Off-By: Manali Bhutiyani <manali@covalent.io>

```release-note
Fix Ginkgo Kafka tests to initialize config for policy enforcement to default
```