### PR TITLE
etcd: Run etcd version check in the background

### DIFF
--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -117,8 +117,14 @@ func (s *EtcdSuite) TestETCDVersionCheck(c *C) {
 	client := etcdClient{
 		client: cli,
 	}
-	e := client.checkMinVersion(1 * time.Second)
-	c.Assert(e, IsNil)
+
+	// disable fatal log message on version mismatch
+	etcdVersionMismatchFatal = false
+
+	// short timeout for tests
+	versionCheckTimeout = time.Second
+
+	c.Assert(client.checkMinVersion(), Equals, true)
 
 	// One endpoint has a bad version and should fail
 	cfg.Endpoints = []string{"http://127.0.0.1:4003", "http://127.0.0.1:4004", "http://127.0.0.1:4005"}
@@ -129,6 +135,5 @@ func (s *EtcdSuite) TestETCDVersionCheck(c *C) {
 		client: cli,
 	}
 
-	e = client.checkMinVersion(1 * time.Second)
-	c.Assert(e, NotNil)
+	c.Assert(client.checkMinVersion(), Equals, false)
 }


### PR DESCRIPTION
When an etcd endpoint is unavailable, the version check retrieves the version
of each etcd endpoint. If one etcd endpoint is not available, the version check
will time out eventually. This is currently a blocking operation which delays
the renewal of etcd sessions. Run the version check in the background instead
to not delay renewal of etcd sessions.

Never return errors on version checks except when the version check clearly
fails.

Fixes: #3496

Signed-off-by: Thomas Graf <thomas@cilium.io>
