### PR TITLE
Add helper script to consolidate go stacktraces

### DIFF
--- a/contrib/scripts/consolidate_go_stacktrace.py
+++ b/contrib/scripts/consolidate_go_stacktrace.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+
+# consolidate_go_stacktrace.py collapses a go stacktrace by uniqueing each
+# stack. Addresses, goroutine ID and goroutine ages are ignored when determining
+# uniqeness. A sample of each unique trace is printed
+
+import re,sys,collections
+
+def get_stacks(f):
+    """
+    get_stacks parses file f and yields all lines in go stackrace as one array
+    """
+    accum = []
+    for line in f:
+        line = line.rstrip()
+        if line.startswith("goroutine"):
+            yield accum
+            accum = []
+        else:
+            accum.append(line)
+
+# Regexes used to find and remove addresses, ids and age
+strip_addresses = re.compile(r"0x[0-9a-fA-F]+")
+strip_goroutine_id = re.compile(r"goroutine [0-9]+")
+strip_goroutine_time = re.compile(r", [0-9]+ minutes")
+def strip_stack(stack):
+    """
+    strip_stack replaces addresses, goroutine IDs and ages with a fixed sentinel
+    """
+    stack = [strip_addresses.sub("0x?", l) for l in stack]
+    stack = [strip_goroutine_id.sub("?", l) for l in stack]
+    stack = [strip_goroutine_time.sub("", l) for l in stack]
+    return stack
+
+def get_hashable_stack_value(stack):
+    """
+    get_hashable_stack_value transforms stack (and array of strings) into
+    something that can be used as a map key
+    """
+    return "".join(strip_stack(stack))
+
+def print_usage():
+    print """usage: {} [-h | path/to/file]
+        -h:         This help.
+        path/to/file:   Read and parse file with go stacktraces
+        "-" or no params: Read and parse stdin""".format(sys.argv[0])
+
+if __name__ == "__main__":
+    # Handle arguments. We only support a file path, or stdin on "-" or no
+    # parameter
+    infile = sys.argv[1] if len(sys.argv) > 1 else ""
+    if infile in ["-h", "help"]:
+        print_usage()
+        sys.exit(0)
+    elif infile in ["-", "", None]:
+        f = sys.stdin
+    else:
+        f = open(infile)
+
+    # collect stacktraces into groups, each keyed by a version of the stack
+    # where unwanted fields have been made into sentinels
+    consolidated = collections.defaultdict(list)
+    for stack in get_stacks(f):
+        h = get_hashable_stack_value(stack)
+        consolidated[h].append(stack)
+
+    # print count of each unique stack, and a sample, sorted by frequency
+    print "{} unique stack traces".format(len(consolidated))
+    for stack in sorted(consolidated.values(), cmp=lambda a,b: len(a)-len(b), reverse=True):
+        print "{} occurences. Sample stack trace:".format(len(stack))
+        print "\n".join(stack[0])
+
+    if f != sys.stdin:
+        f.close()


### PR DESCRIPTION
There has been some positive feedback on this script, and it was useful to debug deadlocks on a few occasions. I've put it under contrib/scripts but I'm not sure if we have a better spot. It's a standalone python file with only stdlib dependencies.

When we report deadlocks the stacktraces can be log and difficult to
follow. This scripts consolidates them, ignoring addresses, goroutine
IDs and goroutine age. The consolidated list of unique stacks (printed
with how often they occurred) are simpler to understand to find
deadlocks.

**How to test (optional)**:
- Find a go stacktrace (it doesn't have to be a deadlock)
- pipe it to this command


Sample output (abridged):
```
$ cat mystack.stack | ./contrib/scripts/consolidate_go_stacktrace.py
44 unique stack traces
130 occurences. Sample stack trace:
main.getEndpointList.func2(0xc420a65c20, 0xc4210182e0, 0xc42040bfe0)
	/go/src/github.com/cilium/cilium/daemon/endpoint.go:87 +0x4e
created by main.getEndpointList
	/go/src/github.com/cilium/cilium/daemon/endpoint.go:91 +0x1e1

14 occurences. Sample stack trace:
net/http.(*persistConn).writeLoop(0xc4204a1d40)
	/usr/local/go/src/net/http/transport.go:1704 +0x43a
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1118 +0xa5a

1 occurences. Sample stack trace:
os/signal.signal_recv(0x91f99b)
	/usr/local/go/src/runtime/sigqueue.go:116 +0x104
os/signal.loop()
	/usr/local/go/src/os/signal/signal_unix.go:22 +0x22
created by os/signal.init.1
	/usr/local/go/src/os/signal/signal_unix.go:28 +0x41
```