### PR TITLE
Correctly check msgSize in ReadResp before discarding.

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -100,7 +100,7 @@ github.com/google/gops 25312cafb9a191a6d377c480a4666beec3105e4a
 github.com/kardianos/osext ae77be60afb1dcacde03767a8c37337fad28ac14
 github.com/kr/text 7cafcd837844e784b526369c9bce262804aebc60
 github.com/kr/pretty cfb55aafdaf3ec08f0db22699ab822c50091b1c4
-github.com/optiopay/kafka 947cc36649a7bbef371f9a7c96d1b2b7500d87b3 https://github.com/cilium/kafka
+github.com/optiopay/kafka c411825615d9959fd44c0b455b86f8684f9c58b0 https://github.com/cilium/kafka
 github.com/golang/snappy 553a641470496b2327abcac10b36396bd98e45c9
 github.com/kevinburke/ssh_config db49ba357de1f26c56dac48a5de39c65785bf24a
 github.com/onsi/ginkgo 11459a886d9cd66b319dac7ef1e917ee221372c9

--- a/vendor/github.com/optiopay/kafka/proto/messages.go
+++ b/vendor/github.com/optiopay/kafka/proto/messages.go
@@ -119,7 +119,6 @@ func discard(r io.Reader, n int32) {
 	}
 }
 
-
 // ReadReq returns request kind ID and byte representation of the whole message
 // in wire protocol format.
 func ReadReq(r io.Reader) (requestKind int16, b []byte, err error) {
@@ -129,7 +128,7 @@ func ReadReq(r io.Reader) (requestKind int16, b []byte, err error) {
 		return 0, nil, err
 	}
 
-	if msgSize <=0 {
+	if msgSize <= 0 {
 		return 0, nil, io.ErrUnexpectedEOF
 	}
 
@@ -143,7 +142,7 @@ func ReadReq(r io.Reader) (requestKind int16, b []byte, err error) {
 	if err != nil {
 		if msgSize > 2 {
 			// We have already read the requestKind
-			discard(r, msgSize - 2)
+			discard(r, msgSize-2)
 		}
 		return 0, nil, err
 	}
@@ -177,7 +176,7 @@ func ReadResp(r io.Reader) (correlationID int32, b []byte, err error) {
 		return 0, nil, err
 	}
 
-	if msgSize <=0 {
+	if msgSize <= 0 {
 		return 0, nil, io.ErrUnexpectedEOF
 	}
 
@@ -189,9 +188,9 @@ func ReadResp(r io.Reader) (correlationID int32, b []byte, err error) {
 	// size of the message + size of the message itself
 	b, err = allocParseBuf(int(msgSize + 4))
 	if err != nil {
-		if msgSize > 2 {
+		if msgSize > 4 {
 			// We have already read the correlationID
-			discard(r, msgSize - 4)
+			discard(r, msgSize-4)
 		}
 		return 0, nil, err
 	}


### PR DESCRIPTION
Taking correlation ID into account, we need to check for 4 bytes and not 2 bytes.

Fixes : #2636

Signed-Off-By: Manali Bhutiyani <manali@covalent.io>

```release-note
Kafka: Correctly check msgSize in ReadResp before discarding.
```