### PR TITLE
Change logging of new connections from warn to info level

### DIFF
--- a/envoy/cilium_network_filter.cc
+++ b/envoy/cilium_network_filter.cc
@@ -52,7 +52,7 @@ namespace Filter {
 namespace CiliumL3 {
 
 Network::FilterStatus Instance::onNewConnection() {
-  ENVOY_LOG(warn, "Cilium Network: onNewConnection");
+  ENVOY_LOG(debug, "Cilium Network: onNewConnection");
   auto& conn = callbacks_->connection();
   const auto& options_ = conn.socketOptions();
   if (options_) {


### PR DESCRIPTION
Signed-off-by: Shantanu Deshpande <shantanud106@gmail.com>

**Summary of changes**:
1. Changed the log level for new connections to `debug` level instead of `warn`.

Fixes: #3557 