### PR TITLE
Pre-identity policy

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -171,8 +171,7 @@ func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressin
 	}
 
 	// Create the endpoint
-	lbl := labels.Labels{labels.IDNameHealth: labels.NewLabel(labels.IDNameHealth, "", labels.LabelSourceReserved)}
-	ep, err := endpoint.NewEndpointFromChangeModel(info, lbl)
+	ep, err := endpoint.NewEndpointFromChangeModel(info)
 	if err != nil {
 		log.WithError(err).Fatal("Error while creating cilium-health endpoint")
 	}
@@ -184,9 +183,8 @@ func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressin
 	}
 
 	// Give the endpoint a security identity
-	if errLabelsAdd := ep.ModifyIdentityLabels(owner, lbl, labels.Labels{}); errLabelsAdd != nil {
-		log.WithError(errLabelsAdd).Fatal("Failed to set labels on cilium-health endpoint")
-	}
+	lbls := labels.Labels{labels.IDNameHealth: labels.NewLabel(labels.IDNameHealth, "", labels.LabelSourceReserved)}
+	ep.SetIdentityLabels(owner, lbls)
 
 	// Wait until the cilium-health endpoint is running before setting up routes
 	deadline := time.Now().Add(5 * time.Second)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cilium/cilium/common"
 	e "github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
