### PR TITLE
agent: Fix panic when node.GetNodes() is empty

### DIFF
--- a/daemon/status.go
+++ b/daemon/status.go
@@ -101,9 +101,6 @@ func (d *Daemon) getNodeStatus() *models.ClusterStatus {
 	for _, node := range node.GetNodes() {
 		clusterStatus.Nodes = append(clusterStatus.Nodes, node.GetModel(ipv4))
 	}
-	if len(clusterStatus.Nodes) == 0 {
-		return nil
-	}
 	return &clusterStatus
 }
 


### PR DESCRIPTION
Fix the following panic:
```
cilium-agent[16942]: panic: runtime error: invalid memory address or nil pointer dereference
cilium-agent[16942]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x18ea5f9]
cilium-agent[16942]: goroutine 217 [running]:
cilium-agent[16942]: main.(*Daemon).getStatus(0xc4221faea0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
cilium-agent[16942]:         /home/vagrant/go/src/github.com/cilium/cilium/daemon/status.go:178 +0x3c9
cilium-agent[16942]: main.(*Daemon).collectStatus(0xc4221faea0)
cilium-agent[16942]:         /home/vagrant/go/src/github.com/cilium/cilium/daemon/status.go:111 +0x63
cilium-agent[16942]: created by main.(*Daemon).startStatusCollector
cilium-agent[16942]:         /home/vagrant/go/src/github.com/cilium/cilium/daemon/status.go:122 +0x3f
```

Signed-off-by: Thomas Graf <thomas@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4105)
<!-- Reviewable:end -->
