### PR TITLE
Make Cilium compatible with Kubernetes 1.9

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -554,7 +554,7 @@ func (d *Daemon) installIptablesRules() error {
 		"-A", ciliumForwardChain,
 		"-d", node.GetIPv4ClusterRange().String(),
 		"-o", "cilium_host",
-		"-m", "comment", "--comment", "cilium: any->cluster forward accept",
+		"-m", "comment", "--comment", "cilium: any->cluster on cilium_host forward accept",
 		"-j", "ACCEPT"}, false); err != nil {
 		return err
 	}
@@ -563,7 +563,6 @@ func (d *Daemon) installIptablesRules() error {
 	// cilium_host interface with a source IP in the cluster range.
 	if err := runProg("iptables", []string{
 		"-A", ciliumForwardChain,
-		"-i", "cilium_host",
 		"-s", node.GetIPv4ClusterRange().String(),
 		"-m", "comment", "--comment", "cilium: cluster->any forward accept",
 		"-j", "ACCEPT"}, false); err != nil {


### PR DESCRIPTION
Kubernetes 1.9 has introduced new iptables rules a part of the FORWARD chain in
the filter table:

    -m mark --mark 0x4000/0x4000 -j ACCEPT
    -s 10.233.64.0/18 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
    -d 10.233.64.0/18 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT

Because it is impossible to guarantee the order of iptables rules with multiple
writers, the following rule required by Cilium did no longer take any effect

    -o cilium_host -j MARK --set-xmark 0x0/0x4000

The rule is required to ensure that Cilium can choose the source IP to
masquerade to.

By moving the above Cilium rule to the mangle table, it is guaranteed to run
before the kube-proxy rules residing in the filter table.

Fixes: #2505
Fixes: #2495

