### PR TITLE
Pin bookinfo container image versions

### DIFF
--- a/test/k8sT/manifests/bookinfo-v1.yaml
+++ b/test/k8sT/manifests/bookinfo-v1.yaml
@@ -44,7 +44,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v1
+        image: istio/examples-bookinfo-details-v1:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -81,7 +81,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v1
+        image: istio/examples-bookinfo-reviews-v1:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -117,8 +117,9 @@ spec:
         zgroup: bookinfo
     spec:
       containers:
+      # Use v0.2.3 because it still contains 'wget', necessary for tests.
       - name: productpage
-        image: istio/examples-bookinfo-productpage-v1
+        image: istio/examples-bookinfo-productpage-v1:0.2.3
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/test/k8sT/manifests/bookinfo-v2.yaml
+++ b/test/k8sT/manifests/bookinfo-v2.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v1
+        image: istio/examples-bookinfo-ratings-v1:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -66,7 +66,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2
+        image: istio/examples-bookinfo-reviews-v2:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080


### PR DESCRIPTION
We rely on specific contents of images in the 'bookinfo' tests, in                                                         
particular that the images contain the 'wget' binary. Pin the container                                                    
image versions in the manifests file to ensure that the tests don't                                                        
break because of upstream changes to the images. 

This currently blocks 1.0 backports.