### PR TITLE
CI: deprecate bash monitor tests

### DIFF
--- a/tests/13-monitor-filtering.sh
+++ b/tests/13-monitor-filtering.sh
@@ -11,7 +11,7 @@ redirect_debug_logs ${LOGS_DIR}
 
 set -ex
 
-echo "Test has beend disabled"
+log "${TEST_NAME} has been deprecated and replaced by test/runtime/monitor.go"
 exit 0
 
 logs_clear

--- a/tests/17-multiple-monitors.sh
+++ b/tests/17-multiple-monitors.sh
@@ -11,6 +11,9 @@ redirect_debug_logs ${LOGS_DIR}
 
 set -uex
 
+log "${TEST_NAME} has been deprecated and replaced by test/runtime/monitor.go"
+exit 0
+
 TEST_NET="cilium"
 MON_1_OUTPUT=$(mktemp)
 MON_2_OUTPUT=$(mktemp)


### PR DESCRIPTION
Corresponding Ginkgo test `test/runtime/monitor.go` has already been marked as validated.

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #1841 