### PR TITLE
test: Fix spelling of Role in Kafka CI test

### DIFF
--- a/test/runtime/manifests/Policies-kafka-Role.json
+++ b/test/runtime/manifests/Policies-kafka-Role.json
@@ -13,8 +13,8 @@
 			"ports": [{"port": "9092", "protocol": "tcp"}],
 			"rules": {
 				"kafka": [
-					{"Role": "produce", "topic": "allowedTopic"},
-					{"Role": "consume", "topic": "allowedTopic"}
+					{"role": "produce", "topic": "allowedTopic"},
+					{"role": "consume", "topic": "allowedTopic"}
 				]
 			}
 		}]


### PR DESCRIPTION
Not sure why the CI test would not fail given this error. Needs to be investigated.