### PR TITLE
Improve CI failure detection

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -736,7 +736,10 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 			// Wait until all the pods are synced
 			for pod, rev := range waitingRev {
 				kub.logger.Infof("CiliumPolicyAction: Wait for endpoints to sync on pod '%s'", pod)
-				kub.ExecPodCmd(namespace, pod, fmt.Sprintf("cilium policy wait %d", rev))
+				res := kub.ExecPodCmd(namespace, pod, fmt.Sprintf("cilium policy wait %d", rev))
+				if !res.WasSuccessful() {
+					return false
+				}
 				kub.logger.Infof("CiliumPolicyAction: revision %d in pod '%s' is ready", rev, pod)
 			}
 			return true

--- a/test/runtime/ct.go
+++ b/test/runtime/ct.go
@@ -725,12 +725,15 @@ var _ = Describe("DisabledRuntimeValidatedConntrackTable", func() {
 	})
 
 	It("Testing L7 proxy redirection after a L3 connection is made with the exact 5 tuple", func() {
-		vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
-		vm.WaitEndpointsReady()
+		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
+		res.ExpectSuccess("Setting policyEnforcement to default")
+		areEndpointsReady := vm.WaitEndpointsReady()
+		Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+
 		epIdentities, err := vm.GetEndpointsIdentityIds()
 		Expect(err).To(BeNil(), "Getting endpoints identity IDs")
 
-		res := vm.PolicyDelAll()
+		res = vm.PolicyDelAll()
 		res.ExpectSuccess("Deleting all policies")
 
 		policy := `
@@ -749,7 +752,7 @@ var _ = Describe("DisabledRuntimeValidatedConntrackTable", func() {
 		_, err = vm.PolicyRenderAndImport(policy)
 		Expect(err).To(BeNil(), "Installing an L3-only policy")
 
-		areEndpointsReady := vm.WaitEndpointsReady()
+		areEndpointsReady = vm.WaitEndpointsReady()
 		Expect(areEndpointsReady).Should(BeTrue(), "Endpoints not ready after timeout")
 
 		meta := containersMeta()


### PR DESCRIPTION
Fix a few issues noted during an attempt to debug a CI issue:
* k8s policy waiting was ignoring failures in the command
* L7 proxy redirect test wasn't waiting for endpoints to be ready

Related: #3470 