### PR TITLE
envoy: Implement an Envoy xDS protocol server

### DIFF
--- a/pkg/envoy/xds/cache.go
+++ b/pkg/envoy/xds/cache.go
@@ -1,0 +1,222 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import (
+	"context"
+	"sort"
+
+	"github.com/cilium/cilium/pkg/envoy/api"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/sirupsen/logrus"
+)
+
+// Cache is a key-value container which allows atomically updating entries and
+// incrementing a version number and notifying observers if the cache is actually
+// modified.
+// Cache implements the ObservableResourceSet interface.
+// This cache implementation ignores the proxy node identifiers, i.e. the same
+// resources are available under the same names to all nodes.
+type Cache struct {
+	*BaseObservableResourceSource
+
+	// resources is the map of cached resource name to resource entry.
+	resources map[cacheKey]cacheValue
+
+	// version is the current version of the resources in the cache.
+	version uint64
+}
+
+// cacheKey uniquely identifies a resource.
+type cacheKey struct {
+	// typeURL is the URL that uniquely identifies the resource's type.
+	typeURL string
+
+	// resourceName is the name of the resource, unique among all the resources
+	// of this type.
+	resourceName string
+}
+
+// cacheValue is a cached resource.
+type cacheValue struct {
+	// resource is the resource in this cache entry.
+	resource proto.Message
+
+	// lastModifiedVersion is the version when this resource entry was last
+	// modified.
+	lastModifiedVersion uint64
+}
+
+// NewCache creates a new, empty cache with 0 as its current version.
+func NewCache() *Cache {
+	return &Cache{
+		BaseObservableResourceSource: NewBaseObservableResourceSource(),
+		resources:                    make(map[cacheKey]cacheValue),
+		version:                      0,
+	}
+}
+
+// tx inserts/updates a set of resources, then deletes a set of resources, then
+// increases the cache's version number atomically if the cache is actually
+// changed.
+// The version after updating the set is returned.
+func (c *Cache) tx(typeURL string, upsertedResources map[string]proto.Message, deletedNames []string) (version uint64, updated bool) {
+	c.locker.Lock()
+	defer c.locker.Unlock()
+
+	cacheIsUpdated := false
+	newVersion := c.version + 1
+
+	cacheLog := log.WithFields(logrus.Fields{
+		logfields.XDSTypeURL:     typeURL,
+		logfields.XDSVersionInfo: newVersion,
+	})
+
+	cacheLog.Debugf("preparing new cache transaction: upserting %d entries, deleting %d entries",
+		len(upsertedResources), len(deletedNames))
+
+	k := cacheKey{
+		typeURL: typeURL,
+	}
+
+	v := cacheValue{
+		lastModifiedVersion: newVersion,
+	}
+
+	for name, value := range upsertedResources {
+		k.resourceName = name
+		oldV, found := c.resources[k]
+		// If the value is unchanged, don't update the entry, to preserve its
+		// lastModifiedVersion. This allows minimizing the frequency of
+		// responses in GetResources.
+		// Calling proto.Message.String is not very cheap, but we assume that
+		// the reduced churn between the clients and the server is worth it.
+		if !found || oldV.resource.String() != value.String() {
+			if found {
+				cacheLog.WithField(logfields.XDSResourceName, name).Debug("updating resource in cache")
+			} else {
+				cacheLog.WithField(logfields.XDSResourceName, name).Debug("inserting resource into cache")
+			}
+			cacheIsUpdated = true
+			v.resource = value
+			c.resources[k] = v
+		}
+	}
+
+	for _, name := range deletedNames {
+		k.resourceName = name
+		_, found := c.resources[k]
+		if found {
+			cacheLog.WithField(logfields.XDSResourceName, name).
+				Debug("deleting resource from cache")
+			cacheIsUpdated = true
+			delete(c.resources, k)
+		}
+	}
+
+	if cacheIsUpdated {
+		cacheLog.Debug("committing cache transaction and notifying of new version")
+		c.version = newVersion
+		c.NotifyNewResourceVersionRLocked(typeURL, c.version)
+	} else {
+		cacheLog.Debug("cache unmodified by transaction; aborting")
+	}
+
+	return c.version, cacheIsUpdated
+}
+
+func (c *Cache) Upsert(typeURL string, resourceName string, resource proto.Message) (version uint64, updated bool) {
+	return c.tx(typeURL, map[string]proto.Message{resourceName: resource}, nil)
+}
+
+func (c *Cache) Delete(typeURL string, resourceName string) (version uint64, updated bool) {
+	return c.tx(typeURL, nil, []string{resourceName})
+}
+
+func (c *Cache) GetResources(ctx context.Context, typeURL string, lastVersion *uint64,
+	node *api.Node, resourceNames []string) (*VersionedResources, error) {
+	c.locker.RLock()
+	defer c.locker.RUnlock()
+
+	cacheLog := log.WithFields(logrus.Fields{
+		logfields.XDSVersionInfo: lastVersion,
+		logfields.XDSClientNode:  node,
+		logfields.XDSTypeURL:     typeURL,
+	})
+
+	res := &VersionedResources{
+		Version: c.version,
+		Canary:  false,
+	}
+
+	// Return all resources.
+	if len(resourceNames) == 0 {
+		res.ResourceNames = make([]string, 0, len(c.resources))
+		res.Resources = make([]proto.Message, 0, len(c.resources))
+		cacheLog.Debugf("no resource names requested, returning all %d resources", len(c.resources))
+		for k, v := range c.resources {
+			res.ResourceNames = append(res.ResourceNames, k.resourceName)
+			res.Resources = append(res.Resources, v.resource)
+		}
+		return res, nil
+	}
+
+	// Return only the resources with the requested names.
+
+	// As an optimization, if all the requested resources are found but none of
+	// them has been modified since the lastVersion, return no response.
+	// If at least one resource is not found, return all the found resources
+	// anyway, because we don't know whether the missing resource was deleted
+	// after the lastVersion, so we can't optimize in this case.
+
+	res.ResourceNames = make([]string, 0, len(resourceNames))
+	res.Resources = make([]proto.Message, 0, len(resourceNames))
+
+	k := cacheKey{typeURL: typeURL}
+
+	allResourcesFound := true
+	updatedSinceLastVersion := false
+
+	cacheLog.Debugf("%d resource names requested, filtering resources", len(resourceNames))
+
+	for _, name := range resourceNames {
+		k.resourceName = name
+		v, found := c.resources[k]
+		if found {
+			cacheLog.WithField(logfields.XDSResourceName, name).
+				Debugf("resource found, last modified in version %d", v.lastModifiedVersion)
+			if lastVersion == nil || (*lastVersion < v.lastModifiedVersion) {
+				updatedSinceLastVersion = true
+			}
+			res.ResourceNames = append(res.ResourceNames, name)
+			res.Resources = append(res.Resources, v.resource)
+		} else {
+			cacheLog.WithField(logfields.XDSResourceName, name).Debug("resource not found")
+			allResourcesFound = false
+		}
+	}
+
+	if allResourcesFound && !updatedSinceLastVersion {
+		cacheLog.Debug("all requested resources found but not updated since last version, returning no response")
+		return nil, nil
+	}
+
+	sort.Strings(res.ResourceNames)
+
+	cacheLog.Debugf("returning %d resources out of %d requested", len(res.Resources), len(resourceNames))
+	return res, nil
+}

