### PR TITLE
test: move creation and deletion and resources outside of `It`

### DIFF
--- a/test/runtime/cli.go
+++ b/test/runtime/cli.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -32,18 +31,12 @@ var _ = Describe("RuntimeValidatedCLI", func() {
 	var logger *logrus.Entry
 	var vm *helpers.SSHMeta
 
-	var once sync.Once
-
-	initialize := func() {
+	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimeCLI"})
 		logger.Info("Starting")
 		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 		areEndpointsReady := vm.WaitEndpointsReady()
 		Expect(areEndpointsReady).Should(BeTrue())
-	}
-
-	BeforeEach(func() {
-		once.Do(initialize)
 	})
 
 	JustAfterEach(func() {

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -72,6 +72,10 @@ var _ = Describe("RuntimeValidatedMonitorTest", func() {
 			vm.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
 		})
 
+		AfterEach(func() {
+			_ = vm.PolicyDelAll()
+		})
+
 		AfterAll(func() {
 			vm.SampleContainersActions(helpers.Delete, helpers.CiliumDockerNetwork)
 		})
@@ -110,10 +114,6 @@ var _ = Describe("RuntimeValidatedMonitorTest", func() {
 
 			_, err := vm.PolicyImportAndWait(vm.GetFullPath(policiesL3JSON), helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
-
-			defer func() {
-				vm.PolicyDelAll().ExpectSuccess("cannot delete the policy")
-			}()
 
 			areEndpointsReady := vm.WaitEndpointsReady()
 			Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")


### PR DESCRIPTION
Fix tests in the following files which have this issue:

* `test/runtime/cli.go`
* `test/runtime/Policies.go`
* `test/runtime/monitor.go`

Signed-off by: Ian Vernon <ian@cilium.io>

Relates-to: #3821 