### PR TITLE
CI: Add colors to builds.

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -11,6 +11,7 @@ pipeline {
     options {
         timeout(time: 500, unit: 'MINUTES')
         timestamps()
+        ansiColor('xterm')
     }
 
     stages {
@@ -32,7 +33,7 @@ pipeline {
             steps {
                 parallel(
                     "Nightly":{
-                        sh 'cd ${TESTDIR}; ginkgo --focus="Nightly*" -v -noColor --timeout 390m'
+                        sh 'cd ${TESTDIR}; ginkgo --focus="Nightly*" -v --timeout 390m'
                     },
                 )
             }
@@ -51,10 +52,10 @@ pipeline {
             steps {
                 parallel(
                     "K8s-1.7":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.7 ginkgo --focus=" K8s*" -v -noColor'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.7 ginkgo --focus=" K8s*" -v'
                     },
                    "K8s-1.8":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.8 ginkgo --focus=" K8s*" -v -noColor'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.8 ginkgo --focus=" K8s*" -v'
                     }
                 )
             }

--- a/docs.Jenkinsfile
+++ b/docs.Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
     options {
         timeout(time: 10, unit: 'MINUTES')
         timestamps()
+        ansiColor('xterm')
     }
     stages {
         stage('Docs') {

--- a/ginkgo-all.Jenkinsfile
+++ b/ginkgo-all.Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
     options {
         timeout(time: 120, unit: 'MINUTES')
         timestamps()
+        ansiColor('xterm')
     }
     stages {
         stage('Checkout') {
@@ -54,13 +55,13 @@ pipeline {
             steps {
                 parallel(
                     "Runtime":{
-                        sh 'cd ${TESTDIR}; ginkgo --focus="Runtime*" -v -noColor'
+                        sh 'cd ${TESTDIR}; ginkgo --focus="Runtime*" -v'
                     },
                     "K8s-1.7":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.7 ginkgo --focus=" K8s*" -noColor'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.7 ginkgo --focus=" K8s*"'
                     },
                     "K8s-1.10":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --focus=" K8s*" -noColor'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --focus=" K8s*"'
                     },
                     failFast: true
                 )

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -21,6 +21,7 @@ pipeline {
     options {
         timeout(time: 140, unit: 'MINUTES')
         timestamps()
+        ansiColor('xterm')
     }
     stages {
         stage('Checkout') {
@@ -47,10 +48,10 @@ pipeline {
             steps {
                 parallel(
                     "K8s-1.8":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.8 ginkgo --focus=" K8s*" -v -noColor ${FAILFAST}'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.8 ginkgo --focus=" K8s*" -v ${FAILFAST}'
                     },
                     "K8s-1.9":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.9 ginkgo --focus=" K8s*" -v -noColor ${FAILFAST}'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.9 ginkgo --focus=" K8s*" -v ${FAILFAST}'
                     },
                 )
             }
@@ -82,7 +83,7 @@ pipeline {
             steps {
                 parallel(
                     "K8s-1.11":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.11 ginkgo --focus=" K8s*" -v -noColor ${FAILFAST}'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.11 ginkgo --focus=" K8s*" -v ${FAILFAST}'
                     },
                 )
             }

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -19,6 +19,7 @@ pipeline {
     options {
         timeout(time: 120, unit: 'MINUTES')
         timestamps()
+        ansiColor('xterm')
     }
     stages {
         stage('Checkout') {
@@ -64,13 +65,13 @@ pipeline {
             steps {
                 parallel(
                     "Runtime":{
-                        sh 'cd ${TESTDIR}; ginkgo --focus=" RuntimeValidated*" -v -noColor ${FAILFAST}'
+                        sh 'cd ${TESTDIR}; ginkgo --focus=" RuntimeValidated*" -v ${FAILFAST}'
                     },
                     "K8s-1.7":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.7 ginkgo --focus=" K8sValidated*" -v -noColor ${FAILFAST}'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.7 ginkgo --focus=" K8sValidated*" -v ${FAILFAST}'
                     },
                     "K8s-1.10":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --focus=" K8sValidated*" -v -noColor ${FAILFAST}'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --focus=" K8sValidated*" -v ${FAILFAST}'
                     },
                     failFast: true
                 )


### PR DESCRIPTION
Using AnsiColors plugin in the builds to use the Ginkgo colors in the CI
logs. This helps to review where a test start and when a test finish.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

