### PR TITLE
Represent Cilium status as Prometheus metrics

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/common/plugins"
 	"github.com/cilium/cilium/pkg/endpoint"
+	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/labels"
@@ -112,7 +113,7 @@ func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressin
 	id := int64(addressing.CiliumIPv6(ip6).EndpointID())
 	info := &models.EndpointChangeRequest{
 		ID:            id,
-		ContainerID:   endpoint.NewCiliumID(id),
+		ContainerID:   endpointid.NewCiliumID(id),
 		ContainerName: "cilium-health",
 		State:         models.EndpointStateWaitingForIdentity,
 		Addressing: &models.AddressPair{

--- a/cilium/cmd/endpoint_config.go
+++ b/cilium/cmd/endpoint_config.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/endpoint"
+	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/spf13/cobra"
@@ -56,7 +57,7 @@ func listEndpointOptions() {
 }
 
 func configEndpoint(cmd *cobra.Command, args []string) {
-	_, id, _ := endpoint.ValidateID(args[0])
+	_, id, _ := endpointid.ValidateID(args[0])
 	cfg, err := client.EndpointConfigGet(id)
 	if err != nil {
 		Fatalf("Cannot get configuration of endpoint %s: %s\n", id, err)

--- a/cilium/cmd/endpoint_labels.go
+++ b/cilium/cmd/endpoint_labels.go
@@ -20,7 +20,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/cilium/cilium/common"
-	"github.com/cilium/cilium/pkg/endpoint"
+	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
@@ -38,7 +38,7 @@ var endpointLabelsCmd = &cobra.Command{
 	Short:  "Manage label configuration of endpoint",
 	PreRun: requireEndpointID,
 	Run: func(cmd *cobra.Command, args []string) {
-		_, id, _ := endpoint.ValidateID(args[0])
+		_, id, _ := endpointid.ValidateID(args[0])
 		addLabels := labels.NewLabelsFromModel(toAdd).GetModel()
 
 		deleteLabels := labels.NewLabelsFromModel(toDelete).GetModel()

--- a/cilium/cmd/helpers.go
+++ b/cilium/cmd/helpers.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/bpf"
-	"github.com/cilium/cilium/pkg/endpoint"
+	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
@@ -59,7 +59,7 @@ func requireEndpointID(cmd *cobra.Command, args []string) {
 	}
 
 	if id := identity.ReservedIdentities[args[0]]; id == identity.IdentityUnknown {
-		_, _, err := endpoint.ValidateID(args[0])
+		_, _, err := endpointid.ValidateID(args[0])
 
 		if err != nil {
 			Fatalf("Cannot parse endpoint id \"%s\": %s", args[0], err)

--- a/cilium/cmd/policy_trace.go
+++ b/cilium/cmd/policy_trace.go
@@ -24,7 +24,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/command"
-	"github.com/cilium/cilium/pkg/endpoint"
+	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/policy/trace"
@@ -233,8 +233,8 @@ func parseLabels(slice []string) ([]string, error) {
 }
 
 func getSecIDFromK8s(podName string) (string, error) {
-	fmtdPodName := endpoint.NewID(endpoint.PodNamePrefix, podName)
-	_, _, err := endpoint.ValidateID(fmtdPodName)
+	fmtdPodName := endpointid.NewID(endpointid.PodNamePrefix, podName)
+	_, _, err := endpointid.ValidateID(fmtdPodName)
 	if err != nil {
 		Fatalf("Cannot parse pod name \"%s\": %s", fmtdPodName, err)
 	}

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
+	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipam"
@@ -197,7 +198,7 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder 
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PUT /endpoint/{id} request")
 
 	epTemplate := params.Endpoint
-	if n, err := endpoint.ParseCiliumID(params.ID); err != nil {
+	if n, err := endpointid.ParseCiliumID(params.ID); err != nil {
 		return apierror.Error(PutEndpointIDInvalidCode, err)
 	} else if n != epTemplate.ID {
 		return apierror.New(PutEndpointIDInvalidCode,

--- a/daemon/endpoint_test.go
+++ b/daemon/endpoint_test.go
@@ -22,7 +22,7 @@ import (
 	apiEndpoint "github.com/cilium/cilium/api/v1/server/restapi/endpoint"
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/comparator"
-	"github.com/cilium/cilium/pkg/endpoint"
+	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipam"
@@ -42,7 +42,7 @@ func getEPTemplate(c *C) *models.EndpointChangeRequest {
 	id := int64(addressing.CiliumIPv6(ip6).EndpointID())
 	return &models.EndpointChangeRequest{
 		ID:            id,
-		ContainerID:   endpoint.NewCiliumID(id),
+		ContainerID:   endpointid.NewCiliumID(id),
 		ContainerName: "foo",
 		State:         models.EndpointStateWaitingForIdentity,
 		Addressing: &models.AddressPair{

--- a/pkg/client/endpoint.go
+++ b/pkg/client/endpoint.go
@@ -17,7 +17,7 @@ package client
 import (
 	"github.com/cilium/cilium/api/v1/client/endpoint"
 	"github.com/cilium/cilium/api/v1/models"
-	pkgEndpoint "github.com/cilium/cilium/pkg/endpoint"
+	pkgEndpointID "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/labels"
 )
 
@@ -45,7 +45,7 @@ func (c *Client) EndpointGet(id string) (*models.Endpoint, error) {
 
 // EndpointCreate creates a new endpoint
 func (c *Client) EndpointCreate(ep *models.EndpointChangeRequest) error {
-	id := pkgEndpoint.NewCiliumID(ep.ID)
+	id := pkgEndpointID.NewCiliumID(ep.ID)
 	params := endpoint.NewPutEndpointIDParams().WithID(id).WithEndpoint(ep)
 	_, err := c.Endpoint.PutEndpointID(params)
 	return Hint(err)

--- a/pkg/endpoint/id/id.go
+++ b/pkg/endpoint/id/id.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package endpoint
+package id
 
 import (
 	"fmt"

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/controller"
+	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -841,7 +842,7 @@ func (e *Endpoint) runIdentityToK8sPodSync() {
 // / <global ID Prefix>:<cluster name>:<node name>:<endpoint ID> as a string.
 func (e *Endpoint) FormatGlobalEndpointID() string {
 	nodeIdentity, _ := node.GetLocalNode()
-	metadata := []string{CiliumGlobalIdPrefix, ipcache.AddressSpace, nodeIdentity.Name, strconv.Itoa(int(e.ID))}
+	metadata := []string{endpointid.CiliumGlobalIdPrefix, ipcache.AddressSpace, nodeIdentity.Name, strconv.Itoa(int(e.ID))}
 	return strings.Join(metadata, ":")
 }
 

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/cilium/cilium/pkg/endpoint"
+	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -72,35 +73,35 @@ func Lookup(id string) (*endpoint.Endpoint, error) {
 	mutex.RLock()
 	defer mutex.RUnlock()
 
-	prefix, eid, err := endpoint.ParseID(id)
+	prefix, eid, err := endpointid.ParseID(id)
 	if err != nil {
 		return nil, err
 	}
 
 	switch prefix {
-	case endpoint.CiliumLocalIdPrefix:
-		n, err := endpoint.ParseCiliumID(id)
+	case endpointid.CiliumLocalIdPrefix:
+		n, err := endpointid.ParseCiliumID(id)
 		if err != nil {
 			return nil, err
 		}
 		return lookupCiliumID(uint16(n)), nil
 
-	case endpoint.CiliumGlobalIdPrefix:
+	case endpointid.CiliumGlobalIdPrefix:
 		return nil, fmt.Errorf("Unsupported id format for now")
 
-	case endpoint.ContainerIdPrefix:
+	case endpointid.ContainerIdPrefix:
 		return lookupDockerID(eid), nil
 
-	case endpoint.DockerEndpointPrefix:
+	case endpointid.DockerEndpointPrefix:
 		return lookupDockerEndpoint(eid), nil
 
-	case endpoint.ContainerNamePrefix:
+	case endpointid.ContainerNamePrefix:
 		return lookupDockerContainerName(eid), nil
 
-	case endpoint.PodNamePrefix:
+	case endpointid.PodNamePrefix:
 		return lookupPodNameLocked(eid), nil
 
-	case endpoint.IPv4Prefix:
+	case endpointid.IPv4Prefix:
 		return lookupIPv4(eid), nil
 
 	default:
@@ -149,23 +150,23 @@ func Remove(ep *endpoint.Endpoint) {
 	delete(endpoints, ep.ID)
 
 	if ep.DockerID != "" {
-		delete(endpointsAux, endpoint.NewID(endpoint.ContainerIdPrefix, ep.DockerID))
+		delete(endpointsAux, endpointid.NewID(endpointid.ContainerIdPrefix, ep.DockerID))
 	}
 
 	if ep.DockerEndpointID != "" {
-		delete(endpointsAux, endpoint.NewID(endpoint.DockerEndpointPrefix, ep.DockerEndpointID))
+		delete(endpointsAux, endpointid.NewID(endpointid.DockerEndpointPrefix, ep.DockerEndpointID))
 	}
 
 	if ep.IPv4.String() != "" {
-		delete(endpointsAux, endpoint.NewID(endpoint.IPv4Prefix, ep.IPv4.String()))
+		delete(endpointsAux, endpointid.NewID(endpointid.IPv4Prefix, ep.IPv4.String()))
 	}
 
 	if ep.ContainerName != "" {
-		delete(endpointsAux, endpoint.NewID(endpoint.ContainerNamePrefix, ep.ContainerName))
+		delete(endpointsAux, endpointid.NewID(endpointid.ContainerNamePrefix, ep.ContainerName))
 	}
 
 	if podName := ep.GetK8sNamespaceAndPodNameLocked(); podName != "" {
-		delete(endpointsAux, endpoint.NewID(endpoint.PodNamePrefix, podName))
+		delete(endpointsAux, endpointid.NewID(endpointid.PodNamePrefix, podName))
 	}
 }
 
@@ -186,42 +187,42 @@ func lookupCiliumID(id uint16) *endpoint.Endpoint {
 }
 
 func lookupDockerEndpoint(id string) *endpoint.Endpoint {
-	if ep, ok := endpointsAux[endpoint.NewID(endpoint.DockerEndpointPrefix, id)]; ok {
+	if ep, ok := endpointsAux[endpointid.NewID(endpointid.DockerEndpointPrefix, id)]; ok {
 		return ep
 	}
 	return nil
 }
 
 func lookupPodNameLocked(name string) *endpoint.Endpoint {
-	if ep, ok := endpointsAux[endpoint.NewID(endpoint.PodNamePrefix, name)]; ok {
+	if ep, ok := endpointsAux[endpointid.NewID(endpointid.PodNamePrefix, name)]; ok {
 		return ep
 	}
 	return nil
 }
 
 func lookupDockerContainerName(name string) *endpoint.Endpoint {
-	if ep, ok := endpointsAux[endpoint.NewID(endpoint.ContainerNamePrefix, name)]; ok {
+	if ep, ok := endpointsAux[endpointid.NewID(endpointid.ContainerNamePrefix, name)]; ok {
 		return ep
 	}
 	return nil
 }
 
 func lookupIPv4(ipv4 string) *endpoint.Endpoint {
-	if ep, ok := endpointsAux[endpoint.NewID(endpoint.IPv4Prefix, ipv4)]; ok {
+	if ep, ok := endpointsAux[endpointid.NewID(endpointid.IPv4Prefix, ipv4)]; ok {
 		return ep
 	}
 	return nil
 }
 
 func lookupDockerID(id string) *endpoint.Endpoint {
-	if ep, ok := endpointsAux[endpoint.NewID(endpoint.ContainerIdPrefix, id)]; ok {
+	if ep, ok := endpointsAux[endpointid.NewID(endpointid.ContainerIdPrefix, id)]; ok {
 		return ep
 	}
 	return nil
 }
 
 func linkContainerID(ep *endpoint.Endpoint) {
-	endpointsAux[endpoint.NewID(endpoint.ContainerIdPrefix, ep.DockerID)] = ep
+	endpointsAux[endpointid.NewID(endpointid.ContainerIdPrefix, ep.DockerID)] = ep
 }
 
 // UpdateReferences updates the mappings of various values to their corresponding
@@ -232,19 +233,19 @@ func updateReferences(ep *endpoint.Endpoint) {
 	}
 
 	if ep.DockerEndpointID != "" {
-		endpointsAux[endpoint.NewID(endpoint.DockerEndpointPrefix, ep.DockerEndpointID)] = ep
+		endpointsAux[endpointid.NewID(endpointid.DockerEndpointPrefix, ep.DockerEndpointID)] = ep
 	}
 
 	if ep.IPv4.String() != "" {
-		endpointsAux[endpoint.NewID(endpoint.IPv4Prefix, ep.IPv4.String())] = ep
+		endpointsAux[endpointid.NewID(endpointid.IPv4Prefix, ep.IPv4.String())] = ep
 	}
 
 	if ep.ContainerName != "" {
-		endpointsAux[endpoint.NewID(endpoint.ContainerNamePrefix, ep.ContainerName)] = ep
+		endpointsAux[endpointid.NewID(endpointid.ContainerNamePrefix, ep.ContainerName)] = ep
 	}
 
 	if podName := ep.GetK8sNamespaceAndPodNameLocked(); podName != "" {
-		endpointsAux[endpoint.NewID(endpoint.PodNamePrefix, podName)] = ep
+		endpointsAux[endpointid.NewID(endpointid.PodNamePrefix, podName)] = ep
 	}
 }
 

--- a/pkg/health/client/client.go
+++ b/pkg/health/client/client.go
@@ -138,7 +138,9 @@ func formatPathStatus(w io.Writer, name string, cp *models.PathStatus, indent st
 	}
 }
 
-func pathIsHealthy(cp *models.PathStatus) bool {
+// PathIsHealthy checks whether ICMP and TCP(HTTP) connectivity to the given
+// path is available.
+func PathIsHealthy(cp *models.PathStatus) bool {
 	if cp == nil {
 		return false
 	}
@@ -156,8 +158,8 @@ func pathIsHealthy(cp *models.PathStatus) bool {
 }
 
 func nodeIsHealthy(node *models.NodeStatus) bool {
-	return pathIsHealthy(node.Host.PrimaryAddress) &&
-		(node.Endpoint == nil || pathIsHealthy(node.Endpoint))
+	return PathIsHealthy(node.Host.PrimaryAddress) &&
+		(node.Endpoint == nil || PathIsHealthy(node.Endpoint))
 }
 
 func nodeIsLocalhost(node *models.NodeStatus, self *models.SelfStatus) bool {
@@ -173,8 +175,8 @@ func formatNodeStatus(w io.Writer, node *models.NodeStatus, printAll, succinct, 
 		if printAll || !nodeIsHealthy(node) {
 			fmt.Fprintf(w, "  %s%s\t%s\t%t\t%t\n", node.Name,
 				localStr, node.Host.PrimaryAddress.IP,
-				pathIsHealthy(node.Host.PrimaryAddress),
-				pathIsHealthy(node.Endpoint))
+				PathIsHealthy(node.Host.PrimaryAddress),
+				PathIsHealthy(node.Endpoint))
 		}
 	} else {
 		fmt.Fprintf(w, "  %s%s:\n", node.Name, localStr)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -205,6 +205,8 @@ func init() {
 
 	MustRegister(DropCount)
 	MustRegister(ForwardCount)
+
+	MustRegister(newStatusCollector())
 }
 
 // MustRegister adds the collector to the registry, exposing this metric to

--- a/pkg/metrics/status.go
+++ b/pkg/metrics/status.go
@@ -1,0 +1,154 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"time"
+
+	clientPkg "github.com/cilium/cilium/pkg/client"
+	healthClientPkg "github.com/cilium/cilium/pkg/health/client"
+
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	updateLatencyMetricsInterval = 30 * time.Second
+)
+
+type statusCollector struct {
+	ciliumClient *clientPkg.Client
+	healthClient *healthClientPkg.Client
+
+	controllersFailingDesc         *prometheus.Desc
+	ipAddressesDesc                *prometheus.Desc
+	unreachableNodesDesc           *prometheus.Desc
+	unreachableHealthEndpointsDesc *prometheus.Desc
+}
+
+func newStatusCollector() *statusCollector {
+	ciliumClient, err := clientPkg.NewClient("")
+	if err != nil {
+		log.WithError(err).Error("Error while creating client")
+	}
+
+	healthClient, err := healthClientPkg.NewClient("")
+	if err != nil {
+		log.WithError(err).Error("Error while creating cilium-health client")
+	}
+
+	return &statusCollector{
+		ciliumClient: ciliumClient,
+		healthClient: healthClient,
+		controllersFailingDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", "controllers_failing"),
+			"Number of failing controllers",
+			nil, nil,
+		),
+		ipAddressesDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", "ip_addresses"),
+			"Number of allocated IP addresses",
+			[]string{"family"}, nil,
+		),
+		unreachableNodesDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", "unreachable_nodes"),
+			"Number of nodes that cannot be reached",
+			nil, nil,
+		),
+		unreachableHealthEndpointsDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", "unreachable_health_endpoints"),
+			"Number of health endpoints that cannot be reached",
+			nil, nil,
+		),
+	}
+}
+
+func (s *statusCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- s.controllersFailingDesc
+	ch <- s.ipAddressesDesc
+	ch <- s.unreachableNodesDesc
+	ch <- s.unreachableHealthEndpointsDesc
+}
+
+func (s *statusCollector) Collect(ch chan<- prometheus.Metric) {
+	statusResponse, err := s.ciliumClient.Daemon.GetHealthz(nil)
+	if err != nil {
+		log.WithError(err).Error("Error while getting Cilium status")
+	}
+
+	healthStatusResponse, err := s.healthClient.Connectivity.GetStatus(nil)
+	if err != nil {
+		log.WithError(err).Error("Error while getting cilium-health status")
+	}
+
+	// Controllers failing
+	controllersFailing := 0
+	for _, ctrl := range statusResponse.Payload.Controllers {
+		if ctrl.Status == nil {
+			continue
+		}
+		if ctrl.Status.ConsecutiveFailureCount > 0 {
+			controllersFailing++
+		}
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		s.controllersFailingDesc,
+		prometheus.GaugeValue,
+		float64(controllersFailing),
+	)
+
+	// Address count
+	ch <- prometheus.MustNewConstMetric(
+		s.ipAddressesDesc,
+		prometheus.GaugeValue,
+		float64(len(statusResponse.Payload.IPAM.IPV4)),
+		"ipv4",
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		s.ipAddressesDesc,
+		prometheus.GaugeValue,
+		float64(len(statusResponse.Payload.IPAM.IPV6)),
+		"ipv6",
+	)
+
+	// Nodes and endpoints healthStatusResponse
+	var (
+		unreachableNodes     int
+		unreachableEndpoints int
+	)
+
+	for _, nodeStatus := range healthStatusResponse.Payload.Nodes {
+		if !healthClientPkg.PathIsHealthy(nodeStatus.Host.PrimaryAddress) {
+			unreachableNodes++
+		}
+		if nodeStatus.Endpoint != nil && !healthClientPkg.PathIsHealthy(nodeStatus.Endpoint) {
+			unreachableEndpoints++
+		}
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		s.unreachableNodesDesc,
+		prometheus.GaugeValue,
+		float64(unreachableNodes),
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		s.unreachableHealthEndpointsDesc,
+		prometheus.GaugeValue,
+		float64(unreachableEndpoints),
+	)
+}

--- a/pkg/workloads/containerd.go
+++ b/pkg/workloads/containerd.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/endpoint"
+	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
 	"github.com/containerd/containerd"
@@ -236,7 +237,7 @@ func (c *containerDClient) processEvent(m EventMessage) {
 		stopIgnoringContainer(m.WorkloadID)
 		c.handleCreateWorkload(m.WorkloadID, true)
 	case EventTypeDelete:
-		Owner().DeleteEndpoint(endpoint.NewID(endpoint.ContainerIdPrefix, m.WorkloadID))
+		Owner().DeleteEndpoint(endpointid.NewID(endpointid.ContainerIdPrefix, m.WorkloadID))
 	}
 }
 

--- a/pkg/workloads/cri.go
+++ b/pkg/workloads/cri.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/endpoint"
+	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -166,7 +167,7 @@ func (c *criClient) processEvent(m EventMessage) {
 		stopIgnoringContainer(m.WorkloadID)
 		c.handleCreateWorkload(m.WorkloadID, true)
 	case EventTypeDelete:
-		Owner().DeleteEndpoint(endpoint.NewID(endpoint.ContainerIdPrefix, m.WorkloadID))
+		Owner().DeleteEndpoint(endpointid.NewID(endpointid.ContainerIdPrefix, m.WorkloadID))
 	}
 }
 

--- a/pkg/workloads/docker.go
+++ b/pkg/workloads/docker.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/endpoint"
+	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -345,7 +346,7 @@ func (d *dockerClient) processEvent(m EventMessage) {
 		stopIgnoringContainer(m.WorkloadID)
 		d.handleCreateWorkload(m.WorkloadID, true)
 	case EventTypeDelete:
-		Owner().DeleteEndpoint(endpoint.NewID(endpoint.ContainerIdPrefix, m.WorkloadID))
+		Owner().DeleteEndpoint(endpointid.NewID(endpointid.ContainerIdPrefix, m.WorkloadID))
 	}
 }
 

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/common/plugins"
 	"github.com/cilium/cilium/pkg/client"
-	"github.com/cilium/cilium/pkg/endpoint"
+	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -446,7 +446,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		return fmt.Errorf("unable to connect to Cilium daemon: %s", err)
 	}
 
-	id := endpoint.NewID(endpoint.ContainerIdPrefix, args.ContainerID)
+	id := endpointid.NewID(endpointid.ContainerIdPrefix, args.ContainerID)
 	if ep, err := client.EndpointGet(id); err != nil {
 		// Ignore endpoints not found
 		log.WithError(err).WithField(logfields.EndpointID, id).Debug("Agent is not aware of endpoint")

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -26,7 +26,7 @@ import (
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/common/plugins"
 	"github.com/cilium/cilium/pkg/client"
-	endpointPkg "github.com/cilium/cilium/pkg/endpoint"
+	endpointIDPkg "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -61,7 +61,7 @@ type driver struct {
 }
 
 func endpointID(id string) string {
-	return endpointPkg.NewID(endpointPkg.DockerEndpointPrefix, id)
+	return endpointIDPkg.NewID(endpointIDPkg.DockerEndpointPrefix, id)
 }
 
 func newLibnetworkRoute(route plugins.Route) api.StaticRoute {


### PR DESCRIPTION
<!--  Thanks for contributing to Cilium!

If this is your first time contributing, then please see the following
guidelines for detailed instructions on how to contribute:
https://github.com/cilium/cilium/blob/master/CONTRIBUTING.md for detailed instructions 

-->

The following metrics are introduced there:
- number of failing controllers
- number of allocated addresses
- number of nodes that cannot be reached
- number of health endpoints that cannot be reached

Fixes: #3997 

```release-note
Represent Cilium status as Prometheus metrics
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4070)
<!-- Reviewable:end -->
