### PR TITLE
Ginkgo: Add a option to run test in different vms

### DIFF
--- a/test/config/config.go
+++ b/test/config/config.go
@@ -20,6 +20,7 @@ import "flag"
 type CiliumTestConfigType struct {
 	Reprovision     bool
 	HoldEnvironment bool
+	SSHConfig       string
 }
 
 // CiliumTestConfig holds the global configuration of commandline flags
@@ -32,4 +33,6 @@ func (c *CiliumTestConfigType) ParseFlags() {
 		"Provision Vagrant boxes and Cilium before running test")
 	flag.BoolVar(&c.HoldEnvironment, "cilium.holdEnvironment", false,
 		"On failure, hold the environment in its current state")
+	flag.StringVar(&c.SSHConfig, "cilium.SSHConfig", "",
+		"Specify a custom command to fetch SSH configuration (eg: 'vagrant ssh-config')")
 }

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -33,7 +33,7 @@ var (
 
 const (
 
-	//CiliumPath the path where cilium test code is located.
+	//CiliumPath is the path where cilium test code is located.
 	CiliumPath = "/src/github.com/cilium/cilium/test"
 
 	// ManifestBase tells ginkgo suite where to look for manifests

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -25,12 +25,16 @@ import (
 var (
 	// HelperTimeout is a predefined timeout value for commands.
 	HelperTimeout time.Duration = 300 // WithTimeout helper translates it to seconds
-)
 
-const (
 	// BasePath is the path in the Vagrant VMs to which the test directory
 	// is mounted
 	BasePath = "/home/vagrant/go/src/github.com/cilium/cilium/test"
+)
+
+const (
+
+	//CiliumPath the path where cilium test code is located.
+	CiliumPath = "/src/github.com/cilium/cilium/test"
 
 	// ManifestBase tells ginkgo suite where to look for manifests
 	K8sManifestBase = "k8sT/manifests"

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -127,6 +127,12 @@ var _ = BeforeAll(func() {
 		return
 	}
 
+	if config.CiliumTestConfig.SSHConfig != "" {
+		// If we set a different VM that it's not in our test environment
+		// ginkgo cannot provision it, so skip setup below.
+		return
+	}
+
 	if progressChan := goReportVagrantStatus(); progressChan != nil {
 		defer func() { progressChan <- err == nil }()
 	}


### PR DESCRIPTION
This commit added a new flag --cilium.SSHConfig that it's a subcommand
that change `vagrant ssh-config ${VM}` to something that we want to have.

For example, if we want to run ginkgo test in a different VM, we can use
the following:

`vagrant ssh-config ${ID} > ssh-config`

And in that file, we should update the Host line to something that
matchs, like:

`Host runtime` --> For Runtime test
`Host k8s1-1.9` --> For Kubernetes test
`Host k8s2-1.9` --> For Kubernetes test

In the case of Kubernetes the value is 1.9, but that should match with
the value from ${K8S_VERSION}. (As described in the contributing guide)

This commit also updates helpers.BasePath, if the flag is defined, the
variable will change to ssh-host $GOPATH value or ${HOME}/go if the
GOPATH is not enabled.

This change fixes multiple approaches that ginkgo should cover:

@aanm Can dump the output of `vagrant shh-config` from his VMs and use
those servers to run the test.
@nebril Can use the test in minukube, a custom ssh-config can be created
file where host and ssh-key can be specified.
@jrfastab can create a custom ssh-config to run the test in baremetal.
`ssh -G $(whoami)@127.0.0.1` can be used and added `Host runtime` in the
top
@joestringer can create a custom ssh-config and use on their laptop and
the system will pickup the `$GOPATH` environment variable and bazel
cache.(Feedback from issue #2900)
@me to run some test in Google Cloud. 


Example: 
```
ginkgo --focus "RuntimeValidatedLB" -v -- --cilium.provision=false --cilium.SSHConfig="cat ssh-config"
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>