### PR TITLE
workloads: Increase timeout to correlate workload event with endpoint

### DIFF
--- a/pkg/workloads/defaults.go
+++ b/pkg/workloads/defaults.go
@@ -1,0 +1,31 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workloads
+
+import (
+	"time"
+)
+
+const (
+	// EndpointCorrelationMaxRetries is the number of retries to correlate
+	// a workload start event with an exising endpoint before giving up.
+	EndpointCorrelationMaxRetries = 20
+)
+
+// EndpointCorrelationSleepTime returns the sleep time between correlation
+// attempts
+func EndpointCorrelationSleepTime(try int) time.Duration {
+	return time.Duration(try) * time.Second
+}


### PR DESCRIPTION
Under heavy system load, it can take a considerable amount between the
time the container start notification (e.g. docker event) has been
received and the endpoint has been created via the network plugin
notification mechanism (e.g. CNI). The existing timeout has been too
short at times which caused legitimate containers to be treated as not
being handled by Cilium when they should have been.

Signed-off-by: Thomas Graf <thomas@cilium.io>

```release-note
Fix too small timeout causing containers not to show up as endpoints under heavy system load
```