### PR TITLE
pkg/endpoint: return error if state change is not achievable for endpoint in PATCH/{id}/config

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -984,20 +984,20 @@ func (e *Endpoint) TriggerPolicyUpdatesLocked(owner Owner, opts models.Configura
 		return false, ctCleaned, nil
 	}
 
-	changed, consumersAdd, consumersRm, err := e.regeneratePolicy(owner, opts)
+	needToRegenerateBPF, consumersAdd, consumersRm, err := e.regeneratePolicy(owner, opts)
 	if err != nil {
 		return false, ctCleaned, fmt.Errorf("%s: %s", e.StringID(), err)
 	}
 
-	if changed && consumersAdd != nil {
+	if needToRegenerateBPF && consumersAdd != nil {
 		policyEnforced := e.IngressOrEgressIsEnforced()
 		isLocal := e.Opts.IsEnabled(OptionConntrackLocal)
 		ctCleaned = updateCT(owner, e, e.IPs(), policyEnforced, isLocal, consumersAdd, consumersRm)
 	}
 
-	e.getLogger().Debugf("TriggerPolicyUpdatesLocked: changed: %t", changed)
+	e.getLogger().Debugf("TriggerPolicyUpdatesLocked: changed: %t", needToRegenerateBPF)
 
-	return changed, ctCleaned, nil
+	return needToRegenerateBPF, ctCleaned, nil
 }
 
 func (e *Endpoint) runIdentityToK8sPodSync() {

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -237,8 +237,7 @@ func (s *SSHMeta) WaitEndpointsReady() bool {
 
 // EndpointSetConfig sets the provided configuration option to the provided
 // value for the endpoint with the endpoint ID id. It returns true if the
-// configuration update command returned successfully and if the endpoint
-// was able to regenerate successfully, false otherwise.
+// configuration update command returned successfully.
 func (s *SSHMeta) EndpointSetConfig(id, option, value string) bool {
 	logger := s.logger.WithFields(logrus.Fields{"endpointID": id})
 	res := s.ExecCilium(fmt.Sprintf(
@@ -261,7 +260,7 @@ func (s *SSHMeta) EndpointSetConfig(id, option, value string) bool {
 		return false
 	}
 
-	return s.WaitEndpointRegenerated(id)
+	return true
 }
 
 // ListEndpoints returns the CmdRes resulting from executing


### PR DESCRIPTION
If the state transition cannot be performed for the given endpoint, return an error. This exposes behavior that was hidden before, in that if we cannot apply configuration to the given endpoint whose configuration is being updated, we no longer silently fail. The CI is built to handle this behavior by waiting for an endpoint to regenerate and be in a `ready` state in `test/helpers/cilium.go:EndpointSetConfig`. 

I do not like this behavior overall, though. I think that Cilium should be able to handle this behavior gracefully and queue configuration updates / regenerations independent of the current state of an endpoint. Further information is located on the parent issue, #3058 .

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #3058 