### PR TITLE
Test: Enable egress-deny

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -402,9 +402,6 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 		})
 
 		It("Denies traffic with k8s default-deny egress policy", func() {
-			// GH-3437 Temporarily disabled
-			return
-
 			if helpers.GetCurrentK8SEnv() == "1.7" {
 				log.Info("K8s 1.7 doesn't offer a default deny for egress")
 				return
@@ -454,7 +451,7 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 				res = kubectl.ExecPodCmd(
 					helpers.DefaultNamespace, pod,
 					"host www.google.com")
-				res.ExpectSuccess("Egress DNS connectivity should be allowed for pod %q", pod)
+				res.ExpectFail("Egress DNS connectivity should be denied for pod %q", pod)
 			}
 		})
 	})


### PR DESCRIPTION
On Egress-deny the DNS traffic is not longer allowed.

Fix #3437

