### PR TITLE
Kafka CI: Add a WaitKafkaBroker to wait for Kafka broker to be up before produce/consume

### DIFF
--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -81,7 +81,7 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 	consumer := func(topic string, maxMsg int) *helpers.CmdRes {
 		res := vm.ContainerExec("client", fmt.Sprintf(
 			"/opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server "+
-				"kafka:9092 --topic %s --max-messages %d --timeout-ms 30000 --from-beginning", topic, maxMsg))
+				"kafka:9092 --topic %s --max-messages %d --timeout-ms 300000 --from-beginning", topic, maxMsg))
 		return res
 	}
 
@@ -98,7 +98,6 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 	waitForKafkaBroker := func(pod string, cmd string) error {
 		body := func() bool {
 			res := vm.ContainerExec(pod, cmd)
-			fmt.Println(res.CombineOutput())
 			return res.WasSuccessful()
 		}
 		err := helpers.WithTimeout(body, "Kafka Broker not ready", &helpers.TimeoutConfig{Timeout: 150})

--- a/test/runtime/manifests/Policies-kafka-Role.json
+++ b/test/runtime/manifests/Policies-kafka-Role.json
@@ -1,7 +1,11 @@
 [{
 	"endpointSelector": {"matchLabels":{"id.kafka":""}},
-	"ingress": [{
-		"fromEndpoints": [
+	"ingress": [
+		{"fromEndpoints": [
+			{"matchLabels": {"id.kafka": ""}
+			}]
+		},
+		{"fromEndpoints": [
 			{"matchLabels":{"reserved:host":""}},
 			{"matchLabels":{"id.client":""}}
 		],

--- a/test/runtime/manifests/Policies-kafka.json
+++ b/test/runtime/manifests/Policies-kafka.json
@@ -1,7 +1,11 @@
 [{
 	"endpointSelector": {"matchLabels":{"id.kafka":""}},
-	"ingress": [{
-		"fromEndpoints": [
+	"ingress": [
+		{"fromEndpoints": [
+			{"matchLabels": {"id.kafka": ""}
+			}]
+		},
+		{"fromEndpoints": [
 			{"matchLabels":{"reserved:host":""}},
 			{"matchLabels":{"id.client":""}}
 		],


### PR DESCRIPTION
Fixes: #3155
Fixes: #3156 
Fixes: #3116 
Signed-Off-By: Manali Bhutiyani <manali@covalent.io>

```release-note
Kafka CI: Add a WaitKafkaBroker to wait for Kafka broker to be up before produce/consume
```