### PR TITLE
policy: plumb egress L3-dependent-L4

### DIFF
--- a/Documentation/cmdref/cilium_bpf_policy_add.md
+++ b/Documentation/cmdref/cilium_bpf_policy_add.md
@@ -10,7 +10,7 @@ Add/update policy entry
 Add/update policy entry
 
 ```
-cilium bpf policy add <endpoint id> <identity> [port/proto]
+cilium bpf policy add <endpoint id> <traffic-direction> <identity> [port/proto]
 ```
 
 ### Options inherited from parent commands

--- a/cilium/cmd/bpf_policy_add.go
+++ b/cilium/cmd/bpf_policy_add.go
@@ -15,14 +15,7 @@
 package cmd
 
 import (
-	"fmt"
-	"strconv"
-
 	"github.com/cilium/cilium/common"
-	"github.com/cilium/cilium/pkg/bpf"
-	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/maps/policymap"
-	"github.com/cilium/cilium/pkg/u8proto"
 
 	"github.com/spf13/cobra"
 )
@@ -40,70 +33,4 @@ var bpfPolicyAddCmd = &cobra.Command{
 
 func init() {
 	bpfPolicyCmd.AddCommand(bpfPolicyAddCmd)
-}
-
-func updatePolicyKey(cmd *cobra.Command, args []string, add bool) {
-	if len(args) < 3 {
-		Usagef(cmd, "<endpoint id>, <traffic-direction>, and <identity> required")
-	}
-
-	trafficDirection := args[1]
-	parsedTd, err := parseTrafficString(trafficDirection)
-	if err != nil {
-		Fatalf("Failed to convert %s to a valid traffic direction: %s", args[1], err)
-	}
-
-	endpointID := args[0]
-	if numericIdentity := identity.GetReservedID(endpointID); numericIdentity != identity.IdentityUnknown {
-		endpointID = "reserved_" + strconv.FormatUint(uint64(numericIdentity), 10)
-	}
-
-	policyMapPath := bpf.MapPath(policymap.MapName + endpointID)
-	policyMap, _, err := policymap.OpenMap(policyMapPath)
-	if err != nil {
-		Fatalf("Cannot open policymap '%s' : %s", policyMapPath, err)
-	}
-
-	peerLbl, err := strconv.ParseUint(args[2], 10, 32)
-	if err != nil {
-		Fatalf("Failed to convert %s", args[2])
-	}
-
-	port := uint16(0)
-	protos := []uint8{}
-	if len(args) > 3 {
-		pp, err := parseL4PortsSlice([]string{args[3]})
-		if err != nil {
-			Fatalf("Failed to parse L4: %s", err)
-		}
-		port = pp[0].Port
-		if port != 0 {
-			proto, _ := u8proto.ParseProtocol(pp[0].Protocol)
-			if proto == 0 {
-				for _, proto := range u8proto.ProtoIDs {
-					protos = append(protos, uint8(proto))
-				}
-			} else {
-				protos = append(protos, uint8(proto))
-			}
-		}
-	}
-	if len(protos) == 0 {
-		protos = append(protos, 0)
-	}
-
-	label := uint32(peerLbl)
-	for _, proto := range protos {
-		u8p := u8proto.U8proto(proto)
-		entry := fmt.Sprintf("%d %d/%s", label, port, u8p.String())
-		if add == true {
-			if err := policyMap.AllowL4(label, port, proto, parsedTd); err != nil {
-				Fatalf("Cannot add policy key '%s': %s\n", entry, err)
-			}
-		} else {
-			if err := policyMap.DeleteL4(label, port, proto, parsedTd); err != nil {
-				Fatalf("Cannot delete policy key '%s': %s\n", entry, err)
-			}
-		}
-	}
 }

--- a/cilium/cmd/bpf_policy_add.go
+++ b/cilium/cmd/bpf_policy_add.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 
 	"github.com/cilium/cilium/common"
@@ -30,7 +29,7 @@ import (
 
 // bpfPolicyAddCmd represents the bpf_policy_add command
 var bpfPolicyAddCmd = &cobra.Command{
-	Use:    "add <endpoint id> <identity> [port/proto]",
+	Use:    "add <endpoint id> <traffic-direction> <identity> [port/proto]",
 	Short:  "Add/update policy entry",
 	PreRun: requireEndpointID,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -43,32 +42,37 @@ func init() {
 	bpfPolicyCmd.AddCommand(bpfPolicyAddCmd)
 }
 
-// TODO - update with support for updating egress policy as well. See GH-3114.
 func updatePolicyKey(cmd *cobra.Command, args []string, add bool) {
-	if len(args) < 2 {
-		Usagef(cmd, "<endpoint id> and <identity> required")
+	if len(args) < 3 {
+		Usagef(cmd, "<endpoint id>, <traffic-direction>, and <identity> required")
 	}
 
-	lbl := args[0]
-	if id := identity.GetReservedID(lbl); id != identity.IdentityUnknown {
-		lbl = "reserved_" + strconv.FormatUint(uint64(id), 10)
-	}
-
-	file := bpf.MapPath(policymap.MapName + lbl)
-	policyMap, _, err := policymap.OpenMap(file)
+	trafficDirection := args[1]
+	parsedTd, err := parseTrafficString(trafficDirection)
 	if err != nil {
-		Fatalf("Cannot open policymap '%s' : %s", file, err)
+		Fatalf("Failed to convert %s to a valid traffic direction: %s", args[1], err)
 	}
 
-	peerLbl, err := strconv.ParseUint(args[1], 10, 32)
+	endpointID := args[0]
+	if numericIdentity := identity.GetReservedID(endpointID); numericIdentity != identity.IdentityUnknown {
+		endpointID = "reserved_" + strconv.FormatUint(uint64(numericIdentity), 10)
+	}
+
+	policyMapPath := bpf.MapPath(policymap.MapName + endpointID)
+	policyMap, _, err := policymap.OpenMap(policyMapPath)
 	if err != nil {
-		Fatalf("Failed to convert %s", args[1])
+		Fatalf("Cannot open policymap '%s' : %s", policyMapPath, err)
+	}
+
+	peerLbl, err := strconv.ParseUint(args[2], 10, 32)
+	if err != nil {
+		Fatalf("Failed to convert %s", args[2])
 	}
 
 	port := uint16(0)
 	protos := []uint8{}
-	if len(args) > 2 {
-		pp, err := parseL4PortsSlice([]string{args[2]})
+	if len(args) > 3 {
+		pp, err := parseL4PortsSlice([]string{args[3]})
 		if err != nil {
 			Fatalf("Failed to parse L4: %s", err)
 		}
@@ -88,24 +92,18 @@ func updatePolicyKey(cmd *cobra.Command, args []string, add bool) {
 		protos = append(protos, 0)
 	}
 
-	ok := true
 	label := uint32(peerLbl)
 	for _, proto := range protos {
 		u8p := u8proto.U8proto(proto)
 		entry := fmt.Sprintf("%d %d/%s", label, port, u8p.String())
 		if add == true {
-			if err := policyMap.AllowL4(label, port, proto, policymap.Ingress); err != nil {
-				fmt.Printf("Cannot add policy key '%s': %s\n", entry, err)
-				ok = false
+			if err := policyMap.AllowL4(label, port, proto, parsedTd); err != nil {
+				Fatalf("Cannot add policy key '%s': %s\n", entry, err)
 			}
 		} else {
-			if err := policyMap.DeleteL4(label, port, proto, policymap.Ingress); err != nil {
-				fmt.Printf("Cannot delete policy key '%s': %s\n", entry, err)
-				ok = false
+			if err := policyMap.DeleteL4(label, port, proto, parsedTd); err != nil {
+				Fatalf("Cannot delete policy key '%s': %s\n", entry, err)
 			}
 		}
-	}
-	if !ok {
-		os.Exit(1)
 	}
 }

--- a/cilium/cmd/helpers.go
+++ b/cilium/cmd/helpers.go
@@ -21,10 +21,12 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/maps/policymap"
 
 	"github.com/spf13/cobra"
 )
@@ -184,4 +186,19 @@ func expandNestedJSON(result bytes.Buffer) (bytes.Buffer, error) {
 	}
 
 	return result, nil
+}
+
+// parseTrafficString converts the provided string to its corresponding
+// TrafficDirection. If the string does not correspond to a valid TrafficDirection
+// type, returns Invalid and a corresponding error.
+func parseTrafficString(td string) (policymap.TrafficDirection, error) {
+	lowered := strings.ToLower(td)
+	if lowered == "ingress" {
+		return policymap.Ingress, nil
+	} else if lowered == "egress" {
+		return policymap.Egress, nil
+	} else {
+		return policymap.Invalid, fmt.Errorf("invalid direction %q provided", td)
+	}
+
 }

--- a/cilium/cmd/helpers.go
+++ b/cilium/cmd/helpers.go
@@ -24,9 +24,11 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/maps/policymap"
+	"github.com/cilium/cilium/pkg/u8proto"
 
 	"github.com/spf13/cobra"
 )
@@ -201,4 +203,70 @@ func parseTrafficString(td string) (policymap.TrafficDirection, error) {
 		return policymap.Invalid, fmt.Errorf("invalid direction %q provided", td)
 	}
 
+}
+
+func updatePolicyKey(cmd *cobra.Command, args []string, add bool) {
+	if len(args) < 3 {
+		Usagef(cmd, "<endpoint id>, <traffic-direction>, and <identity> required")
+	}
+
+	trafficDirection := args[1]
+	parsedTd, err := parseTrafficString(trafficDirection)
+	if err != nil {
+		Fatalf("Failed to convert %s to a valid traffic direction: %s", args[1], err)
+	}
+
+	endpointID := args[0]
+	if numericIdentity := identity.GetReservedID(endpointID); numericIdentity != identity.IdentityUnknown {
+		endpointID = "reserved_" + strconv.FormatUint(uint64(numericIdentity), 10)
+	}
+
+	policyMapPath := bpf.MapPath(policymap.MapName + endpointID)
+	policyMap, _, err := policymap.OpenMap(policyMapPath)
+	if err != nil {
+		Fatalf("Cannot open policymap '%s' : %s", policyMapPath, err)
+	}
+
+	peerLbl, err := strconv.ParseUint(args[2], 10, 32)
+	if err != nil {
+		Fatalf("Failed to convert %s", args[2])
+	}
+
+	port := uint16(0)
+	protos := []uint8{}
+	if len(args) > 3 {
+		pp, err := parseL4PortsSlice([]string{args[3]})
+		if err != nil {
+			Fatalf("Failed to parse L4: %s", err)
+		}
+		port = pp[0].Port
+		if port != 0 {
+			proto, _ := u8proto.ParseProtocol(pp[0].Protocol)
+			if proto == 0 {
+				for _, proto := range u8proto.ProtoIDs {
+					protos = append(protos, uint8(proto))
+				}
+			} else {
+				protos = append(protos, uint8(proto))
+			}
+		}
+	}
+	if len(protos) == 0 {
+		protos = append(protos, 0)
+	}
+
+	label := uint32(peerLbl)
+	for _, proto := range protos {
+		u8p := u8proto.U8proto(proto)
+		entry := fmt.Sprintf("%d %d/%s", label, port, u8p.String())
+		if add == true {
+			if err := policyMap.AllowL4(label, port, proto, parsedTd); err != nil {
+				Fatalf("Cannot add policy key '%s': %s\n", entry, err)
+			}
+		} else {
+			if err := policyMap.DeleteL4(label, port, proto, parsedTd); err != nil {
+				Fatalf("Cannot delete policy key '%s': %s\n", entry, err)
+			}
+		}
+	}
 }

--- a/cilium/cmd/helpers_test.go
+++ b/cilium/cmd/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/maps/policymap"
 	. "gopkg.in/check.v1"
 )
 
@@ -39,4 +40,29 @@ func (s *CMDHelpersSuite) TestExpandNestedJSON(c *C) {
 ]`)
 	_, err = expandNestedJSON(*buf)
 	c.Assert(err, IsNil)
+}
+
+func (s *CMDHelpersSuite) TestParseTrafficString(c *C) {
+
+	validIngressCases := []string{"ingress", "Ingress", "InGrEss"}
+	validEgressCases := []string{"egress", "Egress", "EGrEss"}
+
+	invalidStr := "getItDoneMan"
+
+	for _, validCase := range validIngressCases {
+		ingressDir, err := parseTrafficString(validCase)
+		c.Assert(ingressDir, Equals, policymap.Ingress)
+		c.Assert(err, IsNil)
+	}
+
+	for _, validCase := range validEgressCases {
+		egressDir, err := parseTrafficString(validCase)
+		c.Assert(egressDir, Equals, policymap.Egress)
+		c.Assert(err, IsNil)
+	}
+
+	invalid, err := parseTrafficString(invalidStr)
+	c.Assert(invalid, Equals, policymap.Invalid)
+	c.Assert(err, Not(IsNil))
+
 }

--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -185,6 +185,19 @@ func ParseNetworkPolicy(np *networkingv1.NetworkPolicy) (api.Rules, error) {
 			egress.ToEndpoints = append(egress.ToEndpoints, all)
 		}
 
+		if eRule.Ports != nil && len(eRule.Ports) > 0 {
+			egress.ToPorts = parsePorts(eRule.Ports)
+		} else if eRule.To == nil || len(eRule.To) == 0 {
+			// Based on NetworkPolicyEgressRule docs:
+			//   From []NetworkPolicyPeer
+			//   If this field is empty or missing, this rule matches all
+			//   sources (traffic not restricted by source).
+			all := api.NewESFromLabels(
+				labels.NewLabel(labels.IDNameAll, "", labels.LabelSourceReserved),
+			)
+			egress.ToEndpoints = append(egress.ToEndpoints, all)
+		}
+
 		egresses = append(egresses, egress)
 	}
 

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -441,29 +441,27 @@ func (s *K8sSuite) TestParseNetworkPolicyEgressAllowAll(c *C) {
 	c.Assert(repo.AllowsEgressRLocked(&ctxAToC90), Equals, api.Allowed)
 }
 
-// Re-enable via GH-3099
-//
-// func (s *K8sSuite) TestParseNetworkPolicyEgressL4AllowAll(c *C) {
-// 	repo := parseAndAddRules(c, &networkingv1.NetworkPolicy{
-// 		Spec: networkingv1.NetworkPolicySpec{
-// 			PodSelector: labelSelectorA,
-// 			Egress: []networkingv1.NetworkPolicyEgressRule{
-// 				{
-// 					Ports: []networkingv1.NetworkPolicyPort{port80},
-// 					To:    []networkingv1.NetworkPolicyPeer{},
-// 				},
-// 			},
-// 		},
-// 	})
-//
-// 	ctxAToC80 := ctxAToC
-// 	ctxAToC80.DPorts = []*models.Port{{Port: 80, Protocol: models.PortProtocolTCP}}
-// 	c.Assert(repo.AllowsEgressRLocked(&ctxAToC80), Equals, api.Allowed)
-//
-// 	ctxAToC90 := ctxAToC
-// 	ctxAToC90.DPorts = []*models.Port{{Port: 90, Protocol: models.PortProtocolTCP}}
-// 	c.Assert(repo.AllowsEgressRLocked(&ctxAToC90), Equals, api.Denied)
-// }
+func (s *K8sSuite) TestParseNetworkPolicyEgressL4AllowAll(c *C) {
+	repo := parseAndAddRules(c, &networkingv1.NetworkPolicy{
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: labelSelectorA,
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{port80},
+					To:    []networkingv1.NetworkPolicyPeer{},
+				},
+			},
+		},
+	})
+
+	ctxAToC80 := ctxAToC
+	ctxAToC80.DPorts = []*models.Port{{Port: 80, Protocol: models.PortProtocolTCP}}
+	c.Assert(repo.AllowsEgressRLocked(&ctxAToC80), Equals, api.Allowed)
+
+	ctxAToC90 := ctxAToC
+	ctxAToC90.DPorts = []*models.Port{{Port: 90, Protocol: models.PortProtocolTCP}}
+	c.Assert(repo.AllowsEgressRLocked(&ctxAToC90), Equals, api.Denied)
+}
 
 func (s *K8sSuite) TestParseNetworkPolicyIngressAllowAll(c *C) {
 	repo := parseAndAddRules(c, &networkingv1.NetworkPolicy{

--- a/pkg/maps/policymap/trafficdirection.go
+++ b/pkg/maps/policymap/trafficdirection.go
@@ -18,6 +18,9 @@ package policymap
 type TrafficDirection uint8
 
 const (
+	// Invalid represents an invalid traffic direction.
+	Invalid TrafficDirection = 2
+
 	// Egress represents egress traffic.
 	Egress TrafficDirection = 1
 

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -122,7 +122,7 @@ func (e *EgressRule) sanitize() error {
 	l3DependentL4Support := map[interface{}]bool{
 		"ToCIDR":      false,
 		"ToCIDRSet":   false,
-		"ToEndpoints": false,
+		"ToEndpoints": true,
 		"ToEntities":  false,
 		"ToServices":  false,
 	}

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -55,46 +55,6 @@ func (s *PolicyTestSuite) testDPortCoverage(c *C, policy L4Policy,
 	c.Assert(covers(ports), Equals, api.Allowed)
 }
 
-func (s *PolicyTestSuite) TestIngressCoversDPorts(c *C) {
-	policy := L4Policy{}
-
-	// Empty policy allows traffic
-	c.Assert(policy.IngressCoversDPorts([]*models.Port{}), Equals, api.Allowed)
-
-	// Non-empty policy denies traffic without a port specified
-	policy = L4Policy{
-		Ingress: L4PolicyMap{
-			"8080/TCP": {
-				Port:             8080,
-				Protocol:         api.ProtoTCP,
-				Ingress:          true,
-				DerivedFromRules: []labels.LabelArray{},
-			},
-		},
-	}
-	s.testDPortCoverage(c, policy, policy.IngressCoversDPorts)
-}
-
-func (s *PolicyTestSuite) TestEgressCoversDPorts(c *C) {
-	policy := L4Policy{}
-
-	// Empty policy allows traffic
-	c.Assert(policy.EgressCoversDPorts([]*models.Port{}), Equals, api.Allowed)
-
-	// Non-empty policy denies traffic without a port specified
-	policy = L4Policy{
-		Egress: L4PolicyMap{
-			"8080/TCP": {
-				Port:             8080,
-				Protocol:         api.ProtoTCP,
-				Ingress:          false,
-				DerivedFromRules: []labels.LabelArray{},
-			},
-		},
-	}
-	s.testDPortCoverage(c, policy, policy.EgressCoversDPorts)
-}
-
 func (s *PolicyTestSuite) TestCreateL4Filter(c *C) {
 	tuple := api.PortProtocol{Port: "80", Protocol: api.ProtoTCP}
 	portrule := api.PortRule{
@@ -112,14 +72,14 @@ func (s *PolicyTestSuite) TestCreateL4Filter(c *C) {
 
 	for _, selector := range selectors {
 		eps := []api.EndpointSelector{selector}
-		for _, direction := range []string{"ingress", "egress"} {
-			// Regardless of ingress/egress, we should end up with
-			// a single L7 rule whether the selector is wildcarded
-			// or if it is based on specific labels.
-			filter := CreateL4Filter(eps, portrule, tuple,
-				direction, tuple.Protocol, nil)
-			c.Assert(len(filter.L7RulesPerEp), Equals, 1)
-		}
+		// Regardless of ingress/egress, we should end up with
+		// a single L7 rule whether the selector is wildcarded
+		// or if it is based on specific labels.
+		filter := CreateL4IngressFilter(eps, portrule, tuple, tuple.Protocol, nil)
+		c.Assert(len(filter.L7RulesPerEp), Equals, 1)
+
+		filter = CreateL4EgressFilter(eps, portrule, tuple, tuple.Protocol, nil)
+		c.Assert(len(filter.L7RulesPerEp), Equals, 1)
 	}
 }
 
@@ -148,8 +108,8 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
 		Ingress: L4PolicyMap{
 			"80/TCP": {
 				Port: 80, Protocol: api.ProtoTCP,
-				FromEndpoints: []api.EndpointSelector{fooSelector},
-				L7Parser:      "http",
+				Endpoints: []api.EndpointSelector{fooSelector},
+				L7Parser:  "http",
 				L7RulesPerEp: L7DataMap{
 					fooSelector: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
@@ -159,8 +119,8 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
 			},
 			"8080/TCP": {
 				Port: 8080, Protocol: api.ProtoTCP,
-				FromEndpoints: []api.EndpointSelector{fooSelector},
-				L7Parser:      "http",
+				Endpoints: []api.EndpointSelector{fooSelector},
+				L7Parser:  "http",
 				L7RulesPerEp: L7DataMap{
 					fooSelector: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -68,11 +68,6 @@ type SearchContext struct {
 	From    labels.LabelArray
 	To      labels.LabelArray
 	DPorts  []*models.Port
-
-	// IngressL4Only is true if only ingress L4 policy should be evaluated
-	IngressL4Only bool
-	// EgressL4Only is true if only egress L4 policy should be evaluated
-	EgressL4Only bool
 }
 
 func (s *SearchContext) String() string {

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -120,29 +120,53 @@ func (p *Repository) AllowsIngressLabelAccess(ctx *SearchContext) api.Decision {
 	return decision
 }
 
-// ResolveL4Policy resolves the L4 policy for a set of endpoints by searching
-// the policy repository for `PortRule` rules that are attached to a `Rule`
-// where the EndpointSelector matches `ctx.To`. `ctx.From` takes no effect and
+// ResolveL4IngressPolicy resolves the L4 ingress policy for a set of endpoints
+// by searching the policy repository for `PortRule` rules that are attached to
+// a `Rule` where the EndpointSelector matches `ctx.To`. `ctx.From` takes no effect and
 // is ignored in the search.  If multiple `PortRule` rules are found, all rules
 // are merged together. If rules contains overlapping port definitions, the first
 // rule found in the repository takes precedence.
 //
 // TODO: Coalesce l7 rules?
-func (p *Repository) ResolveL4Policy(ctx *SearchContext) (*L4Policy, error) {
+func (p *Repository) ResolveL4IngressPolicy(ctx *SearchContext) (*L4PolicyMap, error) {
 	result := NewL4Policy()
 
 	ctx.PolicyTrace("\n")
-	if ctx.EgressL4Only {
-		ctx.PolicyTrace("Resolving egress port policy for %+v\n", ctx.To)
-	} else if ctx.IngressL4Only {
-		ctx.PolicyTrace("Resolving ingress port policy for %+v\n", ctx.To)
-	} else {
-		ctx.PolicyTrace("Resolving port policy for %+v\n", ctx.To)
-	}
+	ctx.PolicyTrace("Resolving ingress port policy for %+v\n", ctx.To)
 
 	state := traceState{}
 	for _, r := range p.rules {
-		found, err := r.resolveL4Policy(ctx, &state, result)
+		found, err := r.resolveL4IngressPolicy(ctx, &state, result)
+		if err != nil {
+			return nil, err
+		}
+		state.ruleID++
+		if found != nil {
+			state.matchedRules++
+		}
+	}
+
+	state.trace(p, ctx)
+	return &result.Ingress, nil
+}
+
+// ResolveL4EgressPolicy resolves the L4 egress policy for a set of endpoints
+// by searching the policy repository for `PortRule` rules that are attached to
+// a `Rule` where the EndpointSelector matches `ctx.From`. `ctx.To` takes no effect and
+// is ignored in the search.  If multiple `PortRule` rules are found, all rules
+// are merged together. If rules contains overlapping port definitions, the first
+// rule found in the repository takes precedence.
+//
+// TODO (ianvernon) unit tests
+func (p *Repository) ResolveL4EgressPolicy(ctx *SearchContext) (*L4PolicyMap, error) {
+	result := NewL4Policy()
+
+	ctx.PolicyTrace("\n")
+	ctx.PolicyTrace("Resolving egress port policy for %+v\n", ctx.To)
+
+	state := traceState{}
+	for _, r := range p.rules {
+		found, err := r.resolveL4EgressPolicy(ctx, &state, result)
 		if err != nil {
 			return nil, err
 		}
@@ -157,7 +181,7 @@ func (p *Repository) ResolveL4Policy(ctx *SearchContext) (*L4Policy, error) {
 	}
 
 	state.trace(p, ctx)
-	return result, nil
+	return &result.Egress, nil
 }
 
 // ResolveCIDRPolicy resolves the L3 policy for a set of endpoints by searching
@@ -179,19 +203,14 @@ func (p *Repository) ResolveCIDRPolicy(ctx *SearchContext) *CIDRPolicy {
 	return result
 }
 
-func (p *Repository) allowsL4Egress(searchCtx *SearchContext) api.Decision {
-	ctx := *searchCtx
-	ctx.To = ctx.From
-	ctx.From = labels.LabelArray{}
-	ctx.EgressL4Only = true
-
-	policy, err := p.ResolveL4Policy(&ctx)
+func (p *Repository) allowsL4Egress(ctx *SearchContext) api.Decision {
+	egressL4Policy, err := p.ResolveL4EgressPolicy(ctx)
 	if err != nil {
 		log.WithError(err).Warn("Evaluation error while resolving L4 egress policy")
 	}
 	verdict := api.Undecided
-	if err == nil && len(policy.Egress) > 0 {
-		verdict = policy.EgressCoversDPorts(ctx.DPorts)
+	if err == nil && len(*egressL4Policy) > 0 {
+		verdict = egressL4Policy.EgressCoversContext(ctx)
 	}
 
 	if len(ctx.DPorts) == 0 {
@@ -204,15 +223,13 @@ func (p *Repository) allowsL4Egress(searchCtx *SearchContext) api.Decision {
 }
 
 func (p *Repository) allowsL4Ingress(ctx *SearchContext) api.Decision {
-	ctx.IngressL4Only = true
-
-	policy, err := p.ResolveL4Policy(ctx)
+	ingressPolicy, err := p.ResolveL4IngressPolicy(ctx)
 	if err != nil {
 		log.WithError(err).Warn("Evaluation error while resolving L4 ingress policy")
 	}
 	verdict := api.Undecided
-	if err == nil && len(policy.Ingress) > 0 {
-		verdict = policy.IngressCoversContext(ctx)
+	if err == nil && len(*ingressPolicy) > 0 {
+		verdict = ingressPolicy.IngressCoversContext(ctx)
 	}
 
 	if len(ctx.DPorts) == 0 {
@@ -233,22 +250,14 @@ func (p *Repository) AllowsIngressRLocked(ctx *SearchContext) api.Decision {
 	decision := p.CanReachIngressRLocked(ctx)
 	ctx.PolicyTrace("Label verdict: %s", decision.String())
 	if decision == api.Allowed {
-		ctx.PolicyTrace("L4 ingress & egress policies skipped")
+		ctx.PolicyTrace("L4 ingress policies skipped")
 		return decision
 	}
 
 	// We only report the overall decision as L4 inclusive if a port has
 	// been specified
 	if len(ctx.DPorts) != 0 {
-		l4Egress := p.allowsL4Egress(ctx)
-		l4Ingress := p.allowsL4Ingress(ctx)
-
-		// Explicit deny should deny; Allow+Undecided should allow
-		if l4Egress == api.Denied || l4Ingress == api.Denied {
-			decision = api.Denied
-		} else if l4Egress == api.Allowed || l4Ingress == api.Allowed {
-			decision = api.Allowed
-		}
+		decision = p.allowsL4Ingress(ctx)
 	}
 
 	if decision != api.Allowed {
@@ -274,6 +283,8 @@ func (p *Repository) AllowsEgressRLocked(egressCtx *SearchContext) api.Decision 
 		egressDecision = p.allowsL4Egress(egressCtx)
 	}
 
+	// If we cannot determine whether allowed at L4, undecided decision becomes
+	// deny decision.
 	if egressDecision != api.Allowed {
 		egressDecision = api.Denied
 	}
@@ -346,6 +357,8 @@ func (p *Repository) SearchRLocked(labels labels.LabelArray) api.Rules {
 
 // Add inserts a rule into the policy repository
 // This is just a helper function for unit testing.
+// TODO: this should be in a test_helpers.go file or something similar
+// so we can clearly delineate what helpers are for testing.
 func (p *Repository) Add(r api.Rule) (uint64, error) {
 	p.Mutex.Lock()
 	defer p.Mutex.Unlock()
@@ -375,7 +388,10 @@ func (p *Repository) AddListLocked(rules api.Rules) (uint64, error) {
 	return p.revision, nil
 }
 
-// AddList inserts a rule into the policy repository
+// AddList inserts a rule into the policy repository.
+// This is only used in unit tests.
+// TODO: this should be in a test_helpers.go file or something similar
+// so we can clearly delineate what helpers are for testing.
 func (p *Repository) AddList(rules api.Rules) (uint64, error) {
 	p.Mutex.Lock()
 	defer p.Mutex.Unlock()

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/policy/api"
 
 	"github.com/sirupsen/logrus"
@@ -38,7 +39,7 @@ func (r *rule) String() string {
 }
 
 // sanitize has a side effect of populating the fromEntities and toEntities
-// slices to avoid superfluent map accesses
+// slices to avoid superfluous map accesses.
 func (r *rule) sanitize() error {
 	if r == nil || r.EndpointSelector.LabelSelector == nil {
 		return fmt.Errorf("nil rule")
@@ -79,54 +80,54 @@ func (r *rule) sanitize() error {
 	return nil
 }
 
-func (policy *L4Filter) addFromEndpoints(fromEndpoints []api.EndpointSelector) bool {
+func (policy *L4Filter) addEndpoints(endpoints []api.EndpointSelector) bool {
 
-	if len(policy.FromEndpoints) == 0 && len(fromEndpoints) > 0 {
+	if len(policy.Endpoints) == 0 && len(endpoints) > 0 {
 		log.WithFields(logrus.Fields{
-			logfields.EndpointSelector: fromEndpoints,
+			logfields.EndpointSelector: endpoints,
 			"policy":                   policy,
 		}).Debug("skipping L4 filter as the endpoints are already covered.")
 		return true
 	}
 
-	if len(policy.FromEndpoints) > 0 && len(fromEndpoints) == 0 {
+	if len(policy.Endpoints) > 0 && len(endpoints) == 0 {
 		log.WithFields(logrus.Fields{
-			logfields.EndpointSelector: fromEndpoints,
+			logfields.EndpointSelector: endpoints,
 			"policy":                   policy,
 		}).Debug("new L4 filter applies to all endpoints, making the policy more permissive.")
-		policy.FromEndpoints = nil
+		policy.Endpoints = nil
 	}
 
-	policy.FromEndpoints = append(policy.FromEndpoints, fromEndpoints...)
+	policy.Endpoints = append(policy.Endpoints, endpoints...)
 	return false
 }
 
-func mergeL4Port(ctx *SearchContext, fromEndpoints []api.EndpointSelector, r api.PortRule, p api.PortProtocol,
-	dir string, proto api.L4Proto, ruleLabels labels.LabelArray, resMap L4PolicyMap) (int, error) {
+func mergeL4IngressPort(ctx *SearchContext, endpoints []api.EndpointSelector, r api.PortRule, p api.PortProtocol,
+	proto api.L4Proto, ruleLabels labels.LabelArray, resMap L4PolicyMap) (int, error) {
 
 	key := p.Port + "/" + string(proto)
-	v, ok := resMap[key]
+	filter, ok := resMap[key]
 	if !ok {
-		resMap[key] = CreateL4Filter(fromEndpoints, r, p, dir, proto, ruleLabels)
+		resMap[key] = CreateL4IngressFilter(endpoints, r, p, proto, ruleLabels)
 		return 1, nil
 	}
-	l4Filter := CreateL4Filter(fromEndpoints, r, p, dir, proto, ruleLabels)
+	l4Filter := CreateL4IngressFilter(endpoints, r, p, proto, ruleLabels)
 	if l4Filter.L7Parser != "" {
-		if v.L7Parser == "" {
-			v.L7Parser = l4Filter.L7Parser
-		} else if l4Filter.L7Parser != v.L7Parser {
-			ctx.PolicyTrace("   Merge conflict: mismatching parsers %s/%s\n", l4Filter.L7Parser, v.L7Parser)
-			return 0, fmt.Errorf("Cannot merge conflicting L7 parsers (%s/%s)", l4Filter.L7Parser, v.L7Parser)
+		if filter.L7Parser == "" {
+			filter.L7Parser = l4Filter.L7Parser
+		} else if l4Filter.L7Parser != filter.L7Parser {
+			ctx.PolicyTrace("   Merge conflict: mismatching parsers %s/%s\n", l4Filter.L7Parser, filter.L7Parser)
+			return 0, fmt.Errorf("Cannot merge conflicting L7 parsers (%s/%s)", l4Filter.L7Parser, filter.L7Parser)
 		}
 	}
 
-	if v.addFromEndpoints(fromEndpoints) && r.NumRules() == 0 {
+	if filter.addEndpoints(endpoints) && r.NumRules() == 0 {
 		// skip this policy as it is already covered and it does not contain L7 rules
 		return 1, nil
 	}
 
 	for hash, newL7Rules := range l4Filter.L7RulesPerEp {
-		if ep, ok := v.L7RulesPerEp[hash]; ok {
+		if ep, ok := filter.L7RulesPerEp[hash]; ok {
 			switch {
 			case len(newL7Rules.HTTP) > 0:
 				if len(ep.Kafka) > 0 {
@@ -153,22 +154,22 @@ func mergeL4Port(ctx *SearchContext, fromEndpoints []api.EndpointSelector, r api
 			default:
 				ctx.PolicyTrace("   No L7 rules to merge.\n")
 			}
-			v.L7RulesPerEp[hash] = ep
+			filter.L7RulesPerEp[hash] = ep
 		} else {
-			v.L7RulesPerEp[hash] = newL7Rules
+			filter.L7RulesPerEp[hash] = newL7Rules
 		}
 	}
 
-	v.DerivedFromRules = append(v.DerivedFromRules, ruleLabels)
-	resMap[key] = v
+	filter.DerivedFromRules = append(filter.DerivedFromRules, ruleLabels)
+	resMap[key] = filter
 	return 1, nil
 }
 
-func mergeL4(ctx *SearchContext, dir string, fromEndpoints []api.EndpointSelector, portRules []api.PortRule,
+func mergeL4Ingress(ctx *SearchContext, fromEndpoints []api.EndpointSelector, portRules []api.PortRule,
 	ruleLabels labels.LabelArray, resMap L4PolicyMap) (int, error) {
 
 	if len(portRules) == 0 {
-		ctx.PolicyTrace("    No L4 rules\n")
+		ctx.PolicyTrace("    No L4 %s rules\n", policymap.Ingress)
 		return 0, nil
 	}
 
@@ -177,9 +178,9 @@ func mergeL4(ctx *SearchContext, dir string, fromEndpoints []api.EndpointSelecto
 
 	for _, r := range portRules {
 		if fromEndpoints != nil {
-			ctx.PolicyTrace("    Allows %s port %v from endpoints %v\n", dir, r.Ports, fromEndpoints)
+			ctx.PolicyTrace("    Allows %s port %v from endpoints %v\n", policymap.Ingress, r.Ports, fromEndpoints)
 		} else {
-			ctx.PolicyTrace("    Allows %s port %v\n", dir, r.Ports)
+			ctx.PolicyTrace("    Allows %s port %v\n", policymap.Ingress, r.Ports)
 		}
 
 		if r.Rules != nil {
@@ -206,19 +207,19 @@ func mergeL4(ctx *SearchContext, dir string, fromEndpoints []api.EndpointSelecto
 		for _, p := range r.Ports {
 			var cnt int
 			if p.Protocol != api.ProtoAny {
-				cnt, err = mergeL4Port(ctx, fromEndpoints, r, p, dir, p.Protocol, ruleLabels, resMap)
+				cnt, err = mergeL4IngressPort(ctx, fromEndpoints, r, p, p.Protocol, ruleLabels, resMap)
 				if err != nil {
 					return found, err
 				}
 				found += cnt
 			} else {
-				cnt, err = mergeL4Port(ctx, fromEndpoints, r, p, dir, api.ProtoTCP, ruleLabels, resMap)
+				cnt, err = mergeL4IngressPort(ctx, fromEndpoints, r, p, api.ProtoTCP, ruleLabels, resMap)
 				if err != nil {
 					return found, err
 				}
 				found += cnt
 
-				cnt, err = mergeL4Port(ctx, fromEndpoints, r, p, dir, api.ProtoUDP, ruleLabels, resMap)
+				cnt, err = mergeL4IngressPort(ctx, fromEndpoints, r, p, api.ProtoUDP, ruleLabels, resMap)
 				if err != nil {
 					return found, err
 				}
@@ -235,46 +236,30 @@ func (state *traceState) selectRule(ctx *SearchContext, r *rule) {
 	state.selectedRules++
 }
 
-func (state *traceState) unSelectRule(ctx *SearchContext, r *rule) {
-	ctx.PolicyTraceVerbose("  Rule %s: did not select %+v\n", r, ctx.To)
+func (state *traceState) unSelectRule(ctx *SearchContext, labels labels.LabelArray, r *rule) {
+	ctx.PolicyTraceVerbose("  Rule %s: did not select %+v\n", r, labels)
 }
 
-func (r *rule) resolveL4Policy(ctx *SearchContext, state *traceState, result *L4Policy) (*L4Policy, error) {
+// resolveL4IngressPolicy determines whether (TODO ianvernon)
+func (r *rule) resolveL4IngressPolicy(ctx *SearchContext, state *traceState, result *L4Policy) (*L4Policy, error) {
 	if !r.EndpointSelector.Matches(ctx.To) {
-		state.unSelectRule(ctx, r)
+		state.unSelectRule(ctx, ctx.To, r)
 		return nil, nil
 	}
 
 	state.selectRule(ctx, r)
 	found := 0
 
-	if !ctx.EgressL4Only {
-		if len(r.Ingress) == 0 {
-			ctx.PolicyTrace("    No L4 rules\n")
-		}
-		for _, ingressRule := range r.Ingress {
-			cnt, err := mergeL4(ctx, "Ingress", ingressRule.FromEndpoints, ingressRule.ToPorts, r.Rule.Labels.DeepCopy(), result.Ingress)
-			if err != nil {
-				return nil, err
-			}
-			if cnt > 0 {
-				found += cnt
-			}
-		}
+	if len(r.Ingress) == 0 {
+		ctx.PolicyTrace("    No L4 ingress rules\n")
 	}
-
-	if !ctx.IngressL4Only {
-		if len(r.Egress) == 0 {
-			ctx.PolicyTrace("    No L4 rules\n")
+	for _, ingressRule := range r.Ingress {
+		cnt, err := mergeL4Ingress(ctx, ingressRule.FromEndpoints, ingressRule.ToPorts, r.Rule.Labels.DeepCopy(), result.Ingress)
+		if err != nil {
+			return nil, err
 		}
-		for _, egressRule := range r.Egress {
-			cnt, err := mergeL4(ctx, "Egress", nil, egressRule.ToPorts, r.Rule.Labels.DeepCopy(), result.Egress)
-			if err != nil {
-				return nil, err
-			}
-			if cnt > 0 {
-				found += cnt
-			}
+		if cnt > 0 {
+			found += cnt
 		}
 	}
 
@@ -284,6 +269,8 @@ func (r *rule) resolveL4Policy(ctx *SearchContext, state *traceState, result *L4
 
 	return nil, nil
 }
+
+// ********************** CIDR POLICY **********************
 
 // mergeCIDR inserts all of the CIDRs in ipRules to resMap. Returns the number
 // of CIDRs added to resMap.
@@ -331,7 +318,7 @@ func computeResultantCIDRSet(cidrs []api.CIDRRule) []api.CIDR {
 func (r *rule) resolveCIDRPolicy(ctx *SearchContext, state *traceState, result *CIDRPolicy) *CIDRPolicy {
 	// Don't select rule if it doesn't apply to the given context.
 	if !r.EndpointSelector.Matches(ctx.To) {
-		state.unSelectRule(ctx, r)
+		state.unSelectRule(ctx, ctx.To, r)
 		return nil
 	}
 
@@ -388,7 +375,7 @@ func (r *rule) resolveCIDRPolicy(ctx *SearchContext, state *traceState, result *
 func (r *rule) canReachIngress(ctx *SearchContext, state *traceState) api.Decision {
 
 	if !r.EndpointSelector.Matches(ctx.To) {
-		state.unSelectRule(ctx, r)
+		state.unSelectRule(ctx, ctx.To, r)
 		return api.Undecided
 	}
 
@@ -436,13 +423,15 @@ func (r *rule) canReachIngress(ctx *SearchContext, state *traceState) api.Decisi
 	return api.Undecided
 }
 
+// ****************** EGRESS POLICY ******************
+
 // canReachEgress returns the decision as to whether the set of labels specified
 // in ctx.To match with the label selectors specified in the egress rules
 // contained within r.
 func (r *rule) canReachEgress(ctx *SearchContext, state *traceState) api.Decision {
 
 	if !r.EndpointSelector.Matches(ctx.From) {
-		state.unSelectRule(ctx, r)
+		state.unSelectRule(ctx, ctx.From, r)
 		return api.Undecided
 	}
 
@@ -500,4 +489,163 @@ func (r *rule) canReachEntities(ctx *SearchContext, state *traceState) api.Decis
 	}
 
 	return api.Undecided
+}
+
+func mergeL4Egress(ctx *SearchContext, toEndpoints []api.EndpointSelector, portRules []api.PortRule,
+	ruleLabels labels.LabelArray, resMap L4PolicyMap) (int, error) {
+
+	if len(portRules) == 0 {
+		ctx.PolicyTrace("    No L4 %s rules\n", policymap.Egress)
+		return 0, nil
+	}
+
+	found := 0
+	var err error
+
+	for _, r := range portRules {
+		if toEndpoints != nil {
+			ctx.PolicyTrace("    Allows %s port %v from endpoints %v\n", policymap.Egress, r.Ports, toEndpoints)
+		} else {
+			ctx.PolicyTrace("    Allows %s port %v\n", policymap.Egress, r.Ports)
+		}
+
+		if r.Rules != nil {
+			for _, l7 := range r.Rules.HTTP {
+				ctx.PolicyTrace("        %+v\n", l7)
+			}
+		}
+
+		l3match := false
+		if ctx.To != nil && toEndpoints != nil {
+			for _, labels := range toEndpoints {
+				if labels.Matches(ctx.To) {
+					l3match = true
+					break
+				}
+			}
+			if l3match == false {
+				ctx.PolicyTrace("      Labels %s not found", ctx.To)
+				continue
+			}
+		}
+		ctx.PolicyTrace("      Found all required labels")
+
+		for _, p := range r.Ports {
+			var cnt int
+			if p.Protocol != api.ProtoAny {
+				cnt, err = mergeL4EgressPort(ctx, toEndpoints, r, p, p.Protocol, ruleLabels, resMap)
+				if err != nil {
+					return found, err
+				}
+				found += cnt
+			} else {
+				cnt, err = mergeL4EgressPort(ctx, toEndpoints, r, p, api.ProtoTCP, ruleLabels, resMap)
+				if err != nil {
+					return found, err
+				}
+				found += cnt
+
+				cnt, err = mergeL4EgressPort(ctx, toEndpoints, r, p, api.ProtoUDP, ruleLabels, resMap)
+				if err != nil {
+					return found, err
+				}
+				found += cnt
+			}
+		}
+	}
+
+	return found, nil
+}
+
+func mergeL4EgressPort(ctx *SearchContext, endpoints []api.EndpointSelector, r api.PortRule, p api.PortProtocol,
+	proto api.L4Proto, ruleLabels labels.LabelArray, resMap L4PolicyMap) (int, error) {
+
+	key := p.Port + "/" + string(proto)
+	filter, ok := resMap[key]
+	if !ok {
+		resMap[key] = CreateL4EgressFilter(endpoints, r, p, proto, ruleLabels)
+		return 1, nil
+	}
+	l4Filter := CreateL4EgressFilter(endpoints, r, p, proto, ruleLabels)
+	if l4Filter.L7Parser != "" {
+		if filter.L7Parser == "" {
+			filter.L7Parser = l4Filter.L7Parser
+		} else if l4Filter.L7Parser != filter.L7Parser {
+			ctx.PolicyTrace("   Merge conflict: mismatching parsers %s/%s\n", l4Filter.L7Parser, filter.L7Parser)
+			return 0, fmt.Errorf("Cannot merge conflicting L7 parsers (%s/%s)", l4Filter.L7Parser, filter.L7Parser)
+		}
+	}
+
+	if filter.addEndpoints(endpoints) && r.NumRules() == 0 {
+		// skip this policy as it is already covered and it does not contain L7 rules
+		return 1, nil
+	}
+
+	for hash, newL7Rules := range l4Filter.L7RulesPerEp {
+		if ep, ok := filter.L7RulesPerEp[hash]; ok {
+			switch {
+			case len(newL7Rules.HTTP) > 0:
+				if len(ep.Kafka) > 0 {
+					ctx.PolicyTrace("   Merge conflict: mismatching L7 rule types.\n")
+					return 0, fmt.Errorf("Cannot merge conflicting L7 rule types")
+				}
+
+				for _, newRule := range newL7Rules.HTTP {
+					if !newRule.Exists(ep) {
+						ep.HTTP = append(ep.HTTP, newRule)
+					}
+				}
+			case len(newL7Rules.Kafka) > 0:
+				if len(ep.HTTP) > 0 {
+					ctx.PolicyTrace("   Merge conflict: mismatching L7 rule types.\n")
+					return 0, fmt.Errorf("Cannot merge conflicting L7 rule types")
+				}
+
+				for _, newRule := range newL7Rules.Kafka {
+					if !newRule.Exists(ep) {
+						ep.Kafka = append(ep.Kafka, newRule)
+					}
+				}
+			default:
+				ctx.PolicyTrace("   No L7 rules to merge.\n")
+			}
+			filter.L7RulesPerEp[hash] = ep
+		} else {
+			filter.L7RulesPerEp[hash] = newL7Rules
+		}
+	}
+
+	filter.DerivedFromRules = append(filter.DerivedFromRules, ruleLabels)
+	resMap[key] = filter
+	return 1, nil
+}
+
+func (r *rule) resolveL4EgressPolicy(ctx *SearchContext, state *traceState, result *L4Policy) (*L4Policy, error) {
+
+	if !r.EndpointSelector.Matches(ctx.From) {
+		state.unSelectRule(ctx, ctx.From, r)
+		return nil, nil
+	}
+
+	state.selectRule(ctx, r)
+	found := 0
+
+	if len(r.Egress) == 0 {
+		ctx.PolicyTrace("    No L4 rules\n")
+	}
+	for _, egressRule := range r.Egress {
+		cnt, err := mergeL4Egress(ctx, egressRule.ToEndpoints, egressRule.ToPorts, r.Rule.Labels.DeepCopy(), result.Egress)
+		if err != nil {
+			return nil, err
+		}
+		if cnt > 0 {
+			found += cnt
+		}
+	}
+
+	if found > 0 {
+		return result, nil
+	}
+
+	return nil, nil
 }

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -740,29 +740,6 @@ func (ds *PolicyTestSuite) TestEgressRuleRestrictions(c *C) {
 	err := apiRule1.Sanitize()
 	c.Assert(err, Not(IsNil))
 
-	// Cannot combine ToEndpoints and ToPorts. See GH-3099.
-	apiRule1 = api.Rule{
-		EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("bar")),
-		Egress: []api.EgressRule{
-			{
-				ToEndpoints: fooSelector,
-				ToPorts: []api.PortRule{{
-					Ports: []api.PortProtocol{
-						{Port: "80", Protocol: api.ProtoTCP},
-					},
-					Rules: &api.L7Rules{
-						Kafka: []api.PortRuleKafka{
-							{Topic: "foo"},
-						},
-					},
-				}},
-			},
-		},
-	}
-
-	err = apiRule1.Sanitize()
-	c.Assert(err, Not(IsNil))
-
 	// Cannot combine ToCIDR and ToPorts. See GH-1684.
 	apiRule1 = api.Rule{
 		EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("bar")),

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -109,7 +109,9 @@ func (ds *PolicyTestSuite) TestRuleCanReach(c *C) {
 
 func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	toBar := &SearchContext{To: labels.ParseSelectLabelArray("bar")}
+	fromBar := &SearchContext{From: labels.ParseSelectLabelArray("bar")}
 	toFoo := &SearchContext{To: labels.ParseSelectLabelArray("foo")}
+	fromFoo := &SearchContext{From: labels.ParseSelectLabelArray("foo")}
 
 	rule1 := &rule{
 		Rule: api.Rule{
@@ -150,12 +152,12 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 
 	expected := NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: nil,
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: nil,
 		L7Parser: "http", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil},
 	}
 	expected.Ingress["8080/TCP"] = L4Filter{
-		Port: 8080, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: nil,
+		Port: 8080, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: nil,
 		L7Parser: "http", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil},
 	}
@@ -171,20 +173,38 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 		DerivedFromRules: labels.LabelArrayList{nil},
 	}
 
-	state := traceState{}
-	res, err := rule1.resolveL4Policy(toBar, &state, NewL4Policy())
+	ingressState := traceState{}
+	egressState := traceState{}
+	res, err := rule1.resolveL4IngressPolicy(toBar, &ingressState, NewL4Policy())
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
+
+	res2, err := rule1.resolveL4EgressPolicy(fromBar, &egressState, NewL4Policy())
+	c.Assert(err, IsNil)
+	c.Assert(res2, Not(IsNil))
+
+	res.Egress = res2.Egress
+
 	c.Assert(*res, comparator.DeepEquals, *expected)
-	c.Assert(state.selectedRules, Equals, 1)
-	c.Assert(state.matchedRules, Equals, 0)
+	c.Assert(ingressState.selectedRules, Equals, 1)
+	c.Assert(ingressState.matchedRules, Equals, 0)
+
+	c.Assert(egressState.selectedRules, Equals, 1)
+	c.Assert(egressState.matchedRules, Equals, 0)
 
 	// Foo isn't selected in the rule1's policy.
-	state = traceState{}
-	res, err = rule1.resolveL4Policy(toFoo, &state, NewL4Policy())
+	ingressState = traceState{}
+	egressState = traceState{}
+
+	res, err = rule1.resolveL4IngressPolicy(toFoo, &ingressState, NewL4Policy())
+	res2, err = rule1.resolveL4EgressPolicy(fromFoo, &ingressState, NewL4Policy())
+
 	c.Assert(res, IsNil)
-	c.Assert(state.selectedRules, Equals, 0)
-	c.Assert(state.matchedRules, Equals, 0)
+	c.Assert(res2, IsNil)
+	c.Assert(ingressState.selectedRules, Equals, 0)
+	c.Assert(ingressState.matchedRules, Equals, 0)
+	c.Assert(egressState.selectedRules, Equals, 0)
+	c.Assert(egressState.matchedRules, Equals, 0)
 
 	// This rule actually overlaps with the existing ingress "http" rule,
 	// so we'd expect it to merge.
@@ -226,7 +246,7 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 
 	expected = NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: nil,
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: nil,
 		L7Parser: "http", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
 	}
@@ -241,23 +261,43 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 		DerivedFromRules: labels.LabelArrayList{nil},
 	}
 
-	state = traceState{}
-	res, err = rule2.resolveL4Policy(toBar, &state, NewL4Policy())
+	ingressState = traceState{}
+	egressState = traceState{}
+	res, err = rule2.resolveL4IngressPolicy(toBar, &ingressState, NewL4Policy())
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
+
+	res2, err = rule2.resolveL4EgressPolicy(fromBar, &egressState, NewL4Policy())
+	c.Assert(err, IsNil)
+	c.Assert(res2, Not(IsNil))
+
+	res.Egress = res2.Egress
+
 	c.Assert(len(res.Ingress), Equals, 1)
 	c.Assert(*res, comparator.DeepEquals, *expected)
-	c.Assert(state.selectedRules, Equals, 1)
-	c.Assert(state.matchedRules, Equals, 0)
+	c.Assert(ingressState.selectedRules, Equals, 1)
+	c.Assert(ingressState.matchedRules, Equals, 0)
 
-	state = traceState{}
-	res, err = rule2.resolveL4Policy(toFoo, &state, NewL4Policy())
+	c.Assert(egressState.selectedRules, Equals, 1)
+	c.Assert(egressState.matchedRules, Equals, 0)
+
+	ingressState = traceState{}
+	egressState = traceState{}
+
+	res, err = rule2.resolveL4IngressPolicy(toFoo, &ingressState, NewL4Policy())
 	c.Assert(res, IsNil)
-	c.Assert(state.selectedRules, Equals, 0)
-	c.Assert(state.matchedRules, Equals, 0)
+
+	res2, err = rule2.resolveL4EgressPolicy(fromFoo, &egressState, NewL4Policy())
+	c.Assert(res, IsNil)
+
+	c.Assert(ingressState.selectedRules, Equals, 0)
+	c.Assert(ingressState.matchedRules, Equals, 0)
+
+	c.Assert(egressState.selectedRules, Equals, 0)
+	c.Assert(egressState.matchedRules, Equals, 0)
 }
 
-func (ds *PolicyTestSuite) TestMergeL4Policy(c *C) {
+func (ds *PolicyTestSuite) TestMergeL4PolicyIngress(c *C) {
 	toBar := &SearchContext{To: labels.ParseSelectLabelArray("bar")}
 	//toFoo := &SearchContext{To: labels.ParseSelectLabelArray("foo")}
 
@@ -290,13 +330,13 @@ func (ds *PolicyTestSuite) TestMergeL4Policy(c *C) {
 	mergedES := []api.EndpointSelector{fooSelector, bazSelector}
 	expected := NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: mergedES,
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: mergedES,
 		L7Parser: "", L7RulesPerEp: L7DataMap{}, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
 	}
 
 	state := traceState{}
-	res, err := rule1.resolveL4Policy(toBar, &state, NewL4Policy())
+	res, err := rule1.resolveL4IngressPolicy(toBar, &state, NewL4Policy())
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -304,7 +344,68 @@ func (ds *PolicyTestSuite) TestMergeL4Policy(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 }
 
-func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
+func (ds *PolicyTestSuite) TestMergeL4PolicyEgress(c *C) {
+
+	/*+       ctx := &SearchContext{
+	+               To: labels.ParseSelectLabelArray("foo", "groupB"),
+	+               From:   labels.ParseSelectLabelArray("bar", "groupA"),
+	+               Logging: logging.NewLogBackend(buffer, "", 0),
+	+               Trace:   TRACE_VERBOSE,
+	+       }*/
+	buffer := new(bytes.Buffer)
+	fromBar := &SearchContext{
+		From:    labels.ParseSelectLabelArray("bar"),
+		Logging: logging.NewLogBackend(buffer, "", 0),
+		Trace:   TRACE_VERBOSE,
+	}
+	//toFoo := &SearchContext{To: labels.ParseSelectLabelArray("foo")}
+
+	fooSelector := api.NewESFromLabels(labels.ParseSelectLabel("foo"))
+	bazSelector := api.NewESFromLabels(labels.ParseSelectLabel("baz"))
+
+	// bar can access foo with TCP on port 80, and baz with TCP on port 80.
+	rule1 := &rule{
+		Rule: api.Rule{
+			EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("bar")),
+			Egress: []api.EgressRule{
+				{
+					ToEndpoints: []api.EndpointSelector{fooSelector},
+					ToPorts: []api.PortRule{{
+						Ports: []api.PortProtocol{
+							{Port: "80", Protocol: api.ProtoTCP},
+						},
+					}},
+				},
+				{
+					ToEndpoints: []api.EndpointSelector{bazSelector},
+					ToPorts: []api.PortRule{{
+						Ports: []api.PortProtocol{
+							{Port: "80", Protocol: api.ProtoTCP},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	mergedES := []api.EndpointSelector{fooSelector, bazSelector}
+	expected := NewL4Policy()
+	expected.Egress["80/TCP"] = L4Filter{
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: mergedES,
+		L7Parser: "", L7RulesPerEp: L7DataMap{}, Ingress: false,
+		DerivedFromRules: labels.LabelArrayList{nil, nil},
+	}
+
+	state := traceState{}
+	res, err := rule1.resolveL4EgressPolicy(fromBar, &state, NewL4Policy())
+	c.Assert(err, IsNil)
+	c.Assert(res, Not(IsNil))
+	c.Assert(*res, comparator.DeepEquals, *expected)
+	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 0)
+}
+
+func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	toBar := &SearchContext{To: labels.ParseSelectLabelArray("bar")}
 	toFoo := &SearchContext{To: labels.ParseSelectLabelArray("foo")}
 
@@ -361,13 +462,13 @@ func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
 
 	expected := NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: nil,
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: nil,
 		L7Parser: "http", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil, nil, nil},
 	}
 
 	state := traceState{}
-	res, err := rule1.resolveL4Policy(toBar, &state, NewL4Policy())
+	res, err := rule1.resolveL4IngressPolicy(toBar, &state, NewL4Policy())
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -375,7 +476,7 @@ func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = rule1.resolveL4Policy(toFoo, &state, NewL4Policy())
+	res, err = rule1.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
 	c.Assert(state.matchedRules, Equals, 0)
@@ -430,13 +531,13 @@ func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
 
 	expected = NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: nil,
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: nil,
 		L7Parser: "kafka", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil, nil, nil},
 	}
 
 	state = traceState{}
-	res, err = rule2.resolveL4Policy(toBar, &state, NewL4Policy())
+	res, err = rule2.resolveL4IngressPolicy(toBar, &state, NewL4Policy())
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -444,18 +545,18 @@ func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = rule2.resolveL4Policy(toFoo, &state, NewL4Policy())
+	res, err = rule2.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
 	c.Assert(state.matchedRules, Equals, 0)
 
 	// Resolve rule1's policy, then try to add rule2.
-	res, err = rule1.resolveL4Policy(toBar, &state, NewL4Policy())
+	res, err = rule1.resolveL4IngressPolicy(toBar, &state, NewL4Policy())
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
 	state = traceState{}
-	res, err = rule2.resolveL4Policy(toBar, &state, res)
+	res, err = rule2.resolveL4IngressPolicy(toBar, &state, res)
 	c.Assert(err, Not(IsNil))
 	c.Assert(err.Error(), Equals, "Cannot merge conflicting L7 parsers (kafka/http)")
 
@@ -508,13 +609,231 @@ func (ds *PolicyTestSuite) TestMergeL7Policy(c *C) {
 	}
 	expected = NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, FromEndpoints: nil,
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: nil,
 		L7Parser: "kafka", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
 	}
 
 	state = traceState{}
-	res, err = rule3.resolveL4Policy(toBar, &state, NewL4Policy())
+	res, err = rule3.resolveL4IngressPolicy(toBar, &state, NewL4Policy())
+	c.Assert(err, IsNil)
+	c.Assert(res, Not(IsNil))
+	c.Assert(*res, comparator.DeepEquals, *expected)
+	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 0)
+}
+
+func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
+	fromBar := &SearchContext{From: labels.ParseSelectLabelArray("bar")}
+	fromFoo := &SearchContext{From: labels.ParseSelectLabelArray("foo")}
+
+	fooSelector := []api.EndpointSelector{
+		api.NewESFromLabels(labels.ParseSelectLabel("foo")),
+	}
+
+	rule1 := &rule{
+		Rule: api.Rule{
+			EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("bar")),
+			Egress: []api.EgressRule{
+				{
+					ToPorts: []api.PortRule{{
+						Ports: []api.PortProtocol{
+							{Port: "80", Protocol: api.ProtoTCP},
+						},
+					}},
+				},
+				{
+					ToPorts: []api.PortRule{{
+						Ports: []api.PortProtocol{
+							{Port: "80", Protocol: api.ProtoTCP},
+						},
+						Rules: &api.L7Rules{
+							HTTP: []api.PortRuleHTTP{
+								{Method: "GET", Path: "/"},
+							},
+						},
+					}},
+				},
+				{
+					ToEndpoints: fooSelector,
+					ToPorts: []api.PortRule{{
+						Ports: []api.PortProtocol{
+							{Port: "80", Protocol: api.ProtoTCP},
+						},
+						Rules: &api.L7Rules{
+							HTTP: []api.PortRuleHTTP{
+								{Method: "GET", Path: "/"},
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	l7rules := api.L7Rules{
+		HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
+	}
+	l7map := L7DataMap{
+		WildcardEndpointSelector: l7rules,
+		fooSelector[0]:           l7rules,
+	}
+
+	expected := NewL4Policy()
+	expected.Egress["80/TCP"] = L4Filter{
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: nil,
+		L7Parser: "http", L7RulesPerEp: l7map, Ingress: false,
+		DerivedFromRules: labels.LabelArrayList{nil, nil, nil},
+	}
+
+	state := traceState{}
+	res, err := rule1.resolveL4EgressPolicy(fromBar, &state, NewL4Policy())
+	c.Assert(err, IsNil)
+	c.Assert(res, Not(IsNil))
+	c.Assert(*res, comparator.DeepEquals, *expected)
+	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 0)
+
+	state = traceState{}
+	res, err = rule1.resolveL4EgressPolicy(fromFoo, &state, NewL4Policy())
+	c.Assert(res, IsNil)
+	c.Assert(state.selectedRules, Equals, 0)
+	c.Assert(state.matchedRules, Equals, 0)
+
+	rule2 := &rule{
+		Rule: api.Rule{
+			EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("bar")),
+			Egress: []api.EgressRule{
+				{
+					ToPorts: []api.PortRule{{
+						Ports: []api.PortProtocol{
+							{Port: "80", Protocol: api.ProtoTCP},
+						},
+					}},
+				},
+				{
+					ToPorts: []api.PortRule{{
+						Ports: []api.PortProtocol{
+							{Port: "80", Protocol: api.ProtoTCP},
+						},
+						Rules: &api.L7Rules{
+							Kafka: []api.PortRuleKafka{
+								{Topic: "foo"},
+							},
+						},
+					}},
+				},
+				{
+					ToEndpoints: fooSelector,
+					ToPorts: []api.PortRule{{
+						Ports: []api.PortProtocol{
+							{Port: "80", Protocol: api.ProtoTCP},
+						},
+						Rules: &api.L7Rules{
+							Kafka: []api.PortRuleKafka{
+								{Topic: "foo"},
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	l7rules = api.L7Rules{
+		Kafka: []api.PortRuleKafka{{Topic: "foo"}},
+	}
+	l7map = L7DataMap{
+		WildcardEndpointSelector: l7rules,
+		fooSelector[0]:           l7rules,
+	}
+	expected = NewL4Policy()
+	expected.Egress["80/TCP"] = L4Filter{
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: nil,
+		L7Parser: "kafka", L7RulesPerEp: l7map, Ingress: false,
+		DerivedFromRules: labels.LabelArrayList{nil, nil, nil},
+	}
+
+	state = traceState{}
+	res, err = rule2.resolveL4EgressPolicy(fromBar, &state, NewL4Policy())
+	c.Assert(err, IsNil)
+	c.Assert(res, Not(IsNil))
+	c.Assert(*res, comparator.DeepEquals, *expected)
+	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 0)
+
+	state = traceState{}
+	res, err = rule2.resolveL4EgressPolicy(fromFoo, &state, NewL4Policy())
+	c.Assert(res, IsNil)
+	c.Assert(state.selectedRules, Equals, 0)
+	c.Assert(state.matchedRules, Equals, 0)
+
+	// Resolve rule1's policy, then try to add rule2.
+	res, err = rule1.resolveL4EgressPolicy(fromBar, &state, NewL4Policy())
+	c.Assert(err, IsNil)
+	c.Assert(res, Not(IsNil))
+
+	state = traceState{}
+	res, err = rule2.resolveL4EgressPolicy(fromBar, &state, res)
+	c.Assert(err, Not(IsNil))
+	c.Assert(err.Error(), Equals, "Cannot merge conflicting L7 parsers (kafka/http)")
+
+	// Similar to 'rule2', but with different topics for the l3-dependent
+	// rule and the l4-only rule.
+	rule3 := &rule{
+		Rule: api.Rule{
+			EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("bar")),
+			Egress: []api.EgressRule{
+				{
+					ToEndpoints: fooSelector,
+					ToPorts: []api.PortRule{{
+						Ports: []api.PortProtocol{
+							{Port: "80", Protocol: api.ProtoTCP},
+						},
+						Rules: &api.L7Rules{
+							Kafka: []api.PortRuleKafka{
+								{Topic: "foo"},
+							},
+						},
+					}},
+				},
+				{
+					ToPorts: []api.PortRule{{
+						Ports: []api.PortProtocol{
+							{Port: "80", Protocol: api.ProtoTCP},
+						},
+						Rules: &api.L7Rules{
+							Kafka: []api.PortRuleKafka{
+								{Topic: "bar"},
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	fooRules := api.L7Rules{
+		Kafka: []api.PortRuleKafka{{Topic: "foo"}},
+	}
+	barRules := api.L7Rules{
+		Kafka: []api.PortRuleKafka{{Topic: "bar"}},
+	}
+
+	// The l3-dependent l7 rules are not merged together.
+	l7map = L7DataMap{
+		fooSelector[0]:           fooRules,
+		WildcardEndpointSelector: barRules,
+	}
+	expected = NewL4Policy()
+	expected.Egress["80/TCP"] = L4Filter{
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: nil,
+		L7Parser: "kafka", L7RulesPerEp: l7map, Ingress: false,
+		DerivedFromRules: labels.LabelArrayList{nil, nil},
+	}
+
+	state = traceState{}
+	res, err = rule3.resolveL4EgressPolicy(fromBar, &state, NewL4Policy())
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -1090,6 +1409,7 @@ func (ds *PolicyTestSuite) TestL4RuleLabels(c *C) {
 
 	// endpoint selector for all tests
 	toBar := &SearchContext{To: labels.ParseSelectLabelArray("bar")}
+	fromBar := &SearchContext{From: labels.ParseSelectLabelArray("bar")}
 
 	for _, test := range testCases {
 		finalPolicy := NewL4Policy()
@@ -1102,7 +1422,8 @@ func (ds *PolicyTestSuite) TestL4RuleLabels(c *C) {
 			err = rule.sanitize()
 			c.Assert(err, IsNil, Commentf("Cannot sanitize Rule: %+v", rule))
 
-			rule.resolveL4Policy(toBar, &traceState{}, finalPolicy)
+			rule.resolveL4IngressPolicy(toBar, &traceState{}, finalPolicy)
+			rule.resolveL4EgressPolicy(fromBar, &traceState{}, finalPolicy)
 		}
 
 		c.Assert(len(finalPolicy.Ingress), Equals, len(test.expectedIngressLabels), Commentf(test.description))
@@ -1264,16 +1585,16 @@ func (ds *PolicyTestSuite) TestIngressL4AllowAll(c *C) {
 	ctxAToC90.DPorts = []*models.Port{{Port: 90, Protocol: models.PortProtocolTCP}}
 	checkIngress(c, repo, &ctxAToC90, api.Denied)
 
-	l4policy, err := repo.ResolveL4Policy(&ctxAToC80)
+	l4IngressPolicy, err := repo.ResolveL4IngressPolicy(&ctxAToC80)
 	c.Assert(err, IsNil)
 
-	filter, ok := l4policy.Ingress["80/TCP"]
+	filter, ok := (*l4IngressPolicy)["80/TCP"]
 	c.Assert(ok, Equals, true)
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
 	// must have empty endpoint to select all
-	c.Assert(len(filter.FromEndpoints), Equals, 0)
+	c.Assert(len(filter.Endpoints), Equals, 0)
 }
 
 func (ds *PolicyTestSuite) TestEgressAllowAll(c *C) {
@@ -1308,9 +1629,6 @@ func (ds *PolicyTestSuite) TestEgressL4AllowAll(c *C) {
 			EndpointSelector: endpointSelectorA,
 			Egress: []api.EgressRule{
 				{
-					ToEndpoints: []api.EndpointSelector{
-						api.NewWildcardEndpointSelector(),
-					},
 					ToPorts: []api.PortRule{{
 						Ports: []api.PortProtocol{
 							{Port: "80", Protocol: api.ProtoTCP},
@@ -1322,29 +1640,27 @@ func (ds *PolicyTestSuite) TestEgressL4AllowAll(c *C) {
 	})
 
 	ctxAToC80 := ctxAToC
-	ctxAToC80.EgressL4Only = true
 	ctxAToC80.DPorts = []*models.Port{{Port: 80, Protocol: models.PortProtocolTCP}}
 	checkEgress(c, repo, &ctxAToC80, api.Allowed)
 
 	ctxAToC90 := ctxAToC
-	ctxAToC90.EgressL4Only = true
 	ctxAToC90.DPorts = []*models.Port{{Port: 90, Protocol: models.PortProtocolTCP}}
 	checkEgress(c, repo, &ctxAToC90, api.Denied)
 
 	buffer := new(bytes.Buffer)
-	ctx := SearchContext{To: labelsA, Trace: TRACE_VERBOSE, EgressL4Only: true}
+	ctx := SearchContext{From: labelsA, Trace: TRACE_VERBOSE}
 	ctx.Logging = logging.NewLogBackend(buffer, "", 0)
 
-	l4policy, err := repo.ResolveL4Policy(&ctx)
+	l4EgressPolicy, err := repo.ResolveL4EgressPolicy(&ctx)
 	c.Assert(err, IsNil)
 
 	c.Log(buffer)
 
-	filter, ok := l4policy.Egress["80/TCP"]
+	filter, ok := (*l4EgressPolicy)["80/TCP"]
 	c.Assert(ok, Equals, true)
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, false)
 
 	// must have empty endpoint selector to match on all sources
-	c.Assert(len(filter.FromEndpoints), Equals, 0)
+	c.Assert(len(filter.Endpoints), Equals, 0)
 }


### PR DESCRIPTION
This consists of the following changes:

* pkg/policy: add label-dependent L4 for egress
    - Rename existing functions in terms of ingress and factor out egress-related parts in now-ingress-only functions to their corresponding egress-related counterparts.

* cmd: add directionality to `cilium bpf policy <add,delete>`
    - Add capability to specify whether policy should apply to ingress or egress to the given BPF PolicyMap for an endpoint.

* pkg/maps/policymap: add Invalid TrafficDirection

* cmd: add parseTrafficString helper
    - Add a helper which converts a given string to policymap.TrafficDirection.

* pkg/k8s: enable TestParseNetworkPolicyEgressL4AllowAll
    - Enable this unit test now that L3-dependent-L4 for egress is added.

What this does *not* do:

* Test datapath integration. This only tests the agent-side plumbing down to insertion in the BPF maps.
* Test CLI for `cilium bpf policy <add,delete>`
* Expose egress policy tracing to end-users. I think this needs to be done with an API update with a verdict for ingress and egress accordingly.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #3099 

