### PR TITLE
test: fix star wars demo

### DIFF
--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -131,9 +131,6 @@ var _ = Describe(demoTestName, func() {
 		res = kubectl.Apply(l4PolicyYAMLLink)
 		res.ExpectSuccess("unable to apply %s: %s", l4PolicyYAMLLink, res.CombineOutput())
 
-		arePodsReady := kubectl.CiliumEndpointWait(ciliumPod2)
-		Expect(arePodsReady).To(BeTrue(), "pods running on k8s2 are not ready")
-
 		By("Applying alliance deployment")
 		res = kubectl.Apply(xwingYAMLLink)
 		res.ExpectSuccess("unable to apply %s: %s", xwingYAMLLink, res.CombineOutput())
@@ -149,6 +146,10 @@ var _ = Describe(demoTestName, func() {
 
 		// Test only needs to access one of the pods.
 		xwingPod := xwingPods[0]
+
+		By("Making sure all endpoints are in ready state")
+		arePodsReady := kubectl.CiliumEndpointWait(ciliumPod2)
+		Expect(arePodsReady).To(BeTrue(), "pods running on k8s2 are not ready")
 
 		By("Showing how alliance can execute REST API call to main API endpoint")
 


### PR DESCRIPTION
Once a new endpoint is created, it can trigger regeneration for all the
remaining endpoints. By not checking if all of them were in ready state
before testing the connection all the traffic could potentially be
dropped until the security labels are assigned to that particular endpoint.

For this reason we should wait for all endpoints to be in ready state
before testing out any connection tests.

As an example for endpoint 36125 the monitor would show the following:
```
<- endpoint 36125 flow 0xfd750d60 identity 0->0 state new ifindex 0: 9a:1a:e4:12:33:29 -> ff:ff:ff:ff:ff:ff ARP
-> lxc8d11b: ca:f4:2e:75:46:11 -> 9a:1a:e4:12:33:29 ARP
<- endpoint 36125 flow 0xae0d91ac identity 0->0 state new ifindex 0: 10.1.139.2:45668 -> 172.20.0.10:53 udp
xx drop (Policy denied (L3)) flow 0xae0d91ac to endpoint 0, identity 0->0: 10.1.139.2:45668 -> 172.20.0.10:53 udp
<- endpoint 36125 flow 0xae0d91ac identity 0->0 state new ifindex 0: 10.1.139.2:45668 -> 172.20.0.10:53 udp
xx drop (Policy denied (L3)) flow 0xae0d91ac to endpoint 0, identity 0->0: 10.1.139.2:45668 -> 172.20.0.10:53 udp
<- endpoint 36125 flow 0xae0d91ac identity 0->0 state new ifindex 0: 10.1.139.2:45668 -> 172.20.0.10:53 udp
xx drop (Policy denied (L3)) flow 0xae0d91ac to endpoint 0, identity 0->0: 10.1.139.2:45668 -> 172.20.0.10:53 udp
<- endpoint 36125 flow 0xae0d91ac identity 0->0 state new ifindex 0: 10.1.139.2:45668 -> 172.20.0.10:53 udp
xx drop (Policy denied (L3)) flow 0xae0d91ac to endpoint 0, identity 0->0: 10.1.139.2:45668 -> 172.20.0.10:53 udp
>> Endpoint regenerated: 36125 (k8s:class=spaceship,k8s:org=alliance,k8s:io.kubernetes.pod.namespace=default)
<- endpoint 56687 flow 0xb1f87f1 identity 21577->0 state new ifindex 0: fe80::c41d:a6ff:fef1:7998 -> ff02::2 RouterSolicitation
```
Signed-off-by: André Martins <andre@cilium.io>