### PR TITLE
cli: Fix JSON formatting in "cilium status"

### DIFF
--- a/Documentation/cmdref/cilium_status.md
+++ b/Documentation/cmdref/cilium_status.md
@@ -13,6 +13,12 @@ Display status of daemon
 cilium status
 ```
 
+### Options
+
+```
+  -o, --output string   json| jsonpath='{}'
+```
+
 ### Options inherited from parent commands
 
 ```


### PR DESCRIPTION
Using viper.GetBool("json") is deprecated, the OutputParser
should be used instead.

Ref #2083

Signed-off-by: Michal Rostecki <mrostecki@suse.com>