### PR TITLE
endpoint: Stop using Consumable policy to store redirect ports

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -336,11 +336,11 @@ type Endpoint struct {
 	// other resources
 	controllers controller.Manager
 
-	// realizedRedirects is the set of IDs of proxy redirects that have
-	// been successfully added into proxies for this endpoint.
-	// Every value must be true.
-	// You must hold Endpoint.BuildMutex to read or write it.
-	realizedRedirects map[string]bool
+	// realizedRedirects maps the ID of each proxy redirect that has been
+	// successfully added into a proxy for this endpoint, to the redirect's
+	// proxy port number.
+	// You must hold Endpoint.Mutex to read or write it.
+	realizedRedirects map[string]uint16
 
 	// ProxyWaitGroup waits for pending proxy changes to complete.
 	// You must hold Endpoint.BuildMutex to read or write it.
@@ -1272,12 +1272,12 @@ func (e *Endpoint) LeaveLocked(owner Owner) int {
 
 	owner.RemoveFromEndpointQueue(uint64(e.ID))
 	if c := e.Consumable; c != nil {
-		c.Mutex.RLock()
+		c.Mutex.Lock()
 		if e.L4Policy != nil {
 			// Passing a new map of nil will purge all redirects
 			e.removeOldRedirects(owner, nil)
 		}
-		c.Mutex.RUnlock()
+		c.Mutex.Unlock()
 	}
 
 	if e.PolicyMap != nil {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -115,7 +115,7 @@ func (e *Endpoint) removeOldFilter(owner Owner, labelsMap *policy.IdentityCache,
 	for _, sel := range filter.FromEndpoints {
 		for _, id := range getSecurityIdentities(labelsMap, &sel) {
 			srcID := id.Uint32()
-			l4RuleCtx, l7RuleCtx := policy.ParseL4Filter(*filter)
+			l4RuleCtx, l7RuleCtx := e.ParseL4Filter(filter)
 			if _, ok := fromEndpointsSrcIDs[id]; !ok {
 				fromEndpointsSrcIDs[id] = policy.NewL4RuleContexts()
 			}
@@ -166,7 +166,7 @@ func (e *Endpoint) applyNewFilter(owner Owner, labelsMap *policy.IdentityCache,
 				e.getLogger().WithField("l4Filter", filter).Debug("L4 filter exists")
 				continue
 			}
-			l4RuleCtx, l7RuleCtx := policy.ParseL4Filter(*filter)
+			l4RuleCtx, l7RuleCtx := e.ParseL4Filter(filter)
 			if _, ok := fromEndpointsSrcIDs[id]; !ok {
 				fromEndpointsSrcIDs[id] = policy.NewL4RuleContexts()
 			}
@@ -337,7 +337,7 @@ func (e *Endpoint) regenerateConsumable(owner Owner, labelsMap *policy.IdentityC
 		if c != nil && c.L4Policy != nil && c.L4Policy.Ingress != nil {
 			for _, l4Filter := range c.L4Policy.Ingress {
 				found := false
-				l4RuleCtx, l7RuleCtx := policy.ParseL4Filter(l4Filter)
+				l4RuleCtx, l7RuleCtx := e.ParseL4Filter(&l4Filter)
 				for _, l4RuleContexts := range rulesAdd {
 					if _, found = l4RuleContexts[l4RuleCtx]; found {
 						break

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -121,9 +121,9 @@ func (s *K8sSuite) TestParseNetworkPolicy(c *C) {
 		Ingress: policy.L4PolicyMap{
 			"80/TCP": {
 				Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
-				FromEndpoints:  []api.EndpointSelector{epSelector},
-				L7Parser:       "",
-				L7RedirectPort: 0, L7RulesPerEp: policy.L7DataMap{},
+				FromEndpoints:    []api.EndpointSelector{epSelector},
+				L7Parser:         "",
+				L7RulesPerEp:     policy.L7DataMap{},
 				Ingress:          true,
 				DerivedFromRules: []labels.LabelArray{labels.ParseLabelArray("unspec:io.cilium.k8s-policy-name", "unspec:io.cilium.k8s-policy-namespace=default")},
 			},

--- a/pkg/k8s/network_policy_v1beta_test.go
+++ b/pkg/k8s/network_policy_v1beta_test.go
@@ -109,9 +109,9 @@ func (s *K8sSuite) TestParseNetworkPolicyDeprecated(c *C) {
 		Ingress: policy.L4PolicyMap{
 			"80/TCP": {
 				Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
-				FromEndpoints:  []api.EndpointSelector{epSelector},
-				L7Parser:       "",
-				L7RedirectPort: 0, L7RulesPerEp: policy.L7DataMap{},
+				FromEndpoints:    []api.EndpointSelector{epSelector},
+				L7Parser:         "",
+				L7RulesPerEp:     policy.L7DataMap{},
 				Ingress:          true,
 				DerivedFromRules: []labels.LabelArray{labels.ParseLabelArray("unspec:io.cilium.k8s-policy-name", "unspec:io.cilium.k8s-policy-namespace=default")},
 			},

--- a/pkg/policy/identity.go
+++ b/pkg/policy/identity.go
@@ -147,17 +147,6 @@ func (rc L4RuleContext) PortProto() string {
 	return port + "/" + proto
 }
 
-// ParseL4Filter parses a L4Filter and returns a L4RuleContext and a
-// L7RuleContext with L4Installed set as false.
-func ParseL4Filter(filter L4Filter) (L4RuleContext, L7RuleContext) {
-	return L4RuleContext{
-			Port:  byteorder.HostToNetwork(uint16(filter.Port)).(uint16),
-			Proto: uint8(filter.U8Proto),
-		}, L7RuleContext{
-			RedirectPort: byteorder.HostToNetwork(uint16(filter.L7RedirectPort)).(uint16),
-		}
-}
-
 // Identity is the representation of the security context for a particular set of
 // labels.
 type Identity struct {

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -95,8 +95,6 @@ type L4Filter struct {
 	FromEndpoints []api.EndpointSelector `json:"-"`
 	// L7Parser specifies the L7 protocol parser (optional)
 	L7Parser L7ParserType `json:"-"`
-	// L7RedirectPort is the L7 proxy port to redirect to (optional)
-	L7RedirectPort int `json:"l7-redirect-port,omitempty"`
 	// L7RulesPerEp is a list of L7 rules per endpoint passed to the L7 proxy (optional)
 	L7RulesPerEp L7DataMap `json:"l7-rules,omitempty"`
 	// Ingress is true if filter applies at ingress
@@ -168,7 +166,6 @@ func CreateL4Filter(fromEndpoints []api.EndpointSelector, rule api.PortRule, por
 		Port:             int(p),
 		Protocol:         protocol,
 		U8Proto:          u8p,
-		L7RedirectPort:   0,
 		L7RulesPerEp:     make(L7DataMap),
 		FromEndpoints:    fromEndpoints,
 		DerivedFromRules: labels.LabelArrayList{ruleLabels},

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -120,15 +120,6 @@ func mergeL4Port(ctx *SearchContext, fromEndpoints []api.EndpointSelector, r api
 		}
 	}
 
-	if l4Filter.L7RedirectPort != 0 {
-		if v.L7RedirectPort == 0 {
-			v.L7RedirectPort = l4Filter.L7RedirectPort
-		} else if l4Filter.L7RedirectPort != v.L7RedirectPort {
-			ctx.PolicyTrace("   Merge conflict: mismatching redirect ports %d/%d\n", l4Filter.L7RedirectPort, v.L7RedirectPort)
-			return 0, fmt.Errorf("Cannot merge conflicting redirect ports (%d/%d)", l4Filter.L7RedirectPort, v.L7RedirectPort)
-		}
-	}
-
 	if v.addFromEndpoints(fromEndpoints) && r.NumRules() == 0 {
 		// skip this policy as it is already covered and it does not contain L7 rules
 		return 1, nil

--- a/pkg/proxy/kafka_test.go
+++ b/pkg/proxy/kafka_test.go
@@ -187,10 +187,9 @@ func (k *proxyTestSuite) TestKafkaRedirect(c *C) {
 
 	redir, err := createKafkaRedirect(kafkaConfiguration{
 		policy: &policy.L4Filter{
-			Port:           serverPort,
-			Protocol:       api.ProtoTCP,
-			L7Parser:       policy.ParserTypeKafka,
-			L7RedirectPort: proxyPort,
+			Port:     serverPort,
+			Protocol: api.ProtoTCP,
+			L7Parser: policy.ParserTypeKafka,
 			L7RulesPerEp: policy.L7DataMap{
 				policy.WildcardEndpointSelector: api.L7Rules{
 					Kafka: []api.PortRuleKafka{kafkaRule1, kafkaRule2},


### PR DESCRIPTION
The Consumable's L4Policy was used to store endpoint-specific proxy redirect ports. Therefore, if two or more endpoints had the same security identity on the same node, only the first of those endpoints to be regenerated would have proxy redirects created, and all other endpoints would incorrectly use the same proxy redirects.

Remove the L7RedirectPort from L4Filter, so that it now contains only desired state. Replace it with storing the redirect ports in each endpoint's realizedRedirects map. Ensure all accesses to realizedRedirects are protected by the Endpoint.Mutex.

Signed-off-by: Romain Lenglet <romain@covalent.io>