### PR TITLE
Add reserved IPs to ipcache in XDS

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -1075,7 +1076,8 @@ func NewDaemon(c *Config) (*Daemon, error) {
 	// Start watcher for endpoint IP --> identity mappings in key-value store.
 	// this needs to be done *after* init() for the daemon in that function,
 	// we populate the IPCache with the host's IP(s).
-	ipcache.InitIPIdentityWatcher(&d)
+	ipcacheListeners := []ipcache.IPIdentityMappingListener{&d, &envoy.NetworkPolicyHostsCache}
+	ipcache.InitIPIdentityWatcher(ipcacheListeners)
 
 	// FIXME: Make the port range configurable.
 	d.l7Proxy = proxy.StartProxySupport(10000, 20000, d.conf.RunDir,

--- a/pkg/envoy/xds/cache.go
+++ b/pkg/envoy/xds/cache.go
@@ -254,3 +254,14 @@ func (c *Cache) GetResources(ctx context.Context, typeURL string, lastVersion *u
 	cacheLog.Debugf("returning %d resources out of %d requested", len(res.Resources), len(resourceNames))
 	return res, nil
 }
+
+// Lookup finds the resource corresponding to the specified typeURL and resourceName,
+// if available, and returns it. Otherwise, returns nil. If an error occurs while
+// fetching the resource, also returns the error.
+func (c *Cache) Lookup(typeURL string, resourceName string) (proto.Message, error) {
+	res, err := c.GetResources(context.Background(), typeURL, nil, nil, []string{resourceName})
+	if err != nil || res == nil || len(res.Resources) == 0 {
+		return nil, err
+	}
+	return res.Resources[0], nil
+}


### PR DESCRIPTION
These IPs were not being properly propagated to XDS, because they sidestep the kvstore sync logic. Fix this in a fairly minimal way (Create a function from the existing code that can be called, then call it).

Fixes: #3087 
Fixes: 7448e41 ("endpoint: sync endpoint IP-SecID map to kvstore")