### PR TITLE
WIP: Refactor common configuration into package

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -315,17 +315,17 @@ func (d *Daemon) writeNetdevHeader(dir string) error {
 // returns #define for PolicyIngress based on the configuration of the daemon.
 func (d *Daemon) fmtPolicyEnforcementIngress() string {
 	if policy.GetPolicyEnabled() == configPkg.AlwaysEnforce {
-		return fmt.Sprintf("#define %s\n", endpoint.OptionIngressSpecPolicy.Define)
+		return fmt.Sprintf("#define %s\n", configPkg.OptionIngressSpecPolicy.Define)
 	}
-	return fmt.Sprintf("#undef %s\n", endpoint.OptionIngressSpecPolicy.Define)
+	return fmt.Sprintf("#undef %s\n", configPkg.OptionIngressSpecPolicy.Define)
 }
 
 // returns #define for PolicyEgress based on the configuration of the daemon.
 func (d *Daemon) fmtPolicyEnforcementEgress() string {
 	if policy.GetPolicyEnabled() == configPkg.AlwaysEnforce {
-		return fmt.Sprintf("#define %s\n", endpoint.OptionEgressSpecPolicy.Define)
+		return fmt.Sprintf("#define %s\n", configPkg.OptionEgressSpecPolicy.Define)
 	}
-	return fmt.Sprintf("#undef %s\n", endpoint.OptionEgressSpecPolicy.Define)
+	return fmt.Sprintf("#undef %s\n", configPkg.OptionEgressSpecPolicy.Define)
 }
 
 // Must be called with d.conf.EnablePolicyMU locked.

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cilium/cilium/pkg/apierror"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
+	configPkg "github.com/cilium/cilium/pkg/config"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
@@ -269,7 +270,7 @@ func (d *Daemon) PolicyEnforcement() string {
 
 // DebugEnabled returns if debug mode is enabled.
 func (d *Daemon) DebugEnabled() bool {
-	return d.conf.Opts.IsEnabled(endpoint.OptionDebug)
+	return d.conf.Opts.IsEnabled(configPkg.OptionDebug)
 }
 
 // ResetProxyPort cleans the connection tracking of the given endpoint
@@ -313,7 +314,7 @@ func (d *Daemon) writeNetdevHeader(dir string) error {
 
 // returns #define for PolicyIngress based on the configuration of the daemon.
 func (d *Daemon) fmtPolicyEnforcementIngress() string {
-	if policy.GetPolicyEnabled() == endpoint.AlwaysEnforce {
+	if policy.GetPolicyEnabled() == configPkg.AlwaysEnforce {
 		return fmt.Sprintf("#define %s\n", endpoint.OptionIngressSpecPolicy.Define)
 	}
 	return fmt.Sprintf("#undef %s\n", endpoint.OptionIngressSpecPolicy.Define)
@@ -321,7 +322,7 @@ func (d *Daemon) fmtPolicyEnforcementIngress() string {
 
 // returns #define for PolicyEgress based on the configuration of the daemon.
 func (d *Daemon) fmtPolicyEnforcementEgress() string {
-	if policy.GetPolicyEnabled() == endpoint.AlwaysEnforce {
+	if policy.GetPolicyEnabled() == configPkg.AlwaysEnforce {
 		return fmt.Sprintf("#define %s\n", endpoint.OptionEgressSpecPolicy.Define)
 	}
 	return fmt.Sprintf("#undef %s\n", endpoint.OptionEgressSpecPolicy.Define)
@@ -1206,7 +1207,7 @@ func mapValidateWalker(path string) error {
 
 func changedOption(key string, value bool, data interface{}) {
 	d := data.(*Daemon)
-	if key == endpoint.OptionDebug {
+	if key == configPkg.OptionDebug {
 		// Set the debug toggle (this can be a no-op)
 		logging.ToggleDebugLogs(d.DebugEnabled())
 		// Reflect log level change to proxies
@@ -1256,7 +1257,7 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 	if enforcement != "" {
 		log.Debug("configuration request to change PolicyEnforcement for daemon")
 		switch enforcement {
-		case endpoint.NeverEnforce, endpoint.DefaultEnforcement, endpoint.AlwaysEnforce:
+		case configPkg.NeverEnforce, configPkg.DefaultEnforcement, configPkg.AlwaysEnforce:
 
 			// Update policy enforcement configuration if needed.
 			oldEnforcementValue := policy.GetPolicyEnabled()

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/daemon/options"
+	configPkg "github.com/cilium/cilium/pkg/config"
 	e "github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -92,8 +93,8 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	// Get the default labels prefix filter
 	err = labels.ParseLabelPrefixCfg(nil, "")
 	c.Assert(err, IsNil)
-	daemonConf.Opts.Set(e.OptionDropNotify, true)
-	daemonConf.Opts.Set(e.OptionTraceNotify, true)
+	daemonConf.Opts.Set(configPkg.OptionDropNotify, true)
+	daemonConf.Opts.Set(configPkg.OptionTraceNotify, true)
 
 	d, err := NewDaemon(daemonConf)
 	c.Assert(err, IsNil)

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cilium/cilium/daemon/options"
 	"github.com/cilium/cilium/pkg/bpf"
 	configPkg "github.com/cilium/cilium/pkg/config"
-	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/flowdebug"
@@ -531,7 +530,7 @@ func initEnv(cmd *cobra.Command) {
 	}
 
 	if config.IPv4Disabled {
-		endpoint.IPv4Enabled = false
+		configPkg.IPv4Enabled = false
 		node.EnableIPv4 = false
 	}
 

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cilium/cilium/daemon/defaults"
 	"github.com/cilium/cilium/daemon/options"
 	"github.com/cilium/cilium/pkg/bpf"
+	configPkg "github.com/cilium/cilium/pkg/config"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/envoy"
@@ -337,7 +338,7 @@ func init() {
 		false, "Disable east-west K8s load balancing by cilium")
 	flags.StringVarP(&dockerEndpoint,
 		"docker", "e", workloads.GetRuntimeDefaultOpt(workloads.Docker).Endpoint, "Path to docker runtime socket (DEPRECATED: use container-runtime-endpoint instead)")
-	flags.String("enable-policy", endpoint.DefaultEnforcement, "Enable policy enforcement")
+	flags.String("enable-policy", configPkg.DefaultEnforcement, "Enable policy enforcement")
 	flags.BoolVar(&enableTracing,
 		"enable-tracing", false, "Enable tracing while determining policy (debugging)")
 	flags.String("envoy-log", "/var/log/cilium-envoy.log", "Path to Envoy log")
@@ -613,16 +614,16 @@ func initEnv(cmd *cobra.Command) {
 	bpf.MountFS()
 
 	logging.DefaultLogLevel = defaults.DefaultLogLevel
-	config.Opts.Set(endpoint.OptionDebug, viper.GetBool("debug"))
+	config.Opts.Set(configPkg.OptionDebug, viper.GetBool("debug"))
 
 	autoIPv6NodeRoutes = viper.GetBool("auto-ipv6-node-routes")
 
-	config.Opts.Set(endpoint.OptionDropNotify, true)
-	config.Opts.Set(endpoint.OptionTraceNotify, true)
+	config.Opts.Set(configPkg.OptionDropNotify, true)
+	config.Opts.Set(configPkg.OptionTraceNotify, true)
 	config.Opts.Set(options.PolicyTracing, enableTracing)
-	config.Opts.Set(endpoint.OptionConntrack, !disableConntrack)
-	config.Opts.Set(endpoint.OptionConntrackAccounting, !disableConntrack)
-	config.Opts.Set(endpoint.OptionConntrackLocal, false)
+	config.Opts.Set(configPkg.OptionConntrack, !disableConntrack)
+	config.Opts.Set(configPkg.OptionConntrackAccounting, !disableConntrack)
+	config.Opts.Set(configPkg.OptionConntrackLocal, false)
 
 	policy.SetPolicyEnabled(strings.ToLower(viper.GetString("enable-policy")))
 

--- a/daemon/options/options.go
+++ b/daemon/options/options.go
@@ -15,6 +15,7 @@
 package options
 
 import (
+	configPkg "github.com/cilium/cilium/pkg/config"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -33,14 +34,14 @@ var (
 	}
 
 	DaemonMutableOptionLibrary = option.OptionLibrary{
-		endpoint.OptionConntrackAccounting: &endpoint.OptionSpecConntrackAccounting,
-		endpoint.OptionConntrackLocal:      &endpoint.OptionSpecConntrackLocal,
-		endpoint.OptionConntrack:           &endpoint.OptionSpecConntrack,
-		endpoint.OptionDebug:               &endpoint.OptionSpecDebug,
-		endpoint.OptionDebugLB:             &endpoint.OptionSpecDebugLB,
-		endpoint.OptionDropNotify:          &endpoint.OptionSpecDropNotify,
-		endpoint.OptionTraceNotify:         &endpoint.OptionSpecTraceNotify,
-		endpoint.OptionNAT46:               &endpoint.OptionSpecNAT46,
+		configPkg.OptionConntrackAccounting: &endpoint.OptionSpecConntrackAccounting,
+		configPkg.OptionConntrackLocal:      &endpoint.OptionSpecConntrackLocal,
+		configPkg.OptionConntrack:           &endpoint.OptionSpecConntrack,
+		configPkg.OptionDebug:               &endpoint.OptionSpecDebug,
+		configPkg.OptionDebugLB:             &endpoint.OptionSpecDebugLB,
+		configPkg.OptionDropNotify:          &endpoint.OptionSpecDropNotify,
+		configPkg.OptionTraceNotify:         &endpoint.OptionSpecTraceNotify,
+		configPkg.OptionNAT46:               &endpoint.OptionSpecNAT46,
 	}
 )
 

--- a/daemon/options/options.go
+++ b/daemon/options/options.go
@@ -16,7 +16,6 @@ package options
 
 import (
 	configPkg "github.com/cilium/cilium/pkg/config"
-	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -34,14 +33,14 @@ var (
 	}
 
 	DaemonMutableOptionLibrary = option.OptionLibrary{
-		configPkg.OptionConntrackAccounting: &endpoint.OptionSpecConntrackAccounting,
-		configPkg.OptionConntrackLocal:      &endpoint.OptionSpecConntrackLocal,
-		configPkg.OptionConntrack:           &endpoint.OptionSpecConntrack,
-		configPkg.OptionDebug:               &endpoint.OptionSpecDebug,
-		configPkg.OptionDebugLB:             &endpoint.OptionSpecDebugLB,
-		configPkg.OptionDropNotify:          &endpoint.OptionSpecDropNotify,
-		configPkg.OptionTraceNotify:         &endpoint.OptionSpecTraceNotify,
-		configPkg.OptionNAT46:               &endpoint.OptionSpecNAT46,
+		configPkg.OptionConntrackAccounting: &configPkg.OptionSpecConntrackAccounting,
+		configPkg.OptionConntrackLocal:      &configPkg.OptionSpecConntrackLocal,
+		configPkg.OptionConntrack:           &configPkg.OptionSpecConntrack,
+		configPkg.OptionDebug:               &configPkg.OptionSpecDebug,
+		configPkg.OptionDebugLB:             &configPkg.OptionSpecDebugLB,
+		configPkg.OptionDropNotify:          &configPkg.OptionSpecDropNotify,
+		configPkg.OptionTraceNotify:         &configPkg.OptionSpecTraceNotify,
+		configPkg.OptionNAT46:               &configPkg.OptionSpecNAT46,
 	}
 )
 

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/policy"
 	"github.com/cilium/cilium/pkg/apierror"
+	configPkg "github.com/cilium/cilium/pkg/config"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/labels"
@@ -57,9 +58,9 @@ func (d *Daemon) EnableEndpointPolicyEnforcement(e *endpoint.Endpoint) (ingress 
 	// First check if policy enforcement should be enabled at the daemon level.
 	// If policy enforcement is enabled for the daemon, then it has to be
 	// enabled for the endpoint.
-	if policy.GetPolicyEnabled() == endpoint.AlwaysEnforce {
+	if policy.GetPolicyEnabled() == configPkg.AlwaysEnforce {
 		return true, true
-	} else if policy.GetPolicyEnabled() == endpoint.DefaultEnforcement {
+	} else if policy.GetPolicyEnabled() == configPkg.DefaultEnforcement {
 		// Default mode means that if rules contain labels that match this endpoint,
 		// then enable policy enforcement for this endpoint.
 		// GH-1676: Could check e.Consumable instead? Would be much cheaper.
@@ -91,10 +92,10 @@ func (h *getPolicyResolve) Handle(params GetPolicyResolveParams) middleware.Resp
 	d.policy.Mutex.RLock()
 
 	// If policy enforcement isn't enabled, then traffic is allowed.
-	if policy.GetPolicyEnabled() == endpoint.NeverEnforce {
+	if policy.GetPolicyEnabled() == configPkg.NeverEnforce {
 		policyEnforcementMsg = "Policy enforcement is disabled for the daemon."
 		isPolicyEnforcementEnabled = false
-	} else if policy.GetPolicyEnabled() == endpoint.DefaultEnforcement {
+	} else if policy.GetPolicyEnabled() == configPkg.DefaultEnforcement {
 		// If there are no rules matching the set of from / to labels provided in
 		// the API request, that means that policy enforcement is not enabled
 		// for the endpoints corresponding to said sets of labels; thus, we allow

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 
 	"github.com/cilium/cilium/common"
+	configPkg "github.com/cilium/cilium/pkg/config"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	identityPkg "github.com/cilium/cilium/pkg/identity"
@@ -90,9 +91,9 @@ func (d *Daemon) SyncState(dir string, clean bool) error {
 				ep.SetDefaultOpts(nil)
 			} else {
 				ep.SetDefaultOpts(d.conf.Opts)
-				alwaysEnforce := policy.GetPolicyEnabled() == endpoint.AlwaysEnforce
-				ep.Opts.Set(endpoint.OptionIngressPolicy, alwaysEnforce)
-				ep.Opts.Set(endpoint.OptionEgressPolicy, alwaysEnforce)
+				alwaysEnforce := policy.GetPolicyEnabled() == configPkg.AlwaysEnforce
+				ep.Opts.Set(configPkg.OptionIngressPolicy, alwaysEnforce)
+				ep.Opts.Set(configPkg.OptionEgressPolicy, alwaysEnforce)
 			}
 
 			endpointmanager.Insert(ep)

--- a/pkg/config/common.go
+++ b/pkg/config/common.go
@@ -1,0 +1,93 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/option"
+)
+
+var (
+	//IPv4Enabled can be set to false to indicate IPv6 only operation
+	IPv4Enabled = true
+)
+
+var (
+	OptionSpecAllowToHost = option.Option{
+		Define:      "ALLOW_TO_HOST",
+		Immutable:   true,
+		Description: "Allow all traffic to local host",
+	}
+
+	OptionSpecConntrackAccounting = option.Option{
+		Define:      "CONNTRACK_ACCOUNTING",
+		Description: "Enable per flow (conntrack) statistics",
+		Requires:    []string{OptionConntrack},
+	}
+
+	OptionSpecConntrackLocal = option.Option{
+		Define:      "CONNTRACK_LOCAL",
+		Description: "Use endpoint dedicated tracking table instead of global one",
+		Requires:    []string{OptionConntrack},
+	}
+
+	OptionSpecConntrack = option.Option{
+		Define:      "CONNTRACK",
+		Description: "Enable stateful connection tracking",
+	}
+
+	OptionSpecDebug = option.Option{
+		Define:      "DEBUG",
+		Description: "Enable debugging trace statements",
+	}
+
+	OptionSpecDebugLB = option.Option{
+		Define:      "LB_DEBUG",
+		Description: "Enable debugging trace statements for load balancer",
+	}
+
+	OptionSpecDropNotify = option.Option{
+		Define:      "DROP_NOTIFY",
+		Description: "Enable drop notifications",
+	}
+
+	OptionSpecTraceNotify = option.Option{
+		Define:      "TRACE_NOTIFY",
+		Description: "Enable trace notifications",
+	}
+
+	OptionSpecNAT46 = option.Option{
+		Define:      "ENABLE_NAT46",
+		Description: "Enable automatic NAT46 translation",
+		Requires:    []string{OptionConntrack},
+		Verify: func(key string, val bool) error {
+			if !IPv4Enabled {
+				return fmt.Errorf("NAT46 requires IPv4 to be enabled")
+			}
+			return nil
+		},
+	}
+
+	OptionIngressSpecPolicy = option.Option{
+		Define:      "POLICY_INGRESS",
+		Description: "Enable ingress policy enforcement",
+	}
+
+	OptionEgressSpecPolicy = option.Option{
+		Define:      "POLICY_EGRESS",
+		Description: "Enable egress policy enforcement",
+	}
+)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,18 @@
+package config
+
+const (
+	OptionAllowToHost         = "AllowToHost"
+	OptionConntrackAccounting = "ConntrackAccounting"
+	OptionConntrackLocal      = "ConntrackLocal"
+	OptionConntrack           = "Conntrack"
+	OptionDebug               = "Debug"
+	OptionDebugLB             = "DebugLB"
+	OptionDropNotify          = "DropNotification"
+	OptionTraceNotify         = "TraceNotification"
+	OptionNAT46               = "NAT46"
+	OptionIngressPolicy       = "IngressPolicy"
+	OptionEgressPolicy        = "EgressPolicy"
+	AlwaysEnforce             = "always"
+	NeverEnforce              = "never"
+	DefaultEnforcement        = "default"
+)

--- a/pkg/config/doc.go
+++ b/pkg/config/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package config contains common configuration-values and structures for
+// containing configuration.
+package config

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/config"
 	"github.com/cilium/cilium/pkg/geneve"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -202,8 +203,8 @@ func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 	// all packets, but only if policy enforcement
 	// is enabled for the endpoint / daemon.
 	if !e.PolicyCalculated &&
-		(e.Opts.IsEnabled(OptionIngressPolicy) || e.Opts.IsEnabled(OptionEgressPolicy)) &&
-		owner.PolicyEnforcement() != NeverEnforce {
+		(e.Opts.IsEnabled(config.OptionIngressPolicy) || e.Opts.IsEnabled(config.OptionEgressPolicy)) &&
+		owner.PolicyEnforcement() != config.NeverEnforce {
 		fw.WriteString("#define DROP_ALL\n")
 	}
 
@@ -247,7 +248,7 @@ func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 		}
 	}
 	fmt.Fprintf(fw, "#define CALLS_MAP %s\n", path.Base(e.CallsMapPathLocked()))
-	if e.Opts.IsEnabled(OptionConntrackLocal) {
+	if e.Opts.IsEnabled(config.OptionConntrackLocal) {
 		fmt.Fprintf(fw, "#define CT_MAP_SIZE %s\n", strconv.Itoa(ctmap.MapNumEntriesLocal))
 		fmt.Fprintf(fw, "#define CT_MAP6 %s\n", ctmap.MapName6+strconv.Itoa(int(e.ID)))
 		fmt.Fprintf(fw, "#define CT_MAP4 %s\n", ctmap.MapName4+strconv.Itoa(int(e.ID)))
@@ -771,7 +772,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 	// store the current endpoint state so we can later on
 	// update the CT without requiring to lock the endpoint again.
 	isPolicyEnforced := e.IngressOrEgressIsEnforced()
-	isLocal := e.Opts.IsEnabled(OptionConntrackLocal)
+	isLocal := e.Opts.IsEnabled(config.OptionConntrackLocal)
 	epIPs := e.IPs()
 
 	e.Mutex.Unlock()

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -81,86 +81,21 @@ const (
 )
 
 var (
-	OptionSpecAllowToHost = option.Option{
-		Define:      "ALLOW_TO_HOST",
-		Immutable:   true,
-		Description: "Allow all traffic to local host",
-	}
-
-	OptionSpecConntrackAccounting = option.Option{
-		Define:      "CONNTRACK_ACCOUNTING",
-		Description: "Enable per flow (conntrack) statistics",
-		Requires:    []string{config.OptionConntrack},
-	}
-
-	OptionSpecConntrackLocal = option.Option{
-		Define:      "CONNTRACK_LOCAL",
-		Description: "Use endpoint dedicated tracking table instead of global one",
-		Requires:    []string{config.OptionConntrack},
-	}
-
-	OptionSpecConntrack = option.Option{
-		Define:      "CONNTRACK",
-		Description: "Enable stateful connection tracking",
-	}
-
-	OptionSpecDebug = option.Option{
-		Define:      "DEBUG",
-		Description: "Enable debugging trace statements",
-	}
-
-	OptionSpecDebugLB = option.Option{
-		Define:      "LB_DEBUG",
-		Description: "Enable debugging trace statements for load balancer",
-	}
-
-	OptionSpecDropNotify = option.Option{
-		Define:      "DROP_NOTIFY",
-		Description: "Enable drop notifications",
-	}
-
-	OptionSpecTraceNotify = option.Option{
-		Define:      "TRACE_NOTIFY",
-		Description: "Enable trace notifications",
-	}
-
-	OptionSpecNAT46 = option.Option{
-		Define:      "ENABLE_NAT46",
-		Description: "Enable automatic NAT46 translation",
-		Requires:    []string{config.OptionConntrack},
-		Verify: func(key string, val bool) error {
-			if !IPv4Enabled {
-				return fmt.Errorf("NAT46 requires IPv4 to be enabled")
-			}
-			return nil
-		},
-	}
-
-	OptionIngressSpecPolicy = option.Option{
-		Define:      "POLICY_INGRESS",
-		Description: "Enable ingress policy enforcement",
-	}
-
-	OptionEgressSpecPolicy = option.Option{
-		Define:      "POLICY_EGRESS",
-		Description: "Enable egress policy enforcement",
-	}
-
 	EndpointMutableOptionLibrary = option.OptionLibrary{
-		config.OptionConntrackAccounting: &OptionSpecConntrackAccounting,
-		config.OptionConntrackLocal:      &OptionSpecConntrackLocal,
-		config.OptionConntrack:           &OptionSpecConntrack,
-		config.OptionDebug:               &OptionSpecDebug,
-		config.OptionDebugLB:             &OptionSpecDebugLB,
-		config.OptionDropNotify:          &OptionSpecDropNotify,
-		config.OptionTraceNotify:         &OptionSpecTraceNotify,
-		config.OptionNAT46:               &OptionSpecNAT46,
-		config.OptionIngressPolicy:       &OptionIngressSpecPolicy,
-		config.OptionEgressPolicy:        &OptionEgressSpecPolicy,
+		config.OptionConntrackAccounting: &config.OptionSpecConntrackAccounting,
+		config.OptionConntrackLocal:      &config.OptionSpecConntrackLocal,
+		config.OptionConntrack:           &config.OptionSpecConntrack,
+		config.OptionDebug:               &config.OptionSpecDebug,
+		config.OptionDebugLB:             &config.OptionSpecDebugLB,
+		config.OptionDropNotify:          &config.OptionSpecDropNotify,
+		config.OptionTraceNotify:         &config.OptionSpecTraceNotify,
+		config.OptionNAT46:               &config.OptionSpecNAT46,
+		config.OptionIngressPolicy:       &config.OptionIngressSpecPolicy,
+		config.OptionEgressPolicy:        &config.OptionEgressSpecPolicy,
 	}
 
 	EndpointOptionLibrary = option.OptionLibrary{
-		config.OptionAllowToHost: &OptionSpecAllowToHost,
+		config.OptionAllowToHost: &config.OptionSpecAllowToHost,
 	}
 
 	// ciliumEPControllerLimit is the range of k8s versions with which we are

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -60,6 +60,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
+	"github.com/cilium/cilium/pkg/config"
 	"github.com/sirupsen/logrus"
 )
 
@@ -76,21 +77,6 @@ type PortMap struct {
 }
 
 const (
-	OptionAllowToHost         = "AllowToHost"
-	OptionConntrackAccounting = "ConntrackAccounting"
-	OptionConntrackLocal      = "ConntrackLocal"
-	OptionConntrack           = "Conntrack"
-	OptionDebug               = "Debug"
-	OptionDebugLB             = "DebugLB"
-	OptionDropNotify          = "DropNotification"
-	OptionTraceNotify         = "TraceNotification"
-	OptionNAT46               = "NAT46"
-	OptionIngressPolicy       = "IngressPolicy"
-	OptionEgressPolicy        = "EgressPolicy"
-	AlwaysEnforce             = "always"
-	NeverEnforce              = "never"
-	DefaultEnforcement        = "default"
-
 	maxLogs = 256
 )
 
@@ -104,13 +90,13 @@ var (
 	OptionSpecConntrackAccounting = option.Option{
 		Define:      "CONNTRACK_ACCOUNTING",
 		Description: "Enable per flow (conntrack) statistics",
-		Requires:    []string{OptionConntrack},
+		Requires:    []string{config.OptionConntrack},
 	}
 
 	OptionSpecConntrackLocal = option.Option{
 		Define:      "CONNTRACK_LOCAL",
 		Description: "Use endpoint dedicated tracking table instead of global one",
-		Requires:    []string{OptionConntrack},
+		Requires:    []string{config.OptionConntrack},
 	}
 
 	OptionSpecConntrack = option.Option{
@@ -141,7 +127,7 @@ var (
 	OptionSpecNAT46 = option.Option{
 		Define:      "ENABLE_NAT46",
 		Description: "Enable automatic NAT46 translation",
-		Requires:    []string{OptionConntrack},
+		Requires:    []string{config.OptionConntrack},
 		Verify: func(key string, val bool) error {
 			if !IPv4Enabled {
 				return fmt.Errorf("NAT46 requires IPv4 to be enabled")
@@ -161,20 +147,20 @@ var (
 	}
 
 	EndpointMutableOptionLibrary = option.OptionLibrary{
-		OptionConntrackAccounting: &OptionSpecConntrackAccounting,
-		OptionConntrackLocal:      &OptionSpecConntrackLocal,
-		OptionConntrack:           &OptionSpecConntrack,
-		OptionDebug:               &OptionSpecDebug,
-		OptionDebugLB:             &OptionSpecDebugLB,
-		OptionDropNotify:          &OptionSpecDropNotify,
-		OptionTraceNotify:         &OptionSpecTraceNotify,
-		OptionNAT46:               &OptionSpecNAT46,
-		OptionIngressPolicy:       &OptionIngressSpecPolicy,
-		OptionEgressPolicy:        &OptionEgressSpecPolicy,
+		config.OptionConntrackAccounting: &OptionSpecConntrackAccounting,
+		config.OptionConntrackLocal:      &OptionSpecConntrackLocal,
+		config.OptionConntrack:           &OptionSpecConntrack,
+		config.OptionDebug:               &OptionSpecDebug,
+		config.OptionDebugLB:             &OptionSpecDebugLB,
+		config.OptionDropNotify:          &OptionSpecDropNotify,
+		config.OptionTraceNotify:         &OptionSpecTraceNotify,
+		config.OptionNAT46:               &OptionSpecNAT46,
+		config.OptionIngressPolicy:       &OptionIngressSpecPolicy,
+		config.OptionEgressPolicy:        &OptionEgressSpecPolicy,
 	}
 
 	EndpointOptionLibrary = option.OptionLibrary{
-		OptionAllowToHost: &OptionSpecAllowToHost,
+		config.OptionAllowToHost: &OptionSpecAllowToHost,
 	}
 
 	// ciliumEPControllerLimit is the range of k8s versions with which we are
@@ -740,8 +726,8 @@ func (e *Endpoint) GetModelRLocked() *models.Endpoint {
 		currentState = models.EndpointStateNotReady
 	}
 
-	policyIngressEnabled := e.Opts.IsEnabled(OptionIngressPolicy)
-	policyEgressEnabled := e.Opts.IsEnabled(OptionEgressPolicy)
+	policyIngressEnabled := e.Opts.IsEnabled(config.OptionIngressPolicy)
+	policyEgressEnabled := e.Opts.IsEnabled(config.OptionEgressPolicy)
 
 	if policyIngressEnabled && policyEgressEnabled {
 		policy = models.EndpointPolicyEnabledBoth

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 
+	"github.com/cilium/cilium/pkg/config"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/sirupsen/logrus"
 )
@@ -550,9 +551,9 @@ func (e *Endpoint) regenerateL3Policy(owner Owner, repo *policy.Repository, revi
 // IngressOrEgressIsEnforced returns true if either ingress or egress is in
 // enforcement mode or if the global policy enforcement is enabled.
 func (e *Endpoint) IngressOrEgressIsEnforced() bool {
-	return policy.GetPolicyEnabled() == AlwaysEnforce ||
-		e.Opts.IsEnabled(OptionIngressPolicy) ||
-		e.Opts.IsEnabled(OptionEgressPolicy)
+	return policy.GetPolicyEnabled() == config.AlwaysEnforce ||
+		e.Opts.IsEnabled(config.OptionIngressPolicy) ||
+		e.Opts.IsEnabled(config.OptionEgressPolicy)
 }
 
 func (e *Endpoint) updateNetworkPolicy(owner Owner) error {
@@ -722,17 +723,17 @@ func (e *Endpoint) regeneratePolicy(owner Owner, opts models.ConfigurationMap) (
 	// depends on the conntrack options
 	if c.L4Policy != nil {
 		if c.L4Policy.RequiresConntrack() {
-			opts[OptionConntrack] = optionEnabled
+			opts[config.OptionConntrack] = optionEnabled
 		}
 	}
 
 	ingress, egress := owner.EnableEndpointPolicyEnforcement(e)
 
-	opts[OptionIngressPolicy] = optionDisabled
-	opts[OptionEgressPolicy] = optionDisabled
+	opts[config.OptionIngressPolicy] = optionDisabled
+	opts[config.OptionEgressPolicy] = optionDisabled
 
 	if egress {
-		e.checkEgressAccess(owner, (*labelsMap)[identityPkg.ReservedIdentityHost], opts, OptionAllowToHost)
+		e.checkEgressAccess(owner, (*labelsMap)[identityPkg.ReservedIdentityHost], opts, config.OptionAllowToHost)
 	}
 
 	if !ingress && !egress {
@@ -740,14 +741,14 @@ func (e *Endpoint) regeneratePolicy(owner Owner, opts models.ConfigurationMap) (
 	} else {
 		if ingress && egress {
 			e.getLogger().Debug("Policy Ingress and Egress enabled")
-			opts[OptionIngressPolicy] = optionEnabled
-			opts[OptionEgressPolicy] = optionEnabled
+			opts[config.OptionIngressPolicy] = optionEnabled
+			opts[config.OptionEgressPolicy] = optionEnabled
 		} else if ingress {
 			e.getLogger().Debug("Policy Ingress enabled")
-			opts[OptionIngressPolicy] = optionEnabled
+			opts[config.OptionIngressPolicy] = optionEnabled
 		} else {
 			e.getLogger().Debug("Policy Egress enabled")
-			opts[OptionEgressPolicy] = optionEnabled
+			opts[config.OptionEgressPolicy] = optionEnabled
 		}
 	}
 
@@ -963,7 +964,7 @@ func (e *Endpoint) TriggerPolicyUpdatesLocked(owner Owner, opts models.Configura
 
 	if changed && consumersAdd != nil {
 		policyEnforced := e.IngressOrEgressIsEnforced()
-		isLocal := e.Opts.IsEnabled(OptionConntrackLocal)
+		isLocal := e.Opts.IsEnabled(config.OptionConntrackLocal)
 		ctCleaned = updateCT(owner, e, e.IPs(), policyEnforced, isLocal, consumersAdd, consumersRm)
 	}
 

--- a/pkg/endpointmanager/conntrack.go
+++ b/pkg/endpointmanager/conntrack.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/policy"
 
+	"github.com/cilium/cilium/pkg/config"
 	"github.com/sirupsen/logrus"
 )
 
@@ -106,7 +107,7 @@ func EnableConntrackGC(ipv4, ipv6 bool) {
 				// right now. We still need to traverse
 				// other EPs since some may not be part
 				// of the global CT, but have a local one.
-				isLocal := e.Opts.IsEnabled(endpoint.OptionConntrackLocal)
+				isLocal := e.Opts.IsEnabled(config.OptionConntrackLocal)
 				if isLocal == false {
 					if seenGlobal == true {
 						e.Mutex.RUnlock()

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/cilium/cilium/pkg/config"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
@@ -287,7 +288,7 @@ func HasGlobalCT() bool {
 	eps := GetEndpoints()
 	for _, e := range eps {
 		e.RLock()
-		globalCT := e.Consumable != nil && !e.Opts.IsEnabled(endpoint.OptionConntrackLocal)
+		globalCT := e.Consumable != nil && !e.Opts.IsEnabled(config.OptionConntrackLocal)
 		e.RUnlock()
 		if globalCT {
 			return true
@@ -309,9 +310,9 @@ func GetEndpoints() []*endpoint.Endpoint {
 
 // AddEndpoint takes the prepared endpoint object and starts managing it.
 func AddEndpoint(owner endpoint.Owner, ep *endpoint.Endpoint, reason string) error {
-	alwaysEnforce := policy.GetPolicyEnabled() == endpoint.AlwaysEnforce
-	ep.Opts.Set(endpoint.OptionIngressPolicy, alwaysEnforce)
-	ep.Opts.Set(endpoint.OptionEgressPolicy, alwaysEnforce)
+	alwaysEnforce := policy.GetPolicyEnabled() == config.AlwaysEnforce
+	ep.Opts.Set(config.OptionIngressPolicy, alwaysEnforce)
+	ep.Opts.Set(config.OptionEgressPolicy, alwaysEnforce)
 
 	if err := ep.CreateDirectory(); err != nil {
 		return err


### PR DESCRIPTION
Create `pkg/config`, which is used by both `pkg/endpoint` and `daemon`. Before, such values were in `pkg/endpoint`, which doesn't make sense from an organizational perspective, as both daemon and endpoint configuration use these options / configuration values.