### PR TITLE
k8s: Avoid references in CNP CRD validation

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -51,7 +51,7 @@ const (
 
 	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
 	// Used to determine if CRD needs to be updated in cluster
-	CustomResourceDefinitionSchemaVersion = "1.2"
+	CustomResourceDefinitionSchemaVersion = "1.3"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"
@@ -270,620 +270,619 @@ var (
 	}
 
 	properties = map[string]apiextensionsv1beta1.JSONSchemaProps{
-		"CIDR": {
-			Description: "CIDR is a CIDR prefix / IP Block.",
-			Type:        "string",
-			OneOf: []apiextensionsv1beta1.JSONSchemaProps{
-				{
-					// IPv4 CIDR
-					Type: "string",
-					Pattern: `^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4]` +
-						`[0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$`,
-				},
-				//{
-				//	// IPv6 CIDR
-				//	Type: "string",
-				//	Pattern: `^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]` +
-				//		`{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|` +
-				//		`2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4})` +
-				//		`{1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})` +
-				//		`|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]` +
-				//		`{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}` +
-				//		`))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]` +
-				//		`{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d))` +
-				//		`{3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:` +
-				//		`[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|` +
-				//		`1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|` +
-				//		`((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d` +
-				//		`|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4})` +
-				//		`{0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|` +
-				//		`:)))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$`,
-				//},
+		"CIDR":                     CIDR,
+		"CIDRRule":                 CIDRRule,
+		"EgressRule":               EgressRule,
+		"EndpointSelector":         EndpointSelector,
+		"IngressRule":              IngressRule,
+		"K8sServiceNamespace":      K8sServiceNamespace,
+		"L7Rules":                  L7Rules,
+		"Label":                    Label,
+		"LabelSelector":            LabelSelector,
+		"LabelSelectorRequirement": LabelSelectorRequirement,
+		"PortProtocol":             PortProtocol,
+		"PortRule":                 PortRule,
+		"PortRuleHTTP":             PortRuleHTTP,
+		"PortRuleKafka":            PortRuleKafka,
+		"Rule":                     Rule,
+		"Service":                  Service,
+		"ServiceSelector":          ServiceSelector,
+		"spec":                     spec,
+		"specs":                    specs,
+	}
+
+	CIDR = apiextensionsv1beta1.JSONSchemaProps{
+		Description: "CIDR is a CIDR prefix / IP Block.",
+		Type:        "string",
+		OneOf: []apiextensionsv1beta1.JSONSchemaProps{
+			{
+				// IPv4 CIDR
+				Type: "string",
+				Pattern: `^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4]` +
+					`[0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$`,
 			},
+			//{
+			//	// IPv6 CIDR
+			//	Type: "string",
+			//	Pattern: `^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]` +
+			//		`{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|` +
+			//		`2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4})` +
+			//		`{1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})` +
+			//		`|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]` +
+			//		`{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}` +
+			//		`))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]` +
+			//		`{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d))` +
+			//		`{3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:` +
+			//		`[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|` +
+			//		`1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|` +
+			//		`((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d` +
+			//		`|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4})` +
+			//		`{0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|` +
+			//		`:)))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$`,
+			//},
 		},
-		"CIDRRule": {
-			Description: "CIDRRule is a rule that specifies a CIDR prefix to/from which outside " +
-				"communication is allowed, along with an optional list of subnets within that CIDR " +
-				"prefix to/from which outside communication is not allowed.",
-			Required: []string{
-				"cidr",
-			},
-			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-				"cidr": {
-					Ref: getStr("#/properties/CIDR"),
-				},
-				"except": {
-					Description: "ExceptCIDRs is a list of IP blocks which the endpoint subject to " +
-						"the rule is not allowed to initiate connections to. These CIDR prefixes " +
-						"should be contained within Cidr. These exceptions are only applied to the " +
-						"Cidr in this CIDRRule, and do not apply to any other CIDR prefixes in any " +
-						"other CIDRRules.",
-					Type: "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Ref: getStr("#/properties/CIDR"),
-						},
-					},
-				},
-			},
+	}
+
+	CIDRRule = apiextensionsv1beta1.JSONSchemaProps{
+		Description: "CIDRRule is a rule that specifies a CIDR prefix to/from which outside " +
+			"communication is allowed, along with an optional list of subnets within that CIDR " +
+			"prefix to/from which outside communication is not allowed.",
+		Required: []string{
+			"cidr",
 		},
-		"EgressRule": {
-			Description: "EgressRule contains all rule types which can be applied at egress, i.e. " +
-				"network traffic that originates inside the endpoint and exits the endpoint " +
-				"selected by the endpointSelector.\n\n- All members of this structure are optional. " +
-				"If omitted or empty, the\n  member will have no effect on the rule.\n\n- For now, " +
-				"combining ToPorts and ToCIDR in the same rule is not supported\n  and such rules " +
-				"will be rejected. In the future, this will be supported and\n  if if multiple " +
-				"members of the structure are specified, then all members\n  must match in order " +
-				"for the rule to take effect.",
-			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-				"toCIDR": {
-					Description: "ToCIDR is a list of IP blocks which the endpoint subject to the " +
-						"rule is allowed to initiate connections. This will match on the " +
-						"destination IP address of outgoing connections. Adding a prefix into " +
-						"ToCIDR or into ToCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are " +
-						"allowed between ToCIDR and ToCIDRSet.\n\nExample: Any endpoint with the " +
-						"label \"app=database-proxy\" is allowed to initiate connections to " +
-						"10.2.3.0/24",
-					Type: "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Ref: getStr("#/properties/CIDR"),
-						},
-					},
-				},
-				"toCIDRSet": {
-					Description: "ToCIDRSet is a list of IP blocks which the endpoint subject to " +
-						"the rule is allowed to initiate connections to in addition to connections " +
-						"which are allowed via FromEndpoints, along with a list of subnets " +
-						"contained within their corresponding IP block to which traffic should not " +
-						"be allowed. This will match on the destination IP address of outgoing " +
-						"connections. Adding a prefix into ToCIDR or into ToCIDRSet with no " +
-						"ExcludeCIDRs is equivalent. Overlaps are allowed between ToCIDR and " +
-						"ToCIDRSet.\n\nExample: Any endpoint with the label \"app=database-proxy\" " +
-						"is allowed to initiate connections to 10.2.3.0/24 except from IPs in " +
-						"subnet 10.2.3.0/28.",
-					Type: "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Ref: getStr("#/properties/CIDRRule"),
-						},
-					},
-				},
-				"toEntities": {
-					Description: "ToEntities is a list of special entities to which the endpoint " +
-						"subject to the rule is allowed to initiate connections. Supported " +
-						"entities are `world` and `host`",
-					Type: "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Type: "string",
-						},
-					},
-				},
-				"toPorts": {
-					Description: "ToPorts is a list of destination ports identified by port number " +
-						"and protocol which the endpoint subject to the rule is allowed to connect " +
-						"to.\n\nExample: Any endpoint with the label \"role=frontend\" is allowed " +
-						"to initiate connections to destination port 8080/tcp",
-					Type: "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Ref: getStr("#/properties/PortRule"),
-						},
-					},
-				},
-				"toServices": {
-					Description: "ToServices is a list of services to which the endpoint subject " +
-						"to the rule is allowed to initiate connections.\n\nExample: Any endpoint " +
-						"with the label \"app=backend-app\" is allowed to initiate connections to " +
-						"all cidrs backing the \"external-service\" service",
-					Type: "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Ref: getStr("#/properties/Service"),
-						},
-					},
-				},
-			},
-		},
-		"EndpointSelector": {
-			Description: "EndpointSelector is a wrapper for k8s LabelSelector.",
-			Ref:         getStr("#/properties/LabelSelector"),
-		},
-		"IngressRule": {
-			Description: "IngressRule contains all rule types which can be applied at ingress, " +
-				"i.e. network traffic that originates outside of the endpoint and is entering " +
-				"the endpoint selected by the endpointSelector.\n\n- All members of this structure " +
-				"are optional. If omitted or empty, the\n  member will have no effect on the rule." +
-				"\n\n- If multiple members are set, all of them need to match in order for\n  " +
-				"the rule to take effect. The exception to this rule is FromRequires field;\n  " +
-				"the effects of any Requires field in any rule will apply to all other\n  rules " +
-				"as well.\n\n- For now, combining ToPorts, FromCIDR, and FromEndpoints in the same " +
-				"rule\n  is not supported and any such rules will be rejected. In the future, " +
-				"this\n  will be supported and if multiple members of this structure are specified," +
-				"\n then all members must match in order for the rule to take effect. The\n  " +
-				"exception to this rule is the Requires field, the effects of any Requires\n  " +
-				"field in any rule will apply to all other rules as well.",
-			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-				"fromCIDR": {
-					Description: "FromCIDR is a list of IP blocks which the endpoint subject to " +
-						"the rule is allowed to receive connections from. This will match on the " +
-						"source IP address of incoming connections. Adding  a prefix into FromCIDR " +
-						"or into FromCIDRSet with no ExcludeCIDRs is  equivalent. Overlaps are " +
-						"allowed between FromCIDR and FromCIDRSet.\n\nExample: Any endpoint with " +
-						"the label \"app=my-legacy-pet\" is allowed to receive connections from " +
-						"10.3.9.1",
-					Type: "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Ref: getStr("#/properties/CIDR"),
-						},
-					},
-				},
-				"fromCIDRSet": {
-					Description: "FromCIDRSet is a list of IP blocks which the endpoint subject to " +
-						"the rule is allowed to receive connections from in addition to " +
-						"FromEndpoints, along with a list of subnets contained within their " +
-						"corresponding IP block from which traffic should not be allowed. This " +
-						"will match on the source IP address of incoming connections. Adding a " +
-						"prefix into FromCIDR or into FromCIDRSet with no ExcludeCIDRs is " +
-						"equivalent. Overlaps are allowed between FromCIDR and FromCIDRSet." +
-						"\n\nExample: Any endpoint with the label \"app=my-legacy-pet\" is allowed " +
-						"to receive connections from 10.0.0.0/8 except from IPs in subnet " +
-						"10.96.0.0/12.",
-					Type: "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Ref: getStr("#/properties/CIDRRule"),
-						},
-					},
-				},
-				"fromEndpoints": {
-					Description: "FromEndpoints is a list of endpoints identified by an " +
-						"EndpointSelector which are allowed to communicate with the endpoint " +
-						"subject to the rule.\n\nExample: Any endpoint with the label " +
-						"\"role=backend\" can be consumed by any endpoint carrying the label " +
-						"\"role=frontend\".",
-					Type: "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Ref: getStr("#/properties/EndpointSelector"),
-						},
-					},
-				},
-				"fromEntities": {
-					Description: "FromEntities is a list of special entities which the endpoint " +
-						"subject to the rule is allowed to receive connections from. Supported " +
-						"entities are `world` and `host`",
-					Type: "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Type: "string",
-						},
-					},
-				},
-				"fromRequires": {
-					Description: "FromRequires is a list of additional constraints which must be " +
-						"met in order for the selected endpoints to be reachable. These additional " +
-						"constraints do no by itself grant access privileges and must always be " +
-						"accompanied with at least one matching FromEndpoints.\n\nExample: Any " +
-						"Endpoint with the label \"team=A\" requires consuming endpoint to also " +
-						"carry the label \"team=A\".",
-					Type: "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Ref: getStr("#/properties/EndpointSelector"),
-						},
-					},
-				},
-				"toPorts": {
-					Description: "ToPorts is a list of destination ports identified by port number " +
-						"and protocol which the endpoint subject to the rule is allowed to receive " +
-						"connections on.\n\nExample: Any endpoint with the label \"app=httpd\" can " +
-						"only accept incoming connections on port 80/tcp.",
-					Type: "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Ref: getStr("#/properties/PortRule"),
-						},
-					},
-				},
-			},
-		},
-		"K8sServiceNamespace": {
-			Description: "K8sServiceNamespace is an abstraction for the k8s service + namespace " +
-				"types.",
-			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-				"namespace": {
-					Type: "string",
-				},
-				"serviceName": {
-					Type: "string",
-				},
-			},
-		},
-		"L7Rules": {
-			Description: "L7Rules is a union of port level rule types. Mixing of different port " +
-				"level rule types is disallowed, so exactly one of the following must be set. If " +
-				"none are specified, then no additional port level rules are applied.",
-			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-				"http": {
-					Description: "HTTP specific rules.",
-					Type:        "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Ref: getStr("#/properties/PortRuleHTTP"),
-						},
-					},
-				},
-				"kafka": {
-					Description: "Kafka-specific rules.",
-					Type:        "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Ref: getStr("#/properties/PortRuleKafka"),
-						},
-					},
-				},
-			},
-		},
-		"Label": {
-			Description: "Label is the cilium's representation of a container label.",
-			Required: []string{
-				"key",
-			},
-			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-				"key": {
-					Type: "string",
-				},
-				"source": {
-					Description: "Source can be one of the values present in const.go " +
-						"(e.g.: LabelSourceContainer)",
-					Type: "string",
-				},
-				"value": {
-					Type: "string",
-				},
-			},
-		},
-		"LabelSelector": {
-			Description: "A label selector is a label query over a set of resources. The result " +
-				"of matchLabels and matchExpressions are ANDed. An empty label selector matches " +
-				"all objects. A null label selector matches no objects.",
-			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-				"matchLabels": {
-					Description: "matchLabels is a map of {key,value} pairs. A single {key,value} " +
-						"in the matchLabels map is equivalent to an element of matchExpressions, " +
-						"whose key field is \"key\", the operator is \"In\", and the values array " +
-						"contains only \"value\". The requirements are ANDed.",
-					Type: "object",
-				},
-				"matchExpressions": {
-					Description: "matchExpressions is a list of label selector requirements. " +
-						"The requirements are ANDed.",
-					Type: "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Ref: getStr("#/properties/LabelSelectorRequirement"),
-						},
-					},
-				},
-			},
-		},
-		"LabelSelectorRequirement": {
-			Description: "A label selector requirement is a selector that contains values, a key, " +
-				"and an operator that relates the key and values.",
-			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-				"key": {
-					Description: "key is the label key that the selector applies to.",
-					Type:        "string",
-				},
-				"operator": {
-					Description: "operator represents a key's relationship to a set of values. " +
-						"Valid operators are In, NotIn, Exists and DoesNotExist.",
-					Type: "string",
-					Enum: []apiextensionsv1beta1.JSON{
-						{
-							Raw: []byte(`"In"`),
-						},
-						{
-							Raw: []byte(`"NotIn"`),
-						},
-						{
-							Raw: []byte(`"Exists"`),
-						},
-						{
-							Raw: []byte(`"DoesNotExist"`),
-						},
-					},
-				},
-				"values": {
-					Description: "values is an array of string values. If the operator is In or " +
-						"NotIn, the values array must be non-empty. If the operator is Exists or " +
-						"DoesNotExist, the values array must be empty. This array is replaced " +
-						"during a strategic merge patch.",
-					Type: "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Type: "string",
-						},
-					},
-				},
-			},
-			Required: []string{"key", "operator"},
-		},
-		"PortProtocol": {
-			Description: "PortProtocol specifies an L4 port with an optional transport protocol",
-			Required: []string{
-				"port",
-			},
-			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-				"port": {
-					Description: "Port is an L4 port number. For now the string will be strictly " +
-						"parsed as a single uint16. In the future, this field may support ranges " +
-						"in the form \"1024-2048",
-					Type: "string",
-					// uint16 string regex
-					Pattern: `^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|` +
-						`[1-5][0-9]{4}|[0-9]{1,4})$`,
-				},
-				"protocol": {
-					Description: `Protocol is the L4 protocol. If omitted or empty, any protocol ` +
-						`matches. Accepted values: "TCP", "UDP", ""/"ANY"\n\nMatching on ` +
-						`ICMP is not supported.`,
-					Type: "string",
-					Enum: []apiextensionsv1beta1.JSON{
-						{
-							Raw: []byte(`"TCP"`),
-						},
-						{
-							Raw: []byte(`"UDP"`),
-						},
-						{
-							Raw: []byte(`"ANY"`),
-						},
-					},
-				},
-			},
-		},
-		"PortRule": {
-			Description: "PortRule is a list of ports/protocol combinations with optional Layer 7 " +
-				"rules which must be met.",
-			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-				"ports": {
-					Description: "Ports is a list of L4 port/protocol\n\nIf omitted or empty but " +
-						"RedirectPort is set, then all ports of the endpoint subject to either the " +
-						"ingress or egress rule are being redirected.",
-					Type: "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Ref: getStr("#/properties/PortProtocol"),
-						},
-					},
-				},
-				"redirectPort": {
-					Description: "RedirectPort is the L4 port which, if set, all traffic matching " +
-						"the Ports is being redirected to. Whatever listener behind that port " +
-						"becomes responsible to enforce the port rules and is also responsible to " +
-						"reinject all traffic back and ensure it reaches its original destination.",
-					Type:   "integer",
-					Format: "uint16",
-				},
-				"rules": {
-					Description: "Rules is a list of additional port level rules which must be " +
-						"met in order for the PortRule to allow the traffic. If omitted or empty, " +
-						"no layer 7 rules are enforced.",
-					Ref: getStr("#/properties/L7Rules"),
-				},
-			},
-		},
-		"PortRuleHTTP": {
-			Description: "PortRuleHTTP is a list of HTTP protocol constraints. All fields are " +
-				"optional, if all fields are empty or missing, the rule does not have any effect." +
-				"\n\nAll fields of this type are extended POSIX regex as defined by " +
-				"IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) " +
-				"matched against the path of an incoming request. Currently it can contain " +
-				"characters disallowed from the conventional \"path\" part of a URL as defined by " +
-				"RFC 3986.",
-			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-				"headers": {
-					Description: "Headers is a list of HTTP headers which must be present in the " +
-						"request. If omitted or empty, requests are allowed regardless of headers " +
-						"present.",
-					Type: "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Type: "string",
-						},
-					},
-				},
-				"host": {
-					Description: "Host is an extended POSIX regex matched against the host header " +
-						"of a request, e.g. \"foo.com\"\n\nIf omitted or empty, the value of the " +
-						"host header is ignored.",
-					Type:   "string",
-					Format: "idn-hostname",
-				},
-				"method": {
-					Description: "Method is an extended POSIX regex matched against the method of " +
-						"a request, e.g. \"GET\", \"POST\", \"PUT\", \"PATCH\", \"DELETE\", ...\n\n" +
-						"If omitted or empty, all methods are allowed.",
-					Type: "string",
-				},
-				"path": {
-					Description: "Path is an extended POSIX regex matched against the path of a " +
-						"request. Currently it can contain characters disallowed from the " +
-						"conventional \"path\" part of a URL as defined by RFC 3986.\n\n" +
-						"If omitted or empty, all paths are all allowed.",
-					Type: "string",
-				},
-			},
-		},
-		"PortRuleKafka": {
-			Description: "PortRuleKafka is a list of Kafka protocol constraints. All fields are " +
-				"optional, if all fields are empty or missing, the rule will match all Kafka " +
-				"messages.",
-			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-				"apiKey": {
-					Description: "APIKey is a case-insensitive string matched against the key of " +
-						"a request, e.g. \"produce\", \"fetch\", \"createtopic\", \"deletetopic\", " +
-						"et al Reference: https://kafka.apache.org/protocol#protocol_api_keys\n\n" +
-						"If omitted or empty, all keys are allowed.",
-					Type: "string",
-				},
-				"apiVersion": {
-					Description: "APIVersion is the version matched against the api version of the " +
-						"Kafka message. If set, it has to be a string representing a positive " +
-						"integer.\n\nIf omitted or empty, all versions are allowed.",
-					Type: "string",
-				},
-				"clientID": {
-					Description: "ClientID is the client identifier as provided in the request.\n\n" +
-						"From Kafka protocol documentation: This is a user supplied identifier for " +
-						"the client application. The user can use any identifier they like and it " +
-						"will be used when logging errors, monitoring aggregates, etc. For " +
-						"example, one might want to monitor not just the requests per second " +
-						"overall, but the number coming from each client application (each of " +
-						"which could reside on multiple servers). This id acts as a logical " +
-						"grouping across all requests from a particular client.\n\nIf omitted or " +
-						"empty, all client identifiers are allowed.",
-					Type: "string",
-				},
-				"topic": {
-					Description: "Topic is the topic name contained in the message. If a Kafka " +
-						"request contains multiple topics, then all topics must be allowed or the " +
-						"message will be rejected.\n\nThis constraint is ignored if the matched " +
-						"request message type doesn't contain any topic. Maximum size of Topic can " +
-						"be 249 characters as per recent Kafka spec and allowed characters are " +
-						"a-z, A-Z, 0-9, -, . and _ Older Kafka versions had longer topic lengths " +
-						"of 255, but in Kafka 0.10 version the length was changed from 255 to 249. " +
-						"For compatibility reasons we are using 255\n\nIf omitted or empty, all " +
-						"topics are allowed.",
-					Type:      "string",
-					MaxLength: getInt64(255),
-				},
-			},
-		},
-		"Rule": {
-			Description: "Rule is a policy rule which must be applied to all endpoints which match " +
-				"the labels contained in the endpointSelector\n\nEach rule is split into an " +
-				"ingress section which contains all rules applicable at ingress, and an egress " +
-				"section applicable at egress. For rule types such as `L4Rule` and `CIDR` which " +
-				"can be applied at both ingress and egress, both ingress and egress side have to " +
-				"either specifically allow the connection or one side has to be omitted.\n\n" +
-				"Either ingress, egress, or both can be provided. If both ingress and egress are " +
-				"omitted, the rule has no effect.",
-			Required: []string{
-				"endpointSelector",
-			},
-			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-				"Description": {
-					Description: "Description is a free form string, it can be used by the creator " +
-						"of the rule to store human readable explanation of the purpose of this " +
-						"rule. Rules cannot be identified by comment.",
-					Type: "string",
-				},
-				"egress": {
-					Description: "Egress is a list of EgressRule which are enforced at egress. If " +
-						"omitted or empty, this rule does not apply at egress.",
-					Type: "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Ref: getStr("#/properties/EgressRule"),
-						},
-					},
-				},
-				"endpointSelector": {
-					Description: "EndpointSelector selects all endpoints which should be subject " +
-						"to this rule. Cannot be empty.",
-					Ref: getStr("#/properties/EndpointSelector"),
-				},
-				"ingress": {
-					Description: "Ingress is a list of IngressRule which are enforced at ingress. " +
-						"If omitted or empty, this rule does not apply at ingress.",
-					Type: "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Ref: getStr("#/properties/IngressRule"),
-						},
-					},
-				},
-				"labels": {
-					Description: "Labels is a list of optional strings which can be used to " +
-						"re-identify the rule or to store metadata. It is possible to lookup or " +
-						"delete strings based on labels. Labels are not required to be unique, " +
-						"multiple rules can have overlapping or identical labels.",
-					Type: "array",
-					Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Ref: getStr("#/properties/Label"),
-						},
-					},
-				},
-			},
-		},
-		"Service": {
-			Description: "Service wraps around selectors for services",
-			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-				"k8sService": {
-					Description: "K8sService selects service by name and namespace pair",
-					Ref:         getStr("#/properties/K8sServiceNamespace"),
-				},
-				"k8sServiceSelector": {
-					Description: "K8sServiceSelector selects services by k8s labels. " +
-						"Not supported yet",
-					Ref: getStr("#/properties/ServiceSelector"),
-				},
-			},
-		},
-		"ServiceSelector": {
-			Description: "ServiceSelector is a label selector for k8s services",
-			Required: []string{
-				"selector",
-			},
-			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-				"selector": {
-					Ref: getStr("#/properties/EndpointSelector"),
-				},
-				"namespace": {
-					Type: "string",
-				},
-			},
-		},
-		"spec": {
-			Description: "Spec is the desired Cilium specific rule specification.",
-			Type:        "object",
-			Ref:         getStr("#/properties/Rule"),
-		},
-		"specs": {
-			Description: "Specs is a list of desired Cilium specific rule specification.",
-			Type:        "array",
-			Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-				Schema: &apiextensionsv1beta1.JSONSchemaProps{
-					Ref: getStr("#/properties/Rule"),
+		Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+			"cidr": CIDR,
+			"except": {
+				Description: "ExceptCIDRs is a list of IP blocks which the endpoint subject to " +
+					"the rule is not allowed to initiate connections to. These CIDR prefixes " +
+					"should be contained within Cidr. These exceptions are only applied to the " +
+					"Cidr in this CIDRRule, and do not apply to any other CIDR prefixes in any " +
+					"other CIDRRules.",
+				Type: "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &CIDR,
 				},
 			},
 		},
 	}
