### PR TITLE
Print rule count endpoint list

### DIFF
--- a/Documentation/policy/troubleshooting.rst
+++ b/Documentation/policy/troubleshooting.rst
@@ -5,6 +5,9 @@
 Troubleshooting
 ***************
 
+Policy Tracing
+==============
+
 If Cilium is allowing / denying connections in a way that is not aligned with the
 intent of your Cilium Network policy, there is an easy way to
 verify if and what policy rules apply between two
@@ -42,3 +45,28 @@ endpoint with the label ``id.http`` on port 80:
 
     Final verdict: ALLOWED
 
+Policy Rule to Endpoint Mapping
+===============================
+
+To determine which policy rules are currently in effect for an endpoint the
+data from ``cilium endpoint list`` and ``cilium endpoint get`` can be paired
+with the data from ``cilium policy get``. ``cilium endpoint get`` will list the
+labels of each rule that applies to an endpoint. The list of labels can be
+passed to ``cilium policy get`` to show that exact policy. Unfortunately, rules
+that have no labels cannot be fetched alone (a no label ``cililum policy get``
+returns the complete policy on the node). Rules with the same labels will be
+returned together.
+For an endpoint with endpoint id 51796, We can print all policies applied to it with:
+
+.. code:: bash
+
+    # print out the Layer 4 ingress labels
+    # clean up the data
+    # fetch each policy via each set of labels
+    $ cilium endpoint get 51796 -o jsonpath='{range ..policy.l4.ingress-source-rule-labels[*]}{@}{"\n"}{end}' | \
+      tr -d '][' | \
+      xargs -I{} bash -c 'echo "Labels: {}"; cilium policy get {}'
+    
+    $ cilium endpoint get 51796 -o jsonpath='{range ..policy.l4.egress-source-rule-labels[*]}{@}{"\n"}{end}' | tr -d '][' | xargs -I{} bash -c 'echo "Labels: {}"; cilium policy get {}'
+    $ cilium endpoint get 51796 -o jsonpath='{range ..policy.cidr-policy.ingress-source-rule-labels[*]}{@}{"\n"}{end}' | tr -d '][' | xargs -I{} bash -c 'echo "Labels: {}"; cilium policy get {}'
+    $ cilium endpoint get 51796 -o jsonpath='{range ..policy.cidr-policy.egress-source-rule-labels[*]}{@}{"\n"}{end}' | tr -d '][' | xargs -I{} bash -c 'echo "Labels: {}"; cilium policy get {}'

--- a/api/v1/models/c_id_r_policy.go
+++ b/api/v1/models/c_id_r_policy.go
@@ -20,13 +20,23 @@ type CIDRPolicy struct {
 	// List of CIDR egress rules
 	Egress []string `json:"egress"`
 
+	// Labels of egress L3 rules in effect on this endpoint
+	EgressSourceRuleLabels [][]string `json:"egress-source-rule-labels"`
+
 	// List of CIDR ingress rules
 	Ingress []string `json:"ingress"`
+
+	// Labels of ingress L3 rules in effect on this endpoint
+	IngressSourceRuleLabels [][]string `json:"ingress-source-rule-labels"`
 }
 
 /* polymorph CIDRPolicy egress false */
 
+/* polymorph CIDRPolicy egress-source-rule-labels false */
+
 /* polymorph CIDRPolicy ingress false */
