### PR TITLE
api: Remove PortRule.RedirectPort field

### DIFF
--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -311,13 +311,6 @@ type PortRule struct {
 	// +optional
 	Ports []PortProtocol `json:"ports,omitempty"`
 
-	// RedirectPort is the L4 port which, if set, all traffic matching the
-	// Ports is being redirected to. Whatever listener behind that port
-	// becomes responsible to enforce the port rules and is also
-	// responsible to reinject all traffic back and ensure it reaches its
-	// original destination.
-	RedirectPort int `json:"redirectPort,omitempty"`
-
 	// Rules is a list of additional port level rules which must be met in
 	// order for the PortRule to allow the traffic. If omitted or empty,
 	// no layer 7 rules are enforced.

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -168,7 +168,7 @@ func CreateL4Filter(fromEndpoints []api.EndpointSelector, rule api.PortRule, por
 		Port:             int(p),
 		Protocol:         protocol,
 		U8Proto:          u8p,
-		L7RedirectPort:   rule.RedirectPort,
+		L7RedirectPort:   0,
 		L7RulesPerEp:     make(L7DataMap),
 		FromEndpoints:    fromEndpoints,
 		DerivedFromRules: labels.LabelArrayList{ruleLabels},

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -191,10 +191,6 @@ func mergeL4(ctx *SearchContext, dir string, fromEndpoints []api.EndpointSelecto
 			ctx.PolicyTrace("    Allows %s port %v\n", dir, r.Ports)
 		}
 
-		if r.RedirectPort != 0 {
-			ctx.PolicyTrace("      Redirect-To: %d\n", r.RedirectPort)
-		}
-
 		if r.Rules != nil {
 			for _, l7 := range r.Rules.HTTP {
 				ctx.PolicyTrace("        %+v\n", l7)


### PR DESCRIPTION
The redirectPort field in the policy API's PortRule was not tested, not officially documented, and doesn't work in some cases, notably whenever any L7 rule applies to the same port.
Moreover, K8s's NetworkPolicy doesn't have any such field. Such port redirection can be implemented by K8s services, so it's redundant.

Fixes #2743

Signed-off-by: Romain Lenglet <romain@covalent.io>