### PR TITLE
monitor: use cobra for handling CLI arguments

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1239,7 +1239,8 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 	if numPagesEntry, ok := params.Configuration.Mutable["MonitorNumPages"]; ok {
 		nmArgs := d.nodeMonitor.GetArgs()
 		if len(nmArgs) == 0 || nmArgs[0] != numPagesEntry {
-			d.nodeMonitor.Restart([]string{numPagesEntry})
+			args := []string{"--num-pages %s", numPagesEntry}
+			d.nodeMonitor.Restart(args)
 		}
 		if len(params.Configuration.Mutable) == 0 {
 			return NewPatchConfigOK()


### PR DESCRIPTION
To reduce the diff the package structure has not been changed to be
consistent with the other commands. For example, creating a separate
directory `cmd` would require some more refactoring to get all the
methods accessible.

Related: #2087 (Improve cilium-node-monitor usage and help)

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>
  