### PR TITLE
Envoy: Better debug build, do not strip by default

### DIFF
--- a/envoy/Makefile
+++ b/envoy/Makefile
@@ -92,7 +92,7 @@ docker-istio-proxy-debug: Dockerfile.istio_proxy_debug $(ISTIO_ENVOY_RELEASE_BIN
 envoy-debug: force-non-root
 	@$(ECHO_BAZEL)
 	-rm -f bazel-out/k8-dbg/bin/_objs/envoy/external/envoy/source/common/common/version_linkstamp.o
-	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) -c dbg //:envoy
+	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) -c dbg --config=clang-asan --cxxopt="-fno-omit-frame-pointer" --cxxopt="-D_GLIBCXX_ASSERTIONS" //:envoy
 
 $(CHECK_FORMAT): force-non-root
 	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) //:check_format.py

--- a/envoy/Makefile
+++ b/envoy/Makefile
@@ -100,10 +100,9 @@ $(CHECK_FORMAT): force-non-root
 install: force-root
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	$(INSTALL) -m 0755 -T $(CILIUM_ENVOY_BIN) $(DESTDIR)$(BINDIR)/cilium-envoy
-# Strip only non-debug builds
-ifeq "$(findstring -dbg,$(realpath bazel-bin))" ""
+
+strip-install: install
 	$(STRIP) $(DESTDIR)$(BINDIR)/cilium-envoy
-endif
 
 bazel-archive: force-non-root tests clean-bins
 	-sudo rm -f $(BAZEL_ARCHIVE)


### PR DESCRIPTION
Build envoy debug with address sanitizer, glibc++ assertions and -fno-omit-stack-frame-pointer to get better stack traces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/3848)
<!-- Reviewable:end -->
