### PR TITLE
test: fix issues with runtime/connectivity.go test

### DIFF
--- a/api/v1/models/endpoint.go
+++ b/api/v1/models/endpoint.go
@@ -23,6 +23,9 @@ type Endpoint struct {
 	// addressing
 	Addressing *EndpointAddressing `json:"addressing,omitempty"`
 
+	// configuration options for this endpoint
+	Configuration *Configuration `json:"configuration,omitempty"`
+
 	// ID assigned by container runtime
 	ContainerID string `json:"container-id,omitempty"`
 
@@ -85,6 +88,8 @@ type Endpoint struct {
 
 /* polymorph Endpoint addressing false */
 
+/* polymorph Endpoint configuration false */
+
 /* polymorph Endpoint container-id false */
 
 /* polymorph Endpoint container-name false */
@@ -128,6 +133,11 @@ func (m *Endpoint) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateAddressing(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateConfiguration(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -179,6 +189,25 @@ func (m *Endpoint) validateAddressing(formats strfmt.Registry) error {
 		if err := m.Addressing.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("addressing")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *Endpoint) validateConfiguration(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Configuration) { // not required
+		return nil
+	}
+
+	if m.Configuration != nil {
+
+		if err := m.Configuration.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("configuration")
 			}
 			return err
 		}

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -762,6 +762,9 @@ definitions:
       id:
         description: Local endpoint ID
         type: integer
+      configuration:
+        description: configuration options for this endpoint
+        "$ref": "#/definitions/Configuration"
       container-id:
         description: ID assigned by container runtime
         type: string

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1245,6 +1245,10 @@ func init() {
         "addressing": {
           "$ref": "#/definitions/EndpointAddressing"
         },
+        "configuration": {
+          "description": "configuration options for this endpoint",
+          "$ref": "#/definitions/Configuration"
+        },
         "container-id": {
           "description": "ID assigned by container runtime",
           "type": "string"

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -465,6 +465,7 @@ func (e *Endpoint) GetModelRLocked() *models.Endpoint {
 
 	return &models.Endpoint{
 		ID:               int64(e.ID),
+		Configuration:    e.Opts.GetModel(),
 		ContainerID:      e.DockerID,
 		ContainerName:    e.ContainerName,
 		DockerEndpointID: e.DockerEndpointID,

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -80,6 +80,30 @@ func (s *SSHMeta) EndpointGet(id string) *models.Endpoint {
 	return nil
 }
 
+// GetEndpointMutableConfigurationOption returns the value of the mutable
+// configuration option optionName for the endpoint with ID endpointID, or an
+// error if optionName's corresponding value cannot be retrieved for the
+// endpoint.
+func (s *SSHMeta) GetEndpointMutableConfigurationOption(endpointID, optionName string) (configurationOptionValue string, err error) {
+	endpointModel := s.EndpointGet(endpointID)
+	if endpointModel == nil {
+		return "", fmt.Errorf("endpoint model for endpoint %s is nil", endpointID)
+	}
+
+	endpointConfiguration := endpointModel.Configuration
+	if endpointConfiguration == nil {
+		return "", fmt.Errorf("nil configuration of endpoint %s", endpointID)
+	}
+
+	// Endpoint currently only has mutable options.
+	configurationOptionValue, configOptionExists := endpointModel.Configuration.Mutable[optionName]
+	if !configOptionExists {
+		return "", fmt.Errorf("provided configuration option %s does not exist in endpoint %s configuration", optionName, endpointID)
+	}
+
+	return configurationOptionValue, nil
+}
+
 // EndpointStatusLog returns the status log API model for the specified endpoint.
 // Returns nil if no endpoint corresponds to the provided ID.
 func (s *SSHMeta) EndpointStatusLog(id string) *models.EndpointStatusLog {

--- a/test/runtime/manifests/ct-test-policy.json
+++ b/test/runtime/manifests/ct-test-policy.json
@@ -1,0 +1,51 @@
+[{
+    "endpointSelector": {"matchLabels":{"id.curl":""}},
+    "egress": [{
+	    "toPorts": [{
+		    "ports": [{"port": "80", "protocol": "tcp"}]
+	    }]
+    }],
+    "labels": ["id=curl"]
+},{
+    "endpointSelector": {"matchLabels":{"id.server":""}},
+    "ingress": [{
+        "fromEndpoints": [
+	    {"matchLabels":{"reserved:host":""}},
+	    {"matchLabels":{"id.client":""}}
+	]
+    }],
+    "labels": ["id=server"]
+},{
+    "endpointSelector": {"matchLabels":{"id.httpd":""}},
+    "ingress": [{
+        "fromEndpoints": [
+	    {"matchLabels":{"id.curl":""}}
+	],
+	"toPorts": [
+	    {"ports": [{"port": "80", "protocol": "tcp"}]}
+	]
+    }],
+    "labels": ["id=httpd"]
+},{
+    "endpointSelector": {"matchLabels":{"id.httpd":""}},
+    "ingress": [{
+        "fromEndpoints": [
+	    {"matchLabels":{"id.curl2":""}}
+	],
+	"toPorts": [
+	    {"ports": [{"port": "8080", "protocol": "tcp"}]}
+	]
+    }],
+    "labels": ["id=httpd"]
+},{
+    "endpointSelector": {"matchLabels":{"id.httpd_deny":""}},
+    "ingress": [{
+        "fromEndpoints": [
+	    {"matchLabels":{"id.curl":""}}
+	],
+	"toPorts": [
+	    {"ports": [{"port": "9090", "protocol": "tcp"}]}
+	]
+    }],
+    "labels": ["id=httpd_deny"]
+}]


### PR DESCRIPTION
The test `RuntimeValidatedConntrackTest` was not properly testing the Conntrack
and ConntrackLocal endpoint configuration options. To start, it was testing
Cilium in its default policy enforcement mode, which by default allows all
traffic for endpoints which no rules select in the policy repository. This is an
issue because the test was ran with no policy imported, meaning that the
configuration flags were not really being tested appropriately.

The following changes were made to fix this, and to  ensure the test has true
parity with its Bash-script counterpart, `tests/01-ct.sh`:

* Import the same policy from the corresponding Bash test.
* Set policy enforcement mode for Cilium to be 'always'.
* Add checks for curl, and bidirectional connectivity.

The following changes were made to enhance the test:

* Miscellaneous variable renaming to make it easier to read the test code.
* Combining all Its into one It, which results in the containers used for the
tests only having to be launched and removed once, instead of three times (one
for each previous It).
* Directly porting `connectivity_test` from the Bash test to Ginkgo.

Also made logs in `test/helpers/cilium.go:PolicyImportAndWait` use logrus
Fields to reduce the amount of custom string formatting in its log messages.

Signed-off by: Ian Vernon <ian@cilium.io>"


Fixes: #2835
Related-to: #1841 

```release-note
Fix issues with endpoint Conntrack configuration tests
```

**How to test**:
```ginkgo --focus="RuntimeValidatedConntrackTest" -v```