--- a/pkg/envoy/xds/doc.go
+++ b/pkg/envoy/xds/doc.go
@@ -1,0 +1,60 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package xds is an implementation of Envoy's xDS (Discovery Service)
+// protocol.
+//
+// Server is the base implementation of any gRPC server which supports the xDS
+// protocol. All xDS bi-directional gRPC streams from Stream* calls must be
+// handled by calling Server.HandleRequestStream.
+// For example, to implement the ADS protocol:
+//
+//    func (s *myGRPCServer) StreamAggregatedResources(stream api.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
+//        return s.xdsServer.HandleRequestStream(stream.Context(), stream, xds.AnyTypeURL)
+//    }
+//
+// Server is parameterized by a map of supported resource type URLs to resource
+// sets, e.g. to support the LDS and RDS protocols:
+//
+//    ldsCache := xds.NewCache()
+//    rdsCache := xds.NewCache()
+//    sets := map[string]xds.ObservableResourceSource{
+//        "type.googleapis.com/envoy.api.v2.Listener": ldsCache,
+//        "type.googleapis.com/envoy.api.v2.RouteConfiguration": rdsCache,
+//    }
+//    server := xds.NewServer(sets, 5*time.Seconds)
+//
+// It is recommended to use a distinct resource set for each resource type to
+// minimize the volume of messages sent and received by xDS clients.
+//
+// Resource sets must implement the ResourceSource interface to provide read
+// access to resources of one or multiple resource types:
+//
+//    type ResourceSource interface {
+//        GetResources(ctx context.Context, typeURL string, lastVersion *uint64,
+//            node *api.Node, resourceNames []string) (*VersionedResources, error)
+//    }
+//
+// Resource sets should implement the ResourceSet interface to provide
+// read-write access. It provides an API to atomically update the resources in
+// the set: Upsert inserts or updates a single resource in the set, and
+// Delete deletes a single resource from the set.
+//
+// Cache is an efficient, ready-to-use implementation of ResourceSet:
+//
+//    typeURL := "type.googleapis.com/envoy.api.v2.Listener"
+//    ldsCache := xds.NewCache()
+//    ldsCache.Upsert(typeURL, "listener123", listenerA)
+//    ldsCache.Delete(typeURL, "listener456")
+package xds

