### PR TITLE
examples/mesos: Change ubuntu VB to be correct version

### DIFF
--- a/examples/mesos/Vagrantfile
+++ b/examples/mesos/Vagrantfile
@@ -62,7 +62,7 @@ echo "Deploying Vagrant VM + Cilium + Mesos...done"
 SCRIPT
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "bento/ubuntu-17.04"
+  config.vm.box = "bento/ubuntu-17.10"
   config.vm.provision "file", source: "./allfiles.tar.gz", destination: "./allfiles.tar.gz"
   config.vm.provision "bootstrap", type: "shell", inline: $bootstrap
   config.vm.network "forwarded_port", guest: 8080, host: 8080


### PR DESCRIPTION
**Summary of changes**:

I tried to download the VM in getting-started but it failed because of the fact that Ubuntu was upgraded in January. This is basically the same request of [this PR](https://github.com/cilium/cilium/pull/3020) but a different file.

It's literally a one line change. Simply so when the VM gets downloaded the right version of Ubuntu is installed.

Lemme know if anything else in the file ought to be changed, etc. Thanks!

Fixes: #2620