### PR TITLE
Test: Simplified Kafka K8S test

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -167,6 +167,29 @@ func CreateKubectl(vmName string, log *logrus.Entry) *Kubectl {
 	}
 }
 
+// CepGet returns the endpoint model for the given pod name in the specified
+// namespaces. If the pod is not present it returns nil
+func (kub *Kubectl) CepGet(namespace string, pod string) *models.Endpoint {
+	log := kub.logger.WithFields(logrus.Fields{
+		"cep":       pod,
+		"namespace": namespace})
+
+	cmd := fmt.Sprintf("%s -n %s get cep %s -o json | jq '.status'", KubectlCmd, namespace, pod)
+	res := kub.Exec(cmd)
+	if !res.WasSuccessful() {
+		log.Debug("cep is not present")
+		return nil
+	}
+
+	var data *models.Endpoint
+	err := res.Unmarshal(&data)
+	if err != nil {
+		log.WithError(err).Error("cannot Unmarshal json")
+		return nil
+	}
+	return data
+}
+
 // ExecKafkaPodCmd executes shell command with arguments arg in the specified pod residing in the specified
 // namespace. It returns the stdout of the command that was executed.
 // The kafka producer and consumer scripts do not return error if command

--- a/test/k8sT/manifests/kafka-sw-app.yaml
+++ b/test/k8sT/manifests/kafka-sw-app.yaml
@@ -28,8 +28,17 @@ spec:
           value: "20000"
         - name: KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS
           value: "20000"
-      nodeSelector:
-        "kubernetes.io/hostname": k8s1
+        livenessProbe:
+          tcpSocket:
+            port: 9092
+          initialDelaySeconds: 30
+          failureThreshold: 10
+          periodSeconds: 10
+        readinessProbe:
+          tcpSocket:
+            port: 9092
+          initialDelaySeconds: 5
+          periodSeconds: 5
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -48,8 +57,6 @@ spec:
         image: digitalwonderland/zookeeper
         ports:
         - containerPort: 2181
-      nodeSelector:
-        "kubernetes.io/hostname": k8s2
 ---
 apiVersion: v1
 kind: Service
@@ -116,8 +123,6 @@ spec:
       containers:
       - name: empire-outpost-8888
         image: cilium/kafkaclient
-      nodeSelector:
-        "kubernetes.io/hostname": k8s2
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -135,8 +140,6 @@ spec:
       containers:
       - name: empire-outpost-9999
         image: cilium/kafkaclient
-      nodeSelector:
-        "kubernetes.io/hostname": k8s2
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -153,5 +156,3 @@ spec:
       containers:
       - name: empire-backup
         image: cilium/kafkaclient
-      nodeSelector:
-        "kubernetes.io/hostname": k8s1


### PR DESCRIPTION
- Add a livenessProbe in kafka manifest, wait until kafka is ready.
- Make test code clear
- Add CepGet in kubectl.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

