### PR TITLE
daemon: Add --sidecar-http-proxy flag to disable HTTP proxy redirects

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -394,6 +394,8 @@ func init() {
 		"ipv4-node", "auto", "IPv4 address of node")
 	flags.BoolVar(&config.RestoreState,
 		"restore", true, "Restores state, if possible, from previous daemon")
+	flags.Bool("sidecar-http-proxy", false, "Disable host HTTP proxy, assuming proxies in sidecar containers")
+	flags.MarkHidden("sidecar-http-proxy")
 	flags.BoolVar(&singleClusterRoute, "single-cluster-route", false,
 		"Use a single cluster route instead of per node routes")
 	flags.StringVar(&socketPath,

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/u8proto"
 	"github.com/cilium/cilium/pkg/version"
+	"github.com/spf13/viper"
 )
 
 const (
@@ -445,6 +446,11 @@ func (e *Endpoint) addNewRedirectsFromMap(owner Owner, m policy.L4PolicyMap, des
 
 	for _, l4 := range m {
 		if l4.IsRedirect() {
+			// Ignore the redirect if the proxy is running in a sidecar container.
+			if l4.L7Parser == policy.ParserTypeHTTP && viper.GetBool("sidecar-http-proxy") {
+				continue
+			}
+
 			redirect, err := owner.UpdateProxyRedirect(e, &l4)
 			if err != nil {
 				return err


### PR DESCRIPTION
This is a temporary hidden flag to disable the Cilium host Envoy proxy when used in conjunction with Istio's sidecar proxy.

Signed-off-by: Romain Lenglet <romain@covalent.io>