### PR TITLE
Print endpoint-specific logs in agent log

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1487,6 +1487,11 @@ func (e *Endpoint) logStatusLocked(typ StatusType, code StatusCode, msg string) 
 		Timestamp: time.Now().UTC(),
 	}
 	e.Status.addStatusLog(sts)
+	e.getLogger().WithFields(logrus.Fields{
+		"code":                  sts.Status.Code,
+		"type":                  sts.Status.Type,
+		logfields.EndpointState: sts.Status.State,
+	}).Debug(msg)
 }
 
 type UpdateValidationError struct {

--- a/pkg/k8s/annotate.go
+++ b/pkg/k8s/annotate.go
@@ -62,6 +62,6 @@ func AnnotatePod(e PodEndpoint, annotationKey, annotationValue string) error {
 		return fmt.Errorf("unable to annotate pod, cannot update pod: %s", err)
 	}
 
-	scopedLog.Debug("Successfully annotated pod with %s=%s", annotationKey, annotationValue)
+	scopedLog.Debugf("Successfully annotated pod with %s=%s", annotationKey, annotationValue)
 	return nil
 }


### PR DESCRIPTION
We record information for retrieval with 'cilium endpoint log' but we never log it as part of the agent logs. This change includes an equivalent debug print of these changes.

#3305 