### PR TITLE
envoy: Remove assert, reduce logging.

### DIFF
--- a/envoy/cilium_bpf_metadata.h
+++ b/envoy/cilium_bpf_metadata.h
@@ -27,7 +27,7 @@ public:
   virtual bool getMetadata(Network::ConnectionSocket &socket);
 
   bool is_ingress_;
-  Cilium::ProxyMapSharedPtr maps_;
+  Cilium::ProxyMapSharedPtr maps_{};
   std::shared_ptr<const Cilium::PolicyHostMap> hosts_;
 };
 

--- a/envoy/cilium_network_filter.cc
+++ b/envoy/cilium_network_filter.cc
@@ -62,7 +62,6 @@ Network::FilterStatus Instance::onNewConnection() {
       if (option) {
 	if (option->maps_) {
 	  // Insert connection callback to delete the proxymap entry once the connection is closed.
-	  ASSERT(!maps_);
 	  maps_ = option->maps_;
 	  proxy_port_ = option->proxy_port_;
 	  if (proxy_port_ != 0) {
@@ -71,7 +70,7 @@ Network::FilterStatus Instance::onNewConnection() {
 	  }
 	  break;
 	} else {
-	  ENVOY_CONN_LOG(warn, "Cilium Network: No proxymap", conn);
+	  ENVOY_CONN_LOG(debug, "Cilium Network: No proxymap", conn);
 	}
       }
     }
@@ -89,9 +88,11 @@ void Instance::onEvent(Network::ConnectionEvent event) {
   if (event == Network::ConnectionEvent::RemoteClose ||
       event == Network::ConnectionEvent::LocalClose) {
     auto& conn = callbacks_->connection();
-    bool ok = maps_->removeBpfMetadata(conn, proxy_port_);
-    ENVOY_CONN_LOG(warn, "Cilium Network: Connection Closed, proxymap cleanup {}", conn,
-	           ok ? "succeeded" : "failed");
+    if (maps_) {
+      bool ok = maps_->removeBpfMetadata(conn, proxy_port_);
+      ENVOY_CONN_LOG(debug, "Cilium Network: Connection Closed, proxymap cleanup {}", conn,
+		     ok ? "succeeded" : "failed");
+    }
   }
 }
 


### PR DESCRIPTION
Remove an assert that would have failed if onNewConnection() is called twice. Deal with (logically impossible) null pointer & make logging less chatty by bumping log level to debug.

Given that we have seen so far undiagnozed segfaults in Envoy it would be best to backport this.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
