### PR TITLE
Dependency to LLVM >= 6.0 in Documentation added

### DIFF
--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -750,7 +750,7 @@ The following applies to Fedora 25 or later:
 ::
 
     $ sudo dnf install -y git gcc ncurses-devel elfutils-libelf-devel bc \
-      openssl-devel libcap-devel clang llvm graphviz
+      openssl-devel libcap-devel clang llvm graphviz bison flex glibc-static
 
 .. note:: If you are running some other Fedora derivative and ``dnf`` is missing,
           try using ``yum`` instead.
@@ -833,7 +833,12 @@ failures:
 
 ::
 
-    Summary: 418 PASSED, 0 FAILED
+    Summary: 847 PASSED, 0 SKIPPED, 0 FAILED
+
+.. note:: Since Kernel Release 4.16 the bpf selftests has a dependency on LLVM >= 6.0
+          More info available on some mailing lists. (https://lwn.net/Articles/741773/)
+          Maybe you need to compile LLVM in the current version. More info at
+          http://llvm.org/docs/GettingStarted.html
 
 In order to run through all BPF selftests, the following command is needed:
 

--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -447,6 +447,8 @@ parsing network headers could be structured through tail calls. During runtime,
 functionality can be added or replaced atomically, and thus altering the BPF
 program's execution behavior.
 
+.. _bpf_to_bpf_calls:
+
 BPF to BPF Calls
 ----------------
 
@@ -835,10 +837,13 @@ failures:
 
     Summary: 847 PASSED, 0 SKIPPED, 0 FAILED
 
-.. note:: Since Kernel Release 4.16 the bpf selftests has a dependency on LLVM >= 6.0
-          More info available on some mailing lists. (https://lwn.net/Articles/741773/)
-          Maybe you need to compile LLVM in the current version. More info at
-          http://llvm.org/docs/GettingStarted.html
+.. note:: For Kernel Releases 4.16+ the BPF selftest has a dependency on LLVM 6.0+
+          caused by the BPF function calls which doesn't need to be inlined anymore.
+          See section :ref:`bpf_to_bpf_calls` or the mail 
+          (https://lwn.net/Articles/741773/) for more information. 
+          Not every BPF program has a dependency on LLVM 6.0+.
+          If your distribution doesn't provide LLVM 6.0+ you may compile it by
+          following the LLVM documentation (http://llvm.org/docs/GettingStarted.html).
 
 In order to run through all BPF selftests, the following command is needed:
 


### PR DESCRIPTION
**Summary of changes**:

For Kernel Releases >= 4.16 there is a dependency to LLVM >= 6.0 for tools/testing/selftests/bpf
The info to this dependency was added to the documentation / reference guide.

```release-note
<!-- Enter the release note text here if needed -->
```
