### PR TITLE
configuration: move TracingEnabled to pkg/option

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -261,10 +261,6 @@ func (d *Daemon) GetPolicyRepository() *policy.Repository {
 	return d.policy
 }
 
-func (d *Daemon) TracingEnabled() bool {
-	return option.Config.Opts.IsEnabled(option.PolicyTracing)
-}
-
 func (d *Daemon) DryModeEnabled() bool {
 	return option.Config.DryMode
 }

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -177,13 +177,6 @@ func (ds *DaemonSuite) TestMiniumWorkerThreadsIsSet(c *C) {
 	c.Assert(numWorkerThreads() >= runtime.NumCPU(), Equals, true)
 }
 
-func (ds *DaemonSuite) TracingEnabled() bool {
-	if ds.OnTracingEnabled != nil {
-		return ds.OnTracingEnabled()
-	}
-	panic("TracingEnabled should not have been called")
-}
-
 func (ds *DaemonSuite) DryModeEnabled() bool {
 	if ds.OnDryModeEnabled != nil {
 		return ds.OnDryModeEnabled()

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -23,8 +23,6 @@ import (
 
 // Owner is the interface defines the requirements for anybody owning policies.
 type Owner interface {
-	// Must return true if tracing of the policy resolution is to be enabled
-	TracingEnabled() bool
 
 	// Must return true if dry mode is enabled
 	DryModeEnabled() bool

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -139,7 +139,7 @@ func getLabelsMap() (*identityPkg.IdentityCache, error) {
 }
 
 // Must be called with global endpoint.Mutex held
-func (e *Endpoint) resolveL4Policy(owner Owner, repo *policy.Repository) error {
+func (e *Endpoint) resolveL4Policy(repo *policy.Repository) error {
 
 	ingressCtx := policy.SearchContext{
 		To: e.SecurityIdentity.LabelArray,
@@ -149,7 +149,7 @@ func (e *Endpoint) resolveL4Policy(owner Owner, repo *policy.Repository) error {
 		From: e.SecurityIdentity.LabelArray,
 	}
 
-	if owner.TracingEnabled() {
+	if option.Config.TracingEnabled() {
 		ingressCtx.Trace = policy.TRACE_ENABLED
 		egressCtx.Trace = policy.TRACE_ENABLED
 	}
@@ -176,15 +176,15 @@ func (e *Endpoint) resolveL4Policy(owner Owner, repo *policy.Repository) error {
 	return nil
 }
 
-func (e *Endpoint) computeDesiredPolicyMapState(owner Owner, labelsMap *identityPkg.IdentityCache,
+func (e *Endpoint) computeDesiredPolicyMapState(labelsMap *identityPkg.IdentityCache,
 	repo *policy.Repository) {
 	desiredPolicyKeys := make(map[policymap.PolicyKey]struct{})
 	if e.LabelsMap != labelsMap {
 		e.LabelsMap = labelsMap
 	}
 	e.computeDesiredL4PolicyMapEntries(desiredPolicyKeys)
-	e.determineAllowLocalhost(owner, desiredPolicyKeys)
-	e.computeDesiredL3PolicyMapEntries(owner, labelsMap, repo, desiredPolicyKeys)
+	e.determineAllowLocalhost(desiredPolicyKeys)
+	e.computeDesiredL3PolicyMapEntries(labelsMap, repo, desiredPolicyKeys)
 	e.desiredMapState = desiredPolicyKeys
 }
 
@@ -192,7 +192,7 @@ func (e *Endpoint) computeDesiredPolicyMapState(owner Owner, labelsMap *identity
 // communicate with the localhost. It inserts the PolicyKey corresponding to
 // the localhost in the desiredPolicyKeys if the endpoint is allowed to
 // communicate with the localhost.
-func (e *Endpoint) determineAllowLocalhost(owner Owner, desiredPolicyKeys map[policymap.PolicyKey]struct{}) {
+func (e *Endpoint) determineAllowLocalhost(desiredPolicyKeys map[policymap.PolicyKey]struct{}) {
 
 	if desiredPolicyKeys == nil {
 		desiredPolicyKeys = map[policymap.PolicyKey]struct{}{}
@@ -207,7 +207,7 @@ func (e *Endpoint) determineAllowLocalhost(owner Owner, desiredPolicyKeys map[po
 	}
 }
 
-func (e *Endpoint) computeDesiredL3PolicyMapEntries(owner Owner, identityCache *identityPkg.IdentityCache, repo *policy.Repository, desiredPolicyKeys map[policymap.PolicyKey]struct{}) {
+func (e *Endpoint) computeDesiredL3PolicyMapEntries(identityCache *identityPkg.IdentityCache, repo *policy.Repository, desiredPolicyKeys map[policymap.PolicyKey]struct{}) {
 
 	if desiredPolicyKeys == nil {
 		desiredPolicyKeys = map[policymap.PolicyKey]struct{}{}
@@ -220,7 +220,7 @@ func (e *Endpoint) computeDesiredL3PolicyMapEntries(owner Owner, identityCache *
 		From: e.SecurityIdentity.LabelArray,
 	}
 
-	if owner.TracingEnabled() {
+	if option.Config.TracingEnabled() {
 		ingressCtx.Trace = policy.TRACE_ENABLED
 		egressCtx.Trace = policy.TRACE_ENABLED
 	}
@@ -252,12 +252,12 @@ func (e *Endpoint) computeDesiredL3PolicyMapEntries(owner Owner, identityCache *
 }
 
 // Must be called with global repo.Mutrex, e.Mutex, and c.Mutex held
-func (e *Endpoint) regenerateL3Policy(owner Owner, repo *policy.Repository, revision uint64) (bool, error) {
+func (e *Endpoint) regenerateL3Policy(repo *policy.Repository, revision uint64) (bool, error) {
 
 	ctx := policy.SearchContext{
 		To: e.SecurityIdentity.LabelArray, // keep c.Mutex taken to protect this.
 	}
-	if owner.TracingEnabled() {
+	if option.Config.TracingEnabled() {
 		ctx.Trace = policy.TRACE_ENABLED
 	}
 	newL3policy := repo.ResolveCIDRPolicy(&ctx)
@@ -300,7 +300,7 @@ func (e *Endpoint) updateNetworkPolicy(owner Owner) error {
 	ctx := policy.SearchContext{
 		To: e.SecurityIdentity.LabelArray,
 	}
-	if owner.TracingEnabled() {
+	if option.Config.TracingEnabled() {
 		ctx.Trace = policy.TRACE_ENABLED
 	}
 	deniedIngressIdentities := make(map[identityPkg.NumericIdentity]bool)
@@ -441,7 +441,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner, opts models.ConfigurationMap) (
 	// Skip L4 policy recomputation if possible. However, the rest of the
 	// policy computation still needs to be done for each endpoint separately.
 	if e.Iteration != revision {
-		err = e.resolveL4Policy(owner, repo)
+		err = e.resolveL4Policy(repo)
 		if err != nil {
 			return false, err
 		}
@@ -453,7 +453,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner, opts models.ConfigurationMap) (
 
 	// Calculate L3 (CIDR) policy.
 	var policyChanged bool
-	if policyChanged, err = e.regenerateL3Policy(owner, repo, revision); err != nil {
+	if policyChanged, err = e.regenerateL3Policy(repo, revision); err != nil {
 		return false, err
 	}
 
@@ -494,7 +494,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner, opts models.ConfigurationMap) (
 
 	optsChanged := e.applyOptsLocked(opts)
 
-	e.computeDesiredPolicyMapState(owner, labelsMap, repo)
+	e.computeDesiredPolicyMapState(labelsMap, repo)
 
 	// If we are in this function, then policy has been calculated.
 	if !e.PolicyCalculated {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -123,3 +123,9 @@ func (c *daemonConfig) AlwaysAllowLocalhost() bool {
 		return false
 	}
 }
+
+// TracingEnabled returns if tracing policy (outlining which rules apply to a
+// specific set of labels) is enabled.
+func (c *daemonConfig) TracingEnabled() bool {
+	return c.Opts.IsEnabled(PolicyTracing)
+}


### PR DESCRIPTION
Now that configuration is part of a global singleton, we can remove the
TracingEnabled function out of the Owner interface and into pkg/option. This
allows for the removal of the owner as a parameter in some functions.

Signed-off by: Ian Vernon <ian@cilium.io>
