### PR TITLE
Documentation/policy: add label-based egress documentation

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -34,10 +34,16 @@ Labels Based
 ------------
 
 Label-based L3 policy is used to establish policy between endpoints inside the
-cluster managed by Cilium. An endpoint is allowed to talk to another endpoint
-if at least one rule exists which selects the destination endpoint with the
-`EndpointSelector` in the ``endpointSelector`` field and selects the source
-endpoint with the `EndpointSelector` in the ``fromEndpoints`` field.
+cluster managed by Cilium.
+
+Ingress
+~~~~~~~
+
+An endpoint is allowed to receive traffic from another endpoint if at least one
+ingress rule exists which selects the destination endpoint with the
+`EndpointSelector` in the ``endpointSelector`` field. To restrict traffic upon
+ingress to the selected endpoint, the rule selects the source endpoint with the
+`EndpointSelector` in the ``fromEndpoints`` field.
 
 Simple Ingress Allow
 ~~~~~~~~~~~~~~~~~~~~
@@ -81,6 +87,66 @@ all ingress traffic to an endpoint may be done as follows:
 
         .. literalinclude:: ../../examples/policies/l3/ingress-allow-all/ingress-allow-all.json
 
+Note that while the above examples allow all ingress traffic to an endpoint, this does not 
+mean that all endpoints are allowed to send traffic to this endpoint per their policies. 
+In other words, policy must be configured on both sides (sender and receiver).
+
+Egress
+~~~~~~
+
+An endpoint is allowed to send traffic to another endpoint if at least one
+egress rule exists which selects the destination endpoint with the 
+`EndpointSelector` in the ``endpointSelector`` field. To restrict traffic upon
+egress to the selected endpoint, the rule selects the destination endpoint with
+the `EndpointSelector` in the ``toEndpoints`` field.
+
+Simple Egress Allow
+~~~~~~~~~~~~~~~~~~~~
+
+The following example illustrates how to use a simple egress rule to allow
+communication to endpoints with the label ``role=backend`` from endpoints with
+the label ``role=frontend``.
+
+.. only:: html
+
+   .. tabs::
+     .. group-tab:: k8s YAML
+
+        .. literalinclude:: ../../examples/policies/l3/simple/l3_egress.yaml
+     .. group-tab:: JSON
+
+        .. literalinclude:: ../../examples/policies/l3/simple/l3_egress.json
+
+.. only:: epub or latex
+
+        .. literalinclude:: ../../examples/policies/l3/simple/l3_egress.json
+
+
+Egress Allow All
+~~~~~~~~~~~~~~~~~
+
+An empty `EndpointSelector` will select all endpoints, thus writing a rule that will allow
+all egress traffic from an endpoint may be done as follows:
+
+.. only:: html
+
+   .. tabs::
+     .. group-tab:: k8s YAML
+
+        .. literalinclude:: ../../examples/policies/l3/egress-allow-all/egress-allow-all.yaml
+     .. group-tab:: JSON
+
+        .. literalinclude:: ../../examples/policies/l3/egress-allow-all/egress-allow-all.json
+
+.. only:: epub or latex
+
+        .. literalinclude:: ../../examples/policies/l3/egress-allow-all/egress-allow-all.json
+
+
+Note that while the above examples allow all egress traffic from an endpoint, the receivers
+of the egress traffic may have ingress rules that deny the traffic. In other words, 
+policy must be configured on both sides (sender and receiver).
+
 Ingress/Egress Default Deny
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -118,7 +184,8 @@ requirements which serve as a foundation for any ``fromEndpoints``
 relationship.  ``fromRequires`` is a list of additional constraints which must
 be met in order for the selected endpoints to be reachable. These additional
 constraints do not grant access privileges by themselves, so to allow traffic
-there must also be rules which match ``fromEndpoints``.
+there must also be rules which match ``fromEndpoints``. The same applies for
+egress policies, with ``toRequires`` and ``toEndpoints``.
 
 The purpose of this rule is to allow establishing base requirements such as, any
 endpoint in ``env=prod`` can only be accessed if the source endpoint also carries

--- a/examples/policies/l3/egress-allow-all/egress-allow-all.json
+++ b/examples/policies/l3/egress-allow-all/egress-allow-all.json
@@ -1,0 +1,9 @@
+[{
+    "labels": [{"key": "name", "value": "allow-all-from-frontend"}],
+    "endpointSelector": {"matchLabels": {"role":"frontend"}},
+    "egress": [{
+        "toEndpoints": [
+          {"matchLabels":{}}
+        ]
+    }]
+}]

--- a/examples/policies/l3/egress-allow-all/egress-allow-all.yaml
+++ b/examples/policies/l3/egress-allow-all/egress-allow-all.yaml
@@ -1,0 +1,11 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "allow-all-from-frontend"
+spec:
+  endpointSelector:
+    matchLabels:
+      role: frontend
+  egress:
+  - toEndpoints:
+    - {}

--- a/examples/policies/l3/simple/l3_egress.json
+++ b/examples/policies/l3/simple/l3_egress.json
@@ -1,0 +1,9 @@
+[{
+    "labels": [{"key": "name", "value": "l3-egress-rule"}],
+    "endpointSelector": {"matchLabels": {"role":"frontend"}},
+    "egress": [{
+        "toEndpoints": [
+          {"matchLabels":{"role":"backend"}}
+        ]
+    }]
+}]

--- a/examples/policies/l3/simple/l3_egress.yaml
+++ b/examples/policies/l3/simple/l3_egress.yaml
@@ -1,0 +1,12 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "l3-egress-rule"
+spec:
+  endpointSelector:
+    matchLabels:
+      role: frontend
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        role: backend


### PR DESCRIPTION
Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #2556 

```release-note
Add label-based egress documentation
```

**How to test (optional)**:
Run `make render-docs` and go to `http://localhost:8080/policy/language.html` . The egress documentation will be there.