### PR TITLE
Ginkgo: Added Headless policy for K8s 1.6

### DIFF
--- a/test/k8sT/manifests/1.6/headless_policy.yaml
+++ b/test/k8sT/manifests/1.6/headless_policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: "cilium.io/v1"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "rule-to-services"
+spec:
+  endpointSelector:
+    matchLabels:
+      "test": "toservices"
+  egress:
+  -
+    toServices:
+    - k8sService:
+        serviceName: headless-service
+        namespace: default


### PR DESCRIPTION
On the PR #2380 the headless policy was lost during the rebase with the
master and the use of `kubectl.ManifestGet`.

This PR fixes the Ginkgo builds from 845 to 852.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
