### PR TITLE
metricsmap: Set the key size properly

### DIFF
--- a/pkg/maps/metricsmap/metricsmap.go
+++ b/pkg/maps/metricsmap/metricsmap.go
@@ -72,7 +72,7 @@ var (
 	Metrics = bpf.NewMap(
 		MapName,
 		bpf.BPF_MAP_TYPE_HASH,
-		int(unsafe.Sizeof(Value{})),
+		int(unsafe.Sizeof(Key{})),
 		int(unsafe.Sizeof(Value{})),
 		MaxEntries,
 		0,


### PR DESCRIPTION
The key size when creating this map type from userspace was set to the
size of the value instead of the key. Fix it.

Fixes: 70b1bd28c3b0 ("pkg/maps/metricsmap: Add a new userspace pkg/maps/metricsmap to access BPF metrics maps.")
Fixes: #4228

---

~~I didn't manually test that this got rid of the message as I need to update my developer VMs. However the fix looks trivially correct.~~
EDIT: Manually verified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4233)
<!-- Reviewable:end -->
