### PR TITLE
Reject policies that contain rules with more than one L3 match in a single rule

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -272,8 +272,7 @@ CIDR policies can be applied at ingress and egress:
 
 fromCIDR
   List of source prefixes/CIDRs that are allowed to talk to all endpoints
-  selected by the ``endpointSelector``. Note that this list is **in addition**
-  to the ``fromEndpoints`` specified. It is not required to allow the IPs of
+  selected by the ``endpointSelector``. It is not required to allow the IPs of
   endpoints if the endpoints are already allowed to communicate based on
   ``fromEndpoints`` rules.
 

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -214,12 +214,6 @@ func (d *Daemon) policyAdd(rules api.Rules, opts *AddOptions) (uint64, error) {
 func (d *Daemon) PolicyAdd(rules api.Rules, opts *AddOptions) (uint64, error) {
 	log.WithField(logfields.CiliumNetworkPolicy, logfields.Repr(rules)).Debug("Policy Add Request")
 
-	for _, r := range rules {
-		if err := r.Sanitize(); err != nil {
-			return 0, apierror.Error(PutPolicyFailureCode, err)
-		}
-	}
-
 	rev, err := d.policyAdd(rules, opts)
 	if err != nil {
 		return 0, apierror.Error(PutPolicyFailureCode, err)
@@ -292,6 +286,12 @@ func (h *putPolicy) Handle(params PutPolicyParams) middleware.Responder {
 	var rules api.Rules
 	if err := json.Unmarshal([]byte(*params.Policy), &rules); err != nil {
 		return NewPutPolicyInvalidPolicy()
+	}
+
+	for _, r := range rules {
+		if err := r.Sanitize(); err != nil {
+			return apierror.Error(PutPolicyFailureCode, err)
+		}
 	}
 
 	rev, err := d.PolicyAdd(rules, nil)

--- a/examples/policies/l3/cidr/cidr.json
+++ b/examples/policies/l3/cidr/cidr.json
@@ -4,7 +4,8 @@
     "egress": [{
         "toCIDR": [
             "20.1.1.1/32"
-        ],
+        ]
+    }, {
         "toCIDRSet": [{
             "cidr": "10.0.0.0/8",
             "except": [

--- a/examples/policies/l3/cidr/cidr.yaml
+++ b/examples/policies/l3/cidr/cidr.yaml
@@ -9,7 +9,7 @@ spec:
   egress:
   - toCIDR:
     - 20.1.1.1/32
-    toCIDRSet:
+  - toCIDRSet:
     - cidr: 10.0.0.0/8
       except:
       - 10.96.0.0/12

--- a/pkg/k8s/apis/cilium.io/v1/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v1/types_test.go
@@ -66,7 +66,8 @@ var (
 					},
 				},
 			}, {
-				ToCIDR:    []api.CIDR{"10.0.0.1"},
+				ToCIDR: []api.CIDR{"10.0.0.1"},
+			}, {
 				ToCIDRSet: []api.CIDRRule{{Cidr: api.CIDR("10.0.0.0/8"), ExceptCIDRs: []api.CIDR{"10.96.0.0/12"}}},
 			},
 		},
@@ -102,7 +103,9 @@ var (
 				},
 			},
 			{
-				ToCIDR:    []api.CIDR{"10.0.0.1"},
+				ToCIDR: []api.CIDR{"10.0.0.1"},
+			},
+			{
 				ToCIDRSet: []api.CIDRRule{{Cidr: api.CIDR("10.0.0.0/8"), ExceptCIDRs: []api.CIDR{"10.96.0.0/12"}}},
 			},
 		},
@@ -181,15 +184,16 @@ var (
             },{
                 "toCIDR": [
                     "10.0.0.1"
-                ],
-				"toCIDRSet": [
-					{
-						"cidr": "10.0.0.0/8",
-						"except": [
-							"10.96.0.0/12"
-						]
-					}
-				]
+                ]
+            },{
+                "toCIDRSet": [
+                    {
+			"cidr": "10.0.0.0/8",
+			"except": [
+				"10.96.0.0/12"
+		        ]
+		    }
+		]
             }
         ]
     }`)

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -66,7 +66,8 @@ var (
 					},
 				},
 			}, {
-				ToCIDR:    []api.CIDR{"10.0.0.1"},
+				ToCIDR: []api.CIDR{"10.0.0.1"},
+			}, {
 				ToCIDRSet: []api.CIDRRule{{Cidr: api.CIDR("10.0.0.0/8"), ExceptCIDRs: []api.CIDR{"10.96.0.0/12"}}},
 			},
 		},
@@ -102,7 +103,8 @@ var (
 				},
 			},
 			{
-				ToCIDR:    []api.CIDR{"10.0.0.1"},
+				ToCIDR: []api.CIDR{"10.0.0.1"},
+			}, {
 				ToCIDRSet: []api.CIDRRule{{Cidr: api.CIDR("10.0.0.0/8"), ExceptCIDRs: []api.CIDR{"10.96.0.0/12"}}},
 			},
 		},
@@ -181,15 +183,16 @@ var (
             },{
                 "toCIDR": [
                     "10.0.0.1"
-                ],
-				"toCIDRSet": [
-					{
-						"cidr": "10.0.0.0/8",
-						"except": [
-							"10.96.0.0/12"
-						]
-					}
-				]
+                ]
+            },{
+                "toCIDRSet": [
+                    {
+                        "cidr": "10.0.0.0/8",
+                        "except": [
+                            "10.96.0.0/12"
+                        ]
+                    }
+                ]
             }
         ]
     }`)

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -1067,7 +1067,12 @@ func (s *K8sSuite) TestCIDRPolicyExamples(c *C) {
               "matchLabels": {
                 "user": "bob"
               }
-            },
+            }
+          }
+        ]
+      }, {
+        "from": [
+          {
             "ipBlock": {
               "cidr": "10.0.0.0/8",
 	          "except": [
@@ -1088,7 +1093,7 @@ func (s *K8sSuite) TestCIDRPolicyExamples(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(rules, NotNil)
 	c.Assert(len(rules), Equals, 1)
-	c.Assert(len(rules[0].Ingress), Equals, 1)
+	c.Assert(len(rules[0].Ingress), Equals, 2)
 
 	ex2 := []byte(`{
   "kind": "NetworkPolicy",

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -284,17 +284,12 @@ func (p *Repository) Add(r api.Rule) (uint64, error) {
 }
 
 // AddListLocked inserts a rule into the policy repository with the repository already locked
+// Expects that the entire rule list has already been sanitized.
 func (p *Repository) AddListLocked(rules api.Rules) (uint64, error) {
-	// Validate entire rule list first and only append array if
-	// all rules are valid
 	newList := make([]*rule, len(rules))
 	for i := range rules {
 		newList[i] = &rule{Rule: *rules[i]}
-		if err := newList[i].sanitize(); err != nil {
-			return p.revision, err
-		}
 	}
-
 	p.rules = append(p.rules, newList...)
 	p.revision++
 	metrics.PolicyCount.Add(float64(len(newList)))

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -268,6 +268,7 @@ func (p *Repository) SearchRLocked(labels labels.LabelArray) api.Rules {
 }
 
 // Add inserts a rule into the policy repository
+// This is just a helper function for unit testing.
 func (p *Repository) Add(r api.Rule) (uint64, error) {
 	p.Mutex.Lock()
 	defer p.Mutex.Unlock()
@@ -277,12 +278,9 @@ func (p *Repository) Add(r api.Rule) (uint64, error) {
 		return p.revision, err
 	}
 
-	p.rules = append(p.rules, realRule)
-	p.revision++
-	metrics.PolicyCount.Inc()
-	metrics.PolicyRevision.Inc()
-
-	return p.revision, nil
+	newList := make([]*api.Rule, 1)
+	newList[0] = &r
+	return p.AddListLocked(newList)
 }
 
 // AddListLocked inserts a rule into the policy repository with the repository already locked

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -539,6 +539,7 @@ func (ds *PolicyTestSuite) TestL3Policy(c *C) {
 					"10.1.0.0/16",
 					"2001:dbf::/64",
 				},
+			}, {
 				ToCIDRSet: []api.CIDRRule{{Cidr: api.CIDR("10.0.0.0/8"), ExceptCIDRs: []api.CIDR{"10.96.0.0/12"}}},
 			},
 		},

--- a/test/k8sT/manifests/1.6/headless_policy.yaml
+++ b/test/k8sT/manifests/1.6/headless_policy.yaml
@@ -7,8 +7,7 @@ spec:
     matchLabels:
       "test": "toservices"
   egress:
-  -
-    toServices:
+  - toServices:
     - k8sService:
         serviceName: headless-service
         namespace: default

--- a/test/k8sT/manifests/headless_policy.yaml
+++ b/test/k8sT/manifests/headless_policy.yaml
@@ -7,8 +7,7 @@ spec:
     matchLabels:
       "test": "toservices"
   egress:
-  -
-    toServices:
+  - toServices:
     - k8sService:
         serviceName: headless-service
         namespace: default

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -892,7 +892,8 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 			"ingress": [{
 				"fromEndpoints": [
 					{"matchLabels":{"%s":""}}
-				],
+				]
+			}, {
 				"fromCIDRSet": [ {
 					"cidr": "%s",
 					"except": [

--- a/test/runtime/manifests/Policies-l3-policy.json
+++ b/test/runtime/manifests/Policies-l3-policy.json
@@ -33,18 +33,21 @@
     "endpointSelector": {
         "matchLabels":{"id.app3":""}
     },
-    "egress": [{
-        "toEndpoints": [
-            {"matchLabels":{"id.httpd2":""}}
-        ],
-        "toPorts": [{
-            "ports": [
-                {"port": "8000", "protocol": "tcp"},
-                {"port": "80",   "protocol": "tcp"},
-                {"port": "8080", "protocol": "tcp"},
-                {"port": "8080", "protocol": "udp"}]
-        }]
-   }]
+    "egress": [
+        {
+            "toEndpoints": [
+                {"matchLabels":{"id.httpd2":""}}
+            ]
+        }, {
+            "toPorts": [{
+                "ports": [
+                    {"port": "8000", "protocol": "tcp"},
+                    {"port": "80",   "protocol": "tcp"},
+                    {"port": "8080", "protocol": "tcp"},
+                    {"port": "8080", "protocol": "udp"}]
+            }]
+        }
+    ]
 }]
 
 


### PR DESCRIPTION
This PR rejects policies which are not supported as per the assessment in #3004 .

The combination of `fromCIDR` and `fromEndpoints` was previously allowed, but conflicted with the standard rules for members in an `IngressRule` defined below, so this PR disallows it.

https://github.com/cilium/cilium/blob/ca6e1cba72621a0911b93ebfc0e94b5b47f7ce45/pkg/policy/api/rule.go#L99-L102

Note that there are certain combinations, like the above, which we have previously accepted policies for and treated as OR (eg, `FromCIDR: x` with `FromEndpoints: y` in the same rule). These policies must be split into separate rules, one for each L3 after this PR. Examples can be seen in the unit test changes in this PR.