### PR TITLE
envoy: Build Istio Docker images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ man/
 
 # Bazel symlinks
 bazel-*
+envoy/istio-envoy
+envoy/Dockerfile.istio_proxy
+envoy/Dockerfile.istio_proxy_debug
 
 test/tmp.yaml
 test/*_service_manifest.json

--- a/envoy/BUILD
+++ b/envoy/BUILD
@@ -27,9 +27,32 @@ envoy_cc_binary(
     name = "envoy",
     repository = "@envoy",
     deps = [
+        # Cilium filters.
         ":cilium_bpf_metadata_lib",
         ":cilium_network_filter_lib",
         ":cilium_l7policy_lib",
+
+        "@envoy//source/exe:envoy_main_entry_lib",
+    ],
+)
+
+envoy_cc_binary(
+    name = "istio-envoy",
+    repository = "@envoy",
+    deps = [
+        # Cilium filters.
+        ":cilium_bpf_metadata_lib",
+        ":cilium_network_filter_lib",
+        ":cilium_l7policy_lib",
+
+        # Istio filters.
+        # Cf. https://github.com/istio/proxy/blob/master/src/envoy/BUILD#L23
+        "@istio_proxy//src/envoy/http/authn:filter_lib",
+        "@istio_proxy//src/envoy/http/jwt_auth:http_filter_factory",
+        "@istio_proxy//src/envoy/http/mixer:filter_lib",
+        "@istio_proxy//src/envoy/tcp/mixer:filter_lib",
+        # "@istio_proxy//src/envoy/alts:alts_socket_factory",
+
         "@envoy//source/exe:envoy_main_entry_lib",
     ],
 )

--- a/envoy/Dockerfile.istio_proxy.in
+++ b/envoy/Dockerfile.istio_proxy.in
@@ -1,0 +1,22 @@
+FROM istio/proxy:@ISTIO_VERSION@
+
+# Replace Istio's Envoy binary with Cilium's.
+ADD istio-envoy /usr/local/bin/envoy
+
+# pilot-agent and envoy may run with effective uid 0 in order to run envoy with
+# CAP_NET_ADMIN, so any iptables rule matching on "-m owner --uid-owner
+# istio-proxy" will not match connections from those processes anymore.
+# Instead, rely on the process's effective gid being istio-proxy and create a
+# "-m owner --gid-owner istio-proxy" iptables rule in istio-iptables.sh.
+RUN \
+chgrp 1337 /usr/local/bin/envoy && \
+chmod 2755 /usr/local/bin/envoy
+
+# Override the Envoy bootstrap to configure Envoy to use API v2 and to define
+# the "xds-grpc-cilium" cluster used by the Cilium filters to connect to Cilium
+# agent via a Unix domain socket.
+# This file is adapted from Istio's API v2 bootstrap:
+# https://github.com/istio/istio/blob/67be0412218829febe6539f5360b3f2ce1716adb/tools/deb/envoy_bootstrap_v2.json
+COPY envoy_bootstrap_tmpl.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
+
+ENTRYPOINT ["/usr/local/bin/pilot-agent"]

--- a/envoy/Dockerfile.istio_proxy_debug.in
+++ b/envoy/Dockerfile.istio_proxy_debug.in
@@ -1,0 +1,22 @@
+FROM istio/proxy_debug:@ISTIO_VERSION@
+
+# Replace Istio's Envoy binary with Cilium's.
+ADD istio-envoy /usr/local/bin/envoy
+
+# pilot-agent and envoy may run with effective uid 0 in order to run envoy with
+# CAP_NET_ADMIN, so any iptables rule matching on "-m owner --uid-owner
+# istio-proxy" will not match connections from those processes anymore.
+# Instead, rely on the process's effective gid being istio-proxy and create a
+# "-m owner --gid-owner istio-proxy" iptables rule in istio-iptables.sh.
+RUN \
+chgrp 1337 /usr/local/bin/envoy && \
+chmod 2755 /usr/local/bin/envoy
+
+# Override the Envoy bootstrap to configure Envoy to use API v2 and to define
+# the "xds-grpc-cilium" cluster used by the Cilium filters to connect to Cilium
+# agent via a Unix domain socket.
+# This file is adapted from Istio's API v2 bootstrap:
+# https://github.com/istio/istio/blob/67be0412218829febe6539f5360b3f2ce1716adb/tools/deb/envoy_bootstrap_v2.json
+COPY envoy_bootstrap_tmpl.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
+
+ENTRYPOINT ["/usr/local/bin/pilot-agent"]

--- a/envoy/README.Istio.md
+++ b/envoy/README.Istio.md
@@ -1,0 +1,97 @@
+# Envoy binary for Istio sidecar proxy
+
+The integration of Cilium and Istio requires building artifacts from
+several repositories in order to build Docker images.  Some of those
+artifacts require changes that have not yet been merged upstream.
+
+This document provides the instructions to build the Cilium-specific
+Istio images.
+
+## Build the Istio binaries
+
+Build the Istio binaries, especially a `pilot-discovery` modified to
+configure Cilium filters in every HTTP filter chain.  This work is
+still being developed in Cilium's `inject-cilium-filters` branch.
+
+    mkdir -p ${GOPATH}/src/istio.io
+    cd ${GOPATH}/src/istio.io
+    git clone git@github.com:cilium/istio.git
+    git checkout inject-cilium-filters
+    git submodule sync
+    git submodule update --init --recursive --remote
+    git submodule update --force --checkout
+    make build
+
+## Build the required upstream Istio Docker images
+
+Only one images needs to be built: `cilium/istio_pilot`.
+
+    TAG=0.8.0-pre20180421-09-15 make docker.pilot
+
+The `istio/proxy` and `istio/proxy_debug` for pre-releases are not available on
+Docker Hub. Build them here:
+
+    TAG=0.8.0-pre20180421-09-15 make docker.proxy docker.proxy_debug
+
+## (Optional) Check that the upstream proxy Docker images are consistent
+
+Build the upstream proxy images to check them:
+
+    TAG=0.8.0-pre20180421-09-15 make docker.proxy_init docker.proxyv2 docker.proxy_debugv2
+
+### `istio/proxy_init`
+
+    docker run --rm -it --cap-add=NET_ADMIN --entrypoint /bin/bash istio/proxy_init:0.8.0-pre20180421-09-15
+
+In the container, run the iptables configuration script with various
+combinations of parameters, for example:
+
+    /usr/local/bin/istio-iptables.sh -p 15001 -u 1337 -m TPROXY -b '*'
+    /usr/local/bin/istio-iptables.sh -p 15001 -u 1337 -m TPROXY -b 1234,5678
+    /usr/local/bin/istio-iptables.sh -p 15001 -u 1337 -m TPROXY -b '*' -d 1234,5678
+
+For each combination, check the iptables and routing tables and rules:
+
+    iptables -v -t nat -L
+    iptables -v -t mangle -L
+    ip rule
+    ip route show table 133
+
+### `istio/proxyv2`
+
+    docker run --rm -it --entrypoint /bin/bash istio/proxyv2:0.8.0-pre20180421-09-15
+
+Check that the binaries have the right size, mode, owner, and group.
+
+    stat /usr/local/bin/{envoy,pilot-agent}
+
+Check that the Envoy bootstrap configures Envoy v2 API and ADS (not v1 API):
+
+    cat /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
+
+### `istio/proxy_debugv2`
+
+    docker run --rm -it --entrypoint /bin/bash istio/proxy_debugv2:0.8.0-pre20180421-09-15
+
+Check that the binaries have the right size, mode, owner, and group.
+
+    stat /usr/local/bin/{envoy,pilot-agent}
+
+Check that the Envoy bootstrap configures Envoy v2 API and ADS (not v1 API):
+
+    cat /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
+
+## Build Cilium's sidecar proxy Docker images
+
+    mkdir -p ${GOPATH}/src/github.com/cilium
+    cd ${GOPATH}/src/github.com/cilium
+    git clone git@github.com:cilium/cilium.git
+    cd cilium/envoy
+    make docker-istio-proxy docker-istio-proxy-debug
+
+## Push the Docker images to Docker Hub
+
+    docker login -u ...
+    docker image push cilium/istio_pilot:0.8.0-pre20180421-09-15
+    docker image push cilium/istio_proxy:0.8.0-pre20180421-09-15
+    docker image push cilium/istio_proxy_debug:0.8.0-pre20180421-09-15

--- a/envoy/WORKSPACE
+++ b/envoy/WORKSPACE
@@ -38,3 +38,25 @@ load("@com_lyft_protoc_gen_validate//bazel:go_proto_library.bzl", "go_proto_repo
 go_proto_repositories(shared=0)
 go_rules_dependencies()
 go_register_toolchains()
+load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
+proto_register_toolchains()
+
+
+# Dependencies for Istio filters.
+# Cf. https://github.com/istio/proxy.
+
+ISTIO_PROXY_SHA = "410899cd5a4614c1965778f9856769b744c1d522"
+
+http_archive(
+    name = "istio_proxy",
+    url = "https://github.com/istio/proxy/archive/" + ISTIO_PROXY_SHA + ".zip",
+    strip_prefix = "proxy-" + ISTIO_PROXY_SHA,
+)
+
+load("@istio_proxy//:repositories.bzl", "mixerapi_dependencies")
+mixerapi_dependencies()
+
+bind(
+    name = "boringssl_crypto",
+    actual = "//external:ssl",
+)

--- a/envoy/envoy_bootstrap_tmpl.json
+++ b/envoy/envoy_bootstrap_tmpl.json
@@ -1,0 +1,157 @@
+{
+  "node": {
+    "id": "{{ .nodeID }}",
+    "cluster": "{{ .cluster }}",
+{{ if .zone }}
+    "locality": {
+        "zone": "{{ .zone }}"
+    },
+{{ end }}
+    "metadata": {
+{{- range $a, $s := .meta }}
+          "{{$a}}": "{{$s}}",
+{{- end}}
+      "istio": "sidecar"
+    }
+  },
+  "stats_config": {
+    "use_all_default_tags": false
+  },
+  "admin": {
+    "access_log_path": "/dev/stdout",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 15000
+      }
+    }
+  },
+  "dynamic_resources": {
+    "lds_config": {
+        "ads": {}
+    },
+    "cds_config": {
+        "ads": {}
+    },
+    "ads_config": {
+      "api_type": "GRPC",
+      "refresh_delay": {{ .refresh_delay }},
+      "grpc_services": [
+        {
+          "envoy_grpc": {
+            "cluster_name": "xds-grpc"
+          }
+        }
+      ]
+    }
+  },
+  "static_resources": {
+    "clusters": [
+    {
+    "name": "xds-grpc-cilium",
+    "type": "STATIC",
+    "connect_timeout": {{ .connect_timeout }},
+    "lb_policy": "ROUND_ROBIN",
+    "hosts": [
+    {
+    "pipe":
+    {
+    "path": "/var/run/cilium/xds.sock"
+    }
+    }
+    ],
+    "http2_protocol_options": { }
+    },
+    {
+    "name": "xds-grpc",
+    "type": "STRICT_DNS",
+    "connect_timeout": {{ .connect_timeout }},
+    "lb_policy": "ROUND_ROBIN",
+{{ if eq .config.ControlPlaneAuthPolicy 1 }}
+      "tls_context": {
+        "common_tls_context": {
+          "tls_certificates": {
+            "certificate_chain": {
+              "filename": "/etc/certs/cert-chain.pem"
+            },
+            "private_key": {
+              "filename": "/etc/certs/key.pem"
+            }
+          },
+          "validation_context": {
+            "trusted_ca": {
+              "filename": "/etc/certs/root-cert.pem"
+            },
+            "verify_subject_alt_name": [
+              {{- range $a, $s := .pilot_SAN }}
+              "{{$s}}"
+              {{- end}}
+            ]
+          }
+        }
+      },
+{{ end }}
+    "hosts": [
+    {
+    "socket_address": {{ .pilot_grpc_address }}
+    }
+    ],
+    "circuit_breakers": {
+        "thresholds": [
+      {
+        "priority": "default",
+        "max_connections": "100000",
+        "max_pending_requests": "100000",
+        "max_requests": "100000"
+      },
+      {
+        "priority": "high",
+        "max_connections": "100000",
+        "max_pending_requests": "100000",
+        "max_requests": "100000"
+      }]
+    },
+    "http2_protocol_options": { }
+    }
+
+    {{ if .zipkin }}
+    ,
+      {
+        "name": "zipkin",
+        "type": "STRICT_DNS",
+        "connect_timeout": {
+          "seconds": 1
+        },
+        "lb_policy": "ROUND_ROBIN",
+        "hosts": [
+          {
+            "socket_address": {{ .zipkin }}
+          }
+        ]
+      }
+      {{ end }}
+    ]
+  },
+  {{ if .zipkin }}
+  "tracing": {
+    "http": {
+      "name": "envoy.zipkin",
+      "config": {
+        "collector_cluster": "zipkin"
+      }
+    }
+  },
+  {{ end }}
+  {{ if .statsd }}
+  "stats_sinks": [
+    {
+      "name": "envoy.statsd",
+      "config": {
+        "address": {
+          "socket_address": {{ .statsd }}
+        }
+      }
+    }
+  ]
+{{ end }}
+}


### PR DESCRIPTION
Build Istio filters into Envoy binary.
Split Envoy binary build targets for Cilium and Istio.
Only build the Istio filters into the binary used in Istio sidecar
proxy containers.

Define Makefile targets to build Istio 0.8.0+ proxy images:
docker-istio-proxy builds image cilium/istio_proxy:*
docker-istio-proxy-debug builds image cilium/istio_proxy_debug:*

Add envoy/README.Istio.md to specify Istio image build process.

Signed-off-by: Romain Lenglet <romain@covalent.io>