### PR TITLE
pkg/ip: fix getNextIP for IPv4

### DIFF
--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -454,28 +454,48 @@ func (s *IPTestSuite) TestNextIP(c *C) {
 	expectedNext := net.ParseIP("10.0.0.0")
 	ip := net.ParseIP("9.255.255.255")
 	nextIP := getNextIP(ip)
-	s.testIPsEqual(nextIP, expectedNext, c)
+	c.Assert(nextIP, DeepEquals, expectedNext)
 
 	// Check that overflow does not occur.
 	ip = net.ParseIP("255.255.255.255")
 	nextIP = getNextIP(ip)
 	expectedNext = ip
-	s.testIPsEqual(nextIP, expectedNext, c)
+	c.Assert(nextIP, DeepEquals, expectedNext)
 
 	ip = net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
 	nextIP = getNextIP(ip)
 	expectedNext = ip
-	s.testIPsEqual(nextIP, expectedNext, c)
+	c.Assert(nextIP, DeepEquals, expectedNext)
+
+	ip = net.IP([]byte{0xa, 0, 0, 0})
+	nextIP = getNextIP(ip)
+	expectedNext = net.IP([]byte{0xa, 0, 0, 1})
+	c.Assert(nextIP, DeepEquals, expectedNext)
+
+	ip = net.IP([]byte{0xff, 0xff, 0xff, 0xff})
+	nextIP = getNextIP(ip)
+	expectedNext = net.IP([]byte{0xff, 0xff, 0xff, 0xff})
+	c.Assert(nextIP, DeepEquals, expectedNext)
 
 	ip = net.ParseIP("10.0.0.0")
 	nextIP = getNextIP(ip)
 	expectedNext = net.ParseIP("10.0.0.1")
-	s.testIPsEqual(nextIP, expectedNext, c)
+	c.Assert(nextIP, DeepEquals, expectedNext)
+
+	ip = net.ParseIP("0:0:0:0:ffff:ffff:ffff:ffff")
+	nextIP = getNextIP(ip)
+	expectedNext = net.ParseIP("0:0:0:1:0:0:0:0")
+	c.Assert(nextIP, DeepEquals, expectedNext)
+
+	ip = net.ParseIP("ffff:ffff:ffff:fffe:ffff:ffff:ffff:ffff")
+	nextIP = getNextIP(ip)
+	expectedNext = net.ParseIP("ffff:ffff:ffff:ffff:0:0:0:0")
+	c.Assert(nextIP, DeepEquals, expectedNext)
 
 	ip = net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe")
-	expectedNext = net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
 	nextIP = getNextIP(ip)
-	s.testIPsEqual(nextIP, expectedNext, c)
+	expectedNext = net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+	c.Assert(nextIP, DeepEquals, expectedNext)
 }
 
 func (s *IPTestSuite) TestCreateSpanningCIDR(c *C) {


### PR DESCRIPTION
Fix getNextIP for IPv4 addresses that had a length of 4 bytes.

Fixes: ee23ad0b3e6386427ba0207a381de583a6fc934a
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4106)
<!-- Reviewable:end -->
