### PR TITLE
test: migrate tests/02-cnp-specs.sh to Ginkgo

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -131,6 +131,10 @@ const (
 	GeneratedHTMLManifest   = "html.yaml"
 	GeneratedServerManifest = "server.yaml"
 	GeneratedClientManifest = "client.yaml"
+
+	KubectlCreate = ResourceLifeCycleAction("create")
+	KubectlDelete = ResourceLifeCycleAction("delete")
+	KubectlApply  = ResourceLifeCycleAction("apply")
 )
 
 var ciliumCLICommands = map[string]string{

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -119,6 +119,12 @@ func (kub *Kubectl) GetPodsNodes(namespace string, filter string) (map[string]st
 	return res.KVOutput(), nil
 }
 
+// GetEndpoints gets all of the endpoints in the given namespace that match the
+// provided filter.
+func (kub *Kubectl) GetEndpoints(namespace string, filter string) *CmdRes {
+	return kub.Exec(fmt.Sprintf("%s -n %s get endpoints %s -o json", KubectlCmd, namespace, filter))
+}
+
 // GetPodNames returns the names of all of the pods that are labeled with label
 // in the specified namespace, along with an error if the pod names cannot be
 // retrieved.
@@ -236,11 +242,52 @@ func (kub *Kubectl) WaitforPods(namespace string, filter string, timeout time.Du
 	return true, nil
 }
 
+// WaitForServiceEndpoints waits up until timeout seconds have elapsed for all
+// endpoints in the specified namespace that match the provided JSONPath filter
+// to have their port equal to the provided port. Returns true if all pods achieve
+// the aforementioned desired state within timeout seconds. Returns false and
+// an error if the command failed or the timeout was exceeded.
+func (kub *Kubectl) WaitForServiceEndpoints(namespace string, filter string, service string, port string, timeout time.Duration) (bool, error) {
+	body := func() bool {
+		var jsonPath = fmt.Sprintf("{.items[?(@.metadata.name =='%s')].subsets[0].ports[0].port}", service)
+		data, err := kub.GetEndpoints(namespace, filter).Filter(jsonPath)
+
+		if err != nil {
+			kub.logger.WithError(err)
+			return false
+		}
+
+		if data.String() == port {
+			return true
+		}
+
+		kub.logger.WithFields(logrus.Fields{
+			"namespace": namespace,
+			"filter":    filter,
+			"data":      data,
+		}).Info("WaitForServiceEndpoints: service endpoint not ready")
+		return false
+	}
+
+	err := WithTimeout(body, "could not get service endpoints", &TimeoutConfig{Timeout: timeout})
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // Apply applies the Kubernetes manifest located at path filepath.
 func (kub *Kubectl) Apply(filePath string) *CmdRes {
 	kub.logger.Debugf("applying %s", filePath)
 	return kub.Exec(
 		fmt.Sprintf("%s apply -f  %s", KubectlCmd, filePath))
+}
+
+// Create creates the Kubernetes kanifest located at path filepath.
+func (kub *Kubectl) Create(filePath string) *CmdRes {
+	kub.logger.Debugf("creating %s", filePath)
+	return kub.Exec(
+		fmt.Sprintf("%s create -f  %s", KubectlCmd, filePath))
 }
 
 // Delete deletes the Kubernetes manifest at path filepath.

--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -596,9 +596,10 @@ func (t *TestSpec) NetworkPolicyApply() error {
 		return fmt.Errorf("Network policy cannot be written prefix=%s: %s", t.Prefix, err)
 	}
 
-	_, err = t.Kub.CiliumImportPolicy(
+	_, err = t.Kub.CiliumPolicyAction(
 		helpers.KubeSystemNamespace,
 		fmt.Sprintf("%s/%s", helpers.BasePath, t.NetworkPolicyName()),
+		helpers.KubectlApply,
 		helpers.HelperTimeout)
 
 	if err != nil {

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -256,7 +256,7 @@ var _ = Describe("NightlyExamples", func() {
 		_, err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", 300)
 		Expect(err).Should(BeNil())
 
-		_, err = kubectl.CiliumImportPolicy(helpers.KubeSystemNamespace, l3Policy, 300)
+		_, err = kubectl.CiliumPolicyAction(helpers.KubeSystemNamespace, l3Policy, helpers.KubectlApply, 300)
 		Expect(err).Should(BeNil())
 
 		appPods := getAppPods()

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -189,7 +189,7 @@ var _ = Describe("K8sPolicyTest", func() {
 		By("Testing L3/L4 rules")
 
 		eps := kubectl.CiliumEndpointPolicyVersion(ciliumPod)
-		_, err = kubectl.CiliumImportPolicy(helpers.KubeSystemNamespace, l3Policy, 300)
+		_, err = kubectl.CiliumPolicyAction(helpers.KubeSystemNamespace, l3Policy, helpers.KubectlApply, 300)
 		Expect(err).Should(BeNil())
 
 		err = waitUntilEndpointUpdates(ciliumPod, eps, 4)
@@ -246,7 +246,7 @@ var _ = Describe("K8sPolicyTest", func() {
 		//All Monkey testing in this section is on runtime
 
 		eps = kubectl.CiliumEndpointPolicyVersion(ciliumPod)
-		_, err = kubectl.CiliumImportPolicy(helpers.KubeSystemNamespace, l7Policy, 300)
+		_, err = kubectl.CiliumPolicyAction(helpers.KubeSystemNamespace, l7Policy, helpers.KubectlApply, 300)
 		Expect(err).Should(BeNil())
 		err = waitUntilEndpointUpdates(ciliumPod, eps, 4)
 		Expect(err).Should(BeNil())

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -59,7 +59,8 @@ var _ = Describe("K8sServicesTest", func() {
 			ciliumPod, _ := kubectl.GetCiliumPodOnNode("kube-system", "k8s1")
 			kubectl.CiliumReport("kube-system", ciliumPod, []string{
 				"cilium service list",
-				"cilium endpoint list"})
+				"cilium endpoint list",
+				"cilium policy get"})
 		}
 	})
 
@@ -243,5 +244,175 @@ var _ = Describe("K8sServicesTest", func() {
 
 			validateEgress()
 		})
+	})
+
+	It("CNP Specs Test", func() {
+
+		// Various constants used in this test
+		wgetCommand := "%s exec -t %s wget -- --tries=2 --connect-timeout 10 %s"
+
+		version := "version"
+		v1 := "v1"
+		v2 := "v2"
+
+		productPage := "productpage"
+		reviews := "reviews"
+		ratings := "ratings"
+		details := "details"
+		app := "app"
+		resourceYamls := []string{"bookinfo-v1.yaml", "bookinfo-v2.yaml"}
+		health := "health"
+
+		apiPort := "9080"
+
+		podNameFilter := "{.items[*].metadata.name}"
+
+		// shouldConnect asserts that srcPod can connect to dst.
+		shouldConnect := func(srcPod, dst string) {
+			By(fmt.Sprintf("Checking that %s can connect to %s", srcPod, dst))
+			res := kubectl.Exec(fmt.Sprintf(wgetCommand, helpers.KubectlCmd, srcPod, dst))
+			res.ExpectSuccess(fmt.Sprintf("Unable to connect from %s to %s: %s", srcPod, dst, res.CombineOutput()))
+		}
+
+		// shouldNotConnect asserts that srcPod cannot connect to dst.
+		shouldNotConnect := func(srcPod, dst string) {
+			By(fmt.Sprintf("Checking that %s cannot connect to %s", srcPod, dst))
+			res := kubectl.Exec(fmt.Sprintf(wgetCommand, helpers.KubectlCmd, srcPod, dst))
+			res.ExpectFail(fmt.Sprintf("Was able to connect from %s to %s, but expected no connection: %s", srcPod, dst, res.CombineOutput()))
+		}
+
+		// formatLabelArgument formats the provided key-value pairs as labels for use in
+		// querying Kubernetes.
+		formatLabelArgument := func(firstKey, firstValue string, nextLabels ...string) string {
+			baseString := fmt.Sprintf("-l %s=%s", firstKey, firstValue)
+			if nextLabels == nil {
+				return baseString
+			} else if len(nextLabels)%2 != 0 {
+				panic("must provide even number of arguments for label key-value pairings")
+			} else {
+				for i := 0; i < len(nextLabels); i += 2 {
+					baseString = fmt.Sprintf("%s,%s=%s", baseString, nextLabels[i], nextLabels[i+1])
+				}
+			}
+			return baseString
+		}
+
+		// formatAPI is a helper function which formats a URI to access.
+		formatAPI := func(service, port, resource string) string {
+			if resource != "" {
+				return fmt.Sprintf("%s:%s/%s", service, port, resource)
+			}
+
+			return fmt.Sprintf("%s:%s", service, port)
+		}
+
+		By(fmt.Sprintf("Getting Cilium Pod on node %s", helpers.K8s1))
+		ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
+		Expect(err).Should(BeNil())
+
+		By(fmt.Sprintf("Getting Cilium Pod on node %s", helpers.K8s2))
+		ciliumPodK8s2, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s2)
+		Expect(err).Should(BeNil())
+
+		for _, resource := range resourceYamls {
+			resourcePath := kubectl.ManifestGet(resource)
+			By(fmt.Sprintf("Creating objects in file %s", resourcePath))
+			res := kubectl.Create(resourcePath)
+			defer func(resource string) {
+				By(fmt.Sprintf("Deleting resource %s", resourcePath))
+				kubectl.Delete(resourcePath)
+			}(resource)
+			res.ExpectSuccess()
+		}
+
+		By("Waiting for v1 pods to be ready")
+		pods, err := kubectl.WaitforPods(helpers.DefaultNamespace, formatLabelArgument(version, v1), helpers.HelperTimeout)
+		Expect(pods).Should(BeTrue())
+		Expect(err).Should(BeNil())
+
+		By("Waiting for v2 pods to be ready")
+		pods, err = kubectl.WaitforPods(helpers.DefaultNamespace, formatLabelArgument(version, v2), helpers.HelperTimeout)
+		Expect(pods).Should(BeTrue())
+		Expect(err).Should(BeNil())
+
+		By("Getting reviews v1 pod")
+		reviewsPodV1, err := kubectl.GetPods(helpers.DefaultNamespace, formatLabelArgument(app, reviews, version, v1)).Filter(podNameFilter)
+		Expect(err).Should(BeNil())
+
+		By("Getting productpage v1 pod")
+		productpagePodV1, err := kubectl.GetPods(helpers.DefaultNamespace, formatLabelArgument(app, productPage, version, v1)).Filter(podNameFilter)
+		Expect(err).Should(BeNil())
+
+		By("Waiting for endpoints to be ready in Cilium")
+		areEndpointsReady := kubectl.CiliumEndpointWait(ciliumPodK8s1)
+		Expect(areEndpointsReady).Should(BeTrue())
+
+		By("Waiting for details service endpoints to be ready")
+		pods, err = kubectl.WaitForServiceEndpoints(helpers.DefaultNamespace, "", details, apiPort, helpers.HelperTimeout)
+		Expect(pods).Should(BeTrue())
+		Expect(err).Should(BeNil())
+
+		By("Waiting for ratings service endpoints to be ready")
+		pods, err = kubectl.WaitForServiceEndpoints(helpers.DefaultNamespace, "", ratings, apiPort, helpers.HelperTimeout)
+		Expect(pods).Should(BeTrue())
+		Expect(err).Should(BeNil())
+
+		By("Waiting for reviews service endpoints to be ready")
+		pods, err = kubectl.WaitForServiceEndpoints(helpers.DefaultNamespace, "", reviews, apiPort, helpers.HelperTimeout)
+		Expect(pods).Should(BeTrue())
+		Expect(err).Should(BeNil())
+
+		By("Waiting for productpage service endpoints to be ready")
+		pods, err = kubectl.WaitForServiceEndpoints(helpers.DefaultNamespace, "", productPage, apiPort, helpers.HelperTimeout)
+		Expect(pods).Should(BeTrue())
+		Expect(err).Should(BeNil())
+
+		By("Before policy import; all pods should be able to connect")
+		shouldConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, health))
+		shouldConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, ""))
+
+		shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, health))
+		shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, ""))
+		shouldConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, health))
+		shouldConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, ""))
+
+		var policyPath string
+		var policyCmd string
+
+		policyPath = kubectl.ManifestGet("cnp-specs.yaml")
+		policyCmd = "cilium policy get io.cilium.k8s-policy-name=multi-rules"
+
+		By("Importing policy")
+		res := kubectl.Create(policyPath)
+		defer func() {
+			By("Checking that all policies were deleted in Cilium")
+			output, err := kubectl.ExecPodCmd(helpers.KubeSystemNamespace, ciliumPodK8s1, policyCmd)
+			Expect(err).Should(Not(BeNil()), "policies should be deleted from Cilium: policies found: %s", output)
+		}()
+		defer kubectl.Delete(policyPath)
+
+		res.ExpectSuccess()
+
+		By("Waiting for endpoints on k8s1 to be in ready state")
+		areEndpointsReady = kubectl.CiliumEndpointWait(ciliumPodK8s1)
+		Expect(areEndpointsReady).Should(BeTrue())
+
+		By("Waiting for endpoints on k8s2 to be in ready state")
+		areEndpointsReady = kubectl.CiliumEndpointWait(ciliumPodK8s2)
+		Expect(areEndpointsReady).Should(BeTrue())
+
+		By("Checking that policies were correctly imported into Cilium")
+		_, err = kubectl.ExecPodCmd(helpers.KubeSystemNamespace, ciliumPodK8s1, policyCmd)
+		Expect(err).Should(BeNil())
+
+		By("After policy import")
+		shouldConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, health))
+		shouldNotConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, ""))
+
+		shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, health))
+		shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, ""))
+
+		shouldNotConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, health))
+		shouldNotConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, ""))
 	})
 })

