### PR TITLE
Ginkgo: Test Flake on RuntimeValidatedConntrack

### DIFF
--- a/test/runtime/ct.go
+++ b/test/runtime/ct.go
@@ -619,15 +619,20 @@ var _ = Describe("RuntimeValidatedConntrackTable", func() {
 		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
 		res.ExpectSuccess("Setting policy enforcement as default")
 
+		areEndpointsReady := vm.WaitEndpointsReady()
+		Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+
 		// #FIXME remove these 6 lines once GH-2496 is fixed
 		epIDs, err := vm.GetEndpointsIds()
 		Expect(err).To(BeNil(), "Getting endpoints identity IDs")
 		for _, v := range epIDs {
-			vm.ExecCilium(fmt.Sprintf("endpoint config %s IngressPolicy=false", v)).ExpectSuccess("Setting %s endpoint's IngressPolicy as false", v)
-			vm.ExecCilium(fmt.Sprintf("endpoint config %s EgressPolicy=false", v)).ExpectSuccess("Setting %s endpoint's EgressPolicy as false", v)
+			vm.ExecCilium(fmt.Sprintf("endpoint config %s IngressPolicy=false", v)).ExpectSuccess(
+				"Setting %s endpoint's IngressPolicy as false", v)
+			vm.ExecCilium(fmt.Sprintf("endpoint config %s EgressPolicy=false", v)).ExpectSuccess(
+				"Setting %s endpoint's EgressPolicy as false", v)
 		}
 
-		areEndpointsReady := vm.WaitEndpointsReady()
+		areEndpointsReady = vm.WaitEndpointsReady()
 		Expect(areEndpointsReady).Should(BeTrue(), "Endpoints not ready after timeout")
 
 		meta := containersMeta()

--- a/test/runtime/ct.go
+++ b/test/runtime/ct.go
@@ -136,6 +136,9 @@ var _ = Describe("RuntimeValidatedConntrackTable", func() {
 		containers(helpers.Delete)
 		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
 		res.ExpectSuccess("Setting policyEnforcement to default")
+
+		areEndpointsReady := vm.WaitEndpointsReady()
+		Expect(areEndpointsReady).Should(BeTrue(), "Endpoints not ready after timeout")
 	})
 
 	// containersMeta returns a map where the key is the container name and the
@@ -626,10 +629,11 @@ var _ = Describe("RuntimeValidatedConntrackTable", func() {
 		epIDs, err := vm.GetEndpointsIds()
 		Expect(err).To(BeNil(), "Getting endpoints identity IDs")
 		for _, v := range epIDs {
-			vm.ExecCilium(fmt.Sprintf("endpoint config %s IngressPolicy=false", v)).ExpectSuccess(
-				"Setting %s endpoint's IngressPolicy as false", v)
-			vm.ExecCilium(fmt.Sprintf("endpoint config %s EgressPolicy=false", v)).ExpectSuccess(
-				"Setting %s endpoint's EgressPolicy as false", v)
+			status := vm.EndpointSetConfig(v, helpers.OptionIngressPolicy, "false")
+			Expect(status).To(BeTrue(), "Cannot update %s", helpers.OptionIngressPolicy)
+
+			status = vm.EndpointSetConfig(v, helpers.OptionEgressPolicy, "false")
+			Expect(status).To(BeTrue(), "Cannot update %s", helpers.OptionEgressPolicy)
 		}
 
 		areEndpointsReady = vm.WaitEndpointsReady()


### PR DESCRIPTION
This test was failed randonmly in the last two days because pods were
not ready after a new change was applied.

Test log:

```
level=debug msg="running command: sudo cilium config PolicyEnforcement=default"
cmd: "sudo cilium config PolicyEnforcement=default" exitCode: 0

level=debug msg="running command: sudo cilium endpoint list -o jsonpath='{range [?(@.labels.orchestration-identity[0]!=\"reserved:health\")]}{@.container-name}{\"=\"}{@.id}{\"\\n\"}{end}'"
cmd: "sudo cilium endpoint list -o jsonpath='{range [?(@.labels.orchestration-identity[0]!=\"reserved:health\")]}{@.container-name}{\"=\"}{@.id}{\"\\n\"}{end}'" exitCode: 0
 client=12075
server=14594
server-2=19080
server-3=20084
netcat=27624
client-2=28707

level=debug msg="running command: sudo cilium endpoint config 28707 IngressPolicy=false"
cmd: "sudo cilium endpoint config 28707 IngressPolicy=false" exitCode: 0
 Endpoint 28707 configuration updated successfully

level=debug msg="running command: sudo cilium endpoint config 28707 EgressPolicy=false"
cmd: "sudo cilium endpoint config 28707 EgressPolicy=false" exitCode: 0
 Endpoint 28707 configuration updated successfully

level=debug msg="running command: sudo cilium endpoint config 12075 IngressPolicy=false"
cmd: "sudo cilium endpoint config 12075 IngressPolicy=false" exitCode: 0
 Endpoint 12075 configuration updated successfully

level=debug msg="running command: sudo cilium endpoint config 12075 EgressPolicy=false"
cmd: "sudo cilium endpoint config 12075 EgressPolicy=false" exitCode: 0
 Endpoint 12075 configuration updated successfully

level=debug msg="running command: sudo cilium endpoint config 14594 IngressPolicy=false"
cmd: "sudo cilium endpoint config 14594 IngressPolicy=false" exitCode: 1
 Error: Cannot update endpoint 14594: [PATCH /endpoint/{id}/config][500] patchEndpointIdConfigFailed  unable to regenerate endpoint program because state transition to waiting-to-regenerate was unsuccessful; check `cilium endpoint log 14594` for more information
```

This error happened on:

- https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/1633/testReport/
- https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/1632/testReport/
- https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/1631/testReport/
- https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/1630/testReport/

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>