### PR TITLE
Makefile: Remove instructions to push the -builder Docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,8 +132,6 @@ docker-image-runtime:
 
 docker-image-builder:
 	cd envoy && docker build -t "quay.io/cilium/cilium-builder:$(UTC_DATE)" .
-	@echo "Push like this when ready:"
-	@echo "docker push quay.io/cilium/cilium-builder:$(UTC_DATE)"
 
 build-deb:
 	$(MAKE) -C ./contrib/packaging/deb


### PR DESCRIPTION
Fixes: https://github.com/cilium/cilium/pull/3853
Fixes: 5ce840799999c47ca44aa694e19fd96c2febcc7b
Signed-off-by: Romain Lenglet <romain@covalent.io>