### PR TITLE
test: miscellaneous Ginkgo code cleanup

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -440,6 +440,19 @@ func (s *SSHMeta) SetPolicyEnforcement(status string) *CmdRes {
 	return s.ExecCilium(fmt.Sprintf("config %s=%s", PolicyEnforcement, status))
 }
 
+// SetPolicyEnforcementAndWait and wait sets the PolicyEnforcement configuration
+// value for the Cilium agent to the provided status, and then waits for all endpoints
+// running in s to be ready. Returns whether setting of the configuration value
+// was unsuccessful / if the endpoints go into ready state.
+func (s *SSHMeta) SetPolicyEnforcementAndWait(status string) bool {
+	res := s.SetPolicyEnforcement(status)
+	if !res.WasSuccessful() {
+		return false
+	}
+
+	return s.WaitEndpointsReady()
+}
+
 // PolicyDelAll deletes all policy rules currently imported into Cilium.
 func (s *SSHMeta) PolicyDelAll() *CmdRes {
 	log.Info("Deleting all policy in agent")

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -52,21 +52,22 @@ const (
 var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 
 	var (
-		logger *logrus.Entry
-		vm     *helpers.SSHMeta
+		logger           *logrus.Entry
+		vm               *helpers.SSHMeta
+		appContainerName = "app"
 	)
 
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimePolicyEnforcement"})
 		logger.Info("Starting")
 		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
-		vm.ContainerCreate("app", "cilium/demo-httpd", helpers.CiliumDockerNetwork, "-l id.app")
+		vm.ContainerCreate(appContainerName, helpers.HttpdImage, helpers.CiliumDockerNetwork, "-l id.app")
 		areEndpointsReady := vm.WaitEndpointsReady()
 		Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
 	})
 
 	AfterAll(func() {
-		vm.ContainerRm("app")
+		vm.ContainerRm(appContainerName)
 	})
 
 	BeforeEach(func() {
@@ -93,99 +94,52 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 		It("Default values", func() {
 
 			By("Policy Enforcement should be disabled for containers", func() {
-				endPoints, err := vm.PolicyEndpointsSummary()
-				Expect(err).Should(BeNil())
-				Expect(endPoints[helpers.Disabled]).To(Equal(1))
+				ExpectEndpointSummary(vm, helpers.Disabled, 1)
 			})
 
 			By("Apply a new sample policy")
 			_, err := vm.PolicyImportAndWait(vm.GetFullPath(sampleJSON), helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
-
-			endPoints, err := vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(1))
+			ExpectEndpointSummary(vm, helpers.Enabled, 1)
 		})
 
 		It("Default to Always without policy", func() {
 			By("Check no policy enforcement")
-			endPoints, err := vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Disabled]).To(Equal(1))
+			ExpectEndpointSummary(vm, helpers.Disabled, 1)
 
 			By("Setting to Always")
-
 			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementAlways)
-
-			endPoints, err = vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(1))
+			ExpectEndpointSummary(vm, helpers.Enabled, 1)
 
 			By("Setting to default from Always")
 			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementDefault)
-
-			endPoints, err = vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Disabled]).To(Equal(1))
+			ExpectEndpointSummary(vm, helpers.Disabled, 1)
 		})
 
 		It("Default to Always with policy", func() {
 			_, err := vm.PolicyImportAndWait(vm.GetFullPath(sampleJSON), helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
-
-			endPoints, err := vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(1))
-
+			ExpectEndpointSummary(vm, helpers.Enabled, 1)
 			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementAlways)
-
-			endPoints, err = vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(1))
-
+			ExpectEndpointSummary(vm, helpers.Enabled, 1)
 			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementDefault)
-
-			endPoints, err = vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(1))
+			ExpectEndpointSummary(vm, helpers.Enabled, 1)
 		})
 
 		It("Default to Never without policy", func() {
-			endPoints, err := vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Disabled]).To(Equal(1))
-
+			ExpectEndpointSummary(vm, helpers.Disabled, 1)
 			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementNever)
-
-			endPoints, err = vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Disabled]).To(Equal(1))
-
-			endPoints, err = vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Disabled]).To(Equal(1))
+			ExpectEndpointSummary(vm, helpers.Disabled, 1)
 		})
 
 		It("Default to Never with policy", func() {
-
 			_, err := vm.PolicyImportAndWait(vm.GetFullPath(sampleJSON), helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
-
-			endPoints, err := vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(1))
-
+			ExpectEndpointSummary(vm, helpers.Enabled, 1)
 			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementNever)
-
-			endPoints, err = vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(0))
-
+			ExpectEndpointSummary(vm, helpers.Enabled, 0)
 			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementDefault)
