### PR TITLE
CI: add Runtime DROP_ALL test

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -309,6 +309,19 @@ func (s *SSHMeta) GetEndpointsIDMap() (map[string]string, error) {
 	return endpoints.KVOutput(), nil
 }
 
+// GetAllEndpointsIds returns a mapping of all Docker container name to to its
+// corresponding endpoint ID, and an error if the list of endpoints cannot be
+// retrieved via the Cilium CLI.
+func (s *SSHMeta) GetAllEndpointsIds() (map[string]string, error) {
+	filter := `{range [*]}{@.status.external-identifiers.container-name}{"="}{@.id}{"\n"}{end}`
+	cmd := fmt.Sprintf("endpoint list -o jsonpath='%s'", filter)
+	endpoints := s.ExecCilium(cmd)
+	if !endpoints.WasSuccessful() {
+		return nil, fmt.Errorf("%q failed: %s", cmd, endpoints.CombineOutput())
+	}
+	return endpoints.KVOutput(), nil
+}
+
 // GetEndpointsIds returns a mapping of a Docker container name to to its
 // corresponding endpoint ID, and an error if the list of endpoints cannot be
 // retrieved via the Cilium CLI.

--- a/test/helpers/docker.go
+++ b/test/helpers/docker.go
@@ -31,10 +31,16 @@ func (s *SSHMeta) ContainerExec(name string, cmd string, optionalArgs ...string)
 }
 
 // ContainerCreate is a wrapper for `docker run`. It runs an instance of the
