### PR TITLE
Fix Kafka CI error

### DIFF
--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -77,7 +77,7 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 		res := vm.ContainerExec(client, fmt.Sprintf(
 			"/opt/kafka/bin/kafka-topics.sh --create --zookeeper zook:2181 "+
 				"--replication-factor 1 --partitions 1 --topic %s", name))
-		res.ExpectSuccess()
+		res.ExpectSuccess("Unable to create topic  %s: %s", name, res.CombineOutput())
 	}
 	consumerCmd := func(topic string, maxMsg int) string {
 		return fmt.Sprintf("/opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server "+


### PR DESCRIPTION
Make the Kafka CI errors more descriptive.
Move topic creation to BeforeEach function.

Fixes: #3503
Fixes: #3502
Signed-Off-By: Manali Bhutiyani <manali@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/3504)
<!-- Reviewable:end -->
