### PR TITLE
test: add L3-dependent L7 egress e2e test

### DIFF
--- a/test/runtime/manifests/Policies-l3-dependent-l7-egress.json
+++ b/test/runtime/manifests/Policies-l3-dependent-l7-egress.json
@@ -1,0 +1,25 @@
+[{
+    "endpointSelector":
+        {"matchLabels":{"id.app3":""}},
+    "egress": [{
+	"toEndpoints": [
+	    {"matchLabels":{"id.httpd1":""}}
+	],
+        "toPorts": [{
+            "ports": [
+                  {"port": "80",   "protocol": "tcp"}],
+            "rules": {
+                "HTTP": [
+                    {"method": "GET", "path": "/public"}]
+            }
+        }]
+    }]
+},{
+    "endpointSelector":
+        {"matchLabels":{"id.app3":""}},
+    "egress": [{
+        "toEndpoints": [
+            {"matchLabels":{"id.httpd2":""}}
+        ]
+    }]
+}]


### PR DESCRIPTION
* Add a test which ensures that L7 rules respect L3 restrictions.
* Also add a helper function which checks that when L7 rules are imported, that traffic flows through the proxy and the counters for what is denied, allowed, received, etc. are updated correctly. This validates that traffic is indeed flowing through the proxy.
* test/helpers: validate policy before importing in `PolicyImportAndWait`
    
Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #3408 