### PR TITLE
completion: Refactor proxy completion logic in a new package

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -64,6 +64,7 @@ monitor/payload @cilium/api
 pkg/apierror/ @cilium/api
 pkg/apisocket/ @cilium/api
 pkg/bpf/ @cilium/bpf
+pkg/completion/ @cilium/proxy
 pkg/endpoint/ @cilium/endpoint
 pkg/envoy/ @cilium/proxy
 pkg/health/ @cilium/health

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -124,7 +124,7 @@ func (d *Daemon) UpdateProxyRedirect(e *endpoint.Endpoint, l4 *policy.L4Filter) 
 		return 0, fmt.Errorf("can't redirect, proxy disabled")
 	}
 
-	r, err := d.l7Proxy.CreateOrUpdateRedirect(l4, e.ProxyID(l4), e, d, e)
+	r, err := d.l7Proxy.CreateOrUpdateRedirect(l4, e.ProxyID(l4), e, d, e.ProxyWaitGroup)
 	if err != nil {
 		return 0, err
 	}
@@ -143,7 +143,7 @@ func (d *Daemon) RemoveProxyRedirect(e *endpoint.Endpoint, id string) error {
 		logfields.EndpointID: e.ID,
 		logfields.L4PolicyID: id,
 	}).Debug("Removing redirect to endpoint")
-	return d.l7Proxy.RemoveRedirect(id, e)
+	return d.l7Proxy.RemoveRedirect(id, e.ProxyWaitGroup)
 }
 
 // QueueEndpointBuild puts the given request in the endpoints queue for

--- a/pkg/completion/completion.go
+++ b/pkg/completion/completion.go
@@ -1,0 +1,118 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package completion
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// WaitGroup waits for a collection of Completions to complete.
+type WaitGroup struct {
+	// ctx is the context of all the Completions in the wait group.
+	ctx context.Context
+
+	// counterLocker locks all calls to AddCompletion and Wait, which must not
+	// be called concurrently.
+	counterLocker lock.Mutex
+
+	// pendingCompletions is the list of Completions returned by
+	// AddCompletion() which have not yet been completed.
+	pendingCompletions []*Completion
+}
+
+// NewWaitGroup returns a new WaitGroup using the given context.
+func NewWaitGroup(ctx context.Context) *WaitGroup {
+	return &WaitGroup{ctx: ctx}
+}
+
+// Context returns the context of all the Completions in the wait group.
+func (wg *WaitGroup) Context() context.Context {
+	return wg.ctx
+}
+
+// AddCompletion creates a new completion, adds it into the wait group, and
+// returns it.
+func (wg *WaitGroup) AddCompletion() *Completion {
+	wg.counterLocker.Lock()
+	defer wg.counterLocker.Unlock()
+	c := &Completion{
+		ctx:       wg.ctx,
+		completed: make(chan struct{}),
+	}
+	wg.pendingCompletions = append(wg.pendingCompletions, c)
+	return c
+}
+
+// Wait blocks until all completions added by calling AddCompletion are
+// completed, or the context is canceled, whichever happens first.
+// Returns the context's error if it is cancelled, nil otherwise.
+func (wg *WaitGroup) Wait() error {
+	wg.counterLocker.Lock()
+	defer wg.counterLocker.Unlock()
+
+Loop:
+	for i, comp := range wg.pendingCompletions {
+		select {
+		case <-comp.Completed():
+			continue Loop
+		case <-wg.ctx.Done():
+			// Complete the remaining completions to make sure their completed
+			// channels are closed.
+			for _, comp := range wg.pendingCompletions[i:] {
+				comp.Complete()
+			}
+			break Loop
+		}
+	}
+	wg.pendingCompletions = nil
+	return wg.ctx.Err()
+}
+
+// Completion provides the Complete callback to be called when an asynchronous
+// computation is completed.
+type Completion struct {
+	// ctx is the context of the wait group.
+	ctx context.Context
+
+	// completed is the channel to be closed when Complete is called the first
+	// time.
+	completed chan struct{}
+}
+
+// Context returns the context of the asynchronous computation.
+// If the context is cancelled, e.g. if it times out, the computation must be
+// cancelled.
+func (c *Completion) Context() context.Context {
+	return c.ctx
+}
+
+// Complete notifies of the completion of the asynchronous computation.
+// Idempotent.
+func (c *Completion) Complete() {
+	select {
+	case <-c.completed:
+	default:
+		close(c.completed)
+	}
+}
+
+// Completed returns a channel that's closed when the completion is completed,
+// i.e. when Complete is called the first time, or when the call to the parent
+// WaitGroup's Wait terminated because the context was canceled.
+func (c *Completion) Completed() <-chan struct{} {
+	return c.completed
+}

