### PR TITLE
Bugtool: Add gops output

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cilium/cilium/daemon/defaults"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/test/helpers"
 
 	"github.com/sirupsen/logrus"
 )
@@ -72,6 +73,10 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		"ip6tables -S",
 		"iptables -L -v",
 		"ip rule",
+		// gops
+		fmt.Sprintf("gops memstats $(pidof %s)", helpers.AgentDaemon),
+		fmt.Sprintf("gops stack $(pidof %s)", helpers.AgentDaemon),
+		fmt.Sprintf("gops stats $(pidof %s)", helpers.AgentDaemon),
 	}
 
 	// Commands that require variables and / or more configuration are added

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -603,9 +603,6 @@ func (s *SSHMeta) GatherLogs() {
 		fmt.Sprintf("sudo journalctl -au %s --no-pager", DaemonName):             "cilium.log",
 		fmt.Sprintf("sudo journalctl -au %s --no-pager", CiliumDockerDaemonName): "cilium-docker.log",
 		"sudo docker logs cilium-consul":                                         "consul.log",
-		fmt.Sprintf(`sudo bash -c "gops memstats $(pgrep %s)"`, AgentDaemon):     "gops_memstats.txt",
-		fmt.Sprintf(`sudo bash -c "gops stack $(pgrep %s)"`, AgentDaemon):        "gops_stack.txt",
-		fmt.Sprintf(`sudo bash -c "gops stats $(pgrep %s)"`, AgentDaemon):        "gops_stats.txt",
 	}
 
 	testPath, err := CreateReportDirectory()


### PR DESCRIPTION
- Add gops output for cilium agent to know what happens to the agent in
case of something wrong.

Fixes #3608

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