-
-			endPoints, err = vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(1))
+			ExpectEndpointSummary(vm, helpers.Enabled, 1)
 		})
 	})
 
@@ -197,65 +151,39 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 
 		It("Container creation", func() {
 			//Check default containers are in place.
-			endPoints, err := vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(1))
-			Expect(endPoints[helpers.Disabled]).To(Equal(0))
+			ExpectEndpointSummary(vm, helpers.Enabled, 1)
+			ExpectEndpointSummary(vm, helpers.Disabled, 0)
 
 			By("Create a new container")
 			vm.ContainerCreate("new", "cilium/demo-httpd", helpers.CiliumDockerNetwork, "-l id.new")
-			endPoints, err = vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(2))
-			Expect(endPoints[helpers.Disabled]).To(Equal(0))
+			ExpectEndpointSummary(vm, helpers.Enabled, 2)
+			ExpectEndpointSummary(vm, helpers.Disabled, 0)
 			vm.ContainerRm("new")
 		}, 300)
 
 		It("Always to Never with policy", func() {
-			endPoints, err := vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(1))
-			Expect(endPoints[helpers.Disabled]).To(Equal(0))
+			ExpectEndpointSummary(vm, helpers.Enabled, 1)
+			ExpectEndpointSummary(vm, helpers.Disabled, 0)
 
-			_, err = vm.PolicyImportAndWait(vm.GetFullPath(sampleJSON), helpers.HelperTimeout)
+			_, err := vm.PolicyImportAndWait(vm.GetFullPath(sampleJSON), helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
-			endPoints, err = vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(1))
-			Expect(endPoints[helpers.Disabled]).To(Equal(0))
-
+			ExpectEndpointSummary(vm, helpers.Enabled, 1)
+			ExpectEndpointSummary(vm, helpers.Disabled, 0)
 			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementNever)
-
-			endPoints, err = vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(0))
-
+			ExpectEndpointSummary(vm, helpers.Enabled, 0)
 			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementAlways)
-
-			endPoints, err = vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(1))
+			ExpectEndpointSummary(vm, helpers.Enabled, 1)
 		})
 
 		It("Always to Never without policy", func() {
-			endPoints, err := vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(1))
-			Expect(endPoints[helpers.Disabled]).To(Equal(0))
-
+			ExpectEndpointSummary(vm, helpers.Enabled, 1)
+			ExpectEndpointSummary(vm, helpers.Disabled, 0)
 			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementNever)
-
-			endPoints, err = vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(0))
-			Expect(endPoints[helpers.Disabled]).To(Equal(1))
-
+			ExpectEndpointSummary(vm, helpers.Enabled, 0)
+			ExpectEndpointSummary(vm, helpers.Disabled, 1)
 			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementAlways)
-
-			endPoints, err = vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(1))
+			ExpectEndpointSummary(vm, helpers.Enabled, 1)
 		})
 
 	})
@@ -268,69 +196,43 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 
 		It("Container creation", func() {
 			//Check default containers are in place.
-			endPoints, err := vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(0))
-			Expect(endPoints[helpers.Disabled]).To(Equal(1))
+			ExpectEndpointSummary(vm, helpers.Enabled, 0)
+			ExpectEndpointSummary(vm, helpers.Disabled, 1)
 
 			vm.ContainerCreate("new", "cilium/demo-httpd", helpers.CiliumDockerNetwork, "-l id.new")
 			vm.WaitEndpointsReady()
-			endPoints, err = vm.PolicyEndpointsSummary()
 
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(0))
-			Expect(endPoints[helpers.Disabled]).To(Equal(2))
+			ExpectEndpointSummary(vm, helpers.Enabled, 0)
+			ExpectEndpointSummary(vm, helpers.Disabled, 2)
 			vm.ContainerRm("new")
 		}, 300)
 
 		It("Never to default with policy", func() {
-			endPoints, err := vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(0))
-			Expect(endPoints[helpers.Disabled]).To(Equal(1))
+			ExpectEndpointSummary(vm, helpers.Enabled, 0)
+			ExpectEndpointSummary(vm, helpers.Disabled, 1)
 
-			_, err = vm.PolicyImportAndWait(vm.GetFullPath(sampleJSON), helpers.HelperTimeout)
+			_, err := vm.PolicyImportAndWait(vm.GetFullPath(sampleJSON), helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
-			endPoints, err = vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(0))
-			Expect(endPoints[helpers.Disabled]).To(Equal(1))
-
+			ExpectEndpointSummary(vm, helpers.Enabled, 0)
+			ExpectEndpointSummary(vm, helpers.Disabled, 1)
 			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementDefault)
