### PR TITLE
pkg/ip: add functionality to coalesce CIDR list

### DIFF
--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -17,6 +17,7 @@ package ip
 import (
 	"bytes"
 	"fmt"
+	"math/big"
 	"net"
 	"sort"
 )
@@ -41,6 +42,16 @@ func CountIPsInCIDR(cidr string) int {
 	return 1<<uint(size-subnet) - 1
 }
 
+var (
+	// v4Mappedv6Prefix is the RFC2765 IPv4-mapped address prefix.
+	v4Mappedv6Prefix  = []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff}
+	ipv4LeadingZeroes = []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
+	defaultIPv4       = []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0}
+	defaultIPv6       = []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
+	upperIPv4         = []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 255, 255, 255, 255}
+	upperIPv6         = []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+)
+
 // NetsByMask is used to sort a list of IP networks by the size of their masks.
 // Implements sort.Interface.
 type NetsByMask []*net.IPNet
@@ -53,8 +64,7 @@ func (s NetsByMask) Less(i, j int) bool {
 	iPrefixSize, _ := s[i].Mask.Size()
 	jPrefixSize, _ := s[j].Mask.Size()
 	if iPrefixSize == jPrefixSize {
-		byteArrComp := bytes.Compare(s[i].IP, s[j].IP)
-		if byteArrComp < 0 {
+		if bytes.Compare(s[i].IP, s[j].IP) < 0 {
 			return true
 		}
 		return false
@@ -68,11 +78,48 @@ func (s NetsByMask) Len() int {
 
 // Assert that NetsByMask implements sort.Interface.
 var _ sort.Interface = NetsByMask{}
+var _ sort.Interface = NetsByRange{}
 
-// RemoveCIDRs removes the specified CIDRs from another set of CIDRs. If a CIDR to remove is not
-// contained within the CIDR, the CIDR to remove is ignored. A slice of CIDRs is
-// returned which contains the set of CIDRs provided minus the set of CIDRs which
-// were removed. Both input slices may be modified by calling this function.
+// NetsByRange is used to sort a list of ranges, first by their last IPs, then by
+// their first IPs
+// Implements sort.Interface.
+type NetsByRange []*netWithRange
+
+func (s NetsByRange) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s NetsByRange) Less(i, j int) bool {
+	// First compare by last IP.
+	lastComparison := bytes.Compare(*s[i].Last, *s[j].Last)
+	if lastComparison < 0 {
+		return true
+	} else if lastComparison > 0 {
+		return false
+	}
+
+	// Then compare by first IP.
+	firstComparison := bytes.Compare(*s[i].First, *s[i].First)
+	if firstComparison < 0 {
+		return true
+	} else if firstComparison > 0 {
+		return false
+	}
+
+	// First and last IPs are the same, so thus are equal, and s[i]
+	// is not less than s[j].
+	return false
+}
+
+func (s NetsByRange) Len() int {
+	return len(s)
+}
+
+// RemoveCIDRs removes the specified CIDRs from another set of CIDRs. If a CIDR
+// to remove is not contained within the CIDR, the CIDR to remove is ignored. A
+// slice of CIDRs is returned which contains the set of CIDRs provided minus
+// the set of CIDRs which  were removed. Both input slices may be modified by
+// calling this function.
 func RemoveCIDRs(allowCIDRs, removeCIDRs []*net.IPNet) ([]*net.IPNet, error) {
 
 	// Ensure that we iterate through the provided CIDRs in order of largest
@@ -179,15 +226,13 @@ func removeCIDR(allowCIDR, removeCIDR *net.IPNet) ([]*net.IPNet, error) {
 	allowFirstIPMasked := allowCIDR.IP.Mask(allowCIDR.Mask)
 	removeFirstIPMasked := removeCIDR.IP.Mask(removeCIDR.Mask)
 
-	ipv4Ipv6Slice := []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff}
-
 	// Convert to IPv4 in IPv6 addresses if needed.
 	if allowIsIpv4 {
-		allowFirstIPMasked = append(ipv4Ipv6Slice, allowFirstIPMasked...)
+		allowFirstIPMasked = append(v4Mappedv6Prefix, allowFirstIPMasked...)
 	}
 
 	if removeIsIpv4 {
-		removeFirstIPMasked = append(ipv4Ipv6Slice, removeFirstIPMasked...)
+		removeFirstIPMasked = append(v4Mappedv6Prefix, removeFirstIPMasked...)
 	}
 
 	allowFirstIP := &allowFirstIPMasked
@@ -234,4 +279,434 @@ func flipNthBit(ip *[]byte, bitNum uint) *[]byte {
 	ipCopy[byteNum] = ipCopy[byteNum] ^ 1<<(bitNum%8)
 
 	return &ipCopy
+}
+
+func ipNetToRange(ipNet net.IPNet) netWithRange {
+	firstIP := make(net.IP, len(ipNet.IP))
+	lastIP := make(net.IP, len(ipNet.IP))
+
+	copy(firstIP, ipNet.IP)
+	copy(lastIP, ipNet.IP)
+
+	firstIP = firstIP.Mask(ipNet.Mask)
+	lastIP = lastIP.Mask(ipNet.Mask)
+
+	if firstIP.To4() != nil {
+		firstIP = append(v4Mappedv6Prefix, firstIP...)
+		lastIP = append(v4Mappedv6Prefix, lastIP...)
+	}
+
+	lastIPMask := make(net.IPMask, len(ipNet.Mask))
+	copy(lastIPMask, ipNet.Mask)
+	for i := range lastIPMask {
+		lastIPMask[len(lastIPMask)-i-1] = ^lastIPMask[len(lastIPMask)-i-1]
+		lastIP[net.IPv6len-i-1] = lastIP[net.IPv6len-i-1] | lastIPMask[len(lastIPMask)-i-1]
+	}
+
+	return netWithRange{First: &firstIP, Last: &lastIP, Network: &ipNet}
+}
+
+func getPreviousIP(ip net.IP) net.IP {
+	// Cannot go lower than zero!
+	if ip.Equal(net.IP(defaultIPv4)) || ip.Equal(net.IP(defaultIPv6)) {
+		return ip
+	}
+
+	previousIP := make(net.IP, len(ip))
+	copy(previousIP, ip)
+
+	var overflow bool
+	var lowerByteBound int
+	if ip.To4() != nil {
+		lowerByteBound = net.IPv6len - net.IPv4len
+	} else {
+		lowerByteBound = 0
+	}
+	for i := len(ip) - 1; i >= lowerByteBound; i-- {
+		if overflow || i == len(ip)-1 {
+			previousIP[i]--
+		}
+		// Track if we have overflowed and thus need to continue subtracting.
+		if ip[i] == 0 && previousIP[i] == 255 {
+			overflow = true
+		} else {
+			overflow = false
+		}
+	}
+	return previousIP
+}
+
+func getNextIP(ip net.IP) net.IP {
+	if ip.Equal(net.IP(upperIPv4)) || ip.Equal(net.IP(upperIPv6)) {
+		return ip
+	}
+	nextIP := make(net.IP, len(ip))
+	copy(nextIP, ip)
+
+	var overflow bool
+	var lowerByteBound int
+	if ip.To4() != nil {
+		lowerByteBound = net.IPv6len - net.IPv4len
+	} else {
+		lowerByteBound = 0
+	}
+	for i := len(ip) - 1; i >= lowerByteBound; i-- {
+		if overflow || i == len(ip)-1 {
+			nextIP[i]++
+		}
+
+		if ip[i] == 255 && nextIP[i] == 0 {
+			overflow = true
+		} else {
+			overflow = false
+		}
+	}
+	return nextIP
+}
+
+func createSpanningCIDR(r netWithRange) net.IPNet {
+	// Don't want to modify the values of the provided range, so make copies.
+	lowest := *r.First
+	highest := *r.Last
+
+	var isIPv4 bool
+	var spanningMaskSize, bitLen, byteLen int
+	if lowest.To4() != nil {
+		isIPv4 = true
+		bitLen = ipv4BitLen
+		byteLen = net.IPv4len
+	} else {
+		bitLen = ipv6BitLen
+		byteLen = net.IPv6len
+	}
+
+	if isIPv4 {
+		spanningMaskSize = ipv4BitLen
+	} else {
+		spanningMaskSize = ipv6BitLen
+	}
+
+	// Convert to big Int so we can easily do bitshifting on the IP addresses,
+	// since golang only provides up to 64-bit unsigned integers.
+	lowestBig := big.NewInt(0).SetBytes(lowest)
+	highestBig := big.NewInt(0).SetBytes(highest)
+
+	// Starting from largest mask / smallest range possible, apply a mask one bit
+	// larger in each iteration to the upper bound in the range  until we have
+	// masked enough to pass the lower bound in the range. This
+	// gives us the size of the prefix for the spanning CIDR to return as
+	// well as the IP for the CIDR prefix of the spanning CIDR.
+	for spanningMaskSize > 0 && lowestBig.Cmp(highestBig) < 0 {
+		spanningMaskSize--
+		mask := big.NewInt(1)
+		mask = mask.Lsh(mask, uint(bitLen-spanningMaskSize))
+		mask = mask.Mul(mask, big.NewInt(-1))
+		highestBig = highestBig.And(highestBig, mask)
+	}
+
+	// If ipv4, need to append 0s because math.Big gets rid of preceding zeroes.
+	if isIPv4 {
+		highest = append(ipv4LeadingZeroes, highestBig.Bytes()...)
+	} else {
+		highest = highestBig.Bytes()
+	}
+
+	// Int does not store leading zeroes.
+	if len(highest) == 0 {
+		highest = make([]byte, byteLen)
+	}
+
+	newNet := net.IPNet{IP: highest, Mask: net.CIDRMask(spanningMaskSize, bitLen)}
+	return newNet
+}
+
+type netWithRange struct {
+	First   *net.IP
+	Last    *net.IP
+	Network *net.IPNet
+}
+
+func mergeAdjacentCIDRs(ranges []*netWithRange) []*netWithRange {
+	// Sort the ranges. This sorts first by the last IP, then first IP, then by
+	// the IP network in the list itself
+	sort.Sort(NetsByRange(ranges))
+
+	// Merge adjacent CIDRs if possible.
+	for i := len(ranges) - 1; i > 0; i-- {
+		first1 := getPreviousIP(*ranges[i].First)
+
+		// Since the networks are sorted, we know that if a network in the list
+		// is adjacent to another one in the list, it will be the network next
+		// to it in the list. If the previous IP of the current network we are
+		// processing overlaps with the last IP of the previous network in the
+		// list, then we can merge the two ranges together.
+		if bytes.Compare(first1, *ranges[i-1].Last) <= 0 {
+			// Pick the minimum of the first two IPs to represent the start
+			// of the new range.
+			var minFirstIP *net.IP
+			if bytes.Compare(*ranges[i-1].First, *ranges[i].First) < 0 {
+				minFirstIP = ranges[i-1].First
+			} else {
+				minFirstIP = ranges[i].First
+			}
+
+			// Always take the last IP of the ith IP.
+			newRangeLast := make(net.IP, len(*ranges[i].Last))
+			copy(newRangeLast, *ranges[i].Last)
+
+			newRangeFirst := make(net.IP, len(*minFirstIP))
+			copy(newRangeFirst, *minFirstIP)
+
+			// Can't set the network field because since we are combining a
+			// range of IPs, and we don't yet know what CIDR prefix(es) represent
+			// the new range.
+			ranges[i-1] = &netWithRange{First: &newRangeFirst, Last: &newRangeLast, Network: nil}
+
+			// Since we have combined ranges[i] with the preceding item in the
+			// ranges list, we can delete ranges[i] from the slice.
+			ranges = append(ranges[:i], ranges[i+1:]...)
+		}
+	}
+	return ranges
+}
+
+// coalesceRanges converts ranges into an equivalent list of net.IPNets.
+// All IPs in ranges should be of the same address family (IPv4 or IPv6).
+func coalesceRanges(ranges []*netWithRange) []*net.IPNet {
+	coalescedCIDRs := []*net.IPNet{}
+	// Create CIDRs from ranges that were combined if needed.
+	for _, netRange := range ranges {
+		// If the Network field of netWithRange wasn't modified, then we can
+		// add it to the list which we will return, as it cannot be joined with
+		// any other CIDR in the list.
+		if netRange.Network != nil {
+			coalescedCIDRs = append(coalescedCIDRs, netRange.Network)
+		} else {
+			// We have joined two ranges together, so we need to find the new CIDRs
+			// that represent this range.
+			rangeCIDRs := rangeToCIDRs(*netRange.First, *netRange.Last)
+			coalescedCIDRs = append(coalescedCIDRs, rangeCIDRs...)
+		}
+	}
+
+	return coalescedCIDRs
+}
+
+// CoalesceCIDRs transforms the provided list of CIDRs into the most-minimal
+// equivalent set of IPv4 and IPv6 CIDRs.
+// It removes CIDRs that are subnets of other CIDRs in the list, and groups
+// together CIDRs that have the same mask size into a CIDR of the same mask
+// size provided that they share the same number of most significant
+// mask-size bits.
+//
+// Note: this algorithm was ported from the Python library netaddr.
+// https://github.com/drkjam/netaddr .
+func CoalesceCIDRs(cidrs []*net.IPNet) ([]*net.IPNet, []*net.IPNet) {
+
+	ranges4 := []*netWithRange{}
+	ranges6 := []*netWithRange{}
+
+	for _, network := range cidrs {
+		newNetToRange := ipNetToRange(*network)
+		if network.IP.To4() != nil {
+			ranges4 = append(ranges4, &newNetToRange)
+		} else {
+			ranges6 = append(ranges6, &newNetToRange)
+		}
+	}
+
+	return coalesceRanges(mergeAdjacentCIDRs(ranges4)), coalesceRanges(mergeAdjacentCIDRs(ranges6))
+}
+
+// rangeToCIDRs converts the range of IPs covered by firstIP and lastIP to
+// a list of CIDRs that contains all of the IPs covered by the range.
+func rangeToCIDRs(firstIP, lastIP net.IP) []*net.IPNet {
+
+	// First, create a CIDR that spans both IPs.
+	spanningCIDR := createSpanningCIDR(netWithRange{&firstIP, &lastIP, nil})
+	spanningRange := ipNetToRange(spanningCIDR)
+	firstIPSpanning := spanningRange.First
+	lastIPSpanning := spanningRange.Last
+
+	cidrList := []*net.IPNet{}
+
+	// If the first IP of the spanning CIDR passes the lower bound (firstIP),
+	// we need to split the spanning CIDR and only take the IPs that are
+	// greater than the value which we split on, as we do not want the lesser
+	// values since they are less than the lower-bound (firstIP).
+	if bytes.Compare(*firstIPSpanning, firstIP) < 0 {
+		// Split on the previous IP of the first IP so that the right list of IPs
+		// of the partition includes the firstIP.
+		prevFirstRangeIP := getPreviousIP(firstIP)
+		var bitLen int
+		if prevFirstRangeIP.To4() != nil {
+			bitLen = ipv4BitLen
+		} else {
+			bitLen = ipv6BitLen
+		}
+		_, _, right := partitionCIDR(spanningCIDR, net.IPNet{IP: prevFirstRangeIP, Mask: net.CIDRMask(bitLen, bitLen)})
+
+		// Append all CIDRs but the first, as this CIDR includes the upper
+		// bound of the spanning CIDR, which we still need to partition on.
+		cidrList = append(cidrList, right...)
+		spanningCIDR = *right[0]
+		cidrList = cidrList[1:]
+	}
+
+	// Conversely, if the last IP of the spanning CIDR passes the upper bound
+	// (lastIP), we need to split the spanning CIDR and only take the IPs that
+	// are greater than the value which we split on, as we do not want the greater
+	// values since they are greater than the upper-bound (lastIP).
+	if bytes.Compare(*lastIPSpanning, lastIP) > 0 {
+		// Split on the next IP of the last IP so that the left list of IPs
+		// of the partition include the lastIP.
+		nextFirstRangeIP := getNextIP(lastIP)
+		var bitLen int
+		if nextFirstRangeIP.To4() != nil {
+			bitLen = ipv4BitLen
+		} else {
+			bitLen = ipv6BitLen
+		}
+		left, _, _ := partitionCIDR(spanningCIDR, net.IPNet{IP: nextFirstRangeIP, Mask: net.CIDRMask(bitLen, bitLen)})
+		cidrList = append(cidrList, left...)
+	} else {
+		// Otherwise, there is no need to partition; just use add the spanning
+		// CIDR to the list of networks.
+		cidrList = append(cidrList, &spanningCIDR)
+	}
+	return cidrList
+}
+
+// partitionCIDR returns a list of IP Networks partitioned upon excludeCIDR.
+// The first list contains the networks to the left of the excludeCIDR in the
+// partition,  the second is a list containing the excludeCIDR itself if it is
+// contained within the targetCIDR (nil otherwise), and the
+// third is a list containing the networks to the right of the excludeCIDR in
+// the partition.
+func partitionCIDR(targetCIDR net.IPNet, excludeCIDR net.IPNet) ([]*net.IPNet, []*net.IPNet, []*net.IPNet) {
+	var targetIsIPv4 bool
+	if targetCIDR.IP.To4() != nil {
+		targetIsIPv4 = true
+	}
+
+	targetIPRange := ipNetToRange(targetCIDR)
+	excludeIPRange := ipNetToRange(excludeCIDR)
+
+	targetFirstIP := *targetIPRange.First
+	targetLastIP := *targetIPRange.Last
+
+	excludeFirstIP := *excludeIPRange.First
+	excludeLastIP := *excludeIPRange.Last
+
+	targetMaskSize, _ := targetCIDR.Mask.Size()
+	excludeMaskSize, _ := excludeCIDR.Mask.Size()
+
+	if bytes.Compare(excludeLastIP, targetFirstIP) < 0 {
+		return nil, nil, []*net.IPNet{&targetCIDR}
+	} else if bytes.Compare(targetLastIP, excludeFirstIP) < 0 {
+		return []*net.IPNet{&targetCIDR}, nil, nil
+	}
+
+	if targetMaskSize >= excludeMaskSize {
+		return nil, []*net.IPNet{&targetCIDR}, nil
+	}
+
+	left := []*net.IPNet{}
+	right := []*net.IPNet{}
+
+	newPrefixLen := targetMaskSize + 1
+
+	targetFirstCopy := make(net.IP, len(targetFirstIP))
+	copy(targetFirstCopy, targetFirstIP)
+
+	iLowerOld := make(net.IP, len(targetFirstCopy))
+	copy(iLowerOld, targetFirstCopy)
+
+	// Since golang only supports up to unsigned 64-bit integers, and we need
+	// to perform addition on addresses, use math/big library, which allows
+	// for manipulation of large integers.
+
+	// Used to track the current lower and upper bounds of the ranges to compare
+	// to excludeCIDR.
+	iLower := big.NewInt(0)
+	iUpper := big.NewInt(0)
+	iLower = iLower.SetBytes(targetFirstCopy)
+
+	var bitLen int
+
+	if targetIsIPv4 {
+		bitLen = ipv4BitLen
+	} else {
+		bitLen = ipv6BitLen
+	}
+	shiftAmount := (uint)(bitLen - newPrefixLen)
+
+	targetIPInt := big.NewInt(0)
+	targetIPInt.SetBytes(targetFirstIP.To16())
+
+	exp := big.NewInt(0)
+
+	// Use left shift for exponentiation
+	exp = exp.Lsh(big.NewInt(1), shiftAmount)
+	iUpper = iUpper.Add(targetIPInt, exp)
+
+	matched := big.NewInt(0)
+
+	for excludeMaskSize >= newPrefixLen {
+		// Append leading zeros to IPv4 addresses, as math.Big.Int does not
+		// append them when the IP address is copied from a byte array to
+		// math.Big.Int. Leading zeroes are required for parsing IPv4 addresses
+		// for use with net.IP / net.IPNet.
+		var iUpperBytes, iLowerBytes []byte
+		if targetIsIPv4 {
+			iUpperBytes = append(ipv4LeadingZeroes, iUpper.Bytes()...)
+			iLowerBytes = append(ipv4LeadingZeroes, iLower.Bytes()...)
+		} else {
+			iUpperBytesLen := len(iUpper.Bytes())
+			// Make sure that the number of bytes in the array matches what net
+			// package expects, as big package doesn't append leading zeroes.
+			if iUpperBytesLen != net.IPv6len {
+				numZeroesToAppend := net.IPv6len - iUpperBytesLen
+				zeroBytes := make([]byte, numZeroesToAppend)
+				iUpperBytes = append(zeroBytes, iUpper.Bytes()...)
+			} else {
+				iUpperBytes = iUpper.Bytes()
+
+			}
+
+			iLowerBytesLen := len(iLower.Bytes())
+			if iLowerBytesLen != net.IPv6len {
+				numZeroesToAppend := net.IPv6len - iLowerBytesLen
+				zeroBytes := make([]byte, numZeroesToAppend)
+				iLowerBytes = append(zeroBytes, iLower.Bytes()...)
+			} else {
+				iLowerBytes = iLower.Bytes()
+
+			}
+		}
+		// If the IP we are excluding over is of a higher value than the current
+		// CIDR prefix we are generating, add the CIDR prefix to the set of IPs
+		// to the left of the exclude CIDR
+		if bytes.Compare(excludeFirstIP, iUpperBytes) >= 0 {
+			left = append(left, &net.IPNet{IP: iLowerBytes, Mask: net.CIDRMask(newPrefixLen, bitLen)})
+			matched = matched.Set(iUpper)
+		} else {
+			// Same as above, but opposite.
+			right = append(right, &net.IPNet{IP: iUpperBytes, Mask: net.CIDRMask(newPrefixLen, bitLen)})
+			matched = matched.Set(iLower)
+		}
+
+		newPrefixLen++
+
+		if newPrefixLen > bitLen {
+			break
+		}
+
+		iLower = iLower.Set(matched)
+		iUpper = iUpper.Add(matched, big.NewInt(0).Lsh(big.NewInt(1), uint(bitLen-newPrefixLen)))
+
+	}
+	excludeList := []*net.IPNet{&excludeCIDR}
+
+	return left, excludeList, right
 }

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -16,7 +16,7 @@ package ip
 
 import (
 	"net"
-	"reflect"
+	"sort"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -53,12 +53,12 @@ func (s *IPTestSuite) TestFirstIP(c *C) {
 	testNetv4_1 := net.IPNet{IP: net.ParseIP("10.0.0.5"), Mask: net.CIDRMask(8, 32)}
 	ipNetv4_1 := getNetworkPrefix(&testNetv4_1)
 	for k := range *ipNetv4_1 {
-		c.Assert(reflect.DeepEqual((*ipNetv4_1)[k], desiredIPv4_1[k]), Equals, true)
+		c.Assert((*ipNetv4_1)[k], Equals, desiredIPv4_1[k])
 	}
 	testNetv4_2 := net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(8, 32)}
 	ipNetv4_2 := getNetworkPrefix(&testNetv4_2)
 	for k := range *ipNetv4_2 {
-		c.Assert(reflect.DeepEqual((*ipNetv4_2)[k], desiredIPv4_1[k]), Equals, true)
+		c.Assert((*ipNetv4_2)[k], Equals, desiredIPv4_1[k])
 	}
 
 	// Test IPv6
@@ -66,7 +66,7 @@ func (s *IPTestSuite) TestFirstIP(c *C) {
 
 	ipNetv6_1 := getNetworkPrefix(testNetv6_1)
 	for k := range *ipNetv6_1 {
-		c.Assert(reflect.DeepEqual((*ipNetv6_1)[k], desiredIPv6_1[k]), Equals, true)
+		c.Assert((*ipNetv6_1)[k], Equals, desiredIPv6_1[k])
 	}
 }
 
@@ -77,8 +77,20 @@ func (s *IPTestSuite) testIPNetsEqual(created, expected []*net.IPNet, c *C) {
 	}
 }
 
+func (s *IPTestSuite) testIPsEqual(created, expected net.IP, c *C) {
+	for k := range created {
+		c.Assert(created[k], Equals, expected[k])
+	}
+}
+
 func createIPNet(address string, maskSize int, bitLen int) *net.IPNet {
 	return &net.IPNet{IP: net.ParseIP(address), Mask: net.CIDRMask(maskSize, bitLen)}
+}
+
+func createIPRange(first string, last string) *netWithRange {
+	firstIP := net.ParseIP(first)
+	lastIP := net.ParseIP(last)
+	return &netWithRange{First: &firstIP, Last: &lastIP}
 }
 
 func (s *IPTestSuite) TestRemoveCIDRs(c *C) {
@@ -174,13 +186,431 @@ func (s *IPTestSuite) TestByteFunctions(c *C) {
 	newBytes := flipNthBit(&testBytes, 10)
 	expectedBytes := []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0x0, 0x0, 0x4, 0x0}
 	for k := range expectedBytes {
-		c.Assert(reflect.DeepEqual(expectedBytes[k], (*newBytes)[k]), Equals, true)
+		c.Assert(expectedBytes[k], Equals, (*newBytes)[k])
 	}
 
 	newBytes = flipNthBit(&testBytes, 32)
 	expectedBytes = []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xfe, 0x0, 0x0, 0x0, 0x0}
 	for k := range expectedBytes {
-		c.Assert(reflect.DeepEqual(expectedBytes[k], (*newBytes)[k]), Equals, true)
+		c.Assert(expectedBytes[k], Equals, (*newBytes)[k])
 	}
 
+}
+
+func (s *IPTestSuite) TestIPNetToRange(c *C) {
+
+	testRange := ipNetToRange(*createIPNet("192.0.128.0", 24, int(ipv4BitLen)))
+	var expectedFirst, expectedLast []byte
+	expectedFirst = append(expectedFirst, v4Mappedv6Prefix...)
+	expectedFirst = append(expectedFirst, []byte{192, 0, 128, 0}...)
+	expectedFirstIP := net.IP(expectedFirst)
+
+	expectedLast = append(expectedLast, v4Mappedv6Prefix...)
+	expectedLast = append(expectedLast, []byte{192, 0, 128, 255}...)
+	expectedLastIP := net.IP(expectedLast)
+	expectedRange := netWithRange{First: &expectedFirstIP, Last: &expectedLastIP}
+
+	s.checkRangesEqual(&expectedRange, &testRange, c)
+
+	// Check that all bits are masked correctly.
+	testRange = ipNetToRange(*createIPNet("192.0.128.255", 24, int(ipv4BitLen)))
+	s.checkRangesEqual(&expectedRange, &testRange, c)
+
+	testRange = ipNetToRange(*createIPNet("fd44:7089:ff32:712b:ff00::", 64, int(ipv6BitLen)))
+	testRange = ipNetToRange(*createIPNet("::ffff:0", 128, int(ipv6BitLen)))
+
+}
+
+func (s *IPTestSuite) checkRangesEqual(range1, range2 *netWithRange, c *C) {
+	for l := range *range1.First {
+		c.Assert((*range1.First)[l], Equals, (*range2.First)[l])
+	}
+	for l := range *range1.Last {
+		c.Assert((*range1.Last)[l], Equals, (*range2.Last)[l])
+	}
+}
+
+func (s *IPTestSuite) TestNetsByRange(c *C) {
+	ranges := []*netWithRange{}
+
+	// Check sorting by last IP first
+	cidrs := []*net.IPNet{createIPNet("10.0.0.0", 8, int(ipv4BitLen)),
+		createIPNet("10.0.0.0", 10, int(ipv4BitLen)),
+		createIPNet("10.64.0.0", 11, int(ipv4BitLen)),
+		createIPNet("10.112.0.0", 12, int(ipv4BitLen))}
+
+	for _, network := range cidrs {
+		newNetToRange := ipNetToRange(*network)
+		ranges = append(ranges, &newNetToRange)
+	}
+
+	expectedRanges := []*netWithRange{
+		createIPRange("10.0.0.0", "10.63.255.255"),
+		createIPRange("10.64.0.0", "10.95.255.255"),
+		createIPRange("10.112.0.0", "10.127.255.255"),
+		createIPRange("10.0.0.0", "10.255.255.255")}
+	sort.Sort(NetsByRange(ranges))
+	// Ensure that length of ranges isn't modified first.
+	c.Assert(len(ranges), Equals, len(expectedRanges))
+	for k := range ranges {
+		s.checkRangesEqual(ranges[k], expectedRanges[k], c)
+	}
+
+	ranges = []*netWithRange{createIPRange("10.0.0.0", "10.255.255.255"),
+		createIPRange("10.255.255.254", "10.255.255.255")}
+	expectedRanges = []*netWithRange{createIPRange("10.0.0.0", "10.255.255.255"),
+		createIPRange("10.255.255.254", "10.255.255.255")}
+	sort.Sort(NetsByRange(ranges))
+	// Ensure that length of ranges isn't modified first.
+	c.Assert(len(ranges), Equals, len(expectedRanges))
+	for k := range ranges {
+		s.checkRangesEqual(ranges[k], expectedRanges[k], c)
+	}
+
+}
+
+func (s *IPTestSuite) TestCoalesceCIDRs(c *C) {
+
+	cidrs := []*net.IPNet{createIPNet("192.0.128.0", 24, int(ipv4BitLen)),
+		createIPNet("192.0.129.0", 24, int(ipv4BitLen))}
+	expected := []*net.IPNet{createIPNet("192.0.128.0", 23, int(ipv4BitLen))}
+	mergedV4CIDRs, mergedV6CIDRs := CoalesceCIDRs(cidrs)
+	c.Assert(len(mergedV6CIDRs), Equals, 0)
+	s.testIPNetsEqual(mergedV4CIDRs, expected, c)
+
+	cidrs = []*net.IPNet{createIPNet("192.0.129.0", 24, int(ipv4BitLen)),
+		createIPNet("192.0.130.0", 24, int(ipv4BitLen))}
+	expected = []*net.IPNet{createIPNet("192.0.129.0", 24, int(ipv4BitLen)),
+		createIPNet("192.0.130.0", 24, int(ipv4BitLen))}
+	mergedV4CIDRs, mergedV6CIDRs = CoalesceCIDRs(cidrs)
+	s.testIPNetsEqual(mergedV4CIDRs, expected, c)
+
+	cidrs = []*net.IPNet{createIPNet("192.0.2.112", 30, int(ipv4BitLen)),
+		createIPNet("192.0.2.116", 31, int(ipv4BitLen)),
+		createIPNet("192.0.2.118", 31, int(ipv4BitLen))}
+	expected = []*net.IPNet{createIPNet("192.0.2.112", 29, int(ipv4BitLen))}
+	mergedV4CIDRs, mergedV6CIDRs = CoalesceCIDRs(cidrs)
+	s.testIPNetsEqual(mergedV4CIDRs, expected, c)
+
+	cidrs = []*net.IPNet{createIPNet("192.0.2.112", 30, int(ipv4BitLen)),
+		createIPNet("192.0.2.116", 32, int(ipv4BitLen)),
+		createIPNet("192.0.2.118", 31, int(ipv4BitLen))}
+	expected = []*net.IPNet{createIPNet("192.0.2.112", 30, int(ipv4BitLen)),
+		createIPNet("192.0.2.116", 32, int(ipv4BitLen)),
+		createIPNet("192.0.2.118", 31, int(ipv4BitLen))}
+	mergedV4CIDRs, mergedV6CIDRs = CoalesceCIDRs(cidrs)
+	s.testIPNetsEqual(mergedV4CIDRs, expected, c)
+
+	cidrs = []*net.IPNet{createIPNet("192.0.2.112", 31, int(ipv4BitLen)),
+		createIPNet("192.0.2.116", 31, int(ipv4BitLen)),
+		createIPNet("192.0.2.118", 31, int(ipv4BitLen))}
+	expected = []*net.IPNet{createIPNet("192.0.2.112", 31, int(ipv4BitLen)),
+		createIPNet("192.0.2.116", 30, int(ipv4BitLen))}
+	mergedV4CIDRs, mergedV6CIDRs = CoalesceCIDRs(cidrs)
+	s.testIPNetsEqual(mergedV4CIDRs, expected, c)
+
+	cidrs = []*net.IPNet{createIPNet("192.0.1.254", 31, int(ipv4BitLen)),
+		createIPNet("192.0.2.0", 28, int(ipv4BitLen)),
+		createIPNet("192.0.2.16", 28, int(ipv4BitLen)),
+		createIPNet("192.0.2.32", 28, int(ipv4BitLen)),
+		createIPNet("192.0.2.48", 28, int(ipv4BitLen)),
+		createIPNet("192.0.2.64", 28, int(ipv4BitLen)),
+		createIPNet("192.0.2.80", 28, int(ipv4BitLen)),
+		createIPNet("192.0.2.96", 28, int(ipv4BitLen)),
+		createIPNet("192.0.2.112", 28, int(ipv4BitLen)),
+		createIPNet("192.0.2.128", 28, int(ipv4BitLen)),
+		createIPNet("192.0.2.144", 28, int(ipv4BitLen)),
+		createIPNet("192.0.2.160", 28, int(ipv4BitLen)),
+		createIPNet("192.0.2.176", 28, int(ipv4BitLen)),
+		createIPNet("192.0.2.192", 28, int(ipv4BitLen)),
+		createIPNet("192.0.2.208", 28, int(ipv4BitLen)),
+		createIPNet("192.0.2.224", 28, int(ipv4BitLen)),
+		createIPNet("192.0.2.240", 28, int(ipv4BitLen)),
+		createIPNet("192.0.3.0", 28, int(ipv4BitLen)),
+	}
+
+	expected = []*net.IPNet{createIPNet("192.0.1.254", 31, int(ipv4BitLen)),
+		createIPNet("192.0.2.0", 24, int(ipv4BitLen)),
+		createIPNet("192.0.3.0", 28, int(ipv4BitLen))}
+	mergedV4CIDRs, mergedV6CIDRs = CoalesceCIDRs(cidrs)
+	s.testIPNetsEqual(mergedV4CIDRs, expected, c)
+
+	cidrs = []*net.IPNet{createIPNet("::", 0, int(ipv6BitLen)),
+		createIPNet("fe80::1", 128, int(ipv6BitLen))}
+	expected = []*net.IPNet{createIPNet("::", 0, int(ipv6BitLen))}
+	_, mergedV6CIDRs = CoalesceCIDRs(cidrs)
+	s.testIPNetsEqual(mergedV6CIDRs, expected, c)
+
+	// assert cidr_merge(['::/0', '::192.0.2.0/124', 'ff00::101']) == [IPNetwork('::/0')]
+	cidrs = []*net.IPNet{createIPNet("::", 0, int(ipv6BitLen)),
+		createIPNet("::192.0.2.0", 124, int(ipv6BitLen)),
+		createIPNet("ff00::101", 128, int(ipv6BitLen))}
+	_, mergedV6CIDRs = CoalesceCIDRs(cidrs)
+	s.testIPNetsEqual(mergedV6CIDRs, expected, c)
+}
+
+func (s *IPTestSuite) TestRangeToCIDRs(c *C) {
+	// IPv4 worst case.
+	ipNets := rangeToCIDRs(net.ParseIP("0.0.0.1"), net.ParseIP("255.255.255.254"))
+	expected := []*net.IPNet{createIPNet("0.0.0.1", 32, int(ipv4BitLen)),
+		createIPNet("0.0.0.2", 31, int(ipv4BitLen)),
+		createIPNet("0.0.0.4", 30, int(ipv4BitLen)),
+		createIPNet("0.0.0.8", 29, int(ipv4BitLen)),
+		createIPNet("0.0.0.16", 28, int(ipv4BitLen)),
+		createIPNet("0.0.0.32", 27, int(ipv4BitLen)),
+		createIPNet("0.0.0.64", 26, int(ipv4BitLen)),
+		createIPNet("0.0.0.128", 25, int(ipv4BitLen)),
+		createIPNet("0.0.1.0", 24, int(ipv4BitLen)),
+		createIPNet("0.0.2.0", 23, int(ipv4BitLen)),
+		createIPNet("0.0.4.0", 22, int(ipv4BitLen)),
+		createIPNet("0.0.8.0", 21, int(ipv4BitLen)),
+		createIPNet("0.0.16.0", 20, int(ipv4BitLen)),
+		createIPNet("0.0.32.0", 19, int(ipv4BitLen)),
+		createIPNet("0.0.64.0", 18, int(ipv4BitLen)),
+		createIPNet("0.0.128.0", 17, int(ipv4BitLen)),
+		createIPNet("0.1.0.0", 16, int(ipv4BitLen)),
+		createIPNet("0.2.0.0", 15, int(ipv4BitLen)),
+		createIPNet("0.4.0.0", 14, int(ipv4BitLen)),
+		createIPNet("0.8.0.0", 13, int(ipv4BitLen)),
+		createIPNet("0.16.0.0", 12, int(ipv4BitLen)),
+		createIPNet("0.32.0.0", 11, int(ipv4BitLen)),
+		createIPNet("0.64.0.0", 10, int(ipv4BitLen)),
+		createIPNet("0.128.0.0", 9, int(ipv4BitLen)),
+		createIPNet("1.0.0.0", 8, int(ipv4BitLen)),
+		createIPNet("2.0.0.0", 7, int(ipv4BitLen)),
+		createIPNet("4.0.0.0", 6, int(ipv4BitLen)),
+		createIPNet("8.0.0.0", 5, int(ipv4BitLen)),
+		createIPNet("16.0.0.0", 4, int(ipv4BitLen)),
+		createIPNet("32.0.0.0", 3, int(ipv4BitLen)),
+		createIPNet("64.0.0.0", 2, int(ipv4BitLen)),
+		createIPNet("128.0.0.0", 2, int(ipv4BitLen)),
+		createIPNet("192.0.0.0", 3, int(ipv4BitLen)),
+		createIPNet("224.0.0.0", 4, int(ipv4BitLen)),
+		createIPNet("240.0.0.0", 5, int(ipv4BitLen)),
+		createIPNet("248.0.0.0", 6, int(ipv4BitLen)),
+		createIPNet("252.0.0.0", 7, int(ipv4BitLen)),
+		createIPNet("254.0.0.0", 8, int(ipv4BitLen)),
+		createIPNet("255.0.0.0", 9, int(ipv4BitLen)),
+		createIPNet("255.128.0.0", 10, int(ipv4BitLen)),
+		createIPNet("255.192.0.0", 11, int(ipv4BitLen)),
+		createIPNet("255.224.0.0", 12, int(ipv4BitLen)),
+		createIPNet("255.240.0.0", 13, int(ipv4BitLen)),
+		createIPNet("255.248.0.0", 14, int(ipv4BitLen)),
+		createIPNet("255.252.0.0", 15, int(ipv4BitLen)),
+		createIPNet("255.254.0.0", 16, int(ipv4BitLen)),
+		createIPNet("255.255.0.0", 17, int(ipv4BitLen)),
+		createIPNet("255.255.128.0", 18, int(ipv4BitLen)),
+		createIPNet("255.255.192.0", 19, int(ipv4BitLen)),
+		createIPNet("255.255.224.0", 20, int(ipv4BitLen)),
+		createIPNet("255.255.240.0", 21, int(ipv4BitLen)),
+		createIPNet("255.255.249.0", 22, int(ipv4BitLen)),
+		createIPNet("255.255.252.0", 23, int(ipv4BitLen)),
+		createIPNet("255.255.254.0", 24, int(ipv4BitLen)),
+		createIPNet("255.255.255.0", 25, int(ipv4BitLen)),
+		createIPNet("255.255.255.128", 26, int(ipv4BitLen)),
+		createIPNet("255.255.255.192", 27, int(ipv4BitLen)),
+		createIPNet("255.255.255.224", 28, int(ipv4BitLen)),
+		createIPNet("255.255.255.240", 29, int(ipv4BitLen)),
+		createIPNet("255.255.255.248", 30, int(ipv4BitLen)),
+		createIPNet("255.255.255.252", 31, int(ipv4BitLen)),
+		createIPNet("255.255.255.254", 32, int(ipv4BitLen)),
+	}
+
+	// Sort both so we can compare easily
+	sort.Sort(NetsByMask(expected))
+	sort.Sort(NetsByMask(ipNets))
+	c.Assert(len(ipNets), Equals, len(expected))
+}
+
+func (s *IPTestSuite) TestPreviousIP(c *C) {
+	ip := net.ParseIP("10.0.0.0")
+	expectedPrev := net.ParseIP("9.255.255.255")
+	prevIP := getPreviousIP(ip)
+	s.testIPsEqual(prevIP, expectedPrev, c)
+
+	// Check that underflow does not occur.
+	ip = net.ParseIP("0.0.0.0")
+	prevIP = getPreviousIP(ip)
+	expectedPrev = ip
+	s.testIPsEqual(prevIP, expectedPrev, c)
+
+	ip = net.ParseIP("::")
+	prevIP = getPreviousIP(ip)
+	expectedPrev = ip
+	s.testIPsEqual(prevIP, expectedPrev, c)
+
+	ip = net.ParseIP("10.0.0.1")
+	prevIP = getPreviousIP(ip)
+	expectedPrev = net.ParseIP("10.0.0.0")
+	s.testIPsEqual(prevIP, expectedPrev, c)
+
+	ip = net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+	expectedPrev = net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe")
+	prevIP = getPreviousIP(ip)
+	s.testIPsEqual(prevIP, expectedPrev, c)
+}
+
+func (s *IPTestSuite) TestNextIP(c *C) {
+	expectedNext := net.ParseIP("10.0.0.0")
+	ip := net.ParseIP("9.255.255.255")
+	nextIP := getNextIP(ip)
+	s.testIPsEqual(nextIP, expectedNext, c)
+
+	// Check that overflow does not occur.
+	ip = net.ParseIP("255.255.255.255")
+	nextIP = getNextIP(ip)
+	expectedNext = ip
+	s.testIPsEqual(nextIP, expectedNext, c)
+
+	ip = net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+	nextIP = getNextIP(ip)
+	expectedNext = ip
+	s.testIPsEqual(nextIP, expectedNext, c)
+
+	ip = net.ParseIP("10.0.0.0")
+	nextIP = getNextIP(ip)
+	expectedNext = net.ParseIP("10.0.0.1")
+	s.testIPsEqual(nextIP, expectedNext, c)
+
+	ip = net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe")
+	expectedNext = net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+	nextIP = getNextIP(ip)
+	s.testIPsEqual(nextIP, expectedNext, c)
+}
+
+func (s *IPTestSuite) TestCreateSpanningCIDR(c *C) {
+	netRange := createIPRange("10.0.0.0", "10.255.255.255")
+	expectedSpanningCIDR := createIPNet("10.0.0.0", 8, int(ipv4BitLen))
+	spanningCIDR := createSpanningCIDR(*netRange)
+	s.testIPNetsEqual([]*net.IPNet{expectedSpanningCIDR}, []*net.IPNet{&spanningCIDR}, c)
+
+	netRange = createIPRange("10.0.0.0", "10.255.255.254")
+	expectedSpanningCIDR = createIPNet("10.0.0.0", 8, int(ipv4BitLen))
+	spanningCIDR = createSpanningCIDR(*netRange)
+	s.testIPNetsEqual([]*net.IPNet{expectedSpanningCIDR}, []*net.IPNet{&spanningCIDR}, c)
+
+	netRange = createIPRange("10.0.0.1", "10.0.0.1")
+	expectedSpanningCIDR = createIPNet("10.0.0.1", 32, int(ipv4BitLen))
+	spanningCIDR = createSpanningCIDR(*netRange)
+	s.testIPNetsEqual([]*net.IPNet{expectedSpanningCIDR}, []*net.IPNet{&spanningCIDR}, c)
+
+	netRange = createIPRange("10.0.0.1", "10.0.0.2")
+	expectedSpanningCIDR = createIPNet("10.0.0.0", 30, int(ipv4BitLen))
+	spanningCIDR = createSpanningCIDR(*netRange)
+	s.testIPNetsEqual([]*net.IPNet{expectedSpanningCIDR}, []*net.IPNet{&spanningCIDR}, c)
+
+	netRange = createIPRange("9.0.0.0", "10.0.0.0")
+	expectedSpanningCIDR = createIPNet("8.0.0.0", 6, int(ipv4BitLen))
+	spanningCIDR = createSpanningCIDR(*netRange)
+	s.testIPNetsEqual([]*net.IPNet{expectedSpanningCIDR}, []*net.IPNet{&spanningCIDR}, c)
+
+	netRange = createIPRange("FD44:7089:FF32:712B:FF00:0000:0000:0000", "FD44:7089:FF32:712B:FFFF:FFFF:FFFF:FFFF")
+	expectedSpanningCIDR = createIPNet("fd44:7089:ff32:712b:ff00::", 72, int(ipv6BitLen))
+	spanningCIDR = createSpanningCIDR(*netRange)
+	s.testIPNetsEqual([]*net.IPNet{expectedSpanningCIDR}, []*net.IPNet{&spanningCIDR}, c)
+
+}
+
+func (s *IPTestSuite) TestPartitionCIDR(c *C) {
+	targetCIDR := createIPNet("10.0.0.0", 8, int(ipv4BitLen))
+	excludeCIDR := createIPNet("10.255.255.255", 32, int(ipv4BitLen))
+	left, exclude, right := partitionCIDR(*targetCIDR, *excludeCIDR)
+	// Exclude should just contain exclude CIDR
+	s.testIPNetsEqual([]*net.IPNet{excludeCIDR}, exclude, c)
+	// Nothing should be in right list.
+	c.Assert(len(right), Equals, 0)
+	expectedLeft := []*net.IPNet{createIPNet("10.0.0.0", 9, int(ipv4BitLen)),
+		createIPNet("10.128.0.0", 10, int(ipv4BitLen)),
+		createIPNet("10.192.0.0", 11, int(ipv4BitLen)),
+		createIPNet("10.224.0.0", 12, int(ipv4BitLen)),
+		createIPNet("10.240.0.0", 13, int(ipv4BitLen)),
+		createIPNet("10.248.0.0", 14, int(ipv4BitLen)),
+		createIPNet("10.252.0.0", 15, int(ipv4BitLen)),
+		createIPNet("10.254.0.0", 16, int(ipv4BitLen)),
+		createIPNet("10.255.0.0", 17, int(ipv4BitLen)),
+		createIPNet("10.255.128.0", 18, int(ipv4BitLen)),
+		createIPNet("10.255.192.0", 19, int(ipv4BitLen)),
+		createIPNet("10.255.224.0", 20, int(ipv4BitLen)),
+		createIPNet("10.255.240.0", 21, int(ipv4BitLen)),
+		createIPNet("10.255.248.0", 22, int(ipv4BitLen)),
+		createIPNet("10.255.252.0", 23, int(ipv4BitLen)),
+		createIPNet("10.255.254.0", 24, int(ipv4BitLen)),
+		createIPNet("10.255.255.0", 25, int(ipv4BitLen)),
+		createIPNet("10.255.255.128", 26, int(ipv4BitLen)),
+		createIPNet("10.255.255.192", 27, int(ipv4BitLen)),
+		createIPNet("10.255.255.224", 28, int(ipv4BitLen)),
+		createIPNet("10.255.255.240", 29, int(ipv4BitLen)),
+		createIPNet("10.255.255.248", 30, int(ipv4BitLen)),
+		createIPNet("10.255.255.252", 31, int(ipv4BitLen)),
+		createIPNet("10.255.255.254", 32, int(ipv4BitLen)),
+	}
+	s.testIPNetsEqual(expectedLeft, left, c)
+
+	targetCIDR = createIPNet("10.0.0.0", 8, int(ipv4BitLen))
+	excludeCIDR = createIPNet("10.0.0.0", 32, int(ipv4BitLen))
+	left, exclude, right = partitionCIDR(*targetCIDR, *excludeCIDR)
+	// Exclude should just contain exclude CIDR
+	s.testIPNetsEqual([]*net.IPNet{excludeCIDR}, exclude, c)
+	// Nothing should be in left list.
+	c.Assert(len(left), Equals, 0)
+	expectedRight := []*net.IPNet{createIPNet("10.128.0.0", 9, int(ipv4BitLen)),
+		createIPNet("10.64.0.0", 10, int(ipv4BitLen)),
+		createIPNet("10.32.0.0", 11, int(ipv4BitLen)),
+		createIPNet("10.16.0.0", 12, int(ipv4BitLen)),
+		createIPNet("10.8.0.0", 13, int(ipv4BitLen)),
+		createIPNet("10.4.0.0", 14, int(ipv4BitLen)),
+		createIPNet("10.2.0.0", 15, int(ipv4BitLen)),
+		createIPNet("10.1.0.0", 16, int(ipv4BitLen)),
+		createIPNet("10.0.128.0", 17, int(ipv4BitLen)),
+		createIPNet("10.0.64.0", 18, int(ipv4BitLen)),
+		createIPNet("10.0.32.0", 19, int(ipv4BitLen)),
+		createIPNet("10.0.16.0", 20, int(ipv4BitLen)),
+		createIPNet("10.0.8.0", 21, int(ipv4BitLen)),
+		createIPNet("10.0.4.0", 22, int(ipv4BitLen)),
+		createIPNet("10.0.2.0", 23, int(ipv4BitLen)),
+		createIPNet("10.0.1.0", 24, int(ipv4BitLen)),
+		createIPNet("10.0.0.128", 25, int(ipv4BitLen)),
+		createIPNet("10.0.0.64", 26, int(ipv4BitLen)),
+		createIPNet("10.0.0.32", 27, int(ipv4BitLen)),
+		createIPNet("10.0.0.16", 28, int(ipv4BitLen)),
+		createIPNet("10.0.0.8", 29, int(ipv4BitLen)),
+		createIPNet("10.0.0.4", 30, int(ipv4BitLen)),
+		createIPNet("10.0.0.2", 31, int(ipv4BitLen)),
+		createIPNet("10.0.0.1", 32, int(ipv4BitLen)),
+	}
+	s.testIPNetsEqual(expectedRight, right, c)
+
+	// exclude is not in target CIDR and is to left.
+	targetCIDR = createIPNet("10.0.0.0", 8, int(ipv4BitLen))
+	excludeCIDR = createIPNet("9.0.0.255", 32, int(ipv4BitLen))
+	left, exclude, right = partitionCIDR(*targetCIDR, *excludeCIDR)
+	c.Assert(len(left), Equals, 0)
+	c.Assert(len(exclude), Equals, 0)
+	s.testIPNetsEqual([]*net.IPNet{targetCIDR}, right, c)
+
+	// exclude is not in target CIDR and is to right.
+	targetCIDR = createIPNet("10.255.255.254", 32, int(ipv4BitLen))
+	excludeCIDR = createIPNet("10.255.255.255", 32, int(ipv4BitLen))
+	left, exclude, right = partitionCIDR(*targetCIDR, *excludeCIDR)
+	c.Assert(len(right), Equals, 0)
+	c.Assert(len(exclude), Equals, 0)
+	s.testIPNetsEqual([]*net.IPNet{targetCIDR}, left, c)
+
+	// exclude CIDR larger than target CIDR
+	targetCIDR = createIPNet("10.96.0.0", 12, int(ipv4BitLen))
+	excludeCIDR = createIPNet("10.0.0.0", 8, int(ipv4BitLen))
+	left, exclude, right = partitionCIDR(*targetCIDR, *excludeCIDR)
+	c.Assert(len(left), Equals, 0)
+	c.Assert(len(right), Equals, 0)
+	s.testIPNetsEqual([]*net.IPNet{targetCIDR}, exclude, c)
+
+	targetCIDR = createIPNet("fd44:7089:ff32:712b:ff00::", 64, int(ipv6BitLen))
+	excludeCIDR = createIPNet("fd44:7089:ff32:712b::", 66, int(ipv6BitLen))
+
+	left, exclude, right = partitionCIDR(*targetCIDR, *excludeCIDR)
+
+	expectedCIDRs := []*net.IPNet{createIPNet("fd44:7089:ff32:712b:8000::", 65, int(ipv6BitLen)),
+		createIPNet("fd44:7089:ff32:712b:4000::", 66, int(ipv6BitLen))}
+	s.testIPNetsEqual(expectedCIDRs, right, c)
+	s.testIPNetsEqual([]*net.IPNet{excludeCIDR}, exclude, c)
 }


### PR DESCRIPTION
Add CoalesceCIDRs and associated helper functions, which combines a list of
CIDRs into the smallest equivalent set of CIDRs.

Signed-off by: Ian Vernon <ian@cilium.io>

This was long-lived in a previous PR, but I wanted to separate the library code being merged from the actual consumption of the code in Cilium.

Partially address #1658 : this is only the library functionality. Cilium can consume this change at a later time (this is tracked as part of #1658).