### PR TITLE
Endpoint: added Fields on error message

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -195,7 +195,11 @@ func (e *Endpoint) applyNewFilter(owner Owner, labelsMap *LabelsMap,
 				IsRedirect:     filter.IsRedirect(),
 			}
 			if err := e.PolicyMap.AllowL4(srcID, port, proto); err != nil {
-				e.getLogger().WithError(err).Warn("Update of l4 policy map failed")
+				e.getLogger().WithFields(logrus.Fields{
+					logfields.PolicyID: srcID,
+					logfields.Port:     port,
+					logfields.Protocol: proto}).WithError(err).Warn(
+					"Update of l4 policy map failed")
 				errors++
 				fromEndpointsSrcIDs[ruleCtx] = false
 			} else {
@@ -345,7 +349,6 @@ func (e *Endpoint) regenerateConsumable(owner Owner, labelsMap *LabelsMap,
 				e.cleanUnusedRedirects(owner, e.L4Policy.Ingress, c.L4Policy.Ingress)
 				e.cleanUnusedRedirects(owner, e.L4Policy.Egress, c.L4Policy.Egress)
 			}
-
 			l4Rm, l4Add, err = e.applyL4PolicyLocked(owner, labelsMap, e.L4Policy, c.L4Policy)
 			if err != nil {
 				// This should not happen, and we can't fail at this stage anyway.


### PR DESCRIPTION
This is related to the issue #2415 

I tried to reproduce, but I didn't find a way. The `AllowL4` is given the following error: 

```
error="Unable to update element: invalid argument"
```

I tried to found a way where the arguments are not valid, but I didn't find one, and the error is not consistent in the master builds too. 

With this error message, I should be able to figure it out what happens in the future builds. 

Regards. 




