### PR TITLE
k8s: add some fixes to the kubernetes spec file

### DIFF
--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -158,6 +158,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+      restartPolicy: Always
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -203,6 +203,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+      restartPolicy: Always
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -158,6 +158,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+      restartPolicy: Always
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -203,6 +203,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+      restartPolicy: Always
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -158,6 +158,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+      restartPolicy: Always
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -203,6 +203,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+      restartPolicy: Always
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -158,6 +158,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+      restartPolicy: Always
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -203,6 +203,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+      restartPolicy: Always
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -158,6 +158,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+      restartPolicy: Always
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -203,6 +203,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+      restartPolicy: Always
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -158,6 +158,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+      restartPolicy: Always
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master


### PR DESCRIPTION
Restart always will guarantee that kubelet will restart cilium in case
of failure.

ImagePullPolicy changed to IfNotPresent to prevent connectivity issues
with docker hub although the policy is already downloaded.

Signed-off-by: André Martins <andre@cilium.io>


```release-note
Restart cilium pod in case of failure and download cilium images only if not present (kubernetes environment)
```

**Note**: If kubelet itself can't connect to kube-apiserver the restartAlways will not have any effect.
```
Apr 18 15:29:32 k8s-1932 kubelet[9871]: ker.sock SubPath: MountPropagation:<nil>} {Name:etcd-config-path ReadOnly:true MountPath:/var/lib/etcd-config SubPath: MountPropagation:<nil>} {Name:etcd-secrets ReadOnly:true MountPath:/var/lib/etcd-secrets SubPath: MountPropagation:<nil>} {Name:cilium-token-mj795 ReadOnly:true MountPath:/var/run/secrets/kubernetes.io/serviceaccount SubPath: MountPropagation:<nil>}] VolumeDevices:[] LivenessProbe:&Probe{Handler:Handler{Exec:&ExecAction{Command:[cilium status],},HTTPGet:nil,TCPSocket:nil,},InitialDelaySeconds:120,TimeoutSeconds:1,PeriodSeconds:10,SuccessThreshold:1,FailureThreshold:10,} ReadinessProbe:&Probe{Handler:Handler{Exec:&ExecAction{Command:[cilium status],},HTTPGet:nil,TCPSocket:nil,},InitialDelaySeconds:5,TimeoutSeconds:1,PeriodSeconds:5,SuccessThreshold:1,FailureThreshold:3,} Lifecycle:&Lifecycle{PostStart:&Handler{Exec:&ExecAction{Command:[/cni-install.sh],},HTTPGet:nil,TCPSocket:nil,},PreStop:&Handler{Exec:&ExecAction{Command:[/cni-uninstall.sh],},HTTPGet:nil,TCPSocket:nil,},} TerminationMessagePath:/dev/termination-log TerminationMessagePolicy:File ImagePullPolicy:IfNotPresent SecurityContext:&SecurityContext{Capabilities:&Capabilities{Add:[NET_ADMIN],Drop:[],},Privileged:*true,SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,ReadOnlyRootFilesystem:nil,AllowPrivilegeEscalation:nil,} Stdin:false StdinOnce:false TTY:false} is dead, but RestartPolicy says that we should restart it.
Apr 18 15:29:02 k8s-1932 kubelet[9871]: I0418 15:29:02.280181    9871 kuberuntime_manager.go:758] checking backoff for container "cilium-agent" in pod "cilium-8pnvj_kube-system(deaa2728-431b-11e8-8f84-0800277f6597)"
Apr 18 15:29:03 k8s-1932 kubelet[9871]: E0418 15:29:03.136618    9871 kubelet_node_status.go:383] Error updating node status, will retry: error getting node "k8s-1932": Get https://192.168.33.11:6443/api/v1/nodes/k8s-1932: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```