### PR TITLE
Misc test & debugging improvements

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -2,6 +2,10 @@ provision = true
 # If you set provision to false the test will run without compile the code
 # again.
 
+TEST_ARTIFACTS = ./tmp.yaml ./*_service_manifest.json ./*_manifest.yaml
+TEST_ARTIFACTS += ./*_policy.json ./k8s-*.xml ./runtime.xml ./test_results
+TEST_ARTIFACTS += ./test.test
+
 all: build
 
 build:
@@ -21,3 +25,6 @@ k8s:
 
 k8s16:
 	K8S_VERSION=1.6 ginkgo --focus " K8s*" -v -- --cilium.provision=$(provision)
+
+clean:
+	-rm -rf $(TEST_ARTIFACTS)

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -295,7 +295,7 @@ var _ = Describe("RuntimeValidatedLB", func() {
 		svcIds, err := vm.ServiceGetIds()
 		Expect(err).Should(BeNil())
 		Expect(len(svcIds)).Should(Equal(len(oldSvcIds)),
-			fmt.Sprintf("Service ids %s do not match old service ids %s", svcIds, oldSvcIds))
+			"Service ids %s do not match old service ids %s", svcIds, oldSvcIds)
 		newSvc := vm.ServiceList()
 		newSvc.ExpectSuccess("Cannot retrieve service list after restart")
 		newSvc.ExpectEqual(oldSvc.Output().String(), "Service list does not match")


### PR DESCRIPTION
* Fix #2859, keep generated BPF programs that cannot be inserted around for debugging
* Add a 'make clean' target to `test/`
* Remove an unnecessary sprintf in `test/runtime/lb.go`