### PR TITLE
envoy: Adjust log levels to avoid excessive logging.

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -76,6 +76,7 @@ const (
 	// list of supported verbose debug groups
 	argDebugVerboseFlow    = "flow"
 	argDebugVerboseKvstore = "kvstore"
+	argDebugVerboseEnvoy   = "envoy"
 )
 
 var (
@@ -484,6 +485,9 @@ func initEnv(cmd *cobra.Command) {
 			flowdebug.Enable()
 		case argDebugVerboseKvstore:
 			kvstore.EnableTracing()
+		case argDebugVerboseEnvoy:
+			log.Debugf("Enabling Envoy tracing")
+			envoy.EnableTracing()
 		default:
 			log.Warningf("Unknown verbose debug group: %s", grp)
 		}

--- a/envoy/accesslog.cc
+++ b/envoy/accesslog.cc
@@ -164,13 +164,13 @@ void AccessLog::Log(AccessLog::Entry &entry_,
     ssize_t sent =
         ::send(fd_, msg.data(), length, MSG_DONTWAIT | MSG_EOR | MSG_NOSIGNAL);
     if (sent == length) {
-      ENVOY_LOG(debug, "Cilium access log msg sent: {}", entry.DebugString());
+      ENVOY_LOG(trace, "Cilium access log msg sent: {}", entry.DebugString());
       return;
     }
     if (sent == -1) {
-      ENVOY_LOG(warn, "Cilium access log send failed: {}", strerror(errno));
+      ENVOY_LOG(debug, "Cilium access log send failed: {}", strerror(errno));
     } else {
-      ENVOY_LOG(warn, "Cilium access log send truncated by {} bytes.",
+      ENVOY_LOG(debug, "Cilium access log send truncated by {} bytes.",
                 length - sent);
     }
   }
@@ -189,7 +189,7 @@ bool AccessLog::Connect() {
 
   fd_ = ::socket(AF_UNIX, SOCK_SEQPACKET, 0);
   if (fd_ == -1) {
-    ENVOY_LOG(warn, "Can't create socket: {}", strerror(errno));
+    ENVOY_LOG(error, "Can't create socket: {}", strerror(errno));
     return false;
   }
 

--- a/envoy/cilium_bpf_metadata.cc
+++ b/envoy/cilium_bpf_metadata.cc
@@ -68,11 +68,11 @@ bool Instance::getBpfMetadata(Network::ConnectionSocket &socket) {
 Network::FilterStatus Instance::onAccept(Network::ListenerFilterCallbacks &cb) {
   Network::ConnectionSocket &socket = cb.socket();
   if (!getBpfMetadata(socket)) {
-    ENVOY_LOG(warn,
+    ENVOY_LOG(debug,
               "cilium.bpf_metadata ({}): no bpf metadata for the connection.",
               config_->is_ingress_ ? "ingress" : "egress");
   } else {
-    ENVOY_LOG(debug,
+    ENVOY_LOG(trace,
               "cilium.bpf_metadata ({}): GOT bpf metadata for new connection "
               "(mark: {:x})",
               config_->is_ingress_ ? "ingress" : "egress", socket.options()->hashKey());

--- a/envoy/proxymap.cc
+++ b/envoy/proxymap.cc
@@ -70,16 +70,16 @@ ProxyMap::ProxyMap(const std::string &bpf_root,
   std::string path6(bpf_root + "/tc/globals/cilium_proxy6");
 
   if (!proxy4map_.open(path4)) {
-    ENVOY_LOG(warn, "cilium.bpf_metadata: Cannot open IPv4 proxy map at {}",
+    ENVOY_LOG(info, "cilium.bpf_metadata: Cannot open IPv4 proxy map at {}",
               path4);
     parent_.stats_.bpf_open_error_.inc();
   }
   if (!proxy6map_.open(path6)) {
-    ENVOY_LOG(warn, "cilium.bpf_metadata: Cannot open IPv6 proxy map at {}",
+    ENVOY_LOG(info, "cilium.bpf_metadata: Cannot open IPv6 proxy map at {}",
               path6);
     parent_.stats_.bpf_open_error_.inc();
   }
-  ENVOY_LOG(debug, "cilium.bpf_metadata: Created proxymap for {}",
+  ENVOY_LOG(trace, "cilium.bpf_metadata: Created proxymap for {}",
             parent_.is_ingress_ ? "ingress" : "egress");
 }
 
@@ -105,7 +105,7 @@ bool ProxyMap::getBpfMetadata(Network::ConnectionSocket &socket) {
       key.nexthdr = 6;
 
       ENVOY_LOG(
-          debug,
+          trace,
           "cilium.bpf_metadata: Looking up key: {:x}, {:x}, {:x}, {:x}, {:x}",
           ntohl(key.saddr), ntohs(key.dport), ntohs(key.sport), key.nexthdr,
           key.pad);

--- a/pkg/flowdebug/flowdebug.go
+++ b/pkg/flowdebug/flowdebug.go
@@ -25,6 +25,11 @@ func Enable() {
 	perFlowDebug = true
 }
 
+// Enabled reports the status of per-flow debugging
+func Enabled() bool {
+	return perFlowDebug
+}
+
 // Log must be used to log any debug messages emitted per request/message
 func Log(l *logrus.Entry, msg string) {
 	if perFlowDebug {


### PR DESCRIPTION
Only enable Envoy debug level if cilium-agent option "--debug-verbose
flow" is set. Enable Envoy "trace" log level if "--debug-verbose
envoy" is set.

Adjust the log levels of cilium envoy filters to reduce logging.

Fixes: #3021 
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
