### PR TITLE
nightly tests: move creation / deletion of resources outside of It

### DIFF
--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -320,14 +320,13 @@ var _ = Describe("NightlyExamples", func() {
 
 	var kubectl *helpers.Kubectl
 	var logger *logrus.Entry
-	var once sync.Once
 	var ciliumPath string
 	var demoPath string
 	var l3Policy, l7Policy string
 	var appService = "app1-service"
 	var apps []string
 
-	initialize := func() {
+	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"testName": "NightlyK8sEpsMeasurement"})
 		logger.Info("Starting")
 
@@ -348,10 +347,6 @@ var _ = Describe("NightlyExamples", func() {
 			"%s delete --all pods,svc,cnp -n %s", helpers.KubectlCmd, helpers.DefaultNamespace))
 
 		ExpectAllPodsTerminated(kubectl)
-	}
-
-	BeforeEach(func() {
-		once.Do(initialize)
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -414,8 +414,10 @@ var _ = Describe("NightlyExamples", func() {
 	Context("Getting started guides", func() {
 
 		var (
-			GRPCManifest = "../examples/kubernetes-grpc/cc-door-app.yaml"
-			GRPCPolicy   = "../examples/kubernetes-grpc/cc-door-ingress-security.yaml"
+			GRPCManifest   = "../examples/kubernetes-grpc/cc-door-app.yaml"
+			GRPCPolicy     = "../examples/kubernetes-grpc/cc-door-ingress-security.yaml"
+			AppManifest    = helpers.GetFilePath(GRPCManifest)
+			PolicyManifest = helpers.GetFilePath(GRPCPolicy)
 		)
 
 		BeforeEach(func() {
@@ -427,19 +429,14 @@ var _ = Describe("NightlyExamples", func() {
 		})
 
 		AfterEach(func() {
+			kubectl.Delete(AppManifest)
+			kubectl.Delete(PolicyManifest)
+
 			ExpectAllPodsTerminated(kubectl)
 		})
 
 		It("GRPC example", func() {
-
-			AppManifest := helpers.GetFilePath(GRPCManifest)
-			PolicyManifest := helpers.GetFilePath(GRPCPolicy)
 			clientPod := "terminal-87"
-
-			defer func() {
-				kubectl.Delete(AppManifest)
-				kubectl.Delete(PolicyManifest)
-			}()
 
 			By("Testing the example config")
 			kubectl.Apply(AppManifest).ExpectSuccess("cannot install the GRPC application")


### PR DESCRIPTION
Do this for the TCP Keepalive tests. This ensures that resources are not deleted
before logs are gathered.

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #3821

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4115)
<!-- Reviewable:end -->
