### PR TITLE
envoy: Set source identity correctly in access log.

### DIFF
--- a/envoy/accesslog.cc
+++ b/envoy/accesslog.cc
@@ -91,7 +91,7 @@ void AccessLog::Entry::InitFromRequest(
   }
 
   if (conn) {
-    entry.set_source_security_id(conn->socketMark() & 0xffff);
+    entry.set_source_security_id(conn->socketMark() >> 16);
     entry.set_source_address(conn->remoteAddress().asString());
     entry.set_destination_address(conn->localAddress().asString());
   }


### PR DESCRIPTION
Since 22cfad197 the source identity is in the upper 16 bits of the mark.

Fixes: 22cfad197 ("bpf: Use upper 16 bits for identity")
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
