### PR TITLE
Contrib: Add a jenkins status script.

### DIFF
--- a/contrib/scripts/jenkins-status.sh
+++ b/contrib/scripts/jenkins-status.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# This script checks Jenkins master Jobs and validated that the failed jobs has
+# been already triaged and upstream issue has been created if it's needed.
+# To clean the list of Jenkins builds, build description needs to be updated with a comment.
+NOW=$(printf "%(%s)T" -1);
+YESTERDAY=$(printf "%(%s)T\n" $((NOW - 24*3600)))
+FROM=$(date -d @$YESTERDAY +%s%N  | cut -b1-13)
+
+TAB="   "
+BOLD=$(tput bold)
+NORMAL=$(tput sgr0)
+BLUE=$(tput setaf 4)
+
+get_job_data () {
+    local JOB=$1
+    local FILTER="?tree=builds[fullDisplayName,id,number,timestamp,result,description,result]"
+    local TEST_RESULT="/testReport/junit/api/xml?xpath=//case[status%20=%20%22REGRESSION%22]/name&wrapper=true"
+
+    NO_TRIAGED_FAILURES=$(curl -s "${JOB}api/json${FILTER}" --globoff | jq -r '.builds[] | select ( .timestamp  > '$FROM' and .result == "FAILURE" and .description == null) | .id')
+    for build in $NO_TRIAGED_FAILURES;
+    do
+        echo "${BOLD}BUILD ID: ${build}${NORMAL}"
+        echo -e "${TAB}${BOLD}${BLUE}URL${NORMAL}: ${JOB}${build}"
+        RESULTS=$(curl -s "${JOB}/${build}/${TEST_RESULT}" --globoff)
+        echo -e "${TAB}${BOLD}${BLUE}TEST_FAILURE${NORMAL}: \n \t${RESULTS}"
+    done
+}
+
+get_job_data "https://jenkins.cilium.io/job/cilium-ginkgo/job/cilium/job/master/"
+get_job_data "https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/"
+get_job_data "https://jenkins.cilium.io/job/Cilium-Master-Nightly-Tests-All/"
+get_job_data "https://jenkins.cilium.io/job/cilium-ginkgo/job/cilium/job/v1.0/"


### PR DESCRIPTION
Added a script to dump the list of failed Jenkins builds without
description, so it's easy to debug the failed Jenkins jobs.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
