### PR TITLE
Fix weird indentation for rules in endpoint get output

### DIFF
--- a/cilium/cmd/helpers.go
+++ b/cilium/cmd/helpers.go
@@ -139,7 +139,7 @@ func expandNestedJSON(result bytes.Buffer) (bytes.Buffer, error) {
 			if resBytes[idx] != ' ' {
 				break
 			}
-			indent = fmt.Sprintf("%s ", indent)
+			indent = fmt.Sprintf("\t%s\t", indent)
 		}
 
 		stringStart := loc[0]


### PR DESCRIPTION
Fixing weird indentation rules in cilium endpoint get
command

Signed-off-by: Shantanu Deshpande <shantanud106@gmail.com>

**Summary of changes**:

Fixes: #3322 

```release-note
Fixed nested indentation issue while getting cilium endpoint details in the output
```
