### PR TITLE
tests: Fix go vet warnings in policygen

### DIFF
--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -550,7 +550,7 @@ func (t *TestSpec) CreateCiliumNetworkPolicy() (string, error) {
 		}
 		specs = append(specs, api.Rule{
 			EndpointSelector: api.EndpointSelector{
-				&metav1.LabelSelector{MatchLabels: map[string]string{
+				LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
 					"id": t.DestPod,
 				}},
 			},
@@ -572,7 +572,7 @@ func (t *TestSpec) CreateCiliumNetworkPolicy() (string, error) {
 
 		specs = append(specs, api.Rule{
 			EndpointSelector: api.EndpointSelector{
-				&metav1.LabelSelector{MatchLabels: map[string]string{
+				LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
 					"id": t.SrcPod,
 				}},
 			},


### PR DESCRIPTION
```
models.go:574: github.com/cilium/cilium/pkg/policy/api.EndpointSelector composite literal uses unkeyed fields
```