### PR TITLE
Nightly: Fix log gathering for Kubernetes stages

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -61,8 +61,8 @@ pipeline {
             }
             post {
                 always {
-                    sh 'cd ${TEST_DIR}; ./archive_test_results.sh || true'
-                    archiveArtifacts artifacts: "test_results_k8s_${JOB_BASE_NAME}_${BUILD_NUMBER}.zip", allowEmptyArchive: true
+                    sh 'cd ${TESTDIR}; ./archive_test_results.sh "k8s"|| true'
+                    archiveArtifacts artifacts: "k8s_test_results_${JOB_BASE_NAME}_${BUILD_NUMBER}.zip", allowEmptyArchive: true
                     junit 'test/*.xml'
                 }
             }
@@ -85,7 +85,7 @@ pipeline {
             sh "cd ${TESTDIR}; K8S_VERSION=1.7 vagrant destroy -f || true"
             sh "cd ${TESTDIR}; K8S_VERSION=1.9 vagrant destroy -f || true"
             sh "cd ${TESTDIR}; vagrant destroy -f || true"
-            sh 'cd ${TEST_DIR}; ./post_build_agent.sh || true'
+            sh 'cd ${TESTDIR}; ./post_build_agent.sh || true'
             cleanWs()
         }
     }

--- a/test/archive_test_results.sh
+++ b/test/archive_test_results.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
- 
+
 cd ${WORKSPACE}/test
 
 TEST_RESULTS="test_results"
 ARCHIVE_NAME="${TEST_RESULTS}_${JOB_BASE_NAME}_${BUILD_NUMBER}.zip"
+if [ -n "$1" ]
+then
+    ARCHIVE_NAME="${1}_${TEST_RESULTS}_${JOB_BASE_NAME}_${BUILD_NUMBER}.zip"
+    echo $ARCHIVE_NAME
+fi
 
 zip -r ${ARCHIVE_NAME} ${TEST_RESULTS}
 mv ${ARCHIVE_NAME} ../


### PR DESCRIPTION
Fix a typo in the ENV variable that it does not allow Jenkins to
retrieve Kubernetes logs correctly.

Fix #3656

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/3684)
<!-- Reviewable:end -->
