### PR TITLE
Ginkgo: 05-cni migration

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -143,7 +143,7 @@ func (s *SSHMeta) WaitEndpointRegenerated(id string) bool {
 }
 
 // WaitEndpointsReady waits up until MaxRetries times for all endpoints to
-// not be in any regenerating or waiting-to-generate state. Returns true if
+// not be in any regenerating or waiting-for-identity state. Returns true if
 // all endpoints regenerate before MaxRetries are exceeded, false otherwise.
 func (s *SSHMeta) WaitEndpointsReady() bool {
 	logger := s.logger.WithFields(logrus.Fields{"functionName": "WaitEndpointsReady"})
@@ -154,6 +154,7 @@ func (s *SSHMeta) WaitEndpointsReady() bool {
 	// filter for endpoints (start with an endpoint id) and count not-ready endpoints
 	cmdString := "cilium endpoint list | egrep '^[0-9]+' | grep -v ready -c"
 	infoCmd := "cilium endpoint list"
+	s.Exec(infoCmd) //Executing this command to save all endpoints output in the logs
 	res := s.Exec(cmdString)
 	logger.Infof("string output of cmd: %s", res.stdout.String())
 	numEndpointsRegenerating, err := strconv.Atoi(strings.TrimSuffix(res.stdout.String(), "\n"))
@@ -185,7 +186,6 @@ func (s *SSHMeta) WaitEndpointsReady() bool {
 		}
 		counter++
 	}
-
 	return true
 }
 

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -199,12 +199,12 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 			res = vm.Exec(fmt.Sprintf(
 				"sudo -E PATH=$PATH:/opt/cni/bin -E CNI_PATH=%[1]s/bin %[1]s/cni/scripts/exec-plugins.sh add %s %s",
 				tmpDir.SingleOut(), containerID, netnspath))
-			res.ExpectSuccess()
+			res.ExpectSuccess("CNI exec-plugins did not work correctly '%s'", res.CombineOutput().String())
 
 			res = vm.ContainerCreate(
 				name, helpers.NetperfImage,
 				fmt.Sprintf("container:%s", containerID), fmt.Sprintf("-l %s", label))
-			res.ExpectSuccess()
+			res.ExpectSuccess("Container %s cannot be created", name)
 		}
 
 		It("Basic connectivity test", func() {

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -181,6 +181,7 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 		AfterEach(func() {
 			vm.ContainerRm(cniServer)
 			vm.ContainerRm(cniClient)
+			vm.Exec("docker rm -f $(docker ps | grep busybox:latest | awk '{print $1}')")
 		})
 
 		runCNIContainer := func(name string, label string) {
@@ -261,11 +262,10 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 			serverIPv4 := vm.ContainerExec(
 				cniServer,
 				`ip -4 a show dev eth0 scope global | grep inet | sed -e 's%.*inet \(.*\)\/.*%\1%'`)
-
 			vm.ContainerExec(cniClient, helpers.Ping6(serverIPv6.SingleOut())).ExpectSuccess(
-				"cannot ping6 from client to server %q", serverIPv6)
+				"cannot ping6 from client to server %q", serverIPv6.SingleOut())
 			vm.ContainerExec(cniClient, helpers.Ping(serverIPv4.SingleOut())).ExpectSuccess(
-				"cannot ping from client to server %q", serverIPv4)
+				"cannot ping from client to server %q", serverIPv4.SingleOut())
 		})
 	})
 })

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -2,6 +2,8 @@ package RuntimeTest
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/cilium/cilium/test/helpers"
@@ -25,19 +27,7 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 
 	BeforeEach(func() {
 		once.Do(initialize)
-		vm.ContainerCreate(helpers.Client, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
-		vm.ContainerCreate(helpers.Server, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.server")
-		vm.PolicyDelAll()
-		vm.WaitEndpointsReady()
-		err := helpers.WithTimeout(func() bool {
-			if data, _ := vm.GetEndpointsNames(); len(data) < 2 {
-				logger.Info("Waiting for endpoints to be ready")
-				return false
-			}
-			return true
-		}, "Endpoints are not ready", &helpers.TimeoutConfig{Timeout: 150})
-		Expect(err).Should(BeNil())
-	}, 150)
+	})
 
 	removeContainer := func(containerName string) {
 		By(fmt.Sprintf("removing container %s", containerName))
@@ -46,109 +36,237 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 	}
 
 	AfterEach(func() {
-		removeContainer(helpers.Client)
-		removeContainer(helpers.Server)
+		vm.PolicyDelAll().ExpectSuccess("Policies cannot be deleted")
 		return
 	})
 
