### PR TITLE
Ginkgo: Run monitor on tests

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -105,7 +105,7 @@ Vagrant.configure(2) do |config|
         vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
         vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
         config.vm.box = "cilium/ubuntu"
-        config.vm.box_version = "46"
+        config.vm.box_version = "49"
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i
         if ENV["NFS"] then

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -8,7 +8,7 @@ $K8S_VERSION = ENV['K8S_VERSION'] || "1.10"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 $NFS = ENV['NFS']=="1"? true : false
 $SERVER_BOX= "cilium/ubuntu"
-$SERVER_VERSION="46"
+$SERVER_VERSION="49"
 
 # RAM and CPU settings
 $MEMORY = (ENV['MEMORY'] || "4096").to_i
@@ -47,7 +47,6 @@ Vagrant.configure("2") do |config|
     (1..$K8S_NODES).each do |i|
         config.vm.define "k8s#{i}-#{$K8S_VERSION}" do |server|
             server.vm.provider "virtualbox" do |vb|
-                # vb.customize ["modifyvm", :id, "--memory", "2048"]
                 vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
                 vb.cpus = $CPU
                 vb.memory= $MEMORY

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -357,8 +357,8 @@ func (s *SSHMeta) ManifestsPath() string {
 	return fmt.Sprintf("%s/runtime/manifests/", BasePath)
 }
 
-// MonitorStart starts the  monitor command in background and return a callback
-// function to stop the monitor when the user needs. When the callback is
+// MonitorStart starts the  monitor command in background and returns a callback
+// function wich stops the monitor when the user needs. When the callback is
 // called the command will stop and monitor's output is saved on
 // `monitorLogFileName` file.
 func (s *SSHMeta) MonitorStart() func() error {

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -160,6 +160,9 @@ const (
 	configMap   = "ConfigMap"
 	daemonSet   = "DaemonSet"
 
+	monitorLogFileName = "monitor.log"
+	microscopeManifest = `https://raw.githubusercontent.com/cilium/microscope/master/docs/microscope.yaml`
+
 	deadLockHeader = "POTENTIAL DEADLOCK:" // from github.com/sasha-s/go-deadlock/deadlock.go:header
 
 	// IPv4Host is an IP which is used in some datapath tests for simulating external IPv4 connectivity.

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -302,16 +302,16 @@ func (kub *Kubectl) ManifestGet(manifestFilename string) string {
 	return fmt.Sprintf("%s/k8sT/manifests/%s", BasePath, manifestFilename)
 }
 
-// MicroscopeStart installs (if it is not installed) a new microscope pod, wai
-// until pod is ready and run microscope in background. It returns a error in
-// case of the microscope cannot be installed or it is not ready after a
-// timeout, also it returns a callback function to stop the monitor and save
-// the output to `helpers.monitorLogFileName` file
+// MicroscopeStart installs (if it is not installed) a new microscope pod,
+// waits until pod is ready, and runs microscope in background. It returns an
+// error in the case where microscope cannot be installed, or it is not ready after
+// a timeout. Also it returns a callback function to stop the monitor and save
+// the output to `helpers.monitorLogFileName` file.
 func (kub *Kubectl) MicroscopeStart() (error, func() error) {
 	microscope := "microscope"
 	cmd := fmt.Sprintf("%[1]s -n %[2]s exec %[3]s -- %[3]s --combine",
 		KubectlCmd, KubeSystemNamespace, microscope)
-	kub.Apply(microscopeManifest)
+	_ = kub.Apply(microscopeManifest)
 
 	_, err := kub.WaitforPods(
 		KubeSystemNamespace,

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -28,6 +28,8 @@ import (
 
 var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 
+	var microscopeErr error
+	var microscopeCancel func() error
 	var demoPath string
 	var once sync.Once
 	var kubectl *helpers.Kubectl
@@ -102,8 +104,14 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 			"cilium endpoint list"})
 	})
 
+	JustBeforeEach(func() {
+		microscopeErr, microscopeCancel = kubectl.MicroscopeStart()
+		Expect(microscopeErr).To(BeNil(), "Microscope cannot be started")
+	})
+
 	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+		Expect(microscopeCancel()).To(BeNil(), "cannot stop microscope")
 	})
 
 	AfterEach(func() {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -48,6 +48,8 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 		podServer                                         *v1.Pod
 		namespace                                         string
 		app1Service                                       string = "app1-service"
+		microscopeErr                                     error
+		microscopeCancel                                  func() error
 	)
 
 	initialize := func() {
@@ -94,8 +96,14 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 			"cilium endpoint list"})
 	})
 
