### PR TITLE
Test: Enabled K8sUpdates correctly.

### DIFF
--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -99,8 +99,6 @@ var _ = Describe("K8sValidatedUpdates", func() {
 	}
 
 	It("Updating Cilium stable to master", func() {
-		// GH-3442 Re-enable once stable
-		return
 
 		By("Creating some endpoints and L7 policy")
 		kubectl.Apply(demoPath).ExpectSuccess()


### PR DESCRIPTION
On abc97b91ac7bf088e46e556cca357f1b91f8531d the test was mark to run,
but in the It there was a return that I didn't figure it out, so the
whole test was not running. :-(

Related to: #3624

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

