### PR TITLE
Makefile: Add check-bindata to unit-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ tests: force
 	$(MAKE) unit-tests tests-envoy
 
 unit-tests: start-kvstores
+	$(QUIET) $(MAKE) -C daemon/ check-bindata
 	$(QUIET) echo "mode: count" > coverage-all.out
 	$(QUIET) echo "mode: count" > coverage.out
 	$(foreach pkg,$(TESTPKGS),\


### PR DESCRIPTION
Previously in the CI, it could take up to 15 minutes for a build failure
due to improper bpf.sha to be discovered, as a plain 'make' would only
be issued after booting ginkgo VMs and attempting to provision them. Add
a check-bindata check into the unit-tests target so this will fail
almost immediately.

Signed-off-by: Joe Stringer <joe@covalent.io>
