### PR TITLE
test: check for deadlock in previous cilium instances

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -666,8 +666,14 @@ func (kub *Kubectl) CiliumReport(namespace string, pod string, commands []string
 // CheckLogsForDeadlock checks if the logs for Cilium log messages that signify
 // that a deadlock has occurred.
 func (kub *Kubectl) CheckLogsForDeadlock() {
-	deadlockCheckCmd := fmt.Sprintf("%s -n %s logs -l k8s-app=cilium | grep -qi -B 5 -A 5 deadlock", KubectlCmd, KubeSystemNamespace)
+	deadlockCheckCmd := fmt.Sprintf("%s -n %s --timestamps=true logs -l k8s-app=cilium | grep -qi -B 5 -A 5 deadlock", KubectlCmd, KubeSystemNamespace)
 	res := kub.Exec(deadlockCheckCmd)
+	if res.WasSuccessful() {
+		log.Errorf("Deadlock during test run detected, check Cilium logs for context")
+	}
+	// Also check for previous container
+	deadlockCheckCmd = fmt.Sprintf("%s -n %s --timestamps=true --previous logs -l k8s-app=cilium | grep -qi -B 5 -A 5 deadlock", KubectlCmd, KubeSystemNamespace)
+	res = kub.Exec(deadlockCheckCmd)
 	if res.WasSuccessful() {
 		log.Errorf("Deadlock during test run detected, check Cilium logs for context")
 	}


### PR DESCRIPTION
Since the deadlock detector panics if a deadlock is detected, we need to
check for the logs in the previous cilium instance.

Signed-off-by: André Martins <andre@cilium.io>

I believe this is just a partial fix. AFAIK, we change cilium DaemonSet in the middle of the tests (to switch between VxLAN and GENEVE) so we might need to check for logs on all aftereach

cc @eloycoto 