### PR TITLE
envoy: Better error logging.

### DIFF
--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -199,6 +199,9 @@ const (
 	// XDSResource is an xDS resource message.
 	XDSResource = "xdsResource"
 
+	// XDSErrorDetail is an optional error message returned with a NACK
+	XDSErrorDetail = "xdsErrorDetail"
+
 	// K8s-specific
 
 	// K8sNodeID is the k8s ID of a K8sNode


### PR DESCRIPTION
While we don't want to log too much when debug is not enabled, we
should log all messages on the xDS stream if we ever receive a NACK,
which indicates a bug. To do this keep track if the last message from
Envoy was an ACK or NACK and log sent resources at Info level if we
received a NACK. This helps in cases where we repeatedly send
incorrect configuration to Envoy.

Envoy xDS messages have added an optional Status message, which can
carry an error message from Envoy to Cilium. Log that whenever
included in a request.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4002)
<!-- Reviewable:end -->
