### PR TITLE
test/helpers: change order of checking for deadlock / panic

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -500,9 +500,9 @@ func (s *SSHMeta) PolicyWait(revisionNum int) *CmdRes {
 	return s.ExecCilium(fmt.Sprintf("policy wait %d", revisionNum))
 }
 
-// ReportFailed gathers relevant Cilium runtime data and logs for debugging
+// CiliumReport gathers relevant Cilium runtime data and logs for debugging
 // purposes.
-func (s *SSHMeta) ReportFailed(commands ...string) {
+func (s *SSHMeta) CiliumReport(commands ...string) {
 	wr := s.logger.Logger.Out
 	fmt.Fprint(wr, "===================== TEST FAILED =====================\n")
 	fmt.Fprint(wr, "Gathering Logs and Cilium CLI Output\n")

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -528,11 +528,11 @@ func (s *SSHMeta) ReportFailed(commands ...string) {
 	fmt.Fprint(wr, "===================== EXITING REPORT GENERATION =====================\n")
 }
 
-// ValidateNoErrorsOnLogs checks in cilium logs since the given duration (By
+// ValidateNoErrorsInLogs checks in cilium logs since the given duration (By
 // default `CurrentGinkgoTestDescription().Duration`) do not contain `panic` or
 // `deadlocks` messages . In case of any of these messages, it'll mark the test
 // as failed.
-func (s *SSHMeta) ValidateNoErrorsOnLogs(duration time.Duration) {
+func (s *SSHMeta) ValidateNoErrorsInLogs(duration time.Duration) {
 	logsCmd := fmt.Sprintf(`sudo journalctl -au %s --since '%v seconds ago'`,
 		DaemonName, duration.Seconds())
 	logs := s.Exec(logsCmd).Output().String()

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -778,11 +778,11 @@ func (kub *Kubectl) CiliumReport(namespace string, pod string, commands ...[]str
 
 }
 
-// ValidateNoErrorsOnLogs checks in cilium logs since the given duration (By
+// ValidateNoErrorsInLogs checks in cilium logs since the given duration (By
 // default `CurrentGinkgoTestDescription().Duration`) do not contain `panic` or
 // `deadlocks` messages. In case of any of these messages, it'll mark the test
 // as failed.
-func (kub *Kubectl) ValidateNoErrorsOnLogs(duration time.Duration) {
+func (kub *Kubectl) ValidateNoErrorsInLogs(duration time.Duration) {
 	cmd := fmt.Sprintf("%s -n %s logs --timestamps=true -l k8s-app=cilium --since=%vs",
 		KubectlCmd, KubeSystemNamespace, duration.Seconds())
 	res := kub.Exec(fmt.Sprintf("%s --previous", cmd))

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -61,7 +61,6 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 	})
 
 	AfterEach(func() {
-		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			ciliumPod, _ := kubectl.GetCiliumPodOnNode(
 				helpers.KubeSystemNamespace, helpers.K8s1VMName())
@@ -69,7 +68,7 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 				"cilium service list",
 				"cilium endpoint list"})
 		}
-
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		kubectl.Delete(demoDSPath).ExpectSuccess(
 			"%s deployment cannot be deleted", demoDSPath)
 		err := kubectl.WaitCleanAllTerminatingPods()

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -61,13 +61,11 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(
-				helpers.KubeSystemNamespace, helpers.K8s1VMName())
-			kubectl.CiliumReport("kube-system", ciliumPod, []string{
-				"cilium service list",
-				"cilium endpoint list"})
-		}
+		ciliumPod, _ := kubectl.GetCiliumPodOnNode(
+			helpers.KubeSystemNamespace, helpers.K8s1VMName())
+		kubectl.CiliumReport("kube-system", ciliumPod, []string{
+			"cilium service list",
+			"cilium endpoint list"})
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		kubectl.Delete(demoDSPath).ExpectSuccess(
 			"%s deployment cannot be deleted", demoDSPath)

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -48,13 +48,11 @@ var _ = Describe(testName, func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode("kube-system", "k8s1")
-			kubectl.CiliumReport("kube-system", ciliumPod, []string{
-				"cilium service list",
-				"cilium endpoint list",
-				"cilium policy get"})
-		}
+		ciliumPod, _ := kubectl.GetCiliumPodOnNode("kube-system", "k8s1")
+		kubectl.CiliumReport("kube-system", ciliumPod, []string{
+			"cilium service list",
+			"cilium endpoint list",
+			"cilium policy get"})
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		err := kubectl.WaitCleanAllTerminatingPods()
 		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -48,7 +48,6 @@ var _ = Describe(testName, func() {
 	})
 
 	AfterEach(func() {
-		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			ciliumPod, _ := kubectl.GetCiliumPodOnNode("kube-system", "k8s1")
 			kubectl.CiliumReport("kube-system", ciliumPod, []string{
@@ -56,6 +55,7 @@ var _ = Describe(testName, func() {
 				"cilium endpoint list",
 				"cilium policy get"})
 		}
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		err := kubectl.WaitCleanAllTerminatingPods()
 		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
 	})

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -95,7 +95,6 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 	})
 
 	AfterEach(func() {
-		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
 			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
@@ -104,7 +103,7 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 				"cilium service list",
 				"cilium policy get"})
 		}
