### PR TITLE
test: add helper to wait for CEP revision update in K8s

### DIFF
--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -138,6 +138,10 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 
 		By("Getting policy revision number for each endpoint")
 
+		cep := kubectl.CepGet(helpers.DefaultNamespace, appPods[kafkaApp])
+		Expect(cep).ToNot(BeNil(), "cannot get cep for app %q and pod %s", kafkaApp, appPods[kafkaApp])
+		kafkaRevBeforeUpdate := cep.Status.Policy.Realized.PolicyRevision
+
 		By("Apply L7 kafka policy and wait")
 
 		_, err = kubectl.CiliumPolicyAction(
@@ -146,6 +150,8 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 		Expect(err).To(BeNil(), "L7 policy cannot be imported correctly")
 
 		By("validate that the pods have the correct policy")
+
+		err = kubectl.WaitCEPRevisionIncrease(appPods[kafkaApp], helpers.DefaultNamespace, kafkaRevBeforeUpdate)
 
 		desiredPolicyStatus := map[string]models.EndpointPolicyEnabled{
 			backupApp:   models.EndpointPolicyEnabledNone,

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -136,6 +136,8 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 			helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(prodOutAnnounce))
 		Expect(err).Should(BeNil(), "Failed to produce to outpost on topic empire-announce")
 
+		By("Getting policy revision number for each endpoint")
+
 		By("Apply L7 kafka policy and wait")
 
 		_, err = kubectl.CiliumPolicyAction(
@@ -145,7 +147,7 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 
 		By("validate that the pods have the correct policy")
 
-		policyStatus := map[string]models.EndpointPolicyEnabled{
+		desiredPolicyStatus := map[string]models.EndpointPolicyEnabled{
 			backupApp:   models.EndpointPolicyEnabledNone,
 			empireHqApp: models.EndpointPolicyEnabledNone,
 			kafkaApp:    models.EndpointPolicyEnabledIngress,
@@ -153,7 +155,7 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 			zookApp:     models.EndpointPolicyEnabledNone,
 		}
 
-		for app, policy := range policyStatus {
+		for app, policy := range desiredPolicyStatus {
 			cep := kubectl.CepGet(helpers.DefaultNamespace, appPods[app])
 			Expect(cep).ToNot(BeNil(), "cannot get cep for app %q and pod %s", app, appPods[app])
 			Expect(cep.Status.Policy.Spec.PolicyEnabled).To(Equal(policy), "Policy for %q mismatch", app)


### PR DESCRIPTION
Consume this in the KafkaPolicies test.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #4027 

Marking this as high priority because this is consistently causing test failures in the CI.