### PR TITLE
docs: Move render target to main Makefile as 'render-docs'

### DIFF
--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -3,9 +3,7 @@ FROM ubuntu:16.04
 ENV DOCS_DIR=/srv/Documentation
 ENV API_DIR=/srv/api
 
-WORKDIR $DOCS_DIR
-ADD Documentation $DOCS_DIR
-ADD api $API_DIR
+ADD Documentation/requirements.txt $DOCS_DIR/requirements.txt
 
 RUN apt-get update && \
       apt-get install -y git make python-sphinx python-pip \
@@ -15,3 +13,7 @@ RUN apt-get update && \
       pip install --upgrade pip && \
       pip install -r $DOCS_DIR/requirements.txt && \
       rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR $DOCS_DIR
+ADD api $API_DIR
+ADD Documentation $DOCS_DIR

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -37,13 +37,6 @@ check-requirements:
 	  echo "Run pip install recommonmark";  \
 	  exit 1)
 
-render:
-	-docker rm -f docs-cilium >/dev/null
-	cd .. && \
-	docker run -ti -v $$(pwd):/srv/ cilium/docs-builder /bin/bash -c 'make html' && \
-	docker run -dit --name docs-cilium -p 8080:80 -v $$(pwd)/Documentation/_build/html/:/usr/local/apache2/htdocs/ httpd:2.4
-	@echo "$$(tput setaf 2)Running at http://localhost:8080$$(tput sgr0)"
-
 cmdref:
 	# We don't know what changed so recreate the directory
 	-rm -rvf $(CMDREFDIR)/cilium*

--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -519,23 +519,16 @@ Whenever making changes to Cilium documentation you should check that you did no
 After this you can browse the updated docs as HTML starting at
 ``Documentation\_build\html\index.html``.
 
-Alternatively you can use a Docker container to build the pages.
+Alternatively you can use a Docker container to build the pages:
 
 ::
 
-    $ docker run -ti -v $(pwd):/srv/ cilium/docs-builder /bin/bash -c 'make html'
+    $ make render-docs
 
-This behave similarly to running the ``make`` command above so the path to the
-build is the same.
-
-There is also a separate target for building and starting a web server with
+This builds the docs in a container and builds and starts a web server with
 your document changes.
 
-::
-
-    $ make render
-
-Now the documentation page should be browsable on http://localhost:8080
+Now the documentation page should be browsable on http://localhost:8080.
 
 Debugging datapath code
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,15 @@ update-authors:
 	@cat .authors.aux >> AUTHORS
 
 docs-container:
+	grep -v -E "(SOURCE|GIT)_VERSION" .gitignore >.dockerignore
+	echo ".*" >>.dockerignore # .git pruned out
 	docker build -t cilium/docs-builder -f Documentation/Dockerfile .
+
+render-docs: docs-container
+	-docker rm -f docs-cilium >/dev/null
+	docker run -ti -v $$(pwd):/srv/ cilium/docs-builder /bin/bash -c 'make html' && \
+	docker run -dit --name docs-cilium -p 8080:80 -v $$(pwd)/Documentation/_build/html/:/usr/local/apache2/htdocs/ httpd:2.4
+	@echo "$$(tput setaf 2)Running at http://localhost:8080$$(tput sgr0)"
 
 manpages:
 	-rm -r man


### PR DESCRIPTION
Building docs-container failed if built after building cilium docker
image ('make docker-image') due to the .dockerignore file produced for
building the cilium image being accidentally reused for building
docs-container. Fix this by explicitly creating a .dockerignore file
as part of the docs-container actions.

Move the 'render' target from Documentation folder to the main
Makefile as 'render-docs' and make it depend on the 'docs-container'
target.

Reorganize Documentation/Dockerfile so that any repo changes outside
of Documentation/requirements.txt will use the cached build toolchain,
making repeated 'make render-docs' commands run faster.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
