### PR TITLE
Ginkgo: Fix cilium state on RuntimeValidatedConntrackTest

### DIFF
--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -464,8 +464,10 @@ var _ = Describe("RuntimeValidatedConntrackTest", func() {
 		for _, containerToRm := range containersToRm {
 			vm.ContainerRm(containerToRm)
 		}
+		vm.PolicyDelAll().ExpectSuccess("Policies cannot be deleted")
 
-		vm.PolicyDel("--all")
+		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
+		res.ExpectSuccess("Cannot set policy enforcemet to default")
 	})
 
 	It("Conntrack-related configuration options for endpoints", func() {


### PR DESCRIPTION
On Build 688 on recovery the policy was in place, so it fails after
restart.

The main issue was the leftover policy on the test that run just before.
This ensure that the status are the same after finished the test

https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-Validated/688

```
/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-Validated/src/github.com/cilium/cilium/test/runtime/chaos.go:66
Expected
    <string>: "...     Disabl..."
to equal               |
    <string>: "...     Enable..."
/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-Validated/src/github.com/cilium/cilium/test/runtime/chaos.go:88

level=info msg="Cilium status is true" testName=RuntimeValidatedChaos
STEP: original: ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])   IPv6                 IPv4           STATUS
           ENFORCEMENT        ENFORCEMENT
15009      Enabled            Disabled          3749       container:id.server           f00d::a0f:0:0:3aa1   10.15.222.0    ready
63264      Disabled           Disabled          6263       container:id.client           f00d::a0f:0:0:f720   10.15.154.57   ready

STEP: new: ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])   IPv6                 IPv4           STATUS
           ENFORCEMENT        ENFORCEMENT
15009      Disabled           Disabled          3749       container:id.server           f00d::a0f:0:0:3aa1   10.15.222.0    ready
63264      Disabled           Disabled          6263       container:id.client           f00d::a0f:0:0:f720   10.15.154.57   ready
```