### PR TITLE
examples/minikube: Allow container to mount bpffs itself

### DIFF
--- a/examples/minikube/cilium-ds.yaml
+++ b/examples/minikube/cilium-ds.yaml
@@ -162,8 +162,6 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 5
         volumeMounts:
-          - name: bpf-maps
-            mountPath: /sys/fs/bpf
           - name: cilium-run
             mountPath: /var/run/cilium
           - name: cni-path
@@ -183,6 +181,7 @@ spec:
           capabilities:
             add:
               - "NET_ADMIN"
+              - "SYS_ADMIN"
           privileged: true
       hostNetwork: true
       volumes:
@@ -190,10 +189,6 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-          # To keep state between restarts / upgrades
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
           # To read docker events from the node
         - name: docker-socket
           hostPath:


### PR DESCRIPTION
Containers with the SYS_ADMIN capability are able to create mounts
(even for bpffs) and mounting it from host is not needed. The
requirement of mounting bppfs on host is invalid in case of
Minikube, because Minikube VMs don't mount bpffs.

Signed-off-by: Michal Rostecki <mrostecki@suse.com>

<!--  Thanks for contributing to Cilium!

If this is your first time contributing, then please see the following
guidelines for detailed instructions on how to contribute:
https://github.com/cilium/cilium/blob/master/CONTRIBUTING.md for detailed instructions 

-->

**Summary of changes**:

Fixes: #3717

```release-note
<!-- Enter the release note text here if needed -->
```

**How to test (optional)**:
Run the modified `cilium-ds.yaml` file on Minikube, then `demo.yaml` and `l3_l4_l7_policy.xaml`, after that check whether you got rid of errors like that (which occur every time you run the demo on Minikube without changes from this PR!):

```
level=error msg="bpf: Unable to update in tunnel endpoint map" error="Unable to get object /sys/fs/bpf/tc/globals/tunnel_endpoint_map: no such file or directory" ipAddr=172.16.xxx.xxx/23
```
