### PR TITLE
pkg/endpoint: check if PolicyMap is nil in syncPolicyMap

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2418,6 +2418,14 @@ func (e *Endpoint) syncPolicyMap() error {
 		e.realizedMapState = make(map[policymap.PolicyKey]struct{})
 	}
 
+	if e.desiredMapState == nil {
+		e.desiredMapState = make(map[policymap.PolicyKey]struct{})
+	}
+
+	if e.PolicyMap == nil {
+		return fmt.Errorf("not syncing PolicyMap state for endpoint because PolicyMap is nil")
+	}
+
 	currentMapContents, err := e.PolicyMap.DumpToSlice()
 
 	if err != nil {


### PR DESCRIPTION
If a build fails for an endpoint, the PolicyMap for it will be set to `nil`.
But, the controller that is started to sync the desiredMapState for the endpoint
with the datapath will still run, and thus can result in a panic due to a
nil-dereference of the map. Also add a check if any other fields for endpoint
utilized in this function are nil as well.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #4145 