### PR TITLE
CI: gather debuginfo and bugtool output when runtime tests fail

### DIFF
--- a/cilium/cmd/debuginfo.go
+++ b/cilium/cmd/debuginfo.go
@@ -82,11 +82,12 @@ func runDebugInfo(cmd *cobra.Command, args []string) {
 	for _, ep := range p.EndpointList {
 		epID := strconv.FormatInt(ep.ID, 10)
 		printList(w, "BPF Endpoint List "+epID, "bpf", "endpoint", "list", epID)
-		printList(w, "BPF Policy List "+epID, "bpf", "policy", "list", epID)
+		printList(w, "BPF Policy Get "+epID, "bpf", "policy", "get", epID)
 		printList(w, "BPF CT List "+epID, "bpf", "ct", "list", epID)
 		printList(w, "BPF LB List "+epID, "bpf", "lb", "list", epID)
 		printList(w, "BPF Tunnel List "+epID, "bpf", "tunnel", "list", epID)
 		printList(w, "Endpoint Get "+epID, "endpoint", "get", epID)
+		printList(w, "Endpoint Log "+epID, "endpoint", "log", epID)
 
 		if ep.Identity != nil {
 			id := strconv.FormatInt(ep.Identity.ID, 10)

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -156,6 +156,7 @@ var ciliumCLICommands = map[string]string{
 	"sudo cilium bpf tunnel list":     "bpf_tunnel_list.txt",
 	"cilium policy get":               "policy_get.txt",
 	"cilium status --all-controllers": "status.txt",
+	"sudo cilium debuginfo":           "debuginfo.txt",
 }
 
 // ciliumKubCLICommands these commands are the same as `ciliumCLICommands` but

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -684,7 +684,7 @@ func (kub *Kubectl) CiliumReportDump(namespace string) {
 			"cilium bpf policy get %s": "%s_bpf_policy_get_%s.txt",
 		}
 
-		testPath, err := ReportDirectory()
+		testPath, err := CreateReportDirectory()
 		if err != nil {
 			logger.WithError(err).Errorf("cannot create test result path '%s'", testPath)
 			return
@@ -749,7 +749,7 @@ func (kub *Kubectl) GatherLogs() {
 		"kubectl -n kube-system logs -l k8s-app=cilium": "cilium_logs.txt",
 	}
 
-	testPath, err := ReportDirectory()
+	testPath, err := CreateReportDirectory()
 	if err != nil {
 		kub.logger.WithError(err).Errorf(
 			"cannot create test results path '%s'", testPath)

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -209,10 +209,10 @@ func Fail(description string, callerSkip ...int) {
 	ginkgo.Fail(description, callerSkip...)
 }
 
-// ReportDirectory creates and returns the directory path to export all report
+// CreateReportDirectory creates and returns the directory path to export all report
 // commands that need to be run in the case that a test has failed.
 // If the directory cannot be created it'll return an error
-func ReportDirectory() (string, error) {
+func CreateReportDirectory() (string, error) {
 	testDesc := ginkgo.CurrentGinkgoTestDescription()
 	prefix := ""
 	if strings.HasPrefix(strings.ToLower(testDesc.FullTestText), K8s) {

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -209,7 +209,7 @@ func getOrSetEnvVar(key, value string) {
 }
 
 var _ = AfterEach(func() {
-	path, err := helpers.ReportDirectory()
+	path, err := helpers.CreateReportDirectory()
 
 	if err != nil {
 		log.WithError(err).Errorf("cannot create ReportDirectory")


### PR DESCRIPTION
test: get debuginfo and bugtool output when Ginkgo tests fail.  Save output of these commands to directory which is gathered up by Jenkins.

cmd: add `cilium endpoint log` output for each running endpoint.  Get log of state transitions for each endpoint as part of debugtool.

Signed-off by: Ian Vernon <ian@cilium.io>