--- a/pkg/envoy/xds/log.go
+++ b/pkg/envoy/xds/log.go
@@ -1,0 +1,19 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import "github.com/cilium/cilium/pkg/logging"
+
+var log = logging.DefaultLogger

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -1,0 +1,361 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import (
+	"context"
+	"errors"
+	"io"
+	"reflect"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"github.com/cilium/cilium/pkg/envoy/api"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// AnyTypeURL is the default type URL to use for ADS resource sets.
+	AnyTypeURL = ""
+)
+
+var (
+	// ErrNoADSTypeURL is the error returned when receiving a request without
+	// a type URL from an ADS stream.
+	ErrNoADSTypeURL = errors.New("type URL is required for ADS")
+
+	// ErrUnknownTypeURL is the error returned when receiving a request with
+	// an unknown type URL.
+	ErrUnknownTypeURL = errors.New("unknown type URL")
+
+	// ErrInvalidVersionInfo is the error returned when receiving a request
+	// with a version info that is not a positive integer.
+	ErrInvalidVersionInfo = errors.New("invalid version info")
+
+	// ErrResourceWatch is the error returned whenever an internal error
+	// occurs while waiting for new versions of resources.
+	ErrResourceWatch = errors.New("resource watch failed")
+)
+
+// Server implements the handling of xDS streams.
+type Server struct {
+	// watchers maps each supported type URL to its corresponding resource
+	// watcher.
+	watchers map[string]*ResourceWatcher
+
+	// lastStreamID is the identifier of the last processed stream.
+	// It is incremented atomically when starting the handling of a new stream.
+	lastStreamID uint64
+}
+
+// NewServer creates an xDS gRPC stream handler using the given resource
+// sources. sources maps each supported type URL to its corresponding resource
+// source.
+func NewServer(sources map[string]ObservableResourceSource, resourceAccessTimeout time.Duration) *Server {
+	watchers := make(map[string]*ResourceWatcher, len(sources))
+	for typeURL, source := range sources {
+		w := NewResourceWatcher(typeURL, source, resourceAccessTimeout)
+		source.AddResourceVersionObserver(w)
+		watchers[typeURL] = w
+	}
+
+	// TODO: Unregister the watchers when stopping the server.
+
+	return &Server{watchers: watchers}
+}
+
+func getXDSRequestFields(req *api.DiscoveryRequest) logrus.Fields {
+	return logrus.Fields{
+		logfields.XDSVersionInfo: req.GetVersionInfo(),
+		logfields.XDSClientNode:  req.GetNode().GetId(),
+		logfields.XDSTypeURL:     req.GetTypeUrl(),
+		logfields.XDSNonce:       req.GetResponseNonce(),
+	}
+}
+
+// HandleRequestStream receives and processes the requests from an xDS stream.
+func (s *Server) HandleRequestStream(ctx context.Context, stream Stream, defaultTypeURL string) error {
+	// increment stream count
+	streamID := atomic.AddUint64(&s.lastStreamID, 1)
+
+	streamLog := log.WithField(logfields.XDSStreamID, streamID)
+
+	reqCh := make(chan *api.DiscoveryRequest)
+
+	stopRecv := make(chan struct{})
+	defer close(stopRecv)
+
+	go func() {
+		defer close(reqCh)
+		for {
+			req, err := stream.Recv()
+			if err != nil {
+				if err == io.EOF {
+					streamLog.Debug("xDS stream closed")
+				} else {
+					streamLog.WithError(err).Error("error while receiving request from xDS stream")
+				}
+				return
+			}
+			if req == nil {
+				streamLog.Error("received nil request from xDS stream; stopping xDS stream handling")
+				return
+			}
+			if req.GetTypeUrl() == "" {
+				req.TypeUrl = defaultTypeURL
+			}
+			streamLog.WithFields(getXDSRequestFields(req)).Debug("received request from xDS stream")
+			select {
+			case <-stopRecv:
+				streamLog.Debug("stopping xDS stream handling")
+				return
+			case reqCh <- req:
+			}
+		}
+	}()
+
+	return s.processRequestStream(ctx, streamLog, stream, reqCh, defaultTypeURL)
+}
+
+// perTypeStreamState is the state maintained per resource type for each
+// xDS stream.
+type perTypeStreamState struct {
+	// typeURL identifies the resource type.
+	typeURL string
+
+	// pendingWatchCancel is a pending watch on this resource type.
+	// If nil, no watch is pending.
+	pendingWatchCancel context.CancelFunc
+
+	// nonce is the nonce sent in the last response to a request for this
+	// resource type.
+	nonce string
+
+	// resourceNames is the list of names of resources sent in the last
+	// response to a request for this resource type.
+	resourceNames []string
+}
+
+// processRequestStream processes the requests in an xDS stream from a channel.
+func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Entry, stream Stream,
+	reqCh <-chan *api.DiscoveryRequest, defaultTypeURL string) error {
+	// The request state for every type URL.
+	typeStates := make([]perTypeStreamState, len(s.watchers))
+	defer func() {
+		for _, state := range typeStates {
+			if state.pendingWatchCancel != nil {
+				state.pendingWatchCancel()
+			}
+		}
+	}()
+
+	// A map of a resource type's URL to the corresponding index in typeStates
+	// for the resource type.
+	typeIndexes := make(map[string]int, len(typeStates))
+
+	// The set of channels to select from. Since the set of channels is
+	// dynamic, we use reflection for selection.
+	// The indexes in selectCases from 0 to len(typeStates)-1 match the indexes
+	// in typeStates.
+	selectCases := make([]reflect.SelectCase, len(typeStates)+2)
+
+	// The last select case index is always the request channel.
+	reqChIndex := len(selectCases) - 1
+	selectCases[reqChIndex] = reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(reqCh),
+	}
+
+	// The next-to-last select case is the context's Done channel.
+	doneChIndex := reqChIndex - 1
+	selectCases[doneChIndex] = reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(ctx.Done()),
+	}
+
+	// Initially there are no pending watches, so just select a dead channel
+	// that will never be selected.
+	quietCh := make(chan *VersionedResources)
+	defer close(quietCh)
+	quietChValue := reflect.ValueOf(quietCh)
+
+	i := 0
+	for typeURL := range s.watchers {
+		typeStates[i] = perTypeStreamState{
+			typeURL: typeURL,
+		}
+
+		selectCases[i] = reflect.SelectCase{
+			Dir:  reflect.SelectRecv,
+			Chan: quietChValue,
+		}
+
+		typeIndexes[typeURL] = i
+
+		i++
+	}
+
+	streamLog.Info("starting xDS stream processing")
+
+	// The last nonce returned in a response in this stream.
+	var responseNonce uint64
+
+	for {
+		// Process either a new request from the xDS stream or a response
+		// from the resource watcher.
+		chosen, recv, recvOK := reflect.Select(selectCases)
+
+		switch chosen {
+		case doneChIndex: // Context got canceled.
+			streamLog.WithError(ctx.Err()).Error("xDS stream context canceled")
+			return ctx.Err()
+
+		case reqChIndex: // Request received from the stream.
+			if !recvOK {
+				streamLog.Info("xDS stream closed")
+				return nil
+			}
+
+			req := recv.Interface().(*api.DiscoveryRequest)
+
+			requestLog := streamLog.WithFields(getXDSRequestFields(req))
+
+			// Ensure that the version info is a string that was sent by this
+			// server or the empty string (the first request in a stream should
+			// always have an empty version info).
+			var versionInfo *uint64
+			if req.GetVersionInfo() != "" {
+				versionInfoVal, err := strconv.ParseUint(req.VersionInfo, 10, 64)
+				if err != nil {
+					requestLog.Errorf("invalid version info in xDS request, not a uint64")
+					return ErrInvalidVersionInfo
+				}
+				versionInfo = &versionInfoVal
+			}
+
+			typeURL := req.GetTypeUrl()
+			if defaultTypeURL == AnyTypeURL && typeURL == "" {
+				requestLog.Error("no type URL given in ADS request")
+				return ErrNoADSTypeURL
+			}
+
+			index, exists := typeIndexes[typeURL]
+
+			if !exists {
+				requestLog.Error("unknown type URL in xDS request")
+				return ErrUnknownTypeURL
+			}
+
+			state := &typeStates[index]
+
+			// Only handle a request if the nonce is valid, i.e. if it's
+			// the first request (which nonce is "") or if it's the nonce of
+			// the last response that was sent.
+			//
+			// If the nonce is different (stale), the client hasn't processed
+			// the last response yet. Ignore every request until it processes
+			// that response and sends a request with that response's nonce.
+			if state.nonce == "" || state.nonce == req.GetResponseNonce() {
+				if state.pendingWatchCancel != nil {
+					// A pending watch exists for this type URL. Cancel it to
+					// start a new watch.
+					requestLog.Debug("canceling pending watch")
+					state.pendingWatchCancel()
+				} else {
+					// If no pending watch exists, then this request is an ACK
+					// for the last response for this resource type.
+
+					// TODO: Notify ACK with req.* and state.resourceNames.
+				}
+
+				respCh := make(chan *VersionedResources, 1)
+				selectCases[index].Chan = reflect.ValueOf(respCh)
+
+				ctx, cancel := context.WithCancel(ctx)
+				state.pendingWatchCancel = cancel
+
+				requestLog.Debugf("starting watch on %d resources", len(req.GetResourceNames()))
+				go s.watchers[typeURL].WatchResources(ctx, typeURL, versionInfo,
+					req.GetNode(), req.GetResourceNames(), respCh)
+			} else {
+				requestLog.Debug("received stale nonce in xDS request; ignoring request")
+			}
+
+		default: // Pending watch response.
+			state := &typeStates[chosen]
+			state.pendingWatchCancel()
+			state.pendingWatchCancel = nil
+
+			if !recvOK {
+				streamLog.WithField(logfields.XDSTypeURL, state.typeURL).
+					Error("xDS resource watch failed; terminating")
+				return ErrResourceWatch
+			}
+
+			// Disabling reading from the channel after reading any from it,
+			// since the watcher will close it anyway.
+			selectCases[chosen].Chan = quietChValue
+
+			resp := recv.Interface().(*VersionedResources)
+
+			responseNonce++
+			nonce := strconv.FormatUint(responseNonce, 10)
+
+			responseLog := streamLog.WithFields(logrus.Fields{
+				logfields.XDSVersionInfo: resp.Version,
+				logfields.XDSCanary:      resp.Canary,
+				logfields.XDSTypeURL:     state.typeURL,
+				logfields.XDSNonce:       nonce,
+			})
+
+			resources := make([]*any.Any, len(resp.Resources))
+
+			// Marshall the resources into protobuf's Any type.
+			for i, res := range resp.Resources {
+				data, err := proto.Marshal(res)
+				if err != nil {
+					responseLog.WithError(err).Errorf("error marshalling xDS response (%d resources)", len(resp.Resources))
+					return err
+				}
+				resources[i] = &any.Any{
+					TypeUrl: state.typeURL,
+					Value:   data,
+				}
+			}
+
+			responseLog.Infof("sending xDS response with %d resources", len(resp.Resources))
+
+			out := &api.DiscoveryResponse{
+				VersionInfo: strconv.FormatUint(resp.Version, 10),
+				Resources:   resources,
+				Canary:      resp.Canary,
+				TypeUrl:     state.typeURL,
+				Nonce:       nonce,
+			}
+			err := stream.Send(out)
+			if err != nil {
+				return err
+			}
+
+			state.nonce = nonce
+			state.resourceNames = resp.ResourceNames
+		}
+	}
+}

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -1,0 +1,661 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/cilium/cilium/pkg/envoy/api"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/any"
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	// logging.ToggleDebugLogs(true)
+	TestingT(t)
+}
+
+type ServerSuite struct{}
+
+var _ = Suite(&ServerSuite{})
+
+const (
+	TestTimeout      = 10 * time.Second
+	StreamTimeout    = 2 * time.Second
+	CacheUpdateDelay = 250 * time.Millisecond
+)
+
+// ResponseMatchesChecker checks that a DiscoveryResponse's fields match the given
+// parameters.
+type ResponseMatchesChecker struct {
+	*CheckerInfo
+}
+
+func (c *ResponseMatchesChecker) Check(params []interface{}, names []string) (result bool, error string) {
+	response, ok := params[0].(*api.DiscoveryResponse)
+	if !ok {
+		return false, "response must be an *api.DiscoveryResponse"
+	}
+	if response == nil {
+		return false, "response is nil"
+	}
+
+	versionInfo, ok := params[1].(string)
+	if !ok {
+		return false, "VersionInfo must be a string"
+	}
+	resources, ok := params[2].([]proto.Message)
+	if params[2] != nil && !ok {
+		return false, "Resources must be a []proto.Message"
+	}
+	canary, ok := params[3].(bool)
+	if !ok {
+		return false, "Canary must be a bool"
+	}
+	typeURL, ok := params[4].(string)
+	if !ok {
+		return false, "TypeURL must be a string"
+	}
+
+	error = ""
+
+	result = response.VersionInfo == versionInfo &&
+		len(response.Resources) == len(resources) &&
+		response.Canary == canary &&
+		response.TypeUrl == typeURL
+
+	if result && len(resources) > 0 {
+		// Convert the resources into Any protocol buffer messages, which is
+		// the type of Resources in the response, so that we can compare them.
+		resourcesAny := make([]*any.Any, 0, len(resources))
+		for _, res := range resources {
+			data, err := proto.Marshal(res)
+			if err != nil {
+				return false, fmt.Sprintf("error marshalling protocol buffer %v", res)
+			}
+			resourcesAny = append(resourcesAny,
+				&any.Any{
+					TypeUrl: typeURL,
+					Value:   data,
+				})
+		}
+		// Sort both lists.
+		sort.Slice(response.Resources, func(i, j int) bool {
+			return response.Resources[i].String() < response.Resources[j].String()
+		})
+		sort.Slice(resourcesAny, func(i, j int) bool {
+			return resourcesAny[i].String() < resourcesAny[j].String()
+		})
+		result = reflect.DeepEqual(response.Resources, resourcesAny)
+	}
+
+	return
+}
+
+// ResponseMatches checks that a DiscoveryResponse's fields match the given
+// parameters.
+var ResponseMatches Checker = &ResponseMatchesChecker{
+	&CheckerInfo{Name: "ResponseMatches", Params: []string{
+		"response", "VersionInfo", "Resources", "Canary", "TypeUrl"}},
+}
+
+var resources = []*api.RouteConfiguration{
+	{Name: "resource0"},
+	{Name: "resource1"},
+	{Name: "resource2"},
+}
+
+func (s *ServerSuite) TestRequestAllResources(c *C) {
+	typeURL := "type.googleapis.com/envoy.api.v2.DummyConfiguration"
+
+	var err error
+	var req *api.DiscoveryRequest
+	var resp *api.DiscoveryResponse
+	var v uint64
+	var mod bool
+
+	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	defer cancel()
+
+	cache := NewCache()
+
+	streamCtx, closeStream := context.WithCancel(ctx)
+	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
+	defer stream.Close()
+
+	server := NewServer(map[string]ObservableResourceSource{
+		typeURL: cache,
+	}, TestTimeout)
+
+	streamDone := make(chan struct{})
+
+	// Run the server's stream handler concurrently.
+	go func() {
+		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
+		close(streamDone)
+		c.Check(err, IsNil)
+	}()
+
+	// Request all resources.
+	req = &api.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   "",
+		Node:          nil,
+		ResourceNames: nil,
+		ResponseNonce: "",
+	}
+	err = stream.SendRequest(req)
+	c.Assert(err, IsNil)
+
+	// Expecting an empty response.
+	resp, err = stream.RecvResponse()
+	c.Assert(err, IsNil)
+	c.Assert(resp, ResponseMatches, "0", nil, false, typeURL)
+	c.Assert(resp.Nonce, Not(Equals), "")
+
+	// Request the next version of resources.
+	req = &api.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   resp.VersionInfo, // ACK the received version.
+		Node:          nil,
+		ResourceNames: nil,
+		ResponseNonce: resp.Nonce,
+	}
+	err = stream.SendRequest(req)
+	c.Assert(err, IsNil)
+
+	// Create version 1 with resource 0.
+	time.Sleep(CacheUpdateDelay)
+	v, mod = cache.Upsert(typeURL, resources[0].Name, resources[0])
+	c.Assert(v, Equals, uint64(1))
+	c.Assert(mod, Equals, true)
+
+	// Expecting a response with that resource.
+	resp, err = stream.RecvResponse()
+	c.Assert(err, IsNil)
+	c.Assert(resp, ResponseMatches, "1", []proto.Message{resources[0]}, false, typeURL)
+	c.Assert(resp.Nonce, Not(Equals), "")
+
+	// Create version 2 with resources 0 and 1.
+	// This time, update the cache before sending the request.
+	v, mod = cache.Upsert(typeURL, resources[1].Name, resources[1])
+	c.Assert(v, Equals, uint64(2))
+	c.Assert(mod, Equals, true)
+
+	// Request the next version of resources.
+	req = &api.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   resp.VersionInfo, // ACK the received version.
+		Node:          nil,
+		ResourceNames: nil,
+		ResponseNonce: resp.Nonce,
+	}
+	err = stream.SendRequest(req)
+	c.Assert(err, IsNil)
+
+	// Expecting a response with both resources.
+	resp, err = stream.RecvResponse()
+	c.Assert(err, IsNil)
+	c.Assert(resp, ResponseMatches, "2", []proto.Message{resources[0], resources[1]}, false, typeURL)
+	c.Assert(resp.Nonce, Not(Equals), "")
+
+	// Request the next version of resources.
+	req = &api.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   resp.VersionInfo, // ACK the received version.
+		Node:          nil,
+		ResourceNames: nil,
+		ResponseNonce: resp.Nonce,
+	}
+	err = stream.SendRequest(req)
+	c.Assert(err, IsNil)
+
+	// Create version 3 with resource 1.
+	time.Sleep(CacheUpdateDelay)
+	v, mod = cache.Delete(typeURL, resources[0].Name)
+	c.Assert(v, Equals, uint64(3))
+	c.Assert(mod, Equals, true)
+
+	// Expecting a response with that resource.
+	resp, err = stream.RecvResponse()
+	c.Assert(err, IsNil)
+	c.Assert(resp, ResponseMatches, "3", []proto.Message{resources[1]}, false, typeURL)
+	c.Assert(resp.Nonce, Not(Equals), "")
+
+	// Close the stream.
+	closeStream()
+
+	select {
+	case <-ctx.Done():
+		c.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
+	case <-streamDone:
+	}
+}
+
+func (s *ServerSuite) TestRequestSomeResources(c *C) {
+	typeURL := "type.googleapis.com/envoy.api.v2.DummyConfiguration"
+
+	var err error
+	var req *api.DiscoveryRequest
+	var resp *api.DiscoveryResponse
+	var v uint64
+	var mod bool
+
+	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	defer cancel()
+
+	cache := NewCache()
+
+	streamCtx, closeStream := context.WithCancel(ctx)
+	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
+	defer stream.Close()
+
+	server := NewServer(map[string]ObservableResourceSource{
+		typeURL: cache,
+	}, TestTimeout)
+
+	streamDone := make(chan struct{})
+
+	// Run the server's stream handler concurrently.
+	go func() {
+		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
+		close(streamDone)
+		c.Check(err, IsNil)
+	}()
+
+	// Request resources 1 and 2 (not 0).
+	req = &api.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   "",
+		Node:          nil,
+		ResourceNames: []string{resources[1].Name, resources[2].Name},
+		ResponseNonce: "",
+	}
+	err = stream.SendRequest(req)
+	c.Assert(err, IsNil)
+
+	// Expecting an empty response.
+	resp, err = stream.RecvResponse()
+	c.Assert(err, IsNil)
+	c.Assert(resp, ResponseMatches, "0", nil, false, typeURL)
+	c.Assert(resp.Nonce, Not(Equals), "")
+
+	// Request the next version of resources.
+	req = &api.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   resp.VersionInfo, // ACK the received version.
+		Node:          nil,
+		ResourceNames: []string{resources[1].Name, resources[2].Name},
+		ResponseNonce: resp.Nonce,
+	}
+	err = stream.SendRequest(req)
+	c.Assert(err, IsNil)
+
+	// Create version 1 with resource 0.
+	time.Sleep(CacheUpdateDelay)
+	v, mod = cache.Upsert(typeURL, resources[0].Name, resources[0])
+	c.Assert(v, Equals, uint64(1))
+	c.Assert(mod, Equals, true)
+
+	// There should be a response with no resources.
+	resp, err = stream.RecvResponse()
+	c.Assert(err, IsNil)
+	c.Assert(resp, ResponseMatches, "1", nil, false, typeURL)
+	c.Assert(resp.Nonce, Not(Equals), "")
+
+	// Create version 2 with resource 0 and 1.
+	// This time, update the cache before sending the request.
+	v, mod = cache.Upsert(typeURL, resources[1].Name, resources[1])
+	c.Assert(v, Equals, uint64(2))
+	c.Assert(mod, Equals, true)
+
+	// Request the next version of resources.
+	req = &api.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   resp.VersionInfo, // ACK the received version.
+		Node:          nil,
+		ResourceNames: []string{resources[1].Name, resources[2].Name},
+		ResponseNonce: resp.Nonce,
+	}
+	err = stream.SendRequest(req)
+	c.Assert(err, IsNil)
+
+	// Expecting a response with one resource.
+	resp, err = stream.RecvResponse()
+	c.Assert(err, IsNil)
+	c.Assert(resp, ResponseMatches, "2", []proto.Message{resources[1]}, false, typeURL)
+	c.Assert(resp.Nonce, Not(Equals), "")
+
+	// Request the next version of resources.
+	req = &api.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   resp.VersionInfo, // ACK the received version.
+		Node:          nil,
+		ResourceNames: []string{resources[1].Name, resources[2].Name},
+		ResponseNonce: resp.Nonce,
+	}
+	err = stream.SendRequest(req)
+	c.Assert(err, IsNil)
+
+	// Create version 3 with resources 0, 1 and 2.
+	time.Sleep(CacheUpdateDelay)
+	v, mod = cache.Upsert(typeURL, resources[2].Name, resources[2])
+	c.Assert(v, Equals, uint64(3))
+	c.Assert(mod, Equals, true)
+
+	// Expecting a response with resources 1 and 2.
+	resp, err = stream.RecvResponse()
+	c.Assert(err, IsNil)
+	c.Assert(resp, ResponseMatches, "3", []proto.Message{resources[1], resources[2]}, false, typeURL)
+	c.Assert(resp.Nonce, Not(Equals), "")
+
+	// Request the next version of resources.
+	req = &api.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   resp.VersionInfo, // ACK the received version.
+		Node:          nil,
+		ResourceNames: []string{resources[1].Name, resources[2].Name},
+		ResponseNonce: resp.Nonce,
+	}
+	err = stream.SendRequest(req)
+	c.Assert(err, IsNil)
+
+	// Create version 4 with resources 1 and 2.
+	time.Sleep(CacheUpdateDelay)
+	v, mod = cache.Delete(typeURL, resources[0].Name)
+	c.Assert(v, Equals, uint64(4))
+	c.Assert(mod, Equals, true)
+
+	// Expecting no response for version 4, since neither resources 1 and 2
+	// have changed.
+
+	// Updating resource 2 with the exact same value won't increase the version
+	// number. Remain at version 4.
+	v, mod = cache.Upsert(typeURL, resources[2].Name, resources[2])
+	c.Assert(v, Equals, uint64(4))
+	c.Assert(mod, Equals, false)
+
+	// Create version 5 with resource 1.
+	v, mod = cache.Delete(typeURL, resources[1].Name)
+	c.Assert(v, Equals, uint64(5))
+	c.Assert(mod, Equals, true)
+
+	// Expecting a response with resource 2.
+	resp, err = stream.RecvResponse()
+	c.Assert(err, IsNil)
+	c.Assert(resp, ResponseMatches, "5", []proto.Message{resources[2]}, false, typeURL)
+	c.Assert(resp.Nonce, Not(Equals), "")
+
+	// Close the stream.
+	closeStream()
+
+	select {
+	case <-ctx.Done():
+		c.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
+	case <-streamDone:
+	}
+}
+
+func (s *ServerSuite) TestUpdateRequestResources(c *C) {
+	typeURL := "type.googleapis.com/envoy.api.v2.DummyConfiguration"
+
+	var err error
+	var req *api.DiscoveryRequest
+	var resp *api.DiscoveryResponse
+	var v uint64
+	var mod bool
+
+	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	defer cancel()
+
+	cache := NewCache()
+
+	streamCtx, closeStream := context.WithCancel(ctx)
+	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
+	defer stream.Close()
+
+	server := NewServer(map[string]ObservableResourceSource{
+		typeURL: cache,
+	}, TestTimeout)
+
+	streamDone := make(chan struct{})
+
+	// Run the server's stream handler concurrently.
+	go func() {
+		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
+		close(streamDone)
+		c.Check(err, IsNil)
+	}()
+
+	// Create version 1 with resources 0 and 1.
+	time.Sleep(CacheUpdateDelay)
+	v, mod = cache.tx(typeURL, map[string]proto.Message{
+		resources[0].Name: resources[0],
+		resources[1].Name: resources[1],
+	}, nil)
+	c.Assert(v, Equals, uint64(1))
+	c.Assert(mod, Equals, true)
+
+	// Request resource 1.
+	req = &api.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   "",
+		Node:          nil,
+		ResourceNames: []string{resources[1].Name},
+		ResponseNonce: "",
+	}
+	err = stream.SendRequest(req)
+	c.Assert(err, IsNil)
+
+	// Expecting a response with resource 1.
+	resp, err = stream.RecvResponse()
+	c.Assert(err, IsNil)
+	c.Assert(resp, ResponseMatches, "1", []proto.Message{resources[1]}, false, typeURL)
+	c.Assert(resp.Nonce, Not(Equals), "")
+
+	// Request the next version of resource 1.
+	req = &api.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   resp.VersionInfo, // ACK the received version.
+		Node:          nil,
+		ResourceNames: []string{resources[1].Name},
+		ResponseNonce: resp.Nonce,
+	}
+	err = stream.SendRequest(req)
+	c.Assert(err, IsNil)
+
+	// Create version 2 with resource 0, 1 and 2.
+	time.Sleep(CacheUpdateDelay)
+	v, mod = cache.Upsert(typeURL, resources[2].Name, resources[2])
+	c.Assert(v, Equals, uint64(2))
+	c.Assert(mod, Equals, true)
+
+	// Not expecting any response since resource 1 didn't change in version 2.
+
+	// Send an updated request for both resource 1 and 2.
+	req = &api.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   resp.VersionInfo, // ACK the received version.
+		Node:          nil,
+		ResourceNames: []string{resources[1].Name, resources[2].Name},
+		ResponseNonce: resp.Nonce,
+	}
+	err = stream.SendRequest(req)
+	c.Assert(err, IsNil)
+
+	// Expecting a response with resources 1 and 2.
+	resp, err = stream.RecvResponse()
+	c.Assert(err, IsNil)
+	c.Assert(resp, ResponseMatches, "2", []proto.Message{resources[1], resources[2]}, false, typeURL)
+	c.Assert(resp.Nonce, Not(Equals), "")
+
+	// Close the stream.
+	closeStream()
+
+	select {
+	case <-ctx.Done():
+		c.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
+	case <-streamDone:
+	}
+}
+
+func (s *ServerSuite) TestRequestStaleNonce(c *C) {
+	typeURL := "type.googleapis.com/envoy.api.v2.DummyConfiguration"
+
+	var err error
+	var req *api.DiscoveryRequest
+	var resp *api.DiscoveryResponse
+	var v uint64
+	var mod bool
+
+	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	defer cancel()
+
+	cache := NewCache()
+
+	streamCtx, closeStream := context.WithCancel(ctx)
+	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
+	defer stream.Close()
+
+	server := NewServer(map[string]ObservableResourceSource{
+		typeURL: cache,
+	}, TestTimeout)
+
+	streamDone := make(chan struct{})
+
+	// Run the server's stream handler concurrently.
+	go func() {
+		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
+		close(streamDone)
+		c.Check(err, IsNil)
+	}()
+
+	// Request all resources.
+	req = &api.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   "",
+		Node:          nil,
+		ResourceNames: nil,
+		ResponseNonce: "",
+	}
+	err = stream.SendRequest(req)
+	c.Assert(err, IsNil)
+
+	// Expecting an empty response.
+	resp, err = stream.RecvResponse()
+	c.Assert(err, IsNil)
+	c.Assert(resp, ResponseMatches, "0", nil, false, typeURL)
+	c.Assert(resp.Nonce, Not(Equals), "")
+
+	// Request the next version of resources.
+	req = &api.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   resp.VersionInfo, // ACK the received version.
+		Node:          nil,
+		ResourceNames: nil,
+		ResponseNonce: resp.Nonce,
+	}
+	err = stream.SendRequest(req)
+	c.Assert(err, IsNil)
+
+	// Create version 1 with resource 0.
+	time.Sleep(CacheUpdateDelay)
+	v, mod = cache.Upsert(typeURL, resources[0].Name, resources[0])
+	c.Assert(v, Equals, uint64(1))
+	c.Assert(mod, Equals, true)
+
+	// Expecting a response with that resource.
+	resp, err = stream.RecvResponse()
+	c.Assert(err, IsNil)
+	c.Assert(resp, ResponseMatches, "1", []proto.Message{resources[0]}, false, typeURL)
+	c.Assert(resp.Nonce, Not(Equals), "")
+
+	// Create version 2 with resources 0 and 1.
+	// This time, update the cache before sending the request.
+	v, mod = cache.Upsert(typeURL, resources[1].Name, resources[1])
+	c.Assert(v, Equals, uint64(2))
+	c.Assert(mod, Equals, true)
+
+	// Request the next version of resources, with a stale nonce.
+	req = &api.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   resp.VersionInfo, // ACK the received version.
+		Node:          nil,
+		ResourceNames: nil,
+		ResponseNonce: "stale-nonce",
+	}
+	// Do not update the nonce.
+	err = stream.SendRequest(req)
+	c.Assert(err, IsNil)
+
+	// Expecting no response from the server.
+
+	// Resend the request with the correct nonce.
+	req = &api.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   resp.VersionInfo, // ACK the received version.
+		Node:          nil,
+		ResourceNames: nil,
+		ResponseNonce: resp.Nonce,
+	}
+	err = stream.SendRequest(req)
+	c.Assert(err, IsNil)
+
+	// Expecting a response with both resources.
+	resp, err = stream.RecvResponse()
+	c.Assert(err, IsNil)
+	c.Assert(resp, ResponseMatches, "2", []proto.Message{resources[0], resources[1]}, false, typeURL)
+	c.Assert(resp.Nonce, Not(Equals), "")
+
+	// Request the next version of resources.
+	req = &api.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   resp.VersionInfo, // ACK the received version.
+		Node:          nil,
+		ResourceNames: nil,
+		ResponseNonce: resp.Nonce,
+	}
+	err = stream.SendRequest(req)
+	c.Assert(err, IsNil)
+
+	// Create version 3 with resource 1.
+	time.Sleep(CacheUpdateDelay)
+	v, mod = cache.Delete(typeURL, resources[0].Name)
+	c.Assert(v, Equals, uint64(3))
+	c.Assert(mod, Equals, true)
+
+	// Expecting a response with that resource.
+	resp, err = stream.RecvResponse()
+	c.Assert(err, IsNil)
+	c.Assert(resp, ResponseMatches, "3", []proto.Message{resources[1]}, false, typeURL)
+	c.Assert(resp.Nonce, Not(Equals), "")
+
+	// Close the stream.
+	closeStream()
+
+	select {
+	case <-ctx.Done():
+		c.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
+	case <-streamDone:
+	}
+}

