### PR TITLE
k8s: add some fixes to the kubernetes spec file

### DIFF
--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       serviceAccountName: cilium
       containers:
-      - image: cilium/cilium:v1.0
+      - image: cilium/cilium:v1.0.0-rc13
         imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: cilium
       containers:
       - image: cilium/cilium:v1.0
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]
         args:

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -158,8 +158,8 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
-      tolerations:
       restartPolicy: Always
+      tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -164,7 +164,7 @@ spec:
       serviceAccountName: cilium
       containers:
       - image: cilium/cilium:v1.0
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]
         args:

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -163,7 +163,7 @@ spec:
     spec:
       serviceAccountName: cilium
       containers:
-      - image: cilium/cilium:v1.0
+      - image: cilium/cilium:v1.0.0-rc13
         imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -1,3 +1,133 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+  # This etcd-config contains the etcd endpoints of your cluster. If you use
+  # TLS please make sure you uncomment the ca-file line and add the respective
+  # certificate has a k8s secret, see explanation below in the comment labeled
+  # "ETCD-CERT"
+  etcd-config: |-
+    ---
+    endpoints:
+    - http://127.0.0.1:2379
+    #
+    # In case you want to use TLS in etcd, uncomment the following line
+    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
+    #
+    # In case you want client to server authentication, uncomment the following
+    # lines and add the certificate and key in cilium-etcd-secrets below
+    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  disable-ipv4: "false"
+  sidecar-http-proxy: "false"
+---
+# The etcd secrets can be populated in kubernetes.
+# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
+kind: Secret
+apiVersion: v1
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
+  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
+  # (the "-w 0" generates the output on a single line)
+  etcd-ca: ""
+  etcd-client-key: ""
+  etcd-client-crt: ""
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- kind: Group
+  name: system:nodes
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
+  - thirdpartyresources
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumendpoints
+  verbs:
+  - "*"
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium
+  namespace: kube-system
+---
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -158,8 +288,8 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
-      tolerations:
       restartPolicy: Always
+      tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
@@ -168,134 +298,4 @@ spec:
       # Mark cilium's pod as critical for rescheduling
       - key: CriticalAddonsOnly
         operator: "Exists"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cilium-config
-  namespace: kube-system
-data:
-  # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
-  etcd-config: |-
-    ---
-    endpoints:
-    - http://127.0.0.1:2379
-    #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
-    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
-    #
-    # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
-    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
-    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
-
-  # If you want to run cilium in debug mode change this value to true
-  debug: "false"
-  disable-ipv4: "false"
-  sidecar-http-proxy: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: cilium
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cilium
-subjects:
-- kind: ServiceAccount
-  name: cilium
-  namespace: kube-system
-- kind: Group
-  name: system:nodes
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: cilium
-rules:
-- apiGroups:
-  - "networking.k8s.io"
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - services
-  - nodes
-  - endpoints
-  - componentstatuses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
-  - thirdpartyresources
-  - ingresses
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - "apiextensions.k8s.io"
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - cilium.io
-  resources:
-  - ciliumnetworkpolicies
-  - ciliumendpoints
-  verbs:
-  - "*"
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: cilium
-  namespace: kube-system
 ---

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       serviceAccountName: cilium
       containers:
-      - image: cilium/cilium:v1.0
+      - image: cilium/cilium:v1.0.0-rc13
         imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: cilium
       containers:
       - image: cilium/cilium:v1.0
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]
         args:

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -158,8 +158,8 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
-      tolerations:
       restartPolicy: Always
+      tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -164,7 +164,7 @@ spec:
       serviceAccountName: cilium
       containers:
       - image: cilium/cilium:v1.0
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]
         args:

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -163,7 +163,7 @@ spec:
     spec:
       serviceAccountName: cilium
       containers:
-      - image: cilium/cilium:v1.0
+      - image: cilium/cilium:v1.0.0-rc13
         imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -1,3 +1,133 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+  # This etcd-config contains the etcd endpoints of your cluster. If you use
