### PR TITLE
Backport/v1.0 2018 04 30

### DIFF
--- a/examples/kubernetes/1.10/cilium-cm.yaml
+++ b/examples/kubernetes/1.10/cilium-cm.yaml
@@ -26,6 +26,8 @@ data:
   debug: "false"
   disable-ipv4: "false"
   sidecar-http-proxy: "false"
+  # If you want to clean cilium state; change this value to true
+  clean-cilium-state: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -32,6 +32,22 @@ spec:
         prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
+      initContainers:
+      - name: clean-cilium-state
+        image: busybox
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+        env:
+          - name: "CLEAN_CILIUM_STATE"
+            valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-state
       containers:
       - image: cilium/cilium:v1.0.0
         imagePullPolicy: IfNotPresent

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -1,3 +1,135 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+  # This etcd-config contains the etcd endpoints of your cluster. If you use
+  # TLS please make sure you uncomment the ca-file line and add the respective
+  # certificate has a k8s secret, see explanation below in the comment labeled
+  # "ETCD-CERT"
+  etcd-config: |-
+    ---
+    endpoints:
+    - http://127.0.0.1:2379
+    #
+    # In case you want to use TLS in etcd, uncomment the following line
+    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
+    #
+    # In case you want client to server authentication, uncomment the following
+    # lines and add the certificate and key in cilium-etcd-secrets below
+    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  disable-ipv4: "false"
+  sidecar-http-proxy: "false"
+  # If you want to clean cilium state; change this value to true
+  clean-cilium-state: "false"
+---
+# The etcd secrets can be populated in kubernetes.
+# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
+kind: Secret
+apiVersion: v1
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
+  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
+  # (the "-w 0" generates the output on a single line)
+  etcd-ca: ""
+  etcd-client-key: ""
+  etcd-client-crt: ""
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- kind: Group
+  name: system:nodes
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
+  - thirdpartyresources
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumendpoints
+  verbs:
+  - "*"
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium
+  namespace: kube-system
+---
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -32,6 +164,22 @@ spec:
         prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
+      initContainers:
+      - name: clean-cilium-state
+        image: busybox
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+        env:
+          - name: "CLEAN_CILIUM_STATE"
+            valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-state
       containers:
       - image: cilium/cilium:v1.0.0
         imagePullPolicy: IfNotPresent
@@ -168,134 +316,4 @@ spec:
       # Mark cilium's pod as critical for rescheduling
       - key: CriticalAddonsOnly
         operator: "Exists"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cilium-config
-  namespace: kube-system
-data:
-  # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
-  etcd-config: |-
-    ---
-    endpoints:
-    - http://127.0.0.1:2379
-    #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
-    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
-    #
-    # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
-    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
-    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
-
-  # If you want to run cilium in debug mode change this value to true
-  debug: "false"
-  disable-ipv4: "false"
-  sidecar-http-proxy: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: cilium
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cilium
-subjects:
-- kind: ServiceAccount
-  name: cilium
-  namespace: kube-system
-- kind: Group
-  name: system:nodes
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: cilium
-rules:
-- apiGroups:
-  - "networking.k8s.io"
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - services
-  - nodes
-  - endpoints
-  - componentstatuses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
-  - thirdpartyresources
-  - ingresses
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - "apiextensions.k8s.io"
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - cilium.io
-  resources:
-  - ciliumnetworkpolicies
-  - ciliumendpoints
-  verbs:
-  - "*"
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: cilium
-  namespace: kube-system
 ---

--- a/examples/kubernetes/1.11/cilium-cm.yaml
+++ b/examples/kubernetes/1.11/cilium-cm.yaml
@@ -26,6 +26,8 @@ data:
   debug: "false"
   disable-ipv4: "false"
   sidecar-http-proxy: "false"
+  # If you want to clean cilium state; change this value to true
+  clean-cilium-state: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -32,6 +32,22 @@ spec:
         prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
