### PR TITLE
ginkgo.Jenkinsfile: bump timeout to 90 minutes

### DIFF
--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 60, unit: 'MINUTES')
+        timeout(time: 90, unit: 'MINUTES')
         timestamps()
     }
     stages {


### PR DESCRIPTION
60 minute limit kept getting hit, which caused Jenkins to forcibly abort PRs.

Signed-off by: Ian Vernon <ian@cilium.io>
