### PR TITLE
envoy: Make 403 message configurable.

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -341,6 +341,8 @@ func init() {
 	flags.BoolVar(&enableTracing,
 		"enable-tracing", false, "Enable tracing while determining policy (debugging)")
 	flags.String("envoy-log", "", "Path to a separate Envoy log file, if any")
+	flags.String("http-403-msg", "", "Message returned in proxy L7 403 body")
+	flags.MarkHidden("http-403-msg")
 	flags.BoolVar(&useEnvoy,
 		"envoy-proxy", true, "This flag is deprecated and will be removed in the next release")
 	flags.MarkHidden("envoy-proxy")

--- a/envoy/cilium/cilium_l7policy.proto
+++ b/envoy/cilium/cilium_l7policy.proto
@@ -7,6 +7,10 @@ message L7Policy {
   // Path to the unix domain socket for the cilium access log.
   string access_log_path = 1;
 
-  // Cilium endpoint security policy to enforce
+  // Cilium endpoint security policy to enforce.
   string policy_name = 2;
+
+  // HTTP response body message for 403 status code.
+  // If empty, "Access denied" will be used.
+  string denied_403_body = 3;
 }

--- a/envoy/cilium_l7policy.h
+++ b/envoy/cilium_l7policy.h
@@ -38,7 +38,7 @@ struct FilterStats {
 class Config : public Logger::Loggable<Logger::Id::filter> {
 public:
   Config(const std::string& policy_name, const std::string& access_log_path,
-	 Server::Configuration::FactoryContext& context);
+	 const std::string& denied_403_body, Server::Configuration::FactoryContext& context);
   Config(const Json::Object &config, Server::Configuration::FactoryContext& context);
   Config(const ::cilium::L7Policy &config, Server::Configuration::FactoryContext& context);
   ~Config();
@@ -46,8 +46,9 @@ public:
   void Log(AccessLog::Entry &, ::cilium::EntryType);
 
   FilterStats stats_;
-  std::string policy_name_;
+  const std::string policy_name_;
   std::shared_ptr<const Cilium::NetworkPolicyMap> npmap_;
+  std::string denied_403_body_;
 
 private:
   AccessLog *access_log_;

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -102,6 +102,7 @@ func getXDSPath(stateDir string) string {
 func StartXDSServer(stateDir string) *XDSServer {
 	xdsPath := getXDSPath(stateDir)
 	accessLogPath := getAccessLogPath(stateDir)
+	denied403body := viper.GetString("http-403-msg")
 
 	os.Remove(xdsPath)
 	socketListener, err := net.ListenUnix("unix", &net.UnixAddr{Name: xdsPath, Net: "unix"})
@@ -159,6 +160,7 @@ func StartXDSServer(stateDir string) *XDSServer {
 							"name": {&structpb.Value_StringValue{StringValue: "cilium.l7policy"}},
 							"config": {&structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
 								"access_log_path": {&structpb.Value_StringValue{StringValue: accessLogPath}},
+								"denied_403_body": {&structpb.Value_StringValue{StringValue: denied403body}},
 							}}}},
 						}}}},
 						{&structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{


### PR DESCRIPTION
Accept a new '--403-msg' command line option to specify the message
returned in 403 responses. Defaults to "Access denied". Note that the
message is returned in HTML body and needs to be HTML encoded.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
