### PR TITLE
daemon: Fixup no-name backoff default name

### DIFF
--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -53,7 +53,7 @@ func (b *Exponential) Wait() {
 	b.attempt++
 
 	if b.Name == "" {
-		b.Name = string(uuid.NewUUID())
+		b.Name = uuid.NewUUID().String()
 	}
 
 	min := time.Duration(1) * time.Second


### PR DESCRIPTION
We stringified the UUID of the backoff but this used the uuid binary
representation. Calling String() generates a printable uuid.