### PR TITLE
Fix race while updating L7 proxy redirect in L4PolicyMap

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -52,7 +52,7 @@ func (e *Endpoint) writeL4Map(fw *bufio.Writer, owner Owner, m policy.L4PolicyMa
 	array := ""
 	index := 0
 
-	for k, l4 := range m {
+	for _, l4 := range m {
 		// Represents struct l4_allow in bpf/lib/l4.h
 		protoNum, err := u8proto.ParseProtocol(string(l4.Protocol))
 		if err != nil {
@@ -62,15 +62,6 @@ func (e *Endpoint) writeL4Map(fw *bufio.Writer, owner Owner, m policy.L4PolicyMa
 		dport := byteorder.HostToNetwork(uint16(l4.Port))
 
 		redirect := uint16(l4.L7RedirectPort)
-		if l4.IsRedirect() && redirect == 0 {
-			redirect, err = e.addRedirect(owner, &l4)
-			if err != nil {
-				return err
-			}
-			l4.L7RedirectPort = int(redirect)
-			m[k] = l4
-		}
-
 		redirect = byteorder.HostToNetwork(redirect).(uint16)
 		entry := fmt.Sprintf("%d,%d,%d,%d", index, dport, redirect, protoNum)
 		if array != "" {
@@ -405,6 +396,25 @@ func (e *Endpoint) updateCT(owner Owner, flushEndpointCT bool, consumersAdd, con
 	return wg
 }
 
+// allocateRedirects must be called while holding the endpoint and consumable
+// locks for writing. On success, returns nil; otherwise, returns an error
+// indicating the problem that occurred while adding an l7 redirect for the
+// specified policy.
+func (e *Endpoint) allocateRedirects(owner Owner, m policy.L4PolicyMap) error {
+	for k, l4 := range m {
+		redirect := uint16(l4.L7RedirectPort)
+		if l4.IsRedirect() && redirect == 0 {
+			redirect, err := e.addRedirect(owner, &l4)
+			if err != nil {
+				return err
+			}
+			l4.L7RedirectPort = int(redirect)
+			m[k] = l4
+		}
+	}
+	return nil
+}
+
 // regenerateBPF rewrites all headers and updates all BPF maps to reflect the
 // specified endpoint.
 // Must be called with endpoint.Mutex not held and endpoint.BuildMutex held.
@@ -428,6 +438,26 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 		e.getLogger().WithField(logfields.EndpointState, e.state).Debug("Skipping build due to invalid state")
 		e.Mutex.Unlock()
 		return 0, fmt.Errorf("Skipping build due to invalid state: %s", e.state)
+	}
+
+	// If there is a Consumable, walk the L4Policy for ports that require
+	// an L7 redirect and add them to the endpoint; update the L4PolicyMap
+	// with the redirects.
+	if e.Consumable != nil {
+		e.Consumable.Mutex.Lock()
+		if e.Consumable.L4Policy != nil {
+			if err = e.allocateRedirects(owner, e.Consumable.L4Policy.Ingress); err != nil {
+				e.Consumable.Mutex.Unlock()
+				e.Mutex.Unlock()
+				return 0, fmt.Errorf("Unable to allocate ingress redirects: %s", err)
+			}
+			if err = e.allocateRedirects(owner, e.Consumable.L4Policy.Egress); err != nil {
+				e.Consumable.Mutex.Unlock()
+				e.Mutex.Unlock()
+				return 0, fmt.Errorf("Unable to allocate egress redirects: %s", err)
+			}
+		}
+		e.Consumable.Mutex.Unlock()
 	}
 
 	if err = e.writeHeaderfile(epdir, owner); err != nil {


### PR DESCRIPTION
Previously, the L7 redirects were allocated deep in the L4 BPF code
generation; this commit shifts that functionality up to the
regenerateBPF() layer, and wraps some proper locking around its access
to Consumable, as it modifies the Consumable's L4PolicyMap.

This should fix the following data race:

```
WARNING: DATA RACE
Read at 0x00c420ed3650 by goroutine 42:
  runtime.mapiterinit()
      /home/scanf/opt/go/src/runtime/hashmap.go:709 +0x0
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).writeL4Map()
      /home/scanf/opt/og/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:55 +0xab
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).writeL4Policy()
      /home/scanf/opt/og/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:113 +0x2b5
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).writeHeaderfile()
      /home/scanf/opt/og/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:256 +0x1fa8
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerateBPF()
      /home/scanf/opt/og/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:433 +0x218
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerate()
      /home/scanf/opt/og/src/github.com/cilium/cilium/pkg/endpoint/policy.go:693 +0x4ca
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).Regenerate.func1()
      /home/scanf/opt/og/src/github.com/cilium/cilium/pkg/endpoint/policy.go:759 +0x2a1

Previous write at 0x00c420ed3650 by goroutine 109:
  runtime.mapassign_faststr()
      /home/scanf/opt/go/src/runtime/hashmap_fast.go:598 +0x0
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).writeL4Map()
      /home/scanf/opt/og/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:71 +0x5e5
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).writeL4Policy()
      /home/scanf/opt/og/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:113 +0x2b5
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).writeHeaderfile()
      /home/scanf/opt/og/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:256 +0x1fa8
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerateBPF()
      /home/scanf/opt/og/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:433 +0x218
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerate()
      /home/scanf/opt/og/src/github.com/cilium/cilium/pkg/endpoint/policy.go:693 +0x4ca
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).Regenerate.func1()
      /home/scanf/opt/og/src/github.com/cilium/cilium/pkg/endpoint/policy.go:759 +0x2a1
```

Fixes: #2409

Reported-by: Alexander Alemayhu <alexander@alemayhu.com>
Signed-off-by: Joe Stringer <joe@covalent.io>