### PR TITLE
Add a quiet make option

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -1,9 +1,10 @@
 # Minimal makefile for Sphinx documentation
 #
+include ../Makefile.quiet
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD   = $(QUIET) sphinx-build
 SPHINXPROJ    = Cilium
 SOURCEDIR     = .
 BUILDDIR      = _build
@@ -21,6 +22,7 @@ PIP_REQUIREMENTS = $(shell cat requirements.txt | sed -e 's/==.*//g' -e 's/\n/ /
 
 check-requirements:
 	@set -e;								\
+	$(ECHO_CHECK) documentation dependencies...;				\
 	PYPKGS=$$(pip freeze);							\
 	for pkg in ${PIP_REQUIREMENTS}; do					\
 		echo $${PYPKGS} | grep -q $${pkg}				\
@@ -30,16 +32,21 @@ check-requirements:
 	done
 
 cmdref:
-	# We don't know what changed so recreate the directory
-	-rm -rvf $(CMDREFDIR)/cilium*
-	${CILIUMDIR}/cilium cmdref -d $(CMDREFDIR)
-	${BUGTOOLDIR}/cilium-bugtool cmdref -d $(CMDREFDIR)
-	${AGENTDIR}/cilium-agent --cmdref $(CMDREFDIR)
-	${HEALTHDIR}/cilium-health --cmdref $(CMDREFDIR)
+	$(QUIET) # We don't know what changed so recreate the directory
+	$(QUIET) -rm -rvf $(CMDREFDIR)/cilium*
+	@$(ECHO_GEN)cmdref/cilium
+	$(QUIET) ${CILIUMDIR}/cilium cmdref -d $(CMDREFDIR)
+	@$(ECHO_GEN)cmdref/cilium-bugtool
+	$(QUIET) ${BUGTOOLDIR}/cilium-bugtool cmdref -d $(CMDREFDIR)
+	@$(ECHO_GEN)cmdref/cilium-agent
+	$(QUIET) ${AGENTDIR}/cilium-agent --cmdref $(CMDREFDIR)
+	@$(ECHO_GEN)cmdref/cilium-health
+	$(QUIET) ${HEALTHDIR}/cilium-health --cmdref $(CMDREFDIR)
 
-.PHONY: help Makefile check-requirements cmdref
+.PHONY: help Makefile ../Makefile.quiet check-requirements cmdref
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile check-requirements
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(ECHO_GEN)_build/$@
+	$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ tests-ginkgo-real:
 	go test $(TEST_LDFLAGS) \
             -timeout 360s -coverprofile=coverage.out -covermode=count $(pkg) $(GOTEST_OPTS) || exit 1;\
             tail -n +2 coverage.out >> coverage-all.out;)
-	go tool cover -html=coverage-all.out -o=coverage-all.html
+	$(GO) tool cover -html=coverage-all.out -o=coverage-all.html
 	rm coverage-all.out
 	rm coverage.out
 	@rmdir ./daemon/1 ./daemon/1_backup 2> /dev/null || true
@@ -74,21 +74,22 @@ tests: force
 	$(MAKE) unit-tests tests-envoy
 
 unit-tests: start-kvstores
-	echo "mode: count" > coverage-all.out
-	echo "mode: count" > coverage.out
+	$(QUIET) echo "mode: count" > coverage-all.out
+	$(QUIET) echo "mode: count" > coverage.out
 	$(foreach pkg,$(TESTPKGS),\
-	go test \
+	$(QUIET) go test \
             -timeout 360s -coverprofile=coverage.out -covermode=count $(pkg) $(GOTEST_OPTS) || exit 1;\
             tail -n +2 coverage.out >> coverage-all.out;)
-	go tool cover -html=coverage-all.out -o=coverage-all.html
-	rm coverage-all.out
-	rm coverage.out
+	$(GO) tool cover -html=coverage-all.out -o=coverage-all.html
+	$(QUIET) rm coverage-all.out
+	$(QUIET) rm coverage.out
 	@rmdir ./daemon/1 ./daemon/1_backup 2> /dev/null || true
-	docker rm -f "cilium-etcd-test-container"
-	docker rm -f "cilium-consul-test-container"
+	$(QUIET) docker rm -f "cilium-etcd-test-container"
+	$(QUIET) docker rm -f "cilium-consul-test-container"
 
 clean-tags:
