### PR TITLE
Backport/v1.0 2018 04 17

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -170,7 +170,7 @@ echo -e "PRs for stable backporting: ${#stable_prs[@]}\n"
 if [[ ${#stable_prs[@]} > 0 ]]; then
   for pr in "${stable_prs[@]}"; do
     title=$(extract_pr_title "$pr")
-    echo " * PR: $pr -- $title"
+    echo " * PR: $pr -- $title -- https://github.com/cilium/cilium/pull/$pr"
     generate_commit_list_for_pr $pr
     echo ""
   done

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -53,9 +53,10 @@ extract_pr_title () {
 }
 
 ###############################################################################
-# Get merged PRs that match a specified label
+# Get merged PRs that match a specified label and exclude a specified label
 get_prs () {
   local label=$1
+  local label_exclude=$2
   local -a prs
   local total
   local current_page
@@ -65,14 +66,16 @@ get_prs () {
 
   prs_per_page=100
 
-  url="https://api.github.com/search/issues?per_page=1&q=is:pr%20repo:cilium/cilium%20is:closed%20label:$label"
+  label_opt="%20label:$label"
+  label_exclude_opt="%20-label:$label_exclude"
+  url="https://api.github.com/search/issues?per_page=1&q=is:pr%20repo:cilium/cilium%20is:closed$label_opt$label_exclude_opt"
   total="$($GHCURL $url | jq -r '.total_count')"
 
   # Calculate number of pages, rounding up
   num_pages=$(((total + prs_per_page - 1) / prs_per_page ))
 
   for current_page in `seq 1 $num_pages`; do
-    prs+=($($GHCURL "${CILIUM_GITHUB_SEARCHAPI}label:${label}&page=$current_page" | jq -r '.items[] | (.number | tostring)'))
+    prs+=($($GHCURL "${CILIUM_GITHUB_SEARCHAPI}$label_opt$label_exclude_opt&page=$current_page" | jq -r '.items[] | (.number | tostring)'))
   done
 
   echo "${prs[@]}"
@@ -162,7 +165,7 @@ MYLOG=/tmp/$PROG.log
 # Check token
 gitlib::github_api_token
 
-stable_prs=($(get_prs "stable/needs-backport"))
+stable_prs=($(get_prs "stable/needs-backport" "stable/backport-done"))
 echo -e "PRs for stable backporting: ${#stable_prs[@]}\n"
 if [[ ${#stable_prs[@]} > 0 ]]; then
   for pr in "${stable_prs[@]}"; do


### PR DESCRIPTION
2 backports

[ upstream commit 25c80eb7b366977f6d2696d0bc19bd110d1e0647 ]

- Added kubedns logs in reportFailed.
- Added a new fallback option in `WaitForKubeDNSEntry` to know in case
of fail if the issue is that the DNS entry does not exits, or cannot
connect to kube-dns service.
- Use service IP instead of the kube-dns pod IP.


[ upstream commit 29cab3a38109a5349fc37e0dfa55b64ae291fd9f ]
[ upstream commit 63b39052f349da7c87c5f4a8d1a7c02e823fe5e2 ]
    scripts: contrib/backports/check_stable handles backports-done label
    scripts: contrib/backports/check_stable prints PR link