-
-			endPoints, err = vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(1))
-			Expect(endPoints[helpers.Disabled]).To(Equal(0))
-
+			ExpectEndpointSummary(vm, helpers.Enabled, 1)
+			ExpectEndpointSummary(vm, helpers.Disabled, 0)
 			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementNever)
-
-			endPoints, err = vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(0))
-			Expect(endPoints[helpers.Disabled]).To(Equal(1))
+			ExpectEndpointSummary(vm, helpers.Enabled, 0)
+			ExpectEndpointSummary(vm, helpers.Disabled, 1)
 		})
 
 		It("Never to default without policy", func() {
-			endPoints, err := vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(0))
-			Expect(endPoints[helpers.Disabled]).To(Equal(1))
-
+			ExpectEndpointSummary(vm, helpers.Enabled, 0)
+			ExpectEndpointSummary(vm, helpers.Disabled, 1)
 			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementDefault)
-
-			endPoints, err = vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(0))
-			Expect(endPoints[helpers.Disabled]).To(Equal(1))
-
+			ExpectEndpointSummary(vm, helpers.Enabled, 0)
+			ExpectEndpointSummary(vm, helpers.Disabled, 1)
 			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementNever)
-
-			endPoints, err = vm.PolicyEndpointsSummary()
-			Expect(err).Should(BeNil())
-			Expect(endPoints[helpers.Enabled]).To(Equal(0))
-			Expect(endPoints[helpers.Disabled]).To(Equal(1))
+			ExpectEndpointSummary(vm, helpers.Enabled, 0)
+			ExpectEndpointSummary(vm, helpers.Disabled, 1)
 		})
 	})
 })

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -90,11 +90,7 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 	Context("Policy Enforcement Default", func() {
 
 		BeforeEach(func() {
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
-			res.ExpectSuccess()
-
-			areEndpointsReady := vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementDefault)
 		})
 
 		It("Default values", func() {
@@ -122,22 +118,14 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 
 			By("Setting to Always")
 
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways)
-			res.ExpectSuccess()
-
-			areEndpointsReady := vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementAlways)
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 
 			By("Setting to default from Always")
-			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
-			res.ExpectSuccess()
-
-			areEndpointsReady = vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementDefault)
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -151,23 +139,14 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 			endPoints, err := vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Enabled]).To(Equal(1))
-			//DEfault =APP with PolicyEnforcement
 
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways)
-			res.ExpectSuccess()
-
-			areEndpointsReady := vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementAlways)
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 
-			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
-			res.ExpectSuccess()
-
-			areEndpointsReady = vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementDefault)
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -179,11 +158,7 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementNever)
-			res.ExpectSuccess()
-
-			areEndpointsReady := vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementNever)
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -203,21 +178,13 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementNever)
-			res.ExpectSuccess()
-
-			areEndpointsReady := vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementNever)
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Enabled]).To(Equal(0))
 
-			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
-			res.ExpectSuccess()
-
-			areEndpointsReady = vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementDefault)
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -228,11 +195,7 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 	Context("Policy Enforcement Always", func() {
 		//The test Always to Default is already tested in from default-always
 		BeforeEach(func() {
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways)
-			res.ExpectSuccess()
-
-			areEndpointsReady := vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementAlways)
 		})
 
 		It("Container creation", func() {
@@ -265,21 +228,13 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 			Expect(endPoints[helpers.Disabled]).To(Equal(0))
 
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementNever)
-			res.ExpectSuccess()
-
-			areEndpointsReady := vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementNever)
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Enabled]).To(Equal(0))
 
-			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways)
-			res.ExpectSuccess()
-
-			areEndpointsReady = vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementAlways)
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -292,22 +247,14 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 			Expect(endPoints[helpers.Disabled]).To(Equal(0))
 
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementNever)
-			res.ExpectSuccess()
-
-			areEndpointsReady := vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementNever)
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Enabled]).To(Equal(0))
 			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
