### PR TITLE
Use JSON output for endpoint restore check in runtime chaos test

### DIFF
--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -17,7 +17,9 @@ package RuntimeTest
 import (
 	"crypto/md5"
 	"fmt"
+	"strings"
 
+	"github.com/cilium/cilium/pkg/identity"
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 
@@ -62,7 +64,27 @@ var _ = Describe("RuntimeValidatedChaos", func() {
 		curl -s --unix-socket /var/run/cilium/cilium.sock \
 		http://localhost/v1beta/healthz/ | jq ".ipam.ipv4|length"`)
 
-		endpointListCmd := "cilium endpoint list | grep -v reserved"
+		// List the endpoints, but skip the reserved:health endpoint
+		// (4) because it doesn't matter if that endpoint is different.
+		// Remove fields that are expected to change across restart.
+		//
+		// We don't use -o jsonpath... here due to GH-2395.
+		//
+		// jq 'map(select(.status.identity.id != 4), del(.status.controllers, ..., (.status.identity.labels | sort)))'
+		filterHealthEP := fmt.Sprintf("select(.status.identity.id != %d)", identity.GetReservedID("health"))
+		nonPersistentEndpointFields := strings.Join([]string{
+			".status.controllers",     // Timestamps, UUIDs
+			".status.labels",          // Slice ordering
+			".status.log",             // Timestamp
+			".status.identity.labels", // Slice ordering
+			".status.policy",          // Allowed identities order
+		}, ", ")
+		// Delete fields we're not interested in
+		filterFields := fmt.Sprintf("del(%s)", nonPersistentEndpointFields)
+		// Go back and add the identity labels back into the output
+		getSortedLabels := "(.status.identity.labels | sort)"
+		jqCmd := fmt.Sprintf("jq 'map(%s) | map(%s, %s)'", filterHealthEP, filterFields, getSortedLabels)
+		endpointListCmd := fmt.Sprintf("cilium endpoint list -o json | %s", jqCmd)
 		originalEndpointList := vm.Exec(endpointListCmd)
 
 		err := vm.RestartCilium()


### PR DESCRIPTION
Previously, we used the tabwriter output of `cilium endpoint list` to
check the validity of endpoint restore. However, occasionally this could
add extra spacing in the columns which lead to test flakes.

This patch swaps that fragile logic out to instead filter the JSON
output and compare it instead. The health endpoint is still skipped, as
is any of the endpoint fields which are expected to change, due for
instance to timestamps or fields that have no ordering guarantee.

Fixes: #4255 

For reference, example output of the endpoint command for a particular endpoint:

```
  {
    "id": 65304,
    "spec": {
      "label-configuration": {
        "user": []
      },
      "options": {
        "Conntrack": "Enabled",
        "ConntrackAccounting": "Enabled",
        "ConntrackLocal": "Disabled",
        "Debug": "Enabled",
        "DebugLB": "Disabled",
        "DropNotification": "Enabled",
        "EgressPolicy": "Disabled",
        "IngressPolicy": "Disabled",
        "NAT46": "Disabled",
        "TraceNotification": "Enabled"
      }
    },
    "status": {
      "external-identifiers": {
        "container-id": "3e9124fd857580940a233976315dca971f08aa057ec6a15e6c6dbceed2e88675",
        "container-name": "server-3",
        "docker-endpoint-id": "54cff3d389953a594337c7631ba49228bcf28b65c3c0ac52b37db0248778d3ee",
        "docker-network-id": "8d3898b1df4a04822b432b1ddc5b3d01e70233dc0d182da43f5823ca6597e03b",
        "pod-name": ":"
      },
      "health": {
        "bpf": "OK",
        "connected": true,
        "overallHealth": "OK",
        "policy": "OK"
      },
      "identity": {
        "id": 12210,
        "labelsSHA256": "d38822e91a442dc62c68d17da79d9563eb0e5246672d57db1d383e1f382289c7"
      },
      "networking": {
        "addressing": [
          {
            "ipv4": "10.11.81.227",
            "ipv6": "f00d::a0f:0:0:ff18"
          }
        ],
        "host-mac": "32:14:d3:36:e2:a3",
        "interface-index": 356,
        "interface-name": "lxc54cff",
        "mac": "96:c4:c3:5c:49:da"
      },
      "realized": {
        "label-configuration": {
          "user": []
        },
        "options": {
          "Conntrack": "Enabled",
          "ConntrackAccounting": "Enabled",
          "ConntrackLocal": "Disabled",
          "Debug": "Enabled",
          "DebugLB": "Disabled",
          "DropNotification": "Enabled",
          "EgressPolicy": "Disabled",
          "IngressPolicy": "Disabled",
          "NAT46": "Disabled",
          "TraceNotification": "Enabled"
        }
      },
      "state": "ready"
    }
  },
  [
    "container:id.server-3",
    "container:id.service1"
  ]
```