### PR TITLE
Test: Update Vagrant boxes

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -764,6 +764,26 @@ To run this you can use the following command:
     ginkgo  -v -- --cilium.provision=false --cilium.SSHConfig="cat ssh-config"
 
 
+VMs for Testing
+~~~~~~~~~~~~~~~~
+
+The VMs used for testing are defined in ``test/Vagrantfile``. There are a variety of
+configuration options that can be passed as environment variables:
+
++----------------------+-----------------+--------------+------------------------------------------------------------------+
+| ENV variable         | Default Value   | Options      | Description                                                      |
++======================+=================+==============+==================================================================+
+| K8S\_NODES           | 2               | 0..100       | Number of Kubernetes nodes in the cluster                        |
++----------------------+-----------------+--------------+------------------------------------------------------------------+
+| NFS                  | 0               | 1            | If Cilium folder needs to be shared using NFS                    |
++----------------------+-----------------+--------------+------------------------------------------------------------------+
+| IPv6                 | 0               | 0-1          | If 1 the Kubernetes cluster will use IPv6                        |
++----------------------+-----------------+--------------+------------------------------------------------------------------+
+| CONTAINER\_RUNTIME   | docker          | containerd   | To set the default container runtime in the Kubernetes cluster   |
++----------------------+-----------------+--------------+------------------------------------------------------------------+
+| K8S\_VERSION         | 1.10            | 1.\*\*       | Kubernetes version to install                                    |
++----------------------+-----------------+--------------+------------------------------------------------------------------+
+
 Further Assistance
 ~~~~~~~~~~~~~~~~~~
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -126,7 +126,7 @@ Vagrant.configure(2) do |config|
         vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
         vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
         config.vm.box = "cilium/ubuntu"
-        config.vm.box_version = "69"
+        config.vm.box_version = "70"
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i
         if ENV["NFS"] then

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -8,7 +8,9 @@ $K8S_VERSION = ENV['K8S_VERSION'] || "1.10"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 $NFS = ENV['NFS']=="1"? true : false
 $SERVER_BOX= "cilium/ubuntu"
-$SERVER_VERSION="69"
+$SERVER_VERSION="70"
+$IPv6=(ENV['IPv6'] || "0")
+$CONTAINER_RUNTIME=(ENV['CONTAINER_RUNTIME'] || "docker")
 
 # RAM and CPU settings
 $MEMORY = (ENV['MEMORY'] || "4096").to_i
@@ -60,6 +62,12 @@ Vagrant.configure("2") do |config|
                 ip: "192.168.36.1#{i}",
                 virtualbox__intnet: "cilium-k8s#{$BUILD_NUMBER}-#{$JOB_NAME}-#{$K8S_VERSION}"
 
+            # @TODO: Clean this one when https://github.com/hashicorp/vagrant/issues/9822 is fixed.
+            server.vm.provision "ipv6-config",
+                type: "shell",
+                run: "always",
+                inline: "ip -6 a a fd04::1#{i}/96 dev enp0s8 || true"
+
             # This network is only used by NFS
             server.vm.network "private_network", type: "dhcp"
             server.vm.synced_folder "../", "/home/vagrant/go/src/github.com/cilium/cilium",
@@ -70,7 +78,9 @@ Vagrant.configure("2") do |config|
             server.vm.provision "file", source: "provision", destination: "/tmp/provision"
             server.vm.provision "shell" do |sh|
                 sh.path = "./provision/k8s_install.sh"
-                sh.args = ["k8s#{i}", "192.168.36.1#{i}", "#{$K8S_VERSION}"]
+                sh.args = [
+                    "k8s#{i}", "192.168.36.1#{i}", "#{$K8S_VERSION}",
+                    "#{$IPv6}", "#{$CONTAINER_RUNTIME}"]
             end
         end
     end


### PR DESCRIPTION
- Update Vagrant box to version 70, where containerd support is added.
- Change the way that we provisioned the servers to support IPv6
- Added envtpl utility for templating.
- Added new two options to Vagrantfile `CONTAINER_RUNTIME` and IPv6
- Added a new topic in e2e test related with VM options.

About further work: 

- Need to figure it out a way to use these IPv6 + runtime in Jenkins. Working on it. 

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>