### PR TITLE
Test: Archive in quiet mode

### DIFF
--- a/test/archive_test_results.sh
+++ b/test/archive_test_results.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
- 
+
 cd ${WORKSPACE}/test
 
 TEST_RESULTS="test_results"
 ARCHIVE_NAME="${TEST_RESULTS}_${JOB_BASE_NAME}_${BUILD_NUMBER}.zip"
 
-zip -r ${ARCHIVE_NAME} ${TEST_RESULTS}
+zip -qr ${ARCHIVE_NAME} ${TEST_RESULTS}
 mv ${ARCHIVE_NAME} ../
 rm -rf ./${TEST_RESULTS}


### PR DESCRIPTION
The zip command verbose is a bit high on Nighly test and there is no value added.
Added a -q option will show an error if happens but avoid to list all
the files that are in the zip file.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

