### PR TITLE
etcd: Clear the etcd status error when connectivity is restored

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -673,6 +673,8 @@ func (e *etcdClient) statusChecker() error {
 		// Only mark the etcd health as unstable if no etcd endpoints can be reached
 		if len(endpoints) > 0 && ok == 0 {
 			latestErrorStatus = fmt.Errorf("Not able to connect to any etcd endpoints")
+		} else {
+			latestErrorStatus = nil
 		}
 
 		statusLock.Unlock()


### PR DESCRIPTION
The current implementation makes the agent get restarted due to failing health check if there is any temporary connectivity issue with etcd, even if the connectivity to etcd gets restored.

Fixes: 9f9086e5c68aea7556dbec3b98a249ca7520863a
Fixes: https://github.com/cilium/cilium/pull/3532
Signed-off-by: Romain Lenglet <romain@covalent.io>