### PR TITLE
Kafka : remove noise from logging EOF messages in Kafka parser

### DIFF
--- a/pkg/proxy/kafka.go
+++ b/pkg/proxy/kafka.go
@@ -17,6 +17,8 @@ package proxy
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"net"
 	"time"
 
 	"github.com/cilium/cilium/pkg/completion"
@@ -31,7 +33,6 @@ import (
 
 	"github.com/optiopay/kafka/proto"
 	"github.com/sirupsen/logrus"
-	"net"
 )
 
 const (
@@ -346,7 +347,9 @@ func (k *kafkaRedirect) handleRequests(done <-chan struct{}, pair *connectionPai
 		}
 
 		if err != nil {
-			scopedLog.WithError(err).Error("Unable to parse Kafka request; closing Kafka request connection")
+			if err != io.ErrUnexpectedEOF && err != io.EOF {
+				scopedLog.WithError(err).Error("Unable to parse Kafka request; closing Kafka request connection")
+			}
 			return
 		}
 


### PR DESCRIPTION
We keep seeing a lot of these on normal client (produce/consume) connection close.
We should not be logging valid EOF as errors.
```
level=error msg="Unable to parse Kafka request; closing Kafka request connection" error=EOF id="rx:10.15.161.35:57590->10.15.28.238:10551<->tx:closed"
```

Fixes: #3792
Signed-Off-By: Manali Bhutiyani <manali@covalent.io>

```release-note
Kafka : remove noise from logging EOF messages in Kafka parser
```