### PR TITLE
test/helpers: check result of PolicyWait in PolicyImportAndWait

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -446,8 +446,11 @@ func (s *SSHMeta) PolicyImportAndWait(path string, timeout time.Duration) (int, 
 	body := func() bool {
 		currentRev, _ := s.PolicyGetRevision()
 		if currentRev > revision {
-			s.PolicyWait(currentRev)
-			return true
+			res := s.PolicyWait(currentRev)
+			if !res.WasSuccessful() {
+				log.Errorf("policy wait failed: %s", res.CombineOutput())
+			}
+			return res.WasSuccessful()
 		}
 		s.logger.WithFields(logrus.Fields{
 			logfields.PolicyRevision:    currentRev,


### PR DESCRIPTION
The result of `cilium policy wait` was never checked, and thus did not appropriately signify failure.

Signed-off by: Ian Vernon <ian@cilium.io>