### PR TITLE
Restore error behaviour of endpoint config updates

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1209,7 +1209,9 @@ func (e *Endpoint) Update(owner Owner, opts models.ConfigurationMap) error {
 			return nil
 		}
 
-		return fmt.Errorf("unable to regenerate endpoint program because state transition to %s was unsuccessful; check `cilium endpoint log %d` for more information", StateWaitingToRegenerate, e.ID)
+		// FIXME: GH-3058: We need to queue up a regeneration
+		// nevertheless
+		return nil
 	}
 
 	e.Mutex.Unlock()


### PR DESCRIPTION
This restores the state to before #3043 in terms of not returning an error if
an endpoint is patched while being regenerated. It is an workaround fix to avoid
further CI failures. The long term fix is being developed via GH-3058

Fixes: #3053 