### PR TITLE
Add libraries for API CIDR string to labels / IPNet

### DIFF
--- a/cilium/cmd/bpf_policy_get.go
+++ b/cilium/cmd/bpf_policy_get.go
@@ -133,7 +133,7 @@ func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 			fmt.Fprintf(w, "%s\t%d\t%s\t%d\t%d\t\n", trafficDirectionString, id, port, stat.Bytes, stat.Packets)
 		} else if lbls := labelsID[id]; lbls != nil && len(lbls.Labels) > 0 {
 			first := true
-			for _, lbl := range lbls.Labels {
+			for _, lbl := range lbls.Labels.GetPrintableModel() {
 				if first {
 					fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%d\t\n", trafficDirectionString, lbl, port, stat.Bytes, stat.Packets)
 					first = false

--- a/cilium/cmd/identity_get.go
+++ b/cilium/cmd/identity_get.go
@@ -22,6 +22,7 @@ import (
 	identityApi "github.com/cilium/cilium/api/v1/client/policy"
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/command"
+	"github.com/cilium/cilium/pkg/labels"
 
 	"github.com/spf13/cobra"
 )
@@ -40,7 +41,16 @@ func printIdentities(identities []*models.Identity) {
 
 		fmt.Fprintf(w, "ID\tLABELS\n")
 		for _, identity := range identities {
-			fmt.Fprintf(w, "%d\t%s\n", identity.ID, identity.Labels)
+			lbls := labels.NewLabelsFromModel(identity.Labels)
+			first := true
+			for _, lbl := range lbls.GetPrintableModel() {
+				if first {
+					fmt.Fprintf(w, "%d\t%s\n", identity.ID, lbl)
+					first = false
+				} else {
+					fmt.Fprintf(w, "\t%s\n", lbl)
+				}
+			}
 		}
 
 		w.Flush()

--- a/pkg/labels/cidr.go
+++ b/pkg/labels/cidr.go
@@ -1,0 +1,81 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package labels
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// maskedIPToLabelString is the base method for serializing an IP + prefix into
+// a string that can be used for creating Labels and EndpointSelector objects.
+//
+// For IPv6 addresses, it converts ":" into "-" as EndpointSelectors don't
+// support colons inside the name section of a label.
+func maskedIPToLabelString(ip *net.IP, prefix int) string {
+	ipStr := ip.String()
+	ipNoColons := strings.Replace(ipStr, ":", "-", -1)
+
+	// EndpointSelector keys can't start or end with a "-", so insert a
+	// zero at the start or end if it would otherwise have a "-" at that
+	// position.
+	preZero := ""
+	postZero := ""
+	if ipNoColons[0] == '-' {
+		preZero = "0"
+	}
+	if ipNoColons[len(ipNoColons)-1] == '-' {
+		postZero = "0"
+	}
+	return fmt.Sprintf("%s:%s%s%s/%d", LabelSourceCIDR, preZero,
+		ipNoColons, postZero, prefix)
+}
+
+// IPNetToLabel turns a CIDR into a Label object which can be used to create
+// EndpointSelector objects.
+func IPNetToLabel(cidr *net.IPNet) *Label {
+	ones, _ := cidr.Mask.Size()
+	lblStr := maskedIPToLabelString(&cidr.IP, ones)
+	return ParseLabel(lblStr)
+}
+
+// IPStringToLabel parses a string and returns it as a CIDR label.
+//
+// If "IP" is not a valid IP address or CIDR Prefix, returns nil.
+func IPStringToLabel(IP string) *Label {
+	_, parsedPrefix, err := net.ParseCIDR(IP)
+	if err != nil {
+		parsedIP := net.ParseIP(IP)
+		if parsedIP == nil {
+			return nil
+		}
+		bits := net.IPv6len * 8
+		if parsedIP.To4() != nil {
+			bits = net.IPv4len * 8
+		}
+		parsedPrefix = &net.IPNet{IP: parsedIP, Mask: net.CIDRMask(bits, bits)}
+	}
+
+	return IPNetToLabel(parsedPrefix)
+}
+
+// MaskedIPNetToLabelString masks the prefix/bits of the specified 'cidr' then
+// turns the resulting CIDR into a label string for use elsewhere.
+func MaskedIPNetToLabelString(cidr *net.IPNet, prefix, bits int) string {
+	mask := net.CIDRMask(prefix, bits)
+	maskedIP := cidr.IP.Mask(mask)
+	return maskedIPToLabelString(&maskedIP, prefix)
+}

--- a/pkg/labels/cidr/cidr.go
+++ b/pkg/labels/cidr/cidr.go
@@ -1,0 +1,59 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cidr
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/node"
+)
+
+// GetCIDRLabels turns a CIDR into a set of labels representing the cidr itself
+// and all broader CIDRS which include the specified CIDR in them. For example:
+// CIDR: 10.0.0.0/8 =>
+//     "cidr:10.0.0.0/8", "cidr:10.0.0.0/7", "cidr:8.0.0.0/6",
+//     "cidr:8.0.0.0/5", "cidr:0.0.0.0/4, "cidr:0.0.0.0/3",
+//     "cidr:0.0.0.0/2",  "cidr:0.0.0.0/1",  "cidr:0.0.0.0/0"
+// (plus one of reserved:cluster or reserved:world, depending on whether the
+// cluster falls within the IP range of the cluster or not)
+func GetCIDRLabels(cidr *net.IPNet) labels.Labels {
+	ones, bits := cidr.Mask.Size()
+	result := []string{}
+
+	for i := 0; i <= ones; i++ {
+		label := labels.MaskedIPNetToLabelString(cidr, i, bits)
+		result = append(result, label)
+	}
+
+	var cluster *net.IPNet
+	if cidr.IP.To4() == nil {
+		cluster = node.GetIPv6ClusterRange()
+	} else {
+		cluster = node.GetIPv4ClusterRange()
+	}
+
+	var label string
+	clusterSize, _ := cluster.Mask.Size()
+	if cluster.Contains(cidr.IP) && clusterSize <= ones {
+		label = fmt.Sprintf("%s:%s", labels.LabelSourceReserved, labels.IDNameCluster)
+	} else {
+		label = fmt.Sprintf("%s:%s", labels.LabelSourceReserved, labels.IDNameWorld)
+	}
+	result = append(result, label)
+
+	return labels.NewLabelsFromModel(result)
+}

--- a/pkg/labels/cidr/cidr_test.go
+++ b/pkg/labels/cidr/cidr_test.go
@@ -1,0 +1,131 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cidr
+
+import (
+	"net"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/comparator"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/node"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type CIDRLabelsSuite struct{}
+
+var _ = Suite(&CIDRLabelsSuite{})
+
+func init() {
+	_, v4CIDR, _ := net.ParseCIDR("10.0.0.0/16")
+	_, v6CIDR, _ := net.ParseCIDR("2001:db8:cafe:0:cab::/96")
+	testNode := &node.Node{
+		Name:          "test_node",
+		IPv4AllocCIDR: v4CIDR,
+		IPv6AllocCIDR: v6CIDR,
+	}
+	node.UseNodeCIDR(testNode)
+}
+
+// TestGetCIDRLabels checks that GetCIDRLabels returns a sane set of labels for
+// given CIDRs.
+func (s *CIDRLabelsSuite) TestGetCIDRLabels(c *C) {
+	_, cidr, err := net.ParseCIDR("192.0.2.3/32")
+	c.Assert(err, IsNil)
+	expected := labels.ParseLabelArray(
+		"cidr:0.0.0.0/0",
+		"cidr:128.0.0.0/1",
+		"cidr:192.0.0.0/8",
+		"cidr:192.0.2.0/24",
+		"cidr:192.0.2.3/32",
+		"reserved:world",
+	)
+
+	lbls := GetCIDRLabels(cidr)
+	lblArray := lbls.LabelArray()
+	c.Assert(lblArray.Lacks(expected), comparator.DeepEquals, labels.LabelArray{})
+	// IPs should be masked as the labels are generated
+	c.Assert(lblArray.Has("cidr:192.0.2.3/24"), Equals, false)
+
+	_, cidr, err = net.ParseCIDR("192.0.2.0/24")
+	c.Assert(err, IsNil)
+	expected = labels.ParseLabelArray(
+		"cidr:0.0.0.0/0",
+		"cidr:192.0.2.0/24",
+		"reserved:world",
+	)
+
+	lbls = GetCIDRLabels(cidr)
+	lblArray = lbls.LabelArray()
+	c.Assert(lblArray.Lacks(expected), comparator.DeepEquals, labels.LabelArray{})
+	// CIDRs that are covered by the prefix should not be in the labels
+	c.Assert(lblArray.Has("cidr:192.0.2.3/32"), Equals, false)
+
+	// Note that we convert the colons in IPv6 addresses into dashes when
+	// translating into labels, because endpointSelectors don't support
+	// colons.
+	_, cidr, err = net.ParseCIDR("2001:DB8::1/128")
+	c.Assert(err, IsNil)
+	expected = labels.ParseLabelArray(
+		"cidr:0--0/0",
+		"cidr:2000--0/3",
+		"cidr:2001--0/16",
+		"cidr:2001-d00--0/24",
+		"cidr:2001-db8--0/32",
+		"cidr:2001-db8--1/128",
+		"reserved:world",
+	)
+
+	lbls = GetCIDRLabels(cidr)
+	lblArray = lbls.LabelArray()
+	c.Assert(lblArray.Lacks(expected), comparator.DeepEquals, labels.LabelArray{})
+	// IPs should be masked as the labels are generated
+	c.Assert(lblArray.Has("cidr:2001-db8--1/24"), Equals, false)
+}
+
+// TestGetCIDRLabelsInCluster checks that the cluster label is properly added
+// when getting labels for CIDRs that are equal to or within the cluster range.
+func (s *CIDRLabelsSuite) TestGetCIDRLabelsInCluster(c *C) {
+	_, cidr, err := net.ParseCIDR("10.0.0.0/16")
+	c.Assert(err, IsNil)
+	expected := labels.ParseLabelArray(
+		"cidr:0.0.0.0/0",
+		"cidr:10.0.0.0/16",
+		"reserved:cluster",
+	)
+	lbls := GetCIDRLabels(cidr)
+	lblArray := lbls.LabelArray()
+	c.Assert(lblArray.Lacks(expected), comparator.DeepEquals, labels.LabelArray{})
+
+	// This case is firmly within the cluster range
+	_, cidr, err = net.ParseCIDR("2001:db8:cafe::cab:4:b0b:0/112")
+	c.Assert(err, IsNil)
+	expected = labels.ParseLabelArray(
+		"cidr:0--0/0",
+		"cidr:2001-db8-cafe--0/64",
+		"cidr:2001-db8-cafe-0-cab-4--0/96",
+		"cidr:2001-db8-cafe-0-cab-4-b0b-0/112",
+		"reserved:cluster",
+	)
+	lbls = GetCIDRLabels(cidr)
+	lblArray = lbls.LabelArray()
+	c.Assert(lblArray.Lacks(expected), comparator.DeepEquals, labels.LabelArray{})
+}

--- a/pkg/labels/cidr/doc.go
+++ b/pkg/labels/cidr/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cidr provides helper methods for generating labels for CIDRs which
+// are partially derived from node state.
+package cidr

--- a/pkg/labels/cidr_test.go
+++ b/pkg/labels/cidr_test.go
@@ -1,0 +1,38 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package labels
+
+import (
+	"github.com/cilium/cilium/pkg/comparator"
+
+	. "gopkg.in/check.v1"
+)
+
+var _ = Suite(&LabelsSuite{})
+
+func (s *LabelsSuite) TestIPStringToLabel(c *C) {
+	ipToLabels := map[string]string{
+		"0.0.0.0/0":    "cidr:0.0.0.0/0",
+		"192.0.2.3":    "cidr:192.0.2.3/32",
+		"192.0.2.3/32": "cidr:192.0.2.3/32",
+		"192.0.2.3/24": "cidr:192.0.2.0/24",
+		"192.0.2.0/24": "cidr:192.0.2.0/24",
+		"::/0":         "cidr:0--0/0",
+		"fdff::ff":     "cidr:fdff--ff/128",
+	}
+	for ip, labelStr := range ipToLabels {
+		c.Assert(IPStringToLabel(ip).String(), comparator.DeepEquals, labelStr)
+	}
+}

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -134,6 +134,9 @@ const (
 	// LabelSourceReserved is the label source for reserved types.
 	LabelSourceReserved = "reserved"
 
+	// LabelSourceCIDR is the label source for generated CIDRs.
+	LabelSourceCIDR = "cidr"
+
 	// LabelSourceReservedKeyPrefix is the prefix of a reserved label
 	LabelSourceReservedKeyPrefix = LabelSourceReserved + "."
 )

--- a/pkg/policy/cidr.go
+++ b/pkg/policy/cidr.go
@@ -1,0 +1,85 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"net"
+
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+// getPrefixesFromCIDR fetches all CIDRs referred to by the specified slice
+// and returns them as regular golang CIDR objects.
+func getPrefixesFromCIDR(cidrs api.CIDRSlice) []*net.IPNet {
+	res := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, prefix, err := net.ParseCIDR(string(cidr))
+		if err != nil {
+			// Likely the CIDR is specified in host format.
+			ip := net.ParseIP(string(cidr))
+			if ip != nil {
+				bits := net.IPv6len * 8
+				if ip.To4() != nil {
+					ip = ip.To4()
+					bits = net.IPv4len * 8
+				}
+				prefix = &net.IPNet{ip, net.CIDRMask(bits, bits)}
+			}
+		}
+		if prefix != nil {
+			res = append(res, prefix)
+		}
+	}
+	return res
+}
+
+// getPrefixesFromCIDRSet fetches all CIDRs referred to by the specified slice
+// and returns them as regular golang CIDR objects.
+func getPrefixesFromCIDRSet(rules api.CIDRRuleSlice) []*net.IPNet {
+	cidrs := api.ComputeResultantCIDRSet(rules)
+	return getPrefixesFromCIDR(cidrs)
+}
+
+// GetCIDRPrefixes runs through the specified 'rules' to find every reference
+// to a CIDR in the rules, and returns a slice containing all of these CIDRs.
+// Multiple rules referring to the same CIDR will result in multiple copies of
+// the CIDR in the returned slice.
+//
+// Assumes that validation already occurred on 'rules'.
+func GetCIDRPrefixes(rules api.Rules) []*net.IPNet {
+	if len(rules) == 0 {
+		return nil
+	}
+	res := make([]*net.IPNet, 0, 32)
+	for _, r := range rules {
+		for _, ir := range r.Ingress {
+			if len(ir.FromCIDR) > 0 {
+				res = append(res, getPrefixesFromCIDR(ir.FromCIDR)...)
+			}
+			if len(ir.FromCIDRSet) > 0 {
+				res = append(res, getPrefixesFromCIDRSet(ir.FromCIDRSet)...)
+			}
+		}
+		for _, er := range r.Egress {
+			if len(er.ToCIDR) > 0 {
+				res = append(res, getPrefixesFromCIDR(er.ToCIDR)...)
+			}
+			if len(er.ToCIDRSet) > 0 {
+				res = append(res, getPrefixesFromCIDRSet(er.ToCIDRSet)...)
+			}
+		}
+	}
+	return res
+}

--- a/pkg/policy/cidr_test.go
+++ b/pkg/policy/cidr_test.go
@@ -1,0 +1,133 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"net"
+
+	"github.com/cilium/cilium/pkg/comparator"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/api"
+
+	. "gopkg.in/check.v1"
+)
+
+func (ds *PolicyTestSuite) TestgetPrefixesFromCIDR(c *C) {
+	inputToCIDRString := map[string]string{
+		"0.0.0.0/0":    "0.0.0.0/0",
+		"192.0.2.3":    "192.0.2.3/32",
+		"192.0.2.3/32": "192.0.2.3/32",
+		"192.0.2.3/24": "192.0.2.0/24",
+		"192.0.2.0/24": "192.0.2.0/24",
+		"::/0":         "::/0",
+		"fdff::ff":     "fdff::ff/128",
+	}
+	expected := []*net.IPNet{}
+	inputs := []api.CIDR{}
+	for ruleStr, cidr := range inputToCIDRString {
+		_, net, err := net.ParseCIDR(cidr)
+		c.Assert(err, IsNil)
+		expected = append(expected, net)
+		inputs = append(inputs, api.CIDR(ruleStr))
+	}
+	result := getPrefixesFromCIDR(inputs)
+	c.Assert(result, comparator.DeepEquals, expected)
+}
+
+func (ds *PolicyTestSuite) TestGetCIDRPrefixes(c *C) {
+	rules := api.Rules{
+		&api.Rule{
+			EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("bar")),
+			Ingress: []api.IngressRule{
+				{
+					FromCIDR: []api.CIDR{
+						"192.0.2.0/24",
+					},
+				},
+			},
+			Egress: []api.EgressRule{
+				{
+					ToCIDR: []api.CIDR{
+						"192.0.2.0/24",
+						"192.0.3.0/24",
+					},
+				},
+			},
+		},
+	}
+
+	// We have three CIDR instances in the ruleset, check that all exist
+	expectedCIDRStrings := []string{
+		"192.0.2.0/24",
+		"192.0.2.0/24",
+		"192.0.3.0/24",
+	}
+	expectedCIDRs := []*net.IPNet{}
+	for _, ipStr := range expectedCIDRStrings {
+		_, cidr, err := net.ParseCIDR(ipStr)
+		c.Assert(err, IsNil)
+		expectedCIDRs = append(expectedCIDRs, cidr)
+	}
+	c.Assert(GetCIDRPrefixes(rules), comparator.DeepEquals, expectedCIDRs)
+
+	// Now, test with CIDRSets.
+	rules = api.Rules{
+		&api.Rule{
+			EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("bar")),
+			Ingress: []api.IngressRule{
+				{
+					FromCIDRSet: []api.CIDRRule{
+						{
+							Cidr:        "192.0.2.0/24",
+							ExceptCIDRs: []api.CIDR{"192.0.2.128/25"},
+						},
+					},
+				},
+			},
+			Egress: []api.EgressRule{
+				{
+					ToCIDRSet: []api.CIDRRule{
+						{
+							Cidr:        "10.0.0.0/8",
+							ExceptCIDRs: []api.CIDR{"10.0.0.0/16"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Once exceptions apply, here are the list of CIDRs.
+	expectedCIDRStrings = []string{
+		"192.0.2.0/25",
+		// Not "192.0.2.128/25",
+		"10.128.0.0/9",
+		"10.64.0.0/10",
+		"10.32.0.0/11",
+		"10.16.0.0/12",
+		"10.8.0.0/13",
+		"10.4.0.0/14",
+		"10.2.0.0/15",
+		"10.1.0.0/16",
+		// Not "10.0.0.0/16",
+	}
+	expectedCIDRs = []*net.IPNet{}
+	for _, ipStr := range expectedCIDRStrings {
+		_, cidr, err := net.ParseCIDR(ipStr)
+		c.Assert(err, IsNil)
+		expectedCIDRs = append(expectedCIDRs, cidr)
+	}
+	c.Assert(GetCIDRPrefixes(rules), comparator.DeepEquals, expectedCIDRs)
+}


### PR DESCRIPTION
[Split out from #3835 for easier review]

This PR introduces the library code for #3835 which allows a CIDR rule or CIDRSet rule from the API to be converted into one of two formats:
* `Labels`
* `[]*net.IPNet`

### Labels
Allow conversion into a set of native `Labels` (`pkg/labels/`) that represent the CIDR and all CIDRs that contain it, ie ones with the same prefix but shorter prefix lengths. These are used to allocate an identity, which, when an `EndpointSelector` is created on the CIDR prefix, or any prefix that the CIDR falls under, will be selected. This works by, for instance, for `10.0.0.0/8` creating labels such as:
* 10.0.0.0/8
* 10.0.0.0/7
* 8.0.0.0/6
* ...
* 0.0.0.0/0

Now, if an `EndpointSelector` is created to match `0.0.0.0/0`, for instance, it will match this identity. This is what one might expect - the `0.0.0.0/0` CIDR matches all traffic.

IPv6 addresses are handled a bit specially. Labels are not allowed to contain `:`, however regular IPv6 formatting per RFC5952 typically contains this character. This PR represents such CIDRs using a label that replaces `:` with `-`. The `-` is converted back before formatting to string. Furthermore, label keys used for `EndpointSelector`s cannot begin or end with a `-`, so if the IPv6 CIDR label would otherwise begin or end with with `-`, eg `::/0` -> `--/0`, then insert a zero at the start or end to satisfy the `EndpointSelector` constraints. So `::/0` becomes `cidr:0--0/0`.

Finally, although the identities generated using these labels would contain labels for each CIDR Prefix that is in the rule plus every CIDR prefix that is shorter, it is both redundant and too verbose to print these regularly in output such as `cilium identity get`. This PR adds a patch to represent such CIDRs with just the most-specific CIDR when formatting. Using `cilium identity get --json` will provide the actual underlying information.

### `[]*net.IPNet`

PR #3835 will also need to create CIDR -> Identity mappings in the ipcache. These are currently managed using `net.IP` as they only cover IP addresses. It makes sense to use the native go type `*net.IPNet` to represent prefixes there.  Therefore this PR introduces libraries to also convert the API CIDR rule / CIDRSet rules into slices of `*net.IPNet` for insertion into the IPCache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/3909)
<!-- Reviewable:end -->
