### PR TITLE
Tests: Fix race condition on Update cilium

### DIFF
--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -87,12 +87,13 @@ var _ = Describe("K8sValidatedUpdates", func() {
 	It("Updating Cilium stable to master", func() {
 		By("Creating some endpoints and L7 policy")
 		kubectl.Apply(demoPath).ExpectSuccess()
-		_, err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", timeout)
-		Expect(err).Should(BeNil())
 
-		kubectl.Exec(fmt.Sprintf("%s scale deployment %s --replicas=10",
+		kubectl.Exec(fmt.Sprintf("%s scale deployment %s --replicas=5",
 			helpers.KubectlCmd, helpers.App1)).ExpectSuccess(
 			"Cannot scale %v deployment", helpers.App1)
+
+		_, err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", timeout)
+		Expect(err).Should(BeNil())
 
 		_, err = kubectl.CiliumPolicyAction(
 			helpers.KubeSystemNamespace, l7Policy, helpers.KubectlApply, timeout)


### PR DESCRIPTION
- Pods are scaling but no option to wait until pods are ready. The solution, waiting
until all pods are ready.
- Set scale to 5, in PR only two nodes of Kubernetes, so pods will be
scheduled in both nodes.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
