### PR TITLE
add revision number to CNP status

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -15,6 +15,8 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -23,7 +25,10 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/common/types"
+	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/k8s"
+	cilium_io "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	cilium_v1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v1"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
@@ -33,7 +38,6 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/serializer"
-
 	go_version "github.com/hashicorp/go-version"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -77,6 +81,8 @@ var (
 
 	ciliumv1VerConstr, _ = go_version.NewConstraint("< 1.7.0")
 	ciliumv2VerConstr, _ = go_version.NewConstraint(">= 1.7.0")
+
+	k8sCM = controller.NewManager()
 )
 
 // k8sAPIGroupsUsed is a lockable map to hold which k8s API Groups we have
@@ -1444,36 +1450,94 @@ func (d *Daemon) addCiliumNetworkPolicyV1(ciliumV1Store cache.Store, cnp *cilium
 
 	scopedLog.Debug("Adding CiliumNetworkPolicy")
 
+	var rev uint64
+
 	rules, err := cnp.Parse()
 	if err == nil && len(rules) > 0 {
 		d.loadBalancer.K8sMU.Lock()
 		err = k8s.PreprocessRules(rules, d.loadBalancer.K8sEndpoints, d.loadBalancer.K8sServices)
 		d.loadBalancer.K8sMU.Unlock()
 		if err == nil {
-			_, err = d.PolicyAdd(rules, &AddOptions{Replace: true})
+			rev, err = d.PolicyAdd(rules, &AddOptions{Replace: true})
 		}
 	}
 
-	var cnpns cilium_v1.CiliumNetworkPolicyNodeStatus
 	if err != nil {
-		cnpns = cilium_v1.CiliumNetworkPolicyNodeStatus{
-			OK:          false,
-			Error:       fmt.Sprintf("%s", err),
-			LastUpdated: cilium_v1.NewTimestamp(),
-		}
 		scopedLog.WithError(err).Warn("Unable to add CiliumNetworkPolicy")
 	} else {
-		cnpns = cilium_v1.CiliumNetworkPolicyNodeStatus{
-			OK:          true,
-			LastUpdated: cilium_v1.NewTimestamp(),
-		}
 		scopedLog.Info("Imported CiliumNetworkPolicy")
 	}
+	ctrlName := cnp.GetControllerName()
+	k8sCM.UpdateController(ctrlName,
+		controller.ControllerParams{
+			DoFunc: func() error {
 
-	go func() {
-		k8s.UpdateCNPStatusV1(ciliumNPClient.CiliumV1(), ciliumV1Store,
-			k8s.BackOffLoopTimeout, node.GetName(), cnp, cnpns)
-	}()
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+
+				waitForEPsErr := endpointmanager.WaitForEndpointsAtPolicyRev(ctx, rev)
+
+				serverRuleStore, exists, err2 := ciliumV1Store.Get(cnp)
+				if err2 != nil {
+					return fmt.Errorf("unable to find v1.CiliumNetworkPolicy in local cache: %s", err2)
+				}
+				if !exists {
+					return errors.New("v1.CiliumNetworkPolicy does not exist in local cache")
+				}
+
+				serverRule, ok := serverRuleStore.(*cilium_v1.CiliumNetworkPolicy)
+				if !ok {
+					scopedLog.WithFields(logrus.Fields{
+						logfields.CiliumNetworkPolicy: logfields.Repr(serverRuleStore),
+					}).Warn("Received object of unknown type from API server, expecting v1.CiliumNetworkPolicy")
+					return errors.New("Received object of unknown type from API server, expecting v1.CiliumNetworkPolicy")
+				}
+
+				serverRuleCpy := serverRule.DeepCopy()
+				_, err2 = serverRuleCpy.Parse()
+				if err2 != nil {
+					// If we can't parse the rule then we should signalize
+					// it in the status
+					log.WithError(err2).WithField(logfields.Object, logfields.Repr(serverRuleCpy)).
+						Warn("Error parsing new CiliumNetworkPolicy rule")
+				}
+
+				cnpns := cilium_v1.CiliumNetworkPolicyNodeStatus{
+					OK: true,
+					// If the deadline was reached then not all endpoints are enforcing
+					// the given policy.
+					Enforcing:   waitForEPsErr == nil,
+					Revision:    rev,
+					LastUpdated: cilium_v1.NewTimestamp(),
+				}
+
+				// Most important is the error while adding the CNP
+				if err != nil {
+					cnpns = cilium_v1.CiliumNetworkPolicyNodeStatus{
+						Error: err.Error(),
+						OK:    false,
+					}
+				} else if err2 != nil {
+					cnpns = cilium_v1.CiliumNetworkPolicyNodeStatus{
+						Error: err2.Error(),
+						OK:    false,
+					}
+				}
+
+				nodeName := node.GetName()
+				serverRuleCpy.SetPolicyStatus(nodeName, cnpns)
+				ns := cilium_io.ExtractNamespace(&serverRuleCpy.ObjectMeta)
+
+				_, err2 = ciliumNPClient.CiliumV1().CiliumNetworkPolicies(ns).Update(serverRuleCpy)
+				if err2 == nil {
+					scopedLog.WithField("status", serverRuleCpy.Status).Debug("successfully updated with status")
+				} else {
+					return err2
+				}
+				return waitForEPsErr
+			},
+		},
+	)
 }
 
 // Deprecated: use deleteCiliumNetworkPolicyV2