+
+/* polymorph CIDRPolicy ingress-source-rule-labels false */
 
 // Validate validates this c ID r policy
 func (m *CIDRPolicy) Validate(formats strfmt.Registry) error {
@@ -37,7 +47,17 @@ func (m *CIDRPolicy) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateEgressSourceRuleLabels(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
 	if err := m.validateIngress(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateIngressSourceRuleLabels(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -57,9 +77,27 @@ func (m *CIDRPolicy) validateEgress(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *CIDRPolicy) validateEgressSourceRuleLabels(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.EgressSourceRuleLabels) { // not required
+		return nil
+	}
+
+	return nil
+}
+
 func (m *CIDRPolicy) validateIngress(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.Ingress) { // not required
+		return nil
+	}
+
+	return nil
+}
+
+func (m *CIDRPolicy) validateIngressSourceRuleLabels(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.IngressSourceRuleLabels) { // not required
 		return nil
 	}
 

--- a/api/v1/models/l4_policy.go
+++ b/api/v1/models/l4_policy.go
@@ -20,13 +20,23 @@ type L4Policy struct {
 	// List of L4 egress rules
 	Egress []string `json:"egress"`
 
+	// Labels of egress L4 rules in effect on this endpoint
+	EgressSourceRuleLabels [][]string `json:"egress-source-rule-labels"`
+
 	// List of L4 ingress rules
 	Ingress []string `json:"ingress"`
+
+	// Lables of ingres L4 rules in effect on this endpoint
+	IngressSourceRuleLabels [][]string `json:"ingress-source-rule-labels"`
 }
 
 /* polymorph L4Policy egress false */
 
+/* polymorph L4Policy egress-source-rule-labels false */
+
 /* polymorph L4Policy ingress false */
+
+/* polymorph L4Policy ingress-source-rule-labels false */
 
 // Validate validates this l4 policy
 func (m *L4Policy) Validate(formats strfmt.Registry) error {
@@ -37,7 +47,17 @@ func (m *L4Policy) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateEgressSourceRuleLabels(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
 	if err := m.validateIngress(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateIngressSourceRuleLabels(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -57,9 +77,27 @@ func (m *L4Policy) validateEgress(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *L4Policy) validateEgressSourceRuleLabels(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.EgressSourceRuleLabels) { // not required
+		return nil
+	}
+
+	return nil
+}
+
 func (m *L4Policy) validateIngress(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.Ingress) { // not required
+		return nil
+	}
+
+	return nil
+}
+
+func (m *L4Policy) validateIngressSourceRuleLabels(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.IngressSourceRuleLabels) { // not required
 		return nil
 	}
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -974,11 +974,25 @@ definitions:
         type: array
         items:
           type: string
+      ingress-source-rule-labels:
+        description: Labels of ingress L3 rules in effect on this endpoint
+        type: array
+        items: 
+          type: array
+          items:
+            type: string
       egress:
         description: List of CIDR egress rules
         type: array
         items:
           type: string
+      egress-source-rule-labels:
+        description: Labels of egress L3 rules in effect on this endpoint
+        type: array
+        items: 
+          type: array
+          items:
+            type: string
   CIDRList:
     description: List of CIDRs
     type: object

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -960,11 +960,25 @@ definitions:
         type: array
         items:
           type: string
+      ingress-source-rule-labels:
+        description: Lables of ingres L4 rules in effect on this endpoint
+        type: array
+        items: 
+          type: array
+          items:
+            type: string
       egress:
         description: List of L4 egress rules
         type: array
         items:
           type: string
+      egress-source-rule-labels:
+        description: Labels of egress L4 rules in effect on this endpoint
+        type: array
+        items: 
+          type: array
+          items:
+            type: string
   CIDRPolicy:
     description: CIDR endpoint policy
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1037,11 +1037,31 @@ func init() {
             "type": "string"
           }
         },
+        "egress-source-rule-labels": {
+          "description": "Labels of egress L3 rules in effect on this endpoint",
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
         "ingress": {
           "description": "List of CIDR ingress rules",
           "type": "array",
           "items": {
             "type": "string"
+          }
+        },
+        "ingress-source-rule-labels": {
+          "description": "Labels of ingress L3 rules in effect on this endpoint",
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       }

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1585,11 +1585,31 @@ func init() {
             "type": "string"
           }
         },
+        "egress-source-rule-labels": {
+          "description": "Labels of egress L4 rules in effect on this endpoint",
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
         "ingress": {
           "description": "List of L4 ingress rules",
           "type": "array",
           "items": {
             "type": "string"
+          }
+        },
+        "ingress-source-rule-labels": {
+          "description": "Lables of ingres L4 rules in effect on this endpoint",
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       }

--- a/cilium/cmd/endpoint_list.go
+++ b/cilium/cmd/endpoint_list.go
@@ -67,6 +67,10 @@ func listEndpoint(w *tabwriter.Writer, ep *models.Endpoint, id string, label str
 		isIngressPolicyEnabled = PolicyDisabled
 		isEgressPolicyEnabled = PolicyEnabled
 	}
+	isIngressPolicyEnabled = fmt.Sprintf("%s (%d rules)",
+		isIngressPolicyEnabled, len(ep.Policy.CidrPolicy.IngressSourceRuleLabels)+len(ep.Policy.L4.IngressSourceRuleLabels))
+	isEgressPolicyEnabled = fmt.Sprintf("%s (%d rules)",
+		isEgressPolicyEnabled, len(ep.Policy.CidrPolicy.EgressSourceRuleLabels)+len(ep.Policy.L4.EgressSourceRuleLabels))
 	fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
 		ep.ID, isIngressPolicyEnabled, isEgressPolicyEnabled, id, label, ep.Addressing.IPV6, ep.Addressing.IPV4, ep.State)
 }

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -52,7 +52,7 @@ func (e *Endpoint) writeL4Map(fw *bufio.Writer, owner Owner, m policy.L4PolicyMa
 	array := ""
 	index := 0
 
-	for k, l4 := range m {
+	for k, l4 := range m.Filters {
 		// Represents struct l4_allow in bpf/lib/l4.h
 		protoNum, err := u8proto.ParseProtocol(string(l4.Protocol))
 		if err != nil {
@@ -68,7 +68,7 @@ func (e *Endpoint) writeL4Map(fw *bufio.Writer, owner Owner, m policy.L4PolicyMa
 				return err
 			}
 			l4.L7RedirectPort = int(redirect)
-			m[k] = l4
+			m.Filters[k] = l4
 		}
 
 		redirect = byteorder.HostToNetwork(redirect).(uint16)
@@ -86,7 +86,7 @@ func (e *Endpoint) writeL4Map(fw *bufio.Writer, owner Owner, m policy.L4PolicyMa
 		fmt.Fprintf(fw, "#undef %s\n", config)
 	} else {
 		fmt.Fprintf(fw, "#define %s %s, (), 0\n", config, array)
-		fmt.Fprintf(fw, "#define NR_%s %d\n", config, len(m))
+		fmt.Fprintf(fw, "#define NR_%s %d\n", config, len(m.Filters))
 	}
 
 	return nil

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1253,8 +1253,8 @@ func (e *Endpoint) LeaveLocked(owner Owner) {
 		c.Mutex.RLock()
 		if e.L4Policy != nil {
 			// Passing a new map of nil will purge all redirects
-			e.cleanUnusedRedirects(owner, e.L4Policy.Ingress, nil)
-			e.cleanUnusedRedirects(owner, e.L4Policy.Egress, nil)
+			e.cleanUnusedRedirects(owner, &e.L4Policy.Ingress, nil)
+			e.cleanUnusedRedirects(owner, &e.L4Policy.Egress, nil)
 		}
 		c.Mutex.RUnlock()
 	}

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -119,15 +119,19 @@ func (s *K8sSuite) TestParseNetworkPolicy(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(result, comparator.DeepEquals, &policy.L4Policy{
 		Ingress: policy.L4PolicyMap{
-			"80/TCP": policy.L4Filter{
-				Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
-				FromEndpoints:  []api.EndpointSelector{epSelector},
-				L7Parser:       "",
-				L7RedirectPort: 0, L7RulesPerEp: policy.L7DataMap{},
-				Ingress: true,
+			Filters: map[string]policy.L4Filter{
+				"80/TCP": {
+					Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
+					FromEndpoints:  []api.EndpointSelector{epSelector},
+					L7Parser:       "",
+					L7RedirectPort: 0, L7RulesPerEp: policy.L7DataMap{},
+					Ingress: true,
+				},
 			},
 		},
-		Egress: policy.L4PolicyMap{},
+		Egress: policy.L4PolicyMap{
+			Filters: map[string]policy.L4Filter{},
+		},
 	})
 
 	ctx.To = labels.LabelArray{

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -128,9 +128,13 @@ func (s *K8sSuite) TestParseNetworkPolicy(c *C) {
 					Ingress: true,
 				},
 			},
+			SourceRuleLabels: []labels.LabelArray{
+				labels.ParseLabelArray("unspec:io.cilium.k8s-policy-name", "unspec:io.cilium.k8s-policy-namespace=default"),
+			},
 		},
 		Egress: policy.L4PolicyMap{
-			Filters: map[string]policy.L4Filter{},
+			Filters:          map[string]policy.L4Filter{},
+			SourceRuleLabels: []labels.LabelArray{},
 		},
 	})
 

--- a/pkg/k8s/network_policy_v1beta_test.go
+++ b/pkg/k8s/network_policy_v1beta_test.go
@@ -107,15 +107,19 @@ func (s *K8sSuite) TestParseNetworkPolicyDeprecated(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(result, comparator.DeepEquals, &policy.L4Policy{
 		Ingress: policy.L4PolicyMap{
-			"80/TCP": policy.L4Filter{
-				Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
-				FromEndpoints:  []api.EndpointSelector{epSelector},
-				L7Parser:       "",
-				L7RedirectPort: 0, L7RulesPerEp: policy.L7DataMap{},
-				Ingress: true,
+			Filters: map[string]policy.L4Filter{
+				"80/TCP": {
+					Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
+					FromEndpoints:  []api.EndpointSelector{epSelector},
+					L7Parser:       "",
+					L7RedirectPort: 0, L7RulesPerEp: policy.L7DataMap{},
+					Ingress: true,
+				},
 			},
 		},
-		Egress: policy.L4PolicyMap{},
+		Egress: policy.L4PolicyMap{
+			Filters: map[string]policy.L4Filter{},
+		},
 	})
 
 	ctx.To = labels.LabelArray{

--- a/pkg/k8s/network_policy_v1beta_test.go
+++ b/pkg/k8s/network_policy_v1beta_test.go
@@ -116,9 +116,13 @@ func (s *K8sSuite) TestParseNetworkPolicyDeprecated(c *C) {
 					Ingress: true,
 				},
 			},
+			SourceRuleLabels: []labels.LabelArray{
+				labels.ParseLabelArray("unspec:io.cilium.k8s-policy-name", "unspec:io.cilium.k8s-policy-namespace=default"),
+			},
 		},
 		Egress: policy.L4PolicyMap{
-			Filters: map[string]policy.L4Filter{},
+			Filters:          map[string]policy.L4Filter{},
+			SourceRuleLabels: []labels.LabelArray{},
 		},
 	})
 

--- a/pkg/labels/array.go
+++ b/pkg/labels/array.go
@@ -129,3 +129,29 @@ func (ls LabelArray) Get(key string) string {
 	}
 	return ""
 }
+
+// DeepCopy returns a deep copy of the labels.
+func (ls LabelArray) DeepCopy() LabelArray {
+	o := make(LabelArray, 0, len(ls))
+	for _, v := range ls {
+		if v == nil {
+			o = append(o, nil)
+		} else {
+			o = append(o, v.DeepCopy())
+		}
+	}
+	return o
+}
+
+// GetModel returns model with all the string values of the LabelArray.
+func (ls LabelArray) GetModel() []string {
+	res := []string{}
+	for _, v := range ls {
+		if v == nil {
+			res = append(res, "")
+		} else {
+			res = append(res, v.String())
+		}
+	}
+	return res
+}

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -64,10 +64,12 @@ func (s *PolicyTestSuite) TestIngressCoversDPorts(c *C) {
 	// Non-empty policy denies traffic without a port specified
 	policy = L4Policy{
 		Ingress: L4PolicyMap{
-			"8080/TCP": {
-				Port:     8080,
-				Protocol: api.ProtoTCP,
-				Ingress:  true,
+			Filters: map[string]L4Filter{
+				"8080/TCP": {
+					Port:     8080,
+					Protocol: api.ProtoTCP,
+					Ingress:  true,
+				},
 			},
 		},
 	}
@@ -83,10 +85,12 @@ func (s *PolicyTestSuite) TestEgressCoversDPorts(c *C) {
 	// Non-empty policy denies traffic without a port specified
 	policy = L4Policy{
 		Egress: L4PolicyMap{
-			"8080/TCP": {
-				Port:     8080,
-				Protocol: api.ProtoTCP,
-				Ingress:  false,
+			Filters: map[string]L4Filter{
+				"8080/TCP": {
+					Port:     8080,
+					Protocol: api.ProtoTCP,
+					Ingress:  false,
+				},
 			},
 		},
 	}
@@ -131,40 +135,44 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
 
 	policy := L4Policy{
 		Egress: L4PolicyMap{
-			"8080/TCP": {
-				Port:     8080,
-				Protocol: api.ProtoTCP,
-				Ingress:  false,
+			Filters: map[string]L4Filter{
+				"8080/TCP": {
+					Port:     8080,
+					Protocol: api.ProtoTCP,
+					Ingress:  false,
+				},
 			},
 		},
 		Ingress: L4PolicyMap{
-			"80/TCP": {
-				Port: 80, Protocol: api.ProtoTCP,
-				FromEndpoints: []api.EndpointSelector{fooSelector},
-				L7Parser:      "http",
-				L7RulesPerEp: L7DataMap{
-					fooSelector: api.L7Rules{
-						HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
-					},
-				},
-				Ingress: true,
-			},
-			"8080/TCP": {
-				Port: 8080, Protocol: api.ProtoTCP,
-				FromEndpoints: []api.EndpointSelector{fooSelector},
-				L7Parser:      "http",
-				L7RulesPerEp: L7DataMap{
-					fooSelector: api.L7Rules{
-						HTTP: []api.PortRuleHTTP{
-							{Path: "/", Method: "GET"},
-							{Path: "/bar", Method: "GET"},
+			Filters: map[string]L4Filter{
+				"80/TCP": {
+					Port: 80, Protocol: api.ProtoTCP,
+					FromEndpoints: []api.EndpointSelector{fooSelector},
+					L7Parser:      "http",
+					L7RulesPerEp: L7DataMap{
+						fooSelector: api.L7Rules{
+							HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
 						},
 					},
-					wildcardSelector: api.L7Rules{
-						HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
-					},
+					Ingress: true,
 				},
-				Ingress: true,
+				"8080/TCP": {
+					Port: 8080, Protocol: api.ProtoTCP,
+					FromEndpoints: []api.EndpointSelector{fooSelector},
+					L7Parser:      "http",
+					L7RulesPerEp: L7DataMap{
+						fooSelector: api.L7Rules{
+							HTTP: []api.PortRuleHTTP{
+								{Path: "/", Method: "GET"},
+								{Path: "/bar", Method: "GET"},
+							},
+						},
+						wildcardSelector: api.L7Rules{
+							HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
+						},
+					},
+					Ingress: true,
+				},
 			},
 		},
 	}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -186,7 +186,7 @@ func (p *Repository) allowsL4Egress(searchCtx *SearchContext) api.Decision {
 		log.WithError(err).Warn("Evaluation error while resolving L4 egress policy")
 	}
 	verdict := api.Undecided
-	if err == nil && len(policy.Egress) > 0 {
+	if err == nil && len(policy.Egress.Filters) > 0 {
 		verdict = policy.EgressCoversDPorts(ctx.DPorts)
 	}
 
@@ -207,7 +207,7 @@ func (p *Repository) allowsL4Ingress(ctx *SearchContext) api.Decision {
 		log.WithError(err).Warn("Evaluation error while resolving L4 ingress policy")
 	}
 	verdict := api.Undecided
-	if err == nil && len(policy.Ingress) > 0 {
+	if err == nil && len(policy.Ingress.Filters) > 0 {
 		verdict = policy.IngressCoversContext(ctx)
 	}
 

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -315,7 +315,7 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 	}
 
 	expected := NewL4Policy()
-	expected.Ingress["80/TCP"] = L4Filter{
+	expected.Ingress.Filters["80/TCP"] = L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		FromEndpoints: selectorFromApp2DupList,
 		L7Parser:      "http",
@@ -327,13 +327,13 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 		Ingress: true,
 	}
 
-	c.Assert(len(l4policy.Ingress), Equals, 1)
+	c.Assert(len(l4policy.Ingress.Filters), Equals, 1)
 	c.Assert(*l4policy, comparator.DeepEquals, *expected)
 
 	// L4 from app3 has no rules
 	expected = NewL4Policy()
 	l4policy, err = repo.ResolveL4Policy(fromApp3)
-	c.Assert(len(l4policy.Ingress), Equals, 0)
+	c.Assert(len(l4policy.Ingress.Filters), Equals, 0)
 	c.Assert(*l4policy, comparator.DeepEquals, *expected)
 }
 

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -326,6 +326,8 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 		},
 		Ingress: true,
 	}
+	expected.Ingress.SourceRuleLabels = []labels.LabelArray{labels.ParseLabelArray(), labels.ParseLabelArray(), labels.ParseLabelArray()}
+	expected.Egress.SourceRuleLabels = []labels.LabelArray{}
 
 	c.Assert(len(l4policy.Ingress.Filters), Equals, 1)
 	c.Assert(*l4policy, comparator.DeepEquals, *expected)
@@ -333,6 +335,7 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 	// L4 from app3 has no rules
 	expected = NewL4Policy()
 	l4policy, err = repo.ResolveL4Policy(fromApp3)
+	c.Assert(err, IsNil)
 	c.Assert(len(l4policy.Ingress.Filters), Equals, 0)
 	c.Assert(*l4policy, comparator.DeepEquals, *expected)
 }

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -104,9 +104,9 @@ func mergeL4Port(ctx *SearchContext, fromEndpoints []api.EndpointSelector, r api
 	dir string, proto api.L4Proto, resMap L4PolicyMap) (int, error) {
 
 	key := p.Port + "/" + string(proto)
-	v, ok := resMap[key]
+	v, ok := resMap.Filters[key]
 	if !ok {
-		resMap[key] = CreateL4Filter(fromEndpoints, r, p, dir, proto)
+		resMap.Filters[key] = CreateL4Filter(fromEndpoints, r, p, dir, proto)
 		return 1, nil
 	}
 	l4Filter := CreateL4Filter(fromEndpoints, r, p, dir, proto)
@@ -167,7 +167,7 @@ func mergeL4Port(ctx *SearchContext, fromEndpoints []api.EndpointSelector, r api
 		}
 	}
 
-	resMap[key] = v
+	resMap.Filters[key] = v
 	return 1, nil
 }
 

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -145,19 +145,19 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	}
 
 	expected := NewL4Policy()
-	expected.Ingress["80/TCP"] = L4Filter{
+	expected.Ingress.Filters["80/TCP"] = L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: nil,
 		L7Parser: "http", L7RulesPerEp: l7map, Ingress: true,
 	}
-	expected.Ingress["8080/TCP"] = L4Filter{
+	expected.Ingress.Filters["8080/TCP"] = L4Filter{
 		Port: 8080, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: nil,
 		L7Parser: "http", L7RulesPerEp: l7map, Ingress: true,
 	}
-	expected.Egress["3000/TCP"] = L4Filter{
+	expected.Egress.Filters["3000/TCP"] = L4Filter{
 		Port: 3000, Protocol: api.ProtoTCP, U8Proto: 6, Ingress: false,
 		L7RulesPerEp: L7DataMap{},
 	}
-	expected.Egress["3000/UDP"] = L4Filter{
+	expected.Egress.Filters["3000/UDP"] = L4Filter{
 		Port: 3000, Protocol: api.ProtoUDP, U8Proto: 17, Ingress: false,
 		L7RulesPerEp: L7DataMap{},
 	}
@@ -216,15 +216,15 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	}
 
 	expected = NewL4Policy()
-	expected.Ingress["80/TCP"] = L4Filter{
+	expected.Ingress.Filters["80/TCP"] = L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: nil,
 		L7Parser: "http", L7RulesPerEp: l7map, Ingress: true,
 	}
-	expected.Egress["3000/TCP"] = L4Filter{
+	expected.Egress.Filters["3000/TCP"] = L4Filter{
 		Port: 3000, Protocol: api.ProtoTCP, U8Proto: 6, Ingress: false,
 		L7RulesPerEp: L7DataMap{},
 	}
-	expected.Egress["3000/UDP"] = L4Filter{
+	expected.Egress.Filters["3000/UDP"] = L4Filter{
 		Port: 3000, Protocol: api.ProtoUDP, U8Proto: 17, Ingress: false,
 		L7RulesPerEp: L7DataMap{},
 	}
@@ -233,7 +233,7 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	res, err = rule2.resolveL4Policy(toBar, &state, NewL4Policy())
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
-	c.Assert(len(res.Ingress), Equals, 1)
+	c.Assert(len(res.Ingress.Filters), Equals, 1)
 	c.Assert(*res, comparator.DeepEquals, *expected)
 	c.Assert(state.selectedRules, Equals, 1)
 	c.Assert(state.matchedRules, Equals, 0)
@@ -277,7 +277,7 @@ func (ds *PolicyTestSuite) TestMergeL4Policy(c *C) {
 
 	mergedES := []api.EndpointSelector{fooSelector, bazSelector}
 	expected := NewL4Policy()
-	expected.Ingress["80/TCP"] = L4Filter{
+	expected.Ingress.Filters["80/TCP"] = L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: mergedES,
 		L7Parser: "", L7RulesPerEp: L7DataMap{}, Ingress: true,
 	}
@@ -347,7 +347,7 @@ func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
 	}
 
 	expected := NewL4Policy()
-	expected.Ingress["80/TCP"] = L4Filter{
+	expected.Ingress.Filters["80/TCP"] = L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: nil,
 		L7Parser: "http", L7RulesPerEp: l7map, Ingress: true,
 	}
@@ -415,7 +415,7 @@ func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
 	}
 
 	expected = NewL4Policy()
-	expected.Ingress["80/TCP"] = L4Filter{
+	expected.Ingress.Filters["80/TCP"] = L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: nil,
 		L7Parser: "kafka", L7RulesPerEp: l7map, Ingress: true,
 	}
@@ -492,7 +492,7 @@ func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
 		WildcardEndpointSelector: barRules,
 	}
 	expected = NewL4Policy()
-	expected.Ingress["80/TCP"] = L4Filter{
+	expected.Ingress.Filters["80/TCP"] = L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: nil,
 		L7Parser: "kafka", L7RulesPerEp: l7map, Ingress: true,
 	}

--- a/tests/01-ct.sh
+++ b/tests/01-ct.sh
@@ -40,13 +40,13 @@ function get_container_metadata {
   log "CLIENT_IP: $CLIENT_IP"
   CLIENT_IP4=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' client)
   log "CLIENT_IP4: $CLIENT_IP4"
-  CLIENT_ID=$(cilium endpoint list | grep id.client | awk '{ print $1}')
+  CLIENT_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep id.client | awk '{ print $1}')
   log "CLIENT_ID: $CLIENT_ID"
   SERVER_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server)
   log "SERVER_IP: $SERVER_IP"
   SERVER_IP4=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' server)
   log "SERVER_IP4: $SERVER_IP4"
-  SERVER_ID=$(cilium endpoint list | grep id.server | awk '{ print $1}')
+  SERVER_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep id.server | awk '{ print $1}')
   log "SERVER_ID: $SERVER_ID"
   HTTPD1_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' httpd1)
   log "HTTPD1_IP: $HTTPD1_IP"

--- a/tests/02-perf.sh
+++ b/tests/02-perf.sh
@@ -45,19 +45,19 @@ create_cilium_docker_network
 docker run -dt --net=$TEST_NET --name server -l $SERVER_LABEL $NETPERF_IMAGE
 docker run -dt --net=$TEST_NET --name client -l $CLIENT_LABEL $NETPERF_IMAGE
 
-until [ -n "$(cilium endpoint list | grep $CLIENT_LABEL | awk '{ print $1}')" ]; do
+until [ -n "$(cilium endpoint list -o jsonpath='${CILIUM_JSONPATH_FMT}' | grep $CLIENT_LABEL | awk '{ print $1}')" ]; do
   echo "Waiting for client endpoint to have an identity"
 done
-until [ -n "$(cilium endpoint list | grep $SERVER_LABEL | awk '{ print $1}')" ]; do
+until [ -n "$(cilium endpoint list -o jsonpath='${CILIUM_JSONPATH_FMT}' | grep $SERVER_LABEL | awk '{ print $1}')" ]; do
   echo "Waiting for server endpoint to have an identity"
 done
 
 CLIENT_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' client)
 CLIENT_IP4=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' client)
-CLIENT_ID=$(cilium endpoint list | grep $CLIENT_LABEL | awk '{ print $1}')
+CLIENT_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep $CLIENT_LABEL | awk '{ print $1}')
 SERVER_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server)
 SERVER_IP4=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' server)
-SERVER_ID=$(cilium endpoint list | grep $SERVER_LABEL | awk '{ print $1}')
+SERVER_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep $SERVER_LABEL | awk '{ print $1}')
 HOST_IP=$(echo $SERVER_IP | sed -e 's/:[0-9a-f]\{4\}$/:ffff/')
 SERVER_DEV=$(cilium endpoint get $SERVER_ID | grep interface-name | awk '{print $2}' | sed 's/"//g' | sed 's/,$//')
 NODE_MAC=$(cilium endpoint get $SERVER_ID | grep host-mac | awk '{print $2}' | sed 's/"//g' | sed 's/,$//')

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -395,27 +395,27 @@ for i in server{1..5} client misc; do
 done
 
 CLIENT_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' client)
-CLIENT_ID=$(cilium endpoint list | grep $CLIENT_IP | awk '{ print $1}')
+CLIENT_ID=$(cilium endpoint list --jsonpath="${CILIUM_JSONPATH_FMT}" | grep $CLIENT_IP | awk '{ print $1}')
 
 SERVER1_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server1)
-SERVER1_ID=$(cilium endpoint list | grep $SERVER1_IP | awk '{ print $1}')
-SERVER1_IP4=$(cilium endpoint list | grep $SERVER1_IP | awk '{ print $7}')
+SERVER1_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep $SERVER1_IP | awk '{ print $1}')
+SERVER1_IP4=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep $SERVER1_IP | awk '{ print $4}')
 
 SERVER2_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server2)
