### PR TITLE
CI: add ginkgo-all.Jenkinsfile

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -55,6 +55,7 @@ examples/kubernetes-ingress/ @cilium/kubernetes
 examples/mesos/Vagrantfile @cilium/vagrant
 examples/minikube/ @cilium/kubernetes
 ginkgo.Jenkinsfile @cilium/ci
+ginkgo-all.Jenkinsfile @cilium/ci
 Jenkinsfile @cilium/ci
 Jenkinsfile.nightly @cilium/ci
 monitor/ @cilium/monitor

--- a/ginkgo-all.Jenkinsfile
+++ b/ginkgo-all.Jenkinsfile
@@ -1,0 +1,85 @@
+pipeline {
+    agent {
+        label 'ginkgo'
+    }
+    environment {
+        PROJ_PATH = "src/github.com/cilium/cilium"
+    }
+
+    options {
+        timeout(time: 120, unit: 'MINUTES')
+        timestamps()
+    }
+    stages {
+        stage('Checkout') {
+            steps {
+                sh 'env'
+                sh 'rm -rf src; mkdir -p src/github.com/cilium'
+                sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
+                checkout scm
+            }
+        }
+        stage('UnitTesting') {
+            environment {
+                GOPATH="${WORKSPACE}"
+                TESTDIR="${WORKSPACE}/${PROJ_PATH}/"
+            }
+            steps {
+                sh "cd ${TESTDIR}; make tests-ginkgo"
+            }
+            post {
+                always {
+                    sh "cd ${TESTDIR}; make clean-ginkgo-tests || true"
+                }
+            }
+        }
+        stage('Boot VMs'){
+            environment {
+                GOPATH="${WORKSPACE}"
+                TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
+            }
+            steps {
+                sh 'cd ${TESTDIR}; K8S_VERSION=1.7 vagrant up --no-provision'
+                sh 'cd ${TESTDIR}; K8S_VERSION=1.6 vagrant up --no-provision'
+            }
+            post {
+                failure {
+                    sh "cd ${TESTDIR}; K8S_VERSION=1.7 vagrant destroy -f"
+                    sh "cd ${TESTDIR}; K8S_VERSION=1.6 vagrant destroy -f"
+                }
+            }
+        }
+        stage('BDD-Test') {
+            environment {
+                GOPATH="${WORKSPACE}"
+                TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
+            }
+            steps {
+                parallel(
+                    "Runtime":{
+                        sh 'cd ${TESTDIR}; ginkgo --focus="Runtime*" -v -noColor'
+                    },
+                    "K8s-1.7":{
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.7 ginkgo --focus=" K8s*" -v -noColor'
+                    },
+                    "K8s-1.6":{
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.6 ginkgo --focus=" K8s*" -v -noColor'
+                    },
+                    failFast: true
+                )
+            }
+            post {
+                always {
+                    junit 'test/*.xml'
+                    // Temporary workaround to test cleanup
+                    // rm -rf ${GOPATH}/src/github.com/cilium/cilium
+                    sh 'cd test/; ./post_build_agent.sh || true'
+                    sh 'cd test/; K8S_VERSION=1.7 vagrant destroy -f'
+                    sh 'cd test/; K8S_VERSION=1.6 vagrant destroy -f'
+                    sh 'cd test/; ./archive_test_results.sh || true'
+                    archiveArtifacts artifacts: "test_results_${JOB_BASE_NAME}_${BUILD_NUMBER}.tar", allowEmptyArchive: true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add Jenkinsfile which will be used as part of a separate, but not required
Jenkins job for running all Ginkgo tests. This will ensure that changes to the
Ginkgo framework do not break any non-migrated tests.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #2515 