### PR TITLE
daemon: in k8s mode always allow localhost traffic

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1061,7 +1061,8 @@ func NewDaemon() (*Daemon, error) {
 		// pods. Therefore unless the AllowLocalhost policy is set to a
 		// specific mode, always allow localhost to reach local
 		// endpoints.
-		if option.Config.AlwaysAllowLocalhost() {
+		if option.Config.AllowLocalhost == option.AllowLocalhostAuto {
+			option.Config.AllowLocalhost = option.AllowLocalhostAlways
 			log.Info("k8s mode: Allowing localhost to reach local endpoints")
 		}
 


### PR DESCRIPTION
Fixes: 0da4df30f4b9 ("daemon: move daemon's config to option/config")
Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/4245

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4263)
<!-- Reviewable:end -->
