### PR TITLE
docs: fix shown command in minikube guide

### DIFF
--- a/Documentation/gettingstarted/minikube.rst
+++ b/Documentation/gettingstarted/minikube.rst
@@ -288,7 +288,7 @@ You can observe the L7 policy via ``kubectl``:
 
 ::
 
-    $ kubectl get ciliumnetworkpolicies
+    $ kubectl describe ciliumnetworkpolicies
     Name:         rule1
     Namespace:    default
     Labels:       <none>


### PR DESCRIPTION
The shown command `get` doesn't match the output, which is from
`describe`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4262)
<!-- Reviewable:end -->
