### PR TITLE
CI: deprecate bash GSG test, mark RuntimePolicies test as validated

### DIFF
--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -408,7 +408,7 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 	})
 })
 
-var _ = Describe("RuntimePolicies", func() {
+var _ = Describe("RuntimeValidatedPolicies", func() {
 
 	var once sync.Once
 	var logger *logrus.Entry

--- a/tests/11-getting-started.sh
+++ b/tests/11-getting-started.sh
@@ -11,6 +11,10 @@ redirect_debug_logs ${LOGS_DIR}
 
 set -ex
 
+log "${TEST_NAME} has been deprecated and replaced by /test/runtime/Policies.go:L3/L4 Checks, L7 Checks"
+exit 0
+
+
 DEMO_CONTAINER="cilium/demo-client"
 HTTPD_CONTAINER_NAME="service1-instance1"
 ID_SERVICE1="id.service1"


### PR DESCRIPTION
Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #1841 