### PR TITLE
BLOCKED: K8s CI: Update the multinode tests to use the Kafka Roles

### DIFF
--- a/test/k8sT/manifests/kafka-sw-security-policy-apikey.yaml
+++ b/test/k8sT/manifests/kafka-sw-security-policy-apikey.yaml
@@ -1,0 +1,78 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+description: "Allow only permitted Kafka requests to empire Kafka broker"
+metadata:
+  name: "secure-empire-kafka"
+specs:
+  - endpointSelector:
+      matchLabels:
+        app: kafka
+    ingress:
+    - fromEndpoints:
+      - matchLabels:
+          app: empire-hq
+      toPorts:
+      - ports:
+        - port: "9092"
+          protocol: TCP
+        rules:
+          kafka:
+          - apiKey: "apiversions"
+          - apiKey: "metadata"
+          - apiKey: "produce"
+            topic: "deathstar-plans"
+          - apiKey: "produce"
+            topic: "empire-announce"
+    - fromEndpoints:
+      - matchLabels:
+          app: kafka
+  - endpointSelector:
+      matchLabels:
+        app: kafka
+    ingress:
+    - fromEndpoints:
+      - matchLabels:
+          app: empire-outpost
+      toPorts:
+      - ports:
+        - port: "9092"
+          protocol: TCP
+        rules:
+          kafka:
+          - apiKey: "fetch"
+            topic: "empire-announce"
+          - apiKey: "apiversions"
+          - apiKey: "metadata"
+          - apiKey: "findcoordinator"
+          - apiKey: "joingroup"
+          - apiKey: "leavegroup"
+          - apiKey: "syncgroup"
+          - apiKey: "offsets"
+          - apiKey: "offsetcommit"
+          - apiKey: "offsetfetch"
+          - apiKey: "heartbeat"
+  - endpointSelector:
+      matchLabels:
+        app: kafka
+    ingress:
+    - fromEndpoints:
+      - matchLabels:
+          app: empire-backup
+      toPorts:
+      - ports:
+        - port: "9092"
+          protocol: TCP
+        rules:
+          kafka:
+          - apiKey: "fetch"
+            topic: "deathstar-plans"
+          - apiKey: "apiversions"
+          - apiKey: "metadata"
+          - apiKey: "findcoordinator"
+          - apiKey: "joingroup"
+          - apiKey: "leavegroup"
+          - apiKey: "syncgroup"
+          - apiKey: "offsets"
+          - apiKey: "offsetcommit"
+          - apiKey: "offsetfetch"
+          - apiKey: "heartbeat"

--- a/test/k8sT/manifests/kafka-sw-security-policy.yaml
+++ b/test/k8sT/manifests/kafka-sw-security-policy.yaml
@@ -10,17 +10,6 @@ specs:
     ingress:
     - fromEndpoints:
       - matchLabels:
-          app: kafka
-      toPorts:
-      - ports:
-        - port: "2181"
-          protocol: TCP
-  - endpointSelector:
-      matchLabels:
-        app: kafka
-    ingress:
-    - fromEndpoints:
-      - matchLabels:
           app: empire-hq
       toPorts:
       - ports:
@@ -28,11 +17,9 @@ specs:
           protocol: TCP
         rules:
           kafka:
-          - apiKey: "apiversions"
-          - apiKey: "metadata"
-          - apiKey: "produce"
+          - role: "produce"
             topic: "deathstar-plans"
-          - apiKey: "produce"
+          - role: "produce"
             topic: "empire-announce"
     - fromEndpoints:
       - matchLabels:
@@ -50,18 +37,8 @@ specs:
           protocol: TCP
         rules:
           kafka:
-          - apiKey: "fetch"
+          - role: "consume"
             topic: "empire-announce"
-          - apiKey: "apiversions"
-          - apiKey: "metadata"
-          - apiKey: "findcoordinator"
-          - apiKey: "joingroup"
-          - apiKey: "leavegroup"
-          - apiKey: "syncgroup"
-          - apiKey: "offsets"
-          - apiKey: "offsetcommit"
-          - apiKey: "offsetfetch"
-          - apiKey: "heartbeat"
   - endpointSelector:
       matchLabels:
         app: kafka
@@ -75,15 +52,5 @@ specs:
           protocol: TCP
         rules:
           kafka:
-          - apiKey: "fetch"
+          - role: "consume"
             topic: "deathstar-plans"
-          - apiKey: "apiversions"
-          - apiKey: "metadata"
-          - apiKey: "findcoordinator"
-          - apiKey: "joingroup"
-          - apiKey: "leavegroup"
-          - apiKey: "syncgroup"
-          - apiKey: "offsets"
-          - apiKey: "offsetcommit"
-          - apiKey: "offsetfetch"
-          - apiKey: "heartbeat"


### PR DESCRIPTION
Fixes: #3361
Signed-Off-By: Manali Bhutiyani <manali@covalent.io>

This change also removes the rule allowing Kafka talking to itself, since this will not be needed anymore with the headless Kafka service.

```release-note
K8s CI: Update the multinode tests to use the Kafka Roles
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/3362)
<!-- Reviewable:end -->
