### PR TITLE
CI: enable all debug-verbose logging modes 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 _obj
 _test
 tests/cilium-files
+test/test_results
 _build/
 
 # Architecture specific extensions/prefixes

--- a/contrib/systemd/cilium
+++ b/contrib/systemd/cilium
@@ -1,3 +1,3 @@
 PATH=/usr/lib/llvm-3.8/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
-CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500
+CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug-verbose flow,kvstore,envoy
 INITSYSTEM=SYSTEMD

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -267,7 +267,7 @@ function write_cilium_cfg() {
     ipv6_addr="${3}"
     filename="${4}"
 
-    cilium_options="--auto-ipv6-node-routes --debug-verbose flow"
+    cilium_options="--auto-ipv6-node-routes --debug-verbose flow,kvstore,envoy"
 
     if [[ "${IPV4}" -eq "1" ]]; then
         if [[ -z "${K8S}" ]]; then

--- a/pkg/kvstore/trace.go
+++ b/pkg/kvstore/trace.go
@@ -36,7 +36,11 @@ func EnableTracing() {
 // Trace is used to trace kvstore debug messages
 func Trace(format string, err error, fields logrus.Fields, a ...interface{}) {
 	if traceEnabled {
-		log.WithError(err).WithFields(fields).Debugf(format)
+		if err != nil {
+			log.WithError(err).WithFields(fields).Debugf(format)
+		} else {
+			log.WithFields(fields).Debugf(format)
+		}
 	}
 }
 


### PR DESCRIPTION
* contrib: add --debug-verbose flow,kvstore,envoy options to cilium systemd config
    - This enable all debug-verbose modes for Cilium in developer / CI VMs. This will allow for more information for debugging purposes.
* pkg/kvstore: only use WithError if error non-nil

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #3582

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/3582)
<!-- Reviewable:end -->
