### PR TITLE
Fix log-newlines script

### DIFF
--- a/contrib/scripts/check-log-newlines.sh
+++ b/contrib/scripts/check-log-newlines.sh
@@ -2,10 +2,8 @@
 
 set -e
 
-if grep --include \*.go -r 'log\.' ../../ | grep -v vendor \
-  | grep -v envoy \
-  | grep -v contrib \
-  | grep -v logging.go \
+if grep --include \*.go -r 'log\.' ./ \
+  | grep -v -e vendor -e envoy -e contrib -e logging.go \
   | grep -F "\n"; then
   echo "found newline(s) in log call(s), please remove ending \n"
   exit 1


### PR DESCRIPTION
This script was previously running against every single file in any
source repository in $GOPATH. Fix the path by assuming that it is run
from the root of the repository (like it is when running it via make).
While we're at it, reduce the number of greps the output is passed through.

Signed-off-by: Joe Stringer <joe@covalent.io>