### PR TITLE
Delete obsolete cilium-envoy.log on startup

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -722,6 +722,12 @@ func runDaemon() {
 		log.WithError(err).Warn("Error while enabling k8s watcher")
 	}
 
+	// This block is deprecated and will be removed later (GH-3050)
+	logPath := filepath.Join(viper.GetString("state-dir"), "cilium-envoy.log")
+	if err := os.Remove(logPath); !os.IsNotExist(err) && err != nil {
+		log.WithError(err).Warn("Error deleting cilium-envoy.log")
+	}
+
 	swaggerSpec, err := loads.Analyzed(server.SwaggerJSON, "")
 	if err != nil {
 		log.WithError(err).Fatal("Cannot load swagger spec")


### PR DESCRIPTION
We need to do a one-time cleanup of cilium-envoy.log on startup
and also rename the new file following log-rotation correctly to
envoy.log. This will ensure that users get their claimed disk space back.

Fixes: #3046
Signed-off-by: Manali Bhutiyani <manali@covalent.io>

```release-note
Delete obsolete cilium-envoy.log on startup
```