### PR TITLE
xds: Match the client's version if higher than the server's

### DIFF
--- a/pkg/envoy/xds/cache.go
+++ b/pkg/envoy/xds/cache.go
@@ -255,6 +255,22 @@ func (c *Cache) GetResources(ctx context.Context, typeURL string, lastVersion *u
 	return res, nil
 }
 
+func (c *Cache) EnsureVersion(typeURL string, version uint64) {
+	c.locker.Lock()
+	defer c.locker.Unlock()
+
+	if c.version < version {
+		cacheLog := log.WithFields(logrus.Fields{
+			logfields.XDSTypeURL:     typeURL,
+			logfields.XDSVersionInfo: version,
+		})
+		cacheLog.Debug("increasing version to match client and notifying of new version")
+
+		c.version = version
+		c.NotifyNewResourceVersionRLocked(typeURL, c.version)
+	}
+}
+
 // Lookup finds the resource corresponding to the specified typeURL and resourceName,
 // if available, and returns it. Otherwise, returns nil. If an error occurs while
 // fetching the resource, also returns the error.

--- a/pkg/envoy/xds/set.go
+++ b/pkg/envoy/xds/set.go
@@ -35,6 +35,11 @@ type ResourceSource interface {
 	// Should not be blocking.
 	GetResources(ctx context.Context, typeURL string, lastVersion *uint64,
 		node *envoy_api_v2_core.Node, resourceNames []string) (*VersionedResources, error)
+
+	// EnsureVersion increases this resource set's version to be at least the
+	// given version. If the current version is already higher than the
+	// given version, this has no effect.
+	EnsureVersion(typeURL string, version uint64)
 }
 
 // VersionedResources is a set of protobuf-encoded resources along with their


### PR DESCRIPTION
When Cilium restarts but the xDS clients survive, they keep
requesting the last version they had received from the previous
Cilium instance.
Handle this case by bumping the server's resource version to
match the clients'.

Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4173)
<!-- Reviewable:end -->