+	JustBeforeEach(func() {
+		microscopeErr, microscopeCancel = kubectl.MicroscopeStart()
+		Expect(microscopeErr).To(BeNil(), "Microscope cannot be started")
+	})
+
 	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+		Expect(microscopeCancel()).To(BeNil(), "cannot stop microscope")
 	})
 
 	Context("Basic Test", func() {
@@ -782,6 +790,8 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 		ciliumDaemonSetPath string
 		cnpL7Stresstest     string
 		cnpAnyNamespace     string
+		microscopeErr       error
+		microscopeCancel    func() error
 	)
 
 	initialize := func() {
@@ -832,8 +842,14 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 			"cilium endpoint list"})
 	})
 
+	JustBeforeEach(func() {
+		microscopeErr, microscopeCancel = kubectl.MicroscopeStart()
+		Expect(microscopeErr).To(BeNil(), "Microscope cannot be started")
+	})
+
 	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+		Expect(microscopeCancel()).To(BeNil(), "cannot stop microscope")
 	})
 
 	AfterEach(func() {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -36,6 +36,8 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 	var logger *logrus.Entry
 	var once sync.Once
 	var serviceName string = "app1-service"
+	var microscopeErr error
+	var microscopeCancel func() error
 
 	applyPolicy := func(path string) {
 		_, err := kubectl.CiliumPolicyAction(helpers.KubeSystemNamespace, path, helpers.KubectlApply, helpers.HelperTimeout)
@@ -67,8 +69,14 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 			"cilium endpoint list"})
 	})
 
