### PR TITLE
ginkgo-kubernetes-all.Jenkinsfile: increase timeouts

### DIFF
--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
                 FAILFAST = failFast(env.GIT_BRANCH)
             }
             options {
-                timeout(time: 60, unit: 'MINUTES')
+                timeout(time: 120, unit: 'MINUTES')
             }
             steps {
                 parallel(
@@ -78,7 +78,7 @@ pipeline {
                 FAILFAST = failFast(env.GIT_BRANCH)
             }
             options {
-                timeout(time: 60, unit: 'MINUTES')
+                timeout(time: 120, unit: 'MINUTES')
             }
             steps {
                 parallel(


### PR DESCRIPTION
Use a more generous timeout to allow for variability in build times.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #3836 