### PR TITLE
pkg/policy: remove fromEntities and toEntities from rule type

### DIFF
--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -64,7 +64,7 @@ func (d *Daemon) EnableEndpointPolicyEnforcement(e *endpoint.Endpoint) (ingress 
 		// Default mode means that if rules contain labels that match this endpoint,
 		// then enable policy enforcement for this endpoint.
 		// GH-1676: Could check e.Consumable instead? Would be much cheaper.
-		return d.GetPolicyRepository().GetRulesMatching(e.Consumable.LabelArray, false)
+		return d.GetPolicyRepository().GetRulesMatching(e.Consumable.LabelArray)
 	default:
 		// If policy enforcement isn't enabled for the daemon we do not enable
 		// policy enforcement for the endpoint.
@@ -101,8 +101,8 @@ func (h *getPolicyResolve) Handle(params GetPolicyResolveParams) middleware.Resp
 		// the API request, that means that policy enforcement is not enabled
 		// for the endpoints corresponding to said sets of labels; thus, we allow
 		// traffic between these sets of labels, and do not enforce policy between them.
-		fromIngress, fromEgress := d.policy.GetRulesMatching(labels.NewSelectLabelArrayFromModel(params.IdentityContext.From), true)
-		toIngress, toEgress := d.policy.GetRulesMatching(labels.NewSelectLabelArrayFromModel(params.IdentityContext.To), true)
+		fromIngress, fromEgress := d.policy.GetRulesMatching(labels.NewSelectLabelArrayFromModel(params.IdentityContext.From))
+		toIngress, toEgress := d.policy.GetRulesMatching(labels.NewSelectLabelArrayFromModel(params.IdentityContext.To))
 		if !fromIngress && !fromEgress && !toIngress && !toEgress {
 			policyEnforcementMsg = "Policy enforcement is disabled because " +
 				"no rules in the policy repository match any endpoint selector " +

--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -117,6 +117,11 @@ func parseToCiliumIngressRule(namespace string, inRule, retRule *api.Rule) {
 					}
 				}
 			}
+
+			if ing.FromEntities != nil {
+				retRule.Ingress[i].FromEntities = make([]api.Entity, len(ing.FromEntities))
+				copy(retRule.Ingress[i].FromEntities, ing.FromEntities)
+			}
 		}
 	}
 }
@@ -179,6 +184,11 @@ func parseToCiliumEgressRule(namespace string, inRule, retRule *api.Rule) {
 			if egr.ToServices != nil {
 				retRule.Egress[i].ToServices = make([]api.Service, len(egr.ToServices))
 				copy(retRule.Egress[i].ToServices, egr.ToServices)
+			}
+
+			if egr.ToEntities != nil {
+				retRule.Egress[i].ToEntities = make([]api.Entity, len(egr.ToEntities))
+				copy(retRule.Egress[i].ToEntities, egr.ToEntities)
 			}
 		}
 	}

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -102,6 +102,13 @@ func (i *IngressRule) sanitize() error {
 		prefixLengths[prefixLength] = exists{}
 	}
 
