### PR TITLE
Ginkgo: Added a new helper to ensure pods are terminated.

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -114,6 +114,9 @@ const (
 	OptionDisabled            = "Disabled"
 	OptionEnabled             = "Enabled"
 
+	StateTerminating = "Terminating"
+	StateRunning     = "Running"
+
 	PingCount          = 5
 	CurlConnectTimeout = 5
 

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -55,6 +55,8 @@ var _ = Describe(testName, func() {
 				"cilium endpoint list",
 				"cilium policy get"})
 		}
+		err := kubectl.WaitCleanAllTerminatingPods()
+		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
 	})
 
 	getCilium := func(node string) (pod, ip string) {

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -72,6 +72,8 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 				"cilium service list",
 				"cilium endpoint list"})
 		}
+		err := kubectl.WaitCleanAllTerminatingPods()
+		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
 	})
 
 	endpointCount := 20
@@ -248,6 +250,9 @@ var _ = Describe("NightlyExamples", func() {
 	AfterEach(func() {
 		kubectl.Delete(demoPath)
 		kubectl.Delete(l3Policy)
+
+		err := kubectl.WaitCleanAllTerminatingPods()
+		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
 	})
 
 	// getAppPods return a map where the key is the Application name and the

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -66,6 +66,8 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 				"cilium bpf tunnel list",
 				"cilium endpoint list"})
 		}
+		err := kubectl.WaitCleanAllTerminatingPods()
+		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
 	})
 
 	waitUntilEndpointUpdates := func(pod string, eps map[string]int64, min int) error {
@@ -565,7 +567,10 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 				"cilium bpf tunnel list",
 				"cilium endpoint list"})
 		}
+		err := kubectl.WaitCleanAllTerminatingPods()
+		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
 	})
+
 	It("Policies Across Namespaces", func() {
 
 		namespace := "namespace"

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -58,6 +58,8 @@ var _ = Describe("NightlyPolicies", func() {
 				"cilium endpoint list",
 				"cilium service list"})
 		}
+		err := kubectl.WaitCleanAllTerminatingPods()
+		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
 	})
 
 	Context("PolicyEnforcement default", func() {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -67,6 +67,8 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 				"cilium endpoint list",
 				"cilium policy get"})
 		}
+		err := kubectl.WaitCleanAllTerminatingPods()
+		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
 	})
 
 	testHTTPRequest := func(url string) {

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -60,6 +60,8 @@ var _ = Describe("K8sTunnelTest", func() {
 		}
 
 		kubectl.Delete(demoDSPath)
+		err := kubectl.WaitCleanAllTerminatingPods()
+		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
 	})
 
 	It("Check VXLAN mode", func() {


### PR DESCRIPTION
Added a `WaitCleanAllTerminatingPods` to be sure that all pods are
deleted and not in Terminating state when other test start.

This commit fixes some issues in the latest Jenkins builds:
https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/1291/

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>