### PR TITLE
envoy: Use downstream HTTP protocol for upstream connections.

### DIFF
--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -354,7 +354,7 @@ func createBootstrap(filePath string, name, cluster, version string, xdsSock, en
 					ConnectTimeout:    &duration.Duration{Seconds: 1, Nanos: 0},
 					CleanupInterval:   &duration.Duration{Seconds: 1, Nanos: 500000000},
 					LbPolicy:          envoy_api_v2.Cluster_ORIGINAL_DST_LB,
-					ProtocolSelection: envoy_api_v2.Cluster_USE_CONFIGURED_PROTOCOL,
+					ProtocolSelection: envoy_api_v2.Cluster_USE_DOWNSTREAM_PROTOCOL,
 				},
 				{
 					Name:           "xdsCluster",


### PR DESCRIPTION
gRPC connectivity fail if transported over HTTP/1 connections.

The way this feature is configured changed when upstreaming to Envoy,
and the refactored code inadvertently used the enum for using the
configured rather than downstream protocol for upstream connections.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
Reported-by: Ian Vernon <ian@cilium.io>
