### PR TITLE
Make Kafka K8s GSG CI tests work on multinode setup

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -141,8 +141,8 @@ func GetAppPods(apps []string, namespace string, kubectl *Kubectl, appFmt string
 }
 
 // WaitCiliumEndpointReady gets cilium pod for a ginkgo node (k8s1/k8s2)
-// and waits for all the endpoints of that node to ve ready.
-func WaitCiliumEndpointReady(podFilter string, kubectl *Kubectl, k8sNode string) (string, EndpointMap) {
+// and waits for all the endpoints of that node to be ready.
+func (kubectl *Kubectl) WaitCiliumEndpointReady(podFilter string, k8sNode string) (string, EndpointMap) {
 	ciliumPod, err := kubectl.GetCiliumPodOnNode(KubeSystemNamespace, k8sNode)
 	Expect(err).Should(BeNil())
 

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -119,10 +119,10 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 
 		By("Waiting for all Cilium Pods and endpoints to be ready ")
 		By("Waiting for node K8s1")
-		ciliumPod1, _ := helpers.WaitCiliumEndpointReady(podFilter, kubectl, helpers.K8s1)
+		ciliumPod1, _ := kubectl.WaitCiliumEndpointReady(podFilter, helpers.K8s1)
 
 		By("Waiting for node K8s2")
-		helpers.WaitCiliumEndpointReady(podFilter, kubectl, helpers.K8s2)
+		kubectl.WaitCiliumEndpointReady(podFilter, helpers.K8s2)
 
 		appPods := helpers.GetAppPods(apps, helpers.DefaultNamespace, kubectl, "app")
 		By("Testing basic Kafka Produce and Consume")

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -117,28 +117,12 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 		logger.Infof("KafkaPolicyRulesTest: cluster service ip '%s'", clusterIP)
 		Expect(err).Should(BeNil())
 
-		By("Getting Cilium Pods")
-		ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
-		Expect(err).Should(BeNil())
+		By("Waiting for all Cilium Pods and endpoints to be ready ")
+		By("Waiting for node K8s1")
+		ciliumPod1, _ := helpers.WaitCiliumEndpointReady(podFilter, kubectl, helpers.K8s1)
 
-		status := kubectl.CiliumExec(ciliumPod, fmt.Sprintf("cilium config %s=%s", helpers.PolicyEnforcement, helpers.PolicyEnforcementDefault))
-		status.ExpectSuccess()
-
-		kubectl.CiliumEndpointWait(ciliumPod)
-
-		epsStatus := helpers.WithTimeout(func() bool {
-			endpoints, err := kubectl.CiliumEndpointsListByLabel(ciliumPod, podFilter)
-			if err != nil {
-				return false
-			}
-			return endpoints.AreReady()
-		}, "Could not get endpoints", &helpers.TimeoutConfig{Timeout: 100})
-		Expect(epsStatus).Should(BeNil())
-
-		endpoints, err := kubectl.CiliumEndpointsListByLabel(ciliumPod, podFilter)
-		Expect(err).Should(BeNil())
-
-		Expect(endpoints.AreReady()).Should(BeTrue())
+		By("Waiting for node K8s2")
+		helpers.WaitCiliumEndpointReady(podFilter, kubectl, helpers.K8s2)
 
 		appPods := helpers.GetAppPods(apps, helpers.DefaultNamespace, kubectl, "app")
 		By("Testing basic Kafka Produce and Consume")
@@ -170,54 +154,61 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 		Expect(err).Should(BeNil())
 
 		By("Apply L7 kafka policy")
-		eps := kubectl.CiliumEndpointPolicyVersion(ciliumPod)
+		eps1 := kubectl.CiliumEndpointPolicyVersion(ciliumPod1)
 		_, err = kubectl.CiliumPolicyAction(helpers.KubeSystemNamespace, l7Policy, helpers.KubectlApply, 300)
 		Expect(err).Should(BeNil())
 
 		By("Waiting for endpoint updates with L7 policy")
-		err = helpers.WaitUntilEndpointUpdates(ciliumPod, eps, 6, kubectl)
+		err = helpers.WaitUntilEndpointUpdates(ciliumPod1, eps1, 3, kubectl)
 		Expect(err).Should(BeNil())
-		epsStatus = helpers.WithTimeout(func() bool {
-			endpoints, err := kubectl.CiliumEndpointsListByLabel(ciliumPod, podFilter)
+		epsStatus1 := helpers.WithTimeout(func() bool {
+			endpoints1, err := kubectl.CiliumEndpointsListByLabel(ciliumPod1, podFilter)
 			if err != nil {
 				return false
 			}
-			return endpoints.AreReady()
+			return endpoints1.AreReady()
 		}, "could not get endpoints", &helpers.TimeoutConfig{Timeout: 100})
 
-		Expect(epsStatus).Should(BeNil())
+		Expect(epsStatus1).Should(BeNil())
 
-		endpoints, err = kubectl.CiliumEndpointsListByLabel(ciliumPod, podFilter)
-		policyStatus := endpoints.GetPolicyStatus()
+		endpoints1, err := kubectl.CiliumEndpointsListByLabel(ciliumPod1, podFilter)
+		policyStatus1 := endpoints1.GetPolicyStatus()
 
-		By("Testing Kafka endpoint policy enforcement status")
-		Expect(policyStatus[models.EndpointPolicyEnabledNone]).Should(Equal(5))
+		/*
+			Kafka multinode setup:
+
+			K8s1:
+				1. empire-backup
+				2. empire-hq
+				3. kafka-broker : ingress policy only
+
+			K8s2:
+			   1. zook
+			   2. empire-outpost-8888
+			   3. empire-outpost-9999
+		*/
+		By("Testing Kafka endpoint policy enforcement status on K8s1")
+		Expect(policyStatus1[models.EndpointPolicyEnabledNone]).Should(Equal(2))
 		// Only the kafka broker app should have ingress policy enabled.
-		Expect(policyStatus[models.EndpointPolicyEnabledIngress]).Should(Equal(1))
-		Expect(policyStatus[models.EndpointPolicyEnabledEgress]).Should(Equal(0))
-		Expect(policyStatus[models.EndpointPolicyEnabledBoth]).Should(Equal(0))
+		Expect(policyStatus1[models.EndpointPolicyEnabledIngress]).Should(Equal(1))
+		Expect(policyStatus1[models.EndpointPolicyEnabledEgress]).Should(Equal(0))
+		Expect(policyStatus1[models.EndpointPolicyEnabledBoth]).Should(Equal(0))
 
-		By("Testing endpoint policy trace status")
+		By("Testing endpoint policy trace status on kafka-broker node")
 
-		trace := kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
-			"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 9092",
-			appPods[outpostApp], appPods[kafkaApp]))
-		trace.ExpectSuccess(trace.CombineOutput().String())
-		Expect(trace.Output().String()).Should(ContainSubstring("Final verdict: ALLOWED"))
-
-		trace = kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
-			"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 9092",
-			appPods[backupApp], appPods[kafkaApp]))
-		trace.ExpectSuccess(trace.CombineOutput().String())
-		Expect(trace.Output().String()).Should(ContainSubstring("Final verdict: ALLOWED"))
-
-		trace = kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
+		trace := kubectl.CiliumExec(ciliumPod1, fmt.Sprintf(
 			"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 9092",
 			appPods[empireHqApp], appPods[kafkaApp]))
 		trace.ExpectSuccess(trace.CombineOutput().String())
 		Expect(trace.Output().String()).Should(ContainSubstring("Final verdict: ALLOWED"))
 