+      initContainers:
+      - name: clean-cilium-state
+        image: busybox
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+        env:
+          - name: "CLEAN_CILIUM_STATE"
+            valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-state
       containers:
       - image: cilium/cilium:v1.0.0
         imagePullPolicy: IfNotPresent

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -1,3 +1,135 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+  # This etcd-config contains the etcd endpoints of your cluster. If you use
+  # TLS please make sure you uncomment the ca-file line and add the respective
+  # certificate has a k8s secret, see explanation below in the comment labeled
+  # "ETCD-CERT"
+  etcd-config: |-
+    ---
+    endpoints:
+    - http://127.0.0.1:2379
+    #
+    # In case you want to use TLS in etcd, uncomment the following line
+    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
+    #
+    # In case you want client to server authentication, uncomment the following
+    # lines and add the certificate and key in cilium-etcd-secrets below
+    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  disable-ipv4: "false"
+  sidecar-http-proxy: "false"
+  # If you want to clean cilium state; change this value to true
+  clean-cilium-state: "false"
+---
+# The etcd secrets can be populated in kubernetes.
+# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
+kind: Secret
+apiVersion: v1
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
+  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
+  # (the "-w 0" generates the output on a single line)
+  etcd-ca: ""
+  etcd-client-key: ""
+  etcd-client-crt: ""
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- kind: Group
+  name: system:nodes
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
+  - thirdpartyresources
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumendpoints
+  verbs:
+  - "*"
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium
+  namespace: kube-system
+---
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -32,6 +164,22 @@ spec:
         prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
+      initContainers:
+      - name: clean-cilium-state
+        image: busybox
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+        env:
+          - name: "CLEAN_CILIUM_STATE"
+            valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-state
       containers:
       - image: cilium/cilium:v1.0.0
         imagePullPolicy: IfNotPresent
@@ -168,134 +316,4 @@ spec:
       # Mark cilium's pod as critical for rescheduling
       - key: CriticalAddonsOnly
         operator: "Exists"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cilium-config
-  namespace: kube-system
-data:
-  # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
-  etcd-config: |-
-    ---
-    endpoints:
-    - http://127.0.0.1:2379
-    #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
-    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
-    #
-    # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
-    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
-    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
-
-  # If you want to run cilium in debug mode change this value to true
-  debug: "false"
-  disable-ipv4: "false"
-  sidecar-http-proxy: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: cilium
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cilium
-subjects:
-- kind: ServiceAccount
-  name: cilium
-  namespace: kube-system
-- kind: Group
-  name: system:nodes
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: cilium
-rules:
-- apiGroups:
-  - "networking.k8s.io"
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - services
-  - nodes
-  - endpoints
-  - componentstatuses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
-  - thirdpartyresources
-  - ingresses
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - "apiextensions.k8s.io"
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - cilium.io
-  resources:
-  - ciliumnetworkpolicies
-  - ciliumendpoints
-  verbs:
-  - "*"
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: cilium
-  namespace: kube-system
 ---

--- a/examples/kubernetes/1.7/cilium-cm.yaml
+++ b/examples/kubernetes/1.7/cilium-cm.yaml
@@ -26,6 +26,8 @@ data:
   debug: "false"
   disable-ipv4: "false"
   sidecar-http-proxy: "false"
+  # If you want to clean cilium state; change this value to true
+  clean-cilium-state: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -32,6 +32,22 @@ spec:
         prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
+      initContainers:
+      - name: clean-cilium-state
+        image: busybox
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+        env:
+          - name: "CLEAN_CILIUM_STATE"
+            valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-state
       containers:
       - image: cilium/cilium:v1.0.0
         imagePullPolicy: IfNotPresent

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -1,3 +1,135 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+  # This etcd-config contains the etcd endpoints of your cluster. If you use
+  # TLS please make sure you uncomment the ca-file line and add the respective
+  # certificate has a k8s secret, see explanation below in the comment labeled
+  # "ETCD-CERT"
+  etcd-config: |-
+    ---
+    endpoints:
+    - http://127.0.0.1:2379
+    #
+    # In case you want to use TLS in etcd, uncomment the following line
+    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
+    #
+    # In case you want client to server authentication, uncomment the following
+    # lines and add the certificate and key in cilium-etcd-secrets below
+    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  disable-ipv4: "false"
+  sidecar-http-proxy: "false"
+  # If you want to clean cilium state; change this value to true
+  clean-cilium-state: "false"
+---
+# The etcd secrets can be populated in kubernetes.
+# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
+kind: Secret
+apiVersion: v1
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
+  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
+  # (the "-w 0" generates the output on a single line)
+  etcd-ca: ""
+  etcd-client-key: ""
+  etcd-client-crt: ""
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- kind: Group
+  name: system:nodes
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
+  - thirdpartyresources
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumendpoints
+  verbs:
+  - "*"
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium
+  namespace: kube-system
+---
 kind: DaemonSet
 apiVersion: extensions/v1beta1
 metadata:
