### PR TITLE
test/k8sT: add k8s default-allow tests

### DIFF
--- a/test/k8sT/manifests/1.7/knp-default-allow-ingress.yaml
+++ b/test/k8sT/manifests/1.7/knp-default-allow-ingress.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-ingress
+spec:
+  podSelector: {}
+  ingress:
+  - {}

--- a/test/k8sT/manifests/knp-default-allow-egress.yaml
+++ b/test/k8sT/manifests/knp-default-allow-egress.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-egress
+spec:
+  podSelector: {}
+  egress:
+  - {}
+  policyTypes:
+  - Egress

--- a/test/k8sT/manifests/knp-default-allow-ingress.yaml
+++ b/test/k8sT/manifests/knp-default-allow-ingress.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-ingress
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  policyTypes:
+  - Ingress


### PR DESCRIPTION
Add for ingress and egress. This ensures that we enforce basic
policy examples for Kubernetes and never regress in our CI.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #2337

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4133)
<!-- Reviewable:end -->
