### PR TITLE
daemon: clean up network interfaces before exit

### DIFF
--- a/cilium-health/cmd/root.go
+++ b/cilium-health/cmd/root.go
@@ -138,7 +138,7 @@ func runServer() {
 
 	// Write the pidfile (if specified)
 	if path := viper.GetString("pidfile"); path != "" {
-		if err := pidfile.Write(path); err != nil {
+		if err := pidfile.Write(path, ""); err != nil {
 			fmt.Printf("Failed to write pidfile %s: %s\n", path, err.Error())
 			os.Exit(-1)
 		}

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -568,7 +568,7 @@ func initEnv(cmd *cobra.Command) {
 	}
 	checkMinRequirements()
 
-	if err := pidfile.Write(defaults.PidFilePath); err != nil {
+	if err := pidfile.Write(defaults.PidFilePath, option.Config.Tunnel); err != nil {
 		log.WithField(logfields.Path, defaults.PidFilePath).WithError(err).Fatal("Failed to create Pidfile")
 	}
 


### PR DESCRIPTION
cilium-agent leaves cilium interfaces untouched on exit. 
Signed-off-by: Nirmoy Das <ndas@suse.de>

