### PR TITLE
Makefile: Simplify ctags/cscope tag generation

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -19,10 +19,6 @@ ifeq ("$(PKG_BUILD)","")
 
 all: $(BPF)
 
-tags: *.c $(LIB)
-	cscope -R -b -q
-	ctags -R .
-
 %.o: %.c $(LIB)
 	${CLANG} ${CLANG_FLAGS} -c $< -o - | ${LLC} ${LLC_FLAGS} -o $@
 
@@ -56,8 +52,5 @@ endif
 
 install:
 
-clean-tags:
-	-rm -f cscope.out cscope.in.out cscope.po.out tags
-
-clean: clean-tags
+clean:
 	rm -fr *.o


### PR DESCRIPTION
Having two separate sets of tags files is confusing and doesn't work
terribly well. Newer versions of ctags also support Go, so we can remove
the dependency on gotags. Fix up the dependencies and tags generation in
the top level Makefile to handle the bpf/ directory case as well.

Signed-off-by: Joe Stringer <joe@covalent.io>