### PR TITLE
tunnel: Remove old tunnel map upon upgrade.

### DIFF
--- a/pkg/maps/tunnel/tunnel.go
+++ b/pkg/maps/tunnel/tunnel.go
@@ -16,6 +16,7 @@ package tunnel
 
 import (
 	"net"
+	"os"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -23,6 +24,11 @@ import (
 
 const (
 	MapName = "cilium_tunnel_map"
+
+	// Cilium versions < 1.0 used this tunnel map name, we remove it when
+	// we open the new tunnel map. In a future release, we should remove
+	// this downgrade handling code
+	oldMapName = "tunnel_endpoint_map"
 
 	// MaxEntries is the maximum entries in the tunnel endpoint map
 	MaxEntries = 65536
@@ -50,6 +56,9 @@ var (
 func init() {
 	TunnelMap.NonPersistent = true
 	bpf.OpenAfterMount(TunnelMap)
+
+	// Remove old map and ignore errors; this is the "normal" case.
+	_ = os.Remove(bpf.MapPath(oldMapName))
 }
 
 type tunnelEndpoint struct {


### PR DESCRIPTION
This fixes up #3681 to ensure we don't end up with extraneous map
entries on the filesystem after upgrade.

Signed-off-by: Joe Stringer <joe@covalent.io>