### PR TITLE
random doc updates

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -196,6 +196,13 @@ project root directory:
 
     $ make tests
 
+.. Warning::
+
+ Make tests executes envoy tests. This can sometimes cause the developer VM to
+ run out of memory. This pressure can be alleviated by shutting down the bazel
+ caching daemon left by these tests. Run ``(cd envoy; bazel shutdown)`` after
+ a build to do this. 
+
 Testing individual packages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/policy/troubleshooting.rst
+++ b/Documentation/policy/troubleshooting.rst
@@ -5,6 +5,9 @@
 Troubleshooting
 ***************
 
+Policy Tracing
+==============
+
 If Cilium is allowing / denying connections in a way that is not aligned with the
 intent of your Cilium Network policy, there is an easy way to
 verify if and what policy rules apply between two
@@ -49,3 +52,50 @@ endpoint with the label ``id.http`` on port 80:
 
     Final verdict: ALLOWED
 
+Policy Rule to Endpoint Mapping
+===============================
+
+To determine which policy rules are currently in effect for an endpoint the
+data from ``cilium endpoint list`` and ``cilium endpoint get`` can be paired
+with the data from ``cilium policy get``. ``cilium endpoint get`` will list the
+labels of each rule that applies to an endpoint. The list of labels can be
+passed to ``cilium policy get`` to show that exact source policy.  Note that
+rules that have no labels cannot be fetched alone (a no label ``cililum policy
+get`` returns the complete policy on the node). Rules with the same labels will
+be returned together.
+For an endpoint with endpoint id 51796, We can print all policies applied to it with:
+
+.. code:: bash
+
+    # print out the Layer 4 ingress labels
+    # clean up the data
+    # fetch each policy via each set of labels
+    $ cilium endpoint get 51796 -o jsonpath='{range ..policy.l4.ingress[*].derived-from-rules}{@}{"\n"}{end}' | \
+      tr -d '][' | \
+      xargs -I{} bash -c 'echo "Labels: {}"; cilium policy get {}'
+    Labels: unspec:io.cilium.k8s-policy-name=rule1 unspec:io.cilium.k8s-policy-namespace=default
+    [
+      {
+        "endpointSelector": {
+    ...
+             ],
+        "labels": [
+          {
+            "key": "io.cilium.k8s-policy-name",
+            "value": "rule1",
+            "source": "unspec"
+          },
+          {
+            "key": "io.cilium.k8s-policy-namespace",
+            "value": "default",
+            "source": "unspec"
+          }
+        ]
+      }
+    ]
+    Revision: 6 
+
+    # repeat for L4 egress and L3
+    $ cilium endpoint get 51796 -o jsonpath='{range ..policy.l4.egress[*].derived-from-rules}{@}{"\n"}{end}' | tr -d '][' | xargs -I{} bash -c 'echo "Labels: {}"; cilium policy get {}'
+    $ cilium endpoint get 51796 -o jsonpath='{range ..policy.cidr-policy.ingress[*].derived-from-rules}{@}{"\n"}{end}' | tr -d '][' | xargs -I{} bash -c 'echo "Labels: {}"; cilium policy get {}'
+    $ cilium endpoint get 51796 -o jsonpath='{range ..policy.cidr-policy.egress[*].derived-from-rules}{@}{"\n"}{end}' | tr -d '][' | xargs -I{} bash -c 'echo "Labels: {}"; cilium policy get {}'


### PR DESCRIPTION
**Summary of changes**:
- Docs on how to extract the policy that applied a particular rule to an endpoint
- Docs to tell the user how to shutdown the bazel cache daemon

**How to test (optional)**:
`make render-docs`