### PR TITLE
debuginfo: run `cilium endpoint health` for each endpoint

### DIFF
--- a/cilium/cmd/debuginfo.go
+++ b/cilium/cmd/debuginfo.go
@@ -84,6 +84,7 @@ func runDebugInfo(cmd *cobra.Command, args []string) {
 		printList(w, "BPF Policy Get "+epID, "bpf", "policy", "get", epID)
 		printList(w, "BPF CT List "+epID, "bpf", "ct", "list", epID)
 		printList(w, "Endpoint Get "+epID, "endpoint", "get", epID)
+		printList(w, "Endpoint Health "+epID, "endpoint", "health", epID)
 		printList(w, "Endpoint Log "+epID, "endpoint", "log", epID)
 
 		if ep.Status != nil && ep.Status.Identity != nil {

--- a/cilium/cmd/debuginfo.go
+++ b/cilium/cmd/debuginfo.go
@@ -81,11 +81,8 @@ func runDebugInfo(cmd *cobra.Command, args []string) {
 
 	for _, ep := range p.EndpointList {
 		epID := strconv.FormatInt(ep.ID, 10)
-		printList(w, "BPF Endpoint List "+epID, "bpf", "endpoint", "list", epID)
 		printList(w, "BPF Policy Get "+epID, "bpf", "policy", "get", epID)
 		printList(w, "BPF CT List "+epID, "bpf", "ct", "list", epID)
-		printList(w, "BPF LB List "+epID, "bpf", "lb", "list", epID)
-		printList(w, "BPF Tunnel List "+epID, "bpf", "tunnel", "list", epID)
 		printList(w, "Endpoint Get "+epID, "endpoint", "get", epID)
 		printList(w, "Endpoint Log "+epID, "endpoint", "log", epID)
 


### PR DESCRIPTION
Also removes unneeded per-endpoint calls to some bpf CLI commands.  Calls to `cilium bpf endpoint list`, `cilium bpf lb list`, and `cilium bpf tunnel list` are unnecessary to do per-endpoint, as they unconditionally dump the contents of their corresponding maps regardless of if the endpoint ID is provided as an argument or not. In other words, running the command for each endpoint will result in the same output. Furthermore, these commands are already part of `cilium-bugtool`, so just remove them from `cilium debuginfo`.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #3757 