### PR TITLE
Close Kafka connections on redirect removal

### DIFF
--- a/pkg/proxy/defaults.go
+++ b/pkg/proxy/defaults.go
@@ -26,5 +26,5 @@ const (
 	// proxyConnectionCloseTimeout is the time to wait before closing both
 	// connections of a proxied connection after one side has initiated the
 	// closing and the other side is not being closed.
-	proxyConnectionCloseTimeout = time.Minute * 2
+	proxyConnectionCloseTimeout = 1 * time.Minute
 )

--- a/pkg/proxy/dialer.go
+++ b/pkg/proxy/dialer.go
@@ -15,7 +15,6 @@
 package proxy
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"os"
@@ -67,14 +66,4 @@ func ciliumDialer(identity int, network, address string) (net.Conn, error) {
 	}
 
 	return c, nil
-}
-
-func ciliumDialerWithContext(ctx context.Context, network, address string) (net.Conn, error) {
-	identity := 0
-
-	if id, ok := identityFromContext(ctx); ok {
-		identity = id
-	}
-
-	return ciliumDialer(identity, network, address)
 }

--- a/pkg/proxy/kafka_test.go
+++ b/pkg/proxy/kafka_test.go
@@ -265,5 +265,5 @@ func (k *proxyTestSuite) TestKafkaRedirect(c *C) {
 
 	// In order to see in the logs that the connections get closed after the
 	// 1-minute timeout, uncomment this line:
-	// time.Sleep(2 * Minute)
+	// time.Sleep(2 * time.Minute)
 }

--- a/pkg/proxy/kafka_test.go
+++ b/pkg/proxy/kafka_test.go
@@ -260,7 +260,10 @@ func (k *proxyTestSuite) TestKafkaRedirect(c *C) {
 	_, err = producer.Produce("disallowedTopic", 0, messages...)
 	c.Assert(err, Equals, proto.ErrTopicAuthorizationFailed)
 
-	log.Debug("Testing done, closing socket")
+	log.Debug("Testing done, closing listen socket")
+	redir.Close(nil)
 
-	broker.Close()
+	// In order to see in the logs that the connections get closed after the
+	// 1-minute timeout, uncomment this line:
+	// time.Sleep(2 * Minute)
 }

--- a/pkg/proxy/socket.go
+++ b/pkg/proxy/socket.go
@@ -15,29 +15,38 @@
 package proxy
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"os"
 	"strconv"
