### PR TITLE
Ginkgo: Set PolicyEnforcement default on initialize

### DIFF
--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -24,6 +24,8 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 		logger.Info("Starting")
 		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 		vm.WaitUntilReady(100)
+		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
+		res.ExpectSuccess()
 		vm.NetworkCreate(helpers.CiliumDockerNetwork, "")
 		initialized = true
 	}
@@ -171,6 +173,8 @@ var _ = Describe("RuntimeConntrackTest", func() {
 		logger.Info("Starting")
 		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 		vm.WaitUntilReady(100)
+		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
+		res.ExpectSuccess()
 		vm.NetworkCreate(helpers.CiliumDockerNetwork, "")
 		initialized = true
 

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -39,6 +39,8 @@ var _ = Describe("RuntimeLB", func() {
 		logger.Info("Starting")
 		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 		vm.WaitUntilReady(100)
+		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
+		res.ExpectSuccess()
 		vm.NetworkCreate(helpers.CiliumDockerNetwork, "")
 		initialized = true
 	}


### PR DESCRIPTION
Fix issues where the PolicyEnforcement was to Never and some test were
failing due that.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

