### PR TITLE
bugtool: Add '-a' option to netstat.

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -54,7 +54,7 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		"ip link",
 		"uname -a",
 		"dig",
-		"netstat",
+		"netstat -a",
 		"pidstat",
 		"arp",
 		"top -b -n 1",


### PR DESCRIPTION
It is valuable to get both listening and non-listening sockets, rather
than non-listening sockets only, for example to verify that proxy
ports are listening. Add the '-a' option to 'netstat' to accomplish
this.

Signed-off-buy: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4193)
<!-- Reviewable:end -->