-	"sync/atomic"
+	"sync"
 	"syscall"
 	"time"
 
 	"github.com/cilium/cilium/pkg/flowdebug"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
 	"github.com/sirupsen/logrus"
 )
 
 const (
-	fieldConn = "conn"
-	fieldSize = "size"
+	fieldConn     = "conn"
+	fieldSize     = "size"
+	fieldConnPair = "connPair"
 )
 
 type proxySocket struct {
+	// listener is the TCP listener.
 	listener net.Listener
-	closing  chan struct{}
+
+	// locker protects closing the closing channel and accessing pairs.
+	locker lock.Mutex
+
+	closing chan struct{}
+
+	// pairs is the set of active connection pairs.
+	pairs []*connectionPair
 }
 
 func listenSocket(address string, mark int) (*proxySocket, error) {
@@ -95,75 +104,126 @@ func listenSocket(address string, mark int) (*proxySocket, error) {
 	return socket, nil
 }
 
-// Accept calls Accept() on the listen socket of the proxy
-func (s *proxySocket) Accept() (*connectionPair, error) {
+// Accept calls Accept() on the listen socket of the proxy.
+// If not nil, afterClose is called after the connection pair has been closed.
+// If cascadeClose is true, the returned connectionPair will immediately be
+// closed when this listen socket is closed.
+func (s *proxySocket) Accept(cascadeClose bool) (*connectionPair, error) {
 	c, err := s.listener.Accept()
 	if err != nil {
 		return nil, err
 	}
 
-	pair := newConnectionPair()
-	pair.rx.SetConnection(c)
+	var afterClose func(*connectionPair)
+	if cascadeClose {
+		afterClose = s.connectionPairClosed
+	}
+	pair := newConnectionPair(afterClose)
+
+	s.locker.Lock()
+	if cascadeClose {
+		s.pairs = append(s.pairs, pair)
+	}
+	pair.Rx.SetConnection(c)
+	s.locker.Unlock()
 
 	return pair, nil
 }
 
-// Close closes the proxy socket and stops accepting new connections
+func (s *proxySocket) connectionPairClosed(pair *connectionPair) {
+	scopedLog := log.WithField(fieldConnPair, pair)
+	scopedLog.Debug("Connection pair closed, removing from proxy socket cascading delete list")
+
+	s.locker.Lock()
+	defer s.locker.Unlock()
+	for i, p := range s.pairs {
+		if p == pair {
+			scopedLog.Debug("Connection pair removed from proxy socket cascading delete list")
+			// Delete the pair from the list.
+			numPairs := len(s.pairs)
+			s.pairs[i] = s.pairs[numPairs-1]
+			s.pairs = s.pairs[:numPairs-1]
+			return
+		}
+	}
+}
+
+// Close closes the proxy socket and stops accepting new connections.
 func (s *proxySocket) Close() {
+	s.locker.Lock()
+
+	select {
+	case <-s.closing:
+		s.locker.Unlock()
+		return
+	default:
+	}
+
 	close(s.closing)
 	s.listener.Close()
+
+	pairs := s.pairs
+	s.pairs = nil
+
+	s.locker.Unlock()
+
+	// Immediately close all connection pairs for which cascading close was
+	// requested in Accept.
+	for _, pair := range pairs {
+		pair.Rx.Close()
+	}
 }
 
 type socketQueue chan []byte
 
 type proxyConnection struct {
-	// isRequestDirection whether the connection represents
+	// isRequestDirection indicates the direction of the TCP connection:
+	// ingress/request (true) or egress/response (false).
 	isRequestDirection bool
 
-	// queueStopCount is > 0 if the queue has been stopped, it may only be
-	// read with queueStopped()
-	queueStopCount int32
+	// conn is the underlying TCP connection.
+	conn net.Conn
 
-	conn  net.Conn
+	// queue is the queue of messages to send.
 	queue socketQueue
 
-	stopQueue chan struct{}
+	// closeLocker is used to ensure the close channel may only be closed once.
+	closeLocker lock.Mutex
 
-	queueClose func()
+	// close is the channel that is closed to indicate that the connection
+	// must be closed. closeLocker must be held when attempting to close this
+	// channel to prevent closing it multiple times.
+	close chan struct{}
+
+	// afterClose is a function that is called after the connection's queue is
+	// closed.
+	afterClose func()
 }
 
-func newProxyConnection(rx bool, queueClose func()) *proxyConnection {
+func newProxyConnection(rx bool, afterClose func()) *proxyConnection {
 	return &proxyConnection{
 		isRequestDirection: rx,
 		queue:              make(socketQueue, socketQueueSize),
-		stopQueue:          make(chan struct{}),
-		queueClose:         queueClose,
+		close:              make(chan struct{}),
+		afterClose:         afterClose,
 	}
 }
 
 // SetConnection associates an established connection to the proxy connection.
-// It will also start a go routine to sync Enqueue()ed messages to the
-// connection
+// It starts a goroutine to write Enqueue()ed messages into the connection.
 func (c *proxyConnection) SetConnection(conn net.Conn) {
 	if c.conn != nil {
-		log.WithFields(logrus.Fields{
-			fieldConn: c,
-		}).Panic("Established connection is already associated")
+		log.WithField(fieldConn, c).Panic("Established connection is already associated")
 	}
 
 	c.conn = conn
-	c.startWriter()
-}
-
-func (c *proxyConnection) queueStopped() bool {
-	return atomic.LoadInt32(&c.queueStopCount) > 0
+	go c.writeQueuedMessages()
 }
 
 func fmtAddress(a net.Addr) string {
 	if a == nil {
 		return "nil"
 	}
-
 	return a.String()
 }
 
@@ -192,28 +252,35 @@ func (c *proxyConnection) String() string {
 		fmtAddress(c.conn.RemoteAddr()))
 }
 
-func (c *proxyConnection) startWriter() {
-	go c.socketWriter()
-}
-
-func (c *proxyConnection) socketWriter() {
-	defer c.queueClose()
+func (c *proxyConnection) writeQueuedMessages() {
+	scopedLog := log.WithField(fieldConn, c)
+	defer c.Close()
 
 	for {
 		select {
-		case <-c.stopQueue:
-			atomic.AddInt32(&c.queueStopCount, 1)
+		case <-c.close:
+			scopedLog.Debug("Connection closed, message queue exiting")
 			return
 
 		case msg, more := <-c.queue:
-			if more {
-				// write entire message to socket
-				_, err := c.conn.Write(msg)
-				if err != nil {
-					log.WithError(err).WithField(fieldConn, c).Warn("Error while writing to socket, closing socket")
-					return
-				}
-			} else {
+			if !more {
+				// This should never happen since the queue channel is never closed.
+				return
+			}
+
+			// Write the entire message into the socket.
+			_, err := c.conn.Write(msg)
+
+			// Ignore any write errors in case the socket has been closed by this proxy.
+			select {
+			case <-c.close:
+				scopedLog.Debug("Connection closed, message queue exiting")
+				return
+			default:
+			}
+
+			if err != nil {
+				scopedLog.WithError(err).Warn("Error while writing to socket, closing socket")
 				return
 			}
 		}
@@ -224,89 +291,116 @@ func (c *proxyConnection) direction() string {
 	if c.isRequestDirection {
 		return "request"
 	}
-
 	return "response"
 }
 
-// Enqueue queues a message to be written to the socket
+// Enqueue queues a message to be written into the connection.
 func (c *proxyConnection) Enqueue(msg []byte) {
 	scopedLog := log.WithFields(logrus.Fields{
 		fieldConn: c,
 		fieldSize: len(msg),
 	})
 
-	if c.queueStopped() {
-		flowdebug.Log(scopedLog, "Dropping message, queue is stopped")
-		return
-	}
-
 	flowdebug.Log(scopedLog, fmt.Sprintf("Enqueueing %s message", c.direction()))
 
-	c.queue <- msg
+	select {
+	case <-c.close:
+		flowdebug.Log(scopedLog, fmt.Sprintf("%s connection is closed; dropping message", c.direction()))
+	case c.queue <- msg:
+		flowdebug.Log(scopedLog, fmt.Sprintf("Enqueued %s message", c.direction()))
+	}
 }
 
-// Close schedules closing of one side of the proxied connection. It will drain
-// the queue and then mark the connection to be closed. The connections are closed
-// simultaneously after both connections have been queued for closing or after
-// proxyConnectionCloseTimeout
+// Close closes this connection.
+// The connection on the other side of the proxy is closed after it is queued
+// for closing or after proxyConnectionCloseTimeout.
 func (c *proxyConnection) Close() {
-	// stop writer queue and wait for the queue to be drained
-	close(c.stopQueue)
-}
+	scopedLog := log.WithField(fieldConn, c)
 
-func (c *proxyConnection) realClose() {
-	flowdebug.Log(log.WithField(fieldConn, c), "Closing socket")
+	c.closeLocker.Lock()
+	select {
+	case <-c.close:
+		// Already closed. Nothing to do.
+		c.closeLocker.Unlock()
+		return
+	default:
+	}
+	// Cause writeQueuedMessages to terminate.
+	close(c.close)
+	c.closeLocker.Unlock()
 
-	close(c.queue)
-
+	// Actually close the TCP connection. This will unblock any eventually
+	// blocking c.conn.Write call in writeQueuedMessages.
 	if !c.Closed() {
+		scopedLog.Debug("Closing socket")
 		c.conn.Close()
 	}
+
+	// Call connectionPair.close() concurrently so that this call doesn't block
+	// while waiting for the other connection in the pair to close.
+	go c.afterClose()
 }
 
 type connectionPair struct {
-	// closingCount is used to count the close calls of both connection and
-	// only close both connections when both connections have triggered
-	// closure.
-	closingCount int32
-
-	rx, tx *proxyConnection
+	Rx, Tx         *proxyConnection
+	afterCloseOnce sync.Once
+	afterClose     func()
 }
 
-func newConnectionPair() *connectionPair {
+func newConnectionPair(afterClose func(*connectionPair)) *connectionPair {
 	pair := &connectionPair{}
-	pair.rx = newProxyConnection(true, pair.queueClose)
-	pair.tx = newProxyConnection(false, pair.queueClose)
-
+	pair.Rx = newProxyConnection(true, pair.close)
+	pair.Tx = newProxyConnection(false, pair.close)
+	if afterClose != nil {
+		pair.afterClose = func() { afterClose(pair) }
+	}
 	return pair
 }
 
 func (p *connectionPair) String() string {
-	return p.rx.String() + "<->" + p.tx.String()
+	return p.Rx.String() + "<->" + p.Tx.String()
 }
 
-func (p *connectionPair) closeBoth() {
-	p.rx.realClose()
-	p.tx.realClose()
-}
+func (p *connectionPair) close() {
+	scopedLog := log.WithField(fieldConnPair, p)
 
-func (p *connectionPair) queueClose() {
-	// If this is the first side to close the connection, keep it open
-	// until other side is closed or until timeout occurs
-	if v := atomic.AddInt32(&p.closingCount, 1); v == 1 {
-		time.AfterFunc(time.Minute, func() {
-			// test if the other connection is still alive before closing conn
-			if atomic.AddInt32(&p.closingCount, 1) == 2 {
-				p.closeBoth()
-			}
-		})
-	} else if v == 2 {
-		p.closeBoth()
+	// Wait for both Rx and Tx to be closed or for timeout.
+	timeout := time.NewTimer(proxyConnectionCloseTimeout)
+	var bothClosed bool
+	select {
+	case <-p.Rx.close:
+		scopedLog.Debug("Rx is already closed, waiting for Tx to close")
+		// Rx is closed. Wait for Tx to close or timeout.
+		select {
+		case <-p.Tx.close:
+			bothClosed = true
+		case <-timeout.C:
+			scopedLog.Debug("Timeout while waiting for Tx to close; closing Tx")
+			p.Tx.Close()
+		}
+	case <-p.Tx.close:
+		// Tx is closed. Wait for Rx to close or timeout.
+		scopedLog.Debug("Tx is already closed, waiting for Rx to close")
+		select {
+		case <-p.Rx.close:
+			bothClosed = true
+		case <-timeout.C:
+			scopedLog.Debug("Timeout while waiting for Rx to close; closing Rx")
+			p.Rx.Close()
+		}
+	default:
+		// This case should never be selected, since connectionPair.close() is
+		// called only from proxyConnection.Close() after the close channel is
+		// closed, so at least one of the cases above can always be selected.
 	}
-}
+	timeout.Stop()
 
-func (p *connectionPair) CloseRx() {
-	p.rx.conn.Close()
+	if bothClosed {
+		scopedLog.Debug("Both Rx and Tx are closed")
+		if p.afterClose != nil {
+			p.afterCloseOnce.Do(p.afterClose)
+		}
+	}
 }
 
 func lookupNewDest(remoteAddr string, dport uint16) (uint32, string, error) {
@@ -336,7 +430,7 @@ func lookupNewDest(remoteAddr string, dport uint16) (uint32, string, error) {
 
 		val, err := LookupEgress4(key)
 		if err != nil {
-			return 0, "", fmt.Errorf("Unable to find IPv4 proxy entry for %s: %s", key, err)
+			return 0, "", fmt.Errorf("unable to find IPv4 proxy entry for %s: %s", key, err)
 		}
 
 		flowdebug.Log(log.WithField(logfields.Object, logfields.Repr(val)), "Found IPv4 proxy entry")
@@ -353,24 +447,11 @@ func lookupNewDest(remoteAddr string, dport uint16) (uint32, string, error) {
 
 	val, err := LookupEgress6(key)
 	if err != nil {
-		return 0, "", fmt.Errorf("Unable to find IPv6 proxy entry for %s: %s", key, err)
+		return 0, "", fmt.Errorf("unable to find IPv6 proxy entry for %s: %s", key, err)
 	}
 
 	flowdebug.Log(log.WithField(logfields.Object, logfields.Repr(val)), "Found IPv6 proxy entry")
 	return val.SourceIdentity, val.HostPort(), nil
-}
-
-type proxyIdentity int
-
-const identityKey proxyIdentity = 0
-
-func newIdentityContext(ctx context.Context, id int) context.Context {
-	return context.WithValue(ctx, identityKey, id)
-}
-
-func identityFromContext(ctx context.Context) (int, bool) {
-	val, ok := ctx.Value(identityKey).(int)
-	return val, ok
 }
 
 func setFdMark(fd, mark int) {


### PR DESCRIPTION
Make the connection and pair close methods idempotent: `proxyConnection.Close`, `proxyConnection.realClose`, `connectionPair.closeBoth`.

Simplify the implementation of proxyConnection.Close: replace the atomic int counter with checking whether the stopQueue channel is closed.

Add parameter to proxySocket.Accept to specify whether a connection pair is to be closed when the listen socket is closed.

Close Kafka connections in the proxy on redirect removal.
Set the `SO_LINGER` option on request sockets to bound their closing time, and close with a `RST` in case of close timeout.

Signed-off-by: Romain Lenglet <romain@covalent.io>