### PR TITLE
Jenkins: Updated Jenkinsfiles agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label 'vagrant'
+        label 'baremetal'
     }
     options {
         timeout(time: 140, unit: 'MINUTES')

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label 'nightly'
+        label 'fixed'
     }
     environment {
         PROJ_PATH = "src/github.com/cilium/cilium"

--- a/ginkgo-all.Jenkinsfile
+++ b/ginkgo-all.Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label 'ginkgo'
+        label 'baremetal'
     }
     environment {
         PROJ_PATH = "src/github.com/cilium/cilium"

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label 'ginkgo'
+        label 'baremetal'
     }
     environment {
         PROJ_PATH = "src/github.com/cilium/cilium"

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label 'ginkgo'
+        label 'baremetal'
     }
     environment {
         PROJ_PATH = "src/github.com/cilium/cilium"


### PR DESCRIPTION
Changed the labels in Jenkins, to the following structure:

- Baremetal: servers hosted on Packet.net and in the auto-scaling group.
- Fixed: fixed baremetal servers that are not part of auto-scaling group

This commit is to avoid that long jobs using auto-scaling resources and
block the delition of idle servers.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

