### PR TITLE
test: add Star Wars demo runtime test

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -754,6 +754,8 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 
 // CiliumReport report the cilium pod to the log and appends the logs for the
 // given commands.
+// TODO - remove 'pod' parameter, this function should just get logs from all
+// Cilium pods without the need to provide the parameter itself.
 func (kub *Kubectl) CiliumReport(namespace string, pod string, commands ...[]string) {
 	wr := kub.logger.Logger.Out
 	fmt.Fprint(wr, "StackTrace Begin\n")

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -754,7 +754,7 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 
 // CiliumReport report the cilium pod to the log and appends the logs for the
 // given commands.
-func (kub *Kubectl) CiliumReport(namespace string, pod string, commands []string) {
+func (kub *Kubectl) CiliumReport(namespace string, pod string, commands ...[]string) {
 	wr := kub.logger.Logger.Out
 	fmt.Fprint(wr, "StackTrace Begin\n")
 	data := kub.Logs(namespace, pod)

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -1,1 +1,174 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package k8sTest
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+
+	"github.com/cilium/cilium/test/helpers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	demoTestName         = "K8sValidatedDemosTest"
+	starWarsDemoLinkRoot = "https://raw.githubusercontent.com/cilium/star-wars-demo/master/v1/"
+)
+
+func getStarWarsResourceLink(file string) string {
+	// Cannot use filepath.Join because it removes one of the '/' from
+	// https:// and results in a malformed URL.
+	return fmt.Sprintf("%s/%s", starWarsDemoLinkRoot, file)
+}
+
+var _ = Describe(demoTestName, func() {
+
+	var (
+		demoPath   string
+		once       sync.Once
+		kubectl    *helpers.Kubectl
+		logger     *logrus.Entry
+		ciliumYAML string
+
+		deathStarYAMLLink = getStarWarsResourceLink("02-deathstar.yaml")
+		l4PolicyYAMLLink  = getStarWarsResourceLink("policy/l4_policy.yaml")
+		xwingYAMLLink     = getStarWarsResourceLink("03-xwing.yaml")
+		l7PolicyYAMLLink  = getStarWarsResourceLink("policy/l7_policy.yaml")
+	)
+
+	initialize := func() {
+		logger = log.WithFields(logrus.Fields{"testName": demoTestName})
+		logger.Info("Starting")
+		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+
+		//Manifest paths
+		demoPath = kubectl.ManifestGet("demo.yaml")
+
+		// TODO (ianvernon) - factor this code out into separate functions as it's
+		// boilerplate for most K8s test setup.
+		ciliumYAML = kubectl.ManifestGet("cilium_ds.yaml")
+		res := kubectl.Apply(ciliumYAML)
+		res.ExpectSuccess("unable to apply %s: %s", ciliumYAML, res.CombineOutput())
+		status, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)
+		Expect(status).Should(BeTrue())
+		Expect(err).Should(BeNil())
+		err = kubectl.WaitKubeDNS()
+		Expect(err).Should(BeNil())
+	}
+
+	BeforeEach(func() {
+		once.Do(initialize)
+	})
+
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			log.Debugf("======================== TEST FAILED ======================== ")
+			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
+			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod)
+		}
+
+		By("Deleting all resources created during test")
+		kubectl.Delete(l7PolicyYAMLLink)
+		kubectl.Delete(l4PolicyYAMLLink)
+		kubectl.Delete(deathStarYAMLLink)
+		kubectl.Delete(xwingYAMLLink)
+
+		By("Waiting for all pods to finish terminating")
+		err := kubectl.WaitCleanAllTerminatingPods()
+		Expect(err).To(BeNil(), "Terminating pods are not deleted after timeout")
+	})
+
+	It("Tests Star Wars Demo", func() {
+
+		allianceLabel := "org=alliance"
+		empireLabel := "org=empire"
+		deathstarServiceName := "deathstar.default.svc.cluster.local"
+		exhaustPortPath := filepath.Join(deathstarServiceName, "/v1/exhaust-port")
+
+		By(fmt.Sprintf("Getting Cilium Pod on node %s", helpers.K8s2))
+		ciliumPod2, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s2)
+		Expect(err).Should(BeNil(), "unable to get Cilium pod on node %s", helpers.K8s2)
+
+		// Taint the node instead of adding a nodeselector in the file so that we
+		// don't have to customize the YAML for this test.
+		By(fmt.Sprintf("Tainting %s so that all pods run on %s", helpers.K8s1, helpers.K8s2))
+		res := kubectl.Exec(fmt.Sprintf("kubectl taint nodes %s demo=false:NoSchedule", helpers.K8s1))
+
+		defer func() {
+			By(fmt.Sprintf("Removing taint from %s after test finished", helpers.K8s1))
+			res := kubectl.Exec(fmt.Sprintf("kubectl taint nodes %s demo:NoSchedule-", helpers.K8s1))
+			res.ExpectSuccess("Unable to remove taint from k8s1: %s", res.CombineOutput())
+		}()
+		res.ExpectSuccess("Unable to apply taint to %s: %s", helpers.K8s1, res.CombineOutput())
+
+		By("Applying deathstar Deployment")
+		res = kubectl.Apply(deathStarYAMLLink)
+		res.ExpectSuccess("unable to apply %s: %s", deathStarYAMLLink, res.CombineOutput())
+
+		By("Waiting for deathstart deployment pods to be ready")
+		_, err = kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", empireLabel), 300)
+		Expect(err).Should(BeNil(), "Empire pods are not ready after timeout")
+
+		By("Applying policy and waiting for policy revision to increase in Cilium pods")
+		res = kubectl.Apply(l4PolicyYAMLLink)
+		res.ExpectSuccess("unable to apply %s: %s", l4PolicyYAMLLink, res.CombineOutput())
+
+		arePodsReady := kubectl.CiliumEndpointWait(ciliumPod2)
+		Expect(arePodsReady).To(BeTrue(), "pods running on k8s2 are not ready")
+
+		By("Applying alliance deployment")
+		res = kubectl.Apply(xwingYAMLLink)
+		res.ExpectSuccess("unable to apply %s: %s", xwingYAMLLink, res.CombineOutput())
+
+		By("Waiting for alliance pods to be ready")
+		_, err = kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", allianceLabel), 300)
+		Expect(err).Should(BeNil(), "Alliance pods are not ready after timeout")
+
+		By("Getting xwing pod names")
+		xwingPods, err := kubectl.GetPodNames(helpers.DefaultNamespace, allianceLabel)
+		Expect(err).Should(BeNil())
+		Expect(xwingPods[0]).ShouldNot(Equal(""), "unable to get xwing pod names")
+
+		// Test only needs to access one of the pods.
+		xwingPod := xwingPods[0]
+
+		By("Showing how alliance can execute REST API call to main API endpoint")
+		res = kubectl.Exec(fmt.Sprintf("kubectl exec -it %s -- curl -s --output /dev/stderr -w '%%{http_code}' -XGET %s/v1", xwingPod, deathstarServiceName))
+		res.ExpectContains("200", "unable to curl %s/v1: %s", deathstarServiceName, res.CombineOutput())
+
+		By(fmt.Sprintf("Importing L7 Policy which restricts access to %s", exhaustPortPath))
+		res = kubectl.Apply(l7PolicyYAMLLink)
+		res.ExpectSuccess("unable to apply %s: %s", l7PolicyYAMLLink, res.CombineOutput())
+
+		By("Waiting for endpoints to be ready after importing policy")
+		arePodsReady = kubectl.CiliumEndpointWait(ciliumPod2)
+		Expect(arePodsReady).To(BeTrue(), "pods running on k8s2 are not ready")
+
+		By(fmt.Sprintf("Showing how alliance cannot access %s without force header in API request after importing L7 Policy", exhaustPortPath))
+		res = kubectl.Exec(fmt.Sprintf(`kubectl exec -it %s -- curl -s --output /dev/stderr -w '%%{http_code}' -XPUT %s`, xwingPod, exhaustPortPath))
+
+		res.ExpectContains("403", "able to access %s when policy disallows it; %s", exhaustPortPath, res.CombineOutput())
+
+		By(fmt.Sprintf("Showing how alliance can access %s with force header in API request to attack the deathstar", exhaustPortPath))
+		res = kubectl.Exec(fmt.Sprintf(`kubectl exec -it %s -- curl -s --output /dev/stderr -w '%%{http_code}' -H 'X-Has-Force: True' -XPUT %s`, xwingPod, exhaustPortPath))
+		By("Expecting 503 to be returned when using force header to attack the deathstar")
+		res.ExpectContains("503", "unable to access %s when policy allows it; %s", deathstarServiceName, res.CombineOutput())
+	})
+
+})

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -1,0 +1,1 @@
+package k8sTest


### PR DESCRIPTION
test/k8sT: add Star Wars demo test
    
Add test to CI which tests the functionality in https://github.com/cilium/star-wars-demo/blob/master/v1/demo.sh
    
Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #3163 

I validated that this test succeeds when using the Docker image built from this branch (which tests the code from checking out master as of this morning), and it succeeded. It failed when using `cilium/cilium:v0.13.13`, which was the reason why #3162 was filed. This shows that the test fails when it should and succeeds when it should as well.