### PR TITLE
Spellcheck doc fixes

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -1172,7 +1172,7 @@ simplify our Jenkinsfiles. The exported methods are:
 - **BuildIfLabel(String label, String Job)**: trigger a new Job if the PR has
   that specific Label.
 - **Status(String status, String context)**: set pull request check status on
-  the given context, example `Status("SUCCESS", "$JOB_BASE_NAME"`
+  the given context, example ``Status("SUCCESS", "$JOB_BASE_NAME")``
 
 
 Release Process

--- a/Documentation/install/guides/kops.rst
+++ b/Documentation/install/guides/kops.rst
@@ -1,14 +1,19 @@
+.. _kops_guide:
+
 **********************************
 Kubernetes Kops Installation Guide
 **********************************
 
-As of `kops<https://github.com/kubernetes/kops>`_ 1.9 release, Cilium is a supported CNI plugin for kops-deployed clusters.
+As of `kops`_ 1.9 release, Cilium is a supported CNI plugin for kops-deployed clusters.
 
-Cilium needs a newer kernel version than the default kops images provide (minimum kernel version for Cilium is 4.8), so you need to supply an `ami<https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html>`_ which will be new enough for Cilium to run on it.
+Cilium needs a newer kernel version than the default kops images provide (minimum kernel version for Cilium is 4.8), so you need to supply an `ami`_ which will be new enough for Cilium to run on it.
 
 CoreOS images have new enough kernels for Cilium to run on them and are tested by kops developers, which makes them a perfect candidate.
 
 The latest stable CoreOS AMI can be found using aws cli:
+
+.. _kops: https://github.com/kubernetes/kops
+.. _ami: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html
 
 .. code:: bash
 

--- a/Documentation/kubernetes/index.rst
+++ b/Documentation/kubernetes/index.rst
@@ -11,7 +11,7 @@ to navigate this documentation section:
 * If you are looking for a simple and safe playground to experiment with Cilium
   and Kubernetes `gs_minikube`.
 * If you want to learn more about Cilium on Kubernetes first: `k8s_intro`.
-* If you want to run Cilium on your kops cluster: `kops_guide`
+* If you want to run Cilium on your kops cluster: `kops_guide`.
 
 The following sections describe the Kubernetes integration in detail:
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -301,6 +301,7 @@ onwards
 oolchain
 opcodes
 orchestrator
+org
 pc
 pem
 Pepelnjak


### PR DESCRIPTION
**Summary of changes**:

1. Fixes `reference target not found` warnings.
2. Adds `org` to spellcheck wordlist.
3. Fixes link for new `kops_guide`.

Fixes: #4154 

**How to test (optional)**:
Run:
1. `make -C Documentation html`
2. `make render-docs` for  running docs inside docker container to check changes.
