### PR TITLE
Disabling container runtime requirement in order to run cilium-agent

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -22,12 +22,14 @@ cilium-agent
       --auto-ipv6-node-routes             Automatically adds IPv6 L3 routes to reach other nodes for non-overlay mode (--device) (BETA)
       --bpf-root string                   Path to BPF filesystem
       --config string                     Configuration file (default "$HOME/ciliumd.yaml")
+      --container-runtime stringSlice     Sets the container runtime(s) used by Cilium { docker | none | auto }" (default [auto])
+      --container-runtime-endpoint map    Container runtime(s) endpoint(s). (default: --container-runtime-endpoint=docker=unix:///var/run/docker.sock) (default map[])
   -D, --debug                             Enable debugging mode
   -d, --device string                     Device facing cluster/external network for direct L3 (non-overlay mode) (default "undefined")
       --disable-conntrack                 Disable connection tracking
       --disable-ipv4                      Disable IPv4 mode
       --disable-k8s-services              Disable east-west K8s load balancing by cilium
-  -e, --docker string                     Path to docker runtime socket (default "unix:///var/run/docker.sock")
+  -e, --docker string                     Path to docker runtime socket (DEPRECATED: use container-runtime-endpoint instead) (default "unix:///var/run/docker.sock")
       --enable-policy string              Enable policy enforcement (default "default")
       --enable-tracing                    Enable tracing while determining policy (debugging)
       --envoy-proxy                       Use Envoy for HTTP proxy

--- a/Documentation/install/guides/advanced_options.rst
+++ b/Documentation/install/guides/advanced_options.rst
@@ -1,0 +1,35 @@
+.. _admin_install_options:
+
+****************
+Advanced Options
+****************
+
+This guide covers advanced installation options in a generic way that can be
+applied on top of all other installation guides.
+
+The following sections will describe runtime options that can be passed on to
+the agent. Depending on your chosen form of installation, the steps required to
+modify the agent options will be different:
+
+ * Modify the DaemonSet file if you are using Kubernetes.
+ * Modify the relevant unit or configuration file on all nodes or adjust your
+   configuration management scripts if you are using systemd or another init
+   system.
+
+
+Running the agent on a node without a container runtime
+=======================================================
+
+If you want to run the Cilium agent on a node that will not host any
+application containers, then that node may not have a container runtime
+installed at all. You may still want to run the Cilium agent on the node to
+ensure that local processes on that node can reach application containers on
+other nodes. The default behaviour of Cilium on startup when no container
+runtime has been found is to abort startup. To avoid this abort, you can run
+the ``cilium-agent`` with the following option.
+
+
+.. code:: bash
+
+    --container-runtime=none
+

--- a/Documentation/install/guides/index.rst
+++ b/Documentation/install/guides/index.rst
@@ -12,4 +12,7 @@ experiment, we highly recommend trying out the :ref:`gs_guide` instead.
    :maxdepth: 1
    :glob:
 
-   *
+   kubernetes
+   coreos
+   from_source
+   advanced_options

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -934,8 +934,10 @@ func NewDaemon(c *Config) (*Daemon, error) {
 		return nil, fmt.Errorf("Configuration is nil")
 	}
 
-	if err := containerd.Init(dockerEndpoint); err != nil {
-		return nil, err
+	if opts := workloads.GetRuntimeOpt(workloads.Docker); opts != nil {
+		if err := containerd.Init(dockerEndpoint); err != nil {
+			return nil, err
+		}
 	}
 
 	lb := types.NewLoadBalancer()

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -80,33 +80,33 @@ var (
 	// autoIPv6NodeRoutes automatically adds L3 direct routing when using direct mode (-d)
 	autoIPv6NodeRoutes    bool
 	bpfRoot               string
+	cmdRefDir             string
 	disableConntrack      bool
-	enableTracing         bool
+	dockerEndpoint        string
 	enableLogstash        bool
-	kvStore               string
-	validLabels           []string
-	labelPrefixFile       string
-	logstashAddr          string
-	logstashProbeTimer    uint32
-	loggers               []string
-	nat46prefix           string
-	socketPath            string
-	tracePayloadLen       int
-	v4Prefix              string
-	v6Prefix              string
-	v4Address             string
-	v6Address             string
-	masquerade            bool
-	v4ClusterCidrMaskSize int
-	v4ServicePrefix       string
-	v6ServicePrefix       string
+	enableTracing         bool
 	k8sAPIServer          string
 	k8sKubeConfigPath     string
-	dockerEndpoint        string
-	singleClusterRoute    bool
-	useEnvoy              bool
+	kvStore               string
+	labelPrefixFile       string
+	loggers               []string
+	logstashAddr          string
+	logstashProbeTimer    uint32
+	masquerade            bool
+	nat46prefix           string
 	prometheusServeAddr   string
-	cmdRefDir             string
+	singleClusterRoute    bool
+	socketPath            string
+	tracePayloadLen       int
+	useEnvoy              bool
+	v4Address             string
+	v4ClusterCidrMaskSize int
+	v4Prefix              string
+	v4ServicePrefix       string
+	v6Address             string
+	v6Prefix              string
+	v6ServicePrefix       string
+	validLabels           []string
 )
 
 var logOpts = make(map[string]string)
@@ -327,16 +327,10 @@ func init() {
 		"bpf-root", "", "Path to BPF filesystem")
 	flags.StringVar(&cfgFile,
 		"config", "", `Configuration file (default "$HOME/ciliumd.yaml")`)
-	flags.IntVar(&v4ClusterCidrMaskSize,
-		"ipv4-cluster-cidr-mask-size", 8, "Mask size for the cluster wide CIDR")
 	flags.BoolP(
 		"debug", "D", false, "Enable debugging mode")
 	flags.StringVarP(&config.Device,
 		"device", "d", "undefined", "Device facing cluster/external network for direct L3 (non-overlay mode)")
-	flags.StringVarP(&config.DevicePreFilter,
-		"prefilter-device", "", "undefined", "Device facing external network for XDP prefiltering")
-	flags.StringVarP(&config.ModePreFilter,
-		"prefilter-mode", "", ModePreFilterNative, "Prefilter mode { "+ModePreFilterNative+" | "+ModePreFilterGeneric+" } (default: "+ModePreFilterNative+")")
 	flags.BoolVar(&disableConntrack,
 		"disable-conntrack", false, "Disable connection tracking")
 	flags.BoolVar(&config.IPv4Disabled,
@@ -351,6 +345,8 @@ func init() {
 	flags.BoolVar(&useEnvoy,
 		"envoy-proxy", false, "Use Envoy for HTTP proxy")
 	viper.BindEnv("envoy-proxy", "CILIUM_USE_ENVOY")
+	flags.IntVar(&v4ClusterCidrMaskSize,
+		"ipv4-cluster-cidr-mask-size", 8, "Mask size for the cluster wide CIDR")
 	flags.StringVar(&v4Prefix,
 		"ipv4-range", AutoCIDR, "Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16")
 	flags.StringVar(&v6Prefix,
@@ -413,6 +409,10 @@ func init() {
 		"version", false, "Print version information")
 	flags.Bool(
 		"pprof", false, "Enable serving the pprof debugging API")
+	flags.StringVarP(&config.DevicePreFilter,
+		"prefilter-device", "", "undefined", "Device facing external network for XDP prefiltering")
+	flags.StringVarP(&config.ModePreFilter,
+		"prefilter-mode", "", ModePreFilterNative, "Prefilter mode { "+ModePreFilterNative+" | "+ModePreFilterGeneric+" } (default: "+ModePreFilterNative+")")
 	// We expect only one of the possible variables to be filled. The evaluation order is:
 	// --prometheus-serve-addr, CILIUM_PROMETHEUS_SERVE_ADDR, then PROMETHEUS_SERVE_ADDR
 	// The second environment variable (without the CILIUM_ prefix) is here to
@@ -422,6 +422,7 @@ func init() {
 		"prometheus-serve-addr", "", "IP:Port on which to serve prometheus metrics (pass \":Port\" to bind on all interfaces, \"\" is off)")
 	viper.BindEnv("prometheus-serve-addr", "CILIUM_PROMETHEUS_SERVE_ADDR")
 	viper.BindEnv("prometheus-serve-addr-deprecated", "PROMETHEUS_SERVE_ADDR")
+
 	flags.StringVar(&cmdRefDir,
 		"cmdref", "", "Path to cmdref output directory")
 	flags.MarkHidden("cmdref")

--- a/pkg/workloads/containerd/client.go
+++ b/pkg/workloads/containerd/client.go
@@ -33,11 +33,6 @@ var (
 	dockerClient *client.Client
 )
 
-// Client returns the default containerd client
-func Client() *client.Client {
-	return dockerClient
-}
-
 // Init initializes the containerd package
 func Init(endpoint string) error {
 	defaultHeaders := map[string]string{"User-Agent": "cilium"}

--- a/pkg/workloads/containerd/manager.go
+++ b/pkg/workloads/containerd/manager.go
@@ -25,6 +25,10 @@ import (
 // IsRunning returns false if the provided endpoint cannot be associated with a
 // running workload. The runtime must be reachable to make this decision.
 func IsRunning(ep *endpoint.Endpoint) bool {
+	if dockerClient == nil {
+		return false
+	}
+
 	runtimeRunning := false
 
 	networkID := ep.GetDockerNetworkID()
@@ -71,6 +75,10 @@ func IsRunning(ep *endpoint.Endpoint) bool {
 
 // Status returns the status of the workload runtime
 func Status() *models.Status {
+	if dockerClient == nil {
+		return &models.Status{State: models.StatusStateDisabled}
+	}
+
 	if _, err := dockerClient.Info(ctx.Background()); err != nil {
 		return &models.Status{State: models.StatusStateFailure, Msg: err.Error()}
 	}

--- a/pkg/workloads/containerd/watcher.go
+++ b/pkg/workloads/containerd/watcher.go
@@ -60,6 +60,10 @@ func shortContainerID(id string) string {
 // EnableEventListener watches for docker events. Performs the plumbing for the
 // containers started or dead.
 func EnableEventListener() error {
+	if dockerClient == nil {
+		return nil
+	}
+
 	since := time.Now()
 	ws := newWatcherState(eventQueueBufferSize)
 	ws.syncWithRuntime()
@@ -347,6 +351,10 @@ func retrieveDockerLabels(dockerID string) (*dTypes.ContainerJSON, labels.Labels
 // their IP address, then adds the containers to the list of ignored containers
 // and allocates the IPs they are using to prevent future collisions.
 func IgnoreRunningContainers() {
+	if dockerClient == nil {
+		return
+	}
+
 	conts, err := dockerClient.ContainerList(ctx.Background(), dTypes.ContainerListOptions{})
 	if err != nil {
 		return

--- a/pkg/workloads/runtimes.go
+++ b/pkg/workloads/runtimes.go
@@ -1,0 +1,140 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workloads
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+func init() {
+	containerRuntimes = make(map[containerRuntimeType]containerRuntimeOpts)
+	runtimeDefaultsOpts = map[containerRuntimeType]containerRuntimeOpts{
+		Docker: {
+			Endpoint: "unix:///var/run/docker.sock",
+		},
+	}
+
+}
+
+const (
+	None   containerRuntimeType = "none"
+	Auto   containerRuntimeType = "auto"
+	Docker containerRuntimeType = "docker"
+)
+
+var (
+	runtimeDefaultsOpts    map[containerRuntimeType]containerRuntimeOpts
+	containerRuntimesMutex lock.Mutex
+	containerRuntimes      map[containerRuntimeType]containerRuntimeOpts
+)
+
+type containerRuntimeType string
+
+type containerRuntimeOpts struct {
+	Endpoint string
+}
+
+// GetRuntimeOpt returns the options for the given container runtime.
+func GetRuntimeOpt(crt containerRuntimeType) *containerRuntimeOpts {
+	containerRuntimesMutex.Lock()
+	defer containerRuntimesMutex.Unlock()
+	if opts, ok := containerRuntimes[crt]; ok {
+		return &opts
+	}
+	return nil
+}
+
+// GetRuntimeDefaultOpt returns the default options for the given container
+// runtime.
+func GetRuntimeDefaultOpt(crt containerRuntimeType) *containerRuntimeOpts {
+	if opts, ok := runtimeDefaultsOpts[crt]; ok {
+		return &opts
+	}
+	return nil
+}
+
+// GetRuntimesString returns a string representation of the container runtimes
+// stored and the list of options for each container runtime.
+func GetRuntimesString() string {
+	containerRuntimesMutex.Lock()
+	defer containerRuntimesMutex.Unlock()
+	crtStr := make([]string, 0, len(containerRuntimes))
+	for k, v := range containerRuntimes {
+		crtStr = append(crtStr, fmt.Sprintf("%q on endpoint %q", k, v.Endpoint))
+	}
+	return strings.Join(crtStr, ",")
+}
+
+func addRuntime(crt containerRuntimeType, opts containerRuntimeOpts) {
+	containerRuntimesMutex.Lock()
+	defer containerRuntimesMutex.Unlock()
+	containerRuntimes[crt] = opts
+}
+
+func parseRuntimeType(str string) (containerRuntimeType, error) {
+	switch crt := containerRuntimeType(strings.ToLower(str)); crt {
+	case None, Auto, Docker:
+		return crt, nil
+	default:
+		return None, fmt.Errorf("ContainerRuntime %s is not avaiable", crt)
+	}
+}
+
+// ParseConfig parses the containerRuntimes and the containerRuntime options
+// and adds them to the internal containerRuntime maps.
+// In case any containeRuntime does not exist an error is returned.
+// If `auto` is set in containerRuntimes, the default options of each container
+// runtime will be set. The user defined options of each particular runtime
+// will overwrite defaults.
+// If `none` is set, all containerRuntimes will be ignored.
+func ParseConfig(containerRuntimes []string, containerRuntimesOpts map[string]string) error {
+	for _, runtime := range containerRuntimes {
+		crt, err := parseRuntimeType(runtime)
+		if err != nil {
+			return err
+		}
+		switch crt {
+		case None:
+			return nil
+		case Auto:
+			for crt, opt := range runtimeDefaultsOpts {
+				addRuntime(crt, opt)
+			}
+		}
+	}
+
+	for runtime, opts := range containerRuntimesOpts {
+		crt, err := parseRuntimeType(runtime)
+		if err != nil {
+			return err
+		}
+		switch crt {
+		case None, Auto:
+		default:
+			if opts == "" {
+				addRuntime(crt, runtimeDefaultsOpts[crt])
+			} else {
+				crtOpts := containerRuntimeOpts{
+					Endpoint: opts,
+				}
+				addRuntime(crt, crtOpts)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/workloads/runtimes_test.go
+++ b/pkg/workloads/runtimes_test.go
@@ -1,0 +1,62 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workloads
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type WorkloadsTestSuite struct{}
+
+var _ = Suite(&WorkloadsTestSuite{})
+
+func (w *WorkloadsTestSuite) TestParseConfig(c *C) {
+	// Test if user options overwrites defaults values
+	err := ParseConfig([]string{string(Auto)}, map[string]string{string(Docker): "foo"})
+	c.Assert(err, IsNil)
+
+	opts := GetRuntimeOpt(Docker)
+	c.Assert(opts, Not(IsNil))
+	c.Assert(opts.Endpoint, Equals, "foo")
+
+	// Test if default options are set
+	containerRuntimes = make(map[containerRuntimeType]containerRuntimeOpts)
+	err = ParseConfig([]string{string(Auto)}, map[string]string{})
+	c.Assert(err, IsNil)
+
+	opts = GetRuntimeOpt(Docker)
+	c.Assert(opts, Not(IsNil))
+	c.Assert(opts.Endpoint, Equals, GetRuntimeDefaultOpt(Docker).Endpoint)
+
+	// Test if with none any options are set
+	containerRuntimes = make(map[containerRuntimeType]containerRuntimeOpts)
+	err = ParseConfig([]string{string(None), string(Auto)}, map[string]string{string(Docker): "foo"})
+	c.Assert(err, IsNil)
+
+	opts = GetRuntimeOpt(Docker)
+	c.Assert(opts, IsNil)
+
+	// Test invalid runtime
+	containerRuntimes = make(map[containerRuntimeType]containerRuntimeOpts)
+	err = ParseConfig([]string{"foo"}, map[string]string{"foo": "foo"})
+	c.Assert(err, Not(IsNil))
+}


### PR DESCRIPTION
**Summary of changes**:
    Add new daemon's flags `container-runtime` and `container-runtime-endpoint`
    
`container-runtime` allows the user to select the container runtimes
supported by cilium. It can also be used to select `none` of the
container runtime, disabling any integration with the container runtimes
running on the host.

`container-runtime-endpoint` allows the user to specify which endpoint
cilium should connect to for each particular container runtime. For
example:
`--container-runtime-endpoint=docker=unix:///var/run/docker.sock`

Fixes: #2469

```release-note
Added option to allow running cilium-agent on a node with no container runtime
```