### PR TITLE
CI: add to host entity egress end-to-end test

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -808,3 +808,8 @@ func (s *SSHMeta) AddIPToLoopbackDevice(ip string) *CmdRes {
 func (s *SSHMeta) RemoveIPFromLoopbackDevice(ip string) *CmdRes {
 	return s.Exec(fmt.Sprintf("sudo ip addr del dev lo %s", ip))
 }
+
+// FlushGlobalConntrackTable flushes the global connection tracking table.
+func (s *SSHMeta) FlushGlobalConntrackTable() *CmdRes {
+	return s.ExecCilium("bpf ct flush global")
+}

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -800,13 +800,13 @@ func (s *SSHMeta) RestartCilium() error {
 // AddIPToLoopbackDevice adds the specified IP (assumed to be in form <ip>/<mask>)
 // to the loopback device on s.
 func (s *SSHMeta) AddIPToLoopbackDevice(ip string) *CmdRes {
-	return s.Exec(fmt.Sprintf("sudo ip addr add dev lo %s", ip))
+	return s.ExecWithSudo(fmt.Sprintf("ip addr add dev lo %s", ip))
 }
 
 // RemoveIPFromLoopbackDevice removes the specified IP (assumed to be in form <ip>/<mask>)
 // from the loopback device on s.
 func (s *SSHMeta) RemoveIPFromLoopbackDevice(ip string) *CmdRes {
-	return s.Exec(fmt.Sprintf("sudo ip addr del dev lo %s", ip))
+	return s.ExecWithSudo(fmt.Sprintf("ip addr del dev lo %s", ip))
 }
 
 // FlushGlobalConntrackTable flushes the global connection tracking table.

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -796,3 +796,15 @@ func (s *SSHMeta) RestartCilium() error {
 	}
 	return nil
 }
+
+// AddIPToLoopbackDevice adds the specified IP (assumed to be in form <ip>/<mask>)
+// to the loopback device on s.
+func (s *SSHMeta) AddIPToLoopbackDevice(ip string) *CmdRes {
+	return s.Exec(fmt.Sprintf("sudo ip addr add dev lo %s", ip))
+}
+
+// RemoveIPFromLoopbackDevice removes the specified IP (assumed to be in form <ip>/<mask>)
+// from the loopback device on s.
+func (s *SSHMeta) RemoveIPFromLoopbackDevice(ip string) *CmdRes {
+	return s.Exec(fmt.Sprintf("sudo ip addr del dev lo %s", ip))
+}

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -158,6 +158,12 @@ const (
 	daemonSet   = "DaemonSet"
 
 	deadLockHeader = "POTENTIAL DEADLOCK:" // from github.com/sasha-s/go-deadlock/deadlock.go:header
+
+	// IPv4Host is an IP which is used in some datapath tests for simulating external IPv4 connectivity.
+	IPv4Host = "192.168.254.254"
+
+	// IPv6Host is an IP which is used in some datapath tests for simulating external IPv6 connectivity.
+	IPv6Host = "fdff::ff"
 )
 
 var ciliumCLICommands = map[string]string{

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -77,6 +77,9 @@ const (
 	// CiliumDockerNetwork is the name of the Docker network which Cilium manages.
 	CiliumDockerNetwork = "cilium-net"
 
+	// HostDockerNetwork is the name of the host network driver.
+	HostDockerNetwork = "host"
+
 	// NetperfImage is the Docker image used for performance testing
 	NetperfImage = "tgraf/netperf"
 

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -712,7 +712,6 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 		_, err = vm.PolicyRenderAndImport(script)
 		Expect(err).To(BeNil(), "Unable to import policy: %s", err)
 
-		By(fmt.Sprintf("Pinging host IPv4 (%s) from %s (should work) because it is contained within CIDR %s", helpers.IPv4Host, helpers.Httpd2, ipv4OtherHost))
 		res = vm.ContainerExec(helpers.Httpd2, helpers.Ping(helpers.IPv4Host))
 		res.ExpectSuccess("Unexpected failure pinging host (%s) from %s: %s", helpers.IPv4Host, helpers.Httpd2, res.CombineOutput().String())
 
@@ -1039,6 +1038,70 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 		setupPolicyAndTestEgressToWorld(policy)
 
 		vm.PolicyDelAll().ExpectSuccess("Unable to delete all policies")
+	})
+
+	Context("TestsEgressToHost", func() {
+
+		hostDockerContainer := "hostDockerContainer"
+
+		BeforeAll(func() {
+			By("Starting httpd server using host networking")
+			res := vm.ContainerCreate(hostDockerContainer, helpers.HttpdImage, helpers.HostDockerNetwork, "-l id.hostDockerContainer")
+			res.ExpectSuccess("unable to start Docker container with host networking")
+		})
+
+		AfterAll(func() {
+			vm.ContainerRm(hostDockerContainer)
+		})
+
+		It("Tests Egress To Host", func() {
+
+			app1Label := "id.app1"
+			hostIP := "10.0.2.15"
+
+			By(fmt.Sprintf("Pinging %s from %s before importing policy (should work)", api.EntityHost, helpers.App1))
+			failedPing := vm.ContainerExec(helpers.App1, helpers.Ping(hostIP))
+			failedPing.ExpectSuccess("unable able to ping %s", hostIP)
+
+			// Flush global conntrack table to be safe because egress conntrack cleanup
+			// is still to be completed (GH-3393).
+			By(fmt.Sprintf("Flushing global connection tracking table before importing policy"))
+			vm.FlushGlobalConntrackTable().ExpectSuccess("Unable to flush global conntrack table")
+
+			By(fmt.Sprintf("Importing policy which allows egress to %s entity from %s", api.EntityHost, helpers.App1))
+			policy := fmt.Sprintf(`
+			[{
+				"endpointSelector": {"matchLabels":{"%s":""}},
+				"egress": [{
+					"toEntities": [
+						"%s"
+					]
+				}]
+			}]`, app1Label, api.EntityHost)
+
+			_, err := vm.PolicyRenderAndImport(policy)
+			Expect(err).To(BeNil(), "Unable to import policy: %s", err)
+
+			By(fmt.Sprintf("Pinging %s from %s (should work)", api.EntityHost, helpers.App1))
+			successPing := vm.ContainerExec(helpers.App1, helpers.Ping(hostIP))
+			successPing.ExpectSuccess("not able to ping %s", hostIP)
+
+			// Docker container running with host networking is accessible via
+			// the host's IP address. See https://docs.docker.com/network/host/.
+			By(fmt.Sprintf("Accessing /public using Docker container using host networking from %s (should work)", helpers.App1))
+			successCurl := vm.ContainerExec(helpers.App1, helpers.CurlWithHTTPCode(fmt.Sprintf("http://%s/public", hostIP)))
+			successCurl.ExpectContains("200", "Expected to be able to access /public in host Docker container")
+
+			By(fmt.Sprintf("Pinging %s from %s (shouldn't work)", helpers.App2, helpers.App1))
+			failPing := vm.ContainerExec(helpers.App1, helpers.Ping(helpers.App2))
+			failPing.ExpectFail("not able to ping %s", helpers.App2)
+
+			httpd2, err := vm.ContainerInspectNet(helpers.Httpd2)
+			By(fmt.Sprintf("Accessing /public in %s from %s (shouldn't work)", helpers.App2, helpers.App1))
+			failCurl := vm.ContainerExec(helpers.App1, helpers.CurlFail(fmt.Sprintf("http://%s/public", httpd2[helpers.IPv4])))
+			failCurl.ExpectFail("unexpectedly able to access %s when access should only be allowed to host", helpers.Httpd2)
+
+		})
 	})
 })
 


### PR DESCRIPTION
*  test/runtime: add test for egress to host
* test/helpers: add HostDockerNetwork constant
* test/helpers: add helper function for flushing global connection tracking table
* test: factor out IPs which represent the host
* test/helpers: add helper function for adding IP addresses to VM loopback device
    
Signed-off by: Ian Vernon <ian@cilium.io> 

Related-to: #3436 (contains same commits, but test is separate so that #3436 can get merged before CI is reviewed).