### PR TITLE
Ginkgo: Add more cases NodePort test

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -36,7 +36,9 @@ const (
 	// VM / Test suite constants.
 	K8s     = "k8s"
 	K8s1    = "k8s1"
+	K8s1Ip  = "192.168.36.11"
 	K8s2    = "k8s2"
+	K8s2Ip  = "192.168.36.12"
 	Runtime = "runtime"
 
 	Enabled  = "enabled"

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -154,6 +154,14 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 		url := fmt.Sprintf("http://%s",
 			net.JoinHostPort(data.Spec.ClusterIP, fmt.Sprintf("%d", data.Spec.Ports[0].Port)))
 		testHTTPRequest(url)
+
+		url = fmt.Sprintf("http://%s",
+			net.JoinHostPort(helpers.K8s1Ip, fmt.Sprintf("%d", data.Spec.Ports[0].NodePort)))
+		testHTTPRequest(url)
+
+		url = fmt.Sprintf("http://%s",
+			net.JoinHostPort(helpers.K8s2Ip, fmt.Sprintf("%d", data.Spec.Ports[0].NodePort)))
+		testHTTPRequest(url)
 	})
 
 	Context("Headless services", func() {


### PR DESCRIPTION
At the moment only the service in the local Port is tested, not the
Nodeport. With this change the NodePort is tested on both hosts.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

