### PR TITLE
test/provision/manifest: reduce verbosity for kube-dns

### DIFF
--- a/test/provision/manifest/dns_deployment.yaml
+++ b/test/provision/manifest/dns_deployment.yaml
@@ -126,7 +126,7 @@ spec:
         - --domain=cluster.local.
         - --dns-port=10053
         - --config-dir=/kube-dns-config
-        - --v=5
+        - --v=2
         env:
         - name: PROMETHEUS_PORT
           value: "10055"
@@ -155,7 +155,7 @@ spec:
           successThreshold: 1
           failureThreshold: 5
         args:
-        - -v=5
+        - -v=2
         - -logtostderr
         - -configDir=/etc/k8s/dns/dnsmasq-nanny
         - -restartDnsmasq=true

--- a/test/provision/manifest/dns_deployment.yaml
+++ b/test/provision/manifest/dns_deployment.yaml
@@ -93,7 +93,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.10
+        image: k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.9
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -144,7 +144,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.10
+        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.9
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -183,7 +183,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
+        image: k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.9
         livenessProbe:
           httpGet:
             path: /metrics


### PR DESCRIPTION
kube-dns has been failing due to exit code 137 (out of memory). Reduce verbosity
of it, which was changed recently to see if this fixes that issue.

Signed-off by: Ian Vernon <ian@cilium.io>

