### PR TITLE
Test: Fix issue with Kubectl describe

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -896,7 +896,7 @@ func (kub *Kubectl) GatherLogs() {
 		"kubectl get services --all-namespaces -o json":              "svc.txt",
 		"kubectl get ds --all-namespaces -o json":                    "ds.txt",
 		"kubectl get cnp --all-namespaces -o json":                   "cnp.txt",
-		"kubectl describe pods --all-namespaces -o json":             "pods_status.txt",
+		"kubectl describe pods --all-namespaces":                     "pods_status.txt",
 		"kubectl get replicationcontroller --all-namespaces -o json": "replicationcontroller.txt",
 		"kubectl get deployment --all-namespaces -o json":            "deployment.txt",
 	}


### PR DESCRIPTION
Kubectl describe does not have `-o json` option available. And the output
in a failed test was not correct.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>