### PR TITLE
Backport/v1.0 2018 05 02

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -404,7 +404,7 @@ here is an example showing what tests will be ran using Ginkgo's dryRun option:
 
 ::
 
-    $ ginkgo --focus="Runtime*" -noColor -dryRun
+    $ ginkgo --focus="Runtime*" -noColor -v -dryRun
     Running Suite: runtime
     ======================
     Random Seed: 1516125117

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -20,35 +20,35 @@ Both files are dedicated to "\ |SCM_BRANCH|" for each Kubernetes version.
 
     .. parsed-literal::
 
-      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.7/rbac.yaml
+      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.7/cilium-rbac.yaml
       $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.7/cilium-ds.yaml
 
   .. group-tab:: K8s 1.8
 
     .. parsed-literal::
 
-      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.8/rbac.yaml
+      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.8/cilium-rbac.yaml
       $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.8/cilium-ds.yaml
 
   .. group-tab:: K8s 1.9
 
     .. parsed-literal::
 
-      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.9/rbac.yaml
+      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.9/cilium-rbac.yaml
       $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.9/cilium-ds.yaml
 
   .. group-tab:: K8s 1.10
 
     .. parsed-literal::
 
-      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.10/rbac.yaml
+      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.10/cilium-rbac.yaml
       $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.10/cilium-ds.yaml
 
   .. group-tab:: K8s 1.11
 
     .. parsed-literal::
 
-      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.11/rbac.yaml
+      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.11/cilium-rbac.yaml
       $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.11/cilium-ds.yaml
 
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1226,6 +1226,10 @@ func (e *Endpoint) directoryPath() string {
 	return filepath.Join(".", fmt.Sprintf("%d", e.ID))
 }
 