-SERVER2_ID=$(cilium endpoint list | grep $SERVER2_IP | awk '{ print $1}')
-SERVER2_IP4=$(cilium endpoint list | grep $SERVER2_IP | awk '{ print $7}')
+SERVER2_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep $SERVER2_IP | awk '{ print $1}')
+SERVER2_IP4=$(cilium endpoint list --jsonpath="${CILIUM_JSONPATH_FMT}" | grep $SERVER2_IP | awk '{ print $4}')
 
 SERVER3_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server3)
-SERVER3_ID=$(cilium endpoint list | grep $SERVER3_IP | awk '{ print $1}')
-SERVER3_IP4=$(cilium endpoint list | grep $SERVER3_IP | awk '{ print $7}')
+SERVER3_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep $SERVER3_IP | awk '{ print $1}')
+SERVER3_IP4=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep $SERVER3_IP | awk '{ print $4}')
 
 SERVER4_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server4)
-SERVER4_ID=$(cilium endpoint list | grep $SERVER4_IP | awk '{ print $1}')
-SERVER4_IP4=$(cilium endpoint list | grep $SERVER4_IP | awk '{ print $7}')
+SERVER4_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep $SERVER4_IP | awk '{ print $1}')
+SERVER4_IP4=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep $SERVER4_IP | awk '{ print $4}')
 
 SERVER5_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server5)
