### PR TITLE
proxy: Setup xDS and access log servers to support multiple sidecar Envoy proxies

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1071,7 +1071,7 @@ func NewDaemon(c *Config) (*Daemon, error) {
 	}
 
 	// FIXME: Make configurable
-	d.l7Proxy = proxy.NewProxy(10000, 20000)
+	d.l7Proxy = proxy.StartProxySupport(10000, 20000, d.conf.RunDir)
 
 	if c.RestoreState {
 		if err := d.SyncState(d.conf.StateDir, true); err != nil {

--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -60,7 +60,7 @@ func StartAccessLogServer(stateDir string, xdsServer *XDSServer) {
 				continue
 			}
 			log.Info("Envoy: Accepted access log connection")
-			accessLogger(uc, xdsServer)
+			go accessLogger(uc, xdsServer)
 		}
 	}()
 }

--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -39,6 +39,12 @@ func StartAccessLogServer(stateDir string, xdsServer *XDSServer) {
 	}
 	accessLogListener.SetUnlinkOnClose(true)
 
+	// Make the socket accessible by non-root Envoy proxies, e.g. running in
+	// sidecar containers.
+	if err = os.Chmod(accessLogPath, 0777); err != nil {
+		log.WithError(err).Fatal("Envoy: can't change mode of access log socket at ", accessLogPath)
+	}
+
 	go func() {
 		for {
 			// Each Envoy listener opens a new connection over the Unix domain socket.

--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -1,0 +1,97 @@
+// Copyright 2017, 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"github.com/golang/protobuf/proto"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+func getAccessLogPath(stateDir string) string {
+	return filepath.Join(stateDir, "access_log.sock")
+}
+
+// StartAccessLogServer starts the access log server.
+func StartAccessLogServer(stateDir string, xdsServer *XDSServer) {
+	accessLogPath := getAccessLogPath(stateDir)
+
+	// Create the access log listener
+	os.Remove(accessLogPath) // Remove/Unlink the old unix domain socket, if any.
+	accessLogListener, err := net.ListenUnix("unixpacket", &net.UnixAddr{Name: accessLogPath, Net: "unixpacket"})
+	if err != nil {
+		log.WithError(err).Fatal("Envoy: Failed to listen at ", accessLogPath)
+	}
+	accessLogListener.SetUnlinkOnClose(true)
+
+	go func() {
+		for {
+			// Each Envoy listener opens a new connection over the Unix domain socket.
+			// Multiple worker threads serving the listener share that same connection
+			uc, err := accessLogListener.AcceptUnix()
+			if err != nil {
+				// These errors are expected when we are closing down
+				if !strings.Contains(err.Error(), "closed network connection") &&
+					!strings.Contains(err.Error(), "invalid argument") {
+					log.WithError(err).Error("AcceptUnix failed")
+				}
+				break
+			}
+			log.Info("Envoy: Access log connection opened")
+			accessLogger(uc, xdsServer)
+		}
+	}()
+}
+
+func accessLogger(conn *net.UnixConn, xdsServer *XDSServer) {
+	defer func() {
+		log.Info("Envoy: Access log closing")
+		conn.Close()
+	}()
+
+	buf := make([]byte, 4096)
+	for {
+		n, _, flags, _, err := conn.ReadMsgUnix(buf, nil)
+		if err != nil {
+			if !isEOF(err) {
+				log.WithError(err).Error("Envoy: Access log read error")
+			}
+			break
+		}
+		if flags&syscall.MSG_TRUNC != 0 {
+			log.Warning("Envoy: Truncated access log message discarded.")
+			continue
+		}
+		pblog := HttpLogEntry{}
+		err = proto.Unmarshal(buf[:n], &pblog)
+		if err != nil {
+			log.WithError(err).Warning("Envoy: Invalid accesslog.proto HttpLogEntry message.")
+			continue
+		}
+
+		// Correlate the log entry with a listener
+		logger := xdsServer.findListenerLogger(pblog.CiliumResourceName)
+
+		// Call the logger.
+		if logger != nil {
+			logger.Log(&pblog)
+		} else {
+			log.Infof("Envoy: Orphan Access log message for %s: %s", pblog.CiliumResourceName, pblog.String())
+		}
+	}
+}

--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -58,9 +58,9 @@ func startXDSGRPCServer(listener net.Listener, ldsConfig, npdsConfig, nphdsConfi
 	reflection.Register(grpcServer)
 
 	go func() {
-		log.Infof("starting Envoy xDS gRPC server listening on %s", listener)
+		log.Infof("Envoy: Starting xDS gRPC server listening on %s", listener)
 		if err := grpcServer.Serve(listener); err != nil && !strings.Contains(err.Error(), "closed network connection") {
-			log.WithError(err).Error("failed to serve Envoy xDS gRPC API")
+			log.WithError(err).Fatal("Envoy: Failed to serve xDS gRPC API")
 		}
 	}()
 

--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -37,10 +37,10 @@ var (
 	ErrNotImplemented = errors.New("not implemented")
 )
 
-// StartXDSGRPCServer starts a gRPC server to serve xDS APIs using the given
+// startXDSGRPCServer starts a gRPC server to serve xDS APIs using the given
 // resource watcher and network listener.
 // Returns a function that stops the GRPC server when called.
-func StartXDSGRPCServer(listener net.Listener, ldsConfig, npdsConfig, nphdsConfig *xds.ResourceTypeConfiguration, resourceAccessTimeout time.Duration) context.CancelFunc {
+func startXDSGRPCServer(listener net.Listener, ldsConfig, npdsConfig, nphdsConfig *xds.ResourceTypeConfiguration, resourceAccessTimeout time.Duration) context.CancelFunc {
 	grpcServer := grpc.NewServer()
 
 	xdsServer := xds.NewServer(map[string]*xds.ResourceTypeConfiguration{

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -28,15 +28,6 @@ const (
 )
 
 var (
-	// NetworkPolicyCache is the global cache of resources of type
-	// NetworkPolicy. Resources in this cache must have the
-	// NetworkPolicyTypeURL type URL.
-	NetworkPolicyCache = xds.NewCache()
-
-	// AckingNetworkPolicyMutator handles acknowledgements of NetworkPolicy
-	// resource updates.
-	AckingNetworkPolicyMutator = xds.NewAckingResourceMutatorWrapper(NetworkPolicyCache, xds.IstioNodeToIP)
-
 	// NetworkPolicyHostsCache is the global cache of resources of type
 	// NetworkPolicyHosts. Resources in this cache must have the
 	// NetworkPolicyHostsTypeURL type URL.

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -87,13 +87,13 @@ func StartXDSServer(stateDir string) *XDSServer {
 	os.Remove(xdsPath)
 	socketListener, err := net.ListenUnix("unix", &net.UnixAddr{Name: xdsPath, Net: "unix"})
 	if err != nil {
-		log.WithError(err).Fatal("Envoy: Failed to listen at ", xdsPath)
+		log.WithError(err).Fatalf("Envoy: Failed to open xDS listen socket at %s", xdsPath)
 	}
 
 	// Make the socket accessible by non-root Envoy proxies, e.g. running in
 	// sidecar containers.
 	if err = os.Chmod(xdsPath, 0777); err != nil {
-		log.WithError(err).Fatal("Envoy: can't change mode of xDS socket at ", xdsPath)
+		log.WithError(err).Fatalf("Envoy: Failed to change mode of xDS listen socket at %s", xdsPath)
 	}
 
 	ldsCache := xds.NewCache()
@@ -194,13 +194,13 @@ func StartXDSServer(stateDir string) *XDSServer {
 
 // AddListener adds a listener to a running Envoy proxy.
 func (s *XDSServer) AddListener(name string, endpointPolicyName string, port uint16, isIngress bool, logger Logger, wg *completion.WaitGroup) {
-	log.Debug("Envoy: addListener ", name)
+	log.Debugf("Envoy: addListener %s", name)
 
 	s.mutex.Lock()
 
 	// Bail out if this listener already exists
 	if _, ok := s.loggers[name]; ok {
-		log.Fatalf("Envoy: addListener: Listener %s already exists!", name)
+		log.Fatalf("Envoy: Attempt to add existing listener: %s", name)
 	}
 
 	s.loggers[name] = logger
@@ -224,11 +224,11 @@ func (s *XDSServer) AddListener(name string, endpointPolicyName string, port uin
 // RemoveListener removes an existing Envoy Listener.
 func (s *XDSServer) RemoveListener(name string, wg *completion.WaitGroup) {
 	s.mutex.Lock()
-	log.Debug("Envoy: removeListener ", name)
+	log.Debugf("Envoy: removeListener %s", name)
 	l := s.loggers[name]
 	// Bail out if this listener does not exist
 	if l == nil {
-		log.Fatalf("Envoy: removeListener: Listener %s does not exist", name)
+		log.Fatalf("Envoy: Attempt to remove non-existent listener: %s", name)
 	}
 	delete(s.loggers, name)
 	s.mutex.Unlock()
@@ -361,10 +361,10 @@ func createBootstrap(filePath string, name, cluster, version string, xdsSock, en
 		},
 	}
 
-	log.Debug("Envoy: Bootstrap: ", bs.String())
+	log.Debugf("Envoy: Bootstrap: %s", bs)
 	data, err := proto.Marshal(bs)
 	if err != nil {
-		log.WithError(err).Fatal("Envoy: Marshaling bootstrap failed")
+		log.WithError(err).Fatal("Envoy: Error marshaling Envoy bootstrap")
 	}
 	err = ioutil.WriteFile(filePath, data, 0644)
 	if err != nil {
@@ -509,7 +509,7 @@ func (s *XDSServer) UpdateNetworkPolicy(ep NetworkPolicyEndpoint, policy *policy
 		nodeIDs := make([]string, 0, 1)
 		if viper.GetBool("sidecar-http-proxy") {
 			if ep.GetIPv4Address() == "" {
-				log.Fatal("Envoy: sidecar proxy has no IPv4 address")
+				log.Fatal("Envoy: Sidecar proxy has no IPv4 address")
 			}
 			nodeIDs = append(nodeIDs, ep.GetIPv4Address())
 		} else {

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -16,9 +16,11 @@ package envoy
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -35,7 +37,6 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 
-	"fmt"
 	"github.com/gogo/protobuf/sortkeys"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/duration"
@@ -62,11 +63,27 @@ type XDSServer struct {
 	// listenerMutator publishes listener updates to Envoy proxies.
 	listenerMutator xds.AckingResourceMutator
 
+	// networkPolicyCache publishes network policy configuration updates to
+	// Envoy proxies.
+	networkPolicyCache *xds.Cache
+
+	// networkPolicyMutator wraps networkPolicyCache to publish route
+	// configuration updates to Envoy proxies.
+	networkPolicyMutator xds.AckingResourceMutator
+
 	// stopServer stops the xDS gRPC server.
 	stopServer context.CancelFunc
 }
 
-func createXDSServer(path, accessLogPath string) *XDSServer {
+func getXDSPath(stateDir string) string {
+	return filepath.Join(stateDir, "xds.sock")
+}
+
+// StartXDSServer configures and starts the xDS GRPC server.
+func StartXDSServer(stateDir string) *XDSServer {
+	path := getXDSPath(stateDir)
+	accessLogPath := getAccessLogPath(stateDir)
+
 	os.Remove(path)
 	socketListener, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
 	if err != nil {
@@ -80,9 +97,11 @@ func createXDSServer(path, accessLogPath string) *XDSServer {
 		AckObserver: ldsMutator,
 	}
 
+	npdsCache := xds.NewCache()
+	npdsMutator := xds.NewAckingResourceMutatorWrapper(npdsCache, xds.IstioNodeToIP)
 	npdsConfig := &xds.ResourceTypeConfiguration{
-		Source:      NetworkPolicyCache,
-		AckObserver: AckingNetworkPolicyMutator,
+		Source:      npdsCache,
+		AckObserver: npdsMutator,
 	}
 
 	nphdsConfig := &xds.ResourceTypeConfiguration{
@@ -90,7 +109,7 @@ func createXDSServer(path, accessLogPath string) *XDSServer {
 		AckObserver: nil, // We don't wait for ACKs for those resources.
 	}
 
-	stopServer := StartXDSGRPCServer(socketListener, ldsConfig, npdsConfig, nphdsConfig, 5*time.Second)
+	stopServer := startXDSGRPCServer(socketListener, ldsConfig, npdsConfig, nphdsConfig, 5*time.Second)
 
 	listenerProto := &envoy_api_v2.Listener{
 		Address: &envoy_api_v2_core.Address{
@@ -157,15 +176,18 @@ func createXDSServer(path, accessLogPath string) *XDSServer {
 	}
 
 	return &XDSServer{
-		socketPath:      path,
-		listenerProto:   listenerProto,
-		loggers:         make(map[string]Logger),
-		listenerMutator: ldsMutator,
-		stopServer:      stopServer,
+		socketPath:           path,
+		listenerProto:        listenerProto,
+		loggers:              make(map[string]Logger),
+		listenerMutator:      ldsMutator,
+		networkPolicyCache:   npdsCache,
+		networkPolicyMutator: npdsMutator,
+		stopServer:           stopServer,
 	}
 }
 
-func (s *XDSServer) addListener(name string, endpoint_policy_name string, port uint16, isIngress bool, logger Logger, wg *completion.WaitGroup) {
+// AddListener adds a listener to a running Envoy proxy.
+func (s *XDSServer) AddListener(name string, endpointPolicyName string, port uint16, isIngress bool, logger Logger, wg *completion.WaitGroup) {
 	log.Debug("Envoy: addListener ", name)
 
 	s.mutex.Lock()
@@ -188,12 +210,13 @@ func (s *XDSServer) addListener(name string, endpoint_policy_name string, port u
 	}
 
 	listenerConf.FilterChains[0].Filters[0].Config.Fields["http_filters"].GetListValue().Values[0].GetStructValue().Fields["config"].GetStructValue().Fields["listener_id"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: name}}
-	listenerConf.FilterChains[0].Filters[0].Config.Fields["http_filters"].GetListValue().Values[0].GetStructValue().Fields["config"].GetStructValue().Fields["policy_name"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: endpoint_policy_name}}
+	listenerConf.FilterChains[0].Filters[0].Config.Fields["http_filters"].GetListValue().Values[0].GetStructValue().Fields["config"].GetStructValue().Fields["policy_name"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: endpointPolicyName}}
 
 	s.listenerMutator.Upsert(ListenerTypeURL, name, listenerConf, []string{"127.0.0.1"}, wg.AddCompletion())
 }
 
-func (s *XDSServer) removeListener(name string, wg *completion.WaitGroup) {
+// RemoveListener removes an existing Envoy Listener.
+func (s *XDSServer) RemoveListener(name string, wg *completion.WaitGroup) {
 	s.mutex.Lock()
 	log.Debug("Envoy: removeListener ", name)
 	l := s.loggers[name]
@@ -441,13 +464,12 @@ func getNetworkPolicy(name string, id identity.NumericIdentity, policy *policy.L
 	}
 }
 
-// UpdateNetworkPolicy adds or updates a network policy in the set of published
+// UpdateNetworkPolicy adds or updates a network policy in the set published
 // to L7 proxies.
 // When the proxy acknowledges the network policy update, it will result in
 // a subsequent call to the endpoint's OnProxyPolicyAcknowledge() function.
-func UpdateNetworkPolicy(ep NetworkPolicyEndpoint, policy *policy.L4Policy,
+func (s *XDSServer) UpdateNetworkPolicy(ep NetworkPolicyEndpoint, policy *policy.L4Policy,
 	labelsMap identity.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool, wg *completion.WaitGroup) error {
-
 	// First, validate all policies
 	ips := []string{
 		ep.GetIPv6Address(),
@@ -481,13 +503,13 @@ func UpdateNetworkPolicy(ep NetworkPolicyEndpoint, policy *policy.L4Policy,
 		nodeIDs := make([]string, 0, 1)
 		if viper.GetBool("sidecar-http-proxy") {
 			if ep.GetIPv4Address() == "" {
-				log.Fatal("envoy: sidecar proxy has no IPv4 address")
+				log.Fatal("Envoy: sidecar proxy has no IPv4 address")
 			}
 			nodeIDs = append(nodeIDs, ep.GetIPv4Address())
 		} else {
 			nodeIDs = append(nodeIDs, "127.0.0.1")
 		}
-		AckingNetworkPolicyMutator.Upsert(NetworkPolicyTypeURL, p.Name, p, nodeIDs, c)
+		s.networkPolicyMutator.Upsert(NetworkPolicyTypeURL, p.Name, p, nodeIDs, c)
 	}
 	return nil
 }
@@ -495,11 +517,33 @@ func UpdateNetworkPolicy(ep NetworkPolicyEndpoint, policy *policy.L4Policy,
 // RemoveNetworkPolicy removes network policies relevant to the specified
 // endpoint from the set published to L7 proxies, and stops listening for
 // acks for policies on this endpoint.
-func RemoveNetworkPolicy(ep NetworkPolicyEndpoint) {
+func (s *XDSServer) RemoveNetworkPolicy(ep NetworkPolicyEndpoint) {
 	if ep.GetIPv6Address() != "" {
-		NetworkPolicyCache.Delete(NetworkPolicyTypeURL, ep.GetIPv6Address(), false)
+		s.networkPolicyCache.Delete(NetworkPolicyTypeURL, ep.GetIPv6Address(), false)
 	}
 	if ep.GetIPv4Address() != "" {
-		NetworkPolicyCache.Delete(NetworkPolicyTypeURL, ep.GetIPv4Address(), false)
+		s.networkPolicyCache.Delete(NetworkPolicyTypeURL, ep.GetIPv4Address(), false)
 	}
+}
+
+// RemoveAllNetworkPolicies removes all network policies from the set published
+// to L7 proxies.
+func (s *XDSServer) RemoveAllNetworkPolicies() {
+	s.networkPolicyCache.Clear(NetworkPolicyTypeURL, false)
+}
+
+// GetNetworkPolicies returns the current version of the network policies with
+// the given names.
+// If resourceNames is empty, all resources are returned.
+func (s *XDSServer) GetNetworkPolicies(resourceNames []string) (map[string]*cilium.NetworkPolicy, error) {
+	resources, err := s.networkPolicyCache.GetResources(context.Background(), NetworkPolicyTypeURL, nil, nil, resourceNames)
+	if err != nil {
+		return nil, err
+	}
+	networkPolicies := make(map[string]*cilium.NetworkPolicy, len(resources.Resources))
+	for _, res := range resources.Resources {
+		networkPolicy := res.(*cilium.NetworkPolicy)
+		networkPolicies[networkPolicy.Name] = networkPolicy
+	}
+	return networkPolicies, nil
 }

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -382,7 +382,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				}
 			}
 
-			responseLog.Infof("sending xDS response with %d resources", len(resp.Resources))
+			responseLog.Debugf("sending xDS response with %d resources", len(resp.Resources))
 
 			out := &envoy_api_v2.DiscoveryResponse{
 				VersionInfo: strconv.FormatUint(resp.Version, 10),

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -20,7 +20,6 @@ import (
 	"math/rand"
 	"net"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -424,18 +423,6 @@ func (p *Proxy) RemoveRedirect(id string, wg *completion.WaitGroup) error {
 	}()
 
 	return nil
-}
-
-// UpdateNetworkPolicy adds or updates a network policy in the set
-// published to L7 proxies.
-func (p *Proxy) UpdateNetworkPolicy(ep envoy.NetworkPolicyEndpoint, policy *policy.L4Policy,
-	labelsMap identityPkg.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identityPkg.NumericIdentity]bool, wg *completion.WaitGroup) error {
-	// If there are no redirects configured, Envoy won't query for network policies
-	// and therefore will never ACK them, and we'd wait forever.
-	if !viper.GetBool("sidecar-http-proxy") && atomic.LoadInt32(&redirectCount) == 0 {
-		wg = nil
-	}
-	return p.XDSServer.UpdateNetworkPolicy(ep, policy, labelsMap, deniedIngressIdentities, deniedEgressIdentities, wg)
 }
 
 // ChangeLogLevel changes proxy log level to correspond to the logrus log level 'level'.


### PR DESCRIPTION
Embed envoy.XDSServer and the access log server into proxy.Proxy since they now have the same lifecycle. Start them when Proxy is created.

Remove the coupling between Envoy and XDSServer and access log server.

Make the xDS and access log sockets accessible by non-root proxies.
Support concurrent access log connections from multiple proxies.

Clean up log messages.

Fixes: https://github.com/cilium/cilium/issues/3183
Signed-off-by: Romain Lenglet <romain@covalent.io>