### PR TITLE
maps: Use pointer receivers for MapValue types.

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -789,7 +789,7 @@ func (d *Daemon) OnIPIdentityCacheChange(modType ipcache.CacheModification, ipID
 	switch modType {
 	case ipcache.Upsert:
 		value := ipCacheBPF.RemoteEndpointInfo{SecurityIdentity: uint16(ipIDPair.ID)}
-		err := ipCacheBPF.IPCache.Update(key, value)
+		err := ipCacheBPF.IPCache.Update(key, &value)
 		if err != nil {
 			log.WithError(err).WithFields(logrus.Fields{"key": key.String(),
 				"value": value.String()}).

--- a/pkg/bpf/endpoint.go
+++ b/pkg/bpf/endpoint.go
@@ -40,8 +40,9 @@ type EndpointKey struct {
 // GetKeyPtr returns the unsafe pointer to the BPF key
 func (k EndpointKey) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(&k) }
 
-// GetValuePtr returns the unsafe pointer to the BPF value
-func (k EndpointKey) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(&k) }
+// GetValuePtr returns the unsafe pointer to the BPF key for users that
+// use EndpointKey as a value in bpf maps
+func (k *EndpointKey) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(k) }
 
 // NewEndpointKey returns an EndpointKey based on the provided IP address. The
 // address family is automatically detected.

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -58,12 +58,12 @@ type RemoteEndpointInfo struct {
 	Pad              [3]uint16
 }
 
-func (v RemoteEndpointInfo) String() string {
+func (v *RemoteEndpointInfo) String() string {
 	return fmt.Sprintf("%d", v.SecurityIdentity)
 }
 
 // GetValuePtr returns the unsafe pointer to the BPF value.
-func (v RemoteEndpointInfo) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(&v) }
+func (v *RemoteEndpointInfo) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
 
 var (
 	// IPCache is a mapping of all endpoint IPs in the cluster which this
@@ -82,7 +82,7 @@ var (
 			if err := bpf.ConvertKeyValue(key, value, &k, &v); err != nil {
 				return nil, nil, err
 			}
-			return k, v, nil
+			return k, &v, nil
 		},
 	)
 )

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -74,7 +74,7 @@ var (
 				return nil, nil, err
 			}
 
-			return svcKey.ToNetwork(), svcVal, nil
+			return svcKey.ToNetwork(), &svcVal, nil
 		})
 )
 

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -112,9 +112,9 @@ type RRSeqValue struct {
 	Idx [MaxSeq]uint16
 }
 
-func (s RRSeqValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(&s) }
+func (s *RRSeqValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(s) }
 
-func (s RRSeqValue) String() string {
+func (s *RRSeqValue) String() string {
 	return fmt.Sprintf("count=%d idx=%v", s.Count, s.Idx)
 }
 

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -52,7 +52,7 @@ var (
 				return nil, nil, err
 			}
 
-			return k, v, nil
+			return k, &v, nil
 		},
 	)
 )
@@ -128,7 +128,7 @@ type EndpointInfo struct {
 }
 
 // GetValuePtr returns the unsafe pointer to the BPF value
-func (v EndpointInfo) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(&v) }
+func (v *EndpointInfo) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
 
 type EndpointKey struct {
 	bpf.EndpointKey
@@ -147,7 +147,7 @@ func NewEndpointKey(ip net.IP) EndpointKey {
 }
 
 // String returns the human readable representation of an EndpointInfo
-func (v EndpointInfo) String() string {
+func (v *EndpointInfo) String() string {
 	if v.Flags&EndpointFlagHost != 0 {
 		return fmt.Sprintf("(localhost)")
 	}
@@ -181,7 +181,7 @@ func WriteEndpoint(f EndpointFrontend) error {
 
 	// FIXME: Revert on failure
 	for _, k := range f.GetBPFKeys() {
-		if err := LXCMap.Update(k, *info); err != nil {
+		if err := LXCMap.Update(k, info); err != nil {
 			return err
 		}
 	}
@@ -192,7 +192,7 @@ func WriteEndpoint(f EndpointFrontend) error {
 // AddHostEntry adds a special endpoint which represents the local host
 func AddHostEntry(ip net.IP) error {
 	key := NewEndpointKey(ip)
-	ep := EndpointInfo{Flags: EndpointFlagHost}
+	ep := &EndpointInfo{Flags: EndpointFlagHost}
 	return LXCMap.Update(key, ep)
 }
 

--- a/pkg/maps/tunnel/tunnel.go
+++ b/pkg/maps/tunnel/tunnel.go
@@ -49,7 +49,7 @@ var (
 				return nil, nil, err
 			}
 
-			return k, v, nil
+			return k, &v, nil
 		})
 )
 
@@ -76,7 +76,7 @@ func (v tunnelEndpoint) NewValue() bpf.MapValue { return &tunnelEndpoint{} }
 // SetTunnelEndpoint adds/replaces a prefix => tunnel-endpoint mapping
 func SetTunnelEndpoint(prefix net.IP, endpoint net.IP) error {
 	key, val := newTunnelEndpoint(prefix), newTunnelEndpoint(endpoint)
-	return TunnelMap.Update(key, val)
+	return TunnelMap.Update(key, &val)
 }
 
 // DeleteTunnelEndpoint removes a prefix => tunnel-endpoint mapping


### PR DESCRIPTION
bpf.MapValue interface function GetValuePtr() returns a pointer to a
new temporary if the function receiver is a value rather than a
pointer.

endpoint, lxcmap, ipcache, and lbmap were also using value receivers
for their implementations of MapValue interface. The problem with this
is that any lookups would fail to return the actual value, as the
bpf.LookupElement would write the value into a temporary unaccessible
to the caller. No such lookups were performed, so this did not cause
any problems in practice. Fix the implementations to prevent future
problems.

This fix is otherwise low risk, but it has happened earlier in
development that GetValuePtr() implmentations were not fixed properly
and a pointer to the pointer receiver was returned. This is not
noticed by the compiler, and would result in garbage data being
written to/read from the bpf maps.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