-SERVER5_ID=$(cilium endpoint list | grep $SERVER5_IP | awk '{ print $1}')
-SERVER5_IP4=$(cilium endpoint list | grep $SERVER5_IP | awk '{ print $7}')
+SERVER5_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep $SERVER5_IP | awk '{ print $1}')
+SERVER5_IP4=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep $SERVER5_IP | awk '{ print $4}')
 
 log "getting ConntrackLocal setting for client"
 cilium endpoint config $CLIENT_ID  | grep ConntrackLocal

--- a/tests/08-nat46.sh
+++ b/tests/08-nat46.sh
@@ -45,10 +45,10 @@ log "done starting containers"
 
 CLIENT_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' client)
 CLIENT_IP4=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' client)
-CLIENT_ID=$(cilium endpoint list | grep $CLIENT_IP | awk '{ print $1}')
+CLIENT_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep $CLIENT_IP | awk '{ print $1}')
 SERVER_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server)
 SERVER_IP4=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' server)
-SERVER_ID=$(cilium endpoint list | grep $SERVER_IP | awk '{ print $1}')
+SERVER_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep $SERVER_IP | awk '{ print $1}')
 
 log "CLIENT_IP=$CLIENT_IP"
 log "CLIENT_IP4=$CLIENT_IP4"