-			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways)
-			res.ExpectSuccess()
-
-			areEndpointsReady = vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementAlways)
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -319,8 +266,7 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 	Context("Policy Enforcement Never", func() {
 		//The test Always to Default is already tested in from default-always
 		BeforeEach(func() {
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementNever)
-			res.ExpectSuccess()
+			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementNever)
 		})
 
 		It("Container creation", func() {
@@ -354,22 +300,14 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 			Expect(endPoints[helpers.Enabled]).To(Equal(0))
 			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
-			res.ExpectSuccess()
-
-			areEndpointsReady := vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementDefault)
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Enabled]).To(Equal(1))
 			Expect(endPoints[helpers.Disabled]).To(Equal(0))
 
-			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementNever)
-			res.ExpectSuccess()
-
-			areEndpointsReady = vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementNever)
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -383,22 +321,14 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 			Expect(endPoints[helpers.Enabled]).To(Equal(0))
 			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
-			res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
-			res.ExpectSuccess()
-
-			areEndpointsReady := vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementDefault)
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
 			Expect(endPoints[helpers.Enabled]).To(Equal(0))
 			Expect(endPoints[helpers.Disabled]).To(Equal(1))
 
-			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementNever)
-			res.ExpectSuccess()
-
-			areEndpointsReady = vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue())
+			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementNever)
 
 			endPoints, err = vm.PolicyEndpointsSummary()
 			Expect(err).Should(BeNil())
@@ -429,11 +359,7 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 	})
 
 	BeforeEach(func() {
-		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
-		res.ExpectSuccess()
-
-		areEndpointsReady := vm.WaitEndpointsReady()
-		Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+		ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementDefault)
 	})
 
 	AfterEach(func() {
@@ -760,11 +686,7 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 		By(fmt.Sprintf("IPV4 Prefix Except: %s", ipv4PrefixExcept))
 
 		By("Setting PolicyEnforcement to always enforce (default-deny)")
-		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways)
-		res.ExpectSuccess("Unable to set PolicyEnforcement to %s", helpers.PolicyEnforcementAlways)
-
-		areEndpointsReady := vm.WaitEndpointsReady()
-		Expect(areEndpointsReady).To(BeTrue())
+		ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementAlways)
 
 		// Delete the pseudo-host IPs that we added to localhost after test
 		// finishes. Don't care about success; this is best-effort.
@@ -781,7 +703,7 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 
 		By("Pinging host IPv4 from httpd2 (should NOT work due to default-deny PolicyEnforcement mode)")
 
-		res = vm.ContainerExec(helpers.Httpd2, helpers.Ping(helpers.IPv4Host))
+		res := vm.ContainerExec(helpers.Httpd2, helpers.Ping(helpers.IPv4Host))
 		res.ExpectFail("Unexpected success pinging host (%s) from %s: %s", helpers.IPv4Host, helpers.Httpd2, res.CombineOutput().String())
 
 		By(fmt.Sprintf("Importing L3 CIDR Policy for IPv4 Egress Allowing Egress to %s, %s from %s", ipv4OtherHost, ipv4OtherHost, httpd2Label))
@@ -1076,11 +998,7 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 
 		// Set policy enforcement to default deny so that we can do negative tests
 		// before importing policy
-		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways)
-		res.ExpectSuccess()
-
-		areEndpointsReady := vm.WaitEndpointsReady()
-		Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+		ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementAlways)
 
 		failedPing := vm.ContainerExec(helpers.App1, helpers.Ping(googleDNS))
 		failedPing.ExpectFail("unexpectedly able to ping %s", googleDNS)
