### PR TITLE
endpoints will regenerate when there were previous regeneration failures

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -857,6 +857,13 @@ func (e *Endpoint) TriggerPolicyUpdatesLocked(owner Owner, opts models.Configura
 		return false, fmt.Errorf("%s: %s", e.StringID(), err)
 	}
 
+	// CurrentStatus will be not OK when we have an uncleared error in BPF,
+	// policy or Other. We should keep trying to regenerate in the hopes of
+	// suceeding.
+	// Note: This "retry" behaviour is better suited to a controller, and can be
+	// moved there once we have an endpoint regeneration controller.
+	needToRegenerateBPF = needToRegenerateBPF || (e.Status.CurrentStatus() != OK)
+
 	e.getLogger().Debugf("TriggerPolicyUpdatesLocked: changed: %t", needToRegenerateBPF)
 
 	return needToRegenerateBPF, nil


### PR DESCRIPTION
A corner case exists where a datapath generation error is logged in
endpoint.Status, but later calls to TriggerPolicyUpdates would no-op
since the policy is "up-to-date". This will likely be fixed when we
transition to desired/realised states. In the meantime, this change
allows an endpoint to recover from transient failures.
I'm not sure that this is the correct spot for this check, but `TriggerPolicyUpdatesLocked` is called from two different places and this seemed like the more future-proof change. I can apply the same check to the other spots (although one is in policymanager and the other in daemon, neither of which should have insight into the endpoint, and already rely on it's internal logic to determine if regeneration should proceed).

I've noticed this in the failures in https://github.com/cilium/cilium/issues/3621 and it manifests as an endpoint log that looks like:
```
Timestamp              Status    State                   Message
2018-05-11T06:16:09Z   OK        ready                   Endpoint policy update skipped because no changes were needed
2018-05-11T06:10:02Z   OK        ready                   Endpoint policy update skipped because no changes were needed
2018-05-11T06:08:58Z   OK        ready                   Endpoint policy update skipped because no changes were needed
2018-05-11T06:02:32Z   OK        ready                   Endpoint policy update skipped because no changes were needed
2018-05-11T06:02:31Z   OK        ready                   Endpoint policy update skipped because no changes were needed
2018-05-11T06:02:20Z   OK        ready                   Endpoint policy update skipped because no changes were needed
2018-05-11T06:02:19Z   Failure   ready                   Error regenerating endpoint: Error while configuring proxy redirects: proxy state changes failed: context deadline exceeded
2018-05-11T06:02:19Z   OK        ready                   Completed endpoint regeneration with no pending regeneration requests
2018-05-11T06:02:09Z   OK        regenerating            Regenerating Endpoint BPF: endpoint policy updated & changes were needed
2018-05-11T06:02:08Z   OK        waiting-to-regenerate   Triggering endpoint regeneration due to policy updates
2018-05-11T05:57:21Z   Failure   ready                   Error regenerating endpoint: Error while configuring proxy redirects: proxy state changes failed: context deadline exceeded
2018-05-11T05:57:21Z   OK        ready                   Completed endpoint regeneration with no pending regeneration requests
2018-05-11T05:57:11Z   OK        regenerating            Regenerating Endpoint BPF: endpoint policy updated & changes were needed
2018-05-11T05:57:00Z   OK        waiting-to-regenerate   Triggering endpoint regeneration due to policy updates
2018-05-11T05:55:52Z   OK        ready                   Endpoint policy update skipped because no changes were needed
```

The `not-ready` status reported by `cilium endpoint list` (and co.) and used by our tests will then not clear unless a policy change forces the endpoint to regenerate again.

I've been reproducing those issues by adding a 10s sleep to `endpoint.regenerateBPF` during the proxy updates (since those tests seem to have seen failures with that). This PR doesn't fix the underlying problem, but it does unstick an endpoint so that it can, eventually recover. I'm fairly certain this was once true, and is our intended behaviour.