-		trace = kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
+		trace = kubectl.CiliumExec(ciliumPod1, fmt.Sprintf(
+			"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 9092",
+			appPods[backupApp], appPods[kafkaApp]))
+		trace.ExpectSuccess(trace.CombineOutput().String())
+		Expect(trace.Output().String()).Should(ContainSubstring("Final verdict: ALLOWED"))
+
+		trace = kubectl.CiliumExec(ciliumPod1, fmt.Sprintf(
 			"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 80",
 			appPods[empireHqApp], appPods[kafkaApp]))
 		trace.ExpectSuccess(trace.CombineOutput().String())
@@ -252,14 +243,14 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 			helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(prodOutAnnounce))
 		Expect(err).Should(HaveOccurred())
 
-		eps = kubectl.CiliumEndpointPolicyVersion(ciliumPod)
+		eps1 = kubectl.CiliumEndpointPolicyVersion(ciliumPod1)
 		By("Deleting L7 policy")
-		status = kubectl.Delete(l7Policy)
+		status := kubectl.Delete(l7Policy)
 		status.ExpectSuccess()
-		kubectl.CiliumEndpointWait(ciliumPod)
+		kubectl.CiliumEndpointWait(ciliumPod1)
 
-		//Only 1 endpoint is affected by L7 rule
-		err = helpers.WaitUntilEndpointUpdates(ciliumPod, eps, 6, kubectl)
+		//Only 1 endpoint on node1 is affected by L7 rule
+		err = helpers.WaitUntilEndpointUpdates(ciliumPod1, eps1, 3, kubectl)
 		Expect(err).Should(BeNil())
 
 	}, 500)

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -94,7 +94,7 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 
 		It("tests PolicyEnforcement updates", func() {
 			By("Waiting for cilium pod and endpoints on K8s1 to be ready")
-			ciliumPod, endpoints := helpers.WaitCiliumEndpointReady(podFilter, kubectl, helpers.K8s1)
+			ciliumPod, endpoints := kubectl.WaitCiliumEndpointReady(podFilter, helpers.K8s1)
 			policyStatus := endpoints.GetPolicyStatus()
 			// default mode with no policy, all endpoints must be in allow all
 			Expect(policyStatus[models.EndpointPolicyEnabledNone]).Should(Equal(4))

--- a/test/k8sT/manifests/kafka-sw-app.yaml
+++ b/test/k8sT/manifests/kafka-sw-app.yaml
@@ -45,7 +45,7 @@ spec:
         ports:
         - containerPort: 2181
       nodeSelector:
-        "kubernetes.io/hostname": k8s1
+        "kubernetes.io/hostname": k8s2
 ---
 apiVersion: v1
 kind: Service
@@ -112,7 +112,7 @@ spec:
       - name: empire-outpost-8888
         image: cilium/kafkaclient
       nodeSelector:
-        "kubernetes.io/hostname": k8s1
+        "kubernetes.io/hostname": k8s2
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -131,7 +131,7 @@ spec:
       - name: empire-outpost-9999
         image: cilium/kafkaclient
       nodeSelector:
-        "kubernetes.io/hostname": k8s1
+        "kubernetes.io/hostname": k8s2
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment


### PR DESCRIPTION
This change makes the Kafka K8s GSG CI tests in Ginkgo work on a multinode setup.
The setup looks like this:

Kafka multinode setup:

Ginkgo K8s1:
	1. empire-backup
	2. empire-hq
	3. kafka-broker : ingress policy only

Gingko K8s2:
	1. zook
	2. empire-outpost-8888
	3. empire-outpost-9999

Fixes Issue: #2911
Signed-off-by: Manali Bhutiyani <manali@covalent.io>

```release-note
Make Kafka K8s GSG CI tests work on multinode setup
```