--- a/pkg/completion/completion_test.go
+++ b/pkg/completion/completion_test.go
@@ -1,0 +1,165 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package completion
+
+import (
+	"testing"
+	"time"
+
+	"context"
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	//logging.ToggleDebugLogs(true)
+	TestingT(t)
+}
+
+type CompletionSuite struct{}
+
+var _ = Suite(&CompletionSuite{})
+
+const (
+	TestTimeout      = 10 * time.Second
+	WaitGroupTimeout = 250 * time.Millisecond
+	CompletionDelay  = 250 * time.Millisecond
+)
+
+func (s *CompletionSuite) TestNoCompletion(c *C) {
+	var err error
+
+	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	defer cancel()
+
+	wg := NewWaitGroup(ctx)
+
+	// Wait should return immediately, since there are no completions.
+	err = wg.Wait()
+	c.Assert(err, IsNil)
+}
+
+func (s *CompletionSuite) TestCompletionBeforeWait(c *C) {
+	var err error
+
+	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	defer cancel()
+
+	wg := NewWaitGroup(ctx)
+
+	comp := wg.AddCompletion()
+	c.Assert(comp.Context(), Equals, ctx)
+
+	comp.Complete()
+
+	// Wait should return immediately, since the only completion is already completed.
+	err = wg.Wait()
+	c.Assert(err, IsNil)
+}
+
+func (s *CompletionSuite) TestCompletionAfterWait(c *C) {
+	var err error
+
+	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	defer cancel()
+
+	wg := NewWaitGroup(ctx)
+
+	comp := wg.AddCompletion()
+	c.Assert(comp.Context(), Equals, ctx)
+
+	go func() {
+		time.Sleep(CompletionDelay)
+		comp.Complete()
+	}()
+
+	// Wait should block until comp.Complete is called, then return nil.
+	err = wg.Wait()
+	c.Assert(err, IsNil)
+}
+
+func (s *CompletionSuite) TestCompletionBeforeAndAfterWait(c *C) {
+	var err error
+
+	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	defer cancel()
+
+	wg := NewWaitGroup(ctx)
+
+	comp1 := wg.AddCompletion()
+	c.Assert(comp1.Context(), Equals, ctx)
+
+	comp2 := wg.AddCompletion()
+	c.Assert(comp2.Context(), Equals, ctx)
+
+	comp1.Complete()
+
+	go func() {
+		time.Sleep(CompletionDelay)
+		comp2.Complete()
+	}()
+
+	// Wait should block until comp2.Complete is called, then return nil.
+	err = wg.Wait()
+	c.Assert(err, IsNil)
+}
+
+func (s *CompletionSuite) TestCompletionTimeout(c *C) {
+	var err error
+
+	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	defer cancel()
+
+	// Set a shorter timeout to shorten the test duration.
+	wgCtx, cancel := context.WithTimeout(ctx, WaitGroupTimeout)
+	defer cancel()
+	wg := NewWaitGroup(wgCtx)
+
+	comp := wg.AddCompletion()
+	c.Assert(comp.Context(), Equals, wgCtx)
+
+	// comp never completes.
+
+	// Wait should block until wgCtx expires.
+	err = wg.Wait()
+	c.Assert(err, Not(IsNil))
+	c.Assert(err, Equals, wgCtx.Err())
+
+	// Complete is idempotent and harmless, and can be called after the
+	// context is canceled.
+	comp.Complete()
+}
+
+func (s *CompletionSuite) TestCompletionMultipleCallbacks(c *C) {
+	var err error
+
+	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	defer cancel()
+
+	// Set a shorter timeout to shorten the test duration.
+	wg := NewWaitGroup(ctx)
+
+	comp := wg.AddCompletion()
+	c.Assert(comp.Context(), Equals, ctx)
+
+	// Complete is idempotent.
+	comp.Complete()
+	comp.Complete()
+	comp.Complete()
+
+	// Wait should return immediately, since the only completion is already completed.
+	err = wg.Wait()
+	c.Assert(err, IsNil)
+}

