### PR TITLE
pkg/option: sort options in GetFmtList

### DIFF
--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -252,7 +252,13 @@ func (bo *BoolOptions) GetFmtList() string {
 	txt := ""
 
 	bo.optsMU.RLock()
+	opts := []string{}
 	for k := range bo.Opts {
+		opts = append(opts, k)
+	}
+	sort.Strings(opts)
+
+	for _, k := range opts {
 		def := bo.getFmtOpt(k)
 		if def != "" {
 			txt += def + "\n"

--- a/pkg/option/option_test.go
+++ b/pkg/option/option_test.go
@@ -29,6 +29,49 @@ type OptionSuite struct{}
 
 var _ = Suite(&OptionSuite{})
 
+func (s *OptionSuite) TestGetFmtOpts(c *C) {
+	OptionTest := Option{
+		Define:      "TEST_DEFINE",
+		Description: "This is a test",
+	}
+
+	o := BoolOptions{
+		Opts: OptionMap{
+			"test": true,
+			"BAR":  false,
+			"foo":  true,
+			"bar":  false,
+		},
+		Library: &OptionLibrary{
+			"test": &OptionTest,
+		},
+	}
+
+	fmtList := o.GetFmtList()
+	fmtList2 := o.GetFmtList()
+
+	// Both strings should be equal because the formatted options should be sorted.
+	c.Assert(fmtList, Equals, fmtList2)
+
+	o2 := BoolOptions{
+		Opts: OptionMap{
+			"foo":  true,
+			"BAR":  false,
+			"bar":  false,
+			"test": true,
+		},
+		Library: &OptionLibrary{
+			"test": &OptionTest,
+		},
+	}
+
+	fmtListO := o.GetFmtList()
+	fmtListO2 := o2.GetFmtList()
+
+	// Both strings should be equal because the formatted options should be sorted.
+	c.Assert(fmtListO, Equals, fmtListO2)
+}
+
 func (s *OptionSuite) TestGetFmtOpt(c *C) {
 	OptionTest := Option{
 		Define:      "TEST_DEFINE",


### PR DESCRIPTION
This function is used when generating the #defines for boolean options (e.g.
feature flags), for headerfiles for BPF programs. Since the object containing
these options being iterated over is a map, access is unordered. This presents
a problem when hashing the newly-generated headerfile for an endpoint and
comparing the hash with the existing headerfile for an endpoint, because if
the #defines are out-of-order, but equivalent, the hashes will be different,
and regeneration of the BPF program will needlessly occur for the endpoint.
If we sort the boolean options, then the order is guaranteed to be the same,
and regenerations will only take place if necessary for an endpoint.

Signed-off-by: Ian Vernon <ian@cilium.io>

Related-to: #4215 