### PR TITLE
controller: Cleanup global manager on UpdateController

### DIFF
--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -62,7 +62,7 @@ func (m *Manager) UpdateController(name string, params ControllerParams) *Contro
 	}
 
 	if oldCtrl, ok := m.controllers[name]; ok {
-		oldCtrl.stopController()
+		m.removeController(oldCtrl)
 	}
 
 	ctrl := &Controller{


### PR DESCRIPTION
We left controllers that are being replaced in the global list during
UpdateController. The intent is to wholly replace the previous
controller, and this includes in the global list (also then removing
it's statistics).

Fixes https://github.com/cilium/cilium/issues/4066