### PR TITLE
Bugtool: Fix gops commands

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -166,7 +166,7 @@ func copyConfigCommands(confDir string, k8sPods []string) []string {
 	// them to be one block is the pod prefix and namespace used in the
 	// path. This should be refactored.
 	if len(k8sPods) == 0 {
-		kernel, _ := execCommand("uname", "-r")
+		kernel, _ := execCommand("uname -r")
 		kernel = strings.TrimSpace(kernel)
 		// Append the boot config for the current kernel
 		l := Location{fmt.Sprintf("/boot/config-%s", kernel),
@@ -185,8 +185,7 @@ func copyConfigCommands(confDir string, k8sPods []string) []string {
 		// configs. Therefore we need copy commands for all the pods.
 		for _, pod := range k8sPods {
 			prompt := podPrefix(pod, "uname -r")
-			cmd, args := split(prompt)
-			kernel, _ := execCommand(cmd, args...)
+			kernel, _ := execCommand(prompt)
 			kernel = strings.TrimSpace(kernel)
 			l := Location{fmt.Sprintf("/boot/config-%s", kernel),
 				fmt.Sprintf("%s/kernel-config-%s", confDir, kernel)}

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -309,11 +309,10 @@ func runAll(commands []string, cmdDir string, k8sPods []string) {
 	wg.Wait()
 }
 
-func execCommand(cmd string, args ...string) (string, error) {
-	fmt.Printf("exec: %s %s\n", cmd, args)
+func execCommand(prompt string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), execTimeout)
 	defer cancel()
-	output, err := exec.CommandContext(ctx, cmd, args...).CombinedOutput()
+	output, err := exec.CommandContext(ctx, "bash", "-c", prompt).CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
 		return "", fmt.Errorf("exec timeout")
 	}
@@ -353,7 +352,7 @@ func writeCmdToFile(cmdDir, prompt string, k8sPods []string) {
 		}
 	}
 	// Write prompt as header and the output as body, and / or error but delete empty output.
-	output, err := execCommand(cmd, args...)
+	output, err := execCommand(prompt)
 	if err != nil {
 		fmt.Fprintf(f, fmt.Sprintf("> Error while running '%s':  %s\n\n", prompt, err))
 	}
@@ -386,7 +385,7 @@ func split(prompt string) (string, []string) {
 }
 
 func getCiliumPods(namespace, label string) ([]string, error) {
-	output, err := execCommand("kubectl", "-n", namespace, "get", "pods", "-l", label)
+	output, err := execCommand(fmt.Sprintf("kubectl -n %s get pods -l %s", namespace, label))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Due the changes made in `4fa2bcad0d1c92e12dffdf89513fb59aff915003`
bugtool cannot retrieve gops stacks correctly. The main issue is that
bugtool use `os.exec` and never pass that information to bash, so the
output of gops stack was not correct. More info in #3981

With this change all commands run on bash, so parameters can be
retrieved without issues.

Fix #3981

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
