### PR TITLE
Support CIDR-dependent L4 egress policies

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -70,7 +70,7 @@ pkg/completion/ @cilium/proxy
 pkg/endpoint/ @cilium/endpoint
 pkg/envoy/ @cilium/proxy
 pkg/health/ @cilium/health
-pkg/ipcache/ @ianvernon
+pkg/ipcache/ @cilium/ipcache
 pkg/k8s/ @cilium/kubernetes
 pkg/kafka/ @cilium/proxy
 pkg/kvstore/ @cilium/kvstore

--- a/Documentation/kubernetes/policy.rst
+++ b/Documentation/kubernetes/policy.rst
@@ -34,13 +34,13 @@ For more information, see the official `NetworkPolicy documentation
 
 Known missing features for Kubernetes Network Policy:
 
-+----------------------------+----------------------------------------------+
-| Feature                    | Tracking Issue                               |
-+============================+==============================================+
-| Use of named ports         | https://github.com/cilium/cilium/issues/2942 |
-+----------------------------+----------------------------------------------+
-| CIDR-based L4 policy       | https://github.com/cilium/cilium/issues/1684 |
-+----------------------------+----------------------------------------------+
++------------------------------+----------------------------------------------+
+| Feature                      | Tracking Issue                               |
++==============================+==============================================+
+| Use of named ports           | https://github.com/cilium/cilium/issues/2942 |
++------------------------------+----------------------------------------------+
+| Ingress CIDR-based L4 policy | https://github.com/cilium/cilium/issues/1684 |
++------------------------------+----------------------------------------------+
 
 .. _CiliumNetworkPolicy:
 

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -496,6 +496,33 @@ endpoints with the label ``role=frontend`` will not be able to communicate with
 
         .. literalinclude:: ../../examples/policies/l4/l3_l4_combined.json
 
+CIDR-dependent Layer 4 Rule
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This example enables all endpoints with the label ``role=crawler`` to
+communicate with all remote destinations inside the CIDR ``192.0.2.0/24``, but
+they must communicate using TCP on port 80. The policy does not allow Endpoints
+without the label ``role=crawler`` to communicate with destinations in the CIDR
+``192.0.2.0/24``. Furthermore, endpoints with the label ``role=crawler`` will
+not be able to communicate with destinations in the CIDR ``192.0.2.0/24`` on
+ports other than port 80.
+
+.. only:: html
+
+   .. tabs::
+     .. group-tab:: k8s YAML
+
+        .. literalinclude:: ../../examples/policies/l4/cidr_l4_combined.yaml
+     .. group-tab:: JSON
+
+        .. literalinclude:: ../../examples/policies/l4/cidr_l4_combined.json
+
+.. only:: epub or latex
+
+        .. literalinclude:: ../../examples/policies/l4/cidr_l4_combined.json
+
+
+
 Layer 7 Examples
 ================
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -964,7 +964,7 @@ func (d *Daemon) syncLXCMap() error {
 				log.WithField(logfields.IPAddr, pair.IP).Debugf("Added local ip to endpoint map")
 			}
 		}
-		prefix := pair.PrefixString(isHost)
+		prefix := pair.PrefixString()
 		id, exists := ipcache.IPIdentityCache.LookupByIP(prefix)
 		if !exists || id != pair.ID {
 			// Upsert will not propagate (reserved:foo->ID) mappings across the cluster,

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -931,6 +931,26 @@ func (d *Daemon) syncLXCMap() error {
 			IP: node.GetIPv6Router(),
 			ID: identity.ReservedIdentityHost,
 		},
+		{
+			IP:   node.GetIPv6ClusterRange().IP,
+			Mask: node.GetIPv6ClusterRange().Mask,
+			ID:   identity.ReservedIdentityCluster,
+		},
+		{
+			IP:   node.GetIPv4ClusterRange().IP,
+			Mask: node.GetIPv4ClusterRange().Mask,
+			ID:   identity.ReservedIdentityCluster,
+		},
+		{
+			IP:   net.IPv4zero,
+			Mask: net.CIDRMask(0, net.IPv4len*8),
+			ID:   identity.ReservedIdentityWorld,
+		},
+		{
+			IP:   net.IPv6zero,
+			Mask: net.CIDRMask(0, net.IPv6len*8),
+			ID:   identity.ReservedIdentityWorld,
+		},
 	}
 
 	for _, pair := range specialIdentities {

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -776,6 +776,7 @@ func (d *Daemon) OnIPIdentityCacheChange(modType ipcache.CacheModification, ipID
 
 	log.WithFields(logrus.Fields{logfields.Modification: modType,
 		logfields.IPAddr:   ipIDPair.IP,
+		logfields.IPMask:   ipIDPair.Mask,
 		logfields.Identity: ipIDPair.ID}).
 		Debug("daemon notified of IP-Identity cache state change")
 
@@ -784,7 +785,7 @@ func (d *Daemon) OnIPIdentityCacheChange(modType ipcache.CacheModification, ipID
 	// logically located.
 
 	// Update BPF Maps.
-	key := ipCacheBPF.NewKey(ipIDPair.IP)
+	key := ipCacheBPF.NewKey(ipIDPair.IP, ipIDPair.Mask)
 
 	switch modType {
 	case ipcache.Upsert:

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -838,7 +838,7 @@ func (d *Daemon) OnIPIdentityCacheGC() {
 					keyToIP := k.String()
 
 					// Don't RLock as part of the same goroutine.
-					if _, exists := ipcache.IPIdentityCache.LookupByIPRLocked(keyToIP); !exists {
+					if _, exists := ipcache.IPIdentityCache.LookupByPrefixRLocked(keyToIP); !exists {
 						// Cannot delete from map during callback because DumpWithCallback
 						// RLocks the map.
 						keysToRemove[k] = struct{}{}

--- a/examples/policies/l4/cidr_l4_combined.json
+++ b/examples/policies/l4/cidr_l4_combined.json
@@ -1,0 +1,12 @@
+[{
+    "labels": [{"key": "name", "value": "cidr-l4-rule"}],
+    "endpointSelector": {"matchLabels":{"role":"crawler"}},
+    "egress": [{
+        "toCIDR": [
+            "192.0.2.0/24"
+        ],
+        "toPorts": [
+            {"ports":[ {"port": "80", "protocol": "TCP"}]}
+        ]
+    }]
+}]

--- a/examples/policies/l4/cidr_l4_combined.yaml
+++ b/examples/policies/l4/cidr_l4_combined.yaml
@@ -1,0 +1,15 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "cidr-l4-rule"
+spec:
+  endpointSelector:
+    matchLabels:
+      role: crawler
+  egress:
+  - toCIDR:
+    - 192.0.2.0/24
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -76,7 +76,6 @@ func (cache *NPHDSCache) OnIPIdentityCacheChange(
 		return
 	}
 
-	isHost := ipIDPair.Mask == nil
 	switch modType {
 	case ipcache.Upsert:
 		var npHost *envoyAPI.NetworkPolicyHosts
@@ -85,7 +84,7 @@ func (cache *NPHDSCache) OnIPIdentityCacheChange(
 		} else {
 			npHost = msg.(*envoyAPI.NetworkPolicyHosts)
 		}
-		npHost.HostAddresses = append(npHost.HostAddresses, ipIDPair.PrefixString(isHost))
+		npHost.HostAddresses = append(npHost.HostAddresses, ipIDPair.PrefixString())
 		sort.Strings(npHost.HostAddresses)
 		if err := npHost.Validate(); err != nil {
 			scopedLog.WithError(err).WithFields(logrus.Fields{
@@ -99,7 +98,7 @@ func (cache *NPHDSCache) OnIPIdentityCacheChange(
 			// Doesn't exist; already deleted.
 			return
 		}
-		cache.handleIPDelete(msg.(*envoyAPI.NetworkPolicyHosts), ipIDPair.ID.StringID(), ipIDPair.PrefixString(isHost))
+		cache.handleIPDelete(msg.(*envoyAPI.NetworkPolicyHosts), ipIDPair.ID.StringID(), ipIDPair.PrefixString())
 	}
 }
 

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -76,6 +76,7 @@ func (cache *NPHDSCache) OnIPIdentityCacheChange(
 		return
 	}
 
+	isHost := ipIDPair.Mask == nil
 	switch modType {
 	case ipcache.Upsert:
 		var npHost *envoyAPI.NetworkPolicyHosts
@@ -84,7 +85,7 @@ func (cache *NPHDSCache) OnIPIdentityCacheChange(
 		} else {
 			npHost = msg.(*envoyAPI.NetworkPolicyHosts)
 		}
-		npHost.HostAddresses = append(npHost.HostAddresses, ipIDPair.IP.String())
+		npHost.HostAddresses = append(npHost.HostAddresses, ipIDPair.PrefixString(isHost))
 		sort.Strings(npHost.HostAddresses)
 		if err := npHost.Validate(); err != nil {
 			scopedLog.WithError(err).WithFields(logrus.Fields{
@@ -98,7 +99,7 @@ func (cache *NPHDSCache) OnIPIdentityCacheChange(
 			// Doesn't exist; already deleted.
 			return
 		}
-		cache.handleIPDelete(msg.(*envoyAPI.NetworkPolicyHosts), ipIDPair.ID.StringID(), ipIDPair.IP.String())
+		cache.handleIPDelete(msg.(*envoyAPI.NetworkPolicyHosts), ipIDPair.ID.StringID(), ipIDPair.PrefixString(isHost))
 	}
 }
 

--- a/pkg/identity/allocator.go
+++ b/pkg/identity/allocator.go
@@ -120,3 +120,19 @@ func AllocateIdentity(lbls labels.Labels) (*Identity, bool, error) {
 func (id *Identity) Release() error {
 	return identityAllocator.Release(globalIdentity{id.Labels})
 }
+
+// ReleaseSlice attempts to release a set of identities. It is a helper
+// function that may be useful for cleaning up multiple identities in paths
+// where several identities may be allocated and another error means that they
+// should all be released.
+func ReleaseSlice(identities []*Identity) error {
+	var err error
+	for _, id := range identities {
+		if err = id.Release(); err != nil {
+			log.WithFields(logrus.Fields{
+				logfields.Identity: id,
+			}).Error("Failed to release identity")
+		}
+	}
+	return err
+}

--- a/pkg/identity/cidr.go
+++ b/pkg/identity/cidr.go
@@ -1,0 +1,92 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identity
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/labels/cidr"
+)
+
+// AllocateCIDRIdentities allocates identities for each of the specified CIDR
+// prefixes so they will be available later during policy resolution.
+//
+// On success, the returned slice will have a 1-to-1 correspondence with the
+// CIDR in the provided prefixes slice, eg the identity for prefixes[0] will
+// be held in identities[0].
+// On failure, attempts to clean up after itself and returns the error.
+func AllocateCIDRIdentities(prefixes []*net.IPNet) (res []*Identity, err error) {
+	if len(prefixes) == 0 {
+		return nil, nil
+	}
+
+	log.Debugf("Attempting to allocate identities for %d prefixes", len(prefixes))
+
+	// Allocate identities for each CIDR.
+	var lbls labels.Labels
+	res = make([]*Identity, 0, len(prefixes))
+	for _, prefix := range prefixes {
+		if prefix == nil {
+			continue
+		}
+		lbls := cidr.GetCIDRLabels(prefix)
+		id, _, err := AllocateIdentity(lbls)
+		if err != nil {
+			// If any identity allocation failed, release existing identities
+			// and log the error.
+			if err2 := ReleaseSlice(res); err2 != nil {
+				log.WithError(err2).Error("Could not recover from error during CIDR identity allocation")
+			}
+			res = nil
+			break
+		}
+		res = append(res, id)
+	}
+
+	if err == nil {
+		log.Debugf("Allocated identities for %d prefixes", len(res))
+	} else {
+		log.WithError(err).Warningf("Failed to allocate identities for %d prefixes", len(res))
+	}
+
+	if err != nil {
+		err = fmt.Errorf("Failed to allocate identity for %s: %s", lbls.String(), err)
+	}
+	return
+}
+
+// LookupCIDRIdentities finds identities corresponding to each of the specified
+// prefixes. It expects to be able to find all identities.
+// On success, returns a slice of identities with a 1-to-1 correspondence to
+// the specified slice of prefixes, and nil.
+// On error, returns all identities that can be resolved and an error.
+func LookupCIDRIdentities(prefixes []*net.IPNet) (res []*Identity, err error) {
+	res = make([]*Identity, 0, len(prefixes))
+
+	for _, prefix := range prefixes {
+		labels := cidr.GetCIDRLabels(prefix)
+		id, err2 := identityAllocator.Get(globalIdentity{labels})
+		if err2 == nil {
+			res = append(res, NewIdentity(NumericIdentity(id), labels))
+		} else {
+			err = err2
+			log.Infof("Cannot locate identity for CIDR %s", prefix.String())
+		}
+	}
+
+	return res, err
+}

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -115,12 +115,18 @@ func NewIdentity(id NumericIdentity, lbls labels.Labels) *Identity {
 	return &Identity{ID: id, Labels: lbls, LabelArray: lblArray}
 }
 
+// IsHost determines whether the IP in the pair represents a host (true) or a
+// CIDR prefix (false)
+func (pair *IPIdentityPair) IsHost() bool {
+	return pair.Mask == nil
+}
+
 // PrefixString returns the IPIdentityPair's IP as either a host IP in the
 // format w.x.y.z if 'host' is true, or as a prefix in the format the w.x.y.z/N
 // if 'host' is false.
-func (pair *IPIdentityPair) PrefixString(host bool) string {
+func (pair *IPIdentityPair) PrefixString() string {
 	var suffix string
-	if !host {
+	if !pair.IsHost() {
 		ones := net.IPv6len
 		if pair.Mask == nil && pair.IP.To4() != nil {
 			ones = net.IPv4len

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -51,6 +51,17 @@ var (
 	// computed. It is determined by the orchestration system / runtime.
 	AddressSpace = DefaultAddressSpace
 
+	// MaxPrefixLengths is an approximation of how many different CIDR
+	// prefix lengths may be supported by the BPF datapath without causing
+	// BPF code generation to exceed the verifier instruction limit.
+	//
+	// This was manually determined by setting up an egress policy with a
+	// CIDRSet containing an exception. Reserved 'world' (/0) and 'cluster'
+	// (/8) will always be inserted, which is what the first parameter
+	// denotes. The CIDR for the CIDRSet is the third parameter, and the
+	// exception is the second parameter.
+	MaxPrefixLengths = 2 + 32 - 20
+
 	setupIPIdentityWatcher sync.Once
 )
 
@@ -142,6 +153,42 @@ func UpsertIPNetToKVStore(prefix *net.IPNet, ID *identity.Identity) error {
 	return upsertToKVStore(ipKey, ipIDPair)
 }
 
+func checkPrefixLengthsAgainstMap(prefixes []*net.IPNet, existingPrefixes map[int]int) error {
+	prefixLengths := make(map[int]struct{})
+
+	for i := range existingPrefixes {
+		prefixLengths[i] = struct{}{}
+	}
+
+	for _, prefix := range prefixes {
+		ones, _ := prefix.Mask.Size()
+		if _, ok := prefixLengths[ones]; !ok {
+			prefixLengths[ones] = struct{}{}
+		}
+	}
+
+	if len(prefixLengths) > MaxPrefixLengths {
+		existingPrefixLengths := len(existingPrefixes)
+		return fmt.Errorf("Adding specified CIDR prefixes would result in too many prefix lengths (current: %d, result: %d, max: %d)",
+			existingPrefixLengths, len(prefixLengths), MaxPrefixLengths)
+	}
+	return nil
+}
+
+// checkPrefixLengths ensures that we will reject rules if the import of those
+// rules would cause the ipcache to contain more than the supported number of
+// CIDR prefix lengths.
+func checkPrefixLengths(prefixes []*net.IPNet) (err error) {
+	IPIdentityCache.RLock()
+	defer IPIdentityCache.RUnlock()
+
+	if err = checkPrefixLengthsAgainstMap(prefixes, IPIdentityCache.v4PrefixLengths); err != nil {
+		return
+	}
+
+	return checkPrefixLengthsAgainstMap(prefixes, IPIdentityCache.v6PrefixLengths)
+}
+
 // UpsertIPNetsToKVStore inserts a CIDR->Identity mapping into the kvstore
 // ipcache for each of the specified prefixes and identities. That is to say,
 // prefixes[0] is mapped to identities[0].
@@ -151,6 +198,9 @@ func UpsertIPNetToKVStore(prefix *net.IPNet, ID *identity.Identity) error {
 func UpsertIPNetsToKVStore(prefixes []*net.IPNet, identities []*identity.Identity) (err error) {
 	if len(prefixes) != len(identities) {
 		return fmt.Errorf("Invalid []Prefix->[]Identity ipcache mapping requested: prefixes=%d identities=%d", len(prefixes), len(identities))
+	}
+	if err = checkPrefixLengths(prefixes); err != nil {
+		return
 	}
 	for i, prefix := range prefixes {
 		id := identities[i]
@@ -167,7 +217,7 @@ func UpsertIPNetsToKVStore(prefixes []*net.IPNet, identities []*identity.Identit
 		}
 	}
 
-	return err
+	return
 }
 
 // DeleteIPFromKVStore removes the IP->Identity mapping for the specified ip from the

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -209,3 +209,21 @@ func (s *IPCacheTestSuite) TestKeyToIPNet(c *C) {
 	c.Assert(err, Not(IsNil))
 	c.Assert(isHost, Equals, false)
 }
+
+func (s *IPCacheTestSuite) TestToBPFData(c *C) {
+	identityOffset := 2000
+	prefixes := []string{
+		"192.0.2.0/24",
+		"192.0.64.0/20",
+	}
+
+	ipc := NewIPCache()
+	for i, prefix := range prefixes {
+		id := identityPkg.NumericIdentity(i + identityOffset)
+		ipc.Upsert(prefix, id)
+	}
+
+	s6, s4 := ipc.ToBPFData()
+	c.Assert(s6, comparator.DeepEquals, []int{128})
+	c.Assert(s4, comparator.DeepEquals, []int{32, 24, 20})
+}

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -123,9 +123,15 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	cachedIdentity, exists = IPIdentityCache.LookupByIP("127.0.0.1")
 	c.Assert(cachedIdentity, Equals, identityPkg.NumericIdentity(29))
 
+	cachedIdentity, exists = IPIdentityCache.LookupByPrefix("127.0.0.1/32")
+	c.Assert(cachedIdentity, Equals, identityPkg.NumericIdentity(29))
+
 	IPIdentityCache.delete("127.0.0.1")
 
 	_, exists = IPIdentityCache.LookupByIdentity(29)
+	c.Assert(exists, Equals, false)
+
+	_, exists = IPIdentityCache.LookupByPrefix("127.0.0.1/32")
 	c.Assert(exists, Equals, false)
 
 	// Clean up.

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -66,6 +66,9 @@ const (
 	// IPAddr is an IPV4 or IPv6 address
 	IPAddr = "ipAddr"
 
+	// IPMask is an IPV4 or IPv6 address mask
+	IPMask = "ipMask"
+
 	// IPv4 is an IPv4 address
 	IPv4 = "ipv4"
 

--- a/pkg/policy/api/egress.go
+++ b/pkg/policy/api/egress.go
@@ -111,7 +111,9 @@ type EgressRule struct {
 // GetDestinationEndpointSelectors returns a slice of endpoints selectors
 // covering all L3 destination selectors of the egress rule
 func (e *EgressRule) GetDestinationEndpointSelectors() EndpointSelectorSlice {
-	return append(e.ToEndpoints, e.ToEntities.GetAsEndpointSelectors()...)
+	res := append(e.ToEndpoints, e.ToEntities.GetAsEndpointSelectors()...)
+	res = append(res, e.ToCIDR.GetAsEndpointSelectors()...)
+	return append(res, e.ToCIDRSet.GetAsEndpointSelectors()...)
 }
 
 // IsLabelBased returns true whether the L3 destination endpoints are selected

--- a/pkg/policy/api/ingress.go
+++ b/pkg/policy/api/ingress.go
@@ -109,7 +109,9 @@ type IngressRule struct {
 // GetSourceEndpointSelectors returns a slice of endpoints selectors covering
 // all L3 source selectors of the ingress rule
 func (i *IngressRule) GetSourceEndpointSelectors() EndpointSelectorSlice {
-	return append(i.FromEndpoints, i.FromEntities.GetAsEndpointSelectors()...)
+	res := append(i.FromEndpoints, i.FromEntities.GetAsEndpointSelectors()...)
+	res = append(res, i.FromCIDR.GetAsEndpointSelectors()...)
+	return append(res, i.FromCIDRSet.GetAsEndpointSelectors()...)
 }
 
 // IsLabelBased returns true whether the L3 source endpoints are selected based

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -127,8 +127,8 @@ func (e *EgressRule) sanitize() error {
 		"ToServices":  len(e.ToServices),
 	}
 	l3DependentL4Support := map[interface{}]bool{
-		"ToCIDR":      false,
-		"ToCIDRSet":   false,
+		"ToCIDR":      true,
+		"ToCIDRSet":   true,
 		"ToEndpoints": true,
 		"ToEntities":  true,
 		"ToServices":  false,

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -88,6 +88,8 @@ type L4Filter struct {
 	// U8Proto is the Protocol in numeric format, or 0 for NONE
 	U8Proto u8proto.U8proto `json:"-"`
 	// Endpoints limits the labels for allowing traffic (to / from).
+	// This includes selectors for destinations affected by entity-based
+	// and CIDR-based policy.
 	Endpoints api.EndpointSelectorSlice `json:"-"`
 	// L7Parser specifies the L7 protocol parser (optional). If specified as
 	// an empty string, then means that no L7 proxy redirect is performed.

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -240,6 +240,12 @@ func (r *rule) resolveCIDRPolicy(ctx *SearchContext, state *traceState, result *
 		allCIDRs = append(allCIDRs, ingressRule.FromCIDR...)
 		allCIDRs = append(allCIDRs, api.ComputeResultantCIDRSet(ingressRule.FromCIDRSet)...)
 
+		// CIDR + L4 rules are handled via mergeL4Ingress(),
+		// skip them here.
+		if len(allCIDRs) > 0 && len(ingressRule.ToPorts) > 0 {
+			continue
+		}
+
 		if cnt := mergeCIDR(ctx, "Ingress", allCIDRs, r.Labels, &result.Ingress); cnt > 0 {
 			found += cnt
 		}
@@ -250,6 +256,12 @@ func (r *rule) resolveCIDRPolicy(ctx *SearchContext, state *traceState, result *
 		var allCIDRs []api.CIDR
 		allCIDRs = append(allCIDRs, egressRule.ToCIDR...)
 		allCIDRs = append(allCIDRs, api.ComputeResultantCIDRSet(egressRule.ToCIDRSet)...)
+
+		// CIDR + L4 rules are handled via mergeL4Egress(),
+		// skip them here.
+		if len(allCIDRs) > 0 && len(egressRule.ToPorts) > 0 {
+			continue
+		}
 
 		if cnt := mergeCIDR(ctx, "Egress", allCIDRs, r.Labels, &result.Egress); cnt > 0 {
 			found += cnt

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1071,32 +1071,6 @@ func (ds *PolicyTestSuite) TestEgressRuleRestrictions(c *C) {
 	}
 
 	err := apiRule1.Sanitize()
-	c.Assert(err, Not(IsNil))
-
-	// Cannot combine ToCIDR and ToPorts. See GH-1684.
-	apiRule1 = api.Rule{
-		EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("bar")),
-		Egress: []api.EgressRule{
-			{
-				ToCIDR: []api.CIDR{
-					"10.1.0.0/16",
-					"2001:dbf::/64",
-				},
-				ToPorts: []api.PortRule{{
-					Ports: []api.PortProtocol{
-						{Port: "80", Protocol: api.ProtoTCP},
-					},
-					Rules: &api.L7Rules{
-						Kafka: []api.PortRuleKafka{
-							{Topic: "foo"},
-						},
-					},
-				}},
-			},
-		},
-	}
-
-	err = apiRule1.Sanitize()
 	c.Assert(err, Not(IsNil))
 }
 


### PR DESCRIPTION
Support the combination of `toCIDR`/`toCIDRSet` and `toPorts` in a single egress rule, so this rule will only allow traffic that matches both of these conditions. 

Current limitations:
* Up to about 14 prefix lengths may be used with this PR as-is, eg, a x/1, y/2, ... z/10. Any number of CIDRs may be configured under that set of prefix lengths. Beyond we start to hit BPF instruction limits.
  * This includes CIDRSet "exceptions", eg if you have "allow CIDR /8" and "except this /16" then it might be slightly too complex.
  * When importing a policy, if the supported number of prefix lengths is likely to be exceeded, we will reject the policy (rather than waiting until compilation time)
* Cannot select the host IP(s) via CIDR policy. If you want to filter on host IP, use "entity: host".

Related: #1684

Related dependent PRs:
* [x] #3883 (Policy refactoring)
  * [x] #3909 (Labels libraries)
* [x] #3884 (Endpoint / ipcache refactoring)
* [x] #3885 (Core BPF support)

Short-term todos:
* [x] Make sure that CIDR+L4 doesn't allow the entire CIDR as well as the specified l3+L4 range
* [x] Add cluster cidr to ipcache on startup
* [x] Improve documentation
* [x] Improve unit testing
* [x] Add basic ginkgo tests
* [x] Check the output of every tool that prints labels
  * [x] `cilium identity list`
  * [x] `cilium bpf policy get`
* [x] Fix up NPHDS `OnIPIdentityCacheChange()` to generate prefixes
  * [x] Test CIDR-dependent L7
* [x] Shift regular l3 CIDR over to this model
* [x] Test, fix IPv6 CIDRs

Longer term, unlikely to be addressed by this PR:
* LPM based BPF map for newer kernels
* Enable Ingress CIDR-dependent L4(+L7)
  * Requires minor datapath changes
  * Remove CIDRPolicyMap and related logic

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/3835)
<!-- Reviewable:end -->
