### PR TITLE
k8s: add some fixes to the kubernetes spec file

### DIFF
--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -153,6 +153,7 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
       tolerations:
+      restartPolicy: Always
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -153,6 +153,7 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
       tolerations:
+      restartPolicy: Always
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -153,6 +153,7 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
       tolerations:
+      restartPolicy: Always
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -153,6 +153,7 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
       tolerations:
+      restartPolicy: Always
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -153,6 +153,7 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
       tolerations:
+      restartPolicy: Always
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -153,6 +153,7 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
       tolerations:
+      restartPolicy: Always
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -153,6 +153,7 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
       tolerations:
+      restartPolicy: Always
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -153,6 +153,7 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
       tolerations:
+      restartPolicy: Always
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -153,6 +153,7 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
       tolerations:
+      restartPolicy: Always
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -153,6 +153,7 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
       tolerations:
+      restartPolicy: Always
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -153,6 +153,7 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
       tolerations:
+      restartPolicy: Always
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule


### PR DESCRIPTION
Restart always will guarantee that kubelet will restart cilium in case
of failure.

Signed-off-by: André Martins <andre@cilium.io>