### PR TITLE
refactor naming of CIDR-based policy

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -288,10 +288,10 @@ type Endpoint struct {
 	// reference to all policy related BPF
 	PolicyMap *policymap.PolicyMap `json:"-"`
 
-	// L3Policy is the CIDR based policy configuration of the endpoint
-	L3Policy *policy.L3Policy `json:"-"`
+	// CIDRPolicy is the CIDR based policy configuration of the endpoint
+	L3Policy *policy.CIDRPolicy `json:"-"`
 
-	// L3Maps is the datapath representation of L3Policy
+	// L3Maps is the datapath representation of CIDRPolicy
 	L3Maps L3Maps `json:"-"`
 
 	// Opts are configurable boolean options

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -431,7 +431,7 @@ func (e *Endpoint) regenerateL3Policy(owner Owner, repo *policy.Repository, revi
 	if owner.TracingEnabled() {
 		ctx.Trace = policy.TRACE_ENABLED
 	}
-	newL3policy := repo.ResolveL3Policy(&ctx)
+	newL3policy := repo.ResolveCIDRPolicy(&ctx)
 	// Perform the validation on the new policy
 	err := newL3policy.Validate()
 	valid := err == nil

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -62,7 +62,7 @@ func (i *IngressRule) sanitize() error {
 	}
 
 	if l := len(i.FromCIDR); l > MaxCIDREntries {
-		return fmt.Errorf("too many ingress L3 entries %d/%d", l, MaxCIDREntries)
+		return fmt.Errorf("too many ingress CIDR entries %d/%d", l, MaxCIDREntries)
 	}
 
 	for n := range i.FromCIDR {
@@ -91,7 +91,7 @@ func (e *EgressRule) sanitize() error {
 		}
 	}
 	if l := len(e.ToCIDR); l > MaxCIDREntries {
-		return fmt.Errorf("too many egress L3 entries %d/%d", l, MaxCIDREntries)
+		return fmt.Errorf("too many egress CIDR entries %d/%d", l, MaxCIDREntries)
 	}
 	for i := range e.ToCIDR {
 		if err := e.ToCIDR[i].sanitize(); err != nil {

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -156,18 +156,18 @@ func (p *Repository) ResolveL4Policy(ctx *SearchContext) (*L4Policy, error) {
 	return result, nil
 }
 
-// ResolveL3Policy resolves the L3 policy for a set of endpoints by searching
+// ResolveCIDRPolicy resolves the L3 policy for a set of endpoints by searching
 // the policy repository for `CIDR` rules that are attached to a `Rule`
 // where the EndpointSelector matches `ctx.To`. `ctx.From` takes no effect and
 // is ignored in the search.
-func (p *Repository) ResolveL3Policy(ctx *SearchContext) *L3Policy {
-	result := NewL3Policy()
+func (p *Repository) ResolveCIDRPolicy(ctx *SearchContext) *CIDRPolicy {
+	result := NewCIDRPolicy()
 
 	ctx.PolicyTrace("Resolving L3 (CIDR) policy for %+v\n", ctx.To)
 
 	state := traceState{}
 	for _, r := range p.rules {
-		r.resolveL3Policy(ctx, &state, result)
+		r.resolveCIDRPolicy(ctx, &state, result)
 		state.ruleID++
 	}
 

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -298,8 +298,9 @@ func (r *rule) resolveL4Policy(ctx *SearchContext, state *traceState, result *L4
 	return nil, nil
 }
 
-// mergeL3 checks
-func mergeL3(ctx *SearchContext, dir string, ipRules []api.CIDR, ruleLabels labels.LabelArray, resMap *CIDRPolicyMap) int {
+// mergeCIDR inserts all of the CIDRs in ipRules to resMap. Returns the number
+// of CIDRs added to resMap.
+func mergeCIDR(ctx *SearchContext, dir string, ipRules []api.CIDR, ruleLabels labels.LabelArray, resMap *CIDRPolicyMap) int {
 	found := 0
 
 	for _, r := range ipRules {
@@ -357,7 +358,7 @@ func (r *rule) resolveCIDRPolicy(ctx *SearchContext, state *traceState, result *
 
 		allCIDRs = append(allCIDRs, computeResultantCIDRSet(ingressRule.FromCIDRSet)...)
 
-		if cnt := mergeL3(ctx, "Ingress", allCIDRs, r.Labels, &result.Ingress); cnt > 0 {
+		if cnt := mergeCIDR(ctx, "Ingress", allCIDRs, r.Labels, &result.Ingress); cnt > 0 {
 			found += cnt
 		}
 	}
@@ -369,7 +370,7 @@ func (r *rule) resolveCIDRPolicy(ctx *SearchContext, state *traceState, result *
 
 		allCIDRs = append(allCIDRs, computeResultantCIDRSet(egressRule.ToCIDRSet)...)
 
-		if cnt := mergeL3(ctx, "Egress", allCIDRs, r.Labels, &result.Egress); cnt > 0 {
+		if cnt := mergeCIDR(ctx, "Egress", allCIDRs, r.Labels, &result.Egress); cnt > 0 {
 			found += cnt
 		}
 	}

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -298,7 +298,8 @@ func (r *rule) resolveL4Policy(ctx *SearchContext, state *traceState, result *L4
 	return nil, nil
 }
 
-func mergeL3(ctx *SearchContext, dir string, ipRules []api.CIDR, ruleLabels labels.LabelArray, resMap *L3PolicyMap) int {
+// mergeL3 checks
+func mergeL3(ctx *SearchContext, dir string, ipRules []api.CIDR, ruleLabels labels.LabelArray, resMap *CIDRPolicyMap) int {
 	found := 0
 
 	for _, r := range ipRules {
@@ -335,7 +336,12 @@ func computeResultantCIDRSet(cidrs []api.CIDRRule) []api.CIDR {
 	return allResultantAllowedCIDRs
 }
 
-func (r *rule) resolveL3Policy(ctx *SearchContext, state *traceState, result *L3Policy) *L3Policy {
+// resolveCIDRPolicy inserts the CIDRs from the specified rule into result if
+// the rule corresponds to the current SearchContext. It returns the resultant
+// CIDRPolicy containing the added ingress and egress CIDRs. If no CIDRs are
+// added to result, a nil CIDRPolicy is returned.
+func (r *rule) resolveCIDRPolicy(ctx *SearchContext, state *traceState, result *CIDRPolicy) *CIDRPolicy {
+	// Don't select rule if it doesn't apply to the given context.
 	if !r.EndpointSelector.Matches(ctx.To) {
 		state.unSelectRule(ctx, r)
 		return nil

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -551,26 +551,26 @@ func (ds *PolicyTestSuite) TestL3Policy(c *C) {
 	err = rule1.sanitize()
 	c.Assert(err, IsNil)
 
-	expected := NewL3Policy()
-	expected.Ingress.Map["10.0.1.0/24"] = &L3PolicyMapRule{Prefix: net.IPNet{IP: []byte{10, 0, 1, 0}, Mask: []byte{255, 255, 255, 0}}, DerivedFromRules: labels.LabelArrayList{nil}}
-	expected.Ingress.Map["192.168.2.0/24"] = &L3PolicyMapRule{Prefix: net.IPNet{IP: []byte{192, 168, 2, 0}, Mask: []byte{255, 255, 255, 0}}, DerivedFromRules: labels.LabelArrayList{nil}}
-	expected.Ingress.Map["10.0.3.1/32"] = &L3PolicyMapRule{Prefix: net.IPNet{IP: []byte{10, 0, 3, 1}, Mask: []byte{255, 255, 255, 255}}, DerivedFromRules: labels.LabelArrayList{nil}}
+	expected := NewCIDRPolicy()
+	expected.Ingress.Map["10.0.1.0/24"] = &CIDRPolicyMapRule{Prefix: net.IPNet{IP: []byte{10, 0, 1, 0}, Mask: []byte{255, 255, 255, 0}}, DerivedFromRules: labels.LabelArrayList{nil}}
+	expected.Ingress.Map["192.168.2.0/24"] = &CIDRPolicyMapRule{Prefix: net.IPNet{IP: []byte{192, 168, 2, 0}, Mask: []byte{255, 255, 255, 0}}, DerivedFromRules: labels.LabelArrayList{nil}}
+	expected.Ingress.Map["10.0.3.1/32"] = &CIDRPolicyMapRule{Prefix: net.IPNet{IP: []byte{10, 0, 3, 1}, Mask: []byte{255, 255, 255, 255}}, DerivedFromRules: labels.LabelArrayList{nil}}
 	expected.Ingress.IPv4Count = 3
-	expected.Ingress.Map["2001:db8::/48"] = &L3PolicyMapRule{Prefix: net.IPNet{IP: []byte{0x20, 1, 0xd, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, Mask: []byte{255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}, DerivedFromRules: labels.LabelArrayList{nil}}
-	expected.Ingress.Map["2001:db9::/128"] = &L3PolicyMapRule{Prefix: net.IPNet{IP: []byte{0x20, 1, 0xd, 0xb9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, Mask: []byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255}}, DerivedFromRules: labels.LabelArrayList{nil}}
+	expected.Ingress.Map["2001:db8::/48"] = &CIDRPolicyMapRule{Prefix: net.IPNet{IP: []byte{0x20, 1, 0xd, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, Mask: []byte{255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}, DerivedFromRules: labels.LabelArrayList{nil}}
+	expected.Ingress.Map["2001:db9::/128"] = &CIDRPolicyMapRule{Prefix: net.IPNet{IP: []byte{0x20, 1, 0xd, 0xb9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, Mask: []byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255}}, DerivedFromRules: labels.LabelArrayList{nil}}
 	expected.Ingress.IPv6Count = 2
-	expected.Egress.Map["10.1.0.0/16"] = &L3PolicyMapRule{Prefix: net.IPNet{IP: []byte{10, 1, 0, 0}, Mask: []byte{255, 255, 0, 0}}, DerivedFromRules: labels.LabelArrayList{nil}}
-	expected.Egress.Map["10.128.0.0/9"] = &L3PolicyMapRule{Prefix: net.IPNet{IP: []byte{10, 128, 0, 0}, Mask: []byte{255, 128, 0, 0}}, DerivedFromRules: labels.LabelArrayList{nil}}
-	expected.Egress.Map["10.0.0.0/10"] = &L3PolicyMapRule{Prefix: net.IPNet{IP: []byte{10, 0, 0, 0}, Mask: []byte{255, 192, 0, 0}}, DerivedFromRules: labels.LabelArrayList{nil}}
-	expected.Egress.Map["10.64.0.0/11"] = &L3PolicyMapRule{Prefix: net.IPNet{IP: []byte{10, 64, 0, 0}, Mask: []byte{255, 224, 0, 0}}, DerivedFromRules: labels.LabelArrayList{nil}}
-	expected.Egress.Map["10.112.0.0/12"] = &L3PolicyMapRule{Prefix: net.IPNet{IP: []byte{10, 112, 0, 0}, Mask: []byte{255, 240, 0, 0}}, DerivedFromRules: labels.LabelArrayList{nil}}
+	expected.Egress.Map["10.1.0.0/16"] = &CIDRPolicyMapRule{Prefix: net.IPNet{IP: []byte{10, 1, 0, 0}, Mask: []byte{255, 255, 0, 0}}, DerivedFromRules: labels.LabelArrayList{nil}}
+	expected.Egress.Map["10.128.0.0/9"] = &CIDRPolicyMapRule{Prefix: net.IPNet{IP: []byte{10, 128, 0, 0}, Mask: []byte{255, 128, 0, 0}}, DerivedFromRules: labels.LabelArrayList{nil}}
+	expected.Egress.Map["10.0.0.0/10"] = &CIDRPolicyMapRule{Prefix: net.IPNet{IP: []byte{10, 0, 0, 0}, Mask: []byte{255, 192, 0, 0}}, DerivedFromRules: labels.LabelArrayList{nil}}
+	expected.Egress.Map["10.64.0.0/11"] = &CIDRPolicyMapRule{Prefix: net.IPNet{IP: []byte{10, 64, 0, 0}, Mask: []byte{255, 224, 0, 0}}, DerivedFromRules: labels.LabelArrayList{nil}}
+	expected.Egress.Map["10.112.0.0/12"] = &CIDRPolicyMapRule{Prefix: net.IPNet{IP: []byte{10, 112, 0, 0}, Mask: []byte{255, 240, 0, 0}}, DerivedFromRules: labels.LabelArrayList{nil}}
 	expected.Egress.IPv4Count = 5
-	expected.Egress.Map["2001:dbf::/64"] = &L3PolicyMapRule{Prefix: net.IPNet{IP: []byte{0x20, 1, 0xd, 0xbf, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, Mask: []byte{255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0}}, DerivedFromRules: labels.LabelArrayList{nil}}
+	expected.Egress.Map["2001:dbf::/64"] = &CIDRPolicyMapRule{Prefix: net.IPNet{IP: []byte{0x20, 1, 0xd, 0xbf, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, Mask: []byte{255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0}}, DerivedFromRules: labels.LabelArrayList{nil}}
 	expected.Egress.IPv6Count = 1
 
 	toBar := &SearchContext{To: labels.ParseSelectLabelArray("bar")}
 	state := traceState{}
-	res := rule1.resolveL3Policy(toBar, &state, NewL3Policy())
+	res := rule1.resolveCIDRPolicy(toBar, &state, NewCIDRPolicy())
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
 	c.Assert(state.selectedRules, Equals, 1)
@@ -847,7 +847,7 @@ func (ds *PolicyTestSuite) TestL3RuleLabels(c *C) {
 	toBar := &SearchContext{To: labels.ParseSelectLabelArray("bar")}
 
 	for _, test := range testCases {
-		finalPolicy := NewL3Policy()
+		finalPolicy := NewCIDRPolicy()
 		for _, r := range test.rulesToApply {
 			apiRule := rules[r]
 			err := apiRule.Sanitize()
@@ -857,7 +857,7 @@ func (ds *PolicyTestSuite) TestL3RuleLabels(c *C) {
 			err = rule.sanitize()
 			c.Assert(err, IsNil, Commentf("Cannot sanitize Rule: %+v", rule))
 
-			rule.resolveL3Policy(toBar, &traceState{}, finalPolicy)
+			rule.resolveCIDRPolicy(toBar, &traceState{}, finalPolicy)
 		}
 
 		c.Assert(len(finalPolicy.Ingress.Map), Equals, len(test.expectedIngressLabels), Commentf(test.description))


### PR DESCRIPTION
The phrase L3 was used to refer to CIDR-based (not label-based) policy in some
parts of the codebase. This renames the CIDR-specific parts of code that refer
to CIDR based-policy as L3 policy to contain CIDR instead of L3 to make it
clearer that the relevant code only deals with CIDR-based policy, not
label-based policy.

Signed-off by: Ian Vernon <ian@cilium.io>