-
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		By("Deleting demo path")
 		kubectl.Delete(demoPath)
 		err := kubectl.WaitCleanAllTerminatingPods()

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -95,14 +95,12 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
-				"cilium bpf tunnel list",
-				"cilium endpoint list",
-				"cilium service list",
-				"cilium policy get"})
-		}
+		ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
+		kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
+			"cilium bpf tunnel list",
+			"cilium endpoint list",
+			"cilium service list",
+			"cilium policy get"})
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		By("Deleting demo path")
 		kubectl.Delete(demoPath)

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -80,13 +80,13 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 	})
 
 	AfterEach(func() {
-		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
 			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
 				"cilium service list",
 				"cilium endpoint list"})
 		}
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		err := kubectl.WaitCleanAllTerminatingPods()
 		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
 
@@ -292,7 +292,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 		}
 
 		It("Test TCP Keepalive with L7 Policy", func() {
-			kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 			manifest := kubectl.ManifestGet(netcatDsManifest)
 			kubectl.Apply(manifest).ExpectSuccess("Cannot apply netcat ds")
 			defer kubectl.Delete(manifest)
@@ -350,13 +350,13 @@ var _ = Describe("NightlyExamples", func() {
 	})
 
 	AfterEach(func() {
-		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
 			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
 				"cilium service list",
 				"cilium endpoint list"})
 		}
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 
 		kubectl.Delete(demoPath)
 		kubectl.Delete(l3Policy)

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -80,12 +80,10 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
-				"cilium service list",
-				"cilium endpoint list"})
-		}
+		ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
+		kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
+			"cilium service list",
+			"cilium endpoint list"})
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		err := kubectl.WaitCleanAllTerminatingPods()
 		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
@@ -350,12 +348,10 @@ var _ = Describe("NightlyExamples", func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
-				"cilium service list",
-				"cilium endpoint list"})
-		}
+		ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
+		kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
+			"cilium service list",
+			"cilium endpoint list"})
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 
 		kubectl.Delete(demoPath)

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -81,12 +81,10 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
-				"cilium bpf tunnel list",
-				"cilium endpoint list"})
-		}
+		ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
+		kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
+			"cilium bpf tunnel list",
+			"cilium endpoint list"})
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		err := kubectl.WaitCleanAllTerminatingPods()
 		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
@@ -630,12 +628,10 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 			err := kubectl.CoreV1().Namespaces().Delete(namespace, &metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			if CurrentGinkgoTestDescription().Failed {
-				ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
-				kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
-					"cilium policy get",
-					"cilium endpoint list"})
-			}
+			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
+			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
+				"cilium policy get",
+				"cilium endpoint list"})
 		})
 
 		It("should enforce policy based on NamespaceSelector", func() {
@@ -720,12 +716,10 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
-				"cilium bpf tunnel list",
-				"cilium endpoint list"})
-		}
+		ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
+		kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
+			"cilium bpf tunnel list",
+			"cilium endpoint list"})
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 
 		namespaceAction(qaNs, helpers.Delete)

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -81,13 +81,13 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 	})
 
 	AfterEach(func() {
-		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
 			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
 				"cilium bpf tunnel list",
 				"cilium endpoint list"})
 		}
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		err := kubectl.WaitCleanAllTerminatingPods()
 		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
 	})
