### PR TITLE
Jenkins: Fix issues with new slaves

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
                 MEMORY = '4096'
                 RUN_TEST_SUITE = '1'
             }
-            steps { 
+            steps {
                 parallel(
                     "Print Environment": { sh 'env' },
                     "Runtime Tests": {
@@ -40,8 +40,8 @@ pipeline {
             archiveArtifacts artifacts: "cilium-files-k8s-${JOB_BASE_NAME}-${BUILD_NUMBER}.tar.gz", allowEmptyArchive: true
             sh 'rm -rf ${WORKSPACE}/cilium-files*${JOB_BASE_NAME}-${BUILD_NUMBER}* ${WORKSPACE}/tests/cilium-files ${WORKSPACE}/tests/k8s/tests/cilium-files'
             sh 'ls'
-            sh 'vagrant destroy -f'
-            sh 'cd ./tests/k8s && vagrant destroy -f'
+            sh 'vagrant destroy -f || true'
+            sh 'cd ./tests/k8s && vagrant destroy -f || true'
         }
     }
 }

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -38,7 +38,7 @@ pipeline {
                 always {
                     junit 'test/*.xml'
                     sh 'cd test/; ./post_build_agent.sh || true'
-                    sh 'cd test/; vagrant destroy -f'
+                    sh 'cd test/; vagrant destroy -f || true'
                     sh 'cd test/; ./archive_test_results.sh || true'
                     archiveArtifacts artifacts: "test_results_${JOB_BASE_NAME}_${BUILD_NUMBER}.tar", allowEmptyArchive: true
                 }

--- a/ginkgo-all.Jenkinsfile
+++ b/ginkgo-all.Jenkinsfile
@@ -44,8 +44,8 @@ pipeline {
             }
             post {
                 failure {
-                    sh "cd ${TESTDIR}; K8S_VERSION=1.7 vagrant destroy -f"
-                    sh "cd ${TESTDIR}; K8S_VERSION=1.6 vagrant destroy -f"
+                    sh "cd ${TESTDIR}; K8S_VERSION=1.7 vagrant destroy -f || true"
+                    sh "cd ${TESTDIR}; K8S_VERSION=1.6 vagrant destroy -f || true"
                 }
             }
         }
@@ -74,8 +74,8 @@ pipeline {
                     // Temporary workaround to test cleanup
                     // rm -rf ${GOPATH}/src/github.com/cilium/cilium
                     sh 'cd test/; ./post_build_agent.sh || true'
-                    sh 'cd test/; K8S_VERSION=1.7 vagrant destroy -f'
-                    sh 'cd test/; K8S_VERSION=1.6 vagrant destroy -f'
+                    sh 'cd test/; K8S_VERSION=1.7 vagrant destroy -f || true'
+                    sh 'cd test/; K8S_VERSION=1.6 vagrant destroy -f || true'
                     sh 'cd test/; ./archive_test_results.sh || true'
                     archiveArtifacts artifacts: "test_results_${JOB_BASE_NAME}_${BUILD_NUMBER}.tar", allowEmptyArchive: true
                 }

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -44,8 +44,8 @@ pipeline {
             }
             post {
                 failure {
-                    sh "cd ${TESTDIR}; K8S_VERSION=1.7 vagrant destroy -f"
-                    sh "cd ${TESTDIR}; K8S_VERSION=1.6 vagrant destroy -f"
+                    sh "cd ${TESTDIR}; K8S_VERSION=1.7 vagrant destroy -f || true"
+                    sh "cd ${TESTDIR}; K8S_VERSION=1.6 vagrant destroy -f || true"
                 }
             }
         }
@@ -79,8 +79,8 @@ pipeline {
                     // Temporary workaround to test cleanup
                     // rm -rf ${GOPATH}/src/github.com/cilium/cilium
                     sh 'cd test/; ./post_build_agent.sh || true'
-                    sh 'cd test/; K8S_VERSION=1.7 vagrant destroy -f'
-                    sh 'cd test/; K8S_VERSION=1.6 vagrant destroy -f'
+                    sh 'cd test/; K8S_VERSION=1.7 vagrant destroy -f || true'
+                    sh 'cd test/; K8S_VERSION=1.6 vagrant destroy -f || true'
                     sh 'cd test/; ./archive_test_results.sh || true'
                     archiveArtifacts artifacts: "test_results_${JOB_BASE_NAME}_${BUILD_NUMBER}.tar", allowEmptyArchive: true
                 }
@@ -116,8 +116,8 @@ pipeline {
                     // Temporary workaround to test cleanup
                     // rm -rf ${GOPATH}/src/github.com/cilium/cilium
                     sh 'cd test/; ./post_build_agent.sh || true'
-                    sh 'cd test/; K8S_VERSION=1.7 vagrant destroy -f'
-                    sh 'cd test/; K8S_VERSION=1.6 vagrant destroy -f'
+                    sh 'cd test/; K8S_VERSION=1.7 vagrant destroy -f || true'
+                    sh 'cd test/; K8S_VERSION=1.6 vagrant destroy -f || true'
                     sh 'cd test/; ./archive_test_results.sh || true'
                     archiveArtifacts artifacts: "test_results_${JOB_BASE_NAME}_${BUILD_NUMBER}.tar", allowEmptyArchive: true
                 }

--- a/tests/k8s/run-tests.bash
+++ b/tests/k8s/run-tests.bash
@@ -97,7 +97,7 @@ function run_tests(){
 }
 
 # Docker registry not needed after provisioning.
-VAGRANT_DEFAULT_PROVIDER=virtualbox vagrant destroy -f ${builder}
+VAGRANT_DEFAULT_PROVIDER=virtualbox vagrant destroy -f ${builder} || echo "Nothing to destroy"
 
 # Run tests in k8s 1.6.6 (which is installed by default in Vagrantfile)
 run_tests "1.6.6-00"

--- a/tests/start_vms
+++ b/tests/start_vms
@@ -2,11 +2,11 @@
 
 set -e
 
-# This script must be launched with Jenkins only. 
+# This script must be launched with Jenkins only.
 cd ${WORKSPACE}
 
 echo "Destroying runtime test VM if it's already running"
-vagrant destroy -f
+vagrant destroy -f || echo "Nothing to destroy"
 
 echo "Starting runtime test VM"
 NO_PROVISION=1 ./contrib/vagrant/start.sh
@@ -14,7 +14,7 @@ NO_PROVISION=1 ./contrib/vagrant/start.sh
 cd tests/k8s
 
 echo "Destorying K8s VMs if they are already running"
-vagrant destroy -f
+vagrant destroy -f || echo "Nothing to destroy"
 
 echo "Starting K8s VMs"
 VAGRANT_DEFAULT_PROVIDER=virtualbox vagrant up --provider=virtualbox --no-provision


### PR DESCRIPTION
With Vagrant version 2.0.1 the `vagrant destroy -f` command exits with 1
if no servers are destroyed. Builds with the new slaves failed and it
never completes the test

Related to #2438 

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
