### PR TITLE
cilium/cmd: fix order of strings in error messages

### DIFF
--- a/cilium/cmd/policy_trace.go
+++ b/cilium/cmd/policy_trace.go
@@ -246,12 +246,12 @@ func getSecIDFromK8s(podName string) (string, error) {
 
 	p, err := k8sClient.CoreV1().Pods(namespace).Get(pod, meta_v1.GetOptions{})
 	if err != nil {
-		return "", fmt.Errorf("unable to get pod %s in namespace %s", namespace, pod)
+		return "", fmt.Errorf("unable to get pod %s in namespace %s", pod, namespace)
 	}
 
 	secID := p.GetAnnotations()[common.CiliumIdentityAnnotation]
 	if secID == "" {
-		return "", fmt.Errorf("cilium-identity annotation not set for pod %s in namespace %s", namespace, pod)
+		return "", fmt.Errorf("cilium-identity annotation not set for pod %s in namespace %s", pod, namespace)
 	}
 
 	return secID, nil


### PR DESCRIPTION
The "pod" and "namespace" fields were in the incorrect order in some error
messages.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #2713 