### PR TITLE
cli: Add JSON formatting in "cilium config"

### DIFF
--- a/Documentation/cmdref/cilium_config.md
+++ b/Documentation/cmdref/cilium_config.md
@@ -18,6 +18,7 @@ cilium config [<option>=(enable|disable) ...]
 ```
       --list-options    List available options
   -n, --num-pages int   Number of pages for perf ring buffer. New values have to be > 0
+  -o, --output string   json| jsonpath='{}'
 ```
 
 ### Options inherited from parent commands

--- a/cilium/cmd/config.go
+++ b/cilium/cmd/config.go
@@ -51,6 +51,7 @@ func init() {
 	rootCmd.AddCommand(configCmd)
 	configCmd.Flags().BoolVarP(&listOptions, "list-options", "", false, "List available options")
 	configCmd.Flags().IntVarP(&numPages, "num-pages", "n", 0, "Number of pages for perf ring buffer. New values have to be > 0")
+	AddMultipleOutput(configCmd)
 }
 
 func dumpConfig(Opts map[string]string) {
@@ -84,6 +85,12 @@ func configDaemon(cmd *cobra.Command, opts []string) {
 			dOpts["MonitorNumPages"] = strconv.Itoa(numPages)
 		}
 	} else if len(opts) == 0 {
+		if len(dumpOutput) > 0 {
+			if err := OutputPrinter(resp.Configuration); err != nil {
+				os.Exit(1)
+			}
+			return
+		}
 		dumpConfig(resp.Configuration.Immutable)
 		dumpConfig(resp.Configuration.Mutable)
 		fmt.Printf("%-24s %s\n", "k8s-configuration", resp.K8sConfiguration)


### PR DESCRIPTION
Add the -o option in `cilium config` command. After this
change, `cilium config -o json` command can be used to
get the configuration in JSON format.

Ref #2083

Signed-off-by: Michal Rostecki <mrostecki@suse.com>