### PR TITLE
CmdRes.CombineOutput does not clobber stdout & SW demo fixup

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -100,7 +100,8 @@ func (res *CmdRes) CountLines() int {
 
 // CombineOutput returns the combined output of stdout and stderr for res.
 func (res *CmdRes) CombineOutput() *bytes.Buffer {
-	result := res.stdout
+	result := new(bytes.Buffer)
+	result.WriteString(res.stdout.String())
 	result.WriteString(res.stderr.String())
 	return result
 }

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -166,7 +166,7 @@ var _ = Describe(demoTestName, func() {
 
 		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, xwingPod,
 			helpers.CurlWithHTTPCode("http://%s/v1", deathstarServiceName))
-		res.ExpectContains("200", "unable to curl %s/v1: %s", deathstarServiceName, res.CombineOutput())
+		res.ExpectContains("200", "unable to curl %s/v1: %s", deathstarServiceName, res.Output())
 
 		By(fmt.Sprintf("Importing L7 Policy which restricts access to %s", exhaustPortPath))
 		kubectl.Delete(l4PolicyYAMLLink)
@@ -180,13 +180,13 @@ var _ = Describe(demoTestName, func() {
 		By(fmt.Sprintf("Showing how alliance cannot access %s without force header in API request after importing L7 Policy", exhaustPortPath))
 		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, xwingPod,
 			helpers.CurlWithHTTPCode("-X PUT http://%s", exhaustPortPath))
-		res.ExpectContains("403", "able to access %s when policy disallows it; %s", exhaustPortPath, res.CombineOutput())
+		res.ExpectContains("403", "able to access %s when policy disallows it; %s", exhaustPortPath, res.Output())
 
 		By(fmt.Sprintf("Showing how alliance can access %s with force header in API request to attack the deathstar", exhaustPortPath))
 		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, xwingPod,
 			helpers.CurlWithHTTPCode("-X PUT -H 'X-Has-Force: True' http://%s", exhaustPortPath))
 		By("Expecting 503 to be returned when using force header to attack the deathstar")
-		res.ExpectContains("503", "unable to access %s when policy allows it; %s", exhaustPortPath, res.CombineOutput())
+		res.ExpectContains("503", "unable to access %s when policy allows it; %s", exhaustPortPath, res.Output())
 	})
 
 })

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -169,9 +169,10 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 		By("Sending consume request on kafka topic `allowedTopic`")
 		res := consumer(allowedTopic, MaxMessages)
 		res.ExpectSuccess("Failed to consume messages from kafka topic `allowedTopic`")
+		Expect(res.CombineOutput().String()).
+			Should(ContainSubstring("Processed a total of %d messages", MaxMessages),
+				"Kafka did not process the expected number of messages")
 
-		Expect(res.Output().String()).Should(ContainSubstring(
-			"Processed a total of %d messages", MaxMessages))
 		By("Disable topic")
 		res = consumer(disallowTopic, MaxMessages)
 		res.ExpectFail("Kafka consumer can access to disallowTopic")
@@ -200,9 +201,9 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 		By("Sending consume request on kafka topic `allowedTopic`")
 		res := consumer(allowedTopic, MaxMessages)
 		res.ExpectSuccess("Failed to consume messages from kafka topic `allowedTopic`")
-
-		Expect(res.Output().String()).Should(ContainSubstring(
-			"Processed a total of %d messages", MaxMessages))
+		Expect(res.CombineOutput().String()).
+			Should(ContainSubstring("Processed a total of %d messages", MaxMessages),
+				"Kafka did not process the expected number of messages")
 
 		By("Disable topic")
 		// Consumer timeout didn't work correctly, so make sure that AUTH is present in the reply


### PR DESCRIPTION
`CmdRes.CombineOutput` accidentally reused the `CmdRes.stdout` variable and modified it, corrupting later `CmdRes.StdOut` calls. This PR fixes that, and fixes the SW GSG demo to use only Stdout to check http codes.