### PR TITLE
backport/doc-v1.0 2018 04 30

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -20,35 +20,35 @@ Both files are dedicated to "\ |SCM_BRANCH|" for each Kubernetes version.
 
     .. parsed-literal::
 
-      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.7/rbac.yaml
+      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.7/cilium-rbac.yaml
       $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.7/cilium-ds.yaml
 
   .. group-tab:: K8s 1.8
 
     .. parsed-literal::
 
-      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.8/rbac.yaml
+      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.8/cilium-rbac.yaml
       $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.8/cilium-ds.yaml
 
   .. group-tab:: K8s 1.9
 
     .. parsed-literal::
 
-      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.9/rbac.yaml
+      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.9/cilium-rbac.yaml
       $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.9/cilium-ds.yaml
 
   .. group-tab:: K8s 1.10
 
     .. parsed-literal::
 
-      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.10/rbac.yaml
+      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.10/cilium-rbac.yaml
       $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.10/cilium-ds.yaml
 
   .. group-tab:: K8s 1.11
 
     .. parsed-literal::
 
-      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.11/rbac.yaml
+      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.11/cilium-rbac.yaml
       $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.11/cilium-ds.yaml
 
 


### PR DESCRIPTION
- docs: Correct RBAC urls in upgrade guide
[ upstream commit 346d33b98be338c84a6c4ecc3178fa03b9acd1da ]