### PR TITLE
docs: Fix generated links for latest

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -65,7 +65,7 @@ author = u'Cilium Authors'
 release = open("../VERSION", "r").read().strip()
 
 # Asume the current branch is master but check with VERSION file.
-branch = subprocess.check_output("git symbolic-ref -q --short HEAD || git describe --tags --exact-match", shell=True)
+branch = subprocess.check_output("git describe --tags --exact-match 2>/dev/null || git rev-parse --abbrev-ref HEAD", shell=True)
 githubusercontent = 'https://raw.githubusercontent.com/cilium/cilium/'
 scm_web = githubusercontent + branch
 


### PR DESCRIPTION
Commit 369eb2a464c5 ("Documentation: Fix generated links when
documentation is built from tags") fixed readthedocs generation for
tagged releases, but inadvertently broke them for the latest release.
Add back the previous command as a last resort instead, to hopefully fix
the latest and keep versioned docs builds working.

Related: #3128 

Signed-off-by: Joe Stringer <joe@covalent.io>