### PR TITLE
Nightly: Increase timeouts

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -9,7 +9,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 300, unit: 'MINUTES')
+        timeout(time: 500, unit: 'MINUTES')
         timestamps()
     }
 
@@ -32,7 +32,7 @@ pipeline {
             steps {
                 parallel(
                     "Nightly":{
-                        sh 'cd ${TESTDIR}; ginkgo --focus="Nightly*" -v -noColor --timeout 290m'
+                        sh 'cd ${TESTDIR}; ginkgo --focus="Nightly*" -v -noColor --timeout 390m'
                     },
                 )
             }


### PR DESCRIPTION
Jenkins Nightly test failed due timeout in the following builds:

https://jenkins.cilium.io/job/Cilium-Master-Nightly-Tests-All/143/console
https://jenkins.cilium.io/job/Cilium-Master-Nightly-Tests-All/142/console

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>