### PR TITLE
Sorting controller output by name (alphabetical) in status command

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -274,6 +275,7 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, allAddresses, 
 		fmt.Fprintf(w, "Controller Status:\t%d/%d healthy\n", nOK, len(sr.Controllers))
 		if len(out) > 1 {
 			tab := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+			sort.Strings(out)
 			for _, s := range out {
 				fmt.Fprint(tab, s)
 			}


### PR DESCRIPTION
Signed-off-by: Shantanu Deshpande <shantanud106@gmail.com>

**Summary of changes**:

Sorting controller output in `cilium status` command alphabetically. Ex output:
```
Controller Status:      7/7 healthy
  Name                                 Last success   Last error   Count   Message
  ipcache-bpf-garbage-collection       24s ago        never        0       no error
  kvstore-lease-keepalive              26s ago        never        0       no error
  lxcmap-bpf-host-sync                 4s ago         never        0       no error
  resolve-identity-29898               21s ago        never        0       no error
  sync-IPv4-identity-mapping (29898)   21s ago        never        0       no error
  sync-IPv6-identity-mapping (29898)   21s ago        never        0       no error
  sync-identity-to-k8s-pod (29898)     21s ago        never        0       no error
```

Fixes: #3999 
