### PR TITLE
Ginkgo: Refactor Nightly endpoint measurement

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -357,6 +357,14 @@ func (kub *Kubectl) CiliumEndpointsIDs(pod string) map[string]string {
 		"cilium endpoint list -o jsonpath='%s'", filter)).KVOutput()
 }
 
+// CiliumEndpointsStatus returns a mapping  of a pod name to it is corresponding
+// endpoint's status
+func (kub *Kubectl) CiliumEndpointsStatus(pod string) map[string]string {
+	filter := `{range [*]}{@.pod-name}{"="}{@.state}{"\n"}{end}`
+	return kub.CiliumExec(pod, fmt.Sprintf(
+		"cilium endpoint list -o jsonpath='%s'", filter)).KVOutput()
+}
+
 // CiliumEndpointsIdentityIDs returns a mapping with of a pod name to it is
 // corresponding endpoint's security identity
 func (kub *Kubectl) CiliumEndpointsIdentityIDs(pod string) map[string]string {
@@ -719,7 +727,7 @@ func (epMap *EndpointMap) GetPolicyStatus() map[string]int {
 // AreReady returns true if all Cilium endpoints are in 'ready' state
 func (epMap *EndpointMap) AreReady() bool {
 	for _, ep := range *epMap {
-		if ep.State != "ready" {
+		if ep.State != models.EndpointStateReady {
 			return false
 		}
 	}

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -111,7 +111,10 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 						result[state]++
 					}
 					count += result[desiredState]
-					log.WithField("status", result).Debugf("Cilium %s endpoint status are:", pod)
+					logger.WithFields(logrus.Fields{
+						"status": result,
+						"pod":    pod,
+					}).Info("Cilium endpoint status")
 				}
 				return count >= endpointCount
 			}, endpointsTimeout, 3*time.Second).Should(BeTrue())


### PR DESCRIPTION
- Created a timeout based on the number of endpoints.
- Log endpoints status
- Clean kubectl ready state
- Added Kubectl.CiliumEndpointsStatus

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>