### PR TITLE
health: Fix succinct/verbose modes.

### DIFF
--- a/pkg/health/client/client.go
+++ b/pkg/health/client/client.go
@@ -164,7 +164,7 @@ func nodeIsLocalhost(node *models.NodeStatus, self *models.SelfStatus) bool {
 	return self != nil && node.Name == self.Name
 }
 
-func formatNodeStatus(w io.Writer, node *models.NodeStatus, printAll, verbose, succinct, localhost bool) {
+func formatNodeStatus(w io.Writer, node *models.NodeStatus, printAll, succinct, verbose, localhost bool) {
 	localStr := ""
 	if localhost {
 		localStr = " (localhost)"


### PR DESCRIPTION
Commit 11f420b59d9d ("health: Format localhost first in status output")
inadventently swapped the order of the 'succinct' and 'verbose'
parameters, leading to weird results with respect to verbosity on the
commandline. Put them back in the right order.

Signed-off-by: Joe Stringer <joe@covalent.io>