### PR TITLE
Add "docker info" output to bugtool

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -64,6 +64,7 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		"bpftool prog show",
 		// Versions
 		"docker version",
+		"docker info",
 		// Docker and Kubernetes logs from systemd
 		"journalctl -u cilium*",
 		"journalctl -u kubelet",


### PR DESCRIPTION
@joestringer Is this what you expect for issue #3990

cat cilium-bugtool-20180525-090413.757+0000-UTC-872233256/cmd/docker-info.md 

# docker info

```
Containers: 2
 Running: 2
 Paused: 0
 Stopped: 0
Images: 18
Server Version: 18.03.1-ce
Storage Driver: overlay2
 Backing Filesystem: extfs
 Supports d_type: true
 Native Overlay Diff: true
Logging Driver: json-file
Cgroup Driver: cgroupfs
Plugins:
 Volume: local
 Network: bridge host macvlan null overlay
 Log: awslogs fluentd gcplogs gelf journald json-file logentries splunk syslog
Swarm: inactive
Runtimes: runc
Default Runtime: runc
Init Binary: docker-init
containerd version: 773c489c9c1b21a6d78b5c538cd395416ec50f88
runc version: 4fc53a81fb7c994640722ac585fa9ca548971871
init version: 949e6fa
Security Options:
 apparmor
 seccomp
  Profile: default
Kernel Version: 4.9.13-040913-generic
Operating System: Ubuntu 17.10
OSType: linux
Architecture: x86_64
CPUs: 2
Total Memory: 2.936GiB
Name: runtime1
ID: P2EI:32ZX:AKKL:K4QK:CRU7:RQHR:RL5X:CGFD:YP5H:ZI5B:ZUAX:NCUO
Docker Root Dir: /var/lib/docker
Debug Mode (client): false
Debug Mode (server): false
Registry: https://index.docker.io/v1/
Labels:
Experimental: false
Insecure Registries:
 127.0.0.0/8
Live Restore Enabled: false

WARNING: No swap limit support

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4250)
<!-- Reviewable:end -->
