### PR TITLE
Nightly: Fix issues with failing test

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -24,11 +24,13 @@ pipeline {
             environment {
                 GOPATH="${WORKSPACE}"
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
+                K8S_VERSION=1.7
+                k8S_NODES=4
             }
             steps {
                 parallel(
                     "Nightly":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.7 ginkgo --focus="Nightly*" -v -noColor'
+                        sh 'cd ${TESTDIR}; ginkgo --focus="Nightly*" -v -noColor'
                     },
                 )
             }
@@ -36,7 +38,7 @@ pipeline {
                 always {
                     junit 'test/*.xml'
                     sh 'cd test/; ./post_build_agent.sh || true'
-                    sh 'cd test/; K8S_VERSION=1.7 vagrant destroy -f'
+                    sh 'cd test/; vagrant destroy -f'
                 }
             }
         }

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -4,6 +4,7 @@
 $BUILD_NUMBER = ENV['BUILD_NUMBER'] || "0"
 $JOB_NAME = ENV['JOB_BASE_NAME'] || "LOCAL"
 $K8S_VERSION = ENV['K8S_VERSION'] || "1.7"
+$K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 
 
 $SERVER_BOX= "cilium/ginkgo"
@@ -34,7 +35,7 @@ Vagrant.configure("2") do |config|
         end
     end
 
-    (1..2).each do |i|
+    (1..$K8S_NODES).each do |i|
         config.vm.define "k8s#{i}-#{$K8S_VERSION}" do |server|
             server.vm.provider "virtualbox" do |vb|
                 # vb.customize ["modifyvm", :id, "--memory", "2048"]

--- a/test/helpers/policygen/const.go
+++ b/test/helpers/policygen/const.go
@@ -58,6 +58,13 @@ var (
 		UDP:         ResultTimeout,
 	}
 
+	ConnResultOnlyHTTPPrivateAndPing = ConnTestSpec{
+		HTTP:        ResultAuth,
+		HTTPPrivate: ResultOK,
+		Ping:        ResultOK,
+		UDP:         ResultTimeout,
+	}
+
 	DestinationsTypes = []Target{
 		{Kind: service},
 		{Kind: nodePort},

--- a/test/helpers/policygen/policygen.go
+++ b/test/helpers/policygen/policygen.go
@@ -91,7 +91,7 @@ var policiesTestSuite = PolicyTestSuite{
 		{
 			name:  "Egress policy to /private/",
 			kind:  egress,
-			tests: ConnResultOnlyHTTPPrivate,
+			tests: ConnResultOnlyHTTPPrivateAndPing,
 			template: map[string]string{
 				"Rules": `{"http": [{"method": "GET", "path": "/private"}]}`,
 				"Ports": `[{"port": "{{ .Destination.PortNumber }}", "protocol": "TCP"}]`,


### PR DESCRIPTION
- Allow ping on Egress Policy testcase. Related with #2450
- Added variable on number of Kubernetes nodes in Vagrantfile
- Added four nodes in Nightly.Jenkinsfile instead of two.

Related to task #2424 #2029

@ianvernon  This PR creates four Kubernetes nodes, but the test only runs on one version of Kubernetes, so it's safe enough to have four nodes (TBH, I think that we can create ten nodes or something similar, due the size of the bare metal box)