### PR TITLE
pkg/node: fix nil pointer dereference in non-IPv6 node

### DIFF
--- a/pkg/node/manager.go
+++ b/pkg/node/manager.go
@@ -398,6 +398,10 @@ func updateIPRoute(oldNode, n *Node, ownAddr net.IP) {
 func deleteIPRoute(node *Node) {
 	oldNodeIPv6 := node.GetNodeIP(true)
 
+	if oldNodeIPv6 == nil {
+		return
+	}
+
 	err := routeDel(oldNodeIPv6.String(), node.IPv6AllocCIDR.String(), node.dev)
 	if err != nil {
 		log.WithError(err).WithFields(logrus.Fields{


### PR DESCRIPTION
If a node doesn't have any IPv6 address cilium can panic while trying to
delete the IPv6 routes of that node.

Signed-off-by: André Martins <andre@cilium.io>
Reported-by: Markus Padourek <markus.padourek@gmail.com>

```release-note
pkg/node: fix nil pointer dereference when deleting IPv6 route for non-IPv6 node
```