### PR TITLE
Ginkgo: Fix issues on AfterAll

### DIFF
--- a/test/runtime/ct.go
+++ b/test/runtime/ct.go
@@ -97,8 +97,7 @@ var _ = Describe("DisabledRuntimeValidatedConntrackTable", func() {
 
 		case helpers.Delete:
 			for _, x := range containersNames {
-				//@TODO Add assert here when #3235 is fixed
-				vm.ContainerRm(x)
+				vm.ContainerRm(x).ExpectSuccess("Container %s cannot be deleted", x)
 			}
 		}
 	}


### PR DESCRIPTION
If the describe was like:

```
var _ = Describe("Test", func() {
	AfterAll(func() {
		fmt.Println("------------AfterAll ALL-------------")
	})

	AfterEach(func() {
		fmt.Println("------------AfterEach-------------")
	})

```

The AfterAll Function will be executed two times instead of one. On the
other hand, the AfterAll function will be executed before AfterEach.
This commit fix the incorrect behaviour

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

Fixes: #3235 

