### PR TITLE
Ginkgo: Replace awk usage with jq

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -550,8 +550,7 @@ func (kub *Kubectl) CiliumNodesWait() (bool, error) {
 // CiliumPolicyRevision returns the policy revision in the specified Cilium pod.
 // Returns an error if the policy revision cannot be retrieved.
 func (kub *Kubectl) CiliumPolicyRevision(pod string) (int, error) {
-	// FIXME GH-1725
-	res := kub.CiliumExec(pod, "cilium policy get | grep Revision | awk '{print $2}'")
+	res := kub.CiliumExec(pod, "cilium policy get -o json | jq '.revision'")
 
 	if !res.WasSuccessful() {
 		return -1, fmt.Errorf("Cannot get the revision %s", res.Output())

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -185,7 +185,7 @@ var _ = Describe("RuntimeValidatedConnectivityTest", func() {
 		AfterEach(func() {
 			vm.ContainerRm(cniServer)
 			vm.ContainerRm(cniClient)
-			vm.Exec("docker rm -f $(docker ps | grep busybox:latest | awk '{print $1}')")
+			vm.Exec("docker rm -f $(docker ps --filter ancestor=busybox:latest --format '{{.ID}}')")
 		})
 
 		runCNIContainer := func(name string, label string) {


### PR DESCRIPTION
The majority of the cilium commands now have support for '-o json'
output, so replace these usages of '... | grep ... | awk ...' with
'-o json | jq ...'.

Fixes: #1725

Signed-off-by: Joe Stringer <joe@covalent.io>