### PR TITLE
Test: Fix bugtool on kubernetes 1.7

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -853,8 +853,8 @@ func (kub *Kubectl) DumpCiliumCommandOutput(namespace string) {
 				// Only copy over bugtool output to directory.
 				if strings.Contains(line, CiliumBugtool) {
 					archiveName := fmt.Sprintf("%s-%s", pod, line)
-					res = kub.Exec(fmt.Sprintf(
-						"%s cp %s/%s:/tmp/%s /tmp/", KubectlCmd, namespace, pod, line),
+					res = kub.Exec(fmt.Sprintf("%[1]s cp %[2]s/%[3]s:/tmp/%[4]s /tmp/%[4]s",
+						KubectlCmd, namespace, pod, line),
 						ExecOptions{SkipLog: true})
 					if !res.WasSuccessful() {
 						logger.Errorf("'%s' failed: %s", res.GetCmd(), res.CombineOutput())


### PR DESCRIPTION
On kubernetes 1.7 the cp need to have a specific destination, and the
`kubectl cp` command was failing:

```
vagrant@k8s1:~$ kubectl cp kube-system/cilium-jk0kn:/tmp/cilium-bugtool-20180403-065927.547+0000-UTC-039557248.tar /tmp/
tar: Removing leading `/' from member names
error: open /tmp: is a directory
```

I added a new param to the command and now works as expected
```
vagrant@k8s1:~$ kubectl cp kube-system/cilium-jk0kn:/tmp/cilium-bugtool-20180403-065927.547+0000-UTC-039557248.tar /tmp/cilium-bugtool-20180403-065927.547+0000-UTC-039557248.tar
tar: Removing leading `/' from member names
vagrant@k8s1:~$
```

Related to #3475

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