+  # TLS please make sure you uncomment the ca-file line and add the respective
+  # certificate has a k8s secret, see explanation below in the comment labeled
+  # "ETCD-CERT"
+  etcd-config: |-
+    ---
+    endpoints:
+    - http://127.0.0.1:2379
+    #
+    # In case you want to use TLS in etcd, uncomment the following line
+    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
+    #
+    # In case you want client to server authentication, uncomment the following
+    # lines and add the certificate and key in cilium-etcd-secrets below
+    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  disable-ipv4: "false"
+  sidecar-http-proxy: "false"
+---
+# The etcd secrets can be populated in kubernetes.
+# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
+kind: Secret
+apiVersion: v1
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
+  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
+  # (the "-w 0" generates the output on a single line)
+  etcd-ca: ""
+  etcd-client-key: ""
+  etcd-client-crt: ""
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- kind: Group
+  name: system:nodes
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
+  - thirdpartyresources
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumendpoints
+  verbs:
+  - "*"
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium
+  namespace: kube-system
+---
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -158,8 +288,8 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
-      tolerations:
       restartPolicy: Always
+      tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
@@ -168,134 +298,4 @@ spec:
       # Mark cilium's pod as critical for rescheduling
       - key: CriticalAddonsOnly
         operator: "Exists"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cilium-config
-  namespace: kube-system
-data:
-  # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
-  etcd-config: |-
-    ---
-    endpoints:
-    - http://127.0.0.1:2379
-    #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
-    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
-    #
-    # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
-    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
-    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
-
-  # If you want to run cilium in debug mode change this value to true
-  debug: "false"
-  disable-ipv4: "false"
-  sidecar-http-proxy: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: cilium
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cilium
-subjects:
-- kind: ServiceAccount
-  name: cilium
-  namespace: kube-system
-- kind: Group
-  name: system:nodes
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: cilium
-rules:
-- apiGroups:
-  - "networking.k8s.io"
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - services
-  - nodes
-  - endpoints
-  - componentstatuses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
-  - thirdpartyresources
-  - ingresses
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - "apiextensions.k8s.io"
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - cilium.io
-  resources:
-  - ciliumnetworkpolicies
-  - ciliumendpoints
-  verbs:
-  - "*"
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: cilium
-  namespace: kube-system
 ---

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       serviceAccountName: cilium
       containers:
-      - image: cilium/cilium:v1.0
+      - image: cilium/cilium:v1.0.0-rc13
         imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: cilium
       containers:
       - image: cilium/cilium:v1.0
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]
         args:

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -158,8 +158,8 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
-      tolerations:
       restartPolicy: Always
+      tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -164,7 +164,7 @@ spec:
       serviceAccountName: cilium
       containers:
       - image: cilium/cilium:v1.0
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]
         args:

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -163,7 +163,7 @@ spec:
     spec:
       serviceAccountName: cilium
       containers:
-      - image: cilium/cilium:v1.0
+      - image: cilium/cilium:v1.0.0-rc13
         imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -1,3 +1,133 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+  # This etcd-config contains the etcd endpoints of your cluster. If you use
+  # TLS please make sure you uncomment the ca-file line and add the respective
+  # certificate has a k8s secret, see explanation below in the comment labeled
+  # "ETCD-CERT"
+  etcd-config: |-
+    ---
+    endpoints:
+    - http://127.0.0.1:2379
+    #
+    # In case you want to use TLS in etcd, uncomment the following line
+    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
+    #
+    # In case you want client to server authentication, uncomment the following
+    # lines and add the certificate and key in cilium-etcd-secrets below
+    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  disable-ipv4: "false"
+  sidecar-http-proxy: "false"
+---
+# The etcd secrets can be populated in kubernetes.
+# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
+kind: Secret
+apiVersion: v1
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
+  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
+  # (the "-w 0" generates the output on a single line)
+  etcd-ca: ""
+  etcd-client-key: ""
+  etcd-client-crt: ""
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- kind: Group
+  name: system:nodes
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
+  - thirdpartyresources
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumendpoints
+  verbs:
+  - "*"
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium
+  namespace: kube-system
+---
 kind: DaemonSet
 apiVersion: extensions/v1beta1
 metadata:
