### PR TITLE
Jenkins: Adjust timeouts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
         label 'vagrant'
     }
     options {
-        timeout(time: 120, unit: 'MINUTES')
+        timeout(time: 140, unit: 'MINUTES')
         timestamps()
     }
     stages {
@@ -16,6 +16,9 @@ pipeline {
             environment {
                 MEMORY = '4096'
                 RUN_TEST_SUITE = '1'
+            }
+            options {
+                timeout(time: 120, unit: 'MINUTES')
             }
             steps {
                 parallel(

--- a/ginkgo-all.Jenkinsfile
+++ b/ginkgo-all.Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 60, unit: 'MINUTES')
+        timeout(time: 120, unit: 'MINUTES')
         timestamps()
     }
     stages {
@@ -53,6 +53,9 @@ pipeline {
             environment {
                 GOPATH="${WORKSPACE}"
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
+            }
+            options {
+                timeout(time: 60, unit: 'MINUTES')
             }
             steps {
                 parallel(

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 90, unit: 'MINUTES')
+        timeout(time: 120, unit: 'MINUTES')
         timestamps()
     }
     stages {
@@ -59,6 +59,9 @@ pipeline {
                 GOPATH="${WORKSPACE}"
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
             }
+            options {
+                timeout(time: 60, unit: 'MINUTES')
+            }
             steps {
                 parallel(
                     "Runtime":{
@@ -95,6 +98,9 @@ pipeline {
             environment {
                 GOPATH="${WORKSPACE}"
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
+            }
+            options {
+                timeout(time: 60, unit: 'MINUTES')
             }
             steps {
                 parallel(


### PR DESCRIPTION
With the new behaviour of Jenkins some builds died over timeout. The
global timeout counts from start of the build (Including time in the
queue) with this patch the timeouts are set in the stage part.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>