### PR TITLE
Test: Fix issues with Updates and Kube-dns

### DIFF
--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -75,6 +75,9 @@ var _ = Describe("K8sValidatedUpdates", func() {
 		// because maybe is not present
 		kubectl.DeleteResource("ds", fmt.Sprintf("-n %s cilium", helpers.KubeSystemNamespace))
 		helpers.InstallExampleCilium(kubectl)
+
+		err := kubectl.WaitKubeDNS()
+		Expect(err).Should(BeNil(), "DNS is not ready after timeout")
 	})
 
 	validatedImage := func(image string) {


### PR DESCRIPTION
On `k8sT/Update.go` the system install a new cilium v1.0 image, but it
does not wait for Kubedns to be ready, so time to time the kubedns was
not ready at all.

With this commit we make sure that the DNS is ready before applied any
policy.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

Fix https://github.com/cilium/cilium/issues/3773
