### PR TITLE
docs: Correct backport label in docs from stable/needs-backporting to stable/needs-backport

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -1225,11 +1225,11 @@ Steps to release
 Backporting process
 ~~~~~~~~~~~~~~~~~~~
 
-Cilium PRs that are marked with label ``stable/needs-backporting`` need to be backported to the stable branch(es), listed below. Following steps summarize the process.
+Cilium PRs that are marked with label ``stable/needs-backport`` need to be backported to the stable branch(es), listed below. Following steps summarize the process.
 
 1. Make sure the Github labels are up-to-date, as this process will
    deal with all commits from PRs that have the
-   ``stable/needs-backporting`` set.
+   ``stable/needs-backport`` set.
 2. The scripts referred to below need to be run in Linux, they do not
    work on OSX.  You can use the cilium dev VM for this, but you need
    to configure git to have your name and email address to be used in

--- a/contrib/backporting/README.md
+++ b/contrib/backporting/README.md
@@ -6,7 +6,7 @@ Cilium Backporting Scripts
 `GITHUB_TOKEN=xxx check-stable`
 
 The `check-stable` script is derived from `relnotes` and scans for PRs which
-have been merged and marked with the label `stable/needs-backporting`. The
+have been merged and marked with the label `stable/needs-backport`. The
 script will list those PRs and all non-merge commit ids that were part of the
 merge. There are three columns: first one is the correlated sha of the commit
 from the master branch, second one is the sha of the commit from the pull


### PR DESCRIPTION
Correct backport label in docs from `stable/needs-backporting` to the correct label `stable/needs-backport`

Fixes: #3738
Signed-Off-By: Manali Bhutiyani <manali@covalent.io>