@@ -720,13 +720,13 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 	})
 
 	AfterEach(func() {
-		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
 			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
 				"cilium bpf tunnel list",
 				"cilium endpoint list"})
 		}
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 
 		namespaceAction(qaNs, helpers.Delete)
 		namespaceAction(developmentNs, helpers.Delete)

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -45,7 +45,6 @@ var _ = Describe("NightlyPolicies", func() {
 	})
 
 	AfterEach(func() {
-		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, "k8s1")
 			kubectl.CiliumReport("kube-system", ciliumPod, []string{
@@ -53,6 +52,7 @@ var _ = Describe("NightlyPolicies", func() {
 				"cilium endpoint list",
 				"cilium service list"})
 		}
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		err := kubectl.WaitCleanAllTerminatingPods()
 		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
 	})

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -45,13 +45,11 @@ var _ = Describe("NightlyPolicies", func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, "k8s1")
-			kubectl.CiliumReport("kube-system", ciliumPod, []string{
-				"cilium policy get",
-				"cilium endpoint list",
-				"cilium service list"})
-		}
+		ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, "k8s1")
+		kubectl.CiliumReport("kube-system", ciliumPod, []string{
+			"cilium policy get",
+			"cilium endpoint list",
+			"cilium service list"})
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		err := kubectl.WaitCleanAllTerminatingPods()
 		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -61,13 +61,11 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode("kube-system", "k8s1")
-			kubectl.CiliumReport("kube-system", ciliumPod, []string{
-				"cilium service list",
-				"cilium endpoint list",
-				"cilium policy get"})
-		}
+		ciliumPod, _ := kubectl.GetCiliumPodOnNode("kube-system", "k8s1")
+		kubectl.CiliumReport("kube-system", ciliumPod, []string{
+			"cilium service list",
+			"cilium endpoint list",
+			"cilium policy get"})
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		err := kubectl.WaitCleanAllTerminatingPods()
 		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -61,7 +61,6 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 	})
 
 	AfterEach(func() {
-		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			ciliumPod, _ := kubectl.GetCiliumPodOnNode("kube-system", "k8s1")
 			kubectl.CiliumReport("kube-system", ciliumPod, []string{
@@ -69,6 +68,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 				"cilium endpoint list",
 				"cilium policy get"})
 		}
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		err := kubectl.WaitCleanAllTerminatingPods()
 		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
 	})

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -52,12 +52,10 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 	}, 600)
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
-				"cilium bpf tunnel list",
-				"cilium endpoint list"})
-		}
+		ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
+		kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
+			"cilium bpf tunnel list",
+			"cilium endpoint list"})
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		kubectl.Delete(demoDSPath)
 		err := kubectl.WaitCleanAllTerminatingPods()

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -52,14 +52,13 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 	}, 600)
 
 	AfterEach(func() {
-		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
 			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
 				"cilium bpf tunnel list",
 				"cilium endpoint list"})
 		}
-
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		kubectl.Delete(demoDSPath)
 		err := kubectl.WaitCleanAllTerminatingPods()
 		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -46,12 +46,10 @@ var _ = Describe("K8sValidatedUpdates", func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(
-				helpers.KubeSystemNamespace, helpers.K8s1VMName())
-			kubectl.CiliumReport("kube-system", ciliumPod, []string{
-				"cilium endpoint list"})
-		}
+		ciliumPod, _ := kubectl.GetCiliumPodOnNode(
+			helpers.KubeSystemNamespace, helpers.K8s1VMName())
+		kubectl.CiliumReport("kube-system", ciliumPod, []string{
+			"cilium endpoint list"})
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		//This policies maybe are not loaded, (Test failed before) so no assert here.
 		kubectl.Delete(l7Policy)

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -46,14 +46,13 @@ var _ = Describe("K8sValidatedUpdates", func() {
 	})
 
 	AfterEach(func() {
-		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			ciliumPod, _ := kubectl.GetCiliumPodOnNode(
 				helpers.KubeSystemNamespace, helpers.K8s1VMName())
 			kubectl.CiliumReport("kube-system", ciliumPod, []string{
 				"cilium endpoint list"})
 		}
-
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		//This policies maybe are not loaded, (Test failed before) so no assert here.
 		kubectl.Delete(l7Policy)
 		kubectl.Delete(l3Policy)

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -77,12 +77,11 @@ var _ = Describe(demoTestName, func() {
 	})
 
 	AfterEach(func() {
-		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
 			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod)
 		}
-
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		By("Deleting all resources created during test")
 		kubectl.Delete(l7PolicyYAMLLink)
 		kubectl.Delete(l4PolicyYAMLLink)

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -77,10 +77,8 @@ var _ = Describe(demoTestName, func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod)
-		}
+		ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
+		kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod)
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		By("Deleting all resources created during test")
 		kubectl.Delete(l7PolicyYAMLLink)

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -75,11 +75,10 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 	})
 
 	AfterEach(func() {
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-
 		if CurrentGinkgoTestDescription().Failed {
 			vm.ReportFailed()
 		}
+		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})
 
 	Context("Policy Enforcement Default", func() {
@@ -426,11 +425,10 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 	})
 
 	AfterEach(func() {
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-
 		if CurrentGinkgoTestDescription().Failed {
 			vm.ReportFailed()
 		}
+		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		vm.PolicyDelAll().ExpectSuccess("Unable to delete all policies")
 	})
 
