### PR TITLE
daemon: Fix Envoy version check and add hidden option to skip it

### DIFF
--- a/envoy/Makefile
+++ b/envoy/Makefile
@@ -27,6 +27,11 @@ CLANG_FORMAT ?= clang-format
 BUILDIFIER ?= buildifier
 STRIP ?= strip
 
+ifdef CILIUM_DISABLE_ENVOY_BUILD
+all install clean:
+	echo "Envoy build is disabled by environment variable CILIUM_DISABLE_ENVOY_BUILD"
+else
+
 # Dockerfile builds require special options
 ifdef PKG_BUILD
 BAZEL_OPTS ?= --batch
@@ -48,13 +53,16 @@ api: force-non-root Makefile.api
 
 envoy: force-non-root
 	@$(ECHO_BAZEL)
+	-rm -f bazel-out/k8-fastbuild/bin/_objs/envoy/external/envoy/source/common/common/version_linkstamp.o
 	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) //:envoy
 
 # Allow root build for release
 $(ENVOY_BIN) envoy-release: force
+	-rm -f bazel-out/k8-opt/bin/_objs/envoy/external/envoy/source/common/common/version_linkstamp.o
 	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) -c opt //:envoy
 
 envoy-debug: force-non-root
+	-rm -f bazel-out/k8-dbg/bin/_objs/envoy/external/envoy/source/common/common/version_linkstamp.o
 	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) -c dbg //:envoy
 
 $(CHECK_FORMAT): force-non-root
@@ -122,4 +130,6 @@ endif
 force-non-root:
 ifeq ($(USER),root)
 	$(error This target cannot be run as root!)
+endif
+
 endif


### PR DESCRIPTION
Cilium agent should abort on mismatching Envoy version. The log level
was inadvertently changed from Fatal to Warn in commit 5f18a28b0e
("ct: enforce CT clean up from L3 to L7 policy changes on ingress").

Envoy has not updated its Bazel configuration to correctly set the
linkstamp for the version. Workaround by manually deleteting the
version_linkstamp.o file before build.

Add a new hidden boolean command line option
"--disable-envoy-version-check" that bypasses the version check on
startup. This option is bound to the environment variable
"CILIUM_DISABLE_ENVOY_BUILD" so that if that is defined as "true" or
non-zero the version check will also be skipped. If this environment
variable is defined (at all) when invoking "make" all make actions
within the envoy directory are skipped.

Fixes: 5f18a28b0e ("ct: enforce CT clean up from L3 to L7 policy changes on ingress")
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/3527)
<!-- Reviewable:end -->
