### PR TITLE
Ginkgo: Updating vagrant to Kubernetes 1.8

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -7,7 +7,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 240, unit: 'MINUTES')
+        timeout(time: 360, unit: 'MINUTES')
         timestamps()
     }
 
@@ -44,5 +44,31 @@ pipeline {
                 }
             }
         }
+
+        stage('Kubernetes tests') {
+            environment {
+                GOPATH="${WORKSPACE}"
+                TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
+            }
+            steps {
+                parallel(
+                    "K8s-1.7":{
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.7 ginkgo --focus=" K8s*" -noColor'
+                    }
+                )
+            }
+            post {
+                always {
+                    junit 'test/*.xml'
+                    // Temporary workaround to test cleanup
+                    // rm -rf ${GOPATH}/src/github.com/cilium/cilium
+                    sh 'cd test/; ./post_build_agent.sh || true'
+                    sh 'cd test/; K8S_VERSION=1.7 vagrant destroy -f || true'
+                    sh 'cd test/; ./archive_test_results.sh || true'
+                    archiveArtifacts artifacts: "test_results_${JOB_BASE_NAME}_${BUILD_NUMBER}.tar", allowEmptyArchive: true
+                }
+            }
+        }
+
     }
 }

--- a/ginkgo-all.Jenkinsfile
+++ b/ginkgo-all.Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 120, unit: 'MINUTES')
+        timeout(time: 60, unit: 'MINUTES')
         timestamps()
     }
     stages {
@@ -39,12 +39,12 @@ pipeline {
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
             }
             steps {
-                sh 'cd ${TESTDIR}; K8S_VERSION=1.7 vagrant up --no-provision'
+                sh 'cd ${TESTDIR}; K8S_VERSION=1.8 vagrant up --no-provision'
                 sh 'cd ${TESTDIR}; K8S_VERSION=1.6 vagrant up --no-provision'
             }
             post {
                 failure {
-                    sh "cd ${TESTDIR}; K8S_VERSION=1.7 vagrant destroy -f || true"
+                    sh "cd ${TESTDIR}; K8S_VERSION=1.8 vagrant destroy -f || true"
                     sh "cd ${TESTDIR}; K8S_VERSION=1.6 vagrant destroy -f || true"
                 }
             }
@@ -59,8 +59,8 @@ pipeline {
                     "Runtime":{
                         sh 'cd ${TESTDIR}; ginkgo --focus="Runtime*" -v -noColor'
                     },
-                    "K8s-1.7":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.7 ginkgo --focus=" K8s*" -noColor'
+                    "K8s-1.8":{
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.8 ginkgo --focus=" K8s*" -noColor'
                     },
                     "K8s-1.6":{
                         sh 'cd ${TESTDIR}; K8S_VERSION=1.6 ginkgo --focus=" K8s*" -noColor'
@@ -74,7 +74,7 @@ pipeline {
                     // Temporary workaround to test cleanup
                     // rm -rf ${GOPATH}/src/github.com/cilium/cilium
                     sh 'cd test/; ./post_build_agent.sh || true'
-                    sh 'cd test/; K8S_VERSION=1.7 vagrant destroy -f || true'
+                    sh 'cd test/; K8S_VERSION=1.8 vagrant destroy -f || true'
                     sh 'cd test/; K8S_VERSION=1.6 vagrant destroy -f || true'
                     sh 'cd test/; ./archive_test_results.sh || true'
                     archiveArtifacts artifacts: "test_results_${JOB_BASE_NAME}_${BUILD_NUMBER}.tar", allowEmptyArchive: true

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 120, unit: 'MINUTES')
+        timeout(time: 60, unit: 'MINUTES')
         timestamps()
     }
     stages {
@@ -39,12 +39,12 @@ pipeline {
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
             }
             steps {
-                sh 'cd ${TESTDIR}; K8S_VERSION=1.7 vagrant up --no-provision'
+                sh 'cd ${TESTDIR}; K8S_VERSION=1.8 vagrant up --no-provision'
                 sh 'cd ${TESTDIR}; K8S_VERSION=1.6 vagrant up --no-provision'
             }
             post {
                 failure {
-                    sh "cd ${TESTDIR}; K8S_VERSION=1.7 vagrant destroy -f || true"
+                    sh "cd ${TESTDIR}; K8S_VERSION=1.8 vagrant destroy -f || true"
                     sh "cd ${TESTDIR}; K8S_VERSION=1.6 vagrant destroy -f || true"
                 }
             }
@@ -64,8 +64,8 @@ pipeline {
                     "Runtime":{
                         sh 'cd ${TESTDIR}; ginkgo --focus="Runtime*" -noColor'
                     },
-                    "K8s-1.7":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.7 ginkgo --focus=" K8s*" -noColor'
+                    "K8s-1.8":{
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.8 ginkgo --focus=" K8s*" -noColor'
                     },
                     "K8s-1.6":{
                         sh 'cd ${TESTDIR}; K8S_VERSION=1.6 ginkgo --focus=" K8s*" -noColor'
@@ -79,7 +79,7 @@ pipeline {
                     // Temporary workaround to test cleanup
                     // rm -rf ${GOPATH}/src/github.com/cilium/cilium
                     sh 'cd test/; ./post_build_agent.sh || true'
-                    sh 'cd test/; K8S_VERSION=1.7 vagrant destroy -f || true'
+                    sh 'cd test/; K8S_VERSION=1.8 vagrant destroy -f || true'
                     sh 'cd test/; K8S_VERSION=1.6 vagrant destroy -f || true'
                     sh 'cd test/; ./archive_test_results.sh || true'
                     archiveArtifacts artifacts: "test_results_${JOB_BASE_NAME}_${BUILD_NUMBER}.tar", allowEmptyArchive: true
@@ -101,8 +101,8 @@ pipeline {
                     "Runtime":{
                         sh 'cd ${TESTDIR}; ginkgo --focus="RuntimeValidated*" -v -noColor'
                     },
-                    "K8s-1.7":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.7 ginkgo --focus=" K8sValidated*" -v -noColor'
+                    "K8s-1.8":{
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.8 ginkgo --focus=" K8sValidated*" -v -noColor'
                     },
                     "K8s-1.6":{
                         sh 'cd ${TESTDIR}; K8S_VERSION=1.6 ginkgo --focus=" K8sValidated*" -v -noColor'
@@ -116,7 +116,7 @@ pipeline {
                     // Temporary workaround to test cleanup
                     // rm -rf ${GOPATH}/src/github.com/cilium/cilium
                     sh 'cd test/; ./post_build_agent.sh || true'
-                    sh 'cd test/; K8S_VERSION=1.7 vagrant destroy -f || true'
+                    sh 'cd test/; K8S_VERSION=1.8 vagrant destroy -f || true'
                     sh 'cd test/; K8S_VERSION=1.6 vagrant destroy -f || true'
                     sh 'cd test/; ./archive_test_results.sh || true'
                     archiveArtifacts artifacts: "test_results_${JOB_BASE_NAME}_${BUILD_NUMBER}.tar", allowEmptyArchive: true

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -3,7 +3,7 @@
 
 $BUILD_NUMBER = ENV['BUILD_NUMBER'] || "0"
 $JOB_NAME = ENV['JOB_BASE_NAME'] || "LOCAL"
-$K8S_VERSION = ENV['K8S_VERSION'] || "1.7"
+$K8S_VERSION = ENV['K8S_VERSION'] || "1.8"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 
 $SERVER_BOX= "cilium/ginkgo"

--- a/test/k8sT/manifests/cilium_ds.yaml
+++ b/test/k8sT/manifests/cilium_ds.yaml
@@ -1,63 +1,46 @@
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ConfigMap
+apiVersion: v1
 metadata:
-  name: cilium
-rules:
-- apiGroups:
-  - "networking.k8s.io"
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - nodes
-  - endpoints
-  - componentstatuses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies #FIXME remove this in k8s 1.8
-  - thirdpartyresources
-  - ingresses
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - "apiextensions.k8s.io"
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - cilium.io
-  resources:
-  - ciliumnetworkpolicies
-  verbs:
-  - "*"
+  name: cilium-config
+  namespace: kube-system
+data:
+  # This etcd-config contains the etcd endpoints of your cluster. If you use
+  # TLS please make sure you uncomment the ca-file line and add the respective
+  # certificate has a k8s secret, see explanation bellow in the comment labeled
+  # "ETCD-CERT"
+  etcd-config: |-
+    ---
+    endpoints:
+    - "http://k8s1:9732"
+    #
+    # In case you want to use TLS in etcd, uncomment the following line
+    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
+    #
+    # In case you want client to server authentication, uncomment the following
+    # lines and add the certificate and key in cilium-etcd-secrets bellow
+    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  disable-ipv4: "false"
+---
+# The etcd secrets can be populated in kubernetes.
+# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
+  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
+  # (the "-w 0" generates the output on a single line)
+  etcd-ca: ""
+  etcd-client-key: ""
+  etcd-client-crt: ""
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -97,22 +80,29 @@ spec:
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: >-
+          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
     spec:
+      serviceAccountName: cilium
       containers:
       - image: k8s1:5000/cilium/cilium-dev:latest
         imagePullPolicy: Always
         name: cilium-agent
         command: [ "cilium-agent" ]
         args:
-          - "--debug"
+          - "--debug=$(CILIUM_DEBUG)"
+          - "-t"
+          - "vxlan"
           - "--kvstore"
           - "etcd"
           - "--kvstore-opt"
-          - "etcd.address=http://k8s1:9732"
-          - "--k8s-kubeconfig-path"
-          - "/opt/cilium/kubeconfig"
-          - "-t"
-          - "vxlan"
+          - "etcd.config=/var/lib/etcd-config/etcd.config"
+          - "--disable-ipv4=$(DISABLE_IPV4)"
+        ports:
+          - name: prometheus
+            containerPort: 9090
         lifecycle:
           postStart:
             exec:
@@ -127,11 +117,32 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+          - name: "DISABLE_IPV4"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: disable-ipv4
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+          - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-metrics-config
+                optional: true
+                key: prometheus-serve-addr
         livenessProbe:
           exec:
             command:
             - cilium
             - status
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
           failureThreshold: 10
           periodSeconds: 10
@@ -154,8 +165,11 @@ spec:
           - name: docker-socket
             mountPath: /var/run/docker.sock
             readOnly: true
-          - name: kubeconfig-path
-            mountPath: /opt/cilium/
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
             readOnly: true
         securityContext:
           capabilities:
@@ -164,27 +178,37 @@ spec:
           privileged: true
       hostNetwork: true
       volumes:
+          # To keep state between restarts / upgrades
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
+          # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+          # To read docker events from the node
         - name: docker-socket
           hostPath:
             path: /var/run/docker.sock
+          # To install cilium cni plugin in the host
+        - name: cni-path
+          hostPath:
+            path: /opt/cni/bin
+          # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
               path: /etc/cni/net.d
-        - name: kubeconfig
-          hostPath:
-              path: /etc/kubernetes/kubelet.conf
-        - name: kubeconfig-path
-          hostPath:
-              path: /opt/cilium/
+          # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+            - key: etcd-config
+              path: etcd.config
+          # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
@@ -194,3 +218,65 @@ spec:
       # Mark cilium's pod as critical for rescheduling
       - key: CriticalAddonsOnly
         operator: "Exists"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
+  - thirdpartyresources
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  verbs:
+  - "*"

--- a/test/k8sT/manifests/cilium_ds_geneve.yaml
+++ b/test/k8sT/manifests/cilium_ds_geneve.yaml
@@ -1,63 +1,46 @@
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ConfigMap
+apiVersion: v1
 metadata:
-  name: cilium
-rules:
-- apiGroups:
-  - "networking.k8s.io"
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - nodes
-  - endpoints
-  - componentstatuses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies #FIXME remove this in k8s 1.8
-  - thirdpartyresources
-  - ingresses
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - "apiextensions.k8s.io"
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - cilium.io
-  resources:
-  - ciliumnetworkpolicies
-  verbs:
-  - "*"
+  name: cilium-config
+  namespace: kube-system
+data:
+  # This etcd-config contains the etcd endpoints of your cluster. If you use
+  # TLS please make sure you uncomment the ca-file line and add the respective
+  # certificate has a k8s secret, see explanation bellow in the comment labeled
+  # "ETCD-CERT"
+  etcd-config: |-
+    ---
+    endpoints:
+    - "http://k8s1:9732"
+    #
+    # In case you want to use TLS in etcd, uncomment the following line
+    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
+    #
+    # In case you want client to server authentication, uncomment the following
+    # lines and add the certificate and key in cilium-etcd-secrets bellow
+    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  disable-ipv4: "false"
+---
+# The etcd secrets can be populated in kubernetes.
+# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
+  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
+  # (the "-w 0" generates the output on a single line)
+  etcd-ca: ""
+  etcd-client-key: ""
+  etcd-client-crt: ""
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -97,22 +80,31 @@ spec:
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: >-
+          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
     spec:
+      serviceAccountName: cilium
       containers:
       - image: k8s1:5000/cilium/cilium-dev:latest
         imagePullPolicy: Always
         name: cilium-agent
         command: [ "cilium-agent" ]
         args:
-          - "--debug"
+          - "--debug=$(CILIUM_DEBUG)"
+          - "-t"
+          - "geneve"
           - "--kvstore"
           - "etcd"
           - "--kvstore-opt"
-          - "etcd.address=http://k8s1:9732"
-          - "--k8s-kubeconfig-path"
-          - "/opt/cilium/kubeconfig"
+          - "etcd.config=/var/lib/etcd-config/etcd.config"
+          - "--disable-ipv4=$(DISABLE_IPV4)"
           - "-t"
           - "geneve"
+        ports:
+          - name: prometheus
+            containerPort: 9090
         lifecycle:
           postStart:
             exec:
@@ -127,11 +119,32 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+          - name: "DISABLE_IPV4"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: disable-ipv4
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+          - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-metrics-config
+                optional: true
+                key: prometheus-serve-addr
         livenessProbe:
           exec:
             command:
             - cilium
             - status
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
           failureThreshold: 10
           periodSeconds: 10
@@ -154,8 +167,11 @@ spec:
           - name: docker-socket
             mountPath: /var/run/docker.sock
             readOnly: true
-          - name: kubeconfig-path
-            mountPath: /opt/cilium/
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
             readOnly: true
         securityContext:
           capabilities:
@@ -164,27 +180,37 @@ spec:
           privileged: true
       hostNetwork: true
       volumes:
+          # To keep state between restarts / upgrades
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
+          # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+          # To read docker events from the node
         - name: docker-socket
           hostPath:
             path: /var/run/docker.sock
+          # To install cilium cni plugin in the host
+        - name: cni-path
+          hostPath:
+            path: /opt/cni/bin
+          # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
               path: /etc/cni/net.d
-        - name: kubeconfig
-          hostPath:
-              path: /etc/kubernetes/kubelet.conf
-        - name: kubeconfig-path
-          hostPath:
-              path: /opt/cilium/
+          # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+            - key: etcd-config
+              path: etcd.config
+          # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
@@ -194,3 +220,65 @@ spec:
       # Mark cilium's pod as critical for rescheduling
       - key: CriticalAddonsOnly
         operator: "Exists"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
+  - thirdpartyresources
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  verbs:
+  - "*"

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -38,7 +38,7 @@ import (
 var (
 	log             = logging.DefaultLogger
 	DefaultSettings = map[string]string{
-		"K8S_VERSION": "1.7",
+		"K8S_VERSION": "1.8",
 	}
 	k8sNodesEnv = "K8S_NODES"
 )


### PR DESCRIPTION
- Updating default test to kubernetes 1.8
- Added kubernetes 1.7 test on Nightly
- Some adjustments in the jenkins timeouts
- Updated cilium daemon set

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
