### PR TITLE
test/provision: add retry logic for download cmds

### DIFF
--- a/test/provision/dns.sh
+++ b/test/provision/dns.sh
@@ -3,8 +3,9 @@
 # This script update the dns servers to use google ones.
 set -e
 
+echo "updating /etc/resolv.conf"
+
 cat <<EOF > /etc/resolv.conf
 nameserver 8.8.8.8
 nameserver 8.8.4.4
 EOF
-

--- a/test/provision/helpers.bash
+++ b/test/provision/helpers.bash
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+function log_msg {
+  MSG="$1"
+  echo "***************************************"
+  echo "*"
+  echo "*"
+  echo "* ${MSG}"
+  echo "*"
+  echo "*"
+  echo "***************************************"
+}
+
+function retry_function {
+  set +e
+  FUNC="$1"
+  COUNTER=0
+  MAX_TRIES=10
+  echo "beginning trying up to ${MAX_TRIES} times function \"${FUNC}\""
+  while [ $COUNTER -lt $MAX_TRIES ]; do
+    log_msg "on attempt ${COUNTER} of function \"${FUNC}\""
+    ${FUNC}
+    if [[ "$?" == "0" ]] ; then
+      echo "running of \"${FUNC}\" successful"
+      echo 
+      echo
+      echo
+      set -e
+      return 0
+    fi
+    sleep 1
+    let COUNTER=COUNTER+1
+  done
+
+  log_msg "running function \"${FUNC}\" ${MAX_TRIES} times did not succeed"
+  set -e
+  return 1
+}

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -15,6 +15,8 @@ IP=$2
 K8S_VERSION=$3
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
+source ${PROVISIONSRC}/helpers.bash
+
 if [[ -f  "/etc/provision_finished" ]]; then
     sudo dpkg -l | grep kubelet
     echo "provision is finished, recompiling"
@@ -38,7 +40,7 @@ deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 
 sudo rm /var/lib/apt/lists/lock || true
-wget https://packages.cloud.google.com/apt/doc/apt-key.gpg
+retry_function "wget https://packages.cloud.google.com/apt/doc/apt-key.gpg"
 apt-key add apt-key.gpg
 
 case $K8S_VERSION in
@@ -50,13 +52,13 @@ case $K8S_VERSION in
         ;;
 esac
 
-apt-get update
-apt-get install --allow-downgrades -y \
+retry_function "apt-get update"
+retry_function "apt-get install --allow-downgrades -y \
     llvm \
-    kubernetes-cni="${KUBERNETES_CNI_VERSION}" \
-    kubelet="${K8S_VERSION}*" \
-    kubeadm="${K8S_VERSION}*" \
-    kubectl="${K8S_VERSION}*"
+    kubernetes-cni=${KUBERNETES_CNI_VERSION} \
+    kubelet=${K8S_VERSION}* \
+    kubeadm=${K8S_VERSION}* \
+    kubectl=${K8S_VERSION}* "
 
 sudo mkdir -p ${CILIUM_CONFIG_DIR}
 

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -3,11 +3,17 @@ set -e
 
 HOST=$(hostname)
 PROVISIONSRC="/tmp/provision/"
+GOPATH=/go/
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+source ${PROVISIONSRC}/helpers.bash
+
 
 $PROVISIONSRC/dns.sh
-sudo adduser vagrant docker
 
-export GOPATH=/go/
-go get -u github.com/jteeuwen/go-bindata/...
+sudo adduser vagrant docker
+retry_function "go get -u github.com/jteeuwen/go-bindata/..."
+
 ln -sf /go/bin/* /usr/local/bin/
 $PROVISIONSRC/compile.sh

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -2,18 +2,18 @@
 set -e
 
 HOST=$(hostname)
-PROVISIONSRC="/tmp/provision/"
+PROVISIONSRC="/tmp/provision"
 GOPATH=/go/
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-source ${PROVISIONSRC}/helpers.bash
+source "${PROVISIONSRC}/helpers.bash"
 
 
-$PROVISIONSRC/dns.sh
+"${PROVISIONSRC}"/dns.sh
 
 sudo adduser vagrant docker
 retry_function "go get -u github.com/jteeuwen/go-bindata/..."
 
 ln -sf /go/bin/* /usr/local/bin/
-$PROVISIONSRC/compile.sh
+"${PROVISIONSRC}"/compile.sh


### PR DESCRIPTION
Sometimes, commands to download resources fail. Add logic to retry so that
provisioning does not fail immediately.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #2470 