### PR TITLE
Ginkgo: Dump all cilium logs in case of a fail

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -700,6 +700,7 @@ func (kub *Kubectl) GatherLogs() {
 		"kubectl get ds -o wide --all-namespaces":       "ds.txt",
 		"kubectl get cnp --all-namespaces":              "cnp.txt",
 		"kubectl describe pods --all-namespaces":        "pods_status.txt",
+		"kubectl -n kube-system logs -l k8s-app=cilium": "cilium_logs.txt",
 	}
 
 	testPath, err := ReportDirectory()


### PR DESCRIPTION
At the moment the report only saves the logs for Cilium pod on node
k8s1. With this commit, we save all Cilium pods logs.

(This covers nightly too, where four nodes are deployed)

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>