-	-rm -f cscope.out cscope.in.out cscope.po.out cscope.files tags
+	@$(ECHO_CLEAN) tags
+	@-rm -f cscope.out cscope.in.out cscope.po.out cscope.files tags
 
 tags: $(GOLANG_SRCFILES) $(BPF_SRCFILES)
 	ctags $(GOLANG_SRCFILES) $(BPF_SRCFILES)
@@ -202,9 +203,12 @@ gofmt:
 	for pkg in $(GOFILES); do go fmt $$pkg; done
 
 precheck:
-	contrib/scripts/check-fmt.sh
-	contrib/scripts/check-log-newlines.sh
-	@go vet $(GOFILES)
+	@$(ECHO_CHECK) contrib/scripts/check-fmt.sh
+	$(QUIET) contrib/scripts/check-fmt.sh
+	@$(ECHO_CHECK) contrib/scripts/check-log-newlines.sh
+	$(QUIET) contrib/scripts/check-log-newlines.sh
+	@$(ECHO_CHECK) vetting all GOFILES...
+	$(QUIET)go vet $(GOFILES)
 
 pprof-help:
 	@echo "Available pprof targets:"
@@ -215,20 +219,20 @@ pprof-help:
 	@echo "  pprof-mutex"
 
 pprof-heap:
-	go tool pprof http://localhost:6060/debug/pprof/heap
+	$(GO) tool pprof http://localhost:6060/debug/pprof/heap
 
 pprof-profile:
-	go tool pprof http://localhost:6060/debug/pprof/profile
+	$(GO) tool pprof http://localhost:6060/debug/pprof/profile
 
 
 pprof-block:
-	go tool pprof http://localhost:6060/debug/pprof/block
+	$(GO) tool pprof http://localhost:6060/debug/pprof/block
 
 pprof-trace-5s:
 	curl http://localhost:6060/debug/pprof/trace?seconds=5
 
 pprof-mutex:
-	go tool pprof http://localhost:6060/debug/pprof/mutex
+	$(GO) tool pprof http://localhost:6060/debug/pprof/mutex
 
 update-authors:
 	@echo "Updating AUTHORS file..."
@@ -259,9 +263,11 @@ install-manpages:
 	mandb
 
 postcheck: build
-	MAKE=$(MAKE) contrib/scripts/check-cmdref.sh
-	contrib/scripts/lock-check.sh
-	-$(MAKE) -C Documentation/ dummy SPHINXOPTS="-q" 2>&1 | grep -v "tabs assets"
+	@$(ECHO_CHECK) contrib/scripts/check-cmdref.sh
+	$(QUIET) MAKE=$(MAKE) contrib/scripts/check-cmdref.sh
+	@$(ECHO_CHECK) contrib/scripts/lock-check.sh
+	$(QUIET) contrib/scripts/lock-check.sh
+	-$(QUIET) $(MAKE) -C Documentation/ dummy SPHINXOPTS="-q" 2>&1 | grep -v "tabs assets"
 
 .PHONY: force
 force :;

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -1,17 +1,20 @@
+ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+include $(ROOT_DIR)/Makefile.quiet
+
 PREFIX?=/usr
 BINDIR?=$(PREFIX)/bin
 RUNDIR?=/var/run
 CONFDIR?=/etc
 
-GO = go
-INSTALL = install
+GO = $(QUIET)go
+INSTALL = $(QUIET)install
 
 VERSION = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/VERSION)
 # Use git only if in a Git repo
 ifneq ($(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/.git),)
 	GIT_VERSION = $(shell git show -s --format='format:%h %aI')
 else
-	GIT_VERSION = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/GIT_VERSION)
+	GIT_VERSION = $(shell cat $(ROOT_DIR)/GIT_VERSION)
 endif
 BUILD = $(VERSION) $(GIT_VERSION) $(shell go version)
 GOBUILD = -ldflags '-X "github.com/cilium/cilium/pkg/version.Version=$(BUILD)"'

