### PR TITLE
Create k8s controllers based on kube-apiserver version detected

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -696,7 +696,7 @@ func (d *Daemon) deleteK8sNetworkPolicyV1(k8sNP *networkingv1.NetworkPolicy) {
 // FIXME remove when we drop support to k8s Network Policy extensions/v1beta1
 func (d *Daemon) addK8sNetworkPolicyV1beta1(k8sNP *v1beta1.NetworkPolicy) {
 	scopedLog := log.WithField(logfields.K8sAPIVersion, k8sNP.TypeMeta.APIVersion)
-	rules, err := k8s.ParseNetworkPolicyDeprecated(k8sNP)
+	rules, err := k8s.ParseNetworkPolicyV1beta1(k8sNP)
 	if err != nil {
 		scopedLog.WithError(err).WithField(logfields.Object, logfields.Repr(k8sNP)).Error("Error while parsing k8s NetworkPolicy")
 		return

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -30,6 +30,7 @@ import (
 	cilium_client_v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
+	go_version "github.com/hashicorp/go-version"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -103,6 +104,15 @@ func CreateClient(config *rest.Config) (*kubernetes.Clientset, error) {
 		log.WithField(logfields.IPAddr, config.Host).Info("Connected to k8s api-server")
 	}
 	return cs, err
+}
+
+// GetServerVersion returns the kubernetes api-server version.
+func GetServerVersion() (*go_version.Version, error) {
+	sv, err := Client().Discovery().ServerVersion()
+	if err != nil {
+		return nil, err
+	}
+	return go_version.NewVersion(fmt.Sprintf("%s.%s", sv.Major, sv.Minor))
 }
 
 // isConnReady returns the err for the controller-manager status

--- a/pkg/k8s/network_policy_v1beta.go
+++ b/pkg/k8s/network_policy_v1beta.go
@@ -20,10 +20,12 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 
 	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // GetPolicyLabelsv1beta1 returns the label selector for the given network
@@ -39,83 +41,102 @@ func GetPolicyLabelsv1beta1(np *v1beta1.NetworkPolicy) labels.LabelArray {
 	return k8sconst.GetPolicyLabels(ns, policyName)
 }
 
-// ParseNetworkPolicyDeprecated parses a k8s NetworkPolicy and returns a list of
-// Cilium policy rules that can be added
-func ParseNetworkPolicyDeprecated(np *v1beta1.NetworkPolicy) (api.Rules, error) {
+func parsev1beta1NetworkPolicyPeer(namespace string, peer *v1beta1.NetworkPolicyPeer) *api.EndpointSelector {
+	var labelSelector *metav1.LabelSelector
+
+	// Only one or the other can be set, not both
+	if peer.PodSelector != nil {
+		labelSelector = peer.PodSelector
+		if peer.PodSelector.MatchLabels == nil {
+			peer.PodSelector.MatchLabels = map[string]string{}
+		}
+		// The PodSelector should only reflect to the same namespace
+		// the policy is being stored, thus we add the namespace to
+		// the MatchLabels map.
+		peer.PodSelector.MatchLabels[k8sconst.PodNamespaceLabel] = namespace
+	} else if peer.NamespaceSelector != nil {
+		labelSelector = peer.NamespaceSelector
+		matchLabels := map[string]string{}
+		// We use our own special label prefix for namespace metadata,
+		// thus we need to prefix that prefix to all NamespaceSelector.MatchLabels
+		for k, v := range peer.NamespaceSelector.MatchLabels {
+			matchLabels[policy.JoinPath(PodNamespaceMetaLabels, k)] = v
+		}
+		peer.NamespaceSelector.MatchLabels = matchLabels
+
+		// We use our own special label prefix for namespace metadata,
+		// thus we need to prefix that prefix to all NamespaceSelector.MatchLabels
+		for i, lsr := range peer.NamespaceSelector.MatchExpressions {
+			lsr.Key = policy.JoinPath(PodNamespaceMetaLabels, lsr.Key)
+			peer.NamespaceSelector.MatchExpressions[i] = lsr
+		}
+	} else {
+		// Neither PodSelector nor NamespaceSelector set.
+		return nil
+	}
+
+	selector := api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, labelSelector)
+	return &selector
+}
+
+// ParseNetworkPolicyV1beta1 parses a k8s NetworkPolicyv1beta1. Returns a list of
+// Cilium policy rules that can be added, along with an error if there was an
+// error sanitizing the rules.
+func ParseNetworkPolicyV1beta1(np *v1beta1.NetworkPolicy) (api.Rules, error) {
 	ingresses := []api.IngressRule{}
+	egresses := []api.EgressRule{}
+
 	namespace := k8sconst.ExtractNamespace(&np.ObjectMeta)
 	for _, iRule := range np.Spec.Ingress {
-		// Based on NetworkPolicyIngressRule docs:
-		//   From []NetworkPolicyPeer
-		//   If this field is empty or missing, this rule matches all
-		//   sources (traffic not restricted by source).
 		ingress := api.IngressRule{}
-		if iRule.From == nil || len(iRule.From) == 0 {
-			all := api.NewESFromLabels(
-				labels.NewLabel(labels.IDNameAll, "", labels.LabelSourceReserved),
-			)
-			ingress.FromEndpoints = append(ingress.FromEndpoints, all)
-		} else {
+		if iRule.From != nil && len(iRule.From) > 0 {
 			for _, rule := range iRule.From {
-				// Only one or the other can be set, not both
-				if rule.PodSelector != nil {
-					if rule.PodSelector.MatchLabels == nil {
-						rule.PodSelector.MatchLabels = map[string]string{}
-					}
-					// The PodSelector should only reflect to the same namespace
-					// the policy is being stored, thus we add the namespace to
-					// the MatchLabels map.
-					rule.PodSelector.MatchLabels[k8sconst.PodNamespaceLabel] = namespace
-					ingress.FromEndpoints = append(ingress.FromEndpoints,
-						api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, rule.PodSelector))
-				} else if rule.NamespaceSelector != nil {
-					matchLabels := map[string]string{}
-					// We use our own special label prefix for namespace metadata,
-					// thus we need to prefix that prefix to all NamespaceSelector.MatchLabels
-					for k, v := range rule.NamespaceSelector.MatchLabels {
-						matchLabels[policy.JoinPath(PodNamespaceMetaLabels, k)] = v
-					}
-					rule.NamespaceSelector.MatchLabels = matchLabels
+				endpointSelector := parsev1beta1NetworkPolicyPeer(namespace, &rule)
 
-					// We use our own special label prefix for namespace metadata,
-					// thus we need to prefix that prefix to all NamespaceSelector.MatchLabels
-					for i, lsr := range rule.NamespaceSelector.MatchExpressions {
-						lsr.Key = policy.JoinPath(PodNamespaceMetaLabels, lsr.Key)
-						rule.NamespaceSelector.MatchExpressions[i] = lsr
-					}
-					ingress.FromEndpoints = append(ingress.FromEndpoints,
-						api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, rule.NamespaceSelector))
+				if endpointSelector != nil {
+					ingress.FromEndpoints = append(ingress.FromEndpoints, *endpointSelector)
+				} else {
+					// No label-based selectors were in NetworkPolicyPeer.
+					log.WithField(logfields.K8sNetworkPolicyName, np.Name).Debug("NetworkPolicyPeer does not have PodSelector or NamespaceSelector")
+				}
+
+				// Parse CIDR-based parts of rule.
+				if rule.IPBlock != nil {
+					ingress.FromCIDRSet = append(ingress.FromCIDRSet, v1beta1IPBlockToCIDRRule(rule.IPBlock))
 				}
 			}
 		}
 
 		if iRule.Ports != nil && len(iRule.Ports) > 0 {
-			for _, port := range iRule.Ports {
-				if port.Protocol == nil && port.Port == nil {
-					continue
-				}
-
-				protocol := api.ProtoTCP
-				if port.Protocol != nil {
-					protocol, _ = api.ParseL4Proto(string(*port.Protocol))
-				}
-
-				portStr := ""
-				if port.Port != nil {
-					portStr = port.Port.String()
-				}
-
-				portRule := api.PortRule{
-					Ports: []api.PortProtocol{
-						{Port: portStr, Protocol: protocol},
-					},
-				}
-
-				ingress.ToPorts = append(ingress.ToPorts, portRule)
-			}
+			ingress.ToPorts = parseV1Beta1Ports(iRule.Ports)
+		} else if iRule.From == nil || len(iRule.From) == 0 {
+			// Based on NetworkPolicyIngressRule docs:
+			//   From []NetworkPolicyPeer
+			//   If this field is empty or missing, this rule matches all
+			//   sources (traffic not restricted by source).
+			all := api.NewESFromLabels(
+				labels.NewLabel(labels.IDNameAll, "", labels.LabelSourceReserved),
+			)
+			ingress.FromEndpoints = append(ingress.FromEndpoints, all)
 		}
 
 		ingresses = append(ingresses, ingress)
+	}
+
+	for _, eRule := range np.Spec.Egress {
+		egress := api.EgressRule{}
+		if eRule.To != nil && len(eRule.To) > 0 {
+			for _, rule := range eRule.To {
+				if rule.NamespaceSelector != nil || rule.PodSelector != nil {
+					// TODO: GH-2095
+					log.Warning("Cilium does not support PodSelector or NamespaceSelector for K8s Egress rules")
+				}
+				if rule.IPBlock != nil {
+					egress.ToCIDRSet = append(egress.ToCIDRSet, v1beta1IPBlockToCIDRRule(rule.IPBlock))
+				}
+			}
+		}
+		egresses = append(egresses, egress)
 	}
 
 	if np.Spec.PodSelector.MatchLabels == nil {
@@ -127,6 +148,7 @@ func ParseNetworkPolicyDeprecated(np *v1beta1.NetworkPolicy) (api.Rules, error) 
 		EndpointSelector: api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, &np.Spec.PodSelector),
 		Labels:           GetPolicyLabelsv1beta1(np),
 		Ingress:          ingresses,
+		Egress:           egresses,
 	}
 
 	if err := rule.Sanitize(); err != nil {
@@ -134,4 +156,44 @@ func ParseNetworkPolicyDeprecated(np *v1beta1.NetworkPolicy) (api.Rules, error) 
 	}
 
 	return api.Rules{rule}, nil
+}
+
+func v1beta1IPBlockToCIDRRule(block *v1beta1.IPBlock) api.CIDRRule {
+	cidrRule := api.CIDRRule{}
+	cidrRule.Cidr = api.CIDR(block.CIDR)
+	for _, v := range block.Except {
+		cidrRule.ExceptCIDRs = append(cidrRule.ExceptCIDRs, api.CIDR(v))
+	}
+	return cidrRule
+}
+
+// Converts list of K8s NetworkPolicyPorts to Cilium PortRules.
+// Assumes that provided list of NetworkPolicyPorts is not nil.
+func parseV1Beta1Ports(ports []v1beta1.NetworkPolicyPort) []api.PortRule {
+	portRules := []api.PortRule{}
+	for _, port := range ports {
+		if port.Protocol == nil && port.Port == nil {
+			continue
+		}
+
+		protocol := api.ProtoTCP
+		if port.Protocol != nil {
+			protocol, _ = api.ParseL4Proto(string(*port.Protocol))
+		}
+
+		portStr := ""
+		if port.Port != nil {
+			portStr = port.Port.String()
+		}
+
+		portRule := api.PortRule{
+			Ports: []api.PortProtocol{
+				{Port: portStr, Protocol: protocol},
+			},
+		}
+
+		portRules = append(portRules, portRule)
+	}
+
+	return portRules
 }

--- a/pkg/k8s/network_policy_v1beta_test.go
+++ b/pkg/k8s/network_policy_v1beta_test.go
@@ -68,7 +68,7 @@ func (s *K8sSuite) TestParseNetworkPolicyDeprecated(c *C) {
 		},
 	}
 
-	rules, err := ParseNetworkPolicyDeprecated(netPolicy)
+	rules, err := ParseNetworkPolicyV1beta1(netPolicy)
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
@@ -158,7 +158,7 @@ func (s *K8sSuite) TestParseNetworkPolicyUnknownProtoDeprecated(c *C) {
 		},
 	}
 
