### PR TITLE
Ginkgo: Fix issues with DNS

### DIFF
--- a/test/provision/dns.sh
+++ b/test/provision/dns.sh
@@ -3,6 +3,9 @@
 # This script update the dns servers to use google ones.
 set -e
 
+sudo systemctl disable systemd-resolved.service
+sudo service systemd-resolved stop
+
 echo "updating /etc/resolv.conf"
 
 cat <<EOF > /etc/resolv.conf


### PR DESCRIPTION
Stopped and deleted the systemctl-resolved to avoid issues with kubedns

Kafka logs attached. 
[kafka.log](https://github.com/cilium/cilium/files/1710293/kafka.log)

Message are sent:
```
vagrant@k8s1:~$ HQ_POD=$(kubectl get pods -l app=empire-hq -o jsonpath='{.items[0].metadata.name}') && kubectl exec -it $HQ_POD -- sh -c "PS1=\"empire-hq $\" /bin/bash"
                                                                                                                                                               
empire-hq $                                                                                                                                                    
empire-hq $                                                                                                                                                    
empire-hq $                                                                                                                                                    
empire-hq $./kafka-consume.sh --topic deathstar-plans                                                                                                                     
^CProcessed a total of 0 messages                                                                                                                                         
^[[Aempire-hq $./kafka-consume.sh --topic deathstar-plans^C                                                                                                            
empire-hq $./kafka-consume.sh --topic deathstar-plans^C                                                                                                                   
empire-hq $./kafka-consume.sh --topic empire-announce                                                                                                          
Happy 40th Birthday to General Tagge                                                                                                                           
Happy 40th Birthday to General Tagge                                                                                                                                    
Happy 40th Birthday to General Tagge                                                                                                                           
Happy 40th Birthday to General Tagge                                                                                                                                      
Happy 40th Birthday to General Tagge                                                                                                                                    
Happy 40th Birthday to General Tagge                                                                                                                           
^CProcessed a total of 6 messages                                                                                                                                         
empire-hq $^C                                                                                                                                                  
empire-hq $^C                                                                                                                                                  
empire-hq $exit                                                                                                                                                
command terminated with exit code 130                                                                                                                          
```
Looks like that my box inherit the DNS from the DHCP, so the resolve always work. (And this is why @ianvernon had problems with `go get `  in the past and I didn't have, commit `e627953a7bc469a377ca615dbc1d61950026b82b`)  and this is the same situation for @manalibhutiyani. 

The current deployment file that I'm using: 
```
---
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: kafka-broker
spec:
  replicas: 1
  template:
    metadata:
      labels:
        app: kafka
        zgroup: kafkaTestApp
    spec:
      containers:
      - name: kafka
        image: wurstmeister/kafka
        ports:
        - containerPort: 9092
        env:
        - name: KAFKA_ADVERTISED_HOST_NAME
          value: kafka-service
        - name: KAFKA_ZOOKEEPER_CONNECT
          value: zook:2181
        - name: KAFKA_BROKER_ID
          value: "1"
        - name: KAFKA_CREATE_TOPICS
          value: "empire-announce:1:1,deathstar-plans:1:1"
      nodeSelector:
        "kubernetes.io/hostname": k8s1
---
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: zookeeper
spec:
  replicas: 1
  template:
    metadata:
      labels:
        app: zook
        zgroup: kafkaTestApp
    spec:
      containers:
      - name: zookeeper
        image: digitalwonderland/zookeeper
        ports:
        - containerPort: 2181
      nodeSelector:
        "kubernetes.io/hostname": k8s1
---
apiVersion: v1
kind: Service
metadata:
  name: zook
  labels:
    app: zook
spec:
  ports:
  - port: 2181
    name: zookeeper-port
    targetPort: 2181
    protocol: TCP
  selector:
    app: zook
---
apiVersion: v1
kind: Service
metadata:
  name: kafka-service
  labels:
    app: kafka
spec:
  ports:
  - port: 9092
    name: kafka-port
    targetPort: 9092
    protocol: TCP
  selector:
    app: kafka
---
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: empire-hq
spec:
  replicas: 1
  template:
    metadata:
      labels:
        app: empire-hq
        zgroup: kafkaTestApp
    spec:
      containers:
      - name: empire-hq
        image: cilium/kafkaclient
      nodeSelector:
        "kubernetes.io/hostname": k8s1
---
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: empire-outpost-8888
spec:
  replicas: 1
  template:
    metadata:
      labels:
        app: empire-outpost
        outpostid: "8888"
        zgroup: kafkaTestApp
    spec:
      containers:
      - name: empire-outpost-8888
        image: cilium/kafkaclient
      nodeSelector:
        "kubernetes.io/hostname": k8s1
---
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: empire-outpost-9999
spec:
  replicas: 1
  template:
    metadata:
      labels:
        app: empire-outpost
        outpostid: "9999"
        zgroup: kafkaTestApp
    spec:
      containers:
      - name: empire-outpost-9999
        image: cilium/kafkaclient
      nodeSelector:
        "kubernetes.io/hostname": k8s1
---
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: empire-backup
spec:
  replicas: 1
  template:
    metadata:
      labels:
        app: empire-backup
        zgroup: kafkaTestApp
    spec:
      containers:
      - name: empire-backup
        image: cilium/kafkaclient
      nodeSelector:
        "kubernetes.io/hostname": k8s1
```