### PR TITLE
policy: Support reserved:cluster entity

### DIFF
--- a/Documentation/concepts.rst
+++ b/Documentation/concepts.rst
@@ -377,6 +377,10 @@ identities are prefixed with the string ``reserved:``.
 | reserved:host       | The host network namespace on which the pod or    |
 |                     | container is running.                             |
 +---------------------+---------------------------------------------------+
+| reserved:cluster    | Any network endpoint inside of the cluster that   |
+|                     | is not managed by Cilium. Does not include        |
+|                     | reserved:host.                                    |
++---------------------+---------------------------------------------------+
 | reserved:world      | Any network endpoint outside of the cluster       |
 +---------------------+---------------------------------------------------+
 

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -446,7 +446,7 @@ var (
 			"toEntities": {
 				Description: "ToEntities is a list of special entities to which the endpoint " +
 					"subject to the rule is allowed to initiate connections. Supported " +
-					"entities are `world` and `host`",
+					"entities are `world`, `cluster` and `host`",
 				Type: "array",
 				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
 					Schema: &apiextensionsv1beta1.JSONSchemaProps{
@@ -561,7 +561,7 @@ var (
 			"fromEntities": {
 				Description: "FromEntities is a list of special entities which the endpoint " +
 					"subject to the rule is allowed to receive connections from. Supported " +
-					"entities are `world` and `host`",
+					"entities are `world`, `cluster` and `host`",
 				Type: "array",
 				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
 					Schema: &apiextensionsv1beta1.JSONSchemaProps{

--- a/pkg/policy/api/egress.go
+++ b/pkg/policy/api/egress.go
@@ -93,7 +93,7 @@ type EgressRule struct {
 
 	// ToEntities is a list of special entities to which the endpoint subject
 	// to the rule is allowed to initiate connections. Supported entities are
-	// `world` and `host`
+	// `world`, `cluster` and `host`
 	//
 	// +optional
 	ToEntities EntitySlice `json:"toEntities,omitempty"`

--- a/pkg/policy/api/entity.go
+++ b/pkg/policy/api/entity.go
@@ -31,6 +31,10 @@ const (
 	// endpoint's cluster
 	EntityWorld Entity = "world"
 
+	// EntityCluster is an entity that represents traffic within the
+	// endpoint's cluster, to endpoints not managed by cilium
+	EntityCluster Entity = "cluster"
+
 	// EntityHost is an entity that represents traffic within endpoint host
 	EntityHost Entity = "host"
 )
@@ -41,6 +45,11 @@ var EntitySelectorMapping = map[Entity]EndpointSelector{
 	EntityAll: WildcardEndpointSelector,
 	EntityWorld: NewESFromLabels(&labels.Label{
 		Key:    labels.IDNameWorld,
+		Value:  "",
+		Source: labels.LabelSourceReserved,
+	}),
+	EntityCluster: NewESFromLabels(&labels.Label{
+		Key:    labels.IDNameCluster,
 		Value:  "",
 		Source: labels.LabelSourceReserved,
 	}),

--- a/pkg/policy/api/entity_test.go
+++ b/pkg/policy/api/entity_test.go
@@ -23,14 +23,24 @@ import (
 func (s *PolicyAPITestSuite) TestEntityMatches(c *C) {
 	c.Assert(EntityHost.Matches(labels.ParseLabelArray("reserved:host")), Equals, true)
 	c.Assert(EntityHost.Matches(labels.ParseLabelArray("reserved:host", "id:foo")), Equals, true)
+	c.Assert(EntityHost.Matches(labels.ParseLabelArray("reserved:cluster")), Equals, false)
 	c.Assert(EntityHost.Matches(labels.ParseLabelArray("reserved:world")), Equals, false)
 	c.Assert(EntityHost.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
 
 	c.Assert(EntityAll.Matches(labels.ParseLabelArray("reserved:host")), Equals, true)
+	c.Assert(EntityAll.Matches(labels.ParseLabelArray("reserved:cluster")), Equals, true)
 	c.Assert(EntityAll.Matches(labels.ParseLabelArray("reserved:world")), Equals, true)
 	c.Assert(EntityAll.Matches(labels.ParseLabelArray("id=foo")), Equals, true)
 
+	// EntityCluster doesn't select host, as EndpointSelector can't express OR relationships.
+	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("reserved:host")), Equals, false)
+	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("reserved:cluster")), Equals, true)
+	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("reserved:world")), Equals, false)
+	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
+	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("id=foo", "id=bar")), Equals, false)
+
 	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("reserved:host")), Equals, false)
+	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("reserved:cluster")), Equals, false)
 	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("reserved:world")), Equals, true)
 	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
 	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("id=foo", "id=bar")), Equals, false)

