### PR TITLE
policy: Do not wildcard CIDR 0/0 for world entity

### DIFF
--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -312,13 +312,6 @@ func (r *rule) resolveCIDRPolicy(ctx *SearchContext, state *traceState, result *
 		allCIDRs = append(allCIDRs, ingressRule.FromCIDR...)
 		allCIDRs = append(allCIDRs, computeResultantCIDRSet(ingressRule.FromCIDRSet)...)
 
-		for _, fromEntity := range ingressRule.FromEntities {
-			switch fromEntity {
-			case api.EntityWorld:
-				allCIDRs = append(allCIDRs, api.CIDRMatchAll...)
-			}
-		}
-
 		if cnt := mergeCIDR(ctx, "Ingress", allCIDRs, r.Labels, &result.Ingress); cnt > 0 {
 			found += cnt
 		}
@@ -329,13 +322,6 @@ func (r *rule) resolveCIDRPolicy(ctx *SearchContext, state *traceState, result *
 		var allCIDRs []api.CIDR
 		allCIDRs = append(allCIDRs, egressRule.ToCIDR...)
 		allCIDRs = append(allCIDRs, computeResultantCIDRSet(egressRule.ToCIDRSet)...)
-
-		for _, toEntity := range egressRule.ToEntities {
-			switch toEntity {
-			case api.EntityWorld:
-				allCIDRs = append(allCIDRs, api.CIDRMatchAll...)
-			}
-		}
 
 		if cnt := mergeCIDR(ctx, "Egress", allCIDRs, r.Labels, &result.Egress); cnt > 0 {
 			found += cnt


### PR DESCRIPTION
With the introduction of label based egress including the world identity, it is
no longer required to whitelist CIDR 0/0 for the world identity as it is
covered by the identity based policy map which also supports L4.

This allows to define rules such as:
```
[{
    "endpointSelector": {"matchLabels": {}},
    "egress": [{
        "toEntities": ["world"],
        "toPorts": [
            {"ports":[
		    {"port": "80", "protocol": "TCP"},
		    {"port": "53", "protocol": "UDP"}
	    ]}
        ]
    }]
}]
```

Signed-off-by: Thomas Graf <thomas@cilium.io>
