### PR TITLE
CI: run cilium-docker in debug mode by default in CI

### DIFF
--- a/contrib/systemd/cilium-docker.service
+++ b/contrib/systemd/cilium-docker.service
@@ -7,7 +7,7 @@ Requires=docker.service
 Environment=INITSYSTEM=SYSTEMD
 Type=simple
 ExecStartPre=-/usr/bin/killall -9 cilium-docker
-ExecStart=/usr/bin/cilium-docker
+ExecStart=/usr/bin/cilium-docker --debug
 Restart=on-failure
 
 [Install]

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -579,12 +579,12 @@ func (s *SSHMeta) DumpCiliumCommandOutput() {
 // to the directory testResultsPath
 func (s *SSHMeta) GatherLogs() {
 	ciliumLogCommands := map[string]string{
-		fmt.Sprintf("sudo journalctl -au %s --no-pager", DaemonName):                "cilium.log",
-		fmt.Sprintf("sudo journalctl -xe -u %s --no-pager", CiliumDockerDaemonName): "cilium-docker.log",
-		"sudo docker logs cilium-consul":                                            "consul.log",
-		fmt.Sprintf(`sudo bash -c "gops memstats $(pgrep %s)"`, AgentDaemon):        "gops_memstats.txt",
-		fmt.Sprintf(`sudo bash -c "gops stack $(pgrep %s)"`, AgentDaemon):           "gops_stack.txt",
-		fmt.Sprintf(`sudo bash -c "gops stats $(pgrep %s)"`, AgentDaemon):           "gops_stats.txt",
+		fmt.Sprintf("sudo journalctl -au %s --no-pager", DaemonName):             "cilium.log",
+		fmt.Sprintf("sudo journalctl -au %s --no-pager", CiliumDockerDaemonName): "cilium-docker.log",
+		"sudo docker logs cilium-consul":                                         "consul.log",
+		fmt.Sprintf(`sudo bash -c "gops memstats $(pgrep %s)"`, AgentDaemon):     "gops_memstats.txt",
+		fmt.Sprintf(`sudo bash -c "gops stack $(pgrep %s)"`, AgentDaemon):        "gops_stack.txt",
+		fmt.Sprintf(`sudo bash -c "gops stats $(pgrep %s)"`, AgentDaemon):        "gops_stats.txt",
 	}
 
 	testPath, err := CreateReportDirectory()


### PR DESCRIPTION
* Change log-gathering command for `cilium-docker`.
* Add "--debug" to `cilium-docker` service file to have it run in debug mode by default.

Signed-off by: Ian Vernon <ian@cilium.io>

Relates-to: #3233