### PR TITLE
Don't allow API users to modify reserved labels for endpoints.

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -127,41 +127,31 @@ func NewPutEndpointIDHandler(d *Daemon) PutEndpointIDHandler {
 	return &putEndpointID{d: d}
 }
 
-func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder {
-	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PUT /endpoint/{id} request")
-
-	epTemplate := params.Endpoint
-	if n, err := endpoint.ParseCiliumID(params.ID); err != nil {
-		return apierror.Error(PutEndpointIDInvalidCode, err)
-	} else if n != epTemplate.ID {
-		return apierror.New(PutEndpointIDInvalidCode,
-			"ID parameter does not match ID in endpoint parameter")
-	} else if epTemplate.ID == 0 {
-		return apierror.New(PutEndpointIDInvalidCode,
-			"endpoint ID cannot be 0")
-	}
-
-	addLabels := labels.ParseStringLabels(params.Endpoint.Labels)
+// createEndpoint attempts to create the endpoint corresponding to the change
+// request that was specified. Returns an HTTP code response code and an
+// error msg (or nil on success).
+func (d *Daemon) createEndpoint(epTemplate *models.EndpointChangeRequest, id string, lbls []string) (int, error) {
+	addLabels := labels.ParseStringLabels(lbls)
 	ep, err := endpoint.NewEndpointFromChangeModel(epTemplate, addLabels)
 	if err != nil {
-		return apierror.Error(PutEndpointIDInvalidCode, err)
+		return PutEndpointIDInvalidCode, err
 	}
 
-	ep.SetDefaultOpts(h.d.conf.Opts)
+	ep.SetDefaultOpts(d.conf.Opts)
 	alwaysEnforce := policy.GetPolicyEnabled() == endpoint.AlwaysEnforce
 	ep.Opts.Set(endpoint.OptionIngressPolicy, alwaysEnforce)
 	ep.Opts.Set(endpoint.OptionEgressPolicy, alwaysEnforce)
 
-	oldEp, err2 := endpointmanager.Lookup(params.ID)
+	oldEp, err2 := endpointmanager.Lookup(id)
 	if err2 != nil {
-		return apierror.Error(GetEndpointIDInvalidCode, err2)
+		return PutEndpointIDInvalidCode, err2
 	} else if oldEp != nil {
-		return NewPutEndpointIDExists()
+		return PutEndpointIDExistsCode, fmt.Errorf("Endpoint ID %s exists", id)
 	}
 
 	if err := ep.CreateDirectory(); err != nil {
 		log.WithError(err).Warn("Aborting endpoint join")
-		return apierror.Error(PutEndpointIDFailedCode, err)
+		return PutEndpointIDFailedCode, err
 	}
 
 	// Regenerate immediately if ready or waiting for identity
@@ -182,9 +172,9 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder 
 	}
 	ep.Mutex.Unlock()
 	if build {
-		if err := ep.RegenerateWait(h.d, reason); err != nil {
+		if err := ep.RegenerateWait(d, reason); err != nil {
 			ep.RemoveDirectory()
-			return apierror.Error(PatchEndpointIDFailedCode, err)
+			return PutEndpointIDFailedCode, err
 		}
 	}
 
@@ -192,23 +182,43 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder 
 	endpointmanager.Insert(ep)
 	ep.Mutex.RUnlock()
 
-	add := labels.NewLabelsFromModel(params.Endpoint.Labels)
+	add := labels.NewLabelsFromModel(lbls)
 
 	if len(add) > 0 {
-		errLabelsAdd := h.d.UpdateSecLabels(params.ID, add, labels.Labels{})
+		code, errLabelsAdd := d.UpdateSecLabels(id, add, labels.Labels{})
 		if errLabelsAdd != nil {
 			// XXX: Why should the endpoint remain in this case?
 			log.WithFields(logrus.Fields{
-				logfields.EndpointID:              params.ID,
+				logfields.EndpointID:              id,
 				logfields.IdentityLabels:          logfields.Repr(add),
 				logfields.IdentityLabels + ".bad": errLabelsAdd,
 			}).Error("Could not add labels while creating an ep due to bad labels")
-			return errLabelsAdd
+			return code, errLabelsAdd
 		}
 	}
 
-	ret := NewPutEndpointIDCreated()
-	return ret
+	return PutEndpointIDCreatedCode, nil
+}
+
+func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder {
+	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PUT /endpoint/{id} request")
+
+	epTemplate := params.Endpoint
+	if n, err := endpoint.ParseCiliumID(params.ID); err != nil {
+		return apierror.Error(PutEndpointIDInvalidCode, err)
+	} else if n != epTemplate.ID {
+		return apierror.New(PutEndpointIDInvalidCode,
+			"ID parameter does not match ID in endpoint parameter")
+	} else if epTemplate.ID == 0 {
+		return apierror.New(PutEndpointIDInvalidCode,
+			"endpoint ID cannot be 0")
+	}
+
+	code, err := h.d.createEndpoint(epTemplate, params.ID, params.Endpoint.Labels)
+	if err != nil {
+		apierror.Error(code, err)
+	}
+	return NewPutEndpointIDCreated()
 }
 
 type patchEndpointID struct {
@@ -600,20 +610,21 @@ func (h *getEndpointIDHealthz) Handle(params GetEndpointIDHealthzParams) middlew
 // The `add` labels take precedence over `del` labels, this means if the same
 // label is set on both `add` and `del`, that specific label will exist in the
 // endpoint's labels.
-func (d *Daemon) UpdateSecLabels(id string, add, del labels.Labels) middleware.Responder {
+// Returns an HTTP response code and an error msg (or nil on success).
+func (d *Daemon) UpdateSecLabels(id string, add, del labels.Labels) (int, error) {
 	addLabels, _ := labels.FilterLabels(add)
 	delLabels, _ := labels.FilterLabels(del)
 
 	if len(addLabels) == 0 && len(delLabels) == 0 {
-		return nil
+		return PutEndpointIDLabelsOKCode, nil
 	}
 
 	ep, err := endpointmanager.Lookup(id)
 	if err != nil {
-		return apierror.Error(GetEndpointIDInvalidCode, err)
+		return PutEndpointIDLabelsUpdateFailedCode, err
 	}
 	if ep == nil {
-		return NewPutEndpointIDLabelsNotFound()
+		return PutEndpointIDLabelsNotFoundCode, fmt.Errorf("No endpoint with ID %s found", ep.StringID())
 	}
 
 	// This is safe only if no other goroutine may change the labels in parallel
@@ -632,8 +643,7 @@ func (d *Daemon) UpdateSecLabels(id string, add, del labels.Labels) middleware.R
 				break
 			}
 
-			return apierror.New(PutEndpointIDLabelsLabelNotFoundCode,
-				"label %s not found", k)
+			return PutEndpointIDLabelsLabelNotFoundCode, fmt.Errorf("label %s not found", k)
 		}
 	}
 
@@ -663,7 +673,7 @@ func (d *Daemon) UpdateSecLabels(id string, add, del labels.Labels) middleware.R
 
 	identity, newHash, err2 := d.updateEndpointIdentity(ep.StringID(), ep.LabelsHash, oldLabels)
 	if err2 != nil {
-		return apierror.Error(PutEndpointIDLabelsUpdateFailedCode, err2)
+		return PutEndpointIDLabelsUpdateFailedCode, err2
 	}
 
 	ep.Mutex.Lock()
@@ -675,7 +685,7 @@ func (d *Daemon) UpdateSecLabels(id string, add, del labels.Labels) middleware.R
 				logfields.Identity:   identity.ID,
 			}).WithError(err).Warn("Unable to release temporary identity")
 		}
