### PR TITLE
Recover from panics in Cilium API

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -62,6 +62,7 @@ Jenkinsfile.nightly @cilium/ci
 monitor/ @cilium/monitor
 monitor/payload @cilium/api
 pkg/apierror/ @cilium/api
+pkg/apipanic/ @cilium/api
 pkg/apisocket/ @cilium/api
 pkg/bpf/ @cilium/bpf
 pkg/completion/ @cilium/proxy

--- a/api/v1/server/configure_cilium.go
+++ b/api/v1/server/configure_cilium.go
@@ -11,6 +11,7 @@ import (
 	graceful "github.com/tylerb/graceful"
 
 	"github.com/cilium/cilium/api/v1/server/restapi"
+	"github.com/cilium/cilium/pkg/apipanic"
 	"github.com/cilium/cilium/pkg/metrics"
 )
 
@@ -62,8 +63,12 @@ func setupMiddlewares(handler http.Handler) http.Handler {
 // The middleware configuration happens before anything, this middleware also applies to serving the swagger.json document.
 // So this is a good place to plug in a panic handling middleware, logging and metrics
 func setupGlobalMiddleware(handler http.Handler) http.Handler {
-	return &metrics.APIEventTSHelper{
+	eventsHelper := &metrics.APIEventTSHelper{
 		Next:    handler,
 		TSGauge: metrics.EventTSAPI,
+	}
+
+	return &apipanic.APIPanicHandler{
+		Next: eventsHelper,
 	}
 }

--- a/pkg/apipanic/apipanic.go
+++ b/pkg/apipanic/apipanic.go
@@ -1,0 +1,45 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apipanic
+
+import (
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/logging"
+)
+
+// APIPanicHandler recovers from API panics and logs encountered panics
+type APIPanicHandler struct {
+	Next http.Handler
+}
+
+// ServeHTTP implements the http.Handler interface.
+// It recovers from panics of all next handlers and logs them
+func (h *APIPanicHandler) ServeHTTP(r http.ResponseWriter, req *http.Request) {
+	defer func() {
+		if r := recover(); r != nil {
+			fields := logrus.Fields{
+				"panic_message": r,
+				"url":           req.URL.String(),
+				"method":        req.Method,
+				"client":        req.RemoteAddr,
+			}
+			logging.DefaultLogger.WithFields(fields).Warn("Cilium API handler panicked")
+		}
+	}()
+	h.Next.ServeHTTP(r, req)
+}


### PR DESCRIPTION
APIPanic middleware is added to recover from panics in API HTTP handlers

Related: #649 #3294 #3520