### PR TITLE
daemon: exit if tunnel is not supported

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -562,6 +562,10 @@ func initEnv(cmd *cobra.Command) {
 			scopedLog.WithError(err).Fatal("Unable to restore agent assets")
 		}
 	}
+
+	if !(viper.GetString("tunnel") == "vxlan" || viper.GetString("tunnel") == "geneve") {
+		log.Fatalf("Invalid setting for -t, must be {vxlan, geneve}")
+	}
 	checkMinRequirements()
 
 	if err := pidfile.Write(defaults.PidFilePath); err != nil {


### PR DESCRIPTION
Throw level=fatal msg="Invalid setting for -t, must be {vxlan, geneve}" in case of tunnel doesnt fall into supported one.

Signed-off-by: Nirmoy Das <ndas@suse.de>

