### PR TITLE
Quieten spellcheck output with `make V=0`

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -49,7 +49,7 @@ cmdref:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile check-requirements
 	@$(ECHO_GEN)_build/$@
-	$(SPHINXBUILD) -b spelling -d "$(BUILDDIR)/doctrees" "$(SOURCEDIR)" "$(BUILDDIR)/spelling"
+	$(SPHINXBUILD) -b spelling -d "$(BUILDDIR)/doctrees" "$(SOURCEDIR)" "$(BUILDDIR)/spelling" $(SPHINXOPTS)
 	@if [ "$$(wc -l < "$(BUILDDIR)/spelling/output.txt")" -ne "0" ]; then \
 		echo "ERROR: Found misspelled words in the documentation! If you believe the"; \
 		echo "words are not misspelled, please add them to ./Documentation/spelling_wordlist.txt"; \

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -43,16 +43,20 @@ cmdref:
 	@$(ECHO_GEN)cmdref/cilium-health
 	$(QUIET) ${HEALTHDIR}/cilium-health --cmdref $(CMDREFDIR)
 
+spellcheck: check-requirements
+	@$(ECHO_CHECK) documentation spelling...
+	$(SPHINXBUILD) -b spelling -d "$(BUILDDIR)/doctrees" "$(SOURCEDIR)" "$(BUILDDIR)/spelling" $(SPHINXOPTS)
+	@if [ "$$(wc -l < "$(BUILDDIR)/spelling/output.txt")" -ne "0" ]; then \
+		echo " See Documentation/$(BUILDDIR)/spelling/output.txt for misspelled words."; \
+		echo " Please fix the spelling, or if they are not misspelled,"; \
+		echo " add them to Documentation/spelling_wordlist.txt"; \
+		exit 1; \
+	fi
+
 .PHONY: help Makefile ../Makefile.quiet check-requirements cmdref
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile check-requirements
+%: Makefile check-requirements spellcheck
 	@$(ECHO_GEN)_build/$@
-	$(SPHINXBUILD) -b spelling -d "$(BUILDDIR)/doctrees" "$(SOURCEDIR)" "$(BUILDDIR)/spelling" $(SPHINXOPTS)
-	@if [ "$$(wc -l < "$(BUILDDIR)/spelling/output.txt")" -ne "0" ]; then \
-		echo "ERROR: Found misspelled words in the documentation! If you believe the"; \
-		echo "words are not misspelled, please add them to ./Documentation/spelling_wordlist.txt"; \
-		exit 1; \
-	fi
 	$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -13,6 +13,7 @@ CILIUMDIR     = ../cilium
 AGENTDIR      = ../daemon
 BUGTOOLDIR    = ../bugtool
 HEALTHDIR     = ../cilium-health
+SPELLING_LIST = spelling_wordlist.txt
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -47,9 +48,9 @@ spellcheck: check-requirements
 	@$(ECHO_CHECK) documentation spelling...
 	$(SPHINXBUILD) -b spelling -d "$(BUILDDIR)/doctrees" "$(SOURCEDIR)" "$(BUILDDIR)/spelling" $(SPHINXOPTS)
 	@if [ "$$(wc -l < "$(BUILDDIR)/spelling/output.txt")" -ne "0" ]; then \
-		echo " See Documentation/$(BUILDDIR)/spelling/output.txt for misspelled words."; \
-		echo " Please fix the spelling, or if they are not misspelled,"; \
-		echo " add them to Documentation/spelling_wordlist.txt"; \
+		echo "Please fix the following spelling mistakes:"; \
+		sed 's/^/* Documentation\//' $(BUILDDIR)/spelling/output.txt; \
+		echo "If the words are not misspelled, add them to Documentation/$(SPELLING_LIST)."; \
 		exit 1; \
 	fi
 


### PR DESCRIPTION
Example output:

```
   $ make -C Documentation spellcheck V=0 --quiet SPHINXOPTS="-q"
     CHECK documentation dependencies...
     CHECK documentation spelling...
   WARNING: Found 1 misspelled words
   WARNING: Not copying tabs assets! Not compatible with spelling builder
   Please fix the following spelling mistakes:
   * Documentation/concepts.rst:7: (deplyment)
   If the words are not misspelled, add them to Documentation/spelling_wordlist.txt
   Makefile:48: recipe for target 'spellcheck' failed
   make: *** [spellcheck] Error 1
```