### PR TITLE
pkg/policy: correctly merge L4 rules which apply to the same port

### DIFF
--- a/Documentation/gettingstarted/docker.rst
+++ b/Documentation/gettingstarted/docker.rst
@@ -79,11 +79,15 @@ it using the ``cilium`` CLI client. Check the status of the agent by running
 ::
 
     $ cilium status
-    KVStore:            Ok         Consul: 172.18.0.2:8300
-    ContainerRuntime:   Ok
-    Kubernetes:         Disabled
-    Cilium:             Ok         OK
-    NodeMonitor:        Listening for events on 1 CPUs with 64x4096 of shared memory
+    KVStore:                Ok         Consul: 172.18.0.2:8300
+    ContainerRuntime:       Ok         
+    Kubernetes:             Disabled   
+    Cilium:                 Ok         OK
+    NodeMonitor:            Listening for events on 1 CPUs with 64x4096 of shared memory
+    Cilium health daemon:   Ok   
+    Controller Status:      6/6 healthy
+    Proxy Status:           OK, ip 10.15.28.238, port-range 10000-20000
+    Cluster health:   1/1 reachable   (2018-04-05T16:08:22Z)
 
 The status indicates that all components are operational with the Kubernetes
 integration currently being disabled.

--- a/examples/minikube/l3_l4_policy.yaml
+++ b/examples/minikube/l3_l4_policy.yaml
@@ -1,18 +1,17 @@
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-#for k8s <1.7 use:
-#apiVersion: extensions/v1beta1
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+description: "L3-L4 policy for getting started using Kubernetes guide"
 metadata:
-  name: access-backend
+  name: "rule1"
 spec:
-  podSelector:
+  endpointSelector:
     matchLabels:
       id: app1
   ingress:
-  - from:
-    - podSelector:
-        matchLabels:
-          id: app2
-    ports:
-    - port: 80
-      protocol: TCP
+  - fromEndpoints:
+    - matchLabels:
+        id: app2
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -177,7 +177,7 @@ func (s *K8sSuite) TestParseNetworkPolicyIngress(c *C) {
 		"80/TCP": {
 			Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 			Endpoints:    []api.EndpointSelector{epSelector},
-			L7Parser:     "",
+			L7Parser:     policy.ParserTypeNone,
 			L7RulesPerEp: policy.L7DataMap{},
 			Ingress:      true,
 			DerivedFromRules: []labels.LabelArray{
@@ -373,7 +373,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEgress(c *C) {
 		"80/TCP": {
 			Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 			Endpoints:    []api.EndpointSelector{epSelector},
-			L7Parser:     "",
+			L7Parser:     policy.ParserTypeNone,
 			L7RulesPerEp: policy.L7DataMap{},
 			Ingress:      false,
 			DerivedFromRules: []labels.LabelArray{

--- a/pkg/k8s/network_policy_v1beta_test.go
+++ b/pkg/k8s/network_policy_v1beta_test.go
@@ -109,7 +109,7 @@ func (s *K8sSuite) TestParseNetworkPolicyDeprecated(c *C) {
 		"80/TCP": {
 			Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 			Endpoints:    []api.EndpointSelector{epSelector},
-			L7Parser:     "",
+			L7Parser:     policy.ParserTypeNone,
 			L7RulesPerEp: policy.L7DataMap{},
 			Ingress:      true,
 			DerivedFromRules: []labels.LabelArray{

--- a/pkg/k8s/network_policy_v1beta_test.go
+++ b/pkg/k8s/network_policy_v1beta_test.go
@@ -102,6 +102,8 @@ func (s *K8sSuite) TestParseNetworkPolicyDeprecated(c *C) {
 		LabelSelector: &lblSelector,
 	}
 
+	// TODO - this test is not in the right package. We should test parsing
+	// of policy and internal policy resolution within Cilium *separately*.
 	l4IngressPolicy, err := repo.ResolveL4IngressPolicy(&ctx)
 	c.Assert(l4IngressPolicy, Not(IsNil))
 	c.Assert(err, IsNil)

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -229,3 +229,19 @@ func (s EndpointSelectorSlice) Matches(ctx labels.LabelArray) bool {
 
 	return false
 }
+
+// SelectsAllEndpoints returns whether the EndpointSelectorSlice selects all
+// endpoints (if it contains the WildcardEndpointSelector, or if it is empty).
+func (s EndpointSelectorSlice) SelectsAllEndpoints() bool {
+
+	if len(s) == 0 {
+		return true
+	}
+
+	for _, selector := range s {
+		if selector.IsWildcard() {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/policy/api/selector_test.go
+++ b/pkg/policy/api/selector_test.go
@@ -1,0 +1,40 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"github.com/cilium/cilium/pkg/labels"
+
+	. "gopkg.in/check.v1"
+)
+
+var _ = Suite(&PolicyAPITestSuite{})
+
+func (s *PolicyAPITestSuite) TestSelectsAllEndpoints(c *C) {
+
+	// Empty endpoint selector slice equates to a wildcard.
+	selectorSlice := EndpointSelectorSlice{}
+	c.Assert(selectorSlice.SelectsAllEndpoints(), Equals, true)
+
+	selectorSlice = EndpointSelectorSlice{WildcardEndpointSelector}
+	c.Assert(selectorSlice.SelectsAllEndpoints(), Equals, true)
+
+	// Slice that contains wildcard and other selectors still selects all endpoints.
+	selectorSlice = EndpointSelectorSlice{WildcardEndpointSelector, NewESFromLabels(labels.ParseSelectLabel("bar"))}
+	c.Assert(selectorSlice.SelectsAllEndpoints(), Equals, true)
+
+	selectorSlice = EndpointSelectorSlice{NewESFromLabels(labels.ParseSelectLabel("bar")), NewESFromLabels(labels.ParseSelectLabel("foo"))}
+	c.Assert(selectorSlice.SelectsAllEndpoints(), Equals, false)
+}

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -415,13 +415,9 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 	expected := NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
-		Endpoints: selectorFromApp2DupList,
-		L7Parser:  "http",
-		L7RulesPerEp: L7DataMap{
-			selectorFromApp2[0]: api.L7Rules{
-				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
-			},
-		},
+		Endpoints:        selectorFromApp2DupList,
+		L7Parser:         ParserTypeNone,
+		L7RulesPerEp:     L7DataMap{},
 		Ingress:          true,
 		DerivedFromRules: []labels.LabelArray{nil, nil, nil},
 	}


### PR DESCRIPTION
* pkg/k8s: add TODO for cleaning up unit tests
* Documentation/gettingstarted: update `cilium status` output in Docker GSG
* Documentation/gettingstarted: update Minikube GSG to reflect how we handle L4-only and L4-L7 policy on the same port
    - The GSG needs to be updated to account for the fact that when one rule selects an endpoint with L4-only policy, and another rule selects the same endpoint on the same port/protocol, we resolve internally within Cilium to allow all traffic on L4. Thus, use a CiliumNetworkPolicy with the same name that is used for L4-only policy, and then updated with L4-L7 policy.
* examples/minikube: convert L3-L4 policy to CiliumNetworkPolicy
* pkg/policy/api: add SelectsAllEndpoints function
    - This function tests whether the EndpointSelectorSlice selects all endpoints.
* pkg/policy: fix merging of L4-related policy
    -L4Filter: document what empty L7Parser represents in L4Filter.
    -  add L7ParserType to represent no L7Parser: instead of using an empty string define a constant which represents no parser type.
    - remove addEndpoints function: this function is no longer used; remove it.
    - change type of Endpoints field in L4Filter to EndpointSelectorSlice
        - This should not result in any functional change. This change was made for the L4Filter to consume `EndpointSelectorSlice.SelectsAllEndpoints()`.
    - add AllowsAllAtL3 function for L4Filter
        - This contains the logic to determine whether an L4Filter selects all endpoints at L3.
    - do not treat empty Endpoints in L4Filter as selecting all endpoints
        - For consistency across the policy package, set the slice to contain the `api.WildcardEndpointSelector`, which explicitly shows that the L4Filter applies to all endpoints. If no endpoints are provided when an L4Filter is created, set the list of endpoints to be a slice containing `api.WildcardEndpointSelector`.
    - properly handle merging ingress L4-only and L4-L7 rules which apply to the same port/protocol tuple

For instance, take the following CiliumNetworkPolicy:

```
    specs:
    - endpointSelector:
        matchLabels:
          id: app1
      ingress:
      - fromEndpoints:
        - matchLabels:
            id: app2
        toPorts:
        - ports:
          - port: "9093"
            protocol: TCP
          rules:
            http:
            - method: ^GET$
              path: ^/metrics$
      - toPorts:
        - ports:
          - port: "9093"
            protocol: TCP
```
    
These two separate rules previously resolved to only allowing traffic on `9093/TCP` on `^GET$ ^/metrics$` . This is incorrect, as the toPorts rule implicitly allows all traffic on the port, regardless of the L7 rule.
    
This commit changes how merging of L4 port rules is done to ensure that  the resultant policy allows all traffic on 9093/TCP, ignoring all L7-rules.
Signed-off by: Ian Vernon <ian@cilium.io>

Still todo:
- [x] Review the getting-started-guides to account for this, as it will be affected by this change.
    - [x] Kubernetes GSG
    - TODO (other GSGs?)
- [x] Update Ginkgo tests.
    - To my surprise, the tests passed, so I guess this doesn't need to be done :-) 
- [x] Make corresponding changes on merging egress L4 port rules.

Related-to: #3509

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/3518)
<!-- Reviewable:end -->