+
+	EgressRule = apiextensionsv1beta1.JSONSchemaProps{
+		Description: "EgressRule contains all rule types which can be applied at egress, i.e. " +
+			"network traffic that originates inside the endpoint and exits the endpoint " +
+			"selected by the endpointSelector.\n\n- All members of this structure are optional. " +
+			"If omitted or empty, the\n  member will have no effect on the rule.\n\n- For now, " +
+			"combining ToPorts and ToCIDR in the same rule is not supported\n  and such rules " +
+			"will be rejected. In the future, this will be supported and\n  if if multiple " +
+			"members of the structure are specified, then all members\n  must match in order " +
+			"for the rule to take effect.",
+		Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+			"toCIDR": {
+				Description: "ToCIDR is a list of IP blocks which the endpoint subject to the " +
+					"rule is allowed to initiate connections. This will match on the " +
+					"destination IP address of outgoing connections. Adding a prefix into " +
+					"ToCIDR or into ToCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are " +
+					"allowed between ToCIDR and ToCIDRSet.\n\nExample: Any endpoint with the " +
+					"label \"app=database-proxy\" is allowed to initiate connections to " +
+					"10.2.3.0/24",
+				Type: "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &CIDR,
+				},
+			},
+			"toCIDRSet": {
+				Description: "ToCIDRSet is a list of IP blocks which the endpoint subject to " +
+					"the rule is allowed to initiate connections to in addition to connections " +
+					"which are allowed via FromEndpoints, along with a list of subnets " +
+					"contained within their corresponding IP block to which traffic should not " +
+					"be allowed. This will match on the destination IP address of outgoing " +
+					"connections. Adding a prefix into ToCIDR or into ToCIDRSet with no " +
+					"ExcludeCIDRs is equivalent. Overlaps are allowed between ToCIDR and " +
+					"ToCIDRSet.\n\nExample: Any endpoint with the label \"app=database-proxy\" " +
+					"is allowed to initiate connections to 10.2.3.0/24 except from IPs in " +
+					"subnet 10.2.3.0/28.",
+				Type: "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &CIDRRule,
+				},
+			},
+			"toEntities": {
+				Description: "ToEntities is a list of special entities to which the endpoint " +
+					"subject to the rule is allowed to initiate connections. Supported " +
+					"entities are `world` and `host`",
+				Type: "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &apiextensionsv1beta1.JSONSchemaProps{
+						Type: "string",
+					},
+				},
+			},
+			"toPorts": {
+				Description: "ToPorts is a list of destination ports identified by port number " +
+					"and protocol which the endpoint subject to the rule is allowed to connect " +
+					"to.\n\nExample: Any endpoint with the label \"role=frontend\" is allowed " +
+					"to initiate connections to destination port 8080/tcp",
+				Type: "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &PortRule,
+				},
+			},
+			"toServices": {
+				Description: "ToServices is a list of services to which the endpoint subject " +
+					"to the rule is allowed to initiate connections.\n\nExample: Any endpoint " +
+					"with the label \"app=backend-app\" is allowed to initiate connections to " +
+					"all cidrs backing the \"external-service\" service",
+				Type: "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &Service,
+				},
+			},
+		},
+	}
+
+	EndpointSelector = LabelSelector
+
+	IngressRule = apiextensionsv1beta1.JSONSchemaProps{
+		Description: "IngressRule contains all rule types which can be applied at ingress, " +
+			"i.e. network traffic that originates outside of the endpoint and is entering " +
+			"the endpoint selected by the endpointSelector.\n\n- All members of this structure " +
+			"are optional. If omitted or empty, the\n  member will have no effect on the rule." +
+			"\n\n- If multiple members are set, all of them need to match in order for\n  " +
+			"the rule to take effect. The exception to this rule is FromRequires field;\n  " +
+			"the effects of any Requires field in any rule will apply to all other\n  rules " +
+			"as well.\n\n- For now, combining ToPorts, FromCIDR, and FromEndpoints in the same " +
+			"rule\n  is not supported and any such rules will be rejected. In the future, " +
+			"this\n  will be supported and if multiple members of this structure are specified," +
+			"\n then all members must match in order for the rule to take effect. The\n  " +
+			"exception to this rule is the Requires field, the effects of any Requires\n  " +
+			"field in any rule will apply to all other rules as well.",
+		Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+			"fromCIDR": {
+				Description: "FromCIDR is a list of IP blocks which the endpoint subject to " +
+					"the rule is allowed to receive connections from. This will match on the " +
+					"source IP address of incoming connections. Adding  a prefix into FromCIDR " +
+					"or into FromCIDRSet with no ExcludeCIDRs is  equivalent. Overlaps are " +
+					"allowed between FromCIDR and FromCIDRSet.\n\nExample: Any endpoint with " +
+					"the label \"app=my-legacy-pet\" is allowed to receive connections from " +
+					"10.3.9.1",
+				Type: "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &CIDR,
+				},
+			},
+			"fromCIDRSet": {
+				Description: "FromCIDRSet is a list of IP blocks which the endpoint subject to " +
+					"the rule is allowed to receive connections from in addition to " +
+					"FromEndpoints, along with a list of subnets contained within their " +
+					"corresponding IP block from which traffic should not be allowed. This " +
+					"will match on the source IP address of incoming connections. Adding a " +
+					"prefix into FromCIDR or into FromCIDRSet with no ExcludeCIDRs is " +
+					"equivalent. Overlaps are allowed between FromCIDR and FromCIDRSet." +
+					"\n\nExample: Any endpoint with the label \"app=my-legacy-pet\" is allowed " +
+					"to receive connections from 10.0.0.0/8 except from IPs in subnet " +
+					"10.96.0.0/12.",
+				Type: "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &CIDRRule,
+				},
+			},
+			"fromEndpoints": {
+				Description: "FromEndpoints is a list of endpoints identified by an " +
+					"EndpointSelector which are allowed to communicate with the endpoint " +
+					"subject to the rule.\n\nExample: Any endpoint with the label " +
+					"\"role=backend\" can be consumed by any endpoint carrying the label " +
+					"\"role=frontend\".",
+				Type: "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &EndpointSelector,
+				},
+			},
+			"fromEntities": {
+				Description: "FromEntities is a list of special entities which the endpoint " +
+					"subject to the rule is allowed to receive connections from. Supported " +
+					"entities are `world` and `host`",
+				Type: "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &apiextensionsv1beta1.JSONSchemaProps{
+						Type: "string",
+					},
+				},
+			},
+			"fromRequires": {
+				Description: "FromRequires is a list of additional constraints which must be " +
+					"met in order for the selected endpoints to be reachable. These additional " +
+					"constraints do no by itself grant access privileges and must always be " +
+					"accompanied with at least one matching FromEndpoints.\n\nExample: Any " +
+					"Endpoint with the label \"team=A\" requires consuming endpoint to also " +
+					"carry the label \"team=A\".",
+				Type: "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &EndpointSelector,
+				},
+			},
+			"toPorts": {
+				Description: "ToPorts is a list of destination ports identified by port number " +
+					"and protocol which the endpoint subject to the rule is allowed to receive " +
+					"connections on.\n\nExample: Any endpoint with the label \"app=httpd\" can " +
+					"only accept incoming connections on port 80/tcp.",
+				Type: "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &PortRule,
+				},
+			},
+		},
+	}
+
+	K8sServiceNamespace = apiextensionsv1beta1.JSONSchemaProps{
+		Description: "K8sServiceNamespace is an abstraction for the k8s service + namespace " +
+			"types.",
+		Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+			"namespace": {
+				Type: "string",
+			},
+			"serviceName": {
+				Type: "string",
+			},
+		},
+	}
+
+	L7Rules = apiextensionsv1beta1.JSONSchemaProps{
+		Description: "L7Rules is a union of port level rule types. Mixing of different port " +
+			"level rule types is disallowed, so exactly one of the following must be set. If " +
+			"none are specified, then no additional port level rules are applied.",
+		Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+			"http": {
+				Description: "HTTP specific rules.",
+				Type:        "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &PortRuleHTTP,
+				},
+			},
+			"kafka": {
+				Description: "Kafka-specific rules.",
+				Type:        "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &PortRuleKafka,
+				},
+			},
+		},
+	}
+
+	Label = apiextensionsv1beta1.JSONSchemaProps{
+		Description: "Label is the cilium's representation of a container label.",
+		Required: []string{
+			"key",
+		},
+		Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+			"key": {
+				Type: "string",
+			},
+			"source": {
+				Description: "Source can be one of the values present in const.go " +
+					"(e.g.: LabelSourceContainer)",
+				Type: "string",
+			},
+			"value": {
+				Type: "string",
+			},
+		},
+	}
+
+	LabelSelector = apiextensionsv1beta1.JSONSchemaProps{
+		Description: "A label selector is a label query over a set of resources. The result " +
+			"of matchLabels and matchExpressions are ANDed. An empty label selector matches " +
+			"all objects. A null label selector matches no objects.",
+		Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+			"matchLabels": {
+				Description: "matchLabels is a map of {key,value} pairs. A single {key,value} " +
+					"in the matchLabels map is equivalent to an element of matchExpressions, " +
+					"whose key field is \"key\", the operator is \"In\", and the values array " +
+					"contains only \"value\". The requirements are ANDed.",
+				Type: "object",
+			},
+			"matchExpressions": {
+				Description: "matchExpressions is a list of label selector requirements. " +
+					"The requirements are ANDed.",
+				Type: "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &LabelSelectorRequirement,
+				},
+			},
+		},
+	}
+
+	LabelSelectorRequirement = apiextensionsv1beta1.JSONSchemaProps{
+		Description: "A label selector requirement is a selector that contains values, a key, " +
+			"and an operator that relates the key and values.",
+		Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+			"key": {
+				Description: "key is the label key that the selector applies to.",
+				Type:        "string",
+			},
+			"operator": {
+				Description: "operator represents a key's relationship to a set of values. " +
+					"Valid operators are In, NotIn, Exists and DoesNotExist.",
+				Type: "string",
+				Enum: []apiextensionsv1beta1.JSON{
+					{
+						Raw: []byte(`"In"`),
+					},
+					{
+						Raw: []byte(`"NotIn"`),
+					},
+					{
+						Raw: []byte(`"Exists"`),
+					},
+					{
+						Raw: []byte(`"DoesNotExist"`),
+					},
+				},
+			},
+			"values": {
+				Description: "values is an array of string values. If the operator is In or " +
+					"NotIn, the values array must be non-empty. If the operator is Exists or " +
+					"DoesNotExist, the values array must be empty. This array is replaced " +
+					"during a strategic merge patch.",
+				Type: "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &apiextensionsv1beta1.JSONSchemaProps{
+						Type: "string",
+					},
+				},
+			},
+		},
+		Required: []string{"key", "operator"},
+	}
+
+	PortProtocol = apiextensionsv1beta1.JSONSchemaProps{
+		Description: "PortProtocol specifies an L4 port with an optional transport protocol",
+		Required: []string{
+			"port",
+		},
+		Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+			"port": {
+				Description: "Port is an L4 port number. For now the string will be strictly " +
+					"parsed as a single uint16. In the future, this field may support ranges " +
+					"in the form \"1024-2048",
+				Type: "string",
+				// uint16 string regex
+				Pattern: `^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|` +
+					`[1-5][0-9]{4}|[0-9]{1,4})$`,
+			},
+			"protocol": {
+				Description: `Protocol is the L4 protocol. If omitted or empty, any protocol ` +
+					`matches. Accepted values: "TCP", "UDP", ""/"ANY"\n\nMatching on ` +
+					`ICMP is not supported.`,
+				Type: "string",
+				Enum: []apiextensionsv1beta1.JSON{
+					{
+						Raw: []byte(`"TCP"`),
+					},
+					{
+						Raw: []byte(`"UDP"`),
+					},
+					{
+						Raw: []byte(`"ANY"`),
+					},
+				},
+			},
+		},
+	}
+
+	PortRule = apiextensionsv1beta1.JSONSchemaProps{
+		Description: "PortRule is a list of ports/protocol combinations with optional Layer 7 " +
+			"rules which must be met.",
+		Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+			"ports": {
+				Description: "Ports is a list of L4 port/protocol\n\nIf omitted or empty but " +
+					"RedirectPort is set, then all ports of the endpoint subject to either the " +
+					"ingress or egress rule are being redirected.",
+				Type: "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &PortProtocol,
+				},
+			},
+			"redirectPort": {
+				Description: "RedirectPort is the L4 port which, if set, all traffic matching " +
+					"the Ports is being redirected to. Whatever listener behind that port " +
+					"becomes responsible to enforce the port rules and is also responsible to " +
+					"reinject all traffic back and ensure it reaches its original destination.",
+				Type:   "integer",
+				Format: "uint16",
+			},
+			"rules": L7Rules,
+		},
+	}
+
+	PortRuleHTTP = apiextensionsv1beta1.JSONSchemaProps{
+		Description: "PortRuleHTTP is a list of HTTP protocol constraints. All fields are " +
+			"optional, if all fields are empty or missing, the rule does not have any effect." +
+			"\n\nAll fields of this type are extended POSIX regex as defined by " +
+			"IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) " +
+			"matched against the path of an incoming request. Currently it can contain " +
+			"characters disallowed from the conventional \"path\" part of a URL as defined by " +
+			"RFC 3986.",
+		Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+			"headers": {
+				Description: "Headers is a list of HTTP headers which must be present in the " +
+					"request. If omitted or empty, requests are allowed regardless of headers " +
+					"present.",
+				Type: "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &apiextensionsv1beta1.JSONSchemaProps{
+						Type: "string",
+					},
+				},
+			},
+			"host": {
+				Description: "Host is an extended POSIX regex matched against the host header " +
+					"of a request, e.g. \"foo.com\"\n\nIf omitted or empty, the value of the " +
+					"host header is ignored.",
+				Type:   "string",
+				Format: "idn-hostname",
+			},
+			"method": {
+				Description: "Method is an extended POSIX regex matched against the method of " +
+					"a request, e.g. \"GET\", \"POST\", \"PUT\", \"PATCH\", \"DELETE\", ...\n\n" +
+					"If omitted or empty, all methods are allowed.",
+				Type: "string",
+			},
+			"path": {
+				Description: "Path is an extended POSIX regex matched against the path of a " +
+					"request. Currently it can contain characters disallowed from the " +
+					"conventional \"path\" part of a URL as defined by RFC 3986.\n\n" +
+					"If omitted or empty, all paths are all allowed.",
+				Type: "string",
+			},
+		},
+	}
+
+	PortRuleKafka = apiextensionsv1beta1.JSONSchemaProps{
+		Description: "PortRuleKafka is a list of Kafka protocol constraints. All fields are " +
+			"optional, if all fields are empty or missing, the rule will match all Kafka " +
+			"messages.",
+		Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+			"apiKey": {
+				Description: "APIKey is a case-insensitive string matched against the key of " +
+					"a request, e.g. \"produce\", \"fetch\", \"createtopic\", \"deletetopic\", " +
+					"et al Reference: https://kafka.apache.org/protocol#protocol_api_keys\n\n" +
+					"If omitted or empty, all keys are allowed.",
+				Type: "string",
+			},
+			"apiVersion": {
+				Description: "APIVersion is the version matched against the api version of the " +
+					"Kafka message. If set, it has to be a string representing a positive " +
+					"integer.\n\nIf omitted or empty, all versions are allowed.",
+				Type: "string",
+			},
+			"clientID": {
+				Description: "ClientID is the client identifier as provided in the request.\n\n" +
+					"From Kafka protocol documentation: This is a user supplied identifier for " +
+					"the client application. The user can use any identifier they like and it " +
+					"will be used when logging errors, monitoring aggregates, etc. For " +
+					"example, one might want to monitor not just the requests per second " +
+					"overall, but the number coming from each client application (each of " +
+					"which could reside on multiple servers). This id acts as a logical " +
+					"grouping across all requests from a particular client.\n\nIf omitted or " +
+					"empty, all client identifiers are allowed.",
+				Type: "string",
+			},
+			"topic": {
+				Description: "Topic is the topic name contained in the message. If a Kafka " +
+					"request contains multiple topics, then all topics must be allowed or the " +
+					"message will be rejected.\n\nThis constraint is ignored if the matched " +
+					"request message type doesn't contain any topic. Maximum size of Topic can " +
+					"be 249 characters as per recent Kafka spec and allowed characters are " +
+					"a-z, A-Z, 0-9, -, . and _ Older Kafka versions had longer topic lengths " +
+					"of 255, but in Kafka 0.10 version the length was changed from 255 to 249. " +
+					"For compatibility reasons we are using 255\n\nIf omitted or empty, all " +
+					"topics are allowed.",
+				Type:      "string",
+				MaxLength: getInt64(255),
+			},
+		},
+	}
+
+	Rule = apiextensionsv1beta1.JSONSchemaProps{
+		Description: "Rule is a policy rule which must be applied to all endpoints which match " +
+			"the labels contained in the endpointSelector\n\nEach rule is split into an " +
+			"ingress section which contains all rules applicable at ingress, and an egress " +
+			"section applicable at egress. For rule types such as `L4Rule` and `CIDR` which " +
+			"can be applied at both ingress and egress, both ingress and egress side have to " +
+			"either specifically allow the connection or one side has to be omitted.\n\n" +
+			"Either ingress, egress, or both can be provided. If both ingress and egress are " +
+			"omitted, the rule has no effect.",
+		Required: []string{
+			"endpointSelector",
+		},
+		Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+			"Description": {
+				Description: "Description is a free form string, it can be used by the creator " +
+					"of the rule to store human readable explanation of the purpose of this " +
+					"rule. Rules cannot be identified by comment.",
+				Type: "string",
+			},
+			"egress": {
+				Description: "Egress is a list of EgressRule which are enforced at egress. If " +
+					"omitted or empty, this rule does not apply at egress.",
+				Type: "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &EgressRule,
+				},
+			},
+			"endpointSelector": EndpointSelector,
+			"ingress": {
+				Description: "Ingress is a list of IngressRule which are enforced at ingress. " +
+					"If omitted or empty, this rule does not apply at ingress.",
+				Type: "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &IngressRule,
+				},
+			},
+			"labels": {
+				Description: "Labels is a list of optional strings which can be used to " +
+					"re-identify the rule or to store metadata. It is possible to lookup or " +
+					"delete strings based on labels. Labels are not required to be unique, " +
+					"multiple rules can have overlapping or identical labels.",
+				Type: "array",
+				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+					Schema: &Label,
+				},
+			},
+		},
+	}
+
+	Service = apiextensionsv1beta1.JSONSchemaProps{
+		Description: "Service wraps around selectors for services",
+		Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+			"k8sService":         K8sServiceNamespace,
+			"k8sServiceSelector": ServiceSelector,
+		},
+	}
+
+	ServiceSelector = apiextensionsv1beta1.JSONSchemaProps{
+		Description: "ServiceSelector is a label selector for k8s services",
+		Required: []string{
+			"selector",
+		},
+		Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+			"selector": EndpointSelector,
+			"namespace": {
+				Type: "string",
+			},
+		},
+	}
+
+	spec = Rule
+
+	specs = apiextensionsv1beta1.JSONSchemaProps{
+		Description: "Specs is a list of desired Cilium specific rule specification.",
+		Type:        "array",
+		Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+			Schema: &Rule,
+		},
+	}
 )
