### PR TITLE
CI: deprecate tests covered by test/runtime/connectivity.go and mark it as validated

### DIFF
--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var _ = Describe("RuntimeConnectivityTest", func() {
+var _ = Describe("RuntimeValidatedConnectivityTest", func() {
 
 	var once sync.Once
 	var logger *logrus.Entry
@@ -43,7 +43,7 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 		return
 	})
 
-	Context("Basic Connectivy test", func() {
+	Context("Basic Connectivity test", func() {
 
 		BeforeEach(func() {
 			vm.ContainerCreate(helpers.Client, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
@@ -275,7 +275,7 @@ var _ = Describe("RuntimeConnectivityTest", func() {
 	})
 })
 
-var _ = Describe("RuntimeConntrackTest", func() {
+var _ = Describe("RuntimeValidatedConntrackTest", func() {
 	var logger *logrus.Entry
 	var vm *helpers.SSHMeta
 	var once sync.Once

--- a/tests/01-ct.sh
+++ b/tests/01-ct.sh
@@ -11,6 +11,10 @@ redirect_debug_logs ${LOGS_DIR}
 
 set -ex
 
+log "${TEST_NAME} has been deprecated and replaced by test/runtime/connectivity.go"
+exit 0
+
+
 function cleanup {
   docker rm -f server client httpd1 httpd2 curl curl2 2> /dev/null || true
   monitor_stop

--- a/tests/03-docker.sh
+++ b/tests/03-docker.sh
@@ -11,6 +11,9 @@ redirect_debug_logs ${LOGS_DIR}
 
 set -ex
 
+log "${TEST_NAME} has been deprecated and replaced by test/runtime/connectivity.go: Test connectivity between containers with / without policy imported"
+exit 0
+
 NETPERF_IMAGE="tgraf/netperf"
 
 function cleanup {

--- a/tests/08-nat46.sh
+++ b/tests/08-nat46.sh
@@ -11,6 +11,9 @@ redirect_debug_logs ${LOGS_DIR}
 
 set -ex
 
+log "${TEST_NAME} has been deprecated and replaced by test/runtime/connectivity.go:Test NAT46 connectivity between containers"
+exit 0
+
 function cleanup {
   log "beginning cleanup for ${TEST_NAME}"
   cilium policy delete --all 2> /dev/null || true


### PR DESCRIPTION
* deprecate 01-ct.sh, 08-nat46.sh, 03-docker.sh
* mark test/runtime/connectivity.go as validated, which means that it will run as part of PR builds.

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #1839 , #1841 