### PR TITLE
daemon/k8s: fix k8s API watched status report

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -226,12 +226,12 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 		d.k8sAPIGroups.addAPI(k8sAPIGroupCiliumV1)
 
 	case ciliumv2VerConstr.Check(sv):
-		d.k8sAPIGroups.addAPI(k8sAPIGroupCRD)
-		d.k8sAPIGroups.addAPI(k8sAPIGroupCiliumV2)
 		err = cilium_v2.CreateCustomResourceDefinitions(apiextensionsclientset)
 		if err != nil {
 			return fmt.Errorf("Unable to create custom resource definition: %s", err)
 		}
+		d.k8sAPIGroups.addAPI(k8sAPIGroupCRD)
+		d.k8sAPIGroups.addAPI(k8sAPIGroupCiliumV2)
 	}
 
 	ciliumNPClient, err = clientset.NewForConfig(restConfig)


### PR DESCRIPTION
In case of an error when setting up the CRD, cilium status would wrongly
present as it was watching CRD resources.

Signed-off-by: André Martins <andre@cilium.io>

Related-to: https://github.com/cilium/cilium/issues/3093

```release-note
Fix cilium status of k8s CRD watcher when unable to set up k8s client
```