### PR TITLE
bpf: Generate BPF header in order after generating policy

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -464,11 +464,6 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 		e.Consumable.Mutex.Unlock()
 	}
 
-	if err = e.writeHeaderfile(epdir, owner); err != nil {
-		e.Mutex.Unlock()
-		return 0, fmt.Errorf("Unable to write header file: %s", err)
-	}
-
 	// If dry mode is enabled, no further changes to BPF maps are performed
 	if owner.DryModeEnabled() {
 		// Regenerate policy and apply any options resulting in the
@@ -477,6 +472,11 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 		if _, _, _, _, err = e.regeneratePolicy(owner, nil); err != nil {
 			e.Mutex.Unlock()
 			return 0, fmt.Errorf("Unable to regenerate policy: %s", err)
+		}
+
+		if err = e.writeHeaderfile(epdir, owner); err != nil {
+			e.Mutex.Unlock()
+			return 0, fmt.Errorf("Unable to write header file: %s", err)
 		}
 		e.Mutex.Unlock()
 
@@ -562,6 +562,11 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 		}
 		wg := e.updateCT(owner, flushEndpointCT, consumersAdd, consumersToRm)
 		defer wg.Wait()
+	}
+
+	if err = e.writeHeaderfile(epdir, owner); err != nil {
+		e.Mutex.Unlock()
+		return 0, fmt.Errorf("Unable to write header file: %s", err)
 	}
 
 	epInfoCache := e.createEpInfoCache()


### PR DESCRIPTION
This is a long standing bug. The BPF header file was generated before the
initial policy generation is performed for the first time. This implied that
all configuration options and settings that have been changed in the policy
generation did not take effect until the next generation cycle.

Fixes: #2711

Signed-off-by: Thomas Graf <thomas@cilium.io>
