### PR TITLE
Just after each

### DIFF
--- a/test/ginkgo-ext/scopes.go
+++ b/test/ginkgo-ext/scopes.go
@@ -62,6 +62,7 @@ var (
 	FIt                                   = wrapItFunc(ginkgo.FIt, true)
 	PIt                                   = ginkgo.PIt
 	XIt                                   = ginkgo.XIt
+	Measure                               = ginkgo.Measure
 	By                                    = ginkgo.By
 	JustBeforeEach                        = ginkgo.JustBeforeEach
 	BeforeSuite                           = ginkgo.BeforeSuite

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -503,11 +503,6 @@ func (s *SSHMeta) PolicyWait(revisionNum int) *CmdRes {
 // ReportFailed gathers relevant Cilium runtime data and logs for debugging
 // purposes.
 func (s *SSHMeta) ReportFailed(commands ...string) {
-	sendToLog = false
-	defer func() {
-		sendToLog = true
-	}()
-
 	wr := s.logger.Logger.Out
 	fmt.Fprint(wr, "===================== TEST FAILED =====================\n")
 	fmt.Fprint(wr, "Gathering Logs and Cilium CLI Output\n")
@@ -567,7 +562,9 @@ func (s *SSHMeta) DumpCiliumCommandOutput() {
 
 	// No need to create file for bugtool because it creates an archive of files
 	// for us.
-	res := s.ExecWithSudo(fmt.Sprintf("%s -t %s", CiliumBugtool, filepath.Join(BasePath, testPath)))
+	res := s.ExecWithSudo(
+		fmt.Sprintf("%s -t %s", CiliumBugtool, filepath.Join(BasePath, testPath)),
+		ExecOptions{SkipLog: true})
 	if !res.WasSuccessful() {
 		s.logger.Errorf("Error running bugtool: %s", res.CombineOutput())
 	}
@@ -601,7 +598,7 @@ func (s *SSHMeta) GatherLogs() {
 	}
 
 	for _, cmd := range ciliumStateCommands {
-		res := s.Exec(cmd)
+		res := s.Exec(cmd, ExecOptions{SkipLog: true})
 		if !res.WasSuccessful() {
 			s.logger.Errorf("cannot gather files for cmd '%s': %s", cmd, res.CombineOutput())
 		}

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -503,16 +503,15 @@ func (s *SSHMeta) PolicyWait(revisionNum int) *CmdRes {
 // ReportFailed gathers relevant Cilium runtime data and logs for debugging
 // purposes.
 func (s *SSHMeta) ReportFailed(commands ...string) {
+	sendToLog = false
+	defer func() {
+		sendToLog = true
+	}()
+
 	wr := s.logger.Logger.Out
 	fmt.Fprint(wr, "===================== TEST FAILED =====================\n")
 	fmt.Fprint(wr, "Gathering Logs and Cilium CLI Output\n")
-
-	//FIXME: Ginkgo PR383 add here --since option
-	res := s.Exec("sudo journalctl --no-pager -u cilium | tail -n 50")
-	fmt.Fprint(wr, res.Output())
-
-	fmt.Fprint(wr, "\n")
-	res = s.ExecCilium("endpoint list")
+	res := s.ExecCilium("endpoint list")
 	fmt.Fprint(wr, res.Output())
 
 	for _, cmd := range commands {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -758,6 +758,11 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 // TODO - remove 'pod' parameter, this function should just get logs from all
 // Cilium pods without the need to provide the parameter itself.
 func (kub *Kubectl) CiliumReport(namespace string, pod string, commands ...[]string) {
+	sendToLog = false
+	defer func() {
+		sendToLog = true
+	}()
+
 	wr := kub.logger.Logger.Out
 	fmt.Fprint(wr, "StackTrace Begin\n")
 	data := kub.Logs(namespace, pod)

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -31,7 +31,8 @@ import (
 
 var (
 	//SSHMetaLogs is a buffer where all commands sent over ssh are saved.
-	SSHMetaLogs = NewWriter(new(bytes.Buffer))
+	SSHMetaLogs      = NewWriter(new(bytes.Buffer))
+	sendToLog   bool = true // Set to false if commands don't need to save in the logs
 )
 
 // SSHMeta contains metadata to SSH into a remote location to run tests
@@ -163,8 +164,9 @@ func (s *SSHMeta) Exec(cmd string) *CmdRes {
 	if exiterr, ok := err.(*ssh.ExitError); ok {
 		res.exitcode = exiterr.Waitmsg.ExitStatus()
 	}
-
-	res.SendToLog()
+	if sendToLog {
+		res.SendToLog()
+	}
 	return &res
 }
 
@@ -218,7 +220,9 @@ func (s *SSHMeta) ExecContext(ctx context.Context, cmd string) *CmdRes {
 
 	go func() {
 		s.sshClient.RunCommandContext(ctx, command)
-		res.SendToLog()
+		if sendToLog {
+			res.SendToLog()
+		}
 	}()
 
 	return &res

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -334,7 +334,7 @@ func reportMap(path string, reportCmds map[string]string, node *SSHMeta) {
 	}
 
 	for cmd, logfile := range reportCmds {
-		res := node.Exec(cmd)
+		res := node.Exec(cmd, ExecOptions{SkipLog: true})
 		err := ioutil.WriteFile(
 			fmt.Sprintf("%s/%s", path, logfile),
 			res.CombineOutput().Bytes(),

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"sync"
 
+	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 
-	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 )
@@ -60,14 +60,17 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 		Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 	})
 
-	AfterEach(func() {
-		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-		if CurrentGinkgoTestDescription().Failed {
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
-				"cilium service list",
-				"cilium endpoint list"})
-		}
+	AfterFailed(func() {
+		kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
+			"cilium service list",
+			"cilium endpoint list"})
+	})
 
+	JustAfterEach(func() {
+		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+	})
+
+	AfterEach(func() {
 		kubectl.Delete(demoDSPath).ExpectSuccess(
 			"%s deployment cannot be deleted", demoDSPath)
 		err := kubectl.WaitCleanAllTerminatingPods()

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -63,9 +63,7 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 	AfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(
-				helpers.KubeSystemNamespace, helpers.K8s1VMName())
-			kubectl.CiliumReport("kube-system", ciliumPod, []string{
+			kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
 				"cilium service list",
 				"cilium endpoint list"})
 		}

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"sync"
 
+	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 
-	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 )
@@ -47,14 +47,18 @@ var _ = Describe(testName, func() {
 		once.Do(initialize)
 	})
 
-	AfterEach(func() {
+	AfterFailed(func() {
+		kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
+			"cilium service list",
+			"cilium endpoint list",
+			"cilium policy get"})
+	})
+
+	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-		if CurrentGinkgoTestDescription().Failed {
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
-				"cilium service list",
-				"cilium endpoint list",
-				"cilium policy get"})
-		}
+	})
+
+	AfterEach(func() {
 		err := kubectl.WaitCleanAllTerminatingPods()
 		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
 	})

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -50,8 +50,7 @@ var _ = Describe(testName, func() {
 	AfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode("kube-system", "k8s1")
-			kubectl.CiliumReport("kube-system", ciliumPod, []string{
+			kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
 				"cilium service list",
 				"cilium endpoint list",
 				"cilium policy get"})

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -19,8 +19,9 @@ import (
 	"sync"
 
 	"github.com/cilium/cilium/api/v1/models"
+	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
-	. "github.com/onsi/ginkgo"
+
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 )
@@ -94,16 +95,18 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 		Expect(err).Should(BeNil())
 	})
 
-	AfterEach(func() {
-		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-		if CurrentGinkgoTestDescription().Failed {
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
-				"cilium bpf tunnel list",
-				"cilium endpoint list",
-				"cilium service list",
-				"cilium policy get"})
-		}
+	AfterFailed(func() {
+		kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
+			"cilium service list",
+			"cilium policy get",
+			"cilium endpoint list"})
+	})
 
+	JustAfterEach(func() {
+		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+	})
+
+	AfterEach(func() {
 		By("Deleting demo path")
 		kubectl.Delete(demoPath)
 		err := kubectl.WaitCleanAllTerminatingPods()

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -97,8 +97,7 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 	AfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
+			kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
 				"cilium bpf tunnel list",
 				"cilium endpoint list",
 				"cilium service list",

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -82,8 +82,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 	AfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
+			kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
 				"cilium service list",
 				"cilium endpoint list"})
 		}
@@ -352,8 +351,7 @@ var _ = Describe("NightlyExamples", func() {
 	AfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
+			kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
 				"cilium service list",
 				"cilium endpoint list"})
 		}

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -83,8 +83,7 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 	AfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
+			kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
 				"cilium bpf tunnel list",
 				"cilium endpoint list"})
 		}
