### PR TITLE
Support rolling update strategy for ds/cilium

### DIFF
--- a/examples/kubernetes/cilium.yaml
+++ b/examples/kubernetes/cilium.yaml
@@ -69,6 +69,13 @@ metadata:
   name: cilium
   namespace: kube-system
 spec:
+  updateStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
+      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
+      maxUnavailable: "100%"
   template:
     metadata:
       labels:

--- a/examples/minikube/cilium-ds.yaml
+++ b/examples/minikube/cilium-ds.yaml
@@ -73,6 +73,13 @@ metadata:
   name: cilium
   namespace: kube-system
 spec:
+  updateStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
+      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
+      maxUnavailable: "100%"
   template:
     metadata:
       labels:


### PR DESCRIPTION
Signed-off-by: Ashwin Paranjpe <ashwin@covalent.io>

**Summary of changes**:

```release-note
Update example cilium-ds.yaml files to support rolling updates.
```

**How to test (optional)**:
`kubectl set image daemonset/cilium -n kube-system cilium-agent=cilium/cilium:v0.13.4 &&  kubectl rollout status daemonset/cilium -n kube-system`
