### PR TITLE
cilium: ginkgo option 'useVagrant' to run tests without VMs

### DIFF
--- a/test/config/config.go
+++ b/test/config/config.go
@@ -20,6 +20,7 @@ import "flag"
 type CiliumTestConfigType struct {
 	Reprovision     bool
 	HoldEnvironment bool
+	UseVagrant      bool
 }
 
 // CiliumTestConfig holds the global configuration of commandline flags
@@ -32,4 +33,6 @@ func (c *CiliumTestConfigType) ParseFlags() {
 		"Provision Vagrant boxes and Cilium before running test")
 	flag.BoolVar(&c.HoldEnvironment, "cilium.holdEnvironment", false,
 		"On failure, hold the environment in its current state")
+	flag.BoolVar(&c.UseVagrant, "cilium.useVagrant", true,
+		"Run tests using Vagrant")
 }

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -276,7 +276,7 @@ func (s *SSHMeta) GetEndpointsNames() ([]string, error) {
 // containing policies, DaemonSets, etc.) are stored for the runtime tests.
 // TODO: this can just be a constant; there's no need to have a function.
 func (s *SSHMeta) ManifestsPath() string {
-	return fmt.Sprintf("%s/runtime/manifests/", BasePath)
+	return fmt.Sprintf("%s/runtime/manifests/", GetBasePath())
 }
 
 // GetFullPath returns the path of file name prepended with the absolute path
@@ -517,8 +517,8 @@ func (s *SSHMeta) GatherLogs() {
 	reportMap(testPath, ciliumLogCommands, s)
 
 	ciliumBPFStateCommands := []string{
-		fmt.Sprintf("sudo cp -r %s %s/%s/lib", RunDir, BasePath, testPath),
-		fmt.Sprintf("sudo cp -r %s %s/%s/run", LibDir, BasePath, testPath),
+		fmt.Sprintf("sudo cp -r %s %s/%s/lib", RunDir, GetBasePath(), testPath),
+		fmt.Sprintf("sudo cp -r %s %s/%s/run", LibDir, GetBasePath(), testPath),
 	}
 
 	for _, cmd := range ciliumBPFStateCommands {

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -16,7 +16,10 @@ package helpers
 
 import (
 	"fmt"
+	"os"
 	"time"
+
+	"github.com/cilium/cilium/test/config"
 )
 
 var (
@@ -25,10 +28,6 @@ var (
 )
 
 const (
-	// BasePath is the path in the Vagrant VMs to which the test directory
-	// is mounted
-	BasePath = "/src/test/"
-
 	// ManifestBase tells ginkgo suite where to look for manifests
 	K8sManifestBase = "k8sT/manifests"
 
@@ -167,9 +166,22 @@ var ciliumKubCLICommands = map[string]string{
 	"cilium status --all-controllers": "status.txt",
 }
 
+// BasePath is the path to which the test directory is mounted
+func GetBasePath() string {
+	var BasePath string
+
+	if config.CiliumTestConfig.UseVagrant {
+		BasePath = "/src/test/"
+	} else {
+		BasePath = os.Getenv("GOPATH") + "/src/github.com/cilium/cilium/test/"
+	}
+
+	return BasePath
+}
+
 //GetFilePath returns the absolute path of the provided filename
 func GetFilePath(filename string) string {
-	return fmt.Sprintf("%s%s", BasePath, filename)
+	return fmt.Sprintf("%s%s", GetBasePath(), filename)
 }
 
 // K8s1VMName is the name of the Kubernetes master node when running K8s tests.

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -169,9 +169,9 @@ func (kub *Kubectl) ManifestGet(manifestFilename string) string {
 	fullPath := fmt.Sprintf("%s/%s/%s", manifestsPath, GetCurrentK8SEnv(), manifestFilename)
 	_, err := os.Stat(fullPath)
 	if err == nil {
-		return fmt.Sprintf("%s/%s", BasePath, fullPath)
+		return fmt.Sprintf("%s/%s", GetBasePath(), fullPath)
 	}
-	return fmt.Sprintf("%s/k8sT/manifests/%s", BasePath, manifestFilename)
+	return fmt.Sprintf("%s/k8sT/manifests/%s", GetBasePath(), manifestFilename)
 }
 
 // NodeCleanMetadata annotates each node in the Kubernetes cluster with the

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -47,6 +47,14 @@ func (s *SSHMeta) String() string {
 
 }
 
+func GetLoSSHMeta() *SSHMeta {
+	return &SSHMeta{
+		sshClient: GetSSHClient("127.0.0.1", 22, "john"),
+		rawConfig: []byte(""),
+		nodeName:  "lo",
+	}
+}
+
 // GetVagrantSSHMeta returns a SSHMeta initialized based on the provided
 // SSH-config target.
 func GetVagrantSSHMeta(vmName string) *SSHMeta {

--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -190,7 +190,7 @@ func (t *Target) GetManifestName(spec *TestSpec) string {
 // GetManifestPath returns the manifest path for the target using the spec
 // parameter
 func (t *Target) GetManifestPath(spec *TestSpec) string {
-	return fmt.Sprintf("%s/%s", helpers.BasePath, t.GetManifestName(spec))
+	return fmt.Sprintf("%s/%s", helpers.GetBasePath(), t.GetManifestName(spec))
 }
 
 // CreateApplyManifest creates the manifest for the type of the target and
@@ -350,7 +350,7 @@ func (t *TestSpec) RunTest(kub *helpers.Kubectl) {
 func (t *TestSpec) Destroy(delay time.Duration) error {
 	manifestToDestroy := []string{
 		t.GetManifestsPath(),
-		fmt.Sprintf("%s/%s", helpers.BasePath, t.NetworkPolicyName()),
+		fmt.Sprintf("%s/%s", helpers.GetBasePath(), t.NetworkPolicyName()),
 		fmt.Sprintf("%s", t.Destination.GetManifestPath(t)),
 	}
 
@@ -373,7 +373,7 @@ func (t *TestSpec) GetManifestName() string {
 
 // GetManifestsPath returns the `TestSpec` manifest path
 func (t *TestSpec) GetManifestsPath() string {
-	return fmt.Sprintf("%s/%s", helpers.BasePath, t.GetManifestName())
+	return fmt.Sprintf("%s/%s", helpers.GetBasePath(), t.GetManifestName())
 }
 
 // CreateManifests creates a new pod manifest. It sets a random prefix for the
@@ -599,7 +599,7 @@ func (t *TestSpec) NetworkPolicyApply() error {
 
 	_, err = t.Kub.CiliumPolicyAction(
 		helpers.KubeSystemNamespace,
-		fmt.Sprintf("%s/%s", helpers.BasePath, t.NetworkPolicyName()),
+		fmt.Sprintf("%s/%s", helpers.GetBasePath(), t.NetworkPolicyName()),
 		helpers.KubectlApply,
 		helpers.HelperTimeout)
 

--- a/test/helpers/runtime.go
+++ b/test/helpers/runtime.go
@@ -17,6 +17,7 @@ package helpers
 import (
 	"fmt"
 
+	"github.com/cilium/cilium/test/config"
 	"github.com/onsi/ginkgo"
 	"github.com/sirupsen/logrus"
 )
@@ -29,7 +30,14 @@ import (
 // This function does not set up cilium, so it should only be run by the
 // test_suite; test writers should use CreateNewRuntimeHelper() instead.
 func InitRuntimeHelper(target string, log *logrus.Entry) *SSHMeta {
-	node := GetVagrantSSHMeta(target)
+	var node *SSHMeta
+
+	if config.CiliumTestConfig.UseVagrant {
+		node = GetVagrantSSHMeta(target)
+	} else {
+		node = GetLoSSHMeta()
+	}
+
 	if node == nil {
 		ginkgo.Fail(fmt.Sprintf("Cannot connect to target '%s'", target), 1)
 		return nil

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -78,7 +78,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 
 	endpointCount := 20
 	manifestPath := "tmp.yaml"
-	vagrantManifestPath := path.Join(helpers.BasePath, manifestPath)
+	vagrantManifestPath := path.Join(helpers.GetBasePath(), manifestPath)
 	var lastServer int
 
 	Measure(fmt.Sprintf("%d endpoint creation", endpointCount), func(b Benchmarker) {

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -444,7 +444,7 @@ tc filter add dev lbtest2 ingress bpf da obj tmp_lb.o sec from-netdev
 	}
 
 	// filesystem is mounted at path /vagrant on VM
-	scriptPath := fmt.Sprintf("%s%s", helpers.BasePath, scriptName)
+	scriptPath := fmt.Sprintf("%s%s", helpers.GetBasePath(), scriptName)
 
 	ipAddrCmd := "sudo ip addr add fd02:1:1:1:1:1:1:1 dev cilium_host"
 	res := node.Exec(ipAddrCmd)


### PR DESCRIPTION
Running tests on bare-metal is useful for doing performance analysis
and development work on the datapath in the Linux kernel. The old
test bash scripts could easily be run on bare-metal by simply calling
the script on the system under test.

However, the new gingko test framework insists on launching vagrant
boxes. To avoid this add a new 'useVagrant' flag. The following cmd
will allow running on bare metal,

 $ gingko --focus="Runtime*" -- \
         -cilium.provision=false -cilium.useVagrant=false

Not all tests currently pass with this option, but individual test
failures can be addressed in follow on patches. We may want to
consider adding a --focus class for bare metal testing.

```release-note
cilium: gingko support for bare metal testing
```

**How to test (optional)**:

 $ gingko --focus="Runtime*" --  -cilium.provision=false -cilium.useVagrant=false

