### PR TITLE
Clean up CIDR policy plumbing after Identity-based CIDR policies

### DIFF
--- a/pkg/policy/l3.go
+++ b/pkg/policy/l3.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -126,10 +126,13 @@ func (m *CIDRPolicyMap) PopulateBPF(cidrmap *cidrmap.CIDRMap) error {
 	return nil
 }
 
-// CIDRPolicy contains L3 (CIDR) policy maps for ingress and egress.
+// CIDRPolicy contains L3 (CIDR) policy maps for ingress.
 type CIDRPolicy struct {
 	Ingress CIDRPolicyMap
-	Egress  CIDRPolicyMap
+
+	// Egress is not used for policy generation; this is only used as a way
+	// to reflect desired state in the API.
+	Egress CIDRPolicyMap
 }
 
 // NewCIDRPolicy creates a new CIDRPolicy.
@@ -180,9 +183,6 @@ func (cp *CIDRPolicy) GetModel() *models.CIDRPolicy {
 func (cp *CIDRPolicy) Validate() error {
 	if cp == nil {
 		return nil
-	}
-	if l := len(cp.Egress.IPv6PrefixCount); l > api.MaxCIDRPrefixLengths {
-		return fmt.Errorf("too many egress CIDR prefix lengths %d/%d", l, api.MaxCIDRPrefixLengths)
 	}
 	if l := len(cp.Ingress.IPv6PrefixCount); l > api.MaxCIDRPrefixLengths {
 		return fmt.Errorf("too many ingress CIDR prefix lengths %d/%d", l, api.MaxCIDRPrefixLengths)

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -251,8 +251,9 @@ func (r *rule) resolveCIDRPolicy(ctx *SearchContext, state *traceState, result *
 		}
 	}
 
+	// CIDR egress policy is purely used for visibility of desired state in
+	// the API, it is not plumbed down into the datapath for policy!
 	for _, egressRule := range r.Egress {
-		// TODO(ianvernon): GH-1658
 		var allCIDRs []api.CIDR
 		allCIDRs = append(allCIDRs, egressRule.ToCIDR...)
 		allCIDRs = append(allCIDRs, api.ComputeResultantCIDRSet(egressRule.ToCIDRSet)...)


### PR DESCRIPTION
This PR cleans up the CIDR plumbing through the daemon since #3835 replaced custom CIDR policies in the datapath with the CIDR->Identity lookup.

Actual datapath cleanup for egress CIDR policy will be addressed in another PR (See #4076).