### PR TITLE
Envoy: Reflect cilium log level to Envoy.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1210,6 +1210,12 @@ func mapValidateWalker(path string) error {
 
 func changedOption(key string, value bool, data interface{}) {
 	d := data.(*Daemon)
+	if key == endpoint.OptionDebug {
+		// Set the debug toggle (this can be a no-op)
+		logging.ToggleDebugLogs(d.DebugEnabled())
+		// Reflect log level change to proxies
+		proxy.ChangeLogLevel(log.Level)
+	}
 	d.policy.BumpRevision() // force policy recalculation
 }
 
@@ -1278,9 +1284,6 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 	log.WithField("count", changes).Debug("Applied changes to daemon's configuration")
 
 	if changes > 0 {
-		// Set the debug toggle (this can be a no-op)
-		logging.ToggleDebugLogs(d.DebugEnabled())
-
 		// Only recompile if configuration has changed.
 		log.Debug("daemon configuration has changed; recompiling base programs")
 		if err := d.compileBase(); err != nil {

--- a/envoy/Makefile
+++ b/envoy/Makefile
@@ -96,8 +96,8 @@ install-release: force
 
 install-debug: force
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
-	-rm $(DESTDIR)$(BINDIR)/cilium-envoy-debug
-	$(INSTALL) -m 0755 -T $(DEBUG_TARGET) $(DESTDIR)$(BINDIR)/cilium-envoy-debug
+	-rm $(DESTDIR)$(BINDIR)/cilium-envoy
+	$(INSTALL) -m 0755 -T $(DEBUG_TARGET) $(DESTDIR)$(BINDIR)/cilium-envoy
 
 clean: force
 	echo "Bazel clean skipped, try \"make distclean\" instead."

--- a/pkg/envoy/envoy_test.go
+++ b/pkg/envoy/envoy_test.go
@@ -36,7 +36,7 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 	}
 
 	// launch debug variant of the Envoy proxy
-	Envoy := StartEnvoy(true, 9901, "", "", 42)
+	Envoy := StartEnvoy(9901, "", "", 42)
 	c.Assert(Envoy, NotNil)
 
 	sel := api.NewWildcardEndpointSelector()

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -60,7 +60,7 @@ var envoyOnce sync.Once
 func createEnvoyRedirect(l4 *policy.L4Filter, id string, source ProxySource, to uint16) (Redirect, error) {
 	envoyOnce.Do(func() {
 		// Start Envoy on first invocation
-		envoyProxy = envoy.StartEnvoy(true, 0, viper.GetString("state-dir"),
+		envoyProxy = envoy.StartEnvoy(9901, viper.GetString("state-dir"),
 			viper.GetString("state-dir"), 0)
 	})
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -434,4 +435,11 @@ func (p *Proxy) RemoveRedirect(id string) error {
 	delete(p.allocatedPorts, toPort)
 
 	return nil
+}
+
+// ChangeLogLevel changes proxy log level to correspond to the logrus log level 'level'.
+func ChangeLogLevel(level logrus.Level) {
+	if envoyProxy != nil {
+		envoyProxy.ChangeLogLevel(level)
+	}
 }

--- a/tests/k8s/tests/03-l7-stresstest.sh
+++ b/tests/k8s/tests/03-l7-stresstest.sh
@@ -31,7 +31,16 @@ LOCAL_CILIUM_POD="$(kubectl get pods -n kube-system -o wide | grep $(hostname) |
 
 log "running test: $TEST_NAME"
 
+CILIUM_PODS=$(kubectl -n kube-system get pods -l k8s-app=cilium | grep cilium- | awk '{print $1}')
+
+for pod in $CILIUM_PODS; do
+    kubectl -n kube-system exec $pod -- cilium config Debug=false
+done
+
 function finish_test {
+  for pod in $CILIUM_PODS; do
+      kubectl -n kube-system exec $pod -- cilium config Debug=true
+  done
   log "running finish_test for $TEST_NAME"
   gather_files ${TEST_NAME} k8s-tests
   gather_k8s_logs "2" ${LOGS_DIR}


### PR DESCRIPTION
Simplify interaction with Envoy by requiring that debug version uses
the same binary name.

Use the Envoy admin interface to set the log level at runtime whenever
cilium log level is changed.

Disable Cilium debug output for the duration of the stress tests. This
sets the Cilium internal log level to "info", which is reflected to
the Envoy process using the admin interface. This drastically reduces
the logging output of the Envoy process, as on the debug level a
stress test can fill a disk with logs.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
