### PR TITLE
Fix nested cmdref links in documentation

### DIFF
--- a/Documentation/cmdref/index.rst
+++ b/Documentation/cmdref/index.rst
@@ -4,7 +4,7 @@ Command Reference
 .. only:: html
 
    .. toctree::
-      :maxdepth: 1
+      :maxdepth: 0
       :glob:
 
       cilium-agent


### PR DESCRIPTION
Previously, the cli reference would assume that links within each of the CLI
cmdref markdown files would refer to subcommands as other files under
the same path, eg this URL:
  http://cilium.readthedocs.io/en/latest/cmdref/cilium/

Links under its "See also" section to this URL:
  http://cilium.readthedocs.io/en/latest/cmdref/cilium/cilium_bpf.html

However, the latter never existed so would always serve 404 errors.
Fix this by ensuring the links are referenced by the directory depth of
the cli index.

Fixes: #2733
Fixes: #3260

Signed-off-by: Joe Stringer <joe@covalent.io>