### PR TITLE
Revert retry logic in connectivity.go

### DIFF
--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -376,13 +376,25 @@ var _ = Describe("RuntimeValidatedConntrackTest", func() {
 			},
 			{
 				from:        curl1ContainerName,
-				to:          helpers.CurlFail("http://%s:80", httpd2DockerNetworking[helpers.IPv6]),
+				to:          helpers.CurlFail("http://[%s]:80", httpd2DockerNetworking[helpers.IPv6]),
 				destination: helpers.Httpd2,
 				assert:      BeFalse,
 			},
 			{
 				from:        curl1ContainerName,
-				to:          helpers.CurlFail("http://[%s]:80", httpd2DockerNetworking[helpers.IPv6]),
+				to:          helpers.CurlFail("http://%s:80", httpd2DockerNetworking[helpers.IPv4]),
+				destination: helpers.Httpd2,
+				assert:      BeFalse,
+			},
+			{
+				from:        curl2ContainerName,
+				to:          helpers.CurlFail("http://[%s]:80", httpdDockerNetworking[helpers.IPv6]),
+				destination: helpers.Httpd2,
+				assert:      BeFalse,
+			},
+			{
+				from:        curl2ContainerName,
+				to:          helpers.CurlFail("http://%s:80", httpdDockerNetworking[helpers.IPv4]),
 				destination: helpers.Httpd2,
 				assert:      BeFalse,
 			},
@@ -534,13 +546,25 @@ var _ = Describe("RuntimeValidatedConntrackTest", func() {
 			},
 			{
 				from:        curl1ContainerName,
-				to:          helpers.CurlFail("http://%s:80", httpd2DockerNetworking[helpers.IPv6]),
+				to:          helpers.CurlFail("http://[%s]:80", httpd2DockerNetworking[helpers.IPv6]),
 				destination: helpers.Httpd2,
 				assert:      BeFalse,
 			},
 			{
 				from:        curl1ContainerName,
+				to:          helpers.CurlFail("http://%s:80", httpd2DockerNetworking[helpers.IPv4]),
+				destination: helpers.Httpd2,
+				assert:      BeFalse,
+			},
+			{
+				from:        curl2ContainerName,
 				to:          helpers.CurlFail("http://[%s]:80", httpd2DockerNetworking[helpers.IPv6]),
+				destination: helpers.Httpd2,
+				assert:      BeFalse,
+			},
+			{
+				from:        curl2ContainerName,
+				to:          helpers.CurlFail("http://%s:80", httpd2DockerNetworking[helpers.IPv4]),
 				destination: helpers.Httpd2,
 				assert:      BeFalse,
 			},
@@ -672,7 +696,7 @@ var _ = Describe("RuntimeValidatedConntrackTest", func() {
 			err := vm.SetAndWaitForEndpointConfiguration(endpointToConfigure, helpers.OptionConntrackLocal, helpers.OptionDisabled)
 			Expect(err).To(BeNil(), "Cannot disable ConntrackLocal for the endpoint %q", endpointToConfigure)
 			err = vm.SetAndWaitForEndpointConfiguration(endpointToConfigure, helpers.OptionConntrack, helpers.OptionDisabled)
-			Expect(err).To(BeNil(), "Cannot disable ConnTrackLocal for the endpoint %q", endpointToConfigure)
+			Expect(err).To(BeNil(), "Cannot disable ConnTrack for the endpoint %q", endpointToConfigure)
 		}
 
 		// Need to add policy that allows communication in both directions.

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -292,7 +292,6 @@ var _ = Describe("RuntimeValidatedConntrackTest", func() {
 
 	var curl1ContainerName = "curl"
 	var curl2ContainerName = "curl2"
-	var maxTestTrials = 3
 	var CTPolicyConntrackLocalDisabled = "ct-test-policy-conntrack-local-disabled.json"
 
 	type conntestCases struct {
@@ -449,21 +448,11 @@ var _ = Describe("RuntimeValidatedConntrackTest", func() {
 			},
 		}
 
-		// This retry logic of maxTestTrials per test case is temporary till
-		// GH #3393 issue to support egress CT cleanup is in place.
 		for _, test := range testCases {
 			By(fmt.Sprintf("Container %q test connectivity to %q", test.from, test.destination))
-			for testTryCount := 0; testTryCount <= maxTestTrials; testTryCount++ {
-				res = vm.ContainerExec(test.from, test.to)
-				if res.WasSuccessful() == false {
-					if testTryCount == maxTestTrials {
-						ExpectWithOffset(1, res.WasSuccessful()).To(test.assert(),
-							"The result of %q from container %q to %s does not match", test.to, test.from, test.destination)
-					}
-				} else {
-					break // break from inner loop and try next test-case.
-				}
-			}
+			res = vm.ContainerExec(test.from, test.to)
+			ExpectWithOffset(1, res.WasSuccessful()).To(test.assert(),
+				"The result of %q from container %q to %s does not match", test.to, test.from, test.destination)
 		}
 
 		By("Testing bidirectional connectivity from client to server")


### PR DESCRIPTION
Since PR https://github.com/cilium/cilium/pull/3605 was merge, it can remove this hack altogether

Also fixed some wrongly IPv6 address assigned to some of the connectivity tests.