### PR TITLE
test/helpers: make sure that key is non-empty for running `docker logs`

### DIFF
--- a/test/helpers/docker.go
+++ b/test/helpers/docker.go
@@ -150,8 +150,10 @@ func (s *SSHMeta) GatherDockerLogs() {
 	}
 	commands := map[string]string{}
 	for _, k := range res.ByLines() {
-		key := fmt.Sprintf("docker logs %s", k)
-		commands[key] = fmt.Sprintf("container_%s.log", k)
+		if k != "" {
+			key := fmt.Sprintf("docker logs %s", k)
+			commands[key] = fmt.Sprintf("container_%s.log", k)
+		}
 	}
 
 	testPath, err := CreateReportDirectory()


### PR DESCRIPTION
Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #3827 