### PR TITLE
k8s/daemonset: add update verb to customresourcedefinitions

### DIFF
--- a/examples/kubernetes/cilium.yaml
+++ b/examples/kubernetes/cilium.yaml
@@ -281,6 +281,7 @@ rules:
   - get
   - list
   - watch
+  - update
 - apiGroups:
   - cilium.io
   resources:

--- a/examples/minikube/cilium-ds.yaml
+++ b/examples/minikube/cilium-ds.yaml
@@ -282,6 +282,7 @@ rules:
   - get
   - list
   - watch
+  - update
 - apiGroups:
   - cilium.io
   resources:

--- a/test/k8sT/manifests/cilium_ds.yaml
+++ b/test/k8sT/manifests/cilium_ds.yaml
@@ -274,6 +274,7 @@ rules:
   - get
   - list
   - watch
+  - update
 - apiGroups:
   - cilium.io
   resources:

--- a/test/k8sT/manifests/cilium_ds_geneve.yaml
+++ b/test/k8sT/manifests/cilium_ds_geneve.yaml
@@ -276,6 +276,7 @@ rules:
   - get
   - list
   - watch
+  - update
 - apiGroups:
   - cilium.io
   resources:


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

```release-note
add "update" verb for customresourcedefinitions in cilium DaemonSet spec file
```
