### PR TITLE
Improve sanity checking in endpoint PATCH API

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -315,7 +315,7 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 	}
 	ep.Mutex.Unlock()
 
-	if changed {
+	if ep.GetStateLocked() == endpoint.StateWaitingToRegenerate {
 		if err := ep.RegenerateWait(h.d, "Waiting on endpoint regeneration because identity is known while handling API PATCH"); err != nil {
 			return apierror.Error(PatchEndpointIDFailedCode, err)
 		}

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -240,6 +240,14 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 
 	ep.Mutex.Lock()
 
+	// The endpoint may have just been deleted since the lookup, so return
+	// that it can't be found.
+	if ep.GetStateLocked() == endpoint.StateDisconnecting ||
+		ep.GetStateLocked() == endpoint.StateDisconnected {
+		ep.Mutex.Unlock()
+		return NewPatchEndpointIDNotFound()
+	}
+
 	changed := false
 
 	if epTemplate.InterfaceIndex != 0 && ep.IfIndex != newEp.IfIndex {


### PR DESCRIPTION
Be a bit more strict about finding endpoints when attempting to fulfill a "PATCH /endpoint" request on the API; if the endpoint has recently been deleted or similar, then return an error indicating the endpoint is not found. If it is found, ensure that regeneration is only triggered if the endpoint has enough information to trigger regeneration.