### PR TITLE
daemon: Merge Envoy logs with cilium logs by default.

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -33,7 +33,7 @@ cilium-agent
   -e, --docker string                     Path to docker runtime socket (DEPRECATED: use container-runtime-endpoint instead) (default "unix:///var/run/docker.sock")
       --enable-policy string              Enable policy enforcement (default "default")
       --enable-tracing                    Enable tracing while determining policy (debugging)
-      --envoy-log string                  Path to Envoy log (default "/var/log/cilium-envoy.log")
+      --envoy-log string                  Path to a separate Envoy log file, if any
       --ipv4-cluster-cidr-mask-size int   Mask size for the cluster wide CIDR (default 8)
       --ipv4-node string                  IPv4 address of node (default "auto")
       --ipv4-range string                 Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -340,7 +340,7 @@ func init() {
 	flags.String("enable-policy", endpoint.DefaultEnforcement, "Enable policy enforcement")
 	flags.BoolVar(&enableTracing,
 		"enable-tracing", false, "Enable tracing while determining policy (debugging)")
-	flags.String("envoy-log", "/var/log/cilium-envoy.log", "Path to Envoy log")
+	flags.String("envoy-log", "", "Path to a separate Envoy log file, if any")
 	flags.BoolVar(&useEnvoy,
 		"envoy-proxy", true, "This flag is deprecated and will be removed in the next release")
 	flags.MarkHidden("envoy-proxy")

--- a/envoy/WORKSPACE
+++ b/envoy/WORKSPACE
@@ -7,7 +7,7 @@ workspace(name = "cilium")
 #
 # No other line in this file may have ENVOY_SHA followed by an equals sign!
 #
-ENVOY_SHA = "12434bee6a6be56a62955999ed38e16a7a9ee054"
+ENVOY_SHA = "fc3693b5205518171a590d87e51ae317040f9276"
 
 http_archive(
     name = "envoy",
@@ -38,5 +38,3 @@ load("@com_lyft_protoc_gen_validate//bazel:go_proto_library.bzl", "go_proto_repo
 go_proto_repositories(shared=0)
 go_rules_dependencies()
 go_register_toolchains()
-load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
-proto_register_toolchains()

--- a/envoy/cilium_bpf_metadata.h
+++ b/envoy/cilium_bpf_metadata.h
@@ -23,11 +23,6 @@ public:
   Config(const ::cilium::BpfMetadata &config, Server::Configuration::ListenerFactoryContext& context);
   virtual ~Config() {}
 
-  uint32_t getMark(uint32_t identity) {
-    // Magic marker values must match with Cilium.
-    return ((is_ingress_) ? 0xFEA : 0xFEB) | (identity << 16);
-  }
-
   virtual bool getBpfMetadata(Network::ConnectionSocket &socket);
 
   bool is_ingress_;

--- a/envoy/cilium_integration_test.cc
+++ b/envoy/cilium_integration_test.cc
@@ -36,18 +36,15 @@ namespace BpfMetadata {
 class TestConfig : public Config {
 public:
   TestConfig(const ::cilium::BpfMetadata& config, Server::Configuration::ListenerFactoryContext& context)
-    : Config(config, context),
-      socket_mark_(std::make_shared<Cilium::SocketOption>(maps_, 42, 1, true, 80, 10000)) {}
+    : Config(config, context) {}
 
   bool getBpfMetadata(Network::ConnectionSocket &socket) override {
     // fake setting the local address. It remains the same as required by the test infra, but it will be marked as restored
     // as required by the original_dst cluster.
     socket.setLocalAddress(original_dst_address, true);
-    socket.setOptions(socket_mark_);
+    socket.addOption(std::make_unique<Cilium::SocketOption>(maps_, 42, 1, true, 80, 10000));
     return true;
   }
-
-  Network::Socket::OptionsSharedPtr socket_mark_;
 };
 
 typedef std::shared_ptr<TestConfig> TestConfigSharedPtr;

--- a/envoy/cilium_socket_option.h
+++ b/envoy/cilium_socket_option.h
@@ -8,41 +8,50 @@
 namespace Envoy {
 namespace Cilium {
 
-class SocketMarkOption : public Network::Socket::Options, public Logger::Loggable<Logger::Id::filter> {
+class SocketMarkOption : public Network::Socket::Option, public Logger::Loggable<Logger::Id::filter> {
 public:
-  SocketMarkOption(uint32_t mark) : mark_(mark) {}
+  SocketMarkOption(uint16_t identity, bool ingress) : identity_(identity), ingress_(ingress) {}
 
-  bool setOptions(Network::Socket& socket) const override {
-    int rc = setsockopt(socket.fd(), SOL_SOCKET, SO_MARK, &mark_, sizeof(mark_));
+  bool setOption(Network::Socket& socket, Network::Socket::SocketState state) const override {
+    // Only set the option once per socket
+    if (state != Network::Socket::SocketState::PreBind) {
+      return true;
+    }
+    uint32_t mark = ((ingress_) ? 0xFEA : 0xFEB) | (identity_ << 16);
+    int rc = setsockopt(socket.fd(), SOL_SOCKET, SO_MARK, &mark, sizeof(mark));
     if (rc < 0) {
       if (errno == EPERM) {
 	// Do not assert out in this case so that we can run tests without CAP_NET_ADMIN.
 	ENVOY_LOG(critical,
 		  "Failed to set socket option SO_MARK to {}, capability CAP_NET_ADMIN needed: {}",
-		  mark_, strerror(errno));
+		  mark, strerror(errno));
       } else {
-	ENVOY_LOG(critical, "Socket option failure. Failed to set SO_MARK to {}: {}", mark_,
+	ENVOY_LOG(critical, "Socket option failure. Failed to set SO_MARK to {}: {}", mark,
 		  strerror(errno));
 	return false;
       }
     }
     return true;
   }
-  uint32_t hashKey() const override { return mark_; }
+  void hashKey(std::vector<uint8_t>& key) const override {
+    // Add the source identity to the hash key. This will separate upstream connection pools
+    // per security ID.
+    key.emplace_back(uint8_t(identity_ >> 8));
+    key.emplace_back(uint8_t(identity_));
+  }
 
-  uint32_t mark_;
+  uint32_t identity_;
+  bool ingress_;
 };
 
 class SocketOption : public SocketMarkOption {
 public:
-SocketOption(const ProxyMapSharedPtr& maps, uint32_t mark, uint32_t source_identity, bool ingress, uint16_t port, uint16_t proxy_port)
-    : SocketMarkOption(mark), maps_(maps), source_identity_(source_identity), ingress_(ingress), port_(port), proxy_port_(proxy_port) {
-    ENVOY_LOG(debug, "Cilium SocketOption(): mark: {}, source_identity: {}, ingress: {}, port: {}, proxy_port: {}", mark, source_identity_, ingress_, port_, proxy_port_);
+SocketOption(const ProxyMapSharedPtr& maps, uint32_t source_identity, bool ingress, uint16_t port, uint16_t proxy_port)
+  : SocketMarkOption(source_identity, ingress), maps_(maps), port_(port), proxy_port_(proxy_port) {
+    ENVOY_LOG(debug, "Cilium SocketOption(): source_identity: {}, ingress: {}, port: {}, proxy_port: {}", identity_, ingress_, port_, proxy_port_);
   }
 
   ProxyMapSharedPtr maps_;
-  uint32_t source_identity_;
-  bool ingress_;
   uint16_t port_;
   uint16_t proxy_port_;
 };


### PR DESCRIPTION
Use a file logger for Envoy only if non-empty '--envoy-log' command
line parameter is given. Otherwise merge Envoy logs with Cilium logs
with 'subsys=envoy-<part>', where '<part>' is Envoy's logger name
(e.g., "filter", "upstream", "router", etc.).

Envoy rebase is needed to get support for the new '--log-format' command
line option.