+
+func init() {
+	EndpointSelector.Description = "EndpointSelector is a wrapper for k8s LabelSelector."
+
+	portRuleProps := PortRule.Properties["rules"]
+	portRuleProps.Description = "Rules is a list of additional port level rules which must be " +
+		"met in order for the PortRule to allow the traffic. If omitted or empty, " +
+		"no layer 7 rules are enforced."
+	PortRule.Properties["rules"] = portRuleProps
+
+	ruleProps := Rule.Properties["endpointSelector"]
+	ruleProps.Description = "EndpointSelector selects all endpoints which should be subject " +
+		"to this rule. Cannot be empty."
+	Rule.Properties["endpointSelector"] = ruleProps
+
+	serviceProps := Service.Properties["k8sServiceSelector"]
+	serviceProps.Description = "K8sServiceSelector selects services by k8s labels. " +
+		"Not supported yet"
+	Service.Properties["k8sServiceSelector"] = serviceProps
+
+	spec.Description = "Spec is the desired Cilium specific rule specification."
+	spec.Type = "object"
+
+}


### PR DESCRIPTION
*View the diff with ignore-whitespace https://github.com/cilium/cilium/pull/2820/files?w=1*

**Summary of changes**
We previously used references to previous types in our
CiliumNetworkPolicy validation. As of k8s 1.9.3 this is explicitly an
error (apparently it didn't work to begin with):
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.9.md#other-notable-changes
CustomResourceDefinitions: OpenAPI v3 validation schemas containing $ref
references are no longer permitted (valid references could not be
constructed previously because property ids were not permitted either).
Before upgrading, ensure CRD definitions do not include those $ref
fields. (#58438, carlory)

This change restructures how we build the validation, allowing us to use
references to the objects in go instead of relying on the late-binding
scheme from before.

New CRD as seen by k8s
https://gist.github.com/raybejjani/1804a95dc973a1464afa283b618d4293#file-new-crd-json-without-refs

Old CRD as seen by k8s
https://gist.github.com/raybejjani/1804a95dc973a1464afa283b618d4293#file-sample-old-crd-json-with-refs-not-from-the-same-instance

Fixes: https://github.com/cilium/cilium/issues/2800

***Discussion***
I'm not too happy with this change. It feels a bit brittle. If we're willing to wait for https://github.com/kubernetes/kubernetes/issues/59154 it might simplify things for us. Alternatively, it's possible to do this by resolving the refs into full objects during runtime. I have a branch for that but the code is pretty obtuse (you have to recurse).

aanm noted that there is talk of backporting this error to 1.8 and 1.7. If so, we'll need to backport before k8s does.

**How to test (optional)**:
I've tested manually against the CI vagrant machines (Thanks for the help eloycoto!). I can reproduce the issue (no CNP CRD with k8s 1.9.3) but I haven't tested that all the validation is still working (I did test once).
I start a VM with:
`$ export K8S_VERSION=1.9; for i in $(seq 1);do vagrant up k8s$i-1.9; done `

I then run the modified cilium daemonset (https://gist.github.com/raybejjani/1804a95dc973a1464afa283b618d4293). I can create CNPs with
`vagrant@k8s1:~$ kubectl create -f /src/examples/minikube/l3_l4_l7_policy.yaml`