### PR TITLE
test: fix various tests to not delete resources before log gathering is performed

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -317,12 +317,18 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 		Context("Different namespaces", func() {
 
 			var (
-				namespace    = "second"
-				policy       = fmt.Sprintf("%s -n %s", l3Policy, namespace)
-				demoManifest = fmt.Sprintf("%s -n %s", demoPath, namespace)
+				namespace            = "second"
+				policy, demoManifest string
 			)
 
 			BeforeEach(func() {
+
+				demoPath = kubectl.ManifestGet("demo.yaml")
+				l3Policy = kubectl.ManifestGet("l3_l4_policy.yaml")
+
+				policy = fmt.Sprintf("%s -n %s", l3Policy, namespace)
+				demoManifest = fmt.Sprintf("%s -n %s", demoPath, namespace)
+
 				res := kubectl.NamespaceCreate(namespace)
 				res.ExpectSuccess("unable to create namespace %s: %s", namespace, res.CombineOutput())
 				res = kubectl.Apply(demoManifest)

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -331,9 +331,9 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 
 			AfterEach(func() {
 				// Explicitly do not check results to avoid incomplete teardown of test.
-				_ = kubectl.Delete(demoManifest).ExpectSuccess()
-				_ = kubectl.Delete(policy).ExpectSuccess()
-				_ = kubectl.NamespaceDelete(namespace).ExpectSuccess()
+				_ = kubectl.Delete(demoManifest)
+				_ = kubectl.Delete(policy)
+				_ = kubectl.NamespaceDelete(namespace)
 			})
 
 			It("Tests the same Policy in the different namespaces", func() {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -155,11 +155,23 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 	})
 
 	Context("Checks service across nodes", func() {
-		It("Checks ClusterIP Connectivity", func() {
-			demoDSPath := kubectl.ManifestGet("demo_ds.yaml")
-			kubectl.Apply(demoDSPath)
-			defer kubectl.Delete(demoDSPath)
 
+		var (
+			demoYAML = kubectl.ManifestGet("demo_ds.yaml")
+		)
+
+		BeforeEach(func() {
+			res := kubectl.Apply(demoYAML)
+			res.ExpectSuccess("unable to apply %s: %s", demoYAML, res.CombineOutput())
+		})
+
+		AfterEach(func() {
+			// Explicitly ignore result of deletion of resources to avoid incomplete
+			// teardown if any step fails.
+			_ = kubectl.Delete(demoYAML)
+		})
+
+		It("Checks ClusterIP Connectivity", func() {
 			waitPodsDs()
 
 			svcIP, err := kubectl.Get(

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -154,21 +154,23 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 		}, 300)
 	})
 
-	It("Checks service across nodes", func() {
-		demoDSPath := kubectl.ManifestGet("demo_ds.yaml")
-		kubectl.Apply(demoDSPath)
-		defer kubectl.Delete(demoDSPath)
+	Context("Checks service across nodes", func() {
+		It("Checks ClusterIP Connectivity", func() {
+			demoDSPath := kubectl.ManifestGet("demo_ds.yaml")
+			kubectl.Apply(demoDSPath)
+			defer kubectl.Delete(demoDSPath)
 
-		waitPodsDs()
+			waitPodsDs()
 
-		svcIP, err := kubectl.Get(
-			helpers.DefaultNamespace, "service testds-service").Filter("{.spec.clusterIP}")
-		Expect(err).Should(BeNil())
-		log.Debugf("svcIP: %s", svcIP.String())
-		Expect(govalidator.IsIP(svcIP.String())).Should(BeTrue())
+			svcIP, err := kubectl.Get(
+				helpers.DefaultNamespace, "service testds-service").Filter("{.spec.clusterIP}")
+			Expect(err).Should(BeNil())
+			log.Debugf("svcIP: %s", svcIP.String())
+			Expect(govalidator.IsIP(svcIP.String())).Should(BeTrue())
 
-		url := fmt.Sprintf("http://%s/", svcIP)
-		testHTTPRequest(url)
+			url := fmt.Sprintf("http://%s/", svcIP)
+			testHTTPRequest(url)
+		})
 	})
 
 	//TODO: Check service with IPV6

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -183,32 +183,28 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 			url := fmt.Sprintf("http://%s/", svcIP)
 			testHTTPRequest(url)
 		})
+
+		It("Tests NodePort", func() {
+			waitPodsDs()
+
+			var data v1.Service
+			err := kubectl.Get("default", "service test-nodeport").Unmarshal(&data)
+			Expect(err).Should(BeNil(), "Can not retrieve service")
+			url := fmt.Sprintf("http://%s",
+				net.JoinHostPort(data.Spec.ClusterIP, fmt.Sprintf("%d", data.Spec.Ports[0].Port)))
+			testHTTPRequest(url)
+
+			url = fmt.Sprintf("http://%s",
+				net.JoinHostPort(helpers.K8s1Ip, fmt.Sprintf("%d", data.Spec.Ports[0].NodePort)))
+			testHTTPRequest(url)
+
+			url = fmt.Sprintf("http://%s",
+				net.JoinHostPort(helpers.K8s2Ip, fmt.Sprintf("%d", data.Spec.Ports[0].NodePort)))
+			testHTTPRequest(url)
+		})
 	})
 
 	//TODO: Check service with IPV6
-
-	It("Check NodePort", func() {
-		demoDSPath := kubectl.ManifestGet("demo_ds.yaml")
-		kubectl.Apply(demoDSPath)
-		defer kubectl.Delete(demoDSPath)
-
-		waitPodsDs()
-
-		var data v1.Service
-		err := kubectl.Get("default", "service test-nodeport").Unmarshal(&data)
-		Expect(err).Should(BeNil(), "Can not retrieve service")
-		url := fmt.Sprintf("http://%s",
-			net.JoinHostPort(data.Spec.ClusterIP, fmt.Sprintf("%d", data.Spec.Ports[0].Port)))
-		testHTTPRequest(url)
-
-		url = fmt.Sprintf("http://%s",
-			net.JoinHostPort(helpers.K8s1Ip, fmt.Sprintf("%d", data.Spec.Ports[0].NodePort)))
-		testHTTPRequest(url)
-
-		url = fmt.Sprintf("http://%s",
-			net.JoinHostPort(helpers.K8s2Ip, fmt.Sprintf("%d", data.Spec.Ports[0].NodePort)))
-		testHTTPRequest(url)
-	})
 
 	Context("External services", func() {
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -160,12 +160,12 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 			demoYAML = kubectl.ManifestGet("demo_ds.yaml")
 		)
 
-		BeforeEach(func() {
+		BeforeAll(func() {
 			res := kubectl.Apply(demoYAML)
 			res.ExpectSuccess("unable to apply %s: %s", demoYAML, res.CombineOutput())
 		})
 
-		AfterEach(func() {
+		AfterAll(func() {
 			// Explicitly ignore result of deletion of resources to avoid incomplete
 			// teardown if any step fails.
 			_ = kubectl.Delete(demoYAML)


### PR DESCRIPTION
A variety of tests delete resources that are created within the test (the `It` itself). This means that when the test fails, the resource is already deleted before any logs / associated metadata can be gathered about that resource. This PR attempts to refactor said tests to create said resources in `BeforeEach` and delete them in `AfterEach`.

Signed-off by: Ian Vernon <ian@cilium.io>

Relates-to: #3821 