@@ -129,6 +130,8 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 }
 
 func (ds *DaemonSuite) TearDownTest(c *C) {
+	endpointmanager.RemoveAll()
+
 	if ds.d != nil {
 		os.RemoveAll(option.Config.RunDir)
 	}
@@ -172,7 +175,7 @@ func (e *DaemonConsulSuite) TearDownTest(c *C) {
 	e.DaemonSuite.TearDownTest(c)
 }
 
-func (ds *DaemonSuite) TestMiniumWorkerThreadsIsSet(c *C) {
+func (ds *DaemonSuite) TestMinimumWorkerThreadsIsSet(c *C) {
 	c.Assert(numWorkerThreads() >= 4, Equals, true)
 	c.Assert(numWorkerThreads() >= runtime.NumCPU(), Equals, true)
 }

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -317,8 +317,10 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 	}
 
 	// If desired state is waiting-for-identity but identity is already
-	// known, bump it to ready state immediately to force re-generation
-	if ep.GetStateLocked() == endpoint.StateWaitingForIdentity && ep.SecurityIdentity != nil {
+	// known and hasn't changed, bump it to ready state immediately to force
+	// re-generation.
+	if ep.GetStateLocked() == endpoint.StateWaitingForIdentity &&
+		ep.SecurityIdentity != nil && ep.SecurityIdentity.Labels.Equals(addLabels) {
 		ep.SetStateLocked(endpoint.StateReady, "Preparing to force endpoint regeneration because identity is known while handling API PATCH")
 		changed = true
 	}

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -139,8 +139,7 @@ func NewPutEndpointIDHandler(d *Daemon) PutEndpointIDHandler {
 // request that was specified. Returns an HTTP code response code and an
 // error msg (or nil on success).
 func (d *Daemon) createEndpoint(epTemplate *models.EndpointChangeRequest, id string, lbls []string) (int, error) {
-	addLabels := labels.NewLabelsFromModel(lbls)
-	ep, err := endpoint.NewEndpointFromChangeModel(epTemplate, addLabels)
+	ep, err := endpoint.NewEndpointFromChangeModel(epTemplate)
 	if err != nil {
 		return PutEndpointIDInvalidCode, err
 	}
@@ -156,28 +155,30 @@ func (d *Daemon) createEndpoint(epTemplate *models.EndpointChangeRequest, id str
 		return PutEndpointIDInvalidCode, err
 	}
 
-	if err := endpointmanager.AddEndpoint(d, ep, "Create endpoint from API PUT"); err != nil {
-		log.WithError(err).Warn("Aborting endpoint join")
-		return PutEndpointIDFailedCode, err
-	}
+	addLabels := labels.NewLabelsFromModel(lbls)
 
-	// If the endpoint has no labels, give the endpoint a special identity with
-	// label reserved:init so we can generate a custom policy for it until we
-	// get its actual identity.
-	if len(addLabels) == 0 {
+	if len(addLabels) > 0 {
+		addLabels, _, ok := checkLabels(addLabels, nil)
+		if !ok {
+			return PutEndpointIDInvalidCode, fmt.Errorf("No valid label")
+		}
+		if lbls := addLabels.FindReserved(); lbls != nil {
+			return PutEndpointIDInvalidCode, fmt.Errorf("Not allowed to add reserved labels: %s", lbls)
+		}
+	} else {
+		// If the endpoint has no labels, give the endpoint a special identity with
+		// label reserved:init so we can generate a custom policy for it until we
+		// get its actual identity.
 		addLabels = labels.Labels{
 			labels.IDNameInit: labels.NewLabel(labels.IDNameInit, "", labels.LabelSourceReserved),
 		}
 	}
 
-	code, err := d.updateEndpointLabels(id, addLabels, labels.Labels{})
-	if err != nil {
-		// XXX: Why should the endpoint remain in this case?
-		log.WithFields(logrus.Fields{
-			logfields.EndpointID:     id,
-			logfields.IdentityLabels: logfields.Repr(addLabels),
-		}).WithError(err).Error("Could not add labels while creating an ep")
-		return code, err
+	ep.SetIdentityLabels(d, addLabels)
+
+	if err := endpointmanager.AddEndpoint(d, ep, "Create endpoint from API PUT"); err != nil {
+		log.WithError(err).Warn("Aborting endpoint join")
+		return PutEndpointIDFailedCode, err
 	}
 
 	return PutEndpointIDCreatedCode, nil
@@ -228,8 +229,7 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 
 	// Validate the template. Assignment afterwards is atomic.
 	// Note: newEp's labels are ignored.
-	addLabels := labels.NewLabelsFromModel(params.Endpoint.Labels)
-	newEp, err2 := endpoint.NewEndpointFromChangeModel(epTemplate, addLabels)
+	newEp, err2 := endpoint.NewEndpointFromChangeModel(epTemplate)
 	if err2 != nil {
 		return apierror.Error(PutEndpointIDInvalidCode, err2)
 	}
@@ -316,11 +316,12 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 		}
 	}
 
+	// TODO: Do something with the labels?
+	// addLabels := labels.NewLabelsFromModel(params.Endpoint.Labels)
+
 	// If desired state is waiting-for-identity but identity is already
-	// known and hasn't changed, bump it to ready state immediately to force
-	// re-generation.
-	if ep.GetStateLocked() == endpoint.StateWaitingForIdentity &&
-		ep.SecurityIdentity != nil && ep.SecurityIdentity.Labels.Equals(addLabels) {
+	// known, bump it to ready state immediately to force re-generation
+	if ep.GetStateLocked() == endpoint.StateWaitingForIdentity && ep.SecurityIdentity != nil {
 		ep.SetStateLocked(endpoint.StateReady, "Preparing to force endpoint regeneration because identity is known while handling API PATCH")
 		changed = true
 	}
@@ -658,37 +659,14 @@ func checkLabels(add, del labels.Labels) (addLabels, delLabels labels.Labels, ok
 	return addLabels, delLabels, true
 }
 
-// updateEndpointLabels add and deletes the given labels on given endpoint ID.
-// The received `add` and `del` labels will be filtered with the valid label
-// prefixes.
+// modifyEndpointIdentityLabelsFromAPI adds and deletes the given labels on given endpoint ID.
+// Performs checks for whether the endpoint may be modified by an API call.
+// The received `add` and `del` labels will be filtered with the valid label prefixes.
 // The `add` labels take precedence over `del` labels, this means if the same
 // label is set on both `add` and `del`, that specific label will exist in the
 // endpoint's labels.
 // Returns an HTTP response code and an error msg (or nil on success).
-func (d *Daemon) updateEndpointLabels(id string, add, del labels.Labels) (int, error) {
-	addLabels, delLabels, ok := checkLabels(add, del)
-	if !ok {
-		return 0, nil
-	}
-
-	ep, err := endpointmanager.Lookup(id)
-	if err != nil {
-		return GetEndpointIDInvalidCode, err
-	}
-	if ep == nil {
-		return PatchEndpointIDLabelsNotFoundCode, fmt.Errorf("Endpoint ID %s not found", id)
-	}
-
-	if err := ep.ModifyIdentityLabels(d, addLabels, delLabels); err != nil {
-		return PatchEndpointIDLabelsNotFoundCode, err
-	}
-
-	return PatchEndpointIDLabelsOKCode, nil
-}
-
-// updateEndpointLabelsFromAPI is the same as updateEndpointLabels(), but also
-// performs checks for whether the endpoint may be modified by an API call.
-func (d *Daemon) updateEndpointLabelsFromAPI(id string, add, del labels.Labels) (int, error) {
+func (d *Daemon) modifyEndpointIdentityLabelsFromAPI(id string, add, del labels.Labels) (int, error) {
 	addLabels, delLabels, ok := checkLabels(add, del)
 	if !ok {
 		return 0, nil
@@ -701,7 +679,7 @@ func (d *Daemon) updateEndpointLabelsFromAPI(id string, add, del labels.Labels) 
 
 	ep, err := endpointmanager.Lookup(id)
 	if err != nil {
-		return GetEndpointIDInvalidCode, err
+		return PatchEndpointIDInvalidCode, err
 	}
 	if ep == nil {
 		return PatchEndpointIDLabelsNotFoundCode, fmt.Errorf("Endpoint ID %s not found", id)
@@ -765,7 +743,7 @@ func (h *putEndpointIDLabels) Handle(params PatchEndpointIDLabelsParams) middlew
 		add = nil
 	}
 
-	code, err := d.updateEndpointLabelsFromAPI(params.ID, add, del)
+	code, err := d.modifyEndpointIdentityLabelsFromAPI(params.ID, add, del)
 	if err != nil {
 		return apierror.Error(code, err)
 	}

--- a/daemon/endpoint_test.go
+++ b/daemon/endpoint_test.go
@@ -52,15 +52,18 @@ func getEPTemplate(c *C) *models.EndpointChangeRequest {
 	}
 }
 
-func (ds *DaemonSuite) TestEndpointAdd(c *C) {
+func (ds *DaemonSuite) TestEndpointAddReservedLabel(c *C) {
 	epTemplate := getEPTemplate(c)
 	lbls := []string{"reserved:world"}
 	code, err := ds.d.createEndpoint(epTemplate, strconv.FormatInt(epTemplate.ID, 10), lbls)
 	c.Assert(err, Not(IsNil))
 	c.Assert(code, Equals, apiEndpoint.PutEndpointIDInvalidCode)
+}
 
-	lbls = []string{"reserved:foo"}
-	code, err = ds.d.createEndpoint(epTemplate, strconv.FormatInt(epTemplate.ID, 10), lbls)
+func (ds *DaemonSuite) TestEndpointAddInvalidLabel(c *C) {
+	epTemplate := getEPTemplate(c)
+	lbls := []string{"reserved:foo"}
+	code, err := ds.d.createEndpoint(epTemplate, strconv.FormatInt(epTemplate.ID, 10), lbls)
 	c.Assert(err, Not(IsNil))
 	c.Assert(code, Equals, apiEndpoint.PutEndpointIDInvalidCode)
 }
@@ -125,7 +128,7 @@ Loop:
 
 func (ds *DaemonSuite) TestUpdateSecLabels(c *C) {
 	lbls := labels.NewLabelsFromModel([]string{"reserved:world"})
-	code, err := ds.d.updateEndpointLabelsFromAPI("1", lbls, nil)
+	code, err := ds.d.modifyEndpointIdentityLabelsFromAPI("1", lbls, nil)
 	c.Assert(err, Not(IsNil))
 	c.Assert(code, Equals, apiEndpoint.PatchEndpointIDLabelsUpdateFailedCode)
 }

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/monitor"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 
 	. "gopkg.in/check.v1"
@@ -130,6 +131,10 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 	}
 
 	ds.OnRemoveNetworkPolicy = func(e *e.Endpoint) {}
+
+	ds.OnPolicyEnforcement = func() string {
+		return option.DefaultEnforcement
+	}
 
 	// Since all owner's funcs are implemented we can regenerate every endpoint.
 	epsNames := []string{}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2162,6 +2162,14 @@ func (e *Endpoint) ModifyIdentityLabels(owner Owner, addLabels, delLabels pkgLab
 	return nil
 }
 
+// IsInit returns true if the endpoint still hasn't received identity labels,
+// i.e. has the special identity with label reserved:init.
+func (e *Endpoint) IsInit() bool {
+	lbls := e.OpLabels.IdentityLabels()
+	init := lbls[pkgLabels.IDNameInit]
+	return init != nil && init.Source == pkgLabels.LabelSourceReserved
+}
+
 // UpdateLabels is called to update the labels of an endpoint. Calls to this
 // function do not necessarily mean that the labels actually changed. The
 // container runtime layer will periodically synchronize labels.

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1893,7 +1893,7 @@ func (e *Endpoint) SetStateLocked(toState, reason string) bool {
 		}
 	case StateReady:
 		switch toState {
-		case StateDisconnecting, StateWaitingToRegenerate:
+		case StateWaitingForIdentity, StateDisconnecting, StateWaitingToRegenerate:
 			goto OKState
 		}
 	case StateDisconnecting:
@@ -1906,7 +1906,7 @@ func (e *Endpoint) SetStateLocked(toState, reason string) bool {
 	case StateWaitingToRegenerate:
 		switch toState {
 		// Note that transitions to waiting-to-regenerate state
-		case StateDisconnecting:
+		case StateWaitingForIdentity, StateDisconnecting:
 			goto OKState
 		}
 	case StateRegenerating:
@@ -1915,8 +1915,8 @@ func (e *Endpoint) SetStateLocked(toState, reason string) bool {
 		// possible that further changes require a new
 		// build. In this case the endpoint is transitioned
 		// from the regenerating state to
-		// waiting-to-regenerate state.
-		case StateDisconnecting, StateWaitingToRegenerate:
+		// waiting-for-identity or waiting-to-regenerate state.
+		case StateWaitingForIdentity, StateDisconnecting, StateWaitingToRegenerate:
 			goto OKState
 		}
 	case StateRestoring:

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1383,12 +1383,12 @@ func (e *Endpoint) GetBPFKeys() []lxcmap.EndpointKey {
 func (e *Endpoint) GetBPFValue() (*lxcmap.EndpointInfo, error) {
 	mac, err := e.LXCMAC.Uint64()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid LXC MAC: %v", err)
 	}
 
 	nodeMAC, err := e.NodeMAC.Uint64()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid node MAC: %v", err)
 	}
 
 	info := &lxcmap.EndpointInfo{

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -245,7 +245,8 @@ func (s *EndpointSuite) TestEndpointState(c *C) {
 
 	e.state = StateReady
 	c.Assert(e.SetStateLocked(StateCreating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, false)
+	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, true)
+	e.state = StateReady
 	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, false)
 	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, true)
 	e.state = StateReady
@@ -256,7 +257,8 @@ func (s *EndpointSuite) TestEndpointState(c *C) {
 
 	e.state = StateWaitingToRegenerate
 	c.Assert(e.SetStateLocked(StateCreating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, false)
+	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, true)
+	e.state = StateWaitingToRegenerate
 	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, false)
 	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, false)
 	c.Assert(e.SetStateLocked(StateRegenerating, "test"), Equals, false)
@@ -266,7 +268,8 @@ func (s *EndpointSuite) TestEndpointState(c *C) {
 
 	e.state = StateRegenerating
 	c.Assert(e.SetStateLocked(StateCreating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, false)
+	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, true)
+	e.state = StateRegenerating
 	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, false)
 	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, true)
 	e.state = StateRegenerating

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -169,6 +169,14 @@ func Remove(ep *endpoint.Endpoint) {
 	}
 }
 
+// RemoveAll removes all endpoints from the global maps.
+func RemoveAll() {
+	mutex.Lock()
+	defer mutex.Unlock()
+	endpoints = map[uint16]*endpoint.Endpoint{}
+	endpointsAux = map[string]*endpoint.Endpoint{}
+}
+
 // lookupCiliumID looks up endpoint by endpoint ID
 func lookupCiliumID(id uint16) *endpoint.Endpoint {
 	if ep, ok := endpoints[id]; ok {

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -333,10 +333,6 @@ func AddEndpoint(owner endpoint.Owner, ep *endpoint.Endpoint, reason string) err
 	if state == endpoint.StateReady {
 		ep.SetStateLocked(endpoint.StateWaitingToRegenerate, reason)
 		build = true
-	} else if state == endpoint.StateWaitingForIdentity {
-		// state not changed if it is "waiting-for-identity",
-		// but we still trigger the initial build.
-		build = true
 	}
 	ep.Mutex.Unlock()
 	if build {

--- a/pkg/identity/allocator.go
+++ b/pkg/identity/allocator.go
@@ -91,6 +91,18 @@ func InitIdentityAllocator(owner IdentityAllocatorOwner) {
 	})
 }
 
+// IdentityAllocationIsLocal returns true if a call to AllocateIdentity with
+// the given labels would not require accessing the KV store to allocate the
+// identity.
+// Currently, this function returns true only if the labels are those of a
+// reserved identity, i.e. if the slice contains a single reserved
+// "reserved:*" label.
+func IdentityAllocationIsLocal(lbls labels.Labels) bool {
+	// If there is only one label with the "reserved" source and a well-known
+	// key, the well-known identity for it can be allocated locally.
+	return LookupReservedIdentity(lbls) != nil
+}
+
 // AllocateIdentity allocates an identity described by the specified labels. If
 // an identity for the specified set of labels already exist, the identity is
 // re-used and reference counting is performed, otherwise a new identity is
@@ -99,6 +111,17 @@ func AllocateIdentity(lbls labels.Labels) (*Identity, bool, error) {
 	log.WithFields(logrus.Fields{
 		logfields.IdentityLabels: lbls.String(),
 	}).Debug("Resolving identity")
+
+	// If there is only one label with the "reserved" source and a well-known
+	// key, use the well-known identity for that key.
+	if reservedIdentity := LookupReservedIdentity(lbls); reservedIdentity != nil {
+		log.WithFields(logrus.Fields{
+			logfields.Identity:       reservedIdentity.ID,
+			logfields.IdentityLabels: lbls.String(),
+			"isNew":                  false,
+		}).Debug("Resolved reserved identity")
+		return reservedIdentity, false, nil
+	}
 
 	id, isNew, err := identityAllocator.Allocate(globalIdentity{lbls})
 	if err != nil {
@@ -118,6 +141,10 @@ func AllocateIdentity(lbls labels.Labels) (*Identity, bool, error) {
 // identity again. This function may result in kvstore operations.
 // After the last user has released the ID, the returned lastUse value is true.
 func (id *Identity) Release() error {
+	// Ignore reserved identities.
+	if reservedIdentityCache[id.ID] != nil {
+		return nil
+	}
 	return identityAllocator.Release(globalIdentity{id.Labels})
 }
 

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -34,17 +34,25 @@ type IdentityTestSuite struct{}
 var _ = Suite(&IdentityTestSuite{})
 
 func (s *IdentityTestSuite) TestReservedID(c *C) {
-	i1 := GetReservedID("host")
-	c.Assert(i1, Equals, NumericIdentity(1))
-	c.Assert(i1.String(), Equals, "host")
+	i := GetReservedID("host")
+	c.Assert(i, Equals, NumericIdentity(1))
+	c.Assert(i.String(), Equals, "host")
 
-	i2 := GetReservedID("world")
-	c.Assert(i2, Equals, NumericIdentity(2))
-	c.Assert(i2.String(), Equals, "world")
+	i = GetReservedID("world")
+	c.Assert(i, Equals, NumericIdentity(2))
+	c.Assert(i.String(), Equals, "world")
 
-	i2 = GetReservedID("cluster")
-	c.Assert(i2, Equals, NumericIdentity(3))
-	c.Assert(i2.String(), Equals, "cluster")
+	i = GetReservedID("cluster")
+	c.Assert(i, Equals, NumericIdentity(3))
+	c.Assert(i.String(), Equals, "cluster")
+
+	i = GetReservedID("health")
+	c.Assert(i, Equals, NumericIdentity(4))
+	c.Assert(i.String(), Equals, "health")
+
+	i = GetReservedID("init")
+	c.Assert(i, Equals, NumericIdentity(5))
+	c.Assert(i.String(), Equals, "init")
 
 	c.Assert(GetReservedID("unknown"), Equals, IdentityUnknown)
 	unknown := NumericIdentity(700)
@@ -52,13 +60,67 @@ func (s *IdentityTestSuite) TestReservedID(c *C) {
 }
 
 func (s *IdentityTestSuite) TestIsReservedIdentity(c *C) {
-
 	c.Assert(ReservedIdentityCluster.IsReservedIdentity(), Equals, true)
 	c.Assert(ReservedIdentityHealth.IsReservedIdentity(), Equals, true)
 	c.Assert(ReservedIdentityHost.IsReservedIdentity(), Equals, true)
 	c.Assert(ReservedIdentityWorld.IsReservedIdentity(), Equals, true)
+	c.Assert(ReservedIdentityInit.IsReservedIdentity(), Equals, true)
 
 	c.Assert(NumericIdentity(123456).IsReservedIdentity(), Equals, false)
+}
+
+func (s *IdentityTestSuite) TestAllocateIdentityReserved(c *C) {
+	var (
+		lbls  labels.Labels
+		i     *Identity
+		isNew bool
+		err   error
+	)
+
+	lbls = labels.Labels{
+		labels.IDNameHost: labels.NewLabel(labels.IDNameHost, "", labels.LabelSourceReserved),
+	}
+	c.Assert(IdentityAllocationIsLocal(lbls), Equals, true)
+	i, isNew, err = AllocateIdentity(lbls)
+	c.Assert(err, IsNil)
+	c.Assert(i.ID, Equals, ReservedIdentityHost)
+	c.Assert(isNew, Equals, false)
+
+	lbls = labels.Labels{
+		labels.IDNameWorld: labels.NewLabel(labels.IDNameWorld, "", labels.LabelSourceReserved),
+	}
+	c.Assert(IdentityAllocationIsLocal(lbls), Equals, true)
+	i, isNew, err = AllocateIdentity(lbls)
+	c.Assert(err, IsNil)
+	c.Assert(i.ID, Equals, ReservedIdentityWorld)
+	c.Assert(isNew, Equals, false)
+
+	lbls = labels.Labels{
+		labels.IDNameCluster: labels.NewLabel(labels.IDNameCluster, "", labels.LabelSourceReserved),
+	}
+	c.Assert(IdentityAllocationIsLocal(lbls), Equals, true)
+	i, isNew, err = AllocateIdentity(lbls)
+	c.Assert(err, IsNil)
+	c.Assert(i.ID, Equals, ReservedIdentityCluster)
+	c.Assert(isNew, Equals, false)
+
+	lbls = labels.Labels{
+		labels.IDNameHealth: labels.NewLabel(labels.IDNameHealth, "", labels.LabelSourceReserved),
+	}
+	c.Assert(IdentityAllocationIsLocal(lbls), Equals, true)
+	i, isNew, err = AllocateIdentity(lbls)
+	c.Assert(err, IsNil)
+	c.Assert(i.ID, Equals, ReservedIdentityHealth)
+	c.Assert(isNew, Equals, false)
+
+	lbls = labels.Labels{
+		labels.IDNameInit: labels.NewLabel(labels.IDNameInit, "", labels.LabelSourceReserved),
+	}
+	c.Assert(IdentityAllocationIsLocal(lbls), Equals, true)
+	i, isNew, err = AllocateIdentity(lbls)
+	c.Assert(err, IsNil)
+	c.Assert(i.ID, Equals, ReservedIdentityInit)
+	c.Assert(isNew, Equals, false)
 }
 
 type IdentityAllocatorSuite struct{}

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -16,14 +16,11 @@ package identity
 
 import (
 	"strconv"
-	"time"
 
 	"github.com/cilium/cilium/pkg/labels"
 )
 
 const (
-	secLabelTimeout = 120 * time.Second
-
 	// MinimalNumericIdentity represents the minimal numeric identity not
 	// used for reserved purposes.
 	MinimalNumericIdentity = NumericIdentity(256)
@@ -49,6 +46,10 @@ const (
 
 	// ReservedIdentityHealth represents the local cilium-health endpoint
 	ReservedIdentityHealth
+
+	// ReservedIdentityInit is the identity given to endpoints that have not
+	// received any labels yet.
+	ReservedIdentityInit
 )
 
 var (
@@ -57,12 +58,14 @@ var (
 		labels.IDNameWorld:   ReservedIdentityWorld,
 		labels.IDNameHealth:  ReservedIdentityHealth,
 		labels.IDNameCluster: ReservedIdentityCluster,
+		labels.IDNameInit:    ReservedIdentityInit,
 	}
 	ReservedIdentityNames = map[NumericIdentity]string{
 		ReservedIdentityHost:    labels.IDNameHost,
 		ReservedIdentityWorld:   labels.IDNameWorld,
 		ReservedIdentityHealth:  labels.IDNameHealth,
 		ReservedIdentityCluster: labels.IDNameCluster,
+		ReservedIdentityInit:    labels.IDNameInit,
 	}
 )
 

--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -34,6 +34,10 @@ const (
 	// podPrefixLbl is the value the prefix used in the label selector to
 	// represent pods on the default namespace.
 	podPrefixLbl = labels.LabelSourceK8sKeyPrefix + k8sConst.PodNamespaceLabel
+
+	// podInitLbl is the label used in a label selector to match on
+	// initializing pods.
+	podInitLbl = labels.LabelSourceReservedKeyPrefix + labels.IDNameInit
 )
 
 var (
@@ -82,7 +86,13 @@ func parseToCiliumIngressRule(namespace string, inRule, retRule *api.Rule) {
 					// The user can explicitly specify the namespace in the
 					// FromEndpoints selector. If omitted, we limit the
 					// scope to the namespace the policy lives in.
-					if !retRule.Ingress[i].FromEndpoints[j].HasKey(podPrefixLbl) {
+					//
+					// Policies applying on initializing pods are a special case.
+					// Those pods don't have any labels, so they don't have a namespace label either.
+					// Don't add a namespace label to those endpoint selectors, or we wouldn't be
+					// able to match on those pods.
+					if _, ok := retRule.EndpointSelector.LabelSelector.MatchLabels[podInitLbl]; !ok &&
+						!retRule.Ingress[i].FromEndpoints[j].HasKey(podPrefixLbl) {
 						retRule.Ingress[i].FromEndpoints[j].MatchLabels[podPrefixLbl] = namespace
 					}
 				}
@@ -112,7 +122,13 @@ func parseToCiliumIngressRule(namespace string, inRule, retRule *api.Rule) {
 					// The user can explicitly specify the namespace in the
 					// FromEndpoints selector. If omitted, we limit the
 					// scope to the namespace the policy lives in.
-					if !retRule.Ingress[i].FromRequires[j].HasKey(podPrefixLbl) {
+					//
+					// Policies applying on initializing pods are a special case.
+					// Those pods don't have any labels, so they don't have a namespace label either.
+					// Don't add a namespace label to those endpoint selectors, or we wouldn't be
+					// able to match on those pods.
+					if _, ok := retRule.EndpointSelector.LabelSelector.MatchLabels[podInitLbl]; !ok &&
+						!retRule.Ingress[i].FromRequires[j].HasKey(podPrefixLbl) {
 						retRule.Ingress[i].FromRequires[j].MatchLabels[podPrefixLbl] = namespace
 					}
 				}
@@ -145,7 +161,13 @@ func parseToCiliumEgressRule(namespace string, inRule, retRule *api.Rule) {
 					// The user can explicitly specify the namespace in the
 					// ToEndpoints selector. If omitted, we limit the
 					// scope to the namespace the policy lives in.
-					if !retRule.Egress[i].ToEndpoints[j].HasKey(podPrefixLbl) {
+					//
+					// Policies applying on initializing pods are a special case.
+					// Those pods don't have any labels, so they don't have a namespace label either.
+					// Don't add a namespace label to those endpoint selectors, or we wouldn't be
+					// able to match on those pods.
+					if _, ok := retRule.EndpointSelector.LabelSelector.MatchLabels[podInitLbl]; !ok &&
+						!retRule.Egress[i].ToEndpoints[j].HasKey(podPrefixLbl) {
 						retRule.Egress[i].ToEndpoints[j].MatchLabels[podPrefixLbl] = namespace
 					}
 				}
@@ -175,7 +197,13 @@ func parseToCiliumEgressRule(namespace string, inRule, retRule *api.Rule) {
 					// The user can explicitly specify the namespace in the
 					// ToEndpoints selector. If omitted, we limit the
 					// scope to the namespace the policy lives in.
-					if !retRule.Egress[i].ToRequires[j].HasKey(podPrefixLbl) {
+					//
+					// Policies applying on initializing pods are a special case.
+					// Those pods don't have any labels, so they don't have a namespace label either.
+					// Don't add a namespace label to those endpoint selectors, or we wouldn't be
+					// able to match on those pods.
+					if _, ok := retRule.EndpointSelector.LabelSelector.MatchLabels[podInitLbl]; !ok &&
+						!retRule.Egress[i].ToRequires[j].HasKey(podPrefixLbl) {
 						retRule.Egress[i].ToRequires[j].MatchLabels[podPrefixLbl] = namespace
 					}
 				}
@@ -207,16 +235,22 @@ func ParseToCiliumRule(namespace, name string, r *api.Rule) *api.Rule {
 			retRule.EndpointSelector.LabelSelector.MatchLabels = map[string]string{}
 		}
 
-		userNamespace, ok := retRule.EndpointSelector.LabelSelector.MatchLabels[podPrefixLbl]
-		if ok && userNamespace != namespace {
-			log.WithFields(logrus.Fields{
-				logfields.K8sNamespace:              namespace,
-				logfields.CiliumNetworkPolicyName:   name,
-				logfields.K8sNamespace + ".illegal": userNamespace,
-			}).Warn("CiliumNetworkPolicy contains illegal namespace match in EndpointSelector." +
-				" EndpointSelector always applies in namespace of the policy resource, removing illegal namespace match'.")
+		// Policies applying on initializing pods are a special case.
+		// Those pods don't have any labels, so they don't have a namespace label either.
+		// Don't add a namespace label to those endpoint selectors, or we wouldn't be
+		// able to match on those pods.
+		if _, ok := retRule.EndpointSelector.LabelSelector.MatchLabels[podInitLbl]; !ok {
+			userNamespace, ok := retRule.EndpointSelector.LabelSelector.MatchLabels[podPrefixLbl]
+			if ok && userNamespace != namespace {
+				log.WithFields(logrus.Fields{
+					logfields.K8sNamespace:              namespace,
+					logfields.CiliumNetworkPolicyName:   name,
+					logfields.K8sNamespace + ".illegal": userNamespace,
+				}).Warn("CiliumNetworkPolicy contains illegal namespace match in EndpointSelector." +
+					" EndpointSelector always applies in namespace of the policy resource, removing illegal namespace match'.")
+			}
+			retRule.EndpointSelector.LabelSelector.MatchLabels[podPrefixLbl] = namespace
 		}
-		retRule.EndpointSelector.LabelSelector.MatchLabels[podPrefixLbl] = namespace
 	}
 
 	parseToCiliumIngressRule(namespace, r, retRule)

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -41,7 +41,7 @@ const (
 
 	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
 	// Used to determine if CRD needs to be updated in cluster
-	CustomResourceDefinitionSchemaVersion = "1.7"
+	CustomResourceDefinitionSchemaVersion = "1.8"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"
@@ -555,7 +555,7 @@ var (
 			"fromEntities": {
 				Description: "FromEntities is a list of special entities which the endpoint " +
 					"subject to the rule is allowed to receive connections from. Supported " +
-					"entities are `world`, `cluster` and `host`",
+					"entities are `world`, `cluster`, `host`, and `init`",
 				Type: "array",
 				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
 					Schema: &apiextensionsv1beta1.JSONSchemaProps{

--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -219,6 +219,10 @@ func readLabelPrefixCfgFrom(fileName string) (*labelPrefixCfg, error) {
 }
 
 func (cfg *labelPrefixCfg) filterLabels(lbls Labels) (identityLabels, informationLabels Labels) {
+	if lbls == nil {
+		return nil, nil
+	}
+
 	validLabelPrefixesMU.RLock()
 	defer validLabelPrefixesMU.RUnlock()
 

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -43,6 +43,10 @@ const (
 
 	// IDNameHealth is the label used for the local cilium-health endpoint
 	IDNameHealth = "health"
+
+	// IDNameInit is the label used to identify any endpoint that has not
+	// received any labels yet.
+	IDNameInit = "init"
 )
 
 // OpLabels represents the the possible types.

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -249,6 +249,23 @@ func (l Labels) AppendPrefixInKey(prefix string) Labels {
 	return newLabels
 }
 
+// Equals returns true if the two Labels contain the same set of labels.
+func (l Labels) Equals(other Labels) bool {
+	if len(l) != len(other) {
+		return false
+	}
+
+	for k, lbl1 := range l {
+		if lbl2, ok := other[k]; ok {
+			if lbl1.Source == lbl2.Source && lbl1.Key == lbl2.Key && lbl1.Value == lbl2.Value {
+				continue
+			}
+		}
+		return false
+	}
+	return true
+}
+
 // NewLabel returns a new label from the given key, value and source. If source is empty,
 // the default value will be LabelSourceUnspec. If key starts with '$', the source
 // will be overwritten with LabelSourceReserved. If key contains ':', the value

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -221,3 +221,27 @@ func (s *LabelsSuite) TestLabelParseKey(c *C) {
 		c.Assert(lbl, comparator.DeepEquals, test.out)
 	}
 }
+
+func (s *LabelsSuite) TestLabelsCompare(c *C) {
+	la11 := NewLabel("a", "1", "src1")
+	la12 := NewLabel("a", "1", "src2")
+	la22 := NewLabel("a", "2", "src2")
+	lb22 := NewLabel("b", "2", "src2")
+
+	lblsAll := Labels{la11.Key: la11, la12.Key: la12, la22.Key: la22, lb22.Key: lb22}
+	lblsFewer := Labels{la11.Key: la11, la12.Key: la12, la22.Key: la22}
+	lblsLa11 := Labels{la11.Key: la11}
+	lblsLa12 := Labels{la12.Key: la12}
+	lblsLa22 := Labels{la22.Key: la22}
+	lblsLb22 := Labels{lb22.Key: lb22}
+
+	c.Assert(lblsAll.Equals(lblsAll), Equals, true)
+	c.Assert(lblsAll.Equals(lblsFewer), Equals, false)
+	c.Assert(lblsFewer.Equals(lblsAll), Equals, false)
+	c.Assert(lblsLa11.Equals(lblsLa12), Equals, false)
+	c.Assert(lblsLa12.Equals(lblsLa11), Equals, false)
+	c.Assert(lblsLa12.Equals(lblsLa22), Equals, false)
+	c.Assert(lblsLa22.Equals(lblsLa12), Equals, false)
+	c.Assert(lblsLa22.Equals(lblsLb22), Equals, false)
+	c.Assert(lblsLb22.Equals(lblsLa22), Equals, false)
+}

--- a/pkg/policy/api/entity.go
+++ b/pkg/policy/api/entity.go
@@ -37,6 +37,9 @@ const (
 
 	// EntityHost is an entity that represents traffic within endpoint host
 	EntityHost Entity = "host"
+
+	// EntityInit is an entity that represents an initializing endpoint
+	EntityInit Entity = "init"
 )
 
 // EntitySelectorMapping maps special entity names that come in policies to
@@ -55,6 +58,11 @@ var EntitySelectorMapping = map[Entity]EndpointSelector{
 	}),
 	EntityHost: NewESFromLabels(&labels.Label{
 		Key:    labels.IDNameHost,
+		Value:  "",
+		Source: labels.LabelSourceReserved,
+	}),
+	EntityInit: NewESFromLabels(&labels.Label{
+		Key:    labels.IDNameInit,
 		Value:  "",
 		Source: labels.LabelSourceReserved,
 	}),

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -562,8 +562,6 @@ func (p *Repository) GetJSON() string {
 
 // GetRulesMatching returns whether any of the rules in a repository contain a
 // rule with labels matching the labels in the provided LabelArray.
-// If includeEntities is true, we check if repository contains rules matching
-// fromEntities and toEntities.
 //
 // Must be called with p.Mutex held
 func (p *Repository) GetRulesMatching(labels labels.LabelArray) (ingressMatch bool, egressMatch bool) {

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -385,10 +385,6 @@ func (driver *driver) joinEndpoint(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.WithField(logfields.Object, old).Debug("Existing endpoint")
-	if old.Status.State != models.EndpointStateCreating {
-		sendError(w, "Error: endpoint not in creating state", http.StatusBadRequest)
-		return
-	}
 
 	ep := &models.EndpointChangeRequest{
 		State: models.EndpointStateWaitingForIdentity,

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -306,7 +306,7 @@ func (driver *driver) createEndpoint(w http.ResponseWriter, r *http.Request) {
 
 	endpoint := &models.EndpointChangeRequest{
 		ID:               int64(ip6.EndpointID()),
-		State:            models.EndpointStateCreating,
+		State:            models.EndpointStateWaitingForIdentity,
 		DockerEndpointID: create.EndpointID,
 		DockerNetworkID:  create.NetworkID,
 		Addressing: &models.AddressPair{
@@ -398,16 +398,6 @@ func (driver *driver) joinEndpoint(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.WithField(logfields.Object, old).Debug("Existing endpoint")
-
-	ep := &models.EndpointChangeRequest{
-		State: models.EndpointStateWaitingForIdentity,
-	}
-
-	if err = driver.client.EndpointPatch(endpointPkg.NewCiliumID(old.ID), ep); err != nil {
-		log.WithError(err).Error("Joining endpoint failed")
-		sendError(w, "Unable to connect endpoint to network: "+err.Error(),
-			http.StatusInternalServerError)
-	}
 
 	res := &api.JoinResponse{
 		InterfaceName: &api.InterfaceName{

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -173,7 +173,8 @@ func (s *SSHMeta) WaitEndpointRegenerated(id string) bool {
 
 	epState := endpoint.Status.State
 
-	for ; epState != desiredState && counter < MaxRetries; counter++ {
+	// Consider an endpoint with reserved identity 5 (reserved:init) as not ready.
+	for ; (epState != desiredState || endpoint.Status.Identity.ID == 5) && counter < MaxRetries; counter++ {
 
 		logger.WithFields(logrus.Fields{
 			"endpointState": epState,
@@ -232,7 +233,7 @@ func (s *SSHMeta) WaitEndpointsReady() bool {
 	logger := s.logger.WithFields(logrus.Fields{"functionName": "WaitEndpointsReady"})
 	desiredState := string(models.EndpointStateReady)
 	body := func() bool {
-		filter := `{range [*]}{@.status.external-identifiers.container-name}{"="}{@.status.state}{"\n"}{end}`
+		filter := `{range [*]}{@.status.external-identifiers.container-name}{"="}{@.status.state},{@.status.identity.id}{"\n"}{end}`
 		cmd := fmt.Sprintf(`cilium endpoint list -o jsonpath='%s'`, filter)
 
 		res := s.Exec(cmd)
@@ -245,7 +246,14 @@ func (s *SSHMeta) WaitEndpointsReady() bool {
 
 		result := map[string]int{}
 		for _, status := range values {
-			result[status]++
+			fields := strings.Split(status, ",")
+			state := fields[0]
+			secID := fields[1]
+			// Consider an endpoint with reserved identity 5 (reserved:init) as not ready.
+			if secID == "5" {
+				state = state + "+init"
+			}
+			result[state]++
 		}
 
 		logger.WithField("status", result).Infof(

--- a/test/runtime/cli.go
+++ b/test/runtime/cli.go
@@ -104,7 +104,7 @@ var _ = Describe("RuntimeValidatedCLI", func() {
 			res = vm.Exec(`cilium identity list`)
 			resSingleOut = res.SingleOut()
 
-			reservedIdentities := []string{"health", "cluster", "host", "world"}
+			reservedIdentities := []string{"health", "cluster", "host", "world", "init"}
 
 			for _, id := range reservedIdentities {
 				By("checking that reserved identity '%s' is in 'cilium identity list' output", id)

--- a/test/runtime/manifests/Policies-reserved-init.json
+++ b/test/runtime/manifests/Policies-reserved-init.json
@@ -1,0 +1,36 @@
+[
+  {
+    "endpointSelector": {
+      "matchLabels": {"reserved:init": ""}
+    },
+    "ingress": [{
+      "fromEntities": ["host"]
+    }],
+    "egress": [{
+      "toEntities": ["host"]
+    },{
+      "toPorts": [{
+        "ports": [
+          {"port": "53",   "protocol": "udp"}
+        ]
+      }]
+    }]
+  },
+  {
+    "endpointSelector": {
+      "matchLabels": {"container:somelabel": ""}
+    },
+    "ingress": [{
+      "fromEntities": ["host"]
+    }],
+    "egress": [{
+      "toEntities": ["host"]
+    },{
+      "toPorts": [{
+        "ports": [
+          {"port": "53",   "protocol": "udp"}
+        ]
+      }]
+    }]
+  }
+]


### PR DESCRIPTION
Define `reserved:init` label and set it on endpoints with no labels.

Always enable policy for `reserved:init` endpoints in `default` mode.

Add `init` as supported entity in the API (`FromEntity` / `ToEntity`).

Allocate reserved identities for reserved labels, esp. allocate ID `4` to health daemon endpoints (`health` entities), and allocate ID `5` to initializing endpoints (`init` entities). Allocate such entity IDs synchronously, since that doesn't require any kvstore interactions.

Simplify and clean up `cilium-docker`.
Remove the constraint on endpoint state after creation, since after creation endpoints can now be in different states: `creating`, `waiting-for-identity`, `not-ready`, etc.
Create the veth pair immediately on endpoint creation, so that the LXC and node MAC addresses are known at endpoint creation time, like with the CNI plugin.
Remove the now-unnecessary `PATCH /endpoint/{id}` API call to Cilium agent, since all the information that used to be passed in the `PATCH` call is now passed in the `PUT` call. The remaining state change triggered by the `PATCH` call was also unnecessary. This reduces the number of regenerations required for each endpoint.

Fix the endpoint state machine to support changing endpoint's labels.

Fix the identity label update APIs.
Make `PUT /endpoint/{id}` return status code 400 in case of failure to set labels, instead of code 404 which was not specified in the API. Validate the labels passed by the client.
`PUT /endpoint/{id}` now sets orchestration labels, not custom labels, to be consistent with `PATCH /endpoint/{id}`.

Fix Runtime Policies tests to handle initializing endpoints with the `reserved:init` identity, and to test policies applying to `reserved:init`.

Fixes: https://github.com/cilium/cilium/issues/3855
Fixes: https://github.com/cilium/cilium/issues/3895
Signed-off-by: Romain Lenglet <romain@covalent.io>

```release-note
A new `reserved:init` label is given to every new endpoint that has no label, e.g. an endpoint that is still initializing. Policy rules can be applied to the endpoints in that state using the new `init` entity.
```