### PR TITLE
Check if localStatus is populated in health server

### DIFF
--- a/pkg/health/server/server.go
+++ b/pkg/health/server/server.go
@@ -159,9 +159,16 @@ func (s *Server) updateCluster(connectivity []*healthModels.NodeStatus) {
 func (s *Server) GetStatusResponse() *healthModels.HealthStatusResponse {
 	s.RLock()
 	defer s.RUnlock()
+
+	var name string
+	// Check if localStatus is populated already. If not, the name is empty
+	if s.localStatus != nil {
+		name = s.localStatus.Name
+	}
+
 	return &healthModels.HealthStatusResponse{
 		Local: &healthModels.SelfStatus{
-			Name: s.localStatus.Name,
+			Name: name,
 		},
 		Nodes:     s.connectivity,
 		Timestamp: s.lastProbe.Format(time.RFC3339),


### PR DESCRIPTION
If the status wasn't populated it caused panics.
Node name is set to empty if localStatus is nil.

related-to #3294 


```release-note
  bug: Fix panic in health server logs if /healthz didn't respond before checking status
```