### PR TITLE
v1.0 backports 2018 05 10

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,16 @@ BAZEL_VERSION = ENV['BAZEL_VERSION']
 $bootstrap = <<SCRIPT
 echo "----------------------------------------------------------------"
 export PATH=/home/vagrant/go/bin:/usr/local/clang/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
+
+echo "editing journald configuration"
+sudo bash -c "echo RateLimitIntervalSec=1s >> /etc/systemd/journald.conf"
+sudo bash -c "echo RateLimitBurst=1000 >> /etc/systemd/journald.conf"
+echo "restarting systemd-journald"
+sudo systemctl restart systemd-journald
+echo "getting status of systemd-journald"
+sudo service systemd-journald status
+echo "done configuring journald"
+
 sudo service docker restart
 echo 'cd ~/go/src/github.com/cilium/cilium' >> /home/vagrant/.bashrc
 sudo -E /usr/local/go/bin/go get github.com/cilium/go-bindata/...

--- a/cilium/cmd/helpers.go
+++ b/cilium/cmd/helpers.go
@@ -139,7 +139,7 @@ func expandNestedJSON(result bytes.Buffer) (bytes.Buffer, error) {
 			if resBytes[idx] != ' ' {
 				break
 			}
-			indent = fmt.Sprintf("%s ", indent)
+			indent = fmt.Sprintf("\t%s\t", indent)
 		}
 
 		stringStart := loc[0]

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -123,6 +123,16 @@ var (
 	portRandomizerMutex lock.Mutex
 )
 
+func isPortBindable(port uint16) bool {
+	socket, err := listenSocket(fmt.Sprintf(":%d", port), 0)
+	if err != nil {
+		log.WithError(err).Infof("Skipping port %d already in use", port)
+		return false
+	}
+	socket.Close()
+	return true
+}
+
 func (p *Proxy) allocatePort() (uint16, error) {
 	portRandomizerMutex.Lock()
 	defer portRandomizerMutex.Unlock()
@@ -131,7 +141,9 @@ func (p *Proxy) allocatePort() (uint16, error) {
 		resPort := uint16(r) + p.rangeMin
 
 		if _, ok := p.allocatedPorts[resPort]; !ok {
-			return resPort, nil
+			if isPortBindable(resPort) {
+				return resPort, nil
+			}
 		}
 
 	}

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -794,15 +794,6 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 		ciliumPods, err := kubectl.GetCiliumPods(helpers.KubeSystemNamespace)
 		Expect(err).To(BeNil(), "cannot get cilium pods")
 
-		// Set debug mode to false for both cilium pods.
-		for _, ciliumPod := range ciliumPods {
-			res := kubectl.ExecPodCmd(
-				helpers.KubeSystemNamespace, ciliumPod, "cilium config Debug=false")
-			res.ExpectSuccess(
-				"error disabling debug mode for cilium pod %s: %s",
-				ciliumPod, res.CombineOutput())
-		}
-
 		resources := []string{"1-frontend.json", "2-backend-server.json", "3-backend.json"}
 		for _, resource := range resources {
 			resourcePath := kubectl.ManifestGet(resource)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -297,7 +297,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 
 	It("CNP Specs Test", func() {
 
-		// Various constants used in this test
+		// We use wget in this test because the Istio apps do not provide curl.
 		wgetCommand := "%s exec -t %s wget -- --tries=2 --connect-timeout 10 %s"
 
 		version := "version"
@@ -311,6 +311,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 		app := "app"
 		resourceYamls := []string{"bookinfo-v1.yaml", "bookinfo-v2.yaml"}
 		health := "health"
+		ratingsPath := "ratings/0"
 
 		apiPort := "9080"
 
@@ -421,12 +422,12 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 
 		By("Before policy import; all pods should be able to connect")
 		shouldConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, health))
-		shouldConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, ""))
+		shouldConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, ratingsPath))
 
 		shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, health))
 		shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, ""))
 		shouldConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, health))
-		shouldConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, ""))
+		shouldConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, ratingsPath))
 
 		var policyPath string
 		var policyCmd string
