### PR TITLE
CMD: Add json output on endpoint config

### DIFF
--- a/Documentation/cmdref/cilium_endpoint_config.md
+++ b/Documentation/cmdref/cilium_endpoint_config.md
@@ -22,7 +22,8 @@ endpoint config 5421 DropNotification=false TraceNotification=false
 ### Options
 
 ```
-      --list-options   List available options
+      --list-options    List available options
+  -o, --output string   json| jsonpath='{}'
 ```
 
 ### Options inherited from parent commands

--- a/cilium/cmd/endpoint_config.go
+++ b/cilium/cmd/endpoint_config.go
@@ -16,8 +16,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/option"
 
@@ -45,6 +47,7 @@ var endpointConfigCmd = &cobra.Command{
 func init() {
 	endpointCmd.AddCommand(endpointConfigCmd)
 	endpointConfigCmd.Flags().BoolVarP(&listOptions, "list-options", "", false, "List available options")
+	command.AddJSONOutput(endpointConfigCmd)
 }
 
 func listEndpointOptions() {
@@ -62,6 +65,13 @@ func configEndpoint(cmd *cobra.Command, args []string) {
 
 	opts := args[1:]
 	if len(opts) == 0 {
+		if command.OutputJSON() {
+			if err := command.PrintOutput(cfg); err != nil {
+				os.Exit(1)
+			}
+			return
+		}
+
 		dumpConfig(cfg.Immutable)
 		dumpConfig(cfg.Mutable)
 		return


### PR DESCRIPTION
I saw, a few times, issues  where the config cannot be retrieved
correctly because `endpoint config` does not have `-o json` support.

Added json support to stop failing in the test. Related with failures in
`Conntrack-related configuration options for endpoints` test.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