-	It("Test connectivity between containers without policies imported", func() {
-		// TODO: this code is duplicated in the next "It" in this file. refactor it into a function.
-		// See if we can make the "Filter" strings for getting IPv4 and IPv6 addresses into constants.
-		By(fmt.Sprintf("inspecting container %s", helpers.Server))
-		serverData := vm.ContainerInspect(helpers.Server)
-		serverIP, err := serverData.Filter(fmt.Sprintf("{[0].NetworkSettings.Networks.%s.IPAddress}", helpers.CiliumDockerNetwork))
-		Expect(err).Should(BeNil())
+	Context("Basic Connectivy test", func() {
 
-		By(fmt.Sprintf("serverIP: %s", serverIP))
-		serverIPv6, err := serverData.Filter(fmt.Sprintf("{[0].NetworkSettings.Networks.%s.GlobalIPv6Address}", helpers.CiliumDockerNetwork))
-		By(fmt.Sprintf("serverIPv6: %s", serverIPv6))
-		Expect(err).Should(BeNil())
+		BeforeEach(func() {
+			vm.ContainerCreate(helpers.Client, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
+			vm.ContainerCreate(helpers.Server, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.server")
+			vm.PolicyDelAll()
+			vm.WaitEndpointsReady()
+			err := helpers.WithTimeout(func() bool {
+				if data, _ := vm.GetEndpointsNames(); len(data) < 2 {
+					logger.Info("Waiting for endpoints to be ready")
+					return false
+				}
+				return true
+			}, "Endpoints are not ready", &helpers.TimeoutConfig{Timeout: 150})
+			Expect(err).Should(BeNil())
+		}, 150)
 
-		By(fmt.Sprintf("checking %s can ping to %s IPv6", helpers.Client, helpers.Server))
-		res := vm.ContainerExec(helpers.Client, helpers.Ping6(serverIPv6.String()))
-		res.ExpectSuccess()
+		AfterEach(func() {
+			removeContainer(helpers.Client)
+			removeContainer(helpers.Server)
+			return
+		})
 
-		By(fmt.Sprintf("checking %s can ping to %s IPv4", helpers.Client, helpers.Server))
-		res = vm.ContainerExec(helpers.Client, helpers.Ping(serverIP.String()))
-		res.ExpectSuccess()
+		It("Test connectivity between containers without policies imported", func() {
+			// TODO: this code is duplicated in the next "It" in this file. refactor it into a function.
+			// See if we can make the "Filter" strings for getting IPv4 and IPv6 addresses into constants.
+			By(fmt.Sprintf("inspecting container %s", helpers.Server))
+			serverData := vm.ContainerInspect(helpers.Server)
+			serverIP, err := serverData.Filter(fmt.Sprintf("{[0].NetworkSettings.Networks.%s.IPAddress}", helpers.CiliumDockerNetwork))
+			Expect(err).Should(BeNil())
 
-		// TODO: remove this hardcoding ; it is not clean. Have command wrappers that take maps of strings.
-		By(fmt.Sprintf("netperf to %s from %s IPv6", helpers.Server, helpers.Client))
-		cmd := fmt.Sprintf(
-			"netperf -c -C -t TCP_SENDFILE -H %s", serverIPv6)
+			By(fmt.Sprintf("serverIP: %s", serverIP))
+			serverIPv6, err := serverData.Filter(fmt.Sprintf("{[0].NetworkSettings.Networks.%s.GlobalIPv6Address}", helpers.CiliumDockerNetwork))
+			By(fmt.Sprintf("serverIPv6: %s", serverIPv6))
+			Expect(err).Should(BeNil())
 
-		res = vm.ContainerExec(helpers.Client, cmd)
-		res.ExpectSuccess()
-	}, 300)
+			By(fmt.Sprintf("checking %s can ping to %s IPv6", helpers.Client, helpers.Server))
+			res := vm.ContainerExec(helpers.Client, helpers.Ping6(serverIPv6.String()))
+			res.ExpectSuccess()
 
-	It("Test connectivity between containers with policy imported", func() {
-		policyID, err := vm.PolicyImport(
-			fmt.Sprintf("%s/test.policy", vm.ManifestsPath()), 150)
-		Expect(err).Should(BeNil())
-		logger.Debug("New policy created with id '%d'", policyID)
+			By(fmt.Sprintf("checking %s can ping to %s IPv4", helpers.Client, helpers.Server))
+			res = vm.ContainerExec(helpers.Client, helpers.Ping(serverIP.String()))
+			res.ExpectSuccess()
 
-		serverData := vm.ContainerInspect(helpers.Server)
-		serverIP, err := serverData.Filter(fmt.Sprintf("{[0].NetworkSettings.Networks.%s.IPAddress}", helpers.CiliumDockerNetwork))
-		Expect(err).Should(BeNil())
-		By(fmt.Sprintf("serverIP: %s", serverIP))
-		serverIPv6, err := serverData.Filter(fmt.Sprintf("{[0].NetworkSettings.Networks.%s.GlobalIPv6Address}", helpers.CiliumDockerNetwork))
-		By(fmt.Sprintf("serverIPv6: %s", serverIPv6))
-		Expect(err).Should(BeNil())
+			// TODO: remove this hardcoding ; it is not clean. Have command wrappers that take maps of strings.
+			By(fmt.Sprintf("netperf to %s from %s IPv6", helpers.Server, helpers.Client))
+			cmd := fmt.Sprintf(
+				"netperf -c -C -t TCP_SENDFILE -H %s", serverIPv6)
 
-		By(fmt.Sprintf("%s can ping to %s IPV6", helpers.Client, helpers.Server))
-		res := vm.ContainerExec(helpers.Client, helpers.Ping6(serverIPv6.String()))
-		res.ExpectSuccess()
+			res = vm.ContainerExec(helpers.Client, cmd)
+			res.ExpectSuccess()
+		}, 300)
 
-		By(fmt.Sprintf("%s can ping to %s IPv4", helpers.Client, helpers.Server))
-		res = vm.ContainerExec(helpers.Client, helpers.Ping(serverIP.String()))
-		res.ExpectSuccess()
+		It("Test connectivity between containers with policy imported", func() {
+			policyID, err := vm.PolicyImport(
+				fmt.Sprintf("%s/test.policy", vm.ManifestsPath()), 150)
+			Expect(err).Should(BeNil())
+			logger.Debug("New policy created with id '%d'", policyID)
 
-		By(fmt.Sprintf("netperf to %s from %s (should succeed)", helpers.Server, helpers.Client))
-		cmd := fmt.Sprintf("netperf -c -C -H %s", serverIP)
-		res = vm.ContainerExec(helpers.Client, cmd)
+			serverData := vm.ContainerInspect(helpers.Server)
+			serverIP, err := serverData.Filter(fmt.Sprintf("{[0].NetworkSettings.Networks.%s.IPAddress}", helpers.CiliumDockerNetwork))
+			Expect(err).Should(BeNil())
+			By(fmt.Sprintf("serverIP: %s", serverIP))
+			serverIPv6, err := serverData.Filter(fmt.Sprintf("{[0].NetworkSettings.Networks.%s.GlobalIPv6Address}", helpers.CiliumDockerNetwork))
+			By(fmt.Sprintf("serverIPv6: %s", serverIPv6))
+			Expect(err).Should(BeNil())
 
-		// TODO: remove this hardcoding ; it is not clean. Have command wrappers that take maps of strings.
-		By(fmt.Sprintf("netperf to %s from %s IPv6 with -t TCP_SENDFILE", helpers.Server, helpers.Client))
-		cmd = fmt.Sprintf(
-			"netperf -c -C -t TCP_SENDFILE -H %s", serverIPv6)
+			By(fmt.Sprintf("%s can ping to %s IPV6", helpers.Client, helpers.Server))
+			res := vm.ContainerExec(helpers.Client, helpers.Ping6(serverIPv6.String()))
+			res.ExpectSuccess()
 
-		res = vm.ContainerExec(helpers.Client, cmd)
-		res.ExpectSuccess()
+			By(fmt.Sprintf("%s can ping to %s IPv4", helpers.Client, helpers.Server))
+			res = vm.ContainerExec(helpers.Client, helpers.Ping(serverIP.String()))
+			res.ExpectSuccess()
 
-		By(fmt.Sprintf("super_netperf to %s from %s (should succeed)", helpers.Server, helpers.Client))
-		cmd = fmt.Sprintf("super_netperf 10 -c -C -t TCP_SENDFILE -H %s", serverIP)
-		res = vm.ContainerExec(helpers.Client, cmd)
-		res.ExpectSuccess()
+			By(fmt.Sprintf("netperf to %s from %s (should succeed)", helpers.Server, helpers.Client))
+			cmd := fmt.Sprintf("netperf -c -C -H %s", serverIP)
+			res = vm.ContainerExec(helpers.Client, cmd)
 
-		By(fmt.Sprintf("ping from %s to %s", helpers.Host, helpers.Server))
-		res = vm.Exec(helpers.Ping(serverIP.String()))
-		res.ExpectSuccess()
-	}, 300)
+			// TODO: remove this hardcoding ; it is not clean. Have command wrappers that take maps of strings.
+			By(fmt.Sprintf("netperf to %s from %s IPv6 with -t TCP_SENDFILE", helpers.Server, helpers.Client))
+			cmd = fmt.Sprintf(
+				"netperf -c -C -t TCP_SENDFILE -H %s", serverIPv6)
 
-	It("Test NAT46 connectivity between containers", func() {
+			res = vm.ContainerExec(helpers.Client, cmd)
+			res.ExpectSuccess()
 
-		endpoints, err := vm.GetEndpointsIds()
-		Expect(err).Should(BeNil(), "could not get endpoint IDs")
+			By(fmt.Sprintf("super_netperf to %s from %s (should succeed)", helpers.Server, helpers.Client))
+			cmd = fmt.Sprintf("super_netperf 10 -c -C -t TCP_SENDFILE -H %s", serverIP)
+			res = vm.ContainerExec(helpers.Client, cmd)
+			res.ExpectSuccess()
 
-		server, err := vm.ContainerInspectNet(helpers.Server)
-		Expect(err).Should(BeNil())
-		By(fmt.Sprintf("server: %s", server))
+			By(fmt.Sprintf("ping from %s to %s", helpers.Host, helpers.Server))
+			res = vm.Exec(helpers.Ping(serverIP.String()))
+			res.ExpectSuccess()
+		}, 300)
 
-		client, err := vm.ContainerInspectNet(helpers.Client)
-		Expect(err).Should(BeNil())
-		By(fmt.Sprintf("client: %s", client))
+		It("Test NAT46 connectivity between containers", func() {
 
-		status := vm.EndpointSetConfig(endpoints[helpers.Client], "NAT46", helpers.OptionEnabled)
-		Expect(status).Should(BeTrue())
+			endpoints, err := vm.GetEndpointsIds()
+			Expect(err).Should(BeNil(), "could not get endpoint IDs")
 
-		res := vm.ContainerExec(helpers.Client, helpers.Ping6(fmt.Sprintf(
-			"::FFFF:%s", server[helpers.IPv4])))
+			server, err := vm.ContainerInspectNet(helpers.Server)
+			Expect(err).Should(BeNil())
+			By(fmt.Sprintf("server: %s", server))
 
-		res.ExpectSuccess()
+			client, err := vm.ContainerInspectNet(helpers.Client)
+			Expect(err).Should(BeNil())
+			By(fmt.Sprintf("client: %s", client))
 
-		res = vm.ContainerExec(helpers.Server,
-			helpers.Ping6(fmt.Sprintf("::FFFF:%s", client[helpers.IPv4])))
-		res.ExpectFail(fmt.Sprintf("unexpectedly succeeded pinging IPv6 %s from %s", client[helpers.IPv4], helpers.Server))
+			status := vm.EndpointSetConfig(endpoints[helpers.Client], "NAT46", helpers.OptionEnabled)
+			Expect(status).Should(BeTrue())
+
+			res := vm.ContainerExec(helpers.Client, helpers.Ping6(fmt.Sprintf(
+				"::FFFF:%s", server[helpers.IPv4])))
+
+			res.ExpectSuccess()
+
+			res = vm.ContainerExec(helpers.Server,
+				helpers.Ping6(fmt.Sprintf("::FFFF:%s", client[helpers.IPv4])))
+			res.ExpectFail(fmt.Sprintf("unexpectedly succeeded pinging IPv6 %s from %s",
+				client[helpers.IPv4], helpers.Server))
+		})
+	})
+
+	Context("With CNI", func() {
+		var (
+			cniPlugin   = "/opt/cni/bin/cilium-cni"
+			dockerImage = "busybox:latest"
+			cniServer   = "cni-server"
+			cniClient   = "cni-client"
+		)
+		var tmpDir *helpers.CmdRes
+
+		BeforeEach(func() {
+			vm.PolicyDelAll().ExpectSuccess("Policies cannot be deleted")
+		})
+
+		AfterEach(func() {
+			vm.ContainerRm(cniServer)
+			vm.ContainerRm(cniClient)
+		})
+
+		runCNIContainer := func(name string, label string) {
+			res := vm.Exec(fmt.Sprintf("docker run -t -d --net=none -l %s %s", label, dockerImage))
+			res.ExpectSuccess()
+			containerID := res.SingleOut()
+
+			pid := vm.Exec(fmt.Sprintf("docker inspect -f '{{ .State.Pid }}' %s", containerID))
+			pid.ExpectSuccess()
+			netnspath := fmt.Sprintf("/proc/%s/ns/net", pid.SingleOut())
+
+			res = vm.Exec(fmt.Sprintf(
+				"sudo -E PATH=$PATH:/opt/cni/bin -E CNI_PATH=%[1]s/bin %[1]s/cni/scripts/exec-plugins.sh add %s %s",
+				tmpDir.SingleOut(), containerID, netnspath))
+			res.ExpectSuccess()
+
+			res = vm.ContainerCreate(
+				name, helpers.NetperfImage,
+				fmt.Sprintf("container:%s", containerID), fmt.Sprintf("-l %s", label))
+			res.ExpectSuccess()
+		}
+
+		It("Basic connectivity test", func() {
+			filename := "10-cilium-cni.conf"
+			tmpDir = vm.Exec("mktemp -d")
+			tmpDir.ExpectSuccess("TMP folder cannot be created %s", tmpDir.Output())
+			defer vm.Exec(fmt.Sprintf("rm -rf %s", tmpDir.Output()))
+			netDPath := filepath.Join(tmpDir.SingleOut(), "net.d")
+			vm.Exec(fmt.Sprintf("mkdir -p %s", netDPath)).ExpectSuccess()
+
+			cniConf := `{"name": "cilium",
+				"type": "cilium-cni",
+				"mtu": 1450}`
+
+			err := helpers.RenderTemplateToFile(filename, cniConf, os.ModePerm)
+			Expect(err).To(BeNil())
+
+			cmd := vm.Exec(fmt.Sprintf("cat %s > %s/%s",
+				helpers.GetFilePath(filename), netDPath, filename))
+			cmd.ExpectSuccess()
+			script := fmt.Sprintf(`
+				cd %s && \
+				git clone https://github.com/containernetworking/cni -b v0.5.2 --single-branch && \
+				cd cni && \
+				./build.sh
+			`, tmpDir.SingleOut())
+			vm.Exec(script).ExpectSuccess("Cannot install cni")
+			vm.Exec(fmt.Sprintf("cp %s %s", cniPlugin, filepath.Join(tmpDir.SingleOut(), "bin")))
+
+			By("Importing policy")
+			policyFileName := "CNI-policy.json"
+			policy := `
+				[{
+					"endpointSelector": {"matchLabels":{"id.server":""}},
+					"ingress": [{
+						"fromEndpoints": [
+						{"matchLabels":{"reserved:host":""}},
+						{"matchLabels":{"id.client":""}}
+					]
+					}]
+				}]`
+			err = helpers.RenderTemplateToFile(policyFileName, policy, os.ModePerm)
+			Expect(err).Should(BeNil())
+			_, err = vm.PolicyImport(helpers.GetFilePath(policyFileName), helpers.HelperTimeout)
+
+			By("Adding containers")
+
+			runCNIContainer(cniServer, "id.server")
+			runCNIContainer(cniClient, "id.client")
+
+			areEndpointsReady := vm.WaitEndpointsReady()
+			Expect(areEndpointsReady).Should(BeTrue())
+
+			serverIPv6 := vm.ContainerExec(
+				cniServer,
+				`ip -6 a show dev eth0 scope global | grep inet6 | sed -e 's%.*inet6 \(.*\)\/.*%\1%'`)
+
+			serverIPv4 := vm.ContainerExec(
+				cniServer,
+				`ip -4 a show dev eth0 scope global | grep inet | sed -e 's%.*inet \(.*\)\/.*%\1%'`)
+
+			vm.ContainerExec(cniClient, helpers.Ping6(serverIPv6.SingleOut())).ExpectSuccess(
+				"cannot ping6 from client to server %q", serverIPv6)
+			vm.ContainerExec(cniClient, helpers.Ping(serverIPv4.SingleOut())).ExpectSuccess(
+				"cannot ping from client to server %q", serverIPv4)
+		})
 	})
 })
 

--- a/tests/05-cni.sh
+++ b/tests/05-cni.sh
@@ -13,6 +13,9 @@ redirect_debug_logs ${LOGS_DIR}
 
 set -ex
 
+log "${TEST_NAME} has been deprecated and replaced by /test/runtime/connectivity.go:With CNI"
+exit 0
+
 server_id=""
 client_id=""
 


### PR DESCRIPTION
- Moving 05-cni.sh test to Ginkgo. 
- Added new context on runtime/connectivity.go testcase 



