### PR TITLE
Test: Add more context commands on AfterFailed commands

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -608,7 +608,7 @@ func (s *SSHMeta) ReportFailed(commands ...string) {
 	ginkgoext.GinkgoPrint(res.GetDebugMessage())
 
 	for _, cmd := range commands {
-		res = s.Exec(fmt.Sprintf("%s", cmd))
+		res = s.ExecWithSudo(fmt.Sprintf("%s", cmd))
 		ginkgoext.GinkgoPrint(res.GetDebugMessage())
 	}
 

--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -230,7 +230,7 @@ func (res *CmdRes) Unmarshal(data interface{}) error {
 
 // GetDebugMessage returns executed command and its output
 func (res *CmdRes) GetDebugMessage() string {
-	return fmt.Sprintf("cmd: %s\noutput: %s", res.GetCmd(), res.CombineOutput())
+	return fmt.Sprintf("cmd: %s\n%s", res.GetCmd(), res.CombineOutput())
 }
 
 // WaitUntilMatch waits until the given substring is present in the `CmdRes.stdout`

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -979,8 +979,7 @@ func (kub *Kubectl) CiliumReport(namespace string, commands ...string) {
 
 	for _, pod := range pods {
 		for _, cmd := range commands {
-			command := fmt.Sprintf("%s exec -n %s %s -- %s", KubectlCmd, namespace, pod, cmd)
-			res = kub.Exec(command)
+			res = kub.ExecPodCmd(namespace, pod, cmd)
 			ginkgoext.GinkgoPrint(res.GetDebugMessage())
 		}
 	}

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -44,9 +44,7 @@ var _ = Describe(testName, func() {
 
 	AfterFailed(func() {
 		kubectl.CiliumReport(helpers.KubeSystemNamespace,
-			"cilium service list",
-			"cilium endpoint list",
-			"cilium policy get")
+			"cilium endpoint list")
 	})
 
 	JustAfterEach(func() {

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -74,7 +74,6 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 	AfterFailed(func() {
 		kubectl.CiliumReport(helpers.KubeSystemNamespace,
 			"cilium service list",
-			"cilium policy get",
 			"cilium endpoint list")
 	})
 

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -42,7 +42,6 @@ var _ = Describe("NightlyPolicies", func() {
 
 	AfterFailed(func() {
 		kubectl.CiliumReport(helpers.KubeSystemNamespace,
-			"cilium policy get",
 			"cilium endpoint list",
 			"cilium service list")
 	})

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -63,7 +63,6 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 	AfterFailed(func() {
 		kubectl.CiliumReport(helpers.KubeSystemNamespace,
 			"cilium service list",
-			"cilium policy get",
 			"cilium endpoint list")
 	})
 

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -65,7 +65,9 @@ var _ = Describe(demoTestName, func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace)
+		kubectl.CiliumReport(helpers.KubeSystemNamespace,
+			"cilium endpoint list",
+			"cilium service list")
 	})
 
 	JustBeforeEach(func() {

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -83,7 +83,7 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 	})
 
 	AfterFailed(func() {
-		vm.ReportFailed()
+		vm.ReportFailed("cilium config", "cilium policy get")
 	})
 
 	Context("Policy Enforcement Default", func() {
@@ -1251,7 +1251,7 @@ var _ = Describe("RuntimeValidatedPolicyImportTests", func() {
 	})
 
 	AfterFailed(func() {
-		vm.ReportFailed()
+		vm.ReportFailed("cilium policy get")
 	})
 
 	AfterAll(func() {

--- a/test/runtime/cli.go
+++ b/test/runtime/cli.go
@@ -44,7 +44,7 @@ var _ = Describe("RuntimeValidatedCLI", func() {
 	})
 
 	AfterFailed(func() {
-		vm.ReportFailed("cilium endpoint list")
+		vm.ReportFailed()
 	})
 
 	Context("Identity CLI testing", func() {

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -43,7 +43,6 @@ var _ = Describe("RuntimeValidatedConnectivityTest", func() {
 
 	AfterEach(func() {
 		vm.PolicyDelAll().ExpectSuccess("Policies cannot be deleted")
-		return
 	})
 
 	JustAfterEach(func() {
@@ -648,7 +647,7 @@ var _ = Describe("RuntimeValidatedConntrackTest", func() {
 	})
 
 	AfterFailed(func() {
-		vm.ReportFailed()
+		vm.ReportFailed("cilium policy get")
 	})
 
 	It("Conntrack-related configuration options for endpoints", func() {

--- a/test/runtime/ct.go
+++ b/test/runtime/ct.go
@@ -149,8 +149,7 @@ var _ = Describe("DisabledRuntimeValidatedConntrackTable", func() {
 
 	AfterFailed(func() {
 		vm.ReportFailed(
-			"sudo cilium bpf ct list global",
-			"sudo cilium endpoint list")
+			"sudo cilium bpf ct list global")
 
 	})
 

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -141,7 +141,7 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 	})
 
 	AfterFailed(func() {
-		vm.ReportFailed()
+		vm.ReportFailed("cilium policy get")
 	})
 
 	It("Kafka Policy Ingress", func() {

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -63,9 +63,7 @@ var _ = Describe("RuntimeValidatedKVStoreTest", func() {
 	})
 
 	AfterFailed(func() {
-		vm.ReportFailed(
-			"sudo docker ps -a",
-			"sudo cilium endpoint list")
+		vm.ReportFailed("cilium status")
 	})
 
 	It("Consul KVStore", func() {

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -53,8 +53,9 @@ var _ = Describe("RuntimeValidatedLB", func() {
 
 	AfterFailed(func() {
 		vm.ReportFailed(
-			"sudo cilium service list",
-			"sudo cilium endpoint list")
+			"cilium service list",
+			"cilium bpf lb list",
+			"cilium policy get")
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
The default AfterFailed commands will be in the Jenkins Junit output,
this change provides some command with test context and the output will
be useful for quick overview.

About Policy dump, I tried a few times, but the output of this can be
super verbose, and having a large dump don't help at all. The policy
will be retrieved next week in Junit Attachments.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>
