### PR TITLE
Nightly: Change Ping behaviour on egress rules

### DIFF
--- a/test/helpers/policygen/const.go
+++ b/test/helpers/policygen/const.go
@@ -45,13 +45,6 @@ var (
 		UDP:         ResultTimeout,
 	}
 
-	ConnResultAllTimeoutExceptPing = ConnTestSpec{
-		HTTP:        ResultTimeout,
-		HTTPPrivate: ResultTimeout,
-		Ping:        ResultOK,
-		UDP:         ResultTimeout,
-	}
-
 	ConnResultOnlyHTTP = ConnTestSpec{
 		HTTP:        ResultOK,
 		HTTPPrivate: ResultOK,
@@ -59,24 +52,10 @@ var (
 		UDP:         ResultTimeout,
 	}
 
-	ConnResultOnlyHTTPAndPing = ConnTestSpec{
-		HTTP:        ResultOK,
-		HTTPPrivate: ResultOK,
-		Ping:        ResultOK,
-		UDP:         ResultTimeout,
-	}
-
 	ConnResultOnlyHTTPPrivate = ConnTestSpec{
 		HTTP:        ResultAuth,
 		HTTPPrivate: ResultOK,
 		Ping:        ResultTimeout,
-		UDP:         ResultTimeout,
-	}
-
-	ConnResultOnlyHTTPPrivateAndPing = ConnTestSpec{
-		HTTP:        ResultAuth,
-		HTTPPrivate: ResultOK,
-		Ping:        ResultOK,
 		UDP:         ResultTimeout,
 	}
 

--- a/test/helpers/policygen/policygen.go
+++ b/test/helpers/policygen/policygen.go
@@ -58,7 +58,7 @@ var policiesTestSuite = PolicyTestSuite{
 		{
 			name:  "Egress Port 80 No protocol",
 			kind:  egress,
-			tests: ConnResultOnlyHTTPAndPing,
+			tests: ConnResultOnlyHTTP,
 			template: map[string]string{
 				"ports": `[{"port": "80"}]`,
 			},
@@ -82,7 +82,7 @@ var policiesTestSuite = PolicyTestSuite{
 		{
 			name:  "Egress Port 80 TCP",
 			kind:  egress,
-			tests: ConnResultOnlyHTTPAndPing,
+			tests: ConnResultOnlyHTTP,
 			template: map[string]string{
 				"ports": `[{"port": "80", "protocol": "TCP"}]`,
 			},
@@ -90,7 +90,7 @@ var policiesTestSuite = PolicyTestSuite{
 		{
 			name:  "Egress Port 80 UDP",
 			kind:  egress,
-			tests: ConnResultAllTimeoutExceptPing,
+			tests: ConnResultAllTimeout,
 			template: map[string]string{
 				"ports": `[{"port": "80", "protocol": "UDP"}]`,
 			},
@@ -115,7 +115,7 @@ var policiesTestSuite = PolicyTestSuite{
 		{
 			name:  "Egress policy to /private/",
 			kind:  egress,
-			tests: ConnResultOnlyHTTPPrivateAndPing,
+			tests: ConnResultOnlyHTTPPrivate,
 			template: map[string]string{
 				"rules": `{"http": [{"method": "GET", "path": "/private"}]}`,
 				"ports": `[{"port": "80", "protocol": "TCP"}]`,


### PR DESCRIPTION
With the new L4 egress rules, ping is not longer allowed in egress.

Failed in the latest Nightly: 
https://jenkins.cilium.io/job/Cilium-Master-Nightly-Tests-All/161/

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
