### PR TITLE
Backport/v1.0 2018 05 04

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -166,7 +166,7 @@ func copyConfigCommands(confDir string, k8sPods []string) []string {
 	// them to be one block is the pod prefix and namespace used in the
 	// path. This should be refactored.
 	if len(k8sPods) == 0 {
-		kernel, _ := execCommand("uname", "-r")
+		kernel, _ := execCommand("uname -r")
 		kernel = strings.TrimSpace(kernel)
 		// Append the boot config for the current kernel
 		l := Location{fmt.Sprintf("/boot/config-%s", kernel),
@@ -185,8 +185,7 @@ func copyConfigCommands(confDir string, k8sPods []string) []string {
 		// configs. Therefore we need copy commands for all the pods.
 		for _, pod := range k8sPods {
 			prompt := podPrefix(pod, "uname -r")
-			cmd, args := split(prompt)
-			kernel, _ := execCommand(cmd, args...)
+			kernel, _ := execCommand(prompt)
 			kernel = strings.TrimSpace(kernel)
 			l := Location{fmt.Sprintf("/boot/config-%s", kernel),
 				fmt.Sprintf("%s/kernel-config-%s", confDir, kernel)}

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -309,11 +309,10 @@ func runAll(commands []string, cmdDir string, k8sPods []string) {
 	wg.Wait()
 }
 
-func execCommand(cmd string, args ...string) (string, error) {
-	fmt.Printf("exec: %s %s\n", cmd, args)
+func execCommand(prompt string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), execTimeout)
 	defer cancel()
-	output, err := exec.CommandContext(ctx, cmd, args...).CombinedOutput()
+	output, err := exec.CommandContext(ctx, "bash", "-c", prompt).CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
 		return "", fmt.Errorf("exec timeout")
 	}
@@ -353,7 +352,7 @@ func writeCmdToFile(cmdDir, prompt string, k8sPods []string) {
 		}
 	}
 	// Write prompt as header and the output as body, and / or error but delete empty output.
-	output, err := execCommand(cmd, args...)
+	output, err := execCommand(prompt)
 	if err != nil {
 		fmt.Fprintf(f, fmt.Sprintf("> Error while running '%s':  %s\n\n", prompt, err))
 	}
@@ -386,7 +385,7 @@ func split(prompt string) (string, []string) {
 }
 
 func getCiliumPods(namespace, label string) ([]string, error) {
-	output, err := execCommand("kubectl", "-n", namespace, "get", "pods", "-l", label)
+	output, err := execCommand(fmt.Sprintf("kubectl -n %s get pods -l %s", namespace, label))
 	if err != nil {
 		return nil, err
 	}

--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -100,7 +100,8 @@ func (res *CmdRes) CountLines() int {
 
 // CombineOutput returns the combined output of stdout and stderr for res.
 func (res *CmdRes) CombineOutput() *bytes.Buffer {
-	result := res.stdout
+	result := new(bytes.Buffer)
+	result.WriteString(res.stdout.String())
 	result.WriteString(res.stderr.String())
 	return result
 }

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -153,7 +153,7 @@ var _ = Describe(demoTestName, func() {
 
 		By("Showing how alliance can execute REST API call to main API endpoint")
 		res = kubectl.Exec(fmt.Sprintf("kubectl exec -it %s -- curl -s --output /dev/stderr -w '%%{http_code}' -XGET %s/v1", xwingPod, deathstarServiceName))
-		res.ExpectContains("200", "unable to curl %s/v1: %s", deathstarServiceName, res.CombineOutput())
+		res.ExpectContains("200", "unable to curl %s/v1: %s", deathstarServiceName, res.Output())
 
 		By(fmt.Sprintf("Importing L7 Policy which restricts access to %s", exhaustPortPath))
 		kubectl.Delete(l4PolicyYAMLLink)
@@ -167,12 +167,12 @@ var _ = Describe(demoTestName, func() {
 		By(fmt.Sprintf("Showing how alliance cannot access %s without force header in API request after importing L7 Policy", exhaustPortPath))
 		res = kubectl.Exec(fmt.Sprintf(`kubectl exec -it %s -- curl -s --output /dev/stderr -w '%%{http_code}' -XPUT %s`, xwingPod, exhaustPortPath))
 
-		res.ExpectContains("403", "able to access %s when policy disallows it; %s", exhaustPortPath, res.CombineOutput())
+		res.ExpectContains("403", "able to access %s when policy disallows it; %s", exhaustPortPath, res.Output())
 
 		By(fmt.Sprintf("Showing how alliance can access %s with force header in API request to attack the deathstar", exhaustPortPath))
 		res = kubectl.Exec(fmt.Sprintf(`kubectl exec -it %s -- curl -s --output /dev/stderr -w '%%{http_code}' -H 'X-Has-Force: True' -XPUT %s`, xwingPod, exhaustPortPath))
 		By("Expecting 503 to be returned when using force header to attack the deathstar")
-		res.ExpectContains("503", "unable to access %s when policy allows it; %s", deathstarServiceName, res.CombineOutput())
+		res.ExpectContains("503", "unable to access %s when policy allows it; %s", deathstarServiceName, res.Output())
 	})
 
 })

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -161,9 +161,10 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 		By("Sending consume request on kafka topic `allowedTopic`")
 		res = consumer(allowedTopic, MaxMessages)
 		res.ExpectSuccess("Failed to consume messages from kafka topic `allowedTopic`")
+		Expect(res.CombineOutput().String()).
+			Should(ContainSubstring("Processed a total of %d messages", MaxMessages),
+				"Kafka did not process the expected number of messages")
 
-		Expect(res.Output().String()).Should(ContainSubstring(
-			"Processed a total of %d messages", MaxMessages))
 		By("Disable topic")
 		res = consumer(disallowTopic, MaxMessages)
 		res.ExpectFail("Kafka consumer can access to disallowTopic")
@@ -201,9 +202,9 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 		By("Sending consume request on kafka topic `allowedTopic`")
 		res = consumer(allowedTopic, MaxMessages)
 		res.ExpectSuccess("Failed to consume messages from kafka topic `allowedTopic`")
-
-		Expect(res.Output().String()).Should(ContainSubstring(
-			"Processed a total of %d messages", MaxMessages))
+		Expect(res.CombineOutput().String()).
+			Should(ContainSubstring("Processed a total of %d messages", MaxMessages),
+				"Kafka did not process the expected number of messages")
 
 		By("Disable topic")
 		// Consumer timeout didn't work correctly, so make sure that AUTH is present in the reply


### PR DESCRIPTION
- daemon: Check if device exists on endpoint restore
    [ upstream commit baefa4b9bc500224466895ac5aad597539d8b830 ]
    https://github.com/cilium/cilium/pull/3959

- Bugtool: Fix gops commands
    [ upstream commit 51e865530ab2c7c7bd0a202cf358e8a363fefbbd ]
    https://github.com/cilium/cilium/pull/3996

- test: CmdRes.CombineOutput does not clobber stdout
    [ upstream commit 88f467fa0971d77eade0e7a42c2bc904cdee90eb ]
    https://github.com/cilium/cilium/pull/3957

- test: Switch Kafka runtime test to use CombineOutput
    [ upstream commit 643d4f3a091ec5e4fc581d1fab2d32a37048f565 ]
    https://github.com/cilium/cilium/pull/3957

- test: Star Wars demo checks HTTP status in stdout
    [ upstream commit 005cb21e40cf260c4da03f31f833a52db3915f4f ]
    https://github.com/cilium/cilium/pull/3957