### PR TITLE
Prometheus metrics for L7 proxy requests.

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -29,12 +29,20 @@ Endpoint
 * ``endpoint_regenerating``: Number of endpoints currently regenerating
 * ``endpoint_regenerations``: Count of all endpoint regenerations that have completed, tagged by outcome
 
-Policy
-------
+Policy Imports
+--------------
 
 * ``policy_count``: Number of policies currently loaded
 * ``policy_max_revision``: Highest policy revision number in the agent
 * ``policy_import_errors``: Number of times a policy import has failed
+
+Policy L7 (HTTP/Kafka)
+----------------------
+
+* ``policy_l7_parse_errors_total``: Number of total L7 parse errors
+* ``policy_l7_forwarded_total``: Number of total L7 forwarded requests/responses
+* ``policy_l7_denied_total``: Number of total L7 denied requests/responses due to policy
+* ``policy_l7_received_total``: Number of total L7 received requests/responses
 
 Events external to Cilium
 -------------------------

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
@@ -2093,14 +2094,18 @@ func (e *Endpoint) UpdateProxyStatistics(l7Protocol string, port uint16, ingress
 	}
 
 	stats.Received++
+	metrics.ProxyReceived.Inc()
 
 	switch verdict {
 	case accesslog.VerdictForwarded:
 		stats.Forwarded++
+		metrics.ProxyForwarded.Inc()
 	case accesslog.VerdictDenied:
 		stats.Denied++
+		metrics.ProxyDenied.Inc()
 	case accesslog.VerdictError:
 		stats.Error++
+		metrics.ProxyParseErrors.Inc()
 	}
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -129,6 +129,36 @@ var (
 		Help:        "Last timestamp when we received an event",
 		ConstLabels: prometheus.Labels{"source": LabelEventSourceAPI},
 	})
+
+	// L7 statistics
+
+	// ProxyParseErrors is a count of failed parse errors on proxy
+	ProxyParseErrors = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "policy_l7_parse_errors_total",
+		Help:      "Number of total L7 parse errors",
+	})
+
+	// ProxyForwarded is a count of all forwarded requests by proxy
+	ProxyForwarded = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "policy_l7_forwarded_total",
+		Help:      "Number of total L7 forwarded requests/responses",
+	})
+
+	// ProxyDenied is a count of all denied requests by policy by the proxy
+	ProxyDenied = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "policy_l7_denied_total",
+		Help:      "Number of total L7 denied requests/responses due to policy",
+	})
+
+	// ProxyReceived is a count of all received requests by the proxy
+	ProxyReceived = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "policy_l7_received_total",
+		Help:      "Number of total L7 received requests/responses",
+	})
 )
 
 func init() {
@@ -146,6 +176,11 @@ func init() {
 	MustRegister(EventTSK8s)
 	MustRegister(EventTSContainerd)
 	MustRegister(EventTSAPI)
+
+	MustRegister(ProxyParseErrors)
+	MustRegister(ProxyForwarded)
+	MustRegister(ProxyDenied)
+	MustRegister(ProxyReceived)
 }
 
 // MustRegister adds the collector to the registry, exposing this metric to


### PR DESCRIPTION
Covers adding the following:

- Rejected L7 (HTTP/Kafka) due to parse errors.
- Forwarded L7 (HTTP/Kafka)
- Denied L7 (HTTP/Kafka) due to policy

 Fixes: #4010
 Related to: #3337
    
Signed-Off-By: Manali Bhutiyani <manali@covalent.io>

```release-note
Add prometheus metrics for L7 proxy requests
```