### PR TITLE
endpoint: sync endpoint IP-SecurityID mapping to kvstore

### DIFF
--- a/common/addressing/ip.go
+++ b/common/addressing/ip.go
@@ -32,6 +32,7 @@ type CiliumIP interface {
 	IP() net.IP
 	String() string
 	IsIPv6() bool
+	GetFamilyString() string
 }
 
 type CiliumIPv6 []byte
@@ -278,4 +279,14 @@ func (ip CiliumIPv4) NodeIP() net.IP {
 	nodeIP[3] = 1
 
 	return nodeIP
+}
+
+// GetFamilyString returns the address family of ip as a string.
+func (ip CiliumIPv4) GetFamilyString() string {
+	return "IPv4"
+}
+
+// GetFamilyString returns the address family of ip as a string.
+func (ip CiliumIPv6) GetFamilyString() string {
+	return "IPv6"
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipam"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
@@ -1050,6 +1051,9 @@ func NewDaemon(c *Config) (*Daemon, error) {
 	// This needs to be done after the node addressing has been configured
 	// as the node address is required as sufix
 	identity.InitIdentityAllocator(&d)
+
+	// Start watcher for endpoint IP --> identity mappings in key-value store.
+	ipcache.InitIPIdentityWatcher(&d)
 
 	if !d.conf.IPv4Disabled {
 		// Allocate IPv4 service loopback IP

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -679,3 +679,9 @@ func (h *putEndpointIDLabels) Handle(params PutEndpointIDLabelsParams) middlewar
 	}
 	return NewPutEndpointIDLabelsOK()
 }
+
+// OnIPIdentityCacheChange is called whenever there is a change of state in the
+// IPCache (pkg/ipcache). Currently does nothing as of now.
+func (d *Daemon) OnIPIdentityCacheChange() {
+
+}

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -15,6 +15,8 @@
 package identity
 
 import (
+	"net"
+
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/labels"
 )
@@ -28,6 +30,18 @@ type Identity struct {
 	Labels labels.Labels `json:"labels"`
 	// SHA256 of labels.
 	LabelsSHA256 string `json:"labelsSHA256"`
+}
+
+// IPIdentityPair is a pairing of an IP and the security identity to which that
+// IP corresponds.
+//
+// WARNING - STABLE API
+// This structure is written as JSON to the key-value store. Do NOT modify this
+// structure in ways which are not JSON forward compatible.
+type IPIdentityPair struct {
+	IP       net.IP          `json:"IP"`
+	ID       NumericIdentity `json:"ID"`
+	Metadata string          `json:"Metadata"`
 }
 
 func NewIdentityFromModel(base *models.Identity) *Identity {

--- a/pkg/ipcache/config.go
+++ b/pkg/ipcache/config.go
@@ -1,0 +1,21 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipcache
+
+import "github.com/cilium/cilium/pkg/logging"
+
+var (
+	log = logging.DefaultLogger
+)

--- a/pkg/ipcache/doc.go
+++ b/pkg/ipcache/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ipcache provides a local cache of the mapping of IPs of endpoints
+// managed by Cilium to their corresponding security identities.
+package ipcache

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -1,0 +1,232 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipcache
+
+import (
+	"encoding/json"
+	"path"
+	"sort"
+	"sync"
+
+	"github.com/cilium/cilium/pkg/envoy"
+	envoyAPI "github.com/cilium/cilium/pkg/envoy/cilium"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// DefaultAddressSpace is the address space used if none is provided.
+	// TODO - once pkg/node adds this to clusterConfiguration, remove.
+	DefaultAddressSpace = "default"
+)
+
+var (
+	// IPIdentitiesPath is the path to where endpoint IPs are stored in the key-value
+	//store.
+	IPIdentitiesPath = path.Join(kvstore.BaseKeyPrefix, "state", "ip", "v1")
+
+	// IPIdentityCache caches the mapping of endpoint IPs to their corresponding
+	// security identities across the entire cluster in which this instance of
+	// Cilium is running.
+	IPIdentityCache = NewIPCache()
+
+	// AddressSpace is the address space (cluster, etc.) in which policy is
+	// computed. It is determined by the orchestration system / runtime.
+	AddressSpace = DefaultAddressSpace
+
+	setupIPIdentityWatcher sync.Once
+)
+
+// IPCache is a caching of endpoint IP to security identity (and vice-versa) for
+// all endpoints which are part of the same cluster.
+type IPCache struct {
+	mutex             lock.RWMutex
+	ipToIdentityCache map[string]identity.NumericIdentity
+	identityToIPCache map[identity.NumericIdentity]map[string]struct{}
+}
+
+// NewIPCache returns a new IPCache with the mappings of endpoint IP to security
+// identity (and vice-versa) initialized.
+func NewIPCache() *IPCache {
+	return &IPCache{
+		ipToIdentityCache: map[string]identity.NumericIdentity{},
+		identityToIPCache: map[identity.NumericIdentity]map[string]struct{}{},
+	}
+}
+
+// upsert adds / updates the provided IP and identity into both caches contained
+// within ipc.
+func (ipc *IPCache) upsert(endpointIP string, identity identity.NumericIdentity) {
+	ipc.mutex.Lock()
+	defer ipc.mutex.Unlock()
+
+	// An update is treated as a deletion and then an insert.
+	ipc.deleteLocked(endpointIP)
+
+	// Update both maps.
+	ipc.ipToIdentityCache[endpointIP] = identity
+
+	_, found := ipc.identityToIPCache[identity]
+	if !found {
+		ipc.identityToIPCache[identity] = map[string]struct{}{}
+	}
+	ipc.identityToIPCache[identity][endpointIP] = struct{}{}
+}
+
+// deleteLocked removes removes the provided IP-to-security-identity mapping
+// from both caches within ipc with the assumption that ipc's mutex is held.
+func (ipc *IPCache) deleteLocked(endpointIP string) {
+
+	identity, found := ipc.ipToIdentityCache[endpointIP]
+	if found {
+		delete(ipc.ipToIdentityCache, endpointIP)
+		delete(ipc.identityToIPCache[identity], endpointIP)
+		if len(ipc.identityToIPCache[identity]) == 0 {
+			delete(ipc.identityToIPCache, identity)
+		}
+	}
+}
+
+// delete removes the provided IP-to-security-identity mapping from both caches
+// within ipc.
+func (ipc *IPCache) delete(endpointIP string) {
+	ipc.mutex.Lock()
+	defer ipc.mutex.Unlock()
+	ipc.deleteLocked(endpointIP)
+}
+
+// LookupByIP returns the corresponding security identity that endpoint IP maps
+// to within the provided IPCache, as well as if the corresponding entry exists
+// in the IPCache.
+func (ipc *IPCache) LookupByIP(endpointIP string) (identity.NumericIdentity, bool) {
+	ipc.mutex.RLock()
+	defer ipc.mutex.RUnlock()
+	identity, exists := ipc.ipToIdentityCache[endpointIP]
+	return identity, exists
+}
+
+// LookupByIdentity returns the set of endpoint IPs that have security identity
+// ID, as well as if the corresponding entry exists in the IPCache.
+func (ipc *IPCache) LookupByIdentity(id identity.NumericIdentity) (map[string]struct{}, bool) {
+	ipc.mutex.RLock()
+	defer ipc.mutex.RUnlock()
+	ips, exists := ipc.identityToIPCache[id]
+	return ips, exists
+}
+
+// IPIdentityMappingOwner is the interface the owner of an identity allocator
+// must implement
+type IPIdentityMappingOwner interface {
+	// OnIPIdentityCacheChange will be called whenever there the state of the
+	// IPCache has changed.
+	OnIPIdentityCacheChange()
+}
+
+// GetIPIdentityMapModel returns all known endpoint IP to security identity mappings
+// stored in the key-value store.
+func GetIPIdentityMapModel() {
+	// TODO (ianvernon) return model of ip to identity mapping. For use in CLI.
+	// see GH-2555
+}
+
+func ipIdentityWatcher(owner IPIdentityMappingOwner) {
+
+	for {
+		watcher := kvstore.ListAndWatch("endpointIPWatcher", IPIdentitiesPath, 512)
+
+		// Get events from channel as they come in.
+		for event := range watcher.Events {
+
+			var (
+				cacheChanged bool
+				ipIDPair     identity.IPIdentityPair
+			)
+
+			err := json.Unmarshal(event.Value, &ipIDPair)
+			if err != nil {
+				log.WithFields(logrus.Fields{"value": event.Value}).WithError(err).Errorf("not adding entry to ip cache; error unmarshaling data from key-value store")
+				continue
+			}
+
+			// Synchronize local caching of endpoint IP to ipIDPair mapping with
+			// operation key-value store has informed us about.
+
+			ipStr := ipIDPair.IP.String()
+
+			cachedIdentity, exists := IPIdentityCache.LookupByIP(ipStr)
+
+			switch event.Typ {
+			case kvstore.EventTypeCreate, kvstore.EventTypeModify:
+				if !exists || cachedIdentity != ipIDPair.ID {
+					IPIdentityCache.upsert(ipStr, ipIDPair.ID)
+					cacheChanged = true
+
+					endpointIPs, _ := IPIdentityCache.LookupByIdentity(ipIDPair.ID)
+
+					// Update XDS Cache as well.
+					ipStrings := make([]string, 0, len(endpointIPs))
+					for endpointIP := range endpointIPs {
+						ipStrings = append(ipStrings, endpointIP)
+					}
+					sort.Strings(ipStrings)
+					envoy.NetworkPolicyHostsCache.Upsert(envoy.NetworkPolicyHostsTypeURL, ipIDPair.ID.StringID(), &envoyAPI.NetworkPolicyHosts{Policy: uint64(ipIDPair.ID), HostAddresses: ipStrings}, false)
+				}
+			case kvstore.EventTypeDelete:
+				if exists {
+					IPIdentityCache.delete(ipStr)
+					cacheChanged = true
+
+					endpointIPs, exists := IPIdentityCache.LookupByIdentity(ipIDPair.ID)
+					if !exists {
+						// Delete from XDS Cache as well.
+						envoy.NetworkPolicyHostsCache.Delete(envoy.NetworkPolicyHostsTypeURL, cachedIdentity.StringID(), false)
+					} else {
+
+						// TODO (factor this out into a helper function).
+						ipStrings := make([]string, 0, len(endpointIPs))
+						for endpointIP := range endpointIPs {
+							ipStrings = append(ipStrings, endpointIP)
+						}
+						sort.Strings(ipStrings)
+						envoy.NetworkPolicyHostsCache.Upsert(envoy.NetworkPolicyHostsTypeURL, ipIDPair.ID.StringID(), &envoyAPI.NetworkPolicyHosts{Policy: uint64(ipIDPair.ID), HostAddresses: ipStrings}, false)
+					}
+				}
+			}
+
+			if cacheChanged {
+				log.WithFields(logrus.Fields{
+					"endpoint-ip":      ipIDPair.IP,
+					"cached-identity":  cachedIdentity,
+					logfields.Identity: ipIDPair.ID,
+				}).Debugf("endpoint IP cache changed state")
+				owner.OnIPIdentityCacheChange()
+			}
+		}
+
+		log.Debugf("%s closed, restarting watch", watcher.String())
+	}
+}
+
+// InitIPIdentityWatcher initializes the watcher for ip-identity mapping events
+// in the key-value store.
+func InitIPIdentityWatcher(owner IPIdentityMappingOwner) {
+	setupIPIdentityWatcher.Do(func() {
+		go ipIdentityWatcher(owner)
+	})
+}

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -1,0 +1,142 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipcache
+
+import (
+	"reflect"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	identityPkg "github.com/cilium/cilium/pkg/identity"
+)
+
+// Hook up gocheck into the "go test" runner.
+type IPCacheTestSuite struct{}
+
+var _ = Suite(&IPCacheTestSuite{})
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+func (s *IPCacheTestSuite) TestIPCache(c *C) {
+	endpointIP := "10.0.0.15"
+	identity := (identityPkg.NumericIdentity(68))
+
+	// Assure sane state at start.
+	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 0)
+	c.Assert(len(IPIdentityCache.identityToIPCache), Equals, 0)
+
+	// Deletion of key that doesn't exist doesn't cause panic.
+	IPIdentityCache.delete(endpointIP)
+
+	IPIdentityCache.upsert(endpointIP, identity)
+
+	// Assure both caches are updated..
+	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 1)
+	c.Assert(len(IPIdentityCache.identityToIPCache), Equals, 1)
+
+	cachedIdentity, exists := IPIdentityCache.LookupByIP(endpointIP)
+	c.Assert(cachedIdentity, Equals, identity)
+	c.Assert(exists, Equals, true)
+
+	IPIdentityCache.upsert(endpointIP, identity)
+
+	// No duplicates.
+	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 1)
+	c.Assert(len(IPIdentityCache.identityToIPCache), Equals, 1)
+
+	IPIdentityCache.delete(endpointIP)
+
+	// Assure deletion occurs across both mappings.
+	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 0)
+	c.Assert(len(IPIdentityCache.identityToIPCache), Equals, 0)
+
+	_, exists = IPIdentityCache.LookupByIP(endpointIP)
+
+	c.Assert(exists, Equals, false)
+
+	IPIdentityCache.upsert(endpointIP, identity)
+
+	newIdentity := identityPkg.NumericIdentity(69)
+	IPIdentityCache.upsert(endpointIP, newIdentity)
+
+	// Ensure that update of cache with new identity doesn't keep old identity-to-ip
+	// mapping around.
+	_, exists = IPIdentityCache.LookupByIdentity(identity)
+	c.Assert(exists, Equals, false)
+
+	cachedIPSet, exists := IPIdentityCache.LookupByIdentity(newIdentity)
+	c.Assert(exists, Equals, true)
+	for cachedIP := range cachedIPSet {
+		c.Assert(cachedIP, Equals, endpointIP)
+	}
+
+	IPIdentityCache.delete(endpointIP)
+
+	// Assure deletion occurs across both mappings.
+	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 0)
+	c.Assert(len(IPIdentityCache.identityToIPCache), Equals, 0)
+
+	// Test mapping of multiple IPs to same identity.
+	endpointIPs := []string{"192.168.0.1", "20.3.75.3", "27.2.2.2", "127.0.0.1", "127.0.0.1"}
+	identities := []identityPkg.NumericIdentity{5, 67, 29, 29, 29}
+
+	for index := range endpointIPs {
+		IPIdentityCache.upsert(endpointIPs[index], identities[index])
+		cachedIdentity, _ := IPIdentityCache.LookupByIP(endpointIPs[index])
+		c.Assert(cachedIdentity, Equals, identities[index])
+	}
+
+	expectedIPList := map[string]struct{}{
+		"27.2.2.2":  {},
+		"127.0.0.1": {},
+	}
+
+	cachedEndpointIPs, _ := IPIdentityCache.LookupByIdentity(29)
+	c.Assert(reflect.DeepEqual(cachedEndpointIPs, expectedIPList), Equals, true)
+
+	IPIdentityCache.delete("27.2.2.2")
+
+	expectedIPList = map[string]struct{}{
+		"127.0.0.1": {},
+	}
+
+	cachedEndpointIPs, _ = IPIdentityCache.LookupByIdentity(29)
+	c.Assert(reflect.DeepEqual(cachedEndpointIPs, expectedIPList), Equals, true)
+
+	cachedIdentity, exists = IPIdentityCache.LookupByIP("127.0.0.1")
+	c.Assert(cachedIdentity, Equals, identityPkg.NumericIdentity(29))
+
+	IPIdentityCache.delete("127.0.0.1")
+
+	_, exists = IPIdentityCache.LookupByIdentity(29)
+	c.Assert(exists, Equals, false)
+
+	// Clean up.
+	for index := range endpointIPs {
+		IPIdentityCache.delete(endpointIPs[index])
+		_, exists = IPIdentityCache.LookupByIP(endpointIPs[index])
+		c.Assert(exists, Equals, false)
+
+		_, exists = IPIdentityCache.LookupByIdentity(identities[index])
+		c.Assert(exists, Equals, false)
+	}
+
+	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 0)
+	c.Assert(len(IPIdentityCache.identityToIPCache), Equals, 0)
+
+}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -39,6 +39,10 @@ import (
 var (
 	// ErrNilNode is returned when the Kubernetes API server has returned a nil node
 	ErrNilNode = goerrors.New("API server returned nil node")
+
+	// client is the object through which interactions with Kubernetes are
+	// performed.
+	client kubernetes.Interface
 )
 
 // CreateConfig creates a rest.Config for a given endpoint using a kubeconfig file.
@@ -208,10 +212,6 @@ func AnnotateNode(c kubernetes.Interface, nodeName string, v4CIDR, v6CIDR *net.I
 
 	return nil
 }
-
-var (
-	client kubernetes.Interface
-)
 
 // Client returns the default Kubernetes client
 func Client() kubernetes.Interface {

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -562,12 +562,12 @@ func (s *SSHMeta) DumpCiliumCommandOutput() {
 // to the directory testResultsPath
 func (s *SSHMeta) GatherLogs() {
 	ciliumLogCommands := map[string]string{
-		fmt.Sprintf("sudo journalctl -xe -u %s --no-pager", DaemonName):            "cilium.log",
-		fmt.Sprintf("sudo journalctl -xe -u %s--no-pager", CiliumDockerDaemonName): "cilium-docker.log",
-		"sudo docker logs cilium-consul":                                           "consul.log",
-		fmt.Sprintf(`sudo bash -c "gops memstats $(pgrep %s)"`, AgentDaemon):       "gops_memstats.txt",
-		fmt.Sprintf(`sudo bash -c "gops stack $(pgrep %s)"`, AgentDaemon):          "gops_stack.txt",
-		fmt.Sprintf(`sudo bash -c "gops stats $(pgrep %s)"`, AgentDaemon):          "gops_stats.txt",
+		fmt.Sprintf("sudo journalctl -au %s --no-pager", DaemonName):                "cilium.log",
+		fmt.Sprintf("sudo journalctl -xe -u %s --no-pager", CiliumDockerDaemonName): "cilium-docker.log",
+		"sudo docker logs cilium-consul":                                            "consul.log",
+		fmt.Sprintf(`sudo bash -c "gops memstats $(pgrep %s)"`, AgentDaemon):        "gops_memstats.txt",
+		fmt.Sprintf(`sudo bash -c "gops stack $(pgrep %s)"`, AgentDaemon):           "gops_stack.txt",
+		fmt.Sprintf(`sudo bash -c "gops stats $(pgrep %s)"`, AgentDaemon):           "gops_stats.txt",
 	}
 
 	testPath, err := CreateReportDirectory()


### PR DESCRIPTION
Add controllers within the endpoint that synchronize its IPv4 and IPv6 addresses with the key-value store.

Add a watcher for this mapping in the key-value store, and cache it locally with the new ipcache package. When a new entry is added to this local cache, trigger policy updates for endpoints.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: https://github.com/cilium/cilium/issues/2552

```release-note
Add mapping of endpoint IPs to security identities in the key-value store. Watch the key-value store for updates and cache them locally per agent.
```