### PR TITLE
test/helpers: log to console when report generation begins / ends

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -574,6 +574,9 @@ func (s *SSHMeta) PolicyWait(revisionNum int) *CmdRes {
 // purposes.
 func (s *SSHMeta) ReportFailed(commands ...string) {
 	wr := s.logger.Logger.Out
+	// Log the following line to both the log file, and to console to delineate
+	// when log gathering begins.
+	fmt.Println("===================== TEST FAILED =====================")
 	fmt.Fprint(wr, "===================== TEST FAILED =====================\n")
 	fmt.Fprint(wr, "Gathering Logs and Cilium CLI Output\n")
 	res := s.ExecCilium("endpoint list")
@@ -589,7 +592,10 @@ func (s *SSHMeta) ReportFailed(commands ...string) {
 	s.GatherLogs()
 	s.GatherDockerLogs()
 	s.CheckLogsForDeadlock()
+	// Log the following line to both the log file, and to console to delineate
+	// when log gathering begins.
 	fmt.Fprint(wr, "===================== EXITING REPORT GENERATION =====================\n")
+	fmt.Println("===================== EXITING REPORT GENERATION =====================")
 }
 
 // ValidateNoErrorsOnLogs checks in cilium logs since the given duration (By

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -849,7 +849,8 @@ func (kub *Kubectl) CiliumReport(namespace string, commands ...[]string) {
 	}
 
 	wr := kub.logger.Logger.Out
-	fmt.Fprint(wr, "StackTrace Begin\n")
+	fmt.Println("===================== TEST FAILED =====================")
+	fmt.Fprint(wr, "===================== TEST FAILED =====================\n")
 
 	data := kub.Exec(fmt.Sprintf("%s get pods -o wide", KubectlCmd))
 	fmt.Fprintln(wr, data.Output())
@@ -864,10 +865,11 @@ func (kub *Kubectl) CiliumReport(namespace string, commands ...[]string) {
 			fmt.Fprintln(wr, out.CombineOutput())
 		}
 	}
-	fmt.Fprint(wr, "StackTrace Ends\n")
 	kub.DumpCiliumCommandOutput(namespace)
 	kub.GatherLogs()
 	kub.CheckLogsForDeadlock()
+	fmt.Fprint(wr, "===================== EXITING REPORT GENERATION =====================")
+	fmt.Println("===================== EXITING REPORT GENERATION =====================")
 
 }
 


### PR DESCRIPTION
It is extremely difficult to determine at what point in Console output on Jenkins when
a test failed because if it fails, a bunch of information about commands being ran is logged to console.  Instead of logging this information to the file in which logs are stored,
log it to console directly to make it easier for people to see exactly when tests failed,
as this provides key information to narrow down where to look for information in logs,
endpoint state changes, etc.

Signed-off by: Ian Vernon <ian@cilium.io>