### PR TITLE
docs: Fix the Kafka policy to use the new role in the GSG

### DIFF
--- a/examples/policies/getting-started/kafka.yaml
+++ b/examples/policies/getting-started/kafka.yaml
@@ -17,15 +17,5 @@ spec:
         protocol: TCP
       rules:
         kafka:
-        - apiKey: "fetch"
+        - role: "consume"
           topic: "empire-announce"
-        - apiKey: "apiversions"
-        - apiKey: "metadata"
-        - apiKey: "findcoordinator"
-        - apiKey: "joingroup"
-        - apiKey: "leavegroup"
-        - apiKey: "syncgroup"
-        - apiKey: "offsets"
-        - apiKey: "offsetcommit"
-        - apiKey: "offsetfetch"
-        - apiKey: "heartbeat"


### PR DESCRIPTION
Fixes: #3349
Signed-Off-By: Manali Bhutiyani <manali@covalent.io>


```release-note
  docs: Fix the Kafka policy to use the new role in the GSG
```