### PR TITLE
agent: Increase timeout when executing commands

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -69,7 +69,7 @@ import (
 
 const (
 	// ExecTimeout is the execution timeout to use in init.sh executions
-	ExecTimeout = 30 * time.Second
+	ExecTimeout = 300 * time.Second
 
 	// AutoCIDR indicates that a CIDR should be allocated
 	AutoCIDR = "auto"

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -45,7 +45,7 @@ import (
 
 const (
 	// ExecTimeout is the execution timeout to use in join_ep.sh executions
-	ExecTimeout = 60 * time.Second
+	ExecTimeout = 300 * time.Second
 )
 
 func (e *Endpoint) writeL4Map(fw *bufio.Writer, owner Owner, m policy.L4PolicyMap, config string) error {


### PR DESCRIPTION
Under heavy load, the scripts can take more than 30 seconds to run.
Increase timeout to 300 seconds.

Signed-off-by: Thomas Graf <thomas@cilium.io>
