### PR TITLE
Use alpine as base image for Docs container

### DIFF
--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -1,18 +1,24 @@
-# Container for making it easier to build the documentation via Docker.
-FROM ubuntu:16.04
+FROM alpine:3.7
+
+LABEL "author"="Cilium"
+
 ENV DOCS_DIR=/srv/Documentation
 ENV API_DIR=/srv/api
 
 ADD Documentation/requirements.txt $DOCS_DIR/requirements.txt
 
-RUN apt-get update && \
-      apt-get install -y git make python-sphinx python-pip \
-      # PDF dependencies use a lot of space, left here for others.
-      # latexmk texlive-latex-extra
-      && apt-get clean && \
-      pip install --upgrade pip && \
-      pip install -r $DOCS_DIR/requirements.txt && \
-      rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ENV PACKAGES="\
+    bash \
+    ca-certificates \
+    make \
+    git \
+    python \
+    py-pip \
+    sphinx-python \
+"
+RUN apk add --no-cache --virtual --update $PACKAGES && \
+    pip install --upgrade pip && \
+    pip install -r $DOCS_DIR/requirements.txt
 
 WORKDIR $DOCS_DIR
 ADD api $API_DIR

--- a/Makefile
+++ b/Makefile
@@ -248,12 +248,12 @@ update-authors:
 docs-container:
 	grep -v -E "(SOURCE|GIT)_VERSION" .gitignore >.dockerignore
 	echo ".*" >>.dockerignore # .git pruned out
-	docker build -t cilium/docs-builder -f Documentation/Dockerfile .
+	docker image build -t cilium/docs-builder -f Documentation/Dockerfile .
 
 render-docs: docs-container
-	-docker rm -f docs-cilium >/dev/null
-	docker run -ti -u $$(id -u):$$(id -g $(USER)) -v $$(pwd):/srv/ cilium/docs-builder /bin/bash -c 'make html' && \
-	docker run -dit --name docs-cilium -p 8080:80 -v $$(pwd)/Documentation/_build/html/:/usr/local/apache2/htdocs/ httpd:2.4
+	-docker container rm -f docs-cilium >/dev/null
+	docker container run -ti -u $$(id -u):$$(id -g $(USER)) -v $$(pwd):/srv/ cilium/docs-builder /bin/bash -c 'make html' && \
+	docker container run -dit --name docs-cilium -p 8080:80 -v $$(pwd)/Documentation/_build/html/:/usr/local/apache2/htdocs/ httpd:2.4
 	@echo "$$(tput setaf 2)Running at http://localhost:8080$$(tput sgr0)"
 
 manpages:


### PR DESCRIPTION
1. Modify Docs Dockerfile to use alpine.
2. Modify Makefile to use newer docker cli commands.

Signed-off-by: Shantanu Deshpande <shantanud106@gmail.com>

**Summary of changes**:

Fixes: #3276 


**How to test**:

Run `make render-docs`
