### PR TITLE
pkg/ipcache: fix deletion of entries from ipcache when event received from kvstore

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -717,10 +717,10 @@ func (d *Daemon) OnIPIdentityCacheChange(modType ipcache.CacheModification, ipID
 
 	// Update BPF Maps.
 	key := ipCacheBPF.NewEndpointKey(ipIDPair.IP)
-	value := ipCacheBPF.RemoteEndpointInfo{SecurityIdentity: uint16(ipIDPair.ID)}
 
 	switch modType {
 	case ipcache.Upsert:
+		value := ipCacheBPF.RemoteEndpointInfo{SecurityIdentity: uint16(ipIDPair.ID)}
 		err := ipCacheBPF.IPCache.Update(key, value)
 		if err != nil {
 			log.WithError(err).WithFields(logrus.Fields{"key": key.String(),

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -16,8 +16,11 @@ package ipcache
 
 import (
 	"encoding/json"
+	"fmt"
+	"net"
 	"path"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/cilium/cilium/pkg/envoy"
@@ -189,6 +192,22 @@ const (
 	Delete CacheModification = "Delete"
 )
 
+func keyToIP(key string) (net.IP, error) {
+	requiredPrefix := fmt.Sprintf("%s/", path.Join(IPIdentitiesPath, AddressSpace))
+	if !strings.HasPrefix(key, requiredPrefix) {
+		return nil, fmt.Errorf("Found invalid key %s outside of prefix %s", key, IPIdentitiesPath)
+	}
+
+	suffix := strings.TrimPrefix(key, requiredPrefix)
+
+	parsedIP := net.ParseIP(suffix)
+	if parsedIP == nil {
+		return nil, fmt.Errorf("unable to parse IP from suffix %s", suffix)
+	}
+
+	return parsedIP, nil
+}
+
 func ipIdentityWatcher(owner IPIdentityMappingOwner) {
 
 	for {
@@ -198,34 +217,36 @@ func ipIdentityWatcher(owner IPIdentityMappingOwner) {
 		// Get events from channel as they come in.
 		for event := range watcher.Events {
 
+			scopedLog := log.WithFields(logrus.Fields{"kvstore-event": event.Typ.String(), "key": event.Key})
+			scopedLog.Debug("received event")
+
 			var (
 				cacheChanged      bool
 				cacheModification CacheModification
 				ipIDPair          identity.IPIdentityPair
+				cachedIdentity    identity.NumericIdentity
 			)
 
-			// Key and value are empty for ListDone event types, so just continue.
-			// See GH-3159.
+			// Key and value are empty for ListDone event types; do not try
+			// to unmarshal key or value.
 			if event.Typ == kvstore.EventTypeListDone {
 				owner.OnIPIdentityCacheGC()
 				continue
 			}
 
-			err := json.Unmarshal(event.Value, &ipIDPair)
-			if err != nil {
-				log.WithFields(logrus.Fields{"key": event.Key, "value": event.Value}).WithError(err).Errorf("not adding entry to ip cache; error unmarshaling data from key-value store")
-				continue
-			}
-
-			// Synchronize local caching of endpoint IP to ipIDPair mapping with
-			// operation key-value store has informed us about.
-
-			ipStr := ipIDPair.IP.String()
-
-			cachedIdentity, exists := IPIdentityCache.LookupByIP(ipStr)
-
 			switch event.Typ {
 			case kvstore.EventTypeCreate, kvstore.EventTypeModify:
+
+				err := json.Unmarshal(event.Value, &ipIDPair)
+				if err != nil {
+					scopedLog.WithError(err).Errorf("not adding entry to ip cache; error unmarshaling data from key-value store")
+					continue
+				}
+
+				ipStr := ipIDPair.IP.String()
+
+				cachedIdentity, exists := IPIdentityCache.LookupByIP(ipStr)
+
 				if !exists || cachedIdentity != ipIDPair.ID {
 					IPIdentityCache.upsert(ipStr, ipIDPair.ID)
 					cacheChanged = true
@@ -242,16 +263,40 @@ func ipIdentityWatcher(owner IPIdentityMappingOwner) {
 					envoy.NetworkPolicyHostsCache.Upsert(envoy.NetworkPolicyHostsTypeURL, ipIDPair.ID.StringID(), &envoyAPI.NetworkPolicyHosts{Policy: uint64(ipIDPair.ID), HostAddresses: ipStrings}, false)
 				}
 			case kvstore.EventTypeDelete:
+				// Synchronize local caching of endpoint IP to ipIDPair mapping with
+				// operation key-value store has informed us about.
+
+				convertedKey, err := keyToIP(event.Key)
+
+				// Value is not present in deletion event; need to convert key
+				// to IP.
+				if err != nil {
+					scopedLog.Error("error parsing IP from key: %s", err)
+					continue
+				}
+
+				ipIDPair.IP = convertedKey
+				ipStr := convertedKey.String()
+
+				cachedIdentity, exists := IPIdentityCache.LookupByIP(ipStr)
+
 				if exists {
+
+					// Perform lookup first to get list of identities.
+					identityToDelete, _ := IPIdentityCache.LookupByIP(ipStr)
+					ipIDPair.ID = identityToDelete
+
+					endpointIPs, exists := IPIdentityCache.LookupByIdentity(identityToDelete)
+
 					IPIdentityCache.delete(ipStr)
 					cacheChanged = true
 					cacheModification = Delete
 
-					endpointIPs, exists := IPIdentityCache.LookupByIdentity(ipIDPair.ID)
 					if !exists {
 						// Delete from XDS Cache as well.
 						envoy.NetworkPolicyHostsCache.Delete(envoy.NetworkPolicyHostsTypeURL, cachedIdentity.StringID(), false)
 					} else {
+						// Update list in XDS cache without this ip.
 
 						// TODO (factor this out into a helper function).
 						ipStrings := make([]string, 0, len(endpointIPs))
@@ -259,7 +304,7 @@ func ipIdentityWatcher(owner IPIdentityMappingOwner) {
 							ipStrings = append(ipStrings, endpointIP)
 						}
 						sort.Strings(ipStrings)
-						envoy.NetworkPolicyHostsCache.Upsert(envoy.NetworkPolicyHostsTypeURL, ipIDPair.ID.StringID(), &envoyAPI.NetworkPolicyHosts{Policy: uint64(ipIDPair.ID), HostAddresses: ipStrings}, false)
+						envoy.NetworkPolicyHostsCache.Upsert(envoy.NetworkPolicyHostsTypeURL, identityToDelete.StringID(), &envoyAPI.NetworkPolicyHosts{Policy: uint64(identityToDelete), HostAddresses: ipStrings}, false)
 					}
 				}
 			}


### PR DESCRIPTION
The value is only populated for create events; for delete events, it is not
populated. Thus, added a new function which extracts the IP from the key; this
is similar to what is done for `pkg/kvstore/allocator`. Add unit tests for this
conversion as well.

Also do the following:

* Update code-comment for EventTypeListDone to be more accurate.
* Add event type to log message were we cannot unmarshal data from the key-value store.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #3206 