### PR TITLE
Ginkgo: Changes on initilize functions

### DIFF
--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cilium/cilium/test/helpers"
@@ -39,13 +40,10 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 
 	var kubectl *helpers.Kubectl
 	var logger *logrus.Entry
-	var initialized bool
+	var once sync.Once
 	var ciliumPath string
 
 	initialize := func() {
-		if initialized == true {
-			return
-		}
 		logger = log.WithFields(logrus.Fields{"testName": "NightlyK8sEpsMeasurement"})
 		logger.Info("Starting")
 
@@ -56,11 +54,10 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 
 		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 		Expect(err).Should(BeNil())
-		initialized = true
 	}
 
 	BeforeEach(func() {
-		initialize()
+		once.Do(initialize)
 	})
 
 	AfterEach(func() {
@@ -172,16 +169,13 @@ var _ = Describe("NightlyExamples", func() {
 
 	var kubectl *helpers.Kubectl
 	var logger *logrus.Entry
-	var initialized bool
+	var once sync.Once
 	var ciliumPath string
 	var demoPath string
 	var l3Policy string
 	var appService = "app1-service"
 
 	initialize := func() {
-		if initialized == true {
-			return
-		}
 		logger = log.WithFields(logrus.Fields{"testName": "NightlyK8sEpsMeasurement"})
 		logger.Info("Starting")
 
@@ -190,11 +184,10 @@ var _ = Describe("NightlyExamples", func() {
 
 		demoPath = fmt.Sprintf("%s/demo.yaml", kubectl.ManifestsPath())
 		l3Policy = fmt.Sprintf("%s/l3_l4_policy.yaml", kubectl.ManifestsPath())
-		initialized = true
 	}
 
 	BeforeEach(func() {
-		initialize()
+		once.Do(initialize)
 	})
 
 	AfterEach(func() {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -28,7 +28,7 @@ import (
 var _ = Describe("K8sPolicyTest", func() {
 
 	var demoPath string
-	var initialized bool
+	var once sync.Once
 	var kubectl *helpers.Kubectl
 	var l3Policy, l7Policy string
 	var logger *logrus.Entry
@@ -36,10 +36,6 @@ var _ = Describe("K8sPolicyTest", func() {
 	var podFilter string
 
 	initialize := func() {
-		if initialized == true {
-			return
-		}
-
 		logger = log.WithFields(logrus.Fields{"testName": "K8sPolicyTest"})
 		logger.Info("Starting")
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
@@ -55,11 +51,10 @@ var _ = Describe("K8sPolicyTest", func() {
 		status, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)
 		Expect(status).Should(BeTrue())
 		Expect(err).Should(BeNil())
-		initialized = true
 	}
 
 	BeforeEach(func() {
-		initialize()
+		once.Do(initialize)
 		kubectl.Apply(demoPath)
 		_, err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", 300)
 		Expect(err).Should(BeNil())

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -16,6 +16,7 @@ package k8sTest
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/cilium/cilium/test/helpers"
 	"github.com/cilium/cilium/test/helpers/policygen"
@@ -29,13 +30,9 @@ var _ = Describe("NightlyPolicies", func() {
 
 	var kubectl *helpers.Kubectl
 	var logger *logrus.Entry
-	var initialized bool
+	var once sync.Once
 
 	initialize := func() {
-		if initialized == true {
-			return
-		}
-
 		logger = log.WithFields(logrus.Fields{"testName": "NightlyK8sPolicies"})
 		logger.Info("Starting")
 
@@ -44,11 +41,10 @@ var _ = Describe("NightlyPolicies", func() {
 		kubectl.Apply(ciliumPath)
 		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 		Expect(err).Should(BeNil())
-		initialized = true
 	}
 
 	BeforeEach(func() {
-		initialize()
+		once.Do(initialize)
 	})
 
 	AfterEach(func() {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/cilium/cilium/test/helpers"
@@ -32,12 +33,10 @@ var _ = Describe("K8sServicesTest", func() {
 
 	var kubectl *helpers.Kubectl
 	var logger *logrus.Entry
-	var initialized bool
+	var once sync.Once
 	var serviceName string = "app1-service"
+
 	initialize := func() {
-		if initialized == true {
-			return
-		}
 		logger = log.WithFields(logrus.Fields{"testName": "K8sServiceTest"})
 		logger.Info("Starting")
 
@@ -46,12 +45,10 @@ var _ = Describe("K8sServicesTest", func() {
 		kubectl.Apply(path)
 		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 		Expect(err).Should(BeNil())
-
-		initialized = true
 	}
 
 	BeforeEach(func() {
-		initialize()
+		once.Do(initialize)
 	})
 
 	AfterEach(func() {

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -16,6 +16,7 @@ package k8sTest
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/cilium/cilium/test/helpers"
@@ -29,13 +30,10 @@ var _ = Describe("K8sTunnelTest", func() {
 
 	var kubectl *helpers.Kubectl
 	var demoDSPath string
-	var initialized bool
+	var once sync.Once
 	var logger *logrus.Entry
 
 	initialize := func() {
-		if initialized == true {
-			return
-		}
 		logger = log.WithFields(logrus.Fields{"testName": "K8sTunnelTest"})
 		logger.Info("Starting")
 
@@ -45,11 +43,10 @@ var _ = Describe("K8sTunnelTest", func() {
 		// Expect(res.Correct()).Should(BeTrue())
 
 		waitToDeleteCilium(kubectl, logger)
-		initialized = true
 	}
 
 	BeforeEach(func() {
-		initialize()
+		once.Do(initialize)
 		kubectl.NodeCleanMetadata()
 		kubectl.Apply(demoDSPath)
 	}, 600)

--- a/test/runtime/cli.go
+++ b/test/runtime/cli.go
@@ -16,6 +16,7 @@ package RuntimeTest
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/cilium/cilium/test/helpers"
 
@@ -26,14 +27,12 @@ import (
 
 var _ = Describe("RuntimeCLI", func() {
 
-	var initialized bool
 	var logger *logrus.Entry
 	var vm *helpers.SSHMeta
 
+	var once sync.Once
+
 	initialize := func() {
-		if initialized == true {
-			return
-		}
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimeCLI"})
 		logger.Info("Starting")
 		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
@@ -45,12 +44,10 @@ var _ = Describe("RuntimeCLI", func() {
 
 		areEndpointsReady := vm.WaitEndpointsReady()
 		Expect(areEndpointsReady).Should(BeTrue())
-
-		initialized = true
 	}
 
 	BeforeEach(func() {
-		initialize()
+		once.Do(initialize)
 	})
 
 	AfterEach(func() {

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -16,6 +16,7 @@ package RuntimeTest
 
 import (
 	"context"
+	"sync"
 
 	"github.com/cilium/cilium/test/helpers"
 
@@ -26,19 +27,15 @@ import (
 
 var _ = Describe("RuntimeKVStoreTest", func() {
 
-	var initialized bool
+	var once sync.Once
 	var logger *logrus.Entry
 	var vm *helpers.SSHMeta
 
 	initialize := func() {
-		if initialized == true {
-			return
-		}
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimeKVStoreTest"})
 		logger.Info("Starting")
 		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 		logger.Info("done creating Cilium and Docker helpers")
-		initialized = true
 	}
 	containers := func(option string) {
 		switch option {
@@ -52,7 +49,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 	}
 
 	BeforeEach(func() {
-		initialize()
+		once.Do(initialize)
 		vm.Exec("sudo systemctl stop cilium")
 	}, 150)
 

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -17,6 +17,7 @@ package RuntimeTest
 import (
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/cilium/cilium/test/helpers"
 
@@ -27,14 +28,11 @@ import (
 
 var _ = Describe("RuntimeLB", func() {
 
-	var initialized bool
+	var once sync.Once
 	var logger *logrus.Entry
 	var vm *helpers.SSHMeta
 
 	initialize := func() {
-		if initialized == true {
-			return
-		}
 		logger = log.WithFields(logrus.Fields{"test": "RuntimeLB"})
 		logger.Info("Starting")
 		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
@@ -44,7 +42,6 @@ var _ = Describe("RuntimeLB", func() {
 		vm.NetworkCreate(helpers.CiliumDockerNetwork, "")
 
 		vm.PolicyDelAll().ExpectSuccess()
-		initialized = true
 	}
 
 	// TODO: rename this function; its name is not clear.
@@ -69,7 +66,7 @@ var _ = Describe("RuntimeLB", func() {
 	}
 
 	BeforeEach(func() {
-		initialize()
+		once.Do(initialize)
 		vm.ServiceDelAll().ExpectSuccess()
 	}, 500)
 

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"sync"
 
 	"github.com/cilium/cilium/test/helpers"
 
@@ -42,14 +43,11 @@ const (
 
 var _ = Describe("RuntimeValidatedMonitorTest", func() {
 
-	var initialized bool
+	var once sync.Once
 	var logger *logrus.Entry
 	var vm *helpers.SSHMeta
 
 	initialize := func() {
-		if initialized == true {
-			return
-		}
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimeMonitorTest"})
 		logger.Info("Starting")
 		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
@@ -61,12 +59,10 @@ var _ = Describe("RuntimeValidatedMonitorTest", func() {
 
 		areEndpointsReady := vm.WaitEndpointsReady()
 		Expect(areEndpointsReady).Should(BeTrue())
-
-		initialized = true
 	}
 
 	BeforeEach(func() {
-		initialize()
+		once.Do(initialize)
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
Move all init functions to use `sync.Once` instead of a initialized
variable.

Fix #2500

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>