### PR TITLE
test: Fix K8s demos to not use TTYs with kubectl exec

### DIFF
--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -62,7 +62,7 @@ func CurlWithHTTPCode(endpoint string, optionalValues ...interface{}) string {
 		endpoint = fmt.Sprintf(endpoint, optionalValues...)
 	}
 
-	return fmt.Sprintf(`curl -s --output /dev/stderr -w '%%{http_code}' --connect-timeout %d XGET %s`,
+	return fmt.Sprintf(`curl -s --output /dev/stderr -w '%%{http_code}' --connect-timeout %d %s`,
 		CurlConnectTimeout, endpoint)
 }
 


### PR DESCRIPTION
Signed-off-by: Romain Lenglet <romain@covalent.io>