### PR TITLE
Documentation: add RBAC to upgrade guide

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -7,7 +7,14 @@ Upgrade Guide
 Kubernetes Cilium Upgrade
 =========================
 
-Cilium should be upgraded using Kubernetes rolling upgrade functionality in order to minimize network disruptions for running workloads. 
+Cilium should be upgraded using Kubernetes rolling upgrade functionality in order to minimize network disruptions for running workloads.
+
+Make sure you are using the latest RBAC role and service account definitions
+before performing the rolling upgrade::
+
+::
+
+    kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/rbac.yaml
 
 Substitute the desired Cilium version number of vX.Y.Z in the command below
 

--- a/examples/kubernetes/rbac.yaml
+++ b/examples/kubernetes/rbac.yaml
@@ -1,0 +1,62 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
+  - thirdpartyresources
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  verbs:
+  - "*"


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

I copy paste the RBAC in the primary `cilium.yaml` to avoid re-write all guides that we have.
By doing the `kubectl apply` the users won't see any error messages when upgrading only RBAC rules.