### PR TITLE
Nightly: Fix issues with timeout

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -7,7 +7,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 360, unit: 'MINUTES')
+        timeout(time: 220, unit: 'MINUTES')
         timestamps()
     }
 
@@ -30,7 +30,7 @@ pipeline {
             steps {
                 parallel(
                     "Nightly":{
-                        sh 'cd ${TESTDIR}; ginkgo --focus="Nightly*" -v -noColor'
+                        sh 'cd ${TESTDIR}; ginkgo --focus="Nightly*" -v -noColor --timeout 215m'
                     },
                 )
             }


### PR DESCRIPTION
When Jenkins timeout the Post-Build is not executed (It's a open issue),
so the logs from ginkgo cannot be retrieved.

I decrease the timeout, it took 177minutes in my computer, so 220 should
be enough to run in Jenkins.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
