### PR TITLE
Test: Change how ExpectSuccess report information. 

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -264,7 +264,7 @@ func (matcher *BeSuccesfulMatcher) Match(actual interface{}) (success bool, err 
 // command was not successful.
 func (matcher *BeSuccesfulMatcher) FailureMessage(actual interface{}) (message string) {
 	res, _ := actual.(*CmdRes)
-	return fmt.Sprintf("Expected command: %s \nTo succeed, but it fails:\n%s",
+	return fmt.Sprintf("Expected command: %s \nTo succeed, but it failed:\n%s",
 		res.GetCmd(), res.OutputPrettyPrint())
 }
 
@@ -272,7 +272,7 @@ func (matcher *BeSuccesfulMatcher) FailureMessage(actual interface{}) (message s
 // command is tested with a negative
 func (matcher *BeSuccesfulMatcher) NegatedFailureMessage(actual interface{}) (message string) {
 	res, _ := actual.(*CmdRes)
-	return fmt.Sprintf("Expected command: %s\nTo fails, but it was successful:\n%s",
+	return fmt.Sprintf("Expected command: %s\nTo have failed, but it was successful:\n%s",
 		res.GetCmd(), res.OutputPrettyPrint())
 }
 

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -82,7 +82,7 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 				res := kubectl.ExecPodCmd(
 					helpers.DefaultNamespace, pod, helpers.Ping(ip))
 				log.Debugf("Pod %s ping %v", pod, ip)
-				ExpectWithOffset(1, res.WasSuccessful()).To(BeTrue(),
+				ExpectWithOffset(1, res).To(helpers.CMDSuccess(),
 					"Cannot ping from %q to %q", pod, ip)
 
 				err = kubectl.WaitForKubeDNSEntry(testDSService)
@@ -90,7 +90,7 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 
 				res = kubectl.ExecPodCmd(
 					helpers.DefaultNamespace, pod, helpers.CurlFail("http://%s:80/", testDSService))
-				ExpectWithOffset(1, res.WasSuccessful()).To(BeTrue(),
+				ExpectWithOffset(1, res).To(helpers.CMDSuccess(),
 					"Cannot curl from %q to testds-service", pod)
 			}
 		}

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -165,19 +165,19 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 		trace := kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
 			"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 9092",
 			appPods[empireHqApp], appPods[kafkaApp]))
-		trace.ExpectSuccess(trace.CombineOutput().String())
+		trace.ExpectSuccess("Cilium policy trace failed")
 		trace.ExpectContains("Final verdict: ALLOWED")
 
 		trace = kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
 			"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 9092",
 			appPods[backupApp], appPods[kafkaApp]))
-		trace.ExpectSuccess(trace.CombineOutput().String())
+		trace.ExpectSuccess("Cilium policy trace failed")
 		trace.ExpectContains("Final verdict: ALLOWED")
 
 		trace = kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
 			"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 80",
 			appPods[empireHqApp], appPods[kafkaApp]))
-		trace.ExpectSuccess(trace.CombineOutput().String())
+		trace.ExpectSuccess("Failed cilium policy trace")
 		trace.ExpectContains("Final verdict: DENIED")
 
 		By("Testing Kafka L7 policy enforcement status")

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -74,6 +74,7 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 		kubectl.CiliumReport(helpers.KubeSystemNamespace,
 			"cilium service list",
 			"cilium endpoint list")
