### PR TITLE
Tests: Added CmdRes.WaitUntilMatch

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -212,3 +212,16 @@ func (res *CmdRes) Unmarshal(data interface{}) error {
 func (res *CmdRes) GetDebugMessage() string {
 	return fmt.Sprintf("cmd: %s\noutput: %s", res.GetCmd(), res.CombineOutput())
 }
+
+// WaitUntilMatch waits until the given substring is present in the `CmdRes.stdout`
+// If the timeout is reached it will return an error.
+func (res *CmdRes) WaitUntilMatch(substr string) error {
+	body := func() bool {
+		return strings.Contains(res.Output().String(), substr)
+	}
+
+	return WithTimeout(
+		body,
+		fmt.Sprintf("%s is not in the output after timeout", substr),
+		&TimeoutConfig{Timeout: HelperTimeout})
+}

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -280,6 +280,8 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 				uid := helpers.MakeUID()
 				_ = kubectl.ExecPodCmd(helpers.DefaultNamespace, client,
 					fmt.Sprintf(`echo -e "%s" >> %s`, HTTPRequest(uid), pipePath))
+				Expect(serverctx.WaitUntilMatch(uid)).To(BeNil(),
+					"%q is not in the server output after timeout", uid)
 				helpers.Sleep(5) // Give time to fill the buffer in context.
 				serverctx.ExpectContains(uid, "Cannot get server UUID")
 			}


### PR DESCRIPTION
Added a new helper to avoid the use of `helpers.Sleep` in some test that
have a background command. This function will wait until timeout for the
given output.

This fix some errors in:

- Runtime/monitor.go
- Nightly/TCP Keepalive

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>