### PR TITLE
Update kafka zookeeper session timeout to 20 sec in CI tests and docs

### DIFF
--- a/examples/kubernetes-kafka/kafka-sw-app.yaml
+++ b/examples/kubernetes-kafka/kafka-sw-app.yaml
@@ -24,6 +24,8 @@ spec:
           value: "1"
         - name: KAFKA_CREATE_TOPICS
           value: "empire-announce:1:1,deathstar-plans:1:1"
+        - name: KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS
+          value: "20000"
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/test/k8sT/manifests/kafka-sw-app.yaml
+++ b/test/k8sT/manifests/kafka-sw-app.yaml
@@ -24,6 +24,8 @@ spec:
           value: "1"
         - name: KAFKA_CREATE_TOPICS
           value: "empire-announce:1:1,deathstar-plans:1:1"
+        - name: KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS
+          value: "20000"
       nodeSelector:
         "kubernetes.io/hostname": k8s1
 ---

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -62,7 +62,7 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 			Expect(err).Should(BeNil())
 
 			vm.ContainerCreate("kafka", "wurstmeister/kafka", helpers.CiliumDockerNetwork, fmt.Sprintf(
-				"-l id.kafka -e KAFKA_ZOOKEEPER_CONNECT=%s:2181 ", zook["IPv4"]))
+				"-l id.kafka -e KAFKA_ZOOKEEPER_CONNECT=%s:2181 -e KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS=20000", zook["IPv4"]))
 
 		case "delete":
 			for k := range images {


### PR DESCRIPTION
Update kafka zookeeper session timeout to 20 sec in CI tests and docs
    
  Fixes: #3286
  Signed-Off-By: Manali Bhutiyani <manali@covalent.io>
```release-note
Update kafka zookeeper session timeout to 20 sec in CI tests and docs
```