### PR TITLE
Remove duplicate l3_l4_policy.yaml file

### DIFF
--- a/test/k8sT/manifests/l3_l4_policy.yaml
+++ b/test/k8sT/manifests/l3_l4_policy.yaml
@@ -1,18 +1,1 @@
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-#for k8s <1.7 use:
-#apiVersion: extensions/v1beta1
-metadata:
-  name: access-backend
-spec:
-  podSelector:
-    matchLabels:
-      id: app1
-  ingress:
-  - from:
-    - podSelector:
-        matchLabels:
-          id: app2
-    ports:
-    - port: 80
-      protocol: TCP
+../../../examples/minikube/l3_l4_policy.yaml


### PR DESCRIPTION
k8sT/manifests/l3_l4_policy.yaml is a duplicate of
examples/minikube/l3_l4_policy.yaml. This change creates
a symlink for the file in examples/minikube directory to
avoid that duplication.

Fixes #2472

Signed-off-by: Michal Rostecki <mrostecki@suse.com>