### PR TITLE
Fix bookinfo URL accesses

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -366,7 +366,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 
 		It("Tests bookinfo demo", func() {
 
-			// Various constants used in this test
+			// We use wget in this test because the Istio apps do not provide curl.
 			wgetCommand := fmt.Sprintf("wget --tries=2 --connect-timeout %d", helpers.CurlConnectTimeout)
 
 			version := "version"
@@ -379,6 +379,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 			dnsChecks := []string{productPage, reviews, ratings, details}
 			app := "app"
 			health := "health"
+			ratingsPath := "ratings/0"
 
 			apiPort := "9080"
 
@@ -452,12 +453,12 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 			Expect(err).Should(BeNil(), "cannot get productpageV1 pods")
 
 			shouldConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, health))
-			shouldConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, ""))
+			shouldConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, ratingsPath))
 
 			shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, health))
 			shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, ""))
 			shouldConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, health))
-			shouldConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, ""))
+			shouldConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, ratingsPath))
 
 			policyCmd := "cilium policy get io.cilium.k8s.policy.name=multi-rules"
 
@@ -478,13 +479,13 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 
 			By("After policy import")
 			shouldConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, health))
-			shouldNotConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, ""))
+			shouldNotConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, ratingsPath))
 
 			shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, health))
 			shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, ""))
 
 			shouldNotConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, health))
-			shouldNotConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, ""))
+			shouldNotConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, ratingsPath))
 		})
 	})
 })

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -456,7 +456,6 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 			shouldConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, ratingsPath))
 
 			shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, health))
-			shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, ""))
 			shouldConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, health))
 			shouldConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, ratingsPath))
 
@@ -482,7 +481,6 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 			shouldNotConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, ratingsPath))
 
 			shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, health))
-			shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, ""))
 
 			shouldNotConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, health))
 			shouldNotConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, ratingsPath))


### PR DESCRIPTION
The bookinfo services test was accessing URIs on apps which never served those URIs. This PR remove such accesses, which hopefully addresses the remaining issues with the test.

Fixes: #4042 