### PR TITLE
policy: Do not enable DROP_ALL mode if not needed

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -206,8 +206,14 @@ func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 	fw.WriteString(" */\n\n")
 
 	// If policy has not been derived or calculated yet, all packets must
-	// be dropped until the policy of the endpoint has been determined.
-	if !e.PolicyCalculated && owner.PolicyEnforcement() != NeverEnforce {
+	// be dropped until the policy of the endpoint has been determined,
+	// except when it is known that the current policy will not drop anything,
+	// which is true when:
+	// - policy enforcement mode is "never"
+	// - policy enforcement mode is "default" and no policies are loaded
+	if !e.PolicyCalculated &&
+		!(owner.PolicyEnforcement() == NeverEnforce) &&
+		!(owner.PolicyEnforcement() == DefaultEnforcement && owner.GetPolicyRepository().Empty()) {
 		fw.WriteString("#define DROP_ALL\n")
 	}
 

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -599,6 +599,15 @@ func (p *Repository) GetRevision() uint64 {
 	return p.revision
 }
 
+// Empty returns 'true' if repository has no rules, 'false' otherwise.
+//
+// Must be called without p.Mutex held
+func (p *Repository) Empty() bool {
+	p.Mutex.Lock()
+	defer p.Mutex.Unlock()
+	return p.NumRules() == 0
+}
+
 // TranslateRules traverses rules and applies provided translator to rules
 func (p *Repository) TranslateRules(translator Translator) error {
 	p.Mutex.Lock()

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1016,7 +1016,14 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 			failCurl.ExpectFail("unexpectedly able to access %s when access should only be allowed to host", helpers.Httpd2)
 		})
 	})
-	Context("DROP_ALL  Policy test", func() {
+	Context("DROP_ALL Policy test", func() {
+		BeforeEach(func() {
+			// Install a policy that will not apply to any endpoints in this test. If we don't install any policy
+			// DROP_ALL mode will not be turned on in the "default" policy enforcement mode.
+			_, err := vm.PolicyImportAndWait(vm.GetFullPath(sampleJSON), helpers.HelperTimeout)
+			Expect(err).Should(BeNil(), "Dummy policy import failed")
+		})
+
 		AfterEach(func() {
 			vm.ContainerRm(dropAllContainer).ExpectSuccess("Container dropAllContainer cannot be deleted")
 		})


### PR DESCRIPTION
policy: Do not enable DROP_ALL mode if not needed.

Do not enable DROP_ALL mode if it is known that the current policy
enforcement mode and policy passes all traffic. This is true when:

Policy enforcement mode is "never"
Policy enforcement mode is "default" and no policy is loaded.
This commit adds the exception for the second case.

Fixes: #3933
Signed-off-by: Jarno Rajahalme jarno@covalent.io

Note that this PR is against #3937 which should be merged first.