### PR TITLE
k8s: Consistently check for namespace labels in endpoint selectors

### DIFF
--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -112,7 +112,7 @@ func parseToCiliumIngressRule(namespace string, inRule, retRule *api.Rule) {
 					// The user can explicitly specify the namespace in the
 					// FromEndpoints selector. If omitted, we limit the
 					// scope to the namespace the policy lives in.
-					if _, ok := retRule.Ingress[i].FromRequires[j].MatchLabels[podPrefixLbl]; !ok {
+					if !retRule.Ingress[i].FromRequires[j].HasKey(podPrefixLbl) {
 						retRule.Ingress[i].FromRequires[j].MatchLabels[podPrefixLbl] = namespace
 					}
 				}
@@ -175,7 +175,7 @@ func parseToCiliumEgressRule(namespace string, inRule, retRule *api.Rule) {
 					// The user can explicitly specify the namespace in the
 					// ToEndpoints selector. If omitted, we limit the
 					// scope to the namespace the policy lives in.
-					if _, ok := retRule.Egress[i].ToRequires[j].MatchLabels[podPrefixLbl]; !ok {
+					if !retRule.Egress[i].ToRequires[j].HasKey(podPrefixLbl) {
 						retRule.Egress[i].ToRequires[j].MatchLabels[podPrefixLbl] = namespace
 					}
 				}


### PR DESCRIPTION
Some checks were only looking for the K8s namespace label in
matchLabels, wheras others were looking in both matchLabels and
matchExpressions.  Make it consistent by doing only the latter.

Signed-off-by: Romain Lenglet <romain@covalent.io>