-// specified Docker image with the provided network, name, and options.
-func (s *SSHMeta) ContainerCreate(name, image, net, options string) *CmdRes {
+// specified Docker image with the provided network, name, options and container
+// startup commands.
+func (s *SSHMeta) ContainerCreate(name, image, net, options string, cmdParams ...string) *CmdRes {
+	cmdOnStart := ""
+	if len(cmdParams) > 0 {
+		cmdOnStart = strings.Join(cmdParams, " ")
+	}
 	cmd := fmt.Sprintf(
-		"docker run -d --name %s --net %s %s %s", name, net, options, image)
+		"docker run -d --name %s --net %s %s %s %s", name, net, options, image, cmdOnStart)
+	log.Debugf("spinning up container with command '%v'", cmd)
 	return s.ExecWithSudo(cmd)
 }
 

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -15,6 +15,7 @@
 package RuntimeTest
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sort"
@@ -1476,5 +1477,121 @@ var _ = Describe("RuntimeValidatedPolicyImportTests", func() {
 		By("Checking that policy trace returns allowed verdict without any policies imported")
 		res = vm.Exec(fmt.Sprintf(`cilium policy trace --src-endpoint %s --dst-endpoint %s`, httpd2EndpointID, httpd1EndpointID))
 		Expect(res.Output().String()).Should(ContainSubstring(allowedVerdict), "Policy trace did not contain %s", allowedVerdict)
+	})
+})
+
+var _ = Describe("RuntimeValidatedPolicyDropAllTests", func() {
+	var (
+		logger           *logrus.Entry
+		vm               *helpers.SSHMeta
+		dropAllContainer string
+		monitorStop      func() error
+	)
+
+	BeforeAll(func() {
+		logger = log.WithFields(logrus.Fields{"test": "RuntimeValidatedPolicyDropAllTests"})
+		logger.Info("Starting")
+		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		dropAllContainer = "dropAllContainer"
+		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
+		res.ExpectSuccess("Setting policyEnforcement to default")
+		areEndpointsReady := vm.WaitEndpointsReady()
+		Expect(areEndpointsReady).Should(BeTrue())
+	})
+
+	JustBeforeEach(func() {
+		monitorStop = vm.MonitorStart()
+	})
+
+	JustAfterEach(func() {
+		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+		Expect(monitorStop()).To(BeNil(), "cannot stop monitor command")
+	})
+
+	AfterFailed(func() {
+		vm.ReportFailed()
+	})
+
+	AfterEach(func() {
+		vm.ContainerRm(dropAllContainer).ExpectSuccess("Container dropAllContainer cannot be deleted")
+	})
+
+	Context("DROP_ALL Ingress Policy test", func() {
+
+		BeforeEach(func() {
+			By("Create an endpoint with no labels to test DROP_ALL")
+			res := vm.ContainerCreate(dropAllContainer, "tgraf/netperf", helpers.CiliumDockerNetwork, "")
+			res.ExpectSuccess("Failed to create containter with no labels.")
+		})
+
+		It("DROP_ALL Ingress Policy test", func() {
+			By("Starting cilium monitor in background to filter DROP requests")
+			ctx, cancel := context.WithCancel(context.Background())
+			dropRes := vm.ExecContext(ctx, "cilium monitor --type drop")
+			defer cancel()
+
+			endpoints, err := vm.GetAllEndpointsIds()
+			Expect(err).Should(BeNil(), "Unable to get IDs of endpoints")
+			endpointID, exists := endpoints[dropAllContainer]
+			Expect(exists).To(BeTrue(), "Expected endpoint ID to exist for %s", dropAllContainer)
+			ingressEpModel := vm.EndpointGet(endpointID)
+			Expect(ingressEpModel).To(Not(BeNil()), "nil model returned for endpoint %s", endpointID)
+			Expect(ingressEpModel.Status.State).To(BeEquivalentTo(models.EndpointStateWaitingForIdentity), "endpoint %s not in waiting for identity state", endpointID)
+
+			endpointIP := ingressEpModel.Status.Networking.Addressing[0]
+
+			By("Testing endpoint lxc_config.h for DROP_ALL")
+
+			lxcCmd := fmt.Sprintf("cat /var/run/cilium/state/%s/lxc_config.h | grep 'DROP_ALL'", endpointID)
+
+			res := vm.ExecWithSudo(lxcCmd)
+			res.ExpectSuccess("Cannot get lxc_config")
+			res.ExpectContains("#define DROP_ALL", "DROP_ALL is not defined in lxc_config.h for endpoint %s", endpointID)
+
+			By("Testing ingress with ping from localhost to endpoint with no labels")
+			res = vm.Exec(helpers.Ping(endpointIP.IPV4))
+			res.ExpectFail("Unexpectedly able to ping endpoint with DROP_ALL ingress policy")
+
+			By("Testing cilium monitor drop")
+			err = dropRes.WaitUntilMatch("drop (Policy denied (L3))")
+			Expect(err).To(BeNil(), "DROP all on ingress failed.")
+
+		})
+	})
+
+	Context("DROP_ALL Egress Policy test", func() {
+		BeforeEach(func() {
+			By("Create an endpoint with no labels to test DROP_ALL")
+			res := vm.ContainerCreate(dropAllContainer, "tgraf/netperf", helpers.CiliumDockerNetwork, "", "ping 8.8.8.8")
+			res.ExpectSuccess("Failed to create container with no labels.")
+		})
+
+		It("DROP_ALL Egress Policy test", func() {
+			By("Starting cilium monitor in background to filter DROP requests")
+			ctx, cancel := context.WithCancel(context.Background())
+			dropRes := vm.ExecContext(ctx, "cilium monitor --type drop")
+			defer cancel()
+
+			endpoints, err := vm.GetAllEndpointsIds()
+			Expect(err).To(BeNil(), "Unable to get IDs of endpoints")
+			endpointID, exists := endpoints[dropAllContainer]
+			Expect(exists).To(BeTrue(), "Expected endpoint ID to exist for %s", dropAllContainer)
+			ingressEpModel := vm.EndpointGet(endpointID)
+			Expect(ingressEpModel).To(Not(BeNil()), "nil model returned for endpoint %s", endpointID)
+
+			Expect(ingressEpModel.Status.State).To(BeEquivalentTo(models.EndpointStateWaitingForIdentity), "endpoint %s not in waiting for identity state", endpointID)
+
+			By("Testing endpoint lxc_config.h for DROP_ALL")
+
+			lxcCmd := fmt.Sprintf("cat /var/run/cilium/state/%s/lxc_config.h | grep 'DROP_ALL'", endpointID)
+
+			res := vm.ExecWithSudo(lxcCmd)
+			res.ExpectSuccess("Cannot get lxc_config")
+			res.ExpectContains("#define DROP_ALL", "DROP_ALL is not defined in lxc_config.h for endpoint %s", endpointID)
+
+			By("Testing cilium monitor drop")
+			err = dropRes.WaitUntilMatch("drop (Policy denied (L3))")
+			Expect(err).To(BeNil(), "DROP all on egress failed.")
+		})
 	})
 })


### PR DESCRIPTION
This test adds the runtime `DROP_ALL`  tests and does 3 checks to make sure DROP_ALL is applied properly

1. It starts the container with no labels and checks if state is waiting-for-identity
2. Checks if the corresponding lxc_config.h contains the DROP_ALL macro
3. Checks if cilium monitor shows the correct L3 deny message for the endpoint.

For ingress, we try to ping from host to the container without labels.
For egress, we create a container and make it execute ping to 8.8.8.8

Fixes: #3625
Signed-Off-By: Manali Bhutiyani <manali@covalent.io>