@@ -158,8 +288,8 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
-      tolerations:
       restartPolicy: Always
+      tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
@@ -168,134 +298,4 @@ spec:
       # Mark cilium's pod as critical for rescheduling
       - key: CriticalAddonsOnly
         operator: "Exists"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cilium-config
-  namespace: kube-system
-data:
-  # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
-  etcd-config: |-
-    ---
-    endpoints:
-    - http://127.0.0.1:2379
-    #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
-    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
-    #
-    # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
-    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
-    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
-
-  # If you want to run cilium in debug mode change this value to true
-  debug: "false"
-  disable-ipv4: "false"
-  sidecar-http-proxy: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: cilium
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cilium
-subjects:
-- kind: ServiceAccount
-  name: cilium
-  namespace: kube-system
-- kind: Group
-  name: system:nodes
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: cilium
-rules:
-- apiGroups:
-  - "networking.k8s.io"
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - services
-  - nodes
-  - endpoints
-  - componentstatuses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
-  - thirdpartyresources
-  - ingresses
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - "apiextensions.k8s.io"
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - cilium.io
-  resources:
-  - ciliumnetworkpolicies
-  - ciliumendpoints
-  verbs:
-  - "*"
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: cilium
-  namespace: kube-system
 ---

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       serviceAccountName: cilium
       containers:
-      - image: cilium/cilium:v1.0
+      - image: cilium/cilium:v1.0.0-rc13
         imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: cilium
       containers:
       - image: cilium/cilium:v1.0
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]
         args:

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -158,8 +158,8 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
-      tolerations:
       restartPolicy: Always
+      tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -164,7 +164,7 @@ spec:
       serviceAccountName: cilium
       containers:
       - image: cilium/cilium:v1.0
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]
         args:

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -163,7 +163,7 @@ spec:
     spec:
       serviceAccountName: cilium
       containers:
-      - image: cilium/cilium:v1.0
+      - image: cilium/cilium:v1.0.0-rc13
         imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -1,3 +1,133 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+  # This etcd-config contains the etcd endpoints of your cluster. If you use
+  # TLS please make sure you uncomment the ca-file line and add the respective
+  # certificate has a k8s secret, see explanation below in the comment labeled
+  # "ETCD-CERT"
+  etcd-config: |-
+    ---
+    endpoints:
+    - http://127.0.0.1:2379
+    #
+    # In case you want to use TLS in etcd, uncomment the following line
+    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
+    #
+    # In case you want client to server authentication, uncomment the following
+    # lines and add the certificate and key in cilium-etcd-secrets below
+    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  disable-ipv4: "false"
+  sidecar-http-proxy: "false"
+---
+# The etcd secrets can be populated in kubernetes.
+# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
+kind: Secret
+apiVersion: v1
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
+  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
+  # (the "-w 0" generates the output on a single line)
+  etcd-ca: ""
+  etcd-client-key: ""
+  etcd-client-crt: ""
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- kind: Group
+  name: system:nodes
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
+  - thirdpartyresources
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumendpoints
+  verbs:
+  - "*"
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium
+  namespace: kube-system
+---
 kind: DaemonSet
 apiVersion: apps/v1beta2
 metadata:
@@ -158,8 +288,8 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
-      tolerations:
       restartPolicy: Always
+      tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
@@ -168,134 +298,4 @@ spec:
       # Mark cilium's pod as critical for rescheduling
       - key: CriticalAddonsOnly
         operator: "Exists"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cilium-config
-  namespace: kube-system
-data:
-  # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
-  etcd-config: |-
-    ---
-    endpoints:
-    - http://127.0.0.1:2379
-    #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
-    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
-    #
-    # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
-    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
-    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
-
-  # If you want to run cilium in debug mode change this value to true
-  debug: "false"
-  disable-ipv4: "false"
-  sidecar-http-proxy: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: cilium
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cilium
-subjects:
-- kind: ServiceAccount
-  name: cilium
-  namespace: kube-system
-- kind: Group
-  name: system:nodes
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: cilium
-rules:
-- apiGroups:
-  - "networking.k8s.io"
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - services
-  - nodes
-  - endpoints
-  - componentstatuses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
-  - thirdpartyresources
-  - ingresses
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - "apiextensions.k8s.io"
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - cilium.io
-  resources:
-  - ciliumnetworkpolicies
-  - ciliumendpoints
-  verbs:
-  - "*"
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: cilium
-  namespace: kube-system
 ---

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       serviceAccountName: cilium
       containers:
-      - image: cilium/cilium:v1.0
+      - image: cilium/cilium:v1.0.0-rc13
         imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: cilium
       containers:
       - image: cilium/cilium:v1.0
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]
         args:

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -158,8 +158,8 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
-      tolerations:
       restartPolicy: Always
+      tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -164,7 +164,7 @@ spec:
       serviceAccountName: cilium
       containers:
       - image: cilium/cilium:v1.0
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]
         args:

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -163,7 +163,7 @@ spec:
     spec:
       serviceAccountName: cilium
       containers:
-      - image: cilium/cilium:v1.0
+      - image: cilium/cilium:v1.0.0-rc13
         imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -1,3 +1,133 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+  # This etcd-config contains the etcd endpoints of your cluster. If you use
+  # TLS please make sure you uncomment the ca-file line and add the respective
+  # certificate has a k8s secret, see explanation below in the comment labeled
+  # "ETCD-CERT"
+  etcd-config: |-
+    ---
+    endpoints:
+    - http://127.0.0.1:2379
+    #
+    # In case you want to use TLS in etcd, uncomment the following line
+    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
+    #
+    # In case you want client to server authentication, uncomment the following
+    # lines and add the certificate and key in cilium-etcd-secrets below
+    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  disable-ipv4: "false"
+  sidecar-http-proxy: "false"
+---
+# The etcd secrets can be populated in kubernetes.
+# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
+kind: Secret
+apiVersion: v1
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
+  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
+  # (the "-w 0" generates the output on a single line)
+  etcd-ca: ""
+  etcd-client-key: ""
+  etcd-client-crt: ""
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- kind: Group
+  name: system:nodes
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
+  - thirdpartyresources
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumendpoints
+  verbs:
+  - "*"
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium
+  namespace: kube-system
+---
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -158,8 +288,8 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
-      tolerations:
       restartPolicy: Always
+      tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
@@ -168,134 +298,4 @@ spec:
       # Mark cilium's pod as critical for rescheduling
       - key: CriticalAddonsOnly
         operator: "Exists"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cilium-config
-  namespace: kube-system
-data:
-  # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
-  etcd-config: |-
-    ---
-    endpoints:
-    - http://127.0.0.1:2379
-    #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
-    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
-    #
-    # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
-    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
-    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
-
-  # If you want to run cilium in debug mode change this value to true
-  debug: "false"
-  disable-ipv4: "false"
-  sidecar-http-proxy: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: cilium
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cilium
-subjects:
-- kind: ServiceAccount
-  name: cilium
-  namespace: kube-system
-- kind: Group
-  name: system:nodes
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: cilium
-rules:
-- apiGroups:
-  - "networking.k8s.io"
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - services
-  - nodes
-  - endpoints
-  - componentstatuses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
-  - thirdpartyresources
-  - ingresses
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - "apiextensions.k8s.io"
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - cilium.io
-  resources:
-  - ciliumnetworkpolicies
-  - ciliumendpoints
-  verbs:
-  - "*"
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: cilium
-  namespace: kube-system
 ---

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: cilium
       containers:
       - image: cilium/cilium:__CILIUM_VERSION__
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: [ "cilium-agent" ]
         args:

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -158,8 +158,8 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
-      tolerations:
       restartPolicy: Always
+      tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule


### PR DESCRIPTION
Summary of changes:

* This fixes the previous commit which had the RestartAlways set in the
wrong place.
 Restart always will guarantee that kubelet will restart cilium in case
of failure.
Fixes: (e200aaffc1) k8s: add some fixes to the kubernetes spec file

* changed tag to `v1.0.0-rc13`

* changed image pull policy to `IfNotPresent`