### PR TITLE
cmd: specify JSON format for `cilium policy import`

### DIFF
--- a/Documentation/cmdref/cilium_policy.md
+++ b/Documentation/cmdref/cilium_policy.md
@@ -21,7 +21,7 @@ Manage security policies
 * [cilium](cilium.html)	 - CLI
 * [cilium policy delete](cilium_policy_delete.html)	 - Delete policy rules
 * [cilium policy get](cilium_policy_get.html)	 - Display policy node information
-* [cilium policy import](cilium_policy_import.html)	 - Import security policy
+* [cilium policy import](cilium_policy_import.html)	 - Import security policy in JSON format
 * [cilium policy trace](cilium_policy_trace.html)	 - Trace a policy decision
 * [cilium policy validate](cilium_policy_validate.html)	 - Validate a policy
 * [cilium policy wait](cilium_policy_wait.html)	 - Wait for all endpoints to have updated to a given policy revision

--- a/Documentation/cmdref/cilium_policy_import.md
+++ b/Documentation/cmdref/cilium_policy_import.md
@@ -2,12 +2,12 @@
 
 ## cilium policy import
 
-Import security policy
+Import security policy in JSON format
 
 ### Synopsis
 
 
-Import security policy
+Import security policy in JSON format
 
 ```
 cilium policy import <path>
@@ -16,7 +16,7 @@ cilium policy import <path>
 ### Examples
 
 ```
-  cilium policy import ~/app.policy
+  cilium policy import ~/policy.json
   cilium policy import ./policies/app/
 ```
 

--- a/cilium/cmd/policy_import.go
+++ b/cilium/cmd/policy_import.go
@@ -29,8 +29,8 @@ var printPolicy bool
 // policyImportCmd represents the policy_import command
 var policyImportCmd = &cobra.Command{
 	Use:   "import <path>",
-	Short: "Import security policy",
-	Example: `  cilium policy import ~/app.policy
+	Short: "Import security policy in JSON format",
+	Example: `  cilium policy import ~/policy.json
   cilium policy import ./policies/app/`,
 	PreRun: requirePath,
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Specify that `cilium policy import` only accepts files in JSON format.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #4165 