@@ -32,6 +164,22 @@ spec:
         prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
+      initContainers:
+      - name: clean-cilium-state
+        image: busybox
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+        env:
+          - name: "CLEAN_CILIUM_STATE"
+            valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-state
       containers:
       - image: cilium/cilium:v1.0.0
         imagePullPolicy: IfNotPresent
@@ -168,134 +316,4 @@ spec:
       # Mark cilium's pod as critical for rescheduling
       - key: CriticalAddonsOnly
         operator: "Exists"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cilium-config
-  namespace: kube-system
-data:
-  # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
-  etcd-config: |-
-    ---
-    endpoints:
-    - http://127.0.0.1:2379
-    #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
-    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
-    #
-    # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
-    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
-    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
-
-  # If you want to run cilium in debug mode change this value to true
-  debug: "false"
-  disable-ipv4: "false"
-  sidecar-http-proxy: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: cilium
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cilium
-subjects:
-- kind: ServiceAccount
-  name: cilium
-  namespace: kube-system
-- kind: Group
-  name: system:nodes
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: cilium
-rules:
-- apiGroups:
-  - "networking.k8s.io"
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - services
-  - nodes
-  - endpoints
-  - componentstatuses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
-  - thirdpartyresources
-  - ingresses
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - "apiextensions.k8s.io"
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - cilium.io
-  resources:
-  - ciliumnetworkpolicies
-  - ciliumendpoints
-  verbs:
-  - "*"
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: cilium
-  namespace: kube-system
 ---

--- a/examples/kubernetes/1.8/cilium-cm.yaml
+++ b/examples/kubernetes/1.8/cilium-cm.yaml
@@ -26,6 +26,8 @@ data:
   debug: "false"
   disable-ipv4: "false"
   sidecar-http-proxy: "false"
+  # If you want to clean cilium state; change this value to true
+  clean-cilium-state: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -32,6 +32,22 @@ spec:
         prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
+      initContainers:
+      - name: clean-cilium-state
+        image: busybox
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+        env:
+          - name: "CLEAN_CILIUM_STATE"
+            valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-state
       containers:
       - image: cilium/cilium:v1.0.0
         imagePullPolicy: IfNotPresent

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -1,3 +1,135 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+  # This etcd-config contains the etcd endpoints of your cluster. If you use
+  # TLS please make sure you uncomment the ca-file line and add the respective
+  # certificate has a k8s secret, see explanation below in the comment labeled
+  # "ETCD-CERT"
+  etcd-config: |-
+    ---
+    endpoints:
+    - http://127.0.0.1:2379
+    #
+    # In case you want to use TLS in etcd, uncomment the following line
+    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
+    #
+    # In case you want client to server authentication, uncomment the following
+    # lines and add the certificate and key in cilium-etcd-secrets below
+    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  disable-ipv4: "false"
+  sidecar-http-proxy: "false"
+  # If you want to clean cilium state; change this value to true
+  clean-cilium-state: "false"
+---
+# The etcd secrets can be populated in kubernetes.
+# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
+kind: Secret
+apiVersion: v1
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
+  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
+  # (the "-w 0" generates the output on a single line)
+  etcd-ca: ""
+  etcd-client-key: ""
+  etcd-client-crt: ""
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- kind: Group
+  name: system:nodes
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
+  - thirdpartyresources
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumendpoints
+  verbs:
+  - "*"
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium
+  namespace: kube-system
+---
 kind: DaemonSet
 apiVersion: apps/v1beta2
 metadata:
@@ -32,6 +164,22 @@ spec:
         prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
