### PR TITLE
pkg/bpf: use pointer receiver for GetKeyPtr()

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -775,14 +775,14 @@ func (d *Daemon) OnIPIdentityCacheChange(modType ipcache.CacheModification, oldI
 	switch modType {
 	case ipcache.Upsert:
 		value := ipCacheBPF.RemoteEndpointInfo{SecurityIdentity: uint16(newIPIDPair.ID)}
-		err := ipCacheBPF.IPCache.Update(key, &value)
+		err := ipCacheBPF.IPCache.Update(&key, &value)
 		if err != nil {
 			log.WithError(err).WithFields(logrus.Fields{"key": key.String(),
 				"value": value.String()}).
 				Warning("unable to update bpf map")
 		}
 	case ipcache.Delete:
-		err := ipCacheBPF.IPCache.Delete(key)
+		err := ipCacheBPF.IPCache.Delete(&key)
 		if err != nil {
 			log.WithError(err).WithFields(logrus.Fields{"key": key.String()}).
 				Warning("unable to delete from bpf map")
@@ -814,19 +814,19 @@ func (d *Daemon) OnIPIdentityCacheGC() {
 				ipcache.IPIdentityCache.RLock()
 				defer ipcache.IPIdentityCache.RUnlock()
 
-				keysToRemove := map[ipCacheBPF.Key]struct{}{}
+				keysToRemove := map[string]*ipCacheBPF.Key{}
 
 				// Add all keys which are in BPF map but not in in-memory cache
 				// to set of keys to remove from BPF map.
 				cb := func(key bpf.MapKey, value bpf.MapValue) {
-					k := key.(ipCacheBPF.Key)
+					k := key.(*ipCacheBPF.Key)
 					keyToIP := k.String()
 
 					// Don't RLock as part of the same goroutine.
 					if _, exists := ipcache.IPIdentityCache.LookupByPrefixRLocked(keyToIP); !exists {
 						// Cannot delete from map during callback because DumpWithCallback
 						// RLocks the map.
-						keysToRemove[k] = struct{}{}
+						keysToRemove[keyToIP] = k
 					}
 				}
 
@@ -836,7 +836,7 @@ func (d *Daemon) OnIPIdentityCacheGC() {
 
 				// Remove all keys which are not in in-memory cache from BPF map
 				// for consistency.
-				for k := range keysToRemove {
+				for _, k := range keysToRemove {
 					log.WithFields(logrus.Fields{logfields.BPFMapKey: k}).
 						Debug("deleting from ipcache BPF map")
 					if err := ipCacheBPF.IPCache.Delete(k); err != nil {

--- a/pkg/bpf/endpoint.go
+++ b/pkg/bpf/endpoint.go
@@ -38,7 +38,7 @@ type EndpointKey struct {
 }
 
 // GetKeyPtr returns the unsafe pointer to the BPF key
-func (k EndpointKey) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(&k) }
+func (k *EndpointKey) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 
 // GetValuePtr returns the unsafe pointer to the BPF key for users that
 // use EndpointKey as a value in bpf maps

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -374,7 +374,7 @@ func (e *Endpoint) runInit(libdir, rundir, epdir, ifName, debug string) error {
 // after releasing that lock to push the entries into the datapath.
 // Functions below implement the EndpointFrontend interface with this cached information.
 type epInfoCache struct {
-	keys     []lxcmap.EndpointKey
+	keys     []*lxcmap.EndpointKey
 	value    *lxcmap.EndpointInfo
 	ifName   string
 	revision uint64
@@ -395,7 +395,7 @@ func (e *Endpoint) createEpInfoCache() *epInfoCache {
 
 // GetBPFKeys returns all keys which should represent this endpoint in the BPF
 // endpoints map
-func (ep *epInfoCache) GetBPFKeys() []lxcmap.EndpointKey {
+func (ep *epInfoCache) GetBPFKeys() []*lxcmap.EndpointKey {
 	return ep.keys
 }
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1367,15 +1367,15 @@ func (e *Endpoint) RemoveFromGlobalPolicyMap() error {
 
 // GetBPFKeys returns all keys which should represent this endpoint in the BPF
 // endpoints map
-func (e *Endpoint) GetBPFKeys() []lxcmap.EndpointKey {
+func (e *Endpoint) GetBPFKeys() []*lxcmap.EndpointKey {
 	key := lxcmap.NewEndpointKey(e.IPv6.IP())
 
 	if e.IPv4 != nil {
 		key4 := lxcmap.NewEndpointKey(e.IPv4.IP())
-		return []lxcmap.EndpointKey{key, key4}
+		return []*lxcmap.EndpointKey{key, key4}
 	}
 
-	return []lxcmap.EndpointKey{key}
+	return []*lxcmap.EndpointKey{key}
 }
 
 // GetBPFValue returns the value which should represent this endpoint in the

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -56,7 +56,7 @@ type Key struct {
 }
 
 // GetKeyPtr returns the unsafe pointer to the BPF key
-func (k Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(&k) }
+func (k *Key) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 
 // NewValue returns a new empty instance of the structure representing the BPF
 // map value
@@ -150,7 +150,7 @@ func NewMap() *Map {
 				if err := bpf.ConvertKeyValue(key, value, &k, &v); err != nil {
 					return nil, nil, err
 				}
-				return k, &v, nil
+				return &k, &v, nil
 			},
 		),
 	}

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -51,7 +51,7 @@ var (
 				return nil, nil, err
 			}
 
-			return k, &v, nil
+			return &k, &v, nil
 		},
 	)
 )
@@ -96,7 +96,7 @@ const (
 // with the endpoint BPF map
 type EndpointFrontend interface {
 	// GetBPFKeys must return a slice of EndpointKey which all represent the endpoint
-	GetBPFKeys() []EndpointKey
+	GetBPFKeys() []*EndpointKey
 
 	// GetBPFValue must return an EndpointInfo structure representing the frontend
 	GetBPFValue() (*EndpointInfo, error)
@@ -128,8 +128,8 @@ func (k EndpointKey) NewValue() bpf.MapValue { return &EndpointInfo{} }
 
 // NewEndpointKey returns an EndpointKey based on the provided IP address. The
 // address family is automatically detected
-func NewEndpointKey(ip net.IP) EndpointKey {
-	return EndpointKey{
+func NewEndpointKey(ip net.IP) *EndpointKey {
+	return &EndpointKey{
 		EndpointKey: bpf.NewEndpointKey(ip),
 	}
 }
@@ -158,8 +158,8 @@ func WriteEndpoint(f EndpointFrontend) error {
 	}
 
 	// FIXME: Revert on failure
-	for _, k := range f.GetBPFKeys() {
-		if err := LXCMap.Update(k, info); err != nil {
+	for _, v := range f.GetBPFKeys() {
+		if err := LXCMap.Update(v, info); err != nil {
 			return err
 		}
 	}

--- a/pkg/maps/tunnel/tunnel.go
+++ b/pkg/maps/tunnel/tunnel.go
@@ -51,7 +51,7 @@ var (
 				return nil, nil, err
 			}
 
-			return k, &v, nil
+			return &k, &v, nil
 		})
 )
 
@@ -67,8 +67,8 @@ type tunnelEndpoint struct {
 	bpf.EndpointKey
 }
 
-func newTunnelEndpoint(ip net.IP) tunnelEndpoint {
-	return tunnelEndpoint{
+func newTunnelEndpoint(ip net.IP) *tunnelEndpoint {
+	return &tunnelEndpoint{
 		EndpointKey: bpf.NewEndpointKey(ip),
 	}
 }
@@ -84,7 +84,7 @@ func SetTunnelEndpoint(prefix net.IP, endpoint net.IP) error {
 		fieldEndpoint: endpoint,
 	}).Debug("Updating tunnel map entry")
 
-	return TunnelMap.Update(key, &val)
+	return TunnelMap.Update(key, val)
 }
 
 // DeleteTunnelEndpoint removes a prefix => tunnel-endpoint mapping


### PR DESCRIPTION
Since the receiver is passed by value, the returned pointer will always
be different every time the function GetKeyPtr() is called.

Fixes: e76192a27b (bpf: Refactor EndpointKey)
Fixes: 888a179908 (pkg/maps: add BPF ipcache map)
Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/4192

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4199)
<!-- Reviewable:end -->
