### PR TITLE
pkg/policy: remove ReverseRules from Consumable

### DIFF
--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -86,7 +86,6 @@ func endpointCreator(id uint16, secID policy.NumericIdentity) *e.Endpoint {
 		},
 		Maps:              map[int]*policymap.PolicyMap{},
 		IngressIdentities: map[policy.NumericIdentity]bool{},
-		ReverseRules:      map[policy.NumericIdentity]bool{},
 	}
 	return ep
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -71,11 +71,7 @@ func (e *Endpoint) checkEgressAccess(owner Owner, dstLabels labels.LabelArray, o
 
 // allowIngressIdentity must be called with global endpoint.Mutex held
 func (e *Endpoint) allowIngressIdentity(owner Owner, id policy.NumericIdentity) bool {
-	cache := policy.GetConsumableCache()
-	if !e.Opts.IsEnabled(OptionConntrack) {
-		return e.Consumable.AllowIngressIdentityAndReverseLocked(cache, id)
-	}
-	return e.Consumable.AllowIngressIdentityLocked(cache, id)
+	return e.Consumable.AllowIngressIdentityLocked(policy.GetConsumableCache(), id)
 }
 
 // ProxyID returns a unique string to identify a proxy mapping

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -286,6 +286,7 @@ func (e *Endpoint) resolveL4Policy(owner Owner, repo *policy.Repository, c *poli
 // Returns a boolean to signalize if the policy was changed;
 // and a map matching which rules were successfully added/modified;
 // and a map matching which rules were successfully removed.
+// Must be called with Consumable mutex held.
 func (e *Endpoint) regenerateConsumable(owner Owner, labelsMap *policy.IdentityCache,
 	repo *policy.Repository, c *policy.Consumable) (changed bool, rulesAdd policy.SecurityIDContexts, rulesRm policy.SecurityIDContexts) {
 

--- a/pkg/policy/cache.go
+++ b/pkg/policy/cache.go
@@ -106,7 +106,10 @@ func ResolveIdentityLabels(id NumericIdentity) labels.LabelArray {
 	return nil
 }
 
-// Init must be called to initialize the
+// Init must be called to initialize the Consumables that represent the reserved
+// identities. This is because the reserved identities do not correspond to
+// endpoints, and thus must be created explicitly, as opposed to during policy
+// calculation, which is done for a specific endpoint when it is regenerated.
 func Init() {
 	for key, val := range ReservedIdentities {
 		log.WithField(logfields.Identity, key).Debug("creating policy for identity")

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -187,7 +187,9 @@ func (c *Consumable) AllowIngressIdentityLocked(cache *ConsumableCache, id Numer
 		if id.IsReservedIdentity() {
 			reservedConsumable := cache.Lookup(id)
 			if reservedConsumable != nil {
-				// Avoid deadlock ; is this necessary? Being cautious.
+				// If we are accessing the same Consumable (allowing traffic
+				// to itself), we don't need to take its mutex because it was
+				// already taken before calling this function.
 				if id != c.ID {
 					reservedConsumable.Mutex.Lock()
 					reservedConsumable.AllowIngressIdentityLocked(cache, c.ID)
@@ -220,7 +222,9 @@ func (c *Consumable) RemoveIngressIdentityLocked(id NumericIdentity) {
 		if id.IsReservedIdentity() {
 			reservedConsumable := c.cache.Lookup(id)
 			if reservedConsumable != nil {
-				// Avoid deadlock!
+				// If we are accessing the same Consumable (allowing traffic
+				// to itself), we don't need to take its mutex because it was
+				// already taken before calling this function.
 				if id != c.ID {
 					reservedConsumable.Mutex.Lock()
 					reservedConsumable.RemoveIngressIdentityLocked(c.ID)

--- a/pkg/policy/identity.go
+++ b/pkg/policy/identity.go
@@ -72,6 +72,12 @@ func (id NumericIdentity) String() string {
 	return id.StringID()
 }
 
+// IsReservedIdentity returns whether id is one of the special reserved identities.
+func (id NumericIdentity) IsReservedIdentity() bool {
+	_, isReservedIdentity := ReservedIdentityNames[id]
+	return isReservedIdentity
+}
+
 // Uint32 normalizes the ID for use in BPF program.
 func (id NumericIdentity) Uint32() uint32 {
 	return uint32(id)

--- a/pkg/policy/identity_test.go
+++ b/pkg/policy/identity_test.go
@@ -41,6 +41,16 @@ func (s *PolicyTestSuite) TestReservedID(c *C) {
 	c.Assert(unknown.String(), Equals, "700")
 }
 
+func (s *PolicyTestSuite) TestIsReservedIdentity(c *C) {
+
+	c.Assert(ReservedIdentityCluster.IsReservedIdentity(), Equals, true)
+	c.Assert(ReservedIdentityHealth.IsReservedIdentity(), Equals, true)
+	c.Assert(ReservedIdentityHost.IsReservedIdentity(), Equals, true)
+	c.Assert(ReservedIdentityWorld.IsReservedIdentity(), Equals, true)
+
+	c.Assert(NumericIdentity(123456).IsReservedIdentity(), Equals, false)
+}
+
 type IdentityAllocatorSuite struct{}
 
 type IdentityAllocatorEtcdSuite struct {

--- a/test/runtime/manifests/ct-test-policy-conntrack-local-disabled.json
+++ b/test/runtime/manifests/ct-test-policy-conntrack-local-disabled.json
@@ -1,0 +1,28 @@
+[{
+    "endpointSelector": {"matchLabels":{"id.client":""}},
+    "ingress": [{
+        "fromEndpoints": [
+            {"matchLabels":{"id.server":""}}
+	]
+    }],
+    "labels": ["id=from-server-to-client"]
+},
+{
+    "endpointSelector": {"matchLabels":{"id.client":""}},
+    "ingress": [{
+        "fromEndpoints": [
+            {"matchLabels":{"reserved:host":""}}
+        ]
+    }],
+    "labels": ["id=from-host-to-client"]
+},
+{
+    "endpointSelector": {"matchLabels":{"id.server":""}},
+    "ingress": [{
+        "fromEndpoints": [
+            {"matchLabels":{"reserved:host":""}}
+        ]
+    }],
+    "labels": ["id=from-host-to-server"]
+}
+]


### PR DESCRIPTION
If connection-tracking was not enabled for an endpoint, in order to ensure that
traffic between endpoints managed by Cilium would flow, if a policy allowed
ingress to endpoint A from endpoint B, then B's policy maps were also updated
to allow ingress to itself from A as well. However, this only worked if both
endpoints were local to the same node, as the sharing of this information is
done on a per-daemon level; security identities are not resolved on each node
in the cluster. As such, remove ReverseRules, which was used to store such data,
from the Consumable structure.

There is a special case involving the reserved-identities, whose corresponding
Consumables do need to be updated if an endpoint allows traffic to them. 

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #2795 