### PR TITLE
Misc make / tests fixups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,10 +182,8 @@ vps:
 	VBoxManage list runningvms
 
 reload:
-	cd daemon && make go-bindata
-	make
 	sudo systemctl stop cilium cilium-docker
-	sudo make install
+	sudo $(MAKE) install
 	sudo systemctl start cilium cilium-docker
 	sleep 6
 	cilium status

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,10 @@ start-kvstores:
            consul:0.8.3 \
            agent -client=0.0.0.0 -server -bootstrap-expect 1
 
-tests: start-kvstores tests-envoy
+tests: force
+	$(MAKE) unit-tests tests-envoy
+
+unit-tests: start-kvstores
 	go vet $(GOFILES)
 	echo "mode: count" > coverage-all.out
 	echo "mode: count" > coverage.out

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ include daemon/bpf.sha
 
 SUBDIRS = envoy plugins bpf cilium daemon monitor cilium-health bugtool
 GOFILES ?= $(shell go list ./... | grep -v /vendor/ | grep -v /contrib/ | grep -v envoy.*api)
-TESTPKGS =  $(shell go list ./... | grep -v /vendor/ | grep -v /contrib/ | grep -v envoy.*api | grep -v test)
+TESTPKGS ?=  $(shell go list ./... | grep -v /vendor/ | grep -v /contrib/ | grep -v envoy.*api | grep -v test)
 GOLANGVERSION = $(shell go version 2>/dev/null | grep -Eo '(go[0-9].[0-9])')
 GOLANG_SRCFILES=$(shell for pkg in $(subst github.com/cilium/cilium/,,$(GOFILES)); do find $$pkg -name *.go -print; done | grep -v vendor)
 BPF_FILES ?= $(shell git ls-files ../bpf/ | tr "\n" ' ')

--- a/cilium-health/Makefile
+++ b/cilium-health/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.defs
 
 TARGET=cilium-health
-SOURCES := $(shell find ../api/v1/health ../pkg/health cmd . -name '*.go')
+SOURCES := $(shell find ../api/v1/health ../pkg/health cmd . \( -name '*.go' ! -name '*_test.go' \))
 $(TARGET): $(SOURCES)
 	$(GO) build -i $(GOBUILD) -o $(TARGET)
 

--- a/cilium/Makefile
+++ b/cilium/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.defs
 
 TARGET=cilium
-SOURCES := $(shell find ../api ../daemon ../common ../pkg cmd . -name '*.go')
+SOURCES := $(shell find ../api ../daemon ../common ../pkg cmd . \( -name '*.go' ! -name '*_test.go' \))
 $(TARGET): $(SOURCES)
 	$(GO) build -i $(GOBUILD) -o $(TARGET)
 

--- a/contrib/scripts/check-cmdref.sh
+++ b/contrib/scripts/check-cmdref.sh
@@ -5,6 +5,7 @@ set -e
 DOCS_DIR=./Documentation
 OLD_DIR=${DOCS_DIR}/cmdref
 TMP_DIR=`mktemp -d`
+trap 'rm -rf $TMP_DIR' EXIT INT TERM
 
 make CMDREFDIR=${TMP_DIR} -C ${DOCS_DIR} cmdref
 

--- a/contrib/shell/test.sh
+++ b/contrib/shell/test.sh
@@ -27,8 +27,8 @@ function watchdo
     local FILE=$1
     shift
 
-    if [ ! -z "$GOFILES" ]; then
-        echo -e "${yellow}Using GOFILES=\"$GOFILES\" for run.${reset}"
+    if [ ! -z "$TESTPKGS" ]; then
+        echo -e "${yellow}Using TESTPKGS=\"$TESTPKGS\" for run.${reset}"
     fi
     echo -e "${yellow}Running \"$@\" on changes to \"$FILE\" ...${reset}"
     while inotifywait -q -r -e move $FILE; do
@@ -44,7 +44,7 @@ function watchdo
 function watchtest_
 {
 
-    watchdo "." "make --quiet build tests-consul"
+    watchdo "." "make --quiet build unit-tests"
 }
 
 # Watch a file or directory for changes and trigger tests when it is modified.
@@ -59,7 +59,7 @@ function watchtest
         echo "Cannot find 'inotifywait'. Please install inotify-tools."
         exit 1
     elif [ $# -eq 1 ]; then
-        GOFILES="github.com/cilium/cilium/$1" watchtest_
+        TESTPKGS="github.com/cilium/cilium/$1" watchtest_
     else
         watchtest_
     fi

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -8,7 +8,7 @@ include ../Makefile.defs
 
 
 TARGET=cilium-agent
-SOURCES := $(shell find ../api ../common ../daemon ../pkg ../monitor . -name '*.go')
+SOURCES := $(shell find ../api ../common ../daemon ../pkg ../monitor . \( -name '*.go'  ! -name '*_test.go' \))
 $(TARGET): $(SOURCES) check-bindata
 	$(GO) build -i $(GOBUILD) -o $(TARGET)
 

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -40,11 +40,11 @@ install:
 endif
 
 .PHONY: check-bindata
-check-bindata: go-bindata
+check-bindata: bindata.go
 	../contrib/scripts/bindata.sh $(GO_BINDATA_SHA1SUM)
 
 apply-bindata: go-bindata
 	../contrib/scripts/bindata.sh apply
 
-go-bindata:
+bindata.go go-bindata: $(BPF_FILES)
 	$(GO_BINDATA) -o ./bindata.go $(BPF_FILES)

--- a/monitor/Makefile
+++ b/monitor/Makefile
@@ -15,7 +15,7 @@
 include ../Makefile.defs
 
 TARGET=cilium-node-monitor
-SOURCES := $(shell find ../monitor ../common ../pkg ../api . -name '*.go')
+SOURCES := $(shell find ../monitor ../common ../pkg ../api . \( -name '*.go' ! -name '*_test.go' \))
 $(TARGET): $(SOURCES)
 	$(GO) build -i $(GOBUILD) -o $(TARGET)
 


### PR DESCRIPTION
This is a series of misc changes for Makefiles and contrib scripts, including:
* New `make unit-tests` target to only run unit tests
* Fix up `watchtest` macro in contrib/
* Improve makefile dependencies (removes several seconds off builds when modifying/running unit tests in a loop) 