+      initContainers:
+      - name: clean-cilium-state
+        image: busybox
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+        env:
+          - name: "CLEAN_CILIUM_STATE"
+            valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-state
       containers:
       - image: cilium/cilium:v1.0.0
         imagePullPolicy: IfNotPresent
@@ -168,134 +316,4 @@ spec:
       # Mark cilium's pod as critical for rescheduling
       - key: CriticalAddonsOnly
         operator: "Exists"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cilium-config
-  namespace: kube-system
-data:
-  # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
-  etcd-config: |-
-    ---
-    endpoints:
-    - http://127.0.0.1:2379
-    #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
-    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
-    #
-    # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
-    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
-    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
-
-  # If you want to run cilium in debug mode change this value to true
-  debug: "false"
-  disable-ipv4: "false"
-  sidecar-http-proxy: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: cilium
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cilium
-subjects:
-- kind: ServiceAccount
-  name: cilium
-  namespace: kube-system
-- kind: Group
-  name: system:nodes
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: cilium
-rules:
-- apiGroups:
-  - "networking.k8s.io"
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - services
-  - nodes
-  - endpoints
-  - componentstatuses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
-  - thirdpartyresources
-  - ingresses
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - "apiextensions.k8s.io"
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - cilium.io
-  resources:
-  - ciliumnetworkpolicies
-  - ciliumendpoints
-  verbs:
-  - "*"
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: cilium
-  namespace: kube-system
 ---

--- a/examples/kubernetes/1.9/cilium-cm.yaml
+++ b/examples/kubernetes/1.9/cilium-cm.yaml
@@ -26,6 +26,8 @@ data:
   debug: "false"
   disable-ipv4: "false"
   sidecar-http-proxy: "false"
+  # If you want to clean cilium state; change this value to true
+  clean-cilium-state: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -32,6 +32,22 @@ spec:
         prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
+      initContainers:
+      - name: clean-cilium-state
+        image: busybox
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+        env:
+          - name: "CLEAN_CILIUM_STATE"
+            valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-state
       containers:
       - image: cilium/cilium:v1.0.0
         imagePullPolicy: IfNotPresent

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -1,3 +1,135 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+  # This etcd-config contains the etcd endpoints of your cluster. If you use
+  # TLS please make sure you uncomment the ca-file line and add the respective
+  # certificate has a k8s secret, see explanation below in the comment labeled
+  # "ETCD-CERT"
+  etcd-config: |-
+    ---
+    endpoints:
+    - http://127.0.0.1:2379
+    #
+    # In case you want to use TLS in etcd, uncomment the following line
+    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
+    #
+    # In case you want client to server authentication, uncomment the following
+    # lines and add the certificate and key in cilium-etcd-secrets below
+    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  disable-ipv4: "false"
+  sidecar-http-proxy: "false"
+  # If you want to clean cilium state; change this value to true
+  clean-cilium-state: "false"
+---
+# The etcd secrets can be populated in kubernetes.
+# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
+kind: Secret
+apiVersion: v1
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
+  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
+  # (the "-w 0" generates the output on a single line)
+  etcd-ca: ""
+  etcd-client-key: ""
+  etcd-client-crt: ""
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- kind: Group
+  name: system:nodes
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
+  - thirdpartyresources
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumendpoints
+  verbs:
+  - "*"
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium
+  namespace: kube-system
+---
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -32,6 +164,22 @@ spec:
         prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
+      initContainers:
+      - name: clean-cilium-state
+        image: busybox
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+        env:
+          - name: "CLEAN_CILIUM_STATE"
+            valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-state
       containers:
       - image: cilium/cilium:v1.0.0
         imagePullPolicy: IfNotPresent
@@ -168,134 +316,4 @@ spec:
       # Mark cilium's pod as critical for rescheduling
       - key: CriticalAddonsOnly
         operator: "Exists"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cilium-config
