### PR TITLE
Make `cilium status` output more succinct by default

### DIFF
--- a/Documentation/cmdref/cilium_status.md
+++ b/Documentation/cmdref/cilium_status.md
@@ -16,8 +16,11 @@ cilium status
 ### Options
 
 ```
+      --all-addresses     Show all allocated addresses, not just count
       --all-controllers   Show all controllers, not just failing
+      --all-nodes         Show all nodes, not just localhost
   -o, --output string     json| jsonpath='{}'
+      --verbose           Equivalent to --all-addresses --all-controllers --all-nodes
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium_status.md
+++ b/Documentation/cmdref/cilium_status.md
@@ -19,6 +19,7 @@ cilium status
       --all-addresses     Show all allocated addresses, not just count
       --all-controllers   Show all controllers, not just failing
       --all-nodes         Show all nodes, not just localhost
+      --brief             Only print a one-line status message
   -o, --output string     json| jsonpath='{}'
       --verbose           Equivalent to --all-addresses --all-controllers --all-nodes
 ```

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -210,7 +210,7 @@ func copyCiliumInfoCommands(cmdDir string, k8sPods []string) []string {
 		"cilium bpf lb list",
 		"cilium bpf endpoint list",
 		"cilium bpf ct list global",
-		"cilium status",
+		"cilium status --verbose",
 	}
 	var commands []string
 

--- a/cilium-health/cmd/get.go
+++ b/cilium-health/cmd/get.go
@@ -47,7 +47,7 @@ var healthGetCmd = &cobra.Command{
 			load := sr.SystemLoad
 			fmt.Fprintf(w, "Node load:\t%s %s %s\n",
 				load.Last1min, load.Last5min, load.Last15min)
-			ciliumClient.FormatStatusResponse(w, sr.Cilium, false)
+			ciliumClient.FormatStatusResponse(w, sr.Cilium, false, false, false)
 			w.Flush()
 		}
 	},

