### PR TITLE
Improve k8s specific bootstrap behavior

### DIFF
--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -53,8 +53,7 @@ func Init() error {
 
 		k8sNode, err := GetNode(Client(), nodeName)
 		if err != nil {
-			log.WithError(err).Warning("Unable to retrieve k8s node information, skipping...")
-			return nil
+			return fmt.Errorf("unable to retrieve own node resource")
 		}
 
 		n := ParseNode(k8sNode)

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -57,13 +57,11 @@ func Init() error {
 		}
 
 		n := ParseNode(k8sNode)
-		log.WithField(logfields.NodeName, n.Name).Info("Retrieved node information from kubernetes")
-
 		log.WithFields(logrus.Fields{
 			logfields.NodeName:         n.Name,
 			logfields.IPAddr + ".ipv4": n.GetNodeIP(false),
 			logfields.IPAddr + ".ipv6": n.GetNodeIP(true),
-		}).Info("Received own node information from API server")
+		}).Info("Received own node information from Kubernetes API server")
 
 		if err := node.UseNodeCIDR(n); err != nil {
 			return fmt.Errorf("unable to retrieve k8s node CIDR: %s", err)


### PR DESCRIPTION
While stress testing while the Kubernetes apiservers becomes unreachable, it was noticed that the initial k8s connectivity can succeed and the subsequent retrieval of the node resource can fail. Emission of a warning is insufficient here as Cilium may continue with a configuration that is different (due to the fallback to defaults) than used in a previous run.

@aanm @raybejjani Please review. I remember that we initially wanted to keep this as a warning to not depend on node resources being available but given the above experience. I can't see a way to be reliable without failing hard in this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/3906)
<!-- Reviewable:end -->
