### PR TITLE
Envoy crash fix

### DIFF
--- a/envoy/cilium_host_map.cc
+++ b/envoy/cilium_host_map.cc
@@ -120,8 +120,9 @@ protected:
 };
 
 PolicyHostMap::PolicyHostMap(ThreadLocal::SlotAllocator& tls) : tls_(tls.allocateSlot()) {
-  tls_->set([&](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
-      return null_hostmap_;
+  auto empty_map = std::make_shared<ThreadLocalHostMapInitializer>();
+  tls_->set([empty_map](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
+      return empty_map;
   });
 }
 

--- a/envoy/cilium_host_map.h
+++ b/envoy/cilium_host_map.h
@@ -55,7 +55,9 @@ public:
   PolicyHostMap(std::unique_ptr<Envoy::Config::Subscription<cilium::NetworkPolicyHosts>>&& subscription,
 		ThreadLocal::SlotAllocator& tls);
   PolicyHostMap(ThreadLocal::SlotAllocator& tls);
-  ~PolicyHostMap() {}
+  ~PolicyHostMap() {
+    ENVOY_LOG(debug, "Cilium PolicyHostMap({}): PolicyHostMap is deleted NOW!", name_);
+  }
 
   void startSubscription() { subscription_->start({}, *this); }
 
@@ -116,7 +118,10 @@ public:
 
 private:
   ThreadLocal::SlotPtr tls_;
+  Stats::ScopePtr scope_;
   std::unique_ptr<Envoy::Config::Subscription<cilium::NetworkPolicyHosts>> subscription_;
+  static uint64_t instance_id_;
+  std::string name_;
 };
 
 } // namespace Cilium

--- a/envoy/cilium_host_map.h
+++ b/envoy/cilium_host_map.h
@@ -99,7 +99,7 @@ public:
   typedef std::shared_ptr<ThreadLocalHostMap> ThreadLocalHostMapSharedPtr;
 
   const ThreadLocalHostMap* getHostMap() const {
-    return &tls_->getTyped<ThreadLocalHostMap>();
+    return tls_->get().get() ? &tls_->getTyped<ThreadLocalHostMap>() : nullptr;
   }
 
   uint64_t resolve(const Network::Address::Ip* addr) const {
@@ -117,7 +117,6 @@ public:
 private:
   ThreadLocal::SlotPtr tls_;
   std::unique_ptr<Envoy::Config::Subscription<cilium::NetworkPolicyHosts>> subscription_;
-  const ThreadLocalHostMapSharedPtr null_hostmap_{nullptr};
 };
 
 } // namespace Cilium

--- a/envoy/cilium_network_policy.cc
+++ b/envoy/cilium_network_policy.cc
@@ -5,7 +5,6 @@
 #include <string>
 #include <unordered_set>
 
-#include "common/config/grpc_subscription_impl.h"
 #include "common/config/utility.h"
 #include "common/protobuf/protobuf.h"
 

--- a/envoy/cilium_network_policy.h
+++ b/envoy/cilium_network_policy.h
@@ -21,13 +21,14 @@ class NetworkPolicyMap : public Singleton::Instance,
                          public std::enable_shared_from_this<NetworkPolicyMap>,
                          public Logger::Loggable<Logger::Id::config> {
 public:
+  NetworkPolicyMap(ThreadLocal::SlotAllocator& tls);
   NetworkPolicyMap(const envoy::api::v2::core::Node& node, Upstream::ClusterManager& cm,
 		   Event::Dispatcher& dispatcher, Stats::Scope &scope,
 		   ThreadLocal::SlotAllocator& tls);
   NetworkPolicyMap(std::unique_ptr<Envoy::Config::Subscription<cilium::NetworkPolicy>>&& subscription,
 		   ThreadLocal::SlotAllocator& tls);
   ~NetworkPolicyMap() {
-    ENVOY_LOG(debug, "Cilium L7 NetworkPolicyMap: NetworkPolicyMap is deleted NOW!");
+    ENVOY_LOG(debug, "Cilium L7 NetworkPolicyMap({}): NetworkPolicyMap is deleted NOW!", name_);
   }
 
   // subscription_->start() calls onConfigUpdate(), which uses
@@ -244,8 +245,11 @@ public:
 
 private:
   ThreadLocal::SlotPtr tls_;
+  Stats::ScopePtr scope_;
   std::unique_ptr<Envoy::Config::Subscription<cilium::NetworkPolicy>> subscription_;
   const std::shared_ptr<const PolicyInstance> null_instance_{nullptr};
+  static uint64_t instance_id_;
+  std::string name_;
 };
 
 } // namespace Cilium

--- a/envoy/grpc_subscription.h
+++ b/envoy/grpc_subscription.h
@@ -20,8 +20,6 @@ subscribe(const std::string& grpc_method, const envoy::api::v2::core::Node& node
   api_config_source.add_cluster_names("xds-grpc-cilium");
 
   Config::Utility::checkApiConfigSourceSubscriptionBackingCluster(cm.clusters(), api_config_source);
-  Config::SubscriptionStats stats = Config::Utility::generateStats(scope);
-
   const auto* method = Protobuf::DescriptorPool::generated_pool()->FindMethodByName(grpc_method);
 
   if (method == nullptr) {
@@ -33,7 +31,7 @@ subscribe(const std::string& grpc_method, const envoy::api::v2::core::Node& node
 		Config::Utility::factoryForApiConfigSource(cm.grpcAsyncClientManager(),
 							   api_config_source,
 							   scope)->create(),
-		dispatcher, *method, stats);
+		dispatcher, *method, Config::Utility::generateStats(scope));
 }
 
 } // namespace Cilium


### PR DESCRIPTION
Use distinct stats prefixes for different gRPC protocols with independently managed lifecycles. This should get rid of a use-after-free of gRPC subscription stats.

If this is indeed the right fix, then it is understandable that we would have hit this only after the host map protocol was added.

There is some more code duplication between the xDS protocols that will be refactored in a future commit.