### PR TITLE
Add cluster health summary to `cilium status`

### DIFF
--- a/Documentation/cmdref/cilium-health_status.md
+++ b/Documentation/cmdref/cilium-health_status.md
@@ -18,7 +18,8 @@ cilium-health status
 ```
   -o, --output string   json| jsonpath='{}'
       --probe           Synchronously probe connectivity status
-      --verbose         Print the result verbosely
+      --succinct        Print the result succinctly (one node per line)
+      --verbose         Print more information in results
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium_status.md
+++ b/Documentation/cmdref/cilium_status.md
@@ -18,10 +18,11 @@ cilium status
 ```
       --all-addresses     Show all allocated addresses, not just count
       --all-controllers   Show all controllers, not just failing
+      --all-health        Show all health status, not just failing
       --all-nodes         Show all nodes, not just localhost
       --brief             Only print a one-line status message
   -o, --output string     json| jsonpath='{}'
-      --verbose           Equivalent to --all-addresses --all-controllers --all-nodes
+      --verbose           Equivalent to --all-addresses --all-controllers --all-nodes --all-health
 ```
 
 ### Options inherited from parent commands

--- a/cilium-health/cmd/status.go
+++ b/cilium-health/cmd/status.go
@@ -26,8 +26,9 @@ import (
 )
 
 var (
-	probe   bool
-	verbose bool
+	probe    bool
+	succinct bool
+	verbose  bool
 )
 
 // statusGetCmd represents the status command
@@ -58,7 +59,7 @@ var statusGetCmd = &cobra.Command{
 			}
 		} else {
 			w := tabwriter.NewWriter(os.Stdout, 2, 0, 3, ' ', 0)
-			clientPkg.FormatHealthStatusResponse(w, sr, verbose)
+			clientPkg.FormatHealthStatusResponse(w, sr, true, succinct, verbose, 0)
 			w.Flush()
 		}
 	},
@@ -68,7 +69,9 @@ func init() {
 	rootCmd.AddCommand(statusGetCmd)
 	statusGetCmd.Flags().BoolVarP(&probe, "probe", "", false,
 		"Synchronously probe connectivity status")
+	statusGetCmd.Flags().BoolVarP(&succinct, "succinct", "", false,
+		"Print the result succinctly (one node per line)")
 	statusGetCmd.Flags().BoolVarP(&verbose, "verbose", "", false,
-		"Print the result verbosely")
+		"Print more information in results")
 	command.AddJSONOutput(statusGetCmd)
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -15,7 +15,6 @@
 package client
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"net"
@@ -106,26 +105,6 @@ func Hint(err error) error {
 		return fmt.Errorf("%s\nIs the agent running?", e)
 	}
 	return fmt.Errorf("%s", e)
-}
-
-func formatNodeAddress(w io.Writer, elem *models.NodeAddressingElement, title, prefix string) bool {
-	if elem.Enabled || title == "" {
-		if title != "" {
-			fmt.Fprintf(w, "%s%s Address:\t%s\n", prefix, title, elem.IP)
-		} else {
-			fmt.Fprintf(w, "%s%s:\n", prefix, elem.IP)
-		}
-		if elem.AddressType != "" {
-			fmt.Fprintf(w, "%s Type:\t%s\n", prefix, elem.AddressType)
-		}
-		if elem.AllocRange != "" {
-			fmt.Fprintf(w, "%sAllocRange:\t%s\n", prefix, elem.AllocRange)
-		}
-
-		return true
-	}
-
-	return false
 }
 
 func timeSince(since time.Time) string {
@@ -261,37 +240,6 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, allAddresses, 
 		if allAddresses {
 			for _, ipv6 := range sr.IPAM.IPV6 {
 				fmt.Fprintf(w, "  %s\n", ipv6)
-			}
-		}
-	}
-
-	if sr.Cluster != nil {
-		fmt.Fprintf(w, "Known cluster nodes:\t%d\n", len(sr.Cluster.Nodes))
-		for _, node := range sr.Cluster.Nodes {
-			localStr := ""
-			if node.Name == sr.Cluster.Self {
-				localStr = " (localhost)"
-			} else if !allNodes {
-				continue
-			}
-			fmt.Fprintf(w, " %s%s:\n", node.Name, localStr)
-			formatNodeAddress(w, node.PrimaryAddress.IPV4, "Primary", "  ")
-			formatNodeAddress(w, node.PrimaryAddress.IPV6, "Primary", "  ")
-
-			buf := new(bytes.Buffer)
-			secondary := false
-			fmt.Fprintf(buf, "  Secondary Addresses:\n")
-			for _, elem := range node.SecondaryAddresses {
-				if formatNodeAddress(buf, elem, "", "   ") {
-					secondary = true
-				}
-			}
-			if secondary {
-				fmt.Fprintf(w, "%s", buf.String())
-			}
-			if node.HealthEndpointAddress != nil {
-				formatNodeAddress(w, node.HealthEndpointAddress.IPV4, "Health Endpoint", "  ")
-				formatNodeAddress(w, node.HealthEndpointAddress.IPV6, "Health Endpoint", "  ")
 			}
 		}
 	}

--- a/pkg/health/client/client.go
+++ b/pkg/health/client/client.go
@@ -216,3 +216,24 @@ func FormatHealthStatusResponse(w io.Writer, sr *models.HealthStatusResponse, pr
 		fmt.Fprintf(w, "  ...")
 	}
 }
+
+// GetAndFormatHealthStatus fetches the health status from the cilium-health
+// daemon via the default channel and formats its output as a string to the
+// writer.
+//
+// 'succinct', 'verbose' and 'maxLines' are handled the same as in
+// FormatHealthStatusResponse().
+func GetAndFormatHealthStatus(w io.Writer, succinct, verbose bool, maxLines int) {
+	client, err := NewClient("")
+	if err != nil {
+		fmt.Fprintf(w, "Cluster health:\t\t\tClient error: %s\n", err)
+		return
+	}
+	hr, err := client.Connectivity.GetStatus(nil)
+	if err != nil {
+		// The regular `cilium status` output will print the reason why.
+		fmt.Fprintf(w, "Cluster health:\t\t\tWarning\tcilium-health daemon unreachable\n")
+		return
+	}
+	FormatHealthStatusResponse(w, hr.Payload, verbose, succinct, verbose, maxLines)
+}


### PR DESCRIPTION
This PR depends on ~#2852~ and ~#2821~.

This PR adds a cluster status to `cilium status` via an API call to                                                                                                                                                                                        
`cilium-health`. By default, it prints a single line listing how many           
nodes are reachable and the timestamp:                                          
                                                                                
    $ cilium status                                                             
    ...                                                                         
    Cluster health:   1/1 reachable   (2018-02-16T13:25:53-08:00)               
                                                                                
If any nodes or health endpoints are unexpectedly unreachable, they will be listed           
below this message (up to 10 entries by default).                               
                                                                                
In verbose mode (`--all-health` or `--verbose`), it also prints every node and its status:                      
                                                                                
    $ cilium status --all-health                                                
    Cluster health:   1/1 reachable   (2018-02-16T13:30:53-08:00)               
      Name            IP              Reachable   Endpoints reachable           
      cilium-master   10.0.2.15       true        false 