--- a/pkg/policy/api/ingress.go
+++ b/pkg/policy/api/ingress.go
@@ -100,7 +100,7 @@ type IngressRule struct {
 
 	// FromEntities is a list of special entities which the endpoint subject
 	// to the rule is allowed to receive connections from. Supported entities are
-	// `world` and `host`
+	// `world`, `cluster` and `host`
 	//
 	// +optional
 	FromEntities EntitySlice `json:"fromEntities,omitempty"`

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1106,6 +1106,11 @@ func (ds *PolicyTestSuite) TestRuleCanReachFromEntity(c *C) {
 		To:   labels.ParseSelectLabelArray("bar"),
 	}
 
+	fromCluster := &SearchContext{
+		From: labels.ParseSelectLabelArray("reserved:cluster"),
+		To:   labels.ParseSelectLabelArray("bar"),
+	}
+
 	notFromWorld := &SearchContext{
 		From: labels.ParseSelectLabelArray("foo"),
 		To:   labels.ParseSelectLabelArray("bar"),
@@ -1116,7 +1121,10 @@ func (ds *PolicyTestSuite) TestRuleCanReachFromEntity(c *C) {
 			EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("bar")),
 			Ingress: []api.IngressRule{
 				{
-					FromEntities: []api.Entity{api.EntityWorld},
+					FromEntities: []api.Entity{
+						api.EntityWorld,
+						api.EntityCluster,
+					},
 				},
 			},
 		},
@@ -1126,6 +1134,10 @@ func (ds *PolicyTestSuite) TestRuleCanReachFromEntity(c *C) {
 
 	state := traceState{}
 	c.Assert(rule1.canReachIngress(fromWorld, &state), Equals, api.Allowed)
+	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 1)
+	state = traceState{}
+	c.Assert(rule1.canReachIngress(fromCluster, &state), Equals, api.Allowed)
 	c.Assert(state.selectedRules, Equals, 1)
 	c.Assert(state.matchedRules, Equals, 1)
 	state = traceState{}
@@ -1140,6 +1152,11 @@ func (ds *PolicyTestSuite) TestRuleCanReachEntity(c *C) {
 		To:   labels.ParseSelectLabelArray("reserved:world"),
 	}
 
+	toCluster := &SearchContext{
+		From: labels.ParseSelectLabelArray("bar"),
+		To:   labels.ParseSelectLabelArray("reserved:cluster"),
+	}
+
 	notToWorld := &SearchContext{
 		From: labels.ParseSelectLabelArray("bar"),
 		To:   labels.ParseSelectLabelArray("foo"),
@@ -1150,7 +1167,10 @@ func (ds *PolicyTestSuite) TestRuleCanReachEntity(c *C) {
 			EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("bar")),
 			Egress: []api.EgressRule{
 				{
-					ToEntities: []api.Entity{api.EntityWorld},
+					ToEntities: []api.Entity{
+						api.EntityWorld,
+						api.EntityCluster,
+					},
 				},
 			},
 		},
@@ -1160,6 +1180,10 @@ func (ds *PolicyTestSuite) TestRuleCanReachEntity(c *C) {
 
 	state := traceState{}
 	c.Assert(rule1.canReachEgress(toWorld, &state), Equals, api.Allowed)
+	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 1)
+	state = traceState{}
+	c.Assert(rule1.canReachEgress(toCluster, &state), Equals, api.Allowed)
 	c.Assert(state.selectedRules, Equals, 1)
 	c.Assert(state.matchedRules, Equals, 1)
 	state = traceState{}


### PR DESCRIPTION
The support for this entity was already plumbed through most of Cilium,
it just wasn't exposed in the API. Expose it there.

Manually verified.