### PR TITLE
Monitor: only read BPF perf buffer when listeners are connected

### DIFF
--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/monitor/payload"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 const (
@@ -35,14 +36,6 @@ const (
 
 	// queueSize is the size of the message queue
 	queueSize = 65536
-)
-
-var (
-	mutex            lock.Mutex
-	listeners        = make(map[*monitorListener]struct{})
-	monitorEvents    *bpf.PerCpuEvents
-	perfReaderCancel context.CancelFunc
-	nPages           int
 )
 
 // isCtxDone is a utility function that returns true when the context's Done()
@@ -57,15 +50,37 @@ func isCtxDone(ctx context.Context) bool {
 	}
 }
 
-type monitorListener struct {
-	conn  net.Conn
-	queue chan []byte
+// Monitor structure for centralizing the responsibilities of the main events
+// reader.
+// There is some racey-ness around perfReaderCancel since it replaces on every
+// perf reader start. In the event that a MonitorListener from a previous
+// generation calls its cleanup after the start of the new perf reader, we
+// might call the new, and incorrect, cancel function. We guard for this by
+// checking the number of listeners during the cleanup call. The perf reader
+// must have at least one listener (since it started) so no cancel is called.
+// If it doesn't, the cancel is the correct behavior (the older generation
+// cancel must have been called for us to get this far anyway).
+type Monitor struct {
+	lock.Mutex
+
+	ctx              context.Context
+	perfReaderCancel context.CancelFunc
+	listeners        map[*monitorListener]struct{}
+	nPages           int
+	monitorEvents    *bpf.PerCpuEvents
 }
 
-func newMonitorListener(c net.Conn) *monitorListener {
+type monitorListener struct {
+	conn      net.Conn
+	queue     chan []byte
+	cleanupFn func(*monitorListener)
+}
+
+func newMonitorListener(c net.Conn, cleanupFn func(*monitorListener)) *monitorListener {
 	ml := &monitorListener{
-		conn:  c,
-		queue: make(chan []byte, queueSize),
+		conn:      c,
+		queue:     make(chan []byte, queueSize),
+		cleanupFn: cleanupFn,
 	}
 
 	go ml.drainQueue()
@@ -73,91 +88,139 @@ func newMonitorListener(c net.Conn) *monitorListener {
 	return ml
 }
 
-// Monitor structure for centralizing the responsibilities of the main events reader.
-type Monitor struct {
-}
-
 // agentPipeReader reads agent events from the agentPipe and distributes to all listeners
 func (m *Monitor) agentPipeReader(ctx context.Context, agentPipe io.Reader) {
-	meta, p := payload.Meta{}, payload.Payload{}
+	log.Info("Beginning to read cilium agent events")
+	defer log.Info("Stopped reading cilium agent events")
 
+	meta, p := payload.Meta{}, payload.Payload{}
 	for !isCtxDone(ctx) {
 		err := payload.ReadMetaPayload(agentPipe, &meta, &p)
-		if err == io.EOF || err == io.ErrUnexpectedEOF {
-			log.Panic("Agent pipe closed, shutting down")
-		} else if err != nil {
-			log.WithError(err).Panic("Unable to read from agent pipe")
+		switch {
+		// this captures the case where we are shutting down and main closes the
+		// pipe socket
+		case isCtxDone(ctx):
+			return
+
+		case err == io.EOF || err == io.ErrUnexpectedEOF:
+			log.Panic("Agent pipe unexpectedly closed, shutting down")
+
+		case err != nil:
+			log.WithError(err).Panic("Unable to read cilium agent events from pipe")
 		}
 
 		m.send(&p)
 	}
 }
 
-// Init configures client connection handling and agent event handling.
-// Note that the perf buffer reader is started only when listeners are connected.
-func (m *Monitor) Init(ctx context.Context, npages int, agentPipe io.Reader, server net.Listener) (err error) {
+// NewMonitor creates a Monitor, and starts client connection handling and agent event
+// handling.
+// Note that the perf buffer reader is started only when listeners are
+// connected.
+func NewMonitor(ctx context.Context, nPages int, agentPipe io.Reader, server net.Listener) (m *Monitor, err error) {
+	m = &Monitor{
+		ctx:              ctx,
+		listeners:        make(map[*monitorListener]struct{}),
+		nPages:           nPages,
+		perfReaderCancel: func() {}, // no-op to avoid doing null checks everywhere
+	}
+
 	// start new listener handler
 	go m.connectionHandler(ctx, server)
 
 	// start agent event pipe reader
 	go m.agentPipeReader(ctx, agentPipe)
 
-	mutex.Lock()
-	defer mutex.Unlock()
-	nPages = npages
-
-	return nil
+	return m, nil
 }
 
-// startPerfEventReader spawns a singleton goroutine to read and distribute the
-// events. It passes a cancelable context to this goroutine and the cancelFunc
-// is assigned to perfReaderCancel. Note that cancelling parentCtx (e.g. on
-// program shutdown) will also cancel the derived context.
-func (m *Monitor) startPerfEventReader(parentCtx context.Context) {
-	mutex.Lock()
-	defer mutex.Unlock()
+// registerNewListener adds the new listener to the global list. It also spawns
+// a singleton goroutine to read and distribute the events. It passes a
+// cancelable context to this goroutine and the cancelFunc is assigned to
+// perfReaderCancel. Note that cancelling parentCtx (e.g. on program shutdown)
+// will also cancel the derived context.
+func (m *Monitor) registerNewListener(parentCtx context.Context, conn net.Conn) {
+	m.Lock()
+	defer m.Unlock()
 
-	perfReaderCancel() // don't leak any old readers, just in case.
-	perfEventReaderCtx, cancelFn := context.WithCancel(parentCtx)
-	perfReaderCancel = cancelFn
+	// If this is the first listener, start the perf reader
+	if len(m.listeners) == 0 {
+		m.perfReaderCancel() // don't leak any old readers, just in case.
+		perfEventReaderCtx, cancel := context.WithCancel(parentCtx)
+		m.perfReaderCancel = cancel
+		go m.perfEventReader(perfEventReaderCtx, m.nPages)
+	}
 
-	go m.perfEventReader(perfEventReaderCtx)
+	newListener := newMonitorListener(conn, m.removeListener)
+	m.listeners[newListener] = struct{}{}
+
+	log.WithField("count.listener", len(m.listeners)).Info("New listener connected.")
 }
 
-func (m *Monitor) perfEventReader(stopCtx context.Context) {
-	log.Info("Beginning to read perf buffer")
-	defer log.Info("Stopped reading perf buffer")
+// removeListener deletes the listener from the list, closes its queue, and
+// stops perfReader if this is the last listener
+func (m *Monitor) removeListener(ml *monitorListener) {
+	m.Lock()
+	defer m.Unlock()
+
+	delete(m.listeners, ml)
+	log.WithField("count.listener", len(m.listeners)).Info("Removed listener")
+
+	// If this was the final listener, shutdown the perf reader and unmap our
+	// ring buffer readers. This tells the kernel to not emit this data.
+	// Note: it is critical to hold the lock and check the number of listeners.
+	// This guards against an older generation MonitorListener calling the
+	// current generation perfReaderCancel
+	if len(m.listeners) == 0 {
+		m.perfReaderCancel()
+	}
+}
+
+// perfEventReader is a goroutine that reads events from the perf buffer. It
+// will exit when stopCtx is done. Note, however, that it will block in the
+// Poll call but assumes enough events are generated that these blocks are
+// short.
+func (m *Monitor) perfEventReader(stopCtx context.Context, nPages int) {
+	scopedLog := log.WithField(logfields.StartTime, time.Now())
+	scopedLog.Info("Beginning to read perf buffer")
+	defer scopedLog.Info("Stopped reading perf buffer")
 
 	// configure BPF perf buffer reader
 	c := bpf.DefaultPerfEventConfig()
 	c.NumPages = nPages
 
-	monEvents, err := bpf.NewPerCpuEvents(c)
+	monitorEvents, err := bpf.NewPerCpuEvents(c)
 	if err != nil {
-		log.WithError(err).Fatal("Cannot initialize BPF perf buffer reader")
-		return
+		scopedLog.WithError(err).Panic("Cannot initialise BPF perf ring buffer sockets")
 	}
+	defer monitorEvents.CloseAll()
 
-	defer monEvents.CloseAll()
-
-	// this is only used by .DumpStats()
-	mutex.Lock()
-	monitorEvents = monEvents
-	mutex.Unlock()
+	// update the class's monitorEvents This is only accessed by .DumpStats()
+	// also grab the callbacks we need to avoid locking again. These methods never change.
+	m.Lock()
+	m.monitorEvents = monitorEvents
+	receiveEvent := m.receiveEvent
+	lostEvent := m.lostEvent
+	m.Unlock()
 
 	last := time.Now()
-
 	for !isCtxDone(stopCtx) {
-		todo, err := monEvents.Poll(pollTimeout)
-		if err != nil {
-			log.WithError(err).Error("Error in Poll")
-			if err == syscall.EBADF {
-				break
-			}
+		todo, err := monitorEvents.Poll(pollTimeout)
+		switch {
+		case isCtxDone(stopCtx):
+			return
+
+		case err == syscall.EBADF:
+			return
+
+		case err != nil:
+			scopedLog.WithError(err).Error("Error in Poll")
+			continue
 		}
+
 		if todo > 0 {
-			if err := monEvents.ReadAll(m.receiveEvent, m.lostEvent); err != nil {
-				log.WithError(err).Warn("Error received while reading from perf buffer")
+			if err := monitorEvents.ReadAll(receiveEvent, lostEvent); err != nil {
+				scopedLog.WithError(err).Warn("Error received while reading from perf buffer")
 			}
 		}
 
@@ -170,13 +233,13 @@ func (m *Monitor) perfEventReader(stopCtx context.Context) {
 
 // dumpStat prints out the monitor status in JSON.
 func (m *Monitor) dumpStat() {
-	mutex.Lock()
-	defer mutex.Unlock()
+	m.Lock()
+	defer m.Unlock()
 
-	c := int64(monitorEvents.Cpus)
-	n := int64(monitorEvents.Npages)
-	p := int64(monitorEvents.Pagesize)
-	l, u := monitorEvents.Stats()
+	c := int64(m.monitorEvents.Cpus)
+	n := int64(m.monitorEvents.Npages)
+	p := int64(m.monitorEvents.Pagesize)
+	l, u := m.monitorEvents.Stats()
 	ms := models.MonitorStatus{Cpus: c, Npages: n, Pagesize: p, Lost: int64(l), Unknown: int64(u)}
 
 	mp, err := json.Marshal(ms)
@@ -187,29 +250,26 @@ func (m *Monitor) dumpStat() {
 	fmt.Println(string(mp))
 }
 
-// connectionHandler handles all the incoming connections.
+// connectionHandler handles all the incoming connections and sets up the
+// listener objects. It will block on Accept, but expects the caller to close
+// server, inducing a return.
 func (m *Monitor) connectionHandler(parentCtx context.Context, server net.Listener) {
-	for {
+	for !isCtxDone(parentCtx) {
 		conn, err := server.Accept()
-		if err != nil {
+		switch {
+		case isCtxDone(parentCtx) && conn != nil:
+			conn.Close()
+			fallthrough
+
+		case isCtxDone(parentCtx) && conn == nil:
+			return
+
+		case err != nil:
 			log.WithError(err).Warn("error accepting connection")
 			continue
 		}
 
-		var (
-			listenerCount int
-			newListener   = newMonitorListener(conn)
-		)
-		mutex.Lock()
-		listeners[newListener] = struct{}{}
-		listenerCount = len(listeners)
-		mutex.Unlock()
-		log.WithField("count.listener", listenerCount).Info("New monitor connected.")
-
-		// If this is the first listener, start reading the perf buffer
-		if listenerCount == 1 {
-			m.startPerfEventReader(parentCtx)
-		}
+		m.registerNewListener(parentCtx, conn)
 	}
 }
 
@@ -221,22 +281,10 @@ func (m *Monitor) send(pl *payload.Payload) {
 		log.WithError(err).Error("Unable to send notification to listeners")
 	}
 
-	mutex.Lock()
-	defer mutex.Unlock()
-	for ml := range listeners {
+	m.Lock()
+	defer m.Unlock()
+	for ml := range m.listeners {
 		ml.enqueue(buf)
-	}
-}
-
-func (ml *monitorListener) remove() {
-	mutex.Lock()
-	defer mutex.Unlock()
-
-	delete(listeners, ml)
-
-	// If this was the final listener, shutdown the perf reader
-	if len(listeners) == 0 {
-		perfReaderCancel()
 	}
 }
 
@@ -249,22 +297,24 @@ func (ml *monitorListener) enqueue(msg []byte) {
 }
 
 func (ml *monitorListener) drainQueue() {
+	defer func() {
+		ml.conn.Close()
+		ml.cleanupFn(ml)
+	}()
+
 	for msgBuf := range ml.queue {
 		if _, err := ml.conn.Write(msgBuf); err != nil {
-			ml.conn.Close()
-			ml.remove()
-
 			if op, ok := err.(*net.OpError); ok {
 				if syscerr, ok := op.Err.(*os.SyscallError); ok {
 					if errn, ok := syscerr.Err.(syscall.Errno); ok {
 						if errn == syscall.EPIPE {
-							log.Info("Monitor client disconnected")
+							log.Info("Listener disconnected")
 							return
 						}
 					}
 				}
 			}
-			log.WithError(err).Warn("Monitor removed due to write failure")
+			log.WithError(err).Warn("Removing listener due to write failure")
 			return
 		}
 	}

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -76,7 +76,7 @@ func (m *Monitor) agentPipeReader(agentPipe io.Reader, stop chan struct{}) {
 				log.WithError(err).Panic("Unable to read from agent pipe")
 			}
 
-			m.send(p)
+			m.send(&p)
 
 		case <-stop:
 			return
@@ -157,7 +157,7 @@ func (m *Monitor) handleConnection(server net.Listener) {
 
 // send writes the payload.Meta and the actual payload to the active
 // connections.
-func (m *Monitor) send(pl payload.Payload) {
+func (m *Monitor) send(pl *payload.Payload) {
 	mutex.Lock()
 	defer mutex.Unlock()
 	if len(listeners) == 0 {
@@ -213,10 +213,10 @@ func (ml *monitorListener) drainQueue() {
 
 func (m *Monitor) receiveEvent(es *bpf.PerfEventSample, c int) {
 	pl := payload.Payload{Data: es.DataCopy(), CPU: c, Lost: 0, Type: payload.EventSample}
-	m.send(pl)
+	m.send(&pl)
 }
 
 func (m *Monitor) lostEvent(el *bpf.PerfEventLost, c int) {
 	pl := payload.Payload{Data: []byte{}, CPU: c, Lost: el.Lost, Type: payload.RecordLost}
-	m.send(pl)
+	m.send(&pl)
 }

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -20,6 +20,9 @@ const (
 	// LogSubsys is the field denoting the subsystem when logging
 	LogSubsys = "subsys"
 
+	// Signal is the field to print os signals on exit etc.
+	Signal = "signal"
+
 	// Node is a host machine in the cluster, running cilium
 	Node = "node"
 


### PR DESCRIPTION
This PR is best reviewed commit by commit. The first two are a minimal set of changes. The final commit refactors the code more thoroughly. To fix #3979 only the first two are needed. This is relevant because I suspect we will need to backport the fix but I don't want to overcomplicated that.

This PR change node-monitor to only read the perf ring buffer when at least one client is connected. It will stop reading the buffer when the final client disconnects. It doesn't re-initialise the internal bpf structures, however. This might be a really bad thing and it's fairly easy to close and unmap things on stop, so let me know!

Fixes https://github.com/cilium/cilium/issues/3979