### PR TITLE
test/runtime/manifests: fix typo in policy

### DIFF
--- a/test/runtime/manifests/Policies-l7-multiple.json
+++ b/test/runtime/manifests/Policies-l7-multiple.json
@@ -20,7 +20,7 @@
 },
 {
     "endpointSelector":
-        {"matchLabels":{"id.http2":""}},
+        {"matchLabels":{"id.httpd2":""}},
     "ingress": [{
         "fromEndpoints": [
             {"matchLabels":{"reserved:host":""}},

--- a/test/runtime/manifests/Policies-l7-simple.json
+++ b/test/runtime/manifests/Policies-l7-simple.json
@@ -19,7 +19,7 @@
 },
 {
     "endpointSelector":
-        {"matchLabels":{"id.http2":""}},
+        {"matchLabels":{"id.httpd2":""}},
     "ingress": [{
         "fromEndpoints": [
             {"matchLabels":{"reserved:host":""}},


### PR DESCRIPTION
Change id.http2 --> id.httpd2. This rule wasn't actually selecting any endpoints.

Signed-off by: Ian Vernon <ian@cilium.io>