### PR TITLE
Dockerfile: update cilium-builder to 2018-03-29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM cilium/cilium-builder:2018-03-27 as builder
+FROM cilium/cilium-builder:2018-03-29 as builder
 LABEL maintainer="maintainer@cilium.io"
 WORKDIR /go/src/github.com/cilium/cilium
 ADD . ./


### PR DESCRIPTION
hub.docker.com is currently failing for cilium/cilium. This PR should fix it

Signed-off-by: André Martins <andre@cilium.io>