### PR TITLE
CI: deprecate tests/k8s/tests/{02-cnp-specs.sh,03-l7-stresstest.sh}

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -279,7 +279,7 @@ var _ = Describe("K8sPolicyTest", func() {
 	}, 500)
 })
 
-var _ = Describe("K8sPolicyTestAcrossNamespaces", func() {
+var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 
 	var kubectl *helpers.Kubectl
 	var logger *logrus.Entry

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/api/core/v1"
 )
 
-var _ = Describe("K8sServicesTest", func() {
+var _ = Describe("K8sValidatedServicesTest", func() {
 
 	var kubectl *helpers.Kubectl
 	var logger *logrus.Entry

--- a/tests/k8s/tests/02-cnp-specs.sh
+++ b/tests/k8s/tests/02-cnp-specs.sh
@@ -29,11 +29,18 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 source "${dir}/../cluster/env.bash"
 
+
+
+
 TEST_NAME=$(get_filename_without_extension $0)
 LOGS_DIR="${dir}/cilium-files/${TEST_NAME}/logs"
 redirect_debug_logs ${LOGS_DIR}
 
 set -ex
+
+log "${TEST_NAME} has been deprecated and replaced by test/k8sT/Services.go:CNP Specs Test"
+exit 0
+
 
 bookinfo_dir="${dir}/deployments/bookinfo"
 

--- a/tests/k8s/tests/03-l7-stresstest.sh
+++ b/tests/k8s/tests/03-l7-stresstest.sh
@@ -26,6 +26,10 @@ redirect_debug_logs ${LOGS_DIR}
 
 set -ex
 
+log "${TEST_NAME} has been deprecated and replaced by test/k8sT/Services.go:Policies Across Namespaces"
+exit 0
+
+
 NAMESPACE="kube-system"
 LOCAL_CILIUM_POD="$(kubectl get pods -n kube-system -o wide | grep $(hostname) | awk '{ print $1 }' | grep cilium)"
 


### PR DESCRIPTION
* Depcreate these bash-script tests in favor of their corresponding Ginkgo
counterparts.
* Run Ginkgo counterpart tests as part of each PR build by changing focus to
contain "K8sValidated"

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #1841 - these Ginkgo tests have been validated as having parity with their respective bash-script based counterparts.