-  namespace: kube-system
-data:
-  # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
-  etcd-config: |-
-    ---
-    endpoints:
-    - http://127.0.0.1:2379
-    #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
-    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
-    #
-    # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
-    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
-    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
-
-  # If you want to run cilium in debug mode change this value to true
-  debug: "false"
-  disable-ipv4: "false"
-  sidecar-http-proxy: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: cilium
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cilium
-subjects:
-- kind: ServiceAccount
-  name: cilium
-  namespace: kube-system
-- kind: Group
-  name: system:nodes
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: cilium
-rules:
-- apiGroups:
-  - "networking.k8s.io"
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - services
-  - nodes
-  - endpoints
-  - componentstatuses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
-  - thirdpartyresources
-  - ingresses
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - "apiextensions.k8s.io"
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - cilium.io
-  resources:
-  - ciliumnetworkpolicies
-  - ciliumendpoints
-  verbs:
-  - "*"
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: cilium
-  namespace: kube-system
 ---

--- a/examples/kubernetes/templates/v1/cilium-cm.yaml
+++ b/examples/kubernetes/templates/v1/cilium-cm.yaml
@@ -26,6 +26,8 @@ data:
   debug: "false"
   disable-ipv4: "false"
   sidecar-http-proxy: "false"
+  # If you want to clean cilium state; change this value to true
+  clean-cilium-state: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -32,6 +32,22 @@ spec:
         prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
+      initContainers:
+      - name: clean-cilium-state
+        image: busybox
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+        env:
+          - name: "CLEAN_CILIUM_STATE"
+            valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-state
       containers:
       - image: cilium/cilium:__CILIUM_VERSION__
         imagePullPolicy: IfNotPresent

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -525,7 +525,17 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 	owner.GetCompilationLock().RLock()
 	defer owner.GetCompilationLock().RUnlock()
 
+	buildStart := time.Now()
+
 	e.Mutex.Lock()
+
+	e.getLogger().WithField(logfields.StartTime, time.Now()).Info("Regenerating BPF program")
+	defer func() {
+		e.Mutex.RLock()
+		e.getLogger().WithField(logfields.BuildDuration, time.Since(buildStart).String()).
+			Info("Regeneration of BPF program has completed")
+		e.Mutex.RUnlock()
+	}()
 
 	// If endpoint was marked as disconnected then
 	// it won't be regenerated.

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -217,8 +217,14 @@ func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 	fw.WriteString(" */\n\n")
 
 	// If policy has not been derived or calculated yet, all packets must
-	// be dropped until the policy of the endpoint has been determined.
-	if !e.PolicyCalculated && owner.PolicyEnforcement() != NeverEnforce {
+	// be dropped until the policy of the endpoint has been determined,
+	// except when it is known that the current policy will not drop anything,
+	// which is true when:
+	// - policy enforcement mode is "never"
+	// - policy enforcement mode is "default" and no policies are loaded
+	if !e.PolicyCalculated &&
+		!(owner.PolicyEnforcement() == NeverEnforce) &&
+		!(owner.PolicyEnforcement() == DefaultEnforcement && owner.GetPolicyRepository().Empty()) {
 		fw.WriteString("#define DROP_ALL\n")
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1757,6 +1757,8 @@ func (e *Endpoint) LeaveLocked(owner Owner) []error {
 
 	e.SetStateLocked(StateDisconnected, "Endpoint removed")
 
+	e.getLogger().Info("Removed endpoint")
+
 	return errors
 }
 
@@ -2396,4 +2398,10 @@ func (e *Endpoint) IPs() []net.IP {
 		ips = append(ips, e.IPv6.IP())
 	}
 	return ips
+}
+
+// InsertEvent is called when the endpoint is inserted into the endpoint
+// manager. The endpoint must be read locked.
+func (e *Endpoint) InsertEvent() {
+	e.getLogger().Info("New endpoint")
 }

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -37,6 +37,8 @@ func (e *Endpoint) getLogger() *logrus.Entry {
 func (e *Endpoint) updateLogger() {
 	containerID := e.getShortContainerID()
 
+	podName := e.GetK8sNamespaceAndPodNameLocked()
+
 	// We need to update if
 	// - e.logger is nil (this happens on the first ever call to updateLogger via
 	//   getLogger above). This clause has to come first to guard the others.
@@ -48,6 +50,9 @@ func (e *Endpoint) updateLogger() {
 		e.logger.Data[logfields.EndpointID] != e.ID ||
 		e.logger.Data[logfields.ContainerID] != containerID ||
 		e.logger.Data[logfields.PolicyRevision] != e.policyRevision ||
+		e.logger.Data[logfields.IPv4] != e.IPv4.String() ||
+		e.logger.Data[logfields.IPv6] != e.IPv6.String() ||
+		e.logger.Data[logfields.K8sPodName] != podName ||
 		e.Opts.IsEnabled("Debug") != (e.logger.Level == logrus.DebugLevel)
 
 	// do nothing if we do not need an update
@@ -72,5 +77,8 @@ func (e *Endpoint) updateLogger() {
 		logfields.EndpointID:     e.ID,
 		logfields.ContainerID:    containerID,
 		logfields.PolicyRevision: e.policyRevision,
+		logfields.IPv4:           e.IPv4.String(),
+		logfields.IPv6:           e.IPv6.String(),
+		logfields.K8sPodName:     podName,
 	})
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1170,6 +1170,11 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity) {
 		cache.Remove(e.Consumable)
 	}
 
+	oldIdentity := "no identity"
+	if e.SecurityIdentity != nil {
+		oldIdentity = e.SecurityIdentity.StringID()
+	}
+
 	e.SecurityIdentity = identity
 	e.Consumable = cache.GetOrCreate(identity.ID, identity)
 
@@ -1187,8 +1192,9 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity) {
 
 	e.Consumable.Mutex.RLock()
 	e.getLogger().WithFields(logrus.Fields{
-		logfields.Identity: identity,
-		"consumable":       e.Consumable,
-	}).Debug("Set identity and consumable of EP")
+		logfields.Identity:       identity.StringID(),
+		logfields.OldIdentity:    oldIdentity,
+		logfields.IdentityLabels: identity.Labels.String(),
+	}).Info("Identity of endpoint changed")
 	e.Consumable.Mutex.RUnlock()
 }

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -342,6 +342,7 @@ func AddEndpoint(owner endpoint.Owner, ep *endpoint.Endpoint, reason string) err
 
 	ep.Mutex.RLock()
 	Insert(ep)
