### PR TITLE
Cache bazel to speed up build

### DIFF
--- a/envoy/Makefile
+++ b/envoy/Makefile
@@ -19,7 +19,6 @@ ENVOY_BINS = $(ENVOY_BIN) ./bazel-bin/cilium_integration_test
 CHECK_FORMAT ?= ./bazel-bin/check_format.py.runfiles/envoy/tools/check_format.py
 
 BAZEL ?= bazel
-BAZEL_OPTS ?= --batch
 BAZEL_TEST_OPTS ?= 
 BAZEL_CACHE ?= ~/.cache/bazel
 BAZEL_ARCHIVE ?= ~/bazel-cache.tar.bz2
@@ -74,9 +73,11 @@ GO_TARGETS= $(ENVOY_API_TARGETS) $(CILIUM_TARGETS) $(CILIUM_API_TARGETS) $(FILTE
 
 # Dockerfile builds require special options
 ifdef PKG_BUILD
+BAZEL_OPTS ?= --batch
 BAZEL_BUILD_OPTS = --spawn_strategy=standalone --genrule_strategy=standalone
 all: clean-bins release
 else
+BAZEL_OPTS ?=
 BAZEL_BUILD_OPTS =
 
 all: clean-bins envoy $(GO_TARGETS)


### PR DESCRIPTION
Previously we have used the '--batch' bazel option to ensure that the
bazel daemon is not running after building cilium. However, if bazel
doesn't continue running, then we don't make use of its build caching
either. Remove the `--batch` option to speed up builds. Also, don't
always clean the binary; that will force rebuild and slow down builds.
    
In local builds, this shaves as much as 20s off build time.
