### PR TITLE
Kafka Runtime CI: Avoid possible race between Kafka consume and produce

### DIFF
--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -132,6 +132,9 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 		}
 		cancel()
 
+		err = data.WaitUntilMatch(fmt.Sprintf("Processed a total of %d messages", MaxMessages))
+		Expect(err).To(BeNil())
+
 		Expect(data.Output().String()).Should(ContainSubstring(
 			"Processed a total of %d messages", MaxMessages))
 
@@ -166,6 +169,9 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 		for i := 1; i <= MaxMessages; i++ {
 			producer(allowedTopic, fmt.Sprintf("Message %d", i))
 		}
+
+		err = data.WaitUntilMatch(fmt.Sprintf("Processed a total of %d messages", MaxMessages))
+		Expect(err).To(BeNil())
 
 		Expect(data.Output().String()).Should(ContainSubstring(
 			"Processed a total of %d messages", MaxMessages))


### PR DESCRIPTION
Fixes:#3152
Signed-Off-By: Manali Bhutiyani <manali@covalent.io>


```release-note
GinkgoRuntime CI: Avoid possible race between Kafka consume and produce
```