### PR TITLE
cli: Add JSON formatting in "cilium version"

### DIFF
--- a/Documentation/cmdref/cilium_version.md
+++ b/Documentation/cmdref/cilium_version.md
@@ -13,6 +13,12 @@ Print version information
 cilium version
 ```
 
+### Options
+
+```
+  -o, --output string   json| jsonpath='{}'
+```
+
 ### Options inherited from parent commands
 
 ```

--- a/cilium/cmd/version.go
+++ b/cilium/cmd/version.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/cilium/cilium/pkg/version"
 
@@ -26,10 +27,17 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version information",
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(dumpOutput) > 0 {
+			if err := OutputPrinter(version.GetCiliumVersion()); err != nil {
+				os.Exit(1)
+			}
+			return
+		}
 		fmt.Printf("Cilium %s\n", version.Version)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
+	AddMultipleOutput(versionCmd)
 }


### PR DESCRIPTION
Add the -o option in `cilium version` command. After this
change, `cilium version -o json` command can be used to
get the configuration in JSON format.

Ref #2083

Signed-off-by: Michal Rostecki <mrostecki@suse.com>