--- a/pkg/completion/doc.go
+++ b/pkg/completion/doc.go
@@ -1,0 +1,58 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package completion implements a variant of sync.WaitGroup that is associated
+// with a context.Context.
+//
+// A WaitGroup is created by calling NewWaitGroup with the context:
+//
+//    wg := completion.NewWaitGroup(ctx)
+//
+// For each concurrent computation to wait for, a Completion is created by
+// calling AddCompletion and then passing it to the concurrent computation:
+//
+//    comp1 := wg.AddCompletion()
+//    DoSomethingConcurrently(..., comp1)
+//    comp2 := wg.AddCompletion()
+//    DoSomethingElse(..., comp2)
+//
+// The Completion type provides the WaitGroup's context and the Complete
+// method:
+//
+//    func (c *Completion) Context() context.Context
+//    func (c *Completion) Complete()
+//    func (c *Completion) Completed() <-chan struct{}
+//
+// The Complete method must be called when the concurrent computation is
+// completed, for instance:
+//
+//    func DoSomethingConcurrently(..., comp Completion) {
+//        ...
+//        go func() {
+//            ...
+//            // Computation is completed successfully.
+//            comp.Complete()
+//        }()
+//        ...
+//    }
+//
+// Once all Completions are created, one can wait for the completion of all
+// of the Completions by calling Wait:
+//
+//    err := wg.Wait()
+//
+// Wait blocks until either all Completions are completed, or the context is
+// canceled (e.g. times out), whichever happens first. The returned error is
+// non-nil in the case the context is canceled, nil otherwise.
+package completion

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -13,11 +13,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/policy"
 
 	"github.com/golang/protobuf/proto"
-
 	"github.com/sirupsen/logrus"
 )
 
@@ -298,18 +298,18 @@ func (e *Envoy) StopEnvoy() error {
 }
 
 // AddListener adds a listener to a running Envoy proxy.