--- a/test/k8sT/manifests/1.6/cnp-specs.yaml
+++ b/test/k8sT/manifests/1.6/cnp-specs.yaml
@@ -1,0 +1,43 @@
+apiVersion: "cilium.io/v1"
+kind: CiliumNetworkPolicy
+description: "Policy to test multiple rules in a single file"
+metadata:
+  name: "multi-rules"
+specs:
+  - endpointSelector:
+      matchLabels:
+        app: ratings
+        version: v1
+    ingress:
+    - fromEndpoints:
+      - matchLabels:
+          app: reviews
+          track: stable
+          version: v1
+      toPorts:
+      - ports:
+        - port: "9080"
+          protocol: TCP
+        rules:
+          http:
+          - method: "GET"
+            path: "/health"
+  - endpointSelector:
+      matchLabels:
+        app: details
+        track: stable
+        version: v1
+    ingress:
+    - fromEndpoints:
+      - matchLabels:
+          app: productpage
+          track: stable
+          version: v1
+      toPorts:
+      - ports:
+        - port: "9080"
+          protocol: TCP
+        rules:
+          http:
+          - method: "GET"
+            path: "/.*"

--- a/test/k8sT/manifests/bookinfo-v1.yaml
+++ b/test/k8sT/manifests/bookinfo-v1.yaml
@@ -1,0 +1,122 @@
+# Copyright 2017 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+##################################################################################################
+# Details service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: details
+  labels:
+    app: details
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: details
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: details-v1
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: details
+        version: v1
+        track: stable
+    spec:
+      containers:
+      - name: details
+        image: istio/examples-bookinfo-details-v1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+---
+##################################################################################################
+# Reviews service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviews
+  labels:
+    app: reviews
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: reviews
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: reviews-v1
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: reviews
+        version: v1
+        track: stable
+    spec:
+      containers:
+      - name: reviews
+        image: istio/examples-bookinfo-reviews-v1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+---
+##################################################################################################
+# Productpage service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: productpage
+  labels:
+    app: productpage
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: productpage
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: productpage-v1
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: productpage
+        version: v1
+        track: stable
+    spec:
+      containers:
+      - name: productpage
+        image: istio/examples-bookinfo-productpage-v1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+---