-	rules, err := ParseNetworkPolicyDeprecated(netPolicy)
+	rules, err := ParseNetworkPolicyV1beta1(netPolicy)
 	c.Assert(err, Not(IsNil))
 	c.Assert(len(rules), Equals, 0)
 }
@@ -178,7 +178,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEmptyFromDeprecated(c *C) {
 		},
 	}
 
-	rules, err := ParseNetworkPolicyDeprecated(netPolicy1)
+	rules, err := ParseNetworkPolicyV1beta1(netPolicy1)
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
@@ -215,7 +215,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEmptyFromDeprecated(c *C) {
 		},
 	}
 
-	rules, err = ParseNetworkPolicyDeprecated(netPolicy2)
+	rules, err = ParseNetworkPolicyV1beta1(netPolicy2)
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 	repo = policy.NewPolicyRepository()
@@ -233,7 +233,7 @@ func (s *K8sSuite) TestParseNetworkPolicyDenyAllDeprecated(c *C) {
 		},
 	}
 
-	rules, err := ParseNetworkPolicyDeprecated(netPolicy1)
+	rules, err := ParseNetworkPolicyV1beta1(netPolicy1)
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
@@ -266,7 +266,7 @@ func (s *K8sSuite) TestParseNetworkPolicyNoIngressDeprecated(c *C) {
 		},
 	}
 
