### PR TITLE
pkg/maps/metricsmap/: Add a doc.go in the metricsmap pkg

### DIFF
--- a/pkg/maps/metricsmap/doc.go
+++ b/pkg/maps/metricsmap/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2018Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package metricsmap represents the BPF metrics map in the BPF programs. It is
+// implemented as a hash table containing an entry of different drop and forward
+// counts for different drop/forward reasons and directions.
+package metricsmap


### PR DESCRIPTION
This change adds a doc.go which describes the metricsmap package, so that this package shows up on:
https://godoc.org/github.com/cilium/cilium

Fixes: #4224
Signed-off by: Manali Bhutiyani <manali@covalent.io>

```release-note
Add a doc.go in the metricsmap pkg
```