### PR TITLE
`cilium monitor` json mode

### DIFF
--- a/Documentation/cmdref/cilium_monitor.md
+++ b/Documentation/cmdref/cilium_monitor.md
@@ -22,6 +22,7 @@ cilium monitor
 ```
       --from []uint16         Filter by source endpoint id
       --hex                   Do not dissect, print payload in HEX
+  -j, --json                  Enable json output. Shadows -v flag
       --related-to []uint16   Filter by either source or destination endpoint id
       --to []uint16           Filter by destination endpoint id
   -t, --type []string         Filter by event types [agent capture debug drop l7 trace]

--- a/pkg/monitor/agent.go
+++ b/pkg/monitor/agent.go
@@ -65,6 +65,15 @@ func (n *AgentNotify) DumpInfo() {
 	fmt.Printf(">> %s: %s\n", resolveAgentType(n.Type), n.Text)
 }
 
+func (n *AgentNotify) getJSON() string {
+	return fmt.Sprintf(`{"type":"agent","subtype":"%s","message":%s}`, resolveAgentType(n.Type), n.Text)
+}
+
+// DumpJSON prints notification in json format
+func (n *AgentNotify) DumpJSON() {
+	fmt.Println(n.getJSON())
+}
+
 // PolicyUpdateNotification structures update notification
 type PolicyUpdateNotification struct {
 	Labels    []string `json:"labels,omitempty"`

--- a/pkg/monitor/dissect.go
+++ b/pkg/monitor/dissect.go
@@ -168,3 +168,44 @@ func Dissect(dissect bool, data []byte) {
 		fmt.Print(hex.Dump(data))
 	}
 }
+
+// DissectSummary bundles decoded layers into json-marshallable message
+type DissectSummary struct {
+	Ethernet string `json:"ethernet,omitempty"`
+	IPv4     string `json:"ipv4,omitempty"`
+	IPv6     string `json:"ipv6,omitempty"`
+	TCP      string `json:"tcp,omitempty"`
+	UDP      string `json:"udp,omitempty"`
+	ICMPv4   string `json:"icmpv4,omitempty"`
+	ICMPv6   string `json:"icmpv4,omitempty"`
+}
+
+// GetDissectSummary returns DissectSummary created from data
+func GetDissectSummary(data []byte) *DissectSummary {
+	dissectLock.Lock()
+	defer dissectLock.Unlock()
+
+	parser.DecodeLayers(data, &decoded)
+
+	ret := &DissectSummary{}
+
+	for _, typ := range decoded {
+		switch typ {
+		case layers.LayerTypeEthernet:
+			ret.Ethernet = gopacket.LayerString(&eth)
+		case layers.LayerTypeIPv4:
+			ret.IPv4 = gopacket.LayerString(&ip4)
+		case layers.LayerTypeIPv6:
+			ret.IPv6 = gopacket.LayerString(&ip6)
+		case layers.LayerTypeTCP:
+			ret.TCP = gopacket.LayerString(&tcp)
+		case layers.LayerTypeUDP:
+			ret.UDP = gopacket.LayerString(&udp)
+		case layers.LayerTypeICMPv4:
+			ret.ICMPv4 = gopacket.LayerString(&icmp4)
+		case layers.LayerTypeICMPv6:
+			ret.ICMPv6 = gopacket.LayerString(&icmp6)
+		}
+	}
+	return ret
+}


### PR DESCRIPTION
monitor subcommand now has `--json` flag which causes it to parse all
node-monitor events and spit out their json representation. This will
allow tools like microscope to easily retrieve information about monitor
events.

json representation was based on existing verbose output to make sure
monitor doesn't hide any information we may need later.