### PR TITLE
Kubernetes namespace selector enforcement

### DIFF
--- a/Documentation/gettingstarted/minikube.rst
+++ b/Documentation/gettingstarted/minikube.rst
@@ -395,7 +395,7 @@ and ``cilium`` CLI:
         ],
         "labels": [
           {
-            "key": "io.cilium.k8s-policy-name",
+            "key": "io.cilium.k8s.policy.name",
             "value": "rule1",
             "source": "unspec"
           }
@@ -432,7 +432,7 @@ and ``cilium`` CLI:
         ],
         "labels": [
           {
-            "key": "io.cilium.k8s-policy-name",
+            "key": "io.cilium.k8s.policy.name",
             "value": "access-backend",
             "source": "unspec"
           }

--- a/Documentation/policy/intro.rst
+++ b/Documentation/policy/intro.rst
@@ -112,7 +112,7 @@ egress
 labels
   Labels are used to identify the rule. Rules can be listed and deleted by
   labels. Policy rules which are imported via :ref:`k8s_policy` automatically
-  get the label ``io.cilium.k8s-policy-name=NAME`` assigned where ``NAME``
+  get the label ``io.cilium.k8s.policy.name=NAME`` assigned where ``NAME``
   corresponds to the name specified in the `NetworkPolicy` or
   `CiliumNetworkPolicy` resource.
 

--- a/Documentation/policy/troubleshooting.rst
+++ b/Documentation/policy/troubleshooting.rst
@@ -73,7 +73,7 @@ For an endpoint with endpoint id 51796, We can print all policies applied to it 
     $ cilium endpoint get 51796 -o jsonpath='{range ..policy.l4.ingress[*].derived-from-rules}{@}{"\n"}{end}' | \
       tr -d '][' | \
       xargs -I{} bash -c 'echo "Labels: {}"; cilium policy get {}'
-    Labels: unspec:io.cilium.k8s-policy-name=rule1 unspec:io.cilium.k8s-policy-namespace=default
+    Labels: unspec:io.cilium.k8s.policy.name=rule1 unspec:io.cilium.k8s.policy.namespace=default
     [
       {
         "endpointSelector": {
@@ -81,12 +81,12 @@ For an endpoint with endpoint id 51796, We can print all policies applied to it 
              ],
         "labels": [
           {
-            "key": "io.cilium.k8s-policy-name",
+            "key": "io.cilium.k8s.policy.name",
             "value": "rule1",
             "source": "unspec"
           },
           {
-            "key": "io.cilium.k8s-policy-namespace",
+            "key": "io.cilium.k8s.policy.namespace",
             "value": "default",
             "source": "unspec"
           }

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/k8s"
-	cilium_io "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	k8sUtils "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
 	cilium_v1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v1"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
@@ -1526,7 +1526,7 @@ func (d *Daemon) addCiliumNetworkPolicyV1(ciliumV1Store cache.Store, cnp *cilium
 
 				nodeName := node.GetName()
 				serverRuleCpy.SetPolicyStatus(nodeName, cnpns)
-				ns := cilium_io.ExtractNamespace(&serverRuleCpy.ObjectMeta)
+				ns := k8sUtils.ExtractNamespace(&serverRuleCpy.ObjectMeta)
 
 				_, err2 = ciliumNPClient.CiliumV1().CiliumNetworkPolicies(ns).Update(serverRuleCpy)
 				if err2 == nil {
@@ -1694,7 +1694,7 @@ func (d *Daemon) addCiliumNetworkPolicyV2(ciliumV2Store cache.Store, cnp *cilium
 
 				nodeName := node.GetName()
 				serverRuleCpy.SetPolicyStatus(nodeName, cnpns)
-				ns := cilium_io.ExtractNamespace(&serverRuleCpy.ObjectMeta)
+				ns := k8sUtils.ExtractNamespace(&serverRuleCpy.ObjectMeta)
 
 				_, err2 = ciliumNPClient.CiliumV2().CiliumNetworkPolicies(ns).Update(serverRuleCpy)
 				if err2 == nil {

--- a/pkg/k8s/apis/cilium.io/const.go
+++ b/pkg/k8s/apis/cilium.io/const.go
@@ -21,9 +21,12 @@ import (
 const (
 	// PolicyLabelName is the name of the policy label which refers to the
 	// k8s policy name.
-	PolicyLabelName = "io.cilium.k8s-policy-name"
+	PolicyLabelName = "io.cilium.k8s.policy.name"
 	// PolicyLabelNamespace is the policy's namespace set in k8s.
-	PolicyLabelNamespace = "io.cilium.k8s-policy-namespace"
+	PolicyLabelNamespace = "io.cilium.k8s.policy.namespace"
+	// PodNamespaceMetaLabels is the label used to store the labels of the
+	// kubernetes namespace's labels.
+	PodNamespaceMetaLabels = "io.cilium.k8s.namespace.labels"
 	// PodNamespaceLabel is the label used in kubernetes containers to
 	// specify which namespace they belong to.
 	PodNamespaceLabel = types.KubernetesPodNamespaceLabel

--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ciliumio
+package utils
 
 import (
 	"fmt"
 
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -32,7 +33,7 @@ const (
 	subsysK8s = "k8s"
 	// podPrefixLbl is the value the prefix used in the label selector to
 	// represent pods on the default namespace.
-	podPrefixLbl = labels.LabelSourceK8sKeyPrefix + PodNamespaceLabel
+	podPrefixLbl = labels.LabelSourceK8sKeyPrefix + k8sConst.PodNamespaceLabel
 )
 
 var (
@@ -57,8 +58,8 @@ func GetObjNamespaceName(obj *metav1.ObjectMeta) string {
 // GetPolicyLabels returns a LabelArray for the given namespace and name.
 func GetPolicyLabels(ns, name string) labels.LabelArray {
 	return labels.ParseLabelArray(
-		fmt.Sprintf("%s=%s", PolicyLabelName, name),
-		fmt.Sprintf("%s=%s", PolicyLabelNamespace, ns),
+		fmt.Sprintf("%s=%s", k8sConst.PolicyLabelName, name),
+		fmt.Sprintf("%s=%s", k8sConst.PolicyLabelNamespace, ns),
 	)
 }
 

--- a/pkg/k8s/apis/cilium.io/v1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1/types.go
@@ -19,7 +19,8 @@ import (
 	"reflect"
 	"time"
 
-	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	k8sUtils "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -126,7 +127,7 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 		return nil, fmt.Errorf("CiliumNetworkPolicy must have name")
 	}
 
-	namespace := k8sconst.ExtractNamespace(&r.ObjectMeta)
+	namespace := k8sUtils.ExtractNamespace(&r.ObjectMeta)
 	name := r.ObjectMeta.Name
 
 	retRules := api.Rules{}
@@ -136,7 +137,7 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 			return nil, fmt.Errorf("Invalid CiliumNetworkPolicy spec: %s", err)
 
 		}
-		cr := k8sconst.ParseToCiliumRule(namespace, name, r.Spec)
+		cr := k8sUtils.ParseToCiliumRule(namespace, name, r.Spec)
 		retRules = append(retRules, cr)
 	}
 	if r.Specs != nil {
@@ -145,7 +146,7 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 				return nil, fmt.Errorf("Invalid CiliumNetworkPolicy specs: %s", err)
 
 			}
-			cr := k8sconst.ParseToCiliumRule(namespace, name, rule)
+			cr := k8sUtils.ParseToCiliumRule(namespace, name, rule)
 			retRules = append(retRules, cr)
 		}
 	}
@@ -155,8 +156,8 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 
 // GetControllerName returns the unique name for the controller manager.
 func (r *CiliumNetworkPolicy) GetControllerName() string {
-	name := k8sconst.GetObjNamespaceName(&r.ObjectMeta)
-	return fmt.Sprintf("%s (v1 %s)", k8sconst.CtrlPrefixPolicyStatus, name)
+	name := k8sUtils.GetObjNamespaceName(&r.ObjectMeta)
+	return fmt.Sprintf("%s (v1 %s)", k8sConst.CtrlPrefixPolicyStatus, name)
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/k8s/apis/cilium.io/v1/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v1/types_test.go
@@ -19,7 +19,8 @@ import (
 	"testing"
 
 	"github.com/cilium/cilium/pkg/comparator"
-	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	k8sUtils "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
 
@@ -77,7 +78,7 @@ var (
 				FromEndpoints: []api.EndpointSelector{
 					api.NewESFromLabels(
 						labels.ParseSelectLabel("role=frontend"),
-						labels.ParseSelectLabel("k8s:"+k8sconst.PodNamespaceLabel+"=default"),
+						labels.ParseSelectLabel("k8s:"+k8sConst.PodNamespaceLabel+"=default"),
 					),
 					api.NewESFromLabels(
 						labels.ParseSelectLabel("reserved:world"),
@@ -105,7 +106,7 @@ var (
 				ToCIDRSet: []api.CIDRRule{{Cidr: api.CIDR("10.0.0.0/8"), ExceptCIDRs: []api.CIDR{"10.96.0.0/12"}}},
 			},
 		},
-		Labels: k8sconst.GetPolicyLabels("default", "rule1"),
+		Labels: k8sUtils.GetPolicyLabels("default", "rule1"),
 	}
 
 	rawRule = []byte(`{
@@ -223,7 +224,7 @@ func (s *CiliumV1Suite) TestParseSpec(c *C) {
 		Spec: &apiRule,
 	}
 
-	expectedES := api.NewESFromLabels(labels.ParseSelectLabel("role=backend"), labels.ParseSelectLabel("k8s:"+k8sconst.PodNamespaceLabel+"=default"))
+	expectedES := api.NewESFromLabels(labels.ParseSelectLabel("role=backend"), labels.ParseSelectLabel("k8s:"+k8sConst.PodNamespaceLabel+"=default"))
 	expectedES.MatchExpressions = []metav1.LabelSelectorRequirement{{Key: "any.role", Operator: "NotIn", Values: []string{"production"}}}
 
 	expectedSpecRule.EndpointSelector = expectedES
@@ -259,7 +260,7 @@ func (s *CiliumV1Suite) TestParseRules(c *C) {
 		Specs: api.Rules{&apiRule, &apiRule},
 	}
 
-	expectedES := api.NewESFromLabels(labels.ParseSelectLabel("role=backend"), labels.ParseSelectLabel("k8s:"+k8sconst.PodNamespaceLabel+"=default"))
+	expectedES := api.NewESFromLabels(labels.ParseSelectLabel("role=backend"), labels.ParseSelectLabel("k8s:"+k8sConst.PodNamespaceLabel+"=default"))
 	expectedES.MatchExpressions = []metav1.LabelSelectorRequirement{{Key: "any.role", Operator: "NotIn", Values: []string{"production"}}}
 
 	expectedSpecRule.EndpointSelector = expectedES

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -19,10 +19,12 @@ import (
 	"reflect"
 	"time"
 
-	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	k8sUtils "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy/api"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -128,7 +130,7 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 		return nil, fmt.Errorf("CiliumNetworkPolicy must have name")
 	}
 
-	namespace := k8sconst.ExtractNamespace(&r.ObjectMeta)
+	namespace := k8sUtils.ExtractNamespace(&r.ObjectMeta)
 	name := r.ObjectMeta.Name
 
 	retRules := api.Rules{}
@@ -138,7 +140,7 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 			return nil, fmt.Errorf("Invalid CiliumNetworkPolicy spec: %s", err)
 
 		}
-		cr := k8sconst.ParseToCiliumRule(namespace, name, r.Spec)
+		cr := k8sUtils.ParseToCiliumRule(namespace, name, r.Spec)
 		retRules = append(retRules, cr)
 	}
 	if r.Specs != nil {
@@ -147,7 +149,7 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 				return nil, fmt.Errorf("Invalid CiliumNetworkPolicy specs: %s", err)
 
 			}
-			cr := k8sconst.ParseToCiliumRule(namespace, name, rule)
+			cr := k8sUtils.ParseToCiliumRule(namespace, name, rule)
 			retRules = append(retRules, cr)
 		}
 	}
@@ -157,8 +159,8 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 
 // GetControllerName returns the unique name for the controller manager.
 func (r *CiliumNetworkPolicy) GetControllerName() string {
-	name := k8sconst.GetObjNamespaceName(&r.ObjectMeta)
-	return fmt.Sprintf("%s (v2 %s)", k8sconst.CtrlPrefixPolicyStatus, name)
+	name := k8sUtils.GetObjNamespaceName(&r.ObjectMeta)
+	return fmt.Sprintf("%s (v2 %s)", k8sConst.CtrlPrefixPolicyStatus, name)
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -19,7 +19,8 @@ import (
 	"testing"
 
 	"github.com/cilium/cilium/pkg/comparator"
-	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	k8sUtils "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
 
@@ -77,7 +78,7 @@ var (
 				FromEndpoints: []api.EndpointSelector{
 					api.NewESFromLabels(
 						labels.ParseSelectLabel("role=frontend"),
-						labels.ParseSelectLabel("k8s:"+k8sconst.PodNamespaceLabel+"=default"),
+						labels.ParseSelectLabel("k8s:"+k8sConst.PodNamespaceLabel+"=default"),
 					),
 					api.NewESFromLabels(
 						labels.ParseSelectLabel("reserved:world"),
@@ -105,7 +106,7 @@ var (
 				ToCIDRSet: []api.CIDRRule{{Cidr: api.CIDR("10.0.0.0/8"), ExceptCIDRs: []api.CIDR{"10.96.0.0/12"}}},
 			},
 		},
-		Labels: k8sconst.GetPolicyLabels("default", "rule1"),
+		Labels: k8sUtils.GetPolicyLabels("default", "rule1"),
 	}
 
 	rawRule = []byte(`{
@@ -223,7 +224,7 @@ func (s *CiliumV2Suite) TestParseSpec(c *C) {
 		Spec: &apiRule,
 	}
 
-	expectedES := api.NewESFromLabels(labels.ParseSelectLabel("role=backend"), labels.ParseSelectLabel("k8s:"+k8sconst.PodNamespaceLabel+"=default"))
+	expectedES := api.NewESFromLabels(labels.ParseSelectLabel("role=backend"), labels.ParseSelectLabel("k8s:"+k8sConst.PodNamespaceLabel+"=default"))
 	expectedES.MatchExpressions = []metav1.LabelSelectorRequirement{{Key: "any.role", Operator: "NotIn", Values: []string{"production"}}}
 
 	expectedSpecRule.EndpointSelector = expectedES
@@ -259,7 +260,7 @@ func (s *CiliumV2Suite) TestParseRules(c *C) {
 		Specs: api.Rules{&apiRule, &apiRule},
 	}
 
-	expectedES := api.NewESFromLabels(labels.ParseSelectLabel("role=backend"), labels.ParseSelectLabel("k8s:"+k8sconst.PodNamespaceLabel+"=default"))
+	expectedES := api.NewESFromLabels(labels.ParseSelectLabel("role=backend"), labels.ParseSelectLabel("k8s:"+k8sConst.PodNamespaceLabel+"=default"))
 	expectedES.MatchExpressions = []metav1.LabelSelectorRequirement{{Key: "any.role", Operator: "NotIn", Values: []string{"production"}}}
 
 	expectedSpecRule.EndpointSelector = expectedES

--- a/pkg/k8s/const.go
+++ b/pkg/k8s/const.go
@@ -30,7 +30,4 @@ const (
 	// EnvNodeNameSpec is the environment label used by Kubernetes to
 	// specify the node's name.
 	EnvNodeNameSpec = "K8S_NODE_NAME"
-	// PodNamespaceMetaLabels is the label used to store the labels of the
-	// kubernetes namespace's labels.
-	PodNamespaceMetaLabels = "ns-labels"
 )

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/comparator"
-	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -80,7 +80,7 @@ func (s *K8sSuite) TestParseNetworkPolicy(c *C) {
 	c.Assert(err, IsNil)
 
 	fromEndpoints := labels.LabelArray{
-		labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+		labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 		labels.NewLabel("foo3", "bar3", labels.LabelSourceK8s),
 		labels.NewLabel("foo4", "bar4", labels.LabelSourceK8s),
 	}
@@ -88,7 +88,7 @@ func (s *K8sSuite) TestParseNetworkPolicy(c *C) {
 	ctx := policy.SearchContext{
 		From: fromEndpoints,
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo1", "bar1", labels.LabelSourceK8s),
 			labels.NewLabel("foo2", "bar2", labels.LabelSourceK8s),
 		},
@@ -121,11 +121,16 @@ func (s *K8sSuite) TestParseNetworkPolicy(c *C) {
 		Ingress: policy.L4PolicyMap{
 			"80/TCP": {
 				Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
-				FromEndpoints:    []api.EndpointSelector{epSelector},
-				L7Parser:         "",
-				L7RulesPerEp:     policy.L7DataMap{},
-				Ingress:          true,
-				DerivedFromRules: []labels.LabelArray{labels.ParseLabelArray("unspec:io.cilium.k8s-policy-name", "unspec:io.cilium.k8s-policy-namespace=default")},
+				FromEndpoints: []api.EndpointSelector{epSelector},
+				L7Parser:      "",
+				L7RulesPerEp:  policy.L7DataMap{},
+				Ingress:       true,
+				DerivedFromRules: []labels.LabelArray{
+					labels.ParseLabelArray(
+						"unspec:"+k8sConst.PolicyLabelName,
+						"unspec:"+k8sConst.PolicyLabelNamespace+"=default",
+					),
+				},
 			},
 		},
 		Egress: policy.L4PolicyMap{},
@@ -186,7 +191,7 @@ func (s *K8sSuite) TestParseNetworkPolicyNoSelectors(c *C) {
 }`)
 
 	fromEndpoints := labels.LabelArray{
-		labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+		labels.NewLabel(k8sConst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 		labels.NewLabel("role", "backend", labels.LabelSourceK8s),
 	}
 
@@ -221,7 +226,10 @@ func (s *K8sSuite) TestParseNetworkPolicyNoSelectors(c *C) {
 				},
 			},
 			Egress: []api.EgressRule{},
-			Labels: labels.ParseLabelArray("unspec:io.cilium.k8s-policy-name=ingress-cidr-test", "unspec:io.cilium.k8s-policy-namespace=myns"),
+			Labels: labels.ParseLabelArray(
+				"unspec:"+k8sConst.PolicyLabelName+"=ingress-cidr-test",
+				"unspec:"+k8sConst.PolicyLabelNamespace+"=myns",
+			),
 		},
 	}
 
@@ -275,11 +283,11 @@ func (s *K8sSuite) TestParseNetworkPolicyEmptyFrom(c *C) {
 
 	ctx := policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo0", "bar0", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo1", "bar1", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -330,11 +338,11 @@ func (s *K8sSuite) TestParseNetworkPolicyDenyAll(c *C) {
 
 	ctx := policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo0", "bar0", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo1", "bar1", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -455,7 +463,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	repo.AddList(rules)
 	ctx := policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
@@ -468,7 +476,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
@@ -481,11 +489,11 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			labels.NewLabel("role", "backend", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
@@ -589,11 +597,11 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	repo.AddList(rules)
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -611,8 +619,8 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
 			{
@@ -621,7 +629,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -658,11 +666,11 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	repo.AddList(rules)
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "backend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -672,11 +680,11 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "backend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -686,11 +694,11 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "backend", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
@@ -807,8 +815,8 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
 			{
@@ -817,7 +825,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -827,8 +835,8 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
 			{
@@ -837,7 +845,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -847,8 +855,8 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "alice", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "user"), "alice", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
 			{
@@ -857,7 +865,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -952,15 +960,15 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
 			// doesn't matter the namespace.
-			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			// component==redis is in the policy
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "component"), "redis", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "component"), "redis", labels.LabelSourceK8s),
 			// tier==cache is in the policy
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "tier"), "cache", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "tier"), "cache", labels.LabelSourceK8s),
 			// environment is not in `dev` which is in the policy
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "environment"), "production", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "environment"), "production", labels.LabelSourceK8s),
 			// doesn't matter, there isn't any matchExpression denying traffic from any zone.
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "zone"), "eu-1", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "zone"), "eu-1", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
 			{
@@ -970,7 +978,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 		},
 		To: labels.LabelArray{
 			// Namespace needs to be in `expressions` since the policy is being enforced for that namespace.
-			labels.NewLabel(k8sconst.PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
 			// component==redis is in the policy.
 			labels.NewLabel("component", "redis", labels.LabelSourceK8s),
 			// tier==cache is in the policy
@@ -983,7 +991,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx.To = labels.LabelArray{
 		// Namespace needs to be in `expressions` since the policy is being enforced for that namespace.
-		labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+		labels.NewLabel(k8sConst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 		// component==redis is in the policy.
 		labels.NewLabel("component", "redis", labels.LabelSourceK8s),
 		// tier==cache is in the policy
@@ -994,10 +1002,10 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "component"), "redis", labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "tier"), "cache", labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "environment"), "dev", labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "zone"), "eu-1", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "component"), "redis", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "tier"), "cache", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "environment"), "dev", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "zone"), "eu-1", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
 			{
@@ -1006,7 +1014,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
 			labels.NewLabel("component", "redis", labels.LabelSourceK8s),
 			labels.NewLabel("tier", "cache", labels.LabelSourceK8s),
 		},
@@ -1017,8 +1025,8 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "component"), "redis", labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "tier"), "cache", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "component"), "redis", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "tier"), "cache", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
 			{
@@ -1027,7 +1035,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
 			labels.NewLabel("component", "redis", labels.LabelSourceK8s),
 			labels.NewLabel("tier", "cache", labels.LabelSourceK8s),
 		},

--- a/pkg/k8s/network_policy_v1beta.go
+++ b/pkg/k8s/network_policy_v1beta.go
@@ -18,7 +18,8 @@ package k8s
 
 import (
 	"github.com/cilium/cilium/pkg/annotation"
-	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	k8sUtils "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
@@ -36,9 +37,9 @@ func GetPolicyLabelsv1beta1(np *v1beta1.NetworkPolicy) labels.LabelArray {
 		policyName = np.Name
 	}
 
-	ns := k8sconst.ExtractNamespace(&np.ObjectMeta)
+	ns := k8sUtils.ExtractNamespace(&np.ObjectMeta)
 
-	return k8sconst.GetPolicyLabels(ns, policyName)
+	return k8sUtils.GetPolicyLabels(ns, policyName)
 }
 
 func parsev1beta1NetworkPolicyPeer(namespace string, peer *v1beta1.NetworkPolicyPeer) *api.EndpointSelector {
@@ -53,21 +54,21 @@ func parsev1beta1NetworkPolicyPeer(namespace string, peer *v1beta1.NetworkPolicy
 		// The PodSelector should only reflect to the same namespace
 		// the policy is being stored, thus we add the namespace to
 		// the MatchLabels map.
-		peer.PodSelector.MatchLabels[k8sconst.PodNamespaceLabel] = namespace
+		peer.PodSelector.MatchLabels[k8sConst.PodNamespaceLabel] = namespace
 	} else if peer.NamespaceSelector != nil {
 		labelSelector = peer.NamespaceSelector
 		matchLabels := map[string]string{}
 		// We use our own special label prefix for namespace metadata,
 		// thus we need to prefix that prefix to all NamespaceSelector.MatchLabels
 		for k, v := range peer.NamespaceSelector.MatchLabels {
-			matchLabels[policy.JoinPath(PodNamespaceMetaLabels, k)] = v
+			matchLabels[policy.JoinPath(k8sConst.PodNamespaceMetaLabels, k)] = v
 		}
 		peer.NamespaceSelector.MatchLabels = matchLabels
 
 		// We use our own special label prefix for namespace metadata,
 		// thus we need to prefix that prefix to all NamespaceSelector.MatchLabels
 		for i, lsr := range peer.NamespaceSelector.MatchExpressions {
-			lsr.Key = policy.JoinPath(PodNamespaceMetaLabels, lsr.Key)
+			lsr.Key = policy.JoinPath(k8sConst.PodNamespaceMetaLabels, lsr.Key)
 			peer.NamespaceSelector.MatchExpressions[i] = lsr
 		}
 	} else {
@@ -95,7 +96,7 @@ func ParseNetworkPolicyV1beta1(np *v1beta1.NetworkPolicy) (api.Rules, error) {
 	ingresses := []api.IngressRule{}
 	egresses := []api.EgressRule{}
 
-	namespace := k8sconst.ExtractNamespace(&np.ObjectMeta)
+	namespace := k8sUtils.ExtractNamespace(&np.ObjectMeta)
 	for _, iRule := range np.Spec.Ingress {
 		ingress := api.IngressRule{}
 		if iRule.From != nil && len(iRule.From) > 0 {
@@ -173,7 +174,7 @@ func ParseNetworkPolicyV1beta1(np *v1beta1.NetworkPolicy) (api.Rules, error) {
 	if np.Spec.PodSelector.MatchLabels == nil {
 		np.Spec.PodSelector.MatchLabels = map[string]string{}
 	}
-	np.Spec.PodSelector.MatchLabels[k8sconst.PodNamespaceLabel] = namespace
+	np.Spec.PodSelector.MatchLabels[k8sConst.PodNamespaceLabel] = namespace
 
 	rule := &api.Rule{
 		EndpointSelector: api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, &np.Spec.PodSelector),

--- a/pkg/k8s/network_policy_v1beta_test.go
+++ b/pkg/k8s/network_policy_v1beta_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/comparator"
-	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -73,14 +73,14 @@ func (s *K8sSuite) TestParseNetworkPolicyDeprecated(c *C) {
 	c.Assert(len(rules), Equals, 1)
 
 	fromEndpoints := labels.LabelArray{
-		labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+		labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 		labels.NewLabel("foo3", "bar3", labels.LabelSourceK8s),
 		labels.NewLabel("foo4", "bar4", labels.LabelSourceK8s),
 	}
 	ctx := policy.SearchContext{
 		From: fromEndpoints,
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo1", "bar1", labels.LabelSourceK8s),
 			labels.NewLabel("foo2", "bar2", labels.LabelSourceK8s),
 		},
@@ -109,11 +109,16 @@ func (s *K8sSuite) TestParseNetworkPolicyDeprecated(c *C) {
 		Ingress: policy.L4PolicyMap{
 			"80/TCP": {
 				Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
-				FromEndpoints:    []api.EndpointSelector{epSelector},
-				L7Parser:         "",
-				L7RulesPerEp:     policy.L7DataMap{},
-				Ingress:          true,
-				DerivedFromRules: []labels.LabelArray{labels.ParseLabelArray("unspec:io.cilium.k8s-policy-name", "unspec:io.cilium.k8s-policy-namespace=default")},
+				FromEndpoints: []api.EndpointSelector{epSelector},
+				L7Parser:      "",
+				L7RulesPerEp:  policy.L7DataMap{},
+				Ingress:       true,
+				DerivedFromRules: []labels.LabelArray{
+					labels.ParseLabelArray(
+						"unspec:"+k8sConst.PolicyLabelName,
+						"unspec:"+k8sConst.PolicyLabelNamespace+"=default",
+					),
+				},
 			},
 		},
 		Egress: policy.L4PolicyMap{},
@@ -184,11 +189,11 @@ func (s *K8sSuite) TestParseNetworkPolicyEmptyFromDeprecated(c *C) {
 
 	ctx := policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo0", "bar0", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo1", "bar1", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -239,11 +244,11 @@ func (s *K8sSuite) TestParseNetworkPolicyDenyAllDeprecated(c *C) {
 
 	ctx := policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo0", "bar0", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("foo1", "bar1", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -320,7 +325,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 	repo.AddList(rules)
 	ctx := policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
@@ -333,7 +338,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
@@ -346,11 +351,11 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			labels.NewLabel("role", "backend", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
@@ -412,11 +417,11 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 	repo.AddList(rules)
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -433,8 +438,8 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
 			{
@@ -443,7 +448,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -480,11 +485,11 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 	repo.AddList(rules)
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "backend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -494,11 +499,11 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "backend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -508,11 +513,11 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "backend", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
@@ -585,8 +590,8 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
 			{
@@ -595,7 +600,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -605,8 +610,8 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "user"), "bob", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
 			{
@@ -615,7 +620,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
 			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
 		},
 		Trace: policy.TRACE_VERBOSE,
@@ -710,15 +715,15 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
 			// doesn't matter the namespace.
-			labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 			// component==redis is in the policy
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "component"), "redis", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "component"), "redis", labels.LabelSourceK8s),
 			// tier==cache is in the policy
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "tier"), "cache", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "tier"), "cache", labels.LabelSourceK8s),
 			// environment is not in `dev` which is in the policy
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "environment"), "production", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "environment"), "production", labels.LabelSourceK8s),
 			// doesn't matter, there isn't any matchExpression denying traffic from any zone.
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "zone"), "eu-1", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "zone"), "eu-1", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
 			{
@@ -728,7 +733,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 		},
 		To: labels.LabelArray{
 			// Namespace needs to be in `expressions` since the policy is being enforced for that namespace.
-			labels.NewLabel(k8sconst.PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
 			// component==redis is in the policy.
 			labels.NewLabel("component", "redis", labels.LabelSourceK8s),
 			// tier==cache is in the policy
@@ -741,7 +746,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 
 	ctx.To = labels.LabelArray{
 		// Namespace needs to be in `expressions` since the policy is being enforced for that namespace.
-		labels.NewLabel(k8sconst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
+		labels.NewLabel(k8sConst.PodNamespaceLabel, "myns", labels.LabelSourceK8s),
 		// component==redis is in the policy.
 		labels.NewLabel("component", "redis", labels.LabelSourceK8s),
 		// tier==cache is in the policy
@@ -752,10 +757,10 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "component"), "redis", labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "tier"), "cache", labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "environment"), "dev", labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "zone"), "eu-1", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "component"), "redis", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "tier"), "cache", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "environment"), "dev", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "zone"), "eu-1", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
 			{
@@ -764,7 +769,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
 			labels.NewLabel("component", "redis", labels.LabelSourceK8s),
 			labels.NewLabel("tier", "cache", labels.LabelSourceK8s),
 		},
@@ -775,8 +780,8 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "component"), "redis", labels.LabelSourceK8s),
-			labels.NewLabel(policy.JoinPath(PodNamespaceMetaLabels, "tier"), "cache", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "component"), "redis", labels.LabelSourceK8s),
+			labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "tier"), "cache", labels.LabelSourceK8s),
 		},
 		DPorts: []*models.Port{
 			{
@@ -785,7 +790,7 @@ func (s *K8sSuite) TestNetworkPolicyExamplesDeprecated(c *C) {
 			},
 		},
 		To: labels.LabelArray{
-			labels.NewLabel(k8sconst.PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PodNamespaceLabel, "expressions", labels.LabelSourceK8s),
 			labels.NewLabel("component", "redis", labels.LabelSourceK8s),
 			labels.NewLabel("tier", "cache", labels.LabelSourceK8s),
 		},

--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/cilium/cilium/common"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 )
@@ -158,7 +159,8 @@ func defaultLabelPrefixCfg() *labelPrefixCfg {
 	}
 
 	expressions := []string{
-		K8sNamespaceLabel,                                          // include io.kubernetes.pod.namspace
+		k8sConst.PodNamespaceLabel,                                 // include io.kubernetes.pod.namspace
+		k8sConst.PodNamespaceMetaLabels,                            // include all namespace labels
 		"!io.kubernetes",                                           // ignore all other io.kubernetes labels
 		"!.*kubernetes.io",                                         // ignore all other kubernetes.io labels (annotation.*.k8s.io)
 		"!pod-template-generation",                                 // ignore pod-template-generation

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -136,9 +136,6 @@ const (
 
 	// LabelSourceReservedKeyPrefix is the prefix of a reserved label
 	LabelSourceReservedKeyPrefix = LabelSourceReserved + "."
-
-	// K8sNamespaceLabel is the key that maps to the namespace for a pod.
-	K8sNamespaceLabel = "io.kubernetes.pod.namespace"
 )
 
 // Label is the cilium's representation of a container label.

--- a/pkg/policy/trace/yaml.go
+++ b/pkg/policy/trace/yaml.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 
 	"k8s.io/api/core/v1"
@@ -71,7 +72,7 @@ func GetLabelsFromYaml(file string) ([][]string, error) {
 			} else {
 				ns = DefaultNamespace
 			}
-			yamlLabels = append(yamlLabels, labels.GenerateK8sLabelString(labels.K8sNamespaceLabel, ns))
+			yamlLabels = append(yamlLabels, labels.GenerateK8sLabelString(k8sConst.PodNamespaceLabel, ns))
 
 			for k, v := range deployment.Spec.Template.Labels {
 				yamlLabels = append(yamlLabels, labels.GenerateK8sLabelString(k, v))
@@ -84,7 +85,7 @@ func GetLabelsFromYaml(file string) ([][]string, error) {
 			} else {
 				ns = DefaultNamespace
 			}
-			yamlLabels = append(yamlLabels, labels.GenerateK8sLabelString(labels.K8sNamespaceLabel, ns))
+			yamlLabels = append(yamlLabels, labels.GenerateK8sLabelString(k8sConst.PodNamespaceLabel, ns))
 
 			for k, v := range controller.Spec.Template.Labels {
 				yamlLabels = append(yamlLabels, labels.GenerateK8sLabelString(k, v))
@@ -97,7 +98,7 @@ func GetLabelsFromYaml(file string) ([][]string, error) {
 			} else {
 				ns = DefaultNamespace
 			}
-			yamlLabels = append(yamlLabels, labels.GenerateK8sLabelString(labels.K8sNamespaceLabel, ns))
+			yamlLabels = append(yamlLabels, labels.GenerateK8sLabelString(k8sConst.PodNamespaceLabel, ns))
 
 			for k, v := range rep.Spec.Template.Labels {
 				yamlLabels = append(yamlLabels, labels.GenerateK8sLabelString(k, v))

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"os"
 	"time"
+
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 )
 
 var (
@@ -143,8 +145,8 @@ const (
 	KubectlDelete = ResourceLifeCycleAction("delete")
 	KubectlApply  = ResourceLifeCycleAction("apply")
 
-	KubectlPolicyNameLabel      = "io.cilium.k8s-policy-name"
-	KubectlPolicyNameSpaceLabel = "io.cilium.k8s-policy-namespace"
+	KubectlPolicyNameLabel      = k8sConst.PolicyLabelName
+	KubectlPolicyNameSpaceLabel = k8sConst.PolicyLabelNamespace
 )
 
 var ciliumCLICommands = map[string]string{

--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -52,6 +52,11 @@ type SSHClient struct {
 	// subprocesses, TCP port/streamlocal forwarding and tunneled dialing.
 }
 
+// GetHostPort returns the host port representation of the ssh client
+func (cli *SSHClient) GetHostPort() string {
+	return net.JoinHostPort(cli.Host, strconv.Itoa(cli.Port))
+}
+
 // SSHConfig contains metadata for an SSH session.
 type SSHConfig struct {
 	target       string

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -778,7 +778,7 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 		basicConnectivity := func() {
 			By("Loading Policies into Cilium")
 			policyPath := kubectl.ManifestGet("cnp-l7-stresstest.yaml")
-			policyCmd := "cilium policy get io.cilium.k8s-policy-name=l7-stresstest"
+			policyCmd := "cilium policy get io.cilium.k8s.policy.name=l7-stresstest"
 
 			_, err = kubectl.CiliumPolicyAction(helpers.KubeSystemNamespace, policyPath, helpers.KubectlCreate, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), fmt.Sprintf("Error creating resource %s: %s", policyPath, err))
@@ -798,7 +798,7 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 			By("Testing Cilium NetworkPolicy enforcement from any namespace")
 
 			policyPath := kubectl.ManifestGet("cnp-any-namespace.yaml")
-			policyCmd := "cilium policy get io.cilium.k8s-policy-name=l7-stresstest"
+			policyCmd := "cilium policy get io.cilium.k8s.policy.name=l7-stresstest"
 
 			_, err = kubectl.CiliumPolicyAction(helpers.KubeSystemNamespace, policyPath, helpers.KubectlCreate, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), fmt.Sprintf("Error creating resource %s: %s", policyPath, err))

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -424,7 +424,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 		var policyCmd string
 
 		policyPath = kubectl.ManifestGet("cnp-specs.yaml")
-		policyCmd = "cilium policy get io.cilium.k8s-policy-name=multi-rules"
+		policyCmd = "cilium policy get io.cilium.k8s.policy.name=multi-rules"
 
 		By("Importing policy")
 

--- a/tests/k8s/tests/01-guestbook-test.sh
+++ b/tests/k8s/tests/01-guestbook-test.sh
@@ -53,11 +53,11 @@ function cleanup {
     k8s_apply_policy $NAMESPACE "delete -n kube-system" "${guestbook_dir}/policies/guestbook-policy-redis.json"
 
     log "k8s version is 1.7; checking that guestbook-redis policy is added in Cilium"
-    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=guestbook-redis 2>/dev/null
+    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=guestbook-redis 2>/dev/null
     if [ $? -eq 0 ]; then abort "guestbook-redis policy found in cilium; policy should have been deleted" ; fi
 
     log "k8s version is 1.7; checking that guestbook-web policy is added in Cilium"
-    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=guestbook-web 2>/dev/null
+    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=guestbook-web 2>/dev/null
     if [ $? -eq 0 ]; then abort "guestbook-web policy found in cilium; policy should have been deleted" ; fi
   else
     # guestbook-redis was previously removed
@@ -67,7 +67,7 @@ function cleanup {
     k8s_apply_policy $NAMESPACE "delete -n kube-system" "${guestbook_dir}/policies/guestbook-policy-web-deprecated.yaml"
 
     log "k8s version is 1.6; checking that guestbook-web-deprecated policy is added in Cilium"
-    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=guestbook-web-deprecated 2>/dev/null
+    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=guestbook-web-deprecated 2>/dev/null
     if [ $? -eq 0 ]; then abort "guestbook-web-deprecated policy found in cilium; policy should have been deleted" ; fi
   fi
 
@@ -149,7 +149,7 @@ set +e
 # TPR in k8s < 1.7.0
 if [[ "${k8s_version}" != 1.6.* ]]; then
     log "k8s version is 1.7: checking that guestbook-web policy is added"
-    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=guestbook-web io.cilium.k8s-policy-namespace=default 1>/dev/null
+    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=guestbook-web io.cilium.k8s.policy.namespace=default 1>/dev/null
 
     if [ $? -ne 0 ]; then
       log "Policies in Cilium: "
@@ -158,7 +158,7 @@ if [[ "${k8s_version}" != 1.6.* ]]; then
     fi
 
     log "k8s version is 1.7: checking that kube-system/guestbook-web policy is added"
-    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=guestbook-web io.cilium.k8s-policy-namespace=kube-system 1>/dev/null
+    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=guestbook-web io.cilium.k8s.policy.namespace=kube-system 1>/dev/null
 
     if [ $? -ne 0 ]; then
       log "Policies in Cilium: "
@@ -167,7 +167,7 @@ if [[ "${k8s_version}" != 1.6.* ]]; then
     fi
 else
     log "k8s version is 1.6; checking that guestbook-web-deprecated policy is added"
-    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=guestbook-web-deprecated io.cilium.k8s-policy-namespace=default 1>/dev/null
+    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=guestbook-web-deprecated io.cilium.k8s.policy.namespace=default 1>/dev/null
 
     if [ $? -ne 0 ]; then
       log "Policies in Cilium: "
@@ -175,7 +175,7 @@ else
       abort "default/guestbook-web-deprecated policy not in cilium"
     fi
 
-    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=guestbook-web-deprecated io.cilium.k8s-policy-namespace=kube-system 1>/dev/null
+    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=guestbook-web-deprecated io.cilium.k8s.policy.namespace=kube-system 1>/dev/null
 
     if [ $? -ne 0 ]; then
       log "Policies in Cilium: "
@@ -185,7 +185,7 @@ else
 fi
 
 log "checking that guestbook-redis-deprecated policy is added in Cilium"
-docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=guestbook-redis-deprecated io.cilium.k8s-policy-namespace=default 1>/dev/null
+docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=guestbook-redis-deprecated io.cilium.k8s.policy.namespace=default 1>/dev/null
 
 if [ $? -ne 0 ]; then
   log "Policies in Cilium: "
@@ -216,7 +216,7 @@ k8s_apply_policy $NAMESPACE "delete -n kube-system" "${guestbook_dir}/policies/g
 set +e
 
 log "checking that guestbook-redis-deprecated policy is added in Cilium"
-docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=guestbook-redis-deprecated 2>/dev/null
+docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=guestbook-redis-deprecated 2>/dev/null
 
 if [ $? -eq 0 ]; then abort "guestbook-redis-deprecated policy found in cilium; policy should have been deleted" ; fi
 
@@ -227,7 +227,7 @@ if [[ "${k8s_version}" != 1.6.* ]]; then
     k8s_apply_policy kube-system create "${guestbook_dir}/policies/guestbook-policy-redis.json"
 
     log "k8s version is 1.7, checking that guestbook-policy-redis policy is added in Cilium"
-    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=guestbook-redis 1>/dev/null
+    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=guestbook-redis 1>/dev/null
 
     if [ $? -ne 0 ]; then abort "guestbook-redis policy not in cilium" ; fi
 

--- a/tests/k8s/tests/02-cnp-specs.sh
+++ b/tests/k8s/tests/02-cnp-specs.sh
@@ -135,7 +135,7 @@ if [[ "${k8s_version}" != 1.6.* ]]; then
     if [ $? -ne 0 ]; then abort "policies were not inserted in kubernetes" ; fi
 
     log "checking that multi-rules policy was added in Cilium"
-    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=multi-rules 1>/dev/null
+    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=multi-rules 1>/dev/null
 
     if [ $? -ne 0 ]; then abort "multi-rules policy not in cilium" ; fi
 else
@@ -145,7 +145,7 @@ else
     if [ $? -ne 0 ]; then abort "policies were not inserted in kubernetes" ; fi
 
     log "checking that multi-rules-deprecated policy was added in Cilium"
-    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=multi-rules-deprecated 1>/dev/null
+    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=multi-rules-deprecated 1>/dev/null
 
     if [ $? -ne 0 ]; then abort "multi-rules-deprecated policy not in cilium" ; fi
 fi
@@ -180,6 +180,6 @@ log "deleting all policies in ${bookinfo_dir}/policies"
 k8s_apply_policy $NAMESPACE delete "${bookinfo_dir}/policies"
 
 log "checking that all policies were deleted in Cilium"
-docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=multi-rules 2>/dev/null
+docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=multi-rules 2>/dev/null
 
 if [ $? -eq 0 ]; then abort "multi-rules policy found in cilium; policy should have been deleted" ; fi

--- a/tests/k8s/tests/03-l7-stresstest.sh
+++ b/tests/k8s/tests/03-l7-stresstest.sh
@@ -144,13 +144,13 @@ if [[ "${k8s_version}" != 1.6.* ]]; then
     log "k8s version is 1.7; adding policies"
     k8s_apply_policy kube-system create "${l7_stresstest_dir}/policies/cnp.yaml"
     log "checking that policies were added in Cilium"
-    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=l7-stresstest 1>/dev/null
+    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=l7-stresstest 1>/dev/null
     if [ $? -ne 0 ]; then abort "l7-stresstest policy not in cilium" ; fi
 else
     log "k8s version is 1.6; adding policies"
     k8s_apply_policy kube-system create "${l7_stresstest_dir}/policies/cnp-deprecated.yaml"
     log "checking that policies were added in Cilium"
-    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=l7-stresstest-deprecated 1>/dev/null
+    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=l7-stresstest-deprecated 1>/dev/null
     if [ $? -ne 0 ]; then abort "l7-stresstest-deprecated policy not in cilium" ; fi
 fi
 
@@ -175,11 +175,11 @@ k8s_apply_policy $NAMESPACE delete "${l7_stresstest_dir}/policies"
 # TPR in k8s < 1.7.0
 if [[ "${k8s_version}" != 1.6.* ]]; then
     log "k8s version is 1.7; checking that policies were deleted in Cilium"
-    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=l7-stresstest 2>/dev/null
+    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=l7-stresstest 2>/dev/null
     if [ $? -eq 0 ]; then abort "l7-stresstest policy found in cilium; policy should have been deleted" ; fi
 else
     log "k8s version is 1.6; checking that policies were deleted in Ciliumd"
-    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=l7-stresstest-deprecated 2>/dev/null
+    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=l7-stresstest-deprecated 2>/dev/null
     if [ $? -eq 0 ]; then abort "l7-stresstest-deprecated policy found in cilium; policy should have been deleted" ; fi
 fi
 
@@ -192,13 +192,13 @@ if [[ "${k8s_version}" != 1.6.* ]]; then
     log "k8s version is 1.7; adding policies"
     k8s_apply_policy kube-system create "${l7_stresstest_dir}/policies/cnp-any-namespace.yaml"
     log "checking that policies were added in Cilium"
-    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=l7-stresstest 1>/dev/null
+    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=l7-stresstest 1>/dev/null
     if [ $? -ne 0 ]; then abort "l7-stresstest policy not in cilium" ; fi
 else
     log "k8s version is 1.6; adding policies"
     k8s_apply_policy kube-system create "${l7_stresstest_dir}/policies/cnp-any-namespace-deprecated.yaml"
     log "checking that policies were added in Cilium"
-    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=l7-stresstest-deprecated 1>/dev/null
+    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=l7-stresstest-deprecated 1>/dev/null
     if [ $? -ne 0 ]; then abort "l7-stresstest-deprecated policy not in cilium" ; fi
 fi
 
@@ -228,10 +228,10 @@ kubectl delete namespace qa development
 # TPR in k8s < 1.7.0
 if [[ "${k8s_version}" != 1.6.* ]]; then
     log "k8s version is 1.7; checking that policies were deleted in Cilium"
-    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=l7-stresstest 2>/dev/null
+    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=l7-stresstest 2>/dev/null
     if [ $? -eq 0 ]; then abort "l7-stresstest policy found in cilium; policy should have been deleted" ; fi
 else
     log "k8s version is 1.6; checking that policies were deleted in Ciliumd"
-    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s-policy-name=l7-stresstest-deprecated 2>/dev/null
+    docker exec -i ${cilium_id} cilium policy get io.cilium.k8s.policy.name=l7-stresstest-deprecated 2>/dev/null
     if [ $? -eq 0 ]; then abort "l7-stresstest-deprecated policy found in cilium; policy should have been deleted" ; fi
 fi


### PR DESCRIPTION
**Summary of changes**:

- Add `kubectl` helper to ginkgo framework
- Add namespace selector enforcement for kubernetes network policy

```release-note
Add kubernetes network policy namespace selector enforcement
```

I had to refactor the code a little bit to avoid cycle-dependencies
