### PR TITLE
Makefile: Start etcd test container with -listen-peer-urls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ start-kvstores:
         etcd -name etcd0 \
         -advertise-client-urls http://0.0.0.0:4001 \
         -listen-client-urls http://0.0.0.0:4001 \
+        -listen-peer-urls http://0.0.0.0:2380 \
         -initial-cluster-token etcd-cluster-1 \
         -initial-cluster-state new
 	@docker rm -f "cilium-consul-test-container" 2> /dev/null || true


### PR DESCRIPTION
Without this parameter, the default etcd container could potentially
attempt to resolve a localhost address and bind to that even though
there are no local interfaces with the address, leading to the etcd
container exiting on startup. This would prevent the unit-tests from
running in some environments.

Fixes: #3920