### PR TITLE
endpoint: Push L4-only policies into BPF maps

### DIFF
--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -596,10 +596,12 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 		Expect(err).Should(BeNil())
 
 		for _, app := range []string{helpers.App1, helpers.App2} {
-			connectivityTest(allRequests, app, helpers.Httpd1, BeFalse)
+			connectivityTest(pingRequests, app, helpers.Httpd1, BeFalse)
+			connectivityTest(httpRequestsPublic, app, helpers.Httpd1, BeTrue)
 			connectivityTest(pingRequests, app, helpers.Httpd2, BeFalse)
 			connectivityTest(httpRequestsPublic, app, helpers.Httpd2, BeTrue)
 		}
+		connectivityTest(allRequests, helpers.App3, helpers.Httpd1, BeFalse)
 
 		By("Disabling all the policies. All should work")
 

--- a/test/runtime/manifests/Policies-l4-policy.json
+++ b/test/runtime/manifests/Policies-l4-policy.json
@@ -24,4 +24,28 @@
             ]
         }]
    }]
+},
+{
+    "endpointSelector": {
+        "matchLabels":{"id.app2":""}
+    },
+    "egress": [{
+        "toPorts": [{
+            "ports": [
+                {"port": "80",   "protocol": "tcp"}
+            ]
+        }]
+    }]
+},
+{
+    "endpointSelector": {
+        "matchLabels":{"id.app3":""}
+    },
+    "egress": [{
+        "toPorts": [{
+            "ports": [
+                {"port": "8080",   "protocol": "tcp"}
+            ]
+        }]
+    }]
 }]


### PR DESCRIPTION
```release-note
Fix L4-only policy enforcement on ingress without `fromEndpoints` selector
```

The description of `L4Filter.FromEndpoints` is as follows:

```
// FromEndpoints limit the source labels for allowing traffic. If
// FromEndpoints is empty, then it selects all endpoints.
```

However, to date when pushing L4Filters into the BPF maps, we were
treating an empty `FromEndpoints` slice as selecting nothing. This lead
to L4-only policies not allowing traffic on ingress, and with upcoming
egress label-based policies implementations, would also break the
current workflow for specifying `ToPorts` policies on egress (ie,
without a wildcard EndpointSelector).

Treat the empty L4Filter selector list as a wildcard and push a
label-dependent l4 map entry into the datapath for each known identity
in the node.

While we're at it, extend the L4 policy tests to cover egress as well.

Fixes: #2907

Signed-off-by: Joe Stringer <joe@covalent.io>