### PR TITLE
daemon: Add new '--envoy-log' command line option and change the default path.

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -33,6 +33,7 @@ cilium-agent
   -e, --docker string                     Path to docker runtime socket (DEPRECATED: use container-runtime-endpoint instead) (default "unix:///var/run/docker.sock")
       --enable-policy string              Enable policy enforcement (default "default")
       --enable-tracing                    Enable tracing while determining policy (debugging)
+      --envoy-log string                  Path to Envoy log (default "/var/log/cilium-envoy.log")
       --ipv4-cluster-cidr-mask-size int   Mask size for the cluster wide CIDR (default 8)
       --ipv4-node string                  IPv4 address of node (default "auto")
       --ipv4-range string                 Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -340,6 +340,7 @@ func init() {
 	flags.String("enable-policy", endpoint.DefaultEnforcement, "Enable policy enforcement")
 	flags.BoolVar(&enableTracing,
 		"enable-tracing", false, "Enable tracing while determining policy (debugging)")
+	flags.String("envoy-log", "/var/log/cilium-envoy.log", "Path to Envoy log")
 	flags.BoolVar(&useEnvoy,
 		"envoy-proxy", true, "This flag is deprecated and will be removed in the next release")
 	flags.MarkHidden("envoy-proxy")

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -140,9 +140,8 @@ func GetEnvoyVersion() string {
 }
 
 // StartEnvoy starts an Envoy proxy instance.
-func StartEnvoy(adminPort uint32, stateDir, logDir string, baseID uint64) *Envoy {
+func StartEnvoy(adminPort uint32, stateDir, logPath string, baseID uint64) *Envoy {
 	bootstrapPath := filepath.Join(stateDir, "bootstrap.pb")
-	logPath := filepath.Join(logDir, "cilium-envoy.log")
 	adminAddress := "127.0.0.1:" + strconv.FormatUint(uint64(adminPort), 10)
 	xdsPath := filepath.Join(stateDir, "xds.sock")
 	accessLogPath := filepath.Join(stateDir, "access_log.sock")

--- a/pkg/envoy/envoy_test.go
+++ b/pkg/envoy/envoy_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -73,7 +74,7 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 	log.Debugf("state log directory: %s", stateLogDir)
 
 	// launch debug variant of the Envoy proxy
-	Envoy := StartEnvoy(9942, stateLogDir, stateLogDir, 42)
+	Envoy := StartEnvoy(9942, stateLogDir, filepath.Join(stateLogDir, "cilium-envoy.log"), 42)
 	c.Assert(Envoy, NotNil)
 	log.Debug("started Envoy")
 

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -46,7 +46,7 @@ func createEnvoyRedirect(r *Redirect, wg *completion.WaitGroup) (RedirectImpleme
 	envoyOnce.Do(func() {
 		// Start Envoy on first invocation
 		envoyProxy = envoy.StartEnvoy(9901, viper.GetString("state-dir"),
-			viper.GetString("state-dir"), 0)
+			viper.GetString("envoy-log"), 0)
 	})
 
 	if envoyProxy != nil {


### PR DESCRIPTION
So far the Envoy logs were written to the state directory
(/var/run/cilium/cilium-envoy.log), the file system of which was
easily filled with Envoy debug logs, especially if something went
wrong.

Add a new cilium agent command line option to specify where Envoy logs
shoulld be written to. By default this will be
"/var/log/cilium-envoy.log", which is good for production runs. For
testing this default may need to be overridden with an explicit
commmand line option.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
Fixes: #2810 