-	rules, err := ParseNetworkPolicyDeprecated(netPolicy)
+	rules, err := ParseNetworkPolicyV1beta1(netPolicy)
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 }
@@ -312,7 +312,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 	err := json.Unmarshal(ex1, &np)
 	c.Assert(err, IsNil)
 
-	rules, err := ParseNetworkPolicyDeprecated(&np)
+	rules, err := ParseNetworkPolicyV1beta1(&np)
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
@@ -404,7 +404,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 	err = json.Unmarshal(ex2, &np)
 	c.Assert(err, IsNil)
 
-	rules, err = ParseNetworkPolicyDeprecated(&np)
+	rules, err = ParseNetworkPolicyV1beta1(&np)
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
@@ -472,7 +472,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 	err = json.Unmarshal(ex3, &np)
 	c.Assert(err, IsNil)
 
-	rules, err = ParseNetworkPolicyDeprecated(&np)
+	rules, err = ParseNetworkPolicyV1beta1(&np)
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
@@ -567,7 +567,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 	err = json.Unmarshal(ex4, &np)
 	c.Assert(err, IsNil)
 
-	rules, err = ParseNetworkPolicyDeprecated(&np)
+	rules, err = ParseNetworkPolicyV1beta1(&np)
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
@@ -579,7 +579,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 	err = json.Unmarshal(ex2, &np)
 	c.Assert(err, IsNil)
 
