### PR TITLE
envoy: Fix network policy translation cases

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -148,19 +148,11 @@ func (d *Daemon) RemoveProxyRedirect(e *endpoint.Endpoint, id string) error {
 // UpdateNetworkPolicy adds or updates a network policy in the set
 // published to L7 proxies.
 func (d *Daemon) UpdateNetworkPolicy(id identity.NumericIdentity, policy *policy.L4Policy,
-	labelsMap identity.IdentityCache, allowedIngressIdentities, allowedEgressIdentities map[identity.NumericIdentity]bool) error {
+	labelsMap identity.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool) error {
 	if d.l7Proxy == nil {
 		return fmt.Errorf("can't update network policy, proxy disabled")
 	}
-	ingress := make(identity.IdentityCache, len(allowedIngressIdentities))
-	for id := range allowedIngressIdentities {
-		ingress[id] = labelsMap[id]
-	}
-	egress := make(identity.IdentityCache, len(allowedEgressIdentities))
-	for id := range allowedEgressIdentities {
-		egress[id] = labelsMap[id]
-	}
-	return d.l7Proxy.UpdateNetworkPolicy(id, policy, ingress, egress)
+	return d.l7Proxy.UpdateNetworkPolicy(id, policy, labelsMap, deniedIngressIdentities, deniedEgressIdentities)
 }
 
 // RemoveNetworkPolicy removes a network policy from the set published to

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -56,7 +56,7 @@ type DaemonSuite struct {
 	OnGetPolicyRepository             func() *policy.Repository
 	OnUpdateProxyRedirect             func(e *e.Endpoint, l4 *policy.L4Filter) (uint16, error)
 	OnRemoveProxyRedirect             func(e *e.Endpoint, id string) error
-	OnUpdateNetworkPolicy             func(id identity.NumericIdentity, policy *policy.L4Policy, labelsMap identity.IdentityCache, allowedIngressIdentities, allowedEgressIdentities map[identity.NumericIdentity]bool) error
+	OnUpdateNetworkPolicy             func(id identity.NumericIdentity, policy *policy.L4Policy, labelsMap identity.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool) error
 	OnRemoveNetworkPolicy             func(id identity.NumericIdentity)
 	OnGetStateDir                     func() string
 	OnGetBpfDir                       func() string
@@ -238,9 +238,9 @@ func (ds *DaemonSuite) RemoveProxyRedirect(e *e.Endpoint, id string) error {
 }
 
 func (ds *DaemonSuite) UpdateNetworkPolicy(id identity.NumericIdentity, policy *policy.L4Policy,
-	labelsMap identity.IdentityCache, allowedIngressIdentities, allowedEgressIdentities map[identity.NumericIdentity]bool) error {
+	labelsMap identity.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool) error {
 	if ds.OnUpdateNetworkPolicy != nil {
-		return ds.OnUpdateNetworkPolicy(id, policy, labelsMap, allowedIngressIdentities, allowedEgressIdentities)
+		return ds.OnUpdateNetworkPolicy(id, policy, labelsMap, deniedIngressIdentities, deniedEgressIdentities)
 	}
 	panic("UpdateNetworkPolicy should not have been called")
 }

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -138,7 +138,7 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 	}
 
 	ds.OnUpdateNetworkPolicy = func(id identity.NumericIdentity, policy *policy.L4Policy,
-		labelsMap identity.IdentityCache, allowedIngressIdentities, allowedEgressIdentities map[identity.NumericIdentity]bool) error {
+		labelsMap identity.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool) error {
 		return nil
 	}
 

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -54,7 +54,7 @@ type Owner interface {
 	// UpdateNetworkPolicy adds or updates a network policy in the set
 	// published to L7 proxies.
 	UpdateNetworkPolicy(id identity.NumericIdentity, policy *policy.L4Policy,
-		labelsMap identity.IdentityCache, allowedIngressIdentities, allowedEgressIdentities map[identity.NumericIdentity]bool) error
+		labelsMap identity.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool) error
 
 	// RemoveNetworkPolicy removes a network policy from the set published to
 	// L7 proxies.

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -195,6 +195,12 @@ func (n *EndpointSelector) Matches(lblsToMatch k8sLbls.Labels) bool {
 	return lbSelector.Matches(lblsToMatch)
 }
 
+// IsWildcard returns true if the endpoint selector selects all endpoints.
+func (n *EndpointSelector) IsWildcard() bool {
+	return n.LabelSelector != nil &&
+		len(n.LabelSelector.MatchLabels)+len(n.LabelSelector.MatchExpressions) == 0
+}
+
 // EndpointSelectorSlice is a slice of EndpointSelectors that can be sorted.
 type EndpointSelectorSlice []EndpointSelector
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -562,8 +562,8 @@ func (p *Proxy) RemoveRedirect(id string, wg *completion.WaitGroup) error {
 // UpdateNetworkPolicy adds or updates a network policy in the set
 // published to L7 proxies.
 func (p *Proxy) UpdateNetworkPolicy(id identityPkg.NumericIdentity, policy *policy.L4Policy,
-	allowedIngressIdentities, allowedEgressIdentities identityPkg.IdentityCache) error {
-	return envoy.UpdateNetworkPolicy(id, policy, allowedIngressIdentities, allowedEgressIdentities)
+	labelsMap identityPkg.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identityPkg.NumericIdentity]bool) error {
+	return envoy.UpdateNetworkPolicy(id, policy, labelsMap, deniedIngressIdentities, deniedEgressIdentities)
 }
 
 // RemoveNetworkPolicy removes a network policy from the set published to


### PR DESCRIPTION
Properly Handle rules with wildcard endpoint selectors.
Consider all non-denied identities for NPDS policy translation, and not only identities allowed based on L3 only.

Signed-off-by: Romain Lenglet <romain@covalent.io>