### PR TITLE
vagrant: configure journald to allow for large amounts of logs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,16 @@ BAZEL_VERSION = ENV['BAZEL_VERSION']
 $bootstrap = <<SCRIPT
 echo "----------------------------------------------------------------"
 export PATH=/home/vagrant/go/bin:/usr/local/clang/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
+
+echo "editing journald configuration"
+sudo bash -c "echo RateLimitIntervalSec=1s >> /etc/systemd/journald.conf"
+sudo bash -c "echo RateLimitBurst=1000 >> /etc/systemd/journald.conf"
+echo "restarting systemd-journald"
+sudo systemctl restart systemd-journald
+echo "getting status of systemd-journald"
+sudo service systemd-journald status
+echo "done configuring journald"
+
 sudo service docker restart
 echo 'cd ~/go/src/github.com/cilium/cilium' >> /home/vagrant/.bashrc
 sudo -E /usr/local/go/bin/go get github.com/cilium/go-bindata/...

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -8,6 +8,15 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 source "${PROVISIONSRC}/helpers.bash"
 
+echo "editing journald configuration"
+sudo bash -c "echo RateLimitIntervalSec=1s >> /etc/systemd/journald.conf"
+sudo bash -c "echo RateLimitBurst=1000 >> /etc/systemd/journald.conf"
+echo "restarting systemd-journald"
+sudo systemctl restart systemd-journald
+echo "getting status of systemd-journald"
+sudo service systemd-journald status
+echo "done configuring journald"
+
 # Delete this section when the new server is ready
 # https://github.com/cilium/cilium/pull/3023/files
 export GOPATH="/home/vagrant/go"


### PR DESCRIPTION
We have observed large gaps in time in Cilium logs in runtime tests. Configure
journald rate limit interval and rate limit burst to allow for more logs so that
if we hit an issue in Cilium, logs are not lost.

Signed-off by: Ian Vernon <ian@cilium.io.

Related-to: #3860

I'm not marking this as fixing #3860 because I am not definitively sure if this is the cause of lost logs. But, if we do not see such an issue for some time, we can then think about closing #3860.