### PR TITLE
tests: Wait for Cilium to start up in CIDR limit test

### DIFF
--- a/tests/20-cidr-limit.sh
+++ b/tests/20-cidr-limit.sh
@@ -24,6 +24,7 @@ function cleanup() {
   log "cleanup: `cilium cleanup -f`"
   log "starting cilium with systemctl"
   systemctl start cilium
+  wait_for_cilium_status
 }
 
 trap cleanup EXIT


### PR DESCRIPTION
The 20-cidr-limit.sh test will start Cilium again in the cleanup function but
does not wait for it to come up properly so when the next test is being run,
Cilium is not ready yet which will result in test failures.

Fixes: #2744