### PR TITLE
Makefile: Fix the name of the builder Dockerfile in envoy.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ docker-image-runtime:
 	cd contrib/packaging/docker && docker build -t "cilium/cilium-runtime:$(UTC_DATE)" -f Dockerfile.runtime .
 
 docker-image-builder:
-	cd envoy && docker build -t "cilium/cilium-builder:$(UTC_DATE)" -f Dockerfile.builder .
+	cd envoy && docker build -t "cilium/cilium-builder:$(UTC_DATE)" .
 
 build-deb:
 	$(MAKE) -C ./contrib/packaging/deb


### PR DESCRIPTION
Commit 952ae20e ("envoy: move Dockerfile.builder to envoy directory")
not only just moved, but also renamed the Dockerfile.builder to just
envoy/Dockerfile. Update the main Makefile to reflect this so that a
local build of a builder image is still possible.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
