### PR TITLE
test/k8sT: move creation / deletion of resources outside of `It`

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -228,6 +228,8 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 		})
 
 		AfterEach(func() {
+			_ = kubectl.Delete(policyPath)
+
 			res := kubectl.Delete(endpointPath)
 			res.ExpectSuccess()
 
@@ -280,25 +282,16 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 			}, 5*time.Minute, 10*time.Second).Should(ContainSubstring(expectedCIDR))
 		}
 
-		deletePath := func(path string) {
-			res := kubectl.Delete(path)
-			res.ExpectSuccess()
-		}
-
 		It("To Services first endpoint creation", func() {
 			res := kubectl.Apply(endpointPath)
 			res.ExpectSuccess()
 
 			applyPolicy(policyPath)
-			defer deletePath(policyPath)
-
 			validateEgress()
 		})
 
 		It("To Services first policy", func() {
 			applyPolicy(policyPath)
-			defer deletePath(policyPath)
-
 			res := kubectl.Apply(endpointPath)
 			res.ExpectSuccess()
 
@@ -310,14 +303,12 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 			res.ExpectSuccess()
 
 			applyPolicy(policyLabeledPath)
-			defer deletePath(policyLabeledPath)
 
 			validateEgress()
 		})
 
 		It("To Services first policy, match service by labels", func() {
 			applyPolicy(policyLabeledPath)
-			defer deletePath(policyLabeledPath)
 
 			res := kubectl.Apply(endpointPath)
 			res.ExpectSuccess()

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -259,24 +259,24 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 			kubectl.WaitforPods(helpers.DefaultNamespace, "", 300)
 
 			pods, err := kubectl.GetPodsNodes(helpers.DefaultNamespace, "")
-			Expect(err).To(BeNil())
+			ExpectWithOffset(1, err).To(BeNil())
 
 			node := pods[podName]
 			ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, node)
-			Expect(err).Should(BeNil())
+			ExpectWithOffset(1, err).Should(BeNil())
 
 			status := kubectl.CiliumEndpointWait(ciliumPod)
-			Expect(status).To(BeTrue())
+			ExpectWithOffset(1, status).To(BeTrue())
 
 			endpointIDs := kubectl.CiliumEndpointsIDs(ciliumPod)
 			endpointID := endpointIDs[fmt.Sprintf("%s:%s", helpers.DefaultNamespace, podName)]
-			Expect(endpointID).NotTo(BeNil())
+			ExpectWithOffset(1, endpointID).NotTo(BeNil())
 
 			Eventually(func() string {
 				res := kubectl.CiliumEndpointGet(ciliumPod, endpointID)
 
 				data, err := res.Filter(`{[0].status.policy.realized.cidr-policy.egress}`)
-				Expect(err).To(BeNil())
+				ExpectWithOffset(1, err).To(BeNil())
 				return data.String()
 
 			}, 5*time.Minute, 10*time.Second).Should(ContainSubstring(expectedCIDR))


### PR DESCRIPTION
Do this for the "External Services" test. Also use `ExpectWithOffset` in helper functions, and add failure messages.

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #3821 