### PR TITLE
contrib: Remove KVstore containers in systemd scripts

### DIFF
--- a/contrib/systemd/cilium-consul.service
+++ b/contrib/systemd/cilium-consul.service
@@ -8,6 +8,7 @@ Type=oneshot
 RemainAfterExit=yes
 TimeoutStartSec=0
 ExecStartPre=/usr/bin/docker pull consul:0.8.3
+ExecStartPre=-/usr/bin/docker rm -f cilium-consul
 ExecStartPre=/usr/bin/docker create \
  --name 'cilium-consul'  -p 8500:8500 \
  -e CONSUL_LOCAL_CONFIG='{"skip_leave_on_interrupt": true, "disable_update_check": true}' \

--- a/contrib/systemd/cilium-etcd.service
+++ b/contrib/systemd/cilium-etcd.service
@@ -8,6 +8,7 @@ Type=oneshot
 RemainAfterExit=yes
 TimeoutStartSec=0
 ExecStartPre=/usr/bin/docker pull quay.io/coreos/etcd:v3.1.0
+ExecStartPre=-/usr/bin/docker rm -f cilium-etcd
 ExecStartPre=/usr/bin/docker create \
  -v /usr/share/ca-certificates/:/etc/ssl/certs \
  -p 4001:4001 -p 2380:2380 -p 2379:2379 \


### PR DESCRIPTION
Sometimes, when a VM terminates suddenly or is not shut down properly,
these containers remain sitting around, and on the next boot, Cilium
fails to start because the container exists (but is no longer running).
Nuke all traces of such containers before attempting to recreate them,
so that the create command should always succeed.

Fixes: #3429