### PR TITLE
Split debuginfo into separate files

### DIFF
--- a/Documentation/cmdref/cilium_debuginfo.md
+++ b/Documentation/cmdref/cilium_debuginfo.md
@@ -17,6 +17,7 @@ cilium debuginfo
 
 ```
   -f, --file string        Redirect output to file
+      --file-per-command   Generate a single file per command
       --html-file string   Convert default output to HTML file
 ```
 


### PR DESCRIPTION
@joestringer  Fixes: #3799

I added a flag "--file-per-command" which generates a single file for each command,
and restructured the code to make it more readable

Single file:
```
$ cilium debuginfo -f debug.md
Warning, some of the BPF commands might fail when run as not root
Markdown output at debug.md
```
Multiple files:
```
$ cilium debuginfo -f debug.md --file-per-command
Warning, some of the BPF commands might fail when run as not root
Markdown output at debug-cilium-status.md
Markdown output at debug-cilium-endpoint-list.md
Markdown output at debug-cilium-service-list.md
Markdown output at debug-cilium-policy.md
Markdown output at debug-cilium-memory-map.md
Markdown output at debug-cilium-version.md
Markdown output at debug-kernel-version.md
Markdown output at debug-cilium-environment-keys.md
```
With multiple files, i insert the command name between the file-name and file-extension

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4252)
<!-- Reviewable:end -->
