### PR TITLE
Tests: Fix issues with GSG test

### DIFF
--- a/examples/minikube/demo.yaml
+++ b/examples/minikube/demo.yaml
@@ -27,20 +27,20 @@ spec:
         - containerPort: 80
 ---
 apiVersion: v1
-kind: Pod 
+kind: Pod
 metadata:
   name: app2
   labels:
     id: app2
 spec:
   containers:
-    - name: app-frontend
-      image: cilium/demo-client
-      command: [ "sleep" ]
-      args:
-        - "1000h"
+  - name: app-frontend
+    image: cilium/demo-client
+    command: [ "sleep" ]
+    args:
+      - "1000h"
 ---
-apiVersion: v1 
+apiVersion: v1
 kind: Pod
 metadata:
   name: app3
@@ -48,8 +48,8 @@ metadata:
     id: app3
 spec:
   containers:
-    - name: app-frontend
-      image: cilium/demo-client
-      command: [ "sleep" ]
-      args:
-        - "1000h"
+  - name: app-frontend
+    image: cilium/demo-client
+    command: [ "sleep" ]
+    args:
+      - "1000h"

--- a/tests/k8s/tests/deployments/gsg/minikube-gsg-l7-fix.diff
+++ b/tests/k8s/tests/deployments/gsg/minikube-gsg-l7-fix.diff
@@ -1,28 +1,9 @@
-diff --git a/examples/minikube/demo.yaml b/examples/minikube/demo.yaml
-index 2cef278..72bbbea 100644
---- a/examples/minikube/demo.yaml
-+++ b/examples/minikube/demo.yaml
-@@ -25,6 +25,8 @@ spec:
-         image: cilium/demo-httpd
-         ports:
-         - containerPort: 80
-+  nodeSelector:
-+    "kubernetes.io/hostname": k8s-1
- ---
- apiVersion: v1
- kind: Pod 
-@@ -39,6 +41,8 @@ spec:
-       command: [ "sleep" ]
-       args:
-         - "1000h"
-+  nodeSelector:
-+    "kubernetes.io/hostname": k8s-1
- ---
- apiVersion: v1 
- kind: Pod
-@@ -53,3 +57,5 @@ spec:
-       command: [ "sleep" ]
-       args:
-         - "1000h"
-+  nodeSelector:
-+    "kubernetes.io/hostname": k8s-1
+27a28,29
+>       nodeSelector:
+>         "kubernetes.io/hostname": k8s-1
+41a44,45
+>   nodeSelector:
+>     "kubernetes.io/hostname": k8s-1
+55a60,61
+>   nodeSelector:
+>     "kubernetes.io/hostname": k8s-1


### PR DESCRIPTION
Fix indention problems on minicube yamls that cause a fail on kubernetes
master test.

Fail log message:

```
error validating "/home/vagrant/go/src/github.com/cilium/cilium/tests/k8s/tests/deployments/gsg/demo.yaml": error validating data: found invalid field nodeSelector for v1beta1.DeploymentSpec; if you choose to ignore these errors, turn validation off with --validate=false
```

Generated demo.yaml file: 


```
---
apiVersion: v1
kind: Service
metadata:
  name: app1-service
spec:
  ports:
  - port: 80
  selector:
    id: app1
---
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: app1
spec:
  replicas: 2
  template:
    metadata:
      labels:
        id: app1
    spec:
      containers:
      - name: web
        image: cilium/demo-httpd
        ports:
        - containerPort: 80
      nodeSelector:
        "kubernetes.io/hostname": k8s-1
---
apiVersion: v1
kind: Pod
metadata:
  name: app2
  labels:
    id: app2
spec:
  containers:
  - name: app-frontend
    image: cilium/demo-client
    command: [ "sleep" ]
    args:
      - "1000h"
  nodeSelector:
    "kubernetes.io/hostname": k8s-1
---
apiVersion: v1
kind: Pod
metadata:
  name: app3
  labels:
    id: app3
spec:
  containers:
  - name: app-frontend
    image: cilium/demo-client
    command: [ "sleep" ]
    args:
      - "1000h"
  nodeSelector:
    "kubernetes.io/hostname": k8s-1
```