### PR TITLE
k8s: Bump CRD schema version.

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -41,7 +41,7 @@ const (
 
 	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
 	// Used to determine if CRD needs to be updated in cluster
-	CustomResourceDefinitionSchemaVersion = "1.6"
+	CustomResourceDefinitionSchemaVersion = "1.7"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"


### PR DESCRIPTION
In commit 54b8658b252a ("k8s: Support IPv6 addresses in CIDR policy"),
the schema for validating CNP was updated, but the schema version was
not bumped. As a result, during upgrade, the new schema validation
resource is not updated in k8s, so the new schema does not apply. Bump
the schema version to ensure that the new CRD validation is pushed on
Cilium startup.