### PR TITLE
api: Switch API version from v1beta to v1

### DIFF
--- a/api/v1/client/cilium_client.go
+++ b/api/v1/client/cilium_client.go
@@ -28,7 +28,7 @@ const (
 	DefaultHost string = "localhost"
 	// DefaultBasePath is the default BasePath
 	// found in Meta (info) section of spec file
-	DefaultBasePath string = "/v1beta"
+	DefaultBasePath string = "/v1"
 )
 
 // DefaultSchemes are the default schemes found in Meta (info) section of spec file

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -6,7 +6,7 @@ info:
   version: v1beta
 x-schemes:
 - unix
-basePath: "/v1beta"
+basePath: "/v1"
 produces:
 - application/json
 consumes:

--- a/api/v1/server/doc.go
+++ b/api/v1/server/doc.go
@@ -8,7 +8,7 @@ Cilium
     Schemes:
       unix
     Host: localhost
-    BasePath: /v1beta
+    BasePath: /v1
     Version: v1beta
 
     Consumes:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -26,7 +26,7 @@ func init() {
     "title": "Cilium API",
     "version": "v1beta"
   },
-  "basePath": "/v1beta",
+  "basePath": "/v1",
   "paths": {
     "/config": {
       "get": {

--- a/api/v1/server/restapi/daemon/get_config_urlbuilder.go
+++ b/api/v1/server/restapi/daemon/get_config_urlbuilder.go
@@ -39,7 +39,7 @@ func (o *GetConfigURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/daemon/get_debuginfo_urlbuilder.go
+++ b/api/v1/server/restapi/daemon/get_debuginfo_urlbuilder.go
@@ -39,7 +39,7 @@ func (o *GetDebuginfoURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/daemon/get_healthz_urlbuilder.go
+++ b/api/v1/server/restapi/daemon/get_healthz_urlbuilder.go
@@ -39,7 +39,7 @@ func (o *GetHealthzURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/daemon/patch_config_urlbuilder.go
+++ b/api/v1/server/restapi/daemon/patch_config_urlbuilder.go
@@ -39,7 +39,7 @@ func (o *PatchConfigURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/endpoint/delete_endpoint_id_urlbuilder.go
+++ b/api/v1/server/restapi/endpoint/delete_endpoint_id_urlbuilder.go
@@ -50,7 +50,7 @@ func (o *DeleteEndpointIDURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/endpoint/get_endpoint_id_config_urlbuilder.go
+++ b/api/v1/server/restapi/endpoint/get_endpoint_id_config_urlbuilder.go
@@ -50,7 +50,7 @@ func (o *GetEndpointIDConfigURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/endpoint/get_endpoint_id_healthz_urlbuilder.go
+++ b/api/v1/server/restapi/endpoint/get_endpoint_id_healthz_urlbuilder.go
@@ -50,7 +50,7 @@ func (o *GetEndpointIDHealthzURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/endpoint/get_endpoint_id_labels_urlbuilder.go
+++ b/api/v1/server/restapi/endpoint/get_endpoint_id_labels_urlbuilder.go
@@ -50,7 +50,7 @@ func (o *GetEndpointIDLabelsURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/endpoint/get_endpoint_id_log_urlbuilder.go
+++ b/api/v1/server/restapi/endpoint/get_endpoint_id_log_urlbuilder.go
@@ -50,7 +50,7 @@ func (o *GetEndpointIDLogURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/endpoint/get_endpoint_id_urlbuilder.go
+++ b/api/v1/server/restapi/endpoint/get_endpoint_id_urlbuilder.go
@@ -50,7 +50,7 @@ func (o *GetEndpointIDURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/endpoint/get_endpoint_urlbuilder.go
+++ b/api/v1/server/restapi/endpoint/get_endpoint_urlbuilder.go
@@ -39,7 +39,7 @@ func (o *GetEndpointURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/endpoint/patch_endpoint_id_config_urlbuilder.go
+++ b/api/v1/server/restapi/endpoint/patch_endpoint_id_config_urlbuilder.go
@@ -50,7 +50,7 @@ func (o *PatchEndpointIDConfigURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/endpoint/patch_endpoint_id_labels_urlbuilder.go
+++ b/api/v1/server/restapi/endpoint/patch_endpoint_id_labels_urlbuilder.go
@@ -50,7 +50,7 @@ func (o *PatchEndpointIDLabelsURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/endpoint/patch_endpoint_id_urlbuilder.go
+++ b/api/v1/server/restapi/endpoint/patch_endpoint_id_urlbuilder.go
@@ -50,7 +50,7 @@ func (o *PatchEndpointIDURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/endpoint/put_endpoint_id_urlbuilder.go
+++ b/api/v1/server/restapi/endpoint/put_endpoint_id_urlbuilder.go
@@ -50,7 +50,7 @@ func (o *PutEndpointIDURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/ipam/delete_ip_a_m_ip_urlbuilder.go
+++ b/api/v1/server/restapi/ipam/delete_ip_a_m_ip_urlbuilder.go
@@ -50,7 +50,7 @@ func (o *DeleteIPAMIPURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/ipam/post_ip_a_m_ip_urlbuilder.go
+++ b/api/v1/server/restapi/ipam/post_ip_a_m_ip_urlbuilder.go
@@ -50,7 +50,7 @@ func (o *PostIPAMIPURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/ipam/post_ip_a_m_urlbuilder.go
+++ b/api/v1/server/restapi/ipam/post_ip_a_m_urlbuilder.go
@@ -43,7 +43,7 @@ func (o *PostIPAMURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/policy/delete_policy_urlbuilder.go
+++ b/api/v1/server/restapi/policy/delete_policy_urlbuilder.go
@@ -39,7 +39,7 @@ func (o *DeletePolicyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/policy/get_identity_id_urlbuilder.go
+++ b/api/v1/server/restapi/policy/get_identity_id_urlbuilder.go
@@ -50,7 +50,7 @@ func (o *GetIdentityIDURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/policy/get_identity_urlbuilder.go
+++ b/api/v1/server/restapi/policy/get_identity_urlbuilder.go
@@ -39,7 +39,7 @@ func (o *GetIdentityURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/policy/get_policy_resolve_urlbuilder.go
+++ b/api/v1/server/restapi/policy/get_policy_resolve_urlbuilder.go
@@ -39,7 +39,7 @@ func (o *GetPolicyResolveURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/policy/get_policy_urlbuilder.go
+++ b/api/v1/server/restapi/policy/get_policy_urlbuilder.go
@@ -39,7 +39,7 @@ func (o *GetPolicyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/policy/put_policy_urlbuilder.go
+++ b/api/v1/server/restapi/policy/put_policy_urlbuilder.go
@@ -39,7 +39,7 @@ func (o *PutPolicyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/prefilter/get_prefilter_urlbuilder.go
+++ b/api/v1/server/restapi/prefilter/get_prefilter_urlbuilder.go
@@ -39,7 +39,7 @@ func (o *GetPrefilterURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/prefilter/patch_prefilter_urlbuilder.go
+++ b/api/v1/server/restapi/prefilter/patch_prefilter_urlbuilder.go
@@ -39,7 +39,7 @@ func (o *PatchPrefilterURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/service/delete_service_id_urlbuilder.go
+++ b/api/v1/server/restapi/service/delete_service_id_urlbuilder.go
@@ -52,7 +52,7 @@ func (o *DeleteServiceIDURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/service/get_service_id_urlbuilder.go
+++ b/api/v1/server/restapi/service/get_service_id_urlbuilder.go
@@ -52,7 +52,7 @@ func (o *GetServiceIDURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/service/get_service_urlbuilder.go
+++ b/api/v1/server/restapi/service/get_service_urlbuilder.go
@@ -39,7 +39,7 @@ func (o *GetServiceURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/api/v1/server/restapi/service/put_service_id_urlbuilder.go
+++ b/api/v1/server/restapi/service/put_service_id_urlbuilder.go
@@ -52,7 +52,7 @@ func (o *PutServiceIDURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1beta"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 


### PR DESCRIPTION
**Summary of changes**:
Just what it says on the tin. This changes the basepath on the API urls. I'm not sure it's critical to do this but if we wanted to declare APIv1 stable we might want to make the switch.
To support older client code that will use the older `/v1beta` paths I think the only way to keep the `/v1beta` prefix is to have a second /api/v1beta directory, but this means duplicating code. We could also add a redirect or just rewrite such requests in middleware somewhere.

Fixes https://github.com/cilium/cilium/issues/3280

```release-note
cilium-agent API v1 is stable
```

**How to test (optional)**:
all tests should pass.