### PR TITLE
daemon: Clean endpoint BPF map on start

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -811,6 +811,11 @@ func (d *Daemon) init() error {
 			return err
 		}
 
+		// Clean all endpoint entries
+		if err := lxcmap.DeleteAll(); err != nil {
+			return err
+		}
+
 		localIPs := []net.IP{
 			node.GetInternalIPv4(),
 			node.GetExternalIPv4(),

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -224,3 +224,8 @@ func dumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue, error) {
 func DumpMap(callback bpf.DumpCallback) error {
 	return mapInstance.Dump(dumpParser, callback)
 }
+
+// DeleteAll deletes the content of the local endpoint map
+func DeleteAll() error {
+	return mapInstance.DeleteAll()
+}


### PR DESCRIPTION
Call DeleteAll method of LXCMap on every daemon start, because
some previously existing endpoints and IP addresses can be not
valid anymore (i.e. when we change pod CIDR before restarting
cilium).

Fixes #2748

Signed-off-by: Michal Rostecki <mrostecki@suse.com>

```release-note
Clean endpoint BPF map on daemon start
```