### PR TITLE
release: Print the uploaded binaries in markdown

### DIFF
--- a/contrib/release/uploadrev
+++ b/contrib/release/uploadrev
@@ -105,6 +105,17 @@ function upload_all() {
 }
 
 function print_done() {
+  echo "--- markdown snippet for NEWS.rst  ---"
+  echo "Release binaries"
+  echo "----------------"
+  echo ""
+
+  cd $TARGET_DIR
+  for s in *.sha256sum; do
+    f=$(echo "$s" | sed s/\.sha256sum//)	
+    echo "* [$f](http://$DOMAIN/$REMOTE_DIR/$f) ([$(cat $s | cut -c1-20)](http://$DOMAIN/$REMOTE_DIR/$s))"
+  done
+  echo "--- end ---"
   echo "`tput setaf 2`DONE`tput sgr0` local files are in $TARGET_DIR."
 }
 


### PR DESCRIPTION
Extended the binary upload script to print the markdown required for the release:
https://github.com/cilium/cilium/releases/edit/v1.0.0-rc4

Release binaries
----------------

* [cilium-agent-x86_64](http://releases.cilium.io/v1.0.0-rc4/cilium-agent-x86_64) ([c58a3a05d8531bd8f677](http://releases.cilium.io/v1.0.0-rc4/cilium-agent-x86_64.sha256sum))
 * [cilium-bugtool-x86_64](http://releases.cilium.io/v1.0.0-rc4/cilium-bugtool-x86_64) ([5ba0547857d71a96d99c](http://releases.cilium.io/v1.0.0-rc4/cilium-bugtool-x86_64.sha256sum))
 * [cilium-health-x86_64](http://releases.cilium.io/v1.0.0-rc4/cilium-health-x86_64) ([f0015f1345e9bb7eccec](http://releases.cilium.io/v1.0.0-rc4/cilium-health-x86_64.sha256sum))
 * [cilium-node-monitor-x86_64](http://releases.cilium.io/v1.0.0-rc4/cilium-node-monitor-x86_64) ([81e189969dcf2a97aca3](http://releases.cilium.io/v1.0.0-rc4/cilium-node-monitor-x86_64.sha256sum))
 * [cilium-x86_64](http://releases.cilium.io/v1.0.0-rc4/cilium-x86_64) ([2f63b204753aa7a96bb0](http://releases.cilium.io/v1.0.0-rc4/cilium-x86_64.sha256sum))
 * [v1.0.0-rc4.tar.gz](http://releases.cilium.io/v1.0.0-rc4/v1.0.0-rc4.tar.gz) ([39ff5357ea5920af6bca](http://releases.cilium.io/v1.0.0-rc4/v1.0.0-rc4.tar.gz.sha256sum))
 * [v1.0.0-rc4.zip](http://releases.cilium.io/v1.0.0-rc4/v1.0.0-rc4.zip) ([1c371d84ccad990c6915](http://releases.cilium.io/v1.0.0-rc4/v1.0.0-rc4.zip.sha256sum))

Signed-off-by: Thomas Graf <thomas@cilium.io>