### PR TITLE
CI / GSG : make Kafka service headless

### DIFF
--- a/examples/kubernetes-kafka/kafka-sw-app.yaml
+++ b/examples/kubernetes-kafka/kafka-sw-app.yaml
@@ -75,6 +75,7 @@ spec:
     protocol: TCP
   selector:
     app: kafka
+  clusterIP: None
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/test/k8sT/manifests/kafka-sw-app.yaml
+++ b/test/k8sT/manifests/kafka-sw-app.yaml
@@ -80,6 +80,7 @@ spec:
     protocol: TCP
   selector:
     app: kafka
+  clusterIP: None
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment


### PR DESCRIPTION
The current Kafka yaml in GSG and K8ts test have the Kafka service as a ClusterIP service. When we enforce an allow-all policy, and try to consume, the Kafka broker sends out a service discovery request for the other brokers. Ideally it should resolve to itself (with a single broker configuration), but there is currently a bug in data path which does not resolve the reverse NAT for loopback address correctly. By making this service headless, we can avoid the request from leaving the node altogether.
This also fixes the "first consume delay" which we see due to drops in data path for the Kafka broker service discovery requests.

Fixes: #3319

```release-note
CI / GSG : make Kafka service headless
```