### PR TITLE
ginkgo: Reuse AnnotationNames from `pkg/`

### DIFF
--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -1,0 +1,36 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package annotation
+
+const (
+	// Name is an optional annotation to the NetworkPolicy
+	// resource which specifies the name of the policy node to which all
+	// rules should be applied to.
+	Name = "io.cilium.name"
+
+	// V4CIDRName is the annotation name used to store the IPv4
+	// pod CIDR in the node's annotations.
+	V4CIDRName = "io.cilium.network.ipv4-pod-cidr"
+	// V6CIDRName is the annotation name used to store the IPv6
+	// pod CIDR in the node's annotations.
+	V6CIDRName = "io.cilium.network.ipv6-pod-cidr"
+
+	// V4HealthName is the annotation name used to store the IPv4
+	// address of the cilium-health endpoint in the node's annotations.
+	V4HealthName = "io.cilium.network.ipv4-health-ip"
+	// V6HealthName is the annotation name used to store the IPv6
+	// address of the cilium-health endpoint in the node's annotations.
+	V6HealthName = "io.cilium.network.ipv6-health-ip"
+)

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/annotation"
 	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	cilium_v1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v1"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -116,17 +117,17 @@ func updateNodeAnnotation(c kubernetes.Interface, node *v1.Node, v4CIDR, v6CIDR 
 	}
 
 	if v4CIDR != nil {
-		node.Annotations[Annotationv4CIDRName] = v4CIDR.String()
+		node.Annotations[annotation.V4CIDRName] = v4CIDR.String()
 	}
 	if v6CIDR != nil {
-		node.Annotations[Annotationv6CIDRName] = v6CIDR.String()
+		node.Annotations[annotation.V6CIDRName] = v6CIDR.String()
 	}
 
 	if v4HealthIP != nil {
-		node.Annotations[Annotationv4HealthName] = v4HealthIP.String()
+		node.Annotations[annotation.V4HealthName] = v4HealthIP.String()
 	}
 	if v6HealthIP != nil {
-		node.Annotations[Annotationv6HealthName] = v6HealthIP.String()
+		node.Annotations[annotation.V6HealthName] = v6HealthIP.String()
 	}
 
 	node, err := c.CoreV1().Nodes().Update(node)

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/node"
 
@@ -33,7 +34,7 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node1",
 			Annotations: map[string]string{
-				Annotationv4CIDRName: "10.254.0.0/16",
+				annotation.V4CIDRName: "10.254.0.0/16",
 			},
 		},
 		Spec: v1.NodeSpec{
@@ -58,8 +59,8 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 						OnUpdate: func(n *v1.Node) (*v1.Node, error) {
 							updateChan <- true
 							n1copy := v1.Node(node1)
-							n1copy.Annotations[Annotationv4CIDRName] = "10.2.0.0/16"
-							n1copy.Annotations[Annotationv6CIDRName] = "beef:beef:beef:beef:aaaa:aaaa:1111:0/96"
+							n1copy.Annotations[annotation.V4CIDRName] = "10.2.0.0/16"
+							n1copy.Annotations[annotation.V6CIDRName] = "beef:beef:beef:beef:aaaa:aaaa:1111:0/96"
 							c.Assert(n, comparator.DeepEquals, &n1copy)
 							return &n1copy, nil
 						},
@@ -96,7 +97,7 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node2",
 			Annotations: map[string]string{
-				Annotationv4CIDRName: "10.254.0.0/16",
+				annotation.V4CIDRName: "10.254.0.0/16",
 			},
 		},
 		Spec: v1.NodeSpec{
@@ -124,8 +125,8 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 							}
 							updateChan <- true
 							n1copy := v1.Node(node2)
-							n1copy.Annotations[Annotationv4CIDRName] = "10.2.0.0/16"
-							n1copy.Annotations[Annotationv6CIDRName] = "aaaa:aaaa:aaaa:aaaa:beef:beef::/96"
+							n1copy.Annotations[annotation.V4CIDRName] = "10.2.0.0/16"
+							n1copy.Annotations[annotation.V6CIDRName] = "aaaa:aaaa:aaaa:aaaa:beef:beef::/96"
 							c.Assert(n, comparator.DeepEquals, &n1copy)
 							return &n1copy, nil
 						},

