### PR TITLE
cleanup: remove refs to Consumable in comments

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -406,10 +406,9 @@ func (ep *epInfoCache) GetBPFValue() (*lxcmap.EndpointInfo, error) {
 	return ep.value, nil
 }
 
-// addNewRedirectsFromMap must be called while holding the endpoint and consumable
-// locks for writing. On success, returns nil; otherwise, returns an error
-// indicating the problem that occurred while adding an l7 redirect for the
-// specified policy.
+// addNewRedirectsFromMap must be called while holding the endpoint lock for
+// writing. On success, returns nil; otherwise, returns an error  indicating the
+// problem that occurred while adding an l7 redirect for the specified policy.
 // Must be called with endpoint.Mutex held.
 func (e *Endpoint) addNewRedirectsFromMap(owner Owner, m policy.L4PolicyMap, desiredRedirects map[string]bool) error {
 	if owner.DryModeEnabled() {
@@ -446,10 +445,9 @@ func (e *Endpoint) addNewRedirectsFromMap(owner Owner, m policy.L4PolicyMap, des
 	return nil
 }
 
-// addNewRedirects must be called while holding the endpoint and consumable
-// locks for writing. On success, returns nil; otherwise, returns an error
-// indicating the problem that occurred while adding an l7 redirect for the
-// specified policy.
+// addNewRedirects must be called while holding the endpoint lock for writing.
+// On success, returns nil; otherwise, returns an error indicating the problem
+// that occurred while adding an l7 redirect for the specified policy.
 // The returned map contains the exact set of IDs of proxy redirects that is
 // required to implement the given L4 policy.
 // Must be called with endpoint.Mutex held.

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -335,15 +335,11 @@ type Endpoint struct {
 	LabelsMap *identityPkg.IdentityCache
 
 	// Iteration policy of the Endpoint
-	// TODO: this was moved from Consumable to Endpoint. This documentation is
-	// not clear, and needs to be more specific.
+	// TODO: update documentation; description is not clear, and needs to be
+	// more specific.
 	Iteration uint64 `json:"-"`
 
-	// RealizedL4Policy is the L4Policy in effect for the
-	// endpoint. Outside of policy recalculation, it is the same as the
-	// Consumable's RealizedL4Policy, but this is needed during policy recalculation to
-	// be able to clean up PolicyMap after the endpoint's consumable has already
-	// been updated.
+	// RealizedL4Policy is the L4Policy in effect for the endpoint.
 	RealizedL4Policy *policy.L4Policy `json:"-"`
 
 	// DesiredL4Policy is the desired L4Policy for the endpoint. It is populated
@@ -354,9 +350,7 @@ type Endpoint struct {
 	// reference to all policy related BPF
 	PolicyMap *policymap.PolicyMap `json:"-"`
 
-	// CIDRPolicy is the CIDR based policy configuration of the endpoint. This
-	// is not contained within the Consumable for this endpoint because the
-	// Consumable only contains identity-based policy information.
+	// CIDRPolicy is the CIDR based policy configuration of the endpoint.
 	L3Policy *policy.CIDRPolicy `json:"-"`
 
 	// L3Maps is the datapath representation of CIDRPolicy

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -375,8 +375,7 @@ func (e *Endpoint) updateNetworkPolicy(owner Owner) error {
 }
 
 // regeneratePolicy regenerates endpoint's policy if needed and returns
-// whether the BPF for the given endpoint should be regenerated. Only
-// called when e.Consumable != nil.
+// whether the BPF for the given endpoint should be regenerated.
 //
 // In a typical workflow this is first called to regenerate the policy
 // (if needed), and second time when the BPF program is

--- a/pkg/proxy/logger/logger.go
+++ b/pkg/proxy/logger/logger.go
@@ -155,8 +155,7 @@ func (lr *LogRecord) fillEndpointInfo(info *accesslog.EndpointInfo, ip net.IP) {
 	}
 }
 
-// fillIngressSourceInfo fills the EndpointInfo fields, by fetching
-// the consumable from the consumable cache of endpoint using identity sent by
+// fillIngressSourceInfo fills the EndpointInfo fields using identity sent by
 // source. This is needed in ingress proxy while logging the source endpoint
 // info.  Since there will be 2 proxies on the same host, if both egress and
 // ingress policies are set, the ingress policy cannot determine the source


### PR DESCRIPTION
The Consumable type no longer exists any more; remove all references to it in
documentation.

Signed-off by: Ian Vernon <ian@cilium.io>