### PR TITLE
test/runtime: wait for endpoints to be ready after setting NAT46 config

### DIFF
--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -163,6 +163,9 @@ var _ = Describe("RuntimeValidatedConnectivityTest", func() {
 			status := vm.EndpointSetConfig(endpoints[helpers.Client], "NAT46", helpers.OptionEnabled)
 			Expect(status).Should(BeTrue())
 
+			areEndpointsReady := vm.WaitEndpointsReady()
+			Expect(areEndpointsReady).Should(BeTrue(), "Endpoints not ready after timeout")
+
 			res := vm.ContainerExec(helpers.Client, helpers.Ping6(fmt.Sprintf(
 				"::FFFF:%s", server[helpers.IPv4])))
 


### PR DESCRIPTION
Now that `EndpointSetConfig` does not wait for endpoints to be ready
after setting their configuration values, we need to wait for endpoints
to regenerate separately. Otherwise, tests might try to test the datapath
before it is configured for a specific endpoint in accordance with
policy that has been imported.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #3471

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/3476)
<!-- Reviewable:end -->
