### PR TITLE
app3 -> app1 in stateful conntrack paragraph

### DIFF
--- a/Documentation/gettingstarted/docker.rst
+++ b/Documentation/gettingstarted/docker.rst
@@ -151,7 +151,7 @@ filters only on IP address (network layer 3) and TCP port (network layer 4), so
 it is often referred to as an L3/L4 network security policy.
 
 Cilium performs stateful ''connection tracking'', meaning that if policy allows
-the *app2* to contact *app3*, it will automatically allow return
+the *app2* to contact *app1*, it will automatically allow return
 packets that are part of *app1* replying to *app2* within the context
 of the same TCP/UDP connection.
 


### PR DESCRIPTION
**Summary of changes**:
Changed what was probably a typo: app3 to app1 in stateful connection tracking example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/3910)
<!-- Reviewable:end -->
