### PR TITLE
test: change permissions for created log files

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -510,7 +510,7 @@ func (s *SSHMeta) ReportDump() {
 			err = ioutil.WriteFile(
 				fmt.Sprintf("%s/%s", testPath, fmt.Sprintf(logfile, ep)),
 				res.CombineOutput().Bytes(),
-				os.ModePerm)
+				LogPerm)
 
 			if err != nil {
 				s.logger.WithError(err).Errorf("cannot create test results for '%s'", command)
@@ -527,7 +527,7 @@ func (s *SSHMeta) ReportDump() {
 		err = ioutil.WriteFile(
 			fmt.Sprintf("%s/%s", testPath, fmt.Sprintf("identity_%s.txt", ep)),
 			res.CombineOutput().Bytes(),
-			os.ModePerm)
+			LogPerm)
 		if err != nil {
 			s.logger.WithError(err).Errorf("cannot create test results for identity get")
 		}

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -16,6 +16,7 @@ package helpers
 
 import (
 	"fmt"
+	"os"
 	"time"
 )
 
@@ -92,6 +93,10 @@ const (
 	// IP Address families.
 	IPv4 = "IPv4"
 	IPv6 = "IPv6"
+
+	// LogPerm is the permission for files that are created by this framework
+	// that contain logs, outputs of Cilium CLI commands, etc.
+	LogPerm = os.FileMode(0666)
 
 	// Configuration options for endpoints. Copied from endpoint/endpoint.go
 	// TODO: these should be converted into types for use in configuration

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -669,7 +669,7 @@ func (kub *Kubectl) CiliumReportDump(namespace string, pod string) {
 			err = ioutil.WriteFile(
 				fmt.Sprintf("%s/%s", testPath, fmt.Sprintf(logfile, ep)),
 				res.CombineOutput().Bytes(),
-				os.ModePerm)
+				LogPerm)
 			if err != nil {
 				kub.logger.WithError(err).Errorf(
 					"cannot create test results for command '%s'", command)
@@ -684,7 +684,7 @@ func (kub *Kubectl) CiliumReportDump(namespace string, pod string) {
 		err = ioutil.WriteFile(
 			fmt.Sprintf("%s/%s", testPath, fmt.Sprintf("identity_%s.txt", id)),
 			res.CombineOutput().Bytes(),
-			os.ModePerm)
+			LogPerm)
 		if err != nil {
 			kub.logger.WithError(err).Errorf("cannot create test results for command '%s'", cmd)
 		}

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -183,7 +183,7 @@ func reportMap(path string, reportCmds map[string]string, node *SSHMeta) {
 		err := ioutil.WriteFile(
 			fmt.Sprintf("%s/%s", path, logfile),
 			res.CombineOutput().Bytes(),
-			os.ModePerm)
+			LogPerm)
 		if err != nil {
 			log.WithError(err).Errorf("cannot create test results for command '%s'", cmd)
 		}

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -221,7 +221,7 @@ var _ = AfterEach(func() {
 	err = ioutil.WriteFile(
 		filePath,
 		config.TestLogWriter.Bytes(),
-		os.ModePerm)
+		helpers.LogPerm)
 	if err != nil {
 		log.WithError(err).Errorf("cannot create log file '%s'", filePath)
 		return


### PR DESCRIPTION
The log files were set with 0777 permissions, resulting in them being
executable. This made viewing logs in a text editor on MacOS cumbersome. Change
default log file permission to 0666.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #2557 