### PR TITLE
pkg/ipcache: check if event type is EventTypeListDone before unmarshal of value

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -158,9 +158,15 @@ func ipIdentityWatcher(owner IPIdentityMappingOwner) {
 				ipIDPair     identity.IPIdentityPair
 			)
 
+			// Key and value are empty for ListDone event types, so just continue.
+			// See GH-3159.
+			if event.Typ == kvstore.EventTypeListDone {
+				continue
+			}
+
 			err := json.Unmarshal(event.Value, &ipIDPair)
 			if err != nil {
-				log.WithFields(logrus.Fields{"value": event.Value}).WithError(err).Errorf("not adding entry to ip cache; error unmarshaling data from key-value store")
+				log.WithFields(logrus.Fields{"key": event.Key, "value": event.Value}).WithError(err).Errorf("not adding entry to ip cache; error unmarshaling data from key-value store")
 				continue
 			}
 

--- a/pkg/kvstore/events.go
+++ b/pkg/kvstore/events.go
@@ -46,7 +46,7 @@ func (t EventType) String() string {
 
 // KeyValueEvent is a change event for a Key/Value pair
 type KeyValueEvent struct {
-	// Typ is the type of event { EventTypeCreate | EventTypeModify | EventTypeDelete }
+	// Typ is the type of event { EventTypeCreate | EventTypeModify | EventTypeDelete | EventTypeListDone }
 	Typ EventType
 
 	// Key is the kvstore key that changed


### PR DESCRIPTION
Key and value are empty with this EventType. Continue if this EventType is 
encountered in Identity-IP watcher.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #3159 