@@ -1000,11 +998,10 @@ var _ = Describe("RuntimeValidatedPolicyImportTests", func() {
 	})
 
 	AfterEach(func() {
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			vm.ReportFailed()
 		}
-
+		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		vm.SampleContainersActions(helpers.Delete, helpers.CiliumDockerNetwork)
 		allEndpointsDeleted := vm.WaitEndpointsDeleted()
 		Expect(allEndpointsDeleted).Should(BeTrue(), "Not all endpoints were able to be deleted")

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -76,7 +76,7 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 
 	AfterEach(func() {
 		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed()
+			vm.CiliumReport()
 		}
 		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})
@@ -425,9 +425,7 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed()
-		}
+		vm.CiliumReport()
 		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		vm.PolicyDelAll().ExpectSuccess("Unable to delete all policies")
 	})
@@ -998,9 +996,7 @@ var _ = Describe("RuntimeValidatedPolicyImportTests", func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed()
-		}
+		vm.CiliumReport()
 		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		vm.SampleContainersActions(helpers.Delete, helpers.CiliumDockerNetwork)
 		allEndpointsDeleted := vm.WaitEndpointsDeleted()

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -47,10 +47,11 @@ var _ = Describe("RuntimeValidatedChaos", func() {
 	})
 
 	AfterEach(func() {
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			vm.ReportFailed()
 		}
+		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+
 		vm.ContainerRm(helpers.Client)
 		vm.ContainerRm(helpers.Server)
 	})

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -47,9 +47,7 @@ var _ = Describe("RuntimeValidatedChaos", func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed()
-		}
+		vm.CiliumReport()
 		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 
 		vm.ContainerRm(helpers.Client)

--- a/test/runtime/cli.go
+++ b/test/runtime/cli.go
@@ -47,9 +47,7 @@ var _ = Describe("RuntimeValidatedCLI", func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed("cilium endpoint list")
-		}
+		vm.CiliumReport("cilium endpoint list")
 		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})
 

