### PR TITLE
bugtool: add `ip rule` and `cilium-health status` commands

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -71,6 +71,7 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		"iptables -S",
 		"ip6tables -S",
 		"iptables -L -v",
+		"ip rule",
 	}
 
 	// Commands that require variables and / or more configuration are added

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -214,6 +214,7 @@ func copyCiliumInfoCommands(cmdDir string, k8sPods []string) []string {
 		"cilium bpf proxy list",
 		"cilium bpf ipcache list",
 		"cilium status --verbose",
+		"cilium-health status",
 	}
 	var commands []string
 


### PR DESCRIPTION
Fixes: #3498, #2691 

Signed-off by: Ian Vernon <ian@cilium.io>