+	ep.InsertEvent()
 	ep.Mutex.RUnlock()
 
 	return nil

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -47,6 +47,9 @@ const (
 	// Identity is the identifier of a security identity
 	Identity = "identity"
 
+	// OldIdentity is a previously used security identity
+	OldIdentity = "oldIdentity"
+
 	// PolicyRevision is the revision of the policy in the repository or of
 	// the object in question
 	PolicyRevision = "policyRevision"
@@ -62,6 +65,18 @@ const (
 
 	// IPAddr is an IPV4 or IPv6 address
 	IPAddr = "ipAddr"
+
+	// IPv4 is an IPv4 address
+	IPv4 = "ipv4"
+
+	// IPv6 is an IPv6 address
+	IPv6 = "ipv6"
+
+	// BuildDuration is the time elapsed to build a BPF program
+	BuildDuration = "buildDuration"
+
+	// StartTime is the start time of an event
+	StartTime = "startTime"
 
 	// V4HealthIP is an address used to contact the cilium-health endpoint
 	V4HealthIP = "v4healthIP.IPv4"

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -599,6 +599,15 @@ func (p *Repository) GetRevision() uint64 {
 	return p.revision
 }
 
+// Empty returns 'true' if repository has no rules, 'false' otherwise.
+//
+// Must be called without p.Mutex held
+func (p *Repository) Empty() bool {
+	p.Mutex.Lock()
+	defer p.Mutex.Unlock()
+	return p.NumRules() == 0
+}
+
 // TranslateRules traverses rules and applies provided translator to rules
 func (p *Repository) TranslateRules(translator Translator) error {
 	p.Mutex.Lock()


### PR DESCRIPTION
- endpoint: Improve logging of endpoint lifecycle events 
[ upstream commit 12b6876da414a50308ecafa1932c0b9c2fbd7843 ]
https://github.com/cilium/cilium/pull/3936

- policy: Do not enable DROP_ALL mode if not needed.
[ upstream commit fb333388579c20a4ca9a6e286520b81f7701647c ]
https://github.com/cilium/cilium/pull/3938

- Adds flag to clean up cilium state before startup
[ upstream commit 38ba456dff36f041d586c0dc9f03f7a1362f84f8 ]
https://github.com/cilium/cilium/pull/3852
