### PR TITLE
agent: Provide non-blocking agent status

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -103,6 +103,9 @@ type Daemon struct {
 	policy            *policy.Repository
 	preFilter         *policy.PreFilter
 
+	statusCollectMutex lock.RWMutex
+	statusResponse     models.StatusResponse
+
 	uniqueIDMU lock.Mutex
 	uniqueID   map[uint64]bool
 
@@ -1116,6 +1119,8 @@ func NewDaemon(c *Config) (*Daemon, error) {
 	node.SetIPv6HealthIP(health6)
 	log.Debugf("IPv4 health endpoint address: %s", node.GetIPv4HealthIP())
 	log.Debugf("IPv6 health endpoint address: %s", node.GetIPv6HealthIP())
+
+	d.startStatusCollector()
 
 	return &d, nil
 }

--- a/daemon/debuginfo.go
+++ b/daemon/debuginfo.go
@@ -48,8 +48,7 @@ func (h *getDebugInfo) Handle(params restapi.GetDebuginfoParams) middleware.Resp
 		dr.KernelVersion = fmt.Sprintf("%s", kver)
 	}
 
-	s := getHealthz{d}
-	status := s.getStatus(d)
+	status := d.getStatus()
 	dr.CiliumStatus = &status
 
 	var p endpoint.GetEndpointParams


### PR DESCRIPTION
The cilium status command hat the potential to take quite a while to succeed due to taking a lot of locks, e.g. all controller locks to retrieve status. Make the status API completely async by collecting the status in the background and only return a copy.

This currently breaks the deadlock detector as it will no longer block the `GET /healthz` API call.

Fixes: #3520