### PR TITLE
proxy: envoy: use url.Parse() to generate URL field

### DIFF
--- a/pkg/proxy/envoyproxy_test.go
+++ b/pkg/proxy/envoyproxy_test.go
@@ -1,0 +1,36 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"github.com/cilium/cilium/pkg/envoy"
+
+	. "gopkg.in/check.v1"
+)
+
+func (k *proxyTestSuite) TestParseURL(c *C) {
+	logs := []envoy.HttpLogEntry{
+		{Scheme: "http", Host: "foo", Path: "/foo?blah=131"},
+		{Scheme: "http", Host: "foo", Path: "foo?blah=131"},
+		{Scheme: "http", Host: "foo", Path: "/foo"},
+	}
+
+	for _, l := range logs {
+		u := parseURL(&l)
+		c.Assert(u.Scheme, Equals, "http")
+		c.Assert(u.Host, Equals, "foo")
+		c.Assert(u.Path, Equals, "/foo")
+	}
+}


### PR DESCRIPTION
pblog.Path contains the query and fragments which should not be part of the
Path.  Using url.Parse() will ensure these segments are parsed into the
appropriate fields.

Fixes: #3187

Signed-off-by: Thomas Graf <thomas@cilium.io>