-func (e *Envoy) AddListener(name string, port uint16, l7rules policy.L7DataMap, isIngress bool, logger Logger, completions policy.CompletionContainer) {
-	e.lds.addListener(name, port, l7rules, isIngress, logger, completions)
+func (e *Envoy) AddListener(name string, port uint16, l7rules policy.L7DataMap, isIngress bool, logger Logger, wg *completion.WaitGroup) {
+	e.lds.addListener(name, port, l7rules, isIngress, logger, wg)
 }
 
 // UpdateListener changes to the L7 rules of an existing Envoy Listener.
-func (e *Envoy) UpdateListener(name string, l7rules policy.L7DataMap, completions policy.CompletionContainer) {
-	e.lds.updateListener(name, l7rules, completions)
+func (e *Envoy) UpdateListener(name string, l7rules policy.L7DataMap, wg *completion.WaitGroup) {
+	e.lds.updateListener(name, l7rules, wg)
 }
 
 // RemoveListener removes an existing Envoy Listener.
-func (e *Envoy) RemoveListener(name string, completions policy.CompletionContainer) {
-	e.lds.removeListener(name, completions)
+func (e *Envoy) RemoveListener(name string, wg *completion.WaitGroup) {
+	e.lds.removeListener(name, wg)
 }
 
 // ChangeLogLevel changes Envoy log level to correspond to the logrus log level 'level'.

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/labels"
@@ -26,18 +25,6 @@ import (
 
 	"github.com/op/go-logging"
 )
-
-// Completion is an interface for an individual asynchronous success/failure
-// notification.
-type Completion interface {
-	Completed(bool)
-}
-
-// CompletionContainer is an interface for pooling asynchronous success/failure
-// notifications.
-type CompletionContainer interface {
-	AddCompletion() (Completion, time.Duration)
-}
 
 type Tracing int
 

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/pkg/policy"
@@ -59,7 +60,7 @@ var envoyOnce sync.Once
 
 // createEnvoyRedirect creates a redirect with corresponding proxy
 // configuration. This will launch a proxy instance.
-func createEnvoyRedirect(l4 *policy.L4Filter, id string, source ProxySource, to uint16, completions policy.CompletionContainer) (Redirect, error) {
+func createEnvoyRedirect(l4 *policy.L4Filter, id string, source ProxySource, to uint16, wg *completion.WaitGroup) (Redirect, error) {
 	envoyOnce.Do(func() {
 		// Start Envoy on first invocation
 		envoyProxy = envoy.StartEnvoy(9901, viper.GetString("state-dir"),
@@ -74,7 +75,7 @@ func createEnvoyRedirect(l4 *policy.L4Filter, id string, source ProxySource, to 
 			source:  source,
 		}
 
-		envoyProxy.AddListener(id, to, l4.L7RulesPerEp, l4.Ingress, redir, completions)
+		envoyProxy.AddListener(id, to, l4.L7RulesPerEp, l4.Ingress, redir, wg)
 
 		return redir, nil
 	}
@@ -83,18 +84,18 @@ func createEnvoyRedirect(l4 *policy.L4Filter, id string, source ProxySource, to 
 }
 
 // UpdateRules replaces old l7 rules of a redirect with new ones.
-func (r *EnvoyRedirect) UpdateRules(l4 *policy.L4Filter, completions policy.CompletionContainer) error {
+func (r *EnvoyRedirect) UpdateRules(l4 *policy.L4Filter, wg *completion.WaitGroup) error {
 	if envoyProxy != nil {
-		envoyProxy.UpdateListener(r.id, l4.L7RulesPerEp, completions)
+		envoyProxy.UpdateListener(r.id, l4.L7RulesPerEp, wg)
 		return nil
 	}
 	return fmt.Errorf("%s: Envoy proxy process failed to start, can not update redirect ", r.id)
 }
 
 // Close the redirect.
-func (r *EnvoyRedirect) Close(completions policy.CompletionContainer) {
+func (r *EnvoyRedirect) Close(wg *completion.WaitGroup) {
 	if envoyProxy != nil {
-		envoyProxy.RemoveListener(r.id, completions)
+		envoyProxy.RemoveListener(r.id, wg)
 	}
 }
 

--- a/pkg/proxy/kafka.go
+++ b/pkg/proxy/kafka.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/pkg/kafka"
 	"github.com/cilium/cilium/pkg/lock"
@@ -408,7 +409,7 @@ func (k *kafkaRedirect) handleResponseConnection(pair *connectionPair,
 }
 
 // UpdateRules replaces old l7 rules of a redirect with new ones.
-func (k *kafkaRedirect) UpdateRules(l4 *policy.L4Filter, completions policy.CompletionContainer) error {
+func (k *kafkaRedirect) UpdateRules(l4 *policy.L4Filter, wg *completion.WaitGroup) error {
 	if l4.L7Parser != policy.ParserTypeKafka {
 		return fmt.Errorf("invalid type %q, must be of type ParserTypeKafka", l4.L7Parser)
 	}
@@ -424,7 +425,7 @@ func (k *kafkaRedirect) UpdateRules(l4 *policy.L4Filter, completions policy.Comp
 }
 
 // Close the redirect.
-func (k *kafkaRedirect) Close(policy.CompletionContainer) {
+func (k *kafkaRedirect) Close(wg *completion.WaitGroup) {
 	k.socket.Close()
 }
 


### PR DESCRIPTION
Move the completion into its own package: github.com/cilium/cilium/pkg/completion.
Rename CompletionContainer into WaitGroup to reflect the similarity with sync.WaitGroup.
Refactor Completion and WaitGroup to take a Context and handle context cancellation.
Rename Completion.Completed into Complete to make it a verb.
Added Completion.Completed method to return a channel, to make it easier to use in unit tests.

Revert the (de)serialization of the ProxyCompletions field to/from JSON within the Endpoint struct, and rename ProxyCompletions into ProxyWaitGroup.

Signed-off-by: Romain Lenglet <romain@covalent.io>

This is a follow up to https://github.com/cilium/cilium/pull/2694.