### PR TITLE
Add Kafka roles to simplify policy specification language

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -732,6 +732,27 @@ var (
 			"optional, if all fields are empty or missing, the rule will match all Kafka " +
 			"messages.",
 		Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+			"role": {
+				Description: "Role is a case-insensitive string and describes a group of API keys" +
+					"necessary to perform certain higher level Kafka operations such as" +
+					"\"produce\" or \"consume\". An APIGroup automatically expands into all APIKeys" +
+					"required to perform the specified higher level operation." +
+					"The following values are supported:" +
+					"- \"produce\": Allow producing to the topics specified in the rule" +
+					"- \"consume\": Allow consuming from the topics specified in the rule" +
+					"This field is incompatible with the APIKey field, either APIKey or Role" +
+					"may be specified. If omitted or empty, the field has no effect and the " +
+					"logic of the APIKey field applies.",
+				Type: "string",
+				Enum: []apiextensionsv1beta1.JSON{
+					{
+						Raw: []byte(`"produce"`),
+					},
+					{
+						Raw: []byte(`"consume"`),
+					},
+				},
+			},
 			"apiKey": {
 				Description: "APIKey is a case-insensitive string matched against the key of " +
 					"a request, e.g. \"produce\", \"fetch\", \"createtopic\", \"deletetopic\", " +

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -150,12 +150,24 @@ func (e *EgressRule) sanitize() error {
 // TODO we need to add support to check
 // wildcard and prefix/suffix later on.
 func (kr *PortRuleKafka) Sanitize() error {
+	if (len(kr.APIKey) > 0) && (len(kr.Role) > 0) {
+		return fmt.Errorf("Cannot set both Role:%q and APIKey :%q together", kr.Role, kr.APIKey)
+	}
+
 	if len(kr.APIKey) > 0 {
 		n, ok := KafkaAPIKeyMap[strings.ToLower(kr.APIKey)]
 		if !ok {
 			return fmt.Errorf("invalid Kafka APIKey :%q", kr.APIKey)
 		}
-		kr.apiKeyInt = &n
+		kr.apiKeyInt = append(kr.apiKeyInt, n)
+	}
+
+	if len(kr.Role) > 0 {
+		err := kr.MapRoleToAPIKey()
+		if err != nil {
+			return fmt.Errorf("invalid Kafka APIRole :%q", kr.Role)
+		}
+
 	}
 
 	if len(kr.APIVersion) > 0 {

--- a/pkg/policy/api/utils.go
+++ b/pkg/policy/api/utils.go
@@ -65,7 +65,8 @@ func (k *PortRuleKafka) Exists(rules L7Rules) bool {
 
 // Equal returns true if both rules are equal
 func (k *PortRuleKafka) Equal(o PortRuleKafka) bool {
-	return k.APIVersion == o.APIVersion && k.APIKey == o.APIKey && k.Topic == o.Topic
+	return k.APIVersion == o.APIVersion && k.APIKey == o.APIKey &&
+		k.Topic == o.Topic && k.ClientID == o.ClientID && k.Role == o.Role
 }
 
 // Validate returns an error if the layer 4 protocol is not valid

--- a/pkg/policy/api/zz_generated.deepcopy.go
+++ b/pkg/policy/api/zz_generated.deepcopy.go
@@ -304,12 +304,8 @@ func (in *PortRuleKafka) DeepCopyInto(out *PortRuleKafka) {
 	*out = *in
 	if in.apiKeyInt != nil {
 		in, out := &in.apiKeyInt, &out.apiKeyInt
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int16)
-			**out = **in
-		}
+		*out = make(KafkaRole, len(*in))
+		copy(*out, *in)
 	}
 	if in.apiVersionInt != nil {
 		in, out := &in.apiVersionInt, &out.apiVersionInt

--- a/test/runtime/manifests/Policies-kafka-Role.json
+++ b/test/runtime/manifests/Policies-kafka-Role.json
@@ -1,0 +1,19 @@
+[{
+	"endpointSelector": {"matchLabels":{"id.kafka":""}},
+	"ingress": [{
+		"fromEndpoints": [
+			{"matchLabels":{"reserved:host":""}},
+			{"matchLabels":{"id.client":""}}
+		],
+		"toPorts": [{
+			"ports": [{"port": "9092", "protocol": "tcp"}],
+			"rules": {
+				"kafka": [
+					{"Role": "produce", "topic": "allowedTopic"},
+					{"Role": "consume", "topic": "allowedTopic"}
+				]
+			}
+		}]
+	}]
+}]
+


### PR DESCRIPTION
These changes simplify Kafka rules.
It adds a new "Role" field to the Kafka rules, and the values associated with it can be "produce" and "consume". The respective low level apiKeys are expanded on their own to support this new higher level construct. In addition added runtime test coverage for this new field.  In addition, also fixed a couple of bugs:

1. If topic is configured with a non-topic request like apiversions, we should not allow it.

2. `Equal` routine was missing clientID  and `Role` to be truly equal.

There is also a TODO for GH  #3097 i.e add Client ID parsing in requests with non-topic kind.
Will be doing this as a separate PR.


 Fixes: #1818
 Signed-Off-By: Manali Bhutiyani <manali@covalent.io>

```release-note
Add Kafka roles to simplify policy specification language
```