### PR TITLE
Add policy rule to allow kafka-broker to talk to kafka-service in getting started guides

### DIFF
--- a/examples/kubernetes-istio/kafka-v1-policy.yaml
+++ b/examples/kubernetes-istio/kafka-v1-policy.yaml
@@ -24,6 +24,9 @@ specs:
           - apiKey: "heartbeat"
     - fromEndpoints:
       - matchLabels:
+          app: kafka
+    - fromEndpoints:
+      - matchLabels:
           "k8s:app": authaudit-logger
       toPorts:
       - ports:

--- a/examples/kubernetes-istio/kafka-v1.yaml
+++ b/examples/kubernetes-istio/kafka-v1.yaml
@@ -36,6 +36,9 @@ specs:
           - apiKey: "heartbeat"
     - fromEndpoints:
       - matchLabels:
+          app: kafka
+    - fromEndpoints:
+      - matchLabels:
           "k8s:app": authaudit-logger
       toPorts:
       - ports:

--- a/examples/kubernetes-kafka/kafka-sw-security-policy.yaml
+++ b/examples/kubernetes-kafka/kafka-sw-security-policy.yaml
@@ -23,6 +23,9 @@ specs:
             topic: "deathstar-plans"
           - apiKey: "produce"
             topic: "empire-announce"
+    - fromEndpoints:
+      - matchLabels:
+          app: kafka
   - endpointSelector:
       matchLabels:
         app: kafka


### PR DESCRIPTION

The kafka broker talks to itself through the kafka-service IP. Probably due
to the configuration of the advertised kafka host IP.
This change adds a policy that allows a kafka broker pod to talk to other kafka broker pods.
Fixes : #2570
Signed-Off-By: Manali Bhutiyani <manali@covalent.io>


```release-note
Add policy rule to allow kafka-broker to talk to kafka-service in getting started guides
```