### PR TITLE
Test: Added a --showCommands option

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -500,12 +500,16 @@ framework in the ``test/`` directory and interact with ginkgo directly:
 ::
 
     $ cd test/
-    $ ginkgo -- --help | grep -A 1 cilium
+    $ ginkgo . -- --help | grep -A 1 cilium
+      -cilium.SSHConfig string
+            Specify a custom command to fetch SSH configuration (eg: 'vagrant ssh-config')
       -cilium.holdEnvironment
             On failure, hold the environment in its current state
       -cilium.provision
             Provision Vagrant boxes and Cilium before running test (default true)
-    $ ginkgo --focus "Policies*" -- -cilium.holdEnvironment
+      -cilium.showCommands
+            Output which commands are ran to stdout
+    $ ginkgo --focus "Policies*" -- --cilium.provision=false
 
 For more information about other built-in options to Ginkgo, consult the
 `Ginkgo documentation <https://onsi.github.io/ginkgo/>`_.

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -37,5 +37,5 @@ func (c *CiliumTestConfigType) ParseFlags() {
 	flag.StringVar(&c.SSHConfig, "cilium.SSHConfig", "",
 		"Specify a custom command to fetch SSH configuration (eg: 'vagrant ssh-config')")
 	flag.BoolVar(&c.ShowCommands, "cilium.showCommands", false,
-		"Show the running commands in the stdout")
+		"Output which commands are ran to stdout")
 }

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -21,6 +21,7 @@ type CiliumTestConfigType struct {
 	Reprovision     bool
 	HoldEnvironment bool
 	SSHConfig       string
+	ShowCommands    bool
 }
 
 // CiliumTestConfig holds the global configuration of commandline flags
@@ -35,4 +36,6 @@ func (c *CiliumTestConfigType) ParseFlags() {
 		"On failure, hold the environment in its current state")
 	flag.StringVar(&c.SSHConfig, "cilium.SSHConfig", "",
 		"Specify a custom command to fetch SSH configuration (eg: 'vagrant ssh-config')")
+	flag.BoolVar(&c.ShowCommands, "cilium.showCommands", false,
+		"Show the running commands in the stdout")
 }

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -28,6 +28,11 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+var (
+	//SSHMetaLogs is a buffer where all commands sent over ssh are saved.
+	SSHMetaLogs = NewWriter(new(bytes.Buffer))
+)
+
 // SSHMeta contains metadata to SSH into a remote location to run tests
 type SSHMeta struct {
 	sshClient *SSHClient
@@ -113,7 +118,7 @@ func (s *SSHMeta) Execute(cmd string, stdout io.Writer, stderr io.Writer) error 
 	if stderr == nil {
 		stderr = os.Stderr
 	}
-
+	fmt.Fprintln(SSHMetaLogs, cmd)
 	command := &SSHCommand{
 		Path:   cmd,
 		Stdin:  os.Stdin,
@@ -134,7 +139,6 @@ func (s *SSHMeta) ExecWithSudo(cmd string) *CmdRes {
 // Exec returns the results of executing the provided cmd via SSH.
 func (s *SSHMeta) Exec(cmd string) *CmdRes {
 	log.Debugf("running command: %s", cmd)
-
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	exit := true
@@ -187,6 +191,7 @@ func (s *SSHMeta) ExecContext(ctx context.Context, cmd string) *CmdRes {
 		panic("no context provided")
 	}
 
+	fmt.Fprintln(SSHMetaLogs, cmd)
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -310,6 +310,20 @@ func CreateReportDirectory() (string, error) {
 	return testPath, err
 }
 
+// CreateLogFile creates the ReportDirectory if is not present, writes the
+// given data to the given filename.
+func CreateLogFile(filename string, data []byte) error {
+	path, err := CreateReportDirectory()
+	if err != nil {
+		log.WithError(err).Errorf("ReportDirectory cannot be created")
+		return err
+	}
+
+	finalPath := filepath.Join(path, filename)
+	err = ioutil.WriteFile(finalPath, data, LogPerm)
+	return err
+}
+
 // reportMap saves the output of the given commands to the specified filename.
 // Function needs a directory path where the files are going to be written and
 // a *SSHMeta instance to execute the commands

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -310,7 +310,7 @@ func CreateReportDirectory() (string, error) {
 	return testPath, err
 }
 
-// CreateLogFile creates the ReportDirectory if is not present, writes the
+// CreateLogFile creates the ReportDirectory if it is not present, writes the
 // given data to the given filename.
 func CreateLogFile(filename string, data []byte) error {
 	path, err := CreateReportDirectory()

--- a/test/helpers/writer.go
+++ b/test/helpers/writer.go
@@ -1,0 +1,57 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"bytes"
+	"io"
+)
+
+// A Writer is a struct that has a variable-sized `bytes.Buffer` and one
+// outWriter(`io.writer`) to stream data
+type Writer struct {
+	buffer    *bytes.Buffer
+	outWriter io.Writer
+}
+
+// NewWriter creates and initializes a Writer with a empty Buffer and the given
+// outWriter
+func NewWriter(outWriter io.Writer) *Writer {
+	return &Writer{
+		buffer:    &bytes.Buffer{},
+		outWriter: outWriter,
+	}
+}
+
+// Write appends the contents of b to the buffer and outWriter, growing the
+// buffer as needed. The return value n is the length of p; err is always nil.
+// If the buffer becomes too large, Write will panic with ErrTooLarge.
+func (w *Writer) Write(b []byte) (n int, err error) {
+	n, err = w.buffer.Write(b)
+	if err != nil {
+		return n, err
+	}
+	return w.outWriter.Write(b)
+}
+
+// Reset resets the buffer to be empty,
+func (w *Writer) Reset() {
+	w.buffer.Reset()
+}
+
+// Bytes returns a slice based on buffer.Bytes()
+func (w *Writer) Bytes() []byte {
+	return w.buffer.Bytes()
+}

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -40,8 +40,8 @@ var (
 	DefaultSettings = map[string]string{
 		"K8S_VERSION": "1.9",
 	}
-	k8sNodesEnv  = "K8S_NODES"
-	commandslogs = "cmds.log"
+	k8sNodesEnv         = "K8S_NODES"
+	commandsLogFileName = "cmds.log"
 )
 
 func init() {
@@ -235,9 +235,9 @@ var _ = AfterEach(func() {
 	}
 
 	defer helpers.SSHMetaLogs.Reset()
-	err = helpers.CreateLogFile(commandslogs, helpers.SSHMetaLogs.Bytes())
+	err = helpers.CreateLogFile(commandsLogFileName, helpers.SSHMetaLogs.Bytes())
 	if err != nil {
-		log.WithError(err).Errorf("cannot create log file '%s'", commandslogs)
+		log.WithError(err).Errorf("cannot create log file '%s'", commandsLogFileName)
 		return
 	}
 })


### PR DESCRIPTION
Add a new writter SSHMetaLogs where all commands executed over SSH are
saved in the `commandslogs` variable. By default
`test_results/${testname}/cmds.logs`

To simplify the last AfterEach also created a new helper function
`CreateLogFile`.

On the other hand, I added a new helper Writer, where all the data is
stored in the buffer and streamed to a new io.Writer. This allows use to
have --showCommands options in the cilium config and stream the data to
os.Stdout.

Fixes #2843

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

