### PR TITLE
docs: Attempt to use RTD version for GH URLs

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -65,8 +65,10 @@ author = u'Cilium Authors'
 # The short X.Y version.
 release = open("../VERSION", "r").read().strip()
 
-# Asume the current branch is master but check with VERSION file.
-branch = subprocess.check_output("git describe --tags --exact-match 2>/dev/null || git rev-parse --abbrev-ref HEAD", shell=True)
+# Fetch the docs version from an environment variable. Map latest -> master.
+branch = os.environ.get('READTHEDOCS_VERSION')
+if branch == None or branch == 'latest':
+    branch = 'HEAD'
 githubusercontent = 'https://raw.githubusercontent.com/cilium/cilium/'
 scm_web = githubusercontent + branch
 


### PR DESCRIPTION
ReadTheDocs (RTD) provides an environment variable `READTHEDOCS_VERSION`
which describes the branch of documentation that is currently being
built. We should use this branch to create URLs to GitHub resources such
as kubernetes YAMLs for Cilium install.

This will mean that, for instance, if we build the branch `v1.0` on RTD
then it will point to the latest version of the docs that are present on
that branch.

There's some special cases - if we're building locally, then the
environment variable will not be there, and also on RTD the `latest`
branch name that it provides should point to our `master` branch. In
these cases, use HEAD for generating the URLs.

Fixes: #4183

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4203)
<!-- Reviewable:end -->
