### PR TITLE
Disable code owners reviews in 1.0 branch

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,66 +27,66 @@
 # after the less specific paths, otherwise the ownership for the specific paths
 # is not properly picked up in Github.
 * @cilium/janitors
-api/ @cilium/api
-bpf/ @cilium/bpf
-bpf/*.sh @cilium/bpf-loader
-bugtool/cmd/ @cilium/cli
-cilium/ @cilium/cli
-cilium-health/cmd/ @cilium/cli
-cilium-health/launch/ @cilium/health
-contrib/packaging/deb/ @eloycoto
-contrib/packaging/docker/ @aanm @ianvernon
-contrib/vagrant @cilium/vagrant
-daemon/ @cilium/agent
-daemon/bpf.sha @cilium/bpf
-daemon/endpoint.go @cilium/endpoint
-daemon/k8s_watcher.go @cilium/kubernetes
-daemon/loadbalancer.* @cilium/loadbalancer
-daemon/prefilter.go @cilium/bpf
-daemon/services.* @cilium/loadbalancer
-Documentation/ @cilium/docs
-Documentation/bpf.rst @scanf @borkmann
-Documentation/contributing.rst @cilium/contributing
-envoy/ @cilium/proxy
-examples/ @cilium/docs
-examples/getting-started/Vagrantfile @cilium/vagrant
-examples/kubernetes/ @cilium/kubernetes
-examples/kubernetes-ingress/ @cilium/kubernetes
-examples/mesos/Vagrantfile @cilium/vagrant
-examples/minikube/ @cilium/kubernetes
-ginkgo.Jenkinsfile @cilium/ci
-ginkgo-all.Jenkinsfile @cilium/ci
-ginkgo-kubernetes-all.Jenkinsfile @cilium/ci
-Jenkinsfile @cilium/ci
-Jenkinsfile.nightly @cilium/ci
-monitor/ @cilium/monitor
-monitor/payload @cilium/api
-pkg/apierror/ @cilium/api
-pkg/apipanic/ @cilium/api
-pkg/apisocket/ @cilium/api
-pkg/bpf/ @cilium/bpf
-pkg/completion/ @cilium/proxy
-pkg/endpoint/ @cilium/endpoint
-pkg/envoy/ @cilium/proxy
-pkg/health/ @cilium/health
-pkg/ipcache/ @ianvernon
-pkg/k8s/ @cilium/kubernetes
-pkg/kafka/ @cilium/proxy
-pkg/kvstore/ @cilium/kvstore
-pkg/logging/ @cilium/cli
-pkg/maps/ @cilium/bpf
-pkg/monitor/datapath_debug.go @cilium/bpf
-pkg/policy @cilium/policy
-pkg/policy/api/ @cilium/api
-pkg/policy/prefilter.go @cilium/bpf
-pkg/proxy/ @cilium/proxy
-pkg/proxy/accesslog @cilium/api
-plugins/cilium-cni/ @cilium/kubernetes
-plugins/cilium-docker/ @cilium/docker
-README.md @cilium/docs
-test/ @cilium/ci
-test/Vagrantfile @cilium/vagrant
-tests/ @cilium/ci
-tests/k8s/Vagrantfile @cilium/vagrant
-Vagrantfile @cilium/vagrant
-vendor/ @cilium/vendor
+# api/ @cilium/api
+# bpf/ @cilium/bpf
+# bpf/*.sh @cilium/bpf-loader
+# bugtool/cmd/ @cilium/cli
+# cilium/ @cilium/cli
+# cilium-health/cmd/ @cilium/cli
+# cilium-health/launch/ @cilium/health
+# contrib/packaging/deb/ @eloycoto
+# contrib/packaging/docker/ @aanm @ianvernon
+# contrib/vagrant @cilium/vagrant
+# daemon/ @cilium/agent
+# daemon/bpf.sha @cilium/bpf
+# daemon/endpoint.go @cilium/endpoint
+# daemon/k8s_watcher.go @cilium/kubernetes
+# daemon/loadbalancer.* @cilium/loadbalancer
+# daemon/prefilter.go @cilium/bpf
+# daemon/services.* @cilium/loadbalancer
+# Documentation/ @cilium/docs
+# Documentation/bpf.rst @scanf @borkmann
+# Documentation/contributing.rst @cilium/contributing
+# envoy/ @cilium/proxy
+# examples/ @cilium/docs
+# examples/getting-started/Vagrantfile @cilium/vagrant
+# examples/kubernetes/ @cilium/kubernetes
+# examples/kubernetes-ingress/ @cilium/kubernetes
+# examples/mesos/Vagrantfile @cilium/vagrant
+# examples/minikube/ @cilium/kubernetes
+# ginkgo.Jenkinsfile @cilium/ci
+# ginkgo-all.Jenkinsfile @cilium/ci
+# ginkgo-kubernetes-all.Jenkinsfile @cilium/ci
+# Jenkinsfile @cilium/ci
+# Jenkinsfile.nightly @cilium/ci
+# monitor/ @cilium/monitor
+# monitor/payload @cilium/api
+# pkg/apierror/ @cilium/api
+# pkg/apipanic/ @cilium/api
+# pkg/apisocket/ @cilium/api
+# pkg/bpf/ @cilium/bpf
+# pkg/completion/ @cilium/proxy
+# pkg/endpoint/ @cilium/endpoint
+# pkg/envoy/ @cilium/proxy
+# pkg/health/ @cilium/health
+# pkg/ipcache/ @ianvernon
+# pkg/k8s/ @cilium/kubernetes
+# pkg/kafka/ @cilium/proxy
+# pkg/kvstore/ @cilium/kvstore
+# pkg/logging/ @cilium/cli
+# pkg/maps/ @cilium/bpf
+# pkg/monitor/datapath_debug.go @cilium/bpf
+# pkg/policy @cilium/policy
+# pkg/policy/api/ @cilium/api
+# pkg/policy/prefilter.go @cilium/bpf
+# pkg/proxy/ @cilium/proxy
+# pkg/proxy/accesslog @cilium/api
+# plugins/cilium-cni/ @cilium/kubernetes
+# plugins/cilium-docker/ @cilium/docker
+# README.md @cilium/docs
+# test/ @cilium/ci
+# test/Vagrantfile @cilium/vagrant
+# tests/ @cilium/ci
+# tests/k8s/Vagrantfile @cilium/vagrant
+# Vagrantfile @cilium/vagrant
+# vendor/ @cilium/vendor


### PR DESCRIPTION
Disable code owners in 1.0 branch. The review process for backports is different.