### PR TITLE
pkg/k8s: add default deny for k8s 1.7

### DIFF
--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -146,17 +146,23 @@ func ParseNetworkPolicy(np *networkingv1.NetworkPolicy) (api.Rules, error) {
 	}
 
 	// Convert the k8s default-deny model to the Cilium default-deny model
-	// spec:
-	//   policyTypes:
-	//   - ingress
-	if len(ingresses) == 0 && hasV1PolicyType(np.Spec.PolicyTypes, networkingv1.PolicyTypeIngress) {
+	//spec:
+	//  podSelector: {}
+	//  policyTypes:
+	//	  - Ingress
+	// Since k8s 1.7 doesn't contain any PolicyTypes, we default deny
+	// if podSelector is empty and the policyTypes is not egress
+	if len(ingresses) == 0 &&
+		(hasV1PolicyType(np.Spec.PolicyTypes, networkingv1.PolicyTypeIngress) ||
+			!hasV1PolicyType(np.Spec.PolicyTypes, networkingv1.PolicyTypeEgress)) {
 		ingresses = []api.IngressRule{{}}
 	}
 
 	// Convert the k8s default-deny model to the Cilium default-deny model
-	// spec:
-	//   policyTypes:
-	//   - egress
+	//spec:
+	//  podSelector: {}
+	//  policyTypes:
+	//	  - Egress
 	if len(egresses) == 0 && hasV1PolicyType(np.Spec.PolicyTypes, networkingv1.PolicyTypeEgress) {
 		egresses = []api.EgressRule{{}}
 	}

--- a/pkg/k8s/network_policy_v1beta.go
+++ b/pkg/k8s/network_policy_v1beta.go
@@ -149,17 +149,23 @@ func ParseNetworkPolicyV1beta1(np *v1beta1.NetworkPolicy) (api.Rules, error) {
 	}
 
 	// Convert the k8s default-deny model to the Cilium default-deny model
-	// spec:
-	//   policyTypes:
-	//   - ingress
-	if len(ingresses) == 0 && hasV1beta1PolicyType(np.Spec.PolicyTypes, v1beta1.PolicyTypeIngress) {
+	//spec:
+	//  podSelector: {}
+	//  policyTypes:
+	//	  - Ingress
+	// Since k8s 1.7 doesn't contain any PolicyTypes, we default deny
+	// if podSelector is empty and the policyTypes is not egress
+	if len(ingresses) == 0 &&
+		(hasV1beta1PolicyType(np.Spec.PolicyTypes, v1beta1.PolicyTypeIngress) ||
+			!hasV1beta1PolicyType(np.Spec.PolicyTypes, v1beta1.PolicyTypeEgress)) {
 		ingresses = []api.IngressRule{{}}
 	}
 
 	// Convert the k8s default-deny model to the Cilium default-deny model
-	// spec:
-	//   policyTypes:
-	//   - egress
+	//spec:
+	//  podSelector: {}
+	//  policyTypes:
+	//	  - Egress
 	if len(egresses) == 0 && hasV1beta1PolicyType(np.Spec.PolicyTypes, v1beta1.PolicyTypeEgress) {
 		egresses = []api.EgressRule{{}}
 	}


### PR DESCRIPTION
Since k8s 1.7 doesn't have the PolicyTypes field, to detect if the
podSelector affects ingress or egress traffic, the defautl deny
translation to cilium network policy was not correctly made. The
translation of a default-deny ingress policy is made by checking
if the PolicyTypes is *not* egress and the podSelector is empty.

Signed-off-by: André Martins <andre@cilium.io>

Fixes: #2333 

```release-note
Fix kubernetes default deny policy for kubernetes 1.7
```
