### PR TITLE
Docs: Add a new `test-docs-please` phrase to test only docs

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -890,19 +890,21 @@ regarding which phrase triggers which build, which build is required for
 a pull-request to be merged, etc. Each linked job contains a description
 illustrating which subset of tests the job runs.
 
-+-------------------------------------------------------------------------------------------------------+-----------------+--------------------+
-| Jenkins Job                                                                                           | Trigger Phrase  | Required To Merge? |
-+=======================================================================================================+=================+====================+
-| `Cilium-Master-Bash-Tests-All <https://jenkins.cilium.io/job/Cilium-PR-Bash-Tests-All/>`_             | test-me-please  | Yes                |
-+-------------------------------------------------------------------------------------+-----------------+-----------------+--------------------+
-| `Cilium-PR-Ginkgo-Tests-Validated <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-Validated/>`_ | test-me-please  | Yes                |
-+-------------------------------------------------------------------------------------+-----------------+-----------------+--------------------+
-| `Cilium-PR-Ginkgo-Tests-All <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-All/>`_             | test-all-ginkgo | No                 |
-+-------------------------------------------------------------------------------------------------------+-----------------+--------------------+
-| `Cilium-Pr-Ginkgo-Test-k8s <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-k8s/>`_              | test-missed-k8s | No                 |
-+-------------------------------------------------------------------------------------------------------+-----------------+--------------------+
-| `Cilium-Nightly-Tests-PR <https://jenkins.cilium.io/job/Cilium-PR-Nightly-Tests-All/>`_               | test-nightly    | No                 |
-+-------------------------------------------------------------------------------------------------------+-----------------+--------------------+
++-------------------------------------------------------------------------------------------------------+------------------+--------------------+
+| Jenkins Job                                                                                           | Trigger Phrase   | Required To Merge? |
++=======================================================================================================+==================+====================+
+| `Cilium-Master-Bash-Tests-All <https://jenkins.cilium.io/job/Cilium-PR-Bash-Tests-All/>`_             | test-me-please   | Yes                |
++-------------------------------------------------------------------------------------+-----------------+------------------+--------------------+
+| `Cilium-PR-Ginkgo-Tests-Validated <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-Validated/>`_ | test-me-please   | Yes                |
++-------------------------------------------------------------------------------------+-----------------+------------------+--------------------+
+| `Cilium-PR-Ginkgo-Tests-All <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-All/>`_             | test-all-ginkgo  | No                 |
++-------------------------------------------------------------------------------------------------------+------------------+--------------------+
+| `Cilium-Pr-Ginkgo-Test-k8s <https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-k8s/>`_              | test-missed-k8s  | No                 |
++-------------------------------------------------------------------------------------------------------+------------------+--------------------+
+| `Cilium-Nightly-Tests-PR <https://jenkins.cilium.io/job/Cilium-PR-Nightly-Tests-All/>`_               | test-nightly     | No                 |
++-------------------------------------------------------------------------------------------------------+------------------+--------------------+
+| `Cilium-PR-Doc-Tests <https://jenkins.cilium.io/view/all/job/Cilium-PR-Doc-Tests/>`_                  | test-docs-please | No                 |
++-------------------------------------------------------------------------------------------------------+------------------+--------------------+
 
 Using Jenkins for testing
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Makefile
+++ b/Makefile
@@ -250,11 +250,16 @@ docs-container:
 	echo ".*" >>.dockerignore # .git pruned out
 	docker image build -t cilium/docs-builder -f Documentation/Dockerfile .
 
+
 render-docs: docs-container
 	-docker container rm -f docs-cilium >/dev/null
 	docker container run -ti -u $$(id -u):$$(id -g $(USER)) -v $$(pwd):/srv/ cilium/docs-builder /bin/bash -c 'make html' && \
 	docker container run -dit --name docs-cilium -p 8080:80 -v $$(pwd)/Documentation/_build/html/:/usr/local/apache2/htdocs/ httpd:2.4
 	@echo "$$(tput setaf 2)Running at http://localhost:8080$$(tput sgr0)"
+
+test-docs: docs-container
+	-docker container rm -f docs-cilium >/dev/null
+	docker container run --rm -v $$(pwd):/srv/ cilium/docs-builder /bin/bash -c 'make html'
 
 manpages:
 	-rm -r man

--- a/docs.Jenkinsfile
+++ b/docs.Jenkinsfile
@@ -1,0 +1,23 @@
+pipeline {
+    agent {
+        label 'baremetal'
+    }
+
+    options {
+        timeout(time: 10, unit: 'MINUTES')
+        timestamps()
+    }
+    stages {
+        stage('Docs') {
+            steps {
+                checkout scm
+                sh "make test-docs"
+            }
+        }
+    }
+    post {
+        always {
+            cleanWs()
+        }
+    }
+}


### PR DESCRIPTION
This PR added a new `test-docs-please` phrase in Jenkins. This tool build the docs and validate that the docs are correct. 

The current fail of this, is because there are some misspelled words. It'll be addressed in other PR. 

Fix https://github.com/cilium/cilium/issues/3653