--- a/pkg/envoy/xds/set.go
+++ b/pkg/envoy/xds/set.go
@@ -1,0 +1,156 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/envoy/api"
+	"github.com/cilium/cilium/pkg/lock"
+
+	"github.com/golang/protobuf/proto"
+)
+
+// ResourceSource provides read access to a versioned set of resources.
+// A single version is associated to all the contained resources.
+// The version is monotonically increased for any change to the set.
+type ResourceSource interface {
+	// GetResources returns the current version of the resources with the given
+	// names.
+	// If lastVersion is not nil and the resources with the given names haven't
+	// changed since lastVersion, nil is returned.
+	// If resourceNames is empty, all resources are returned.
+	// Should not be blocking.
+	GetResources(ctx context.Context, typeURL string, lastVersion *uint64,
+		node *api.Node, resourceNames []string) (*VersionedResources, error)
+}
+
+// VersionedResources is a set of protobuf-encoded resources along with their
+// version.
+type VersionedResources struct {
+	// Version is the version of the resources.
+	Version uint64
+
+	// ResourceNames is the list of names of resources.
+	// May be empty.
+	ResourceNames []string
+
+	// Resources is the list of protobuf-encoded resources.
+	// May be empty. Must be of the same length as ResourceNames.
+	Resources []proto.Message
+
+	// Canary indicates whether the client should only do a dry run of
+	// using  the resources.
+	Canary bool
+}
+
+// ResourceMutator provides write access to a versioned set of resources.
+// A single version is associated to all the contained resources.
+// The version is monotonically increased for any change to the set.
+type ResourceMutator interface {
+	// Upsert inserts or updates a resource from this set by name and increases
+	// the set's version number atomically if the resource is actually inserted
+	// or updated.
+	// The version after updating the set is returned.
+	Upsert(typeURL string, resourceName string, resource proto.Message) (version uint64, updated bool)
+
+	// Delete deletes a resource from this set by name and increases the cache's
+	// version number atomically if the resource is actually deleted.
+	// The version after updating the set is returned.
+	Delete(typeURL string, resourceName string) (version uint64, updated bool)
+}
+
+// ResourceSet provides read-write access to a versioned set of resources.
+// A single version is associated to all the contained resources.
+// The version is monotonically increased for any change to the set.
+type ResourceSet interface {
+	ResourceSource
+	ResourceMutator
+}
+
+// ObservableResourceSource is a ResourceSource that allows registering observers of
+// new resource versions from this source.
+type ObservableResourceSource interface {
+	ResourceSource
+
+	// AddResourceVersionObserver registers an observer of new versions of
+	// resources from this source.
+	AddResourceVersionObserver(listener ResourceVersionObserver)
+
+	// RemoveResourceVersionObserver unregisters an observer of new versions of
+	// resources from this source.
+	RemoveResourceVersionObserver(listener ResourceVersionObserver)
+}
+
+// ObservableResourceSet is a ResourceSet that allows registering observers of
+// new resource versions from this source.
+type ObservableResourceSet interface {
+	ObservableResourceSource
+	ResourceMutator
+}
+
+// ResourceVersionObserver defines the HandleNewResourceVersion method which is
+// called whenever the version of the resources of a given type has changed.
+type ResourceVersionObserver interface {
+	// HandleNewResourceVersion notifies of a new version of the resources of
+	// the given type.
+	HandleNewResourceVersion(typeURL string, version uint64)
+}
+
+// BaseObservableResourceSource implements the AddResourceVersionObserver and
+// RemoveResourceVersionObserver methods to handle the notification of new
+// resource versions. This is meant to be used as a base to implement
+// ObservableResourceSource.
+type BaseObservableResourceSource struct {
+	// locker is the locker used to synchronize all accesses to this source.
+	locker lock.RWMutex
+
+	// observers is the set of registered observers.
+	observers map[ResourceVersionObserver]struct{}
+}
+
+// NewBaseObservableResourceSource initializes the given set.
+func NewBaseObservableResourceSource() *BaseObservableResourceSource {
+	return &BaseObservableResourceSource{
+		observers: make(map[ResourceVersionObserver]struct{}),
+	}
+}
+
+// AddResourceVersionObserver registers an observer to be notified of new
+// resource version.
+func (s *BaseObservableResourceSource) AddResourceVersionObserver(observer ResourceVersionObserver) {
+	s.locker.Lock()
+	defer s.locker.Unlock()
+
+	s.observers[observer] = struct{}{}
+}
+
+// RemoveResourceVersionObserver unregisters an observer that was previously
+// registered by calling AddResourceVersionObserver.
+func (s *BaseObservableResourceSource) RemoveResourceVersionObserver(observer ResourceVersionObserver) {
+	s.locker.Lock()
+	defer s.locker.Unlock()
+
+	delete(s.observers, observer)
+}
+
+// NotifyNewResourceVersionRLocked notifies registered observers that a new version of
+// the resources of the given type is available.
+// This function MUST be called with locker's lock acquired.
+func (s *BaseObservableResourceSource) NotifyNewResourceVersionRLocked(typeURL string, version uint64) {
+	for o := range s.observers {
+		o.HandleNewResourceVersion(typeURL, version)
+	}
+}

