### PR TITLE
policy: Do not enable DROP_ALL mode if not needed.

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -206,8 +206,14 @@ func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 	fw.WriteString(" */\n\n")
 
 	// If policy has not been derived or calculated yet, all packets must
-	// be dropped until the policy of the endpoint has been determined.
-	if !e.PolicyCalculated && owner.PolicyEnforcement() != NeverEnforce {
+	// be dropped until the policy of the endpoint has been determined,
+	// except when it is known that the current policy will not drop anything,
+	// which is true when:
+	// - policy enforcement mode is "never"
+	// - policy enforcement mode is "default" and no policies are loaded
+	if !e.PolicyCalculated &&
+		!(owner.PolicyEnforcement() == NeverEnforce) &&
+		!(owner.PolicyEnforcement() == DefaultEnforcement && owner.GetPolicyRepository().Empty()) {
 		fw.WriteString("#define DROP_ALL\n")
 	}
 

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -599,6 +599,15 @@ func (p *Repository) GetRevision() uint64 {
 	return p.revision
 }
 
+// Empty returns 'true' if repository has no rules, 'false' otherwise.
+//
+// Must be called without p.Mutex held
+func (p *Repository) Empty() bool {
+	p.Mutex.Lock()
+	defer p.Mutex.Unlock()
+	return p.NumRules() == 0
+}
+
 // TranslateRules traverses rules and applies provided translator to rules
 func (p *Repository) TranslateRules(translator Translator) error {
 	p.Mutex.Lock()


### PR DESCRIPTION
policy: Do not enable DROP_ALL mode if not needed.

Do not enable DROP_ALL mode if it is known that the current policy
enforcement mode and policy passes all traffic. This is true when:

- Policy enforcement mode is "never"
- Policy enforcement mode is "default" and no policy is loaded.

This commit adds the exception for the second case.

Fixes: #3933
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

Note that this PR is against #3937 which should be merged first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/3938)
<!-- Reviewable:end -->
