### PR TITLE
Speed up go code vetting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,13 +202,15 @@ release:
 gofmt:
 	for pkg in $(GOFILES); do go fmt $$pkg; done
 
-precheck:
+govet:
+	@$(ECHO_CHECK) vetting all GOFILES...
+	$(GO) tool vet $(SUBDIRS)
+
+precheck: govet
 	@$(ECHO_CHECK) contrib/scripts/check-fmt.sh
 	$(QUIET) contrib/scripts/check-fmt.sh
 	@$(ECHO_CHECK) contrib/scripts/check-log-newlines.sh
 	$(QUIET) contrib/scripts/check-log-newlines.sh
-	@$(ECHO_CHECK) vetting all GOFILES...
-	$(QUIET)go vet $(GOFILES)
 
 pprof-help:
 	@echo "Available pprof targets:"


### PR DESCRIPTION
This PR speeds up the vetting of gofiles by as much as 3x by using `go tool vet` rather than `go vet`:

Before:
```
  $ time make govet
    CHECK vetting all GOFILES...
  vet: cilium/cmd/status.go: cilium/cmd/status.go:48:1: expected declaration, found 'IDENT' myb
  vet: no files checked
  exit status 1
  Makefile:206: recipe for target 'govet' failed
  make: *** [govet] Error 1

  real    0m15.506s
  user    0m10.310s
  sys     0m2.865s
```

After:
```
  $ time make govet
    CHECK vetting all GOFILES...
  vet: cilium/cmd/status.go: cilium/cmd/status.go:48:1: expected declaration, found 'IDENT' myb
  Makefile:206: recipe for target 'govet' failed
  make: *** [govet] Error 1

  real    0m6.316s
  user    0m3.231s
  sys     0m1.304s
```

Signed-off-by: Joe Stringer <joe@covalent.io>