### PR TITLE
Improve some checks in CT test and helpers

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -235,6 +235,10 @@ func (s *SSHMeta) WaitEndpointsReady() bool {
 		cmd := fmt.Sprintf(`cilium endpoint list -o jsonpath='%s'`, filter)
 
 		res := s.Exec(cmd)
+		if !res.WasSuccessful() {
+			logger.Infof("Cannot get endpoint list: %s", res.CombineOutput())
+			return false
+		}
 		values := res.KVOutput()
 		total := len(values)
 

--- a/test/runtime/ct.go
+++ b/test/runtime/ct.go
@@ -475,7 +475,7 @@ var _ = Describe("DisabledRuntimeValidatedConntrackTable", func() {
 		}
 
 		res := vm.PolicyDel(policyLabels)
-		res.WasSuccessful()
+		res.ExpectSuccess("Expected delete of policy %q to succeed", policyLabels)
 
 		By("Installing L3-L4-L7 policy")
 
@@ -511,7 +511,7 @@ var _ = Describe("DisabledRuntimeValidatedConntrackTable", func() {
 
 		By("Removing policy %q", policyLabels)
 		res = vm.PolicyDel(policyLabels)
-		res.WasSuccessful()
+		res.ExpectSuccess("Expected delete of policy %q to succeed", policyLabels)
 
 		By("Installing other L7 rule after testing L7. The previous rule shouldn't work!")
 

--- a/test/runtime/ct.go
+++ b/test/runtime/ct.go
@@ -437,10 +437,11 @@ var _ = Describe("DisabledRuntimeValidatedConntrackTable", func() {
 	It("testing conntrack entries clean up with L7 policy after a L3-L4 connectivity", func() {
 
 		meta := containersMeta()
+		policyLabels := "l3-l4-policy-server-3"
 
 		By("Installing L3-L4 policy")
 
-		policy := `
+		policy := fmt.Sprintf(`
 		[{
 			"endpointSelector": {"matchLabels":{"id.server-3":""}},
 			"ingress": [{
@@ -451,9 +452,9 @@ var _ = Describe("DisabledRuntimeValidatedConntrackTable", func() {
 					"ports": [{"port": "80", "protocol": "tcp"}]
 				}]
 			}],
-			"labels": ["l3-l4-policy-server-3"]
+			"labels": [%q]
 		}]
-		`
+		`, policyLabels)
 		_, err := vm.PolicyRenderAndImport(policy)
 		Expect(err).To(BeNil())
 
@@ -473,12 +474,12 @@ var _ = Describe("DisabledRuntimeValidatedConntrackTable", func() {
 			testReach(testCase.src[helpers.Name], testCase.destination[testCase.kind], testCase.dstPort, testCase.mode, BeTrue)
 		}
 
-		res := vm.PolicyDel("l3-l4-policy-server-3")
+		res := vm.PolicyDel(policyLabels)
 		res.WasSuccessful()
 
 		By("Installing L3-L4-L7 policy")
 
-		policy2 := `
+		policy2 := fmt.Sprintf(`
 		[{
 			"endpointSelector": {"matchLabels":{"id.server-3":""}},
 			"ingress": [{
@@ -493,8 +494,8 @@ var _ = Describe("DisabledRuntimeValidatedConntrackTable", func() {
 					}]}
 				}]
 			}],
-			"labels": ["l3-l4-policy-server-3"]
-		}]`
+			"labels": [%q]
+		}]`, policyLabels)
 
 		_, err = vm.PolicyRenderAndImport(policy2)
 		Expect(err).To(BeNil(), "Installing an L3-L4-L7 policy")
@@ -508,8 +509,8 @@ var _ = Describe("DisabledRuntimeValidatedConntrackTable", func() {
 			testReach(testCase.src[helpers.Name], testCase.destination[testCase.kind], testCase.dstPort, testCase.mode, assertfn)
 		}
 
-		By("Removing policy `l3-l4-policy-server-3`")
-		res = vm.PolicyDel("l3-l4-policy-server-3")
+		By("Removing policy %q", policyLabels)
+		res = vm.PolicyDel(policyLabels)
 		res.WasSuccessful()
 
 		By("Installing other L7 rule after testing L7. The previous rule shouldn't work!")


### PR DESCRIPTION
Don't discard the results of checks in the CT tests;
Handle endpoint list errors in the helper.