### PR TITLE
Test: Enable containerd on Jenkins builds.

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -1041,6 +1041,12 @@ illustrating which subset of tests the job runs.
 +----------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 
 
+There are some feature flags based on Pull Requets labels, the list of lables
+are the following:
+
+- area/containerd: Enable containerd runtime on all Kubernetes test.
+
+
 Using Jenkins for testing
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -42,6 +42,7 @@ pipeline {
         stage('BDD-Test-k8s') {
             environment {
                 FAILFAST = failFast(env.GIT_BRANCH)
+                CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
             }
             options {
                 timeout(time: 120, unit: 'MINUTES')
@@ -77,6 +78,7 @@ pipeline {
         stage('Non-release-k8s-versions') {
             environment {
                 FAILFAST = failFast(env.GIT_BRANCH)
+                CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
             }
             options {
                 timeout(time: 120, unit: 'MINUTES')

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -57,6 +57,7 @@ pipeline {
                 GOPATH="${WORKSPACE}"
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
                 FAILFAST=setIfPR("true", "false")
+                CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
             }
 
             options {


### PR DESCRIPTION
- Add `setIfLabel` function to send some parameters need by features
toggles.
- Enable containerd when area/containerd label is present in the PR.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>