### PR TITLE
3673 do not forcibly trigger policy updates k8s endpoint watcher

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -845,7 +845,7 @@ func (d *Daemon) addK8sEndpointV1(ep *v1.Endpoints) {
 		if err != nil {
 			log.Errorf("Unable to repopulate egress policies from ToService rules: %v", err)
 		} else {
-			d.TriggerPolicyUpdates(true)
+			d.TriggerPolicyUpdates(false)
 		}
 	}
 }

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -37,7 +37,9 @@ import (
 
 // TriggerPolicyUpdates triggers policy updates for every daemon's endpoint.
 // This is called after policy changes, but also after some changes in daemon
-// configuration and endpoint labels.
+// configuration and endpoint labels. If force is set to true, then the global
+// policy revision is incremented, which forces all endpoints to have their
+// BPF programs regenerated.
 // Returns a waiting group which signalizes when all endpoints are regenerated.
 func (d *Daemon) TriggerPolicyUpdates(force bool) *sync.WaitGroup {
 	if force {


### PR DESCRIPTION
* daemon: do not forcibly trigger policy updates in addK8sEndpointV1()
    -  This function is eventually called as part of the OnUpdate function for the Kubernetes informer for the endpoint resource. Since we provide a nonzero resync period to our informer, this means that OnUpdate is called unconditionally at the cadence specified in the resync period, even if no resources have changed. This means that before, all endpoints had their programs regenerated every five minutes when Cilium was used in tandem with Kubernetes. This is a costly operation and could place high load onto systems with large numbers of endpoints. Instead, TriggerPolicyUpdates, but with the `force` argument set to `false` so that endpoints which only need to be regenerated are regenerated.
* daemon: update documentation for TriggerPolicyUpdates
    - Specify that all endpoints have their programs regenerated when force parameter is set to true.

 Signed-off-by: Ian Vernon <ian@cilium.io>

Related-to: #3673

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/3674)
<!-- Reviewable:end -->
