### PR TITLE
docs: Fix ginkgo command line.

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -408,7 +408,7 @@ here is an example showing what tests will be ran using Ginkgo's dryRun option:
 
 ::
 
-    $ ginkgo --focus="Runtime*" -noColor -dryRun
+    $ ginkgo --focus="Runtime*" -noColor -v -dryRun
     Running Suite: runtime
     ======================
     Random Seed: 1516125117


### PR DESCRIPTION
Ginkgo needs the '-v' option to actually show the test names in the dry run mode.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
