### PR TITLE
Update CI and docs : kafka zookeeper connection timeout to 20 sec

### DIFF
--- a/examples/kubernetes-kafka/kafka-sw-app.yaml
+++ b/examples/kubernetes-kafka/kafka-sw-app.yaml
@@ -26,6 +26,8 @@ spec:
           value: "empire-announce:1:1,deathstar-plans:1:1"
         - name: KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS
           value: "20000"
+        - name: KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS
+          value: "20000"
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/test/k8sT/manifests/kafka-sw-app.yaml
+++ b/test/k8sT/manifests/kafka-sw-app.yaml
@@ -26,6 +26,8 @@ spec:
           value: "empire-announce:1:1,deathstar-plans:1:1"
         - name: KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS
           value: "20000"
+        - name: KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS
+          value: "20000"
       nodeSelector:
         "kubernetes.io/hostname": k8s1
 ---

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -62,7 +62,7 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 			Expect(err).Should(BeNil())
 
 			vm.ContainerCreate("kafka", "wurstmeister/kafka", helpers.CiliumDockerNetwork, fmt.Sprintf(
-				"-l id.kafka -e KAFKA_ZOOKEEPER_CONNECT=%s:2181 -e KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS=20000", zook["IPv4"]))
+				"-l id.kafka -e KAFKA_ZOOKEEPER_CONNECT=%s:2181 -e KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS=20000 -e KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS=20000", zook["IPv4"]))
 
 		case "delete":
 			for k := range images {


### PR DESCRIPTION
Update kafka zookeeper connection timeout to 20 sec
 Fixes: #3307
Signed-Off-By: Manali Bhutiyani <manali@covalent.io>
```release-note
Update CI and docs : kafka zookeeper connection timeout to 20 sec
```