### PR TITLE
cilium node-monitor no longer panics during normal cilium-agent shutdowns

### DIFF
--- a/monitor/main.go
+++ b/monitor/main.go
@@ -97,7 +97,6 @@ func runNodeMonitor() {
 	log.Infof("Serving cilium node monitor at unix://%s", defaults.MonitorSockPath)
 
 	mainCtx, mainCtxCancel := context.WithCancel(context.Background())
-	defer mainCtxCancel() // Signal a shutdown to spawned goroutines
 
 	monitorSingleton, err = NewMonitor(mainCtx, npages, pipe, server)
 	if err != nil {
@@ -108,4 +107,5 @@ func runNodeMonitor() {
 	signal.Notify(shutdownChan, syscall.SIGQUIT, syscall.SIGINT, syscall.SIGTERM, syscall.SIGINT)
 	sig := <-shutdownChan
 	log.WithField(logfields.Signal, sig).Info("Exiting due to signal")
+	mainCtxCancel() // Signal a shutdown to spawned goroutines
 }

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -103,10 +103,10 @@ func (m *Monitor) agentPipeReader(ctx context.Context, agentPipe io.Reader) {
 			return
 
 		case err == io.EOF || err == io.ErrUnexpectedEOF:
-			log.Panic("Agent pipe unexpectedly closed, shutting down")
+			log.Fatal("Agent pipe unexpectedly closed, shutting down")
 
 		case err != nil:
-			log.WithError(err).Panic("Unable to read cilium agent events from pipe")
+			log.WithError(err).Fatal("Unable to read cilium agent events from pipe")
 		}
 
 		m.send(&p)
@@ -191,7 +191,7 @@ func (m *Monitor) perfEventReader(stopCtx context.Context, nPages int) {
 
 	monitorEvents, err := bpf.NewPerCpuEvents(c)
 	if err != nil {
-		scopedLog.WithError(err).Panic("Cannot initialise BPF perf ring buffer sockets")
+		scopedLog.WithError(err).Fatal("Cannot initialise BPF perf ring buffer sockets")
 	}
 	defer monitorEvents.CloseAll()
 


### PR DESCRIPTION
This fixes #4088 (I hope).

The monitor would throw a panic when the BPF perf ring buffer or the
cilium-agent events pipe would return errors. This was causing our CI
panic checkers to trigger. Switching to Fatal avoids the panic, but
keeps it clear that this is a bad event. Fatal does a exit(1).

We previously used a deferred cancel for the main coordination context.
For some reason, the defer was deferred too much and we would see the
agent pipe close before we cancel the context. This caused Fatal errors
and was unseemly.