### PR TITLE
tests: deprecate remaining K8s tests and remove bash-script based framework

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,9 +23,6 @@ pipeline {
                     "Runtime Tests": {
                          sh 'PROVISION=1 ./contrib/vagrant/start.sh'
                      },
-                    "K8s multi node Tests": {
-                         sh './tests/k8s/start.sh'
-                    },
                     failFast: true
                 )
             }
@@ -36,12 +33,7 @@ pipeline {
             sh './test/post_build_agent.sh || true'
             sh './tests/copy_files || true'
             archiveArtifacts artifacts: "cilium-files-runtime-${JOB_BASE_NAME}-${BUILD_NUMBER}.tar.gz", allowEmptyArchive: true
-            sh './tests/k8s/copy_files || true'
-            archiveArtifacts artifacts: "cilium-files-k8s-${JOB_BASE_NAME}-${BUILD_NUMBER}.tar.gz", allowEmptyArchive: true
-            sh 'rm -rf ${WORKSPACE}/cilium-files*${JOB_BASE_NAME}-${BUILD_NUMBER}* ${WORKSPACE}/tests/cilium-files ${WORKSPACE}/tests/k8s/tests/cilium-files'
-            sh 'ls'
             sh 'vagrant destroy -f || true'
-            sh 'cd ./tests/k8s && vagrant destroy -f || true'
         }
     }
 }

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -47,7 +47,7 @@ const (
 	policiesL3JSON     = "Policies-l3-policy.json"
 )
 
-var _ = Describe("RuntimePolicyEnforcement", func() {
+var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 
 	var once sync.Once
 	var logger *logrus.Entry

--- a/tests/k8s/tests/04-bad-cnp-import.sh
+++ b/tests/k8s/tests/04-bad-cnp-import.sh
@@ -17,6 +17,10 @@ redirect_debug_logs ${LOGS_DIR}
 
 set -ex
 
+log "${TEST_NAME} has been deprecated and replaced by test/runtime/Policies.go:Handles missing required fields"
+exit 0
+
+
 case ${k8s_version} in
 	1.6*)
     bad_policy_path="${dir}/deployments/bad-cnp/no-endpoint-selector-ciliumv1.yaml"

--- a/tests/k8s/tests/04-toservices-test.sh
+++ b/tests/k8s/tests/04-toservices-test.sh
@@ -18,6 +18,9 @@ set -ex
 
 log "running test: $TEST_NAME"
 
+log "${TEST_NAME} has been deprecated and replaced by test/k8sT/Services.go:Headless services"
+exit 0
+
 headless_dir="${dir}/deployments/headless"
 
 create_policy() {

--- a/tests/k8s/tests/99-restore-state.sh
+++ b/tests/k8s/tests/99-restore-state.sh
@@ -14,6 +14,9 @@ redirect_debug_logs ${LOGS_DIR}
 
 set -ex
 
+log "${TEST_NAME} has been deprecated. Restore functionality is taken care of by test/runtime/chaos.go"
+exit 0
+
 manangement_dir="${dir}/../cluster"
 
 # To run the restore functionality, we need to remove cilium ds and re-add it

--- a/tests/start_vms
+++ b/tests/start_vms
@@ -10,11 +10,3 @@ vagrant destroy -f || echo "Nothing to destroy"
 
 echo "Starting runtime test VM"
 NO_PROVISION=1 ./contrib/vagrant/start.sh
-
-cd tests/k8s
-
-echo "Destorying K8s VMs if they are already running"
-vagrant destroy -f || echo "Nothing to destroy"
-
-echo "Starting K8s VMs"
-VAGRANT_DEFAULT_PROVIDER=virtualbox vagrant up --provider=virtualbox --no-provision


### PR DESCRIPTION
* deprecate 04-toservices-test.sh, which was migrated by #2380.
* deprecate 99-restore-state.sh, which is covered by `test/runtime/chaos.go`
* deprecate 04-bad-cnp-import.sh, which is covered by `test/runtime/Policies.go:Handles missing required fields`
* validate runtime policy tests; we should enable these sooner rather than later, as they are a significant portion of the Ginkgo framework.
* Jenkinsfile / tests: remove bash Kubernetes test stage, as all bash-script based Kubernetes tests have now been validated / migrated over to the Ginkgo framework.

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to #1839 , #1841 