### PR TITLE
Ginkgo: Added L4 egress rules to Nightly test

### DIFF
--- a/test/helpers/policygen/const.go
+++ b/test/helpers/policygen/const.go
@@ -44,10 +44,25 @@ var (
 		Ping:        ResultTimeout,
 		UDP:         ResultTimeout,
 	}
+
+	ConnResultAllTimeoutExceptPing = ConnTestSpec{
+		HTTP:        ResultTimeout,
+		HTTPPrivate: ResultTimeout,
+		Ping:        ResultOK,
+		UDP:         ResultTimeout,
+	}
+
 	ConnResultOnlyHTTP = ConnTestSpec{
 		HTTP:        ResultOK,
 		HTTPPrivate: ResultOK,
 		Ping:        ResultTimeout,
+		UDP:         ResultTimeout,
+	}
+
+	ConnResultOnlyHTTPAndPing = ConnTestSpec{
+		HTTP:        ResultOK,
+		HTTPPrivate: ResultOK,
+		Ping:        ResultOK,
 		UDP:         ResultTimeout,
 	}
 

--- a/test/helpers/policygen/policygen.go
+++ b/test/helpers/policygen/policygen.go
@@ -56,6 +56,14 @@ var policiesTestSuite = PolicyTestSuite{
 			},
 		},
 		{
+			name:  "Egress Port 80 No protocol",
+			kind:  egress,
+			tests: ConnResultOnlyHTTPAndPing,
+			template: map[string]string{
+				"Ports": `[{"port": "80"}]`,
+			},
+		},
+		{
 			name:  "Ingress Port 80 TCP",
 			kind:  ingress,
 			tests: ConnResultOnlyHTTP,
@@ -67,6 +75,22 @@ var policiesTestSuite = PolicyTestSuite{
 			name:  "Ingress Port 80 UDP",
 			kind:  ingress,
 			tests: ConnResultAllTimeout,
+			template: map[string]string{
+				"Ports": `[{"port": "80", "protocol": "UDP"}]`,
+			},
+		},
+		{
+			name:  "Egress Port 80 TCP",
+			kind:  egress,
+			tests: ConnResultOnlyHTTPAndPing,
+			template: map[string]string{
+				"Ports": `[{"port": "80", "protocol": "TCP"}]`,
+			},
+		},
+		{
+			name:  "Egress Port 80 UDP",
+			kind:  egress,
+			tests: ConnResultAllTimeoutExceptPing,
 			template: map[string]string{
 				"Ports": `[{"port": "80", "protocol": "UDP"}]`,
 			},
@@ -94,7 +118,7 @@ var policiesTestSuite = PolicyTestSuite{
 			tests: ConnResultOnlyHTTPPrivateAndPing,
 			template: map[string]string{
 				"Rules": `{"http": [{"method": "GET", "path": "/private"}]}`,
-				"Ports": `[{"port": "{{ .Destination.PortNumber }}", "protocol": "TCP"}]`,
+				"Ports": `[{"port": "80", "protocol": "TCP"}]`,
 			},
 		},
 	},


### PR DESCRIPTION
Added the following rules:

- Layer 4 Egress to protocol TCP
- Layer 4 Egress to protocol UDP
- Layer 4 Egress using protocol and port
- Layer 4 Egress using protocol and port
- Layer 4 Ingress using only protocol

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>