### PR TITLE
Vendor Kafka Optiopay to handle large fetch responses.

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -100,7 +100,7 @@ github.com/google/gops 25312cafb9a191a6d377c480a4666beec3105e4a
 github.com/kardianos/osext ae77be60afb1dcacde03767a8c37337fad28ac14
 github.com/kr/text 7cafcd837844e784b526369c9bce262804aebc60
 github.com/kr/pretty cfb55aafdaf3ec08f0db22699ab822c50091b1c4
-github.com/optiopay/kafka b5a758dbffc5786a8cac42703bd5d63f503bd008 https://github.com/cilium/kafka
+github.com/optiopay/kafka 947cc36649a7bbef371f9a7c96d1b2b7500d87b3 https://github.com/cilium/kafka
 github.com/golang/snappy 553a641470496b2327abcac10b36396bd98e45c9
 github.com/kevinburke/ssh_config db49ba357de1f26c56dac48a5de39c65785bf24a
 github.com/onsi/ginkgo 11459a886d9cd66b319dac7ef1e917ee221372c9

--- a/vendor/github.com/optiopay/kafka/proto/messages.go
+++ b/vendor/github.com/optiopay/kafka/proto/messages.go
@@ -98,18 +98,53 @@ func boolToInt8(val bool) int8 {
 	return res
 }
 
+// discard tries to discard bytes
+// from the io.Reader in chunks of maxDiscardSize(4096) bytes
+// to avoid allocating huge amount of memory in
+// one go.
+func discard(r io.Reader, n int32) {
+	remBytes := n
+	var delBytes int32
+
+	delBytes = 0
+	for remBytes > 0 {
+		if remBytes > maxDiscardSize {
+			delBytes = maxDiscardSize
+			remBytes = remBytes - maxDiscardSize
+		} else {
+			delBytes = remBytes
+			remBytes = 0
+		}
+		io.CopyN(ioutil.Discard, r, int64(delBytes))
+	}
+}
+
+
 // ReadReq returns request kind ID and byte representation of the whole message
 // in wire protocol format.
 func ReadReq(r io.Reader) (requestKind int16, b []byte, err error) {
 	dec := NewDecoder(r)
 	msgSize := dec.DecodeInt32()
+	if err := dec.Err(); err != nil {
+		return 0, nil, err
+	}
+
+	if msgSize <=0 {
+		return 0, nil, io.ErrUnexpectedEOF
+	}
+
 	requestKind = dec.DecodeInt16()
 	if err := dec.Err(); err != nil {
+		discard(r, msgSize)
 		return 0, nil, err
 	}
 	// size of the message + size of the message itself
 	b, err = allocParseBuf(int(msgSize + 4))
 	if err != nil {
+		if msgSize > 2 {
+			// We have already read the requestKind
+			discard(r, msgSize - 2)
+		}
 		return 0, nil, err
 	}
 
@@ -138,13 +173,26 @@ func ReadReq(r io.Reader) (requestKind int16, b []byte, err error) {
 func ReadResp(r io.Reader) (correlationID int32, b []byte, err error) {
 	dec := NewDecoder(r)
 	msgSize := dec.DecodeInt32()
+	if err := dec.Err(); err != nil {
+		return 0, nil, err
+	}
+
+	if msgSize <=0 {
+		return 0, nil, io.ErrUnexpectedEOF
+	}
+
 	correlationID = dec.DecodeInt32()
 	if err := dec.Err(); err != nil {
+		discard(r, msgSize)
 		return 0, nil, err
 	}
 	// size of the message + size of the message itself
 	b, err = allocParseBuf(int(msgSize + 4))
 	if err != nil {
+		if msgSize > 2 {
+			// We have already read the correlationID
+			discard(r, msgSize - 4)
+		}
 		return 0, nil, err
 	}
 

--- a/vendor/github.com/optiopay/kafka/proto/utils.go
+++ b/vendor/github.com/optiopay/kafka/proto/utils.go
@@ -6,7 +6,8 @@ import (
 )
 
 const (
-	maxParseBufSize = 10 * math.MaxUint16
+	maxParseBufSize = 100 * math.MaxUint16
+	maxDiscardSize  = 4096
 )
 
 func messageSizeError(size int) error {


### PR DESCRIPTION
Cilium panics with error "index out of range error" on receiving messages of very large size. Hence we vendor Kafka Optio-pay to change maxParseBufSize to 100 * math.MaxUint16


Additionally we have added code to discard the remaining bytes of the message correctly.


Fixes Issue: #2454
Signed-Off-By: Manali Bhutiyani <manali@covalent.io>


```release-note
Vendor Kafka Optiopay to handle large fetch responses.
```