### PR TITLE
Reusable CRD creation in agent

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -137,7 +137,10 @@ func CreateCustomResourceDefinitions(clientset apiextensionsclient.Interface) er
 
 	log.Debug("Creating CiliumNetworkPolicy/v2 CustomResourceDefinition...")
 	clusterCRD, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Create(res)
-	if err != nil && !errors.IsAlreadyExists(err) {
+	if errors.IsAlreadyExists(err) {
+		clusterCRD, err = clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(cnpCRDName, metav1.GetOptions{})
+	}
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**Summary of changes**:
***Background***
I'm introducing a new CRD that represents endpoints. These are installed and managed by the agent.

***Changes***
- refactor CRD creation code into a reusable function
- CRD creation now always gets the CRD from k8s and creates it if it isn't found. The older code would always see `clusterCRD.Spec.Validation == nil` and update the validation, but only because the `Validation` object was nil on return from the initial CRD `Create`
- The code uses a scoped logrus logger now

***Things to consider***
- I switched most of the log text to use CRD to aid with grepping. It says CustomResourceDefinition on the primary info lines. We could just stick with the longfom name.

In support of https://github.com/cilium/cilium/issues/2183


**How to test (optional)**:
none. I did add a unit test, however.