+	JustBeforeEach(func() {
+		microscopeErr, microscopeCancel = kubectl.MicroscopeStart()
+		Expect(microscopeErr).To(BeNil(), "Microscope cannot be started")
+	})
+
 	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+		Expect(microscopeCancel()).To(BeNil(), "cannot stop microscope")
 	})
 
 	AfterEach(func() {

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -40,11 +40,13 @@ func getStarWarsResourceLink(file string) string {
 var _ = Describe(demoTestName, func() {
 
 	var (
-		demoPath   string
-		once       sync.Once
-		kubectl    *helpers.Kubectl
-		logger     *logrus.Entry
-		ciliumYAML string
+		demoPath         string
+		once             sync.Once
+		kubectl          *helpers.Kubectl
+		logger           *logrus.Entry
+		ciliumYAML       string
+		microscopeErr    error
+		microscopeCancel func() error
 
 		deathStarYAMLLink = getStarWarsResourceLink("02-deathstar.yaml")
 		l4PolicyYAMLLink  = getStarWarsResourceLink("policy/l4_policy.yaml")
@@ -80,8 +82,14 @@ var _ = Describe(demoTestName, func() {
 		kubectl.CiliumReport(helpers.KubeSystemNamespace)
 	})
 
+	JustBeforeEach(func() {
+		microscopeErr, microscopeCancel = kubectl.MicroscopeStart()
+		Expect(microscopeErr).To(BeNil(), "Microscope cannot be started")
+	})
+
 	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+		Expect(microscopeCancel()).To(BeNil(), "cannot stop microscope")
 	})
 
 	AfterEach(func() {

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -52,8 +52,10 @@ const (
 
 var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 
-	var logger *logrus.Entry
-	var vm *helpers.SSHMeta
+	var (
+		logger *logrus.Entry
+		vm     *helpers.SSHMeta
+	)
 
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimePolicyEnforcement"})
@@ -406,8 +408,11 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 
 var _ = Describe("RuntimeValidatedPolicies", func() {
 
-	var logger *logrus.Entry
-	var vm *helpers.SSHMeta
+	var (
+		logger      *logrus.Entry
+		vm          *helpers.SSHMeta
+		monitorStop func() error
+	)
 
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"test": "RunPolicies"})
@@ -433,8 +438,13 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 		vm.PolicyDelAll().ExpectSuccess("Unable to delete all policies")
 	})
 
+	JustBeforeEach(func() {
+		monitorStop = vm.MonitorStart()
+	})
+
 	JustAfterEach(func() {
 		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+		Expect(monitorStop()).To(BeNil(), "cannot stop monitor command")
 	})
 
 	AfterFailed(func() {

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -20,12 +20,17 @@ var _ = Describe("RuntimeValidatedConnectivityTest", func() {
 	var once sync.Once
 	var logger *logrus.Entry
 	var vm *helpers.SSHMeta
+	var monitorStop func() error
 
 	initialize := func() {
 		logger = log.WithFields(logrus.Fields{"test": "RuntimeConnectivityTest"})
 		logger.Info("Starting")
 		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 	}
+
+	JustBeforeEach(func() {
+		monitorStop = vm.MonitorStart()
+	})
 
 	BeforeEach(func() {
 		once.Do(initialize)
@@ -44,6 +49,7 @@ var _ = Describe("RuntimeValidatedConnectivityTest", func() {
 
 	JustAfterEach(func() {
 		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+		Expect(monitorStop()).To(BeNil(), "cannot stop monitor command")
 	})
 
 	AfterFailed(func() {
@@ -289,6 +295,7 @@ var _ = Describe("RuntimeValidatedConntrackTest", func() {
 	var logger *logrus.Entry
 	var vm *helpers.SSHMeta
 	var once sync.Once
+	var monitorStop func() error
 
 	var curl1ContainerName = "curl"
 	var curl2ContainerName = "curl2"
@@ -623,6 +630,10 @@ var _ = Describe("RuntimeValidatedConntrackTest", func() {
 
 	})
 
+	JustBeforeEach(func() {
+		monitorStop = vm.MonitorStart()
+	})
+
 	AfterEach(func() {
 		containersToRm := []string{helpers.Client, helpers.Server, helpers.Httpd1, helpers.Httpd2, curl1ContainerName, curl2ContainerName}
 		for _, containerToRm := range containersToRm {
@@ -636,6 +647,7 @@ var _ = Describe("RuntimeValidatedConntrackTest", func() {
 
 	JustAfterEach(func() {
 		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+		Expect(monitorStop()).To(BeNil(), "cannot stop monitor command")
 	})
 
 	AfterFailed(func() {

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -31,6 +31,7 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 	var once sync.Once
 	var logger *logrus.Entry
 	var vm *helpers.SSHMeta
+	var monitorStop func() error
 
 	var allowedTopic string = "allowedTopic"
 	var disallowTopic string = "disallowTopic"
@@ -130,8 +131,13 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 		containers("delete")
 	})
 
+	JustBeforeEach(func() {
+		monitorStop = vm.MonitorStart()
+	})
+
 	JustAfterEach(func() {
 		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+		Expect(monitorStop()).To(BeNil(), "cannot stop monitor command")
 	})
 
 	AfterFailed(func() {

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -64,7 +64,7 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 			Expect(err).Should(BeNil())
 
 			vm.ContainerCreate("kafka", "wurstmeister/kafka", helpers.CiliumDockerNetwork, fmt.Sprintf(
-				"-l id.kafka -e KAFKA_ZOOKEEPER_CONNECT=%s:2181 -e KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS=20000 -e KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS=20000", zook["IPv4"]))
+				"-l id.kafka -e KAFKA_ZOOKEEPER_CONNECT=%s:2181 -e KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS=20000 -e KAFKA_LISTENERS=PLAINTEXT://:9092 -e KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS=20000", zook["IPv4"]))
 
 		case "delete":
 			for k := range images {

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -29,6 +29,7 @@ var _ = Describe("RuntimeValidatedLB", func() {
 
 	var logger *logrus.Entry
 	var vm *helpers.SSHMeta
+	var monitorStop func() error
 
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"test": "RuntimeLB"})
@@ -41,8 +42,13 @@ var _ = Describe("RuntimeValidatedLB", func() {
 		vm.ServiceDelAll().ExpectSuccess()
 	})
 
+	JustBeforeEach(func() {
+		monitorStop = vm.MonitorStart()
+	})
+
 	JustAfterEach(func() {
 		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+		Expect(monitorStop()).To(BeNil(), "cannot stop monitor command")
 	})
 
 	AfterFailed(func() {


### PR DESCRIPTION
Hi @ianvernon 

I would like to have your input here. The monitor was added in the test, and I think that this is the best approach that we can have without to much trouble and keep code simple. 

The monitor utility will run in the background, and it'll be started in the background, and in `JustAfterEach` monitor will be stopped . 

Logs will be saved in `test-output.log` per each test at the end. I saw that you want monitor with timestamps and different files, but in this way, we can have all monitor output in the same file. 

The only problem that I see is that the endpoint regeneration is marked in monitor, but policy revision is not in there: 

```
cmd: "cilium monitor" exitCode: 0 
 Listening for events on 2 CPUs with 64x4096 of shared memory
Press Ctrl-C to quit
>> Endpoint regenerated: 13949 (container:id.service1,container:id.httpd2)
>> Endpoint regenerated: 48896 (container:id.app1)
>> Endpoint regenerated: 60670 (container:id.app2)
>> Endpoint regenerated: 29381 (container:id.service1,container:id.httpd3)
>> Endpoint regenerated: 29898 (reserved:health)
>> Endpoint regenerated: 38939 (container:id.app3)
>> Endpoint regenerated: 173 (container:id.httpd1,container:id.service1)
<- endpoint 173 flow 0x1def40be identity 61740->0 state new ifindex 0: fe80::bc22:84ff:fe51:a568 -> ff02::2 RouterSolicitation
```

An improvement that I will do here is to add policy revision to monitor, so you can see the traffic from A to B within the policy revision that you want. 

I think that this should work, and the logic to add it to test will be around 6 lines of code per Describe. Obviously, I'll do a helper that will be like `cancel = vm.StartMonitorDebug()` so it'll easy. 

Does this satisfy you, or want something more complex?

Best regards

Related to: #3233
