### PR TITLE
pkg/policy/api: add basic HTTP Rule sanitization

### DIFF
--- a/pkg/policy/api/http.go
+++ b/pkg/policy/api/http.go
@@ -14,6 +14,8 @@
 
 package api
 
+import "regexp"
+
 // PortRuleHTTP is a list of HTTP protocol constraints. All fields are
 // optional, if all fields are empty or missing, the rule does not have any
 // effect.
@@ -55,4 +57,28 @@ type PortRuleHTTP struct {
 	//
 	// +optional
 	Headers []string `json:"headers,omitempty"`
+}
+
+// Sanitize sanitizes HTTP rules. It ensures that the path and method fields
+// are valid regular expressions. Note that the proxy may support a wider-range
+// of regular expressions (e.g. that specified by ECMAScript), so this function
+// may return some false positives. If the rule is invalid, returns an error.
+func (h *PortRuleHTTP) Sanitize() error {
+
+	if h.Path != "" {
+		_, err := regexp.Compile(h.Path)
+		if err != nil {
+			return err
+		}
+	}
+
+	if h.Method != "" {
+		_, err := regexp.Compile(h.Method)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Headers are not sanitized.
+	return nil
 }

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -237,6 +237,14 @@ func (pr *L7Rules) sanitize() error {
 		return fmt.Errorf("multiple L7 protocol rule types specified in single rule")
 	}
 
+	if pr.HTTP != nil {
+		for i := range pr.HTTP {
+			if err := pr.HTTP[i].Sanitize(); err != nil {
+				return err
+			}
+		}
+	}
+
 	if pr.Kafka != nil {
 		for i := range pr.Kafka {
 			if err := pr.Kafka[i].Sanitize(); err != nil {

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -145,3 +145,54 @@ func (s *PolicyAPITestSuite) TestL7RulesWithNonTCPProtocols(c *C) {
 	c.Assert(err.Error(), Equals, "L7 rules can only apply exclusively to TCP, not UDP")
 
 }
+
+// This test ensures that PortRules using the HTTP protocol have valid regular
+// expressions for the method and path fields.
+func (s *PolicyAPITestSuite) TestHTTPRuleRegexes(c *C) {
+
+	invalidHTTPRegexPathRule := Rule{
+		EndpointSelector: WildcardEndpointSelector,
+		Ingress: []IngressRule{
+			{
+				FromEndpoints: []EndpointSelector{WildcardEndpointSelector},
+				ToPorts: []PortRule{{
+					Ports: []PortProtocol{
+						{Port: "80", Protocol: ProtoTCP},
+						{Port: "81", Protocol: ProtoTCP},
+					},
+					Rules: &L7Rules{
+						HTTP: []PortRuleHTTP{
+							{Method: "GET", Path: "*"},
+						},
+					},
+				}},
+			},
+		},
+	}
+
+	err := invalidHTTPRegexPathRule.Sanitize()
+	c.Assert(err, Not(IsNil))
+
+	invalidHTTPRegexMethodRule := Rule{
+		EndpointSelector: WildcardEndpointSelector,
+		Ingress: []IngressRule{
+			{
+				FromEndpoints: []EndpointSelector{WildcardEndpointSelector},
+				ToPorts: []PortRule{{
+					Ports: []PortProtocol{
+						{Port: "80", Protocol: ProtoTCP},
+						{Port: "81", Protocol: ProtoTCP},
+					},
+					Rules: &L7Rules{
+						HTTP: []PortRuleHTTP{
+							{Method: "*", Path: "/"},
+						},
+					},
+				}},
+			},
+		},
+	}
+
+	err = invalidHTTPRegexMethodRule.Sanitize()
+	c.Assert(err, Not(IsNil))
+}


### PR DESCRIPTION
Check whether the HTTP Path and Method are regular expressions per golang's
regexp.Compile(). While Envoy uses ECMAScript for regular expression matching,
which does not correspond fully to golang's regexp library's regular expression
matching, it's best that we have at least some type of regular expression
validation for now for fields requiring regular expressions in HTTP Rules.
A future fix would be to validate against ECMAScript.
See: http://en.cppreference.com/w/cpp/regex/ecmascript

Signed-off by: Ian Vernon <ian@cilium.io>

I am hesitant of saying that this "fixes" #3401 because do to so, we need to match the regular expressions which Envoy fully supports. This change is better than what we have now (nothing), but is more of a stop-gap than anything else.

```release-note
restrict regular expressions for HTTP Method and Path
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4110)
<!-- Reviewable:end -->
