### PR TITLE
contrib: Simplify the release notes gaterhing script

### DIFF
--- a/contrib/release/README.md
+++ b/contrib/release/README.md
@@ -33,7 +33,9 @@ a PR to specify the release note text.
 
 2. Run the script to generate the NEWS.rst file:
 
-   `GITHUB_TOKEN=xxx `./relnotes --markdown-file=NEWS.rst v0.11..v0.12`
+   `Usage: relnotes [OPTIONS] RELEASE-TAG RANGE`
+
+   `GITHUB_TOKEN=xxx ./relnotes --markdown-file=NEWS.rst v1.0.0-rc4 v1.0.0-rc3..`
 
    In case the generated `NEWS.rst` file is not as expected, you can run
    `relnotes` with the `--verbose` flag to see individual decision taken for

--- a/contrib/release/relnotes
+++ b/contrib/release/relnotes
@@ -94,7 +94,7 @@ source $(dirname $(readlink -ne $BASH_SOURCE))/lib/common.sh
 source $TOOL_LIB_PATH/gitlib.sh
 
 # Validate command-line
-common::argc_validate 1
+common::argc_validate 2
 
 ###############################################################################
 # FUNCTIONS
@@ -277,28 +277,22 @@ generate_notes () {
   : ${LAST_RELEASE[$CURRENT_BRANCH]:=${LAST_RELEASE[master]}}
 
   # Default
-  range="${POSITIONAL_ARGV[0]:-"${LAST_RELEASE[$CURRENT_BRANCH]}..$branch_head"}"
+  release_tag="${POSITIONAL_ARGV[0]}"
+  range="${POSITIONAL_ARGV[1]}"
 
-  if [[ "${POSITIONAL_ARGV[0]}" =~ ([v0-9.]*-*(alpha|beta|rc)*\.*[0-9]*)\.\.([v0-9.]*-*(alpha|beta|rc)*\.*[0-9]*)$ ]]; then
+  [[ "$range" =~ (.*)\.\.(.*) ]] &&
     start_tag=${BASH_REMATCH[1]}
-    release_tag=${BASH_REMATCH[3]}
-  else
-    start_tag="${LAST_RELEASE[$CURRENT_BRANCH]}"
-    release_tag=${POSITIONAL_ARGV[0]}
-  fi
-  # Describe/tag $branch_head if no release_tag set
-  : ${release_tag:=$(git describe $branch_head)}
 
   if [[ -z "$start_tag" ]]; then
     common::exit 1 "Unable to set beginning of range automatically." \
                    "Specify on the command-line. Exiting..."
   fi
 
-  range="$start_tag..$release_tag"
+  #range="$start_tag..$release_tag"
   logecho "Release tag range: $range"
 
   # If range is unterminated, finish it with $branch_head
-  [[ $range =~ \.\.$ ]] && range+=$branch_head
+  #[[ $range =~ \.\.$ ]] && range+=$branch_head
 
   # Validate range
   if ! git rev-parse $range &>/dev/null; then
@@ -309,7 +303,7 @@ generate_notes () {
 
   logecho
 
-  logecho "Scanning for merged PRs requiring release notes on the $CURRENT_BRANCH branch..."
+  logecho "Scanning for all merged PRs in the repository requiring release notes on the $CURRENT_BRANCH branch..."
   major_prs=($(get_prs "release-note/major"))
   echo "Major PRs: ${#major_prs[@]}"
 
@@ -318,7 +312,6 @@ generate_notes () {
 
   bug_prs=($(get_prs "release-note/bug"))
   echo "Bugfix PRs: ${#bug_prs[@]}"
-
 
   logecho
   logecho "Generating release notes..."
@@ -409,19 +402,5 @@ common::check_packages jq pandoc
 gitlib::last_releases
 
 generate_notes || common::exit 1
-
-#logecho
-#if ((FLAGS_quiet)); then
-#  logecho -n "Notes written to $RELEASE_NOTES_MD"
-#  if [[ -f $RELEASE_NOTES_HTML ]]; then
-#    logecho " and $RELEASE_NOTES_HTML"
-#  else
-#    logecho
-#  fi
-#else
-#  logecho -r "$HR"
-#  cat $RELEASE_NOTES_MD
-#  logecho -r "$HR"
-#fi
 
 common::timestamp end


### PR DESCRIPTION
Remove the complicated logic to try and guess the release tag and the range and
just ask for it.

Signed-off-by: Thomas Graf <thomas@cilium.io>
