### PR TITLE
Nightly: Exclude connectivity test on invalid policies

### DIFF
--- a/test/helpers/policygen/policygen.go
+++ b/test/helpers/policygen/policygen.go
@@ -111,6 +111,10 @@ var policiesTestSuite = PolicyTestSuite{
 				"rules": `{"http": [{"method": "GET", "path": "/private"}]}`,
 				"ports": `[{"port": "80", "protocol": "TCP"}]`,
 			},
+			exclude: []string{
+				"L4:Ingress Port 80 UDP",
+				"L4:Ingress Port 80 No protocol",
+			},
 		},
 		{
 			name:  "Egress policy to /private/",
@@ -119,6 +123,10 @@ var policiesTestSuite = PolicyTestSuite{
 			template: map[string]string{
 				"rules": `{"http": [{"method": "GET", "path": "/private"}]}`,
 				"ports": `[{"port": "80", "protocol": "TCP"}]`,
+			},
+			exclude: []string{
+				"L4:Egress Port 80 UDP",
+				"L4:Egress Port 80 No protocol",
 			},
 		},
 	},


### PR DESCRIPTION
Due `c7b1a677ca61607695dae504c0db7a1f6f698bec` HTTP L7 policies need to
have L4 port and protocol defined. Nightly test policies combinations
test that these policies work.

To test these combinations, a exclude parameters in Policy definition is
added, so we can test that the CNP resource returns an error message.

Fix #3894

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
