### PR TITLE
Ginkgo: Added MaxTime option in Curl.

### DIFF
--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -45,7 +45,8 @@ func Ping6(endpoint string) string {
 // CurlFail returns the string representing the curl command with `-s` and `--fail`
 // options enabled to curl the specified endpoint.
 func CurlFail(endpoint string) string {
-	return fmt.Sprintf("curl -s --fail --connect-timeout %d %s", CurlConnectTimeout, endpoint)
+	return fmt.Sprintf("curl -s --fail --connect-timeout %[1]d --max-time %[1]d %[2]s",
+		CurlConnectTimeout, endpoint)
 }
 
 // Netperf returns the string representing the netperf command to use when testing


### PR DESCRIPTION
This fixes an issue with the following Nightly test:
`L3:Ingress Label L4:Ingress Port 80 UDP L7:Egress policy to /private/ Destination:service`

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
