### PR TITLE
vagrant: Add openSUSE support

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -57,13 +57,13 @@ contribute to Cilium:
 
 To run Cilium locally on VMs, you need:
 
-+----------------------------------------------------------------------------------+-----------------------+--------------------------------------------------------------------------------+
-| Dependency                                                                       | Version / Commit ID   | Download Command                                                               |
-+==================================================================================+=======================+================================================================================+
-| `Vagrant <https://www.vagrantup.com/downloads.html>`_                            | >= 1.8.3              | `Vagrant Install Instructions <https://www.vagrantup.com/docs/installation/>`_ |
-+----------------------------------------------------------------------------------+-----------------------+--------------------------------------------------------------------------------+
-| `VirtualBox <https://www.virtualbox.org/wiki/Downloads>`_ (if not using libvirt) | >= 5.1.22             | N/A (OS-specific)                                                              |
-+----------------------------------------------------------------------------------+-----------------------+--------------------------------------------------------------------------------+
++-----------------------------------------------------------+---------------------+--------------------------------------------------------------------------------+
+| Dependency                                                | Version / Commit ID | Download Command                                                               |
++===========================================================+=====================+================================================================================+
+| `Vagrant <https://www.vagrantup.com/downloads.html>`_     | >= 1.8.3            | `Vagrant Install Instructions <https://www.vagrantup.com/docs/installation/>`_ |
++-----------------------------------------------------------+---------------------+--------------------------------------------------------------------------------+
+| `VirtualBox <https://www.virtualbox.org/wiki/Downloads>`_ | >= 5.1.22           | N/A (OS-specific)                                                              |
++-----------------------------------------------------------+---------------------+--------------------------------------------------------------------------------+
 
 Finally, in order to build the documentation, you should have Sphinx installed:
 
@@ -87,8 +87,13 @@ environment variables and network setup that are managed via
 Using the provided Vagrantfile
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To bring up a Vagrant VM  with Cilium
-plus dependencies installed, run:
+Cilium's Vagrantfile supports two boxes:
+
+* ``cilium/ubuntu`` (default)
+* ``cilium/opensuse``
+
+To bring up a Vagrant VM with Cilium plus dependencies installed, using the
+default Ubuntu box, run:
 
 ::
 
@@ -99,6 +104,14 @@ This will create and run a vagrant VM based on the base box
 following providers:
 
 * virtualbox
+
+To use openSUSE box, run.
+
+::
+
+    $ export DISTRIBUTION=opensuse
+    $ contrib/vagrant/start.sh
+
 
 Options
 ^^^^^^^
@@ -121,15 +134,15 @@ kubernetes installed and plus a worker, run:
 
 	$ IPV4=1 K8S=1 NWORKERS=1 contrib/vagrant/start.sh
 
-If you have any issue with the provided vagrant box
-``cilium/ubuntu-16.10`` or need a different box format, you may
-build the box yourself using the `packer scripts <https://github.com/cilium/packer-ubuntu-16.10>`_
+If you have any issue with the provided vagrant boxes
+(``cilium/ubuntu`` or ``cilium/opensuse``) or need a different box format,
+you may build the box yourself using the `packer scripts <https://github.com/cilium/packer-ci-build>`_
 
 Manual Installation
 ^^^^^^^^^^^^^^^^^^^
 
-Alternatively you can import the vagrant box ``cilium/ubuntu``
-directly and manually install Cilium:
+Alternatively you can import the vagrant box ``cilium/ubuntu`` or
+``cilium/opensuse`` directly and manually install Cilium:
 
 ::
 

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -7,12 +7,12 @@ $JOB_NAME = ENV['JOB_BASE_NAME'] || "LOCAL"
 $K8S_VERSION = ENV['K8S_VERSION'] || "1.9"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 
-$SERVER_BOX= "cilium/ubuntu"
+$DISTRIBUTION = ENV['DISTRIBUTION'] || "ubuntu"
 $SERVER_VERSION="41"
 
 # RAM and CPU settings
 $MEMORY = (ENV['MEMORY'] || "4096").to_i
-$CPU = (ENV['CPU'] || "2").to_i
+$VCPU = (ENV['VCPU'] || "2").to_i
 
 ENV["VAGRANT_DEFAULT_PROVIDER"] = "virtualbox"
 Vagrant.configure("2") do |config|
@@ -20,19 +20,19 @@ Vagrant.configure("2") do |config|
     config.vm.define "runtime" do |server|
         server.vm.provider "virtualbox" do |vb|
             vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
-            vb.cpus = $CPU
+            vb.cpus = $VCPU
             vb.memory= $MEMORY
             vb.linked_clone = true
         end
 
-        server.vm.box =  "#{$SERVER_BOX}"
+        server.vm.box = "cilium/#{$DISTRIBUTION}"
         server.vm.box_version = $SERVER_VERSION
         server.vm.hostname = "runtime"
         server.vm.synced_folder "../", "/home/vagrant/go/src/github.com/cilium/cilium"
 
         # Provision section
         server.vm.provision :shell,
-            :inline => "sed -i 's/^mesg n$/tty -s \\&\\& mesg n/g' /root/.profile"
+                            :path => "./provision/profile.sh"
         server.vm.provision "file", source: "provision", destination: "/tmp/provision"
         server.vm.provision "shell" do |sh|
             sh.path = "./provision/runtime_install.sh"
@@ -45,12 +45,12 @@ Vagrant.configure("2") do |config|
             server.vm.provider "virtualbox" do |vb|
                 # vb.customize ["modifyvm", :id, "--memory", "2048"]
                 vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
