### PR TITLE
Ginkgo: Updated vagrant box to 0.0.4

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -8,7 +8,7 @@ $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 
 
 $SERVER_BOX= "cilium/ginkgo"
-$SERVER_VERSION= "0.0.2"
+$SERVER_VERSION="0.0.4"
 
 ENV["VAGRANT_DEFAULT_PROVIDER"] = "virtualbox"
 Vagrant.configure("2") do |config|
@@ -22,7 +22,7 @@ Vagrant.configure("2") do |config|
         end
 
         server.vm.box =  "#{$SERVER_BOX}"
-        server.vm.box_version = "#{$SERVER_VERSION}"
+        server.vm.box_version = $SERVER_VERSION
         server.vm.hostname = "runtime"
         server.vm.synced_folder "../", "/src/"
 
@@ -46,7 +46,7 @@ Vagrant.configure("2") do |config|
             end
 
             server.vm.box =  "#{$SERVER_BOX}"
-            server.vm.box_version = "#{$SERVER_VERSION}"
+            server.vm.box_version = $SERVER_VERSION
             server.vm.hostname = "k8s#{i}"
             server.vm.network "private_network",
                 ip: "192.168.36.1#{i}",

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -26,18 +26,6 @@ fi
 
 $PROVISIONSRC/dns.sh
 
-cat <<EOF > /etc/apt/sources.list
-deb http://old-releases.ubuntu.com/ubuntu/ zesty main restricted
-deb http://old-releases.ubuntu.com/ubuntu/ zesty-updates main restricted
-deb http://old-releases.ubuntu.com/ubuntu/ zesty universe
-deb http://old-releases.ubuntu.com/ubuntu/ zesty-updates universe
-deb http://old-releases.ubuntu.com/ubuntu/ zesty multiverse
-deb http://old-releases.ubuntu.com/ubuntu/ zesty-updates multiverse
-deb http://old-releases.ubuntu.com/ubuntu/ zesty-backports main restricted universe multiverse
-deb [arch=amd64] https://download.docker.com/linux/ubuntu zesty stable
-EOF
-
-
 cat <<EOF > /etc/hosts
 127.0.0.1       localhost
 ::1     localhost ip6-localhost ip6-loopback

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -1,18 +1,6 @@
 #!/bin/bash
 set -e
 
-cat <<EOF > /etc/apt/sources.list
-deb http://old-releases.ubuntu.com/ubuntu/ zesty main restricted
-deb http://old-releases.ubuntu.com/ubuntu/ zesty-updates main restricted
-deb http://old-releases.ubuntu.com/ubuntu/ zesty universe
-deb http://old-releases.ubuntu.com/ubuntu/ zesty-updates universe
-deb http://old-releases.ubuntu.com/ubuntu/ zesty multiverse
-deb http://old-releases.ubuntu.com/ubuntu/ zesty-updates multiverse
-deb http://old-releases.ubuntu.com/ubuntu/ zesty-backports main restricted universe multiverse
-deb [arch=amd64] https://download.docker.com/linux/ubuntu zesty stable
-EOF
-sudo apt-get update
-
 HOST=$(hostname)
 PROVISIONSRC="/tmp/provision"
 GOPATH=/go/


### PR DESCRIPTION
- Updated vagrant box to Ubuntu 17.10

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

Related to https://github.com/cilium/packer-ci-build/pull/7