--- a/tests/09-perf-gce.sh
+++ b/tests/09-perf-gce.sh
@@ -75,10 +75,10 @@ trap cleanup_cilium EXIT
 
 CLIENT_IP=$(kubectl exec ${client_pod} -- ip -6 a s | grep global | tr -s ' ' | cut -d' ' -f 3 | sed 's:/.*::')
 CLIENT_IP4=$(kubectl exec ${client_pod} -- ip -4 a s | grep global | tr -s ' ' | cut -d' ' -f 3 | sed 's:/.*::')
-CLIENT_ID=$(kubectl exec ${client_cilium} -- cilium endpoint list | grep $CLIENT_LABEL | awk '{ print $1}')
+CLIENT_ID=$(kubectl exec ${client_cilium} -- cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep $CLIENT_LABEL | awk '{ print $1}')
 SERVER_IP=$(kubectl exec ${server_pod} -- ip -6 a s | grep global | tr -s ' ' | cut -d' ' -f 3 | sed 's:/.*::')
 SERVER_IP4=$(kubectl exec ${server_pod} -- ip -4 a s | grep global | tr -s ' ' | cut -d' ' -f 3 | sed 's:/.*::')
-SERVER_ID=$(kubectl exec ${server_cilium} -- cilium endpoint list | grep $SERVER_LABEL | awk '{ print $1}')
+SERVER_ID=$(kubectl exec ${server_cilium} -- cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep $SERVER_LABEL | awk '{ print $1}')
 
 HOST_IP=$(echo $SERVER_IP | sed -e 's/:[0-9a-f]\{4\}$/:ffff/')
 SERVER_DEV=$(kubectl exec ${server_cilium} -- cilium endpoint get $SERVER_ID | grep interface-name | awk '{print $2}' | sed 's/"//g' | sed 's/,$//')

