### PR TITLE
CI: migrate 12-policy-import fully over to Ginkgo CI

### DIFF
--- a/tests/12-policy-import.sh
+++ b/tests/12-policy-import.sh
@@ -11,6 +11,9 @@ redirect_debug_logs ${LOGS_DIR}
 
 set -ex
 
+log "${TEST_NAME} has been deprecated and replaced by /test/runtime/Policies.go:checks policy trace output"
+exit 0
+
 DENIED="Final verdict: DENIED"
 ALLOWED="Final verdict: ALLOWED"
 


### PR DESCRIPTION
I took this on in some off time to try to alleviate the long turnaround time on CI due to having to provision two separate packet.net instances per PR. 

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #1841 
Fixes: #2526