### PR TITLE
CI: migrate chaos tests

### DIFF
--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -26,13 +26,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var _ = Describe("RuntimeChaos", func() {
+var _ = Describe("RuntimeValidatedChaos", func() {
 
 	var vm *helpers.SSHMeta
 	var once sync.Once
 
 	initialize := func() {
-		logger := log.WithFields(logrus.Fields{"testName": "RuntimeChaos"})
+		logger := log.WithFields(logrus.Fields{"testName": "RuntimeValidatedChaos"})
 		logger.Info("Starting")
 		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 		vm.NetworkCreate(helpers.CiliumDockerNetwork, "")

--- a/tests/96-restore-endpoints.sh
+++ b/tests/96-restore-endpoints.sh
@@ -11,6 +11,9 @@ redirect_debug_logs ${LOGS_DIR}
 
 set -ex
 
+log "${TEST_NAME} has been deprecated and replaced by test/runtime/chaos.go:Endpoint recovery on restart"
+exit 0
+
 NETPERF_IMAGE="tgraf/netperf"
 
 function cleanup {

--- a/tests/97-clean-leftovers.sh
+++ b/tests/97-clean-leftovers.sh
@@ -11,6 +11,9 @@ redirect_debug_logs ${LOGS_DIR}
 
 set -ex
 
+log "${TEST_NAME} has been deprecated and replaced by test/runtime/chaos.go:removing leftover Cilium interfaces"
+exit 0
+
 NETPERF_IMAGE="tgraf/netperf"
 
 create_cilium_docker_network


### PR DESCRIPTION
* Enable test/runtime/chaos.go for the new Ginkgo framework
* Deprecate the corresponding bash script-based tests, 96-restore-endpoints.sh
and 97-clean-leftovers.sh

Signed-off by: Ian Vernon <ian@cilium.io>

`test/runtime/chaos.go` has proven to be quite stable, and the tests which it covers are validated to have been migrated as part of the work in #1841 . Thus, deprecating the old tests and enabling their Ginkgo counterparts to be ran as part of the `Cilium-Ginkgo-Tests` job, which runs validated Ginkgo tests as part of each PR build.