### PR TITLE
Test: Fix issues on `kubectl.CiliumReport`

### DIFF
--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -62,9 +62,9 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
+		kubectl.CiliumReport(helpers.KubeSystemNamespace,
 			"cilium service list",
-			"cilium endpoint list"})
+			"cilium endpoint list")
 	})
 
 	JustAfterEach(func() {

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -48,10 +48,10 @@ var _ = Describe(testName, func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
+		kubectl.CiliumReport(helpers.KubeSystemNamespace,
 			"cilium service list",
 			"cilium endpoint list",
-			"cilium policy get"})
+			"cilium policy get")
 	})
 
 	JustAfterEach(func() {

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -98,10 +98,10 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
+		kubectl.CiliumReport(helpers.KubeSystemNamespace,
 			"cilium service list",
 			"cilium policy get",
-			"cilium endpoint list"})
+			"cilium endpoint list")
 	})
 
 	JustBeforeEach(func() {

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -81,9 +81,9 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
+		kubectl.CiliumReport(helpers.KubeSystemNamespace,
 			"cilium service list",
-			"cilium endpoint list"})
+			"cilium endpoint list")
 	})
 
 	JustAfterEach(func() {
@@ -357,9 +357,9 @@ var _ = Describe("NightlyExamples", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
+		kubectl.CiliumReport(helpers.KubeSystemNamespace,
 			"cilium service list",
-			"cilium endpoint list"})
+			"cilium endpoint list")
 	})
 
 	JustAfterEach(func() {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -92,9 +92,9 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
+		kubectl.CiliumReport(helpers.KubeSystemNamespace,
 			"cilium service list",
-			"cilium endpoint list"})
+			"cilium endpoint list")
 	})
 
 	JustBeforeEach(func() {
@@ -912,9 +912,9 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
+		kubectl.CiliumReport(helpers.KubeSystemNamespace,
 			"cilium service list",
-			"cilium endpoint list"})
+			"cilium endpoint list")
 	})
 
 	JustBeforeEach(func() {

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -45,10 +45,10 @@ var _ = Describe("NightlyPolicies", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
+		kubectl.CiliumReport(helpers.KubeSystemNamespace,
 			"cilium policy get",
 			"cilium endpoint list",
-			"cilium service list"})
+			"cilium service list")
 	})
 
 	JustAfterEach(func() {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -61,10 +61,10 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
+		kubectl.CiliumReport(helpers.KubeSystemNamespace,
 			"cilium service list",
 			"cilium policy get",
-			"cilium endpoint list"})
+			"cilium endpoint list")
 	})
 
 	JustBeforeEach(func() {

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -52,9 +52,9 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 	}, 600)
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
+		kubectl.CiliumReport(helpers.KubeSystemNamespace,
 			"cilium bpf tunnel list",
-			"cilium endpoint list"})
+			"cilium endpoint list")
 	})
 
 	JustAfterEach(func() {
@@ -99,13 +99,6 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 
 			By("Checking that BPF tunnels are in place")
 			status := kubectl.CiliumExec(ciliumPod, "cilium bpf tunnel list | wc -l")
-			if tunnels, _ := status.IntOutput(); tunnels != 4 {
-				cmds := []string{
-					"cilium bpf tunnel list",
-				}
-				kubectl.CiliumReport(helpers.KubeSystemNamespace, cmds)
-			}
-
 			status.ExpectSuccess()
 			Expect(status.IntOutput()).Should(Equal(5))
 
@@ -148,12 +141,6 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 			By("Checking that BPF tunnels are in place")
 			status := kubectl.CiliumExec(ciliumPod, "cilium bpf tunnel list | wc -l")
 			status.ExpectSuccess()
-			if tunnels, _ := status.IntOutput(); tunnels != 4 {
-				cmds := []string{
-					"cilium bpf tunnel list",
-				}
-				kubectl.CiliumReport(helpers.KubeSystemNamespace, cmds)
-			}
 			Expect(status.IntOutput()).Should(Equal(5))
 
 			By("Checking that BPF tunnels are working correctly")

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -47,8 +47,7 @@ var _ = Describe("K8sValidatedUpdates", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace, []string{
-			"cilium endpoint list"})
+		kubectl.CiliumReport(helpers.KubeSystemNamespace, "cilium endpoint list")
 	})
 
 	JustAfterEach(func() {


### PR DESCRIPTION
- Fix issues on duplicated data in CiliumReport
- Fix issues with Variadic arguments
- Delete some os.Stdout messages on CiliumReport (Os.Stdout is not in
order with ginkgoWriter)

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
