### PR TITLE
Test: Validate DNS before trying to connect on curl

### DIFF
--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -32,6 +32,7 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 	var once sync.Once
 	var demoDSPath string
 	var ciliumPath string
+	var testDSService string = "testds-service.default.svc.cluster.local"
 
 	initialize := func() {
 		logger = log.WithFields(logrus.Fields{"testName": "K8sChaosTest"})
@@ -95,8 +96,11 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 				ExpectWithOffset(1, res.WasSuccessful()).To(BeTrue(),
 					"Cannot ping from %q to %q", pod, ip)
 
+				err = kubectl.WaitForKubeDNSEntry(testDSService)
+				ExpectWithOffset(1, err).To(BeNil(), "DNS entry is not ready after timeout")
+
 				res = kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, pod, helpers.CurlFail("http://testds-service:80/"))
+					helpers.DefaultNamespace, pod, helpers.CurlFail("http://%s:80/", testDSService))
 				ExpectWithOffset(1, res.WasSuccessful()).To(BeTrue(),
 					"Cannot curl from %q to testds-service", pod)
 			}

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -630,13 +630,13 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 
 			serviceIP, port, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, "redis-master")
 
+			serviceName := "redis-master.default.svc.cluster.local"
+			err = kubectl.WaitForKubeDNSEntry(serviceName)
+			Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
+
 			for pod := range webPods {
 
-				// GH-3462: only access service IP, not host name of redis-master.
-				// Work to revert this change is tracked by GH-3663.
-				//redisMetadata := map[string]int{serviceIP: port, "redis-master": port}
-
-				redisMetadata := map[string]int{serviceIP: port}
+				redisMetadata := map[string]int{serviceIP: port, serviceName: port}
 				for k, v := range redisMetadata {
 					command := fmt.Sprintf(`nc %s %d <<EOF
 PING

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -304,10 +304,10 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 		v1 := "v1"
 		v2 := "v2"
 
-		productPage := "productpage.default.svc.cluster.local"
-		reviews := "reviews.default.svc.cluster.local"
-		ratings := "ratings.default.svc.cluster.local"
-		details := "details.default.svc.cluster.local"
+		productPage := "productpage"
+		reviews := "reviews"
+		ratings := "ratings"
+		details := "details"
 		dnsChecks := []string{productPage, reviews, ratings, details}
 		app := "app"
 		resourceYamls := []string{"bookinfo-v1.yaml", "bookinfo-v2.yaml"}
@@ -349,11 +349,13 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 
 		// formatAPI is a helper function which formats a URI to access.
 		formatAPI := func(service, port, resource string) string {
+			target := fmt.Sprintf(
+				"%s.%s.svc.cluster.local:%s",
+				service, helpers.DefaultNamespace, port)
 			if resource != "" {
-				return fmt.Sprintf("%s:%s/%s", service, port, resource)
+				return fmt.Sprintf("%s/%s", target, resource)
 			}
-
-			return fmt.Sprintf("%s:%s", service, port)
+			return target
 		}
 
 		By(fmt.Sprintf("Getting Cilium Pod on node %s", helpers.K8s1))
@@ -422,7 +424,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 
 		By("Validating DNS")
 		for _, name := range dnsChecks {
-			err = kubectl.WaitForKubeDNSEntry(name)
+			err = kubectl.WaitForKubeDNSEntry(fmt.Sprintf("%s.%s", name, helpers.DefaultNamespace))
 			Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
 		}
 
@@ -463,7 +465,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 
 		By("Validating DNS")
 		for _, name := range dnsChecks {
-			err = kubectl.WaitForKubeDNSEntry(name)
+			err = kubectl.WaitForKubeDNSEntry(fmt.Sprintf("%s.%s", name, helpers.DefaultNamespace))
 			Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
 		}
 

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -101,6 +101,7 @@ var _ = Describe(demoTestName, func() {
 		allianceLabel := "org=alliance"
 		empireLabel := "org=empire"
 		deathstarServiceName := "deathstar.default.svc.cluster.local"
+
 		exhaustPortPath := filepath.Join(deathstarServiceName, "/v1/exhaust-port")
 
 		By(fmt.Sprintf("Getting Cilium Pod on node %s", helpers.K8s2))
@@ -111,7 +112,6 @@ var _ = Describe(demoTestName, func() {
 		// don't have to customize the YAML for this test.
 		By(fmt.Sprintf("Tainting %s so that all pods run on %s", helpers.K8s1, helpers.K8s2))
 		res := kubectl.Exec(fmt.Sprintf("kubectl taint nodes %s demo=false:NoSchedule", helpers.K8s1))
-
 		defer func() {
 			By(fmt.Sprintf("Removing taint from %s after test finished", helpers.K8s1))
 			res := kubectl.Exec(fmt.Sprintf("kubectl taint nodes %s demo:NoSchedule-", helpers.K8s1))
@@ -151,6 +151,10 @@ var _ = Describe(demoTestName, func() {
 		xwingPod := xwingPods[0]
 
 		By("Showing how alliance can execute REST API call to main API endpoint")
+
+		err = kubectl.WaitForKubeDNSEntry(deathstarServiceName)
+		Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
+
 		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, xwingPod,
 			helpers.CurlWithHTTPCode("http://%s/v1", deathstarServiceName))
 		res.ExpectContains("200", "unable to curl %s/v1: %s", deathstarServiceName, res.CombineOutput())


### PR DESCRIPTION
This commit intruduced a new Kubectl method that make sure that the DNS
exits before pods try to connect to other pod using DNS.

On the other hand, changed all services names to use the full FQDN, some
containers didn't use the search directive commands [0] and the name
resolution didn't work as expected:

Example trace:
```
U +0.477121 10.10.0.77:47324 -> 10.10.0.18:53
~''''''''''''deathstar'default'''''
U +0.000141 10.10.0.18:19419 -> 8.8.8.8:53
'''''''''''''deathstar'default'''''
U +0.000320 10.10.0.18:19419 -> 8.8.4.4:53
'''''''''''''deathstar'default'''''
U +0.000318 10.10.0.77:47324 -> 10.10.0.18:53
'''''''''''''deathstar'default'''''
U +0.000070 10.10.0.18:40244 -> 8.8.8.8:53
'''''''''''''deathstar'default'''''
U +0.064932 8.8.4.4:53 -> 10.10.0.18:19419
'''''''''''''deathstar'default''''''''''''Q{'@'a'root-servers'net''nstld'verisign-grs'com'xH'''''''''''':'''Q'
```

[0] https://github.com/gliderlabs/docker-alpine/blob/master/docs/caveats.commands#dns

Fix #3712
Fix #3710 
Fix #3675
Fix #3462
Fix #3676
Fix #3694
Fix #3695
Fix #3692

