### PR TITLE
daemon: Regenerate endpoint in PATCH handler also when endpoint is in waiting-for-identity state

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -968,7 +968,8 @@ func (e *Endpoint) regenerate(owner Owner, reason string) (retErr error) {
 }
 
 // Regenerate forces the regeneration of endpoint programs & policy
-// Should only be called with e.state == StateWaitingToRegenerate
+// Should only be called with e.state == StateWaitingToRegenerate or with
+// e.state == StateWaitingForIdentity
 func (e *Endpoint) Regenerate(owner Owner, reason string) <-chan bool {
 	newReq := &Request{
 		ID:           uint64(e.ID),


### PR DESCRIPTION
commit 41c08396ce ("daemon: Only regenerate in PATCH from valid
state") intended to limit endpoint regeneration calls from the API
PATCH endpoint handler to valid endpoint states, but inadvertently
limited the allowed states only to waiting-to-regenerate, while the
endpoint should also be built while in the waiting-for-identity state.

The symptom was that endpoints created via docker never built the
initial drop-all bpf program while waiting for identity.

This commit allows endpoint regeneration via the PATCH endpoint API
also when the endpoint is in wairing-for-identity state.

Note that `cilium endpoint regenerate`uses the PATCH API without any
changes and this does not currently trigger regeneration. We should define
a different API for that.

CI testing for this is done by #3625

Fixes: #3705
Fixes: 41c08396ce ("daemon: Only regenerate in PATCH from valid state")
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