--- a/tests/12-policy-import.sh
+++ b/tests/12-policy-import.sh
@@ -18,8 +18,8 @@ ALLOWED="Final verdict: ALLOWED"
 function test_policy_trace_policy_disabled {
   # If policy enforcement is disabled, then `cilium policy trace` should return that traffic is allowed between all security identities.
   wait_for_endpoints 3
-  local FOO_ID=$(cilium endpoint list | grep id.foo | awk '{print $1}')
-  local BAR_ID=$(cilium endpoint list | grep id.bar | awk '{ print $1}')
+  local FOO_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep id.foo | awk '{print $1}')
+  local BAR_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep id.bar | awk '{ print $1}')
   log "verify verbose trace for expected output using endpoint IDs "
   local TRACE_OUTPUT=$(cilium policy trace --src-endpoint $FOO_ID --dst-endpoint $BAR_ID -v)
   log "Trace output: ${TRACE_OUTPUT}"
@@ -145,8 +145,8 @@ if [[ "$DIFF" != "" ]]; then
   abort "$DIFF"
 fi
 
-BAR_ID=$(cilium endpoint list | grep id.bar | awk '{ print $1}')
-FOO_SEC_ID=$(cilium endpoint list | grep id.foo | awk '{ print $4}')
+BAR_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep id.bar | awk '{ print $1}')
+FOO_SEC_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep id.foo | awk '{ print $4}')
 
 EXPECTED_CONSUMER="1\n$FOO_SEC_ID"
 
