### PR TITLE
test/k8sT: do not access redis-master via hostname, only service IP

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -550,8 +550,11 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 
 			for pod := range webPods {
 
-				// Access both service IP / host name of redis-master.
-				redisMetadata := map[string]int{serviceIP: port, "redis-master": port}
+				// GH-3462: only access service IP, not host name of redis-master.
+				// Work to revert this change is tracked by GH-3663.
+				//redisMetadata := map[string]int{serviceIP: port, "redis-master": port}
+
+				redisMetadata := map[string]int{serviceIP: port}
 				for k, v := range redisMetadata {
 					command := fmt.Sprintf(`nc %s %d <<EOF
 PING


### PR DESCRIPTION
In K8s 1.7 tests, there are issues accessing redis-master via hostname. Disable accessing redis-master via its hostname until K8s 1.7 is updated in CI to a newer version. See GH-3462 for more information.

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #3462 . We still test connectivity to the service, but to its cluster IP, not its hostname. 