### PR TITLE
ipcache: Create copies of NPHDS cache resources when updating

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -827,7 +827,7 @@ func (d *Daemon) init() error {
 
 		// Set up the list of IPCache listeners in the daemon, to be
 		// used by syncLXCMap().
-		d.ipcacheListeners = []ipcache.IPIdentityMappingListener{d, &envoy.NetworkPolicyHostsCache}
+		d.ipcacheListeners = []ipcache.IPIdentityMappingListener{&envoy.NetworkPolicyHostsCache, d}
 
 		// Insert local host entries to bpf maps
 		if err := d.syncLXCMap(); err != nil {


### PR DESCRIPTION
NPHDS resources were modified in place within the cache, which
prevented notifying IP-to-ID mapping updates to Envoy.

Fixes: https://github.com/cilium/cilium/issues/3992
Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4167)
<!-- Reviewable:end -->