@@ -631,8 +630,7 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			if CurrentGinkgoTestDescription().Failed {
-				ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
-				kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
+				kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
 					"cilium policy get",
 					"cilium endpoint list"})
 			}
@@ -722,8 +720,7 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 	AfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
+			kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
 				"cilium bpf tunnel list",
 				"cilium endpoint list"})
 		}

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -47,8 +47,7 @@ var _ = Describe("NightlyPolicies", func() {
 	AfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, "k8s1")
-			kubectl.CiliumReport("kube-system", ciliumPod, []string{
+			kubectl.CiliumReport("kube-system", []string{
 				"cilium policy get",
 				"cilium endpoint list",
 				"cilium service list"})

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -44,14 +44,18 @@ var _ = Describe("NightlyPolicies", func() {
 		Expect(err).Should(BeNil())
 	})
 
-	AfterEach(func() {
+	AfterFailed(func() {
+		kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
+			"cilium policy get",
+			"cilium endpoint list",
+			"cilium service list"})
+	})
+
+	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-		if CurrentGinkgoTestDescription().Failed {
-			kubectl.CiliumReport("kube-system", []string{
-				"cilium policy get",
-				"cilium endpoint list",
-				"cilium service list"})
-		}
+	})
+
+	AfterEach(func() {
 		err := kubectl.WaitCleanAllTerminatingPods()
 		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
 	})

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -63,8 +63,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 	AfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode("kube-system", "k8s1")
-			kubectl.CiliumReport("kube-system", ciliumPod, []string{
+			kubectl.CiliumReport("kube-system", []string{
 				"cilium service list",
 				"cilium endpoint list",
 				"cilium policy get"})

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -22,9 +22,9 @@ import (
 	"time"
 
 	"github.com/asaskevich/govalidator"
+	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 
-	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
@@ -60,14 +60,18 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 		once.Do(initialize)
 	})
 
-	AfterEach(func() {
+	AfterFailed(func() {
+		kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
+			"cilium service list",
+			"cilium policy get",
+			"cilium endpoint list"})
+	})
+
+	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-		if CurrentGinkgoTestDescription().Failed {
-			kubectl.CiliumReport("kube-system", []string{
-				"cilium service list",
-				"cilium endpoint list",
-				"cilium policy get"})
-		}
+	})
+
+	AfterEach(func() {
 		err := kubectl.WaitCleanAllTerminatingPods()
 		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
 	})

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -19,10 +19,10 @@ import (
 	"sync"
 	"time"
 
+	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 
+	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 )
 
