### PR TITLE
Nightly Tests: add Envoy Tests Stage

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -60,12 +60,24 @@ pipeline {
             post {
                 always {
                     junit 'test/*.xml'
-                    // Temporary workaround to test cleanup
-                    // rm -rf ${GOPATH}/src/github.com/cilium/cilium
                     sh 'cd test/; ./post_build_agent.sh || true'
                     sh 'cd test/; K8S_VERSION=1.7 vagrant destroy -f || true'
                     sh 'cd test/; ./archive_test_results.sh || true'
                     archiveArtifacts artifacts: "test_results_${JOB_BASE_NAME}_${BUILD_NUMBER}.tar", allowEmptyArchive: true
+                }
+            }
+        }
+        stage('Envoy Tests') {
+            environment {
+                TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
+            }
+            steps {
+                 sh 'cd ${TESTDIR}; vagrant up runtime --no-provision'
+                 sh 'cd ${TESTDIR}; ./run-envoy-unit-tests.sh'
+            }
+            post {
+                always {
+                    sh "cd ${TESTDIR}; vagrant destroy -f || true"
                 }
             }
         }

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -62,7 +62,6 @@ sudo usermod -a -G cilium vagrant
 SCRIPT
 
 $testsuite = <<SCRIPT
-make -C ~/go/src/github.com/cilium/cilium/ tests || exit 1
 sudo -E env PATH="${PATH}" make -C ~/go/src/github.com/cilium/cilium/ runtime-tests
 SCRIPT
 

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -35,7 +35,6 @@ pipeline {
         }
         stage('Boot VMs'){
             environment {
-                GOPATH="${WORKSPACE}"
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
             }
             steps {

--- a/test/run-envoy-unit-tests.sh
+++ b/test/run-envoy-unit-tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+vagrant ssh runtime -c "cd /home/vagrant/go/src/github.com/cilium/cilium ; make tests-envoy"


### PR DESCRIPTION
Add stage to run `make tests-envoy` as part of Nightly tests.

Signed-off by: Ian Vernon <ian@cilium.io>