--- a/pkg/k8s/const.go
+++ b/pkg/k8s/const.go
@@ -27,25 +27,6 @@ const (
 	// updating k8s resources
 	maxUpdateRetries = 30
 
-	// AnnotationName is an optional annotation to the NetworkPolicy
-	// resource which specifies the name of the policy node to which all
-	// rules should be applied to.
-	AnnotationName = "io.cilium.name"
-
-	// Annotationv4CIDRName is the annotation name used to store the IPv4
-	// pod CIDR in the node's annotations.
-	Annotationv4CIDRName = "io.cilium.network.ipv4-pod-cidr"
-	// Annotationv6CIDRName is the annotation name used to store the IPv6
-	// pod CIDR in the node's annotations.
-	Annotationv6CIDRName = "io.cilium.network.ipv6-pod-cidr"
-
-	// Annotationv4HealthName is the annotation name used to store the IPv4
-	// address of the cilium-health endpoint in the node's annotations.
-	Annotationv4HealthName = "io.cilium.network.ipv4-health-ip"
-	// Annotationv6HealthName is the annotation name used to store the IPv6
-	// address of the cilium-health endpoint in the node's annotations.
-	Annotationv6HealthName = "io.cilium.network.ipv6-health-ip"
-
 	// EnvNodeNameSpec is the environment label used by Kubernetes to
 	// specify the node's name.
 	EnvNodeNameSpec = "K8S_NODE_NAME"

--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -15,6 +15,7 @@
 package k8s
 
 import (
+	"github.com/cilium/cilium/pkg/annotation"
 	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
@@ -26,7 +27,7 @@ import (
 
 // GetPolicyLabelsv1 extracts the name of policy name
 func GetPolicyLabelsv1(np *networkingv1.NetworkPolicy) labels.LabelArray {
-	policyName := np.Annotations[AnnotationName]
+	policyName := np.Annotations[annotation.Name]
 	if policyName == "" {
 		policyName = np.Name
 	}

--- a/pkg/k8s/network_policy_v1beta.go
+++ b/pkg/k8s/network_policy_v1beta.go
@@ -17,6 +17,7 @@ package k8s
 // FIXME Remove this file in k8s 1.8
 
 import (
+	"github.com/cilium/cilium/pkg/annotation"
 	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
@@ -28,7 +29,7 @@ import (
 // GetPolicyLabelsv1beta1 returns the label selector for the given network
 // policy.
 func GetPolicyLabelsv1beta1(np *v1beta1.NetworkPolicy) labels.LabelArray {
-	policyName := np.Annotations[AnnotationName]
+	policyName := np.Annotations[annotation.Name]
 	if policyName == "" {
 		policyName = np.Name
 	}

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -17,6 +17,7 @@ package k8s
 import (
 	"net"
 
+	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
 
@@ -76,7 +77,7 @@ func ParseNode(k8sNode *v1.Node) *node.Node {
 	// the CIDR assigned by k8s controller manager
 	// In case it's invalid or empty then we fall back to our annotations.
 	if node.IPv4AllocCIDR == nil {
-		if ipv4CIDR, ok := k8sNode.Annotations[Annotationv4CIDRName]; !ok {
+		if ipv4CIDR, ok := k8sNode.Annotations[annotation.V4CIDRName]; !ok {
 			scopedLog.Debug("Empty IPv4 CIDR annotation in node")
 		} else {
 			_, cidr, err := net.ParseCIDR(ipv4CIDR)
@@ -89,7 +90,7 @@ func ParseNode(k8sNode *v1.Node) *node.Node {
 	}
 
 	if node.IPv6AllocCIDR == nil {
-		if ipv6CIDR, ok := k8sNode.Annotations[Annotationv6CIDRName]; !ok {
+		if ipv6CIDR, ok := k8sNode.Annotations[annotation.V6CIDRName]; !ok {
 			scopedLog.Debug("Empty IPv6 CIDR annotation in node")
 		} else {
 			_, cidr, err := net.ParseCIDR(ipv6CIDR)
@@ -102,7 +103,7 @@ func ParseNode(k8sNode *v1.Node) *node.Node {
 	}
 
 	if node.IPv4HealthIP == nil {
-		if healthIP, ok := k8sNode.Annotations[Annotationv4HealthName]; !ok {
+		if healthIP, ok := k8sNode.Annotations[annotation.V4HealthName]; !ok {
 			scopedLog.Debug("Empty IPv4 health endpoint annotation in node")
 		} else if ip := net.ParseIP(healthIP); ip == nil {
 			scopedLog.WithField(logfields.V4HealthIP, healthIP).Error("BUG, invalid IPv4 health endpoint annotation in node")
@@ -112,7 +113,7 @@ func ParseNode(k8sNode *v1.Node) *node.Node {
 	}
 
 	if node.IPv6HealthIP == nil {
-		if healthIP, ok := k8sNode.Annotations[Annotationv6HealthName]; !ok {
+		if healthIP, ok := k8sNode.Annotations[annotation.V6HealthName]; !ok {
 			scopedLog.Debug("Empty IPv6 health endpoint annotation in node")
 		} else if ip := net.ParseIP(healthIP); ip == nil {
 			scopedLog.WithField(logfields.V6HealthIP, healthIP).Error("BUG, invalid IPv6 health endpoint annotation in node")

--- a/pkg/k8s/node_test.go
+++ b/pkg/k8s/node_test.go
@@ -15,6 +15,7 @@
 package k8s
 
 import (
+	"github.com/cilium/cilium/pkg/annotation"
 	. "gopkg.in/check.v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,8 +27,8 @@ func (s *K8sSuite) TestParseNode(c *C) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node1",
 			Annotations: map[string]string{
-				Annotationv4CIDRName: "10.254.0.0/16",
-				Annotationv6CIDRName: "f00d:aaaa:bbbb:cccc:dddd:eeee::/112",
+				annotation.V4CIDRName: "10.254.0.0/16",
+				annotation.V6CIDRName: "f00d:aaaa:bbbb:cccc:dddd:eeee::/112",
 			},
 		},
 		Spec: v1.NodeSpec{
@@ -47,7 +48,7 @@ func (s *K8sSuite) TestParseNode(c *C) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node2",
 			Annotations: map[string]string{
-				Annotationv4CIDRName: "10.254.0.0/16",
+				annotation.V4CIDRName: "10.254.0.0/16",
 			},
 		},
 		Spec: v1.NodeSpec{
@@ -66,7 +67,7 @@ func (s *K8sSuite) TestParseNode(c *C) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node2",
 			Annotations: map[string]string{
-				Annotationv4CIDRName: "10.254.0.0/16",
+				annotation.V4CIDRName: "10.254.0.0/16",
 			},
 		},
 		Spec: v1.NodeSpec{

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/annotation"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/onsi/ginkgo"
@@ -31,15 +32,9 @@ import (
 )
 
 const (
-	// Annotationv4CIDRName is the annotation name used to store the IPv4
-	// pod CIDR in the node's annotations. From pkg/k8s
-	Annotationv4CIDRName = "io.cilium.network.ipv4-pod-cidr"
-	// Annotationv6CIDRName is the annotation name used to store the IPv6
-	// pod CIDR in the node's annotations. From pkg/k8s
-	Annotationv6CIDRName = "io.cilium.network.ipv6-pod-cidr"
-	KubectlCmd           = "kubectl"
-	manifestsPath        = "k8sT/manifests/"
-	kubeDNSLabel         = "k8s-app=kube-dns"
+	KubectlCmd    = "kubectl"
+	manifestsPath = "k8sT/manifests/"
+	kubeDNSLabel  = "k8s-app=kube-dns"
 )
 
 // GetCurrentK8SEnv returns the value of K8S_VERSION from the OS environment.
@@ -180,12 +175,12 @@ func (kub *Kubectl) ManifestGet(manifestFilename string) string {
 }
 
 // NodeCleanMetadata annotates each node in the Kubernetes cluster with the
-// Annotationv4CIDRName and Annotationv6CIDRName annotations. It returns an
+// annotation.V4CIDRName and annotation.V6CIDRName annotations. It returns an
 // error if the nodes cannot be retrieved via the Kubernetes API.
 func (kub *Kubectl) NodeCleanMetadata() error {
 	metadata := []string{
-		Annotationv4CIDRName,
-		Annotationv6CIDRName,
+		annotation.V4CIDRName,
+		annotation.V6CIDRName,
 	}
 
 	data := kub.Exec(fmt.Sprintf("%s get nodes -o jsonpath='{.items[*].metadata.name}'", KubectlCmd))


### PR DESCRIPTION
<!--  Thanks for contributing to Cilium!

If this is your first time contributing, then please see the following
guidelines for detailed instructions on how to contribute:
https://github.com/cilium/cilium/blob/master/CONTRIBUTING.md for detailed instructions 

-->

**Summary of changes**:
Create new package `annotation`. This allows for the removal of duplicate
test constants from test helpers which were failing due to importing a
package which includes cgo code that requires BPF headers to be present.

Fixes: #2308
