### PR TITLE
Fix ineffassign warnings

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -376,7 +376,9 @@ func (d *Daemon) deleteEndpointQuiet(ep *endpoint.Endpoint) []error {
 
 	// If dry mode is enabled, no changes to BPF maps are performed
 	if !d.DryModeEnabled() {
-		errors := lxcmap.DeleteElement(ep)
+		if err := lxcmap.DeleteElement(ep); err != nil {
+			errors = append(errors, fmt.Errorf("unable to delete element %d from map %s: %s", ep.ID, ep.PolicyMapPathLocked(), err))
+		}
 
 		if ep.Consumable != nil {
 			ep.Consumable.RemovePolicyMap(ep.PolicyMap)

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -248,8 +248,8 @@ func (e *Endpoint) applyL4PolicyLocked(oldIdentities, newIdentities *identityPkg
 	oldL4Policy, newL4Policy *policy.L4Policy) (addedPolicyMapEntries, removedPolicyMapEntries policy.SecurityIDContexts, err error) {
 
 	var (
-		errors, errs = 0, 0
-		secIDs       policy.SecurityIDContexts
+		errors = 0
+		secIDs policy.SecurityIDContexts
 	)
 
 	addedPolicyMapEntries = policy.NewSecurityIDContexts()
@@ -278,13 +278,15 @@ func (e *Endpoint) applyL4PolicyLocked(oldIdentities, newIdentities *identityPkg
 	// Need to iterate through new L3-L4 policy and insert new PolicyMap entries
 	// for both ingress and egress.
 	for _, filter := range newL4Policy.Ingress {
+		var errs int
 		secIDs, errs = e.applyNewFilter(newIdentities, &filter, policymap.Ingress)
 		setMapOperationResult(addedPolicyMapEntries, secIDs)
 		errors += errs
 	}
 
 	for _, filter := range newL4Policy.Egress {
-		_, errs = e.applyNewFilter(newIdentities, &filter, policymap.Egress)
+		_, errs := e.applyNewFilter(newIdentities, &filter, policymap.Egress)
+		errors += errs
 		// TODO: GH-3393 update maps for egress. Not touching conntrack for now.
 	}
 

--- a/pkg/envoy/xds/node_test.go
+++ b/pkg/envoy/xds/node_test.go
@@ -35,10 +35,10 @@ func (s *NodeSuite) TestIstioNodeToIP(c *C) {
 	c.Check(ip, Equals, "10.1.1.0")
 
 	node.Id = "sidecar~10.1.1.0~v0.default"
-	ip, err = IstioNodeToIP(&node)
+	_, err = IstioNodeToIP(&node)
 	c.Assert(err, Not(IsNil))
 
 	node.Id = "sidecar~not-an-ip~v0.default~default.svc.cluster.local"
-	ip, err = IstioNodeToIP(&node)
+	_, err = IstioNodeToIP(&node)
 	c.Assert(err, Not(IsNil))
 }

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -136,7 +136,7 @@ func (s *IPTestSuite) TestRemoveCIDRs(c *C) {
 
 	// Cannot remove CIDRs that are of a different address family.
 	removeCIDRs = []*net.IPNet{createIPNet("fd44:7089:ff32:712b::", 66, int(ipv6BitLen))}
-	allowedCIDRs, err = RemoveCIDRs(allowCIDRs, removeCIDRs)
+	_, err = RemoveCIDRs(allowCIDRs, removeCIDRs)
 	c.Assert(err, NotNil)
 
 	//IPv6 tests

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -190,7 +190,7 @@ func AnnotateNode(c kubernetes.Interface, nodeName string, v4CIDR, v6CIDR *net.I
 		for n := 1; n <= maxUpdateRetries; n++ {
 			node, err = GetNode(c, nodeName)
 			if err == nil {
-				node, err = updateNodeAnnotation(c, node, v4CIDR, v6CIDR, v4HealthIP, v6HealthIP)
+				_, err = updateNodeAnnotation(c, node, v4CIDR, v6CIDR, v4HealthIP, v6HealthIP)
 			} else {
 				if errors.IsNotFound(err) {
 					err = ErrNilNode

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -132,7 +132,7 @@ func (s *K8sSuite) TestParseNetworkPolicyIngress(c *C) {
 		},
 	}
 
-	rules, err := ParseNetworkPolicy(netPolicy)
+	_, err := ParseNetworkPolicy(netPolicy)
 	c.Assert(err, IsNil)
 
 	fromEndpoints := labels.LabelArray{
@@ -151,7 +151,7 @@ func (s *K8sSuite) TestParseNetworkPolicyIngress(c *C) {
 		Trace: policy.TRACE_VERBOSE,
 	}
 
-	rules, err = ParseNetworkPolicy(netPolicy)
+	rules, err := ParseNetworkPolicy(netPolicy)
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
@@ -683,7 +683,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	err := json.Unmarshal(ex1, &np)
 	c.Assert(err, IsNil)
 
-	rules, err := ParseNetworkPolicy(&np)
+	_, err = ParseNetworkPolicy(&np)
 	c.Assert(err, IsNil)
 
 	// Example 1b: Only allow traffic from frontend pods to backend pods
@@ -727,7 +727,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	err = json.Unmarshal(ex1, &np)
 	c.Assert(err, IsNil)
 
-	rules, err = ParseNetworkPolicy(&np)
+	rules, err := ParseNetworkPolicy(&np)
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
@@ -819,7 +819,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	err = json.Unmarshal(ex2, &np)
 	c.Assert(err, IsNil)
 
-	rules, err = ParseNetworkPolicy(&np)
+	_, err = ParseNetworkPolicy(&np)
 	c.Assert(err, IsNil)
 
 	// Example 2b: Allow from any source in Bob's namespaces.
@@ -1080,6 +1080,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	c.Assert(err, IsNil)
 
 	rules, err = ParseNetworkPolicy(&np)
+	c.Assert(err, IsNil)
 	// add example 2
 	repo.AddList(rules)
 

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -287,6 +287,9 @@ func (c *consulClient) SetMaxID(key string, firstID, maxID uint32) error {
 			return err
 		}
 		k, _, err = c.KV().Get(key, nil)
+		if err != nil {
+			return err
+		}
 		if k == nil {
 			// Something is really wrong
 			errMsg := "Unable to setting ID because the key is always empty\n"

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -199,7 +199,9 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	egressState = traceState{}
 
 	res, err = rule1.resolveL4IngressPolicy(toFoo, &ingressState, NewL4Policy())
+	c.Assert(err, IsNil)
 	res2, err = rule1.resolveL4EgressPolicy(fromFoo, &ingressState, NewL4Policy())
+	c.Assert(err, IsNil)
 
 	c.Assert(res, IsNil)
 	c.Assert(res2, IsNil)
@@ -289,9 +291,11 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	egressState = traceState{}
 
 	res, err = rule2.resolveL4IngressPolicy(toFoo, &ingressState, NewL4Policy())
+	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 
 	res2, err = rule2.resolveL4EgressPolicy(fromFoo, &egressState, NewL4Policy())
+	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 
 	c.Assert(ingressState.selectedRules, Equals, 0)
@@ -458,10 +462,6 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 		},
 	}
 
-	l7map := L7DataMap{
-		api.WildcardEndpointSelector: api.L7Rules{},
-	}
-
 	expected := NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
@@ -479,6 +479,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 
 	state = traceState{}
 	res, err = rule1.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
 	c.Assert(state.matchedRules, Equals, 0)
@@ -519,7 +520,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	l7rules := api.L7Rules{
 		Kafka: []api.PortRuleKafka{{Topic: "foo"}},
 	}
-	l7map = L7DataMap{
+	l7map := L7DataMap{
 		api.WildcardEndpointSelector: l7rules,
 		fooSelectorSlice[0]:          l7rules,
 	}
@@ -541,6 +542,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 
 	state = traceState{}
 	res, err = rule2.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
 	c.Assert(state.matchedRules, Equals, 0)
@@ -551,7 +553,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	c.Assert(res, Not(IsNil))
 
 	state = traceState{}
-	res, err = rule2.resolveL4IngressPolicy(toBar, &state, res)
+	_, err = rule2.resolveL4IngressPolicy(toBar, &state, res)
 
 	// Despite there being conflicting L7 parsers, because we allow all at L4,
 	// we do not even worry about L7 policy within the rules when merging.
@@ -671,14 +673,6 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 		},
 	}
 
-	l7rules := api.L7Rules{
-		HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
-	}
-	l7map := L7DataMap{
-		api.WildcardEndpointSelector: l7rules,
-		fooSelector[0]:               l7rules,
-	}
-
 	expected := NewL4Policy()
 	expected.Egress["80/TCP"] = L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: []api.EndpointSelector{api.WildcardEndpointSelector},
@@ -696,6 +690,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 
 	state = traceState{}
 	res, err = rule1.resolveL4EgressPolicy(fromFoo, &state, NewL4Policy())
+	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
 	c.Assert(state.matchedRules, Equals, 0)
@@ -740,13 +735,6 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 		},
 	}
 
-	l7rules = api.L7Rules{
-		Kafka: []api.PortRuleKafka{{Topic: "foo"}},
-	}
-	l7map = L7DataMap{
-		api.WildcardEndpointSelector: l7rules,
-		fooSelector[0]:               l7rules,
-	}
 	expected = NewL4Policy()
 	expected.Egress["80/TCP"] = L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
@@ -764,6 +752,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 
 	state = traceState{}
 	res, err = rule2.resolveL4EgressPolicy(fromFoo, &state, NewL4Policy())
+	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
 	c.Assert(state.matchedRules, Equals, 0)
@@ -774,7 +763,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	c.Assert(res, Not(IsNil))
 
 	state = traceState{}
-	res, err = rule2.resolveL4EgressPolicy(fromBar, &state, res)
+	_, err = rule2.resolveL4EgressPolicy(fromBar, &state, res)
 	// Despite there being conflicting L7 parsers, because we allow all at L4,
 	// we do not even worry about L7 policy within the rules when merging.
 	c.Assert(err, IsNil)
@@ -822,7 +811,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	}
 
 	// The l3-dependent l7 rules are not merged together.
-	l7map = L7DataMap{
+	l7map := L7DataMap{
 		fooSelector[0]:               fooRules,
 		api.WildcardEndpointSelector: barRules,
 	}


### PR DESCRIPTION
Fixes for several ineffassign warnings, which were about assigning values o variables which were not used later.

Ref: #3577