### PR TITLE
test: get kvstore and bugtool output

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -551,7 +551,7 @@ func (s *SSHMeta) DumpCiliumCommandOutput() {
 
 	// No need to create file for bugtool because it creates an archive of files
 	// for us.
-	res := s.ExecCilium(fmt.Sprintf("bugtool -t %s", filepath.Join(BasePath, testPath)))
+	res := s.ExecWithSudo(fmt.Sprintf("cilium-bugtool -t %s", filepath.Join(BasePath, testPath)))
 	if !res.WasSuccessful() {
 		s.logger.Errorf("Error running bugtool: %s", res.CombineOutput())
 	}

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -519,7 +519,7 @@ func (s *SSHMeta) ReportFailed(commands ...string) {
 		res = s.Exec(fmt.Sprintf("%s", cmd))
 		fmt.Fprint(wr, res.Output())
 	}
-	fmt.Fprint(wr, "Gathering Logs and Cilium CLI Output\n")
+
 	s.DumpCiliumCommandOutput()
 	s.GatherLogs()
 	s.CheckLogsForDeadlock()

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -148,28 +148,29 @@ const (
 )
 
 var ciliumCLICommands = map[string]string{
-	"cilium endpoint list -o json":    "endpoint_list.txt",
-	"cilium service list -o json":     "service_list.txt",
-	"cilium config":                   "config.txt",
-	"sudo cilium bpf lb list":         "bpf_lb_list.txt",
-	"sudo cilium bpf ct list global":  "bpf_ct_list.txt",
-	"sudo cilium bpf tunnel list":     "bpf_tunnel_list.txt",
-	"cilium policy get":               "policy_get.txt",
-	"cilium status --all-controllers": "status.txt",
-	"sudo cilium debuginfo":           "debuginfo.txt",
+	"cilium endpoint list -o json":          "endpoint_list.txt",
+	"cilium service list -o json":           "service_list.txt",
+	"cilium config":                         "config.txt",
+	"sudo cilium bpf lb list":               "bpf_lb_list.txt",
+	"sudo cilium bpf ct list global":        "bpf_ct_list.txt",
+	"sudo cilium bpf tunnel list":           "bpf_tunnel_list.txt",
+	"cilium policy get":                     "policy_get.txt",
+	"cilium status --all-controllers":       "status.txt",
+	"cilium kvstore get cilium --recursive": "kvstore_get.txt",
 }
 
 // ciliumKubCLICommands these commands are the same as `ciliumCLICommands` but
 // it'll run inside a container and it does not have sudo support
 var ciliumKubCLICommands = map[string]string{
-	"cilium endpoint list -o json":    "endpoint_list.txt",
-	"cilium service list -o json":     "service_list.txt",
-	"cilium config":                   "config.txt",
-	"cilium bpf lb list":              "bpf_lb_list.txt",
-	"cilium bpf ct list global":       "bpf_ct_list.txt",
-	"cilium bpf tunnel list":          "bpf_tunnel_list.txt",
-	"cilium policy get":               "policy_get.txt",
-	"cilium status --all-controllers": "status.txt",
+	"cilium endpoint list -o json":          "endpoint_list.txt",
+	"cilium service list -o json":           "service_list.txt",
+	"cilium config":                         "config.txt",
+	"cilium bpf lb list":                    "bpf_lb_list.txt",
+	"cilium bpf ct list global":             "bpf_ct_list.txt",
+	"cilium bpf tunnel list":                "bpf_tunnel_list.txt",
+	"cilium policy get":                     "policy_get.txt",
+	"cilium status --all-controllers":       "status.txt",
+	"cilium kvstore get cilium --recursive": "kvstore_get.txt",
 }
 
 //GetFilePath returns the absolute path of the provided filename

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -17,8 +17,8 @@ package helpers
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -657,7 +657,7 @@ func (kub *Kubectl) CiliumReport(namespace string, pod string, commands []string
 		fmt.Fprintln(wr, out.CombineOutput())
 	}
 	fmt.Fprint(wr, "StackTrace Ends\n")
-	kub.CiliumReportDump(namespace)
+	kub.DumpCiliumCommandOutput(namespace)
 	kub.GatherLogs()
 	kub.CheckLogsForDeadlock()
 
@@ -673,16 +673,11 @@ func (kub *Kubectl) CheckLogsForDeadlock() {
 	}
 }
 
