### PR TITLE
envoy: Rename xDS cluster and fix envoy integration test

### DIFF
--- a/envoy/cilium_integration_test.cc
+++ b/envoy/cilium_integration_test.cc
@@ -38,11 +38,11 @@ public:
   TestConfig(const ::cilium::BpfMetadata& config, Server::Configuration::ListenerFactoryContext& context)
     : Config(config, context) {}
 
-  bool getBpfMetadata(Network::ConnectionSocket &socket) override {
+  bool getMetadata(Network::ConnectionSocket &socket) override {
     // fake setting the local address. It remains the same as required by the test infra, but it will be marked as restored
     // as required by the original_dst cluster.
     socket.setLocalAddress(original_dst_address, true);
-    socket.addOption(std::make_unique<Cilium::SocketOption>(maps_, 42, 1, true, 80, 10000));
+    socket.addOption(std::make_unique<Cilium::SocketOption>(maps_, 1, 173, true, 80, 10000));
     return true;
   }
 };
@@ -171,7 +171,7 @@ static_resources:
     - socket_address:
         address: 127.0.0.1
         port_value: 0
-  - name: xds_cluster
+  - name: xds-grpc-cilium
     connect_timeout: { seconds: 5 }
     type: STATIC
     lb_policy: ROUND_ROBIN
@@ -201,9 +201,6 @@ static_resources:
             config:
               access_log_path: ""
               policy_name: "173"
-              api_config_source:
-                api_type: GRPC
-                cluster_names: xds_cluster
           - name: envoy.router
           route_config:
             name: policy_enabled

--- a/envoy/grpc_subscription.h
+++ b/envoy/grpc_subscription.h
@@ -17,7 +17,7 @@ subscribe(const std::string& grpc_method, const envoy::api::v2::core::Node& node
   // Hard-coded Cilium gRPC cluster
   envoy::api::v2::core::ApiConfigSource api_config_source{};
   api_config_source.set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
-  api_config_source.add_cluster_names("xdsCluster");
+  api_config_source.add_cluster_names("xds-grpc-cilium");
 
   Config::Utility::checkApiConfigSourceSubscriptionBackingCluster(cm.clusters(), api_config_source);
   Config::SubscriptionStats stats = Config::Utility::generateStats(scope);

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -329,7 +329,7 @@ func createBootstrap(filePath string, name, cluster, version string, xdsSock, en
 					ProtocolSelection: envoy_api_v2.Cluster_USE_DOWNSTREAM_PROTOCOL,
 				},
 				{
-					Name:           "xdsCluster",
+					Name:           "xds-grpc-cilium",
 					Type:           envoy_api_v2.Cluster_STATIC,
 					ConnectTimeout: &duration.Duration{Seconds: 1, Nanos: 0},
 					LbPolicy:       envoy_api_v2.Cluster_ROUND_ROBIN,
@@ -348,7 +348,7 @@ func createBootstrap(filePath string, name, cluster, version string, xdsSock, en
 				ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_ApiConfigSource{
 					ApiConfigSource: &envoy_api_v2_core.ApiConfigSource{
 						ApiType:      envoy_api_v2_core.ApiConfigSource_GRPC,
-						ClusterNames: []string{"xdsCluster"},
+						ClusterNames: []string{"xds-grpc-cilium"},
 					},
 				},
 			},


### PR DESCRIPTION
Rename the Envoy xDS cluster from xdsCluster into xds-grpc-cilium
for style consistency with Istio's xds-grpc cluster, and to make it
clear that this cluster is specific to Cilium.

The 'tests' target in 'envoy/' is not run in the CI, allowing the
integration test to rot a bit. Bring it up-to-date.

Fixes: #3452

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/3517)
<!-- Reviewable:end -->
