### PR TITLE
Don't block daemon startup due to syncing loadbalancer BPF maps with KVstore

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1093,9 +1093,11 @@ func NewDaemon(c *Config) (*Daemon, error) {
 		if err := d.SyncState(d.conf.StateDir, true); err != nil {
 			log.WithError(err).Warn("Error while recovering endpoints")
 		}
-		if err := d.SyncLBMap(); err != nil {
-			log.WithError(err).Warn("Error while recovering endpoints")
-		}
+		go func() {
+			if err := d.SyncLBMap(); err != nil {
+				log.WithError(err).Warn("Error while recovering endpoints")
+			}
+		}()
 	} else {
 		// We need to read all docker containers so we know we won't
 		// going to allocate the same IP addresses and we will ignore


### PR DESCRIPTION
In setups with several cilium nodes, we have observed cilium startup
blocking for significant periods (eg, one minute or more). One of the
few points that blocks during startup for potentially long times is the
synchronization of the BPF loadbalancer maps with the KVStore. If this
takes too long, then in kubernetes environments cilium may end up being
killed because it's not serving the Cilium API while this is happening.

To work around such issues, run this logic in a separate goroutine in the
background. In future, we can improve the logic to speed it up (see #3533).

Signed-off-by: Joe Stringer <joe@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/3535)
<!-- Reviewable:end -->
