### PR TITLE
tests: change deadlock check log message

### DIFF
--- a/tests/999-deadlock-check.sh
+++ b/tests/999-deadlock-check.sh
@@ -13,7 +13,7 @@ set -ex
 
 log "Checking for deadlocks in cilium service log"
 if $(journalctl -au cilium | grep -qi -B 5 -A 5 deadlock); then
-	abort "Deadlock during test run detected, check the log above for context"
+	abort "Deadlock during test run detected, check Cilium logs for context"
 fi
 
 test_succeeded "${TEST_NAME}"

--- a/tests/k8s/tests/999-deadlock-check.sh
+++ b/tests/k8s/tests/999-deadlock-check.sh
@@ -15,7 +15,7 @@ set -ex
 
 log "Checking for deadlocks in k8s cilium log"
 if $(docker ps -a | grep cilium-agent | awk '{print $1}' | xargs -n1 docker logs 2>&1 | grep -qi -B 5 -A 5 deadlock); then
-	abort "Deadlock during test run detected, check the log above for context"
+	abort "Deadlock during test run detected, check Cilium logs for context"
 fi
 
 test_succeeded "${TEST_NAME}"


### PR DESCRIPTION
Update message to check the CIlium logs, as logs are no longer output to console.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #2442 