### PR TITLE
pkg/bpf: Unify dumping for all maps

### DIFF
--- a/cilium/cmd/bpf_proxy_list.go
+++ b/cilium/cmd/bpf_proxy_list.go
@@ -15,15 +15,11 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
-	"text/tabwriter"
 
 	"github.com/cilium/cilium/common"
-	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/command"
-	"github.com/cilium/cilium/pkg/proxy"
-
+	"github.com/cilium/cilium/pkg/maps/proxymap"
 	"github.com/spf13/cobra"
 )
 
@@ -32,16 +28,20 @@ const (
 	destinationTitle = "DESTINATION"
 )
 
-var proxyList = map[string]string{}
-
 // bpfProxyListCmd represents the bpf_proxy_list command
 var bpfProxyListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List proxy configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf proxy list")
-		proxy.Dump(dumpProxy4)
-		proxy.Dump6(dumpProxy6)
+
+		proxyList := make(map[string][]string)
+		if err := proxymap.Proxy4Map.Dump(proxyList); err != nil {
+			os.Exit(1)
+		}
+		if err := proxymap.Proxy6Map.Dump(proxyList); err != nil {
+			os.Exit(1)
+		}
 
 		if command.OutputJSON() {
 			if err := command.PrintOutput(proxyList); err != nil {
@@ -50,30 +50,11 @@ var bpfProxyListCmd = &cobra.Command{
 			return
 		}
 
-		w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
-
-		fmt.Fprintf(w, "%s\t%s\t\n", proxyTitle, destinationTitle)
-		for k, v := range proxyList {
-			fmt.Fprintf(w, "%s\t%s\t\n", k, v)
-		}
-
-		w.Flush()
+		TablePrinter(proxyTitle, destinationTitle, proxyList)
 	},
 }
 
 func init() {
 	bpfProxyCmd.AddCommand(bpfProxyListCmd)
 	command.AddJSONOutput(bpfProxyListCmd)
-}
-
-func dumpProxy4(key bpf.MapKey, value bpf.MapValue) {
-	proxyKey := key.(*proxy.Proxy4Key)
-	proxyValue := value.(*proxy.Proxy4Value)
-	proxyList[proxyKey.String()] = proxyValue.String()
-}
-
-func dumpProxy6(key bpf.MapKey, value bpf.MapValue) {
-	proxyKey := key.(*proxy.Proxy6Key)
-	proxyValue := value.(*proxy.Proxy6Value)
-	proxyList[proxyKey.String()] = proxyValue.String()
 }

--- a/cilium/cmd/helpers.go
+++ b/cilium/cmd/helpers.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"text/tabwriter"
 
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/identity"
@@ -87,6 +88,26 @@ func requireServiceID(cmd *cobra.Command, args []string) {
 	if args[0] == "" {
 		Usagef(cmd, "Empty service id argument")
 	}
+}
+
+// TablePrinter prints the map[string][]string, which is an usual representation
+// of dumped BPF map, using tabwriter.
+func TablePrinter(firstTitle, secondTitle string, data map[string][]string) {
+	w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
+
+	fmt.Fprintf(w, "%s\t%s\t\n", firstTitle, secondTitle)
+
+	for key, value := range data {
+		for k, v := range value {
+			if k == 0 {
+				fmt.Fprintf(w, "%s\t%s\t\n", key, v)
+			} else {
+				fmt.Fprintf(w, "%s\t%s\t\n", "", v)
+			}
+		}
+	}
+
+	w.Flush()
 }
 
 // Search 'result' for strings with escaped JSON inside, and expand the JSON.

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -813,7 +813,7 @@ func (d *Daemon) init() error {
 		}
 
 		// Clean all endpoint entries
