### PR TITLE
Fix prefix based CIDR matching

### DIFF
--- a/pkg/policy/l3.go
+++ b/pkg/policy/l3.go
@@ -118,6 +118,8 @@ func (m *CIDRPolicyMap) PopulateBPF(cidrmap *cidrmap.CIDRMap) error {
 		}
 		err := cidrmap.InsertCIDR(value)
 		if err != nil {
+			log.WithError(err).WithField("CIDR", value).
+				Warningf("Failed to insert CIDR")
 			return err
 		}
 	}


### PR DESCRIPTION
* Log errors attempting to insert CIDRs into the BPF maps
* Avoid erroring out due to invalid prefix length when we expect to support the specified prefix length

I'd like to propose at least the log commit for backport.