### PR TITLE
Test: Disable cilium update from stable

### DIFF
--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var _ = Describe("K8sValidatedUpdates", func() {
+var _ = Describe("DisabledK8sValidatedUpdates", func() {
 
 	var kubectl *helpers.Kubectl
 	var logger *logrus.Entry


### PR DESCRIPTION
Flake test, disabled until rolling update works always.

https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-Validated/1421/testReport/k8s-1/9/K8sValidatedUpdates_Updating_Cilium_stable_to_master/

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
