### PR TITLE
pkg/endpoint: release lock if syncPolicyMap fails

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -642,6 +642,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 		// with the old one.
 		err := e.syncPolicyMap()
 		if err != nil {
+			e.Mutex.Unlock()
 			return 0, fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
 		}
 


### PR DESCRIPTION
The endpoint mutex was not released if syncPolicyMap failed in
regenerateBPF. Unlock the endpoint mutex accordingly.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #4140 