### PR TITLE
NPDS: Send allow-all policy to proxy when enforcement is disabled

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -153,7 +153,9 @@ func (d *Daemon) UpdateNetworkPolicy(e *endpoint.Endpoint, policy *policy.L4Poli
 	if d.l7Proxy == nil {
 		return fmt.Errorf("can't update network policy, proxy disabled")
 	}
-	return d.l7Proxy.UpdateNetworkPolicy(e, policy, labelsMap, deniedIngressIdentities, deniedEgressIdentities, e.ProxyWaitGroup)
+	ingressPolicyEnforced, egressPolicyEnforced := d.EnableEndpointPolicyEnforcement(e)
+	return d.l7Proxy.UpdateNetworkPolicy(e, policy, ingressPolicyEnforced, egressPolicyEnforced,
+		labelsMap, deniedIngressIdentities, deniedEgressIdentities, e.ProxyWaitGroup)
 }
 
 // RemoveNetworkPolicy removes a network policy from the set published to

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -44,6 +44,10 @@ func Test(t *testing.T) { TestingT(t) }
 type DaemonSuite struct {
 	d *Daemon
 
+	// oldPolicyEnabled is the policy enforcement mode that was set before the test,
+	// as returned by policy.GetPolicyEnabled().
+	oldPolicyEnabled string
+
 	kvstoreInit bool
 
 	// Owners interface mock
@@ -72,6 +76,9 @@ type DaemonSuite struct {
 }
 
 func (ds *DaemonSuite) SetUpTest(c *C) {
+	ds.oldPolicyEnabled = policy.GetPolicyEnabled()
+	policy.SetPolicyEnabled(e.DefaultEnforcement)
+
 	// kvstore is initialized before generic SetUpTest so it must have been completed
 	ds.kvstoreInit = true
 
@@ -137,6 +144,9 @@ func (ds *DaemonSuite) TearDownTest(c *C) {
 		kvstore.DeletePrefix(common.OperationalPath)
 		kvstore.DeletePrefix(kvstore.BaseKeyPrefix)
 	}
+
+	// Restore the policy enforcement mode.
+	policy.SetPolicyEnabled(ds.oldPolicyEnabled)
 }
 
 type DaemonEtcdSuite struct {

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -55,21 +55,23 @@ func (d *Daemon) TriggerPolicyUpdates(force bool) *sync.WaitGroup {
 // Must be called with e.Consumable.Mutex and d.GetPolicyRepository().Mutex held.
 func (d *Daemon) EnableEndpointPolicyEnforcement(e *endpoint.Endpoint) (ingress bool, egress bool) {
 	// First check if policy enforcement should be enabled at the daemon level.
-	// If policy enforcement is enabled for the daemon, then it has to be
-	// enabled for the endpoint.
-	if policy.GetPolicyEnabled() == endpoint.AlwaysEnforce {
+	switch policy.GetPolicyEnabled() {
+	case endpoint.AlwaysEnforce:
+		// If policy enforcement is enabled for the daemon, then it has to be
+		// enabled for the endpoint.
 		return true, true
-	} else if policy.GetPolicyEnabled() == endpoint.DefaultEnforcement {
+	case endpoint.DefaultEnforcement:
 		// Default mode means that if rules contain labels that match this endpoint,
 		// then enable policy enforcement for this endpoint.
 		// GH-1676: Could check e.Consumable instead? Would be much cheaper.
 		return d.GetPolicyRepository().GetRulesMatching(e.Consumable.LabelArray, false)
+	default:
+		// If policy enforcement isn't enabled for the daemon we do not enable
+		// policy enforcement for the endpoint.
+		// This means that daemon policy enforcement mode is 'never', so no policy
+		// enforcement should be applied to the specified endpoint.
+		return false, false
 	}
-	// If policy enforcement isn't enabled for the daemon we do not enable
-	// policy enforcement for the endpoint.
-	// This means that daemon policy enforcement mode is 'never', so no policy
-	// enforcement should be applied to the specified endpoint.
-	return false, false
 }
 
 type getPolicyResolve struct {

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -236,6 +236,10 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 				},
 			},
 		},
+		EgressPerPortPolicies: []*cilium.PortNetworkPolicy{ // Allow-all policy.
+			{Protocol: envoy_api_v2_core.SocketAddress_TCP},
+			{Protocol: envoy_api_v2_core.SocketAddress_UDP},
+		},
 	}
 	c.Assert(qaBarNetworkPolicy, comparator.DeepEquals, expectedNetworkPolicy)
 

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -458,12 +458,18 @@ func getDirectionNetworkPolicy(l4Policy policy.L4PolicyMap, labelsMap identity.I
 // getNetworkPolicy converts a network policy into a cilium.NetworkPolicy.
 func getNetworkPolicy(name string, id identity.NumericIdentity, policy *policy.L4Policy,
 	labelsMap identity.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool) *cilium.NetworkPolicy {
-	return &cilium.NetworkPolicy{
-		Name:                   name,
-		Policy:                 uint64(id),
-		IngressPerPortPolicies: getDirectionNetworkPolicy(policy.Ingress, labelsMap, deniedIngressIdentities),
-		EgressPerPortPolicies:  getDirectionNetworkPolicy(policy.Egress, labelsMap, deniedEgressIdentities),
+	p := &cilium.NetworkPolicy{
+		Name:   name,
+		Policy: uint64(id),
 	}
+
+	// If no policy, deny all traffic. Otherwise, convert the policies for ingress and egress.
+	if policy != nil {
+		p.IngressPerPortPolicies = getDirectionNetworkPolicy(policy.Ingress, labelsMap, deniedIngressIdentities)
+		p.EgressPerPortPolicies = getDirectionNetworkPolicy(policy.Egress, labelsMap, deniedEgressIdentities)
+	}
+
+	return p
 }
 
 // UpdateNetworkPolicy adds or updates a network policy in the set published

--- a/pkg/envoy/server_test.go
+++ b/pkg/envoy/server_test.go
@@ -354,3 +354,14 @@ func (s *ServerSuite) TestGetNetworkPolicyWildcardDeny(c *C) {
 	}
 	c.Assert(obtained, comparator.DeepEquals, expected)
 }
+
+func (s *ServerSuite) TestGetNetworkPolicyNil(c *C) {
+	obtained := getNetworkPolicy(IPv4Addr, Identity, nil, IdentityCache, DeniedIdentities1001, DeniedIdentitiesNone)
+	expected := &cilium.NetworkPolicy{
+		Name:                   IPv4Addr,
+		Policy:                 uint64(Identity),
+		IngressPerPortPolicies: nil,
+		EgressPerPortPolicies:  nil,
+	}
+	c.Assert(obtained, comparator.DeepEquals, expected)
+}

--- a/pkg/envoy/server_test.go
+++ b/pkg/envoy/server_test.go
@@ -304,15 +304,15 @@ func (s *ServerSuite) TestGetPortNetworkPolicyRule(c *C) {
 }
 
 func (s *ServerSuite) TestGetDirectionNetworkPolicy(c *C) {
-	obtained := getDirectionNetworkPolicy(L4PolicyMap1, IdentityCache, DeniedIdentitiesNone)
+	obtained := getDirectionNetworkPolicy(L4PolicyMap1, true, IdentityCache, DeniedIdentitiesNone)
 	c.Assert(obtained, comparator.DeepEquals, ExpectedPerPortPolicies1)
 
-	obtained = getDirectionNetworkPolicy(L4PolicyMap2, IdentityCache, DeniedIdentitiesNone)
+	obtained = getDirectionNetworkPolicy(L4PolicyMap2, true, IdentityCache, DeniedIdentitiesNone)
 	c.Assert(obtained, comparator.DeepEquals, ExpectedPerPortPolicies2)
 }
 
 func (s *ServerSuite) TestGetNetworkPolicy(c *C) {
-	obtained := getNetworkPolicy(IPv4Addr, Identity, L4Policy1, IdentityCache, DeniedIdentitiesNone, DeniedIdentitiesNone)
+	obtained := getNetworkPolicy(IPv4Addr, Identity, L4Policy1, true, true, IdentityCache, DeniedIdentitiesNone, DeniedIdentitiesNone)
 	expected := &cilium.NetworkPolicy{
 		Name:                   IPv4Addr,
 		Policy:                 uint64(Identity),
@@ -323,7 +323,7 @@ func (s *ServerSuite) TestGetNetworkPolicy(c *C) {
 }
 
 func (s *ServerSuite) TestGetNetworkPolicyWildcard(c *C) {
-	obtained := getNetworkPolicy(IPv4Addr, Identity, L4Policy2, IdentityCache, DeniedIdentitiesNone, DeniedIdentitiesNone)
+	obtained := getNetworkPolicy(IPv4Addr, Identity, L4Policy2, true, true, IdentityCache, DeniedIdentitiesNone, DeniedIdentitiesNone)
 	expected := &cilium.NetworkPolicy{
 		Name:                   IPv4Addr,
 		Policy:                 uint64(Identity),
@@ -334,7 +334,7 @@ func (s *ServerSuite) TestGetNetworkPolicyWildcard(c *C) {
 }
 
 func (s *ServerSuite) TestGetNetworkPolicyDeny(c *C) {
-	obtained := getNetworkPolicy(IPv4Addr, Identity, L4Policy1, IdentityCache, DeniedIdentities1001, DeniedIdentitiesNone)
+	obtained := getNetworkPolicy(IPv4Addr, Identity, L4Policy1, true, true, IdentityCache, DeniedIdentities1001, DeniedIdentitiesNone)
 	expected := &cilium.NetworkPolicy{
 		Name:                   IPv4Addr,
 		Policy:                 uint64(Identity),
@@ -345,7 +345,7 @@ func (s *ServerSuite) TestGetNetworkPolicyDeny(c *C) {
 }
 
 func (s *ServerSuite) TestGetNetworkPolicyWildcardDeny(c *C) {
-	obtained := getNetworkPolicy(IPv4Addr, Identity, L4Policy2, IdentityCache, DeniedIdentities1001, DeniedIdentitiesNone)
+	obtained := getNetworkPolicy(IPv4Addr, Identity, L4Policy2, true, true, IdentityCache, DeniedIdentities1001, DeniedIdentitiesNone)
 	expected := &cilium.NetworkPolicy{
 		Name:                   IPv4Addr,
 		Policy:                 uint64(Identity),
@@ -356,12 +356,34 @@ func (s *ServerSuite) TestGetNetworkPolicyWildcardDeny(c *C) {
 }
 
 func (s *ServerSuite) TestGetNetworkPolicyNil(c *C) {
-	obtained := getNetworkPolicy(IPv4Addr, Identity, nil, IdentityCache, DeniedIdentities1001, DeniedIdentitiesNone)
+	obtained := getNetworkPolicy(IPv4Addr, Identity, nil, true, true, IdentityCache, DeniedIdentities1001, DeniedIdentitiesNone)
 	expected := &cilium.NetworkPolicy{
 		Name:                   IPv4Addr,
 		Policy:                 uint64(Identity),
 		IngressPerPortPolicies: nil,
 		EgressPerPortPolicies:  nil,
+	}
+	c.Assert(obtained, comparator.DeepEquals, expected)
+}
+
+func (s *ServerSuite) TestGetNetworkPolicyIngressNotEnforced(c *C) {
+	obtained := getNetworkPolicy(IPv4Addr, Identity, L4Policy2, false, true, IdentityCache, DeniedIdentities1001, DeniedIdentitiesNone)
+	expected := &cilium.NetworkPolicy{
+		Name:                   IPv4Addr,
+		Policy:                 uint64(Identity),
+		IngressPerPortPolicies: allowAllPortNetworkPolicy,
+		EgressPerPortPolicies:  ExpectedPerPortPolicies2,
+	}
+	c.Assert(obtained, comparator.DeepEquals, expected)
+}
+
+func (s *ServerSuite) TestGetNetworkPolicyEgressNotEnforced(c *C) {
+	obtained := getNetworkPolicy(IPv4Addr, Identity, L4Policy2, true, false, IdentityCache, DeniedIdentities1001, DeniedIdentitiesNone)
+	expected := &cilium.NetworkPolicy{
+		Name:                   IPv4Addr,
+		Policy:                 uint64(Identity),
+		IngressPerPortPolicies: ExpectedPerPortPolicies5,
+		EgressPerPortPolicies:  allowAllPortNetworkPolicy,
 	}
 	c.Assert(obtained, comparator.DeepEquals, expected)
 }


### PR DESCRIPTION
Any endpoint with a `nil` `L4Policy` was causing a panic. Instead, generate a policy that denies all traffic at both ingress and egress.

Send an allow-all policy when enforcement is disabled for an endpoint. This lets the sidecar proxy forward traffic in this case (traffic is always redirected to the proxy in this case even when Cilium's enforcement is disabled).

Signed-off-by: Romain Lenglet <romain@covalent.io>