### PR TITLE
monitor: Introduce channel to buffer notifications and listeners

### DIFF
--- a/monitor/launch/launcher.go
+++ b/monitor/launch/launcher.go
@@ -175,20 +175,12 @@ func (nm *NodeMonitor) send(data []byte) error {
 
 	p := payload.Payload{Data: data, CPU: 0, Lost: nm.lostSinceLastTime(), Type: payload.EventSample}
 
-	payloadBuf, err := p.Encode()
+	buf, err := p.BuildMessage()
 	if err != nil {
-		return fmt.Errorf("Unable to encode payload: %s", err)
+		return err
 	}
 
-	meta := &payload.Meta{Size: uint32(len(payloadBuf))}
-	metaBuf, err := meta.MarshalBinary()
-	if err != nil {
-		return fmt.Errorf("Unable to encode metadata: %s", err)
-	}
-
-	msgBuf := append(metaBuf, payloadBuf...)
-
-	if _, err := nm.pipe.Write(msgBuf); err != nil {
+	if _, err := nm.pipe.Write(buf); err != nil {
 		nm.pipe.Close()
 		nm.pipe = nil
 		return fmt.Errorf("Unable to write message buffer to pipe: %s", err)

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -163,20 +163,13 @@ func (m *Monitor) send(pl payload.Payload) {
 		return
 	}
 
-	payloadBuf, err := pl.Encode()
+	buf, err := pl.BuildMessage()
 	if err != nil {
-		log.WithError(err).Fatal("payload encode")
+		log.WithError(err).Error("Unable to send notification to listeners")
 	}
-	meta := &payload.Meta{Size: uint32(len(payloadBuf))}
-	metaBuf, err := meta.MarshalBinary()
-	if err != nil {
-		log.WithError(err).Fatal("meta encode")
-	}
-
-	msgBuf := append(metaBuf, payloadBuf...)
 
 	for ml := range listeners {
-		ml.enqueue(msgBuf)
+		ml.enqueue(buf)
 	}
 }
 

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -156,22 +156,18 @@ func (m *Monitor) send(pl payload.Payload) {
 	if err != nil {
 		log.WithError(err).Fatal("meta encode")
 	}
+
+	msgBuf := append(metaBuf, payloadBuf...)
+
 	var next *list.Element
 	for e := listeners.Front(); e != nil; e = next {
 		client := e.Value.(net.Conn)
 		next = e.Next()
 
-		if _, err := client.Write(metaBuf); err != nil {
+		if _, err := client.Write(msgBuf); err != nil {
 			client.Close()
 			listeners.Remove(e)
 			writeError("metadata", err)
-			continue
-		}
-
-		if _, err := client.Write(payloadBuf); err != nil {
-			client.Close()
-			listeners.Remove(e)
-			writeError("payload", err)
 			continue
 		}
 	}

--- a/monitor/payload/monitor_payload.go
+++ b/monitor/payload/monitor_payload.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/gob"
+	"fmt"
 	"io"
 
 	"github.com/cilium/cilium/pkg/byteorder"
@@ -120,4 +121,20 @@ func WriteMetaPayload(w io.Writer, meta *Meta, pl *Payload) error {
 	meta.WriteBinary(w)
 	_, err = w.Write(payloadBuf)
 	return err
+}
+
+// BuildMessage builds the binary message to be sent and returns it
+func (pl *Payload) BuildMessage() ([]byte, error) {
+	plBuf, err := pl.Encode()
+	if err != nil {
+		return nil, fmt.Errorf("unable to encode payload: %s", err)
+	}
+
+	meta := &Meta{Size: uint32(len(plBuf))}
+	metaBuf, err := meta.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("unable to encode metadata: %s", err)
+	}
+
+	return append(metaBuf, plBuf...), nil
 }


### PR DESCRIPTION
The current monitor code has two drawbacks:
 * `sendEvent()` blocks until the notification has been read, this can block fast path operations such as policy regeneration or even processing of L7 requests.
 * If multiple readers are connected, sending of events is blocked until all listeners have read the notification.

Changes:
 * Moves sendEvent() to NodeMonitor
 * Makes SendEvent() lockless and non-blocking. Notifications are enqueued
   to a channel and in case the channel is full, the notification is dropped.
 * Lost notifications are accounted for and reported
 * The writing to the pipe is made via a single Write() call to maximise the
   chances that either none of the message buffer or all of it is written to
   the pipe.
 * Decouple multiple monitor readers by introducing per listener queues