### PR TITLE
completion: Fix race condition that can cause panic

### DIFF
--- a/pkg/completion/doc.go
+++ b/pkg/completion/doc.go
@@ -55,4 +55,12 @@
 // Wait blocks until either all Completions are completed, or the context is
 // canceled (e.g. times out), whichever happens first. The returned error is
 // non-nil in the case the context is canceled, nil otherwise.
+//
+// A Completion can also be created with a callback, which is called at most
+// once when the Completion is successfully completed before the context is
+// cancelled:
+//
+//    comp := wg.AddCompletionWithCallback(func() { fmt.Println("completed') })
+//
+// The callback is called in the goroutine which calls Complete the first time.
 package completion


### PR DESCRIPTION
If a `Completion`'s `Complete` method is called around the same time a `WaitGroup.Wait` is unblocked by a context cancelation, `Complete` may be called concurrently. This can lead to multiple closures of the same channel, which would cause a panic. Prevent this by making the `Complete` method atomic.

Don't call the completion's callback in case of context cancelation.

Unit test the completion callback logic.

Signed-off-by: Romain Lenglet <romain@covalent.io>