### PR TITLE
Add ginkgo option to run ginkgo tests against developer VMs

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -17,7 +17,7 @@ $CPU = (ENV['CPU'] || "2").to_i
 ENV["VAGRANT_DEFAULT_PROVIDER"] = "virtualbox"
 Vagrant.configure("2") do |config|
 
-    config.vm.define "runtime" do |server|
+    config.vm.define "runtime1" do |server|
         server.vm.provider "virtualbox" do |vb|
             vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
             vb.cpus = $CPU
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
 
         server.vm.box =  "#{$SERVER_BOX}"
         server.vm.box_version = $SERVER_VERSION
-        server.vm.hostname = "runtime"
+        server.vm.hostname = "runtime1"
 
         # This network is only used by NFS
         server.vm.network "private_network", type: "dhcp"

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -21,6 +21,7 @@ type CiliumTestConfigType struct {
 	Reprovision     bool
 	HoldEnvironment bool
 	SSHConfig       string
+	Developer       bool
 	ShowCommands    bool
 }
 
@@ -34,6 +35,9 @@ func (c *CiliumTestConfigType) ParseFlags() {
 		"Provision Vagrant boxes and Cilium before running test")
 	flag.BoolVar(&c.HoldEnvironment, "cilium.holdEnvironment", false,
 		"On failure, hold the environment in its current state")
+	flag.BoolVar(&c.Developer, "cilium.developer", false,
+		"Is set with true, `holdEnvironment` will also be true and the VMs won't "+
+			"be provisioned. But they will be configured")
 	flag.StringVar(&c.SSHConfig, "cilium.SSHConfig", "",
 		"Specify a custom command to fetch SSH configuration (eg: 'vagrant ssh-config')")
 	flag.BoolVar(&c.ShowCommands, "cilium.showCommands", false,

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -796,3 +796,8 @@ func (s *SSHMeta) RestartCilium() error {
 	}
 	return nil
 }
+
+//GetFilePath returns the absolute path of the provided filename
+func (s *SSHMeta) GetFilePath(filename string) string {
+	return filepath.Join(s.ciliumRootPath, "test", filename)
+}

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -39,6 +39,45 @@ const (
 	MaxRetries = 30
 )
 
+// CiliumOpts specify the options that can be used in the cilium options
+// template
+type CiliumOpts struct {
+	AutoIPv6NodeRoutes bool
+	Debug              bool
+	DebugVerbose       string
+	K8sKubeConfigPath  string
+	KVStore            string
+	KVStoreOpt         string
+	AccessLog          string
+	K8sNodeName        string
+	TunnelType         string
+	ManifestName       string
+}
+
+func DefaultRuntimeCiliumOpts() CiliumOpts {
+	return CiliumOpts{
+		AutoIPv6NodeRoutes: true,
+		KVStore:            "consul",
+		KVStoreOpt:         "consul.address=127.0.0.1:8500",
+		Debug:              true,
+		DebugVerbose:       "flow",
+		AccessLog:          "/var/log/cilium-access.log",
+	}
+}
+
+func DefaultK8sTCiliumOpts() CiliumOpts {
+	return CiliumOpts{
+		AutoIPv6NodeRoutes: true,
+		KVStore:            "etcd",
+		KVStoreOpt:         "etcd.config=/var/lib/cilium/etcd-config.yml",
+		Debug:              true,
+		DebugVerbose:       "flow",
+		K8sKubeConfigPath:  "/var/lib/cilium/cilium.kubeconfig",
+		AccessLog:          "/var/log/cilium-access.log",
+		ManifestName:       "cilium_ds.yaml",
+	}
+}
+
 // BpfLBList returns the output of `cilium bpf lb list -o json` as a map
 // Key will be the frontend address and the value is an array with all backend
 // addresses
