### PR TITLE
Ginkgo: Added --all-controllers on ReportDump

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -141,27 +141,27 @@ const (
 )
 
 var ciliumCLICommands = map[string]string{
-	"cilium endpoint list -o json":   "endpoint_list.txt",
-	"cilium service list -o json":    "service_list.txt",
-	"cilium config":                  "config.txt",
-	"sudo cilium bpf lb list":        "bpf_lb_list.txt",
-	"sudo cilium bpf ct list global": "bpf_ct_list.txt",
-	"sudo cilium bpf tunnel list":    "bpf_tunnel_list.txt",
-	"cilium policy get":              "policy_get.txt",
-	"cilium status":                  "status.txt",
+	"cilium endpoint list -o json":    "endpoint_list.txt",
+	"cilium service list -o json":     "service_list.txt",
+	"cilium config":                   "config.txt",
+	"sudo cilium bpf lb list":         "bpf_lb_list.txt",
+	"sudo cilium bpf ct list global":  "bpf_ct_list.txt",
+	"sudo cilium bpf tunnel list":     "bpf_tunnel_list.txt",
+	"cilium policy get":               "policy_get.txt",
+	"cilium status --all-controllers": "status.txt",
 }
 
 // ciliumKubCLICommands these commands are the same as `ciliumCLICommands` but
 // it'll run inside a container and it does not have sudo support
 var ciliumKubCLICommands = map[string]string{
-	"cilium endpoint list -o json": "endpoint_list.txt",
-	"cilium service list -o json":  "service_list.txt",
-	"cilium config":                "config.txt",
-	"cilium bpf lb list":           "bpf_lb_list.txt",
-	"cilium bpf ct list global":    "bpf_ct_list.txt",
-	"cilium bpf tunnel list":       "bpf_tunnel_list.txt",
-	"cilium policy get":            "policy_get.txt",
-	"cilium status":                "status.txt",
+	"cilium endpoint list -o json":    "endpoint_list.txt",
+	"cilium service list -o json":     "service_list.txt",
+	"cilium config":                   "config.txt",
+	"cilium bpf lb list":              "bpf_lb_list.txt",
+	"cilium bpf ct list global":       "bpf_ct_list.txt",
+	"cilium bpf tunnel list":          "bpf_tunnel_list.txt",
+	"cilium policy get":               "policy_get.txt",
+	"cilium status --all-controllers": "status.txt",
 }
 
 //GetFilePath returns the absolute path of the provided filename


### PR DESCRIPTION
Added the full output of `cilium status` with the option
--all-controllers

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
