### PR TITLE
ipcache: Fix ipcache deletion of old identities on update

### DIFF
--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -118,7 +118,7 @@ func (cache *NPHDSCache) handleIPDelete(npHost *envoyAPI.NetworkPolicyHosts, pee
 		}
 	}
 	if targetIndex < 0 {
-		scopedLog.Warning("Can't find IP in NPHDS cache")
+		scopedLog.Fatal("Can't find IP in NPHDS cache")
 		return
 	}
 


### PR DESCRIPTION
Fix the scope of the cachedIdentity variable in ipIdentityWatcher.
Make the agent crash in case an invalid IP-ID mapping is deleted.

Fixes: https://github.com/cilium/cilium/issues/3825
Signed-off-by: Romain Lenglet <romain@covalent.io>