### PR TITLE
Tests: Fix issues on Kafka AfterEach

### DIFF
--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -116,7 +116,7 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 		if CurrentGinkgoTestDescription().Failed {
 			vm.ReportFailed()
 		}
-		vm.Exec("policy delete --all")
+		vm.PolicyDelAll()
 		containers("delete")
 	})
 


### PR DESCRIPTION
I saw the following error in the test logs:

```
time="2018-03-22T01:51:03Z" level=debug msg="running command: policy delete --all"
cmd: "policy delete --all" exitCode: 127
 bash: policy: command not found
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
