### PR TITLE
Test: Fix recursion issue with Kubectl.CiliumExec

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -705,9 +705,8 @@ func (kub *Kubectl) CiliumEndpointPolicyVersion(pod string) map[string]int64 {
 func (kub *Kubectl) CiliumExec(pod string, cmd string) *CmdRes {
 	limitTimes := 5
 	execute := func() *CmdRes {
-		cmd = fmt.Sprintf("%s exec -n kube-system %s -- %s", KubectlCmd, pod, cmd)
-
-		return kub.Exec(cmd)
+		command := fmt.Sprintf("%s exec -n kube-system %s -- %s", KubectlCmd, pod, cmd)
+		return kub.Exec(command)
 	}
 	var res *CmdRes
 	// Sometimes Kubectl returns 126 exit code, It use to happen in Nightly


### PR DESCRIPTION
When a command fails with 126 output, the cmd was incorrect, issue:

```
cmd: "kubectl exec -n kube-system cilium-7kk4h -- cilium policy get -o json" exitCode: 126
 OCI runtime exec failed: exec failed: container_linux.go:348: starting container process caused "process_linux.go:90: adding pid 26306 to cgroups caused \"failed to write 26306 to cgroup.procs: write /sys/fs/cgroup/cpu,cpuacct/kubepods/besteffort/pod9e21b025-48ab-11e8-aa09-080027a14d3d/5eff051712be6ddd9a8964d653f235dbcdcba0204ec5f51096be8a1f560f9ece/cgroup.procs: invalid argument\"": unknown
command terminated with exit code 126

time="2018-04-25T18:58:58Z" level=debug msg="running command: kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- cilium policy get -o json"
cmd: "kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- cilium policy get -o json" exitCode: 126
 OCI runtime exec failed: exec failed: container_linux.go:348: starting container process caused "exec: \"kubectl\": executable file not found in $PATH": unknown
command terminated with exit code 126

time="2018-04-25T18:59:00Z" level=debug msg="running command: kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- cilium policy get -o json"
cmd: "kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- cilium policy get -o json" exitCode: 126
 OCI runtime exec failed: exec failed: container_linux.go:348: starting container process caused "exec: \"kubectl\": executable file not found in $PATH": unknown
command terminated with exit code 126

time="2018-04-25T18:59:02Z" level=debug msg="running command: kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- cilium policy get -o json"
cmd: "kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- cilium policy get -o json" exitCode: 126
 OCI runtime exec failed: exec failed: container_linux.go:348: starting container process caused "exec: \"kubectl\": executable file not found in $PATH": unknown
command terminated with exit code 126

time="2018-04-25T18:59:03Z" level=debug msg="running command: kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- cilium policy get -o json"
cmd: "kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- kubectl exec -n kube-system cilium-7kk4h -- cilium policy get -o json" exitCode: 126
 OCI runtime exec failed: exec failed: container_linux.go:348: starting container process caused "exec: \"kubectl\": executable file not found in $PATH": unknown
command terminated with exit code 126
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

