### PR TITLE
Ginkgo: Fixed Branch Variable on Ginkgo.Jenkinsfile

### DIFF
--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
         stage('BDD-Test-Master') {
             when {
                 expression {
-                    return env.BRANCH_NAME == 'master';
+                    return env.GIT_BRANCH == 'origin/master';
                 }
             }
             environment {
@@ -89,7 +89,7 @@ pipeline {
         stage('BDD-Test-PR') {
             when {
                 expression {
-                    return env.BRANCH_NAME != 'master';
+                    return env.GIT_BRANCH != 'origin/master';
                 }
             }
             environment {


### PR DESCRIPTION
In the list of env variables set by Jenkins,  `BRANCH_NAME` is not present,
but GIT_BRANCH is present with the value `origin/master`. Fixed the
ginkgo.Jenkinsfile to run all test on master.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

