### PR TITLE
Use policy for IPCache LPM prefix length generation, not IPCache

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net"
 	"path"
-	"sort"
 	"strings"
 	"sync"
 
@@ -319,35 +318,6 @@ func (ipc *IPCache) deleteLocked(IP string) {
 			}
 		}
 	}
-}
-
-// ToBPFData renders the ipcache into the relevant set of CIDR prefixes for
-// the BPF datapath to use for lookup.
-func (ipc *IPCache) ToBPFData() (s6, s4 []int) {
-	ipc.mutex.RLock()
-	defer ipc.mutex.RUnlock()
-	s6 = make([]int, 0, len(ipc.v6PrefixLengths))
-	s4 = make([]int, 0, len(ipc.v4PrefixLengths))
-
-	// Always include host prefix
-	s6 = append(s6, net.IPv6len*8)
-	for prefix := range ipc.v6PrefixLengths {
-		if prefix != net.IPv6len*8 {
-			s6 = append(s6, prefix)
-		}
-	}
-	sort.Sort(sort.Reverse(sort.IntSlice(s6)))
-
-	// Always include host prefix
-	s4 = append(s4, net.IPv4len*8)
-	for prefix := range ipc.v4PrefixLengths {
-		if prefix != net.IPv4len*8 {
-			s4 = append(s4, prefix)
-		}
-	}
-	sort.Sort(sort.Reverse(sort.IntSlice(s4)))
-
-	return
 }
 
 // delete removes the provided IP-to-security-identity mapping from the IPCache.

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -215,21 +215,3 @@ func (s *IPCacheTestSuite) TestKeyToIPNet(c *C) {
 	c.Assert(err, Not(IsNil))
 	c.Assert(isHost, Equals, false)
 }
-
-func (s *IPCacheTestSuite) TestToBPFData(c *C) {
-	identityOffset := 2000
-	prefixes := []string{
-		"192.0.2.0/24",
-		"192.0.64.0/20",
-	}
-
-	ipc := NewIPCache()
-	for i, prefix := range prefixes {
-		id := identityPkg.NumericIdentity(i + identityOffset)
-		ipc.Upsert(prefix, id)
-	}
-
-	s6, s4 := ipc.ToBPFData()
-	c.Assert(s6, comparator.DeepEquals, []int{128})
-	c.Assert(s4, comparator.DeepEquals, []int{32, 24, 20})
-}

--- a/pkg/node/node_address.go
+++ b/pkg/node/node_address.go
@@ -233,6 +233,13 @@ func SetIPv4AllocRange(net *net.IPNet) {
 	ipv4AllocRange = net
 }
 