--- a/pkg/envoy/xds/stream.go
+++ b/pkg/envoy/xds/stream.go
@@ -1,0 +1,125 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/cilium/cilium/pkg/envoy/api"
+)
+
+// Stream is the subset of the gRPC bi-directional stream types which is used
+// by Server.
+type Stream interface {
+	// Send sends a xDS response back to the client.
+	Send(*api.DiscoveryResponse) error
+
+	// Recv receives a xDS request from the client.
+	Recv() (*api.DiscoveryRequest, error)
+}
+
+// MockStream is a mock implementation of Stream used for testing.
+type MockStream struct {
+	ctx         context.Context
+	recv        chan *api.DiscoveryRequest
+	sent        chan *api.DiscoveryResponse
+	recvTimeout time.Duration
+	sentTimeout time.Duration
+}
+
+// NewMockStream creates a new mock Stream for testing.
+func NewMockStream(ctx context.Context, recvSize, sentSize int, recvTimeout, sentTimeout time.Duration) *MockStream {
+	return &MockStream{
+		ctx:         ctx,
+		recv:        make(chan *api.DiscoveryRequest, recvSize),
+		sent:        make(chan *api.DiscoveryResponse, sentSize),
+		recvTimeout: recvTimeout,
+		sentTimeout: sentTimeout,
+	}
+}
+
+func (s *MockStream) Send(resp *api.DiscoveryResponse) error {
+	subCtx, cancel := context.WithTimeout(s.ctx, s.sentTimeout)
+
+	select {
+	case <-subCtx.Done():
+		cancel()
+		if subCtx.Err() == context.Canceled {
+			return io.EOF
+		}
+		return subCtx.Err()
+	case s.sent <- resp:
+		cancel()
+		return nil
+	}
+}
+
+func (s *MockStream) Recv() (*api.DiscoveryRequest, error) {
+	subCtx, cancel := context.WithTimeout(s.ctx, s.recvTimeout)
+
+	select {
+	case <-subCtx.Done():
+		cancel()
+		if subCtx.Err() == context.Canceled {
+			return nil, io.EOF
+		}
+		return nil, subCtx.Err()
+	case req := <-s.recv:
+		cancel()
+		return req, nil
+	}
+}
+
+// SendRequest queues a request to be received by calling Recv.
+func (s *MockStream) SendRequest(req *api.DiscoveryRequest) error {
+	subCtx, cancel := context.WithTimeout(s.ctx, s.recvTimeout)
+
+	select {
+	case <-subCtx.Done():
+		cancel()
+		if subCtx.Err() == context.Canceled {
+			return io.EOF
+		}
+		return subCtx.Err()
+	case s.recv <- req:
+		cancel()
+		return nil
+	}
+}
+
+// RecvResponse receives a response that was queued by calling Send.
+func (s *MockStream) RecvResponse() (*api.DiscoveryResponse, error) {
+	subCtx, cancel := context.WithTimeout(s.ctx, s.sentTimeout)
+
+	select {
+	case <-subCtx.Done():
+		cancel()
+		if subCtx.Err() == context.Canceled {
+			return nil, io.EOF
+		}
+		return nil, subCtx.Err()
+	case resp := <-s.sent:
+		cancel()
+		return resp, nil
+	}
+}
+
+// Close closes the resources used by this MockStream.
+func (s *MockStream) Close() {
+	close(s.recv)
+	close(s.sent)
+}