+
 	})
 
 	JustBeforeEach(func() {
@@ -682,7 +683,7 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 PING
 EOF`, k, v)
 					res := kubectl.ExecPodCmd(helpers.DefaultNamespace, pod, command)
-					ExpectWithOffset(1, res.WasSuccessful()).To(BeTrue(),
+					ExpectWithOffset(1, res).To(helpers.CMDSuccess(),
 						"Web pod %q cannot connect to redis-master on '%s:%d'", pod, k, v)
 				}
 			}

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -94,7 +94,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 				res := kubectl.ExecPodCmd(
 					helpers.DefaultNamespace, pod,
 					helpers.CurlFail(url))
-				ExpectWithOffset(1, res.WasSuccessful()).Should(BeTrue(),
+				ExpectWithOffset(1, res).Should(helpers.CMDSuccess(),
 					"Pod %q can not connect to service %q", pod, url)
 			}
 		}

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -85,7 +85,7 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 
 		It("Check VXLAN mode", func() {
 			res := kubectl.Apply(vxlanDSPath)
-			res.ExpectSuccess("Unable to apply %s: %s", vxlanDSPath, res.CombineOutput())
+			res.ExpectSuccess("Unable to apply %q", vxlanDSPath)
 
 			ExpectCiliumReady(kubectl)
 
@@ -125,7 +125,7 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 
 		It("Check Geneve mode", func() {
 			res := kubectl.Apply(geneveDSPath)
-			res.ExpectSuccess("unable to apply %s: %s", geneveDSPath, res.CombineOutput())
+			res.ExpectSuccess("unable to apply %s", geneveDSPath)
 			ExpectCiliumReady(kubectl)
 
 			ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -606,7 +606,7 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 		By("Pinging host IPv4 from httpd2 (should NOT work due to default-deny PolicyEnforcement mode)")
 
 		res := vm.ContainerExec(helpers.Httpd2, helpers.Ping(helpers.IPv4Host))
-		res.ExpectFail("Unexpected success pinging host (%s) from %s: %s", helpers.IPv4Host, helpers.Httpd2, res.CombineOutput().String())
+		res.ExpectFail("Unexpected success pinging host (%s) from %s", helpers.IPv4Host, helpers.Httpd2)
 
 		By(fmt.Sprintf("Importing L3 CIDR Policy for IPv4 Egress Allowing Egress to %s, %s from %s", ipv4OtherHost, ipv4OtherHost, httpd2Label))
 		script := fmt.Sprintf(`
@@ -624,8 +624,7 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 		Expect(err).To(BeNil(), "Unable to import policy: %s", err)
 
 		res = vm.ContainerExec(helpers.Httpd2, helpers.Ping(helpers.IPv4Host))
-		res.ExpectSuccess("Unexpected failure pinging host (%s) from %s: %s", helpers.IPv4Host, helpers.Httpd2, res.CombineOutput().String())
-
+		res.ExpectSuccess("Unexpected failure pinging host (%s) from %s", helpers.IPv4Host, helpers.Httpd2)
 		vm.PolicyDelAll().ExpectSuccess("Unable to delete all policies")
 
 		By("Pinging host IPv6 from httpd2 (should NOT work because we did not specify IPv6 CIDR of host as part of previously imported policy)")
@@ -647,8 +646,7 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 
 		By(fmt.Sprintf("Pinging host IPv6 from httpd2 (should work because policy allows IPv6 CIDR %s)", helpers.IPv6Host))
 		res = vm.ContainerExec(helpers.Httpd2, helpers.Ping6(helpers.IPv6Host))
-		res.ExpectSuccess("Unexpected failure pinging host (%s) from %s: %s", helpers.IPv6Host, helpers.Httpd2, res.CombineOutput().String())
-
+		res.ExpectSuccess("Unexpected failure pinging host (%s) from %s", helpers.IPv6Host, helpers.Httpd2)
 		vm.PolicyDelAll().ExpectSuccess("Unable to delete all policies")
 
 		// This test case checks that ping works even without explicit CIDR policies
@@ -676,20 +674,16 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 
 		By("Pinging httpd1 IPV4 from httpd2 (should work because we allowed traffic to httpd1 labels from httpd2 labels)")
 		res = vm.ContainerExec(helpers.Httpd2, helpers.Ping(httpd1DockerNetworking[helpers.IPv4]))
-		res.ExpectSuccess("Unexpected failure pinging %s (%s) from %s: %s", helpers.Httpd1, httpd1DockerNetworking[helpers.IPv4], helpers.Httpd2, res.CombineOutput().String())
-
+		res.ExpectSuccess("Unexpected failure pinging %s (%s) from %s", helpers.Httpd1, httpd1DockerNetworking[helpers.IPv4], helpers.Httpd2)
 		By("Pinging httpd1 IPv6 from httpd2 (should work because we allowed traffic to httpd1 labels from httpd2 labels)")
 		res = vm.ContainerExec(helpers.Httpd2, helpers.Ping6(httpd1DockerNetworking[helpers.IPv6]))
-		res.ExpectSuccess("Unexpected failure pinging %s (%s) from %s: %s", helpers.Httpd1, httpd1DockerNetworking[helpers.IPv6], helpers.Httpd2, res.CombineOutput().String())
-
+		res.ExpectSuccess("Unexpected failure pinging %s (%s) from %s", helpers.Httpd1, httpd1DockerNetworking[helpers.IPv6], helpers.Httpd2)
 		By("Pinging httpd1 IPv4 from app3 (should NOT work because app3 hasn't been whitelisted to communicate with httpd1)")
 		res = vm.ContainerExec(helpers.App3, helpers.Ping(helpers.Httpd1))
-		res.ExpectFail("Unexpected success pinging %s IPv4 from %s: %s", helpers.Httpd1, helpers.App3, res.CombineOutput().String())
-
+		res.ExpectFail("Unexpected success pinging %s IPv4 from %s", helpers.Httpd1, helpers.App3)
 		By("Pinging httpd1 IPv6 from app3 (should NOT work because app3 hasn't been whitelisted to communicate with httpd1)")
 		res = vm.ContainerExec(helpers.App3, helpers.Ping6(helpers.Httpd1))
-		res.ExpectFail("Unexpected success pinging %s IPv6 from %s: %s", helpers.Httpd1, helpers.App3, res.CombineOutput().String())
-
+		res.ExpectFail("Unexpected success pinging %s IPv6 from %s", helpers.Httpd1, helpers.App3)
 		vm.PolicyDelAll().ExpectSuccess("Unable to delete all policies")
 
 		// Checking combined policy allowing traffic from IPv4 and IPv6 CIDR ranges.
@@ -722,19 +716,19 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 
 		By("Pinging httpd1 IPV4 from httpd2 (should work because we allowed traffic to httpd1 labels from httpd2 labels)")
 		res = vm.ContainerExec(helpers.Httpd2, helpers.Ping(httpd1DockerNetworking[helpers.IPv4]))
-		res.ExpectSuccess("Unexpected failure pinging %s (%s) from %s: %s", helpers.Httpd1, httpd1DockerNetworking[helpers.IPv4], helpers.Httpd2, res.CombineOutput().String())
+		res.ExpectSuccess("Unexpected failure pinging %s (%s) from %s", helpers.Httpd1, httpd1DockerNetworking[helpers.IPv4], helpers.Httpd2)
 
 		By("Pinging httpd1 IPv6 from httpd2 (should work because we allowed traffic to httpd1 labels from httpd2 labels)")
 		res = vm.ContainerExec(helpers.Httpd2, helpers.Ping6(httpd1DockerNetworking[helpers.IPv6]))
-		res.ExpectSuccess("Unexpected failure pinging %s (%s) from %s: %s", helpers.Httpd1, httpd1DockerNetworking[helpers.IPv6], helpers.Httpd2, res.CombineOutput().String())
+		res.ExpectSuccess("Unexpected failure pinging %s (%s) from %s", helpers.Httpd1, httpd1DockerNetworking[helpers.IPv6], helpers.Httpd2)
 
 		By(fmt.Sprintf("Pinging httpd1 IPv4 %q from app3 (shouldn't work because CIDR policies don't apply to endpoint-endpoint communication)", ipv4Prefix))
 		res = vm.ContainerExec(helpers.App3, helpers.Ping(helpers.Httpd1))
-		res.ExpectFail("Unexpected success pinging %s IPv4 from %s: %s", helpers.Httpd1, helpers.App3, res.CombineOutput().String())
+		res.ExpectFail("Unexpected success pinging %s IPv4 from %s", helpers.Httpd1, helpers.App3)
 
 		By(fmt.Sprintf("Pinging httpd1 IPv6 %q from app3 (shouldn't work because CIDR policies don't apply to endpoint-endpoint communication)", ipv6Prefix))
 		res = vm.ContainerExec(helpers.App3, helpers.Ping6(helpers.Httpd1))
-		res.ExpectFail("Unexpected success pinging %s IPv6 from %s: %s", helpers.Httpd1, helpers.App3, res.CombineOutput().String())
+		res.ExpectFail("Unexpected success pinging %s IPv6 from %s", helpers.Httpd1, helpers.App3)
 
 		vm.PolicyDelAll().ExpectSuccess("Unable to delete all policies")
 
@@ -766,11 +760,11 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 
 		By(fmt.Sprintf("Pinging httpd1 IPv4 from app3 (should NOT work because we only allow traffic from %s to %s)", httpd2Label, httpd1Label))
 		res = vm.ContainerExec(helpers.App3, helpers.Ping(helpers.Httpd1))
-		res.ExpectFail("Unexpected success pinging %s IPv4 from %s: %s", helpers.Httpd1, helpers.App3, res.CombineOutput().String())
+		res.ExpectFail("Unexpected success pinging %s IPv4 from %s", helpers.Httpd1, helpers.App3)
 
 		By(fmt.Sprintf("Pinging httpd1 IPv6 from app3 (should NOT work because we only allow traffic from %s to %s)", httpd2Label, httpd1Label))
 		res = vm.ContainerExec(helpers.App3, helpers.Ping6(helpers.Httpd1))
-		res.ExpectFail("Unexpected success pinging %s IPv6 from %s: %s", helpers.Httpd1, helpers.App3, res.CombineOutput().String())
+		res.ExpectFail("Unexpected success pinging %s IPv6 from %s", helpers.Httpd1, helpers.App3)
 
 		vm.PolicyDelAll().ExpectSuccess("Unable to delete all policies")
 

--- a/test/runtime/cli.go
+++ b/test/runtime/cli.go
@@ -62,7 +62,7 @@ var _ = Describe("RuntimeValidatedCLI", func() {
 			for _, set := range namesLabels {
 				res := vm.ContainerCreate(set[0], helpers.NetperfImage, helpers.CiliumDockerNetwork, fmt.Sprintf("-l %s", set[1]))
 				defer vm.ContainerRm(set[0])
-				res.ExpectSuccess("Unable to create container: %s", res.CombineOutput())
+				res.ExpectSuccess("Unable to create container")
 			}
 			areEndpointsReady := vm.WaitEndpointsReady()
 			Expect(areEndpointsReady).Should(BeTrue(), "endpoints not ready")
@@ -86,7 +86,7 @@ var _ = Describe("RuntimeValidatedCLI", func() {
 			for _, set := range namesLabels {
 				res := vm.ContainerCreate(set[0], helpers.NetperfImage, helpers.CiliumDockerNetwork, fmt.Sprintf("-l %s", set[1]))
 				defer vm.ContainerRm(set[0])
-				res.ExpectSuccess("Unable to create container: %s", res.CombineOutput())
+				res.ExpectSuccess("Unable to create container")
 			}
 
 			epModel := vm.EndpointGet(fmt.Sprintf("-l container:%s", fooID))

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -215,7 +215,7 @@ var _ = Describe("RuntimeValidatedConnectivityTest", func() {
 			res = vm.Exec(fmt.Sprintf(
 				"sudo -E PATH=$PATH:/opt/cni/bin -E CNI_PATH=%[1]s/bin %[1]s/cni/scripts/exec-plugins.sh add %s %s",
 				tmpDir.SingleOut(), containerID, netnspath))
-			res.ExpectSuccess("CNI exec-plugins did not work correctly '%s'", res.CombineOutput().String())
+			res.ExpectSuccess("CNI exec-plugins did not work correctly")
 
 			res = vm.ContainerCreate(
 				name, helpers.NetperfImage,

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -39,7 +39,7 @@ var _ = Describe("RuntimeValidatedConnectivityTest", func() {
 	removeContainer := func(containerName string) {
 		By(fmt.Sprintf("removing container %s", containerName))
 		res := vm.ContainerRm(containerName)
-		Expect(res.WasSuccessful()).Should(BeTrue())
+		ExpectWithOffset(1, res).To(helpers.CMDSuccess(), "cannot delete container")
 	}
 
 	AfterEach(func() {
@@ -465,13 +465,13 @@ var _ = Describe("RuntimeValidatedConntrackTest", func() {
 
 		By(fmt.Sprintf("container %s pinging %s IPv6 (should NOT work)", helpers.Server, helpers.Client))
 		res = vm.ContainerExec(helpers.Server, helpers.Ping6(clientDockerNetworking[helpers.IPv6]))
-		ExpectWithOffset(1, res.WasSuccessful()).Should(BeFalse(), fmt.Sprintf(
-			"container %s unexpectedly was able to ping to %s %s", helpers.Server, helpers.Client, clientDockerNetworking[helpers.IPv6]))
+		ExpectWithOffset(1, res).ShouldNot(helpers.CMDSuccess(),
+			"container %q unexpectedly was able to ping to %q IP:%q", helpers.Server, helpers.Client, clientDockerNetworking[helpers.IPv6])
 
 		By(fmt.Sprintf("container %s pinging %s IPv4 (should NOT work)", helpers.Server, helpers.Client))
 		res = vm.ContainerExec(helpers.Server, helpers.Ping(clientDockerNetworking[helpers.IPv4]))
-		ExpectWithOffset(1, res.WasSuccessful()).Should(BeFalse(), fmt.Sprintf(
-			"%s was unexpectedly able to ping to %s %s", helpers.Server, helpers.Client, clientDockerNetworking[helpers.IPv4]))
+		ExpectWithOffset(1, res).ShouldNot(helpers.CMDSuccess(),
+			"%q was unexpectedly able to ping to %q IP:%q", helpers.Server, helpers.Client, clientDockerNetworking[helpers.IPv4])
 
 		By("============= Finished Connectivity Test ============= ")
 	}

--- a/test/runtime/ct.go
+++ b/test/runtime/ct.go
@@ -83,17 +83,17 @@ var _ = Describe("DisabledRuntimeValidatedConntrackTable", func() {
 		case helpers.Create:
 			for k, v := range images {
 				res := vm.ContainerCreate(k, v, helpers.CiliumDockerNetwork, fmt.Sprintf("-l id.%s", k))
-				res.ExpectSuccess(fmt.Sprintf("Creating container %q. Error: %s", k, res.CombineOutput().String()))
+				res.ExpectSuccess("Creating container %q.", k)
 			}
 			cmdStr := "docker run -dt --name netcat --net %s -l id.server-4 busybox:1.28.0 sleep 30000s"
 			vm.Exec(fmt.Sprintf(cmdStr, helpers.CiliumDockerNetwork)).ExpectSuccess()
 
 			cmdStr = "docker run -dt -v %s:/nc.py --net=%s --name client -l id.client python:2.7.14"
 			res := vm.Exec(fmt.Sprintf(cmdStr, vm.GetFullPath(ctCleanUpNC), helpers.CiliumDockerNetwork))
-			res.ExpectSuccess(fmt.Sprintf("Creating container %q. Error: %s", client, res.CombineOutput().String()))
+			res.ExpectSuccess("Creating container %q.", client)
 
 			res = vm.ContainerCreate(client2, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
-			res.ExpectSuccess(fmt.Sprintf("Creating container %q. Error: %s", client2, res.CombineOutput().String()))
+			res.ExpectSuccess("Creating container %q", client2)
 
 		case helpers.Delete:
 			for _, x := range containersNames {
@@ -613,7 +613,7 @@ var _ = Describe("DisabledRuntimeValidatedConntrackTable", func() {
 
 		By("Removing policy with labels `l3-l4-l7-policy-server-3`")
 		res := vm.PolicyDel("l3-l4-l7-policy-server-3")
-		res.ExpectSuccess("Deleting policy `l3-l4-l7-policy-server-3`: %s", res.CombineOutput())
+		res.ExpectSuccess("Deleting policy `l3-l4-l7-policy-server-3`")
 
 		By("Testing connectivity to confirm policy enforcement without going through the proxy")
 		for _, testCase := range testCombinations {

--- a/test/runtime/examples.go
+++ b/test/runtime/examples.go
@@ -122,7 +122,7 @@ var _ = Describe("RuntimeValidatedPolicyValidationTests", func() {
 		for _, file := range jsonFiles {
 			yamlPolicyPath := filepath.Join(yamlExamplesPathVM, file)
 			res := vm.Exec(fmt.Sprintf("yamllint -c %s %s", filepath.Join(helpers.BasePath, "yaml.config"), yamlPolicyPath))
-			res.ExpectSuccess("Unable to validate YAML %s: %s", yamlPolicyPath, res.CombineOutput())
+			res.ExpectSuccess("Unable to validate YAML %s", yamlPolicyPath)
 		}
 	})
 })

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -79,7 +79,7 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 		res := vm.ContainerExec(client, fmt.Sprintf(
 			"/opt/kafka/bin/kafka-topics.sh --create --zookeeper zook:2181 "+
 				"--replication-factor 1 --partitions 1 --topic %s", name))
-		res.ExpectSuccess("Unable to create topic  %s: %s", name, res.CombineOutput())
+		res.ExpectSuccess("Unable to create topic  %s", name)
 	}
 	consumerCmd := func(topic string, maxMsg int) string {
 		return fmt.Sprintf("/opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server "+


### PR DESCRIPTION
This PR is too much fun :-) 

I added a new Gomega Matcher, so with this change each new *ResCmd struct can be checked and the output if *fails* will provide all the information related with the run command. 

The example is the following: 

Example code:
```
vm.Exec("ls /tmp/").ExpectFail("Can access to /tmp/ when it should not")
```

Example output:

```
/home/eloy/.go/src/github.com/cilium/cilium/test/ginkgo-ext/scopes.go:280
  validates basic service management functionality [It]
  /home/eloy/.go/src/github.com/cilium/cilium/test/ginkgo-ext/scopes.go:312

  Can access to /tmp/ when it should not
  Expected command: ls /tmp/
  To fails, but it was successful:
  Exitcode: 0
  Stdout:
		 hsperfdata_vagrant
		 provision
		 vagrant-shell

  Stderr:
```

On the other hand, I updated all `res.ExpectSuccess()` that contains `res.CombineOutput()` so in case of fail there is not duplicated data. 

Regards