### PR TITLE
Fix remaining CI bash tests issues with dependencies on Ubuntu repositories

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,9 +34,10 @@ EOF
 "
 sudo service docker restart
 sudo apt-get -y update || true
-sudo apt-get -y install socat curl jq realpath pv tmux python-sphinx python-pip yamllint
+sudo apt-get -y install socat curl jq realpath pv tmux python-sphinx python-pip
 sudo pip install --upgrade pip
 sudo pip install sphinx sphinxcontrib-httpdomain sphinxcontrib-openapi
+sudo pip install yamllint
 echo 'cd ~/go/src/github.com/cilium/cilium' >> /home/vagrant/.bashrc
 export GOPATH=/home/vagrant/go
 sudo -E /usr/local/go/bin/go get github.com/jteeuwen/go-bindata/...

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -134,7 +134,7 @@ function run_benchmark_tests {
 function test_svc_restore_functionality {
   log "checking restore functionality for services"
   local SVCS_BEFORE_RESTART=$(cilium service list | tail -n+2 | sort)
-  local BPF_LB_LIST_BEFORE_RESTART=$(cilium bpf lb list | tail -n+3 | sort)
+  local BPF_LB_LIST_BEFORE_RESTART=$(cilium bpf lb list | tail -n+2 | sort)
 
   log "restarting Cilium"
   service cilium restart
@@ -142,7 +142,7 @@ function test_svc_restore_functionality {
 
   log "checking services and BPF maps after restarting Cilium"
   local SVCS_AFTER_RESTART=$(cilium service list | tail -n+2 | sort)
-  local BPF_LB_LIST_AFTER_RESTART=$(cilium bpf lb list | tail -n+3 | sort)
+  local BPF_LB_LIST_AFTER_RESTART=$(cilium bpf lb list | tail -n+2 | sort)
 
   if [[ "$SVCS_BEFORE_RESTART" != "$SVCS_AFTER_RESTART" ]]; then
     log "Services before restart: $SVCS_BEFORE_RESTART"

--- a/tests/k8s/cluster/cluster-manager.bash
+++ b/tests/k8s/cluster/cluster-manager.bash
@@ -179,6 +179,19 @@ EOF
 }
 
 function install_kubeadm_dependencies(){
+    # This hack may be removed when the box images are based on Ubuntu 17.10+.
+    curl -O -s http://old-releases.ubuntu.com/ubuntu/pool/universe/s/socat/socat_1.7.3.1-2_amd64.deb
+    dpkg -i ./socat_1.7.3.1-2_amd64.deb
+    sudo bash -c "cat <<EOF > /etc/apt/sources.list
+deb http://old-releases.ubuntu.com/ubuntu/ yakkety main restricted
+deb http://old-releases.ubuntu.com/ubuntu/ yakkety-updates main restricted
+deb http://old-releases.ubuntu.com/ubuntu/ yakkety universe
+deb http://old-releases.ubuntu.com/ubuntu/ yakkety-updates universe
+deb http://old-releases.ubuntu.com/ubuntu/ yakkety multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ yakkety-updates multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ yakkety-backports main restricted universe multiverse
+EOF
+"
     sudo touch /etc/apt/sources.list.d/kubernetes.list
     curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg  | sudo apt-key add -
     sudo bash -c "cat <<EOF > /etc/apt/sources.list.d/kubernetes.list


### PR DESCRIPTION
This PR fixes all remaining bash CI issues relating to the Ubuntu EOL of yakkety distro which is currently used in those tests.

Fixes: #2573, #2579
Deprecates: #2576