### PR TITLE
Ginkgo: Nightly fix multiple issues

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -25,7 +25,7 @@ pipeline {
                 GOPATH="${WORKSPACE}"
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
                 K8S_VERSION=1.7
-                k8S_NODES=4
+                K8S_NODES=4
             }
             steps {
                 parallel(

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -84,7 +84,6 @@ const (
 	Client = "client"
 	Server = "server"
 	Host   = "host"
-
 	// Container lifecycle actions.
 	Create = "create"
 	Delete = "delete"

--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -388,10 +388,10 @@ func (t *TestSpec) CreateManifests() error {
 apiVersion: v1
 kind: Pod
 metadata:
-  name: %[2]s
+  name: "%[2]s"
   labels:
-    id: %[2]s
-    zgroup: %[1]s
+    id: "%[2]s"
+    zgroup: "%[1]s"
 spec:
   containers:
   - name: app-frontend
@@ -403,10 +403,10 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: %[3]s
+  name: "%[3]s"
   labels:
-    id: %[3]s
-    zgroup: %[1]s
+    id: "%[3]s"
+    zgroup: "%[1]s"
 spec:
   containers:
   - name: web

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -31,6 +31,10 @@ ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 192.168.36.11 k8s1
 192.168.36.12 k8s2
+192.168.36.13 k8s3
+192.168.36.14 k8s4
+192.168.36.15 k8s5
+192.168.36.16 k8s6
 EOF
 
 cat <<EOF > /etc/apt/sources.list.d/kubernetes.list


### PR DESCRIPTION
- Fix issues when egress policy is set and endpoint receives a 503
reply.
- Fix typo on Nightly jenkinsfile.
- Fix issue on pod yaml when prefix is only numbers.
- Added more K8s nodes in /etc/hosts
- Provision Kubernetes nodes when more than 2 are set.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>