-	rules, err = ParseNetworkPolicyDeprecated(&np)
+	rules, err = ParseNetworkPolicyV1beta1(&np)
 	// add example 2
 	repo.AddList(rules)
 
@@ -695,7 +695,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 	err = json.Unmarshal(ex5, &np)
 	c.Assert(err, IsNil)
 
-	rules, err = ParseNetworkPolicyDeprecated(&np)
+	rules, err = ParseNetworkPolicyV1beta1(&np)
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 	repo.AddList(rules)


### PR DESCRIPTION
**Summary of changes**:

-  k8s: set up informers / controllers based on api-server version

    Since kubernetes automatically adds a v1 network policy to both v1 and
    v1beta1 resources and a v1beta1 network policy also to both v1 and
    v1beta1 resources, it will be useless to watch for both resource types
    at the same time. For that reason it was added a kube-apiserver version
    detection to set up the necessary informers / controllers based on the
    kube-apiserver version detected.
    
    For example, if kube-apiserver is running with version 1.6. only the
    Cilium TPR (v1) and the kubernetes network policy v1beta1 controllers
    will be started. If kube-apiserver is running with version 1.8 only the
    Cilium CRD (v2) and the kubernetes network policy v1 controllers will be
    started


 - pkg/k8s: mirror parseNetworkPolicy for kubernetes NP v1beta1
Fixes: #2731

```release-note
Set up the k8s watchers based on the kube-apiserver version #2731
```