-		if err := lxcmap.DeleteAll(); err != nil {
+		if err := lxcmap.LXCMap.DeleteAll(); err != nil {
 			return err
 		}
 

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -545,24 +545,20 @@ func (d *Daemon) SyncLBMap() error {
 	if !d.conf.IPv4Disabled {
 		// lbmap.RRSeq4Map is updated as part of Service4Map and does
 		// not need separate dump.
-		err := lbmap.Service4Map.Dump(lbmap.Service4DumpParser, parseSVCEntries)
-		if err != nil {
+		if err := lbmap.Service4Map.DumpWithCallback(parseSVCEntries); err != nil {
 			log.WithError(err).Warn("error dumping Service4Map")
 		}
-		err = lbmap.RevNat4Map.Dump(lbmap.RevNat4DumpParser, parseRevNATEntries)
-		if err != nil {
+		if err := lbmap.RevNat4Map.DumpWithCallback(parseRevNATEntries); err != nil {
 			log.WithError(err).Warn("error dumping RevNat4Map")
 		}
 	}
 
 	// lbmap.RRSeq6Map is updated as part of Service6Map and does not need
 	// separate dump.
-	err := lbmap.Service6Map.Dump(lbmap.Service6DumpParser, parseSVCEntries)
-	if err != nil {
+	if err := lbmap.Service6Map.DumpWithCallback(parseSVCEntries); err != nil {
 		log.WithError(err).Warn("error dumping Service6Map")
 	}
-	lbmap.RevNat6Map.Dump(lbmap.RevNat6DumpParser, parseRevNATEntries)
-	if err != nil {
+	if err := lbmap.RevNat6Map.DumpWithCallback(parseRevNATEntries); err != nil {
 		log.WithError(err).Warn("error dumping RevNat6Map")
 	}
 

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -57,9 +57,6 @@ type CtType int
 type CtKey interface {
 	bpf.MapKey
 
-	// Returns human readable string representation
-	String() string
-
 	// ToNetwork converts fields to network byte order.
 	ToNetwork() CtKey
 
@@ -87,6 +84,20 @@ type CtEntry struct {
 
 // GetValuePtr returns the unsafe.Pointer for s.
 func (c *CtEntry) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(c) }
+
+// String returns the readable format
+func (c *CtEntry) String() string {
+	return fmt.Sprintf("expires=%d rx_packets=%d rx_bytes=%d tx_packets=%d tx_bytes=%d flags=%x revnat=%d proxyport=%d src_sec_id=%d\n",
+		c.lifetime,
+		c.rx_packets,
+		c.rx_bytes,
+		c.tx_packets,
+		c.tx_bytes,
+		c.flags,
+		byteorder.NetworkToHost(c.revnat),
+		byteorder.NetworkToHost(c.proxy_port),
+		c.src_sec_id)
+}
 
 // CtEntryDump represents the key and value contained in the conntrack map.
 type CtEntryDump struct {

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -41,9 +41,6 @@ const (
 type ServiceKey interface {
 	bpf.MapKey
 
-	// Returns human readable string representation
-	String() string
-
 	// Returns true if the key is of type IPv6
 	IsIPv6() bool
 
@@ -75,9 +72,6 @@ type ServiceKey interface {
 // ServiceValue is the interface describing protocol independent value for services map.
 type ServiceValue interface {
 	bpf.MapValue
-
-	// Returns human readable string representation
-	String() string
 
 	// Returns a RevNatKey matching a ServiceValue
 	RevNatKey() RevNatKey
@@ -119,6 +113,10 @@ type RRSeqValue struct {
 }
 
 func (s RRSeqValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(&s) }
+
+func (s RRSeqValue) String() string {
+	return fmt.Sprintf("count=%d idx=%v", s.Count, s.Idx)
+}
 
 func UpdateService(key ServiceKey, value ServiceValue) error {
 	log.WithFields(logrus.Fields{
@@ -195,9 +193,6 @@ type RevNatKey interface {
 
 	// Returns the key value
 	GetKey() uint16
-
-	// Return human readable string
-	String() string
 }
 
 type RevNatValue interface {
@@ -205,9 +200,6 @@ type RevNatValue interface {
 
 	// ToNetwork converts fields to network byte order.
 	ToNetwork() RevNatValue
-
-	// Return human readable string
-	String() string
 }
 
 func UpdateRevNat(key RevNatKey, value RevNatValue) error {

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -210,7 +210,7 @@ func (pm *PolicyMap) Close() error {
 func Validate(path string) (bool, error) {
 	dummy := bpf.NewMap(path, bpf.BPF_MAP_TYPE_HASH,
 		int(unsafe.Sizeof(policyKey{})),
-		int(unsafe.Sizeof(PolicyEntry{})), MAX_KEYS, 0)
+		int(unsafe.Sizeof(PolicyEntry{})), MAX_KEYS, 0, nil)
 
 	existing, err := bpf.OpenMap(path)
 	if err != nil {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maps/proxymap"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
@@ -365,7 +366,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, source Pr
 		go func() {
 			for {
 				time.Sleep(time.Duration(10) * time.Second)
-				if deleted := GC(); deleted > 0 {
+				if deleted := proxymap.GC(); deleted > 0 {
 					log.WithField("count", deleted).
 						Debug("Evicted entries from proxy table")
 				}

--- a/pkg/proxy/socket.go
+++ b/pkg/proxy/socket.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maps/proxymap"
 
 	"github.com/sirupsen/logrus"
 )
@@ -448,7 +449,7 @@ func lookupNewDest(remoteAddr string, dport uint16) (uint32, string, error) {
 	}
 
 	if pIP.To4() != nil {
-		key := &Proxy4Key{
+		key := &proxymap.Proxy4Key{
 			SPort:   uint16(sport),
 			DPort:   dport,
 			Nexthdr: 6,
@@ -456,7 +457,7 @@ func lookupNewDest(remoteAddr string, dport uint16) (uint32, string, error) {
 
 		copy(key.SAddr[:], pIP.To4())
 
-		val, err := LookupEgress4(key)
+		val, err := proxymap.LookupEgress4(key)
 		if err != nil {
 			return 0, "", fmt.Errorf("unable to find IPv4 proxy entry for %s: %s", key, err)
 		}
@@ -465,7 +466,7 @@ func lookupNewDest(remoteAddr string, dport uint16) (uint32, string, error) {
 		return val.SourceIdentity, val.HostPort(), nil
 	}
 
-	key := &Proxy6Key{
+	key := &proxymap.Proxy6Key{
 		SPort:   uint16(sport),
 		DPort:   dport,
 		Nexthdr: 6,
@@ -473,7 +474,7 @@ func lookupNewDest(remoteAddr string, dport uint16) (uint32, string, error) {
 
 	copy(key.SAddr[:], pIP.To16())
 
-	val, err := LookupEgress6(key)
+	val, err := proxymap.LookupEgress6(key)
 	if err != nil {
 		return 0, "", fmt.Errorf("unable to find IPv6 proxy entry for %s: %s", key, err)
 	}

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -88,7 +88,7 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 		}
 
 		status.ExpectSuccess()
-		Expect(status.IntOutput()).Should(Equal(4))
+		Expect(status.IntOutput()).Should(Equal(5))
 
 		By("Checking that BPF tunnels are working correctly")
 		tunnStatus := isNodeNetworkingWorking(kubectl, "zgroup=testDS")
@@ -122,7 +122,7 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 			}
 			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, cmds)
 		}
-		Expect(status.IntOutput()).Should(Equal(4))
+		Expect(status.IntOutput()).Should(Equal(5))
 
 		By("Checking that BPF tunnels are working correctly")
 		tunnStatus := isNodeNetworkingWorking(kubectl, "zgroup=testDS")


### PR DESCRIPTION
Before this change, every module in cilium/cmd which lists the
content of maps, implemented its own callback function for dumping
BPF maps as Go maps. That resulted in many copied&pasted code.

After introducing the Dump method for all maps, and moving the
functionality of dumping with custom callback function to
DumpWithCallback, we can get rid of repetetive code in CLI.

Signed-off-by: Michal Rostecki <mrostecki@suse.com>