--- a/test/runtime/cli.go
+++ b/test/runtime/cli.go
@@ -47,10 +47,10 @@ var _ = Describe("RuntimeValidatedCLI", func() {
 	})
 
 	AfterEach(func() {
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			vm.ReportFailed("cilium endpoint list")
 		}
+		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})
 
 	Context("Identity CLI testing", func() {

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -38,9 +38,7 @@ var _ = Describe("RuntimeValidatedConnectivityTest", func() {
 	}
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed()
-		}
+		vm.CiliumReport()
 		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		vm.PolicyDelAll().ExpectSuccess("Policies cannot be deleted")
 		return
@@ -486,9 +484,7 @@ var _ = Describe("RuntimeValidatedConntrackTest", func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed()
-		}
+		vm.CiliumReport()
 		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		containersToRm := []string{helpers.Client, helpers.Server, helpers.Httpd1, helpers.Httpd2, curl1ContainerName, curl2ContainerName}
 		for _, containerToRm := range containersToRm {

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -38,10 +38,10 @@ var _ = Describe("RuntimeValidatedConnectivityTest", func() {
 	}
 
 	AfterEach(func() {
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			vm.ReportFailed()
 		}
+		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		vm.PolicyDelAll().ExpectSuccess("Policies cannot be deleted")
 		return
 	})
@@ -486,11 +486,10 @@ var _ = Describe("RuntimeValidatedConntrackTest", func() {
 	})
 
 	AfterEach(func() {
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			vm.ReportFailed()
 		}
-
+		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		containersToRm := []string{helpers.Client, helpers.Server, helpers.Httpd1, helpers.Httpd2, curl1ContainerName, curl2ContainerName}
 		for _, containerToRm := range containersToRm {
 			vm.ContainerRm(containerToRm)

--- a/test/runtime/ct.go
+++ b/test/runtime/ct.go
@@ -134,13 +134,12 @@ var _ = Describe("DisabledRuntimeValidatedConntrackTable", func() {
 	})
 
 	AfterEach(func() {
-
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			vm.ReportFailed(
 				"sudo cilium bpf ct list global",
 				"sudo cilium endpoint list")
 		}
+		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		vm.PolicyDelAll()
 		netcatPort = 11111
 

--- a/test/runtime/ct.go
+++ b/test/runtime/ct.go
@@ -134,11 +134,9 @@ var _ = Describe("DisabledRuntimeValidatedConntrackTable", func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed(
-				"sudo cilium bpf ct list global",
-				"sudo cilium endpoint list")
-		}
+		vm.CiliumReport(
+			"sudo cilium bpf ct list global",
+			"sudo cilium endpoint list")
 		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		vm.PolicyDelAll()
 		netcatPort = 11111

--- a/test/runtime/examples.go
+++ b/test/runtime/examples.go
@@ -44,9 +44,7 @@ var _ = Describe("RuntimeValidatedPolicyValidationTests", func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed()
-		}
+		vm.CiliumReport()
 		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})
 

--- a/test/runtime/examples.go
+++ b/test/runtime/examples.go
@@ -44,11 +44,10 @@ var _ = Describe("RuntimeValidatedPolicyValidationTests", func() {
 	})
 
 	AfterEach(func() {
-
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			vm.ReportFailed()
 		}
+		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})
 
 	It("Validates Example Policies", func() {

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -116,9 +116,7 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed()
-		}
+		vm.CiliumReport()
 		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		vm.PolicyDelAll()
 		containers("delete")

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -116,10 +116,10 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 	})
 
 	AfterEach(func() {
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			vm.ReportFailed()
 		}
+		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		vm.PolicyDelAll()
 		containers("delete")
 	})

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -54,12 +54,12 @@ var _ = Describe("RuntimeValidatedKVStoreTest", func() {
 	}, 150)
 
 	AfterEach(func() {
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			vm.ReportFailed(
 				"sudo docker ps -a",
 				"sudo cilium endpoint list")
 		}
+		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		containers(helpers.Delete)
 		vm.Exec("sudo systemctl start cilium")
 	})

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -54,11 +54,9 @@ var _ = Describe("RuntimeValidatedKVStoreTest", func() {
 	}, 150)
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed(
-				"sudo docker ps -a",
-				"sudo cilium endpoint list")
-		}
+		vm.CiliumReport(
+			"sudo docker ps -a",
+			"sudo cilium endpoint list")
 		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		containers(helpers.Delete)
 		vm.Exec("sudo systemctl start cilium")

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -68,13 +68,12 @@ var _ = Describe("RuntimeValidatedLB", func() {
 	}, 500)
 
 	AfterEach(func() {
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-
 		if CurrentGinkgoTestDescription().Failed {
 			vm.ReportFailed(
 				"sudo cilium service list",
 				"sudo cilium endpoint list")
 		}
+		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		cleanupLBDevice(vm)
 	}, 500)
 

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -68,11 +68,10 @@ var _ = Describe("RuntimeValidatedLB", func() {
 	}, 500)
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed(
-				"sudo cilium service list",
-				"sudo cilium endpoint list")
-		}
+		vm.CiliumReport(
+			"sudo cilium service list",
+			"sudo cilium endpoint list")
+
 		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		cleanupLBDevice(vm)
 	}, 500)

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -55,10 +55,10 @@ var _ = Describe("RuntimeValidatedMonitorTest", func() {
 	})
 
 	AfterEach(func() {
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
 			vm.ReportFailed()
 		}
+		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})
 
 	BeforeEach(func() {

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -55,9 +55,7 @@ var _ = Describe("RuntimeValidatedMonitorTest", func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed()
-		}
+		vm.CiliumReport()
 		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})
 


### PR DESCRIPTION
* Rename ValidateNoErrorsOnLogs --> ValidateNoErrorsInLogs, which is
grammatically correct for kubectl and cilium helpers.
* Move calls to `ValidateNoErrorsInLogs()` to be after check for
`if CurrentGinkgoTestDescription().Failed` as `ValidateNoErrorsInLogs` makes
assertions and fails the tests. If ran before we gather logs, the test framework
will exit.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #3243 