### PR TITLE
envoy: Fix concurrency issues in Cilium xDS server

### DIFF
--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -530,9 +530,12 @@ func (s *XDSServer) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *polic
 
 	// When successful, push them into the cache.
 	for _, p := range policies {
-		policyRevision := policy.Revision
-		callback := func() {
-			go ep.OnProxyPolicyUpdate(policyRevision)
+		var callback func()
+		if policy != nil {
+			policyRevision := policy.Revision
+			callback = func() {
+				go ep.OnProxyPolicyUpdate(policyRevision)
+			}
 		}
 		var c *completion.Completion
 		if wg == nil {


### PR DESCRIPTION
Use mutex to protect field accesses in Cilium xDS server.
Don't try to set the endpoint's policy revision if `policy` is `nil`.

Fixes: #3329
Signed-off-by: Romain Lenglet <romain@covalent.io>