### PR TITLE
proxy: Create access log file and setup notifier at startup

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -127,7 +127,7 @@ func (d *Daemon) UpdateProxyRedirect(e *endpoint.Endpoint, l4 *policy.L4Filter) 
 		return 0, fmt.Errorf("can't redirect, proxy disabled")
 	}
 
-	r, err := d.l7Proxy.CreateOrUpdateRedirect(l4, e.ProxyID(l4), e, d, e.ProxyWaitGroup)
+	r, err := d.l7Proxy.CreateOrUpdateRedirect(l4, e.ProxyID(l4), e, e.ProxyWaitGroup)
 	if err != nil {
 		return 0, err
 	}
@@ -1083,8 +1083,8 @@ func NewDaemon(c *Config) (*Daemon, error) {
 	// we populate the IPCache with the host's IP(s).
 	ipcache.InitIPIdentityWatcher(&d)
 
-	// FIXME: Make configurable
-	d.l7Proxy = proxy.StartProxySupport(10000, 20000, d.conf.RunDir)
+	// FIXME: Make the port range configurable.
+	d.l7Proxy = proxy.StartProxySupport(10000, 20000, d.conf.RunDir, &d)
 
 	if c.RestoreState {
 		log.Info("Restoring state...")


### PR DESCRIPTION
Move the access log file and notifier and metadata configuration
at daemon startup instead of when creating the first redirect, so
access logging is usable with sidecar proxies, for which Cilium
doesn't create redirects.

Signed-off-by: Romain Lenglet <romain@covalent.io>