### PR TITLE
Jenkinsfile: remove disabling of concurrent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,6 @@ pipeline {
     options {
         timeout(time: 120, unit: 'MINUTES')
         timestamps()
-        disableConcurrentBuilds()
     }
     stages {
         stage('Boot VMs') {


### PR DESCRIPTION
Disabling of concurrent builds in the Jenkinsfile results in builds being queued
for different PRs as part of the new Cilium-Bash-Tests Jenkins job, which is
undesirable. Remove this from the Jenkinsfile.

Signed-off by: Ian Vernon <ian@cilium.io>