### PR TITLE
CI: deprecate tests/06-lb.sh bash test, mark test/runtime/lb.go as validated

### DIFF
--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -26,7 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var _ = Describe("RuntimeLB", func() {
+var _ = Describe("RuntimeValidatedLB", func() {
 
 	var once sync.Once
 	var logger *logrus.Entry

--- a/tests/06-lb.sh
+++ b/tests/06-lb.sh
@@ -24,6 +24,9 @@ redirect_debug_logs ${LOGS_DIR}
 
 set -ex
 
+log "${TEST_NAME} has been deprecated and replaced by test/runtime/lb.go"
+exit 0
+
 #cilium config ConntrackLocal=true
 
 NETPERF_IMAGE="tgraf/netperf"


### PR DESCRIPTION
Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #1841 