### PR TITLE
k8sT: Make health test more robust

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -725,6 +725,21 @@ func (kub *Kubectl) CiliumExec(pod string, cmd string) *CmdRes {
 	return res
 }
 
+// CiliumExecUntilMatch executes the specified command repeatedly for the
+// specified Cilium pod until the given substring is present in stdout.
+// If the timeout is reached it will return an error.
+func (kub *Kubectl) CiliumExecUntilMatch(pod, cmd, substr string) error {
+	body := func() bool {
+		res := kub.CiliumExec(pod, cmd)
+		return strings.Contains(res.Output().String(), substr)
+	}
+
+	return WithTimeout(
+		body,
+		fmt.Sprintf("%s is not in the output after timeout", substr),
+		&TimeoutConfig{Timeout: HelperTimeout})
+}
+
 // CiliumNodesWait waits until all nodes in the Kubernetes cluster are annotated
 // with Cilium annotations. Its runtime is bounded by a maximum of `HelperTimeout`.
 // When a node is annotated with said annotations, it indicates

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -79,9 +79,9 @@ var _ = Describe(testName, func() {
 	checkIP := func(pod, ip string) {
 		jsonpath := fmt.Sprintf("{.cluster.nodes[*].primary-address.*}")
 		ciliumCmd := fmt.Sprintf("cilium status -o jsonpath='%s'", jsonpath)
-		status := kubectl.CiliumExec(pod, ciliumCmd)
-		Expect(status.Output().String()).Should(ContainSubstring(ip))
-		status.ExpectSuccess()
+
+		err := kubectl.CiliumExecUntilMatch(pod, ciliumCmd, ip)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Never saw cilium-health ip %s in pod %s", ip, pod)
 	}
 
 	It("checks cilium-health status between nodes", func() {


### PR DESCRIPTION
Previously we never retried attempting to find each cilium-health
endpoint IP in each Cilium pod, so if startup was delayed slightly then
it would be possible for the test to query the list of cluster nodes
before Cilium had a chance to find all of the k8s annotations for
cilium-health instances.

This patch makes this logic a bit more robust by retrying the fetch
logic multiple times, and only failing if particular cilium-health
instances are not known in all Cilium instances after a regular helper
timeout.

Fixes: #3802
Fixes: beff61ed313a ("test: Add basic cilium-health tests")

Signed-off-by: Joe Stringer <joe@covalent.io>