### PR TITLE
test: miscellaneous fixes

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -213,13 +213,14 @@ func (s *SSHMeta) WaitEndpointsReady() bool {
 			result[status]++
 		}
 
+		logger.WithField("status", result).Infof(
+			"'%d' containers are in a '%s' state of a total of '%d' containers.",
+			result[desiredState], desiredState, total)
+
 		if result[desiredState] == total {
 			return true
 		}
 
-		logger.WithField("status", result).Infof(
-			"Only '%d' containers are in a '%s' state of a total of '%d' containers.",
-			result[desiredState], desiredState, total)
 		return false
 	}
 

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -687,12 +687,21 @@ var _ = Describe("RuntimeValidatedPolicyImportTests", func() {
 	BeforeEach(func() {
 		once.Do(initialize)
 		vm.PolicyDelAll()
+
+		vm.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
+		areEndpointsReady := vm.WaitEndpointsReady()
+		Expect(areEndpointsReady).Should(BeTrue(), "Timed out waiting for endpoints to be ready")
+
 	})
 
 	AfterEach(func() {
 		if CurrentGinkgoTestDescription().Failed {
 			vm.ReportFailed()
 		}
+
+		vm.SampleContainersActions(helpers.Delete, helpers.CiliumDockerNetwork)
+		allEndpointsDeleted := vm.WaitEndpointsDeleted()
+		Expect(allEndpointsDeleted).Should(BeTrue(), "Not all endpoints were able to be deleted")
 	})
 
 	It("Invalid Policies", func() {


### PR DESCRIPTION
- test/runtime: create and delete containers before policy tests
    - This ensures that Cilium can handle invalid policy while endpoints are running, and that cleanup tests are tested with endpoints running.
- test/helpers: always log current state of endpoints
    - Always log the number of "ready" endpoints to the logger in WaitEndpointsReady.

Signed-off by: Ian Vernon <ian@cilium.io>