### PR TITLE
pkg/endpoint: change Endpoint SecLabels field to SecurityIdentity

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -286,7 +286,7 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 
 	// If desired state is waiting-for-identity but identity is already
 	// known, bump it to ready state immediately to force re-generation
-	if ep.GetStateLocked() == endpoint.StateWaitingForIdentity && ep.SecLabel != nil {
+	if ep.GetStateLocked() == endpoint.StateWaitingForIdentity && ep.SecurityIdentity != nil {
 		ep.SetStateLocked(endpoint.StateReady, "Preparing to force endpoint regeneration because identity is known while handling API PATCH")
 		changed = true
 	}

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -245,23 +245,23 @@ func readEPsFromDirNames(basePath string, eptsDirNames []string) []*endpoint.End
 // syncLabels syncs the labels from the labels' database for the given endpoint.
 // To be used with endpoint.Mutex locked.
 func (d *Daemon) syncLabels(ep *endpoint.Endpoint) error {
-	if ep.SecLabel == nil {
+	if ep.SecurityIdentity == nil {
 		return fmt.Errorf("Endpoint doesn't have a security label.")
 	}
 
 	// Filter the restored labels with the new daemon's filter
-	l, _ := labels.FilterLabels(ep.SecLabel.Labels)
-	ep.SecLabel.Labels = l
+	l, _ := labels.FilterLabels(ep.SecurityIdentity.Labels)
+	ep.SecurityIdentity.Labels = l
 
-	identity, _, err := policy.AllocateIdentity(ep.SecLabel.Labels)
+	identity, _, err := policy.AllocateIdentity(ep.SecurityIdentity.Labels)
 	if err != nil {
 		return err
 	}
 
-	if identity.ID != ep.SecLabel.ID {
+	if identity.ID != ep.SecurityIdentity.ID {
 		log.WithFields(logrus.Fields{
 			logfields.EndpointID:              ep.ID,
-			logfields.IdentityLabels + ".old": ep.SecLabel.ID,
+			logfields.IdentityLabels + ".old": ep.SecurityIdentity.ID,
 			logfields.IdentityLabels + ".new": identity.ID,
 		}).Info("Security label ID for endpoint is different that the one stored, updating")
 	}

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -69,7 +69,7 @@ func endpointCreator(id uint16, secID policy.NumericIdentity) *e.Endpoint {
 	ep.IPv6 = addressing.DeriveCiliumIPv6(net.IP{0xbe, 0xef, 0xbe, 0xef, 0xbe, 0xef, 0xbe, 0xef, 0xaa, 0xaa, 0xaa, 0xaa, 0x00, 0x00, b[0], b[1]})
 	ep.IfIndex = 1
 	ep.NodeMAC = mac.MAC([]byte{0x02, 0xff, 0xf2, 0x12, 0x0, 0x0})
-	ep.SecLabel = &policy.Identity{
+	ep.SecurityIdentity = &policy.Identity{
 		ID: secID,
 		Labels: labels.Labels{
 			"foo" + strID: labels.NewLabel("foo"+strID, "", ""),
@@ -169,7 +169,7 @@ func (ds *DaemonSuite) TestSyncLabels(c *C) {
 	epsWanted, _ := createEndpoints()
 
 	ep1 := epsWanted[0]
-	ep1.SecLabel = nil
+	ep1.SecurityIdentity = nil
 	err := ds.d.syncLabels(ep1)
 	// Endpoint doesn't have a security label, syncLabels should not sync
 	// anything.
@@ -177,14 +177,14 @@ func (ds *DaemonSuite) TestSyncLabels(c *C) {
 
 	// Let's make sure we delete all labels from the kv store first
 	ep2 := epsWanted[1]
-	ep2.SecLabel.Release()
+	ep2.SecurityIdentity.Release()
 
 	err = ds.d.syncLabels(ep2)
 	c.Assert(err, IsNil)
 
-	// let's change the ep2 sec label ID and see if sync labels properly sets
+	// let's change the ep2 security identity and see if sync labels properly sets
 	// it with the one from kv store
-	ep2.SecLabel.ID = policy.NumericIdentity(1)
+	ep2.SecurityIdentity.ID = policy.NumericIdentity(1)
 
 	err = ds.d.syncLabels(ep2)
 	c.Assert(err, IsNil)

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -159,11 +159,11 @@ func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 
 	fw.WriteString("/*\n")
 	fw.WriteString(" * Labels:\n")
-	if e.SecLabel != nil {
-		if len(e.SecLabel.Labels) == 0 {
+	if e.SecurityIdentity != nil {
+		if len(e.SecurityIdentity.Labels) == 0 {
 			fmt.Fprintf(fw, " * - %s\n", "(no labels)")
 		} else {
-			for _, v := range e.SecLabel.Labels {
+			for _, v := range e.SecurityIdentity.Labels {
 				fmt.Fprintf(fw, " * - %s\n", v)
 			}
 		}
@@ -194,9 +194,9 @@ func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 
 	fmt.Fprintf(fw, "#define LXC_ID %#x\n", e.ID)
 	fmt.Fprintf(fw, "#define LXC_ID_NB %#x\n", byteorder.HostToNetwork(e.ID))
-	if e.SecLabel != nil {
-		fmt.Fprintf(fw, "#define SECLABEL %s\n", e.SecLabel.ID.StringID())
-		fmt.Fprintf(fw, "#define SECLABEL_NB %#x\n", byteorder.HostToNetwork(e.SecLabel.ID.Uint32()))
+	if e.SecurityIdentity != nil {
+		fmt.Fprintf(fw, "#define SECLABEL %s\n", e.SecurityIdentity.ID.StringID())
+		fmt.Fprintf(fw, "#define SECLABEL_NB %#x\n", byteorder.HostToNetwork(e.SecurityIdentity.ID.Uint32()))
 	} else {
 		invalid := policy.InvalidIdentity
 		fmt.Fprintf(fw, "#define SECLABEL %s\n", invalid.StringID())

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -254,12 +254,11 @@ type Endpoint struct {
 	// NodeMAC is the MAC of the node (agent). The MAC is different for every endpoint.
 	NodeMAC mac.MAC
 
-	// SecLabel is (L3) the identity of this endpoint
-	//
-	// FIXME: Rename this field to Identity
-	SecLabel *policy.Identity // Security Label  set to this endpoint.
+	// SecurityIdentity is the security identity of this endpoint. This is computed from
+	// the endpoint's labels.
+	SecurityIdentity *policy.Identity
 
-	// LabelsHash is a SHA256 hash over the SecLabel labels
+	// LabelsHash is a SHA256 hash over the SecurityIdentity labels
 	LabelsHash string
 
 	// LabelsMap is the Set of all security labels used in the last policy computation
@@ -464,7 +463,7 @@ func (e *Endpoint) GetModelRLocked() *models.Endpoint {
 		ContainerName:    e.ContainerName,
 		DockerEndpointID: e.DockerEndpointID,
 		DockerNetworkID:  e.DockerNetworkID,
-		Identity:         e.SecLabel.GetModel(),
+		Identity:         e.SecurityIdentity.GetModel(),
 		InterfaceIndex:   int64(e.IfIndex),
 		InterfaceName:    e.IfName,
 		Labels: &models.LabelConfiguration{
@@ -628,20 +627,20 @@ func (e *Endpoint) Unlock() {
 
 // GetLabels returns the labels as slice
 func (e *Endpoint) GetLabels() []string {
-	if e.SecLabel == nil {
+	if e.SecurityIdentity == nil {
 		return []string{}
 	}
 
-	return e.SecLabel.Labels.GetModel()
+	return e.SecurityIdentity.Labels.GetModel()
 }
 
 // GetLabelsSHA returns the SHA of labels
 func (e *Endpoint) GetLabelsSHA() string {
-	if e.SecLabel == nil {
+	if e.SecurityIdentity == nil {
 		return ""
 	}
 
-	return e.SecLabel.GetLabelsSHA256()
+	return e.SecurityIdentity.GetLabelsSHA256()
 }
 
 // GetIPv4Address returns the IPv4 address of the endpoint
@@ -818,8 +817,8 @@ func (e *Endpoint) StringID() string {
 }
 
 func (e *Endpoint) GetIdentity() policy.NumericIdentity {
-	if e.SecLabel != nil {
-		return e.SecLabel.ID
+	if e.SecurityIdentity != nil {
+		return e.SecurityIdentity.ID
 	}
 
 	return policy.InvalidIdentity
@@ -1030,7 +1029,7 @@ func (e *Endpoint) GetBPFValue() (*lxcmap.EndpointInfo, error) {
 
 	info := &lxcmap.EndpointInfo{
 		IfIndex: uint32(e.IfIndex),
-		// Store security label in network byte order so it can be
+		// Store security identity in network byte order so it can be
 		// written into the packet without an additional byte order
 		// conversion.
 		SecLabelID: byteorder.HostToNetwork(uint16(e.GetIdentity())).(uint16),
@@ -1291,14 +1290,14 @@ func (e *Endpoint) LeaveLocked(owner Owner) int {
 		}
 	}
 
-	if e.SecLabel != nil {
-		if err := e.SecLabel.Release(); err != nil {
-			log.WithError(err).WithField(logfields.Identity, e.SecLabel.ID).
+	if e.SecurityIdentity != nil {
+		if err := e.SecurityIdentity.Release(); err != nil {
+			log.WithError(err).WithField(logfields.Identity, e.SecurityIdentity.ID).
 				Error("Unable to release identity of endpoint")
 			errors++
 		}
 
-		e.SecLabel = nil
+		e.SecurityIdentity = nil
 	}
 
 	e.L3Maps.Close()
@@ -1601,8 +1600,8 @@ func (e *Endpoint) getIDandLabels() string {
 	defer e.Mutex.RUnlock()
 
 	labels := ""
-	if e.SecLabel != nil {
-		labels = e.SecLabel.Labels.String()
+	if e.SecurityIdentity != nil {
+		labels = e.SecurityIdentity.Labels.String()
 	}
 
 	return fmt.Sprintf("%d (%s)", e.ID, labels)
@@ -1738,7 +1737,7 @@ func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
 		return nil
 	}
 
-	if e.SecLabel != nil && string(e.SecLabel.Labels.SortedList()) != string(newLabels.SortedList()) {
+	if e.SecurityIdentity != nil && string(e.SecurityIdentity.Labels.SortedList()) != string(newLabels.SortedList()) {
 		e.Mutex.RUnlock()
 		elog.Debug("Endpoint labels unchanged, skipping resolution of identity")
 		return nil
@@ -1772,8 +1771,8 @@ func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
 
 	// If endpoint has an old identity, defer release of it to the end of
 	// the function after the endpoint structured has been unlocked again
-	if e.SecLabel != nil {
-		oldIdentity := e.SecLabel
+	if e.SecurityIdentity != nil {
+		oldIdentity := e.SecurityIdentity
 		defer func() {
 			if err := oldIdentity.Release(); err != nil {
 				elog.WithFields(logrus.Fields{logfields.Identity: oldIdentity.ID}).

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -49,7 +49,7 @@ type Consumable struct {
 	ID NumericIdentity `json:"id"`
 	// Mutex protects all variables from this structure below this line
 	Mutex lock.RWMutex
-	// Labels are the Identity of this consumable
+	// Labels are the SecurityIdentity of this consumable
 	Labels *Identity `json:"labels"`
 	// LabelArray contains the same labels from identity in a form of a list, used for faster lookup
 	LabelArray labels.LabelArray `json:"-"`


### PR DESCRIPTION
Address the FIXME comment to rename Endpoint's SecLabels field to Identity.
This results in more consistent naming across the code.

Signed-off by: Ian Vernon <ian@cilium.io>