### PR TITLE
test: use cilium-ubuntu 16.10 image for runtime tests

### DIFF
--- a/common/build.sh
+++ b/common/build.sh
@@ -11,4 +11,4 @@ go install ./... 2> /dev/null || true
 make clean
 
 # Compile with deadlock detection during runtime tests. See GH-1654.
-LOCKDEBUG=1 make
+CILIUM_USE_ENVOY=1 LOCKDEBUG=1 make

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -10,6 +10,119 @@ $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 $SERVER_BOX= "cilium/ginkgo"
 $SERVER_VERSION= "0.0.2"
 
+BAZEL_VERSION = "0.8.1"
+
+$bootstrap = <<SCRIPT
+sudo service docker restart
+sudo apt-get -y update || true
+sudo apt-get -y install socat curl jq realpath pv tmux python-sphinx python-pip yamllint
+sudo pip install --upgrade pip
+sudo pip install sphinx sphinxcontrib-httpdomain sphinxcontrib-openapi
+echo 'cd ~/go/src/github.com/cilium/cilium' >> /home/vagrant/.bashrc
+export GOPATH=/home/vagrant/go
+sudo -E /usr/local/go/bin/go get github.com/jteeuwen/go-bindata/...
+sudo -E /usr/local/go/bin/go get -u github.com/google/gops
+chown -R vagrant:vagrant $GOPATH
+curl -SsL https://github.com/cilium/bpf-map/releases/download/v1.0/bpf-map -o bpf-map
+chmod +x bpf-map
+mv bpf-map /usr/bin
+if [[ $(command -v bazel) && "$(bazel version | grep 'label' | cut -d ' ' -f 3)" = #{BAZEL_VERSION} ]]; then
+  echo "Bazel #{BAZEL_VERSION} already installed, skipping fetch."
+else
+  wget -nv https://github.com/bazelbuild/bazel/releases/download/#{BAZEL_VERSION}/bazel-#{BAZEL_VERSION}-installer-linux-x86_64.sh
+  chmod +x bazel-#{BAZEL_VERSION}-installer-linux-x86_64.sh
+  sudo -E ./bazel-#{BAZEL_VERSION}-installer-linux-x86_64.sh
+  sudo -E mv /usr/local/bin/bazel /usr/bin
+  rm bazel-#{BAZEL_VERSION}-installer-linux-x86_64.sh
+fi
+SCRIPT
+
+
+$build = <<SCRIPT
+CILIUM_USE_ENVOY=1
+/home/vagrant/go/src/github.com/cilium/cilium/common/build.sh
+SCRIPT
+
+$install = <<SCRIPT
+CILIUM_USE_ENVOY=1
+sudo -E make -C /home/vagrant/go/src/github.com/cilium/cilium/ install
+
+if [ -n "$(grep DISTRIB_RELEASE=14.04 /etc/lsb-release)" ]; then
+    sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/upstart/cilium-docker.conf /etc/init/
+    sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/upstart/cilium.conf /etc/init/
+    sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/upstart/cilium-consul.conf /etc/init/
+    sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/upstart/cilium-policy-watcher.conf /etc/init/
+    sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/upstart/cilium-etcd.conf /etc/init/
+    sudo rm -rf /var/log/upstart/cilium-*
+else
+    sudo mkdir -p /etc/sysconfig
+    sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/systemd/cilium-consul.service /lib/systemd/system
+    sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/systemd/cilium-docker.service /lib/systemd/system
+    sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/systemd/cilium-etcd.service /lib/systemd/system
+    sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/systemd/cilium.service /lib/systemd/system
+    sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/systemd/cilium /etc/sysconfig
+fi
+
+sudo usermod -a -G cilium vagrant
+SCRIPT
+
+$install_etcd = <<SCRIPT
+#TODO - install etcd in the cilium-ubuntu-16.10 Vagrantfile
+
+ETCD_VERSION="v3.1.0"
+wget -nv https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz
+tar -xf etcd-${ETCD_VERSION}-linux-amd64.tar.gz
+sudo mv etcd-${ETCD_VERSION}-linux-amd64/etcd* /usr/bin/
+
+sudo tee /etc/systemd/system/etcd.service <<EOF
+[Unit]
+Description=etcd
+Documentation=https://github.com/coreos
+[Service]
+ExecStart=/usr/bin/etcd --name=cilium --data-dir=/var/etcd/cilium --advertise-client-urls=http://192.168.36.11:9732 --listen-client-urls=http://0.0.0.0:9732 --listen-peer-urls=http://0.0.0.0:9733
+Restart=on-failure
+RestartSec=5
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl enable etcd
+sudo systemctl start etcd
+SCRIPT
+
+$start_cilium = <<SCRIPT
+sudo service cilium restart
+
+cilium_started=false
+
+for ((i = 0 ; i < 60; i++)); do
+    if cilium status > /dev/null 2>&1; then
+        cilium_started=true
+        break
+    fi
+    sleep 5s
+    echo "Waiting for Cilium daemon to come up..."
+done
+
+if [ "\$cilium_started" = true ] ; then
+    echo 'Cilium successfully started!'
+else
+    >&2 echo 'Timeout waiting for Cilium to start...'
+    journalctl -u cilium.service --since \$(systemctl show -p ActiveEnterTimestamp cilium.service | awk '{print \$2 \$3}')
+    >&2 echo 'Cilium failed to start'
+    exit 1
+fi
+SCRIPT
+
+if ENV['BUILD_NUMBER'] then
+    $build_id_name = "-build-#{$build_id}"
+    $rsync_exclude = "../.git"
+else
+    $rsync_exclude = "../GIT_VERSION"
+end
+
+
+
 ENV["VAGRANT_DEFAULT_PROVIDER"] = "virtualbox"
 Vagrant.configure("2") do |config|
 
@@ -17,22 +130,36 @@ Vagrant.configure("2") do |config|
         server.vm.provider "virtualbox" do |vb|
             vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
             vb.cpus = 2
-            vb.memory=2048
+            vb.memory=3072
             vb.linked_clone = true
         end
 
-        server.vm.box =  "#{$SERVER_BOX}"
-        server.vm.box_version = "#{$SERVER_VERSION}"
+        server.vm.box = "cilium/ubuntu-16.10"
+        server.vm.box_version = "2.7"
         server.vm.hostname = "runtime"
-        server.vm.synced_folder "../", "/src/"
 
         # Provision section
         server.vm.provision :shell,
             :inline => "sed -i 's/^mesg n$/tty -s \\&\\& mesg n/g' /root/.profile"
-        server.vm.provision "file", source: "provision", destination: "/tmp/provision"
-        server.vm.provision "shell" do |sh|
-            sh.path = "./provision/runtime_install.sh"
-        end
+        config.vm.provision "bootstrap", type: "shell", inline: $bootstrap
+        config.vm.provision "build", type: "shell", run: "always", privileged: false, inline: $build
+        config.vm.provision "install", type: "shell", run: "always", privileged: false, inline: $install
+        config.vm.provision "install_etcd", type: "shell", run: "always", privileged: false, inline: $install_etcd
+        config.vm.provision "start_cilium", type: "shell", run: "always",  inline: $start_cilium
+
+        server.vm.synced_folder ".", "/vagrant", disabled: true
+ 
+        # run rsync with options:
+        #  --links: preserve symlinks
+        #  --checksum: skip based on checksum, not mod-time & size (avoid unnecessary bazel rebuilds)
+        #  --delete: delete extraneous files from dest dirs
+        #  --force: force deletion of dirs even if not empty
+        #  --delete-excluded: also delete excluded files from dest dirs
+        #  --archive: archive mode; equals -rlptgoD (no -H,-A,-X)
+        #  -z: compress file data during the transfer
+        server.vm.synced_folder '../', '/home/vagrant/go/src/github.com/cilium/cilium', type: "rsync",
+           rsync__exclude: [$rsync_exclude, "src"], rsync__args: ["--verbose", "--archive", "--delete", "--force", "--delete-excluded", "-z", "--links", "--checksum"]
+
     end
 
     (1..$K8S_NODES).each do |i|

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -612,31 +612,6 @@ func (s *SSHMeta) ServiceDelAll() *CmdRes {
 	return s.ExecCilium("service delete --all")
 }
 
-// SetUpCilium sets up Cilium as a systemd service with a hardcoded set of options. It
-// returns an error if any of the operations needed to start Cilium fails.
-func (s *SSHMeta) SetUpCilium() error {
-	template := `
-PATH=/usr/lib/llvm-3.8/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
-CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug
-INITSYSTEM=SYSTEMD`
-
-	err := RenderTemplateToFile("cilium", template, os.ModePerm)
-	if err != nil {
-		return err
-	}
-	defer os.Remove("cilium")
-
-	res := s.Exec("sudo cp /vagrant/cilium /etc/sysconfig/cilium")
-	if !res.WasSuccessful() {
-		return fmt.Errorf("%s", res.CombineOutput())
-	}
-	res = s.Exec("sudo systemctl restart cilium")
-	if !res.WasSuccessful() {
-		return fmt.Errorf("%s", res.CombineOutput())
-	}
-	return nil
-}
-
 // WaitUntilReady waits until the output of `cilium status` returns with code
 // zero. Returns an error if the output of `cilium status` returns a nonzero
 // return code after the specified timeout duration has elapsed.

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -27,7 +27,7 @@ var (
 const (
 	// BasePath is the path in the Vagrant VMs to which the test directory
 	// is mounted
-	BasePath = "/vagrant/"
+	BasePath = "/home/vagrant/go/src/github.com/cilium/cilium/test/"
 
 	// ManifestBase tells ginkgo suite where to look for manifests
 	K8sManifestBase = "k8sT/manifests"

--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -64,6 +64,12 @@ type SSHConfig struct {
 // SSHConfigs maps the name of a host (VM) to its corresponding SSHConfiguration
 type SSHConfigs map[string]*SSHConfig
 
+// GenerateSCPToCommand returns the command to scp the file at scrPath to the
+// dstPath on the host whose metadata is contained within cfg.
+func (cfg *SSHConfig) GenerateSCPToCommand(srcPath, dstPath string) string {
+	return fmt.Sprintf("scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -r -P %d -i %s %s vagrant@127.0.0.1:%s", cfg.port, cfg.identityFile, srcPath, dstPath)
+}
+
 // GetSSHClient initializes an SSHClient based on the provided SSHConfig
 func (cfg *SSHConfig) GetSSHClient() *SSHClient {
 	sshConfig := &ssh.ClientConfig{

--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -25,8 +25,8 @@ then
         echo "No on master K8S node; no need to compile Cilium container"
     fi
 else
-    make
-    make install
+    CILIUM_USE_ENVOY=1 make
+    CILIUM_USE_ENVOY=1 make install
     mkdir -p /etc/sysconfig/
     cp -f contrib/systemd/cilium /etc/sysconfig/cilium
     for svc in $(ls -1 ./contrib/systemd/*.*); do

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -3,11 +3,10 @@ set -e
 
 HOST=$(hostname)
 PROVISIONSRC="/tmp/provision/"
+export PATH="/usr/local/go/bin:/home/vagrant/go/bin:/usr/local/clang/bin:/home/vagrant/bin:/home/vagrant/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/local/clang/bin:/usr/local/go/bin"
+
 
 $PROVISIONSRC/dns.sh
-sudo adduser vagrant docker
 
-export GOPATH=/go/
-go get -u github.com/jteeuwen/go-bindata/...
-ln -sf /go/bin/* /usr/local/bin/
-$PROVISIONSRC/compile.sh
+echo "adding user vagrant to run docker"
+sudo adduser vagrant docker

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -17,6 +17,7 @@ package RuntimeTest
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/cilium/cilium/test/helpers"
 
@@ -566,6 +567,9 @@ var _ = Describe("RuntimePolicies", func() {
 		err = helpers.RenderTemplateToFile(ingressJSON, script, 0777)
 		Expect(err).Should(BeNil())
 
+		err = vm.SCPToVM(ingressJSON, filepath.Join(helpers.BasePath, ingressJSON))
+		Expect(err).Should(BeNil())
+
 		path := helpers.GetFilePath(ingressJSON)
 		_, err = vm.PolicyImport(path, helpers.HelperTimeout)
 		Expect(err).Should(BeNil())
@@ -597,6 +601,10 @@ var _ = Describe("RuntimePolicies", func() {
 		}]`, helpers.App1, httpd1[helpers.IPv4], httpd1[helpers.IPv6])
 		err = helpers.RenderTemplateToFile(egressJSON, script, 0777)
 		Expect(err).Should(BeNil())
+
+		err = vm.SCPToVM(egressJSON, filepath.Join(helpers.BasePath, egressJSON))
+		Expect(err).Should(BeNil())
+
 		path = helpers.GetFilePath(egressJSON)
 		defer os.Remove(egressJSON)
 		_, err = vm.PolicyImport(path, helpers.HelperTimeout)
@@ -693,6 +701,9 @@ var _ = Describe("RuntimePolicies", func() {
 			err := helpers.RenderTemplateToFile(invalidJSON, data, 0777)
 			Expect(err).Should(BeNil())
 
+			err = vm.SCPToVM(invalidJSON, filepath.Join(helpers.BasePath, invalidJSON))
+			Expect(err).Should(BeNil())
+
 			path := helpers.GetFilePath(invalidJSON)
 			_, err = vm.PolicyImport(path, helpers.HelperTimeout)
 			Expect(err).Should(HaveOccurred())
@@ -755,6 +766,11 @@ var _ = Describe("RuntimePolicies", func() {
 		err := helpers.RenderTemplateToFile(policyJSON, policy, 0777)
 		Expect(err).Should(BeNil())
 
+		By("scping file to vm")
+		err = vm.SCPToVM(policyJSON, filepath.Join(helpers.BasePath, policyJSON))
+		Expect(err).Should(BeNil())
+
+		By("getting file path")
 		path := helpers.GetFilePath(policyJSON)
 		_, err = vm.PolicyImport(path, helpers.HelperTimeout)
 		Expect(err).Should(BeNil())

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -53,6 +53,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 
 	BeforeEach(func() {
 		initialize()
+		By("Stopping cilium service")
 		vm.Exec("sudo systemctl stop cilium")
 	}, 150)
 
@@ -63,12 +64,14 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 				"sudo cilium endpoint list")
 		}
 		containers(helpers.Delete)
+		By("Starting cilium service")
 		vm.Exec("sudo systemctl start cilium")
 	})
 
 	It("Consul KVStore", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		By("Starting Cilium using Consul as backing key-value store")
 		vm.ExecContext(
 			ctx,
 			"sudo cilium-agent --kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug")
@@ -87,12 +90,14 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 	It("Etcd KVStore", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		By("Starting Cilium using etcd as backing key-value store")
 		vm.ExecContext(
 			ctx,
-			"sudo cilium-agent --kvstore etcd --kvstore-opt etcd.address=127.0.0.1:4001")
+			"sudo cilium-agent --kvstore etcd --kvstore-opt etcd.address=127.0.0.1:9732")
 		err := vm.WaitUntilReady(150)
 		Expect(err).Should(BeNil())
 
+		By("Restarting cilium-docker service")
 		vm.Exec("sudo systemctl restart cilium-docker")
 		helpers.Sleep(2)
 		containers(helpers.Create)

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -17,6 +17,7 @@ package RuntimeTest
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/cilium/cilium/test/helpers"
 
@@ -450,6 +451,9 @@ tc filter add dev lbtest2 ingress bpf da obj tmp_lb.o sec from-netdev
 	if err != nil {
 		return err
 	}
+
+	err = node.SCPToVM(scriptName, filepath.Join(helpers.BasePath, scriptName))
+	Expect(err).Should(BeNil())
 
 	// filesystem is mounted at path /vagrant on VM
 	scriptPath := fmt.Sprintf("%s%s", helpers.BasePath, scriptName)

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -129,13 +129,8 @@ var _ = BeforeSuite(func() {
 			Fail(fmt.Sprintf("error starting VM %q: %s", helpers.Runtime, err))
 		}
 
-		vm := helpers.CreateNewRuntimeHelper(helpers.Runtime, log.WithFields(
+		_ = helpers.CreateNewRuntimeHelper(helpers.Runtime, log.WithFields(
 			logrus.Fields{"testName": "BeforeSuite"}))
-		err = vm.SetUpCilium()
-
-		if err != nil {
-			Fail(fmt.Sprintf("cilium was unable to be set up correctly: %s", err))
-		}
 
 	case helpers.K8s:
 		//FIXME: This should be:


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/2483 commenced the removal of the oxy proxy from the Cilium tests for the bash-script based build. Thus, move to testing Envoy for the runtime test build for the Ginkgo tests.

Signed-off by: Ian Vernon <ian@cilium.io>