### PR TITLE
envoy: Create test sockets and logs in temp dir and delete them

### DIFF
--- a/pkg/envoy/envoy_test.go
+++ b/pkg/envoy/envoy_test.go
@@ -35,8 +35,10 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 		c.Skip("skipping envoy unit test; CILIUM_ENABLE_ENVOY_UNIT_TEST not set")
 	}
 
+	stateLogDir := c.MkDir()
+
 	// launch debug variant of the Envoy proxy
-	Envoy := StartEnvoy(9901, "", "", 42)
+	Envoy := StartEnvoy(9901, stateLogDir, stateLogDir, 42)
 	c.Assert(Envoy, NotNil)
 
 	sel := api.NewWildcardEndpointSelector()
@@ -74,7 +76,7 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	// Remove listerner3
+	// Remove listener3
 	Envoy.RemoveListener("listener3")
 
 	time.Sleep(100 * time.Millisecond)
@@ -87,7 +89,7 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	// Remove listerner3 again
+	// Remove listener3 again
 	Envoy.RemoveListener("listener3")
 
 	time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
`pkg/envoy/envoy_test.go` was creating named sockets and logs in the source directory, which sometimes caused Ginkgo test build failures, with the following build logs:
```
00:12:11 ==> runtime: cp: cannot open '/src/pkg/envoy/lds.sock' for reading: Input/output error
00:12:11 ==> runtime: cp: cannot open '/src/pkg/envoy/access_log.sock' for reading: Input/output error
00:12:11 ==> runtime: cp: cannot open '/src/pkg/envoy/rds.sock' for reading: Input/output error
```

Create a temporary directory for those sockets and logs, and delete them at the end of the test.

Signed-off-by: Romain Lenglet <romain@covalent.io>