--- a/test/k8sT/manifests/bookinfo-v2.yaml
+++ b/test/k8sT/manifests/bookinfo-v2.yaml
@@ -1,0 +1,71 @@
+# Copyright 2017 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+##################################################################################################
+# Ratings service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: ratings
+  labels:
+    app: ratings
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: ratings
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: ratings-v1
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ratings
+        version: v1
+    spec:
+      containers:
+      - name: ratings
+        image: istio/examples-bookinfo-ratings-v1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+---
+##################################################################################################
+# Reviews service v2
+##################################################################################################
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: reviews-v2
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: reviews
+        version: v2
+    spec:
+      containers:
+      - name: reviews
+        image: istio/examples-bookinfo-reviews-v2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+---

--- a/test/k8sT/manifests/cnp-specs.yaml
+++ b/test/k8sT/manifests/cnp-specs.yaml
@@ -1,0 +1,43 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+description: "Policy to test multiple rules in a single file"
+metadata:
+  name: "multi-rules"
+specs:
+  - endpointSelector:
+      matchLabels:
+        app: ratings
+        version: v1
+    ingress:
+    - fromEndpoints:
+      - matchLabels:
+          app: reviews
+          track: stable
+          version: v1
+      toPorts:
+      - ports:
+        - port: "9080"
+          protocol: TCP
+        rules:
+          http:
+          - method: "GET"
+            path: "/health"
+  - endpointSelector:
+      matchLabels:
+        app: details
+        track: stable
+        version: v1
+    ingress:
+    - fromEndpoints:
+      - matchLabels:
+          app: productpage
+          track: stable
+          version: v1
+      toPorts:
+      - ports:
+        - port: "9080"
+          protocol: TCP
+        rules:
+          http:
+          - method: "GET"
+            path: "/.*"

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -37,7 +37,7 @@ cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 
-sudo rm /var/lib/apt/lists/lock
+sudo rm /var/lib/apt/lists/lock || true
 wget https://packages.cloud.google.com/apt/doc/apt-key.gpg
 apt-key add apt-key.gpg
 
@@ -64,6 +64,9 @@ sudo cp "$SYSTEMD_SERVICES/$MOUNT_SYSTEMD" /etc/systemd/system/
 sudo systemctl enable $MOUNT_SYSTEMD
 sudo systemctl restart $MOUNT_SYSTEMD
 sudo rm -rfv /var/lib/kubelet
+
+# Allow iptables forwarding so kube-dns can function.
+sudo iptables --policy FORWARD ACCEPT
 
 #check hostname to know if is kubernetes or runtime test
 if [[ "${HOST}" == "k8s1" ]]; then


### PR DESCRIPTION
To expedite the migration of the Kubernetes tests, which are the rate-determining part of the build, migrate over `tests/02-cnp-specs.sh` in a 1:1 manner. This ensures that we support the bookinfo demo policy configuration as part of our CI.

Signed-off by: Ian Vernon <ian@cilium.io>  