### PR TITLE
envoy: Configure gRPC service explicitly to get rid of deprecation warning in the logs

### DIFF
--- a/envoy/grpc_subscription.h
+++ b/envoy/grpc_subscription.h
@@ -17,7 +17,7 @@ subscribe(const std::string& grpc_method, const envoy::api::v2::core::Node& node
   // Hard-coded Cilium gRPC cluster
   envoy::api::v2::core::ApiConfigSource api_config_source{};
   api_config_source.set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
-  api_config_source.add_cluster_names("xds-grpc-cilium");
+  api_config_source.add_grpc_services()->mutable_envoy_grpc()->set_cluster_name("xds-grpc-cilium");
 
   Config::Utility::checkApiConfigSourceSubscriptionBackingCluster(cm.clusters(), api_config_source);
   const auto* method = Protobuf::DescriptorPool::generated_pool()->FindMethodByName(grpc_method);

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -351,8 +351,16 @@ func createBootstrap(filePath string, name, cluster, version string, xdsSock, en
 			LdsConfig: &envoy_api_v2_core.ConfigSource{
 				ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_ApiConfigSource{
 					ApiConfigSource: &envoy_api_v2_core.ApiConfigSource{
-						ApiType:      envoy_api_v2_core.ApiConfigSource_GRPC,
-						ClusterNames: []string{"xds-grpc-cilium"},
+						ApiType: envoy_api_v2_core.ApiConfigSource_GRPC,
+						GrpcServices: []*envoy_api_v2_core.GrpcService{
+							{
+								TargetSpecifier: &envoy_api_v2_core.GrpcService_EnvoyGrpc_{
+									EnvoyGrpc: &envoy_api_v2_core.GrpcService_EnvoyGrpc{
+										ClusterName: "xds-grpc-cilium",
+									},
+								},
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Configuring gRPC services via "cluster_name" is deprecated in
Envoy. Use "grpc_services" explicitly to get rid of the deprecation
warning and to be future-proof.

Requested-by: Romain Lenglet <romain@covalent.io>
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