-                vb.cpus = $CPU
+                vb.cpus = $VCPU
                 vb.memory= $MEMORY
                 vb.linked_clone = true
             end
 
-            server.vm.box =  "#{$SERVER_BOX}"
+            server.vm.box = "cilium/#{$DISTRIBUTION}"
             server.vm.box_version = $SERVER_VERSION
             server.vm.hostname = "k8s#{i}"
             server.vm.network "private_network",
@@ -60,7 +60,7 @@ Vagrant.configure("2") do |config|
             server.vm.synced_folder "../", "/home/vagrant/go/src/github.com/cilium/cilium"
             # Provision section
             server.vm.provision :shell,
-                :inline => "sed -i 's/^mesg n$/tty -s \\&\\& mesg n/g' /root/.profile"
+                                :path => "./provision/profile.sh"
             server.vm.provision "file", source: "provision", destination: "/tmp/provision"
             server.vm.provision "shell" do |sh|
                 sh.path = "./provision/k8s_install.sh"

--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -36,6 +36,6 @@ else
         systemctl enable $service || echo "service $service failed"
         systemctl restart $service || echo "service $service failed to restart"
     done
-    echo "running \"sudo adduser vagrant cilium\" "
-    sudo adduser vagrant cilium
+    echo "running \"sudo usermod -a -G cilium vagrant\" "
+    sudo usermod -a -G cilium vagrant
 fi

--- a/test/provision/dns.sh
+++ b/test/provision/dns.sh
@@ -3,8 +3,9 @@
 # This script update the dns servers to use google ones.
 set -e
 
-sudo systemctl disable systemd-resolved.service
-sudo service systemd-resolved stop
+if systemctl status systemd-resolved; then
+    sudo systemctl disable systemd-resolved
+fi
 
 echo "updating /etc/resolv.conf"
 

--- a/test/provision/helpers.bash
+++ b/test/provision/helpers.bash
@@ -43,8 +43,16 @@ function install_using_apt {
         "$@"
 }
 
+function install_using_zypper {
+    zypper -n --gpg-auto-import-key in --no-recommends -f "$@"
+}
+
 function install_k8s_using_packages {
-    install_using_apt "$@"
+    if grep Ubuntu /etc/lsb-release; then
+        install_using_apt "$@"
+    else
+        install_using_zypper "$@"
+    fi
 }
 
 function install_k8s_using_binary {

--- a/test/provision/profile.sh
+++ b/test/provision/profile.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+cat <<EOF > /root/.profile
+# ~/.profile: executed by Bourne-compatible login shells.
+
+if [ "$BASH" ]; then
+  if [ -f ~/.bashrc ]; then
+    . ~/.bashrc
+  fi
+fi
+
+mesg n || true
+EOF

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -11,7 +11,7 @@ source "${PROVISIONSRC}/helpers.bash"
 # Delete this section when the new server is ready
 # https://github.com/cilium/cilium/pull/3023/files
 export GOPATH="/home/vagrant/go"
-sudo -E /usr/local/go/bin/go get -d github.com/lyft/protoc-gen-validate
+sudo -E go get -d github.com/lyft/protoc-gen-validate
 
 cd ${GOPATH}/src/github.com/lyft/protoc-gen-validate
 sudo git checkout 930a67cf7ba41b9d9436ad7a1be70a5d5ff6e1fc


### PR DESCRIPTION
We already have a Vagrant box for openSUSE and this change brings
the support of them in all Vagrantfiles. To sum it up, we will
support Ubuntu and openSUSE as distributions that developer
can choose for his dev environment and we may use both of them
in CI in the future.

The choice of distribution is determined by the DISTRIBUTION
environment variable. If it's not defined, then Ubuntu will be
chosen. So, for example, if someone wants to use Ubuntu, then our
script for running Vagrant can be used as usually:

```
./contrib/vagrant/start.sh
```

Or we can explicitly tell the script to use Ubuntu:

```
export DISTRIBUTION=ubuntu
./contrib/vagrant/start.sh
```

If someone wants to use openSUSE, then the following commands
need to be used:

```
export DISTRIBUTION=opensuse
./contrib/vagrant/start.sh
```

In order to bring the support of openSUSE, some other changes were
needed.

First of them was changing the directory for systemd units from
/lib/systemd/system to /etc/systemd/system. That's because Ubuntu
and openSUSE use different directories for installing systemd units
from packages. Ubuntu - /lib/systemd/system, openSUSE (and other
RPM-based distributions) - /usr/lib/systemd/system. On the other
hand, /etc/systemd/system directory is expected to be used by
administrators to put hand-written units in and it doesn't differ
in distributions. That's why using /etc/systemd/system is more
appropriate for us.

The other change is related to network interface names. Ubuntu
uses NetworkManager[1] which uses names like i.e. enp0s8.
openSUSE uses wicked[2] which uses names like i.e. eth1.

Usage of go binary for fetching dependencies (go-bindata, gops)
needed to change as well - we're using it from $PATH instead of
hardcoding the absolute path. In Ubuntu we fetch go binary and
save it in /usr/local/go/bin/go, in openSUSE we install go from
packages.

On Ubuntu, test/Vagrantfile needs to modify the mesg command in
/root/.profile, but openSUSE doesn't contain that file at all,
so it's just created with the appropriate content for both
distros.

The last needed change was using useradd instead of adduser.
useradd is the more commonly used project and adduser isn't
packaged in openSUSE (and in the most RPM-based distributions
as well).

[1] https://wiki.gnome.org/Projects/NetworkManager
[2] https://github.com/openSUSE/wicked

Signed-off-by: Michal Rostecki <mrostecki@suse.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/2712)
<!-- Reviewable:end -->
