### PR TITLE
cilium/cmd: add ls alias for list commands

### DIFF
--- a/cilium/cmd/bpf_ct_list.go
+++ b/cilium/cmd/bpf_ct_list.go
@@ -28,9 +28,10 @@ import (
 
 // bpfCtListCmd represents the bpf_ct_list command
 var bpfCtListCmd = &cobra.Command{
-	Use:    "list ( <endpoint identifier> | global )",
-	Short:  "List connection tracking entries",
-	PreRun: requireEndpointIDorGlobal,
+	Use:     "list ( <endpoint identifier> | global )",
+	Aliases: []string{"ls"},
+	Short:   "List connection tracking entries",
+	PreRun:  requireEndpointIDorGlobal,
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf ct list")
 		if args[0] == "global" {

--- a/cilium/cmd/bpf_endpoint_list.go
+++ b/cilium/cmd/bpf_endpoint_list.go
@@ -30,8 +30,9 @@ const (
 )
 
 var bpfEndpointListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List local endpoint entries",
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List local endpoint entries",
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf endpoint list")
 

--- a/cilium/cmd/bpf_ipcache_list.go
+++ b/cilium/cmd/bpf_ipcache_list.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/command"
 
 	"fmt"
+
 	"github.com/cilium/cilium/pkg/maps/ipcache"
 	"github.com/spf13/cobra"
 )
@@ -31,8 +32,9 @@ const (
 )
 
 var bpfIPCacheListCmd = &cobra.Command{
-	Use:   "ipcache list",
-	Short: "List endpoint IPs (local and remote) and their corresponding security identities",
+	Use:     "ipcache list",
+	Aliases: []string{"ls"},
+	Short:   "List endpoint IPs (local and remote) and their corresponding security identities",
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf ipcache list")
 

--- a/cilium/cmd/bpf_lb_list.go
+++ b/cilium/cmd/bpf_lb_list.go
@@ -34,8 +34,9 @@ var listRevNAT bool
 
 // bpfCtListCmd represents the bpf_ct_list command
 var bpfLBListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List load-balancing configuration",
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List load-balancing configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf lb list")
 

--- a/cilium/cmd/bpf_proxy_list.go
+++ b/cilium/cmd/bpf_proxy_list.go
@@ -30,8 +30,9 @@ const (
 
 // bpfProxyListCmd represents the bpf_proxy_list command
 var bpfProxyListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List proxy configuration",
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List proxy configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf proxy list")
 

--- a/cilium/cmd/bpf_tunnel_list.go
+++ b/cilium/cmd/bpf_tunnel_list.go
@@ -29,8 +29,9 @@ const (
 )
 
 var bpfTunnelListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List tunnel endpoint entries",
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List tunnel endpoint entries",
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf tunnel list")
 

--- a/cilium/cmd/endpoint_list.go
+++ b/cilium/cmd/endpoint_list.go
@@ -38,8 +38,9 @@ var noHeaders bool
 
 // endpointListCmd represents the endpoint_list command
 var endpointListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List all endpoints",
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List all endpoints",
 	Run: func(cmd *cobra.Command, args []string) {
 		listEndpoints()
 	},

--- a/cilium/cmd/identity_list.go
+++ b/cilium/cmd/identity_list.go
@@ -27,8 +27,9 @@ import (
 
 // identityListCmd represents the identity_list command
 var identityListCmd = &cobra.Command{
-	Use:   "list [LABELS]",
-	Short: "List identities",
+	Use:     "list [LABELS]",
+	Aliases: []string{"ls"},
+	Short:   "List identities",
 	Run: func(cmd *cobra.Command, args []string) {
 		listIdentities(args)
 	},

--- a/cilium/cmd/prefilter_list.go
+++ b/cilium/cmd/prefilter_list.go
@@ -25,8 +25,9 @@ import (
 )
 
 var preFilterListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List CIDR filters",
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List CIDR filters",
 	Run: func(cmd *cobra.Command, args []string) {
 		listFilters(cmd, args)
 	},

--- a/cilium/cmd/service_list.go
+++ b/cilium/cmd/service_list.go
@@ -29,8 +29,9 @@ import (
 
 // serviceListCmd represents the service_list command
 var serviceListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List services",
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List services",
 	Run: func(cmd *cobra.Command, args []string) {
 		listServices(cmd, args)
 	},


### PR DESCRIPTION
Add shorthand aliases to the list sub-commands. This is a "first
issue" related change to get more familiar with the code. cobra
supports aliases through an `Aliases` field, so I used that to add
shorthand support.

Fixes #4018

```release-note
Add ls shorthand to list sub-commands
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4062)
<!-- Reviewable:end -->
