### PR TITLE
kafka: Use policy identity cache to lookup identity for L3 dependant rules

### DIFF
--- a/pkg/proxy/kafka.go
+++ b/pkg/proxy/kafka.go
@@ -137,7 +137,7 @@ func (k *kafkaRedirect) canAccess(req *kafka.RequestMessage, numIdentity policy.
 	var identity *policy.Identity
 
 	if numIdentity != 0 {
-		identity = k.conf.source.ResolveIdentity(numIdentity)
+		identity = policy.LookupIdentityByID(numIdentity)
 		if identity == nil {
 			log.WithFields(logrus.Fields{
 				logfields.Request:  req.String(),

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -106,7 +106,6 @@ type ProxySource interface {
 	GetLabels() []string
 	GetLabelsSHA() string
 	GetIdentity() policy.NumericIdentity
-	ResolveIdentity(policy.NumericIdentity) *policy.Identity
 	GetIPv4Address() string
 	GetIPv6Address() string
 }

--- a/pkg/proxy/source_mock_test.go
+++ b/pkg/proxy/source_mock_test.go
@@ -41,7 +41,3 @@ func (m *proxySourceMocker) GetIdentity() policy.NumericIdentity { return m.iden
 func (m *proxySourceMocker) GetLabelsSHA() string {
 	return labels.NewLabelsFromModel(m.labels).SHA256Sum()
 }
-
-func (m *proxySourceMocker) ResolveIdentity(policy.NumericIdentity) *policy.Identity {
-	return policy.NewIdentity(m.identity, labels.NewLabelsFromModel(m.labels))
-}


### PR DESCRIPTION
 kafka: Use policy identity cache to lookup identity for L3 dependant rules
 Fixes Issue: #2824

```release-note
kafka: Use policy identity cache to lookup identity for L3 dependant rules
```