### PR TITLE
envoy: Manage life-cycles of singleton maps properly

### DIFF
--- a/envoy/cilium_bpf_metadata.cc
+++ b/envoy/cilium_bpf_metadata.cc
@@ -69,9 +69,11 @@ std::shared_ptr<const Cilium::PolicyHostMap>
 createHostMap(Server::Configuration::ListenerFactoryContext& context) {
   return context.singletonManager().getTyped<const Cilium::PolicyHostMap>(
     SINGLETON_MANAGER_REGISTERED_NAME(cilium_host_map), [&context] {
-      return std::make_shared<Cilium::PolicyHostMap>(
-        context.localInfo().node(), context.clusterManager(),
-	context.dispatcher(), context.scope(), context.threadLocal());
+      auto map = std::make_shared<Cilium::PolicyHostMap>(
+          context.localInfo().node(), context.clusterManager(),
+	  context.dispatcher(), context.scope(), context.threadLocal());
+      map->startSubscription();
+      return map;
     });
 }
 

--- a/envoy/cilium_host_map.h
+++ b/envoy/cilium_host_map.h
@@ -46,6 +46,7 @@ enum ID : uint64_t { UNKNOWN = 0, WORLD = 2 };
 
 class PolicyHostMap : public Singleton::Instance,
                       Config::SubscriptionCallbacks<cilium::NetworkPolicyHosts>,
+                      public std::enable_shared_from_this<PolicyHostMap>,
                       public Logger::Loggable<Logger::Id::config> {
 public:
   PolicyHostMap(const envoy::api::v2::core::Node& node,
@@ -55,6 +56,8 @@ public:
 		ThreadLocal::SlotAllocator& tls);
   PolicyHostMap(ThreadLocal::SlotAllocator& tls);
   ~PolicyHostMap() {}
+
+  void startSubscription() { subscription_->start({}, *this); }
 
   // A shared pointer to a immutable copy is held by each thread. Changes are done by
   // creating a new version and assigning the new shared pointer to the thread local

--- a/envoy/cilium_l7policy.cc
+++ b/envoy/cilium_l7policy.cc
@@ -65,9 +65,11 @@ std::shared_ptr<const Cilium::NetworkPolicyMap>
 createPolicyMap(Server::Configuration::FactoryContext& context) {
   return context.singletonManager().getTyped<const Cilium::NetworkPolicyMap>(
     SINGLETON_MANAGER_REGISTERED_NAME(cilium_network_policy), [&context] {
-      return std::make_shared<Cilium::NetworkPolicyMap>(
-	context.localInfo().node(), context.clusterManager(),
-	context.dispatcher(), context.scope(), context.threadLocal());
+      auto map = std::make_shared<Cilium::NetworkPolicyMap>(
+	  context.localInfo().node(), context.clusterManager(),
+	  context.dispatcher(), context.scope(), context.threadLocal());
+      map->startSubscription();
+      return map;
     });
 }
 


### PR DESCRIPTION
Both policy and host maps are managed as singletons, which are
initialized when first required, and destructed when the last listener
referring to them via Cilium filter instances is removed.

Internally, the maps "post" configuration changes to Envoy worker
threads via thread dispatch queues. These changes are packaged as C++
lambda closures. The problem with this is that while the "posts" are
queued, it is possible for all the listeners to be removed, and thus
the associated singleton maps being freed. If the posted closure
refers to the (now stale) map, bad things can happen.

Fix this by capturing either a weak or shared pointer to the lambda
closure.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>