--- a/cilium/cmd/debuginfo.go
+++ b/cilium/cmd/debuginfo.go
@@ -69,7 +69,7 @@ func runDebugInfo(cmd *cobra.Command, args []string) {
 
 	printMD(w, "Cilium status", "")
 	printTicks(w)
-	pkg.FormatStatusResponse(w, p.CiliumStatus, true)
+	pkg.FormatStatusResponse(w, p.CiliumStatus, true, true, true)
 	printTicks(w)
 
 	printMD(w, "Cilium environment keys", strings.Join(p.EnvironmentVariables, "\n"))

--- a/cilium/cmd/policy_trace.go
+++ b/cilium/cmd/policy_trace.go
@@ -42,7 +42,6 @@ type supportedKinds string
 var src, dst, dports []string
 var srcIdentity, dstIdentity int64
 var srcEndpoint, dstEndpoint, srcK8sPod, dstK8sPod, srcK8sYaml, dstK8sYaml string
-var verbose bool
 
 // policyTraceCmd represents the policy_trace command
 var policyTraceCmd = &cobra.Command{

--- a/cilium/cmd/root.go
+++ b/cilium/cmd/root.go
@@ -30,6 +30,7 @@ var (
 	cfgFile string
 	client  *clientPkg.Client
 	log     = logrus.New()
+	verbose = false
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cilium/cmd/status.go
+++ b/cilium/cmd/status.go
@@ -38,6 +38,7 @@ var (
 	allAddresses   bool
 	allControllers bool
 	allNodes       bool
+	brief          bool
 )
 
 func init() {
@@ -45,6 +46,7 @@ func init() {
 	statusCmd.Flags().BoolVar(&allAddresses, "all-addresses", false, "Show all allocated addresses, not just count")
 	statusCmd.Flags().BoolVar(&allControllers, "all-controllers", false, "Show all controllers, not just failing")
 	statusCmd.Flags().BoolVar(&allNodes, "all-nodes", false, "Show all nodes, not just localhost")
+	statusCmd.Flags().BoolVar(&brief, "brief", false, "Only print a one-line status message")
 	statusCmd.Flags().BoolVar(&verbose, "verbose", false, "Equivalent to --all-addresses --all-controllers --all-nodes")
 	command.AddJSONOutput(statusCmd)
 }
@@ -62,7 +64,8 @@ func statusDaemon() {
 		if err := command.PrintOutput(resp.Payload); err != nil {
 			os.Exit(1)
 		}
-		return
+	} else if brief {
+		pkg.FormatStatusResponseBrief(os.Stdout, resp.Payload)
 	} else {
 		sr := resp.Payload
 		w := tabwriter.NewWriter(os.Stdout, 2, 0, 3, ' ', 0)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -243,7 +243,8 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, allControllers
 				ctrl.Name, successSince, failSince, status.ConsecutiveFailureCount, err))
 		}
 
-		fmt.Fprintf(w, "Controller Status (%d/%d failing)\n", nFailing, len(sr.Controllers))
+		nOK := len(sr.Controllers) - nFailing
+		fmt.Fprintf(w, "Controller Status:\t%d/%d healthy\n", nOK, len(sr.Controllers))
 		if len(out) > 1 {
 			tab := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
 			for _, s := range out {

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -26,6 +26,21 @@ const (
 	ipv6BitLen = 8 * net.IPv6len
 )
 
+// CountIPsInCIDR takes a RFC4632/RFC4291-formatted IPv4/IPv6 CIDR and
+// determines how many IP addresses reside within that CIDR.
+// Returns 0 if the input CIDR cannot be parsed.
+func CountIPsInCIDR(cidr string) int {
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return 0
+	}
+	subnet, size := ipnet.Mask.Size()
+	if subnet == size {
+		return 1
+	}
+	return 1<<uint(size-subnet) - 1
+}
+
 // NetsByMask is used to sort a list of IP networks by the size of their masks.
 // Implements sort.Interface.
 type NetsByMask []*net.IPNet

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -31,6 +31,22 @@ func Test(t *testing.T) {
 	TestingT(t)
 }
 
+func (s *IPTestSuite) TestCountIPs(c *C) {
+	tests := map[string]int{
+		"192.168.0.1/32": 1,
+		"192.168.0.1/31": 1,
+		"192.168.0.1/30": 3,
+		"192.168.0.1/24": 255,
+		"192.168.0.1/16": 65535,
+		"::1/128":        1,
+		"::1/120":        255,
+	}
+	for cidr, nIPs := range tests {
+		count := CountIPsInCIDR(cidr)
+		c.Assert(count, Equals, nIPs)
+	}
+}
+
 func (s *IPTestSuite) TestFirstIP(c *C) {
 	// Test IPv4.
 	desiredIPv4_1 := net.IP{0xa, 0, 0, 0}


### PR DESCRIPTION
```release-note-minor
Simplify output of `cilium status` by default, add new `--verbose`, `--brief` options
```

Add `--verbose` mode and some extra options to choose how much output you want from the cilium status API. Gather the verbose output in bugtool. Fold in a minor change to phrase controller states in terms of success rather than failure.

Example output with this series:

```
$ cilium status                                                                                                                                                                                                                                                
KVStore:                    Ok         Consul: 172.17.0.2:8300                  
ContainerRuntime:           Ok                                                  
Kubernetes:                 Disabled                                            
Cilium:                     Ok         OK                                       
NodeMonitor:                Disabled                                            
Cilium health daemon:       Warning   Get http:///var/run/cilium/health.sock/v1beta/hello: dial unix /var/run/cilium/health.sock:
 connect: no such file or directory                                             
IPv4 address pool:   3/65535 allocated                                                   
IPv6 address pool:   2/65535 allocated                                                   
Controller Status:     3/3 healthy
```

There's also this command for a brief, one-line summary:
```
$ cilium status --brief
OK
```
