### PR TITLE
Ginkgo: Add segmentation fault check on `ValidateErrorsOnLogs`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ COPY plugins/cilium-cni/cni-uninstall.sh /cni-uninstall.sh
 WORKDIR /root
 RUN groupadd -f cilium \
 	&& echo ". /etc/profile.d/bash_completion.sh" >> /root/.bashrc \
-	&& cilium completion bash >> /root/.bashrc
+    && cilium completion bash >> /root/.bashrc \
+    && sysctl -w kernel.core_pattern=/tmp/core.%e.%p.%t
 ENV INITSYSTEM="SYSTEMD"
-
 CMD ["/usr/bin/cilium"]

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -625,9 +625,9 @@ func (s *SSHMeta) ReportFailed(commands ...string) {
 }
 
 // ValidateNoErrorsOnLogs checks in cilium logs since the given duration (By
-// default `CurrentGinkgoTestDescription().Duration`) do not contain `panic` or
-// `deadlocks` messages . In case of any of these messages, it'll mark the test
-// as failed.
+// default `CurrentGinkgoTestDescription().Duration`) do not contain `panic`,
+// `deadlocks` or `segmentation faults` messages . In case of any of these
+// messages, it'll mark the test as failed.
 func (s *SSHMeta) ValidateNoErrorsOnLogs(duration time.Duration) {
 	logsCmd := fmt.Sprintf(`sudo journalctl -au %s --since '%v seconds ago'`,
 		DaemonName, duration.Seconds())
@@ -637,6 +637,8 @@ func (s *SSHMeta) ValidateNoErrorsOnLogs(duration time.Duration) {
 		"Found a panic in Cilium logs")
 	gomega.ExpectWithOffset(1, logs).ToNot(gomega.ContainSubstring(deadLockHeader),
 		"Found a deadlock in Cilium logs")
+	gomega.ExpectWithOffset(1, logs).ToNot(gomega.ContainSubstring(segmentationFault),
+		"Found a %q in Cilium logs", segmentationFault)
 }
 
 // CheckLogsForDeadlock checks if the logs for Cilium log messages that signify

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -695,6 +695,7 @@ func (s *SSHMeta) GatherLogs() {
 	ciliumStateCommands := []string{
 		fmt.Sprintf("sudo rsync -rv --exclude=*.sock %s %s", RunDir, filepath.Join(BasePath, testPath, "lib")),
 		fmt.Sprintf("sudo rsync -rv --exclude=*.sock %s %s", LibDir, filepath.Join(BasePath, testPath, "run")),
+		fmt.Sprintf("sudo mv /tmp/core* %s", filepath.Join(BasePath, testPath)),
 	}
 
 	for _, cmd := range ciliumStateCommands {

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -163,13 +163,14 @@ const (
 	monitorLogFileName = "monitor.log"
 	microscopeManifest = `https://raw.githubusercontent.com/cilium/microscope/master/docs/microscope.yaml`
 
-	deadLockHeader = "POTENTIAL DEADLOCK:" // from github.com/sasha-s/go-deadlock/deadlock.go:header
-
 	// IPv4Host is an IP which is used in some datapath tests for simulating external IPv4 connectivity.
 	IPv4Host = "192.168.254.254"
 
 	// IPv6Host is an IP which is used in some datapath tests for simulating external IPv6 connectivity.
 	IPv6Host = "fdff::ff"
+
+	deadLockHeader    = "POTENTIAL DEADLOCK:" // from github.com/sasha-s/go-deadlock/deadlock.go:header
+	segmentationFault = "segmentation fault"  // from https://github.com/cilium/cilium/issues/3233
 )
 
 var ciliumCLICommands = map[string]string{

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -973,9 +973,9 @@ func (kub *Kubectl) CiliumReport(namespace string, commands ...[]string) {
 }
 
 // ValidateNoErrorsOnLogs checks in cilium logs since the given duration (By
-// default `CurrentGinkgoTestDescription().Duration`) do not contain `panic` or
-// `deadlocks` messages. In case of any of these messages, it'll mark the test
-// as failed.
+// default `CurrentGinkgoTestDescription().Duration`) do not contain `panic`,
+// `deadlocks` or `segmentation faults` messages. In case of any of these
+// messages, it'll mark the test as failed.
 func (kub *Kubectl) ValidateNoErrorsOnLogs(duration time.Duration) {
 	cmd := fmt.Sprintf("%s -n %s logs --timestamps=true -l k8s-app=cilium --since=%vs",
 		KubectlCmd, KubeSystemNamespace, duration.Seconds())
@@ -988,6 +988,8 @@ func (kub *Kubectl) ValidateNoErrorsOnLogs(duration time.Duration) {
 		"Found a panic in Cilium logs")
 	gomega.ExpectWithOffset(1, logs).ToNot(gomega.ContainSubstring(deadLockHeader),
 		"Found a deadlock in Cilium logs")
+	gomega.ExpectWithOffset(1, logs).ToNot(gomega.ContainSubstring(segmentationFault),
+		"Found a %q in Cilium logs", segmentationFault)
 }
 
 // CheckLogsForDeadlock checks if the logs for Cilium log messages that signify


### PR DESCRIPTION
Add new assert to validate that Envoy didn't crash.

Related #3233

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>