### PR TITLE
test/k8sT/manifests: re-add l3_l4_policy.yaml

### DIFF
--- a/test/k8sT/manifests/l3_l4_policy.yaml
+++ b/test/k8sT/manifests/l3_l4_policy.yaml
@@ -1,1 +1,17 @@
-../../../examples/minikube/l3_l4_policy.yaml
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+description: "L3-L4 policy"
+metadata:
+  name: "rule1"
+spec:
+  endpointSelector:
+    matchLabels:
+      id: app1
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        id: app2
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP


### PR DESCRIPTION
This file (`test/k8sT/manifests/l3_l4_policy.yaml`) was symlinked to a file which was deleted.

Fixes: dc36592246cc3853574adf587a9f5d6a714f2d56

Signed-off by: Ian Vernon <ian@cilium.io>