-		return NewPutEndpointIDLabelsNotFound()
+		return PutEndpointIDLabelsNotFoundCode, fmt.Errorf("No endpoint with ID %s found", ep.StringID())
 	}
 
 	ep.LabelsHash = newHash
@@ -691,7 +701,7 @@ func (d *Daemon) UpdateSecLabels(id string, add, del labels.Labels) middleware.R
 		ep.Regenerate(d, "updated security labels")
 	}
 
-	return nil
+	return PutEndpointIDLabelsOKCode, nil
 }
 
 type putEndpointIDLabels struct {
@@ -710,11 +720,10 @@ func (h *putEndpointIDLabels) Handle(params PutEndpointIDLabelsParams) middlewar
 	add := labels.NewLabelsFromModel(mod.Add)
 	del := labels.NewLabelsFromModel(mod.Delete)
 
-	err := d.UpdateSecLabels(params.ID, add, del)
+	code, err := d.UpdateSecLabels(params.ID, add, del)
 	if err != nil {
-		return err
+		return apierror.Error(code, err)
 	}
-
 	return NewPutEndpointIDLabelsOK()
 }
 

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -618,6 +618,11 @@ func (d *Daemon) UpdateSecLabels(id string, add, del labels.Labels) (int, error)
 	if len(addLabels) == 0 && len(delLabels) == 0 {
 		return PutEndpointIDLabelsOKCode, nil
 	}
