### PR TITLE
test: Whitelist Kafka pod to talk to itself via zook service

### DIFF
--- a/test/k8sT/manifests/kafka-sw-security-policy.yaml
+++ b/test/k8sT/manifests/kafka-sw-security-policy.yaml
@@ -10,6 +10,17 @@ specs:
     ingress:
     - fromEndpoints:
       - matchLabels:
+          app: kafka
+      toPorts:
+      - ports:
+        - port: "2181"
+          protocol: TCP
+  - endpointSelector:
+      matchLabels:
+        app: kafka
+    ingress:
+    - fromEndpoints:
+      - matchLabels:
           app: empire-hq
       toPorts:
       - ports:


### PR DESCRIPTION
Kafka and Zookeeper are in the same pod as individual containers but Kafka
talks to zookeeper via the zook service IP so the packets leave the pod and
re-enter.