### PR TITLE
test: ensure that CEP objects are not nil before analyzing their contents

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1333,7 +1333,7 @@ func (kub *Kubectl) WaitCEPRevisionIncrease(podName, podNamespace string, oldRev
 	body := func() bool {
 		cep := kub.CepGet(podNamespace, podName)
 
-		if cep.Status.Policy.Realized.PolicyRevision <= oldRev {
+		if cep == nil || cep.Status.Policy.Realized.PolicyRevision <= oldRev {
 			log.Debugf("CEP revision has not updated: waiting for revision to be greater than %d", oldRev)
 			return false
 		}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1343,3 +1343,18 @@ func (kub *Kubectl) WaitCEPRevisionIncrease(podName, podNamespace string, oldRev
 	return WithTimeout(body, "CEP revision did not increase after specified timeout", &TimeoutConfig{Timeout: HelperTimeout})
 
 }
+
+// WaitForCEPToExist waits for the endpoint model representing the CiliumEndpoint
+// for pod podName in the specified namespace podNamespace to be non-nil. If it
+// is still nil after a specified timeout, returns an error.
+func (kub *Kubectl) WaitForCEPToExist(podName, podNamespace string) error {
+	body := func() bool {
+		cep := kub.CepGet(podNamespace, podName)
+		if cep == nil {
+			return false
+		}
+		return true
+	}
+
+	return WithTimeout(body, "CEP was still nil after specified timeout", &TimeoutConfig{Timeout: HelperTimeout})
+}

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -136,8 +136,11 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 			helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(prodOutAnnounce))
 		Expect(err).Should(BeNil(), "Failed to produce to outpost on topic empire-announce")
 
-		By("Getting policy revision number for each endpoint")
+		By(fmt.Sprintf("Waiting for CEP to exist for %s", appPods[kafkaApp]))
+		err = kubectl.WaitForCEPToExist(appPods[kafkaApp], helpers.DefaultNamespace)
+		Expect(err).To(BeNil(), "CEP did not get created for %s", appPods[kafkaApp])
 
+		By("Getting policy revision number for each endpoint")
 		cep := kubectl.CepGet(helpers.DefaultNamespace, appPods[kafkaApp])
 		Expect(cep).ToNot(BeNil(), "cannot get cep for app %q and pod %s", kafkaApp, appPods[kafkaApp])
 		kafkaRevBeforeUpdate := cep.Status.Policy.Realized.PolicyRevision


### PR DESCRIPTION
* test/helpers
    - check whether cep is nil before trying to access its fields in `WaitCEPRevisionIncrease`
    - add `WaitForCEPToExist` function, which waits for the endpoint model returned by `helpers/CepGet` to be non-nil
* test/k8sT
    -  wait for CEP to exist before getting policy revision in KafkaPolicies test

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #4046 