### PR TITLE
WIP: remove Consumer type from Cilium

### DIFF
--- a/api/v1/models/endpoint_policy.go
+++ b/api/v1/models/endpoint_policy.go
@@ -19,7 +19,7 @@ type EndpointPolicy struct {
 
 	// List of identities allowed to communicate to this endpoint
 	//
-	AllowedConsumers []int64 `json:"allowed-consumers"`
+	AllowedIngressSecurityIdentities []int64 `json:"allowed-ingress-security-identities"`
 
 	// Build number of calculated policy in use
 	Build int64 `json:"build,omitempty"`
@@ -34,7 +34,7 @@ type EndpointPolicy struct {
 	L4 *L4Policy `json:"l4,omitempty"`
 }
 
-/* polymorph EndpointPolicy allowed-consumers false */
+/* polymorph EndpointPolicy allowed-ingress-security-identities false */
 
 /* polymorph EndpointPolicy build false */
 
@@ -48,7 +48,7 @@ type EndpointPolicy struct {
 func (m *EndpointPolicy) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateAllowedConsumers(formats); err != nil {
+	if err := m.validateAllowedIngressSecurityIdentities(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -69,9 +69,9 @@ func (m *EndpointPolicy) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *EndpointPolicy) validateAllowedConsumers(formats strfmt.Registry) error {
+func (m *EndpointPolicy) validateAllowedIngressSecurityIdentities(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.AllowedConsumers) { // not required
+	if swag.IsZero(m.AllowedIngressSecurityIdentities) { // not required
 		return nil
 	}
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -944,7 +944,7 @@ definitions:
       build:
         description: Build number of calculated policy in use
         type: integer
-      allowed-consumers:
+      allowed-ingress-security-identities:
         description: |
           List of identities allowed to communicate to this endpoint
         type: array

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1438,7 +1438,7 @@ func init() {
       "description": "Policy information of an endpoint",
       "type": "object",
       "properties": {
-        "allowed-consumers": {
+        "allowed-ingress-security-identities": {
           "description": "List of identities allowed to communicate to this endpoint\n",
           "type": "array",
           "items": {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1102,7 +1102,7 @@ func (d *Daemon) removeStaleMap(path string) {
 func (d *Daemon) removeStaleIDFromPolicyMap(id uint32) {
 	gpm, err := policymap.OpenGlobalMap(bpf.MapPath(endpoint.PolicyGlobalMapName))
 	if err == nil {
-		gpm.DeleteConsumer(id)
+		gpm.DeleteIdentity(id)
 		gpm.Close()
 	}
 }

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -85,7 +85,7 @@ func endpointCreator(id uint16, secID policy.NumericIdentity) *e.Endpoint {
 			},
 		},
 		Maps:         map[int]*policymap.PolicyMap{},
-		Consumers:    map[string]*policy.Consumer{},
+		Consumers:    map[policy.NumericIdentity]*policy.Consumer{},
 		ReverseRules: map[policy.NumericIdentity]*policy.Consumer{},
 	}
 	return ep

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -84,9 +84,9 @@ func endpointCreator(id uint16, secID policy.NumericIdentity) *e.Endpoint {
 				"foo" + strID: labels.NewLabel("foo"+strID, "", ""),
 			},
 		},
-		Maps:         map[int]*policymap.PolicyMap{},
-		Consumers:    map[policy.NumericIdentity]*policy.Consumer{},
-		ReverseRules: map[policy.NumericIdentity]*policy.Consumer{},
+		Maps:              map[int]*policymap.PolicyMap{},
+		IngressIdentities: map[policy.NumericIdentity]bool{},
+		ReverseRules:      map[policy.NumericIdentity]bool{},
 	}
 	return ep
 }

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -391,15 +391,16 @@ func updateCT(owner Owner, e *Endpoint, epIPs []net.IP,
 	if isPolicyEnforced {
 		wg.Add(1)
 		go func(wg *sync.WaitGroup) {
-			// consumers added, so we need to flush all CT entries except the idsToKeep
+			// New security identities added, so we need to flush all CT entries
+			// except the idsToKeep.
 			owner.FlushCTEntries(e, isLocal, epIPs, idsToKeep)
 			wg.Done()
 		}(wg)
 	} else {
 		wg.Add(1)
 		go func(wg *sync.WaitGroup) {
-			// consumers removed, so we need to modify all CT entries with ids To Mod
-			// because there's on policy being enforced
+			// Security identities removed, so we need to modify all CT entries
+			// with idsToMod because there's no policy being enforced.
 			owner.ResetProxyPort(e, isLocal, epIPs, idsToMod)
 			wg.Done()
 		}(wg)
@@ -553,7 +554,8 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 		modifiedRules, deletedRules policy.SecurityIDContexts
 		policyChanged               bool
 	)
-	// Only generate & populate policy map if a seclabel and consumer model is set up
+	// Only generate & populate policy map if a security identity is set up for
+	// this endpoint.
 	if c != nil {
 		c.AddMap(e.PolicyMap)
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -624,11 +624,11 @@ func (e *Endpoint) GetPolicyModel() *models.EndpointPolicy {
 	}
 
 	return &models.EndpointPolicy{
-		ID:               int64(e.Consumable.ID),
-		Build:            int64(e.Consumable.Iteration),
-		AllowedConsumers: ingressIdentities,
-		CidrPolicy:       e.L3Policy.GetModel(),
-		L4:               e.Consumable.L4Policy.GetModel(),
+		ID:    int64(e.Consumable.ID),
+		Build: int64(e.Consumable.Iteration),
+		AllowedIngressSecurityIdentities: ingressIdentities,
+		CidrPolicy:                       e.L3Policy.GetModel(),
+		L4:                               e.Consumable.L4Policy.GetModel(),
 	}
 }
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -268,8 +268,7 @@ type Endpoint struct {
 	// PortMap is port mapping configuration of the endpoint
 	PortMap []PortMap // Port mapping used for this endpoint.
 
-	// Consumable is the list of allowed consumers of this endpoint. This
-	// is populated based on the policy.
+	// Consumable represents the security-identity-based policy for this endpoint.
 	Consumable *policy.Consumable `json:"-"`
 
 	// L4Policy is the L4Policy in effect for the
@@ -619,15 +618,15 @@ func (e *Endpoint) GetPolicyModel() *models.EndpointPolicy {
 	e.Consumable.Mutex.RLock()
 	defer e.Consumable.Mutex.RUnlock()
 
-	consumers := []int64{}
-	for _, v := range e.Consumable.Consumers {
-		consumers = append(consumers, int64(v.ID))
+	ingressIdentities := []int64{}
+	for ingressIdentity := range e.Consumable.IngressIdentities {
+		ingressIdentities = append(ingressIdentities, int64(ingressIdentity))
 	}
 
 	return &models.EndpointPolicy{
 		ID:               int64(e.Consumable.ID),
 		Build:            int64(e.Consumable.Iteration),
-		AllowedConsumers: consumers,
+		AllowedConsumers: ingressIdentities,
 		CidrPolicy:       e.L3Policy.GetModel(),
 		L4:               e.Consumable.L4Policy.GetModel(),
 	}
@@ -1027,7 +1026,7 @@ func (e *Endpoint) RemoveFromGlobalPolicyMap() error {
 	if err == nil {
 		// We need to remove ourselves from global map, so that
 		// resources (prog/map reference counts) can be released.
-		gpm.DeleteConsumer(uint32(e.ID))
+		gpm.DeleteIdentity(uint32(e.ID))
 		gpm.Close()
 	}
 

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -78,7 +78,7 @@ func (key *policyKey) String() string {
 	return fmt.Sprintf("%d", key.Identity)
 }
 
-func (pm *PolicyMap) AllowConsumer(id uint32) error {
+func (pm *PolicyMap) AllowIdentity(id uint32) error {
 	key := policyKey{Identity: id}
 	entry := PolicyEntry{Action: 1}
 	return bpf.UpdateElement(pm.Fd, unsafe.Pointer(&key), unsafe.Pointer(&entry), 0)
@@ -92,7 +92,7 @@ func (pm *PolicyMap) AllowL4(id uint32, dport uint16, proto uint8) error {
 	return bpf.UpdateElement(pm.Fd, unsafe.Pointer(&key), unsafe.Pointer(&entry), 0)
 }
 
-func (pm *PolicyMap) ConsumerExists(id uint32) bool {
+func (pm *PolicyMap) IdentityExists(id uint32) bool {
 	key := policyKey{Identity: id}
 	var entry PolicyEntry
 	return bpf.LookupElement(pm.Fd, unsafe.Pointer(&key), unsafe.Pointer(&entry)) == nil
@@ -107,7 +107,7 @@ func (pm *PolicyMap) L4Exists(id uint32, dport uint16, proto uint8) bool {
 	return bpf.LookupElement(pm.Fd, unsafe.Pointer(&key), unsafe.Pointer(&entry)) == nil
 }
 
-func (pm *PolicyMap) DeleteConsumer(id uint32) error {
+func (pm *PolicyMap) DeleteIdentity(id uint32) error {
 	key := policyKey{Identity: id}
 	return bpf.DeleteElement(pm.Fd, unsafe.Pointer(&key))
 }

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -78,6 +78,8 @@ func (key *policyKey) String() string {
 	return fmt.Sprintf("%d", key.Identity)
 }
 
+// AllowIdentity adds an entry into the PolicyMap with key id. Returns an error
+// if the addition did not complete successfully.
 func (pm *PolicyMap) AllowIdentity(id uint32) error {
 	key := policyKey{Identity: id}
 	entry := PolicyEntry{Action: 1}
@@ -92,6 +94,7 @@ func (pm *PolicyMap) AllowL4(id uint32, dport uint16, proto uint8) error {
 	return bpf.UpdateElement(pm.Fd, unsafe.Pointer(&key), unsafe.Pointer(&entry), 0)
 }
 
+// IdentityExists returns whether there is an entry in the PolicyMap with key id.
 func (pm *PolicyMap) IdentityExists(id uint32) bool {
 	key := policyKey{Identity: id}
 	var entry PolicyEntry
@@ -107,6 +110,8 @@ func (pm *PolicyMap) L4Exists(id uint32, dport uint16, proto uint8) bool {
 	return bpf.LookupElement(pm.Fd, unsafe.Pointer(&key), unsafe.Pointer(&entry)) == nil
 }
 
+// DeleteIdentity deletes id from the PolicyMap. Returns an error if the deletion
+// did not succeed.
 func (pm *PolicyMap) DeleteIdentity(id uint32) error {
 	key := policyKey{Identity: id}
 	return bpf.DeleteElement(pm.Fd, unsafe.Pointer(&key))

--- a/pkg/policy/cache.go
+++ b/pkg/policy/cache.go
@@ -36,8 +36,7 @@ type ConsumableCache struct {
 }
 
 // GetConsumableCache returns the consumable cache. The cache is a list of all
-// identities which are in use by local endpoints, either as consumable or
-// consumer.
+// identities which are in use by local endpoints.
 func GetConsumableCache() *ConsumableCache {
 	return consumableCache
 }

--- a/pkg/policy/cache.go
+++ b/pkg/policy/cache.go
@@ -91,22 +91,6 @@ func (c *ConsumableCache) GetReservedIDs() []NumericIdentity {
 	return identities
 }
 
-// GetConsumables returns a map of consumables numeric identity mapped to
-// consumers numeric identities.
-func (c *ConsumableCache) GetConsumables() map[NumericIdentity][]NumericIdentity {
-	consumables := map[NumericIdentity][]NumericIdentity{}
-	c.cacheMU.RLock()
-	for _, consumable := range c.cache {
-		consumers := []NumericIdentity{}
-		for _, consumer := range consumable.Consumers {
-			consumers = append(consumers, consumer.ID)
-		}
-		consumables[consumable.ID] = consumers
-	}
-	c.cacheMU.RUnlock()
-	return consumables
-}
-
 // ResolveIdentityLabels resolves a numeric identity to the identity's labels
 // or nil
 func ResolveIdentityLabels(id NumericIdentity) labels.LabelArray {

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -30,7 +30,6 @@ type Consumer struct {
 	ID           NumericIdentity
 	Reverse      *Consumer
 	DeletionMark bool
-	Decision     api.Decision
 }
 
 func (c *Consumer) StringID() string {
@@ -38,7 +37,7 @@ func (c *Consumer) StringID() string {
 }
 
 func NewConsumer(id NumericIdentity) *Consumer {
-	return &Consumer{ID: id, Decision: api.Allowed}
+	return &Consumer{ID: id}
 }
 
 // Consumable is the entity that is being consumed by a Consumer. It holds all
@@ -289,5 +288,5 @@ func (c *Consumable) Allows(id NumericIdentity) bool {
 	c.Mutex.RLock()
 	consumer := c.getConsumer(id)
 	c.Mutex.RUnlock()
-	return consumer != nil && consumer.Decision == api.Allowed
+	return consumer != nil
 }

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -19,30 +19,12 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/policymap"
-	"github.com/cilium/cilium/pkg/policy/api"
 
 	"github.com/sirupsen/logrus"
 )
 
-// Consumer is the entity that consumes a Consumable. It identifies a source
-// security identity and an allow/deny decision for traffic from that identity.
-type Consumer struct {
-	ID           NumericIdentity
-	Reverse      *Consumer
-	DeletionMark bool
-}
-
-func (c *Consumer) StringID() string {
-	return c.ID.String()
-}
-
-func NewConsumer(id NumericIdentity) *Consumer {
-	return &Consumer{ID: id}
-}
-
-// Consumable is the entity that is being consumed by a Consumer. It holds all
-// of the policies relevant to this security identity, including label-based
-// policies which act on Consumers, and L4Policy.
+// Consumable holds all of the policies relevant to this security identity,
+// including label-based policies, L4Policy, and L7 policy.
 type Consumable struct {
 	// ID of the consumable (same as security ID)
 	ID NumericIdentity `json:"id"`
@@ -56,10 +38,13 @@ type Consumable struct {
 	Iteration uint64 `json:"-"`
 	// Map from bpf map fd to the policymap, the go representation of an endpoint's bpf policy map.
 	Maps map[int]*policymap.PolicyMap `json:"-"`
-	// Consumers contains the list of consumers where the key is the Consumers ID
-	Consumers map[NumericIdentity]*Consumer `json:"consumers"`
-	// ReverseRules contains the consumers that are allowed to receive a reply from this Consumable
-	ReverseRules map[NumericIdentity]*Consumer `json:"-"`
+	// IngressIdentities is the set of security identities from which ingress
+	// traffic is allowed. The value corresponds to whether the corresponding
+	// key (security identity) should be garbage collected upon policy calculation.
+	IngressIdentities map[NumericIdentity]bool `json:"ingress-identities"`
+	// ReverseRules contains the security identities that are allowed to receive
+	// a reply from this Consumable.
+	ReverseRules map[NumericIdentity]bool `json:"-"`
 	// L4Policy contains the policy of this consumable
 	L4Policy *L4Policy `json:"l4-policy"`
 	// L3L4Policy contains the L3, L4 and L7 ingress policy of this consumable
@@ -70,13 +55,13 @@ type Consumable struct {
 // NewConsumable creates a new consumable
 func NewConsumable(id NumericIdentity, lbls *Identity, cache *ConsumableCache) *Consumable {
 	consumable := &Consumable{
-		ID:           id,
-		Iteration:    0,
-		Labels:       lbls,
-		Maps:         map[int]*policymap.PolicyMap{},
-		Consumers:    map[NumericIdentity]*Consumer{},
-		ReverseRules: map[NumericIdentity]*Consumer{},
-		cache:        cache,
+		ID:                id,
+		Iteration:         0,
+		Labels:            lbls,
+		Maps:              map[int]*policymap.PolicyMap{},
+		IngressIdentities: map[NumericIdentity]bool{},
+		ReverseRules:      map[NumericIdentity]bool{},
+		cache:             cache,
 	}
 	if lbls != nil {
 		consumable.LabelArray = lbls.Labels.ToSlice()
@@ -115,42 +100,42 @@ func (c *Consumable) AddMap(m *policymap.PolicyMap) {
 	}).Debug("Adding policy map to consumable")
 	c.Maps[m.Fd] = m
 
-	// Populate the new map with the already established consumers of
-	// this consumable
-	for _, c := range c.Consumers {
-		if err := m.AllowConsumer(c.ID.Uint32()); err != nil {
+	// Populate the new map with the already established allowed identities from
+	// which ingress traffic is allowed.
+	for ingressIdentity := range c.IngressIdentities {
+		if err := m.AllowIdentity(ingressIdentity.Uint32()); err != nil {
 			log.WithError(err).Warn("Update of policy map failed")
 		}
 	}
 }
 
-func (c *Consumable) deleteReverseRule(consumable NumericIdentity, consumer NumericIdentity) {
+func (c *Consumable) deleteReverseRule(consumable NumericIdentity, reverseIdentity NumericIdentity) {
 	if c.cache == nil {
-		log.WithField("consumer", consumer).Error("Consumable without cache association")
+		log.WithField("reverseIdentity", reverseIdentity).Error("Consumable without cache association")
 		return
 	}
 
 	if reverse := c.cache.Lookup(consumable); reverse != nil {
 		// In case Conntrack is disabled, we'll find a reverse
 		// policy rule here that we can delete.
-		if _, ok := reverse.ReverseRules[consumer]; ok {
-			delete(reverse.ReverseRules, consumer)
-			if reverse.wasLastRule(consumer) {
-				reverse.removeFromMaps(consumer)
+		if _, ok := reverse.ReverseRules[reverseIdentity]; ok {
+			delete(reverse.ReverseRules, reverseIdentity)
+			if reverse.wasLastRule(reverseIdentity) {
+				reverse.removeFromMaps(reverseIdentity)
 			}
 		}
 	}
 }
 
 func (c *Consumable) delete() {
-	for _, consumer := range c.Consumers {
+	for identity := range c.IngressIdentities {
 		// FIXME: This explicit removal could be removed eventually to
 		// speed things up as the policy map should get deleted anyway
-		if c.wasLastRule(consumer.ID) {
-			c.removeFromMaps(consumer.ID)
+		if c.wasLastRule(identity) {
+			c.removeFromMaps(identity)
 		}
 
-		c.deleteReverseRule(consumer.ID, c.ID)
+		c.deleteReverseRule(identity, c.ID)
 	}
 
 	if c.cache != nil {
@@ -179,14 +164,9 @@ func (c *Consumable) RemoveMap(m *policymap.PolicyMap) {
 
 }
 
-func (c *Consumable) getConsumer(id NumericIdentity) *Consumer {
-	val, _ := c.Consumers[id]
-	return val
-}
-
 func (c *Consumable) addToMaps(id NumericIdentity) {
 	for _, m := range c.Maps {
-		if m.ConsumerExists(id.Uint32()) {
+		if m.IdentityExists(id.Uint32()) {
 			continue
 		}
 
@@ -196,14 +176,16 @@ func (c *Consumable) addToMaps(id NumericIdentity) {
 		})
 
 		scopedLog.Debug("Updating policy BPF map: allowing Identity")
-		if err := m.AllowConsumer(id.Uint32()); err != nil {
+		if err := m.AllowIdentity(id.Uint32()); err != nil {
 			scopedLog.WithError(err).Warn("Update of policy map failed")
 		}
 	}
 }
 
 func (c *Consumable) wasLastRule(id NumericIdentity) bool {
-	return c.ReverseRules[id] == nil && c.Consumers[id] == nil
+	_, existsIngressIdentity := c.IngressIdentities[id]
+	_, existsInReverseRulesMap := c.ReverseRules[id]
+	return !existsInReverseRulesMap && !existsIngressIdentity
 }
 
 func (c *Consumable) removeFromMaps(id NumericIdentity) {
@@ -214,40 +196,42 @@ func (c *Consumable) removeFromMaps(id NumericIdentity) {
 		})
 
 		scopedLog.Debug("Updating policy BPF map: denying Identity")
-		if err := m.DeleteConsumer(id.Uint32()); err != nil {
+		if err := m.DeleteIdentity(id.Uint32()); err != nil {
 			scopedLog.WithError(err).Warn("Update of policy map failed")
 		}
 	}
 }
 
-// AllowConsumerLocked adds the given consumer ID to the Consumable's
-// consumers map. Must be called with Consumable mutex Locked.
-// returns true if changed, false if not
-func (c *Consumable) AllowConsumerLocked(cache *ConsumableCache, id NumericIdentity) bool {
-	consumer := c.getConsumer(id)
-	if consumer == nil {
+// AllowIngressIdentityLocked adds the given security identity to the Consumable's
+// IngressIdentities map. Must be called with Consumable mutex Locked.
+// Returns true if the identity was not present in this Consumable's
+// IngressIdentities map, and thus had to be added, false if it is already added.
+func (c *Consumable) AllowIngressIdentityLocked(cache *ConsumableCache, id NumericIdentity) bool {
+	_, ok := c.IngressIdentities[id]
+	if !ok {
 		log.WithFields(logrus.Fields{
 			logfields.Identity: id,
 			"consumable":       logfields.Repr(c),
-		}).Debug("New consumer Identity for consumable")
+		}).Debug("New ingress security identity for consumable")
 		c.addToMaps(id)
-		c.Consumers[id] = NewConsumer(id)
+		c.IngressIdentities[id] = true
 		return true
 	}
-	consumer.DeletionMark = false
 	return false // not changed.
 }
 
-// AllowConsumerAndReverseLocked adds the given consumer ID to the Consumable's
-// consumers map and the given consumable to the given consumer's consumers map.
+// AllowIngressIdentityAndReverseLocked adds the given security identity to the
+// Consumable's IngressIdentities map and BPF policy map, as well as this
+// Consumable's security identity to the Consumable representing id's Ingress
+// Identities map and its BPF policy map.
 // Must be called with Consumable mutex Locked.
-// returns true if changed, false if not
-func (c *Consumable) AllowConsumerAndReverseLocked(cache *ConsumableCache, id NumericIdentity) bool {
+// Returns true if changed, false if not.
+func (c *Consumable) AllowIngressIdentityAndReverseLocked(cache *ConsumableCache, id NumericIdentity) bool {
 	log.WithFields(logrus.Fields{
 		logfields.Identity + ".from": id,
 		logfields.Identity + ".to":   c.ID,
 	}).Debug("Allowing direction")
-	changed := c.AllowConsumerLocked(cache, id)
+	changed := c.AllowIngressIdentityLocked(cache, id)
 
 	if reverse := cache.Lookup(id); reverse != nil {
 		log.WithFields(logrus.Fields{
@@ -256,37 +240,35 @@ func (c *Consumable) AllowConsumerAndReverseLocked(cache *ConsumableCache, id Nu
 		}).Debug("Allowing reverse direction")
 		if _, ok := reverse.ReverseRules[c.ID]; !ok {
 			reverse.addToMaps(c.ID)
-			reverse.ReverseRules[c.ID] = NewConsumer(c.ID)
+			reverse.ReverseRules[c.ID] = true
 			return true
 		}
 	}
 	log.WithFields(logrus.Fields{
 		logfields.Identity + ".from": c.ID,
 		logfields.Identity + ".to":   id,
-	}).Warn("Allowed a consumer which can't be found in the reverse direction")
+	}).Warn("Allowed an ingress security identity which can't be found in the reverse direction")
 	return changed
 }
 
-// BanConsumerLocked removes the given consumer from the Consumable's consumers
-// map. Must be called with the Consumable mutex locked.
-func (c *Consumable) BanConsumerLocked(id NumericIdentity) {
-	if consumer, ok := c.Consumers[id]; ok {
-		log.WithField("consumer", logfields.Repr(consumer)).Debug("Removing consumer")
-		delete(c.Consumers, id)
+// RemoveIngressIdentityLocked removes the given security identity from Consumable's
+// IngressIdentities map.
+// Must be called with the Consumable mutex locked.
+func (c *Consumable) RemoveIngressIdentityLocked(id NumericIdentity) {
+	if _, ok := c.IngressIdentities[id]; ok {
+		// TODO (ianvernon) add log field for consumer ID
+		log.WithField(logfields.Identity, id).Debug("Removing ingress identity")
+		delete(c.IngressIdentities, id)
 
 		if c.wasLastRule(id) {
 			c.removeFromMaps(id)
-		}
-
-		if consumer.Reverse != nil {
-			c.deleteReverseRule(id, c.ID)
 		}
 	}
 }
 
 func (c *Consumable) Allows(id NumericIdentity) bool {
 	c.Mutex.RLock()
-	consumer := c.getConsumer(id)
+	_, ok := c.IngressIdentities[id]
 	c.Mutex.RUnlock()
-	return consumer != nil
+	return ok
 }

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -41,7 +41,7 @@ type Consumable struct {
 	// IngressIdentities is the set of security identities from which ingress
 	// traffic is allowed. The value corresponds to whether the corresponding
 	// key (security identity) should be garbage collected upon policy calculation.
-	IngressIdentities map[NumericIdentity]bool `json:"ingress-identities"`
+	IngressIdentities map[NumericIdentity]bool `json:"allowed-ingress-security-identities"`
 	// ReverseRules contains the security identities that are allowed to receive
 	// a reply from this Consumable.
 	ReverseRules map[NumericIdentity]bool `json:"-"`

--- a/pkg/policy/consumer_test.go
+++ b/pkg/policy/consumer_test.go
@@ -29,7 +29,6 @@ const (
 func (s *PolicyTestSuite) TestNewConsumer(c *C) {
 	consumer := NewConsumer(CONSUMER_ID1)
 	c.Assert(consumer.ID, Equals, CONSUMER_ID1)
-	c.Assert(consumer.Decision, Equals, api.Allowed)
 }
 
 func (s *PolicyTestSuite) TestGetConsumer(c *C) {

--- a/pkg/policy/consumer_test.go
+++ b/pkg/policy/consumer_test.go
@@ -16,62 +16,46 @@ package policy
 
 import (
 	. "gopkg.in/check.v1"
-
-	"github.com/cilium/cilium/pkg/policy/api"
 )
 
 const (
-	CONSUMER_ID1 = NumericIdentity(10)
-	CONSUMER_ID2 = NumericIdentity(20)
-	CONSUMER_ID3 = NumericIdentity(30)
+	ID1 = NumericIdentity(10)
+	ID2 = NumericIdentity(20)
+	ID3 = NumericIdentity(30)
 )
 
-func (s *PolicyTestSuite) TestNewConsumer(c *C) {
-	consumer := NewConsumer(CONSUMER_ID1)
-	c.Assert(consumer.ID, Equals, CONSUMER_ID1)
-}
-
-func (s *PolicyTestSuite) TestGetConsumer(c *C) {
+func (s *PolicyTestSuite) TestGetConsumable(c *C) {
 	cache := newConsumableCache()
 
-	c1 := cache.GetOrCreate(CONSUMER_ID1, nil)
+	c1 := cache.GetOrCreate(ID1, nil)
 	c.Assert(c1.Iteration, Equals, uint64(0))
-	c2 := cache.GetOrCreate(CONSUMER_ID1, nil)
+	c2 := cache.GetOrCreate(ID1, nil)
 	c.Assert(c1, Equals, c2)
 
-	c3 := cache.GetOrCreate(CONSUMER_ID2, nil)
+	c3 := cache.GetOrCreate(ID2, nil)
 	c.Assert(c1, Not(Equals), c3)
 }
 
-func (s *PolicyTestSuite) TestConsumer(c *C) {
+// TODO (ianvernon) this might not be needed.
+func (s *PolicyTestSuite) TestConsumable(c *C) {
 	cache := newConsumableCache()
 
-	c1 := cache.GetOrCreate(CONSUMER_ID1, nil)
-	c.Assert(c1.Allows(CONSUMER_ID2), Equals, false)
-	c.Assert(c1.Allows(CONSUMER_ID3), Equals, false)
+	c1 := cache.GetOrCreate(ID1, nil)
+	c.Assert(c1.Allows(ID2), Equals, false)
+	c.Assert(c1.Allows(ID3), Equals, false)
 
-	c1.AllowConsumerLocked(cache, CONSUMER_ID2)
-	c.Assert(c1.Allows(CONSUMER_ID2), Equals, true)
-	consumer1 := c1.getConsumer(CONSUMER_ID2)
-	c.Assert(consumer1.ID, Equals, CONSUMER_ID2)
+	c1.AllowIngressIdentityLocked(cache, ID2)
+	c.Assert(c1.Allows(ID2), Equals, true)
 
-	c1.AllowConsumerLocked(cache, CONSUMER_ID2)
-	c.Assert(c1.Allows(CONSUMER_ID2), Equals, true)
-	consumer2 := c1.getConsumer(CONSUMER_ID2)
-	c.Assert(consumer2.ID, Equals, CONSUMER_ID2)
+	c1.AllowIngressIdentityLocked(cache, ID2)
+	c.Assert(c1.Allows(ID2), Equals, true)
 
-	c1.AllowConsumerLocked(cache, CONSUMER_ID3)
-	c.Assert(c1.Allows(CONSUMER_ID3), Equals, true)
-	consumer3 := c1.getConsumer(CONSUMER_ID3)
-	c.Assert(consumer3.ID, Equals, CONSUMER_ID3)
+	c1.AllowIngressIdentityLocked(cache, ID3)
+	c.Assert(c1.Allows(ID3), Equals, true)
 
-	c1.BanConsumerLocked(CONSUMER_ID2)
-	c.Assert(c1.Allows(CONSUMER_ID2), Equals, false)
-	consumer2 = c1.getConsumer(CONSUMER_ID2)
-	c.Assert(consumer2, IsNil)
+	c1.RemoveIngressIdentityLocked(ID2)
+	c.Assert(c1.Allows(ID2), Equals, false)
 
-	c1.BanConsumerLocked(CONSUMER_ID3)
-	c.Assert(c1.Allows(CONSUMER_ID3), Equals, false)
-	consumer3 = c1.getConsumer(CONSUMER_ID3)
-	c.Assert(consumer3, IsNil)
+	c1.RemoveIngressIdentityLocked(ID3)
+	c.Assert(c1.Allows(ID3), Equals, false)
 }

--- a/pkg/policy/identity.go
+++ b/pkg/policy/identity.go
@@ -48,8 +48,8 @@ var (
 	IdentitiesPath = path.Join(kvstore.BaseKeyPrefix, "state", "identities", "v1")
 )
 
-// NumericIdentity represents an identity of an entity to which consumer policy
-// can be applied to.
+// NumericIdentity is the numeric representation of a security identity / a
+// security policy.
 type NumericIdentity uint32
 
 func ParseNumericIdentity(id string) (NumericIdentity, error) {

--- a/test/runtime/ct.go
+++ b/test/runtime/ct.go
@@ -126,6 +126,11 @@ var _ = Describe("RuntimeValidatedConntrackTable", func() {
 	})
 
 	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			vm.ReportFailed(
+				"sudo cilium bpf ct list global",
+				"sudo cilium endpoint list")
+		}
 		vm.PolicyDelAll()
 		netcatPort = 11111
 		containers(helpers.Delete)

--- a/tests/12-policy-import.sh
+++ b/tests/12-policy-import.sh
@@ -151,7 +151,7 @@ FOO_SEC_ID=$(cilium endpoint list | grep id.foo | awk '{ print $4}')
 EXPECTED_CONSUMER="1\n$FOO_SEC_ID"
 
 log "verify allowed consumers"
-DIFF=$(diff -Nru <(echo -e "$EXPECTED_CONSUMER") <(cilium endpoint get $BAR_ID | jq '.[].policy | .["allowed-consumers"] | .[]' | sort)) || true
+DIFF=$(diff -Nru <(echo -e "$EXPECTED_CONSUMER") <(cilium endpoint get $BAR_ID | jq '.[].policy | .["allowed-ingress-security-identities"] | .[]' | sort)) || true
 if [[ "$DIFF" != "" ]]; then
   abort "$DIFF"
 fi
@@ -210,7 +210,7 @@ fi
 EXPECTED_CONSUMER="$FOO_SEC_ID"
 
 log "verify allowed consumers"
-DIFF=$(diff -Nru <(echo -e "$EXPECTED_CONSUMER") <(cilium endpoint get $BAR_ID | jq '.[].policy | .["allowed-consumers"] | .[]')) || true
+DIFF=$(diff -Nru <(echo -e "$EXPECTED_CONSUMER") <(cilium endpoint get $BAR_ID | jq '.[].policy | .["allowed-ingress-security-identities"] | .[]')) || true
 if [[ "$DIFF" != "" ]]; then
   abort "$DIFF"
 fi


### PR DESCRIPTION
The Consumer object did not possess any useful state, as a variety of its
fields were not in use throughout the policy package. These fields included
a Decision, which was never populated during policy calculation, and Reverse,
a field which was never populated at all.
In a Consumable, there was a mapping of security identities from which ingress
traffic is allowed to Consumers. But, once the aforementioned unused fields were
removed, the only useful information within the Consumer was the identity of
the Consumer, which was key in the aforementioned map within a Consumable, and
the DeletionMark within a Consumer, which indicated whether the given entry
in the map should be garbage collected after policy recalculation for a
Consumable. Given that the key in the Consumable's map was  already the same
security identity as that within the Consumer, that left the DeletionMark as
the only field within a Consumer that was necessary to keep. Thus, it made
sense to get rid of the notion of a Consumer, and just have the map within the
Consumable map from a security identity to a boolean indicating whether it
should be garbage-collected or not during policy recalculation.
    
This patch removes the notion of a Consumer from the policy package, and defined
the fields within a Consumable to refer to ingress security-identity-based
policy. This sets the groundwork for adding identity-based egress policy
within Cilium, and  makes the code more readable and easier to understand.

Signed-off by: Ian Vernon <ian@cilium.io>
