### PR TITLE
pkg/lock: override default options for deadlock detection

### DIFF
--- a/pkg/lock/lock_debug.go
+++ b/pkg/lock/lock_debug.go
@@ -17,8 +17,14 @@
 package lock
 
 import (
+	"time"
+
 	"github.com/sasha-s/go-deadlock"
 )
+
+func init() {
+	deadlock.Opts.DeadlockTimeout = time.Second * 310
+}
 
 type internalRWMutex struct {
 	deadlock.RWMutex


### PR DESCRIPTION
Set timeout to be 310 seconds instead of 30 seconds. This is to avoid
false-positives in deadlock detection when endpoint BPF programs are
being regenerated and are taking a while (up to 300 seconds) to regenerate.

Signed-off by: Ian Vernon <ian@cilium.io>