### PR TITLE
test: Use current cilium-builder also for Ginkgo tests.

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - consul
       - etcd
-    image: "cilium/cilium-builder:2018-03-16"
+    image: "cilium/cilium-builder:2018-03-29"
     command: "bash -c 'cd /go/src/github.com/cilium/cilium/; make tests-ginkgo-real'"
     privileged: true
     volumes:


### PR DESCRIPTION
The cilium-builder image has been updated for the main Dockerfile, but
the docker-compose.yml reference was left intact. Update it too.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