--- a/pkg/envoy/xds/watcher.go
+++ b/pkg/envoy/xds/watcher.go
@@ -1,0 +1,166 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cilium/cilium/pkg/envoy/api"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/sirupsen/logrus"
+)
+
+// ResourceWatcher watches and retrieves new versions of resources from a
+// resource set.
+// ResourceWatcher implements ResourceVersionObserver to get notified when new
+// resource versions are available in the set.
+type ResourceWatcher struct {
+	// typeURL is the URL that uniquely identifies the resource type.
+	typeURL string
+
+	// resourceSet is the set of resources to watch.
+	resourceSet ResourceSource
+
+	// version is the current version of the resources. Updated in calls to
+	// NotifyNewVersion.
+	version uint64
+
+	// versionLocker is used to lock all accesses to version.
+	versionLocker lock.Mutex
+
+	// versionCond is a condition that is broadcast whenever the source's
+	// current version is increased.
+	// versionCond is associated with versionLocker.
+	versionCond *sync.Cond
+
+	// resourceAccessTimeout is the timeout to use for any access to the
+	// resource set.
+	resourceAccessTimeout time.Duration
+}
+
+// NewResourceWatcher creates a new ResourceWatcher backed by the given
+// resource set.
+func NewResourceWatcher(typeURL string, resourceSet ResourceSource, resourceAccessTimeout time.Duration) *ResourceWatcher {
+	w := &ResourceWatcher{
+		typeURL:               typeURL,
+		resourceSet:           resourceSet,
+		resourceAccessTimeout: resourceAccessTimeout,
+	}
+	w.versionCond = sync.NewCond(&w.versionLocker)
+	return w
+}
+
+func (w *ResourceWatcher) HandleNewResourceVersion(typeURL string, version uint64) {
+	w.versionLocker.Lock()
+	defer w.versionLocker.Unlock()
+
+	if typeURL != w.typeURL {
+		return
+	}
+
+	if version < w.version {
+		log.WithFields(logrus.Fields{
+			logfields.XDSVersionInfo: version,
+			logfields.XDSTypeURL:     typeURL,
+		}).Panicf(fmt.Sprintf("decreasing version number found for resources of type %s: %d < %d",
+			typeURL, version, w.version))
+	}
+	w.version = version
+
+	w.versionCond.Broadcast()
+}
+
+// WatchResources watches for new versions of specific resources and sends them
+// into the given out channel.
+//
+// A call to this method blocks until a version greater than lastVersion is
+// available. Therefore, every call must be done in a separate goroutine.
+// A watch can be canceled by canceling the given context.
+//
+// lastVersion is the last version successfully applied by the
+// client; nil if this is the first request for resources.
+// This method call must always close the out channel.
+func (w *ResourceWatcher) WatchResources(ctx context.Context, typeURL string, lastVersion *uint64, node *api.Node,
+	resourceNames []string, out chan<- *VersionedResources) {
+	defer close(out)
+
+	watchLog := log.WithFields(logrus.Fields{
+		logfields.XDSVersionInfo: lastVersion,
+		logfields.XDSClientNode:  node,
+		logfields.XDSTypeURL:     typeURL,
+	})
+
+	var res *VersionedResources
+
+	var waitVersion uint64
+	var waitForVersion bool
+	if lastVersion != nil {
+		waitForVersion = true
+		waitVersion = *lastVersion
+	}
+
+	for ctx.Err() == nil && res == nil {
+		w.versionLocker.Lock()
+		for ctx.Err() == nil && waitForVersion && w.version <= waitVersion {
+			watchLog.Debugf("current resource version is %d, waiting for it to become > %d", w.version, waitVersion)
+			w.versionCond.Wait()
+		}
+		// In case we need to loop again, wait for any version more recent than
+		// the current one.
+		waitForVersion = true
+		waitVersion = w.version
+		w.versionLocker.Unlock()
+
+		if ctx.Err() != nil {
+			break
+		}
+
+		subCtx, cancel := context.WithTimeout(ctx, w.resourceAccessTimeout)
+		var err error
+		watchLog.Debugf("getting %d resources from set", len(resourceNames))
+		res, err = w.resourceSet.GetResources(subCtx, typeURL, lastVersion, node, resourceNames)
+		cancel()
+
+		if err != nil {
+			watchLog.WithError(err).Errorf("failed to query resources named: %v; terminating resource watch", resourceNames)
+			return
+		}
+	}
+
+	if res != nil {
+		// Resources have changed since the last version returned to the
+		// client. Send out the new version.
+		select {
+		case <-ctx.Done():
+		case out <- res:
+			return
+		}
+	}
+
+	err := ctx.Err()
+	if err != nil {
+		switch err {
+		case context.Canceled:
+			watchLog.Debug("context canceled, terminating resource watch")
+		default:
+			watchLog.WithError(err).Error("context error, terminating resource watch")
+		}
+	}
+}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -149,7 +149,30 @@ const (
 	// RetryUUID is an UUID identical for all retries of a set
 	RetryUUID = "retryUUID"
 
-	// K8s specific
+	// Envoy xDS-protocol-specific
+
+	// XDSStreamID is the ID of an xDS request stream.
+	XDSStreamID = "xdsStreamID"
+
+	// XDSVersionInfo is the version info of an xDS resource.
+	XDSVersionInfo = "xdsVersionInfo"
+
+	// XDSTypeURL is the URL that identifies an xDS resource type.
+	XDSTypeURL = "xdsTypeURL"
+
+	// XDSNonce is a nonce sent in xDS requests and responses.
+	XDSNonce = "xdsNonce"
+
+	// XDSCanary is a boolean indicating whether a response is a dry run.
+	XDSCanary = "xdsCanary"
+
+	// XDSResourceName is the name of an xDS resource.
+	XDSResourceName = "xdsResourceName"
+
+	// XDSClientNode is the ID of an XDS client, e.g. an Envoy node.
+	XDSClientNode = "xdsClientNode"
+
+	// K8s-specific
 
 	// K8sNodeID is the k8s ID of a K8sNode
 	K8sNodeID = "k8sNodeID"


### PR DESCRIPTION
Implement a generic server that supports Envoy's xDS (discovery service) protocol.
This server will be used to implement Envoy's ADS, LDS and RDS protocols, as well as Cilium's own NPDS and NPHDS configuration protocols (defined in https://github.com/cilium/cilium/pull/2621).

Specification of Envoy's xDS protocol:
https://github.com/envoyproxy/data-plane-api/blob/master/XDS_PROTOCOL.md

Signed-off-by: Romain Lenglet <romain@covalent.io>

Fixes: #2596