### PR TITLE
bugtool: make archive output configurable

### DIFF
--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -37,6 +37,7 @@ cilium-bugtool [OPTIONS]
 
 ```
       --archive                 Create archive when false skips deletion of the output directory (default true)
+  -o, --archiveType string      Archive type: tar | gz (default "tar")
       --config string           Configuration to decide what should be run (default "./.cilium-bugtool.config")
       --dry-run                 Create configuration file of all commands that would have been executed
       --exec-timeout duration   The default timeout for any cmd execution in seconds (default 30s)


### PR DESCRIPTION
@michi-covalent @scanf 

I added a flag to select tar | gz output (if archive flag == true)

Fixes: #2306

```
$ cilium-bugtool --help
Collects agent & system information useful for bug reporting

...

Flags:
      --archive                 Create archive when false skips deletion of the output directory (default true)
  -o, --archiveType string      Archive type: tar | gz (default "tar")
      --config string           Configuration to decide what should be run (default "./.cilium-bugtool.config")
      --dry-run                 Create configuration file of all commands that would have been executed
      --exec-timeout duration   The default timeout for any cmd execution in seconds (default 30s)
  -H, --host string             URI to server-side API
      --k8s-label string        Kubernetes label for Cilium pod (default "k8s-app=cilium")
      --k8s-mode                Require Kubernetes pods to be found or fail
      --k8s-namespace string    Kubernetes namespace for Cilium pod (default "kube-system")
  -p, --port int                Port to use for the HTTP server, (default 4444) (default 4444)
      --serve                   Start HTTP server to serve static files
  -t, --tmp string              Path to store extracted files (default "/tmp")

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4264)
<!-- Reviewable:end -->
