### PR TITLE
Test: Fix Bookinfo issues

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -116,7 +116,7 @@ Vagrant.configure(2) do |config|
         vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
         vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
         config.vm.box = "cilium/ubuntu"
-        config.vm.box_version = "68"
+        config.vm.box_version = "69"
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i
         if ENV["NFS"] then

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -8,7 +8,7 @@ $K8S_VERSION = ENV['K8S_VERSION'] || "1.10"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 $NFS = ENV['NFS']=="1"? true : false
 $SERVER_BOX= "cilium/ubuntu"
-$SERVER_VERSION="68"
+$SERVER_VERSION="69"
 
 # RAM and CPU settings
 $MEMORY = (ENV['MEMORY'] || "4096").to_i

--- a/test/k8sT/manifests/bookinfo-v1.yaml
+++ b/test/k8sT/manifests/bookinfo-v1.yaml
@@ -40,6 +40,7 @@ spec:
         app: details
         version: v1
         track: stable
+        zgroup: bookinfo
     spec:
       containers:
       - name: details
@@ -76,6 +77,7 @@ spec:
         app: reviews
         version: v1
         track: stable
+        zgroup: bookinfo
     spec:
       containers:
       - name: reviews
@@ -112,6 +114,7 @@ spec:
         app: productpage
         version: v1
         track: stable
+        zgroup: bookinfo
     spec:
       containers:
       - name: productpage

--- a/test/k8sT/manifests/bookinfo-v2.yaml
+++ b/test/k8sT/manifests/bookinfo-v2.yaml
@@ -39,6 +39,7 @@ spec:
       labels:
         app: ratings
         version: v1
+        zgroup: bookinfo
     spec:
       containers:
       - name: ratings
@@ -61,6 +62,7 @@ spec:
       labels:
         app: reviews
         version: v2
+        zgroup: bookinfo
     spec:
       containers:
       - name: reviews


### PR DESCRIPTION
- Updated vagrant box to have all the images locally. Some failures
because can't be downloaded in the given timeout
- Change pods labels to make test simpler, only wait one time for all
pods.
- Change Wget command to use ExecPod instead of Exec.
- Using global connect timeout const instead of custom timeout.
- Updates assert messages.

Fix #3903
Fix #3923

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

