### PR TITLE
pkg/identity: move LabelArray from Consumable to SecurityIdentity

### DIFF
--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -64,7 +64,7 @@ func (d *Daemon) EnableEndpointPolicyEnforcement(e *endpoint.Endpoint) (ingress 
 		// Default mode means that if rules contain labels that match this endpoint,
 		// then enable policy enforcement for this endpoint.
 		// GH-1676: Could check e.Consumable instead? Would be much cheaper.
-		return d.GetPolicyRepository().GetRulesMatching(e.Consumable.LabelArray)
+		return d.GetPolicyRepository().GetRulesMatching(e.SecurityIdentity.LabelArray)
 	default:
 		// If policy enforcement isn't enabled for the daemon we do not enable
 		// policy enforcement for the endpoint.

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -77,14 +77,8 @@ func endpointCreator(id uint16, secID identity.NumericIdentity) *e.Endpoint {
 		},
 	}
 	ep.Consumable = &policy.Consumable{
-		ID:        secID,
-		Iteration: 0,
-		Labels: &identity.Identity{
-			ID: secID,
-			Labels: labels.Labels{
-				"foo" + strID: labels.NewLabel("foo"+strID, "", ""),
-			},
-		},
+		ID:                secID,
+		Iteration:         0,
 		PolicyMaps:        map[int]*policymap.PolicyMap{},
 		IngressIdentities: map[identity.NumericIdentity]bool{},
 	}

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -30,6 +30,10 @@ type Identity struct {
 	Labels labels.Labels `json:"labels"`
 	// SHA256 of labels.
 	LabelsSHA256 string `json:"labelsSHA256"`
+
+	// LabelArray contains the same labels as Labels in a form of a list, used
+	// for faster lookup.
+	LabelArray labels.LabelArray `json:"-"`
 }
 
 // IPIdentityPair is a pairing of an IP and the security identity to which that
@@ -56,6 +60,10 @@ func NewIdentityFromModel(base *models.Identity) *Identity {
 	for _, v := range base.Labels {
 		lbl := labels.ParseLabel(v)
 		id.Labels[lbl.Key] = lbl
+	}
+
+	if id.Labels != nil {
+		id.LabelArray = id.Labels.ToSlice()
 	}
 
 	return id
@@ -96,5 +104,10 @@ func (id *Identity) GetModel() *models.Identity {
 
 // NewIdentity creates a new identity
 func NewIdentity(id NumericIdentity, lbls labels.Labels) *Identity {
-	return &Identity{ID: id, Labels: lbls}
+	var lblArray labels.LabelArray
+
+	if lbls != nil {
+		lblArray = lbls.ToSlice()
+	}
+	return &Identity{ID: id, Labels: lbls, LabelArray: lblArray}
 }

--- a/pkg/policy/consumer.go
+++ b/pkg/policy/consumer.go
@@ -16,7 +16,6 @@ package policy
 
 import (
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/policymap"
@@ -34,12 +33,6 @@ type Consumable struct {
 	ID identity.NumericIdentity `json:"id"`
 	// Mutex protects all variables from this structure below this line
 	Mutex lock.RWMutex
-
-	// Labels are the SecurityIdentity of this consumable
-	Labels *identity.Identity `json:"labels"`
-
-	// LabelArray contains the same labels from identity in a form of a list, used for faster lookup
-	LabelArray labels.LabelArray `json:"-"`
 
 	// Iteration policy of the Consumable
 	Iteration uint64 `json:"-"`
@@ -74,13 +67,9 @@ func NewConsumable(id identity.NumericIdentity, lbls *identity.Identity) *Consum
 	consumable := &Consumable{
 		ID:                id,
 		Iteration:         0,
-		Labels:            lbls,
 		PolicyMaps:        map[int]*policymap.PolicyMap{},
 		IngressIdentities: map[identity.NumericIdentity]bool{},
 		EgressIdentities:  map[identity.NumericIdentity]bool{},
-	}
-	if lbls != nil {
-		consumable.LabelArray = lbls.Labels.ToSlice()
 	}
 
 	return consumable


### PR DESCRIPTION
Also remove Labels field from Consumable as well. This is part of the groundwork for removing Consumable / general policy refactoring (related to #3161 ).

Signed-off by: Ian Vernon <ian@cilium.io>