### PR TITLE
labels: Ignore istio sidecar annotation labels

### DIFF
--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -168,6 +168,7 @@ func defaultLabelPrefixCfg() *labelPrefixCfg {
 		"!controller-revision-hash",                                // ignore controller-revision-hash
 		"!annotation." + common.CiliumK8sAnnotationPrefix,          // ignore all cilium annotations
 		"!annotation." + common.CiliumIdentityAnnotationDeprecated, // ignore all cilium annotations
+		"!annotation.sidecar.istio.io",                             // ignore all istio sidecar annotation labels
 	}
 
 	for _, e := range expressions {


### PR DESCRIPTION
These labels should never be security relevant

```
42910      Disabled           Disabled          4915       container:annotation.sidecar.istio.io/status={"version":"d43d7bfe312f98e60ea4bc98ee5c132bf17bf18ea84fcd3b788bb2f7ee4fd3b2","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}   f00d::ae8:4200:0:a79e   10.232.66.18    ready
```