### PR TITLE
ipcache: Avoid issuing delete for identity=0

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -286,7 +286,7 @@ func ipIdentityWatcher(listeners []IPIdentityMappingListener) {
 
 				// Callback upon cache updates.
 				for _, listener := range listeners {
-					if ipIDPair.ID != cachedIdentity {
+					if cachedIdentity != 0 && ipIDPair.ID != cachedIdentity {
 						cachedPair := ipIDPair
 						cachedPair.ID = cachedIdentity
 						listener.OnIPIdentityCacheChange(Delete, cachedPair)


### PR DESCRIPTION
This prevents extraneous deletes for id=0 as seen in the logs:

```
Apr 19 06:20:52 runtime1 cilium-agent[16315]: level=debug msg="endpoint IP cache state change" cached-identity=0 identity=21881 ipAddr=10.11.13.38 ipMask="<nil>" modification=Upsert
Apr 19 06:20:52 runtime1 cilium-agent[16315]: level=debug msg="daemon notified of IP-Identity cache state change" identity=0 ipAddr=10.11.13.38 ipMask="<nil>" modification=Delete
Apr 19 06:20:52 runtime1 cilium-agent[16315]: level=warning msg="unable to delete from bpf map" error="Unable to delete element: no such file or directory" key="<nil>/32"
Apr 19 06:20:52 runtime1 cilium-agent[16315]: level=debug msg="daemon notified of IP-Identity cache state change" identity=21881 ipAddr=10.11.13.38 ipMask="<nil>" modification=Upsert
```

Fixes: b6c5cb0f1bf5 ("ipcache: Shift NPHDS logic to envoy")
Signed-off-by: Joe Stringer <joe@covalent.io>