@@ -1467,11 +1385,7 @@ var _ = Describe("RuntimeValidatedPolicyImportTests", func() {
 		res = vm.PolicyDelAll()
 		res.ExpectSuccess("Unable to delete all policies")
 
-		res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
-		res.ExpectSuccess("Unable to change PolicyEnforcement configuration")
-
-		areEndpointsReady := vm.WaitEndpointsReady()
-		Expect(areEndpointsReady).Should(BeTrue())
+		ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementDefault)
 
 		By("Checking that policy trace returns allowed verdict without any policies imported")
 		res = vm.Exec(fmt.Sprintf(`cilium policy trace --src-endpoint %s --dst-endpoint %s`, httpd2EndpointID, httpd1EndpointID))

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -43,8 +43,6 @@ const (
 	policyJSON                      = "policy.json"
 	invalidJSON                     = "invalid.json"
 	sampleJSON                      = "sample_policy.json"
-	ingressJSON                     = "ingress.json"
-	egressJSON                      = "egress.json"
 	multL7PoliciesJSON              = "Policies-l7-multiple.json"
 	policiesL7JSON                  = "Policies-l7-simple.json"
 	policiesL3JSON                  = "Policies-l3-policy.json"

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -1113,37 +1112,41 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 })
 
 var _ = Describe("RuntimeValidatedPolicyImportTests", func() {
-	var once sync.Once
-	var logger *logrus.Entry
-	var vm *helpers.SSHMeta
+	var (
+		logger *logrus.Entry
+		vm     *helpers.SSHMeta
+	)
 
-	initialize := func() {
+	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"test": "RuntimeValidatedPoliciesImportTests"})
 		logger.Info("Starting")
 		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
-		areEndpointsReady := vm.WaitEndpointsReady()
-		Expect(areEndpointsReady).Should(BeTrue())
-	}
-
-	BeforeEach(func() {
-		once.Do(initialize)
-		vm.PolicyDelAll()
 
 		vm.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
-		areEndpointsReady := vm.WaitEndpointsReady()
-		Expect(areEndpointsReady).Should(BeTrue(), "Timed out waiting for endpoints to be ready")
 
+		areEndpointsReady := vm.WaitEndpointsReady()
+		Expect(areEndpointsReady).Should(BeTrue())
+	})
+
+	BeforeEach(func() {
+		ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementDefault)
 	})
 
 	AfterEach(func() {
-		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-		if CurrentGinkgoTestDescription().Failed {
-			vm.ReportFailed()
-		}
+		_ = vm.PolicyDelAll()
+	})
 