@@ -1485,6 +1549,12 @@ func (d *Daemon) deleteCiliumNetworkPolicyV1(cnp *cilium_v1.CiliumNetworkPolicy)
 	})
 
 	scopedLog.Debug("Deleting CiliumNetworkPolicy")
+
+	ctrlName := cnp.GetControllerName()
+	err := k8sCM.RemoveController(ctrlName)
+	if err != nil {
+		log.Debugf("Unable to remove controller %s: %s", ctrlName, err)
+	}
 
 	rules, err := cnp.Parse()
 	if err == nil {
@@ -1548,36 +1618,94 @@ func (d *Daemon) addCiliumNetworkPolicyV2(ciliumV2Store cache.Store, cnp *cilium
 
 	scopedLog.Debug("Adding CiliumNetworkPolicy")
 
+	var rev uint64
+
 	rules, err := cnp.Parse()
 	if err == nil && len(rules) > 0 {
 		d.loadBalancer.K8sMU.Lock()
 		err = k8s.PreprocessRules(rules, d.loadBalancer.K8sEndpoints, d.loadBalancer.K8sServices)
 		d.loadBalancer.K8sMU.Unlock()
 		if err == nil {
-			_, err = d.PolicyAdd(rules, &AddOptions{Replace: true})
+			rev, err = d.PolicyAdd(rules, &AddOptions{Replace: true})
 		}
 	}
 
-	var cnpns cilium_v2.CiliumNetworkPolicyNodeStatus
 	if err != nil {
-		cnpns = cilium_v2.CiliumNetworkPolicyNodeStatus{
-			OK:          false,
-			Error:       fmt.Sprintf("%s", err),
-			LastUpdated: cilium_v2.NewTimestamp(),
-		}
 		scopedLog.WithError(err).Warn("Unable to add CiliumNetworkPolicy")
 	} else {
-		cnpns = cilium_v2.CiliumNetworkPolicyNodeStatus{
-			OK:          true,
-			LastUpdated: cilium_v2.NewTimestamp(),
-		}
 		scopedLog.Info("Imported CiliumNetworkPolicy")
 	}
+	ctrlName := cnp.GetControllerName()
+	k8sCM.UpdateController(ctrlName,
+		controller.ControllerParams{
+			DoFunc: func() error {
 
-	go func() {
-		k8s.UpdateCNPStatusV2(ciliumNPClient.CiliumV2(), ciliumV2Store,
-			k8s.BackOffLoopTimeout, node.GetName(), cnp, cnpns)
-	}()
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+
+				waitForEPsErr := endpointmanager.WaitForEndpointsAtPolicyRev(ctx, rev)
+
+				serverRuleStore, exists, err2 := ciliumV2Store.Get(cnp)
+				if err2 != nil {
+					return fmt.Errorf("unable to find v2.CiliumNetworkPolicy in local cache: %s", err2)
+				}
+				if !exists {
+					return errors.New("v2.CiliumNetworkPolicy does not exist in local cache")
+				}
+
+				serverRule, ok := serverRuleStore.(*cilium_v2.CiliumNetworkPolicy)
+				if !ok {
+					scopedLog.WithFields(logrus.Fields{
+						logfields.CiliumNetworkPolicy: logfields.Repr(serverRuleStore),
+					}).Warn("Received object of unknown type from API server, expecting v2.CiliumNetworkPolicy")
+					return errors.New("Received object of unknown type from API server, expecting v2.CiliumNetworkPolicy")
+				}
+
+				serverRuleCpy := serverRule.DeepCopy()
+				_, err2 = serverRuleCpy.Parse()
+				if err2 != nil {
+					// If we can't parse the rule then we should signalize
+					// it in the status
+					log.WithError(err2).WithField(logfields.Object, logfields.Repr(serverRuleCpy)).
+						Warn("Error parsing new CiliumNetworkPolicy rule")
+				}
+
+				cnpns := cilium_v2.CiliumNetworkPolicyNodeStatus{
+					OK: true,
+					// If the deadline was reached then not all endpoints are enforcing
+					// the given policy.
+					Enforcing:   waitForEPsErr == nil,
+					Revision:    rev,
+					LastUpdated: cilium_v2.NewTimestamp(),
+				}
+
+				// Most important is the error while adding the CNP
+				if err != nil {
+					cnpns = cilium_v2.CiliumNetworkPolicyNodeStatus{
+						Error: err.Error(),
+						OK:    false,
+					}
+				} else if err2 != nil {
+					cnpns = cilium_v2.CiliumNetworkPolicyNodeStatus{
+						Error: err2.Error(),
+						OK:    false,
+					}
+				}
+
+				nodeName := node.GetName()
+				serverRuleCpy.SetPolicyStatus(nodeName, cnpns)
+				ns := cilium_io.ExtractNamespace(&serverRuleCpy.ObjectMeta)
+
+				_, err2 = ciliumNPClient.CiliumV2().CiliumNetworkPolicies(ns).Update(serverRuleCpy)
+				if err2 == nil {
+					scopedLog.WithField("status", serverRuleCpy.Status).Debug("successfully updated with status")
+				} else {
+					return err2
+				}
+				return waitForEPsErr
+			},
+		},
+	)
 }
 
 func (d *Daemon) deleteCiliumNetworkPolicyV2(cnp *cilium_v2.CiliumNetworkPolicy) {
@@ -1588,6 +1716,12 @@ func (d *Daemon) deleteCiliumNetworkPolicyV2(cnp *cilium_v2.CiliumNetworkPolicy)
 	})
 
 	scopedLog.Debug("Deleting CiliumNetworkPolicy")