+// Uninitialize resets this package to the default state, for use in
+// testsuite code.
+func Uninitialize() {
+	ipv4AllocRange = nil
+	ipv6AllocRange = nil
+}
+
 // SetIPv6NodeRange sets the IPv6 address pool to be used on this node
 func SetIPv6NodeRange(net *net.IPNet) error {
 	if ones, _ := net.Mask.Size(); ones != IPv6NodePrefixLen {

--- a/pkg/policy/l3_test.go
+++ b/pkg/policy/l3_test.go
@@ -15,26 +15,51 @@
 package policy
 
 import (
+	"net"
+
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/node"
 
 	. "gopkg.in/check.v1"
 )
 
-func (ds *PolicyTestSuite) TestToBPFData(c *C) {
-	cidrPolicy := NewCIDRPolicy()
-	m := cidrPolicy.Ingress
+func (ds *PolicyTestSuite) SetUpTest(c *C) {
+	_, v6node, err := net.ParseCIDR("2001:DB8::/96")
+	c.Assert(err, IsNil)
+	_, v4node, err := net.ParseCIDR("192.0.2.3/24")
+	c.Assert(err, IsNil)
+	err = node.SetIPv6NodeRange(v6node)
+	c.Assert(err, IsNil)
+	node.SetIPv4AllocRange(v4node)
+}
 
+func (ds *PolicyTestSuite) TearDownTest(c *C) {
+	node.Uninitialize()
+}
+
+func populateMap(m *CIDRPolicyMap) {
 	lbls := labels.LabelArray{}
-
 	m.Insert("10.1.1.0/24", lbls)
 	m.Insert("10.2.0.0/20", lbls)
 	m.Insert("10.3.3.3/32", lbls)
 	m.Insert("10.4.4.0/26", lbls)
 	m.Insert("10.5.0.0/16", lbls)
+}
 
+func (ds *PolicyTestSuite) TestToBPFData(c *C) {
+	cidrPolicy := NewCIDRPolicy()
+
+	// FIXME GH-4129: On Ingress, we don't get cluster / world prefixes yet
+	m := &cidrPolicy.Ingress
+	populateMap(m)
 	_, s4 := m.ToBPFData()
 	exp := []int{32, 26, 24, 20, 16}
-	for i := range s4 {
-		c.Assert(s4[i], Equals, exp[i])
-	}
+	c.Assert(s4, comparator.DeepEquals, exp)
+
+	// On Egress, we get the host/ cluster / world prefixes.
+	m = &cidrPolicy.Egress
+	populateMap(m)
+	_, s4 = m.ToBPFData()
+	exp = []int{32, 26, 24, 20, 16, 8, 0}
+	c.Assert(s4, comparator.DeepEquals, exp)
 }

--- a/pkg/policy/l3_test.go
+++ b/pkg/policy/l3_test.go
@@ -17,6 +17,7 @@ package policy
 import (
 	"net"
 
+	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/node"
 
@@ -62,4 +63,13 @@ func (ds *PolicyTestSuite) TestToBPFData(c *C) {
 	_, s4 = m.ToBPFData()
 	exp = []int{32, 26, 24, 20, 16, 8, 0}
 	c.Assert(s4, comparator.DeepEquals, exp)
+}
+
+func (ds *PolicyTestSuite) TestGetDefaultPrefixLengths(c *C) {
+	expected6 := []int{128, 64, 0}
+	expected4 := []int{32, 8, 0}
+	s6, s4 := GetDefaultPrefixLengths()
+
+	c.Assert(s6, comparator.DeepEquals, expected6)
+	c.Assert(s4, comparator.DeepEquals, expected4)
 }

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -258,12 +258,10 @@ func (r *rule) resolveCIDRPolicy(ctx *SearchContext, state *traceState, result *
 		allCIDRs = append(allCIDRs, egressRule.ToCIDR...)
 		allCIDRs = append(allCIDRs, api.ComputeResultantCIDRSet(egressRule.ToCIDRSet)...)
 
-		// CIDR + L4 rules are handled via mergeL4Egress(),
-		// skip them here.
-		if len(allCIDRs) > 0 && len(egressRule.ToPorts) > 0 {
-			continue
-		}
-
+		// Unlike the Ingress policy which only counts L3 policy in
+		// this function, we count the CIDR+L4 policy in the
+		// desired egress CIDR policy here as well. This ensures
+		// proper computation of IPcache prefix lengths.
 		if cnt := mergeCIDR(ctx, "Egress", allCIDRs, r.Labels, &result.Egress); cnt > 0 {
 			found += cnt
 		}

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -251,8 +251,10 @@ func (r *rule) resolveCIDRPolicy(ctx *SearchContext, state *traceState, result *
 		}
 	}
 
-	// CIDR egress policy is purely used for visibility of desired state in
-	// the API, it is not plumbed down into the datapath for policy!
+	// CIDR egress policy is used for visibility of desired state in
+	// the API and for determining which prefix lengths are available,
+	// however it does not determine the actual CIDRs in the BPF maps
+	// for allowing traffic by CIDR!
 	for _, egressRule := range r.Egress {
 		var allCIDRs []api.CIDR
 		allCIDRs = append(allCIDRs, egressRule.ToCIDR...)


### PR DESCRIPTION
Previously, CIDR insertion in policy would queue updates for the IPCache                                                                                                                                             
via the KVstore, then go straight into policy add / policy regeneration         
for endpoints. This would reach into IPCache to fetch the set of prefix         
lengths (ipcache.ToBPFData()) before the original IPCache KVstore update        
has propagated into the local IPCache.                                          
                                                                                
Thus, the set of prefix lengths used in generating the BPF programs may         
not include the prefix lengths for the newly inserted CIDRs. When the           
IPCache KVstore event is eventually processed, no regeneration of BPF is        
triggered so the old set of prefix lengths is used for endpoints until          
the next time the endpoints are regenerated. This leads to improper             
CIDR->Identity mapping in the datapath, which may lead to unexpected            
packet drops as the broader "reserved:world" policy would apply rather          
than the CIDR policy.                                                           
                                                                                
For reference, one plausible solution would be to trigger regeneration          
from IPCache, however this could be costly if you have dozens of IPCache        
updates occurring. There's no good way to batch the updates for these           
currently. Furthermore, it would trigger multiple rebuilds of the               
datapath based on a single policy update.                                       
                                                                                
Alternatively, we should have enough information already during policy          
resolution to generate the appropriate set of prefix lengths for the            
datapath from that policy path. This patch implements this. In other            
words:                                                                          
* Policy generation inserts elements into the L3Policy                          
* Endpoint regeneration uses the L3Policy to determine which CIDR               
prefixes need to be used by the endpoint to perform CIDR->ID mappings           
in order to implement that policy                                               
* The IPCache (by way of the KVstore) will plumb the actual CIDR->ID            
mappings into the BPF maps.                                                     
                                                                                
This should mean that the datapath is eventually consistent with the            
configured CIDR policies.

Note that this will not solve all of the problems; there is still no ability to wait
for the ipcache to be in sync with the policy. However, it does address the
problem that the endpoint BPF programs get stuck in a state where they
can't properly look up the CIDR identity for an extended period.
                                       
Fixes: https://github.com/cilium/cilium/issues/4188
Related: https://github.com/cilium/cilium/issues/4055 (This should further improve test reliability)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4231)
<!-- Reviewable:end -->
