### PR TITLE
examples/k8s: fix 1.8 spec files

### DIFF
--- a/examples/kubernetes/1.8/cilium-rbac.yaml
+++ b/examples/kubernetes/1.8/cilium-rbac.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta2
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: cilium
 roleRef:
@@ -14,7 +14,7 @@ subjects:
   name: system:nodes
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta2
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: cilium
 rules:

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -207,7 +207,7 @@ spec:
         operator: "Exists"
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta2
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: cilium
 roleRef:
@@ -222,7 +222,7 @@ subjects:
   name: system:nodes
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta2
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: cilium
 rules:

--- a/examples/kubernetes/1.8/transforms2sed.sed
+++ b/examples/kubernetes/1.8/transforms2sed.sed
@@ -1,2 +1,2 @@
 s+__DS_API_VERSION__+apps/v1beta2+g
-s+__RBAC_API_VERSION__+rbac.authorization.k8s.io/v1beta2+g
+s+__RBAC_API_VERSION__+rbac.authorization.k8s.io/v1beta1+g


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

For some reason, `rbac.authorization.k8s.io/v1beta2` is not available in k8s `1.8.0` so we have to keep with `v1beta1`.

```release-note
Fix cilium spec files for kubernetes 1.8.0
```

Does **not** need backport, changes are already in https://github.com/cilium/cilium/pull/3613