### PR TITLE
endpoint: Endpoint state directories can be left behind after build failure

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1230,6 +1230,10 @@ func (e *Endpoint) directoryPath() string {
 	return filepath.Join(".", fmt.Sprintf("%d", e.ID))
 }
 
+func (e *Endpoint) failedDirectoryPath() string {
+	return filepath.Join(".", fmt.Sprintf("%d%s", e.ID, "_next_fail"))
+}
+
 func (e *Endpoint) Allows(id identityPkg.NumericIdentity) bool {
 	e.Mutex.RLock()
 	defer e.Mutex.RUnlock()
@@ -1756,6 +1760,7 @@ func (e *Endpoint) LeaveLocked(owner Owner) []error {
 
 	e.L3Maps.Close()
 	e.removeDirectory()
+	e.removeFailedDirectory()
 	e.controllers.RemoveAll()
 	e.cleanPolicySignals()
 
@@ -1768,6 +1773,10 @@ func (e *Endpoint) LeaveLocked(owner Owner) []error {
 
 func (e *Endpoint) removeDirectory() {
 	os.RemoveAll(e.directoryPath())
+}
+
+func (e *Endpoint) removeFailedDirectory() {
+	os.RemoveAll(e.failedDirectoryPath())
 }
 
 func (e *Endpoint) RemoveDirectory() {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -760,8 +760,8 @@ func (e *Endpoint) regenerate(owner Owner, reason string) (retErr error) {
 	revision, err := e.regenerateBPF(owner, tmpDir, reason)
 
 	// If generation fails, keep the directory around. If it ever succeeds
-	// again, clean up this copy.
-	failDir := tmpDir + "_fail"
+	// again, clean up the XXX_next_fail copy.
+	failDir := e.failedDirectoryPath()
 	os.RemoveAll(failDir) // Most likely will not exist; ignore failure.
 	if err != nil {
 		e.getLogger().WithFields(logrus.Fields{


### PR DESCRIPTION
Failed regeneration files `XXXXX_next_fail` may stick around after regeneration.
We are correctly deleting these files on regeneration, but not on deletion of endpoint.
This commit deletes the endpoint XXX_next_fail files on endpoint deletion.

Fixes: #3494
Fixes: #3175

Signed-Off-By: Manali Bhutiyani <manali@covalent.io>


```release-note
Remove endpoint  state directories left behind after build failure
```