### PR TITLE
RFC: k8s: CEP does not nest under .Status

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -304,7 +304,7 @@ func RunK8sCiliumEndpointSyncGC() {
 					if _, found := clusterPodSet[cepFullName]; !found {
 						// delete
 						scopedLog = scopedLog.WithFields(logrus.Fields{
-							logfields.EndpointID: cep.Status.ID,
+							logfields.EndpointID: cep.ID,
 							logfields.K8sPodName: cepFullName,
 						})
 						scopedLog.Info("Orphaned CiliumEndpoint is being garbage collected")
@@ -620,7 +620,7 @@ func (e *Endpoint) RunK8sCiliumEndpointSync() {
 					scopedLog.Debug("Skipping CiliumEndpoint update because it has not changed")
 					return nil
 				}
-				k8sMdl := (*cilium_v2.CiliumEndpointDetail)(mdl)
+				k8sMdl := (*cilium_v2.CiliumEndpointStatus)(mdl.Status)
 
 				cep, err := ciliumClient.CiliumEndpoints(namespace).Get(podName, meta_v1.GetOptions{})
 				switch {
@@ -671,6 +671,7 @@ func (e *Endpoint) RunK8sCiliumEndpointSync() {
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name: podName,
 					},
+					ID:     mdl.ID,
 					Status: *k8sMdl,
 				}
 

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -188,29 +188,30 @@ type CiliumEndpoint struct {
 	// +k8s:openapi-gen=false
 	metav1.ObjectMeta `json:"metadata"`
 
-	Status CiliumEndpointDetail `json:"status"`
+	ID     int64                `json:"id,omitempty"`
+	Status CiliumEndpointStatus `json:"status"`
 }
 
-// CiliumEndpointDetail is the status of a Cilium policy rule
-// The custom deepcopy function below is a workaround. We can generate a
-// deepcopy for CiliumEndpointDetail but not for the various models.* types it
-// includes. We can't generate functions for classes in other packages, nor can
-// we change the models.Endpoint type to use proxy types we define here.
+// CiliumEndpointStatus is the status of a Cilium policy rule The custom
+// deepcopy function below is a workaround. We can generate a deepcopy for
+// CiliumEndpointStatus but not for the various models.* types it includes. We
+// can't generate functions for classes in other packages, nor can we change
+// the models.EndpointStatus type to use proxy types we define here.
 // +k8s:deepcopy-gen=false
-type CiliumEndpointDetail models.Endpoint
+type CiliumEndpointStatus models.EndpointStatus
 
 // DeepCopyInto is an inefficient hack to allow reusing models.Endpoint in the
 // CiliumEndpoint CRD.
-func (in *CiliumEndpointDetail) DeepCopyInto(out *CiliumEndpointDetail) {
+func (in *CiliumEndpointStatus) DeepCopyInto(out *CiliumEndpointStatus) {
 	*out = *in
-	b, err := (*models.Endpoint)(in).MarshalBinary()
+	b, err := (*models.EndpointStatus)(in).MarshalBinary()
 	if err != nil {
-		log.WithError(err).Error("Cannot marshal models.Endpoint during CiliumEndpoitnDetail deepcopy")
+		log.WithError(err).Error("Cannot marshal models.Endpoint during CiliumEndpointStatus deepcopy")
 		return
 	}
-	err = (*models.Endpoint)(out).UnmarshalBinary(b)
+	err = (*models.EndpointStatus)(out).UnmarshalBinary(b)
 	if err != nil {
-		log.WithError(err).Error("Cannot unmarshal models.Endpoint during CiliumEndpoitnDetail deepcopy")
+		log.WithError(err).Error("Cannot unmarshal models.Endpoint during CiliumEndpointStatus deepcopy")
 		return
 	}
 }


### PR DESCRIPTION
_Please don't merge this since it breaks some things_
This implements https://github.com/cilium/cilium/issues/3659.

When we refactored the API for 1.0 the CEP continued to include the
top-level models.Endpoint type under .Status. This should have become a
models.EndpointStatus. This change corrects this and adds the ID field
to the top level CEP to mimic models.Endpoint.

Fixes: https://github.com/cilium/cilium/issues/3659