### PR TITLE
CNP CRD schema versioning

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -28,6 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/hashicorp/go-version"
 )
 
 const (
@@ -45,6 +47,13 @@ const (
 
 	// CustomResourceDefinitionVersion is the current version of the resource
 	CustomResourceDefinitionVersion = "v2"
+
+	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
+	// Used to determine if CRD needs to be updated in cluster
+	CustomResourceDefinitionSchemaVersion = "1.0"
+
+	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
+	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"
 )
 
 // SchemeGroupVersion is group version used to register these objects
@@ -76,9 +85,14 @@ var (
 	//   kclientset, _ := kubernetes.NewForConfig(c)
 	//   aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 	AddToScheme = localSchemeBuilder.AddToScheme
+
+	comparableCRDSchemaVersion *version.Version
 )
 
 func init() {
+	comparableCRDSchemaVersion = version.Must(
+		version.NewVersion(CustomResourceDefinitionSchemaVersion))
+
 	// We only register manually written functions here. The registration of the
 	// generated functions takes place in the generated files. The separation
 	// makes the code compile even when the generated files are missing.
@@ -103,6 +117,9 @@ func CreateCustomResourceDefinitions(clientset apiextensionsclient.Interface) er
 	res := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: cnpCRDName,
+			Labels: map[string]string{
+				CustomResourceDefinitionSchemaVersionKey: CustomResourceDefinitionSchemaVersion,
+			},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   SchemeGroupVersion.Group,
@@ -123,9 +140,8 @@ func CreateCustomResourceDefinitions(clientset apiextensionsclient.Interface) er
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
-	// If the CRD already exists in the cluster but without any validation then
-	// we need to create it.
-	if errors.IsAlreadyExists(err) && clusterCRD.Spec.Validation == nil {
+
+	if needsUpdate(clusterCRD, err) {
 		// Update the CRD with the validation schema.
 		err = wait.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
 			clusterCRD, err = clientset.ApiextensionsV1beta1().
@@ -183,6 +199,29 @@ func CreateCustomResourceDefinitions(clientset apiextensionsclient.Interface) er
 	log.Info("done creating v2.CiliumNetworkPolicy CustomResourceDefinition")
 
 	return nil
+}
+
+func needsUpdate(
+	clusterCRD *apiextensionsv1beta1.CustomResourceDefinition,
+	createError error) bool {
+
+	if errors.IsAlreadyExists(createError) {
+		if clusterCRD.Spec.Validation == nil {
+			// no validation detected
+			return true
+		}
+		v, ok := clusterCRD.Labels[CustomResourceDefinitionSchemaVersionKey]
+		if !ok {
+			// no schema version detected
+			return true
+		}
+		clusterVersion, err := version.NewVersion(v)
+		if err != nil || clusterVersion.LessThan(comparableCRDSchemaVersion) {
+			// version in cluster is either unparsable or smaller than current version
+			return true
+		}
+	}
+	return false
 }
 
 func getStr(str string) *string {

--- a/pkg/k8s/apis/cilium.io/v2/register_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/register_test.go
@@ -1,0 +1,102 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	. "gopkg.in/check.v1"
+
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type CiliumV2RegisterSuite struct{}
+
+var _ = Suite(&CiliumV2RegisterSuite{})
+
+func (s *CiliumV2RegisterSuite) getTestUpToDateDefinition() *apiextensionsv1beta1.CustomResourceDefinition {
+	return &apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				CustomResourceDefinitionSchemaVersionKey: CustomResourceDefinitionSchemaVersion,
+			},
+		},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Validation: &crv,
+		},
+	}
+}
+
+func (s *CiliumV2RegisterSuite) TestNeedsUpdateNoUpdate(c *C) {
+	crd := s.getTestUpToDateDefinition()
+	e := errors.NewAlreadyExists(schema.GroupResource{}, "")
+
+	c.Assert(needsUpdate(crd, e), Equals, false)
+}
+
+func (s *CiliumV2RegisterSuite) TestNeedsUpdateNoValidation(c *C) {
+	crd := s.getTestUpToDateDefinition()
+	e := errors.NewAlreadyExists(schema.GroupResource{}, "")
+
+	crd.Spec.Validation = nil
+
+	c.Assert(needsUpdate(crd, e), Equals, true)
+}
+
+func (s *CiliumV2RegisterSuite) TestNeedsUpdateNoLabels(c *C) {
+	crd := s.getTestUpToDateDefinition()
+	e := errors.NewAlreadyExists(schema.GroupResource{}, "")
+
+	crd.Labels = nil
+
+	c.Assert(needsUpdate(crd, e), Equals, true)
+}
+
+func (s *CiliumV2RegisterSuite) TestNeedsUpdateNoVersionLabel(c *C) {
+	crd := s.getTestUpToDateDefinition()
+	e := errors.NewAlreadyExists(schema.GroupResource{}, "")
+
+	crd.Labels = map[string]string{"test": "test"}
+
+	c.Assert(needsUpdate(crd, e), Equals, true)
+}
+
+func (s *CiliumV2RegisterSuite) TestNeedsUpdateOlderVersion(c *C) {
+	crd := s.getTestUpToDateDefinition()
+	e := errors.NewAlreadyExists(schema.GroupResource{}, "")
+
+	crd.Labels[CustomResourceDefinitionSchemaVersionKey] = "0.9"
+
+	c.Assert(needsUpdate(crd, e), Equals, true)
+}
+
+func (s *CiliumV2RegisterSuite) TestNeedsUpdateCorruptedVersion(c *C) {
+	crd := s.getTestUpToDateDefinition()
+	e := errors.NewAlreadyExists(schema.GroupResource{}, "")
+
+	crd.Labels[CustomResourceDefinitionSchemaVersionKey] = "totally-not-semver"
+
+	c.Assert(needsUpdate(crd, e), Equals, true)
+}
+
+func (s *CiliumV2RegisterSuite) TestNeedsUpdateWrongError(c *C) {
+	crd := s.getTestUpToDateDefinition()
+	e := errors.NewUnauthorized("")
+
+	// Should be false, but this code path is unavailable in normal use.
+	// All errors other than AlreadyExists are handled before calling needsUpdate
+	c.Assert(needsUpdate(crd, e), Equals, false)
+}


### PR DESCRIPTION
Schema version for Cilium Network Policy CRD is stored in CRD label.
Label is taken into account when registering CRD to determine
whether CRD needs updating.

fixes #2544

Until this feature is implemented we need to do it on our side https://github.com/kubernetes/features/issues/544