### PR TITLE
k8s: CEP controller detects and handles health ep

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -177,8 +177,6 @@ func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressin
 		log.WithError(err).Fatal("Error while creating cilium-health endpoint")
 	}
 	ep.SetDefaultOpts(opts)
-	// This is used by the k8s sync-to-k8s-ciliumendpoint controller.
-	ep.SetK8sNamespace(endpoint.ReservedEPNamespace)
 
 	// Add the endpoint
 	if err := endpointmanager.AddEndpoint(owner, ep, "Create cilium-health endpoint"); err != nil {


### PR DESCRIPTION
The health endpoint has a corresponding CEP but isn't part of the
orchestration system (in this case, k8s). It isn't initialized to work
with the default CEP naming scheme, and requires special casing.


**How to test (optional)**:
Don't see "Cannot get pod name for endpoint" messages from the CEP controller.