@@ -456,12 +457,12 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 
 		By("After policy import")
 		shouldConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, health))
-		shouldNotConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, ""))
+		shouldNotConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, ratingsPath))
 
 		shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, health))
 		shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, ""))
 
 		shouldNotConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, health))
-		shouldNotConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, ""))
+		shouldNotConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, ratingsPath))
 	})
 })

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -425,7 +425,6 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 		shouldConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, ratingsPath))
 
 		shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, health))
-		shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, ""))
 		shouldConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, health))
 		shouldConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, ratingsPath))
 
@@ -460,7 +459,6 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 		shouldNotConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, ratingsPath))
 
 		shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, health))
-		shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, ""))
 
 		shouldNotConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, health))
 		shouldNotConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, ratingsPath))

--- a/test/k8sT/manifests/bookinfo-v1.yaml
+++ b/test/k8sT/manifests/bookinfo-v1.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v1
+        image: istio/examples-bookinfo-details-v1:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -79,7 +79,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v1
+        image: istio/examples-bookinfo-reviews-v1:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -114,8 +114,9 @@ spec:
         track: stable
     spec:
       containers:
+      # Use v0.2.3 because it still contains 'wget', necessary for tests.
       - name: productpage
-        image: istio/examples-bookinfo-productpage-v1
+        image: istio/examples-bookinfo-productpage-v1:0.2.3
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/test/k8sT/manifests/bookinfo-v2.yaml
+++ b/test/k8sT/manifests/bookinfo-v2.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v1
+        image: istio/examples-bookinfo-ratings-v1:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -64,7 +64,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2
+        image: istio/examples-bookinfo-reviews-v2:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/test/k8sT/manifests/cilium_ds.yaml
+++ b/test/k8sT/manifests/cilium_ds.yaml
@@ -23,7 +23,7 @@ data:
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
   # If you want to run cilium in debug mode change this value to true
-  debug: "false"
+  debug: "true"
   disable-ipv4: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
@@ -93,6 +93,7 @@ spec:
         command: [ "cilium-agent" ]
         args:
           - "--debug=$(CILIUM_DEBUG)"
+          - "--debug-verbose=flow"
           - "-t"
           - "vxlan"
           - "--kvstore"

--- a/test/k8sT/manifests/cilium_ds_geneve.yaml
+++ b/test/k8sT/manifests/cilium_ds_geneve.yaml
@@ -23,7 +23,7 @@ data:
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
   # If you want to run cilium in debug mode change this value to true
-  debug: "false"
+  debug: "true"
   disable-ipv4: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
@@ -93,6 +93,7 @@ spec:
         command: [ "cilium-agent" ]
         args:
           - "--debug=$(CILIUM_DEBUG)"
+          - "--debug-verbose=flow"
           - "-t"
           - "geneve"
           - "--kvstore"

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -8,6 +8,15 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 source "${PROVISIONSRC}/helpers.bash"
 
+echo "editing journald configuration"
+sudo bash -c "echo RateLimitIntervalSec=1s >> /etc/systemd/journald.conf"
+sudo bash -c "echo RateLimitBurst=1000 >> /etc/systemd/journald.conf"
+echo "restarting systemd-journald"
+sudo systemctl restart systemd-journald
+echo "getting status of systemd-journald"
+sudo service systemd-journald status
+echo "done configuring journald"
+
 # Delete this section when the new server is ready
 # https://github.com/cilium/cilium/pull/3023/files
 export GOPATH="/home/vagrant/go"


### PR DESCRIPTION
Backports:
* https://github.com/cilium/cilium/pull/4006
* https://github.com/cilium/cilium/pull/4019
* https://github.com/cilium/cilium/pull/4034
* https://github.com/cilium/cilium/pull/4045
* https://github.com/cilium/cilium/pull/4054
* https://github.com/cilium/cilium/pull/4056
* https://github.com/cilium/cilium/pull/4059

The backport of #4045 was a bit interesting, because the test got refactored on master prior to that fix. Given that I was the original author and understood what needed to be done, I just applied the equivalent changes to the test on v1.0. This seemed less invasive than attempting to cherrypick the test refactoring.