### PR TITLE
Ginkgo: Dump docker containers log on Fail test

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -522,6 +522,7 @@ func (s *SSHMeta) ReportFailed(commands ...string) {
 
 	s.DumpCiliumCommandOutput()
 	s.GatherLogs()
+	s.GatherDockerLogs()
 	s.CheckLogsForDeadlock()
 	fmt.Fprint(wr, "===================== EXITING REPORT GENERATION =====================\n")
 }


### PR DESCRIPTION
This commits adds the log of all containers that are in docker into the
test_results directory for further debugging.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>