@@ -350,15 +389,14 @@ func (s *SSHMeta) GetEndpointsNames() ([]string, error) {
 
 // ManifestsPath returns the path of the directory where manifests (YAMLs
 // containing policies, DaemonSets, etc.) are stored for the runtime tests.
-// TODO: this can just be a constant; there's no need to have a function.
 func (s *SSHMeta) ManifestsPath() string {
-	return fmt.Sprintf("%s/runtime/manifests/", BasePath)
+	return filepath.Join(s.ciliumRootPath, "test", "runtime", "manifests")
 }
 
 // GetFullPath returns the path of file name prepended with the absolute path
 // where manifests (YAMLs containing policies, DaemonSets, etc.) are stored.
 func (s *SSHMeta) GetFullPath(name string) string {
-	return fmt.Sprintf("%s%s", s.ManifestsPath(), name)
+	return filepath.Join(s.ManifestsPath(), name)
 }
 
 // PolicyEndpointsSummary returns the count of whether policy enforcement is
@@ -508,12 +546,12 @@ func (s *SSHMeta) PolicyImport(path string) error {
 func (s *SSHMeta) PolicyRenderAndImport(policy string) (int, error) {
 	filename := fmt.Sprintf("policy_%s.json", MakeUID())
 	s.logger.Debugf("PolicyRenderAndImport: render policy to '%s'", filename)
-	err := RenderTemplateToFile(filename, policy, os.ModePerm)
+	err := RenderTemplateToFile(filename, policy, nil, os.ModePerm)
 	if err != nil {
 		s.logger.Errorf("PolicyRenderAndImport: cannot create policy file on '%s'", filename)
 		return 0, fmt.Errorf("cannot render the policy:  %s", err)
 	}
-	path := GetFilePath(filename)
+	path := s.GetFilePath(filename)
 	s.logger.Debugf("PolicyRenderAndImport: import policy from '%s'", path)
 	defer os.Remove(filename)
 	return s.PolicyImportAndWait(path, HelperTimeout)
@@ -742,19 +780,50 @@ func (s *SSHMeta) ServiceDelAll() *CmdRes {
 
 // SetUpCilium sets up Cilium as a systemd service with a hardcoded set of options. It
 // returns an error if any of the operations needed to start Cilium fails.
-func (s *SSHMeta) SetUpCilium() error {
-	template := `
-PATH=/usr/lib/llvm-3.8/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
-CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug --debug-verbose flow
-INITSYSTEM=SYSTEMD`
+func (s *SSHMeta) SetUpCilium(ciliumOpts CiliumOpts) error {
+	template := `PATH=/usr/lib/llvm-3.8/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+CILIUM_OPTS=--kvstore={{.KVStore}} --kvstore-opt={{.KVStoreOpt}} --debug={{.Debug}} --debug-verbose={{.DebugVerbose}}
+INITSYSTEM=SYSTEMD
+`
 
-	err := RenderTemplateToFile("cilium", template, os.ModePerm)
+	err := RenderTemplateToFile("cilium-opts", template, ciliumOpts, 0644)
 	if err != nil {
 		return err
 	}
-	defer os.Remove("cilium")
+	defer os.Remove("cilium-opts")
+	ciliumOptsPath := filepath.Join(s.ciliumRootPath, "test", "cilium-opts")
 
-	res := s.Exec("sudo cp /vagrant/cilium /etc/sysconfig/cilium")
+	res := s.Exec(fmt.Sprintf("sudo cp %s /etc/sysconfig/cilium", ciliumOptsPath))
+	if !res.WasSuccessful() {
+		return fmt.Errorf("%s", res.CombineOutput())
+	}
+	res = s.Exec("sudo systemctl restart cilium")
+	if !res.WasSuccessful() {
+		return fmt.Errorf("%s", res.CombineOutput())
+	}
+	return nil
+}
+
+// SetUpCilium sets up Cilium as a systemd service with a hardcoded set of options. It
+// returns an error if any of the operations needed to start Cilium fails.
+func (s *SSHMeta) SetUpCiliumK8s(ciliumOpts CiliumOpts) error {
+	// Always use the node's name with the one we are connecting to
+	ciliumOpts.K8sNodeName = s.nodeName
+
+	template := `PATH=/usr/local/clang/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+INITSYSTEM=SYSTEMD
+K8S_NODE_NAME={{.K8sNodeName}}
+CILIUM_OPTS="--auto-ipv6-node-routes={{.AutoIPv6NodeRoutes}} --debug-verbose={{.DebugVerbose}} --k8s-kubeconfig-path={{.K8sKubeConfigPath}} --kvstore={{.KVStore}} --kvstore-opt={{.KVStoreOpt}} -t vxlan --access-log={{.AccessLog}}"
+`
+
+	err := RenderTemplateToFile("cilium-opts", template, ciliumOpts, 0644)
+	if err != nil {
+		return err
+	}
+	defer os.Remove("cilium-opts")
+	ciliumOptsPath := filepath.Join(s.ciliumRootPath, "test", "cilium-opts")
+
+	res := s.ExecWithSudo(fmt.Sprintf("cp %s /etc/sysconfig/cilium", ciliumOptsPath))
 	if !res.WasSuccessful() {
 		return fmt.Errorf("%s", res.CombineOutput())
 	}

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -27,7 +27,7 @@ var (
 	HelperTimeout time.Duration = 300 // WithTimeout helper translates it to seconds
 
 	// Runtime VM name
-	RuntimeVM = "runtime"
+	RuntimeVM = "runtime1"
 
 	// K8s VM names
 	K8s1 = "k8s1"

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -26,6 +26,13 @@ var (
 	// HelperTimeout is a predefined timeout value for commands.
 	HelperTimeout time.Duration = 300 // WithTimeout helper translates it to seconds
 
+	// Runtime VM name
+	RuntimeVM = "runtime"
+
+	// K8s VM names
+	K8s1 = "k8s1"
+	K8s2 = "k8s2"
+
 	// BasePath is the path in the Vagrant VMs to which the test directory
 	// is mounted
 	BasePath = "/home/vagrant/go/src/github.com/cilium/cilium/test"
@@ -40,10 +47,10 @@ const (
 	K8sManifestBase = "k8sT/manifests"
 
 	// VM / Test suite constants.
+
+	//Scopes
 	K8s     = "k8s"
-	K8s1    = "k8s1"
 	K8s1Ip  = "192.168.36.11"
-	K8s2    = "k8s2"
 	K8s2Ip  = "192.168.36.12"
 	Runtime = "runtime"
 
@@ -193,10 +200,10 @@ func GetFilePath(filename string) string {
 
 // K8s1VMName is the name of the Kubernetes master node when running K8s tests.
 func K8s1VMName() string {
-	return fmt.Sprintf("k8s1-%s", GetCurrentK8SEnv())
+	return fmt.Sprintf("%s-%s", K8s1, GetCurrentK8SEnv())
 }
 
 // K8s2VMName is the name of the Kubernetes worker node when running K8s tests.
 func K8s2VMName() string {
-	return fmt.Sprintf("k8s2-%s", GetCurrentK8SEnv())
+	return fmt.Sprintf("%s-%s", K8s2, GetCurrentK8SEnv())
 }

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	"github.com/cilium/cilium/test/config"
 )
 
 var (
@@ -195,10 +196,16 @@ var ciliumKubCLICommands = map[string]string{
 
 // K8s1VMName is the name of the Kubernetes master node when running K8s tests.
 func K8s1VMName() string {
+	if config.CiliumTestConfig.Developer {
+		return K8s1
+	}
 	return fmt.Sprintf("%s-%s", K8s1, GetCurrentK8SEnv())
 }
 
 // K8s2VMName is the name of the Kubernetes worker node when running K8s tests.
 func K8s2VMName() string {
+	if config.CiliumTestConfig.Developer {
+		return K8s2
+	}
 	return fmt.Sprintf("%s-%s", K8s2, GetCurrentK8SEnv())
 }

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -193,11 +193,6 @@ var ciliumKubCLICommands = map[string]string{
 	"cilium kvstore get cilium --recursive": "kvstore_get.txt",
 }
 
-//GetFilePath returns the absolute path of the provided filename
-func GetFilePath(filename string) string {
-	return fmt.Sprintf("%s/%s", BasePath, filename)
-}
-
 // K8s1VMName is the name of the Kubernetes master node when running K8s tests.
 func K8s1VMName() string {
 	return fmt.Sprintf("%s-%s", K8s1, GetCurrentK8SEnv())

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -36,11 +36,12 @@ var (
 
 // SSHMeta contains metadata to SSH into a remote location to run tests
 type SSHMeta struct {
-	sshClient *SSHClient
-	env       []string
-	rawConfig []byte
-	nodeName  string
-	logger    *logrus.Entry
+	sshClient      *SSHClient
+	env            []string
+	rawConfig      []byte
+	nodeName       string
+	logger         *logrus.Entry
+	ciliumRootPath string
 }
 
 // CreateSSHMeta returns an SSHMeta with the specified host, port, and user, as
@@ -83,9 +84,10 @@ func GetVagrantSSHMeta(vmName string) *SSHMeta {
 		return nil
 	}
 	sshMeta := &SSHMeta{
-		sshClient: node.GetSSHClient(),
-		rawConfig: config,
-		nodeName:  vmName,
+		sshClient:      node.GetSSHClient(),
+		rawConfig:      config,
+		nodeName:       vmName,
+		ciliumRootPath: "/home/vagrant/go/src/github.com/cilium/cilium",
 	}
 
 	sshMeta.setBasePath()

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -62,6 +62,7 @@ func (s *SSHMeta) String() string {
 func GetVagrantSSHMeta(vmName string) *SSHMeta {
 	config, err := GetVagrantSSHMetadata(vmName)
 	if err != nil {
+		log.WithError(err).WithField("output", string(config)).Error("Error importing ssh config")
 		return nil
 	}
 

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -189,7 +189,7 @@ func InstallExampleCilium(kubectl *Kubectl) {
 
 	fmt.Fprint(fp, result.String())
 
-	kubectl.Apply(GetFilePath(newCiliumDSName)).ExpectSuccess(
+	kubectl.Apply(kubectl.GetFilePath(newCiliumDSName)).ExpectSuccess(
 		"cannot apply cilium example daemonset")
 
 	status, err := kubectl.WaitforPods(

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -81,22 +81,18 @@ func MakeUID() string {
 // RenderTemplateToFile renders a text/template string into a target filename
 // with specific persmisions. Returns eturn an error if the template cannot be
 // validated or the file cannot be created.
-func RenderTemplateToFile(filename string, tmplt string, perm os.FileMode) error {
+func RenderTemplateToFile(filename string, tmplt string, data interface{}, perm os.FileMode) error {
 	t, err := template.New("").Parse(tmplt)
 	if err != nil {
 		return err
 	}
 	content := new(bytes.Buffer)
-	err = t.Execute(content, nil)
+	err = t.Execute(content, data)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(filename, content.Bytes(), perm)
-	if err != nil {
-		return err
-	}
-	return nil
+	return ioutil.WriteFile(filename, content.Bytes(), perm)
 }
 
 // TimeoutConfig represents the configuration for the timeout of a command.

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -43,7 +43,6 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 	var kubectl *helpers.Kubectl
 	var logger *logrus.Entry
 	var once sync.Once
-	var ciliumPath string
 
 	endpointCount := 45
 	endpointsTimeout := endpointTimeout * time.Duration(endpointCount)
@@ -443,8 +442,8 @@ var _ = Describe("NightlyExamples", func() {
 
 		It("GRPC example", func() {
 
-			AppManifest := helpers.GetFilePath(GRPCManifest)
-			PolicyManifest := helpers.GetFilePath(GRPCPolicy)
+			AppManifest := kubectl.GetFilePath(GRPCManifest)
+			PolicyManifest := kubectl.GetFilePath(GRPCPolicy)
 			clientPod := "terminal-87"
 
 			defer func() {

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -57,10 +57,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
-		ciliumPath = kubectl.ManifestGet("cilium_ds.yaml")
-		kubectl.Apply(ciliumPath)
-
-		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
+		err := kubectl.DeployCiliumDS(helpers.DefaultK8sTCiliumOpts())
 		Expect(err).Should(BeNil())
 
 		err = kubectl.WaitKubeDNS()

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -41,7 +41,6 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 		l3Policy, l7Policy, knpDenyIngress, knpDenyEgress string
 		cnpDenyIngress, cnpDenyEgress                     string
 		logger                                            *logrus.Entry
-		path                                              string
 		podFilter                                         string
 		apps                                              []string
 		service                                           *v1.Service
@@ -70,10 +69,7 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 		// App pods
 		apps = []string{helpers.App1, helpers.App2, helpers.App3}
 
-		path = kubectl.ManifestGet("cilium_ds.yaml")
-		kubectl.Apply(path)
-		status, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)
-		Expect(status).Should(BeTrue())
+		err := kubectl.DeployCiliumDS(helpers.DefaultK8sTCiliumOpts())
 		Expect(err).Should(BeNil())
 		err = kubectl.WaitKubeDNS()
 		Expect(err).Should(BeNil())
@@ -793,12 +789,9 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 		cnpL7Stresstest = kubectl.ManifestGet("cnp-l7-stresstest.yaml")
 		cnpAnyNamespace = kubectl.ManifestGet("cnp-any-namespace.yaml")
 
-		_ = kubectl.Apply(ciliumDaemonSetPath)
-		status, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)
-		Expect(status).Should(BeTrue())
-		Expect(err).Should(BeNil())
+		kubectl.Apply(ciliumDaemonSetPath)
 
-		err = kubectl.WaitKubeDNS()
+		err := kubectl.WaitKubeDNS()
 		Expect(err).Should(BeNil())
 	}
 

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -35,9 +35,7 @@ var _ = Describe("NightlyPolicies", func() {
 		logger.Info("Starting")
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-		ciliumPath := kubectl.ManifestGet("cilium_ds.yaml")
-		kubectl.Apply(ciliumPath)
-		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
+		err := kubectl.DeployCiliumDS(helpers.DefaultK8sTCiliumOpts())
 		Expect(err).Should(BeNil())
 
 		err = kubectl.WaitKubeDNS()

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -47,9 +47,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 		logger.Info("Starting")
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-		path := kubectl.ManifestGet("cilium_ds.yaml")
-		kubectl.Apply(path)
-		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
+		err := kubectl.DeployCiliumDS(helpers.DefaultK8sTCiliumOpts())
 		Expect(err).Should(BeNil())
 
 		err = kubectl.WaitKubeDNS()

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1083,7 +1083,7 @@ var _ = Describe("RuntimeValidatedPolicyImportTests", func() {
 	It("Invalid Policies", func() {
 
 		testInvalidPolicy := func(data string) {
-			err := helpers.RenderTemplateToFile(invalidJSON, data, 0777)
+			err := helpers.RenderTemplateToFile(invalidJSON, data, nil, 0777)
 			Expect(err).Should(BeNil())
 
 			path := vm.GetFilePath(invalidJSON)
@@ -1145,7 +1145,7 @@ var _ = Describe("RuntimeValidatedPolicyImportTests", func() {
 			"labels": ["key3"]
 		}]`
 
-		err := helpers.RenderTemplateToFile(policyJSON, policy, 0777)
+		err := helpers.RenderTemplateToFile(policyJSON, policy, nil, 0777)
 		Expect(err).Should(BeNil())
 
 		path := vm.GetFilePath(policyJSON)

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1086,7 +1086,7 @@ var _ = Describe("RuntimeValidatedPolicyImportTests", func() {
 			err := helpers.RenderTemplateToFile(invalidJSON, data, 0777)
 			Expect(err).Should(BeNil())
 
-			path := helpers.GetFilePath(invalidJSON)
+			path := vm.GetFilePath(invalidJSON)
 			_, err = vm.PolicyImportAndWait(path, helpers.HelperTimeout)
 			Expect(err).Should(HaveOccurred())
 			defer os.Remove(invalidJSON)
@@ -1148,7 +1148,7 @@ var _ = Describe("RuntimeValidatedPolicyImportTests", func() {
 		err := helpers.RenderTemplateToFile(policyJSON, policy, 0777)
 		Expect(err).Should(BeNil())
 
-		path := helpers.GetFilePath(policyJSON)
+		path := vm.GetFilePath(policyJSON)
 		_, err = vm.PolicyImportAndWait(path, helpers.HelperTimeout)
 		Expect(err).Should(BeNil())
 		defer os.Remove(policyJSON)

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -58,7 +58,7 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimePolicyEnforcement"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		vm = helpers.CreateNewRuntimeHelper(helpers.RuntimeVM, logger)
 		vm.ContainerCreate("app", "cilium/demo-httpd", helpers.CiliumDockerNetwork, "-l id.app")
 		areEndpointsReady := vm.WaitEndpointsReady()
 		Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
@@ -412,7 +412,7 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"test": "RunPolicies"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		vm = helpers.CreateNewRuntimeHelper(helpers.RuntimeVM, logger)
 
 		vm.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
 		vm.PolicyDelAll()

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -34,7 +34,7 @@ var _ = Describe("RuntimeValidatedChaos", func() {
 	initialize := func() {
 		logger := log.WithFields(logrus.Fields{"testName": "RuntimeValidatedChaos"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		vm = helpers.CreateNewRuntimeHelper(helpers.RuntimeVM, logger)
 	}
 
 	BeforeEach(func() {

--- a/test/runtime/cli.go
+++ b/test/runtime/cli.go
@@ -37,7 +37,7 @@ var _ = Describe("RuntimeValidatedCLI", func() {
 	initialize := func() {
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimeCLI"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		vm = helpers.CreateNewRuntimeHelper(helpers.RuntimeVM, logger)
 		areEndpointsReady := vm.WaitEndpointsReady()
 		Expect(areEndpointsReady).Should(BeTrue())
 	}

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -24,7 +24,7 @@ var _ = Describe("RuntimeValidatedConnectivityTest", func() {
 	initialize := func() {
 		logger = log.WithFields(logrus.Fields{"test": "RuntimeConnectivityTest"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		vm = helpers.CreateNewRuntimeHelper(helpers.RuntimeVM, logger)
 	}
 
 	BeforeEach(func() {
@@ -304,7 +304,7 @@ var _ = Describe("RuntimeValidatedConntrackTest", func() {
 	initialize := func() {
 		logger = log.WithFields(logrus.Fields{"test": "RunConntrackTest"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		vm = helpers.CreateNewRuntimeHelper(helpers.RuntimeVM, logger)
 
 		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways)
 		res.ExpectSuccess(fmt.Sprintf("Unable to set PolicyEnforcement to %s", helpers.PolicyEnforcementAlways))

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -229,7 +229,7 @@ var _ = Describe("RuntimeValidatedConnectivityTest", func() {
 				"type": "cilium-cni",
 				"mtu": 1450}`
 
-			err := helpers.RenderTemplateToFile(filename, cniConf, os.ModePerm)
+			err := helpers.RenderTemplateToFile(filename, cniConf, nil, os.ModePerm)
 			Expect(err).To(BeNil())
 
 			cmd := vm.Exec(fmt.Sprintf("cat %s > %s/%s",
@@ -256,7 +256,7 @@ var _ = Describe("RuntimeValidatedConnectivityTest", func() {
 					]
 					}]
 				}]`
-			err = helpers.RenderTemplateToFile(policyFileName, policy, os.ModePerm)
+			err = helpers.RenderTemplateToFile(policyFileName, policy, nil, os.ModePerm)
 			Expect(err).Should(BeNil())
 			_, err = vm.PolicyImportAndWait(vm.GetFilePath(policyFileName), helpers.HelperTimeout)
 

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -105,7 +105,7 @@ var _ = Describe("RuntimeValidatedConnectivityTest", func() {
 
 		It("Test connectivity between containers with policy imported", func() {
 			policyID, err := vm.PolicyImportAndWait(
-				fmt.Sprintf("%s/test.policy", vm.ManifestsPath()), 150)
+				filepath.Join(vm.ManifestsPath(), "test.policy"), 150)
 			Expect(err).Should(BeNil())
 			logger.Debug("New policy created with id '%d'", policyID)
 
@@ -233,7 +233,7 @@ var _ = Describe("RuntimeValidatedConnectivityTest", func() {
 			Expect(err).To(BeNil())
 
 			cmd := vm.Exec(fmt.Sprintf("cat %s > %s/%s",
-				helpers.GetFilePath(filename), netDPath, filename))
+				vm.GetFilePath(filename), netDPath, filename))
 			cmd.ExpectSuccess()
 			script := fmt.Sprintf(`
 				cd %s && \
@@ -258,7 +258,7 @@ var _ = Describe("RuntimeValidatedConnectivityTest", func() {
 				}]`
 			err = helpers.RenderTemplateToFile(policyFileName, policy, os.ModePerm)
 			Expect(err).Should(BeNil())
-			_, err = vm.PolicyImportAndWait(helpers.GetFilePath(policyFileName), helpers.HelperTimeout)
+			_, err = vm.PolicyImportAndWait(vm.GetFilePath(policyFileName), helpers.HelperTimeout)
 
 			By("Adding containers")
 

--- a/test/runtime/ct.go
+++ b/test/runtime/ct.go
@@ -105,7 +105,7 @@ var _ = Describe("DisabledRuntimeValidatedConntrackTable", func() {
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimeConntrack"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		vm = helpers.CreateNewRuntimeHelper(helpers.RuntimeVM, logger)
 		err := vm.WaitUntilReady(100)
 		Expect(err).To(BeNil())
 		vm.NetworkCreate(helpers.CiliumDockerNetwork, "")

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -44,7 +44,7 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 	initialize := func() {
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimeKafka"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		vm = helpers.CreateNewRuntimeHelper(helpers.RuntimeVM, logger)
 	}
 
 	containers := func(mode string) {

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -34,7 +34,7 @@ var _ = Describe("RuntimeValidatedKVStoreTest", func() {
 	initialize := func() {
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimeKVStoreTest"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		vm = helpers.CreateNewRuntimeHelper(helpers.RuntimeVM, logger)
 		logger.Info("done creating Cilium and Docker helpers")
 	}
 	containers := func(option string) {

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -503,7 +503,7 @@ tc filter add dev lbtest2 ingress bpf da obj tmp_lb.o sec from-netdev
 	By("Creating LB device to handle service requests")
 	scriptName := "create_veth_interface"
 	log.Infof("generating veth script: %s", scriptName)
-	err := helpers.RenderTemplateToFile(scriptName, script, os.ModePerm)
+	err := helpers.RenderTemplateToFile(scriptName, script, nil, os.ModePerm)
 	if err != nil {
 		return err
 	}

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -33,7 +33,7 @@ var _ = Describe("RuntimeValidatedLB", func() {
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"test": "RuntimeLB"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		vm = helpers.CreateNewRuntimeHelper(helpers.RuntimeVM, logger)
 		vm.PolicyDelAll().ExpectSuccess()
 	})
 

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -49,7 +49,7 @@ var _ = Describe("RuntimeValidatedMonitorTest", func() {
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimeMonitorTest"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		vm = helpers.CreateNewRuntimeHelper(helpers.RuntimeVM, logger)
 		areEndpointsReady := vm.WaitEndpointsReady()
 		Expect(areEndpointsReady).Should(BeTrue())
 	})

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -156,7 +156,7 @@ var _ = BeforeAll(func() {
 
 		vm := helpers.InitRuntimeHelper(helpers.RuntimeVM, log.WithFields(
 			logrus.Fields{"testName": "BeforeSuite"}))
-		err = vm.SetUpCilium()
+		err = vm.SetUpCilium(helpers.DefaultRuntimeCiliumOpts())
 
 		if err != nil {
 			// AfterFailed function is not defined in this scope, fired the

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -149,13 +149,12 @@ var _ = BeforeAll(func() {
 
 	switch ginkgoext.GetScope() {
 	case helpers.Runtime:
-		err = helpers.CreateVM(helpers.Runtime)
+		err = helpers.CreateVM(helpers.RuntimeVM)
 		if err != nil {
 			log.WithError(err).Error("Error starting VM")
-			Fail(fmt.Sprintf("error starting VM %q: %s", helpers.Runtime, err))
 		}
 
-		vm := helpers.InitRuntimeHelper(helpers.Runtime, log.WithFields(
+		vm := helpers.InitRuntimeHelper(helpers.RuntimeVM, log.WithFields(
 			logrus.Fields{"testName": "BeforeSuite"}))
 		err = vm.SetUpCilium()
 
@@ -216,7 +215,7 @@ var _ = AfterAll(func() {
 	log.Infof("cleaning up VMs started for %s tests", scope)
 	switch scope {
 	case helpers.Runtime:
-		helpers.DestroyVM(helpers.Runtime)
+		helpers.DestroyVM(helpers.RuntimeVM)
 	case helpers.K8s:
 		helpers.DestroyVM(helpers.K8s1VMName())
 		helpers.DestroyVM(helpers.K8s2VMName())


### PR DESCRIPTION
test: add cilium developer option

This new variable can be used on already running developer VMs by using
the flag `--cilium.developer=true`. It also uses the environment
variables set in order to detect which developer VMs it should connect
to.

For example:

    NWORKERS=1 K8S=1 ginkgo -v --focus="K8sHealthTest" -- --cilium.developer=true

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/2792)
<!-- Reviewable:end -->
