### PR TITLE
docker: Install protoc-gen-validate in cilium-builder image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,5 +67,6 @@ test/*_policy.json
 # Temporary files that allow build containers/VMs work without git
 GIT_VERSION
 envoy/SOURCE_VERSION
+envoy/Dockerfile.builder
 
 test/bpf/_results

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM cilium/cilium-builder:2018-02-16 as builder
+FROM cilium/cilium-builder:2018-03-09 as builder
 LABEL maintainer="maintainer@cilium.io"
 WORKDIR /go/src/github.com/cilium/cilium
 ADD . ./

--- a/contrib/packaging/docker/Dockerfile.builder
+++ b/contrib/packaging/docker/Dockerfile.builder
@@ -21,17 +21,20 @@ apt-get update && \
 #
 # Install Go
 #
-apt-get install -y --no-install-recommends apt-utils curl git ca-certificates && \
+apt-get install -y --no-install-recommends apt-utils curl git make ca-certificates && \
 curl -Sslk -o /tmp/go.linux-amd64.tar.gz https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz && \
 tar -C /usr/local -xzf /tmp/go.linux-amd64.tar.gz && \
 rm /tmp/go.linux-amd64.tar.gz && \
 go get -u github.com/cilium/go-bindata/... && \
 go get -u github.com/golang/protobuf/protoc-gen-go && \
+go get -d github.com/lyft/protoc-gen-validate && \
+(cd /go/src/github.com/lyft/protoc-gen-validate ; git checkout 930a67cf7ba41b9d9436ad7a1be70a5d5ff6e1fc ; make build) && \
 #
 # Install build requirements
 #
-apt-get -y install --no-install-recommends gcc make binutils \
- pkg-config zip g++ zlib1g-dev unzip python wget rsync libtool cmake realpath m4 automake
+apt-get -y install --no-install-recommends gcc binutils \
+ pkg-config zip g++ zlib1g-dev unzip python wget rsync libtool cmake realpath m4 automake && \
+apt-get clean
 #
 # Extract the needed Bazel version from the repo
 #

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - consul
       - etcd
-    image: "cilium/cilium-builder:2018-02-16"
+    image: "cilium/cilium-builder:2018-03-09"
     command: "bash -c 'cd /go/src/github.com/cilium/cilium/; make tests-ginkgo-real'"
     privileged: true
     volumes:


### PR DESCRIPTION
Signed-off-by: Romain Lenglet <romain@covalent.io>