### PR TITLE
Support log rotation for envoy log

### DIFF
--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -124,13 +124,6 @@ func StartEnvoy(adminPort uint32, stateDir, logDir string, baseID uint64) *Envoy
 	adminAddress := "127.0.0.1:" + strconv.FormatUint(uint64(adminPort), 10)
 	xdsPath := filepath.Join(stateDir, "xds.sock")
 	accessLogPath := filepath.Join(stateDir, "access_log.sock")
-	logger := &lumberjack.Logger{
-		Filename:   logPath,
-		MaxSize:    100, // megabytes
-		MaxBackups: 3,
-		MaxAge:     28,   //days
-		Compress:   true, // disabled by default
-	}
 
 	e := &Envoy{
 		stopCh:        make(chan struct{}),
@@ -160,6 +153,14 @@ func StartEnvoy(adminPort uint32, stateDir, logDir string, baseID uint64) *Envoy
 	// case no one reader reads it.
 	started := make(chan bool, 1)
 	go func() {
+		logger := &lumberjack.Logger{
+			Filename:   logPath,
+			MaxSize:    100, // megabytes
+			MaxBackups: 3,
+			MaxAge:     28,   //days
+			Compress:   true, // disabled by default
+		}
+		defer logger.Close()
 		var err error
 		for {
 			name := "cilium-envoy"


### PR DESCRIPTION
This change uses lumbarjack package to log rotate the `cilium-envoy.log` file

Fixes: #3033
Signed-off-by: Manali Bhutiyani <manali@covalent.io>


```release-note
Support log rotation for envoy log
```


Testing:

```
Local testing with 1MB max file size and 3 backups:
For more details see ps(1).
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ ls -la /var/run/cilium/cilium-envoy.log 
-rw-r--r-- 1 root root 572535 Mar  6 22:04 /var/run/cilium/cilium-envoy.log
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ 
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ ls -la /var/run/cilium/cilium-envoy.log 
-rw-r--r-- 1 root root 89321 Mar  6 22:05 /var/run/cilium/cilium-envoy.log
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ ls -la /var/run/cilium/cilium-envoy.log 
-rw-r--r-- 1 root root 293594 Mar  6 22:05 /var/run/cilium/cilium-envoy.log
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ ls -la /var/run/cilium/cilium-envoy.log 
-rw-r--r-- 1 root root 462267 Mar  6 22:05 /var/run/cilium/cilium-envoy.log
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ ls -la /var/run/cilium/cilium-envoy.log 
-rw-r--r-- 1 root root 542269 Mar  6 22:05 /var/run/cilium/cilium-envoy.log
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ ls -la /var/run/cilium/cilium-envoy.log 
-rw-r--r-- 1 root root 601570 Mar  6 22:05 /var/run/cilium/cilium-envoy.log
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ ls -la /var/run/cilium/cilium-envoy.log 
-rw-r--r-- 1 root root 663466 Mar  6 22:05 /var/run/cilium/cilium-envoy.log
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ ls -la /var/run/cilium/cilium-envoy.log 
-rw-r--r-- 1 root root 718656 Mar  6 22:05 /var/run/cilium/cilium-envoy.log
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ ls -la /var/run/cilium/cilium-envoy.log 
-rw-r--r-- 1 root root 788268 Mar  6 22:05 /var/run/cilium/cilium-envoy.log
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ ls -la /var/run/cilium/cilium-envoy.log 
-rw-r--r-- 1 root root 915804 Mar  6 22:05 /var/run/cilium/cilium-envoy.log
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ ls -la /var/run/cilium/cilium-envoy.log 
-rw-r--r-- 1 root root 1019657 Mar  6 22:05 /var/run/cilium/cilium-envoy.log
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ ls -la /var/run/cilium/cilium-envoy.log 
-rw-r--r-- 1 root root 73076 Mar  6 22:05 /var/run/cilium/cilium-envoy.log
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ ls -la /var/run/cilium/cilium-envoy.log*
-rw-r--r-- 1 root root 1010733 Mar  6 22:05 /var/run/cilium/cilium-envoy.log
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ ls -la /var/run/cilium/cilium-envoy*    
-rw-r--r-- 1 root root  55331 Mar  6 22:05 /var/run/cilium/cilium-envoy-2018-03-06T22-05-01.700.log.gz
-rw-r--r-- 1 root root  55289 Mar  6 22:05 /var/run/cilium/cilium-envoy-2018-03-06T22-05-17.486.log.gz
-rw-r--r-- 1 root root  55131 Mar  6 22:05 /var/run/cilium/cilium-envoy-2018-03-06T22-05-33.147.log.gz
-rw-r--r-- 1 root root 916840 Mar  6 22:05 /var/run/cilium/cilium-envoy.log
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ gunzip -c /var/run/cilium/cilium-envoy-2018-03-06T22-05-33.147.log.gz | wc -c
1045730
```

Note that it will go around slightly higher than 1MB and then roll over (depending on when the kernel actually flushes all the file blocks” and how/when the file size is reported.