### PR TITLE
Run consul with disable_update_check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ tests-consul:
 	-docker run -d \
            --name "cilium-consul-test-container" \
            -p 8501:8500 \
-           -e 'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true}' \
+           -e 'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true, "disable_update_check": true}' \
            consul:0.8.3 \
            agent -client=0.0.0.0 -server -bootstrap-expect 1
 	echo "mode: count" > coverage-all.out

--- a/contrib/scripts/cilium-up.sh
+++ b/contrib/scripts/cilium-up.sh
@@ -23,7 +23,7 @@ sleep 3s
 docker run -d \
    --name "cilium-consul" \
    -p 8501:8500 \
-   -e 'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true}' \
+   -e 'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true, "disable_update_check": true}' \
    consul:0.8.3 \
    agent -client=0.0.0.0 -server -bootstrap-expect 1
 

--- a/contrib/systemd/cilium-consul.service
+++ b/contrib/systemd/cilium-consul.service
@@ -9,7 +9,7 @@ ExecStartPre=/usr/bin/docker pull consul:0.8.3
 ExecStart=/usr/bin/docker run \
  --name "cilium-consul" \
  -p 8500:8500 \
- -e 'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true}' \
+ -e 'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true, "disable_update_check": true}' \
  consul:0.8.3 \
  agent -client=0.0.0.0 -server -bootstrap-expect 1 \
 

--- a/contrib/upstart/cilium-consul.conf
+++ b/contrib/upstart/cilium-consul.conf
@@ -8,7 +8,7 @@ pre-start script
 		exec docker run -d \
                     --name "cilium-consul" \
                     -p 8500:8500 \
-                    -e 'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true}' \
+                    -e 'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true, "disable_update_check": true}' \
                     consul:0.8.3 \
                     agent -client=0.0.0.0 -server -bootstrap-expect 1
 	fi

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     ports:
       - "8500:8500"
     environment:
-      - "CONSUL_LOCAL_CONFIG={\"skip_leave_on_interrupt\": true}"
+      - "CONSUL_LOCAL_CONFIG={\"skip_leave_on_interrupt\": true, \"disable_update_check\": true}"
     image: consul:0.8.3
     command: agent -client=0.0.0.0 -server -bootstrap-expect 1
 

--- a/examples/getting-started/docker-compose.yml
+++ b/examples/getting-started/docker-compose.yml
@@ -35,6 +35,6 @@ services:
     ports:
       - "8500:8500"
     environment:
-      - "CONSUL_LOCAL_CONFIG={\"skip_leave_on_interrupt\": true}"
+      - "CONSUL_LOCAL_CONFIG={\"skip_leave_on_interrupt\": true, \"disable_update_check\": true}"
     image: consul:0.8.3
     command: agent -client=0.0.0.0 -server -bootstrap-expect 1

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     # ports:
     #   - "8500:8500"
     environment:
-      - 'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true}'
+      - 'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true, "disable_update_check": true}'
   test:
     depends_on:
       - consul


### PR DESCRIPTION
Consul is sometimes failing when the hashicorp service is not reachable. This
causes CI failures.
