### PR TITLE
Jenkins: Fix timeout on docs.

### DIFF
--- a/docs.Jenkinsfile
+++ b/docs.Jenkinsfile
@@ -4,11 +4,15 @@ pipeline {
     }
 
     options {
-        timeout(time: 10, unit: 'MINUTES')
+        timeout(time: 100, unit: 'MINUTES')
         timestamps()
     }
+
     stages {
         stage('Docs') {
+            options {
+                timeout(time: 10, unit: 'MINUTES')
+            }
             steps {
                 checkout scm
                 sh "make test-docs"


### PR DESCRIPTION
The timeout was set as a global. Time to time the job needs to wait for
a node and the build was aborted due timeout.

Added a bigger global timeout, and  a shorted timeout to make sure that
the test docs does not hang.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>