### PR TITLE
daemon: Log Envoy version at startup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ GIT_VERSION: .git
 	echo "$(GIT_VERSION)" >GIT_VERSION
 
 envoy/SOURCE_VERSION: .git
-	git rev-parse HEAD >>envoy/SOURCE_VERSION
+	git rev-parse HEAD >envoy/SOURCE_VERSION
 
 docker-image: clean GIT_VERSION envoy/SOURCE_VERSION
 	grep -v -E "(SOURCE|GIT)_VERSION" .gitignore >.dockerignore

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -499,6 +500,18 @@ func initEnv(cmd *cobra.Command) {
 	log.Info("|  _| | | | | |     |")
 	log.Info("|___|_|_|_|___|_|_|_|")
 	log.Infof("Cilium %s", version.Version)
+
+	envoyVersion := envoy.GetEnvoyVersion()
+	log.Infof("%s", envoyVersion)
+
+	envoyVersionArray := strings.Fields(envoyVersion)
+	if len(envoyVersionArray) < 3 {
+		log.Fatal("Truncated Envoy version string, cannot verify version match.")
+	}
+	// Make sure Envoy version matches ours
+	if !strings.HasPrefix(envoyVersionArray[2], version.GetCiliumVersion().Revision) {
+		log.Fatal("Envoy version mismatch, aborting.")
+	}
 
 	if viper.GetBool("pprof") {
 		pprof.Enable()

--- a/envoy/Makefile
+++ b/envoy/Makefile
@@ -56,11 +56,11 @@ GO_TARGETS= $(API_TARGETS) $(CILIUM_TARGETS) $(FILTER_TARGETS)
 # Dockerfile builds require special options
 ifdef PKG_BUILD
 BAZEL_BUILD_OPTS = --spawn_strategy=standalone --genrule_strategy=standalone
-all: release
+all: clean-bins release
 else
 BAZEL_BUILD_OPTS =
 
-all: envoy $(GO_TARGETS)
+all: clean-bins envoy $(GO_TARGETS)
 endif
 
 debug: envoy-debug $(GO_TARGETS)
@@ -112,8 +112,7 @@ bazel-restore: $(BAZEL_ARCHIVE)
 	-mkdir $(dir $(BAZEL_CACHE))
 	cd $(dir $(BAZEL_CACHE)) && sudo tar xjf $(BAZEL_ARCHIVE) --warning=no-timestamp
 
-# Only remove the binaries, as relinking them takes minimal time, as this allows
-# the bazel cache size to be a little smaller.
+# Remove the binaries to get fresh version SHA
 clean-bins: force
 	-rm -f $(ENVOY_BINS)
 

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -94,6 +94,15 @@ type Logger interface {
 	Log(entry *HttpLogEntry)
 }
 
+// GetEnvoyVersion returns the envoy binary version string
+func GetEnvoyVersion() string {
+	out, err := exec.Command("cilium-envoy", "--version").Output()
+	if err != nil {
+		log.WithError(err).Fatal(`Envoy binary "cilium-envoy" cannot be executed`)
+	}
+	return strings.TrimSpace(string(out))
+}
+
 // StartEnvoy starts an Envoy proxy instance.
 func StartEnvoy(adminPort uint32, stateDir, logDir string, baseID uint64) *Envoy {
 	bootstrapPath := filepath.Join(stateDir, "bootstrap.pb")


### PR DESCRIPTION
Run the "cilium-envoy" binary with the "--version" option at the
startup and log version string that is output. Cause cilium-agent to
fail to start if "cilium-envoy" cannot be executed.

Fixes: #2632
Requested-by: André Martins <andre@cilium.io>
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