+	for _, fromEntity := range i.FromEntities {
+		_, ok := EntitySelectorMapping[fromEntity]
+		if !ok {
+			return fmt.Errorf("unsupported entity: %s", fromEntity)
+		}
+	}
+
 	// FIXME GH-1781 count coalesced CIDRs and restrict the number of
 	// prefix lengths based on the CIDRSet exclusions.
 	if l := len(prefixLengths); l > MaxCIDRPrefixLengths {
@@ -159,6 +166,13 @@ func (e *EgressRule) sanitize() error {
 			return err
 		}
 		prefixLengths[prefixLength] = exists{}
+	}
+
+	for _, toEntity := range e.ToEntities {
+		_, ok := EntitySelectorMapping[toEntity]
+		if !ok {
+			return fmt.Errorf("unsupported entity: %s", toEntity)
+		}
 	}
 
 	// FIXME GH-1781 count coalesced CIDRs and restrict the number of

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -350,8 +350,7 @@ func (p *Repository) Add(r api.Rule) (uint64, error) {
 	p.Mutex.Lock()
 	defer p.Mutex.Unlock()
 
-	realRule := &rule{Rule: r}
-	if err := realRule.sanitize(); err != nil {
+	if err := r.Sanitize(); err != nil {
 		return p.revision, err
 	}
 
@@ -444,7 +443,7 @@ func (p *Repository) GetJSON() string {
 // fromEntities and toEntities.
 //
 // Must be called with p.Mutex held
-func (p *Repository) GetRulesMatching(labels labels.LabelArray, includeEntities bool) (ingressMatch bool, egressMatch bool) {
+func (p *Repository) GetRulesMatching(labels labels.LabelArray) (ingressMatch bool, egressMatch bool) {
 	ingressMatch = false
 	egressMatch = false
 	for _, r := range p.rules {
@@ -454,15 +453,6 @@ func (p *Repository) GetRulesMatching(labels labels.LabelArray, includeEntities 
 				ingressMatch = true
 			}
 			if len(r.Egress) > 0 {
-				egressMatch = true
-			}
-		}
-
-		if includeEntities {
-			if len(r.fromEntities) > 0 {
-				ingressMatch = true
-			}
-			if len(r.toEntities) > 0 {
 				egressMatch = true
 			}
 		}


### PR DESCRIPTION
Due to a regression introduced with the calling of rule sanitization functions,
rule.sanitize() (different than Rule.sanitize) was never called at runtime,
only during unit tests. As a result, any rule with toEntities or fromEntities
was not properly populated during runtime. This was because the type
pkg/policy:rule only populated these fields during rule.sanitize(), which as
mentioned before, was not called outside of unit tests. Remove the toEntities
and fromEntities fields, and just use the ToEntities and FromEntities within
Rule.Ingress and Rule.Egress accordingly. While this involves a map lookup
to map entities to their corresponding EndpointSelector, this means that we now
only have one code path for validating rules; having multiple ones, as shown
by the regression, is error-prone. Update the policy resolution functions
to account for this change, as well as unit tests.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #3358 

Testing done:

Manually tested. This *needs* CI end-to-end coverage ASAP so we do not face regressions like this again! Will work on adding those ASAP.

1. Deploy the following resources in K8s using the following YAML:
```
---
apiVersion: v1
kind: Service
metadata:
  name: app1-service
spec:
  ports:
  - port: 80
  selector:
    id: app1
---
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: app1
spec:
  replicas: 2
  template:
    metadata:
      labels:
        id: app1
    spec:
      containers:
      - name: web
        image: cilium/demo-httpd
        ports:
        - containerPort: 80
---
apiVersion: v1
kind: Pod
metadata:
  name: app2
  labels:
    id: app2
spec:
  containers:
  - name: app-frontend
    image: cilium/demo-client
    command: [ "sleep" ]
    args:
      - "1000h"
---
apiVersion: v1
kind: Pod
metadata:
  name: app3
  labels:
    id: app3
spec:
  containers:
  - name: app-frontend
    image: cilium/demo-client
    command: [ "sleep" ]
    args:
      - "1000h"
```

2. Create policy with toEntities selecting a pod in K8s:
```
$ cat policy.yaml 
apiVersion: "cilium.io/v2"                                                 
kind: CiliumNetworkPolicy                                                  
description: "L7 policy for getting started using Kubernetes guide"        
metadata:                                                                  
  name: "rule1"                                                            
spec:                                                                      
  endpointSelector:                                                        
    matchLabels:                                                           
      id: app2                                                             
  egress:                                                                  
  - toEntities:                                                            
    - host                                                                 
    - world 
$ kubectl create -f policy.yaml
```

3. Policy appears in both K8s and Cilium:
```
vagrant@k8s1:~/go/src/github.com/cilium/cilium$ kubectl get cnp -o json
{
    "apiVersion": "v1",
    "items": [
        {
            "apiVersion": "cilium.io/v2",
            "kind": "CiliumNetworkPolicy",
            "metadata": {
                "clusterName": "",
                "creationTimestamp": "2018-03-29T05:15:00Z",
                "generation": 0,
                "name": "rule1",
                "namespace": "default",
                "resourceVersion": "5807",
                "selfLink": "/apis/cilium.io/v2/namespaces/default/ciliumnetworkpolicies/rule1",
                "uid": "2158fd87-3310-11e8-8214-0800279ce2d5"
            },
            "spec": {
                "egress": [
                    {
                        "toEntities": [
                            "host",
                            "world"
                        ]
                    }
                ],
                "endpointSelector": {
                    "matchLabels": {
                        "any:id": "app2"
                    }
                }
            },
            "status": {
                "nodes": {
                    "k8s1": {
                        "enforcing": true,
                        "lastUpdated": "2018-03-29T06:22:42.217258397Z",
                        "localPolicyRevision": 6,
                        "ok": true
                    }
                }
            }
        }
    ],
    "kind": "List",
    "metadata": {
        "resourceVersion": "",
        "selfLink": ""
    }
}
```

```
vagrant@k8s1:~/go/src/github.com/cilium/cilium$ cilium policy get
[
  {
    "endpointSelector": {
      "matchLabels": {
        "any:id": "app2",
        "k8s:io.kubernetes.pod.namespace": "default"
      }
    },
    "egress": [
      {
        "toEntities": [
          "host",
          "world"
        ]
      }
    ],
    "labels": [
      {
        "key": "io.cilium.k8s.policy.name",
        "value": "rule1",
        "source": "unspec"
      },
      {
        "key": "io.cilium.k8s.policy.namespace",
        "value": "default",
        "source": "unspec"
      }
    ]
  }
]
Revision: 12
```

4.  The entities are translated to CIDRs in the policy for the endpoint:
```
vagrant@k8s1:~/go/src/github.com/cilium/cilium$ cilium endpoint get 49508
[
  {
...
    "policy": {
      "allowed-egress-identities": [
        1,
        2
      ],
      "allowed-ingress-identities": [
        1
      ],
      "build": 12,
      "cidr-policy": {
        "egress": [
          {
            "derived-from-rules": [
              [
                "unspec:io.cilium.k8s.policy.name=rule1",
                "unspec:io.cilium.k8s.policy.namespace=default"
              ]
            ],
            "rule": "0.0.0.0/0"
          },
          {
            "derived-from-rules": [
              [
                "unspec:io.cilium.k8s.policy.name=rule1",
                "unspec:io.cilium.k8s.policy.namespace=default"
              ]
            ],
            "rule": "::/0"
          }
        ],
        "ingress": []
      },
      "id": 17030,
      "l4": {
        "egress": [],
        "ingress": []
      }
    },
    "policy-enabled": "egress",
    "policy-revision": 12,
    "proxy-statistics": [],
    "state": "ready",
    "status": [
      {
        "code": "OK",
        "message": "Successfully regenerated endpoint program due to endpoint policy updated & changes were needed",
        "state": "ready",
        "timestamp": "2018-03-29T06:47:43Z"
      }
    ]
  }
]
```

5. Access to world succeeds:
```
$ kubectl exec -ti app2 -- curl -s -o /dev/null -w "%{http_code}" http://www.google.com
200
```
