### PR TITLE
agent: Fix indentation of loopback address

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1130,15 +1130,6 @@ func NewDaemon(c *Config) (*Daemon, error) {
 	log.Infof("  IPv4 allocation prefix: %s", node.GetIPv4AllocRange())
 	log.Infof("  IPv6 router address: %s", node.GetIPv6Router())
 
-	// Populate list of nodes with local node entry
-	log.Info("Adding local node to local cluster node list")
-	ni, n := node.GetLocalNode()
-	node.UpdateNode(ni, n, node.TunnelRoute, nil)
-
-	// This needs to be done after the node addressing has been configured
-	// as the node address is required as sufix
-	identity.InitIdentityAllocator(&d)
-
 	if !d.conf.IPv4Disabled {
 		// Allocate IPv4 service loopback IP
 		loopbackIPv4, _, err := ipam.AllocateNext("ipv4")
@@ -1148,6 +1139,15 @@ func NewDaemon(c *Config) (*Daemon, error) {
 		d.loopbackIPv4 = loopbackIPv4
 		log.Infof("  Loopback IPv4: %s", d.loopbackIPv4.String())
 	}
+
+	// Populate list of nodes with local node entry
+	log.Info("Adding local node to local cluster node list")
+	ni, n := node.GetLocalNode()
+	node.UpdateNode(ni, n, node.TunnelRoute, nil)
+
+	// This needs to be done after the node addressing has been configured
+	// as the node address is required as sufix
+	identity.InitIdentityAllocator(&d)
 
 	if err = d.init(); err != nil {
 		log.WithError(err).Error("Error while initializing daemon")


### PR DESCRIPTION
Fix this:
```
cilium-agent[636]: level=info msg="  IPv6 router address: f00d::a0f:0:0:8ad6"
cilium-agent[636]: level=info msg="Initializing identity allocator"
cilium-agent[636]: level=info msg="  Loopback IPv4: 10.11.247.232"
```

Signed-off-by: Thomas Graf <thomas@cilium.io>