### PR TITLE
Shift some remaining build scripts into contrib/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,7 @@ install-manpages:
 	mandb
 
 cmdref-check:
-	tests/00-check-cmdref.sh
+	contrib/scripts/check-cmdref.sh
 
 lock-check:
 	contrib/scripts/lock-check.sh

--- a/contrib/scripts/check-cmdref.sh
+++ b/contrib/scripts/check-cmdref.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
 
-# We need to include the helper file so that it makes sure we are using the
-# locally compiled Cilium binary.
-dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source "${dir}/helpers.bash"
-# dir might have been overwritten by helpers.bash
-dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 set -ex
 
-# Running this script should work both from CI and while building Cilium.
-DOCS_DIR=${dir}/../Documentation
+DOCS_DIR=./Documentation
 OLD_DIR=${DOCS_DIR}/cmdref
 TMP_DIR=`mktemp -d`
 

--- a/contrib/scripts/check-cmdref.sh
+++ b/contrib/scripts/check-cmdref.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 DOCS_DIR=./Documentation
 OLD_DIR=${DOCS_DIR}/cmdref

--- a/contrib/scripts/check-fmt.sh
+++ b/contrib/scripts/check-fmt.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env sh
 
-set -x
-
 diff="$(find . ! \( -path './contrib' -prune \) \
         ! \( -path './vendor' -prune \) \
         ! \( -path './.git' -prune \) \
         ! -samefile ./daemon/bindata.go \
         -type f -name '*.go' -print0 \
                 | xargs -0 gofmt -d -l -s )"
-set -e
 
 if [ -n "$diff" ]; then
 	echo "Unformatted Go source code:"


### PR DESCRIPTION
The cmdref checker is run on every build, so it can be shifted into `contrib/scripts/` to reduce the set of remaining tests to validate in `tests/`.  While we're at it, reduce the verbosity of these scripts as they seem to be pretty stable and can be more easily debugged when running locally.