### PR TITLE
Use UpdateStatus for Cilium Network Policy Status in k8s 1.11

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -40,7 +40,6 @@ var (
 )
 
 // +genclient
-// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CiliumNetworkPolicy is a Kubernetes third-party resource with an extended version

--- a/pkg/k8s/client/clientset/versioned/clientset.go
+++ b/pkg/k8s/client/clientset/versioned/clientset.go
@@ -18,7 +18,6 @@ package versioned
 
 import (
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
-	glog "github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -72,7 +71,6 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/pkg/k8s/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/k8s/client/clientset/versioned/fake/clientset_generated.go
@@ -39,9 +39,10 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	fakePtr := testing.Fake{}
-	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
-	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+	cs := &Clientset{}
+	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
 		ns := action.GetNamespace()
 		watch, err := o.Watch(gvr, ns)
@@ -51,7 +52,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		return true, watch, nil
 	})
 
-	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
+	return cs
 }
 
 // Clientset implements clientset.Interface. Meant to be embedded into a

--- a/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2/ciliumnetworkpolicy.go
+++ b/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2/ciliumnetworkpolicy.go
@@ -35,6 +35,7 @@ type CiliumNetworkPoliciesGetter interface {
 type CiliumNetworkPolicyInterface interface {
 	Create(*v2.CiliumNetworkPolicy) (*v2.CiliumNetworkPolicy, error)
 	Update(*v2.CiliumNetworkPolicy) (*v2.CiliumNetworkPolicy, error)
+	UpdateStatus(*v2.CiliumNetworkPolicy) (*v2.CiliumNetworkPolicy, error)
 	Delete(name string, options *v1.DeleteOptions) error
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v2.CiliumNetworkPolicy, error)
@@ -112,6 +113,22 @@ func (c *ciliumNetworkPolicies) Update(ciliumNetworkPolicy *v2.CiliumNetworkPoli
 		Namespace(c.ns).
 		Resource("ciliumnetworkpolicies").
 		Name(ciliumNetworkPolicy.Name).
+		Body(ciliumNetworkPolicy).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+
+func (c *ciliumNetworkPolicies) UpdateStatus(ciliumNetworkPolicy *v2.CiliumNetworkPolicy) (result *v2.CiliumNetworkPolicy, err error) {
+	result = &v2.CiliumNetworkPolicy{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("ciliumnetworkpolicies").
+		Name(ciliumNetworkPolicy.Name).
+		SubResource("status").
 		Body(ciliumNetworkPolicy).
 		Do().
 		Into(result)

--- a/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2/fake/fake_ciliumendpoint.go
+++ b/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2/fake/fake_ciliumendpoint.go
@@ -60,7 +60,7 @@ func (c *FakeCiliumEndpoints) List(opts v1.ListOptions) (result *v2.CiliumEndpoi
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v2.CiliumEndpointList{}
+	list := &v2.CiliumEndpointList{ListMeta: obj.(*v2.CiliumEndpointList).ListMeta}
 	for _, item := range obj.(*v2.CiliumEndpointList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2/fake/fake_ciliumnetworkpolicy.go
+++ b/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2/fake/fake_ciliumnetworkpolicy.go
@@ -60,7 +60,7 @@ func (c *FakeCiliumNetworkPolicies) List(opts v1.ListOptions) (result *v2.Cilium
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v2.CiliumNetworkPolicyList{}
+	list := &v2.CiliumNetworkPolicyList{ListMeta: obj.(*v2.CiliumNetworkPolicyList).ListMeta}
 	for _, item := range obj.(*v2.CiliumNetworkPolicyList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
@@ -91,6 +91,18 @@ func (c *FakeCiliumNetworkPolicies) Create(ciliumNetworkPolicy *v2.CiliumNetwork
 func (c *FakeCiliumNetworkPolicies) Update(ciliumNetworkPolicy *v2.CiliumNetworkPolicy) (result *v2.CiliumNetworkPolicy, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(ciliumnetworkpoliciesResource, c.ns, ciliumNetworkPolicy), &v2.CiliumNetworkPolicy{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v2.CiliumNetworkPolicy), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeCiliumNetworkPolicies) UpdateStatus(ciliumNetworkPolicy *v2.CiliumNetworkPolicy) (*v2.CiliumNetworkPolicy, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(ciliumnetworkpoliciesResource, "status", c.ns, ciliumNetworkPolicy), &v2.CiliumNetworkPolicy{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/k8s/client/informers/externalversions/factory.go
+++ b/pkg/k8s/client/informers/externalversions/factory.go
@@ -30,12 +30,16 @@ import (
 	cache "k8s.io/client-go/tools/cache"
 )
 
+// SharedInformerOption defines the functional option type for SharedInformerFactory.
+type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
+
 type sharedInformerFactory struct {
 	client           versioned.Interface
 	namespace        string
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
 	lock             sync.Mutex
 	defaultResync    time.Duration
+	customResync     map[reflect.Type]time.Duration
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -43,23 +47,62 @@ type sharedInformerFactory struct {
 	startedInformers map[reflect.Type]bool
 }
 
-// NewSharedInformerFactory constructs a new instance of sharedInformerFactory
+// WithCustomResyncConfig sets a custom resync period for the specified informer types.
+func WithCustomResyncConfig(resyncConfig map[v1.Object]time.Duration) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		for k, v := range resyncConfig {
+			factory.customResync[reflect.TypeOf(k)] = v
+		}
+		return factory
+	}
+}
+
+// WithTweakListOptions sets a custom filter on all listers of the configured SharedInformerFactory.
+func WithTweakListOptions(tweakListOptions internalinterfaces.TweakListOptionsFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.tweakListOptions = tweakListOptions
+		return factory
+	}
+}
+
+// WithNamespace limits the SharedInformerFactory to the specified namespace.
+func WithNamespace(namespace string) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.namespace = namespace
+		return factory
+	}
+}
+
+// NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
-	return NewFilteredSharedInformerFactory(client, defaultResync, v1.NamespaceAll, nil)
+	return NewSharedInformerFactoryWithOptions(client, defaultResync)
 }
 
 // NewFilteredSharedInformerFactory constructs a new instance of sharedInformerFactory.
 // Listers obtained via this SharedInformerFactory will be subject to the same filters
 // as specified here.
+// Deprecated: Please use NewSharedInformerFactoryWithOptions instead
 func NewFilteredSharedInformerFactory(client versioned.Interface, defaultResync time.Duration, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc) SharedInformerFactory {
-	return &sharedInformerFactory{
+	return NewSharedInformerFactoryWithOptions(client, defaultResync, WithNamespace(namespace), WithTweakListOptions(tweakListOptions))
+}
+
+// NewSharedInformerFactoryWithOptions constructs a new instance of a SharedInformerFactory with additional options.
+func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResync time.Duration, options ...SharedInformerOption) SharedInformerFactory {
+	factory := &sharedInformerFactory{
 		client:           client,
-		namespace:        namespace,
-		tweakListOptions: tweakListOptions,
+		namespace:        v1.NamespaceAll,
 		defaultResync:    defaultResync,
 		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
 		startedInformers: make(map[reflect.Type]bool),
+		customResync:     make(map[reflect.Type]time.Duration),
 	}
+
+	// Apply all options
+	for _, opt := range options {
+		factory = opt(factory)
+	}
+
+	return factory
 }
 
 // Start initializes all requested informers.
@@ -108,7 +151,13 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
-	informer = newFunc(f.client, f.defaultResync)
+
+	resyncPeriod, exists := f.customResync[informerType]
+	if !exists {
+		resyncPeriod = f.defaultResync
+	}
+
+	informer = newFunc(f.client, resyncPeriod)
 	f.informers[informerType] = informer
 
 	return informer


### PR DESCRIPTION
```release-note
Use UpdateStatus for Cilium Network Policy Status in k8s 1.11
```

Since kubernetes will enable CustomResourceSubresource in k8s 1.11 we can leverage the UpdateStatus call to update the CNP Status in the kube-apiserver

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/2972)
<!-- Reviewable:end -->
