### PR TITLE
policymap: Avoid using golang arrays in entry

### DIFF
--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -63,7 +63,9 @@ type policyKey struct {
 
 type PolicyEntry struct {
 	ProxyPort uint16 // In network byte-order
-	Pad       [3]uint16
+	Pad0      uint16
+	Pad1      uint16
+	Pad2      uint16
 	Packets   uint64
 	Bytes     uint64
 }


### PR DESCRIPTION
Split the array into separate fields in case it has any effect on #3491.

Signed-off-by: Joe Stringer <joe@covalent.io>