### PR TITLE
controller: Ensure same uuid during Manager.RemoveController

### DIFF
--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -98,7 +98,7 @@ func (m *Manager) removeController(ctrl *Controller) {
 
 // RemoveController stops and removes a controller from the manager. If DoFunc
 // is currently running, DoFunc is allowed to complete in the background.
-func (m *Manager) RemoveController(name string) error {
+func (m *Manager) RemoveController(ctrl *Controller) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -106,9 +106,10 @@ func (m *Manager) RemoveController(name string) error {
 		return fmt.Errorf("empty controller map")
 	}
 
-	oldCtrl, ok := m.controllers[name]
-	if !ok {
-		return fmt.Errorf("unable to find controller %s", name)
+	oldCtrl, ok := m.controllers[ctrl.name]
+	if !ok || oldCtrl.uuid != ctrl.uuid {
+		// only remove if it's in the map and the uuid matches
+		return fmt.Errorf("unable to find controller %s", ctrl.name)
 	}
 
 	m.removeController(oldCtrl)


### PR DESCRIPTION
**Summary of changes**:
Managers would remove any controller with the same name (which is the
key in the contoller map in the manager). We now check that the uuid
matches the entry being removed, in case we have a race between an
UpdateController and a RemoveController.

**How to test (optional)**:
none

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/2895)
<!-- Reviewable:end -->