-// CiliumReportDump runs a variety of commands (CiliumKubCLICommands) and writes the results to
+// DumpCiliumCommandOutput runs a variety of commands (CiliumKubCLICommands) and writes the results to
 // TestResultsPath
-func (kub *Kubectl) CiliumReportDump(namespace string) {
+func (kub *Kubectl) DumpCiliumCommandOutput(namespace string) {
 	ReportOnPod := func(pod string) {
 		logger := kub.logger.WithField("CiliumPod", pod)
-
-		reportEndpointCommands := map[string]string{
-			"cilium endpoint get %s":   "%s_endpoint_get_%s.txt",
-			"cilium bpf policy get %s": "%s_bpf_policy_get_%s.txt",
-		}
 
 		testPath, err := CreateReportDirectory()
 		if err != nil {
@@ -697,33 +692,23 @@ func (kub *Kubectl) CiliumReportDump(namespace string) {
 		}
 		reportMap(testPath, reportCmds, kub.SSHMeta)
 
-		for _, ep := range kub.CiliumEndpointsIDs(pod) {
-			for cmd, logfile := range reportEndpointCommands {
-				command := fmt.Sprintf(cmd, ep)
-				res := kub.Exec(fmt.Sprintf(
-					"kubectl exec -n %s %s -- %s", namespace, pod, command))
-				err = ioutil.WriteFile(
-					fmt.Sprintf("%s/%s", testPath, fmt.Sprintf(logfile, pod, ep)),
-					res.CombineOutput().Bytes(),
-					LogPerm)
-				if err != nil {
-					logger.WithError(err).Errorf(
-						"cannot create test results for command '%s'", command)
+		// Get bugtool output. Since bugtool output is dumped in the pod's filesystem,
+		// copy it over with `kubectl cp`.
+		bugtoolCmd := fmt.Sprintf("kubectl exec -n %s %s -- cilium-bugtool", namespace, pod)
+		res := kub.Exec(bugtoolCmd)
+		if res.WasSuccessful() {
+			// Default output directory is /tmp for bugtool.
+			res = kub.Exec(fmt.Sprintf("kubectl exec -n %s %s -- ls /tmp/", namespace, pod))
+			tmpList := res.ByLines()
+			for _, line := range tmpList {
+				// Only copy over bugtool output to directory.
+				if strings.Contains(line, "cilium-bugtool") {
+					archiveName := fmt.Sprintf("%s-%s", pod, line)
+					res = kub.Exec(fmt.Sprintf("kubectl cp %s/%s:/tmp/%s %s", namespace, pod, line, filepath.Join(BasePath, testPath, archiveName)))
 				}
 			}
-		}
-
-		for _, id := range kub.CiliumEndpointsIdentityIDs(pod) {
-			cmd := fmt.Sprintf("kubectl exec -n %s %s -- cilium identity get %s", namespace, pod, id)
-
-			res := kub.Exec(cmd)
-			err = ioutil.WriteFile(
-				fmt.Sprintf("%s/%s", testPath, fmt.Sprintf("%s_identity_%s.txt", pod, id)),
-				res.CombineOutput().Bytes(),
-				LogPerm)
-			if err != nil {
-				logger.WithError(err).Errorf("cannot create test results for command '%s'", cmd)
-			}
+		} else {
+			log.Errorf("%s failed: %s", bugtoolCmd, res.CombineOutput().String())
 		}
 	}
 


### PR DESCRIPTION
* Get output of `cilium kvstore get cilium --recursive` in both runtime and
Kubernetes test suites.
* Get debugtool output and bugtool archive for each Cilium pod in the
Kubernetes test suite.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #2746 
Fixes: #3006 