### PR TITLE
Add controller StopFunc support

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -38,6 +38,28 @@ func (b *ControllerSuite) TestUpdateRemoveController(c *C) {
 	c.Assert(mngr.RemoveController("not-exist"), Not(IsNil))
 }
 
+func (b *ControllerSuite) TestStopFunc(c *C) {
+	stopFuncRan := false
+	waitChan := make(chan bool)
+
+	mngr := Manager{}
+	mngr.UpdateController("test", ControllerParams{
+		RunInterval: time.Second,
+		DoFunc:      NoopFunc,
+		StopFunc: func() error {
+			stopFuncRan = true
+			close(waitChan)
+			return nil
+		},
+	})
+	c.Assert(mngr.RemoveController("test"), IsNil)
+	select {
+	case <-waitChan:
+	case <-time.After(2 * time.Second):
+	}
+	c.Assert(stopFuncRan, Equals, true)
+}
+
 func (b *ControllerSuite) TestRemoveAll(c *C) {
 	mngr := NewManager()
 	// create


### PR DESCRIPTION
**Summary of changes**:
***Background***
I need to do some resource cleanup when an endpoint is deleted. The state is syncronised via a controller. The current controller design doesn't allow us to use a defer for this, since the user provided DoFunc is called repeatedly (vs the whole controller being a goroutine we write).

***Changes***
- When DoFunc is not set, it will be set to an appropriate stub function. This avoids some extra nil checks in the loop code of the controller
- StopFunc is called on a controller exit.
- Some small contoller refactoring of stats collection to make StopFunc work consistently

***Things to consider***
- Should StopFunc be a defer? We would then wrap the whole shutdown section into a deferred function. This would allow it to catch panics and handle those, but that may not be too useful.
- Does a StopFunc even make sense? A controller is rather long lived, and in the use case I have in mind (endpoint.LeaveLocked) we can install a delete controller instead, so maybe it isn't needed.

In support of https://github.com/cilium/cilium/issues/2183


**How to test (optional)**:
none. I did add a unit test, however.