### PR TITLE
Improve cilium cluster health status / formatting

### DIFF
--- a/pkg/health/client/client.go
+++ b/pkg/health/client/client.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -225,7 +226,12 @@ func FormatHealthStatusResponse(w io.Writer, sr *models.HealthStatusResponse, pr
 		formatNodeStatus(w, localhost, printAll, succinct, verbose, true)
 		maxLines--
 	}
-	for n, node := range sr.Nodes {
+
+	nodes := sr.Nodes
+	sort.Slice(nodes, func(i, j int) bool {
+		return strings.Compare(nodes[i].Name, nodes[j].Name) < 0
+	})
+	for n, node := range nodes {
 		if maxLines > 0 && n > maxLines {
 			break
 		}

--- a/pkg/health/client/client.go
+++ b/pkg/health/client/client.go
@@ -130,14 +130,11 @@ func formatPathStatus(w io.Writer, name string, cp *models.PathStatus, indent st
 	fmt.Fprintf(w, "%s%s connectivity to %s:\n", indent, name, cp.IP)
 	indent = fmt.Sprintf("%s  ", indent)
 
-	statuses := map[string]*models.ConnectivityStatus{
-		"ICMP":        cp.Icmp,
-		"HTTP via L3": cp.HTTP,
+	if cp.Icmp != nil {
+		formatConnectivityStatus(w, cp.Icmp, "ICMP", indent)
 	}
-	for name, status := range statuses {
-		if status != nil {
-			formatConnectivityStatus(w, status, name, indent)
-		}
+	if cp.HTTP != nil {
+		formatConnectivityStatus(w, cp.HTTP, "HTTP via L3", indent)
 	}
 }
 

--- a/pkg/health/client/client.go
+++ b/pkg/health/client/client.go
@@ -179,6 +179,9 @@ func FormatHealthStatusResponse(w io.Writer, sr *models.HealthStatusResponse, pr
 	if succinct {
 		fmt.Fprintf(w, "Cluster health:\t%d/%d reachable\t(%s)\n",
 			healthy, len(sr.Nodes), sr.Timestamp)
+		if printAll || healthy < len(sr.Nodes) {
+			fmt.Fprintf(w, "  Name\tIP\tReachable\tEndpoints reachable\n")
+		}
 	} else {
 		fmt.Fprintf(w, "Probe time:\t%s\n", sr.Timestamp)
 		fmt.Fprintf(w, "Nodes:\n")
@@ -192,9 +195,6 @@ func FormatHealthStatusResponse(w io.Writer, sr *models.HealthStatusResponse, pr
 			localStr = " (localhost)"
 		}
 		if succinct {
-			if printAll || healthy < len(sr.Nodes) {
-				fmt.Fprintf(w, "  Name\tIP\tReachable\tEndpoints reachable\n")
-			}
 			if printAll || !nodeIsHealthy(node) {
 				fmt.Fprintf(w, "  %s\t%s\t%t\t%t\n", node.Name,
 					node.Host.PrimaryAddress.IP,


### PR DESCRIPTION
* Don't print the title multiple times in `cilium status --all-nodes` output
* Print localhost node first
* Print the remaining nodes in sorted order