### PR TITLE
Jenkins: Increase memory in VMs

### DIFF
--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -13,6 +13,7 @@ pipeline {
     environment {
         PROJ_PATH = "src/github.com/cilium/cilium"
         TESTDIR = "${WORKSPACE}/${PROJ_PATH}/"
+        MEMORY = "3072"
     }
 
     options {


### PR DESCRIPTION
Issues on builds:
https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/1767/
https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/1766/

Kafka has no enough memory to start, and container died and test failed.
Logs from kafka container:

```
Java HotSpot(TM) 64-Bit Server VM warning: INFO: os::commit_memory(0x00000000c0000000, 1073741824, 0) failed; error='Cannot allocate memory' (errno=12)
Java HotSpot(TM) 64-Bit Server VM warning: INFO: os::commit_memory(0x00000000c0000000, 1073741824, 0) failed; error='Cannot allocate memory' (errno=12)
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
