### PR TITLE
ginkgo.Jenkinsfile: only run validated tests as part of PRs

### DIFF
--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -40,7 +40,7 @@ const (
 	MonitorDebug = "Debug"
 )
 
-var _ = Describe("RuntimeMonitorTest", func() {
+var _ = Describe("RuntimeValidatedMonitorTest", func() {
 
 	var initialized bool
 	var logger *logrus.Entry


### PR DESCRIPTION
To ensure that there is trust in the Ginkgo tests as being a good indicator of stability of Cilium, only run a subset of the tests that have proven to be stable over a long period of time. That is, edit the Jenkinsfile for Ginkgo tests to only run tests with the prefix `RuntimeValidated` or `K8sValidated` if the branch being tested is not master. If the branch is master, run all Ginkgo tests. This will allow tests to be piecemeal moved over to the Ginkgo tests as they have been validated and proven stable, as well as allow us to continue using Ginkgo-CI-Tests-Pipeline to run all the tests at a regular cadence to prove that the Ginkgo tests are stable. Currently, the monitor test is the only test that runs as part of the Ginkgo tests during PRs, as @scanf has said that this test has migrated the monitor tests from the Bash-script based CI.

Signed-off by: Ian Vernon <ian@cilium.io>
  