### PR TITLE
Ginkgo: Fix issues with Direct connectivity

### DIFF
--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -276,6 +276,7 @@ func (t *Target) CreateApplyManifest(spec *TestSpec) error {
 			return err
 		}
 	case direct:
+		t.PortNumber = 80
 		return nil
 	}
 	res := spec.Kub.Apply(manifestPath)


### PR DESCRIPTION
At the moment the Direct connectivity in Nightly is failing due invalid
target port. This commit fixes the direct connectivity.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>