### PR TITLE
Nightly: Adjust timeouts and stdout Curl on exec

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -7,7 +7,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 220, unit: 'MINUTES')
+        timeout(time: 300, unit: 'MINUTES')
         timestamps()
     }
 
@@ -32,7 +32,7 @@ pipeline {
             steps {
                 parallel(
                     "Nightly":{
-                        sh 'cd ${TESTDIR}; ginkgo --focus="Nightly*" -v -noColor --timeout 215m'
+                        sh 'cd ${TESTDIR}; ginkgo --focus="Nightly*" -v -noColor --timeout 290m'
                     },
                 )
             }

--- a/test/helpers/policygen/actions.go
+++ b/test/helpers/policygen/actions.go
@@ -26,7 +26,8 @@ import (
 // It needs a `helpers.Kubectl` instance to run the command in the pod. It
 // returns a ResultType struct.
 func HTTPAction(srcPod string, target string, kub *helpers.Kubectl) ResultType {
-	command := fmt.Sprintf("%s exec -n %s %s -- %s -w \"%%{http_code}\"",
+	command := fmt.Sprintf(
+		"%s exec -n %s %s 2>/dev/null -- %s --output /dev/stout -w '%%{http_code}'",
 		helpers.KubectlCmd, helpers.DefaultNamespace,
 		srcPod, helpers.CurlFail(target))
 


### PR DESCRIPTION
- Change the timeouts, Jenkins is failing due timeout.
- Update kubectl exec, as default always return the message `command
terminated with exit code 22` and the Action didn't work as exepected
(Only in k8s >= 1.8 )

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
