### PR TITLE
envoy: Lock stream server while adding remove completion.

### DIFF
--- a/pkg/envoy/streamctrl.go
+++ b/pkg/envoy/streamctrl.go
@@ -49,6 +49,7 @@ type StreamControl struct {
 	completions             []versionCompletion
 }
 
+// Called with ctrl.cond.L.Lock() held
 func (ctrl *StreamControl) addCompletion(completions policy.CompletionContainer, msg string) {
 	if completions == nil {
 		return


### PR DESCRIPTION
Internal slice manipulations must be protected, and one of the calls
to addCompletions() missed this.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
