### PR TITLE
test: Don't gather logs in -holdEnvironment

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/test/config"
 	ginkgoext "github.com/cilium/cilium/test/ginkgo-ext"
 
 	"github.com/onsi/ginkgo"
@@ -604,9 +605,13 @@ func (s *SSHMeta) PolicyWait(revisionNum int) *CmdRes {
 // ReportFailed gathers relevant Cilium runtime data and logs for debugging
 // purposes.
 func (s *SSHMeta) ReportFailed(commands ...string) {
+	if config.CiliumTestConfig.HoldEnvironment {
+		ginkgoext.GinkgoPrint("Skipped gathering logs (-cilium.holdEnvironment=true)\n")
+		return
+	}
+
 	// Log the following line to both the log file, and to console to delineate
 	// when log gathering begins.
-
 	ginkgoext.GinkgoPrint("===================== TEST FAILED =====================")
 	res := s.ExecCilium("endpoint list") // save the output in the logs
 	ginkgoext.GinkgoPrint(res.GetDebugMessage())

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/annotation"
 	cnpv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/test/config"
 	ginkgoext "github.com/cilium/cilium/test/ginkgo-ext"
 
 	"github.com/asaskevich/govalidator"
@@ -963,6 +964,11 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 // CiliumReport report the cilium pod to the log and appends the logs for the
 // given commands.
 func (kub *Kubectl) CiliumReport(namespace string, commands ...string) {
+	if config.CiliumTestConfig.HoldEnvironment {
+		ginkgoext.GinkgoPrint("Skipped gathering logs (-cilium.holdEnvironment=true)\n")
+		return
+	}
+
 	pods, err := kub.GetCiliumPods(namespace)
 	if err != nil {
 		kub.logger.WithError(err).Error("cannot retrieve cilium pods on ReportDump")


### PR DESCRIPTION
When developers are running a test repeatedly using
`-cilium.holdEnvironment`, they typically do not need to gather logs
because they are manually investigating the failure when it fails rather
than after the failure. In such cases, disable log gathering since it's
not used. This speeds up the iterative cycle for retrying a test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4150)
<!-- Reviewable:end -->
