### PR TITLE
test: misc. CI improvements

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -471,7 +471,7 @@ func (kub *Kubectl) WaitforPods(namespace string, filter string, timeout time.Du
 // to have their port equal to the provided port. Returns true if all pods achieve
 // the aforementioned desired state within timeout seconds. Returns false and
 // an error if the command failed or the timeout was exceeded.
-func (kub *Kubectl) WaitForServiceEndpoints(namespace string, filter string, service string, port string, timeout time.Duration) (bool, error) {
+func (kub *Kubectl) WaitForServiceEndpoints(namespace string, filter string, service string, port string, timeout time.Duration) error {
 	body := func() bool {
 		var jsonPath = fmt.Sprintf("{.items[?(@.metadata.name =='%s')].subsets[0].ports[0].port}", service)
 		data, err := kub.GetEndpoints(namespace, filter).Filter(jsonPath)
@@ -495,11 +495,7 @@ func (kub *Kubectl) WaitForServiceEndpoints(namespace string, filter string, ser
 		return false
 	}
 
-	err := WithTimeout(body, "could not get service endpoints", &TimeoutConfig{Timeout: timeout})
-	if err != nil {
-		return false, err
-	}
-	return true, nil
+	return WithTimeout(body, "could not get service endpoints", &TimeoutConfig{Timeout: timeout})
 }
 
 // Action performs the specified ResourceLifeCycleAction on the Kubernetes

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -341,7 +341,7 @@ func (kub *Kubectl) Logs(namespace string, pod string) *CmdRes {
 // ManifestGet returns the full path of the given manifest corresponding to the
 // Kubernetes version being tested, if such a manifest exists, if not it
 // returns the global manifest file.
-func (kub *Kubectl) ManifestGet(manifestFilename string) string {
+func ManifestGet(manifestFilename string) string {
 	fullPath := filepath.Join(manifestsPath, GetCurrentK8SEnv(), manifestFilename)
 	_, err := os.Stat(fullPath)
 	if err == nil {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -338,18 +338,6 @@ func (kub *Kubectl) Logs(namespace string, pod string) *CmdRes {
 		fmt.Sprintf("%s -n %s logs %s", KubectlCmd, namespace, pod))
 }
 
-// ManifestGet returns the full path of the given manifest corresponding to the
-// Kubernetes version being tested, if such a manifest exists, if not it
-// returns the global manifest file.
-func ManifestGet(manifestFilename string) string {
-	fullPath := filepath.Join(manifestsPath, GetCurrentK8SEnv(), manifestFilename)
-	_, err := os.Stat(fullPath)
-	if err == nil {
-		return filepath.Join(BasePath, fullPath)
-	}
-	return filepath.Join(BasePath, "k8sT", "manifests", manifestFilename)
-}
-
 // MicroscopeStart installs (if it is not installed) a new microscope pod,
 // waits until pod is ready, and runs microscope in background. It returns an
 // error in the case where microscope cannot be installed, or it is not ready after

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -342,12 +342,12 @@ func (kub *Kubectl) Logs(namespace string, pod string) *CmdRes {
 // Kubernetes version being tested, if such a manifest exists, if not it
 // returns the global manifest file.
 func (kub *Kubectl) ManifestGet(manifestFilename string) string {
-	fullPath := fmt.Sprintf("%s/%s/%s", manifestsPath, GetCurrentK8SEnv(), manifestFilename)
+	fullPath := filepath.Join(manifestsPath, GetCurrentK8SEnv(), manifestFilename)
 	_, err := os.Stat(fullPath)
 	if err == nil {
-		return fmt.Sprintf("%s/%s", BasePath, fullPath)
+		return filepath.Join(BasePath, fullPath)
 	}
-	return fmt.Sprintf("%s/k8sT/manifests/%s", BasePath, manifestFilename)
+	return filepath.Join(BasePath, "k8sT", "manifests", manifestFilename)
 }
 
 // MicroscopeStart installs (if it is not installed) a new microscope pod,

--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -475,11 +475,11 @@ func (t *TestSpec) ApplyManifest() (string, error) {
 	if !res.WasSuccessful() {
 		return "", fmt.Errorf("%s", res.CombineOutput())
 	}
-	status, err := t.Kub.WaitforPods(
+	err = t.Kub.WaitforPods(
 		helpers.DefaultNamespace,
 		fmt.Sprintf("-l zgroup=%s", t.Prefix),
 		600)
-	if err != nil || !status {
+	if err != nil {
 		return "", err
 	}
 	return t.GetManifestName(), nil

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -192,9 +192,8 @@ func InstallExampleCilium(kubectl *Kubectl) {
 	kubectl.Apply(GetFilePath(newCiliumDSName)).ExpectSuccess(
 		"cannot apply cilium example daemonset")
 
-	status, err := kubectl.WaitforPods(
+	err = kubectl.WaitforPods(
 		KubeSystemNamespace, "-l k8s-app=cilium", timeout)
-	ExpectWithOffset(1, status).Should(BeTrue(), "Cilium is not ready after timeout")
 	ExpectWithOffset(1, err).Should(BeNil(), "Cilium is not ready after timeout")
 
 	ginkgo.By(fmt.Sprintf("Checking that installed image is %q", StableImage))

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -370,3 +370,15 @@ func DecodeYAMLOrJSON(path string) ([]interface{}, error) {
 	}
 	return result, nil
 }
+
+// ManifestGet returns the full path of the given manifest corresponding to the
+// Kubernetes version being tested, if such a manifest exists, if not it
+// returns the global manifest file.
+func ManifestGet(manifestFilename string) string {
+	fullPath := filepath.Join(manifestsPath, GetCurrentK8SEnv(), manifestFilename)
+	_, err := os.Stat(fullPath)
+	if err == nil {
+		return filepath.Join(BasePath, fullPath)
+	}
+	return filepath.Join(BasePath, "k8sT", "manifests", manifestFilename)
+}

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -16,7 +16,6 @@ package k8sTest
 
 import (
 	"fmt"
-	"sync"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -29,14 +28,13 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 
 	var (
 		kubectl       *helpers.Kubectl
-		once          sync.Once
 		logger        = log.WithFields(logrus.Fields{"testName": "K8sChaosTest"})
 		demoDSPath    = helpers.ManifestGet("demo_ds.yaml")
 		ciliumPath    = helpers.ManifestGet("cilium_ds.yaml")
 		testDSService = "testds-service.default.svc.cluster.local"
 	)
 
-	initialize := func() {
+	BeforeAll(func() {
 		logger.Info("Starting")
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		kubectl.Apply(ciliumPath)
@@ -46,10 +44,9 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 
 		err = kubectl.WaitKubeDNS()
 		Expect(err).Should(BeNil())
-	}
+	})
 
 	BeforeEach(func() {
-		once.Do(initialize)
 		kubectl.Apply(demoDSPath).ExpectSuccess("DS deployment cannot be applied")
 
 		_, err := kubectl.WaitforPods(

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -109,8 +109,7 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 			helpers.KubectlCmd, helpers.KubeSystemNamespace))
 		res.ExpectSuccess()
 
-		err = kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
-		Expect(err).Should(BeNil(), "Cilium is not ready after deleting some pods")
+		ExpectCiliumReady(kubectl)
 
 		PingService()
 
@@ -126,8 +125,7 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 		res = kubectl.Apply(ciliumPath)
 		res.ExpectSuccess(res.GetDebugMessage())
 
-		err = kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
-		Expect(err).Should(BeNil(), "Cilium is not ready after deleting some pods")
+		ExpectCiliumReady(kubectl)
 
 		PingService()
 	})

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -27,12 +27,14 @@ import (
 
 var _ = Describe("K8sValidatedChaosTest", func() {
 
-	var kubectl *helpers.Kubectl
-	var logger *logrus.Entry
-	var once sync.Once
-	var demoDSPath string
-	var ciliumPath string
-	var testDSService string = "testds-service.default.svc.cluster.local"
+	var (
+		kubectl       *helpers.Kubectl
+		logger        *logrus.Entry
+		once          sync.Once
+		demoDSPath    string
+		ciliumPath    string
+		testDSService string = "testds-service.default.svc.cluster.local"
+	)
 
 	initialize := func() {
 		logger = log.WithFields(logrus.Fields{"testName": "K8sChaosTest"})

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -39,11 +39,8 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		kubectl.Apply(ciliumPath)
 
-		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
-		Expect(err).Should(BeNil())
-
-		err = kubectl.WaitKubeDNS()
-		Expect(err).Should(BeNil())
+		ExpectCiliumReady(kubectl)
+		ExpectKubeDNSReady(kubectl)
 	})
 
 	BeforeEach(func() {

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -46,7 +46,7 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 	BeforeEach(func() {
 		kubectl.Apply(demoDSPath).ExpectSuccess("DS deployment cannot be applied")
 
-		_, err := kubectl.WaitforPods(
+		err := kubectl.WaitforPods(
 			helpers.DefaultNamespace, fmt.Sprintf("-l zgroup=testDS"), 300)
 		Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 	})
@@ -97,7 +97,7 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 	}
 
 	It("Endpoint can still connect while Cilium is not running", func() {
-		_, err := kubectl.WaitforPods(
+		err := kubectl.WaitforPods(
 			helpers.DefaultNamespace,
 			fmt.Sprintf("-l zgroup=testDSClient"), 300)
 		Expect(err).Should(BeNil(), "Pods are not ready after timeout")
@@ -109,7 +109,7 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 			helpers.KubectlCmd, helpers.KubeSystemNamespace))
 		res.ExpectSuccess()
 
-		_, err = kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
+		err = kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 		Expect(err).Should(BeNil(), "Cilium is not ready after deleting some pods")
 
 		PingService()
@@ -126,7 +126,7 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 		res = kubectl.Apply(ciliumPath)
 		res.ExpectSuccess(res.GetDebugMessage())
 
-		_, err = kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
+		err = kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 		Expect(err).Should(BeNil(), "Cilium is not ready after deleting some pods")
 
 		PingService()

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -64,8 +64,7 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 	AfterEach(func() {
 		kubectl.Delete(demoDSPath).ExpectSuccess(
 			"%s deployment cannot be deleted", demoDSPath)
-		err := kubectl.WaitCleanAllTerminatingPods()
-		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
+		ExpectAllPodsTerminated(kubectl)
 
 	})
 
@@ -119,8 +118,7 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 		res = kubectl.Delete(ciliumPath)
 		res.ExpectSuccess(res.GetDebugMessage())
 
-		err = kubectl.WaitCleanAllTerminatingPods()
-		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
+		ExpectAllPodsTerminated(kubectl)
 
 		PingService()
 

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -40,7 +40,7 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
-		ciliumPath = kubectl.ManifestGet("cilium_ds.yaml")
+		ciliumPath = helpers.ManifestGet("cilium_ds.yaml")
 		kubectl.Apply(ciliumPath)
 
 		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
@@ -49,7 +49,7 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 		err = kubectl.WaitKubeDNS()
 		Expect(err).Should(BeNil())
 
-		demoDSPath = kubectl.ManifestGet("demo_ds.yaml")
+		demoDSPath = helpers.ManifestGet("demo_ds.yaml")
 	}
 
 	BeforeEach(func() {

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -29,20 +29,16 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 
 	var (
 		kubectl       *helpers.Kubectl
-		logger        *logrus.Entry
 		once          sync.Once
-		demoDSPath    string
-		ciliumPath    string
-		testDSService string = "testds-service.default.svc.cluster.local"
+		logger        = log.WithFields(logrus.Fields{"testName": "K8sChaosTest"})
+		demoDSPath    = helpers.ManifestGet("demo_ds.yaml")
+		ciliumPath    = helpers.ManifestGet("cilium_ds.yaml")
+		testDSService = "testds-service.default.svc.cluster.local"
 	)
 
 	initialize := func() {
-		logger = log.WithFields(logrus.Fields{"testName": "K8sChaosTest"})
 		logger.Info("Starting")
-
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-
-		ciliumPath = helpers.ManifestGet("cilium_ds.yaml")
 		kubectl.Apply(ciliumPath)
 
 		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
@@ -50,8 +46,6 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 
 		err = kubectl.WaitKubeDNS()
 		Expect(err).Should(BeNil())
-
-		demoDSPath = helpers.ManifestGet("demo_ds.yaml")
 	}
 
 	BeforeEach(func() {

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -39,8 +39,7 @@ var _ = Describe(testName, func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		path := helpers.ManifestGet("cilium_ds.yaml")
 		kubectl.Apply(path)
-		err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
-		Expect(err).Should(BeNil())
+		ExpectCiliumReady(kubectl)
 	}
 
 	BeforeEach(func() {

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -29,9 +29,12 @@ var testName = "K8sValidatedHealthTest"
 
 var _ = Describe(testName, func() {
 
-	var kubectl *helpers.Kubectl
-	var logger *logrus.Entry
-	var once sync.Once
+	var (
+		kubectl *helpers.Kubectl
+		logger  *logrus.Entry
+		once    sync.Once
+	)
+
 	initialize := func() {
 		logger = log.WithFields(logrus.Fields{"testName": testName})
 		logger.Info("Starting")

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -59,8 +59,7 @@ var _ = Describe(testName, func() {
 	})
 
 	AfterEach(func() {
-		err := kubectl.WaitCleanAllTerminatingPods()
-		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
+		ExpectAllPodsTerminated(kubectl)
 	})
 
 	getCilium := func(node string) (pod, ip string) {

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -39,7 +39,7 @@ var _ = Describe(testName, func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		path := helpers.ManifestGet("cilium_ds.yaml")
 		kubectl.Apply(path)
-		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
+		err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 		Expect(err).Should(BeNil())
 	}
 

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -37,7 +37,7 @@ var _ = Describe(testName, func() {
 		logger.Info("Starting")
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-		path := kubectl.ManifestGet("cilium_ds.yaml")
+		path := helpers.ManifestGet("cilium_ds.yaml")
 		kubectl.Apply(path)
 		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 		Expect(err).Should(BeNil())

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -16,7 +16,6 @@ package k8sTest
 
 import (
 	"fmt"
-	"sync"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -31,22 +30,16 @@ var _ = Describe(testName, func() {
 
 	var (
 		kubectl *helpers.Kubectl
-		logger  *logrus.Entry
-		once    sync.Once
+		logger  = log.WithFields(logrus.Fields{"testName": testName})
 	)
 
-	initialize := func() {
-		logger = log.WithFields(logrus.Fields{"testName": testName})
+	BeforeAll(func() {
 		logger.Info("Starting")
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-		path := helpers.ManifestGet("cilium_ds.yaml")
-		kubectl.Apply(path)
+		ciliumYAML := helpers.ManifestGet("cilium_ds.yaml")
+		kubectl.Apply(ciliumYAML)
 		ExpectCiliumReady(kubectl)
-	}
-
-	BeforeEach(func() {
-		once.Do(initialize)
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -93,8 +93,7 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 		_ = kubectl.Delete(demoPath)
 		_ = kubectl.Delete(l7Policy)
 
-		err := kubectl.WaitCleanAllTerminatingPods()
-		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
+		ExpectAllPodsTerminated(kubectl)
 
 	})
 

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -61,7 +61,7 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 		ExpectKubeDNSReady(kubectl)
 
 		kubectl.Apply(demoPath)
-		_, err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=kafkaTestApp", 300)
+		err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=kafkaTestApp", 300)
 		Expect(err).Should(BeNil(), "Kafka Pods are not ready after timeout")
 
 		appPods = helpers.GetAppPods(apps, helpers.DefaultNamespace, kubectl, "app")

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -29,36 +29,32 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 
 	var microscopeErr error
 	var microscopeCancel func() error
-	var demoPath string
 	var kubectl *helpers.Kubectl
-	var l7Policy string
-	var logger *logrus.Entry
 	var ciliumPod string
 
 	var (
-		kafkaApp    string            = "kafka"
-		zookApp     string            = "zook"
-		backupApp   string            = "empire-backup"
-		empireHqApp string            = "empire-hq"
-		outpostApp  string            = "empire-outpost"
-		apps        []string          = []string{kafkaApp, zookApp, backupApp, empireHqApp, outpostApp}
-		appPods     map[string]string = map[string]string{}
+		logger      = log.WithFields(logrus.Fields{"testName": "K8sValidatedKafkaPolicyTest"})
+		l7Policy    = helpers.ManifestGet("kafka-sw-security-policy.yaml")
+		demoPath    = helpers.ManifestGet("kafka-sw-app.yaml")
+		kafkaApp    = "kafka"
+		zookApp     = "zook"
+		backupApp   = "empire-backup"
+		empireHqApp = "empire-hq"
+		outpostApp  = "empire-outpost"
+		apps        = []string{kafkaApp, zookApp, backupApp, empireHqApp, outpostApp}
+		appPods     = map[string]string{}
 
-		prodHqAnnounce    string = `-c "echo 'Happy 40th Birthday to General Tagge' | ./kafka-produce.sh --topic empire-announce"`
-		conOutpostAnnoune string = `-c "./kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1"`
-		prodHqDeathStar   string = `-c "echo 'deathstar reactor design v3' | ./kafka-produce.sh --topic deathstar-plans"`
-		conOutDeathStar   string = `-c "./kafka-consume.sh --topic deathstar-plans --from-beginning --max-messages 1"`
-		prodBackAnnounce  string = `-c "echo 'Happy 40th Birthday to General Tagge' | ./kafka-produce.sh --topic empire-announce"`
-		prodOutAnnounce   string = `-c "echo 'Vader Booed at Empire Karaoke Party' | ./kafka-produce.sh --topic empire-announce"`
+		prodHqAnnounce    = `-c "echo 'Happy 40th Birthday to General Tagge' | ./kafka-produce.sh --topic empire-announce"`
+		conOutpostAnnoune = `-c "./kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1"`
+		prodHqDeathStar   = `-c "echo 'deathstar reactor design v3' | ./kafka-produce.sh --topic deathstar-plans"`
+		conOutDeathStar   = `-c "./kafka-consume.sh --topic deathstar-plans --from-beginning --max-messages 1"`
+		prodBackAnnounce  = `-c "echo 'Happy 40th Birthday to General Tagge' | ./kafka-produce.sh --topic empire-announce"`
+		prodOutAnnounce   = `-c "echo 'Vader Booed at Empire Karaoke Party' | ./kafka-produce.sh --topic empire-announce"`
 	)
 
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"testName": "K8sValidatedKafkaPolicyTest"})
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-
-		//Manifest paths
-		demoPath = helpers.ManifestGet("kafka-sw-app.yaml")
-		l7Policy = helpers.ManifestGet("kafka-sw-security-policy.yaml")
 
 		kubectl.Apply(helpers.ManifestGet("cilium_ds.yaml"))
 		status, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -57,15 +57,11 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
 		kubectl.Apply(helpers.ManifestGet("cilium_ds.yaml"))
-		status, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)
-		Expect(status).Should(BeTrue(), "Cilium is not ready after timeout")
-		Expect(err).Should(BeNil(), "Cilium is not ready after timeout")
-
-		err = kubectl.WaitKubeDNS()
-		Expect(err).Should(BeNil(), "DNS is not ready after timeout")
+		ExpectCiliumReady(kubectl)
+		ExpectKubeDNSReady(kubectl)
 
 		kubectl.Apply(demoPath)
-		_, err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=kafkaTestApp", 300)
+		_, err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=kafkaTestApp", 300)
 		Expect(err).Should(BeNil(), "Kafka Pods are not ready after timeout")
 
 		appPods = helpers.GetAppPods(apps, helpers.DefaultNamespace, kubectl, "app")

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -57,10 +57,10 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
 		//Manifest paths
-		demoPath = kubectl.ManifestGet("kafka-sw-app.yaml")
-		l7Policy = kubectl.ManifestGet("kafka-sw-security-policy.yaml")
+		demoPath = helpers.ManifestGet("kafka-sw-app.yaml")
+		l7Policy = helpers.ManifestGet("kafka-sw-security-policy.yaml")
 
-		kubectl.Apply(kubectl.ManifestGet("cilium_ds.yaml"))
+		kubectl.Apply(helpers.ManifestGet("cilium_ds.yaml"))
 		status, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)
 		Expect(status).Should(BeTrue(), "Cilium is not ready after timeout")
 		Expect(err).Should(BeNil(), "Cilium is not ready after timeout")

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -61,7 +61,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 		ciliumPath = helpers.ManifestGet("cilium_ds.yaml")
 		kubectl.Apply(ciliumPath)
 
-		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
+		err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 		Expect(err).Should(BeNil())
 
 		ExpectKubeDNSReady(kubectl)
@@ -123,10 +123,9 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 
 		deployEndpoints()
 		waitForPodsTime := b.Time("Wait for pods", func() {
-			pods, err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", endpointTimeout)
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", endpointTimeout)
 			Expect(err).Should(BeNil(),
 				"Cannot retrieve %d pods in %d seconds", endpointCount, endpointsTimeout)
-			Expect(pods).Should(BeTrue())
 		})
 
 		log.WithFields(logrus.Fields{"pod creation time": waitForPodsTime}).Info("")
@@ -252,7 +251,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 			pipePath := "/tmp/nc_pipe.txt"
 			listeningString := "listening on [::]:8888"
 
-			_, err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=netcatds", 600)
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=netcatds", 600)
 			Expect(err).To(BeNil(), "Pods are not ready after timeout")
 
 			netcatPods, err := kubectl.GetPodNames(helpers.DefaultNamespace, "zgroup=netcatds")
@@ -387,7 +386,7 @@ var _ = Describe("NightlyExamples", func() {
 
 		It("Check Kubernetes Example is working correctly", func() {
 			kubectl.Apply(demoPath).ExpectSuccess()
-			_, err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", timeout)
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", timeout)
 			Expect(err).Should(BeNil())
 
 			_, err = kubectl.CiliumPolicyAction(
@@ -424,7 +423,7 @@ var _ = Describe("NightlyExamples", func() {
 		BeforeEach(func() {
 			path := helpers.ManifestGet("cilium_ds.yaml")
 			kubectl.Apply(path)
-			_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
+			err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 			Expect(err).Should(BeNil())
 
 			ExpectKubeDNSReady(kubectl)
@@ -448,7 +447,7 @@ var _ = Describe("NightlyExamples", func() {
 			By("Testing the example config")
 			kubectl.Apply(AppManifest).ExpectSuccess("cannot install the GRPC application")
 
-			_, err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=grpcExample", 300)
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=grpcExample", 300)
 			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 
 			res := kubectl.ExecPodCmd(

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -72,8 +72,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 		kubectl.Exec(fmt.Sprintf(
 			"%s delete --all pods,svc,cnp -n %s", helpers.KubectlCmd, helpers.DefaultNamespace))
 
-		err = kubectl.WaitCleanAllTerminatingPods()
-		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
+		ExpectAllPodsTerminated(kubectl)
 	}
 
 	BeforeEach(func() {
@@ -91,11 +90,10 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 	})
 
 	AfterEach(func() {
-		err := kubectl.WaitCleanAllTerminatingPods()
-		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
+		ExpectAllPodsTerminated(kubectl)
 
 		kubectl.Delete(vagrantManifestPath)
-		kubectl.WaitCleanAllTerminatingPods()
+		ExpectAllPodsTerminated(kubectl)
 	})
 
 	deployEndpoints := func() {
@@ -348,8 +346,7 @@ var _ = Describe("NightlyExamples", func() {
 		kubectl.Exec(fmt.Sprintf(
 			"%s delete --all pods,svc,cnp -n %s", helpers.KubectlCmd, helpers.DefaultNamespace))
 
-		err := kubectl.WaitCleanAllTerminatingPods()
-		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
+		ExpectAllPodsTerminated(kubectl)
 	}
 
 	BeforeEach(func() {
@@ -371,8 +368,7 @@ var _ = Describe("NightlyExamples", func() {
 		kubectl.Delete(l3Policy)
 		kubectl.Delete(l7Policy)
 
-		err := kubectl.WaitCleanAllTerminatingPods()
-		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
+		ExpectAllPodsTerminated(kubectl)
 	})
 
 	Context("Cilium DaemonSet from example", func() {
@@ -437,8 +433,7 @@ var _ = Describe("NightlyExamples", func() {
 		})
 
 		AfterEach(func() {
-			err := kubectl.WaitCleanAllTerminatingPods()
-			Expect(err).To(BeNil(), "cannot clean all terminating pods")
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		It("GRPC example", func() {

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -64,8 +64,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 		Expect(err).Should(BeNil())
 
-		err = kubectl.WaitKubeDNS()
-		Expect(err).Should(BeNil())
+		ExpectKubeDNSReady(kubectl)
 
 		// Sometimes PolicyGen has a lot of pods running around without delete
 		// it. Using this we are sure that we delete before this test start
@@ -428,8 +427,7 @@ var _ = Describe("NightlyExamples", func() {
 			_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 			Expect(err).Should(BeNil())
 
-			err = kubectl.WaitKubeDNS()
-			Expect(err).Should(BeNil())
+			ExpectKubeDNSReady(kubectl)
 		})
 
 		AfterEach(func() {

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -61,9 +61,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 		ciliumPath = helpers.ManifestGet("cilium_ds.yaml")
 		kubectl.Apply(ciliumPath)
 
-		err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
-		Expect(err).Should(BeNil())
-
+		ExpectCiliumReady(kubectl)
 		ExpectKubeDNSReady(kubectl)
 
 		// Sometimes PolicyGen has a lot of pods running around without delete
@@ -423,8 +421,7 @@ var _ = Describe("NightlyExamples", func() {
 		BeforeEach(func() {
 			path := helpers.ManifestGet("cilium_ds.yaml")
 			kubectl.Apply(path)
-			err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
-			Expect(err).Should(BeNil())
+			ExpectCiliumReady(kubectl)
 
 			ExpectKubeDNSReady(kubectl)
 		})

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -58,7 +58,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
-		ciliumPath = kubectl.ManifestGet("cilium_ds.yaml")
+		ciliumPath = helpers.ManifestGet("cilium_ds.yaml")
 		kubectl.Apply(ciliumPath)
 
 		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
@@ -300,14 +300,14 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 
 		It("Test TCP Keepalive with L7 Policy", func() {
 			kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-			manifest := kubectl.ManifestGet(netcatDsManifest)
+			manifest := helpers.ManifestGet(netcatDsManifest)
 			kubectl.Apply(manifest).ExpectSuccess("Cannot apply netcat ds")
 			defer kubectl.Delete(manifest)
 			testConnectivity()
 		})
 
 		It("Test TCP Keepalive without L7 Policy", func() {
-			manifest := kubectl.ManifestGet(netcatDsManifest)
+			manifest := helpers.ManifestGet(netcatDsManifest)
 			kubectl.Apply(manifest).ExpectSuccess("Cannot apply netcat ds")
 			defer kubectl.Delete(manifest)
 			kubectl.Exec(fmt.Sprintf(
@@ -334,14 +334,14 @@ var _ = Describe("NightlyExamples", func() {
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
-		ciliumPath = kubectl.ManifestGet("cilium_ds.yaml")
+		ciliumPath = helpers.ManifestGet("cilium_ds.yaml")
 		kubectl.Delete(ciliumPath)
 
 		apps = []string{helpers.App1, helpers.App2, helpers.App3}
 
-		demoPath = kubectl.ManifestGet("demo.yaml")
-		l3Policy = kubectl.ManifestGet("l3_l4_policy.yaml")
-		l7Policy = kubectl.ManifestGet("l7_policy.yaml")
+		demoPath = helpers.ManifestGet("demo.yaml")
+		l3Policy = helpers.ManifestGet("l3_l4_policy.yaml")
+		l7Policy = helpers.ManifestGet("l7_policy.yaml")
 
 		// Sometimes PolicyGen has a lot of pods running around without delete
 		// it. Using this we are sure that we delete before this test start
@@ -427,7 +427,7 @@ var _ = Describe("NightlyExamples", func() {
 		)
 
 		BeforeEach(func() {
-			path := kubectl.ManifestGet("cilium_ds.yaml")
+			path := helpers.ManifestGet("cilium_ds.yaml")
 			kubectl.Apply(path)
 			_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 			Expect(err).Should(BeNil())

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -35,16 +35,21 @@ import (
 var _ = Describe("K8sValidatedPolicyTest", func() {
 
 	var (
-		demoPath                                                                string
-		kubectl                                                                 *helpers.Kubectl
-		l3Policy, l7Policy, knpDenyIngress, knpDenyEgress, knpDenyIngressEgress string
-		cnpDenyIngress, cnpDenyEgress                                           string
-		logger                                                                  *logrus.Entry
-		service                                                                 *v1.Service
-		podServer                                                               *v1.Pod
-		app1Service                                                             string = "app1-service"
-		microscopeErr                                                           error
-		microscopeCancel                                                        func() error
+		kubectl              *helpers.Kubectl
+		demoPath             = helpers.ManifestGet("demo.yaml")
+		l3Policy             = helpers.ManifestGet("l3_l4_policy.yaml")
+		l7Policy             = helpers.ManifestGet("l7_policy.yaml")
+		knpDenyIngress       = helpers.ManifestGet("knp-default-deny-ingress.yaml")
+		knpDenyEgress        = helpers.ManifestGet("knp-default-deny-egress.yaml")
+		knpDenyIngressEgress = helpers.ManifestGet("knp-default-deny-ingress-egress.yaml")
+		cnpDenyIngress       = helpers.ManifestGet("cnp-default-deny-ingress.yaml")
+		cnpDenyEgress        = helpers.ManifestGet("cnp-default-deny-egress.yaml")
+		logger               *logrus.Entry
+		service              *v1.Service
+		podServer            *v1.Pod
+		app1Service          = "app1-service"
+		microscopeErr        error
+		microscopeCancel     func() error
 
 		namespace string   = "namespace-selector-test"
 		podFilter string   = "k8s:zgroup=testapp"
@@ -56,16 +61,6 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 		logger = log.WithFields(logrus.Fields{"testName": "K8sPolicyTest"})
 		logger.Info("Starting")
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-
-		//Manifest paths
-		demoPath = helpers.ManifestGet("demo.yaml")
-		l3Policy = helpers.ManifestGet("l3_l4_policy.yaml")
-		knpDenyIngress = helpers.ManifestGet("knp-default-deny-ingress.yaml")
-		knpDenyEgress = helpers.ManifestGet("knp-default-deny-egress.yaml")
-		knpDenyIngressEgress = helpers.ManifestGet("knp-default-deny-ingress-egress.yaml")
-		l7Policy = helpers.ManifestGet("l7_policy.yaml")
-		cnpDenyIngress = helpers.ManifestGet("cnp-default-deny-ingress.yaml")
-		cnpDenyEgress = helpers.ManifestGet("cnp-default-deny-egress.yaml")
 
 		_ = kubectl.Apply(helpers.ManifestGet("cilium_ds.yaml"))
 		ExpectCiliumReady(kubectl)

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -75,8 +75,7 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 	})
 
 	AfterEach(func() {
-		err := kubectl.WaitCleanAllTerminatingPods()
-		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
+		ExpectAllPodsTerminated(kubectl)
 	})
 
 	AfterFailed(func() {
@@ -655,8 +654,7 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 			Expect(kubectl.CiliumIsPolicyLoaded(ciliumPod, getPolicyCmd(redisPolicyName))).To(
 				BeFalse(), "RedisPolicyName is not deleted")
 
-			err := kubectl.WaitCleanAllTerminatingPods()
-			Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		waitforPods := func() {
@@ -922,8 +920,7 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 		namespaceAction(qaNs, helpers.Delete)
 		namespaceAction(developmentNs, helpers.Delete)
 
-		err := kubectl.WaitCleanAllTerminatingPods()
-		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
+		ExpectAllPodsTerminated(kubectl)
 	})
 
 	checkCiliumPoliciesDeleted := func(ciliumPod, policyCmd string) {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -70,8 +70,7 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 		_ = kubectl.Apply(helpers.ManifestGet("cilium_ds.yaml"))
 		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)
 		Expect(err).Should(BeNil(), "Cannot install cilium correctly")
-		err = kubectl.WaitKubeDNS()
-		Expect(err).Should(BeNil(), "Kubedns is not ready after timeout")
+		ExpectKubeDNSReady(kubectl)
 	})
 
 	AfterEach(func() {
@@ -862,8 +861,7 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 		Expect(status).Should(BeTrue())
 		Expect(err).Should(BeNil())
 
-		err = kubectl.WaitKubeDNS()
-		Expect(err).Should(BeNil())
+		ExpectKubeDNSReady(kubectl)
 	}
 
 	namespaceAction := func(ns string, action string) {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -68,7 +68,7 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 		cnpDenyEgress = helpers.ManifestGet("cnp-default-deny-egress.yaml")
 
 		_ = kubectl.Apply(helpers.ManifestGet("cilium_ds.yaml"))
-		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)
+		err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)
 		Expect(err).Should(BeNil(), "Cannot install cilium correctly")
 		ExpectKubeDNSReady(kubectl)
 	})
@@ -103,7 +103,7 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 		BeforeAll(func() {
 			kubectl.Apply(demoPath)
 
-			_, err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", 300)
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", 300)
 			Expect(err).Should(BeNil(), "Test pods are not ready after timeout")
 
 			ciliumPod, err = kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
@@ -130,7 +130,7 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 			status.ExpectSuccess()
 			kubectl.CiliumEndpointWait(ciliumPod)
 
-			_, err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", 300)
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", 300)
 			Expect(err).Should(BeNil())
 
 		})
@@ -322,10 +322,9 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 			})
 
 			It("Tests the same Policy in the different namespaces", func() {
-				pods, err := kubectl.WaitforPods(
+				err := kubectl.WaitforPods(
 					namespace,
 					"-l zgroup=testapp", 300)
-				Expect(pods).To(BeTrue(), "testapp pods are not ready after timeout")
 				Expect(err).To(BeNil(), "testapp pods are not ready after timeout")
 
 				By("Applying Policy in namespace")
@@ -668,10 +667,9 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 			Expect(err).Should(BeNil(), "error waiting for redis-slave service to be ready on port %s", port)
 			Expect(pods).Should(BeTrue(), "timed out waiting for redis-slave service to be ready")
 
-			pods, err = kubectl.WaitforPods(
+			err = kubectl.WaitforPods(
 				helpers.DefaultNamespace,
 				fmt.Sprintf("-l %s", groupLabel), 300)
-			ExpectWithOffset(1, pods).Should(BeTrue())
 			ExpectWithOffset(1, err).Should(BeNil())
 		}
 
@@ -857,8 +855,7 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 		cnpAnyNamespace = helpers.ManifestGet("cnp-any-namespace.yaml")
 
 		_ = kubectl.Apply(ciliumDaemonSetPath)
-		status, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)
-		Expect(status).Should(BeTrue())
+		err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)
 		Expect(err).Should(BeNil())
 
 		ExpectKubeDNSReady(kubectl)

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -830,9 +830,9 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 		kubectl             *helpers.Kubectl
 		logger              *logrus.Entry
 		once                sync.Once
-		ciliumDaemonSetPath string
-		cnpL7Stresstest     string
-		cnpAnyNamespace     string
+		ciliumDaemonSetPath = helpers.ManifestGet("cilium_ds.yaml")
+		cnpL7Stresstest     = helpers.ManifestGet("cnp-l7-stresstest.yaml")
+		cnpAnyNamespace     = helpers.ManifestGet("cnp-any-namespace.yaml")
 		microscopeErr       error
 		microscopeCancel    func() error
 	)
@@ -841,10 +841,6 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 		logger = log.WithFields(logrus.Fields{"testName": "K8sPolicyTestAcrossNamespaces"})
 		logger.Info("Starting")
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-
-		ciliumDaemonSetPath = helpers.ManifestGet("cilium_ds.yaml")
-		cnpL7Stresstest = helpers.ManifestGet("cnp-l7-stresstest.yaml")
-		cnpAnyNamespace = helpers.ManifestGet("cnp-any-namespace.yaml")
 
 		_ = kubectl.Apply(ciliumDaemonSetPath)
 		ExpectCiliumReady(kubectl)

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -51,9 +51,9 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 		microscopeErr        error
 		microscopeCancel     func() error
 
-		namespace string   = "namespace-selector-test"
-		podFilter string   = "k8s:zgroup=testapp"
-		apps      []string = []string{helpers.App1, helpers.App2, helpers.App3}
+		namespace = "namespace-selector-test"
+		podFilter = "k8s:zgroup=testapp"
+		apps      = []string{helpers.App1, helpers.App2, helpers.App3}
 	)
 
 	BeforeAll(func() {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -68,8 +68,7 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 		cnpDenyEgress = helpers.ManifestGet("cnp-default-deny-egress.yaml")
 
 		_ = kubectl.Apply(helpers.ManifestGet("cilium_ds.yaml"))
-		err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)
-		Expect(err).Should(BeNil(), "Cannot install cilium correctly")
+		ExpectCiliumReady(kubectl)
 		ExpectKubeDNSReady(kubectl)
 	})
 
@@ -855,9 +854,7 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 		cnpAnyNamespace = helpers.ManifestGet("cnp-any-namespace.yaml")
 
 		_ = kubectl.Apply(ciliumDaemonSetPath)
-		err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)
-		Expect(err).Should(BeNil())
-
+		ExpectCiliumReady(kubectl)
 		ExpectKubeDNSReady(kubectl)
 	}
 

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -58,16 +58,16 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
 		//Manifest paths
-		demoPath = kubectl.ManifestGet("demo.yaml")
-		l3Policy = kubectl.ManifestGet("l3_l4_policy.yaml")
-		knpDenyIngress = kubectl.ManifestGet("knp-default-deny-ingress.yaml")
-		knpDenyEgress = kubectl.ManifestGet("knp-default-deny-egress.yaml")
-		knpDenyIngressEgress = kubectl.ManifestGet("knp-default-deny-ingress-egress.yaml")
-		l7Policy = kubectl.ManifestGet("l7_policy.yaml")
-		cnpDenyIngress = kubectl.ManifestGet("cnp-default-deny-ingress.yaml")
-		cnpDenyEgress = kubectl.ManifestGet("cnp-default-deny-egress.yaml")
+		demoPath = helpers.ManifestGet("demo.yaml")
+		l3Policy = helpers.ManifestGet("l3_l4_policy.yaml")
+		knpDenyIngress = helpers.ManifestGet("knp-default-deny-ingress.yaml")
+		knpDenyEgress = helpers.ManifestGet("knp-default-deny-egress.yaml")
+		knpDenyIngressEgress = helpers.ManifestGet("knp-default-deny-ingress-egress.yaml")
+		l7Policy = helpers.ManifestGet("l7_policy.yaml")
+		cnpDenyIngress = helpers.ManifestGet("cnp-default-deny-ingress.yaml")
+		cnpDenyEgress = helpers.ManifestGet("cnp-default-deny-egress.yaml")
 
-		_ = kubectl.Apply(kubectl.ManifestGet("cilium_ds.yaml"))
+		_ = kubectl.Apply(helpers.ManifestGet("cilium_ds.yaml"))
 		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)
 		Expect(err).Should(BeNil(), "Cannot install cilium correctly")
 		err = kubectl.WaitKubeDNS()
@@ -304,8 +304,8 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 
 			BeforeEach(func() {
 
-				demoPath = kubectl.ManifestGet("demo.yaml")
-				l3Policy = kubectl.ManifestGet("l3_l4_policy.yaml")
+				demoPath = helpers.ManifestGet("demo.yaml")
+				l3Policy = helpers.ManifestGet("l3_l4_policy.yaml")
 
 				policy = fmt.Sprintf("%s -n %s", l3Policy, namespace)
 				demoManifest = fmt.Sprintf("%s -n %s", demoPath, namespace)
@@ -622,7 +622,7 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 		var err error
 
 		BeforeEach(func() {
-			kubectl.Apply(kubectl.ManifestGet(deployment))
+			kubectl.Apply(helpers.ManifestGet(deployment))
 
 			ciliumPod, err = kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
 			Expect(err).Should(BeNil())
@@ -639,16 +639,16 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 
 		AfterEach(func() {
 
-			kubectl.Delete(kubectl.ManifestGet(webPolicy)).ExpectSuccess(
+			kubectl.Delete(helpers.ManifestGet(webPolicy)).ExpectSuccess(
 				"Web policy cannot be deleted")
-			kubectl.Delete(kubectl.ManifestGet(redisPolicyDeprecated)).ExpectSuccess(
+			kubectl.Delete(helpers.ManifestGet(redisPolicyDeprecated)).ExpectSuccess(
 				"Redis deprecated policy cannot be deleted")
-			kubectl.Delete(kubectl.ManifestGet(deployment)).ExpectSuccess(
+			kubectl.Delete(helpers.ManifestGet(deployment)).ExpectSuccess(
 				"Guestbook deployment cannot be deleted")
 
 			// This policy shouldn't be there, but test can fail before delete
 			// the policy and we want to make sure that it's deleted
-			kubectl.Delete(kubectl.ManifestGet(redisPolicy))
+			kubectl.Delete(helpers.ManifestGet(redisPolicy))
 
 			Expect(kubectl.CiliumIsPolicyLoaded(ciliumPod, getPolicyCmd(webPolicyName))).To(
 				BeFalse(), "WebPolicy is not deleted")
@@ -707,7 +707,7 @@ EOF`, k, v)
 
 			By("Apply policy to web")
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, kubectl.ManifestGet(webPolicy),
+				helpers.KubeSystemNamespace, helpers.ManifestGet(webPolicy),
 				helpers.KubectlApply, 300)
 			Expect(err).Should(BeNil(), "Cannot apply web-policy")
 
@@ -721,7 +721,7 @@ EOF`, k, v)
 
 			By("Apply policy to Redis")
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, kubectl.ManifestGet(redisPolicy),
+				helpers.KubeSystemNamespace, helpers.ManifestGet(redisPolicy),
 				helpers.KubectlApply, 300)
 
 			Expect(err).Should(BeNil(), "Cannot apply redis policy")
@@ -737,14 +737,14 @@ EOF`, k, v)
 			testConnectivitytoRedis()
 
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, kubectl.ManifestGet(redisPolicy),
+				helpers.KubeSystemNamespace, helpers.ManifestGet(redisPolicy),
 				helpers.KubectlDelete, 300)
 			Expect(err).Should(BeNil(), "Cannot apply redis policy")
 
 			By("Apply deprecated policy to Redis")
 
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, kubectl.ManifestGet(redisPolicyDeprecated),
+				helpers.KubeSystemNamespace, helpers.ManifestGet(redisPolicyDeprecated),
 				helpers.KubectlApply, 300)
 			Expect(err).Should(BeNil(), "Cannot apply redis deprecated policy err: %q", err)
 
@@ -855,9 +855,9 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 		logger.Info("Starting")
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
-		ciliumDaemonSetPath = kubectl.ManifestGet("cilium_ds.yaml")
-		cnpL7Stresstest = kubectl.ManifestGet("cnp-l7-stresstest.yaml")
-		cnpAnyNamespace = kubectl.ManifestGet("cnp-any-namespace.yaml")
+		ciliumDaemonSetPath = helpers.ManifestGet("cilium_ds.yaml")
+		cnpL7Stresstest = helpers.ManifestGet("cnp-l7-stresstest.yaml")
+		cnpAnyNamespace = helpers.ManifestGet("cnp-any-namespace.yaml")
 
 		_ = kubectl.Apply(ciliumDaemonSetPath)
 		status, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)
@@ -886,7 +886,7 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 		namespaceAction(developmentNs, helpers.Create)
 
 		for _, resource := range resources {
-			resourcePath := kubectl.ManifestGet(resource)
+			resourcePath := helpers.ManifestGet(resource)
 			res := kubectl.Create(resourcePath)
 			res.ExpectSuccess()
 		}
@@ -910,7 +910,7 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 
 	AfterEach(func() {
 		for _, resource := range resources {
-			resourcePath := kubectl.ManifestGet(resource)
+			resourcePath := helpers.ManifestGet(resource)
 			// Do not check result of deletion of resources because we do not
 			// want to perform assertions in AfterEach.
 			_ = kubectl.Delete(resourcePath)

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -656,15 +656,13 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 
 		waitforPods := func() {
 			port := "6379"
-			pods, err := kubectl.WaitForServiceEndpoints(
+			err := kubectl.WaitForServiceEndpoints(
 				helpers.DefaultNamespace, "", "redis-master", port, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "error waiting for redis-master service to be ready on port %s", port)
-			Expect(pods).Should(BeTrue(), "timed out waiting for redis-master service to be ready")
 
-			pods, err = kubectl.WaitForServiceEndpoints(
+			err = kubectl.WaitForServiceEndpoints(
 				helpers.DefaultNamespace, "", "redis-slave", port, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "error waiting for redis-slave service to be ready on port %s", port)
-			Expect(pods).Should(BeTrue(), "timed out waiting for redis-slave service to be ready")
 
 			err = kubectl.WaitforPods(
 				helpers.DefaultNamespace,
@@ -963,10 +961,9 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 		areEndpointsReady := kubectl.CiliumEndpointWait(ciliumPodK8s2)
 		Expect(areEndpointsReady).Should(BeTrue())
 
-		pods, err := kubectl.WaitForServiceEndpoints(
+		err = kubectl.WaitForServiceEndpoints(
 			developmentNs, "", "backend", "80", helpers.HelperTimeout)
 		Expect(err).Should(BeNil())
-		Expect(pods).Should(BeTrue())
 
 		frontendPod, err := kubectl.GetPods(qaNs, "-l id=client").Filter(podNameFilter)
 		Expect(err).Should(BeNil())

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -56,8 +56,7 @@ var _ = Describe("NightlyPolicies", func() {
 	})
 
 	AfterEach(func() {
-		err := kubectl.WaitCleanAllTerminatingPods()
-		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
+		ExpectAllPodsTerminated(kubectl)
 	})
 
 	AfterAll(func() {
@@ -65,8 +64,7 @@ var _ = Describe("NightlyPolicies", func() {
 		kubectl.Exec(fmt.Sprintf(
 			"%s delete --all pods,svc,cnp -n %s", helpers.KubectlCmd, helpers.DefaultNamespace))
 
-		err := kubectl.WaitCleanAllTerminatingPods()
-		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
+		ExpectAllPodsTerminated(kubectl)
 	})
 	Context("PolicyEnforcement default", func() {
 		createTests := func() {

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cilium/cilium/test/helpers"
 	"github.com/cilium/cilium/test/helpers/policygen"
 
-	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 )
 
@@ -37,9 +36,7 @@ var _ = Describe("NightlyPolicies", func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		ciliumPath := helpers.ManifestGet("cilium_ds.yaml")
 		kubectl.Apply(ciliumPath)
-		err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
-		Expect(err).Should(BeNil())
-
+		ExpectCiliumReady(kubectl)
 		ExpectKubeDNSReady(kubectl)
 	})
 

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -40,8 +40,7 @@ var _ = Describe("NightlyPolicies", func() {
 		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 		Expect(err).Should(BeNil())
 
-		err = kubectl.WaitKubeDNS()
-		Expect(err).Should(BeNil())
+		ExpectKubeDNSReady(kubectl)
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -37,7 +37,7 @@ var _ = Describe("NightlyPolicies", func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		ciliumPath := helpers.ManifestGet("cilium_ds.yaml")
 		kubectl.Apply(ciliumPath)
-		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
+		err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 		Expect(err).Should(BeNil())
 
 		ExpectKubeDNSReady(kubectl)

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -35,7 +35,7 @@ var _ = Describe("NightlyPolicies", func() {
 		logger.Info("Starting")
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-		ciliumPath := kubectl.ManifestGet("cilium_ds.yaml")
+		ciliumPath := helpers.ManifestGet("cilium_ds.yaml")
 		kubectl.Apply(ciliumPath)
 		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 		Expect(err).Should(BeNil())

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -50,7 +50,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		path := helpers.ManifestGet("cilium_ds.yaml")
 		kubectl.Apply(path)
-		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
+		err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 		Expect(err).Should(BeNil())
 
 		ExpectKubeDNSReady(kubectl)
@@ -102,8 +102,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 	waitPodsDs := func() {
 		groups := []string{"zgroup=testDS", "zgroup=testDSClient"}
 		for _, pod := range groups {
-			pods, err := kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", pod), 300)
-			ExpectWithOffset(1, pods).Should(BeTrue())
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", pod), 300)
 			ExpectWithOffset(1, err).Should(BeNil())
 		}
 	}
@@ -126,8 +125,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 		})
 
 		It("Checks service on same node", func() {
-			pods, err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", 300)
-			Expect(pods).Should(BeTrue())
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", 300)
 			Expect(err).Should(BeNil())
 
 			res, err := kubectl.Get(
@@ -427,7 +425,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 			}
 
 			By("Waiting for pods to be ready")
-			_, err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=bookinfo", helpers.HelperTimeout)
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=bookinfo", helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 
 			By("Waiting for services to be ready")

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -44,14 +44,15 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 	}
 
 	BeforeAll(func() {
+		var err error
+
 		logger = log.WithFields(logrus.Fields{"testName": "K8sServiceTest"})
 		logger.Info("Starting")
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		path := helpers.ManifestGet("cilium_ds.yaml")
 		kubectl.Apply(path)
-		err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
-		Expect(err).Should(BeNil())
+		ExpectCiliumReady(kubectl)
 
 		ExpectKubeDNSReady(kubectl)
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -78,8 +78,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 	})
 
 	AfterEach(func() {
-		err := kubectl.WaitCleanAllTerminatingPods()
-		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
+		ExpectAllPodsTerminated(kubectl)
 	})
 
 	testHTTPRequest := func(url string) {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -48,7 +48,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 		logger.Info("Starting")
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-		path := kubectl.ManifestGet("cilium_ds.yaml")
+		path := helpers.ManifestGet("cilium_ds.yaml")
 		kubectl.Apply(path)
 		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 		Expect(err).Should(BeNil())
@@ -113,7 +113,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 	Context("Checks ClusterIP Connectivity", func() {
 
 		var (
-			demoYAML = kubectl.ManifestGet("demo.yaml")
+			demoYAML = helpers.ManifestGet("demo.yaml")
 		)
 
 		BeforeEach(func() {
@@ -155,7 +155,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 	Context("Checks service across nodes", func() {
 
 		var (
-			demoYAML = kubectl.ManifestGet("demo_ds.yaml")
+			demoYAML = helpers.ManifestGet("demo_ds.yaml")
 		)
 
 		BeforeAll(func() {
@@ -217,14 +217,14 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 		)
 
 		BeforeEach(func() {
-			servicePath = kubectl.ManifestGet("external_service.yaml")
+			servicePath = helpers.ManifestGet("external_service.yaml")
 			res := kubectl.Apply(servicePath)
 			res.ExpectSuccess(res.GetDebugMessage())
 
-			endpointPath = kubectl.ManifestGet("external_endpoint.yaml")
-			podPath = kubectl.ManifestGet("external_pod.yaml")
-			policyPath = kubectl.ManifestGet("external_policy.yaml")
-			policyLabeledPath = kubectl.ManifestGet("external_policy_labeled.yaml")
+			endpointPath = helpers.ManifestGet("external_endpoint.yaml")
+			podPath = helpers.ManifestGet("external_pod.yaml")
+			policyPath = helpers.ManifestGet("external_policy.yaml")
+			policyLabeledPath = helpers.ManifestGet("external_policy_labeled.yaml")
 
 			res = kubectl.Apply(podPath)
 			res.ExpectSuccess()
@@ -339,9 +339,9 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 
 		BeforeEach(func() {
 
-			bookinfoV1YAML = kubectl.ManifestGet("bookinfo-v1.yaml")
-			bookinfoV2YAML = kubectl.ManifestGet("bookinfo-v2.yaml")
-			policyPath = kubectl.ManifestGet("cnp-specs.yaml")
+			bookinfoV1YAML = helpers.ManifestGet("bookinfo-v1.yaml")
+			bookinfoV2YAML = helpers.ManifestGet("bookinfo-v2.yaml")
+			policyPath = helpers.ManifestGet("cnp-specs.yaml")
 
 			resourceYAMLs = []string{bookinfoV1YAML, bookinfoV2YAML}
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -53,8 +53,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 		_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 		Expect(err).Should(BeNil())
 
-		err = kubectl.WaitKubeDNS()
-		Expect(err).Should(BeNil())
+		ExpectKubeDNSReady(kubectl)
 
 		ciliumPodK8s1, err = kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
 		Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -431,7 +431,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 
 			By("Waiting for services to be ready")
 			for _, service := range []string{details, ratings, reviews, productPage} {
-				_, err = kubectl.WaitForServiceEndpoints(
+				err = kubectl.WaitForServiceEndpoints(
 					helpers.DefaultNamespace, "", service,
 					apiPort, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "Service %q is not ready after timeout", service)

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -87,7 +87,7 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 			res := kubectl.Apply(vxlanDSPath)
 			res.ExpectSuccess("Unable to apply %s: %s", vxlanDSPath, res.CombineOutput())
 
-			_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 500)
+			err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 500)
 			Expect(err).Should(BeNil())
 
 			ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
@@ -127,7 +127,7 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 		It("Check Geneve mode", func() {
 			res := kubectl.Apply(geneveDSPath)
 			res.ExpectSuccess("unable to apply %s: %s", geneveDSPath, res.CombineOutput())
-			_, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 500)
+			err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 500)
 			Expect(err).Should(BeNil())
 
 			ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
@@ -153,8 +153,8 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 })
 
 func isNodeNetworkingWorking(kubectl *helpers.Kubectl, filter string) bool {
-	waitReady, _ := kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", filter), 3000)
-	Expect(waitReady).Should(BeTrue())
+	err := kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", filter), 3000)
+	Expect(err).Should(BeNil())
 	pods, err := kubectl.GetPodNames(helpers.DefaultNamespace, filter)
 	Expect(err).Should(BeNil())
 	podIP, err := kubectl.Get(

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -87,8 +87,7 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 			res := kubectl.Apply(vxlanDSPath)
 			res.ExpectSuccess("Unable to apply %s: %s", vxlanDSPath, res.CombineOutput())
 
-			err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 500)
-			Expect(err).Should(BeNil())
+			ExpectCiliumReady(kubectl)
 
 			ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
 			Expect(err).Should(BeNil())
@@ -127,8 +126,7 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 		It("Check Geneve mode", func() {
 			res := kubectl.Apply(geneveDSPath)
 			res.ExpectSuccess("unable to apply %s: %s", geneveDSPath, res.CombineOutput())
-			err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 500)
-			Expect(err).Should(BeNil())
+			ExpectCiliumReady(kubectl)
 
 			ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
 			Expect(err).Should(BeNil())

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -63,8 +63,7 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 
 	AfterEach(func() {
 		kubectl.Delete(demoDSPath)
-		err := kubectl.WaitCleanAllTerminatingPods()
-		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
+		ExpectAllPodsTerminated(kubectl)
 	})
 
 	Context("VXLan", func() {

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -38,7 +38,7 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 		logger.Info("Starting")
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-		demoDSPath = kubectl.ManifestGet("demo_ds.yaml")
+		demoDSPath = helpers.ManifestGet("demo_ds.yaml")
 		kubectl.Exec("kubectl -n kube-system delete ds cilium")
 		// Expect(res.Correct()).Should(BeTrue())
 
@@ -74,7 +74,7 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 		)
 
 		BeforeEach(func() {
-			vxlanDSPath = kubectl.ManifestGet("cilium_ds.yaml")
+			vxlanDSPath = helpers.ManifestGet("cilium_ds.yaml")
 		})
 
 		AfterEach(func() {
@@ -115,7 +115,7 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 		)
 
 		BeforeEach(func() {
-			geneveDSPath = kubectl.ManifestGet("cilium_ds_geneve.yaml")
+			geneveDSPath = helpers.ManifestGet("cilium_ds_geneve.yaml")
 		})
 
 		AfterEach(func() {

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -41,9 +41,7 @@ var _ = Describe("K8sValidatedUpdates", func() {
 		kubectl.Exec(fmt.Sprintf(
 			"%s delete --all pods,svc,cnp -n %s", helpers.KubectlCmd, helpers.DefaultNamespace))
 
-		err := kubectl.WaitCleanAllTerminatingPods()
-		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
-
+		ExpectAllPodsTerminated(kubectl)
 	})
 
 	AfterFailed(func() {
@@ -64,8 +62,7 @@ var _ = Describe("K8sValidatedUpdates", func() {
 			"ds", fmt.Sprintf("-n %s cilium", helpers.KubeSystemNamespace))
 		res.ExpectSuccess("Cilium DS cannot be deleted")
 
-		err := kubectl.WaitCleanAllTerminatingPods()
-		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
+		ExpectAllPodsTerminated(kubectl)
 	})
 
 	BeforeEach(func() {

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -102,7 +102,7 @@ var _ = Describe("K8sValidatedUpdates", func() {
 		By("Creating some endpoints and L7 policy")
 		kubectl.Apply(demoPath).ExpectSuccess()
 
-		_, err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", timeout)
+		err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", timeout)
 		Expect(err).Should(BeNil())
 
 		_, err = kubectl.CiliumPolicyAction(
@@ -163,9 +163,8 @@ var _ = Describe("K8sValidatedUpdates", func() {
 			&helpers.TimeoutConfig{Timeout: timeout})
 		Expect(err).To(BeNil(), "Pods are not updating")
 
-		status, err := kubectl.WaitforPods(
+		err = kubectl.WaitforPods(
 			helpers.KubeSystemNamespace, "-l k8s-app=cilium", timeout)
-		Expect(status).Should(BeTrue(), "Cilium is not ready after timeout")
 		Expect(err).Should(BeNil(), "Cilium is not ready after timeout")
 
 		validatedImage(localImage)

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -27,14 +27,14 @@ var _ = Describe("K8sValidatedUpdates", func() {
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
-		ciliumPath = kubectl.ManifestGet("cilium_ds.yaml")
+		ciliumPath = helpers.ManifestGet("cilium_ds.yaml")
 		kubectl.Delete(ciliumPath)
 
 		apps = []string{helpers.App1, helpers.App2, helpers.App3}
 
-		demoPath = kubectl.ManifestGet("demo.yaml")
-		l3Policy = kubectl.ManifestGet("l3_l4_policy.yaml")
-		l7Policy = kubectl.ManifestGet("l7_policy.yaml")
+		demoPath = helpers.ManifestGet("demo.yaml")
+		l3Policy = helpers.ManifestGet("l3_l4_policy.yaml")
+		l7Policy = helpers.ManifestGet("l7_policy.yaml")
 
 		// Sometimes PolicyGen has a lot of pods running around without delete
 		// it. Using this we are sure that we delete before this test start

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -72,8 +72,7 @@ var _ = Describe("K8sValidatedUpdates", func() {
 		kubectl.DeleteResource("ds", fmt.Sprintf("-n %s cilium", helpers.KubeSystemNamespace))
 		helpers.InstallExampleCilium(kubectl)
 
-		err := kubectl.WaitKubeDNS()
-		Expect(err).Should(BeNil(), "DNS is not ready after timeout")
+		ExpectKubeDNSReady(kubectl)
 	})
 
 	validatedImage := func(image string) {

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -30,7 +30,7 @@ func ExpectKubeDNSReady(vm *helpers.Kubectl) {
 // ExpectCiliumReady is a wrapper around helpers/WaitForPods. It asserts that
 // the error returned by that function is nil.
 func ExpectCiliumReady(vm *helpers.Kubectl) {
-	_, err := vm.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
+	err := vm.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 	ExpectWithOffset(1, err).Should(BeNil(), "cilium was not able to get into ready state")
 }
 

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -1,0 +1,35 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sTest
+
+import (
+	"github.com/cilium/cilium/test/helpers"
+
+	. "github.com/onsi/gomega"
+)
+
+// ExpectKubeDNSReady is a wrapper around helpers/WaitKubeDNS. It asserts that
+// the error returned by that function is nil.
+func ExpectKubeDNSReady(vm *helpers.Kubectl) {
+	err := vm.WaitKubeDNS()
+	ExpectWithOffset(1, err).Should(BeNil(), "kube-dns was not able to get into ready state")
+}
+
+// ExpectCiliumReady is a wrapper around helpers/WaitForPods. It asserts that
+// the error returned by that function is nil.
+func ExpectCiliumReady(vm *helpers.Kubectl) {
+	_, err := vm.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
+	ExpectWithOffset(1, err).Should(BeNil(), "cilium was not able to get into ready state")
+}

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -33,3 +33,10 @@ func ExpectCiliumReady(vm *helpers.Kubectl) {
 	_, err := vm.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 	ExpectWithOffset(1, err).Should(BeNil(), "cilium was not able to get into ready state")
 }
+
+// ExpectAllPodsTerminated is a wrapper around helpers/WaitCleanAllTerminatingPods.
+// It asserts that the error returned by that function is nil.
+func ExpectAllPodsTerminated(vm *helpers.Kubectl) {
+	err := vm.WaitCleanAllTerminatingPods()
+	ExpectWithOffset(1, err).To(BeNil(), "terminating containers are not deleted after timeout")
+}

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -17,7 +17,6 @@ package k8sTest
 import (
 	"fmt"
 	"path/filepath"
-	"sync"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -40,7 +39,6 @@ func getStarWarsResourceLink(file string) string {
 var _ = Describe(demoTestName, func() {
 
 	var (
-		once             sync.Once
 		kubectl          *helpers.Kubectl
 		logger           *logrus.Entry
 		ciliumYAML       = helpers.ManifestGet("cilium_ds.yaml")
@@ -53,7 +51,7 @@ var _ = Describe(demoTestName, func() {
 		l7PolicyYAMLLink  = getStarWarsResourceLink("policy/l7_policy.yaml")
 	)
 
-	initialize := func() {
+	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"testName": demoTestName})
 		logger.Info("Starting")
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
@@ -64,10 +62,6 @@ var _ = Describe(demoTestName, func() {
 		res.ExpectSuccess("unable to apply %s: %s", ciliumYAML, res.CombineOutput())
 		ExpectCiliumReady(kubectl)
 		ExpectKubeDNSReady(kubectl)
-	}
-
-	BeforeEach(func() {
-		once.Do(initialize)
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -43,7 +43,7 @@ var _ = Describe(demoTestName, func() {
 		once             sync.Once
 		kubectl          *helpers.Kubectl
 		logger           *logrus.Entry
-		ciliumYAML       string
+		ciliumYAML       = helpers.ManifestGet("cilium_ds.yaml")
 		microscopeErr    error
 		microscopeCancel func() error
 
@@ -60,7 +60,6 @@ var _ = Describe(demoTestName, func() {
 
 		// TODO (ianvernon) - factor this code out into separate functions as it's
 		// boilerplate for most K8s test setup.
-		ciliumYAML = helpers.ManifestGet("cilium_ds.yaml")
 		res := kubectl.Apply(ciliumYAML)
 		res.ExpectSuccess("unable to apply %s: %s", ciliumYAML, res.CombineOutput())
 		ExpectCiliumReady(kubectl)

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -70,8 +70,7 @@ var _ = Describe(demoTestName, func() {
 		status, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)
 		Expect(status).Should(BeTrue())
 		Expect(err).Should(BeNil())
-		err = kubectl.WaitKubeDNS()
-		Expect(err).Should(BeNil())
+		ExpectKubeDNSReady(kubectl)
 	}
 
 	BeforeEach(func() {

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -100,8 +100,7 @@ var _ = Describe(demoTestName, func() {
 		kubectl.Delete(xwingYAMLLink)
 
 		By("Waiting for all pods to finish terminating")
-		err := kubectl.WaitCleanAllTerminatingPods()
-		Expect(err).To(BeNil(), "Terminating pods are not deleted after timeout")
+		ExpectAllPodsTerminated(kubectl)
 	})
 
 	It("Tests Star Wars Demo", func() {

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -67,8 +67,7 @@ var _ = Describe(demoTestName, func() {
 		ciliumYAML = helpers.ManifestGet("cilium_ds.yaml")
 		res := kubectl.Apply(ciliumYAML)
 		res.ExpectSuccess("unable to apply %s: %s", ciliumYAML, res.CombineOutput())
-		status, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)
-		Expect(status).Should(BeTrue())
+		err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)
 		Expect(err).Should(BeNil())
 		ExpectKubeDNSReady(kubectl)
 	}
@@ -130,7 +129,7 @@ var _ = Describe(demoTestName, func() {
 		res.ExpectSuccess("unable to apply %s: %s", deathStarYAMLLink, res.CombineOutput())
 
 		By("Waiting for deathstar deployment pods to be ready")
-		_, err = kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", empireLabel), 300)
+		err = kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", empireLabel), 300)
 		Expect(err).Should(BeNil(), "Empire pods are not ready after timeout")
 
 		By("Applying policy and waiting for policy revision to increase in Cilium pods")
@@ -142,7 +141,7 @@ var _ = Describe(demoTestName, func() {
 		res.ExpectSuccess("unable to apply %s: %s", xwingYAMLLink, res.CombineOutput())
 
 		By("Waiting for alliance pods to be ready")
-		_, err = kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", allianceLabel), 300)
+		err = kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", allianceLabel), 300)
 		Expect(err).Should(BeNil(), "Alliance pods are not ready after timeout")
 
 		By("Getting xwing pod names")

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -40,7 +40,6 @@ func getStarWarsResourceLink(file string) string {
 var _ = Describe(demoTestName, func() {
 
 	var (
-		demoPath         string
 		once             sync.Once
 		kubectl          *helpers.Kubectl
 		logger           *logrus.Entry
@@ -58,9 +57,6 @@ var _ = Describe(demoTestName, func() {
 		logger = log.WithFields(logrus.Fields{"testName": demoTestName})
 		logger.Info("Starting")
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-
-		//Manifest paths
-		demoPath = helpers.ManifestGet("demo.yaml")
 
 		// TODO (ianvernon) - factor this code out into separate functions as it's
 		// boilerplate for most K8s test setup.

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -60,11 +60,11 @@ var _ = Describe(demoTestName, func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
 		//Manifest paths
-		demoPath = kubectl.ManifestGet("demo.yaml")
+		demoPath = helpers.ManifestGet("demo.yaml")
 
 		// TODO (ianvernon) - factor this code out into separate functions as it's
 		// boilerplate for most K8s test setup.
-		ciliumYAML = kubectl.ManifestGet("cilium_ds.yaml")
+		ciliumYAML = helpers.ManifestGet("cilium_ds.yaml")
 		res := kubectl.Apply(ciliumYAML)
 		res.ExpectSuccess("unable to apply %s: %s", ciliumYAML, res.CombineOutput())
 		status, err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -67,8 +67,7 @@ var _ = Describe(demoTestName, func() {
 		ciliumYAML = helpers.ManifestGet("cilium_ds.yaml")
 		res := kubectl.Apply(ciliumYAML)
 		res.ExpectSuccess("unable to apply %s: %s", ciliumYAML, res.CombineOutput())
-		err := kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 300)
-		Expect(err).Should(BeNil())
+		ExpectCiliumReady(kubectl)
 		ExpectKubeDNSReady(kubectl)
 	}
 


### PR DESCRIPTION
This PR performs some miscellaneous cleanup of the tests themselves, as well as adds wrappers around the results of some of the helper functions. This will reduce the amount of boilerplate code in the tests. Furthermore, it refactors some of the helper functions to remove useless return values and groups declarations of `var`s together.

Signed-off by: Ian Vernon <ian@cilium.io>