### PR TITLE
CI: migrate 16-cidr-ingress-policy.sh to Ginkgo CI Framework

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -499,6 +499,7 @@ func (s *SSHMeta) PolicyWait(revisionNum int) *CmdRes {
 // purposes.
 func (s *SSHMeta) ReportFailed(commands ...string) {
 	wr := s.logger.Logger.Out
+	fmt.Fprint(wr, "===================== TEST FAILED =====================\n")
 	fmt.Fprint(wr, "StackTrace Begin\n")
 
 	//FIXME: Ginkgo PR383 add here --since option
@@ -517,6 +518,7 @@ func (s *SSHMeta) ReportFailed(commands ...string) {
 	fmt.Fprint(wr, "StackTrace Ends\n")
 	s.ReportDump()
 	s.GatherLogs()
+	fmt.Fprint(wr, "===================== EXITING REPORT GENERATION =====================\n")
 }
 
 // ReportDump runs a variety of commands and writes the results to

--- a/test/helpers/docker.go
+++ b/test/helpers/docker.go
@@ -57,6 +57,7 @@ func (s *SSHMeta) ContainerInspectNet(name string) (map[string]string, error) {
 		"GlobalIPv6Address": IPv6,
 		"IPAddress":         IPv4,
 		"NetworkID":         "NetworkID",
+		"IPv6Gateway":       "IPv6Gateway",
 	}
 
 	if !res.WasSuccessful() {

--- a/test/helpers/docker.go
+++ b/test/helpers/docker.go
@@ -16,11 +16,17 @@ package helpers
 
 import (
 	"fmt"
+	"strings"
 )
 
-// ContainerExec executes cmd in the container with the provided name.
-func (s *SSHMeta) ContainerExec(name string, cmd string) *CmdRes {
-	dockerCmd := fmt.Sprintf("docker exec -i %s %s", name, cmd)
+// ContainerExec executes cmd in the container with the provided name along with
+// any other additional arguments needed.
+func (s *SSHMeta) ContainerExec(name string, cmd string, optionalArgs ...string) *CmdRes {
+	optionalArgsCoalesced := ""
+	if len(optionalArgs) > 0 {
+		optionalArgsCoalesced = strings.Join(optionalArgs, " ")
+	}
+	dockerCmd := fmt.Sprintf("docker exec -i %s %s %s", optionalArgsCoalesced, name, cmd)
 	return s.Exec(dockerCmd)
 }
 

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -862,7 +862,7 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 			   "%s"
 		   ]
 		   }]
-	   }]`, httpd1Label, httpd2Label, ipv4OtherNet)
+		}]`, httpd1Label, httpd2Label, ipv4OtherNet)
 		_, err = vm.PolicyRenderAndImport(script)
 		Expect(err).To(BeNil(), "Unable to import policy: %s", err)
 

--- a/tests/16-cidr-ingress-policy.sh
+++ b/tests/16-cidr-ingress-policy.sh
@@ -11,6 +11,9 @@ redirect_debug_logs ${LOGS_DIR}
 
 set -ex
 
+log "${TEST_NAME} has been deprecated and replaced by test/runtime/Policies.go:Checks CIDR Policy"
+exit 0
+
 DEMO_CONTAINER="cilium/demo-client"
 HTTPD_CONTAINER_NAME="service1-instance1"
 ID_SERVICE1="id.service1"


### PR DESCRIPTION
Migrate Bash test to Ginkgo framework.

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #1841 
Fixes: #2528