### PR TITLE
cilium-docker: Update HostAddressing via IPAM allocation call

### DIFF
--- a/plugins/cilium-docker/driver/ipam.go
+++ b/plugins/cilium-docker/driver/ipam.go
@@ -122,6 +122,9 @@ func (driver *driver) requestAddress(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The host addressing may have changed due to a daemon restart, update it
+	driver.updateRoutes(ipam.HostAddressing)
+
 	addr := ipam.Endpoint
 	if addr == nil {
 		sendError(w, "No IP addressing provided", http.StatusBadRequest)


### PR DESCRIPTION
The agent may be restarted which can lead to updated host addressing
details such as different gateway addresses, keep the HostAddressing up
to date and recalculate routes as required.