@@ -190,10 +190,10 @@ if [[ "$DIFF" != "" ]]; then
   abort "$DIFF"
 fi
 
-FOO_ID=$(cilium endpoint list | grep id.foo | awk '{print $1}')
-BAR_ID=$(cilium endpoint list | grep id.bar | awk '{ print $1}')
-FOO_SEC_ID=$(cilium endpoint list | grep id.foo | awk '{ print $4}')
-BAR_SEC_ID=$(cilium endpoint list | grep id.bar | awk '{print $4}')
+FOO_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep id.foo | awk '{print $1}')
+BAR_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep id.bar | awk '{ print $1}')
+FOO_SEC_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep id.foo | awk '{ print $4}')
+BAR_SEC_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep id.bar | awk '{print $4}')
 
 log "verify verbose trace for expected output using security identities"
 DIFF=$(diff -Nru <(echo "$ALLOWED") <(cilium policy trace --src-identity $FOO_SEC_ID --dst-identity $BAR_SEC_ID -v | grep "Final verdict:")) || true

--- a/tests/14-policy-enforcement-docker.sh
+++ b/tests/14-policy-enforcement-docker.sh
@@ -17,11 +17,11 @@ NUM_ENDPOINTS="3"
 NAMESPACE="kube-system"
 GOPATH="/home/vagrant/go"
 
-INGRESS_ENABLED_CMD="cilium endpoint list | awk '{print $2}' | grep 'Enabled' -c"
-INGRESS_DISABLED_CMD="cilium endpoint list | awk '{print $2}' | grep 'Disabled' -c"
+INGRESS_ENABLED_CMD="cilium endpoint list -o jsonpath='${CILIUM_JSONPATH_FMT}' | awk '{ print $2}' | grep -E '(ingress|both)' -c"
+INGRESS_DISABLED_CMD="cilium endpoint list -o jsonpath='${CILIUM_JSONPATH_FMT}' | awk '{ print $2}' | grep -E '(none|egress)' -c"
 
-EGRESS_ENABLED_CMD="cilium endpoint list | awk '{print $3}' | grep 'Enabled' -c"
-EGRESS_DISABLED_CMD="cilium endpoint list | awk '{print $3}' | grep 'Disabled' -c"
+EGRESS_ENABLED_CMD="cilium endpoint list -o jsonpath='${CILIUM_JSONPATH_FMT}' | awk '{ print $2}' | grep -E '(egress|both)' -c"
+EGRESS_DISABLED_CMD="cilium endpoint list -o jsonpath='${CILIUM_JSONPATH_FMT}' | awk '{ print $2}' | grep -E '(none|ingress)' -c"
 
 function cleanup {
   log "beginning cleanup for ${TEST_NAME}"

--- a/tests/15-check-container-id.sh
+++ b/tests/15-check-container-id.sh
@@ -45,7 +45,7 @@ cilium endpoint list
 
 docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server
 SERVER_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server)
-SERVER_ID=$(cilium endpoint list | grep ${SERVER_LABEL} | awk '{ print $1}')
+SERVER_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep ${SERVER_LABEL} | awk '{ print $1}')
 
 log "pinging server at IP ${SERVER_IP}"
 ping6 -c 1 ${SERVER_IP} || true
@@ -53,7 +53,7 @@ ping6 -c 1 ${SERVER_IP} || true
 docker run -d --net cilium --name client -l ${CLIENT_LABEL} tgraf/netperf
 
 CLIENT_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' client)
-CLIENT_ID=$(cilium endpoint list | grep ${CLIENT_LABEL} | awk '{ print $1}')
+CLIENT_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep ${CLIENT_LABEL} | awk '{ print $1}')
 
 log "output of \"cilium endpoint list\""
 cilium endpoint list

--- a/tests/19-identity-get.sh
+++ b/tests/19-identity-get.sh
@@ -55,7 +55,7 @@ function test_identity_get {
   start_containers
   wait_for_endpoints 3
   cilium endpoint list
-  local ID=$(cilium endpoint list | grep id.foo | awk '{print $4}')
+  local ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep id.foo | awk '{print $4}')
 
   # Get expected response and replace all newline chars with a single space.
   local response=$(cilium identity get $ID | sed ':a;N;$!ba;s/\n/ /g')

--- a/tests/20-identity-list.sh
+++ b/tests/20-identity-list.sh
@@ -51,7 +51,7 @@ function test_identity_list {
   start_containers
   wait_for_endpoints 3
   cilium endpoint list
-  local ID=$(cilium endpoint list | grep id.foo | awk '{print $4}')
+  local ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep id.foo | awk '{print $4}')
 
   # Get expected response and replace all newline chars with a single space.
   local response=$(cilium identity list "container:id.foo" | sed ':a;N;$!ba;s/\n/ /g')

