### PR TITLE
pkg/envoy: always use dport in proxy statistics

### DIFF
--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -165,12 +165,6 @@ func (s *accessLogServer) logRecord(localEndpoint logger.EndpointUpdater, pblog 
 
 	// Update stats for the endpoint.
 	ingress := r.ObservationPoint == accesslog.Ingress
-	var port uint16
-	if ingress {
-		port = r.DestinationEndpoint.Port
-	} else {
-		port = r.SourceEndpoint.Port
-	}
 	request := r.Type == accesslog.TypeRequest
-	localEndpoint.UpdateProxyStatistics("http", port, ingress, request, r.Verdict)
+	localEndpoint.UpdateProxyStatistics("http", r.DestinationEndpoint.Port, ingress, request, r.Verdict)
 }


### PR DESCRIPTION
Even on egress, rules are always defined with 'ToPorts'; thus, in proxy
statistics, only use the port to which traffic is flowing (destination port).

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #3777 