### PR TITLE
envoy: Fix handling of zero length CIDR prefixes.

### DIFF
--- a/envoy/cilium_host_map.h
+++ b/envoy/cilium_host_map.h
@@ -39,7 +39,7 @@ template <> inline absl::uint128 hton(absl::uint128 addr) { return Network::Util
 
 template <typename I> I masked(I addr, unsigned int plen) {
   const unsigned int PLEN_MAX = sizeof(I)*8;
-  return addr & ~hton((I(1) << (PLEN_MAX - plen)) - 1);
+  return plen == 0 ? I(0) : addr & ~hton((I(1) << (PLEN_MAX - plen)) - 1);
 };
 
 enum ID : uint64_t { UNKNOWN = 0, WORLD = 2 };


### PR DESCRIPTION
Zero length prefixes were not really tested and were treated as
full-length prefixes instead.

Testing was relying on the default 'WORLD' mapping instead of really
testing matches on the default CIDRs. Change the tests to use a
different id and fix the implementation.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/3805)
<!-- Reviewable:end -->
