### PR TITLE
policy: add host IPs to IPCache

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -715,6 +715,12 @@ func (h *putEndpointIDLabels) Handle(params PutEndpointIDLabelsParams) middlewar
 // IPCache (pkg/ipcache).
 // TODO (FIXME): GH-3161.
 func (d *Daemon) OnIPIdentityCacheChange(modType ipcache.CacheModification, ipIDPair identity.IPIdentityPair) {
+
+	log.WithFields(logrus.Fields{logfields.Modification: modType,
+		logfields.IPAddr:   ipIDPair.IP,
+		logfields.Identity: ipIDPair.ID}).
+		Debug("daemon notified of IP-Identity cache state change")
+
 	// TODO - see if we can factor this into an interface under something like
 	// pkg/datapath instead of in the daemon directly so that the code is more
 	// logically located.

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -818,21 +818,23 @@ func (e *Endpoint) regeneratePolicy(owner Owner, opts models.ConfigurationMap) (
 	opts[OptionEgressPolicy] = optionDisabled
 
 	if egress {
+		// Need to explicitly check for access to host because localhost access
+		// is a special case in the datapath.
 		e.checkEgressAccess(owner, (*labelsMap)[identityPkg.ReservedIdentityHost], opts, OptionAllowToHost)
 	}
 
 	if !ingress && !egress {
-		e.getLogger().Debug("Policy Ingress and Egress disabled")
+		e.getLogger().Debug("ingress and egress policy enforcement not enabled")
 	} else {
 		if ingress && egress {
-			e.getLogger().Debug("Policy Ingress and Egress enabled")
+			e.getLogger().Debug("policy enforcement for ingress and egress enabled")
 			opts[OptionIngressPolicy] = optionEnabled
 			opts[OptionEgressPolicy] = optionEnabled
 		} else if ingress {
-			e.getLogger().Debug("Policy Ingress enabled")
+			e.getLogger().Debug("policy enforcement for ingress enabled")
 			opts[OptionIngressPolicy] = optionEnabled
 		} else {
-			e.getLogger().Debug("Policy Egress enabled")
+			e.getLogger().Debug("policy enforcement for egress enabled")
 			opts[OptionEgressPolicy] = optionEnabled
 		}
 	}

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -44,7 +44,7 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	// Deletion of key that doesn't exist doesn't cause panic.
 	IPIdentityCache.delete(endpointIP)
 
-	IPIdentityCache.upsert(endpointIP, identity)
+	IPIdentityCache.Upsert(endpointIP, identity)
 
 	// Assure both caches are updated..
 	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 1)
@@ -54,7 +54,7 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	c.Assert(cachedIdentity, Equals, identity)
 	c.Assert(exists, Equals, true)
 
-	IPIdentityCache.upsert(endpointIP, identity)
+	IPIdentityCache.Upsert(endpointIP, identity)
 
 	// No duplicates.
 	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 1)
@@ -70,10 +70,10 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 
 	c.Assert(exists, Equals, false)
 
-	IPIdentityCache.upsert(endpointIP, identity)
+	IPIdentityCache.Upsert(endpointIP, identity)
 
 	newIdentity := identityPkg.NumericIdentity(69)
-	IPIdentityCache.upsert(endpointIP, newIdentity)
+	IPIdentityCache.Upsert(endpointIP, newIdentity)
 
 	// Ensure that update of cache with new identity doesn't keep old identity-to-ip
 	// mapping around.
@@ -97,7 +97,7 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	identities := []identityPkg.NumericIdentity{5, 67, 29, 29, 29}
 
 	for index := range endpointIPs {
-		IPIdentityCache.upsert(endpointIPs[index], identities[index])
+		IPIdentityCache.Upsert(endpointIPs[index], identities[index])
 		cachedIdentity, _ := IPIdentityCache.LookupByIP(endpointIPs[index])
 		c.Assert(cachedIdentity, Equals, identities[index])
 	}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -219,4 +219,8 @@ const (
 	// TrafficDirection represents the directionality of traffic with respect
 	// to an endpoint.
 	TrafficDirection = "trafficDirection"
+
+	// Modification represents a type of state change operation (insert, delete,
+	// upsert, etc.).
+	Modification = "modification"
 )

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -81,7 +81,7 @@ var (
 			}
 			return k, v, nil
 		},
-	).WithNonPersistent()
+	)
 )
 
 func init() {


### PR DESCRIPTION
Egress to host did not work with policy containing toEndpoints "reserved:host" label because previously, only endpoint IPs were added to the local IPCache in each cilium-agent. To allow for label based selecting of the host, we need to add the host IPs to the IPCache so lookup in the datapath succeeds when mapping the IP of the host to its identity.
    
Signed-off by: Ian Vernon <ian@cilium.io>