--- a/tests/21-ct-clean-up.sh
+++ b/tests/21-ct-clean-up.sh
@@ -41,7 +41,7 @@ function start_containers {
 }
 
 function get_container_metadata {
-  CLIENT_SEC_ID=$(cilium endpoint list | grep id.client-2 | awk '{ print $4}')
+  CLIENT_SEC_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep id.client-2 | awk '{ print $4}')
   log "CLIENT_SEC_ID: $CLIENT_SEC_ID"
   CLIENT_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' client)
   log "CLIENT_IP: $CLIENT_IP"
@@ -51,33 +51,33 @@ function get_container_metadata {
   log "CLIENT_2_IP: $CLIENT_2_IP"
   CLIENT_2_IP4=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' client-2)
   log "CLIENT_2_IP4: $CLIENT_2_IP4"
-  CLIENT_ID=$(cilium endpoint list | grep "${CLIENT_IP4}" | awk '{ print $1}')
+  CLIENT_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep "${CLIENT_IP4}" | awk '{ print $1}')
   log "CLIENT_ID: $CLIENT_ID"
-  CLIENT_2_ID=$(cilium endpoint list | grep "${CLIENT_2_IP4}" | awk '{ print $1}')
+  CLIENT_2_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep "${CLIENT_2_IP4}" | awk '{ print $1}')
   log "CLIENT_2_ID: $CLIENT_2_ID"
   SERVER_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server)
   log "SERVER_IP: $SERVER_IP"
   SERVER_IP4=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' server)
   log "SERVER_IP4: $SERVER_IP4"
-  SERVER_ID=$(cilium endpoint list | grep -E 'id.server($|\s)' | awk '{ print $1}')
+  SERVER_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep -E 'id.server($|\s)' | awk '{ print $1}')
   log "SERVER_ID: $SERVER_ID"
   SERVER_2_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' server-2)
   log "SERVER_2_IP: $SERVER_2_IP"
   SERVER_2_IP4=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' server-2)
   log "SERVER_2_IP4: $SERVER_2_IP4"
-  SERVER_2_ID=$(cilium endpoint list | grep id.server-2 | awk '{ print $1}')
+  SERVER_2_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep id.server-2 | awk '{ print $1}')
   log "SERVER_2_ID: $SERVER_2_ID"
   SERVER_3_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' httpd-server)
   log "SERVER_3_IP: $SERVER_3_IP"
   SERVER_3_IP4=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' httpd-server)
   log "SERVER_3_IP4: $SERVER_3_IP4"
-  SERVER_3_ID=$(cilium endpoint list | grep id.server-3 | awk '{ print $1}')
+  SERVER_3_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep id.server-3 | awk '{ print $1}')
   log "SERVER_3_ID: $SERVER_3_ID"
   SERVER_4_IP=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.GlobalIPv6Address }}' netcat)
   log "SERVER_3_IP: $SERVER_4_IP"
   SERVER_4_IP4=$(docker inspect --format '{{ .NetworkSettings.Networks.cilium.IPAddress }}' netcat)
   log "SERVER_4_IP4: $SERVER_4_IP4"
-  SERVER_4_ID=$(cilium endpoint list | grep id.server-4 | awk '{ print $1}')
+  SERVER_4_ID=$(cilium endpoint list -o jsonpath="${CILIUM_JSONPATH_FMT}" | grep id.server-4 | awk '{ print $1}')
   log "SERVER_4_ID: $SERVER_4_ID"
 }
 


### PR DESCRIPTION
NOTE: This PR depends on https://github.com/cilium/cilium/pull/2390 so review that one first. Don't merge this one before!

**Summary of changes**:
I'm adding returning applicable policy rule labels in https://github.com/cilium/cilium/pull/2390 This PR builds on that, adding a summary view to `cilium endpoint list`. The real PR is trivial but we needed to fix many tests that relied on the human readable output. I've tried to improve them enough to last until they are replaced.

Fixes: #2184 

```release-note
cilium endpoint list reports the count of rules that apply to each endpoint
```

**How to test (optional)**:
- setup some endpoints, add some policies
```
kubectl create -f examples/minikube/demo.yaml
kubectl create -f examples/minikube/l3_l4_policy.yaml -f examples/minikube/l3_l4_l7_policy.yaml
```
- `cilium endpoint list`
```
vagrant@cilium-k8s-master:~/go/src/github.com/cilium/cilium$ cilium endpoint list
ENDPOINT   POLICY (ingress)     POLICY (egress)      IDENTITY   LABELS (source:key[=value])                   IPv6                 IPv4          STATUS
           ENFORCEMENT          ENFORCEMENT
173        Disabled (0 rules)   Disabled (0 rules)   284        k8s:io.kubernetes.pod.namespace=kube-system   f00d::a0b:0:0:ad     10.0.42.252   ready
                                                                k8s:k8s-app=kube-dns
21274      Disabled (0 rules)   Disabled (0 rules)   282        k8s:id=app2                                   f00d::a0b:0:0:531a   10.0.244.38   ready
                                                                k8s:io.kubernetes.pod.namespace=default
30391      Disabled (0 rules)   Disabled (0 rules)   281        k8s:id=app3                                   f00d::a0b:0:0:76b7   10.0.66.100   ready
                                                                k8s:io.kubernetes.pod.namespace=default
33243      Enabled (2 rules)    Disabled (0 rules)   283        k8s:id=app1                                   f00d::a0b:0:0:81db   10.0.41.191   ready
                                                                k8s:io.kubernetes.pod.namespace=default
51796      Enabled (2 rules)    Disabled (0 rules)   283        k8s:id=app1                                   f00d::a0b:0:0:ca54   10.0.17.80    ready
                                                                k8s:io.kubernetes.pod.namespace=default
```