### PR TITLE
envoy: Fix access log path config.

### DIFF
--- a/envoy/cilium_l7policy.cc
+++ b/envoy/cilium_l7policy.cc
@@ -50,7 +50,7 @@ static Registry::RegisterFactory<
     ConfigFactory, Server::Configuration::NamedHttpFilterConfigFactory>
     register_;
 
-Config::Config(const std::string& access_log_path, const std::string& listener_id,
+Config::Config(const std::string& listener_id, const std::string& access_log_path,
                Stats::Scope &scope)
     : stats_{ALL_CILIUM_STATS(POOL_COUNTER_PREFIX(scope, "cilium"))},
       listener_id_(listener_id), access_log_(nullptr) {

--- a/envoy/cilium_l7policy.h
+++ b/envoy/cilium_l7policy.h
@@ -35,7 +35,7 @@ struct FilterStats {
  */
 class Config : Logger::Loggable<Logger::Id::router> {
 public:
-  Config(const std::string& access_log_path, const std::string& listener_id, Stats::Scope &scope);
+  Config(const std::string& listener_id, const std::string& access_log_path, Stats::Scope &scope);
   Config(const Json::Object &config, Stats::Scope &scope);
   Config(const ::cilium::L7Policy &config, Stats::Scope& scope);
   ~Config();


### PR DESCRIPTION
Access log path and listener ID were swapped between the callers and
the constructor. Fix by swapping them in the constructor.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
