### PR TITLE
envoy: Update Istio to the latest 0.8 RC version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM quay.io/cilium/cilium-builder:2018-05-18 as builder
+FROM quay.io/cilium/cilium-builder:2018-05-22 as builder
 LABEL maintainer="maintainer@cilium.io"
 WORKDIR /go/src/github.com/cilium/cilium
 COPY . ./

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -126,7 +126,7 @@ Vagrant.configure(2) do |config|
         vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
         vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
         config.vm.box = "cilium/ubuntu"
-        config.vm.box_version = "72"
+        config.vm.box_version = "75"
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i
         if ENV["NFS"] then

--- a/envoy/Makefile
+++ b/envoy/Makefile
@@ -37,7 +37,7 @@ STRIP ?= $(QUIET) strip
 # https://github.com/istio/istio/tree/master/release#daily-releases
 # https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/
 # TODO: Update to "0.8.0" when it's released.
-ISTIO_VERSION = 0.8.0-pre20180421-09-15
+ISTIO_VERSION = release-0.8-20180521-15-16
 
 ifdef CILIUM_DISABLE_ENVOY_BUILD
 all install clean:

--- a/envoy/README.Istio.md
+++ b/envoy/README.Istio.md
@@ -24,24 +24,24 @@ still being developed in Cilium's `inject-cilium-filters` branch.
 
 ## Build the required upstream Istio Docker images
 
-Only one images needs to be built: `cilium/istio_pilot`.
+Only one image needs to be built: `cilium/istio_pilot`.
 
-    TAG=0.8.0-pre20180421-09-15 make docker.pilot
+    TAG=release-0.8-20180521-15-16 make docker.pilot
 
 The `istio/proxy` and `istio/proxy_debug` for pre-releases are not available on
 Docker Hub. Build them here:
 
-    TAG=0.8.0-pre20180421-09-15 make docker.proxy docker.proxy_debug
+    TAG=release-0.8-20180521-15-16 make docker.proxy docker.proxy_debug
 
 ## (Optional) Check that the upstream proxy Docker images are consistent
 
 Build the upstream proxy images to check them:
 
-    TAG=0.8.0-pre20180421-09-15 make docker.proxy_init docker.proxyv2 docker.proxy_debugv2
+    TAG=release-0.8-20180521-15-16 make docker.proxy_init docker.proxyv2 docker.proxy_debugv2
 
 ### `istio/proxy_init`
 
-    docker run --rm -it --cap-add=NET_ADMIN --entrypoint /bin/bash istio/proxy_init:0.8.0-pre20180421-09-15
+    docker run --rm -it --cap-add=NET_ADMIN --entrypoint /bin/bash istio/proxy_init:release-0.8-20180521-15-16
 
 In the container, run the iptables configuration script with various
 combinations of parameters, for example:
@@ -59,7 +59,7 @@ For each combination, check the iptables and routing tables and rules:
 
 ### `istio/proxyv2`
 
-    docker run --rm -it --entrypoint /bin/bash istio/proxyv2:0.8.0-pre20180421-09-15
+    docker run --rm -it --entrypoint /bin/bash istio/proxyv2:release-0.8-20180521-15-16
 
 Check that the binaries have the right size, mode, owner, and group.
 
@@ -71,7 +71,7 @@ Check that the Envoy bootstrap configures Envoy v2 API and ADS (not v1 API):
 
 ### `istio/proxy_debugv2`
 
-    docker run --rm -it --entrypoint /bin/bash istio/proxy_debugv2:0.8.0-pre20180421-09-15
+    docker run --rm -it --entrypoint /bin/bash istio/proxy_debugv2:release-0.8-20180521-15-16
 
 Check that the binaries have the right size, mode, owner, and group.
 
@@ -92,6 +92,6 @@ Check that the Envoy bootstrap configures Envoy v2 API and ADS (not v1 API):
 ## Push the Docker images to Docker Hub
 
     docker login -u ...
-    docker image push cilium/istio_pilot:0.8.0-pre20180421-09-15
-    docker image push cilium/istio_proxy:0.8.0-pre20180421-09-15
-    docker image push cilium/istio_proxy_debug:0.8.0-pre20180421-09-15
+    docker image push cilium/istio_pilot:release-0.8-20180521-15-16
+    docker image push cilium/istio_proxy:release-0.8-20180521-15-16
+    docker image push cilium/istio_proxy_debug:release-0.8-20180521-15-16

--- a/envoy/WORKSPACE
+++ b/envoy/WORKSPACE
@@ -7,7 +7,7 @@ workspace(name = "cilium")
 #
 # No other line in this file may have ENVOY_SHA followed by an equals sign!
 #
-ENVOY_SHA = "5843954375fe548776d3d5c36ff8bb79cd61f2a0"
+ENVOY_SHA = "12c470e666d23f1cedaea92cdae6c747d6081dfe"
 
 http_archive(
     name = "envoy",
@@ -42,7 +42,7 @@ go_register_toolchains()
 # Dependencies for Istio filters.
 # Cf. https://github.com/istio/proxy.
 
-ISTIO_PROXY_SHA = "410899cd5a4614c1965778f9856769b744c1d522"
+ISTIO_PROXY_SHA = "c05a6fc5c23b46345ba57f19cc014b72649b8dfa"
 
 http_archive(
     name = "istio_proxy",

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -8,7 +8,7 @@ $K8S_VERSION = ENV['K8S_VERSION'] || "1.10"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 $NFS = ENV['NFS']=="1"? true : false
 $SERVER_BOX= "cilium/ubuntu"
-$SERVER_VERSION="72"
+$SERVER_VERSION="75"
 $IPv6=(ENV['IPv6'] || "0")
 $CONTAINER_RUNTIME=(ENV['CONTAINER_RUNTIME'] || "docker")
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - consul
       - etcd
-    image: "quay.io/cilium/cilium-builder:2018-05-18"
+    image: "quay.io/cilium/cilium-builder:2018-05-22"
     command: "bash -c 'cd /go/src/github.com/cilium/cilium/; make tests-ginkgo-real'"
     privileged: true
     volumes:


### PR DESCRIPTION
Update the Envoy and Istio Proxy SHAs to match Istio Proxy's
release-0.8 HEAD.
Update the builder Docker image and Vagrant box.

Update the Istio version to the latest 0.8 RC:
release-0.8-20180521-15-16.

Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4207)
<!-- Reviewable:end -->
