### PR TITLE
check-log-newlines: Check only the cilium repo.

### DIFF
--- a/contrib/scripts/check-log-newlines.sh
+++ b/contrib/scripts/check-log-newlines.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if grep --include \*.go -r 'log\.' ../../ | grep -v vendor \
+if grep --include \*.go -r 'log\.' . | grep -v vendor \
   | grep -v envoy \
   | grep -v contrib \
   | grep -v logging.go \


### PR DESCRIPTION
The script checked everyting under github.com and failed for non-related code. Start the check on the current directory instead of backing up by two levels, since the script is run by make in the main cilium directory.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
