### PR TITLE
bpf: Fix failure handling in CreateMap

### DIFF
--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -121,10 +121,10 @@ func CreateMap(mapType int, keySize, valueSize, maxEntries, flags uint32) (int, 
 		unsafe.Sizeof(uba),
 	)
 
-	if ret != 0 {
-		return int(ret), nil
+	if err != 0 {
+		return 0, fmt.Errorf("Unable to create map: %s", err)
 	}
-	return 0, fmt.Errorf("Unable to create map: %s", err)
+	return int(ret), nil
 }
 
 // This struct must be in sync with union bpf_attr's anonymous struct used by


### PR DESCRIPTION
When the Golang syscall returns an fd plus an error, it is possible for
the fd to be negative (which indicates an error), along with a non-nil
error. Previously, if the call returned a negative FD, then we would not
treat this as an error in this function, because we did the fd check first
and returned it with no error if it was nonzero. The error would propagate
to the pinning function, which would fail with -EBADF.

Instead, check the error first and return an error if it is non-nil.
This avoids the bad file descriptor being passed further down into the
map pinning syscall, which would subsequently fail, but hiding the
original problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4111)
<!-- Reviewable:end -->
