### PR TITLE
k8s: Rename CEPs to match their pod name

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -220,6 +220,13 @@ func getCiliumClient() (ciliumClient cilium_client_v2.CiliumV2Interface, err err
 		return nil, err
 	}
 
+	// This guards against the situation where another invocation of this
+	// function (in another thread or previous in time) might have returned an
+	// error and not initialized ciliumEndpointSyncControllerK8sClient
+	if ciliumEndpointSyncControllerK8sClient == nil {
+		return nil, errors.New("No initialised k8s Cilium CRD client")
+	}
+
 	return ciliumEndpointSyncControllerK8sClient.CiliumV2(), nil
 }
 


### PR DESCRIPTION
User feedback suggests it's easier to correlate a CEP with it's pod if it has a similar name. The name may as well be the same, since one fetches one type or the other explicitly.

```
$ kubectl get pods
NAME                    READY     STATUS    RESTARTS   AGE
app1-799c454b56-6rxtz   1/1       Running   0          4d
app1-799c454b56-v69c9   1/1       Running   0          4d
app2                    1/1       Running   0          4d
app3                    1/1       Running   0          4d
$ kubectl get cep
NAME                    AGE
app1-799c454b56-6rxtz   2m
app1-799c454b56-v69c9   2m
app2                    2m
app3                    2m
```

I also threw in a small fixup of the k8s cilium client getter function but I can make that it's own PR.