### PR TITLE
docs: JSON network policy examples include name

### DIFF
--- a/examples/policies/getting-started/cilium_dkr_demo_l3-l4-policy-170817.json
+++ b/examples/policies/getting-started/cilium_dkr_demo_l3-l4-policy-170817.json
@@ -1,4 +1,5 @@
 [{
+    "labels": [{"key": "name", "value": "l3-rule"}],
     "endpointSelector": {"matchLabels":{"id":"app1"}},
     "ingress": [{
         "fromEndpoints": [

--- a/examples/policies/getting-started/cilium_dkr_demo_l7-policy-230817.json
+++ b/examples/policies/getting-started/cilium_dkr_demo_l7-policy-230817.json
@@ -1,4 +1,5 @@
 [{
+    "labels": [{"key": "name", "value": "l7-rule"}],
     "endpointSelector": {"matchLabels":{"id":"app1"}},
     "ingress": [{
         "fromEndpoints": [

--- a/examples/policies/getting-started/l3-l4-policy.json
+++ b/examples/policies/getting-started/l3-l4-policy.json
@@ -1,4 +1,5 @@
 [{
+    "labels": [{"key": "name", "value": "l3-l4-rule"}],
     "endpointSelector": {"matchLabels":{"id":"web-server"}},
     "ingress": [{
         "fromEndpoints": [

--- a/examples/policies/getting-started/l7-policy.json
+++ b/examples/policies/getting-started/l7-policy.json
@@ -1,4 +1,5 @@
 [{
+    "labels": [{"key": "name", "value": "l7-rule"}],
     "endpointSelector": {"matchLabels":{"id":"web-server"}},
     "ingress": [{
         "fromEndpoints": [

--- a/examples/policies/l3/cidr/cidr.json
+++ b/examples/policies/l3/cidr/cidr.json
@@ -1,4 +1,5 @@
 [{
+    "labels": [{"key": "name", "value": "cidr-rule"}],
     "endpointSelector": {"matchLabels":{"app":"myService"}},
     "egress": [{
         "toCIDR": [

--- a/examples/policies/l3/cidr/cidr.yaml
+++ b/examples/policies/l3/cidr/cidr.yaml
@@ -1,7 +1,7 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  name: "requires-rule"
+  name: "cidr-rule"
 spec:
   endpointSelector:
     matchLabels:

--- a/examples/policies/l3/egress-default-deny/egress-default-deny.json
+++ b/examples/policies/l3/egress-default-deny/egress-default-deny.json
@@ -1,4 +1,5 @@
 [{
+    "labels": [{"key": "name", "value": "deny-all-egress"}],
     "endpointSelector": {"matchLabels": {"role":"restricted"}},
     "egress": []
 }]

--- a/examples/policies/l3/entities/host.json
+++ b/examples/policies/l3/entities/host.json
@@ -1,4 +1,5 @@
 [{
+    "labels": [{"key": "name", "value": "dev-to-host"}],
     "endpointSelector": {"matchLabels": {"env":"dev"}},
     "egress": [{
         "toEntities": ["host"]

--- a/examples/policies/l3/entities/world.json
+++ b/examples/policies/l3/entities/world.json
@@ -1,4 +1,5 @@
 [{
+    "labels": [{"key": "name", "value":"from-world-to-role-public"}],
     "endpointSelector": {"matchLabels": {"role":"public"}},
     "ingress": [{
         "fromEntities": ["world"]

--- a/examples/policies/l3/ingress-allow-all/ingress-allow-all.json
+++ b/examples/policies/l3/ingress-allow-all/ingress-allow-all.json
@@ -1,4 +1,5 @@
 [{
+    "labels": [{"key": "name", "value": "allow-all-to-victim"}],
     "endpointSelector": {"matchLabels": {"role":"victim"}},
     "ingress": [{
         "fromEndpoints": [

--- a/examples/policies/l3/requires/requires.json
+++ b/examples/policies/l3/requires/requires.json
@@ -1,4 +1,5 @@
 [{
+    "labels": [{"key": "name", "value": "requires-rule"}],
     "endpointSelector": {"matchLabels": {"env":"prod"}},
     "ingress": [{
         "fromRequires": [

--- a/examples/policies/l3/service/service.json
+++ b/examples/policies/l3/service/service.json
@@ -1,4 +1,5 @@
 [{
+      "labels": [{"key": "name", "value": "service-rule"}],
       "endpointSelector": {
         "matchLabels": {
           "id": "app2"

--- a/examples/policies/l3/service/service.yaml
+++ b/examples/policies/l3/service/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  name: "requires-rule"
+  name: "service-rule"
 spec:
   endpointSelector:
     matchLabels:

--- a/examples/policies/l3/simple/l3.json
+++ b/examples/policies/l3/simple/l3.json
@@ -1,4 +1,5 @@
 [{
+    "labels": [{"key": "name", "value": "l3-rule"}],
     "endpointSelector": {"matchLabels": {"role":"backend"}},
     "ingress": [{
         "fromEndpoints": [

--- a/examples/policies/l4/l3_l4_combined.json
+++ b/examples/policies/l4/l3_l4_combined.json
@@ -1,4 +1,5 @@
 [{
+    "labels": [{"key": "name", "value": "l4-rule"}],
     "endpointSelector": {"matchLabels":{"role":"backend"}},
     "ingress": [{
         "fromEndpoints": [

--- a/examples/policies/l4/l4.json
+++ b/examples/policies/l4/l4.json
@@ -1,4 +1,5 @@
 [{
+    "labels": [{"key": "name", "value": "l4-rule"}],
     "endpointSelector": {"matchLabels":{"app":"myService"}},
     "egress": [{
         "toPorts": [

--- a/examples/policies/l4/multi_rule.json
+++ b/examples/policies/l4/multi_rule.json
@@ -1,4 +1,5 @@
 [{
+    "labels": [{"key": "name", "value": "l4-rules"}],
     "endpointSelector": {"matchLabels":{"role":"backend"}},
     "ingress": [{
         "fromEndpoints": [

--- a/examples/policies/l7/http/http.json
+++ b/examples/policies/l7/http/http.json
@@ -1,4 +1,5 @@
 [{
+    "labels": [{"key": "name", "value": "l7-rule"}],
     "endpointSelector": {"matchLabels":{"app":"myService"}},
     "ingress": [{
         "toPorts": [{

--- a/examples/policies/l7/http/l7_multi.json
+++ b/examples/policies/l7/http/l7_multi.json
@@ -1,4 +1,5 @@
 [{
+  "labels": [{"key": "name", "value": "fancyrule"}],
   "endpointSelector": {"matchLabels": {"app": "service"}},
   "ingress": [{
     "fromEndpoints": [
@@ -19,6 +20,7 @@
     }]
   }]
 },{
+  "labels": [{"key": "name", "value": "fancyrule"}],
   "endpointSelector": {"matchLabels": {"env": "prod"}},
   "egress":[{
     "toPorts": [{

--- a/examples/policies/l7/http/simple/l7.json
+++ b/examples/policies/l7/http/simple/l7.json
@@ -1,4 +1,5 @@
 [{
+  "labels": [{"key": "name", "value": "rule1"}],
   "endpointSelector": {"matchLabels": {"app": "service"}},
   "ingress": [{
     "fromEndpoints": [

--- a/examples/policies/l7/kafka/kafka.json
+++ b/examples/policies/l7/kafka/kafka.json
@@ -1,4 +1,5 @@
 [{
+  "labels": [{"key": "name", "value": "rule1"}],
   "endpointSelector": {"matchLabels": {"app": "kafka"}},
   "ingress": [{
     "fromEndpoints": [


### PR DESCRIPTION
We annotated the k8s YAML with a name for these policies, but not the
JSON cilium specific ones. By having labels included in the examples, we
can encourage users to utilise them.

**How to test (optional)**:
- `make -C Documentation html` (per http://cilium.readthedocs.io/en/latest/contributing/#building-documentation)
- view `Documentation/_build/html/policy/language.html`