### PR TITLE
daemon: Handle IP consistency for headless k8s services

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1058,9 +1058,12 @@ func (d *Daemon) addK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 		logfields.K8sNamespace: svc.Namespace,
 	})
 
-	isSvcIPv4 := svcInfo.FEIP.To4() != nil
-	if err := areIPsConsistent(!d.conf.IPv4Disabled, isSvcIPv4, svc, se); err != nil {
-		return err
+	// Frontend IPs must be of the same type as backend IPs. Headless services, however, are consistent because they have no frontend IP.
+	if !svcInfo.IsHeadless {
+		isSvcIPv4 := svcInfo.FEIP.To4() != nil
+		if err := areIPsConsistent(!d.conf.IPv4Disabled, isSvcIPv4, svc, se); err != nil {
+			return err
+		}
 	}
 
 	uniqPorts := getUniqPorts(svcInfo.Ports)


### PR DESCRIPTION
We asserted a check for IP type consistency between frontend and backend
IPs in services, including headless ones. Due to the nature of the check
a nil frontend IP field would be percieved as non-IPv4, which then
caused the consistency check to fail on the IPv4 backend fields.

Signed-off-by: Ray Bejjani <ray@covalent.io>

<!--  Thanks for contributing to Cilium!

If this is your first time contributing, then please see the following
guidelines for detailed instructions on how to contribute:
https://github.com/cilium/cilium/blob/master/CONTRIBUTING.md for detailed instructions 

-->

**Summary of changes**:

Fixes: #2310

```release-note
Correct a bug that rejected IPv4 backend headless services from k8s
```

**How to test (optional)**:
- make a headless service
```yaml
kind: Service
apiVersion: v1
metadata:
  name: headless-service
spec:
  selector:
    id: app1
  clusterIP: None
  ports:
  - protocol: TCP
    port: 80
    targetPort: 9376
```
- run with IPv4 enabled
- create it
- Grep for the error "Unable to add k8s service" in the logs. It should not show up with this patch.