### PR TITLE
Improve logging in xDS server and ctmap

### DIFF
--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -58,7 +58,7 @@ func startXDSGRPCServer(listener net.Listener, ldsConfig, npdsConfig, nphdsConfi
 	reflection.Register(grpcServer)
 
 	go func() {
-		log.Infof("Envoy: Starting xDS gRPC server listening on %s", listener)
+		log.Infof("Envoy: Starting xDS gRPC server listening on %s", listener.Addr())
 		if err := grpcServer.Serve(listener); err != nil && !strings.Contains(err.Error(), "closed network connection") {
 			log.WithError(err).Fatal("Envoy: Failed to serve xDS gRPC API")
 		}

--- a/pkg/flowdebug/flowdebug.go
+++ b/pkg/flowdebug/flowdebug.go
@@ -30,9 +30,16 @@ func Enabled() bool {
 	return perFlowDebug
 }
 
-// Log must be used to log any debug messages emitted per request/message
-func Log(l *logrus.Entry, msg string) {
+// Log must be used to log any debug messages emitted per request/message/connection
+func Log(l *logrus.Entry, args ...interface{}) {
 	if perFlowDebug {
-		l.Debug(msg)
+		l.Debug(args...)
+	}
+}
+
+// Logf must be used to log any debug messages emitted per request/message/connection
+func Logf(l *logrus.Entry, format string, args ...interface{}) {
+	if perFlowDebug {
+		l.Debugf(format, args...)
 	}
 }


### PR DESCRIPTION
Fix xDS server start log message.
Move `doFiltering`'s debug logs under `flowdebug` to reduce debug verbosity.

Fixes: #3273
Fixes: #3295

Signed-off-by: Romain Lenglet <romain@covalent.io>