### PR TITLE
policy: Overwrite eventual L4 localhost policies when AllowLocalhost=true

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -210,7 +210,17 @@ func (e *Endpoint) determineAllowLocalhost(desiredPolicyKeys map[policymap.Polic
 			Identity:         identityPkg.ReservedIdentityHost.Uint32(),
 			TrafficDirection: policymap.Ingress.Uint8(),
 		}
+
+		// Remove eventual existing ingress L4 localhost restrictions
+		for key := range desiredPolicyKeys {
+			if key.Identity == identityPkg.ReservedIdentityHost.Uint32() &&
+				key.TrafficDirection == policymap.Ingress.Uint8() {
+				delete(desiredPolicyKeys, key)
+			}
+		}
+
 		desiredPolicyKeys[localHostKey] = struct{}{}
+
 	}
 }
 


### PR DESCRIPTION
The move to desired/realized policy map state has broken the allow localhost
logic required for Kubernetes. Fix this by removing eventual L4 entries from
localhost in the DesiredL4Policy map.

Fixes: f79e85666986 ("pkg/endpoint: add DesiredL4Policy field for endpoint")
Fixes: #4245

Test validation:
```
ExecStart=/usr/bin/cilium-agent --debug $CILIUM_OPTS --allow-localhost=always
```

```
docker run -d --net cilium -l id.foo tgraf/netperf
```

l4.json:
```
[{
    "labels": [{"key": "name", "value": "l4-rule"}],
    "endpointSelector": {"matchLabels":{"reserved:all":""}},
    "ingress": [{
        "toPorts": [
            {"ports":[ {"port": "80", "protocol": "TCP"}]}
        ]
    }]
}]
```

```
cilium policy import l4.json
```

```
sudo cilium bpf policy get 35296 | grep Ingress
Ingress     reserved:health               80/TCP       0       0
Ingress     reserved:cluster              80/TCP       0       0
Ingress     reserved:world                80/TCP       0       0
Ingress     reserved:host                 ANY          0       0
Ingress     reserved:init                 80/TCP       0       0
Ingress     container:id.foo              80/TCP       0       0
```



Signed-off-by: Thomas Graf <thomas@cilium.io>