### PR TITLE
Fix identity assignment when labels are changed 

### DIFF
--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -178,9 +178,10 @@ func (ds *DaemonSuite) TestSyncLabels(c *C) {
 	ep1 := epsWanted[0]
 	ep1.SecurityIdentity = nil
 	err := ds.d.syncLabels(ep1)
-	// Endpoint doesn't have a security label, syncLabels should not sync
-	// anything.
-	c.Assert(err, Not(IsNil))
+	// Endpoint doesn't have a security label but it has some operational labels
+	// so endpoint will have a new identity assigned
+	c.Assert(err, IsNil)
+	c.Assert(ep1.SecurityIdentity, NotNil)
 
 	// Let's make sure we delete all labels from the kv store first
 	ep2 := epsWanted[1]

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1768,7 +1768,9 @@ func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
 		return nil
 	}
 
-	if e.SecurityIdentity != nil && string(e.SecurityIdentity.Labels.SortedList()) != string(newLabels.SortedList()) {
+	if e.SecurityIdentity != nil &&
+		string(e.SecurityIdentity.Labels.SortedList()) == string(newLabels.SortedList()) {
+
 		e.Mutex.RUnlock()
 		elog.Debug("Endpoint labels unchanged, skipping resolution of identity")
 		return nil


### PR DESCRIPTION
**Summary of changes**:

- Re assign identity based on OpLabels
- Create new identity when endpoint labels change

```release-note
create new identity when endpoint labels change and re assign identity based on all endpoint labels when restoring
```

Reported by @mrdima