### PR TITLE
test: misc. K8s test enhancements

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -892,11 +892,13 @@ func (kub *Kubectl) DumpCiliumCommandOutput(namespace string) {
 // directory
 func (kub *Kubectl) GatherLogs() {
 	reportCmds := map[string]string{
-		"kubectl get pods -o wide --all-namespaces":                  "pods.txt",
-		"kubectl get services -o wide --all-namespaces":              "svc.txt",
-		"kubectl get ds -o wide --all-namespaces":                    "ds.txt",
-		"kubectl get cnp --all-namespaces":                           "cnp.txt",
-		"kubectl describe pods --all-namespaces":                     "pods_status.txt",
+		"kubectl get pods --all-namespaces -o json":                  "pods.txt",
+		"kubectl get services --all-namespaces -o json":              "svc.txt",
+		"kubectl get ds --all-namespaces -o json":                    "ds.txt",
+		"kubectl get cnp --all-namespaces -o json":                   "cnp.txt",
+		"kubectl describe pods --all-namespaces -o json":             "pods_status.txt",
+		"kubectl get replicationcontroller --all-namespaces -o json": "replicationcontroller.txt",
+		"kubectl get deployment --all-namespaces -o json":            "deployment.txt",
 		"kubectl -n kube-system logs -l k8s-app=cilium --timestamps": "cilium_logs.txt",
 	}
 

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -524,15 +524,16 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 		})
 
 		waitforPods := func() {
+			port := "6379"
 			pods, err := kubectl.WaitForServiceEndpoints(
-				helpers.DefaultNamespace, "", "redis-master", "6379", helpers.HelperTimeout)
-			Expect(err).Should(BeNil())
-			Expect(pods).Should(BeTrue())
+				helpers.DefaultNamespace, "", "redis-master", port, helpers.HelperTimeout)
+			Expect(err).Should(BeNil(), "error waiting for redis-master service to be ready on port %s", port)
+			Expect(pods).Should(BeTrue(), "timed out waiting for redis-master service to be ready")
 
 			pods, err = kubectl.WaitForServiceEndpoints(
-				helpers.DefaultNamespace, "", "redis-slave", "6379", helpers.HelperTimeout)
-			Expect(err).Should(BeNil())
-			Expect(pods).Should(BeTrue())
+				helpers.DefaultNamespace, "", "redis-slave", port, helpers.HelperTimeout)
+			Expect(err).Should(BeNil(), "error waiting for redis-slave service to be ready on port %s", port)
+			Expect(pods).Should(BeTrue(), "timed out waiting for redis-slave service to be ready")
 
 			pods, err = kubectl.WaitforPods(
 				helpers.DefaultNamespace,
@@ -557,7 +558,7 @@ PING
 EOF`, k, v)
 					res := kubectl.ExecPodCmd(helpers.DefaultNamespace, pod, command)
 					ExpectWithOffset(1, res.WasSuccessful()).To(BeTrue(),
-						"Web pod %q cannot connect to redis", pod)
+						"Web pod %q cannot connect to redis-master on '%s:%d'", pod, k, v)
 				}
 			}
 		}

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -524,7 +524,17 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 		})
 
 		waitforPods := func() {
-			pods, err := kubectl.WaitforPods(
+			pods, err := kubectl.WaitForServiceEndpoints(
+				helpers.DefaultNamespace, "", "redis-master", "6379", helpers.HelperTimeout)
+			Expect(err).Should(BeNil())
+			Expect(pods).Should(BeTrue())
+
+			pods, err = kubectl.WaitForServiceEndpoints(
+				helpers.DefaultNamespace, "", "redis-slave", "6379", helpers.HelperTimeout)
+			Expect(err).Should(BeNil())
+			Expect(pods).Should(BeTrue())
+
+			pods, err = kubectl.WaitforPods(
 				helpers.DefaultNamespace,
 				fmt.Sprintf("-l %s", groupLabel), 300)
 			ExpectWithOffset(1, pods).Should(BeTrue())


### PR DESCRIPTION
* test/helpers: gather more K8s metadata
    - Get output in JSON for more K8s-related objects in K8s log-gathering functions.
    - Get replicationcontroller and deployment data.
* test/k8sT: query both service IP and hostname of redis master
    - This will add more visibility to cases where there is an issue with resolving service names via DNS. Tests have been failing when accessing `redis-master` in K8s 1.7. Accessing the service IP directly first will reveal if there is an issue with connecting to the service itself, or an issue with resolving the IP of `redis-master.

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #3462 . Still need to add a check which waits for services to be plumbed in the CIlium datapath / BPF maps. However, this will give us more information for debugging + adds what I think its a necessary thing to do in waiting for services to be ready on the Kubernetes side.