@@ -51,14 +51,17 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 		kubectl.Apply(demoDSPath)
 	}, 600)
 
-	AfterEach(func() {
-		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-		if CurrentGinkgoTestDescription().Failed {
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
-				"cilium bpf tunnel list",
-				"cilium endpoint list"})
-		}
+	AfterFailed(func() {
+		kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
+			"cilium bpf tunnel list",
+			"cilium endpoint list"})
+	})
 
+	JustAfterEach(func() {
+		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+	})
+
+	AfterEach(func() {
 		kubectl.Delete(demoDSPath)
 		err := kubectl.WaitCleanAllTerminatingPods()
 		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -54,8 +54,7 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 	AfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, []string{
+			kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
 				"cilium bpf tunnel list",
 				"cilium endpoint list"})
 		}
@@ -85,7 +84,7 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 			cmds := []string{
 				"cilium bpf tunnel list",
 			}
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, cmds)
+			kubectl.CiliumReport(helpers.KubeSystemNamespace, cmds)
 		}
 
 		status.ExpectSuccess()
@@ -121,7 +120,7 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 			cmds := []string{
 				"cilium bpf tunnel list",
 			}
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod, cmds)
+			kubectl.CiliumReport(helpers.KubeSystemNamespace, cmds)
 		}
 		Expect(status.IntOutput()).Should(Equal(5))
 

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -48,9 +48,7 @@ var _ = Describe("K8sValidatedUpdates", func() {
 	AfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(
-				helpers.KubeSystemNamespace, helpers.K8s1VMName())
-			kubectl.CiliumReport("kube-system", ciliumPod, []string{
+			kubectl.CiliumReport("kube-system", []string{
 				"cilium endpoint list"})
 		}
 

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -45,13 +45,16 @@ var _ = Describe("K8sValidatedUpdates", func() {
 
 	})
 
-	AfterEach(func() {
-		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-		if CurrentGinkgoTestDescription().Failed {
-			kubectl.CiliumReport("kube-system", []string{
-				"cilium endpoint list"})
-		}
+	AfterFailed(func() {
+		kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
+			"cilium endpoint list"})
+	})
 
+	JustAfterEach(func() {
+		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+	})
+
+	AfterEach(func() {
 		//This policies maybe are not loaded, (Test failed before) so no assert here.
 		kubectl.Delete(l7Policy)
 		kubectl.Delete(l3Policy)

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -79,8 +79,7 @@ var _ = Describe(demoTestName, func() {
 	AfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 		if CurrentGinkgoTestDescription().Failed {
-			ciliumPod, _ := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
-			kubectl.CiliumReport(helpers.KubeSystemNamespace, ciliumPod)
+			kubectl.CiliumReport(helpers.KubeSystemNamespace)
 		}
 
 		By("Deleting all resources created during test")

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -19,9 +19,9 @@ import (
 	"path/filepath"
 	"sync"
 
+	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 
-	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 )
@@ -76,12 +76,15 @@ var _ = Describe(demoTestName, func() {
 		once.Do(initialize)
 	})
 
-	AfterEach(func() {
-		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-		if CurrentGinkgoTestDescription().Failed {
-			kubectl.CiliumReport(helpers.KubeSystemNamespace)
-		}
+	AfterFailed(func() {
+		kubectl.CiliumReport(helpers.KubeSystemNamespace)
+	})
 
+	JustAfterEach(func() {
+		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+	})
+
+	AfterEach(func() {
 		By("Deleting all resources created during test")
 		kubectl.Delete(l7PolicyYAMLLink)
 		kubectl.Delete(l4PolicyYAMLLink)

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -74,12 +74,12 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 		Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
 	})
 
-	AfterEach(func() {
+	JustAfterEach(func() {
 		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+	})
 
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed()
-		}
+	AfterFailed(func() {
+		vm.ReportFailed()
 	})
 
 	Context("Policy Enforcement Default", func() {
@@ -426,12 +426,15 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 	})
 
 	AfterEach(func() {
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed()
-		}
 		vm.PolicyDelAll().ExpectSuccess("Unable to delete all policies")
+	})
+
+	JustAfterEach(func() {
+		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+	})
+
+	AfterFailed(func() {
+		vm.ReportFailed()
 	})
 
 	AfterAll(func() {

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -47,12 +47,16 @@ var _ = Describe("RuntimeValidatedChaos", func() {
 	})
 
 	AfterEach(func() {
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed()
-		}
 		vm.ContainerRm(helpers.Client)
 		vm.ContainerRm(helpers.Server)
+	})
+
+	JustAfterEach(func() {
+		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+	})
+
+	AfterFailed(func() {
+		vm.ReportFailed()
 	})
 
 	It("Endpoint recovery on restart", func() {

--- a/test/runtime/cli.go
+++ b/test/runtime/cli.go
@@ -46,11 +46,12 @@ var _ = Describe("RuntimeValidatedCLI", func() {
 		once.Do(initialize)
 	})
 
-	AfterEach(func() {
+	JustAfterEach(func() {
 		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed("cilium endpoint list")
-		}
+	})
+
+	AfterFailed(func() {
+		vm.ReportFailed("cilium endpoint list")
 	})
 
 	Context("Identity CLI testing", func() {

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -38,12 +38,16 @@ var _ = Describe("RuntimeValidatedConnectivityTest", func() {
 	}
 
 	AfterEach(func() {
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed()
-		}
 		vm.PolicyDelAll().ExpectSuccess("Policies cannot be deleted")
 		return
+	})
+
+	JustAfterEach(func() {
+		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+	})
+
+	AfterFailed(func() {
+		vm.ReportFailed()
 	})
 
 	Context("Basic Connectivity test", func() {
@@ -486,11 +490,6 @@ var _ = Describe("RuntimeValidatedConntrackTest", func() {
 	})
 
 	AfterEach(func() {
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed()
-		}
-
 		containersToRm := []string{helpers.Client, helpers.Server, helpers.Httpd1, helpers.Httpd2, curl1ContainerName, curl2ContainerName}
 		for _, containerToRm := range containersToRm {
 			vm.ContainerRm(containerToRm)
@@ -499,6 +498,14 @@ var _ = Describe("RuntimeValidatedConntrackTest", func() {
 
 		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
 		res.ExpectSuccess("Cannot set policy enforcement to default mode")
+	})
+
+	JustAfterEach(func() {
+		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+	})
+
+	AfterFailed(func() {
+		vm.ReportFailed()
 	})
 
 	It("Conntrack-related configuration options for endpoints", func() {

--- a/test/runtime/ct.go
+++ b/test/runtime/ct.go
@@ -134,19 +134,23 @@ var _ = Describe("DisabledRuntimeValidatedConntrackTable", func() {
 	})
 
 	AfterEach(func() {
-
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed(
-				"sudo cilium bpf ct list global",
-				"sudo cilium endpoint list")
-		}
 		vm.PolicyDelAll()
 		netcatPort = 11111
 
 		// A lot of these test checks the number of connections. To avoid
 		// having false positives clean CT table after each test
 		vm.ExecCilium("bpf ct flush global")
+
+	})
+
+	JustAfterEach(func() {
+		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+	})
+
+	AfterFailed(func() {
+		vm.ReportFailed(
+			"sudo cilium bpf ct list global",
+			"sudo cilium endpoint list")
 
 	})
 

--- a/test/runtime/examples.go
+++ b/test/runtime/examples.go
@@ -43,12 +43,12 @@ var _ = Describe("RuntimeValidatedPolicyValidationTests", func() {
 		once.Do(initialize)
 	})
 
-	AfterEach(func() {
-
+	JustAfterEach(func() {
 		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed()
-		}
+	})
+
+	AfterFailed(func() {
+		vm.ReportFailed()
 	})
 
 	It("Validates Example Policies", func() {

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -116,12 +116,16 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 	})
 
 	AfterEach(func() {
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed()
-		}
 		vm.PolicyDelAll()
 		containers("delete")
+	})
+
+	JustAfterEach(func() {
+		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+	})
+
+	AfterFailed(func() {
+		vm.ReportFailed()
 	})
 
 	It("Kafka Policy Ingress", func() {

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -54,14 +54,18 @@ var _ = Describe("RuntimeValidatedKVStoreTest", func() {
 	}, 150)
 
 	AfterEach(func() {
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed(
-				"sudo docker ps -a",
-				"sudo cilium endpoint list")
-		}
 		containers(helpers.Delete)
 		vm.Exec("sudo systemctl start cilium")
+	})
+
+	JustAfterEach(func() {
+		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+	})
+
+	AfterFailed(func() {
+		vm.ReportFailed(
+			"sudo docker ps -a",
+			"sudo cilium endpoint list")
 	})
 
 	It("Consul KVStore", func() {

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -41,6 +41,20 @@ var _ = Describe("RuntimeValidatedLB", func() {
 		vm.ServiceDelAll().ExpectSuccess()
 	})
 
+	JustAfterEach(func() {
+		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+	})
+
+	AfterFailed(func() {
+		vm.ReportFailed(
+			"sudo cilium service list",
+			"sudo cilium endpoint list")
+	})
+
+	AfterEach(func() {
+		cleanupLBDevice(vm)
+	}, 500)
+
 	images := map[string]string{
 		helpers.Httpd1: helpers.HttpdImage,
 		helpers.Httpd2: helpers.HttpdImage,
@@ -65,17 +79,6 @@ var _ = Describe("RuntimeValidatedLB", func() {
 
 	BeforeEach(func() {
 		vm.ServiceDelAll().ExpectSuccess()
-	}, 500)
-
-	AfterEach(func() {
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed(
-				"sudo cilium service list",
-				"sudo cilium endpoint list")
-		}
-		cleanupLBDevice(vm)
 	}, 500)
 
 	It("validates basic service management functionality", func() {

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -54,11 +54,12 @@ var _ = Describe("RuntimeValidatedMonitorTest", func() {
 		Expect(areEndpointsReady).Should(BeTrue())
 	})
 
-	AfterEach(func() {
+	JustAfterEach(func() {
 		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed()
-		}
+	})
+
+	AfterFailed(func() {
+		vm.ReportFailed()
 	})
 
 	BeforeEach(func() {


### PR DESCRIPTION
Summary: 

- Added JustAfterEach to run functions like `ValidateIfErrorsOnLogs` that will run before `AfterFailed`
- `AfterFailed` a new helper function that only runs if the test failed an **just before** of  `AfterEach` and `AfterAll`
- Added a option to not report to Output the ReportCilium. 
- Added Measure option in ginkgo-ext

Fixes: https://github.com/cilium/cilium/issues/3243
Fixes: https://github.com/cilium/cilium/issues/3285