--- a/Makefile.quiet
+++ b/Makefile.quiet
@@ -1,0 +1,20 @@
+ifeq ($(V),0)
+	QUIET=@
+	ECHO_CC=echo "  CC    $(notdir $(shell pwd))/$@"
+	ECHO_GEN=echo "  GEN   $(notdir $(shell pwd))/"
+	ECHO_GO=echo "  GO    $(notdir $(shell pwd))/$@"
+	ECHO_CHECK=echo "  CHECK"
+	ECHO_BAZEL=echo "  BAZEL $(notdir $(shell pwd))/$(notdir $(shell dirname $(ENVOY_BIN)))/$@"
+	ECHO_GINKGO=echo "  GINKG $(notdir $(shell pwd))"
+	ECHO_CLEAN=echo "  CLEAN"
+else
+	# The whitespace at below EOLs is required for verbose case!
+	ECHO_CC=: 
+	ECHO_GEN=: 
+	ECHO_GO=: 
+	ECHO_CHECK=: 
+	ECHO_BAZEL=: 
+	ECHO_GINKGO=: 
+	ECHO_CLEAN=: 
+endif
+

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -20,12 +20,14 @@ ifeq ("$(PKG_BUILD)","")
 all: $(BPF)
 
 %.o: %.c $(LIB)
-	${CLANG} ${CLANG_FLAGS} -c $< -o $(patsubst %.o,%.ll,$@)
-	${LLC} ${LLC_FLAGS} -o $@ $(patsubst %.o,%.ll,$@)
+	@$(ECHO_CC)
+	$(QUIET) ${CLANG} ${CLANG_FLAGS} -c $< -o $(patsubst %.o,%.ll,$@)
+	$(QUIET) ${LLC} ${LLC_FLAGS} -o $@ $(patsubst %.o,%.ll,$@)
 
 check:
-	sparse -Wsparse-all ${FLAGS} *.c
-	clang ${CLANG_FLAGS} --analyze *.c
+	@$(ECHO_CHECK) bpf/*.c
+	$(QUIET) sparse -Wsparse-all ${FLAGS} *.c
+	$(QUIET) $(CLANG) ${CLANG_FLAGS} --analyze *.c
 
 LB_OPTIONS = \
 	-DSKIP_DEBUG \
@@ -34,12 +36,14 @@ LB_OPTIONS = \
 	-DLB_L3 -DLB_L4
 
 bpf_lb.o: bpf_lb.c $(LIB)
-	set -e; \
+	$(QUIET) set -e; \
 	$(foreach OPTS,$(LB_OPTIONS), \
+		$(ECHO_CC) " [$(OPTS)]"; \
 		${CLANG} ${OPTS} ${CLANG_FLAGS} -c $< -o $(patsubst %.o,%.ll,$@); \
 		${LLC} ${LLC_FLAGS} -o /dev/null $(patsubst %.o,%.ll,$@); )
-	${CLANG} ${CLANG_FLAGS} -c $< -o $(patsubst %.o,%.ll,$@)
-	${LLC} ${LLC_FLAGS} -o $@ $(patsubst %.o,%.ll,$@)
+	@$(ECHO_CC)
+	$(QUIET) ${CLANG} ${CLANG_FLAGS} -c $< -o $(patsubst %.o,%.ll,$@)
+	$(QUIET) ${LLC} ${LLC_FLAGS} -o $@ $(patsubst %.o,%.ll,$@)
 
 LXC_OPTIONS = \
 	 -DSKIP_DEBUG \
@@ -49,12 +53,14 @@ LXC_OPTIONS = \
 	# FIXME: GH-2906: Test with both HAVE_LPM_MAP_TYPE and SKIP_CIDR_PREFIXES
 
 bpf_lxc.o: bpf_lxc.c $(LIB)
-	set -e; \
+	$(QUIET) set -e; \
 	$(foreach OPTS,$(LXC_OPTIONS), \
+		$(ECHO_CC) " [$(OPTS)]"; \
 		${CLANG} ${OPTS} ${CLANG_FLAGS} -c $< -o $(patsubst %.o,%.ll,$@); \
 		${LLC} ${LLC_FLAGS} -o /dev/null $(patsubst %.o,%.ll,$@); )
-	${CLANG} ${CLANG_FLAGS} -c $< -o $(patsubst %.o,%.ll,$@)
-	${LLC} ${LLC_FLAGS} -o $@ $(patsubst %.o,%.ll,$@)
+	@$(ECHO_CC)
+	$(QUIET) ${CLANG} ${CLANG_FLAGS} -c $< -o $(patsubst %.o,%.ll,$@)
+	$(QUIET) ${LLC} ${LLC_FLAGS} -o $@ $(patsubst %.o,%.ll,$@)
 
 else
 
@@ -65,4 +71,5 @@ endif
 install:
 
 clean:
-	rm -fr *.o
+	@$(ECHO_CLEAN) $(notdir $(shell pwd))
+	$(QUIET)rm -fr *.o

--- a/bugtool/Makefile
+++ b/bugtool/Makefile
@@ -17,13 +17,14 @@ include ../Makefile.defs
 TARGET=cilium-bugtool
 SOURCES := $(shell find ../common . -name '*.go')
 $(TARGET): $(SOURCES)
+	@$(ECHO_GO)
 	$(GO) build -i $(GOBUILD) -o $(TARGET)
 
 all: $(TARGET)
 
 clean:
-	-rm .cilium-bugtool.config
-	rm -f $(TARGET)
+	@$(ECHO_CLEAN) $(notdir $(shell pwd))
+	-$(QUIET)rm -f .cilium-bugtool.config $(TARGET)
 	$(GO) clean
 
 install:

--- a/cilium-health/Makefile
+++ b/cilium-health/Makefile
@@ -3,12 +3,14 @@ include ../Makefile.defs
 TARGET=cilium-health
 SOURCES := $(shell find ../api/v1/health ../pkg/health cmd . \( -name '*.go' ! -name '*_test.go' \))
 $(TARGET): $(SOURCES)
+	@$(ECHO_GO)
 	$(GO) build -i $(GOBUILD) -o $(TARGET)
 
 all: $(TARGET)
 
 clean:
-	rm -f $(TARGET)
+	@$(ECHO_CLEAN) $(notdir $(shell pwd))
+	-$(QUIET)rm -f $(TARGET)
 	$(GO) clean
 
 install:

--- a/cilium/Makefile
+++ b/cilium/Makefile
@@ -1,14 +1,17 @@
+include ../Makefile.quiet
 include ../Makefile.defs
 
 TARGET=cilium
 SOURCES := $(shell find ../api ../daemon ../common ../pkg cmd . \( -name '*.go' ! -name '*_test.go' \))
 $(TARGET): $(SOURCES)
+	@$(ECHO_GO)
 	$(GO) build -i $(GOBUILD) -o $(TARGET)
 
 all: $(TARGET)
 
 clean:
-	rm -f $(TARGET)
+	@$(ECHO_CLEAN) $(notdir $(shell pwd))
+	-$(QUIET)rm -f $(TARGET)
 	$(GO) clean
 
 install:

--- a/contrib/packaging/deb/Makefile
+++ b/contrib/packaging/deb/Makefile
@@ -13,7 +13,8 @@ build: clean
 	docker run --rm -v $(CURDIR)/output:/output cilium:cilium-bin-deb-$(VERSION)
 
 clean:
-	rm -rf cilium output version_*
+	@$(ECHO_CLEAN) $(notdir $(shell pwd))
+	$(QUIET)rm -rf cilium output version_*
 
 release:
 	cd $(BASEDIR)

--- a/contrib/packaging/rpm/Makefile
+++ b/contrib/packaging/rpm/Makefile
@@ -17,7 +17,8 @@ build: clean
 	echo -e "\nCilium version $(VERSION) packages are located here:\n$(CURDIR)/output/\n"
 
 clean:
-	rm -rf env cilium output version_* cilium-*.tar.gz
+	@$(ECHO_CLEAN) $(notdir $(shell pwd))
+	$(QUIET)rm -rf env cilium output version_* cilium-*.tar.gz
 
 .PHONY: force build clean
 force :;

--- a/contrib/scripts/bindata.sh
+++ b/contrib/scripts/bindata.sh
@@ -21,7 +21,7 @@ if [[ $GO_BINDATA_SHA1SUM == "" ]]; then
   exit 1
 fi
 
-if echo "$GO_BINDATA_SHA1SUM bindata.go" | sha1sum -c; then
+if echo "$GO_BINDATA_SHA1SUM bindata.go" | sha1sum -c --quiet; then
   exit 0
 fi
 

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -10,9 +10,10 @@ include ../Makefile.defs
 TARGET=cilium-agent
 SOURCES := $(shell find ../api ../common ../daemon ../pkg ../monitor . \( -name '*.go'  ! -name '*_test.go' \))
 $(TARGET): $(SOURCES) check-bindata
+	@$(ECHO_GO)
 	$(GO) build -i $(GOBUILD) -o $(TARGET)
 
-GO_BINDATA := go-bindata -prefix ../ -mode 0640 -modtime 1450269211 \
+GO_BINDATA := $(QUIET) go-bindata -prefix ../ -mode 0640 -modtime 1450269211 \
 	-ignore Makefile -ignore bpf_features.h -ignore lxc_config.h \
 	-ignore netdev_config.h -ignore node_config.h -ignore filter_config.h \
 	-ignore '.+\.o$$' -ignore '.+\.orig$$' -ignore '.+~$$' \
@@ -21,7 +22,8 @@ GO_BINDATA := go-bindata -prefix ../ -mode 0640 -modtime 1450269211 \
 all: $(TARGET)
 
 clean:
-	rm -f $(TARGET)
+	@$(ECHO_CLEAN) $(notdir $(shell pwd))
+	$(QUIET)rm -f $(TARGET)
 	$(GO) clean
 
 ifeq ("$(PKG_BUILD)","")
@@ -41,10 +43,13 @@ endif
 
 .PHONY: check-bindata
 check-bindata: bindata.go
-	../contrib/scripts/bindata.sh $(GO_BINDATA_SHA1SUM)
+	@$(ECHO_CHECK) contrib/scripts/bindata.sh
+	$(QUIET) ../contrib/scripts/bindata.sh $(GO_BINDATA_SHA1SUM)
 
 apply-bindata: go-bindata
-	../contrib/scripts/bindata.sh apply
+	@$(ECHO_GEN)bpf.sha
+	$(QUIET) ../contrib/scripts/bindata.sh apply
 
 bindata.go go-bindata: $(BPF_FILES)
+	@$(ECHO_GEN) $@
 	$(GO_BINDATA) -o ./bindata.go $(BPF_FILES)

--- a/envoy/Makefile
+++ b/envoy/Makefile
@@ -18,7 +18,7 @@ ENVOY_BIN = ./bazel-bin/envoy
 ENVOY_BINS = $(ENVOY_BIN) ./bazel-bin/cilium_integration_test
 CHECK_FORMAT ?= ./bazel-bin/check_format.py.runfiles/envoy/tools/check_format.py
 
-BAZEL ?= bazel
+BAZEL ?= $(QUIET) bazel
 BAZEL_TEST_OPTS ?= --jobs=1
 BAZEL_CACHE ?= ~/.cache/bazel
 BAZEL_ARCHIVE ?= ~/bazel-cache.tar.bz2
@@ -47,6 +47,7 @@ api: force-non-root Makefile.api
 	$(MAKE) -f Makefile.api all
 
 envoy: force-non-root
+	@$(ECHO_BAZEL)
 	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) //:envoy
 
 # Allow root build for release
@@ -82,10 +83,12 @@ bazel-restore: $(BAZEL_ARCHIVE)
 
 # Remove the binaries to get fresh version SHA
 clean-bins: force
-	-rm -f $(ENVOY_BINS)
+	@$(ECHO_CLEAN) $(notdir $(shell pwd))
+	-$(QUIET) rm -f $(ENVOY_BINS)
 
 clean: force
-	echo "Bazel clean skipped, try \"make veryclean\" instead."
+	@$(ECHO_CLEAN) $(notdir $(shell pwd))
+	@echo "Bazel clean skipped, try 'make veryclean' instead."
 
 veryclean: force
 	-sudo $(BAZEL) $(BAZEL_OPTS) clean

--- a/envoy/Makefile.api
+++ b/envoy/Makefile.api
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include ../Makefile.quiet
+
 # Depends on Envoy dependencies, Envoy must be built first
 
 PROTOC ?= bazel-out/host/bin/external/com_google_protobuf/protoc
@@ -59,16 +61,16 @@ GO_MAPPINGS := $(patsubst %/,%,$(map_sep)$(subst $(file_sep),$(map_sep),$(RAW_GO
 all: $(ENVOY_API_PROTO_PATH) $(ENVOY_GO_TARGETS) $(CILIUM_GO_TARGETS)
 
 $(ENVOY_GO_TARGETS): $(ENVOY_PROTO_SOURCES) Makefile.api
-	set -e; \
+	$(QUIET)set -e; \
 	for path in $(ENVOY_PROTO_DIRS) ; do \
-		echo Compiling protos in $$path; \
+		$(ECHO_GEN) envoy/$$path; \
 		$(PROTOC) -I $(ENVOY_API_PROTO_PATH) -I $(CILIUM_PROTO_PATH) $(PROTO_DEPS) --go_out=plugins=grpc$(GO_MAPPINGS):$(GO_OUT) $${path}*.proto; \
 	done
 
 $(CILIUM_GO_TARGETS): $(CILIUM_PROTO_SOURCES) Makefile.api
-	set -e; \
+	$(QUIET)set -e; \
 	for path in $(CILIUM_PROTO_DIRS) ; do \
-		echo Compiling protos in $$path; \
+		$(ECHO_GEN) envoy/$$path; \
 		$(PROTOC) -I $(ENVOY_API_PROTO_PATH) -I $(CILIUM_PROTO_PATH) $(PROTO_DEPS) --go_out=plugins=grpc$(GO_MAPPINGS):$(GO_OUT) --validate_out=lang=go:$(GO_OUT) $${path}*.proto; \
 	done
 

--- a/monitor/Makefile
+++ b/monitor/Makefile
@@ -17,12 +17,14 @@ include ../Makefile.defs
 TARGET=cilium-node-monitor
 SOURCES := $(shell find ../monitor ../common ../pkg ../api . \( -name '*.go' ! -name '*_test.go' \))
 $(TARGET): $(SOURCES)
+	@$(ECHO_GO)
 	$(GO) build -i $(GOBUILD) -o $(TARGET)
 
 all: $(TARGET)
 
 clean:
-	rm -f $(TARGET)
+	@$(ECHO_CLEAN) $(notdir $(shell pwd))
+	$(QUIET)rm -f $(TARGET)
 	$(GO) clean
 
 install:

--- a/plugins/cilium-cni/Makefile
+++ b/plugins/cilium-cni/Makefile
@@ -5,12 +5,14 @@ all: cilium-cni
 TARGET=cilium-cni
 
 clean:
+	@$(ECHO_CLEAN) $(notdir $(shell pwd))
 	$(GO) clean
-	rm -f $(TARGET)
+	-$(QUIET)rm -f $(TARGET)
 
 SOURCES := $(shell find ../../api/v1/models ../../common ../../pkg/client ../../pkg/endpoint . -name '*.go')
 
 $(TARGET): $(SOURCES)
+	@$(ECHO_GO)
 	$(GO) build -i $(GOBUILD) -o $(TARGET) ./cilium-cni.go
 
 install:

--- a/plugins/cilium-docker/Makefile
+++ b/plugins/cilium-docker/Makefile
@@ -7,14 +7,16 @@ all: $(TARGET)
 SOURCES := $(shell find ../../api/v1 ../../common ../../pkg/client ../../pkg/endpoint driver . -name '*.go')
 
 $(TARGET): $(SOURCES)
+	@$(ECHO_GO)
 	$(GO) build -i $(GOBUILD) -o $(TARGET)
 
 run:
 	./cilium-docker -d
 
 clean:
+	@$(ECHO_CLEAN) $(notdir $(shell pwd))
 	$(GO) clean
-	rm -f $(TARGET)
+	-$(QUIET) rm -f $(TARGET)
 
 install:
 	$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,3 +1,5 @@
+include ../Makefile.defs
+
 provision = true
 # If you set provision to false the test will run without compile the code
 # again.
@@ -6,6 +8,8 @@ TEST_ARTIFACTS = ./tmp.yaml ./*_service_manifest.json ./*_manifest.yaml
 TEST_ARTIFACTS += ./*_policy.json ./k8s-*.xml ./runtime.xml ./test_results
 TEST_ARTIFACTS += ./test.test
 
+GINKGO = $(QUIET) ginkgo
+
 all: build
 
 build:
@@ -13,7 +17,8 @@ build:
 	# bash-based test VM to run CI without needing to add Ginkgo to it.
 	# Once the bash-based tests are migrated, the "|| true" can be removed.
 	# GH #1839
-	ginkgo build || true
+	@$(ECHO_GINKGO)$@
+	$(GINKGO) build || true
 
 test: run k8s
 
@@ -24,4 +29,5 @@ k8s:
 	ginkgo --focus " K8s*" -v -- --cilium.provision=$(provision)
 
 clean:
-	-rm -rf $(TEST_ARTIFACTS)
+	@$(ECHO_CLEAN) $(notdir $(shell pwd))
+	-$(QUIET) rm -rf $(TEST_ARTIFACTS)

--- a/test/bpf/Makefile
+++ b/test/bpf/Makefile
@@ -1,12 +1,19 @@
 include ../../Makefile.defs
 
+FLAGS := -I../../bpf/include -I. -D__NR_CPUS__=$(shell nproc) -O2
+BPF_CC_FLAGS :=  ${FLAGS} -target bpf -emit-llvm
+BPF_LLC_FLAGS   := -march=bpf -mcpu=probe -filetype=obj
+
+CLANG ?= clang
+LLC ?= llc
+
 all: perf-event-test bpf-event-test.o
 
 perf-event-test: perf-event-test.go
 	$(GO) build -i $(GOBUILD) -o $@ $<
 
 bpf-event-test.o: bpf-event-test.c
-	clang -I../../bpf/include -O2 -emit-llvm -D__NR_CPUS__=$(shell nproc) -c $< -o - | llc -march=bpf -filetype=obj -o $@
+	$(CLANG) ${BPF_CC_FLAGS} -c $< -o - | $(LLC) ${BPF_LLC_FLAGS} -o $@
 
 clean:
 	rm -f bpf-event-test.o perf-event-test

--- a/test/bpf/Makefile
+++ b/test/bpf/Makefile
@@ -4,16 +4,19 @@ FLAGS := -I../../bpf/include -I. -D__NR_CPUS__=$(shell nproc) -O2
 BPF_CC_FLAGS :=  ${FLAGS} -target bpf -emit-llvm
 BPF_LLC_FLAGS   := -march=bpf -mcpu=probe -filetype=obj
 
-CLANG ?= clang
+CLANG ?= $(QUIET) clang
 LLC ?= llc
 
 all: perf-event-test bpf-event-test.o
 
 perf-event-test: perf-event-test.go
+	@$(ECHO_GO)
 	$(GO) build -i $(GOBUILD) -o $@ $<
 
 bpf-event-test.o: bpf-event-test.c
+	@$(ECHO_CC)
 	$(CLANG) ${BPF_CC_FLAGS} -c $< -o - | $(LLC) ${BPF_LLC_FLAGS} -o $@
 
 clean:
-	rm -f bpf-event-test.o perf-event-test
+	@$(ECHO_CLEAN) $(ROOT_DIR)/test/$(notdir $(shell pwd))
+	-$(QUIET)rm -f bpf-event-test.o perf-event-test


### PR DESCRIPTION
Annotate all of the command invocations in the makefiles so that when developers run `make --quiet V=0`, it only prints the objects being touched or checks being made. Example:

```
$ make --quiet V=0
...
  GEN   envoy/ envoy/cilium/                             
  GO    cilium-docker/cilium-docker                      
  GO    cilium-cni/cilium-cni                            
  GO    cilium/cilium       
  GEN   daemon/ bindata.go  
  CHECK contrib/scripts/bindata.sh                       
  GO    daemon/cilium-agent 
  GO    monitor/cilium-node-monitor
  CHECK contrib/scripts/check-cmdref.sh
  GEN   Documentation/cmdref/cilium
  GEN   Documentation/cmdref/cilium-bugtool
  GEN   Documentation/cmdref/cilium-agent
  GEN   Documentation/cmdref/cilium-health
  CHECK contrib/scripts/lock-check.sh
  CHECK documentation dependencies...
  GEN   Documentation/_build/dummy
Build finished.
```

To enable by default, `export V=0` in your shell profile.

If you really want minimal output, it's non-intuitive but here's how:
`$ make --quiet V=1`