### PR TITLE
remove Consumer type from Cilium

### DIFF
--- a/api/v1/models/endpoint_policy.go
+++ b/api/v1/models/endpoint_policy.go
@@ -19,7 +19,7 @@ type EndpointPolicy struct {
 
 	// List of identities allowed to communicate to this endpoint
 	//
-	AllowedConsumers []int64 `json:"allowed-consumers"`
+	AllowedIngressIdentities []int64 `json:"allowed-ingress-identities"`
 
 	// Build number of calculated policy in use
 	Build int64 `json:"build,omitempty"`
@@ -34,7 +34,7 @@ type EndpointPolicy struct {
 	L4 *L4Policy `json:"l4,omitempty"`
 }
 
-/* polymorph EndpointPolicy allowed-consumers false */
+/* polymorph EndpointPolicy allowed-ingress-identities false */
 
 /* polymorph EndpointPolicy build false */
 
@@ -48,7 +48,7 @@ type EndpointPolicy struct {
 func (m *EndpointPolicy) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateAllowedConsumers(formats); err != nil {
+	if err := m.validateAllowedIngressIdentities(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -69,9 +69,9 @@ func (m *EndpointPolicy) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *EndpointPolicy) validateAllowedConsumers(formats strfmt.Registry) error {
+func (m *EndpointPolicy) validateAllowedIngressIdentities(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.AllowedConsumers) { // not required
+	if swag.IsZero(m.AllowedIngressIdentities) { // not required
 		return nil
 	}
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -944,7 +944,7 @@ definitions:
       build:
         description: Build number of calculated policy in use
         type: integer
-      allowed-consumers:
+      allowed-ingress-identities:
         description: |
           List of identities allowed to communicate to this endpoint
         type: array

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1438,7 +1438,7 @@ func init() {
       "description": "Policy information of an endpoint",
       "type": "object",
       "properties": {
-        "allowed-consumers": {
+        "allowed-ingress-identities": {
           "description": "List of identities allowed to communicate to this endpoint\n",
           "type": "array",
           "items": {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1102,7 +1102,7 @@ func (d *Daemon) removeStaleMap(path string) {
 func (d *Daemon) removeStaleIDFromPolicyMap(id uint32) {
 	gpm, err := policymap.OpenGlobalMap(bpf.MapPath(endpoint.PolicyGlobalMapName))
 	if err == nil {
-		gpm.DeleteConsumer(id)
+		gpm.DeleteIdentity(id)
 		gpm.Close()
 	}
 }

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -85,7 +85,7 @@ func endpointCreator(id uint16, secID policy.NumericIdentity) *e.Endpoint {
 			},
 		},
 		Maps:         map[int]*policymap.PolicyMap{},
-		Consumers:    map[policy.NumericIdentity]*policy.Consumer{},
+		Consumers:    map[policy.NumericIdentity]bool{},
 		ReverseRules: map[policy.NumericIdentity]*policy.Consumer{},
 	}
 	return ep

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -86,7 +86,7 @@ func endpointCreator(id uint16, secID policy.NumericIdentity) *e.Endpoint {
 		},
 		Maps:         map[int]*policymap.PolicyMap{},
 		Consumers:    map[policy.NumericIdentity]bool{},
-		ReverseRules: map[policy.NumericIdentity]*policy.Consumer{},
+		ReverseRules: map[policy.NumericIdentity]bool{},
 	}
 	return ep
 }

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -84,9 +84,9 @@ func endpointCreator(id uint16, secID policy.NumericIdentity) *e.Endpoint {
 				"foo" + strID: labels.NewLabel("foo"+strID, "", ""),
 			},
 		},
-		Maps:         map[int]*policymap.PolicyMap{},
-		Consumers:    map[policy.NumericIdentity]bool{},
-		ReverseRules: map[policy.NumericIdentity]bool{},
+		Maps:              map[int]*policymap.PolicyMap{},
+		IngressIdentities: map[policy.NumericIdentity]bool{},
+		ReverseRules:      map[policy.NumericIdentity]bool{},
 	}
 	return ep
 }

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -85,7 +85,7 @@ func endpointCreator(id uint16, secID policy.NumericIdentity) *e.Endpoint {
 			},
 		},
 		Maps:         map[int]*policymap.PolicyMap{},
-		Consumers:    map[string]*policy.Consumer{},
+		Consumers:    map[policy.NumericIdentity]*policy.Consumer{},
 		ReverseRules: map[policy.NumericIdentity]*policy.Consumer{},
 	}
 	return ep

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -391,15 +391,16 @@ func updateCT(owner Owner, e *Endpoint, epIPs []net.IP,
 	if isPolicyEnforced {
 		wg.Add(1)
 		go func(wg *sync.WaitGroup) {
-			// consumers added, so we need to flush all CT entries except the idsToKeep
+			// New security identities added, so we need to flush all CT entries
+			// except the idsToKeep.
 			owner.FlushCTEntries(e, isLocal, epIPs, idsToKeep)
 			wg.Done()
 		}(wg)
 	} else {
 		wg.Add(1)
 		go func(wg *sync.WaitGroup) {
-			// consumers removed, so we need to modify all CT entries with ids To Mod
-			// because there's on policy being enforced
+			// Security identities removed, so we need to modify all CT entries
+			// with idsToMod because there's no policy being enforced.
 			owner.ResetProxyPort(e, isLocal, epIPs, idsToMod)
 			wg.Done()
 		}(wg)
@@ -553,7 +554,8 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 		modifiedRules, deletedRules policy.SecurityIDContexts
 		policyChanged               bool
 	)
-	// Only generate & populate policy map if a seclabel and consumer model is set up
+	// Only generate & populate policy map if a security identity is set up for
+	// this endpoint.
 	if c != nil {
 		c.AddMap(e.PolicyMap)
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -586,7 +586,7 @@ func (e *Endpoint) GetPolicyModel() *models.EndpointPolicy {
 	e.Consumable.Mutex.RLock()
 	defer e.Consumable.Mutex.RUnlock()
 
-	ingressIdentities := []int64{}
+	ingressIdentities := make([]int64, 0, len(e.Consumable.IngressIdentities))
 	for ingressIdentity := range e.Consumable.IngressIdentities {
 		ingressIdentities = append(ingressIdentities, int64(ingressIdentity))
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -995,7 +995,7 @@ func (e *Endpoint) RemoveFromGlobalPolicyMap() error {
 	if err == nil {
 		// We need to remove ourselves from global map, so that
 		// resources (prog/map reference counts) can be released.
-		gpm.DeleteConsumer(uint32(e.ID))
+		gpm.DeleteIdentity(uint32(e.ID))
 		gpm.Close()
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -588,7 +588,7 @@ func (e *Endpoint) GetPolicyModel() *models.EndpointPolicy {
 	defer e.Consumable.Mutex.RUnlock()
 
 	consumers := []int64{}
-	for v := range e.Consumable.Consumers {
+	for v := range e.Consumable.IngressIdentities {
 		consumers = append(consumers, int64(v))
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -268,8 +268,7 @@ type Endpoint struct {
 	// PortMap is port mapping configuration of the endpoint
 	PortMap []PortMap // Port mapping used for this endpoint.
 
-	// Consumable is the list of allowed consumers of this endpoint. This
-	// is populated based on the policy.
+	// Consumable represents the security-identity-based policy for this endpoint.
 	Consumable *policy.Consumable `json:"-"`
 
 	// L4Policy is the L4Policy in effect for the
@@ -587,15 +586,15 @@ func (e *Endpoint) GetPolicyModel() *models.EndpointPolicy {
 	e.Consumable.Mutex.RLock()
 	defer e.Consumable.Mutex.RUnlock()
 
-	consumers := []int64{}
-	for v := range e.Consumable.IngressIdentities {
-		consumers = append(consumers, int64(v))
+	ingressIdentities := []int64{}
+	for ingressIdentity := range e.Consumable.IngressIdentities {
+		ingressIdentities = append(ingressIdentities, int64(ingressIdentity))
 	}
 
 	return &models.EndpointPolicy{
 		ID:               int64(e.Consumable.ID),
 		Build:            int64(e.Consumable.Iteration),
-		AllowedConsumers: consumers,
+		AllowedConsumers: ingressIdentities,
 		CidrPolicy:       e.L3Policy.GetModel(),
 		L4:               e.Consumable.L4Policy.GetModel(),
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -588,8 +588,8 @@ func (e *Endpoint) GetPolicyModel() *models.EndpointPolicy {
 	defer e.Consumable.Mutex.RUnlock()
 
 	consumers := []int64{}
-	for _, v := range e.Consumable.Consumers {
-		consumers = append(consumers, int64(v.ID))
+	for v := range e.Consumable.Consumers {
+		consumers = append(consumers, int64(v))
 	}
 
 	return &models.EndpointPolicy{

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -592,11 +592,11 @@ func (e *Endpoint) GetPolicyModel() *models.EndpointPolicy {
 	}
 
 	return &models.EndpointPolicy{
-		ID:               int64(e.Consumable.ID),
-		Build:            int64(e.Consumable.Iteration),
-		AllowedConsumers: ingressIdentities,
-		CidrPolicy:       e.L3Policy.GetModel(),
-		L4:               e.Consumable.L4Policy.GetModel(),
+		ID:    int64(e.Consumable.ID),
+		Build: int64(e.Consumable.Iteration),
+		AllowedIngressIdentities: ingressIdentities,
+		CidrPolicy:               e.L3Policy.GetModel(),
+		L4:                       e.Consumable.L4Policy.GetModel(),
 	}
 }
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -453,7 +453,7 @@ func (e *Endpoint) regenerateConsumable(owner Owner, labelsMap *policy.IdentityC
 		if !keepIdentity {
 			c.RemoveIngressIdentityLocked(ingressIdentity)
 			changed = true
-			// Since we have removed an allowed ingress security identity, the
+			// Since we have removed an allowed security identity for ingress, the
 			// L3 rule should be also be marked as removed, but only if it was
 			// not previously created by a L3-L4 rule.
 			if _, ok := rulesRm[ingressIdentity]; !ok {
@@ -465,7 +465,7 @@ func (e *Endpoint) regenerateConsumable(owner Owner, labelsMap *policy.IdentityC
 				delete(rulesAdd, ingressIdentity)
 			}
 		} else {
-			// Since we have (re)added an ingress security identity, the L3 rule
+			// Since we have (re)added a security identity upon ingress, the L3 rule
 			// should be also be marked as added. But only if it was not previously
 			// created by an L3-L4 rule.
 			if _, ok := rulesAdd[ingressIdentity]; !ok {
@@ -485,7 +485,7 @@ func (e *Endpoint) regenerateConsumable(owner Owner, labelsMap *policy.IdentityC
 		"rulesAdd":                  rulesAdd,
 		"l4Rm":                      l4Rm,
 		"rulesRm":                   rulesRm,
-	}).Debug("New consumable with ingress security identities")
+	}).Debug("consumable regenerated")
 	return changed, rulesAdd, rulesRm
 }
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -335,9 +335,9 @@ func (e *Endpoint) regenerateConsumable(owner Owner, labelsMap *policy.IdentityC
 	)
 
 	// Mark all entries unused by denying them
-	for k := range c.Consumers {
+	for k := range c.IngressIdentities {
 		// Mark as false indicates denying
-		c.Consumers[k] = false
+		c.IngressIdentities[k] = false
 	}
 
 	rulesAdd = policy.NewSecurityIDContexts()
@@ -449,7 +449,7 @@ func (e *Endpoint) regenerateConsumable(owner Owner, labelsMap *policy.IdentityC
 	}
 
 	// Garbage collect all unused entries
-	for val, ok := range c.Consumers {
+	for val, ok := range c.IngressIdentities {
 		if !ok {
 			c.BanConsumerLocked(val)
 			changed = true
@@ -481,7 +481,7 @@ func (e *Endpoint) regenerateConsumable(owner Owner, labelsMap *policy.IdentityC
 
 	e.getLogger().WithFields(logrus.Fields{
 		logfields.Identity: c.ID,
-		"consumers":        logfields.Repr(c.Consumers),
+		"consumers":        logfields.Repr(c.IngressIdentities),
 		"rulesAdd":         rulesAdd,
 		"l4Rm":             l4Rm,
 		"rulesRm":          rulesRm,

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -78,7 +78,9 @@ func (key *policyKey) String() string {
 	return fmt.Sprintf("%d", key.Identity)
 }
 
-func (pm *PolicyMap) AllowConsumer(id uint32) error {
+// AllowIdentity adds an entry into the PolicyMap with key id. Returns an error
+// if the addition did not complete successfully.
+func (pm *PolicyMap) AllowIdentity(id uint32) error {
 	key := policyKey{Identity: id}
 	entry := PolicyEntry{Action: 1}
 	return bpf.UpdateElement(pm.Fd, unsafe.Pointer(&key), unsafe.Pointer(&entry), 0)
@@ -92,7 +94,8 @@ func (pm *PolicyMap) AllowL4(id uint32, dport uint16, proto uint8) error {
 	return bpf.UpdateElement(pm.Fd, unsafe.Pointer(&key), unsafe.Pointer(&entry), 0)
 }
 
-func (pm *PolicyMap) ConsumerExists(id uint32) bool {
+// IdentityExists returns whether there is an entry in the PolicyMap with key id.
+func (pm *PolicyMap) IdentityExists(id uint32) bool {
 	key := policyKey{Identity: id}
 	var entry PolicyEntry
 	return bpf.LookupElement(pm.Fd, unsafe.Pointer(&key), unsafe.Pointer(&entry)) == nil
@@ -107,7 +110,9 @@ func (pm *PolicyMap) L4Exists(id uint32, dport uint16, proto uint8) bool {
 	return bpf.LookupElement(pm.Fd, unsafe.Pointer(&key), unsafe.Pointer(&entry)) == nil
 }
 
-func (pm *PolicyMap) DeleteConsumer(id uint32) error {
+// DeleteIdentity deletes id from the PolicyMap. Returns an error if the deletion
+// did not succeed.
+func (pm *PolicyMap) DeleteIdentity(id uint32) error {
 	key := policyKey{Identity: id}
 	return bpf.DeleteElement(pm.Fd, unsafe.Pointer(&key))
 }

--- a/pkg/policy/cache.go
+++ b/pkg/policy/cache.go
@@ -36,8 +36,7 @@ type ConsumableCache struct {
 }
 
 // GetConsumableCache returns the consumable cache. The cache is a list of all
-// identities which are in use by local endpoints, either as consumable or
-// consumer.
+// identities which are in use by local endpoints.
 func GetConsumableCache() *ConsumableCache {
 	return consumableCache
 }

--- a/pkg/policy/cache.go
+++ b/pkg/policy/cache.go
@@ -91,22 +91,6 @@ func (c *ConsumableCache) GetReservedIDs() []NumericIdentity {
 	return identities
 }
 
-// GetConsumables returns a map of consumables numeric identity mapped to
-// consumers numeric identities.
-func (c *ConsumableCache) GetConsumables() map[NumericIdentity][]NumericIdentity {
-	consumables := map[NumericIdentity][]NumericIdentity{}
-	c.cacheMU.RLock()
-	for _, consumable := range c.cache {
-		consumers := []NumericIdentity{}
-		for _, consumer := range consumable.Consumers {
-			consumers = append(consumers, consumer.ID)
-		}
-		consumables[consumable.ID] = consumers
-	}
-	c.cacheMU.RUnlock()
-	return consumables
-}
-
 // ResolveIdentityLabels resolves a numeric identity to the identity's labels
 // or nil
 func ResolveIdentityLabels(id NumericIdentity) labels.LabelArray {

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -41,7 +41,7 @@ type Consumable struct {
 	// IngressIdentities is the set of security identities from which ingress
 	// traffic is allowed. The value corresponds to whether the corresponding
 	// key (security identity) should be garbage collected upon policy calculation.
-	IngressIdentities map[NumericIdentity]bool `json:"consumers"`
+	IngressIdentities map[NumericIdentity]bool `json:"ingress-identities"`
 	// ReverseRules contains the security identities that are allowed to receive
 	// a reply from this Consumable. The value represents whether the element is
 	// valid after policy recalculation.

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -49,7 +49,7 @@ type Consumable struct {
 	// Consumers contains the list of consumers where the key is the Consumers ID
 	Consumers map[NumericIdentity]bool `json:"consumers"`
 	// ReverseRules contains the consumers that are allowed to receive a reply from this Consumable
-	ReverseRules map[NumericIdentity]*Consumer `json:"-"`
+	ReverseRules map[NumericIdentity]bool `json:"-"`
 	// L4Policy contains the policy of this consumable
 	L4Policy *L4Policy `json:"l4-policy"`
 	// L3L4Policy contains the L3, L4 and L7 ingress policy of this consumable
@@ -65,7 +65,7 @@ func NewConsumable(id NumericIdentity, lbls *Identity, cache *ConsumableCache) *
 		Labels:       lbls,
 		Maps:         map[int]*policymap.PolicyMap{},
 		Consumers:    map[NumericIdentity]bool{},
-		ReverseRules: map[NumericIdentity]*Consumer{},
+		ReverseRules: map[NumericIdentity]bool{},
 		cache:        cache,
 	}
 	if lbls != nil {
@@ -193,7 +193,7 @@ func (c *Consumable) addToMaps(id NumericIdentity) {
 }
 
 func (c *Consumable) wasLastRule(id NumericIdentity) bool {
-	return c.ReverseRules[id] == nil && c.Consumers[id] == false
+	return c.ReverseRules[id] == false && c.Consumers[id] == false
 }
 
 func (c *Consumable) removeFromMaps(id NumericIdentity) {
@@ -246,7 +246,7 @@ func (c *Consumable) AllowConsumerAndReverseLocked(cache *ConsumableCache, id Nu
 		}).Debug("Allowing reverse direction")
 		if _, ok := reverse.ReverseRules[c.ID]; !ok {
 			reverse.addToMaps(c.ID)
-			reverse.ReverseRules[c.ID] = &Consumer{ID: id}
+			reverse.ReverseRules[c.ID] = true
 			return true
 		}
 	}

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -30,7 +30,6 @@ type Consumer struct {
 	ID           NumericIdentity
 	Reverse      *Consumer
 	DeletionMark bool
-	Decision     api.Decision
 }
 
 func (c *Consumer) StringID() string {
@@ -38,7 +37,7 @@ func (c *Consumer) StringID() string {
 }
 
 func NewConsumer(id NumericIdentity) *Consumer {
-	return &Consumer{ID: id, Decision: api.Allowed}
+	return &Consumer{ID: id}
 }
 
 // Consumable is the entity that is being consumed by a Consumer. It holds all
@@ -289,5 +288,5 @@ func (c *Consumable) Allows(id NumericIdentity) bool {
 	c.Mutex.RLock()
 	consumer := c.getConsumer(id)
 	c.Mutex.RUnlock()
-	return consumer != nil && consumer.Decision == api.Allowed
+	return consumer != nil
 }

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -23,13 +23,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Consumer is the entity that consumes a Consumable. It identifies a source
-// security identity and an allow/deny decision for traffic from that identity.
-type Consumer struct {
-	ID           NumericIdentity
-	DeletionMark bool
-}
-
 // Consumable is the entity that is being consumed by a Consumer. It holds all
 // of the policies relevant to this security identity, including label-based
 // policies which act on Consumers, and L4Policy.

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -184,7 +184,11 @@ func (c *Consumable) addToMaps(id NumericIdentity) {
 }
 
 func (c *Consumable) wasLastRule(id NumericIdentity) bool {
-	return c.ReverseRules[id] == false && c.IngressIdentities[id] == false
+	// A rule is the 'last rule' for an identity if it does not exist as a key
+	// in any of the maps for this Consumable.
+	_, existsReverse := c.ReverseRules[id]
+	_, existsIngressIdentity := c.IngressIdentities[id]
+	return !existsReverse && !existsIngressIdentity
 }
 
 func (c *Consumable) removeFromMaps(id NumericIdentity) {

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -101,7 +101,7 @@ func (c *Consumable) AddMap(m *policymap.PolicyMap) {
 	// Populate the new map with the already established consumers of
 	// this consumable
 	for c := range c.Consumers {
-		if err := m.AllowConsumer(c.Uint32()); err != nil {
+		if err := m.AllowIdentity(c.Uint32()); err != nil {
 			log.WithError(err).Warn("Update of policy map failed")
 		}
 	}
@@ -169,7 +169,7 @@ func (c *Consumable) getConsumer(id NumericIdentity) bool {
 
 func (c *Consumable) addToMaps(id NumericIdentity) {
 	for _, m := range c.Maps {
-		if m.ConsumerExists(id.Uint32()) {
+		if m.IdentityExists(id.Uint32()) {
 			continue
 		}
 
@@ -179,7 +179,7 @@ func (c *Consumable) addToMaps(id NumericIdentity) {
 		})
 
 		scopedLog.Debug("Updating policy BPF map: allowing Identity")
-		if err := m.AllowConsumer(id.Uint32()); err != nil {
+		if err := m.AllowIdentity(id.Uint32()); err != nil {
 			scopedLog.WithError(err).Warn("Update of policy map failed")
 		}
 	}
@@ -197,7 +197,7 @@ func (c *Consumable) removeFromMaps(id NumericIdentity) {
 		})
 
 		scopedLog.Debug("Updating policy BPF map: denying Identity")
-		if err := m.DeleteConsumer(id.Uint32()); err != nil {
+		if err := m.DeleteIdentity(id.Uint32()); err != nil {
 			scopedLog.WithError(err).Warn("Update of policy map failed")
 		}
 	}

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -268,6 +268,8 @@ func (c *Consumable) RemoveIngressIdentityLocked(id NumericIdentity) {
 		if c.wasLastRule(id) {
 			c.removeFromMaps(id)
 		}
+
+		// TODO - call deleteReverseRule as well? GH-2795
 	}
 }
 

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -28,7 +28,6 @@ import (
 // security identity and an allow/deny decision for traffic from that identity.
 type Consumer struct {
 	ID           NumericIdentity
-	Reverse      *Consumer
 	DeletionMark bool
 }
 
@@ -276,10 +275,6 @@ func (c *Consumable) BanConsumerLocked(id NumericIdentity) {
 
 		if c.wasLastRule(id) {
 			c.removeFromMaps(id)
-		}
-
-		if consumer.Reverse != nil {
-			c.deleteReverseRule(id, c.ID)
 		}
 	}
 }

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -31,14 +31,6 @@ type Consumer struct {
 	DeletionMark bool
 }
 
-func (c *Consumer) StringID() string {
-	return c.ID.String()
-}
-
-func NewConsumer(id NumericIdentity) *Consumer {
-	return &Consumer{ID: id}
-}
-
 // Consumable is the entity that is being consumed by a Consumer. It holds all
 // of the policies relevant to this security identity, including label-based
 // policies which act on Consumers, and L4Policy.
@@ -230,7 +222,7 @@ func (c *Consumable) AllowConsumerLocked(cache *ConsumableCache, id NumericIdent
 			"consumable":       logfields.Repr(c),
 		}).Debug("New consumer Identity for consumable")
 		c.addToMaps(id)
-		c.Consumers[id] = NewConsumer(id)
+		c.Consumers[id] = &Consumer{ID: id}
 		return true
 	}
 	consumer.DeletionMark = false
@@ -255,7 +247,7 @@ func (c *Consumable) AllowConsumerAndReverseLocked(cache *ConsumableCache, id Nu
 		}).Debug("Allowing reverse direction")
 		if _, ok := reverse.ReverseRules[c.ID]; !ok {
 			reverse.addToMaps(c.ID)
-			reverse.ReverseRules[c.ID] = NewConsumer(c.ID)
+			reverse.ReverseRules[c.ID] = &Consumer{ID: id}
 			return true
 		}
 	}

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -215,7 +215,7 @@ func (c *Consumable) AllowIngressIdentityLocked(cache *ConsumableCache, id Numer
 		log.WithFields(logrus.Fields{
 			logfields.Identity: id,
 			"consumable":       logfields.Repr(c),
-		}).Debug("New ingress security identity for consumable")
+		}).Debug("Allowing security identity on ingress for consumable")
 		c.addToMaps(id)
 		c.IngressIdentities[id] = true
 		return true
@@ -253,7 +253,7 @@ func (c *Consumable) AllowIngressIdentityAndReverseLocked(cache *ConsumableCache
 	log.WithFields(logrus.Fields{
 		logfields.Identity + ".from": c.ID,
 		logfields.Identity + ".to":   id,
-	}).Warn("Allowed an ingress security identity which can't be found in the reverse direction")
+	}).Warn("Allowed a security identity on ingress, but could not resolve the identity for the reverse direction")
 	return changed
 }
 
@@ -262,7 +262,7 @@ func (c *Consumable) AllowIngressIdentityAndReverseLocked(cache *ConsumableCache
 // Must be called with the Consumable mutex locked.
 func (c *Consumable) RemoveIngressIdentityLocked(id NumericIdentity) {
 	if _, ok := c.IngressIdentities[id]; ok {
-		log.WithField(logfields.Identity, id).Debug("Removing ingress identity")
+		log.WithField(logfields.Identity, id).Debug("Removing identity from ingress map")
 		delete(c.IngressIdentities, id)
 
 		if c.wasLastRule(id) {

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -183,9 +183,9 @@ func (c *Consumable) addToMaps(id NumericIdentity) {
 	}
 }
 
+// A rule is the 'last rule' for an identity if it does not exist as a key
+// in any of the maps for this Consumable.
 func (c *Consumable) wasLastRule(id NumericIdentity) bool {
-	// A rule is the 'last rule' for an identity if it does not exist as a key
-	// in any of the maps for this Consumable.
 	_, existsReverse := c.ReverseRules[id]
 	_, existsIngressIdentity := c.IngressIdentities[id]
 	return !existsReverse && !existsIngressIdentity

--- a/pkg/policy/consumer_test.go
+++ b/pkg/policy/consumer_test.go
@@ -19,52 +19,52 @@ import (
 )
 
 const (
-	CONSUMER_ID1 = NumericIdentity(10)
-	CONSUMER_ID2 = NumericIdentity(20)
-	CONSUMER_ID3 = NumericIdentity(30)
+	ID1 = NumericIdentity(10)
+	ID2 = NumericIdentity(20)
+	ID3 = NumericIdentity(30)
 )
 
-func (s *PolicyTestSuite) TestGetConsumer(c *C) {
+func (s *PolicyTestSuite) TestGetConsumable(c *C) {
 	cache := newConsumableCache()
 
-	c1 := cache.GetOrCreate(CONSUMER_ID1, nil)
+	c1 := cache.GetOrCreate(ID1, nil)
 	c.Assert(c1.Iteration, Equals, uint64(0))
-	c2 := cache.GetOrCreate(CONSUMER_ID1, nil)
+	c2 := cache.GetOrCreate(ID1, nil)
 	c.Assert(c1, Equals, c2)
 
-	c3 := cache.GetOrCreate(CONSUMER_ID2, nil)
+	c3 := cache.GetOrCreate(ID2, nil)
 	c.Assert(c1, Not(Equals), c3)
 }
 
-func (s *PolicyTestSuite) TestConsumer(c *C) {
+func (s *PolicyTestSuite) TestIdentityAllowed(c *C) {
 	cache := newConsumableCache()
 
-	c1 := cache.GetOrCreate(CONSUMER_ID1, nil)
-	c.Assert(c1.Allows(CONSUMER_ID2), Equals, false)
-	c.Assert(c1.Allows(CONSUMER_ID3), Equals, false)
+	c1 := cache.GetOrCreate(ID1, nil)
+	c.Assert(c1.Allows(ID2), Equals, false)
+	c.Assert(c1.Allows(ID3), Equals, false)
 
-	c1.AllowConsumerLocked(cache, CONSUMER_ID2)
-	c.Assert(c1.Allows(CONSUMER_ID2), Equals, true)
-	consumer1 := c1.getConsumer(CONSUMER_ID2)
-	c.Assert(consumer1, Equals, true)
+	c1.AllowIngressIdentityLocked(cache, ID2)
+	c.Assert(c1.Allows(ID2), Equals, true)
+	id2Allowed := c1.isIdentityAllowed(ID2)
+	c.Assert(id2Allowed, Equals, true)
 
-	c1.AllowConsumerLocked(cache, CONSUMER_ID2)
-	c.Assert(c1.Allows(CONSUMER_ID2), Equals, true)
-	consumer2 := c1.getConsumer(CONSUMER_ID2)
-	c.Assert(consumer2, Equals, true)
+	c1.AllowIngressIdentityLocked(cache, ID2)
+	c.Assert(c1.Allows(ID2), Equals, true)
+	id2Allowed = c1.isIdentityAllowed(ID2)
+	c.Assert(id2Allowed, Equals, true)
 
-	c1.AllowConsumerLocked(cache, CONSUMER_ID3)
-	c.Assert(c1.Allows(CONSUMER_ID3), Equals, true)
-	consumer3 := c1.getConsumer(CONSUMER_ID3)
-	c.Assert(consumer3, Equals, true)
+	c1.AllowIngressIdentityLocked(cache, ID3)
+	c.Assert(c1.Allows(ID3), Equals, true)
+	id3Allowed := c1.isIdentityAllowed(ID3)
+	c.Assert(id3Allowed, Equals, true)
 
-	c1.BanConsumerLocked(CONSUMER_ID2)
-	c.Assert(c1.Allows(CONSUMER_ID2), Equals, false)
-	consumer2 = c1.getConsumer(CONSUMER_ID2)
-	c.Assert(consumer2, Equals, false)
+	c1.RemoveIngressIdentityLocked(ID2)
+	c.Assert(c1.Allows(ID2), Equals, false)
+	id2Allowed = c1.isIdentityAllowed(ID2)
+	c.Assert(id2Allowed, Equals, false)
 
-	c1.BanConsumerLocked(CONSUMER_ID3)
-	c.Assert(c1.Allows(CONSUMER_ID3), Equals, false)
-	consumer3 = c1.getConsumer(CONSUMER_ID3)
-	c.Assert(consumer3, Equals, false)
+	c1.RemoveIngressIdentityLocked(ID3)
+	c.Assert(c1.Allows(ID3), Equals, false)
+	id3Allowed = c1.isIdentityAllowed(ID3)
+	c.Assert(id3Allowed, Equals, false)
 }

--- a/pkg/policy/consumer_test.go
+++ b/pkg/policy/consumer_test.go
@@ -16,8 +16,6 @@ package policy
 
 import (
 	. "gopkg.in/check.v1"
-
-	"github.com/cilium/cilium/pkg/policy/api"
 )
 
 const (
@@ -25,11 +23,6 @@ const (
 	CONSUMER_ID2 = NumericIdentity(20)
 	CONSUMER_ID3 = NumericIdentity(30)
 )
-
-func (s *PolicyTestSuite) TestNewConsumer(c *C) {
-	consumer := &Consumer{ID: CONSUMER_ID1}
-	c.Assert(consumer.ID, Equals, CONSUMER_ID1)
-}
 
 func (s *PolicyTestSuite) TestGetConsumer(c *C) {
 	cache := newConsumableCache()
@@ -53,25 +46,25 @@ func (s *PolicyTestSuite) TestConsumer(c *C) {
 	c1.AllowConsumerLocked(cache, CONSUMER_ID2)
 	c.Assert(c1.Allows(CONSUMER_ID2), Equals, true)
 	consumer1 := c1.getConsumer(CONSUMER_ID2)
-	c.Assert(consumer1.ID, Equals, CONSUMER_ID2)
+	c.Assert(consumer1, Equals, true)
 
 	c1.AllowConsumerLocked(cache, CONSUMER_ID2)
 	c.Assert(c1.Allows(CONSUMER_ID2), Equals, true)
 	consumer2 := c1.getConsumer(CONSUMER_ID2)
-	c.Assert(consumer2.ID, Equals, CONSUMER_ID2)
+	c.Assert(consumer2, Equals, true)
 
 	c1.AllowConsumerLocked(cache, CONSUMER_ID3)
 	c.Assert(c1.Allows(CONSUMER_ID3), Equals, true)
 	consumer3 := c1.getConsumer(CONSUMER_ID3)
-	c.Assert(consumer3.ID, Equals, CONSUMER_ID3)
+	c.Assert(consumer3, Equals, true)
 
 	c1.BanConsumerLocked(CONSUMER_ID2)
 	c.Assert(c1.Allows(CONSUMER_ID2), Equals, false)
 	consumer2 = c1.getConsumer(CONSUMER_ID2)
-	c.Assert(consumer2, IsNil)
+	c.Assert(consumer2, Equals, false)
 
 	c1.BanConsumerLocked(CONSUMER_ID3)
 	c.Assert(c1.Allows(CONSUMER_ID3), Equals, false)
 	consumer3 = c1.getConsumer(CONSUMER_ID3)
-	c.Assert(consumer3, IsNil)
+	c.Assert(consumer3, Equals, false)
 }

--- a/pkg/policy/consumer_test.go
+++ b/pkg/policy/consumer_test.go
@@ -27,7 +27,7 @@ const (
 )
 
 func (s *PolicyTestSuite) TestNewConsumer(c *C) {
-	consumer := NewConsumer(CONSUMER_ID1)
+	consumer := &Consumer{ID: CONSUMER_ID1}
 	c.Assert(consumer.ID, Equals, CONSUMER_ID1)
 }
 

--- a/pkg/policy/consumer_test.go
+++ b/pkg/policy/consumer_test.go
@@ -29,7 +29,6 @@ const (
 func (s *PolicyTestSuite) TestNewConsumer(c *C) {
 	consumer := NewConsumer(CONSUMER_ID1)
 	c.Assert(consumer.ID, Equals, CONSUMER_ID1)
-	c.Assert(consumer.Decision, Equals, api.Allowed)
 }
 
 func (s *PolicyTestSuite) TestGetConsumer(c *C) {

--- a/pkg/policy/consumer_test.go
+++ b/pkg/policy/consumer_test.go
@@ -45,26 +45,26 @@ func (s *PolicyTestSuite) TestIdentityAllowed(c *C) {
 
 	c1.AllowIngressIdentityLocked(cache, ID2)
 	c.Assert(c1.Allows(ID2), Equals, true)
-	id2Allowed := c1.isIdentityAllowed(ID2)
+	id2Allowed, _ := c1.IngressIdentities[ID2]
 	c.Assert(id2Allowed, Equals, true)
 
 	c1.AllowIngressIdentityLocked(cache, ID2)
 	c.Assert(c1.Allows(ID2), Equals, true)
-	id2Allowed = c1.isIdentityAllowed(ID2)
+	id2Allowed, _ = c1.IngressIdentities[ID2]
 	c.Assert(id2Allowed, Equals, true)
 
 	c1.AllowIngressIdentityLocked(cache, ID3)
 	c.Assert(c1.Allows(ID3), Equals, true)
-	id3Allowed := c1.isIdentityAllowed(ID3)
+	id3Allowed, _ := c1.IngressIdentities[ID3]
 	c.Assert(id3Allowed, Equals, true)
 
 	c1.RemoveIngressIdentityLocked(ID2)
 	c.Assert(c1.Allows(ID2), Equals, false)
-	id2Allowed = c1.isIdentityAllowed(ID2)
+	id2Allowed, _ = c1.IngressIdentities[ID2]
 	c.Assert(id2Allowed, Equals, false)
 
 	c1.RemoveIngressIdentityLocked(ID3)
 	c.Assert(c1.Allows(ID3), Equals, false)
-	id3Allowed = c1.isIdentityAllowed(ID3)
+	id3Allowed, _ = c1.IngressIdentities[ID3]
 	c.Assert(id3Allowed, Equals, false)
 }

--- a/pkg/policy/identity.go
+++ b/pkg/policy/identity.go
@@ -48,8 +48,8 @@ var (
 	IdentitiesPath = path.Join(kvstore.BaseKeyPrefix, "state", "identities", "v1")
 )
 
-// NumericIdentity represents an identity of an entity to which consumer policy
-// can be applied to.
+// NumericIdentity is the numeric representation of a security identity / a
+// security policy.
 type NumericIdentity uint32
 
 func ParseNumericIdentity(id string) (NumericIdentity, error) {

--- a/test/runtime/ct.go
+++ b/test/runtime/ct.go
@@ -126,6 +126,11 @@ var _ = Describe("RuntimeValidatedConntrackTable", func() {
 	})
 
 	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			vm.ReportFailed(
+				"sudo cilium bpf ct list global",
+				"sudo cilium endpoint list")
+		}
 		vm.PolicyDelAll()
 		netcatPort = 11111
 		containers(helpers.Delete)

--- a/tests/12-policy-import.sh
+++ b/tests/12-policy-import.sh
@@ -150,8 +150,8 @@ FOO_SEC_ID=$(cilium endpoint list | grep id.foo | awk '{ print $4}')
 
 EXPECTED_CONSUMER="1\n$FOO_SEC_ID"
 
-log "verify allowed consumers"
-DIFF=$(diff -Nru <(echo -e "$EXPECTED_CONSUMER") <(cilium endpoint get $BAR_ID | jq '.[].policy | .["allowed-consumers"] | .[]' | sort)) || true
+log "verify allowed-ingress-identities"
+DIFF=$(diff -Nru <(echo -e "$EXPECTED_CONSUMER") <(cilium endpoint get $BAR_ID | jq '.[].policy | .["allowed-ingress-identities"] | .[]' | sort)) || true
 if [[ "$DIFF" != "" ]]; then
   abort "$DIFF"
 fi
@@ -209,8 +209,8 @@ fi
 
 EXPECTED_CONSUMER="$FOO_SEC_ID"
 
-log "verify allowed consumers"
-DIFF=$(diff -Nru <(echo -e "$EXPECTED_CONSUMER") <(cilium endpoint get $BAR_ID | jq '.[].policy | .["allowed-consumers"] | .[]')) || true
+log "verify allowed-ingress-identities"
+DIFF=$(diff -Nru <(echo -e "$EXPECTED_CONSUMER") <(cilium endpoint get $BAR_ID | jq '.[].policy | .["allowed-ingress-identities"] | .[]')) || true
 if [[ "$DIFF" != "" ]]; then
   abort "$DIFF"
 fi


### PR DESCRIPTION
The Consumer object did not possess any useful state, as a variety of its
fields were not in use throughout the policy package. These fields included
a Decision, which was never populated during policy calculation, and Reverse,
a field which was never populated at all.
In a Consumable, there was a mapping of security identities from which ingress
traffic is allowed to Consumers. But, once the aforementioned unused fields were
removed, the only useful information within the Consumer was the identity of
the Consumer, which was key in the aforementioned map within a Consumable, and
the DeletionMark within a Consumer, which indicated whether the given entry
in the map should be garbage collected after policy recalculation for a
Consumable. Given that the key in the Consumable's map was  already the same
security identity as that within the Consumer, that left the DeletionMark as
the only field within a Consumer that was necessary to keep. Thus, it made
sense to get rid of the notion of a Consumer, and just have the map within the
Consumable map from a security identity to a boolean indicating whether it
should be garbage-collected or not during policy recalculation.
    
This patch removes the notion of a Consumer from the policy package, and defined
the fields within a Consumable to refer to ingress security-identity-based
policy. This sets the groundwork for adding identity-based egress policy
within Cilium, and  makes the code more readable and easier to understand.

Signed-off by: Ian Vernon <ian@cilium.io>
