### PR TITLE
policy: always regenerate if policy forcibly computed

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1401,7 +1401,6 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 				log.Debug("configuration request to change PolicyEnforcement for daemon")
 				changes++
 				policy.SetPolicyEnabled(enforcement)
-				d.TriggerPolicyUpdates(true)
 			}
 
 		default:
@@ -1420,10 +1419,10 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 		// Only recompile if configuration has changed.
 		log.Debug("daemon configuration has changed; recompiling base programs")
 		if err := d.compileBase(); err != nil {
-			log.WithError(err).Warn("Invalid option for PolicyEnforcement")
 			msg := fmt.Errorf("Unable to recompile base programs: %s", err)
 			return apierror.Error(PatchConfigFailureCode, msg)
 		}
+		d.TriggerPolicyUpdates(true)
 	}
 
 	return NewPatchConfigOK()

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -52,7 +52,7 @@ func (d *Daemon) TriggerPolicyUpdates(force bool) *sync.WaitGroup {
 	} else {
 		log.Debugf("Full policy recalculation triggered")
 	}
-	return endpointmanager.TriggerPolicyUpdates(d)
+	return endpointmanager.TriggerPolicyUpdates(d, force)
 }
 
 // UpdateEndpointPolicyEnforcement returns whether policy enforcement needs to be


### PR DESCRIPTION
* pkg/endpointmanager: always regenerate if policy forcibly computed
    - Regardless of if there is no change in the computed policy for an endpoint, still try to regenerate it. Previously, only a difference in the endpoint's policy and configuration, not  the agent's configuration, resulted in an endpoint regeneration, which was incorrect. This is because if there is a change in the configuration of the cilium-agent, a regeneration of endpoints may still be required, beacuse the endpoint's program is compiled not only with its headerfile (lxc_config.h), but the agent's headerfile (node_config.h) as well. Thus, checking only the result of pkg/endpoint/policy.go:regeneratePolicy` is not sufficient for determining whether an endpoint's program should be rebuilt.
* daemon: trigger policy updates upon daemon configuration update
    - Daemon configuration directly affects endpoint programs; trigger policy updates accordingly.
    

Signed-off-by: Ian Vernon <ian@cilium.io>

Related-to: #4215

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4239)
<!-- Reviewable:end -->
