### PR TITLE
Ginkgo: Fix issues with link

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -27,7 +27,7 @@ var (
 const (
 	// BasePath is the path in the Vagrant VMs to which the test directory
 	// is mounted
-	BasePath = "/vagrant/"
+	BasePath = "/src/test/"
 
 	// ManifestBase tells ginkgo suite where to look for manifests
 	K8sManifestBase = "k8sT/manifests"


### PR DESCRIPTION
In commit 55839982e9a13c53237e9f7fb3b76179ec0d48ba a new symlink was
added that break the ginkgo master build.

https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/895/

Change the base path to /src/test/ fix the problem.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>