### PR TITLE
daemon: Clean up access log setup

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -87,6 +87,12 @@ type Config struct {
 
 	// Monitor contains the configuration for the node monitor.
 	Monitor *models.MonitorStatus
+
+	// AccessLog is the path to the access log of supported L7 requests observed.
+	AccessLog string
+
+	// AgentLabels contains additional labels to identify this agent in monitor events.
+	AgentLabels []string
 }
 
 func NewConfig() *Config {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1078,7 +1078,8 @@ func NewDaemon(c *Config) (*Daemon, error) {
 	ipcache.InitIPIdentityWatcher(&d)
 
 	// FIXME: Make the port range configurable.
-	d.l7Proxy = proxy.StartProxySupport(10000, 20000, d.conf.RunDir, &d)
+	d.l7Proxy = proxy.StartProxySupport(10000, 20000, d.conf.RunDir,
+		d.conf.AccessLog, &d, d.conf.AgentLabels)
 
 	if c.RestoreState {
 		log.Info("Restoring state...")
@@ -1091,7 +1092,7 @@ func NewDaemon(c *Config) (*Daemon, error) {
 			}
 		}()
 	} else {
-		log.Info("No previous state to restore. Cilium will not manage existing continers")
+		log.Info("No previous state to restore. Cilium will not manage existing containers")
 		// We need to read all docker containers so we know we won't
 		// going to allocate the same IP addresses and we will ignore
 		// these containers from reading.

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -86,11 +86,12 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	daemonConf := &Config{
-		DryMode:  true,
-		Opts:     option.NewBoolOptions(&options.Library),
-		Device:   "undefined",
-		RunDir:   tempRunDir,
-		StateDir: tempRunDir,
+		DryMode:   true,
+		Opts:      option.NewBoolOptions(&options.Library),
+		Device:    "undefined",
+		RunDir:    tempRunDir,
+		StateDir:  tempRunDir,
+		AccessLog: filepath.Join(tempRunDir, "cilium-access.log"),
 	}
 
 	// Get the default labels prefix filter

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -307,9 +307,9 @@ func checkMinRequirements() {
 func init() {
 	cobra.OnInitialize(initConfig)
 	flags := RootCmd.Flags()
-	flags.String(
+	flags.StringVar(&config.AccessLog,
 		"access-log", "", "Path to access log of supported L7 requests observed")
-	flags.StringSlice(
+	flags.StringSliceVar(&config.AgentLabels,
 		"agent-labels", []string{}, "Additional labels to identify this agent")
 	flags.StringVar(&config.AllowLocalhost,
 		"allow-localhost", AllowLocalhostAuto, "Policy when to allow local stack to reach local endpoints { auto | always | policy } ")

--- a/pkg/proxy/logger/logger.go
+++ b/pkg/proxy/logger/logger.go
@@ -358,7 +358,7 @@ func (lr *LogRecord) Log() {
 // Called with lock held
 func openLogfileLocked(lf string) error {
 	logPath = lf
-	log.WithField(FieldFilePath, logPath).Debug("Opened access log")
+	log.WithField(FieldFilePath, logPath).Info("Opened access log")
 
 	logger = &lumberjack.Logger{
 		Filename:   lf,

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/logger"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -84,12 +83,9 @@ type Proxy struct {
 
 // StartProxySupport starts the servers to support L7 proxies: xDS GRPC server
 // and access log server.
-func StartProxySupport(minPort uint16, maxPort uint16, stateDir string, accessLogNotifier logger.LogRecordNotifier) *Proxy {
+func StartProxySupport(minPort uint16, maxPort uint16, stateDir string,
+	accessLogFile string, accessLogNotifier logger.LogRecordNotifier, accessLogMetadata []string) *Proxy {
 	xdsServer := envoy.StartXDSServer(stateDir)
-
-	// TODO: Pass those as parameters.
-	accessLogFile := viper.GetString("access-log")
-	accessLogMetadata := viper.GetStringSlice("agent-labels")
 
 	if accessLogFile != "" {
 		if err := logger.OpenLogfile(accessLogFile); err != nil {
@@ -150,7 +146,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, localEndp
 	gcOnce.Do(func() {
 		go func() {
 			for {
-				time.Sleep(time.Duration(10) * time.Second)
+				time.Sleep(10 * time.Second)
 				if deleted := proxymap.GC(); deleted > 0 {
 					log.WithField("count", deleted).
 						Debug("Evicted entries from proxy table")


### PR DESCRIPTION
Pass access logging settings as parameters instead of coupling
via viper flags.

Minor log message cleanups.

Fixes: #3600
Signed-off-by: Romain Lenglet <romain@covalent.io>