### PR TITLE
Update rpm packaging files

### DIFF
--- a/contrib/packaging/rpm/Dockerfile
+++ b/contrib/packaging/rpm/Dockerfile
@@ -1,10 +1,14 @@
-FROM fedora:26
+FROM fedora:27
 
 LABEL maintainer="Tony Lambiris <tony@criticalstack.com>"
 
+RUN curl -sSL -o /etc/yum.repos.d/vbatts-bazel-fedora-27.repo \
+	https://copr.fedorainfracloud.org/coprs/vbatts/bazel/repo/fedora-27/vbatts-bazel-fedora-27.repo
+
 RUN dnf -y update && \
 	dnf -y install fedora-packager fedora-review golang go-bindata gettext \
-		git glibc-devel.x86_64 glibc-devel.i686 && \
+		git glibc-devel.x86_64 glibc-devel.i686 cmake bazel libtool wget \
+		gcc-c++ elfutils-libelf-devel libstdc++-static && \
     mkdir -p /opt/cilium/
 
 WORKDIR /opt/cilium

--- a/contrib/packaging/rpm/cilium.spec.envsubst
+++ b/contrib/packaging/rpm/cilium.spec.envsubst
@@ -9,7 +9,7 @@ License:       Apache
 URL:           https://github/cilium/cilium
 ExclusiveArch: x86_64
 Source0:       https://github.com/cilium/%{name}/archive/%{commit0}.tar.gz#/%{name}-%{shortcommit0}.tar.gz
-BuildRequires: golang, go-bindata, glibc-devel(x86-32)
+BuildRequires: golang, go-bindata, glibc-devel(x86-32), cmake, bazel, gcc-c++, elfutils-libelf-devel, libstdc++-static, libtool, wget
 Requires:      docker-engine >= 1.12, glibc-devel(x86-32), iproute >= 4.10, clang
 %{?fc25:Requires: clang >= 3.8, clang < 3.9}
 
@@ -33,7 +33,10 @@ export GOPATH=$(pwd)/%{name}-%{commit0}
 export PKG_BUILD=1
 cd %{name}-%{commit0}/src/github.com/cilium/%{name}
 %{__make} -C daemon apply-bindata
-%{__make} build
+%{__make} V=1 plugins bpf cilium daemon monitor cilium-health bugtool
+git submodule update --init
+cd envoy
+bazel build //:envoy
 
 %install
 export GOPATH=$(pwd)/%{name}-%{commit0}
@@ -67,8 +70,13 @@ chmod 644 "%{buildroot}%{_sysconfdir}/sysconfig/cilium"
 %{_bindir}/cilium-node-monitor
 %{_bindir}/cilium-bugtool
 %{_bindir}/cilium-health
+%{_bindir}/cilium-envoy
+%{_bindir}/cilium-map-migrate
 
 %changelog
+* Thu Mar 29 2018 Tony Lambiris <tony@criticalstack.com> - 1.0.0rc8-0.git${SHORTCOMMIT}
+- Added cilium-envoy and cilium-map-migrate to %files
+
 * Wed Dec 20 2017 Tony Lambiris <tony@criticalstack.com> - 0.13.90-0.git${SHORTCOMMIT}
 - Added cilium-bugtool, cilium-bugtool and sys-fs-bpf.mount to %files
 

--- a/contrib/packaging/rpm/create_rpm.sh
+++ b/contrib/packaging/rpm/create_rpm.sh
@@ -6,6 +6,9 @@ set -x
 source /opt/cilium/env
 
 envsubst < /opt/cilium/cilium.spec.envsubst > /opt/cilium/cilium.spec
-fedpkg --release f26 local
+# Remove dash (in case of a version like 1.0.0-rc8)
+sed -i -re '/^Version/s/-//g' /opt/cilium/cilium.spec
+
+fedpkg --release f27 local
 
 find /opt/cilium -type f -name 'cilium*.rpm' -exec mv -f "{}" /output/ \;


### PR DESCRIPTION
<!--  Thanks for contributing to Cilium!

If this is your first time contributing, then please see the following
guidelines for detailed instructions on how to contribute:
https://github.com/cilium/cilium/blob/master/CONTRIBUTING.md for detailed instructions 

-->

**Summary of changes**:

Updates to include recent changes for building envoy support as well as using Fedora 27 as the base build container.