### PR TITLE
Nightly- Fixes some errors

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -105,7 +105,7 @@ Vagrant.configure(2) do |config|
         vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
         vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
         config.vm.box = "cilium/ubuntu"
-        config.vm.box_version = "32"
+        config.vm.box_version = "37"
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i
         if ENV["NFS"] then

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -7,7 +7,7 @@ $K8S_VERSION = ENV['K8S_VERSION'] || "1.9"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 
 $SERVER_BOX= "cilium/ubuntu"
-$SERVER_VERSION="32"
+$SERVER_VERSION="37"
 
 # RAM and CPU settings
 $MEMORY = (ENV['MEMORY'] || "2048").to_i

--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -436,7 +436,10 @@ func (t *TestSpec) ApplyManifest() (string, error) {
 	if !res.WasSuccessful() {
 		return "", fmt.Errorf("%s", res.CombineOutput())
 	}
-	status, err := t.Kub.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l zgroup=%s", t.Prefix), 300)
+	status, err := t.Kub.WaitforPods(
+		helpers.DefaultNamespace,
+		fmt.Sprintf("-l zgroup=%s", t.Prefix),
+		600)
 	if err != nil || !status {
 		return "", err
 	}

--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -478,10 +478,6 @@ func (t *TestSpec) CreateCiliumNetworkPolicy() (string, error) {
 
 	type rule map[string]interface{}
 
-	type endpointSelector struct {
-		Matchlabels map[string]string `json:"matchlabels"`
-	}
-
 	specs := []api.Rule{}
 	var err error
 

--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -544,7 +544,7 @@ func (t *TestSpec) CreateCiliumNetworkPolicy() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		err = json.Unmarshal(jsonOut, ingressVal)
+		err = json.Unmarshal(jsonOut, &ingressVal)
 		if err != nil {
 			return "", err
 		}
@@ -565,7 +565,7 @@ func (t *TestSpec) CreateCiliumNetworkPolicy() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		err = json.Unmarshal(jsonOut, egressVal)
+		err = json.Unmarshal(jsonOut, &egressVal)
 		if err != nil {
 			return "", err
 		}

--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -480,9 +480,9 @@ func (t *TestSpec) CreateCiliumNetworkPolicy() (string, error) {
 	}
 
 	type Spec struct {
-		EndpointSelector endpointSelector
-		Ingress          []rule
-		Egress           []rule
+		EndpointSelector endpointSelector `json:"endpointSelector"`
+		Ingress          []rule           `json:"ingress"`
+		Egress           []rule           `json:"egress"`
 	}
 	specs := []Spec{}
 	var err error
@@ -551,6 +551,7 @@ func (t *TestSpec) CreateCiliumNetworkPolicy() (string, error) {
 					"id": t.DestPod},
 			},
 			Ingress: []rule{ingressMap},
+			Egress:  []rule{},
 		})
 	}
 
@@ -560,7 +561,8 @@ func (t *TestSpec) CreateCiliumNetworkPolicy() (string, error) {
 				Matchlabels: map[string]string{
 					"id": t.SrcPod},
 			},
-			Egress: []rule{egressMap},
+			Egress:  []rule{egressMap},
+			Ingress: []rule{},
 		})
 	}
 

