### PR TITLE
Fix: `cilium monitor` allows invalid arguments

### DIFF
--- a/cilium/cmd/monitor.go
+++ b/cilium/cmd/monitor.go
@@ -51,7 +51,7 @@ programs attached to endpoints and devices. This includes:
   * Captured packet traces
   * Debugging information`,
 	Run: func(cmd *cobra.Command, args []string) {
-		runMonitor()
+		runMonitor(args)
 	},
 }
 
@@ -312,7 +312,12 @@ func setupSigHandler() {
 	}()
 }
 
-func runMonitor() {
+func runMonitor(args []string) {
+	if len(args) > 0 {
+		fmt.Println("Error: arguments not recognized")
+		os.Exit(1)
+	}
+
 	setVerbosity()
 	setupSigHandler()
 	if resp, err := client.Daemon.GetHealthz(nil); err == nil {


### PR DESCRIPTION
@joestringer Adding unknown arguments now throws

```
$ cilium monitor invalid arguments
Error: arguments not recognized
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4259)
<!-- Reviewable:end -->
