### PR TITLE
Makefile: Update filtering for generated Envoy API go files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ include Makefile.defs
 include daemon/bpf.sha
 
 SUBDIRS = envoy plugins bpf cilium daemon monitor cilium-health bugtool
-GOFILES ?= $(shell go list ./... | grep -v /vendor/ | grep -v /contrib/ | grep -v envoy.*api)
-TESTPKGS ?=  $(shell go list ./... | grep -v /vendor/ | grep -v /contrib/ | grep -v envoy.*api | grep -v test)
+GOFILES ?= $(shell go list ./... | grep -v /vendor/ | grep -v /contrib/ | grep -v envoy/envoy)
+TESTPKGS ?= $(shell go list ./... | grep -v /vendor/ | grep -v /contrib/ | grep -v envoy/envoy | grep -v test)
 GOLANGVERSION = $(shell go version 2>/dev/null | grep -Eo '(go[0-9].[0-9])')
 GOLANG_SRCFILES=$(shell for pkg in $(subst github.com/cilium/cilium/,,$(GOFILES)); do find $$pkg -name *.go -print; done | grep -v vendor)
 BPF_FILES ?= $(shell git ls-files ../bpf/ | tr "\n" ' ')


### PR DESCRIPTION
Update the filters in Makefile to match the current directory
structure for generated Envoy API go-files.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
