### PR TITLE
CI: deprecate 14-policy-enforcement-docker.sh

### DIFF
--- a/tests/14-policy-enforcement-docker.sh
+++ b/tests/14-policy-enforcement-docker.sh
@@ -11,6 +11,9 @@ redirect_debug_logs ${LOGS_DIR}
 
 set -ex
 
+log "${TEST_NAME} has been deprecated and replaced by test/runtime/Policies.go:RuntimeValidatedPolicyEnforcement"
+exit 0
+
 TEST_NET="cilium-net"
 NUM_ENDPOINTS="3"
 


### PR DESCRIPTION
Corresponding Ginkgo test has been marked as validated already.

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #1841 