+	if lbls := addLabels.FindReserved(); lbls != nil {
+		return PutEndpointIDLabelsUpdateFailedCode, fmt.Errorf("Not allowed to add reserved labels: %s", lbls)
+	} else if lbls := delLabels.FindReserved(); lbls != nil {
+		return PutEndpointIDLabelsUpdateFailedCode, fmt.Errorf("Not allowed to delete reserved labels: %s", lbls)
+	}
 
 	ep, err := endpointmanager.Lookup(id)
 	if err != nil {

--- a/daemon/endpoint_test.go
+++ b/daemon/endpoint_test.go
@@ -1,0 +1,65 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/cilium/cilium/api/v1/models"
+	apiEndpoint "github.com/cilium/cilium/api/v1/server/restapi/endpoint"
+	"github.com/cilium/cilium/common/addressing"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/ipam"
+	"github.com/cilium/cilium/pkg/labels"
+
+	. "gopkg.in/check.v1"
+)
+
+func getEPTemplate(c *C) *models.EndpointChangeRequest {
+	ip4, ip6, err := ipam.AllocateNext("")
+	c.Assert(err, Equals, nil)
+	c.Assert(ip4, Not(IsNil))
+	c.Assert(ip6, Not(IsNil))
+
+	id := int64(addressing.CiliumIPv6(ip6).EndpointID())
+	return &models.EndpointChangeRequest{
+		ID:            id,
+		ContainerID:   endpoint.NewCiliumID(id),
+		ContainerName: "foo",
+		State:         models.EndpointStateWaitingForIdentity,
+		Addressing: &models.EndpointAddressing{
+			IPV6: ip6.String(),
+			IPV4: ip4.String(),
+		},
+	}
+}
+
+func (ds *DaemonSuite) TestEndpointAdd(c *C) {
+	epTemplate := getEPTemplate(c)
+	lbls := []string{"reserved:world"}
+	code, err := ds.d.createEndpoint(epTemplate, "1", lbls)
+	c.Assert(err, Not(IsNil))
+	c.Assert(code, Equals, apiEndpoint.PutEndpointIDInvalidCode)
+
+	lbls = []string{"reserved:foo"}
+	code, err = ds.d.createEndpoint(epTemplate, "1", lbls)
+	c.Assert(err, Not(IsNil))
+	c.Assert(code, Equals, apiEndpoint.PutEndpointIDInvalidCode)
+}
+
+func (ds *DaemonSuite) TestUpdateSecLabels(c *C) {
+	lbls := labels.NewLabelsFromModel([]string{"reserved:world"})
+	code, err := ds.d.UpdateSecLabels("1", lbls, nil)
+	c.Assert(err, Not(IsNil))
+	c.Assert(code, Equals, apiEndpoint.PutEndpointIDLabelsUpdateFailedCode)
+}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -350,6 +350,10 @@ func NewEndpointWithState(ID uint16, state string) *Endpoint {
 func NewEndpointFromChangeModel(base *models.EndpointChangeRequest, l pkgLabels.Labels) (*Endpoint, error) {
 	if base == nil {
 		return nil, nil
+	}
+
+	if lbls := l.FindReserved(); lbls != nil {
+		return nil, fmt.Errorf("Not allowed to create endpoint with reserved labels %s", lbls)
 	}
 
 	ep := &Endpoint{

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -454,6 +454,23 @@ func (l Labels) ToSlice() []*Label {
 // LabelArray returns the labels as label array
 func (l Labels) LabelArray() LabelArray {
 	return l.ToSlice()
+}
+
+// FindReserved locates all labels with reserved source in the labels and
+// returns a copy of them. If there are no reserved labels, returns nil.
+func (l Labels) FindReserved() Labels {
+	lbls := Labels{}
+
+	for k, lbl := range l {
+		if lbl.Source == LabelSourceReserved {
+			lbls[k] = lbl.DeepCopy()
+		}
+	}
+
+	if len(lbls) > 0 {
+		return lbls
+	}
+	return nil
 }
 
 // parseSource returns the parsed source of the given str. It also returns the next piece


### PR DESCRIPTION
This series refactors a little bit of daemon code and restricts API access to modifying endpoint labels when the label source is `reserved`. Some simple tests are added as well, but this series mainly focuses on the API restriction rather than attempting to comprehensively test endpoint instantiation.