### PR TITLE
Test: Gather core dumps in test if are present.

### DIFF
--- a/contrib/systemd/cilium.service
+++ b/contrib/systemd/cilium.service
@@ -5,6 +5,7 @@ Requires=docker.service cilium-consul.service cilium-docker.service
 
 [Service]
 Type=simple
+LimitCORE=infinity
 EnvironmentFile=-/etc/sysconfig/cilium
 ExecStart=/usr/bin/cilium-agent $CILIUM_OPTS
 Restart=on-failure

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -616,6 +616,7 @@ func (s *SSHMeta) GatherLogs() {
 	ciliumStateCommands := []string{
 		fmt.Sprintf("sudo cp -r %s %s", RunDir, filepath.Join(BasePath, testPath, "lib")),
 		fmt.Sprintf("sudo cp -r %s %s", LibDir, filepath.Join(BasePath, testPath, "run")),
+		fmt.Sprintf("sudo mv /tmp/core* %s", filepath.Join(BasePath, testPath)),
 	}
 
 	for _, cmd := range ciliumStateCommands {


### PR DESCRIPTION
If cilium dies by a core dump the core is not saved on Jenkins artifact.
With this change the core will be created and saved in the test folder
to further analysis.

Fix #3399
Needs to wait until: PR #3354
This unblocks PR #3355

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>