+func (e *Endpoint) failedDirectoryPath() string {
+	return filepath.Join(".", fmt.Sprintf("%d%s", e.ID, "_next_fail"))
+}
+
 func (e *Endpoint) Allows(id identityPkg.NumericIdentity) bool {
 	e.Mutex.RLock()
 	defer e.Mutex.RUnlock()
@@ -1752,6 +1756,7 @@ func (e *Endpoint) LeaveLocked(owner Owner) []error {
 
 	e.L3Maps.Close()
 	e.removeDirectory()
+	e.removeFailedDirectory()
 	e.controllers.RemoveAll()
 	e.cleanPolicySignals()
 
@@ -1764,6 +1769,10 @@ func (e *Endpoint) LeaveLocked(owner Owner) []error {
 
 func (e *Endpoint) removeDirectory() {
 	os.RemoveAll(e.directoryPath())
+}
+
+func (e *Endpoint) removeFailedDirectory() {
+	os.RemoveAll(e.failedDirectoryPath())
 }
 
 func (e *Endpoint) RemoveDirectory() {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -932,8 +932,8 @@ func (e *Endpoint) regenerate(owner Owner, reason string) (retErr error) {
 	revision, err := e.regenerateBPF(owner, tmpDir, reason)
 
 	// If generation fails, keep the directory around. If it ever succeeds
-	// again, clean up this copy.
-	failDir := tmpDir + "_fail"
+	// again, clean up the XXX_next_fail copy.
+	failDir := e.failedDirectoryPath()
 	os.RemoveAll(failDir) // Most likely will not exist; ignore failure.
 	if err != nil {
 		e.getLogger().WithFields(logrus.Fields{

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -233,21 +233,40 @@ func dumpToSlice(m *bpf.Map, mapType string) ([]CtEntryDump, error) {
 // filter.
 func doGC6(m *bpf.Map, filter *GCFilter) int {
 	var (
-		action, deleted int
-		nextKey, tmpKey CtKey6Global
+		action, deleted              int
+		prevKey, currentKey, nextKey CtKey6Global
 	)
 
-	err := m.GetNextKey(&tmpKey, &nextKey)
+	// prevKey is initially invalid, causing GetNextKey to return the first key in the map as currentKey.
+	prevKeyValid := false
+	err := m.GetNextKey(&prevKey, &currentKey)
 	if err != nil {
+		// Map is empty, nothing to clean up.
 		return 0
 	}
 
-	for {
-		nextKeyValid := m.GetNextKey(&nextKey, &tmpKey)
-		entryMap, err := m.Lookup(&nextKey)
+	var count uint32
+	for count = 1; count <= m.MapInfo.MaxEntries; count++ {
+		// currentKey was returned by GetNextKey() so we know it existed in the map, but it may have been
+		// deleted by a concurrent map operation. If currentKey is no longer in the map, nextKey will be
+		// the first key in the map again. Use the nextKey only if we still find currentKey in the Lookup()
+		// after the GetNextKey() call, this way we know nextKey is NOT the first key in the map.
+		nextKeyValid := m.GetNextKey(&currentKey, &nextKey)
+		entryMap, err := m.Lookup(&currentKey)
 		if err != nil {
-			log.WithError(err).Error("error during map Lookup")
-			break
+			// Restarting from a invalid key starts the iteration again from the beginning.
+			// If we have a previously found key, try to restart from there instead
+			if prevKeyValid {
+				currentKey = prevKey
+				// Restart from a given previous key only once, otherwise if the prevKey is
+				// concurrently deleted we might loop forever trying to look it up.
+				prevKeyValid = false
+			} else {
+				// Depending on exactly when currentKey was deleted from the map, nextKey may be the actual
+				// keyelement after the deleted one, or the first element in the map.
+				currentKey = nextKey
+			}
+			continue
 		}
 
 		entry := entryMap.(*CtEntry)
@@ -255,13 +274,14 @@ func doGC6(m *bpf.Map, filter *GCFilter) int {
 		// In CT entries, the source address of the conntrack entry (`saddr`) is
 		// the destination of the packet received, therefore it's the packet's
 		// destination IP
-		action = filter.doFiltering(nextKey.daddr.IP(), nextKey.saddr.IP(), nextKey.sport, uint8(nextKey.nexthdr), nextKey.flags, entry)
+		action = filter.doFiltering(currentKey.daddr.IP(), currentKey.saddr.IP(), currentKey.sport,
+			uint8(currentKey.nexthdr), currentKey.flags, entry)
 
 		switch action {
 		case deleteEntry:
-			err := m.Delete(&nextKey)
+			err := m.Delete(&currentKey)
 			if err != nil {
-				log.WithError(err).Errorf("Unable to delete CT entry %s", nextKey.String())
+				log.WithError(err).Errorf("Unable to delete CT entry %s", currentKey.String())
 			} else {
 				deleted++
 			}
@@ -270,8 +290,18 @@ func doGC6(m *bpf.Map, filter *GCFilter) int {
 		if nextKeyValid != nil {
 			break
 		}
-		nextKey = tmpKey
+		// remember the last found key
+		prevKey = currentKey
+		prevKeyValid = true
+		// continue from the next key
+		currentKey = nextKey
 	}
+
+	if count > m.MapInfo.MaxEntries {
+		// TODO Add a metric we can bump and observe here.
+		log.WithError(err).Warning("Garbage collection on IPv6 CT map failed to finish")
+	}
+
 	return deleted
 }
 
@@ -279,21 +309,40 @@ func doGC6(m *bpf.Map, filter *GCFilter) int {
 // filter.
 func doGC4(m *bpf.Map, filter *GCFilter) int {
 	var (
-		action, deleted int
-		nextKey, tmpKey CtKey4Global
+		action, deleted              int
+		prevKey, currentKey, nextKey CtKey4Global
 	)
 
-	err := m.GetNextKey(&tmpKey, &nextKey)
+	// prevKey is initially invalid, causing GetNextKey to return the first key in the map as currentKey.
+	prevKeyValid := false
+	err := m.GetNextKey(&prevKey, &currentKey)
 	if err != nil {
+		// Map is empty, nothing to clean up.
 		return 0
 	}
 
-	for true {
-		nextKeyValid := m.GetNextKey(&nextKey, &tmpKey)
-		entryMap, err := m.Lookup(&nextKey)
+	var count uint32
+	for count = 1; count <= m.MapInfo.MaxEntries; count++ {
+		// currentKey was returned by GetNextKey() so we know it existed in the map, but it may have been
+		// deleted by a concurrent map operation. If currentKey is no longer in the map, nextKey will be
+		// the first key in the map again. Use the nextKey only if we still find currentKey in the Lookup()
+		// after the GetNextKey() call, this way we know nextKey is NOT the first key in the map.
+		nextKeyValid := m.GetNextKey(&currentKey, &nextKey)
+		entryMap, err := m.Lookup(&currentKey)
 		if err != nil {
-			log.WithError(err).Error("error during map Lookup")
-			break
+			// Restarting from a invalid key starts the iteration again from the beginning.
+			// If we have a previously found key, try to restart from there instead
+			if prevKeyValid {
+				currentKey = prevKey
+				// Restart from a given previous key only once, otherwise if the prevKey is
+				// concurrently deleted we might loop forever trying to look it up.
+				prevKeyValid = false
+			} else {
+				// Depending on exactly when currentKey was deleted from the map, nextKey may be the actual
+				// keyelement after the deleted one, or the first element in the map.
+				currentKey = nextKey
+			}
+			continue
 		}
 
 		entry := entryMap.(*CtEntry)
@@ -301,13 +350,14 @@ func doGC4(m *bpf.Map, filter *GCFilter) int {
 		// In CT entries, the source address of the conntrack entry (`saddr`) is
 		// the destination of the packet received, therefore it's the packet's
 		// destination IP
-		action = filter.doFiltering(nextKey.daddr.IP(), nextKey.saddr.IP(), nextKey.sport, uint8(nextKey.nexthdr), nextKey.flags, entry)
+		action = filter.doFiltering(currentKey.daddr.IP(), currentKey.saddr.IP(), currentKey.sport,
+			uint8(currentKey.nexthdr), currentKey.flags, entry)
 
 		switch action {
 		case deleteEntry:
-			err := m.Delete(&nextKey)
+			err := m.Delete(&currentKey)
 			if err != nil {
-				log.WithError(err).Errorf("Unable to delete CT entry %s", nextKey.String())
+				log.WithError(err).Errorf("Unable to delete CT entry %s", currentKey.String())
 			} else {
 				deleted++
 			}
@@ -316,8 +366,18 @@ func doGC4(m *bpf.Map, filter *GCFilter) int {
 		if nextKeyValid != nil {
 			break
 		}
-		nextKey = tmpKey
+		// remember the last found key
+		prevKey = currentKey
+		prevKeyValid = true
+		// continue from the next key
+		currentKey = nextKey
 	}
+
+	if count > m.MapInfo.MaxEntries {
+		// TODO Add a metric we can bump and observe here.
+		log.WithError(err).Warning("Garbage collection on IPv4 CT map failed to finish")
+	}
+
 	return deleted
 }
 


### PR DESCRIPTION
- docs: Fix ginkgo command line.
    [ upstream commit 82c462e4840572ed874c190b7c5e3c6d9b5d7e70 ]
    https://github.com/cilium/cilium/pull/3939

- ctmap: Make GC bpf map dumps more robust.
    [ upstream commit c9bff58f6716b82ae89edb10a69639c375bcf97d ]
    https://github.com/cilium/cilium/pull/3946

- endpoint: Remove endpoint state directories left behind after build failure
    [ upstream commit 79f48d8b6e2d5c4703c91dc0980b0ea5454445a0 ]
    https://github.com/cilium/cilium/pull/3962

- docs: Correct RBAC urls in upgrade guide
    [ upstream commit 346d33b98be338c84a6c4ecc3178fa03b9acd1da ]
    https://github.com/cilium/cilium/pull/3977