### PR TITLE
k8s: Do not overwrite CRD validation fields

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -501,7 +501,7 @@ var (
 		},
 	}
 
-	EndpointSelector = LabelSelector
+	EndpointSelector = *LabelSelector.DeepCopy()
 
 	IngressRule = apiextensionsv1beta1.JSONSchemaProps{
 		Description: "IngressRule contains all rule types which can be applied at ingress, " +
@@ -955,13 +955,13 @@ var (
 		},
 	}
 
-	spec = Rule
+	spec = *Rule.DeepCopy()
 
 	specs = apiextensionsv1beta1.JSONSchemaProps{
 		Description: "Specs is a list of desired Cilium specific rule specification.",
 		Type:        "array",
 		Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-			Schema: &Rule,
+			Schema: &spec,
 		},
 	}
 )


### PR DESCRIPTION
When we unrolled using references in the validation we ended up reusing
validation objects directly, cloberring the original's description.
We can also make full objects out of the 5 or so that are reused, but the goal might have been to reduce repetition.

