### PR TITLE
Ginkgo: Add a jenkinsfile to trigger kubernetes 1.7 and 1.9

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -705,17 +705,19 @@ regarding which phrase triggers which build, which build is required for
 a pull-request to be merged, etc. Each linked job contains a description
 illustrating which subset of tests the job runs.
 
++-------------------------------------------------------------------------------------------------------+-----------------+--------------------+
+| Jenkins Job                                                                                           | Trigger Phrase  | Required To Merge? |
++=======================================================================================================+=================+====================+
+| `Cilium-Master-Bash-Tests-All <https://jenkins.cilium.io/job/Cilium-PR-Bash-Tests-All/>`_             | test-me-please  | Yes                |
 +-------------------------------------------------------------------------------------+-----------------+--------------------+
-| Jenkins Job                                                                         | Trigger Phrase  | Required To Merge? |
-+=====================================================================================+=================+====================+
-| `Cilium-Bash-Tests <https://jenkins.cilium.io/job/Cilium-Bash-Tests/>`_             | test-me-please  | Yes                |
+| `Cilium-PR-Ginkgo-Tests-Validated <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-Validated/>`_ | test-me-please  | Yes                |
 +-------------------------------------------------------------------------------------+-----------------+--------------------+
-| `Cilium-Ginkgo-Tests <https://jenkins.cilium.io/job/Cilium-Ginkgo-Tests/>`_         | test-me-please  | Yes                |
-+-------------------------------------------------------------------------------------+-----------------+--------------------+
-| `Cilium-Ginkgo-Tests-All <https://jenkins.cilium.io/job/Cilium-Ginkgo-Tests-All/>`_ | test-all-ginkgo | No                 |
-+-------------------------------------------------------------------------------------+-----------------+--------------------+
-| `Cilium-Nightly-Tests-PR <https://jenkins.cilium.io/job/Cilium-Nightly-Tests-PR/>`_ | test-nightly    | No                 |
-+-------------------------------------------------------------------------------------+-----------------+--------------------+
+| `Cilium-PR-Ginkgo-Tests-All <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-All/>`_             | test-all-ginkgo | No                 |
++-------------------------------------------------------------------------------------------------------+-----------------+--------------------+
+| `Cilium-Pr-Ginkgo-Test-k8s <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-K8s/c>`_             | test-missed-k8s | No                 |
++-------------------------------------------------------------------------------------------------------+-----------------+--------------------+
+| `Cilium-Nightly-Tests-PR <https://jenkins.cilium.io/job/Cilium-PR-Nightly-Tests-All/>`_               | test-nightly    | No                 |
++-------------------------------------------------------------------------------------------------------+-----------------+--------------------+
 
 
 CI / Testing environment

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -1,0 +1,67 @@
+pipeline {
+    agent {
+        label 'ginkgo'
+    }
+    environment {
+        PROJ_PATH = "src/github.com/cilium/cilium"
+    }
+
+    options {
+        timeout(time: 90, unit: 'MINUTES')
+        timestamps()
+    }
+    stages {
+        stage('Checkout') {
+            steps {
+                sh 'env'
+                sh 'rm -rf src; mkdir -p src/github.com/cilium'
+                sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
+                checkout scm
+            }
+        }
+        stage('Boot VMs'){
+            environment {
+                GOPATH="${WORKSPACE}"
+                TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
+            }
+            steps {
+                sh 'cd ${TESTDIR}; K8S_VERSION=1.7 vagrant up --no-provision'
+                sh 'cd ${TESTDIR}; K8S_VERSION=1.9 vagrant up --no-provision'
+            }
+        }
+        stage('BDD-Test-k8s') {
+            environment {
+                GOPATH="${WORKSPACE}"
+                TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
+            }
+            options {
+                timeout(time: 60, unit: 'MINUTES')
+            }
+            steps {
+                parallel(
+                    "K8s-1.7":{
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.7 ginkgo --focus=" K8s*" -v -noColor'
+                    },
+                    "K8s-1.9":{
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.9 ginkgo --focus=" K8s*" -v -noColor'
+                    },
+                )
+            }
+            post {
+                always {
+                    junit 'test/*.xml'
+                    sh 'cd test/; ./post_build_agent.sh || true'
+                    sh 'cd test/; ./archive_test_results.sh || true'
+                    archiveArtifacts artifacts: "test_results_${JOB_BASE_NAME}_${BUILD_NUMBER}.tar", allowEmptyArchive: true
+                }
+            }
+        }
+    }
+    post {
+        always {
+            cleanWs()
+            sh "cd ${TESTDIR}; K8S_VERSION=1.7 vagrant destroy -f || true"
+            sh "cd ${TESTDIR}; K8S_VERSION=1.9 vagrant destroy -f || true"
+        }
+    }
+}


### PR DESCRIPTION
Added a new trigger (`test-missed-k8s`) to test all Kubernetes version not tested on the normal runs.

cc @aanm 

