### PR TITLE
cli: protect against API nils

### DIFF
--- a/cilium/cmd/config.go
+++ b/cilium/cmd/config.go
@@ -59,6 +59,9 @@ func configDaemon(cmd *cobra.Command, opts []string) {
 	if err != nil {
 		Fatalf("Error while retrieving configuration: %s", err)
 	}
+	if resp.Status == nil {
+		Fatalf("Empty configuration status returned")
+	}
 
 	cfgStatus := resp.Status
 	if numPages > 0 {

--- a/cilium/cmd/debuginfo.go
+++ b/cilium/cmd/debuginfo.go
@@ -89,7 +89,7 @@ func runDebugInfo(cmd *cobra.Command, args []string) {
 		printList(w, "Endpoint Get "+epID, "endpoint", "get", epID)
 		printList(w, "Endpoint Log "+epID, "endpoint", "log", epID)
 
-		if ep.Status.Identity != nil {
+		if ep.Status != nil && ep.Status.Identity != nil {
 			id := strconv.FormatInt(ep.Status.Identity.ID, 10)
 			printList(w, "Identity get "+id, "identity", "get", id)
 		}

--- a/cilium/cmd/endpoint_labels.go
+++ b/cilium/cmd/endpoint_labels.go
@@ -49,9 +49,13 @@ var endpointLabelsCmd = &cobra.Command{
 			}
 		}
 
-		if lbls, err := client.EndpointLabelsGet(id); err != nil {
+		lbls, err := client.EndpointLabelsGet(id)
+		switch {
+		case err != nil:
 			Fatalf("Cannot get endpoint labels: %s", err)
-		} else {
+		case lbls == nil || lbls.Status == nil:
+			Fatalf("Cannot get endpoint labels: empty response")
+		default:
 			printEndpointLabels(labels.NewOplabelsFromModel(lbls.Status))
 		}
 	},

--- a/cilium/cmd/kvstore.go
+++ b/cilium/cmd/kvstore.go
@@ -39,6 +39,10 @@ func setupKvstore() {
 		if err != nil {
 			Fatalf("Unable to retrieve cilium configuration: %s", err)
 		}
+		if resp.Status == nil {
+			Fatalf("Unable to retrieve cilium configuration: empty response")
+		}
+
 		cfgStatus := resp.Status
 
 		if kvStore == "" {

--- a/cilium/cmd/policy_trace.go
+++ b/cilium/cmd/policy_trace.go
@@ -216,7 +216,13 @@ func appendEpLabelsToSlice(labelSlice []string, epID string) []string {
 	if err != nil {
 		Fatalf("Cannot get endpoint corresponding to identifier %s: %s\n", epID, err)
 	}
-	return append(labelSlice, ep.Status.Identity.Labels...)
+
+	lbls := []string{}
+	if ep.Status != nil && ep.Status.Identity != nil && ep.Status.Identity.Labels != nil {
+		lbls = ep.Status.Identity.Labels
+	}
+
+	return append(labelSlice, lbls...)
 }
 
 func parseLabels(slice []string) ([]string, error) {

--- a/cilium/cmd/policy_wait.go
+++ b/cilium/cmd/policy_wait.go
@@ -55,13 +55,16 @@ var policyWaitCmd = &cobra.Command{
 			notReady := 0
 
 			for _, ep := range eps {
-				if ep.Status.Policy != nil && ep.Status.Policy.Realized != nil {
-					if ep.Status.Policy.Realized.PolicyRevision >= reqRevision &&
-						ep.Status.State == models.EndpointStateReady {
-						ready++
-					} else if ep.Status.State == models.EndpointStateNotReady {
-						notReady++
-					}
+				switch {
+				case ep.Status.Policy == nil || ep.Status.Policy.Realized == nil:
+					notReady++
+
+				case ep.Status.Policy.Realized.PolicyRevision >= reqRevision &&
+					ep.Status.State == models.EndpointStateReady:
+					ready++
+
+				case ep.Status.State == models.EndpointStateNotReady:
+					notReady++
 				}
 			}
 

--- a/cilium/cmd/prefilter_list.go
+++ b/cilium/cmd/prefilter_list.go
@@ -48,16 +48,18 @@ func listFilters(cmd *cobra.Command, args []string) {
 		if err := command.PrintOutput(spec); err != nil {
 			os.Exit(1)
 		}
-	} else {
-		w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
-		str = fmt.Sprintf("Revision: %d", spec.Status.Realized.Revision)
-		fmt.Fprintln(w, str)
-		if spec.Status != nil && spec.Status.Realized != nil {
-			for _, pfx := range spec.Status.Realized.Deny {
-				str = fmt.Sprintf("%s", pfx)
-				fmt.Fprintln(w, str)
-			}
-		}
-		w.Flush()
+		return
 	}
+
+	if spec.Status == nil || spec.Status.Realized == nil {
+		Fatalf("Cannot get CIDR list: empty response")
+	}
+	w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
+	str = fmt.Sprintf("Revision: %d", spec.Status.Realized.Revision)
+	fmt.Fprintln(w, str)
+	for _, pfx := range spec.Status.Realized.Deny {
+		str = fmt.Sprintf("%s", pfx)
+		fmt.Fprintln(w, str)
+	}
+	w.Flush()
 }

--- a/cilium/cmd/service_delete.go
+++ b/cilium/cmd/service_delete.go
@@ -36,6 +36,11 @@ var serviceDeleteCmd = &cobra.Command{
 			}
 
 			for _, svc := range list {
+				if svc.Status == nil || svc.Status.Realized == nil {
+					log.Error("Skipping service due to empty state")
+					continue
+				}
+
 				if err := client.DeleteServiceID(svc.Status.Realized.ID); err != nil {
 					log.WithError(err).WithField(logfields.ServiceID, svc.Status.Realized.ID).Error("Cannot delete service")
 				}

--- a/cilium/cmd/service_get.go
+++ b/cilium/cmd/service_get.go
@@ -41,6 +41,9 @@ var serviceGetCmd = &cobra.Command{
 		if err != nil {
 			Fatalf("Cannot get service '%v': %s\n", id, err)
 		}
+		if svc.Status == nil || svc.Status.Realized == nil {
+			Fatalf("Cannot get service '%v': empty response\n", id)
+		}
 
 		slice := []string{}
 		for _, be := range svc.Status.Realized.BackendAddresses {

--- a/cilium/cmd/service_list.go
+++ b/cilium/cmd/service_list.go
@@ -69,6 +69,11 @@ func printServiceList(w *tabwriter.Writer, list []*models.Service) {
 	svcs := []ServiceOutput{}
 
 	for _, svc := range list {
+		if svc.Status == nil || svc.Status.Realized == nil {
+			fmt.Fprint(os.Stderr, "error parsing svc: empty state")
+			continue
+		}
+
 		feA, err := types.NewL3n4AddrFromModel(svc.Status.Realized.FrontendAddress)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error parsing frontend %+v", svc.Status.Realized.FrontendAddress)

--- a/cilium/cmd/service_update.go
+++ b/cilium/cmd/service_update.go
@@ -72,10 +72,15 @@ func updateService(cmd *cobra.Command, args []string) {
 
 	var spec *models.ServiceSpec
 	svc, err := client.GetServiceID(id)
-	if err == nil {
+	switch {
+	case err == nil && (svc.Status == nil || svc.Status.Realized == nil):
+		Fatalf("Cannot update service %d: empty state", id)
+
+	case err == nil:
 		spec = svc.Status.Realized
 		fmt.Printf("Updating existing service with id '%v'\n", id)
-	} else {
+
+	default:
 		spec = &models.ServiceSpec{ID: id}
 		fmt.Printf("Creating new service with id '%v'\n", id)
 	}


### PR DESCRIPTION
The newer API has more nested fields and they may be nil. The CLI
tooling needs to check this more rigourously.
