### PR TITLE
test/helpers: use rsync to copy files instead of cp

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -627,8 +627,8 @@ func (s *SSHMeta) GatherLogs() {
 	reportMap(testPath, ciliumLogCommands, s)
 
 	ciliumStateCommands := []string{
-		fmt.Sprintf("sudo cp -r %s %s", RunDir, filepath.Join(BasePath, testPath, "lib")),
-		fmt.Sprintf("sudo cp -r %s %s", LibDir, filepath.Join(BasePath, testPath, "run")),
+		fmt.Sprintf("sudo rsync -rv --exclude=*.sock %s %s", RunDir, filepath.Join(BasePath, testPath, "lib")),
+		fmt.Sprintf("sudo rsync -rv --exclude=*.sock %s %s", LibDir, filepath.Join(BasePath, testPath, "run")),
 	}
 
 	for _, cmd := range ciliumStateCommands {


### PR DESCRIPTION
This allows for excluding certain types of files when copying them, specifically
socket files, which are present in the directories which are copied over in
the log gathering functions for Ginkgo.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #3559 