### PR TITLE
Ginkgo: Add support to kubernetes Beta and Alpha versions

### DIFF
--- a/test/provision/helpers.bash
+++ b/test/provision/helpers.bash
@@ -22,7 +22,7 @@ function retry_function {
     ${FUNC}
     if [[ "$?" == "0" ]] ; then
       echo "running of \"${FUNC}\" successful"
-      echo 
+      echo
       echo
       echo
       set -e
@@ -35,4 +35,35 @@ function retry_function {
   log_msg "running function \"${FUNC}\" ${MAX_TRIES} times did not succeed"
   set -e
   return 1
+}
+
+function install_using_apt {
+    apt-get update
+    apt-get install --allow-downgrades -y \
+        "$@"
+}
+
+function install_k8s_using_packages {
+    install_using_apt "$@"
+}
+
+function install_k8s_using_binary {
+    local RELEASE=$1
+    local CNI_VERSION=$2
+    cd $(mktemp -d)
+
+    mkdir -p /opt/cni/bin
+    mkdir -p /etc/systemd/system/kubelet.service.d
+
+    curl -sSL "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
+
+    wget -q https://storage.googleapis.com/kubernetes-release/release/$RELEASE/bin/linux/amd64/{kubectl,kubeadm,kubelet}
+    chmod 777 ku*
+    cp -fv ku* /usr/bin/
+    rm -rf /etc/systemd/system/kubelet.service || true
+    curl -sSL https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service > /etc/systemd/system/kubelet.service
+
+
+    curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+    systemctl enable kubelet
 }


### PR DESCRIPTION
- Added support in `test/Vagrantfile` to alpha and Beta versions.
- Added another step on test-kubernetes jenkinsfile
- Fix some tables issues in docs

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>