### PR TITLE
envoy: changed Makefile's PATH env variable to be static

### DIFF
--- a/envoy/Makefile
+++ b/envoy/Makefile
@@ -27,6 +27,8 @@ CLANG ?= clang
 CLANG_FORMAT ?= clang-format
 BUILDIFIER ?= buildifier
 STRIP ?= strip
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
+export PATH
 
 PROTOC ?= bazel-out/host/bin/external/com_google_protobuf/protoc
 ENVOY_API_PROTO_PATH = bazel-envoy/external/envoy_api

--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -26,6 +26,12 @@ then
         echo "Not on master K8S node; no need to compile Cilium container"
     fi
 else
+
+    # symlink all go bins to /usr/bin so envoy can use them without
+    # changing envoy's PATH to include $GOPATH/bin
+    # Clean this once we move to the next ginkgo VM image
+    sudo -E ln -s ${GOPATH}/bin/* /usr/local/bin
+
     sudo -u vagrant -H -E make PKG_BUILD=1
     make install
     mkdir -p /etc/sysconfig/


### PR DESCRIPTION
This allows to re-build envoy even if PATH is changed without compiling
it from scratch.

Signed-off-by: André Martins <andre@cilium.io>