### PR TITLE
pkg/endpoint: remove WaitGroup return value from TriggerPolicyUpdatesLocked

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1583,10 +1583,9 @@ func (e *Endpoint) Update(owner Owner, cfg *models.EndpointConfigurationSpec) er
 
 	// Option changes may be overridden by the policy configuration.
 	// Currently we return all-OK even in that case.
-	needToRegenerate, ctCleaned, err := e.TriggerPolicyUpdatesLocked(owner, cfg.Options)
+	needToRegenerate, err := e.TriggerPolicyUpdatesLocked(owner, cfg.Options)
 	if err != nil {
 		e.Mutex.Unlock()
-		ctCleaned.Wait()
 		return UpdateCompilationError{err.Error()}
 	}
 
@@ -1630,7 +1629,6 @@ func (e *Endpoint) Update(owner Owner, cfg *models.EndpointConfigurationSpec) er
 				stateTransitionSucceeded := e.SetStateLocked(StateWaitingToRegenerate, reason)
 				if stateTransitionSucceeded {
 					e.Mutex.Unlock()
-					ctCleaned.Wait()
 					e.Regenerate(owner, reason)
 					return nil
 				}
@@ -1639,7 +1637,6 @@ func (e *Endpoint) Update(owner Owner, cfg *models.EndpointConfigurationSpec) er
 				e.Mutex.Lock()
 				e.getLogger().Warningf("timed out waiting for endpoint state to change")
 				e.Mutex.Unlock()
-				ctCleaned.Wait()
 				return UpdateStateChangeError{fmt.Sprintf("unable to regenerate endpoint program because state transition to %s was unsuccessful; check `cilium endpoint log %d` for more information", StateWaitingToRegenerate, e.ID)}
 			}
 		}
@@ -1647,7 +1644,6 @@ func (e *Endpoint) Update(owner Owner, cfg *models.EndpointConfigurationSpec) er
 	}
 
 	e.Mutex.Unlock()
-	ctCleaned.Wait()
 
 	return nil
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -866,21 +865,20 @@ func (e *Endpoint) Regenerate(owner Owner, reason string) <-chan bool {
 // state to reflect new policy.
 //
 // Returns true if policy was changed and the endpoint needs to be rebuilt
-func (e *Endpoint) TriggerPolicyUpdatesLocked(owner Owner, opts models.ConfigurationMap) (bool, *sync.WaitGroup, error) {
-	ctCleaned := &sync.WaitGroup{}
+func (e *Endpoint) TriggerPolicyUpdatesLocked(owner Owner, opts models.ConfigurationMap) (bool, error) {
 
 	if e.Consumable == nil {
-		return false, ctCleaned, nil
+		return false, nil
 	}
 
 	needToRegenerateBPF, err := e.regeneratePolicy(owner, opts)
 	if err != nil {
-		return false, ctCleaned, fmt.Errorf("%s: %s", e.StringID(), err)
+		return false, fmt.Errorf("%s: %s", e.StringID(), err)
 	}
 
 	e.getLogger().Debugf("TriggerPolicyUpdatesLocked: changed: %t", needToRegenerateBPF)
 
-	return needToRegenerateBPF, ctCleaned, nil
+	return needToRegenerateBPF, nil
 }
 
 func (e *Endpoint) runIdentityToK8sPodSync() {

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -253,7 +253,7 @@ func TriggerPolicyUpdates(owner endpoint.Owner) *sync.WaitGroup {
 	for _, ep := range eps {
 		go func(ep *endpoint.Endpoint, wg *sync.WaitGroup) {
 			ep.Mutex.Lock()
-			policyChanges, ctCleaned, err := ep.TriggerPolicyUpdatesLocked(owner, nil)
+			policyChanges, err := ep.TriggerPolicyUpdatesLocked(owner, nil)
 			regen := false
 			if err == nil && policyChanges {
 				// Regenerate only if state transition succeeds
@@ -265,9 +265,6 @@ func TriggerPolicyUpdates(owner endpoint.Owner) *sync.WaitGroup {
 				log.WithError(err).Warn("Error while handling policy updates for endpoint")
 				ep.LogStatus(endpoint.Policy, endpoint.Failure, "Error while handling policy updates for endpoint: "+err.Error())
 			} else {
-				// Wait for endpoint CT clean has complete before
-				// regenerating endpoint.
-				ctCleaned.Wait()
 				if !policyChanges {
 					ep.LogStatusOK(endpoint.Policy, "Endpoint policy update skipped because no changes were needed")
 				} else if regen {


### PR DESCRIPTION
This wait group is no longer used since conntrack cleanup is not done based on
policy recalculation per endpoint.

Signed-off by: Ian Vernon <ian@cilium.io>