### PR TITLE
Fix byteorder of ports in verbose monitor output

### DIFF
--- a/pkg/monitor/datapath_debug.go
+++ b/pkg/monitor/datapath_debug.go
@@ -155,8 +155,7 @@ func ctInfo(arg1 uint32, arg2 uint32) string {
 
 func ctLookup4Info1(n *DebugMsg) string {
 	return fmt.Sprintf("src=%s:%d dst=%s:%d", ip4Str(n.Arg1),
-		byteorder.NetworkToHost(uint16(n.Arg3&0xFFFF)),
-		ip4Str(n.Arg2), byteorder.NetworkToHost(uint16(n.Arg3>>16)))
+		n.Arg3&0xFFFF, ip4Str(n.Arg2), n.Arg3>>16)
 }
 
 func ctLookup4Info2(n *DebugMsg) string {
@@ -170,9 +169,8 @@ func ctCreate4Info(n *DebugMsg) string {
 }
 
 func ctLookup6Info1(n *DebugMsg) string {
-	return fmt.Sprintf("src=[::%s]:%d dst=[::%s]:%d", ip6Str(n.Arg1),
-		byteorder.NetworkToHost(uint16(n.Arg3&0xFFFF)),
-		ip6Str(n.Arg2), byteorder.NetworkToHost(uint16(n.Arg3>>16)))
+	return fmt.Sprintf("src=[::%x]:%d dst=[::%x]:%d", ip6Str(n.Arg1),
+		n.Arg3&0xFFFF, ip6Str(n.Arg2), n.Arg3>>16)
 }
 
 func ctCreate6Info(n *DebugMsg) string {


### PR DESCRIPTION
Previously:

```
CPU 01: MARK 0xc7343b21 FROM 56326 DEBUG: Conntrack lookup 1/2: src=10.11.129.91:11428 dst=157.240.11.35:47873
```

Now:

```
CPU 01: MARK 0xc7343b21 FROM 56326 DEBUG: Conntrack lookup 1/2: src=10.11.129.91:42028 dst=157.240.11.35:443
```