### PR TITLE
Ginkgo: log docker execution in verbose mode

### DIFF
--- a/test/helpers/docker.go
+++ b/test/helpers/docker.go
@@ -20,7 +20,9 @@ import (
 
 // ContainerExec executes cmd in the container with the provided name.
 func (s *SSHMeta) ContainerExec(name string, cmd string) *CmdRes {
-	return s.ExecWithSudo(fmt.Sprintf("docker exec -i %s %s", name, cmd))
+	dockerCmd := fmt.Sprintf("docker exec -i %s %s", name, cmd)
+	log.Debugf("running command '%s'", dockerCmd)
+	return s.ExecWithSudo(dockerCmd)
 }
 
 // ContainerCreate is a wrapper for `docker run`. It runs an instance of the


### PR DESCRIPTION
When in verbose mode, print all commands that are executing in the runtime tests. Helps debug.

Signed-off-by: Joe Stringer <joe@covalent.io>