+	JustAfterEach(func() {
+		vm.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+	})
+
+	AfterFailed(func() {
+		vm.ReportFailed()
+	})
+
+	AfterAll(func() {
+		vm.PolicyDelAll().ExpectSuccess("Unable to delete all policies")
 		vm.SampleContainersActions(helpers.Delete, helpers.CiliumDockerNetwork)
-		allEndpointsDeleted := vm.WaitEndpointsDeleted()
-		Expect(allEndpointsDeleted).Should(BeTrue(), "Not all endpoints were able to be deleted")
 	})
 
 	It("Invalid Policies", func() {
@@ -1273,6 +1276,8 @@ var _ = Describe("RuntimeValidatedPolicyImportTests", func() {
 		By("Checking that all policy maps for endpoints have been deleted")
 		Expect(strings.TrimSpace(policyMapsInVM.GetStdOut())).To(Equal(expected), "Only %s PolicyMap should be present", expected)
 
+		By("Creating endpoints after deleting them to restore test state")
+		vm.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
 	})
 
 	It("checks policy trace output", func() {

--- a/test/runtime/assertionHelpers.go
+++ b/test/runtime/assertionHelpers.go
@@ -32,3 +32,12 @@ func ExpectPolicyEnforcementUpdated(vm *helpers.SSHMeta, policyEnforcementType s
 	areEndpointsReady := vm.SetPolicyEnforcementAndWait(policyEnforcementType)
 	ExpectWithOffset(1, areEndpointsReady).Should(BeTrue(), "unable to set PolicyEnforcement=%s", policyEnforcementType)
 }
+
+// ExpectEndpointSummary asserts whether the amount of endpoints managed by
+// Cilium running on vm with PolicyEnforcement equal to policyEnforcementType
+// is equal to numWithPolicyEnforcementType.
+func ExpectEndpointSummary(vm *helpers.SSHMeta, policyEnforcementType string, numWithPolicyEnforcementType int) {
+	endpoints, err := vm.PolicyEndpointsSummary()
+	ExpectWithOffset(1, err).Should(BeNil(), "error getting endpoint summary")
+	ExpectWithOffset(1, endpoints[policyEnforcementType]).To(Equal(numWithPolicyEnforcementType), "number of endpoints with %s=%s does not match", helpers.PolicyEnforcement, policyEnforcementType)
+}

--- a/test/runtime/assertionHelpers.go
+++ b/test/runtime/assertionHelpers.go
@@ -1,0 +1,34 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package RuntimeTest
+
+import (
+	"fmt"
+
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
+
+	. "github.com/onsi/gomega"
+)
+
+// ExpectPolicyEnforcementUpdated sets PolicyEnforcement mode on the provided vm
+// running Cilium to policyEnforcementType, and waits for endpoints on vm to
+// be in 'ready' state. It asserts whether the configuration update was successful,
+// and if the endpoints are ready.
+func ExpectPolicyEnforcementUpdated(vm *helpers.SSHMeta, policyEnforcementType string) {
+	By(fmt.Sprintf("Setting PolicyEnforcement=%s", policyEnforcementType))
+	areEndpointsReady := vm.SetPolicyEnforcementAndWait(policyEnforcementType)
+	ExpectWithOffset(1, areEndpointsReady).Should(BeTrue(), "unable to set PolicyEnforcement=%s", policyEnforcementType)
+}

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -17,7 +17,6 @@ package RuntimeTest
 import (
 	"crypto/md5"
 	"fmt"
-	"sync"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -29,24 +28,21 @@ import (
 var _ = Describe("RuntimeValidatedChaos", func() {
 
 	var vm *helpers.SSHMeta
-	var once sync.Once
 
-	initialize := func() {
+	BeforeAll(func() {
 		logger := log.WithFields(logrus.Fields{"testName": "RuntimeValidatedChaos"})
 		logger.Info("Starting")
 		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
-	}
 
-	BeforeEach(func() {
-		once.Do(initialize)
 		vm.ContainerCreate(helpers.Client, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
 		vm.ContainerCreate(helpers.Server, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.server")
-
-		areEndpointsReady := vm.WaitEndpointsReady()
-		Expect(areEndpointsReady).Should(BeTrue())
 	})
 
-	AfterEach(func() {
+	BeforeEach(func() {
+		Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
+	})
+
+	AfterAll(func() {
 		vm.ContainerRm(helpers.Client)
 		vm.ContainerRm(helpers.Server)
 	})

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -313,8 +313,7 @@ var _ = Describe("RuntimeValidatedConntrackTest", func() {
 		logger.Info("Starting")
 		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 
-		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways)
-		res.ExpectSuccess(fmt.Sprintf("Unable to set PolicyEnforcement to %s", helpers.PolicyEnforcementAlways))
+		ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementAlways)
 	}
 
 	clientServerConnectivity := func() {
@@ -641,8 +640,7 @@ var _ = Describe("RuntimeValidatedConntrackTest", func() {
 		}
 		vm.PolicyDelAll().ExpectSuccess("Policies cannot be deleted")
 
-		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
-		res.ExpectSuccess("Cannot set policy enforcement to default mode")
+		ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementDefault)
 	})
 
 	JustAfterEach(func() {

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -63,8 +63,7 @@ var _ = Describe("RuntimeValidatedMonitorTest", func() {
 	})
 
 	BeforeEach(func() {
-		res := vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
-		res.ExpectSuccess("cannot change policy enforcement to Default")
+		ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementDefault)
 	})
 
 	Context("With Sample Containers", func() {
@@ -277,11 +276,7 @@ var _ = Describe("RuntimeValidatedMonitorTest", func() {
 		It("checks container ids match monitor output", func() {
 			res := vm.ExecCilium(fmt.Sprintf("config %s=true", MonitorDebug))
 			res.ExpectSuccess()
-			res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementAlways)
-			res.ExpectSuccess()
-
-			areEndpointsReady := vm.WaitEndpointsReady()
-			Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementAlways)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			res = vm.ExecContext(ctx, "cilium monitor -v")


### PR DESCRIPTION
* test/runtime: cleanup RuntimeValidatedChaos test
    - Change test to use new Ginkgo constructs (`BeforeAll`, `AfterAll`).
* test/runtime: add ExpectEndpointSummary helper
    - This helper removes a lot of boilerplate code in the PolicyEnforcement test checks.
* test/runtime: remove unused constants
*  test/runtime: convert RuntimeValidatedPolicyImportTests to use BeforeAll / AfterAll
    -  Convert this test to use the new, standard constructs created for Cilium e2e testing.
* test: add helper PolicyEnforcement assertion to avoid boilerplate code
    - Group setting of PolicyEnforcement configuration for daemon and waiting for  endpoints to be ready into a helper function, and then wrap this helper function in another helper function for asserting that the configuration was updated and that endpoints were ready after updating said configuration value accordingly. This reduces the amount of boilerplate significantly in some tests.
    
Signed-off by: Ian Vernon <ian@cilium.io>

Reasons I did this: 
* That people do not forget to assert whether the results of checks in tests match expectations or not. This has been a common source of problems in the code - I myself have done this :)  
* I want to reduce the amount of boilerplate code in tests if possible, and wrap common assertions into helper functions within each respective test suite. This will ensure that people do not forget to add descriptions to their assertions. It also means that we will have less code to maintain overall.