### PR TITLE
k8s: Crash when k8s cannot init or talk to apiserver

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -721,7 +721,7 @@ func runDaemon() {
 	}
 
 	if err := d.EnableK8sWatcher(5 * time.Minute); err != nil {
-		log.WithError(err).Warn("Error while enabling k8s watcher")
+		log.WithError(err).Fatal("Unable to establish connection to Kubernetes apiserver")
 	}
 
 	// This block is deprecated and will be removed later (GH-3050)

--- a/pkg/k8s/const.go
+++ b/pkg/k8s/const.go
@@ -30,4 +30,9 @@ const (
 	// EnvNodeNameSpec is the environment label used by Kubernetes to
 	// specify the node's name.
 	EnvNodeNameSpec = "K8S_NODE_NAME"
+
+	// compatibleK8sVersions is the range of k8s versions this cilium is able to
+	// work with. It will change as we add new support or deprecate older k8s
+	// versions.
+	compatibleK8sVersions = "> 1.6"
 )

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -31,6 +31,9 @@ func Init() error {
 	if err := createDefaultClient(); err != nil {
 		return fmt.Errorf("unable to create k8s client: %s", err)
 	}
+	if _, err := GetServerVersion(); err != nil {
+		return fmt.Errorf("k8s client failed to talk to k8s api-server: %s", err)
+	}
 
 	if nodeName := os.Getenv(EnvNodeNameSpec); nodeName != "" {
 		// Use of the environment variable overwrites the node-name


### PR DESCRIPTION
We want to be more aggressive about indicating errors to the user on
startup. Talking to the k8s server is fairly critical and so exiting on
an error is worthwhile.

Related: #3093 