### PR TITLE
CI: Build and test with Envoy only.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,9 +24,6 @@ pipeline {
                     "Runtime Tests": {
                          sh 'PROVISION=1 ./contrib/vagrant/start.sh'
                      },
-                    "Runtime Tests with Envoy": {
-                         sh 'CILIUM_USE_ENVOY=1 PROVISION=1 ./contrib/vagrant/start.sh'
-                     },
                     "K8s multi node Tests": {
                          sh './tests/k8s/start.sh'
                     },
@@ -45,7 +42,6 @@ pipeline {
             sh 'rm -rf ${WORKSPACE}/cilium-files*${JOB_BASE_NAME}-${BUILD_NUMBER}* ${WORKSPACE}/tests/cilium-files ${WORKSPACE}/tests/k8s/tests/cilium-files'
             sh 'ls'
             sh 'vagrant destroy -f'
-            sh 'CILIUM_USE_ENVOY=1 vagrant destroy -f'
             sh 'cd ./tests/k8s && vagrant destroy -f'
         }
     }

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,7 +45,7 @@ else
 fi
 SCRIPT
 
-$envoyexport = ENV['CILIUM_USE_ENVOY'] ? "export CILIUM_USE_ENVOY=1\n" : ""
+$envoyexport = "export CILIUM_USE_ENVOY=1\n"
 $build = $envoyexport
 $install = $envoyexport
 $testsuite = $envoyexport
@@ -97,9 +97,6 @@ $job_name = ENV['JOB_BASE_NAME'] || "local"
 
 $build_number = ENV['BUILD_NUMBER'] || "0"
 $build_id = "#{$job_name}-#{$build_number}"
-if ENV['CILIUM_USE_ENVOY'] then
-    $build_id += "-envoy"
-end
 
 # Only create the build_id_name for Jenkins environment so that
 # we can run VMs locally without having any the `build_id` in the name.
@@ -202,8 +199,7 @@ Vagrant.configure(2) do |config|
                    privileged: true,
                    path: k8sinstall
            end
-           script = "#{ENV['CILIUM_TEMP']}/"
-           script += ENV['CILIUM_USE_ENVOY'] ? "cilium-master-envoy.sh" : "cilium-master.sh"
+           script = "#{ENV['CILIUM_TEMP']}/cilium-master.sh"
            cm.vm.provision "config-install", type: "shell", privileged: true, run: "always", path: script
            # In k8s mode cilium needs etcd in order to run which was started in
            # the first part of the script. The 2nd part will install the

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -357,9 +357,7 @@ else
     echo "K8S_NODE_NAME=\$(hostname)" >> /etc/sysconfig/cilium
     echo 'CILIUM_OPTS="${ubuntu_1604_cilium_lb} ${ubuntu_1604_interface} ${cilium_options}"' >> /etc/sysconfig/cilium
     echo 'PATH=/usr/local/clang/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin' >> /etc/sysconfig/cilium
-    if test ${CILIUM_USE_ENVOY}; then
-        echo 'CILIUM_USE_ENVOY=1' >> /etc/sysconfig/cilium
-    fi
+    echo 'CILIUM_USE_ENVOY=1' >> /etc/sysconfig/cilium
     chmod 644 /etc/sysconfig/cilium
 fi
 
@@ -403,11 +401,7 @@ EOF
 function create_master(){
     split_ipv4 ipv4_array "${MASTER_IPV4}"
     get_cilium_node_addr master_cilium_ipv6 "${MASTER_IPV4}"
-    if test ${CILIUM_USE_ENVOY}; then
-	output_file="${dir}/cilium-master-envoy.sh"
-    else
-	output_file="${dir}/cilium-master.sh"
-    fi
+    output_file="${dir}/cilium-master.sh"
     write_netcfg_header "${MASTER_IPV6}" "${MASTER_IPV6}" "${output_file}"
 
     if [ -n "${NWORKERS}" ]; then

--- a/tests/start_vms
+++ b/tests/start_vms
@@ -11,13 +11,6 @@ vagrant destroy -f
 echo "Starting runtime test VM"
 NO_PROVISION=1 ./contrib/vagrant/start.sh
 
-echo "Destroying Envoy runtime test VM if it's already running"
-CILIUM_USE_ENVOY=1 vagrant destroy -f
-
-echo "Starting Envoy runtime test VM"
-NO_PROVISION=1 CILIUM_USE_ENVOY=1 ./contrib/vagrant/start.sh
-
-
 cd tests/k8s
 
 echo "Destorying K8s VMs if they are already running"


### PR DESCRIPTION
CI provisioning scripts are modified to implicitly export CILIUM_USE_ENVOY=1. Makefiles are not modified yet, so it is still needed when issuing make commands manually.

Drop the parallel step that runs the runtime tests with the Oxy proxy. This reduces the resource needs of the CI builds and fixes the issue of not being able to collect build artifacts for both Oxy and Envoy runs of the runtime tests.

In a later step we can simplify the makefiles to always build Envoy and drop the Oxy proxy code from the code base.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

 Fixes: #2150 