+
+	ctrlName := cnp.GetControllerName()
+	err := k8sCM.RemoveController(ctrlName)
+	if err != nil {
+		log.Debugf("Unable to remove controller %s: %s", ctrlName, err)
+	}
 
 	rules, err := cnp.Parse()
 	if err == nil {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -311,6 +311,7 @@ type Endpoint struct {
 	k8sNamespace string
 
 	// policyRevision is the policy revision this endpoint is currently on
+	// to modify this field please use endpoint.setPolicyRevision instead
 	policyRevision uint64
 
 	// nextPolicyRevision is the policy revision that the endpoint has
@@ -1584,7 +1585,7 @@ OKState:
 func (e *Endpoint) bumpPolicyRevision(revision uint64) {
 	e.Mutex.Lock()
 	if revision > e.policyRevision {
-		e.policyRevision = revision
+		e.setPolicyRevision(revision)
 	}
 	e.Mutex.Unlock()
 }
@@ -1809,4 +1810,9 @@ func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
 	}
 
 	return nil
+}
+
+// setPolicyRevision sets the policy revision with the given revision.
+func (e *Endpoint) setPolicyRevision(rev uint64) {
+	e.policyRevision = rev
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -668,7 +668,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner, opts models.ConfigurationMap) (
 	// already running the latest revision, otherwise we have to wait for
 	// the regeneration of the endpoint to complete.
 	if !policyChanged && !optsChanged {
-		e.policyRevision = revision
+		e.setPolicyRevision(revision)
 	}
 
 	e.getLogger().WithFields(logrus.Fields{

--- a/pkg/k8s/apis/cilium.io/const.go
+++ b/pkg/k8s/apis/cilium.io/const.go
@@ -27,6 +27,9 @@ const (
 	// PodNamespaceLabel is the label used in kubernetes containers to
 	// specify which namespace they belong to.
 	PodNamespaceLabel = types.KubernetesPodNamespaceLabel
+	// CtrlPrefixPolicyStatus is the prefix used for the controllers set up
+	// to sync the CNP with kube-apiserver.
+	CtrlPrefixPolicyStatus = "sync-cnp-policy-status"
 )
 
 const (

--- a/pkg/k8s/apis/cilium.io/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils.go
@@ -49,6 +49,11 @@ func ExtractNamespace(np *metav1.ObjectMeta) string {
 	return np.Namespace
 }
 
+// GetObjNamespaceName returns the object's namespace and name.
+func GetObjNamespaceName(obj *metav1.ObjectMeta) string {
+	return ExtractNamespace(obj) + "/" + obj.GetName()
+}
+
 // GetPolicyLabels returns a LabelArray for the given namespace and name.
 func GetPolicyLabels(ns, name string) labels.LabelArray {
 	return labels.ParseLabelArray(

--- a/pkg/k8s/apis/cilium.io/v1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1/types.go
@@ -74,6 +74,14 @@ type CiliumNetworkPolicyNodeStatus struct {
 
 	// LastUpdated contains the last time this status was updated
 	LastUpdated Timestamp `json:"lastUpdated,omitempty"`
+
+	// Revision is the policy revision of the repository which first implemented
+	// this policy.
+	Revision uint64 `json:"localPolicyRevision,omitempty"`
+
+	// Enforcing is set to true once all endpoints present at the time the
+	// policy has been imported are enforcing this policy.
+	Enforcing bool `json:"enforcing,omitempty"`
 }
 
 // NewTimestamp creates a new Timestamp with the current time.Now()
@@ -143,6 +151,12 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 	}
 
 	return retRules, nil
+}
+
+// GetControllerName returns the unique name for the controller manager.
+func (r *CiliumNetworkPolicy) GetControllerName() string {
+	name := k8sconst.GetObjNamespaceName(&r.ObjectMeta)
+	return fmt.Sprintf("%s (v1 %s)", k8sconst.CtrlPrefixPolicyStatus, name)
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -76,6 +76,14 @@ type CiliumNetworkPolicyNodeStatus struct {
 
 	// LastUpdated contains the last time this status was updated
 	LastUpdated Timestamp `json:"lastUpdated,omitempty"`
+
+	// Revision is the policy revision of the repository which first implemented
+	// this policy.
+	Revision uint64 `json:"localPolicyRevision,omitempty"`
+
+	// Enforcing is set to true once all endpoints present at the time the
+	// policy has been imported are enforcing this policy.
+	Enforcing bool `json:"enforcing,omitempty"`
 }
 
 // NewTimestamp creates a new Timestamp with the current time.Now()
@@ -145,6 +153,12 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 	}
 
 	return retRules, nil
+}
+
+// GetControllerName returns the unique name for the controller manager.
+func (r *CiliumNetworkPolicy) GetControllerName() string {
+	name := k8sconst.GetObjNamespaceName(&r.ObjectMeta)
+	return fmt.Sprintf("%s (v2 %s)", k8sconst.CtrlPrefixPolicyStatus, name)
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
**Summary of changes**:

Add revision number and enforcement status to CNP status.

Add controllers for each cilium network policy that allows to update the
revision number and its enforcement on the endpoints running on each
node.

Output example from different sources (K8S - 172 is not running with
this changes):
```
$ cilium status --all-controllers
...
  Name                                                Last success   Last error   Count   Message
...
  sync-cnp-policy-status (v2 default/guestbook-web)   4s ago         never        0       no error
...

$ kubectl describe cnp
Name:           guestbook-web
Namespace:      default
API Version:    cilium.io/v2
....
Status:
  Nodes:
	K 8 S - 171:
	  Enforcing:                true
	  Last Updated:             2018-02-21T02:49:53.063373958Z
	  Local Policy Revision:    7
	  Ok:                       true
	K 8 S - 172:
	  Last Updated:     2018-02-20T14:53:51.928648228Z
	  Ok:               true

$ cilium policy get | tail -n 1
Revision: 7
```
Fixes: #2873

```release-note
Add node policy revision number to the Cilium Network Policy Status 
```
