### PR TITLE
test: misc. cleanups and enhancements

### DIFF
--- a/pkg/policy/l4Filter_test.go
+++ b/pkg/policy/l4Filter_test.go
@@ -16,10 +16,10 @@ package policy
 
 import (
 	"bytes"
+
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/op/go-logging"
 
-	"fmt"
 	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/labels"
 	. "gopkg.in/check.v1"
@@ -605,13 +605,6 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 // which restricts on L7. Should resolve to just allowing all on L3/L7 (first rule
 // shadows the second), but setting traffic to the HTTP proxy.
 func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *C) {
-
-	fmt.Println("TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll")
-	fmt.Println("TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll")
-	fmt.Println("TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll")
-	fmt.Println("TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll")
-	fmt.Println("TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll")
-
 	// Case 7A: selects specific endpoint with L7 restrictions rule first, then
 	// rule which selects all endpoints and allows all on L7. Net result sets
 	// parser type to whatever is in first rule, but without the restriction

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -876,6 +876,7 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 		googleHTTP := "google.com"
 		checkEgressToWorld := func() {
 			By("Testing egress access to the world")
+
 			res := vm.ContainerExec(helpers.App1, helpers.Ping(googleDNS))
 			ExpectWithOffset(2, res.WasSuccessful()).Should(
 				BeTrue(), "not able to ping %s", googleDNS)
@@ -886,7 +887,7 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 
 			res = vm.ContainerExec(helpers.App1, helpers.CurlFail("-4 http://%s", googleHTTP))
 			ExpectWithOffset(2, res.WasSuccessful()).Should(
-				BeTrue(), "not able to curl %s", googleHTTP)
+				BeTrue(), "not able to curl %s: %s", googleHTTP, res.CombineOutput())
 		}
 
 		setupPolicyAndTestEgressToWorld := func(policy string) {
@@ -943,6 +944,7 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 				}]
 			}]
 		}]`, app1Label, api.EntityWorld, app2Label)
+
 		setupPolicyAndTestEgressToWorld(policy)
 
 		vm.PolicyDelAll().ExpectSuccess("Unable to delete all policies")


### PR DESCRIPTION
* Remove `fmt.Println` statements erroneously left in unit test.
* Add output from `curl` command in `Expect` statement for easier debugging in `checkEgressToWorld` helper function.

Signed-off by: Ian Vernon <ian@cilium.io>