### PR TITLE
Ginkgo: Migrated 01-guestbook test

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -135,6 +135,9 @@ const (
 	KubectlCreate = ResourceLifeCycleAction("create")
 	KubectlDelete = ResourceLifeCycleAction("delete")
 	KubectlApply  = ResourceLifeCycleAction("apply")
+
+	KubectlPolicyNameLabel      = "io.cilium.k8s-policy-name"
+	KubectlPolicyNameSpaceLabel = "io.cilium.k8s-policy-namespace"
 )
 
 var ciliumCLICommands = map[string]string{

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -509,6 +509,16 @@ func (kub *Kubectl) CiliumPolicyRevision(pod string) (int, error) {
 	return revi, nil
 }
 
+// CiliumIsPolicyLoaded returns true if the policy is loaded in the given
+// cilium Pod. it returns false in case that the policy is not in place
+func (kub *Kubectl) CiliumIsPolicyLoaded(pod string, policyCmd string) bool {
+	_, err := kub.ExecPodCmd(KubeSystemNamespace, pod, fmt.Sprintf("cilium policy get %s", policyCmd))
+	if err == nil {
+		return true
+	}
+	return false
+}
+
 // ResourceLifeCycleAction represents an action performed upon objects in
 // Kubernetes.
 type ResourceLifeCycleAction string

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -200,12 +200,12 @@ func (kub *Kubectl) NodeCleanMetadata() error {
 	return nil
 }
 
-// NamespaceCreate it creates a new kubernetes namespace with the given name
+// NamespaceCreate creates a new Kubernetes namespace with the given name
 func (kub *Kubectl) NamespaceCreate(name string) *CmdRes {
 	return kub.Exec(fmt.Sprintf("%s create namespace %s", KubectlCmd, name))
 }
 
-// NamespaceDelete it deletes a given kubernetes namespace
+// NamespaceDelete deletes a given Kubernetes namespace
 func (kub *Kubectl) NamespaceDelete(name string) *CmdRes {
 	return kub.Exec(fmt.Sprintf("%s delete namespace %s", KubectlCmd, name))
 }

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -200,6 +200,16 @@ func (kub *Kubectl) NodeCleanMetadata() error {
 	return nil
 }
 
+// NamespaceCreate it creates a new kubernetes namespace with the given name
+func (kub *Kubectl) NamespaceCreate(name string) *CmdRes {
+	return kub.Exec(fmt.Sprintf("%s create namespace %s", KubectlCmd, name))
+}
+
+// NamespaceDelete it deletes a given kubernetes namespace
+func (kub *Kubectl) NamespaceDelete(name string) *CmdRes {
+	return kub.Exec(fmt.Sprintf("%s delete namespace %s", KubectlCmd, name))
+}
+
 // WaitforPods waits up until timeout seconds have elapsed for all pods in the
 // specified namespace that match the provided JSONPath filter to have their
 // containterStatuses equal to "ready". Returns true if all pods achieve
@@ -274,7 +284,7 @@ func (kub *Kubectl) WaitForServiceEndpoints(namespace string, filter string, ser
 }
 
 // Action performs the specified ResourceLifeCycleAction on the Kubernetes
-// manifest located at path filepath.
+// manifest located at path filepath in the given namespace
 func (kub *Kubectl) Action(action ResourceLifeCycleAction, filePath string) *CmdRes {
 	kub.logger.Debugf("performing '%v' on '%v'", action, filePath)
 	return kub.Exec(fmt.Sprintf("%s %s -f %s", KubectlCmd, action, filePath))
@@ -523,9 +533,7 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 			return "", err
 		}
 		revisions[v] = revi
-		//kub.logger.Infof("CiliumPolicyAction: pod %q has revision %v", v, revi)
-		fmt.Printf("CiliumPolicyAction: pod %q has revision %d\n", v, revi)
-
+		kub.logger.Infof("CiliumPolicyAction: pod '%s' has revision '%v'", v, revi)
 	}
 
 	if status := kub.Action(action, filepath); !status.WasSuccessful() {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -112,18 +112,18 @@ var _ = Describe("K8sPolicyTest", func() {
 			return appPods
 		}
 
-		It("PolicyEnforcement Changes", func() {
+		It("tests PolicyEnforcement updates", func() {
 			// This is a small test that checks that basic policy enforcement
 			// changes are working in k8s. All the policy enforcement
 			// changes/combinations are tested in runtime/Policies.go
 			ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
-			Expect(err).Should(BeNil())
+			Expect(err).Should(BeNil(), "cannot get cilium pod on node %s", helpers.K8s1)
 
 			status := kubectl.CiliumExec(
 				ciliumPod, fmt.Sprintf("cilium config %s=%s",
 					helpers.PolicyEnforcement, helpers.PolicyEnforcementDefault))
-			status.ExpectSuccess()
-			helpers.Sleep(5)
+			status.ExpectSuccess("cannot change %s to %s",
+				helpers.PolicyEnforcement, helpers.PolicyEnforcementDefault)
 			kubectl.CiliumEndpointWait(ciliumPod)
 
 			epsStatus := helpers.WithTimeout(func() bool {
@@ -184,7 +184,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			Expect(policyStatus[models.EndpointPolicyEnabledBoth]).Should(Equal(0))
 		}, 500)
 
-		It("Policies", func() {
+		It("checks all kind of kubernetes policies", func() {
 			appPods := getAppPods(helpers.DefaultNamespace)
 			service := "app1-service"
 			clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, service)

--- a/test/k8sT/manifests/1.6/guestbook-policy-redis-deprecated.json
+++ b/test/k8sT/manifests/1.6/guestbook-policy-redis-deprecated.json
@@ -1,0 +1,40 @@
+{
+  "apiVersion": "extensions/v1beta1",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "guestbook-redis-deprecated"
+  },
+  "spec": {
+    "podSelector": {
+      "matchLabels": {
+        "k8s-app.guestbook": "redis"
+      }
+    },
+    "ingress": [
+      {
+        "from": [
+          {
+            "podSelector": {
+              "matchLabels": {
+                "k8s-app.guestbook": "web"
+              }
+            }
+          },
+          {
+            "podSelector": {
+              "matchLabels": {
+                "k8s-app.guestbook": "redis"
+              }
+            }
+          }
+        ],
+        "ports": [
+          {
+            "protocol": "TCP",
+            "port": 6379
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/k8sT/manifests/1.6/guestbook-policy-redis.json
+++ b/test/k8sT/manifests/1.6/guestbook-policy-redis.json
@@ -1,0 +1,40 @@
+{
+  "apiVersion": "extensions/v1beta1",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "guestbook-redis"
+  },
+  "spec": {
+    "podSelector": {
+      "matchLabels": {
+        "k8s-app.guestbook": "redis"
+      }
+    },
+    "ingress": [
+      {
+        "from": [
+          {
+            "podSelector": {
+              "matchLabels": {
+                "k8s-app.guestbook": "web"
+              }
+            }
+          },
+          {
+            "podSelector": {
+              "matchLabels": {
+                "k8s-app.guestbook": "redis"
+              }
+            }
+          }
+        ],
+        "ports": [
+          {
+            "protocol": "TCP",
+            "port": 6379
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/k8sT/manifests/1.6/guestbook-policy-web.yaml
+++ b/test/k8sT/manifests/1.6/guestbook-policy-web.yaml
@@ -1,0 +1,16 @@
+apiVersion: "cilium.io/v1"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "guestbook-web"
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s-app.guestbook: web
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        "reserved.world": ""
+    toPorts:
+    - ports:
+      - port: "3000"
+        protocol: TCP

--- a/test/k8sT/manifests/guestbook-policy-redis-deprecated.json
+++ b/test/k8sT/manifests/guestbook-policy-redis-deprecated.json
@@ -1,0 +1,40 @@
+{
+  "apiVersion": "extensions/v1beta1",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "guestbook-redis-deprecated"
+  },
+  "spec": {
+    "podSelector": {
+      "matchLabels": {
+        "k8s-app.guestbook": "redis"
+      }
+    },
+    "ingress": [
+      {
+        "from": [
+          {
+            "podSelector": {
+              "matchLabels": {
+                "k8s-app.guestbook": "web"
+              }
+            }
+          },
+          {
+            "podSelector": {
+              "matchLabels": {
+                "k8s-app.guestbook": "redis"
+              }
+            }
+          }
+        ],
+        "ports": [
+          {
+            "protocol": "TCP",
+            "port": 6379
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/k8sT/manifests/guestbook-policy-redis.json
+++ b/test/k8sT/manifests/guestbook-policy-redis.json
@@ -1,0 +1,40 @@
+{
+  "apiVersion": "networking.k8s.io/v1",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "guestbook-redis"
+  },
+  "spec": {
+    "podSelector": {
+      "matchLabels": {
+        "k8s-app.guestbook": "redis"
+      }
+    },
+    "ingress": [
+      {
+        "from": [
+          {
+            "podSelector": {
+              "matchLabels": {
+                "k8s-app.guestbook": "web"
+              }
+            }
+          },
+          {
+            "podSelector": {
+              "matchLabels": {
+                "k8s-app.guestbook": "redis"
+              }
+            }
+          }
+        ],
+        "ports": [
+          {
+            "protocol": "TCP",
+            "port": 6379
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/k8sT/manifests/guestbook-policy-web.yaml
+++ b/test/k8sT/manifests/guestbook-policy-web.yaml
@@ -1,0 +1,16 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "guestbook-web"
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s-app.guestbook: web
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        "reserved.world": ""
+    toPorts:
+    - ports:
+      - port: "3000"
+        protocol: TCP

--- a/test/k8sT/manifests/guestbook_deployment.json
+++ b/test/k8sT/manifests/guestbook_deployment.json
@@ -1,0 +1,160 @@
+{
+    "kind":"ReplicationController",
+    "apiVersion":"v1",
+    "metadata":{
+        "name":"redis-master",
+        "labels":{
+            "k8s-app.guestbook":"redis",
+            "role":"master"
+        }
+    },
+    "spec":{
+        "replicas":1,
+        "selector":{
+            "k8s-app.guestbook":"redis",
+            "role":"master"
+        },
+        "template":{
+            "metadata":{
+                "labels":{
+                    "k8s-app.guestbook":"redis",
+                    "role":"master",
+                    "zgroup": "guestbook"
+                }
+            },
+            "spec":{
+                "containers":[{
+                    "name":"redis-master",
+                    "image":"redis",
+                    "ports":[{
+                        "name":"redis-server",
+                        "containerPort":6379
+                    }]
+                }],
+                "nodeSelector": {
+                    "kubernetes.io/hostname": "k8s1"
+                }
+            }
+        }
+    }
+}
+{
+    "kind":"Service",
+    "apiVersion":"v1",
+    "metadata":{
+        "name":"redis-master",
+        "labels":{
+            "k8s-app.guestbook":"redis",
+            "role":"master",
+            "zgroup": "guestbook"
+        }
+    },
+    "spec":{
+        "ports": [{
+            "port":6379,
+            "targetPort":"redis-server"
+        }],
+        "selector":{
+            "k8s-app.guestbook":"redis",
+            "role":"master"
+        }
+    }
+}
+{
+    "kind":"ReplicationController",
+    "apiVersion":"v1",
+    "metadata":{
+        "name":"redis-slave",
+        "labels":{
+            "k8s-app.guestbook":"redis",
+            "role":"slave"
+        }
+    },
+    "spec":{
+        "replicas":1,
+        "selector":{
+            "k8s-app.guestbook":"redis",
+            "role":"slave"
+        },
+        "template":{
+            "metadata":{
+                "labels":{
+                    "k8s-app.guestbook":"redis",
+                    "role":"slave",
+                    "zgroup": "guestbook"
+                }
+            },
+            "spec":{
+                "containers":[{
+                    "name":"redis-slave",
+                    "image":"gcr.io/google_samples/gb-redisslave:v1",
+                    "ports":[{
+                        "name":"redis-server",
+                        "containerPort":6379
+                    }]
+                }],
+                "nodeSelector": {
+                    "kubernetes.io/hostname": "k8s1"
+                }
+            }
+        }
+    }
+}
+{
+    "kind":"Service",
+    "apiVersion":"v1",
+    "metadata":{
+        "name":"redis-slave",
+        "labels":{
+            "k8s-app.guestbook":"redis",
+            "role":"slave"
+        }
+    },
+    "spec":{
+        "ports": [{
+            "port":6379,
+            "targetPort":"redis-server"
+        }],
+        "selector":{
+            "k8s-app.guestbook":"redis",
+            "role":"slave"
+        }
+    }
+}
+{
+    "kind":"ReplicationController",
+    "apiVersion":"v1",
+    "metadata":{
+        "name":"guestbook",
+        "labels":{
+            "k8s-app.guestbook":"web"
+        }
+    },
+    "spec":{
+        "replicas":1,
+        "selector":{
+            "k8s-app.guestbook":"web"
+        },
+        "template":{
+            "metadata":{
+                "labels":{
+                    "k8s-app.guestbook":"web",
+                    "zgroup": "guestbook"
+                }
+            },
+            "spec":{
+                "containers":[{
+                    "name":"guestbook",
+                    "image":"kubernetes/guestbook:v2",
+                    "ports":[{
+                        "name":"http-server",
+                        "containerPort":3000
+                    }]
+                }],
+                "nodeSelector": {
+                    "kubernetes.io/hostname": "k8s2"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Migrated tests/k8s/tests/01-guestbook-test.sh to ginkgo
- Added the same policy in different namespace in a different test.

I didn't deprecated the 01-guestbook mainly because `k8sT/policies` are not validated yet. 

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

