### PR TITLE
Fix datapath connectivity issue during ipcache upsert

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -962,7 +962,7 @@ func (d *Daemon) syncLXCMap() error {
 			log.WithField(logfields.IPAddr, prefix).Debug("Adding special identity to ipcache")
 			ipcache.IPIdentityCache.Upsert(prefix, pair.ID)
 			for _, listener := range d.ipcacheListeners {
-				listener.OnIPIdentityCacheChange(ipcache.Upsert, pair)
+				listener.OnIPIdentityCacheChange(ipcache.Upsert, nil, pair)
 			}
 		}
 	}

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -767,7 +767,11 @@ func (h *putEndpointIDLabels) Handle(params PatchEndpointIDLabelsParams) middlew
 // OnIPIdentityCacheChange is called whenever there is a change of state in the
 // IPCache (pkg/ipcache).
 // TODO (FIXME): GH-3161.
-func (d *Daemon) OnIPIdentityCacheChange(modType ipcache.CacheModification, newIPIDPair identity.IPIdentityPair) {
+//
+// 'oldIPIDPair' is ignored here, because in the BPF maps an update for the
+// IP->ID mapping will replace any existing contents; knowledge of the old pair
+// is not required to upsert the new pair.
+func (d *Daemon) OnIPIdentityCacheChange(modType ipcache.CacheModification, oldIPIDPair *identity.IPIdentityPair, newIPIDPair identity.IPIdentityPair) {
 
 	log.WithFields(logrus.Fields{logfields.Modification: modType,
 		logfields.IPAddr:   newIPIDPair.IP,

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -767,12 +767,12 @@ func (h *putEndpointIDLabels) Handle(params PatchEndpointIDLabelsParams) middlew
 // OnIPIdentityCacheChange is called whenever there is a change of state in the
 // IPCache (pkg/ipcache).
 // TODO (FIXME): GH-3161.
-func (d *Daemon) OnIPIdentityCacheChange(modType ipcache.CacheModification, ipIDPair identity.IPIdentityPair) {
+func (d *Daemon) OnIPIdentityCacheChange(modType ipcache.CacheModification, newIPIDPair identity.IPIdentityPair) {
 
 	log.WithFields(logrus.Fields{logfields.Modification: modType,
-		logfields.IPAddr:   ipIDPair.IP,
-		logfields.IPMask:   ipIDPair.Mask,
-		logfields.Identity: ipIDPair.ID}).
+		logfields.IPAddr:   newIPIDPair.IP,
+		logfields.IPMask:   newIPIDPair.Mask,
+		logfields.Identity: newIPIDPair.ID}).
 		Debug("daemon notified of IP-Identity cache state change")
 
 	// TODO - see if we can factor this into an interface under something like
@@ -780,11 +780,11 @@ func (d *Daemon) OnIPIdentityCacheChange(modType ipcache.CacheModification, ipID
 	// logically located.
 
 	// Update BPF Maps.
-	key := ipCacheBPF.NewKey(ipIDPair.IP, ipIDPair.Mask)
+	key := ipCacheBPF.NewKey(newIPIDPair.IP, newIPIDPair.Mask)
 
 	switch modType {
 	case ipcache.Upsert:
-		value := ipCacheBPF.RemoteEndpointInfo{SecurityIdentity: uint16(ipIDPair.ID)}
+		value := ipCacheBPF.RemoteEndpointInfo{SecurityIdentity: uint16(newIPIDPair.ID)}
 		err := ipCacheBPF.IPCache.Update(key, &value)
 		if err != nil {
 			log.WithError(err).WithFields(logrus.Fields{"key": key.String(),

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -418,7 +418,7 @@ func (ipc *IPCache) LookupByIdentity(id identity.NumericIdentity) (map[string]st
 type IPIdentityMappingListener interface {
 	// OnIPIdentityCacheChange will be called whenever there the state of the
 	// IPCache has changed.
-	OnIPIdentityCacheChange(modType CacheModification, ipIDPair identity.IPIdentityPair)
+	OnIPIdentityCacheChange(modType CacheModification, newIPIDPair identity.IPIdentityPair)
 
 	// OnIPIdentityCacheGC will be called to sync other components which are
 	// reliant upon the IPIdentityCache with the IPIdentityCache.


### PR DESCRIPTION
When an ipcache change occurs, we pass the event down to two                                                                                                                                                                            
implementations which handle updates of existing entries differently:           
                                                                                
* The BPF implementation organises its ipcache indexed by IP. When it           
  sees an upsert for an IP that already has a corresponding ID, it will         
  overwrite the existing entry directly.                                        
* The NPHDS implementation organises its ipcache by ID. When it sees            
  an upsert for an IP that already has a corresponding ID, it needs to          
  issue a delete for the old ID->IP pair, then issue an upsert for the          
  new ID->IP pair.                                                              
                                                                                
Previously, the core ipcache logic would issue a delete + upsert which          
fit with the NPHDS model, but it could cause traffic drops on the BPF           
side in the brief period between applying the delete and the new insert.        
                                                                                
This patch fixes this behaviour by shifting the logic down to the               
listener implementation so that the BPF implementation never needs to           
handle a delete.                                                                
                                                                                
Fixes: #3840