### PR TITLE
CI: gather cilium-envoy.log if tests fail

### DIFF
--- a/test/config/logs.go
+++ b/test/config/logs.go
@@ -21,7 +21,7 @@ var (
 	TestLogWriter bytes.Buffer
 	// TestLogFileName is the file name to dump `TestLogWriter` content when
 	// test finish
-	TestLogFileName = "logs"
+	TestLogFileName = "test-output.log"
 )
 
 // TestLogWriterReset resets the current buffer

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -595,12 +595,13 @@ func (s *SSHMeta) GatherLogs() {
 	}
 	reportMap(testPath, ciliumLogCommands, s)
 
-	ciliumBPFStateCommands := []string{
-		fmt.Sprintf("sudo cp -r %s %s/%s/lib", RunDir, BasePath, testPath),
-		fmt.Sprintf("sudo cp -r %s %s/%s/run", LibDir, BasePath, testPath),
+	ciliumStateCommands := []string{
+		fmt.Sprintf("sudo cp %s %s", CiliumEnvoyLogPath, filepath.Join(BasePath, testPath)),
+		fmt.Sprintf("sudo cp -r %s %s", RunDir, filepath.Join(BasePath, testPath, "lib")),
+		fmt.Sprintf("sudo cp -r %s %s", LibDir, filepath.Join(BasePath, testPath, "run")),
 	}
 
-	for _, cmd := range ciliumBPFStateCommands {
+	for _, cmd := range ciliumStateCommands {
 		res := s.Exec(cmd)
 		if !res.WasSuccessful() {
 			s.logger.Errorf("cannot gather files for cmd '%s': %s", cmd, res.CombineOutput())

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -137,6 +137,9 @@ const (
 	RunDir          = "/var/run/cilium"
 	LibDir          = "/var/lib/cilium"
 
+	CiliumEnvoyLogName = "cilium-envoy.log"
+	CiliumEnvoyLogPath = "/var/log/cilium-envoy.log"
+
 	DaemonName             = "cilium"
 	CiliumDockerDaemonName = "cilium-docker"
 	AgentDaemon            = "cilium-agent"

--- a/test/helpers/docker.go
+++ b/test/helpers/docker.go
@@ -151,7 +151,7 @@ func (s *SSHMeta) GatherDockerLogs() {
 	commands := map[string]string{}
 	for _, k := range res.ByLines() {
 		key := fmt.Sprintf("docker logs %s", k)
-		commands[key] = fmt.Sprintf("container_%s.logs", k)
+		commands[key] = fmt.Sprintf("container_%s.log", k)
 	}
 
 	testPath, err := CreateReportDirectory()

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -849,6 +849,14 @@ func (kub *Kubectl) DumpCiliumCommandOutput(namespace string) {
 		} else {
 			log.Errorf("%s failed: %s", bugtoolCmd, res.CombineOutput().String())
 		}
+
+		// Copy Cilium envoy logs. Since the logs are in the pod's filesystem,
+		// copy them over with `kubectl cp`.
+		ciliumEnvoyLogCmd := fmt.Sprintf("kubectl cp %s/%s:%s %s", namespace, pod, CiliumEnvoyLogPath, filepath.Join(BasePath, testPath, CiliumEnvoyLogName))
+		res = kub.Exec(ciliumEnvoyLogCmd)
+		if !res.WasSuccessful() {
+			log.Errorf("%s failed: %s", ciliumEnvoyLogCmd, res.CombineOutput().String())
+		}
 	}
 
 	pods, err := kub.GetCiliumPods(namespace)


### PR DESCRIPTION
Copy this file in Runtime & K8s tests to the folder which is archived with each Jenkins job.
Also standardize some file names for other log files.

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #3233 