### PR TITLE
Loosen VM name matching for `ginkgo -- -cilium.SSHConfig` to match dev VM name

### DIFF
--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/cilium/cilium/test/config"
 
@@ -69,8 +70,14 @@ func GetVagrantSSHMeta(vmName string) *SSHMeta {
 		log.WithError(err).Error("Error importing ssh config")
 		return nil
 	}
+	var node *SSHConfig
 	log.Debugf("done importing ssh config")
-	node := nodes[vmName]
+	for name := range nodes {
+		if strings.HasPrefix(name, vmName) {
+			node = nodes[name]
+			break
+		}
+	}
 	if node == nil {
 		log.Errorf("Node %s not found in ssh config", vmName)
 		return nil


### PR DESCRIPTION
The developer VM defined in the Vagrantfile in the root of the Cilium
repository is named "runtime1". Using `gingko ... -- -cilium.SSHConfig`
and fetching the runtime VM config would previously fail, because ginkgo
is looking for a machine named exactly "runtime". Loosen the
restrictions by just searching for a vagrant configuration of a VM with
the same prefix as the target VM.

Tested manually via:
  `ginkgo -- -cilium.SSHConfig="cd ../cilium && vagrant ssh-config"`

Signed-off-by: Joe Stringer <joe@covalent.io>