### PR TITLE
test: Change DROP_ALL to install a dummy policy.

### DIFF
--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1016,7 +1016,14 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 			failCurl.ExpectFail("unexpectedly able to access %s when access should only be allowed to host", helpers.Httpd2)
 		})
 	})
-	Context("DROP_ALL  Policy test", func() {
+	Context("DROP_ALL Policy test", func() {
+		BeforeEach(func() {
+			// Install a policy that will not apply to any endpoints in this test. If we don't install any policy
+			// DROP_ALL mode will not be turned on in the "default" policy enforcement mode.
+			_, err := vm.PolicyImportAndWait(vm.GetFullPath(sampleJSON), helpers.HelperTimeout)
+			Expect(err).Should(BeNil(), "Dummy policy import failed")
+		})
+
 		AfterEach(func() {
 			vm.ContainerRm(dropAllContainer).ExpectSuccess("Container dropAllContainer cannot be deleted")
 		})


### PR DESCRIPTION
DROP_ALL mode can be skipped in the default policy enforcement mode if
there are no imported policies, as in that case the policy will not
drop any packets. Augment the DROP_ALL test to install a policy that
does not apply to the endpoints being tested. With this the policy is
still allowing all traffic by default for the tested endpoints, but
only after it is known that the policy does not apply.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
