### PR TITLE
Ginkgo: Refactor Kubectl.ExecPodCmd

### DIFF
--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -87,14 +87,16 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 
 		for _, pod := range pods {
 			for _, ip := range dsPods {
-				_, err := kubectl.ExecPodCmd(
+				res := kubectl.ExecPodCmd(
 					helpers.DefaultNamespace, pod, helpers.Ping(ip))
 				log.Debugf("Pod %s ping %v", pod, ip)
-				ExpectWithOffset(1, err).To(BeNil(), "Cannot ping from %q to %q", pod, ip)
+				ExpectWithOffset(1, res.WasSuccessful()).To(BeTrue(),
+					"Cannot ping from %q to %q", pod, ip)
 
-				_, err = kubectl.ExecPodCmd(
+				res = kubectl.ExecPodCmd(
 					helpers.DefaultNamespace, pod, helpers.CurlFail("http://testds-service:80/"))
-				ExpectWithOffset(1, err).To(BeNil(), "Cannot curl from %q to testds-service", pod)
+				ExpectWithOffset(1, res.WasSuccessful()).To(BeTrue(),
+					"Cannot curl from %q to testds-service", pod)
 			}
 		}
 	}

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -360,7 +360,7 @@ var _ = Describe("NightlyExamples", func() {
 			res = kubectl.ExecPodCmd(
 				helpers.DefaultNamespace, appPods[helpers.App3],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
-			res.ExpectFail("Can curl to %q from %q and it should",
+			res.ExpectFail("Can curl to %q from %q and it shouldn't",
 				clusterIP, appPods[helpers.App3])
 
 		})

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -201,12 +201,12 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 			res := kubectl.ExecPodCmd(
 				helpers.DefaultNamespace, appPods[helpers.App2],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
-			res.ExpectSuccess("App2 %q cannot curl clusterIP %q", appPods[helpers.App2], clusterIP)
+			res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], clusterIP)
 
 			res = kubectl.ExecPodCmd(
 				helpers.DefaultNamespace, appPods[helpers.App3],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
-			res.ExpectFail("App3 %q can curl to %q", appPods[helpers.App3], clusterIP)
+			res.ExpectFail("%q can curl to %q", appPods[helpers.App3], clusterIP)
 
 			eps = kubectl.CiliumEndpointPolicyVersion(ciliumPod)
 			status = kubectl.Delete(l3Policy)
@@ -232,23 +232,23 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 			res = kubectl.ExecPodCmd(
 				helpers.DefaultNamespace, appPods[helpers.App2],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
-			res.ExpectSuccess("App2 %q cannot curl clusterIP %q", appPods[helpers.App2], clusterIP)
+			res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], clusterIP)
 
 			res = kubectl.ExecPodCmd(
 				helpers.DefaultNamespace, appPods[helpers.App2],
 				helpers.CurlFail(fmt.Sprintf("http://%s/private", clusterIP)))
-			res.ExpectFail("App2 %q cannot curl clusterIP %q private",
+			res.ExpectFail("%q cannot curl clusterIP %q private",
 				appPods[helpers.App2], clusterIP)
 
 			res = kubectl.ExecPodCmd(
 				helpers.DefaultNamespace, appPods[helpers.App3],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
-			res.ExpectFail("App3 %q can curl to %q", appPods[helpers.App3], clusterIP)
+			res.ExpectFail("%q can curl to %q", appPods[helpers.App3], clusterIP)
 
 			res = kubectl.ExecPodCmd(
 				helpers.DefaultNamespace, appPods[helpers.App3],
 				helpers.CurlFail(fmt.Sprintf("http://%s/private", clusterIP)))
-			res.ExpectFail("App3 %q can curl to %q private", appPods[helpers.App3], clusterIP)
+			res.ExpectFail("%q can curl to %q private", appPods[helpers.App3], clusterIP)
 
 			eps = kubectl.CiliumEndpointPolicyVersion(ciliumPod)
 			status = kubectl.Delete(l7Policy)
@@ -261,7 +261,7 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 			res = kubectl.ExecPodCmd(
 				helpers.DefaultNamespace, appPods[helpers.App3],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
-			res.ExpectSuccess("App3 %q cannot curl to %q public", appPods[helpers.App3], clusterIP)
+			res.ExpectSuccess("%q cannot curl to %q public", appPods[helpers.App3], clusterIP)
 
 		}, 500)
 
@@ -312,12 +312,12 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 			res := kubectl.ExecPodCmd(
 				namespace, appPods[helpers.App2],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
-			res.ExpectSuccess("App2 %q cannot curl clusterIP %q", appPods[helpers.App2], clusterIP)
+			res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], clusterIP)
 
 			res = kubectl.ExecPodCmd(
 				namespace, appPods[helpers.App3],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
-			res.ExpectFail("App3 %q can curl to %q", appPods[helpers.App3], clusterIP)
+			res.ExpectFail("%q can curl to %q", appPods[helpers.App3], clusterIP)
 
 			By("Testing default namespace")
 			clusterIP, _, err = kubectl.GetServiceHostPort(helpers.DefaultNamespace, "app1-service")
@@ -327,12 +327,12 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 			res = kubectl.ExecPodCmd(
 				helpers.DefaultNamespace, appPods[helpers.App2],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
-			res.ExpectSuccess("App2 %q cannot curl clusterIP %q", appPods[helpers.App2], clusterIP)
+			res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], clusterIP)
 
 			res = kubectl.ExecPodCmd(
 				helpers.DefaultNamespace, appPods[helpers.App3],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
-			res.ExpectFail("App3 %q can curl to %q", appPods[helpers.App3], clusterIP)
+			res.ExpectFail("%q can curl to %q", appPods[helpers.App3], clusterIP)
 		})
 
 		It("Denies traffic with k8s default-deny policy", func() {
@@ -361,12 +361,12 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 			res := kubectl.ExecPodCmd(
 				namespace, appPods[helpers.App2],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
-			res.ExpectSuccess("App2 %q cannot curl clusterIP %q", appPods[helpers.App2], clusterIP)
+			res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], clusterIP)
 
 			res = kubectl.ExecPodCmd(
 				namespace, appPods[helpers.App3],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
-			res.ExpectFail("App3 %q can curl to %q", appPods[helpers.App3], clusterIP)
+			res.ExpectSuccess("%q cannot curl to %q", appPods[helpers.App3], clusterIP)
 
 			By("Installing ingress default-deny")
 

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -142,11 +142,8 @@ func isNodeNetworkingWorking(kubectl *helpers.Kubectl, filter string) bool {
 		helpers.DefaultNamespace,
 		fmt.Sprintf("pod %s -o json", pods[1])).Filter("{.status.podIP}")
 	Expect(err).Should(BeNil())
-	_, err = kubectl.ExecPodCmd(helpers.DefaultNamespace, pods[0], helpers.Ping(podIP.String()))
-	if err != nil {
-		return false
-	}
-	return true
+	res := kubectl.ExecPodCmd(helpers.DefaultNamespace, pods[0], helpers.Ping(podIP.String()))
+	return res.WasSuccessful()
 }
 
 func waitToDeleteCilium(kubectl *helpers.Kubectl, logger *logrus.Entry) {


### PR DESCRIPTION
ExecPodCmd function uses a unique buffer instead of the global one. The
execution was not saved on log, and the output was not the standard
ResCmd. With this change, all ExecPodCmd calls are using the standard
way.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>