### PR TITLE
pkg/policy/api: reject rules which use non-TCP protocols in conduit with L7 Rules

### DIFF
--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -255,6 +255,9 @@ func (pr *PortRule) sanitize() error {
 		if err := pr.Ports[i].sanitize(); err != nil {
 			return err
 		}
+		if pr.Rules != nil && pr.Ports[i].Protocol != ProtoTCP {
+			return fmt.Errorf("L7 rules can only apply exclusively to TCP, not %s", pr.Ports[i].Protocol)
+		}
 	}
 
 	// Sanitize L7 rules

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -1,0 +1,147 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+// This test ensures that only PortRules which have L7Rules associated with them
+// are invalid if any protocol except TCP is used as a protocol for any port
+// in the list of PortProtocol supplied to the rule.
+func (s *PolicyAPITestSuite) TestL7RulesWithNonTCPProtocols(c *C) {
+
+	// Rule is valid because L7 rules are only allowed for ProtoTCP.
+	validPortRule := Rule{
+		EndpointSelector: WildcardEndpointSelector,
+		Ingress: []IngressRule{
+			{
+				FromEndpoints: []EndpointSelector{WildcardEndpointSelector},
+				ToPorts: []PortRule{{
+					Ports: []PortProtocol{
+						{Port: "80", Protocol: ProtoTCP},
+						{Port: "81", Protocol: ProtoTCP},
+					},
+					Rules: &L7Rules{
+						HTTP: []PortRuleHTTP{
+							{Method: "GET", Path: "/"},
+						},
+					},
+				}},
+			},
+		},
+	}
+
+	err := validPortRule.Sanitize()
+	c.Assert(err, IsNil)
+
+	// Rule is invalid because L7 rules are only allowed for ProtoTCP.
+	invalidPortRule := Rule{
+		EndpointSelector: WildcardEndpointSelector,
+		Ingress: []IngressRule{
+			{
+				FromEndpoints: []EndpointSelector{WildcardEndpointSelector},
+				ToPorts: []PortRule{{
+					Ports: []PortProtocol{
+						{Port: "80", Protocol: ProtoUDP},
+					},
+					Rules: &L7Rules{
+						HTTP: []PortRuleHTTP{
+							{Method: "GET", Path: "/"},
+						},
+					},
+				}},
+			},
+		},
+	}
+
+	err = invalidPortRule.Sanitize()
+	c.Assert(err.Error(), Equals, "L7 rules can only apply exclusively to TCP, not UDP")
+
+	// Rule is invalid because L7 rules are only allowed for ProtoTCP.
+	invalidPortRule = Rule{
+		EndpointSelector: WildcardEndpointSelector,
+		Ingress: []IngressRule{
+			{
+				FromEndpoints: []EndpointSelector{WildcardEndpointSelector},
+				ToPorts: []PortRule{{
+					Ports: []PortProtocol{
+						{Port: "80", Protocol: ProtoAny},
+					},
+					Rules: &L7Rules{
+						HTTP: []PortRuleHTTP{
+							{Method: "GET", Path: "/"},
+						},
+					},
+				}},
+			},
+		},
+	}
+
+	err = invalidPortRule.Sanitize()
+	c.Assert(err, Not(IsNil))
+	c.Assert(err.Error(), Equals, "L7 rules can only apply exclusively to TCP, not ANY")
+
+	// Rule is invalid because L7 rules are only allowed for ProtoTCP.
+	invalidPortRule = Rule{
+		EndpointSelector: WildcardEndpointSelector,
+		Ingress: []IngressRule{
+			{
+				FromEndpoints: []EndpointSelector{WildcardEndpointSelector},
+				ToPorts: []PortRule{{
+					Ports: []PortProtocol{
+						{Port: "80", Protocol: ProtoTCP},
+						{Port: "12345", Protocol: ProtoUDP},
+					},
+					Rules: &L7Rules{
+						HTTP: []PortRuleHTTP{
+							{Method: "GET", Path: "/"},
+						},
+					},
+				}},
+			},
+		},
+	}
+
+	err = invalidPortRule.Sanitize()
+	c.Assert(err, Not(IsNil))
+	c.Assert(err.Error(), Equals, "L7 rules can only apply exclusively to TCP, not UDP")
+
+	// Same as previous rule, but ensure ordering doesn't affect validation.
+	invalidPortRule = Rule{
+		EndpointSelector: WildcardEndpointSelector,
+		Ingress: []IngressRule{
+			{
+				FromEndpoints: []EndpointSelector{WildcardEndpointSelector},
+				ToPorts: []PortRule{{
+					Ports: []PortProtocol{
+						{Port: "80", Protocol: ProtoUDP},
+						{Port: "12345", Protocol: ProtoTCP},
+					},
+					Rules: &L7Rules{
+						HTTP: []PortRuleHTTP{
+							{Method: "GET", Path: "/"},
+						},
+					},
+				}},
+			},
+		},
+	}
+
+	err = invalidPortRule.Sanitize()
+	c.Assert(err, Not(IsNil))
+	c.Assert(err.Error(), Equals, "L7 rules can only apply exclusively to TCP, not UDP")
+
+}


### PR DESCRIPTION
**Summary of changes**:

L4Filter parsing only checks for L7Rules if the corresponding protocol for the set of L7 Rules is of type TCP. Reject policies that try to have L7 Rules apply to non-TCP protocols, as they are ignored anyway.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #3573 

```release-note
Reject policy with L7 Rules that do not apply to TCP protocol
```