### PR TITLE
Fix some bugs in developer VMs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -95,6 +95,17 @@ else
     $vm_base_name = "runtime"
 end
 
+# We need this workaround since kube-proxy is not aware of multiple network
+# interfaces. If we send a packet to a service IP that packet is sent
+# to the default route, because the service IP is unknown by the linux routing
+# table, with the source IP of the interface in the default routing table, even
+# though the service IP should be routed to a different interface.
+# This particular workaround is only needed for cilium, running on a pod on host
+# network namespace, to reach out kube-api-server.
+$kube_proxy_workaround = <<SCRIPT
+sudo iptables -t nat -A POSTROUTING -o enp0s8 ! -s 192.168.34.12 -j MASQUERADE
+SCRIPT
+
 Vagrant.configure(2) do |config|
     config.vm.provision "bootstrap", type: "shell", inline: $bootstrap
     config.vm.provision "build", type: "shell", run: "always", privileged: false, inline: $build

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -114,7 +114,7 @@ EOF
     fi
 
     cat <<EOF >> "${filename}"
-echo "${worker_ipv6} k8s${node_index}" >> /etc/hosts
+echo "${worker_ipv6} ${VM_BASENAME}${node_index}" >> /etc/hosts
 
 EOF
 }
@@ -147,7 +147,7 @@ EOF
         fi
 
         cat <<EOF >> "${filename}"
-echo "${worker_internal_ipv6} k8s${index}" >> /etc/hosts
+echo "${worker_internal_ipv6} ${VM_BASENAME}${index}" >> /etc/hosts
 EOF
     done
 


### PR DESCRIPTION
See commit description.

@tgraf we still need 7a06b98 for cilium running on node-2. I hit this bug again with k8s 1.9.3