### PR TITLE
policy: Simplify L7PolicyMap creation.

### DIFF
--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -136,18 +136,12 @@ func (dm L7DataMap) addRulesForEndpoints(rules api.L7Rules, fromEndpoints []api.
 	}
 
 	if len(fromEndpoints) > 0 {
-		for _, ep := range fromEndpoints {
-			dm[ep] = api.L7Rules{
-				HTTP:  append(dm[ep].HTTP, rules.HTTP...),
-				Kafka: append(dm[ep].Kafka, rules.Kafka...),
-			}
+		for _, epsel := range fromEndpoints {
+			dm[epsel] = rules
 		}
 	} else {
 		// If there are no explicit fromEps, have a 'special' wildcard endpoint.
-		dm[WildcardEndpointSelector] = api.L7Rules{
-			HTTP:  append(dm[WildcardEndpointSelector].HTTP, rules.HTTP...),
-			Kafka: append(dm[WildcardEndpointSelector].Kafka, rules.Kafka...),
-		}
+		dm[WildcardEndpointSelector] = rules
 	}
 }
 


### PR DESCRIPTION
Initially the map is empty, so there is no point in appending the rules.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