--- a/test/helpers/policygen/policygen.go
+++ b/test/helpers/policygen/policygen.go
@@ -20,7 +20,7 @@ var policiesTestSuite = PolicyTestSuite{
 			kind:  ingress,
 			tests: ConnResultAllOK,
 			template: map[string]string{
-				"FromEndpoints": `[{}]`,
+				"fromEndpoints": `[{}]`,
 			},
 		},
 		{
@@ -28,7 +28,7 @@ var policiesTestSuite = PolicyTestSuite{
 			kind:  ingress,
 			tests: ConnResultAllOK,
 			template: map[string]string{
-				"FromEndpoints": `[{"matchLabels": { "id": "{{.SrcPod}}"}}]`,
+				"fromEndpoints": `[{"matchLabels": { "id": "{{.SrcPod}}"}}]`,
 			},
 		},
 		{
@@ -36,7 +36,7 @@ var policiesTestSuite = PolicyTestSuite{
 			kind:  ingress,
 			tests: ConnResultAllTimeout,
 			template: map[string]string{
-				"FromEndpoints": `[{"matchLabels": { "id": "{{.SrcPod}}Invalid"}}]`,
+				"fromEndpoints": `[{"matchLabels": { "id": "{{.SrcPod}}Invalid"}}]`,
 			},
 		},
 	},
@@ -52,7 +52,7 @@ var policiesTestSuite = PolicyTestSuite{
 			kind:  ingress,
 			tests: ConnResultOnlyHTTP,
 			template: map[string]string{
-				"Ports": `[{"port": "80"}]`,
+				"ports": `[{"port": "80"}]`,
 			},
 		},
 		{
@@ -60,7 +60,7 @@ var policiesTestSuite = PolicyTestSuite{
 			kind:  egress,
 			tests: ConnResultOnlyHTTPAndPing,
 			template: map[string]string{
-				"Ports": `[{"port": "80"}]`,
+				"ports": `[{"port": "80"}]`,
 			},
 		},
 		{
@@ -68,7 +68,7 @@ var policiesTestSuite = PolicyTestSuite{
 			kind:  ingress,
 			tests: ConnResultOnlyHTTP,
 			template: map[string]string{
-				"Ports": `[{"port": "80", "protocol": "TCP"}]`,
+				"ports": `[{"port": "80", "protocol": "TCP"}]`,
 			},
 		},
 		{
@@ -76,7 +76,7 @@ var policiesTestSuite = PolicyTestSuite{
 			kind:  ingress,
 			tests: ConnResultAllTimeout,
 			template: map[string]string{
-				"Ports": `[{"port": "80", "protocol": "UDP"}]`,
+				"ports": `[{"port": "80", "protocol": "UDP"}]`,
 			},
 		},
 		{
@@ -84,7 +84,7 @@ var policiesTestSuite = PolicyTestSuite{
 			kind:  egress,
 			tests: ConnResultOnlyHTTPAndPing,
 			template: map[string]string{
-				"Ports": `[{"port": "80", "protocol": "TCP"}]`,
+				"ports": `[{"port": "80", "protocol": "TCP"}]`,
 			},
 		},
 		{
@@ -92,7 +92,7 @@ var policiesTestSuite = PolicyTestSuite{
 			kind:  egress,
 			tests: ConnResultAllTimeoutExceptPing,
 			template: map[string]string{
-				"Ports": `[{"port": "80", "protocol": "UDP"}]`,
+				"ports": `[{"port": "80", "protocol": "UDP"}]`,
 			},
 		},
 	},
@@ -108,8 +108,8 @@ var policiesTestSuite = PolicyTestSuite{
 			kind:  ingress,
 			tests: ConnResultOnlyHTTPPrivate,
 			template: map[string]string{
-				"Rules": `{"http": [{"method": "GET", "path": "/private"}]}`,
-				"Ports": `[{"port": "80", "protocol": "TCP"}]`,
+				"rules": `{"http": [{"method": "GET", "path": "/private"}]}`,
+				"ports": `[{"port": "80", "protocol": "TCP"}]`,
 			},
 		},
 		{
@@ -117,8 +117,8 @@ var policiesTestSuite = PolicyTestSuite{
 			kind:  egress,
 			tests: ConnResultOnlyHTTPPrivateAndPing,
 			template: map[string]string{
-				"Rules": `{"http": [{"method": "GET", "path": "/private"}]}`,
-				"Ports": `[{"port": "80", "protocol": "TCP"}]`,
+				"rules": `{"http": [{"method": "GET", "path": "/private"}]}`,
+				"ports": `[{"port": "80", "protocol": "TCP"}]`,
 			},
 		},
 	},

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -334,6 +334,14 @@ var _ = Describe("NightlyExamples", func() {
 		demoPath = kubectl.ManifestGet("demo.yaml")
 		l3Policy = kubectl.ManifestGet("l3_l4_policy.yaml")
 		l7Policy = kubectl.ManifestGet("l7_policy.yaml")
+
+		// Sometimes PolicyGen has a lot of pods running around without delete
+		// it. Using this we are sure that we delete before this test start
+		kubectl.Exec(fmt.Sprintf(
+			"%s delete --all pods,svc,cnp -n %s", helpers.KubectlCmd, helpers.DefaultNamespace))
+
+		err := kubectl.WaitCleanAllTerminatingPods()
+		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
 	}
 
 	BeforeEach(func() {


### PR DESCRIPTION
Hi, 

Fixed few errors that has been fired in the last Nightly PR: 

- Issues on retrieve pods (Due the high load, it's a Kubernetes resource, no Cilium related)
- Issues with policy templates. I have seen this two times this week. 
- Added logs in `kub.CiliumPolicyRevision` that it was fired one time and I'm not sure why. With this change we can see the log output instead `jq` output. 