### PR TITLE
cli: Use text/tabwriter in all the commands

### DIFF
--- a/cilium/cmd/bpf_endpoint_list.go
+++ b/cilium/cmd/bpf_endpoint_list.go
@@ -17,12 +17,18 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"text/tabwriter"
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 
 	"github.com/spf13/cobra"
+)
+
+const (
+	ipAddressTitle         = "IP ADDRESS"
+	localEndpointInfoTitle = "LOCAL ENDPOINT INFO"
 )
 
 var bpfEndpointList = make(map[string]string)
@@ -32,20 +38,31 @@ var bpfEndpointListCmd = &cobra.Command{
 	Short: "List local endpoint entries",
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf endpoint list")
-		fmt.Printf("%-32s %s\n", "IP address", "Local endpoint info")
+
+		lxcmap.DumpMap(dumpEndpoint)
+
 		if len(dumpOutput) > 0 {
-			lxcmap.DumpMap(dumpEndpointToJSON)
 			if err := OutputPrinter(bpfEndpointList); err != nil {
 				os.Exit(1)
 			}
 			return
 		}
-		lxcmap.DumpMap(nil)
+
+		w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
+
+		fmt.Fprintf(w, "%s\t%s\t\n", ipAddressTitle, localEndpointInfoTitle)
+
+		for k, v := range bpfEndpointList {
+			fmt.Fprintf(w, "%s\t%s\t\n", k, v)
+		}
+
+		w.Flush()
 	},
 }
 
-func dumpEndpointToJSON(key bpf.MapKey, value bpf.MapValue) {
-	bpfEndpointList[fmt.Sprintf("%s", key)] = fmt.Sprintf("%s", value)
+func dumpEndpoint(key bpf.MapKey, value bpf.MapValue) {
+	endpointKey, endpointValue := key.(lxcmap.EndpointKey), value.(lxcmap.EndpointInfo)
+	bpfEndpointList[endpointKey.String()] = endpointValue.String()
 }
 
 func init() {

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -215,15 +215,7 @@ func dumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue, error) {
 	return k, v, nil
 }
 
-func dumpCallback(key bpf.MapKey, value bpf.MapValue) {
-	k, v := key.(EndpointKey), value.(EndpointInfo)
-	fmt.Printf("%-32s %s\n", k.String(), v.String())
-}
-
 // DumpMap prints the content of the local endpoint map to stdout
 func DumpMap(callback bpf.DumpCallback) error {
-	if callback == nil {
-		return mapInstance.Dump(dumpParser, dumpCallback)
-	}
 	return mapInstance.Dump(dumpParser, callback)
 }


### PR DESCRIPTION
The advantage of using text/tabwriter instead of fmt.Sprintf
and %20-s is that we don't assume the length of the content,
so the table looks good no matter how long its content is.

Signed-off-by: Michal Rostecki <mrostecki@suse.com>