### PR TITLE
CI: build Cilium with deadlock detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,12 @@ FROM cilium/cilium-builder:2018-02-16 as builder
 LABEL maintainer="maintainer@cilium.io"
 WORKDIR /go/src/github.com/cilium/cilium
 ADD . ./
+ARG LOCKDEBUG
 #
 # Please do not add any dependency updates before the 'make install' here,
 # as that will mess with caching for incremental builds!
 #
-RUN make PKG_BUILD=1 DESTDIR=/tmp/install clean-container build install
+RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 DESTDIR=/tmp/install clean-container build install
 
 #
 # Cilium runtime install.

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ docker-image: clean GIT_VERSION envoy/SOURCE_VERSION
 	grep -v -E "(SOURCE|GIT)_VERSION" .gitignore >.dockerignore
 	echo ".*" >>.dockerignore # .git pruned out
 	echo "Documentation" >>.dockerignore # Not needed
-	docker build -t "cilium/cilium:$(DOCKER_IMAGE_TAG)" .
+	docker build --build-arg LOCKDEBUG=${LOCKDEBUG} -t "cilium/cilium:$(DOCKER_IMAGE_TAG)" .
 	echo -e "Push like this when ready:\ndocker push cilium/cilium:$(DOCKER_IMAGE_TAG)"
 
 docker-image-runtime:

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -652,9 +652,9 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 	return "", nil
 }
 
-//CiliumReport report the cilium pod to the log and apppend the logs for the
-//given commands. Return err in case of any problem
-func (kub *Kubectl) CiliumReport(namespace string, pod string, commands []string) error {
+// CiliumReport report the cilium pod to the log and appends the logs for the
+// given commands.
+func (kub *Kubectl) CiliumReport(namespace string, pod string, commands []string) {
 	wr := kub.logger.Logger.Out
 	fmt.Fprint(wr, "StackTrace Begin\n")
 	data := kub.Logs(namespace, pod)
@@ -671,8 +671,18 @@ func (kub *Kubectl) CiliumReport(namespace string, pod string, commands []string
 	fmt.Fprint(wr, "StackTrace Ends\n")
 	kub.CiliumReportDump(namespace)
 	kub.GatherLogs()
+	kub.CheckLogsForDeadlock()
 
-	return nil
+}
+
+// CheckLogsForDeadlock checks if the logs for Cilium log messages that signify
+// that a deadlock has occurred.
+func (kub *Kubectl) CheckLogsForDeadlock() {
+	deadlockCheckCmd := fmt.Sprintf("%s -n %s logs -l k8s-app=cilium | grep -qi -B 5 -A 5 deadlock", KubectlCmd, KubeSystemNamespace)
+	res := kub.Exec(deadlockCheckCmd)
+	if res.WasSuccessful() {
+		log.Errorf("Deadlock during test run detected, check Cilium logs for context")
+	}
 }
 
 // CiliumReportDump runs a variety of commands (CiliumKubCLICommands) and writes the results to

--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -16,7 +16,7 @@ cd ${GOPATH}/src/github.com/cilium/cilium
 if echo $(hostname) | grep "k8s" -q;
 then
     if [[ "$(hostname)" == "k8s1" ]]; then
-        make docker-image
+        make LOCKDEBUG=1 docker-image
         docker tag cilium/cilium k8s1:5000/cilium/cilium-dev
         docker push k8s1:5000/cilium/cilium-dev
         echo "Executing: $KUBECTL delete pods -n $KUBE_SYSTEM_NAMESPACE -l $CILIUM_DS_TAG"

--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -25,7 +25,7 @@ then
         echo "Not on master K8S node; no need to compile Cilium container"
     fi
 else
-    sudo -u vagrant -H -E make PKG_BUILD=1
+    sudo -u vagrant -H -E make PKG_BUILD=1 LOCKDEBUG=1
     make install
     mkdir -p /etc/sysconfig/
     cp -f contrib/systemd/cilium /etc/sysconfig/cilium


### PR DESCRIPTION
* Add capability of building Cilium with deadlock detection in the Docker image
* Build Cilium with deadlock detection in both Ginkgo runtime / K8s tests 
* Add helpers into Cilium runtime / K8s Ginkgo CI code which will check for deadlocks in Cilium logs.

Signed-off by: Ian Vernon <ian@cilium.io>