### PR TITLE
Change Version string to json for client and daemon #1272

### DIFF
--- a/Documentation/cmdref/cilium_version.md
+++ b/Documentation/cmdref/cilium_version.md
@@ -13,6 +13,12 @@ Print version information
 cilium version
 ```
 
+### Options
+
+```
+  -o, --output string   json| jsonpath='{}'
+```
+
 ### Options inherited from parent commands
 
 ```

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -9,7 +9,7 @@ INSTALL = install
 VERSION = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/VERSION)
 # Use git only if in a Git repo
 ifneq ($(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/.git),)
-	GIT_VERSION = $(shell git show -s --format='format:%h %aD')
+	GIT_VERSION = $(shell git show -s --format='format:%h %aI')
 else
 	GIT_VERSION = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/GIT_VERSION)
 endif

--- a/daemon/debuginfo.go
+++ b/daemon/debuginfo.go
@@ -38,11 +38,10 @@ func NewGetDebugInfoHandler(d *Daemon) restapi.GetDebuginfoHandler {
 }
 
 func (h *getDebugInfo) Handle(params restapi.GetDebuginfoParams) middleware.Responder {
-	cver := version.GetCiliumVersion()
 	dr := models.DebugInfo{}
 	d := h.daemon
 
-	dr.CiliumVersion = fmt.Sprintf("%s (%s) %s", cver.Version, cver.Revision, cver.Arch)
+	dr.CiliumVersion = version.Version
 	if kver, err := getKernelVersion(); err != nil {
 		dr.KernelVersion = fmt.Sprintf("Error: %s\n", err)
 	} else {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,12 +17,8 @@ package version
 import (
 	"encoding/base64"
 	"encoding/json"
-	"runtime"
 	"strings"
 )
-
-// FIXME Write version on a JSON format. Currently a single string:
-// `Cilium 0.11.90 774ecd3 Wed, 19 Jul 2017 06:27:28 +0000 go version go1.8.3 linux/amd64`
 
 // CiliumVersion provides a minimal structure to the version string
 type CiliumVersion struct {
@@ -34,26 +30,34 @@ type CiliumVersion struct {
 	GoRuntimeVersion string
 	// Arch is the architecture where Cilium was compiled
 	Arch string
+	// AuthorDate is the git author time reference stored as string ISO 8601 formatted
+	AuthorDate string
 }
 
+// Version is set during build
 var Version string
 
-func versionFrom(versionString string) CiliumVersion {
-	cver := CiliumVersion{}
-	output := strings.Replace(versionString, "Cilium ", "", 1)
+// FromString converts a version string into struct
+func FromString(versionString string) CiliumVersion {
+	// string to parse: "0.13.90 a722bdb 2018-01-09T22:32:37+01:00 go version go1.9 linux/amd64"
+	fields := strings.Split(versionString, " ")
+	if len(fields) != 7 {
+		return CiliumVersion{}
+	}
 
-	fields := strings.Split(output, " ")
-	cver.Version = fields[0]
-	cver.Revision = fields[1]
-	cver.Arch = fields[len(fields)-1]
-	cver.GoRuntimeVersion = runtime.Version()
-
+	cver := CiliumVersion{
+		Version:          fields[0],
+		Revision:         fields[1],
+		AuthorDate:       fields[2],
+		GoRuntimeVersion: fields[5],
+		Arch:             fields[6],
+	}
 	return cver
 }
 
 // GetCiliumVersion returns a initialized CiliumVersion structure
 func GetCiliumVersion() CiliumVersion {
-	return versionFrom(Version)
+	return FromString(Version)
 }
 
 // Base64 returns the version in a base64 format.

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -29,10 +29,69 @@ type VersionSuite struct {
 var _ = Suite(&VersionSuite{})
 
 func (vs *VersionSuite) TestStructIsSet(c *C) {
-	output := "Cilium 0.13.90 7330b8d Sun, 12 Nov 2017 13:34:43 +0900 go version go1.8.3 linux/amd64"
-	cver := versionFrom(output)
+	var versionDataList = []struct {
+		in  string
+		out CiliumVersion
+	}{
+		{
+			"0.11.90 774ecd3 2018-01-09T22:32:37+01:00 go version go1.8.3 linux/amd64",
+			CiliumVersion{
+				Version:          "0.11.90",
+				Revision:         "774ecd3",
+				GoRuntimeVersion: "go1.8.3",
+				Arch:             "linux/amd64",
+				AuthorDate:       "2018-01-09T22:32:37+01:00",
+			},
+		},
+		{
+			"0.11.90 774ecd3 2018-01-09T22:32:37+01:00 go version go1.9 someArch/i8726",
+			CiliumVersion{
+				Version:          "0.11.90",
+				Revision:         "774ecd3",
+				GoRuntimeVersion: "go1.9",
+				Arch:             "someArch/i8726",
+				AuthorDate:       "2018-01-09T22:32:37+01:00",
+			},
+		},
+		{
+			"278.121.290 774ecd3 2018-01-09T22:32:37+01:00 go version go2522.2520.25251 windows/amd64",
+			CiliumVersion{
+				Version:          "278.121.290",
+				Revision:         "774ecd3",
+				GoRuntimeVersion: "go2522.2520.25251",
+				Arch:             "windows/amd64",
+				AuthorDate:       "2018-01-09T22:32:37+01:00",
+			},
+		},
+		{
+			"0.13.90 7330b8d 2018-01-09T22:32:37+01:00 go version go1.8.3 linux/arm",
+			CiliumVersion{
+				Version:          "0.13.90",
+				Revision:         "7330b8d",
+				GoRuntimeVersion: "go1.8.3",
+				Arch:             "linux/arm",
+				AuthorDate:       "2018-01-09T22:32:37+01:00",
+			},
+		},
+		// Unformatted string should return empty struct
+		{
+			"0.13.90 7330b8d linux/arm",
+			CiliumVersion{
+				Version:          "",
+				Revision:         "",
+				GoRuntimeVersion: "",
+				Arch:             "",
+				AuthorDate:       "",
+			},
+		},
+	}
 
-	c.Assert(cver.Version, Equals, "0.13.90")
-	c.Assert(cver.Revision, Equals, "7330b8d")
-	c.Assert(cver.Arch, Equals, "linux/amd64")
+	for _, tt := range versionDataList {
+		cver := FromString(tt.in)
+		c.Assert(cver.Version, Equals, tt.out.Version)
+		c.Assert(cver.Revision, Equals, tt.out.Revision)
+		c.Assert(cver.GoRuntimeVersion, Equals, tt.out.GoRuntimeVersion)
+		c.Assert(cver.Arch, Equals, tt.out.Arch)
+		c.Assert(cver.AuthorDate, Equals, tt.out.AuthorDate)
+	}
 }


### PR DESCRIPTION
Client prints client and daemon version to the prompt in JSON format

Fixes: #1272

Signed-off-by: Steven Ceuppens <steven.ceuppens@icloud.com>

```release-note
Update version cmd output to json
```
  