### PR TITLE
pkg/k8s: handle nil PodSelector and NamespaceSelector within ingress rules

### DIFF
--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -36,7 +36,7 @@ func GetPolicyLabelsv1(np *networkingv1.NetworkPolicy) labels.LabelArray {
 	return k8sconst.GetPolicyLabels(ns, policyName)
 }
 
-func parseNetworkPolicyPeer(namespace string, peer *networkingv1.NetworkPolicyPeer) (*api.EndpointSelector, error) {
+func parseNetworkPolicyPeer(namespace string, peer *networkingv1.NetworkPolicyPeer) *api.EndpointSelector {
 	var labelSelector *metav1.LabelSelector
 
 	// Only one or the other can be set, not both
@@ -65,14 +65,18 @@ func parseNetworkPolicyPeer(namespace string, peer *networkingv1.NetworkPolicyPe
 			lsr.Key = policy.JoinPath(PodNamespaceMetaLabels, lsr.Key)
 			peer.NamespaceSelector.MatchExpressions[i] = lsr
 		}
+	} else {
+		// Neither PodSelector nor NamespaceSelector set.
+		return nil
 	}
 
 	selector := api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, labelSelector)
-	return &selector, nil
+	return &selector
 }
 
-// ParseNetworkPolicy parses a k8s NetworkPolicy and returns a list of
-// Cilium policy rules that can be added
+// ParseNetworkPolicy parses a k8s NetworkPolicy. Returns a list of
+// Cilium policy rules that can be added, along with an error if there was an
+// error sanitizing the rules.
 func ParseNetworkPolicy(np *networkingv1.NetworkPolicy) (api.Rules, error) {
 	ingresses := []api.IngressRule{}
 	egresses := []api.EgressRule{}
@@ -82,14 +86,17 @@ func ParseNetworkPolicy(np *networkingv1.NetworkPolicy) (api.Rules, error) {
 		ingress := api.IngressRule{}
 		if iRule.From != nil && len(iRule.From) > 0 {
 			for _, rule := range iRule.From {
-				endpointSelector, err := parseNetworkPolicyPeer(namespace, &rule)
-				if err != nil {
-					return nil, err
+				endpointSelector := parseNetworkPolicyPeer(namespace, &rule)
+
+				// Case where no label-based selectors were in rule.
+				if endpointSelector != nil {
+					ingress.FromEndpoints = append(ingress.FromEndpoints, *endpointSelector)
 				}
+
+				// Parse CIDR-based parts of rule.
 				if rule.IPBlock != nil {
 					ingress.FromCIDRSet = append(ingress.FromCIDRSet, ipBlockToCIDRRule(rule.IPBlock))
 				}
-				ingress.FromEndpoints = append(ingress.FromEndpoints, *endpointSelector)
 			}
 		}
 

--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -17,6 +17,7 @@ package k8s
 import (
 	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 
@@ -88,9 +89,11 @@ func ParseNetworkPolicy(np *networkingv1.NetworkPolicy) (api.Rules, error) {
 			for _, rule := range iRule.From {
 				endpointSelector := parseNetworkPolicyPeer(namespace, &rule)
 
-				// Case where no label-based selectors were in rule.
 				if endpointSelector != nil {
 					ingress.FromEndpoints = append(ingress.FromEndpoints, *endpointSelector)
+				} else {
+					// No label-based selectors were in NetworkPolicyPeer.
+					log.WithField(logfields.K8sNetworkPolicyName, np.Name).Debug("NetworkPolicyPeer does not have PodSelector or NamespaceSelector")
 				}
 
 				// Parse CIDR-based parts of rule.

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -185,13 +185,50 @@ func (s *K8sSuite) TestParseNetworkPolicyNoSelectors(c *C) {
 }
 }`)
 
+	fromEndpoints := labels.LabelArray{
+		labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+		labels.NewLabel("role", "backend", labels.LabelSourceK8s),
+	}
+
+	matchLabels := make(map[string]string)
+	for _, v := range fromEndpoints {
+		matchLabels[fmt.Sprintf("%s.%s", v.Source, v.Key)] = v.Value
+	}
+	lblSelector := metav1.LabelSelector{
+		MatchLabels: matchLabels,
+	}
+	epSelector := api.EndpointSelector{
+		LabelSelector: &lblSelector,
+	}
+
 	np := networkingv1.NetworkPolicy{}
 	err := json.Unmarshal(ex1, &np)
 	c.Assert(err, IsNil)
 
+	expectedRules := api.Rules{
+		&api.Rule{
+			EndpointSelector: epSelector,
+			Ingress: []api.IngressRule{
+				{
+					FromCIDRSet: []api.CIDRRule{
+						{
+							Cidr: api.CIDR("10.0.0.0/8"),
+							ExceptCIDRs: []api.CIDR{
+								"10.96.0.0/12",
+							},
+						},
+					},
+				},
+			},
+			Egress: []api.EgressRule{},
+			Labels: labels.ParseLabelArray("unspec:io.cilium.k8s-policy-name=ingress-cidr-test", "unspec:io.cilium.k8s-policy-namespace=myns"),
+		},
+	}
+
 	rules, err := ParseNetworkPolicy(&np)
 	c.Assert(err, IsNil)
 	c.Assert(rules, NotNil)
+	c.Assert(rules, comparator.DeepEquals, expectedRules)
 }
 
 func (s *K8sSuite) TestParseNetworkPolicyUnknownProto(c *C) {


### PR DESCRIPTION
Kubernetes NetworkPolicyPeer allows for PodSelector and NamespaceSelector fields to be optional.
Gracefully handle when these objects are nil when we are parsing NetworkPolicy.

Signed-off by: Ian Vernon <ian@cilium.io>


Fixes: #2698 

```release-note
Kubernetes NetworkPolicyPeer allows for PodSelector and NamespaceSelector fields to be optional.
Gracefully handle when these objects are nil when we are parsing NetworkPolicy.
```

**How to test**:
1. Start up the Kubernetes developer VM:
``` K8S=1 ./contrib/vagrant/start.sh```
2. Import the following NetworkPolicy:
```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: andre-example-policy
  namespace: default
spec:
  podSelector:
    matchLabels:
      id: app1
  policyTypes:
  - Ingress
  ingress:
  - from:
    - ipBlock:
        cidr: 172.17.0.0/16
        except:
        - 172.17.1.0/24
```

``` kubectl create -f <policy file>```
3. Cilium doesn't crash and the policy is present in `cilium policy get`
```
[
  {
    "endpointSelector": {
      "matchLabels": {
        "k8s:id": "app1",
        "k8s:io.kubernetes.pod.namespace": "default"
      }
    },
    "ingress": [
      {
        "fromCIDRSet": [
          {
            "cidr": "172.17.0.0/16",
            "except": [
              "172.17.1.0/24"
            ]
          }
        ]
      }
    ],
    "labels": [
      {
        "key": "io.cilium.k8s-policy-name",
        "value": "andre-example-policy",
        "source": "unspec"
      },
      {
        "key": "io.cilium.k8s-policy-namespace",
        "value": "default",
        "source": "unspec"
      }
    ]
  }
]
Revision: 12
```