### PR TITLE
endpoint: Improve logging of endpoint lifecycle events

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -564,7 +564,17 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 	owner.GetCompilationLock().RLock()
 	defer owner.GetCompilationLock().RUnlock()
 
+	buildStart := time.Now()
+
 	e.Mutex.Lock()
+
+	e.getLogger().WithField(logfields.StartTime, time.Now()).Info("Regenerating BPF program")
+	defer func() {
+		e.Mutex.RLock()
+		e.getLogger().WithField(logfields.BuildDuration, time.Since(buildStart).String()).
+			Info("Regeneration of BPF program has completed")
+		e.Mutex.RUnlock()
+	}()
 
 	// If endpoint was marked as disconnected then
 	// it won't be regenerated.

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1761,6 +1761,8 @@ func (e *Endpoint) LeaveLocked(owner Owner) []error {
 
 	e.SetStateLocked(StateDisconnected, "Endpoint removed")
 
+	e.getLogger().Info("Removed endpoint")
+
 	return errors
 }
 
@@ -2400,4 +2402,10 @@ func (e *Endpoint) IPs() []net.IP {
 		ips = append(ips, e.IPv6.IP())
 	}
 	return ips
+}
+
+// InsertEvent is called when the endpoint is inserted into the endpoint
+// manager. The endpoint must be read locked.
+func (e *Endpoint) InsertEvent() {
+	e.getLogger().Info("New endpoint")
 }

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -37,6 +37,8 @@ func (e *Endpoint) getLogger() *logrus.Entry {
 func (e *Endpoint) updateLogger() {
 	containerID := e.getShortContainerID()
 
+	podName := e.GetK8sNamespaceAndPodNameLocked()
+
 	// We need to update if
 	// - e.logger is nil (this happens on the first ever call to updateLogger via
 	//   getLogger above). This clause has to come first to guard the others.
@@ -48,6 +50,9 @@ func (e *Endpoint) updateLogger() {
 		e.logger.Data[logfields.EndpointID] != e.ID ||
 		e.logger.Data[logfields.ContainerID] != containerID ||
 		e.logger.Data[logfields.PolicyRevision] != e.policyRevision ||
+		e.logger.Data[logfields.IPv4] != e.IPv4.String() ||
+		e.logger.Data[logfields.IPv6] != e.IPv6.String() ||
+		e.logger.Data[logfields.K8sPodName] != podName ||
 		e.Opts.IsEnabled("Debug") != (e.logger.Level == logrus.DebugLevel)
 
 	// do nothing if we do not need an update
@@ -72,5 +77,8 @@ func (e *Endpoint) updateLogger() {
 		logfields.EndpointID:     e.ID,
 		logfields.ContainerID:    containerID,
 		logfields.PolicyRevision: e.policyRevision,
+		logfields.IPv4:           e.IPv4.String(),
+		logfields.IPv6:           e.IPv6.String(),
+		logfields.K8sPodName:     podName,
 	})
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -991,6 +991,11 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity) {
 		cache.Remove(e.Consumable)
 	}
 
+	oldIdentity := "no identity"
+	if e.SecurityIdentity != nil {
+		oldIdentity = e.SecurityIdentity.StringID()
+	}
+
 	e.SecurityIdentity = identity
 	e.Consumable = cache.GetOrCreate(identity.ID, identity)
 
@@ -1008,8 +1013,9 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity) {
 
 	e.Consumable.Mutex.RLock()
 	e.getLogger().WithFields(logrus.Fields{
-		logfields.Identity: identity,
-		"consumable":       e.Consumable,
-	}).Debug("Set identity and consumable of EP")
+		logfields.Identity:       identity.StringID(),
+		logfields.OldIdentity:    oldIdentity,
+		logfields.IdentityLabels: identity.Labels.String(),
+	}).Info("Identity of endpoint changed")
 	e.Consumable.Mutex.RUnlock()
 }

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -342,6 +342,7 @@ func AddEndpoint(owner endpoint.Owner, ep *endpoint.Endpoint, reason string) err
 
 	ep.Mutex.RLock()
 	Insert(ep)
+	ep.InsertEvent()
 	ep.Mutex.RUnlock()
 
 	return nil

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -47,6 +47,9 @@ const (
 	// Identity is the identifier of a security identity
 	Identity = "identity"
 
+	// OldIdentity is a previously used security identity
+	OldIdentity = "oldIdentity"
+
 	// PolicyRevision is the revision of the policy in the repository or of
 	// the object in question
 	PolicyRevision = "policyRevision"
@@ -62,6 +65,18 @@ const (
 
 	// IPAddr is an IPV4 or IPv6 address
 	IPAddr = "ipAddr"
+
+	// IPv4 is an IPv4 address
+	IPv4 = "ipv4"
+
+	// IPv6 is an IPv6 address
+	IPv6 = "ipv6"
+
+	// BuildDuration is the time elapsed to build a BPF program
+	BuildDuration = "buildDuration"
+
+	// StartTime is the start time of an event
+	StartTime = "startTime"
 
 	// V4HealthIP is an address used to contact the cilium-health endpoint
 	V4HealthIP = "v4healthIP.IPv4"


### PR DESCRIPTION
This commit introduces several info level log messages:

New endpoint event:
```
msg="New endpoint" containerID=cilium-loc endpointID=29898 ipv4=10.11.242.54 ipv6="f00d::a0f:0:0:74ca" k8sPodName= policyRevision=0
```

Removed endpoint event:
```
msg="Removed endpoint" containerID=03ed013784 endpointID=56326 ipv4=10.11.129.91 ipv6="f00d::a0f:0:0:dc06" k8sPodName= policyRevision=2
```

BPF program generation:
```
msg="Regenerating BPF program" containerID=cilium-loc endpointID=29898 ipv4=10.11.242.54 ipv6="f00d::a0f:0:0:74ca" k8sPodName= policyRevision=0
msg="Regeneration of BPF program has completed" buildTime=2.32680802s containerID=cilium-loc endpointID=29898 ipv4=10.11.242.54 ipv6="f00d::a0f:0:0:74ca" k8sPodName= policyRevision=0
```

Endpoint identity changes:
```
msg="Identity of endpoint has changed" containerID=cilium-loc endpointID=29898 identity=1261 identityLabels="reserved:health" ipv4=10.11.242.54 ipv6="f00d::a0f:0:0:74ca" k8sPodName= policyRevision=0
```

Signed-off-by: Thomas Graf <thomas@cilium.io>