### PR TITLE
Test: Use BeforeAll instead of initialize function

### DIFF
--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -17,7 +17,6 @@ package k8sTest
 import (
 	"fmt"
 	"path/filepath"
-	"sync"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -41,7 +40,6 @@ var _ = Describe(demoTestName, func() {
 
 	var (
 		demoPath         string
-		once             sync.Once
 		kubectl          *helpers.Kubectl
 		logger           *logrus.Entry
 		ciliumYAML       string
@@ -54,7 +52,7 @@ var _ = Describe(demoTestName, func() {
 		l7PolicyYAMLLink  = getStarWarsResourceLink("policy/l7_policy.yaml")
 	)
 
-	initialize := func() {
+	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"testName": demoTestName})
 		logger.Info("Starting")
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
@@ -72,10 +70,6 @@ var _ = Describe(demoTestName, func() {
 		Expect(err).Should(BeNil())
 		err = kubectl.WaitKubeDNS()
 		Expect(err).Should(BeNil())
-	}
-
-	BeforeEach(func() {
-		once.Do(initialize)
 	})
 
 	AfterFailed(func() {


### PR DESCRIPTION
On #4014 the DNS logs was not retrieved because it uses initalize
function instead of the BeforeAll function. With this change the logs
will be retrieved correctly.

Related to #4014