### PR TITLE
test/k8sT: skip default deny egress tests for kubernetes 1.7

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -438,6 +438,11 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 			Expect(err).Should(HaveOccurred(), "Ingress connectivity should be denied by policy")
 
+			if helpers.GetCurrentK8SEnv() == "1.7" {
+				log.Info("K8s 1.7 doesn't offer a default deny for egress")
+				return
+			}
+
 			By("Installing egress default-deny")
 
 			eps = kubectl.CiliumEndpointPolicyVersion(ciliumPod)

--- a/test/k8sT/manifests/1.7/knp-default-deny-ingress.yaml
+++ b/test/k8sT/manifests/1.7/knp-default-deny-ingress.yaml
@@ -1,0 +1,6 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+spec:
+  podSelector: {}


### PR DESCRIPTION
Since kubernetes 1.7 doesn't support default deny for egress in 1.7 we
need to skip the test for that version.

Signed-off-by: André Martins <andre@cilium.io>
