### PR TITLE
RFC: Istio e2e testing

### DIFF
--- a/test/k8sT/Istio.go
+++ b/test/k8sT/Istio.go
@@ -1,0 +1,171 @@
+// Copyright 2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sTest
+
+import (
+	"fmt"
+
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
+
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+var _ = Describe("K8sValidatedIstioTest", func() {
+
+	var (
+		kubectl          *helpers.Kubectl
+		logger           *logrus.Entry
+		microscopeErr    error
+		microscopeCancel func() error
+		ciliumPodK8s1    string
+		ciliumFilter     string = "-l k8s-app=cilium"
+		ciliumPath       string = helpers.ManifestGet("cilium_ds_istio.yaml")
+		istioManifest    string = helpers.ManifestGet("istio-auth.yaml")
+		istioNS          string = "istio-system"
+		istioFilter      string = "-l zgroup=istio"
+		istioVersion     string = "release-0.8-20180521-15-16"
+		istioURL         string = fmt.Sprintf("https://storage.googleapis.com/istio-prerelease/daily-build/%[1]s/istio-%[1]s-linux.tar.gz", istioVersion)
+		istioConfigMap   string = helpers.ManifestGet("istio-kube-inject-template.yaml")
+		istioInitPolicy  string = helpers.ManifestGet("istio-sidecar-init-policy.yaml")
+		demoPath         string = helpers.ManifestGet("demo_big.yaml")
+		container        string = "app-frontend"
+	)
+
+	BeforeAll(func() {
+		logger = log.WithFields(logrus.Fields{"testName": "K8sValidatedIstioTest"})
+		logger.Info("Starting")
+
+		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+		kubectl.Apply(ciliumPath)
+
+		_ = kubectl.Exec(fmt.Sprintf(
+			"%s -n %s delete pods %s",
+			helpers.KubectlCmd, helpers.KubeSystemNamespace, ciliumFilter))
+
+		err := kubectl.WaitforPods(helpers.KubeSystemNamespace, ciliumFilter, 600)
+		Expect(err).Should(BeNil())
+
+		err = kubectl.WaitKubeDNS()
+		Expect(err).Should(BeNil(), "DNS is not ready after timeout")
+
+		_, err = kubectl.CiliumPolicyAction(
+			helpers.KubeSystemNamespace, istioInitPolicy,
+			helpers.KubectlApply, 300)
+		Expect(err).Should(BeNil(), "Cannot apply init policy")
+
+		ciliumPodK8s1, err = kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
+		Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")
+
+		// Installing Istio
+		res := kubectl.Exec(fmt.Sprintf("cd /tmp/; curl -L %s | tar xz ", istioURL))
+		res.ExpectSuccess("Cannot download istio: %s", res.CombineOutput())
+
+		res = kubectl.ExecWithSudo(fmt.Sprintf("mv -f /tmp/istio-%s /usr/local/istio", istioVersion))
+		res.ExpectSuccess("Cannot mv Istio source folder ")
+
+		res = kubectl.ExecWithSudo("ln -sf /usr/local/istio/bin/* /usr/local/bin/")
+		res.ExpectSuccess("cannot copy Istio binaries")
+
+		kubectl.Apply(istioManifest)
+
+		err = kubectl.WaitforPods(istioNS, istioFilter, 600)
+		Expect(err).Should(BeNil(), "Istio cannot be installed correctly")
+	})
+
+	kubeInject := func(fileName string, command string) *helpers.CmdRes {
+		cmd := fmt.Sprintf("istioctl kube-inject --injectConfigFile %s -f %s | %s %s -f -",
+			istioConfigMap,
+			fileName,
+			helpers.KubectlCmd,
+			command)
+		return kubectl.Exec(cmd)
+	}
+
+	AfterAll(func() {
+		kubectl.Delete(ciliumPath)
+		kubectl.Delete(istioManifest)
+		kubectl.ExecWithSudo("rm -rf /ust/local/istio")
+	})
+
+	AfterFailed(func() {
+		kubectl.CiliumReport(helpers.KubeSystemNamespace,
+			"cilium service list",
+			"cilium policy get",
+			"cilium endpoint list")
+	})
+
+	JustBeforeEach(func() {
+		microscopeErr, microscopeCancel = kubectl.MicroscopeStart()
+		Expect(microscopeErr).To(BeNil(), "Microscope cannot be started")
+	})
+
+	JustAfterEach(func() {
+		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+		Expect(microscopeCancel()).To(BeNil(), "cannot stop microscope")
+	})
+
+	AfterEach(func() {
+		err := kubectl.WaitCleanAllTerminatingPods()
+		Expect(err).To(BeNil(), "Terminating containers are not deleted after timeout")
+	})
+
+	Context("With Basic Application", func() {
+
+		execPodContainer := func(ns, pod, container, cmd string) *helpers.CmdRes {
+			return kubectl.Exec(fmt.Sprintf("%s -n %s exec -t %s -c %s -- %s",
+				helpers.KubectlCmd, ns, pod, container, cmd))
+		}
+
+		var (
+			clusterIP     string
+			httpd1Service string = "httpd1-service"
+			appPods       map[string]string
+			apps          []string = []string{
+				helpers.Httpd1, helpers.Httpd2, helpers.App1, helpers.App2, helpers.App3}
+		)
+
+		BeforeAll(func() {
+			res := kubeInject(demoPath, "apply")
+			res.ExpectSuccess("cannot install demo: %s", res.CombineOutput())
+
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", 300)
+			Expect(err).Should(BeNil(), "Test pods are not ready after timeout")
+
+			clusterIP, _, err = kubectl.GetServiceHostPort(helpers.DefaultNamespace, httpd1Service)
+			Expect(err).To(BeNil(), "Cannot get service on %q namespace", helpers.DefaultNamespace)
+
+			appPods = helpers.GetAppPods(apps, helpers.DefaultNamespace, kubectl, "id")
+		})
+
+		AfterAll(func() {
+			res := kubeInject(demoPath, helpers.Delete)
+			res.ExpectSuccess("cannot install demo: %s", res.CombineOutput())
+		})
+
+		It("Basic connectivity test", func() {
+			res := execPodContainer(
+				helpers.DefaultNamespace, appPods[helpers.App1], container,
+				helpers.CurlFail("http://%s/public", clusterIP))
+			res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App1], clusterIP)
+
+			res = execPodContainer(
+				helpers.DefaultNamespace, appPods[helpers.App2], container,
+				helpers.CurlFail("http://%s/public", clusterIP))
+			res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], clusterIP)
+		})
+	})
+})

--- a/test/k8sT/manifests/cilium_ds_geneve.yaml
+++ b/test/k8sT/manifests/cilium_ds_geneve.yaml
@@ -1,5 +1,5 @@
-kind: ConfigMap
 apiVersion: v1
+kind: ConfigMap
 metadata:
   name: cilium-config
   namespace: kube-system
@@ -11,7 +11,7 @@ data:
   etcd-config: |-
     ---
     endpoints:
-    - "http://k8s1:9732"
+      - http://k8s1:9732
     #
     # In case you want to use TLS in etcd, uncomment the following line
     # and add the certificate as explained in the comment labeled "ETCD-CERT"
@@ -25,11 +25,14 @@ data:
   # If you want to run cilium in debug mode change this value to true
   debug: "true"
   disable-ipv4: "false"
+  sidecar-http-proxy: "false"
+  # If you want to clean cilium state; change this value to true
+  clean-cilium-state: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-apiVersion: v1
 kind: Secret
+apiVersion: v1
 type: Opaque
 metadata:
   name: cilium-etcd-secrets
@@ -42,33 +45,23 @@ data:
   etcd-client-key: ""
   etcd-client-crt: ""
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium
-  namespace: kube-system
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: cilium
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cilium
-subjects:
-- kind: ServiceAccount
-  name: cilium
-  namespace: kube-system
-- kind: Group
-  name: system:nodes
----
-apiVersion: extensions/v1beta1
 kind: DaemonSet
+apiVersion: apps/v1
 metadata:
   name: cilium
   namespace: kube-system
 spec:
+  updateStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
+      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
+      maxUnavailable: "100%"
+  selector:
+    matchLabels:
+      k8s-app: cilium
+      kubernetes.io/cluster-service: "true"
   template:
     metadata:
       labels:
@@ -86,6 +79,22 @@ spec:
         prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
+      initContainers:
+      - name: clean-cilium-state
+        image: busybox
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+        env:
+          - name: "CLEAN_CILIUM_STATE"
+            valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-state
       containers:
       - image: k8s1:5000/cilium/cilium-dev:latest
         imagePullPolicy: Always
@@ -100,9 +109,6 @@ spec:
           - "etcd"
           - "--kvstore-opt"
           - "etcd.config=/var/lib/etcd-config/etcd.config"
-          - "--disable-ipv4=$(DISABLE_IPV4)"
-          - "-t"
-          - "geneve"
         ports:
           - name: prometheus
             containerPort: 9090
@@ -130,6 +136,12 @@ spec:
               configMapKeyRef:
                 name: cilium-config
                 key: disable-ipv4
+          - name: "CILIUM_SIDECAR_HTTP_PROXY"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-http-proxy
+                optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
@@ -212,6 +224,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+      restartPolicy: Always
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
@@ -222,8 +235,23 @@ spec:
       - key: CriticalAddonsOnly
         operator: "Exists"
 ---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- kind: Group
+  name: system:nodes
+---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cilium
 rules:
@@ -285,3 +313,10 @@ rules:
   - ciliumendpoints
   verbs:
   - "*"
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium
+  namespace: kube-system
+---

--- a/test/k8sT/manifests/cilium_ds_istio.yaml
+++ b/test/k8sT/manifests/cilium_ds_istio.yaml
@@ -23,9 +23,9 @@ data:
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
   # If you want to run cilium in debug mode change this value to true
-  debug: "true"
+  debug: "false"
   disable-ipv4: "false"
-  sidecar-http-proxy: "false"
+  sidecar-http-proxy: "true"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
 ---
@@ -102,13 +102,10 @@ spec:
         command: [ "cilium-agent" ]
         args:
           - "--debug=$(CILIUM_DEBUG)"
-          - "--debug-verbose=flow"
-          - "-t"
-          - "vxlan"
-          - "--kvstore"
-          - "etcd"
-          - "--kvstore-opt"
-          - "etcd.config=/var/lib/etcd-config/etcd.config"
+          - "-t=vxlan"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+          - "--disable-ipv4=$(DISABLE_IPV4)"
         ports:
           - name: prometheus
             containerPort: 9090

--- a/test/k8sT/manifests/demo_big.yaml
+++ b/test/k8sT/manifests/demo_big.yaml
@@ -1,0 +1,125 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpd1-service
+spec:
+  ports:
+  - port: 80
+  selector:
+    id: httpd1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpd2-service
+spec:
+  ports:
+  - port: 80
+  selector:
+    id: httpd2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpd-meta
+spec:
+  ports:
+  - port: 80
+  selector:
+    httpdType: meta
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: httpd1
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        id: httpd1
+        zgroup: testapp
+        httpdType: meta
+    spec:
+      containers:
+        - name: web
+          image: cilium/demo-httpd
+          ports:
+          - containerPort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: httpd2
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        id: httpd2
+        zgroup: testapp
+        httpdType: meta
+    spec:
+      containers:
+        - name: web
+          image: cilium/demo-httpd
+          ports:
+          - containerPort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        id: app1
+        zgroup: testapp
+    spec:
+      containers:
+      - name: app-frontend
+        image: cilium/demo-client
+        command: [ "sleep" ]
+        args:
+          - "1000h"
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: app2
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        id: app2
+        zgroup: testapp
+    spec:
+      containers:
+      - name: app-frontend
+        image: cilium/demo-client
+        command: [ "sleep" ]
+        args:
+          - "1000h"
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: app3
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        id: app3
+        zgroup: testapp
+    spec:
+      containers:
+      - name: app-frontend
+        image: cilium/demo-client
+        command: [ "sleep" ]
+        args:
+          - "1000h"

--- a/test/k8sT/manifests/istio-auth.yaml
+++ b/test/k8sT/manifests/istio-auth.yaml
@@ -1,0 +1,3366 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+ name: istio-system
+---
+# Source: istio/charts/mixer/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-statsd-prom-bridge
+  namespace: istio-system
+  labels:
+    app: istio-statsd-prom-bridge
+    chart: mixer-0.8.0
+    release: RELEASE-NAME
+    heritage: Tiller
+    istio: mixer
+data:
+  mapping.conf: |-
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-mixer-custom-resources
+  namespace: istio-system
+  labels:
+    app: istio-mixer
+    chart: mixer-0.8.0
+    release: RELEASE-NAME
+    heritage: Tiller
+    istio: mixer
+data:
+  custom-resources.yaml: |-
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: attributemanifest
+    metadata:
+      name: istioproxy
+      namespace: istio-system
+    spec:
+      attributes:
+        origin.ip:
+          valueType: IP_ADDRESS
+        origin.uid:
+          valueType: STRING
+        origin.user:
+          valueType: STRING
+        request.headers:
+          valueType: STRING_MAP
+        request.id:
+          valueType: STRING
+        request.host:
+          valueType: STRING
+        request.method:
+          valueType: STRING
+        request.path:
+          valueType: STRING
+        request.reason:
+          valueType: STRING
+        request.referer:
+          valueType: STRING
+        request.scheme:
+          valueType: STRING
+        request.total_size:
+              valueType: INT64
+        request.size:
+          valueType: INT64
+        request.time:
+          valueType: TIMESTAMP
+        request.useragent:
+          valueType: STRING
+        response.code:
+          valueType: INT64
+        response.duration:
+          valueType: DURATION
+        response.headers:
+          valueType: STRING_MAP
+        response.total_size:
+              valueType: INT64
+        response.size:
+          valueType: INT64
+        response.time:
+          valueType: TIMESTAMP
+        source.uid:
+          valueType: STRING
+        source.user:
+          valueType: STRING
+        destination.uid:
+          valueType: STRING
+        connection.id:
+          valueType: STRING
+        connection.received.bytes:
+          valueType: INT64
+        connection.received.bytes_total:
+          valueType: INT64
+        connection.sent.bytes:
+          valueType: INT64
+        connection.sent.bytes_total:
+          valueType: INT64
+        connection.duration:
+          valueType: DURATION
+        connection.mtls:
+          valueType: BOOL
+        context.protocol:
+          valueType: STRING
+        context.timestamp:
+          valueType: TIMESTAMP
+        context.time:
+          valueType: TIMESTAMP
+        api.service:
+          valueType: STRING
+        api.version:
+          valueType: STRING
+        api.operation:
+          valueType: STRING
+        api.protocol:
+          valueType: STRING
+        request.auth.principal:
+          valueType: STRING
+        request.auth.audiences:
+          valueType: STRING
+        request.auth.presenter:
+          valueType: STRING
+        request.auth.claims:
+          valueType: STRING_MAP
+        request.api_key:
+          valueType: STRING
+
+    ---
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: attributemanifest
+    metadata:
+      name: kubernetes
+      namespace: istio-system
+    spec:
+      attributes:
+        source.ip:
+          valueType: IP_ADDRESS
+        source.labels:
+          valueType: STRING_MAP
+        source.name:
+          valueType: STRING
+        source.namespace:
+          valueType: STRING
+        source.service:
+          valueType: STRING
+        source.serviceAccount:
+          valueType: STRING
+        destination.ip:
+          valueType: IP_ADDRESS
+        destination.labels:
+          valueType: STRING_MAP
+        destination.name:
+          valueType: STRING
+        destination.namespace:
+          valueType: STRING
+        destination.service:
+          valueType: STRING
+        destination.serviceAccount:
+          valueType: STRING
+    ---
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: stdio
+    metadata:
+      name: handler
+      namespace: istio-system
+    spec:
+      outputAsJson: true
+    ---
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: logentry
+    metadata:
+      name: accesslog
+      namespace: istio-system
+    spec:
+      severity: '"Info"'
+      timestamp: request.time
+      variables:
+        originIp: origin.ip | ip("0.0.0.0")
+        sourceIp: source.ip | ip("0.0.0.0")
+        sourceService: source.service | ""
+        sourceUser: source.user | source.uid | ""
+        sourceNamespace: source.namespace | ""
+        destinationIp: destination.ip | ip("0.0.0.0")
+        destinationService: destination.service | ""
+        destinationNamespace: destination.namespace | ""
+        apiName: api.service | ""
+        apiVersion: api.version | ""
+        apiClaims: request.headers["sec-istio-auth-userinfo"]| ""
+        apiKey: request.api_key | request.headers["x-api-key"] | ""
+        requestOperation: api.operation | ""
+        protocol: request.scheme | "http"
+        method: request.method | ""
+        url: request.path | ""
+        responseCode: response.code | 0
+        responseSize: response.size | 0
+        requestSize: request.size | 0
+        latency: response.duration | "0ms"
+        connectionMtls: connection.mtls | false
+        userAgent: request.useragent | ""
+        responseTimestamp: response.time
+        receivedBytes: request.total_size | connection.received.bytes | 0
+        sentBytes: response.total_size | connection.sent.bytes | 0
+        referer: request.referer | ""
+      monitored_resource_type: '"UNSPECIFIED"'
+    ---
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: rule
+    metadata:
+      name: stdio
+      namespace: istio-system
+    spec:
+      match: "true" # If omitted match is true.
+      actions:
+      - handler: handler.stdio
+        instances:
+        - accesslog.logentry
+    ---
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: metric
+    metadata:
+      name: requestcount
+      namespace: istio-system
+    spec:
+      value: "1"
+      dimensions:
+        source_service: source.service | "unknown"
+        source_version: source.labels["version"] | "unknown"
+        destination_service: destination.service | "unknown"
+        destination_version: destination.labels["version"] | "unknown"
+        response_code: response.code | 200
+        connection_mtls: connection.mtls | false
+      monitored_resource_type: '"UNSPECIFIED"'
+    ---
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: metric
+    metadata:
+      name: requestduration
+      namespace: istio-system
+    spec:
+      value: response.duration | "0ms"
+      dimensions:
+        source_service: source.service | "unknown"
+        source_version: source.labels["version"] | "unknown"
+        destination_service: destination.service | "unknown"
+        destination_version: destination.labels["version"] | "unknown"
+        response_code: response.code | 200
+        connection_mtls: connection.mtls | false
+      monitored_resource_type: '"UNSPECIFIED"'
+    ---
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: metric
+    metadata:
+      name: requestsize
+      namespace: istio-system
+    spec:
+      value: request.size | 0
+      dimensions:
+        source_service: source.service | "unknown"
+        source_version: source.labels["version"] | "unknown"
+        destination_service: destination.service | "unknown"
+        destination_version: destination.labels["version"] | "unknown"
+        response_code: response.code | 200
+        connection_mtls: connection.mtls | false
+      monitored_resource_type: '"UNSPECIFIED"'
+    ---
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: metric
+    metadata:
+      name: responsesize
+      namespace: istio-system
+    spec:
+      value: response.size | 0
+      dimensions:
+        source_service: source.service | "unknown"
+        source_version: source.labels["version"] | "unknown"
+        destination_service: destination.service | "unknown"
+        destination_version: destination.labels["version"] | "unknown"
+        response_code: response.code | 200
+        connection_mtls: connection.mtls | false
+      monitored_resource_type: '"UNSPECIFIED"'
+    ---
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: metric
+    metadata:
+      name: tcpbytesent
+      namespace: istio-system
+      labels:
+        istio-protocol: tcp # needed so that mixer will only generate when context.protocol == tcp
+    spec:
+      value: connection.sent.bytes | 0
+      dimensions:
+        source_service: source.service | "unknown"
+        source_version: source.labels["version"] | "unknown"
+        destination_service: destination.service | "unknown"
+        destination_version: destination.labels["version"] | "unknown"
+        connection_mtls: connection.mtls | false
+      monitored_resource_type: '"UNSPECIFIED"'
+    ---
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: metric
+    metadata:
+      name: tcpbytereceived
+      namespace: istio-system
+      labels:
+        istio-protocol: tcp # needed so that mixer will only generate when context.protocol == tcp
+    spec:
+      value: connection.received.bytes | 0
+      dimensions:
+        source_service: source.service | "unknown"
+        source_version: source.labels["version"] | "unknown"
+        destination_service: destination.service | "unknown"
+        destination_version: destination.labels["version"] | "unknown"
+        connection_mtls: connection.mtls | false
+      monitored_resource_type: '"UNSPECIFIED"'
+    ---
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: prometheus
+    metadata:
+      name: handler
+      namespace: istio-system
+    spec:
+      metrics:
+      - name: request_count
+        instance_name: requestcount.metric.istio-system
+        kind: COUNTER
+        label_names:
+        - source_service
+        - source_version
+        - destination_service
+        - destination_version
+        - response_code
+        - connection_mtls
+      - name: request_duration
+        instance_name: requestduration.metric.istio-system
+        kind: DISTRIBUTION
+        label_names:
+        - source_service
+        - source_version
+        - destination_service
+        - destination_version
+        - response_code
+        - connection_mtls
+        buckets:
+          explicit_buckets:
+            bounds: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
+      - name: request_size
+        instance_name: requestsize.metric.istio-system
+        kind: DISTRIBUTION
+        label_names:
+        - source_service
+        - source_version
+        - destination_service
+        - destination_version
+        - response_code
+        - connection_mtls
+        buckets:
+          exponentialBuckets:
+            numFiniteBuckets: 8
+            scale: 1
+            growthFactor: 10
+      - name: response_size
+        instance_name: responsesize.metric.istio-system
+        kind: DISTRIBUTION
+        label_names:
+        - source_service
+        - source_version
+        - destination_service
+        - destination_version
+        - response_code
+        - connection_mtls
+        buckets:
+          exponentialBuckets:
+            numFiniteBuckets: 8
+            scale: 1
+            growthFactor: 10
+      - name: tcp_bytes_sent
+        instance_name: tcpbytesent.metric.istio-system
+        kind: COUNTER
+        label_names:
+        - source_service
+        - source_version
+        - destination_service
+        - destination_version
+        - connection_mtls
+      - name: tcp_bytes_received
+        instance_name: tcpbytereceived.metric.istio-system
+        kind: COUNTER
+        label_names:
+        - source_service
+        - source_version
+        - destination_service
+        - destination_version
+        - connection_mtls
+    ---
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: rule
+    metadata:
+      name: promhttp
+      namespace: istio-system
+      labels:
+        istio-protocol: http
+    spec:
+      actions:
+      - handler: handler.prometheus
+        instances:
+        - requestcount.metric
+        - requestduration.metric
+        - requestsize.metric
+        - responsesize.metric
+    ---
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: rule
+    metadata:
+      name: promtcp
+      namespace: istio-system
+      labels:
+        istio-protocol: tcp # needed so that mixer will only execute when context.protocol == TCP
+    spec:
+      actions:
+      - handler: handler.prometheus
+        instances:
+        - tcpbytesent.metric
+        - tcpbytereceived.metric
+    ---
+
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: kubernetesenv
+    metadata:
+      name: handler
+      namespace: istio-system
+    spec:
+      # when running from mixer root, use the following config after adding a
+      # symbolic link to a kubernetes config file via:
+      #
+      # $ ln -s ~/.kube/config mixer/adapter/kubernetes/kubeconfig
+      #
+      # kubeconfig_path: "mixer/adapter/kubernetes/kubeconfig"
+
+    ---
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: rule
+    metadata:
+      name: kubeattrgenrulerule
+      namespace: istio-system
+    spec:
+      actions:
+      - handler: handler.kubernetesenv
+        instances:
+        - attributes.kubernetes
+    ---
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: rule
+    metadata:
+      name: tcpkubeattrgenrulerule
+      namespace: istio-system
+    spec:
+      match: context.protocol == "tcp"
+      actions:
+      - handler: handler.kubernetesenv
+        instances:
+        - attributes.kubernetes
+    ---
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: kubernetes
+    metadata:
+      name: attributes
+      namespace: istio-system
+    spec:
+      # Pass the required attribute data to the adapter
+      source_uid: source.uid | ""
+      source_ip: source.ip | ip("0.0.0.0") # default to unspecified ip addr
+      destination_uid: destination.uid | ""
+      origin_uid: '""'
+      origin_ip: ip("0.0.0.0") # default to unspecified ip addr
+      attribute_bindings:
+        # Fill the new attributes from the adapter produced output.
+        # $out refers to an instance of OutputTemplate message
+        source.ip: $out.source_pod_ip | ip("0.0.0.0")
+        source.labels: $out.source_labels | emptyStringMap()
+        source.namespace: $out.source_namespace | "default"
+        source.service: $out.source_service | "unknown"
+        source.serviceAccount: $out.source_service_account_name | "unknown"
+        destination.ip: $out.destination_pod_ip | ip("0.0.0.0")
+        destination.labels: $out.destination_labels | emptyStringMap()
+        destination.namespace: $out.destination_namespace | "default"
+        destination.service: $out.destination_service | "unknown"
+        destination.serviceAccount: $out.destination_service_account_name | "unknown"
+    ---
+
+
+---
+# Source: istio/charts/prometheus/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus
+  namespace: istio-system
+  labels:
+    app: prometheus
+    chart: prometheus-0.1.0
+    release: RELEASE-NAME
+    heritage: Tiller
+data:
+  prometheus.yml: |-
+    global:
+      scrape_interval: 15s
+    scrape_configs:
+
+    - job_name: 'istio-mesh'
+      # Override the global default and scrape targets from this job every 5 seconds.
+      scrape_interval: 5s
+
+      kubernetes_sd_configs:
+      - role: endpoints
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-system;istio-telemetry;prometheus
+
+    - job_name: 'envoy'
+      # Override the global default and scrape targets from this job every 5 seconds.
+      scrape_interval: 5s
+      # metrics_path defaults to '/metrics'
+      # scheme defaults to 'http'.
+
+      kubernetes_sd_configs:
+      - role: endpoints
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-system;istio-statsd-prom-bridge;statsd-prom
+
+    - job_name: 'istio-policy'
+      # Override the global default and scrape targets from this job every 5 seconds.
+      scrape_interval: 5s
+      # metrics_path defaults to '/metrics'
+      # scheme defaults to 'http'.
+
+      kubernetes_sd_configs:
+      - role: endpoints
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-system;istio-policy;http-monitoring
+
+    - job_name: 'istio-telemetry'
+      # Override the global default and scrape targets from this job every 5 seconds.
+      scrape_interval: 5s
+      # metrics_path defaults to '/metrics'
+      # scheme defaults to 'http'.
+
+      kubernetes_sd_configs:
+      - role: endpoints
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-system;istio-telemetry;http-monitoring
+
+    - job_name: 'pilot'
+      # Override the global default and scrape targets from this job every 5 seconds.
+      scrape_interval: 5s
+      # metrics_path defaults to '/metrics'
+      # scheme defaults to 'http'.
+
+      kubernetes_sd_configs:
+      - role: endpoints
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-system;istio-pilot;http-monitoring
+
+    # scrape config for API servers
+    - job_name: 'kubernetes-apiservers'
+      kubernetes_sd_configs:
+      - role: endpoints
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: default;kubernetes;https
+
+    # scrape config for nodes (kubelet)
+    - job_name: 'kubernetes-nodes'
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: kubernetes.default.svc:443
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics
+
+    # Scrape config for Kubelet cAdvisor.
+    #
+    # This is required for Kubernetes 1.7.3 and later, where cAdvisor metrics
+    # (those whose names begin with 'container_') have been removed from the
+    # Kubelet metrics endpoint.  This job scrapes the cAdvisor endpoint to
+    # retrieve those metrics.
+    #
+    # In Kubernetes 1.7.0-1.7.2, these metrics are only exposed on the cAdvisor
+    # HTTP endpoint; use "replacement: /api/v1/nodes/${1}:4194/proxy/metrics"
+    # in that case (and ensure cAdvisor's HTTP server hasn't been disabled with
+    # the --cadvisor-port=0 Kubelet flag).
+    #
+    # This job is not necessary and should be removed in Kubernetes 1.6 and
+    # earlier versions, or it will cause the metrics to be scraped twice.
+    - job_name: 'kubernetes-cadvisor'
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: kubernetes.default.svc:443
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
+    # scrape config for service endpoints.
+    - job_name: 'kubernetes-service-endpoints'
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+        action: replace
+        target_label: __scheme__
+        regex: (https?)
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+        action: replace
+        target_label: __address__
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: kubernetes_namespace
+      - source_labels: [__meta_kubernetes_service_name]
+        action: replace
+        target_label: kubernetes_name
+
+    # Example scrape config for pods
+    - job_name: 'kubernetes-pods'
+      kubernetes_sd_configs:
+      - role: pod
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod_name
+
+---
+# Source: istio/charts/sidecar-injector/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-sidecar-injector
+  namespace: istio-system
+  labels:
+    app: sidecar-injector
+    chart: sidecar-injector-0.8.0
+    release: RELEASE-NAME
+    heritage: Tiller
+    istio: sidecar-injector
+data:
+  config: |-
+    policy: enabled
+    template: |-
+      initContainers:
+      - name: istio-init
+        image: gcr.io/istio-release/proxy_init:release-0.8-20180521-15-16
+        args:
+        - "-p"
+        - [[ .MeshConfig.ProxyListenPort ]]
+        - "-u"
+        - 1337
+        - "-m"
+        - [[ or (index .ObjectMeta.Annotations "sidecar.istio.io/interceptionMode") .ProxyConfig.InterceptionMode.String ]]
+        - "-i"
+        [[ if (isset .ObjectMeta.Annotations "traffic.sidecar.istio.io/includeOutboundIPRanges") -]]
+        - "[[ index .ObjectMeta.Annotations "traffic.sidecar.istio.io/includeOutboundIPRanges"  ]]"
+        [[ else -]]
+        - "*"
+        [[ end -]]
+        - "-x"
+        [[ if (isset .ObjectMeta.Annotations "traffic.sidecar.istio.io/excludeOutboundIPRanges") -]]
+        - "[[ index .ObjectMeta.Annotations "traffic.sidecar.istio.io/excludeOutboundIPRanges"  ]]"
+        [[ else -]]
+        - ""
+        [[ end -]]
+        - "-b"
+        [[ if (isset .ObjectMeta.Annotations "traffic.sidecar.istio.io/includeInboundPorts") -]]
+        - "[[ index .ObjectMeta.Annotations "traffic.sidecar.istio.io/includeInboundPorts"  ]]"
+        [[ else -]]
+        - [[ range .Spec.Containers -]][[ range .Ports -]][[ .ContainerPort -]], [[ end -]][[ end -]][[ end]]
+        - "-d"
+        [[ if (isset .ObjectMeta.Annotations "traffic.sidecar.istio.io/excludeInboundPorts") -]]
+        - "[[ index .ObjectMeta.Annotations "traffic.sidecar.istio.io/excludeInboundPorts" ]]"
+        [[ else -]]
+        - ""
+        [[ end -]]
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        restartPolicy: Always
+
+      containers:
+      - name: istio-proxy
+        image: [[ if (isset .ObjectMeta.Annotations "sidecar.istio.io/proxyImage") -]]
+        "[[ index .ObjectMeta.Annotations "sidecar.istio.io/proxyImage" ]]"
+        [[ else -]]
+        gcr.io/istio-release/proxyv2:release-0.8-20180521-15-16
+        [[ end -]]
+        args:
+        - proxy
+        - sidecar
+        - --configPath
+        - [[ .ProxyConfig.ConfigPath ]]
+        - --binaryPath
+        - [[ .ProxyConfig.BinaryPath ]]
+        - --serviceCluster
+        [[ if ne "" (index .ObjectMeta.Labels "app") -]]
+        - [[ index .ObjectMeta.Labels "app" ]]
+        [[ else -]]
+        - "istio-proxy"
+        [[ end -]]
+        - --drainDuration
+        - [[ formatDuration .ProxyConfig.DrainDuration ]]
+        - --parentShutdownDuration
+        - [[ formatDuration .ProxyConfig.ParentShutdownDuration ]]
+        - --discoveryAddress
+        - [[ .ProxyConfig.DiscoveryAddress ]]
+        - --discoveryRefreshDelay
+        - [[ formatDuration .ProxyConfig.DiscoveryRefreshDelay ]]
+        - --zipkinAddress
+        - [[ .ProxyConfig.ZipkinAddress ]]
+        - --connectTimeout
+        - [[ formatDuration .ProxyConfig.ConnectTimeout ]]
+        - --statsdUdpAddress
+        - [[ .ProxyConfig.StatsdUdpAddress ]]
+        - --proxyAdminPort
+        - [[ .ProxyConfig.ProxyAdminPort ]]
+        - --controlPlaneAuthPolicy
+        - [[ .ProxyConfig.ControlPlaneAuthPolicy ]]
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: [[ or (index .ObjectMeta.Annotations "sidecar.istio.io/interceptionMode") .ProxyConfig.InterceptionMode.String ]]
+        imagePullPolicy: IfNotPresent
+        securityContext:
+            privileged: false
+            readOnlyRootFilesystem: true
+            [[ if eq (or (index .ObjectMeta.Annotations "sidecar.istio.io/interceptionMode") .ProxyConfig.InterceptionMode.String) "TPROXY" -]]
+            capabilities:
+              add:
+              - NET_ADMIN
+            [[ else -]]
+            runAsUser: 1337
+            [[ end -]]
+        restartPolicy: Always
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+
+        volumeMounts:
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /etc/certs/
+          name: istio-certs
+          readOnly: true
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - name: istio-certs
+        secret:
+          optional: true
+          [[ if eq .Spec.ServiceAccountName "" -]]
+          secretName: istio.default
+          [[ else -]]
+          secretName: [[ printf "istio.%s" .Spec.ServiceAccountName ]]
+          [[ end -]]
+
+
+---
+# Source: istio/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio
+  namespace: istio-system
+  labels:
+    app: istio
+    chart: istio-0.8.0
+    release: RELEASE-NAME
+    heritage: Tiller
+data:
+  mesh: |-
+    # Mutual TLS between proxies
+    authPolicy: MUTUAL_TLS
+    mtlsExcludedServices: ["kubernetes.default.svc.cluster.local", "kafka.default.svc.cluster.local"]
+    #
+    # Edit this list to avoid using mTLS to connect to these services.
+    # Typically, these are control services (e.g kubernetes API server) that don't have istio sidecar
+    # to transparently terminate mTLS authentication.
+    # mtlsExcludedServices: ["kubernetes.default.svc.cluster.local", "kafka.default.svc.cluster.local"]
+
+    # Set the following variable to true to disable policy checks by the Mixer.
+    # Note that metrics will still be reported to the Mixer.
+    disablePolicyChecks: false
+    # Set enableTracing to false to disable request tracing.
+    enableTracing: true
+    #
+    # To disable the mixer completely (including metrics), comment out
+    # the following lines
+    mixerCheckServer: istio-policy.istio-system.svc.cluster.local:15004
+    mixerReportServer: istio-telemetry.istio-system.svc.cluster.local:15004
+    # This is the ingress service name, update if you used a different name
+    ingressService: istio-ingress
+    #
+    # Along with discoveryRefreshDelay, this setting determines how
+    # frequently should Envoy fetch and update its internal configuration
+    # from istio Pilot. Lower refresh delay results in higher CPU
+    # utilization and potential performance loss in exchange for faster
+    # convergence. Tweak this value according to your setup.
+    rdsRefreshDelay: 10s
+    #
+    defaultConfig:
+      # NOTE: If you change any values in this section, make sure to make
+      # the same changes in start up args in istio-ingress pods.
+      # See rdsRefreshDelay for explanation about this setting.
+      discoveryRefreshDelay: 10s
+      #
+      # TCP connection timeout between Envoy & the application, and between Envoys.
+      connectTimeout: 10s
+      #
+      ### ADVANCED SETTINGS #############
+      # Where should envoy's configuration be stored in the istio-proxy container
+      configPath: "/etc/istio/proxy"
+      binaryPath: "/usr/local/bin/envoy"
+      # The pseudo service name used for Envoy.
+      serviceCluster: istio-proxy
+      # These settings that determine how long an old Envoy
+      # process should be kept alive after an occasional reload.
+      drainDuration: 45s
+      parentShutdownDuration: 1m0s
+      #
+      # The mode used to redirect inbound connections to Envoy. This setting
+      # has no effect on outbound traffic: iptables REDIRECT is always used for
+      # outbound connections.
+      # If "REDIRECT", use iptables REDIRECT to NAT and redirect to Envoy.
+      # The "REDIRECT" mode loses source addresses during redirection.
+      # If "TPROXY", use iptables TPROXY to redirect to Envoy.
+      # The "TPROXY" mode preserves both the source and destination IP
+      # addresses and ports, so that they can be used for advanced filtering
+      # and manipulation.
+      # The "TPROXY" mode also configures the sidecar to run with the
+      # CAP_NET_ADMIN capability, which is required to use TPROXY.
+      interceptionMode: TPROXY
+      #
+      # Port where Envoy listens (on local host) for admin commands
+      # You can exec into the istio-proxy container in a pod and
+      # curl the admin port (curl http://localhost:15000/) to obtain
+      # diagnostic information from Envoy. See
+      # https://lyft.github.io/envoy/docs/operations/admin.html
+      # for more details
+      proxyAdminPort: 15000
+      #
+      # Zipkin trace collector
+      zipkinAddress: zipkin.istio-system:9411
+      #
+      # Statsd metrics collector converts statsd metrics into Prometheus metrics.
+      statsdUdpAddress: istio-statsd-prom-bridge.istio-system:9125
+      #
+      # Mutual TLS authentication between sidecars and istio control plane.
+      controlPlaneAuthPolicy: MUTUAL_TLS
+      #
+      # Address where istio Pilot service is running
+      discoveryAddress: istio-pilot.istio-system:15005
+
+---
+# Source: istio/charts/egressgateway/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-egressgateway-service-account
+  namespace: istio-system
+  labels:
+    app: egressgateway
+    chart: egressgateway-0.8.0
+    heritage: Tiller
+    release: RELEASE-NAME
+
+---
+# Source: istio/charts/ingressgateway/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-ingressgateway-service-account
+  namespace: istio-system
+  labels:
+    app: ingressgateway
+    chart: ingressgateway-0.8.0
+    heritage: Tiller
+    release: RELEASE-NAME
+
+---
+# Source: istio/charts/mixer/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-mixer-service-account
+  namespace: istio-system
+  labels:
+    app: mixer
+    chart: mixer-0.8.0
+    heritage: Tiller
+    release: RELEASE-NAME
+
+---
+# Source: istio/charts/pilot/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-pilot-service-account
+  namespace: istio-system
+  labels:
+    app: istio-pilot
+    chart: pilot-0.8.0
+    heritage: Tiller
+    release: RELEASE-NAME
+
+---
+# Source: istio/charts/prometheus/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: istio-system
+
+---
+# Source: istio/charts/security/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-citadel-service-account
+  namespace: istio-system
+  labels:
+    app: security
+    chart: security-0.8.0
+    heritage: Tiller
+    release: RELEASE-NAME
+
+---
+# Source: istio/charts/sidecar-injector/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-sidecar-injector-service-account
+  namespace: istio-system
+  labels:
+    app: istio-sidecar-injector
+    chart: sidecar-injector-0.8.0
+    heritage: Tiller
+    release: RELEASE-NAME
+
+---
+# Source: istio/charts/mixer/templates/crds.yaml
+# Mixer CRDs
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: rules.config.istio.io
+  labels:
+    app: mixer
+    package: istio.io.mixer
+    istio: core
+spec:
+  group: config.istio.io
+  names:
+    kind: rule
+    plural: rules
+    singular: rule
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: attributemanifests.config.istio.io
+  labels:
+    app: mixer
+    package: istio.io.mixer
+    istio: core
+spec:
+  group: config.istio.io
+  names:
+    kind: attributemanifest
+    plural: attributemanifests
+    singular: attributemanifest
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: circonuses.config.istio.io
+  labels:
+    app: mixer
+    package: circonus
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: circonus
+    plural: circonuses
+    singular: circonus
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: deniers.config.istio.io
+  labels:
+    app: mixer
+    package: denier
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: denier
+    plural: deniers
+    singular: denier
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: fluentds.config.istio.io
+  labels:
+    app: mixer
+    package: fluentd
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: fluentd
+    plural: fluentds
+    singular: fluentd
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: kubernetesenvs.config.istio.io
+  labels:
+    app: mixer
+    package: kubernetesenv
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: kubernetesenv
+    plural: kubernetesenvs
+    singular: kubernetesenv
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: listcheckers.config.istio.io
+  labels:
+    app: mixer
+    package: listchecker
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: listchecker
+    plural: listcheckers
+    singular: listchecker
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: memquotas.config.istio.io
+  labels:
+    app: mixer
+    package: memquota
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: memquota
+    plural: memquotas
+    singular: memquota
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: noops.config.istio.io
+  labels:
+    app: mixer
+    package: noop
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: noop
+    plural: noops
+    singular: noop
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: opas.config.istio.io
+  labels:
+    app: mixer
+    package: opa
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: opa
+    plural: opas
+    singular: opa
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: prometheuses.config.istio.io
+  labels:
+    app: mixer
+    package: prometheus
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: prometheus
+    plural: prometheuses
+    singular: prometheus
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: rbacs.config.istio.io
+  labels:
+    app: mixer
+    package: rbac
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: rbac
+    plural: rbacs
+    singular: rbac
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: servicecontrols.config.istio.io
+  labels:
+    app: mixer
+    package: servicecontrol
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: servicecontrol
+    plural: servicecontrols
+    singular: servicecontrol
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: solarwindses.config.istio.io
+  labels:
+    app: mixer
+    package: solarwinds
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: solarwinds
+    plural: solarwindses
+    singular: solarwinds
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: stackdrivers.config.istio.io
+  labels:
+    app: mixer
+    package: stackdriver
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: stackdriver
+    plural: stackdrivers
+    singular: stackdriver
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: statsds.config.istio.io
+  labels:
+    app: mixer
+    package: statsd
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: statsd
+    plural: statsds
+    singular: statsd
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: stdios.config.istio.io
+  labels:
+    app: mixer
+    package: stdio
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: stdio
+    plural: stdios
+    singular: stdio
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: apikeys.config.istio.io
+  labels:
+    app: mixer
+    package: apikey
+    istio: mixer-instance
+spec:
+  group: config.istio.io
+  names:
+    kind: apikey
+    plural: apikeys
+    singular: apikey
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: authorizations.config.istio.io
+  labels:
+    app: mixer
+    package: authorization
+    istio: mixer-instance
+spec:
+  group: config.istio.io
+  names:
+    kind: authorization
+    plural: authorizations
+    singular: authorization
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: checknothings.config.istio.io
+  labels:
+    app: mixer
+    package: checknothing
+    istio: mixer-instance
+spec:
+  group: config.istio.io
+  names:
+    kind: checknothing
+    plural: checknothings
+    singular: checknothing
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: kuberneteses.config.istio.io
+  labels:
+    app: mixer
+    package: adapter.template.kubernetes
+    istio: mixer-instance
+spec:
+  group: config.istio.io
+  names:
+    kind: kubernetes
+    plural: kuberneteses
+    singular: kubernetes
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: listentries.config.istio.io
+  labels:
+    app: mixer
+    package: listentry
+    istio: mixer-instance
+spec:
+  group: config.istio.io
+  names:
+    kind: listentry
+    plural: listentries
+    singular: listentry
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: logentries.config.istio.io
+  labels:
+    app: mixer
+    package: logentry
+    istio: mixer-instance
+spec:
+  group: config.istio.io
+  names:
+    kind: logentry
+    plural: logentries
+    singular: logentry
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: metrics.config.istio.io
+  labels:
+    app: mixer
+    package: metric
+    istio: mixer-instance
+spec:
+  group: config.istio.io
+  names:
+    kind: metric
+    plural: metrics
+    singular: metric
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: quotas.config.istio.io
+  labels:
+    app: mixer
+    package: quota
+    istio: mixer-instance
+spec:
+  group: config.istio.io
+  names:
+    kind: quota
+    plural: quotas
+    singular: quota
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: reportnothings.config.istio.io
+  labels:
+    app: mixer
+    package: reportnothing
+    istio: mixer-instance
+spec:
+  group: config.istio.io
+  names:
+    kind: reportnothing
+    plural: reportnothings
+    singular: reportnothing
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: servicecontrolreports.config.istio.io
+  labels:
+    app: mixer
+    package: servicecontrolreport
+    istio: mixer-instance
+spec:
+  group: config.istio.io
+  names:
+    kind: servicecontrolreport
+    plural: servicecontrolreports
+    singular: servicecontrolreport
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: tracespans.config.istio.io
+  labels:
+    app: mixer
+    package: tracespan
+    istio: mixer-instance
+spec:
+  group: config.istio.io
+  names:
+    kind: tracespan
+    plural: tracespans
+    singular: tracespan
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: serviceroles.config.istio.io
+  labels:
+    app: mixer
+    package: istio.io.mixer
+    istio: rbac
+spec:
+  group: config.istio.io
+  names:
+    kind: ServiceRole
+    plural: serviceroles
+    singular: servicerole
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: servicerolebindings.config.istio.io
+  labels:
+    app: mixer
+    package: istio.io.mixer
+    istio: rbac
+spec:
+  group: config.istio.io
+  names:
+    kind: ServiceRoleBinding
+    plural: servicerolebindings
+    singular: servicerolebinding
+  scope: Namespaced
+  version: v1alpha2
+
+---
+# Source: istio/charts/pilot/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: destinationpolicies.config.istio.io
+  labels:
+    app: istio-pilot
+spec:
+  group: config.istio.io
+  names:
+    kind: DestinationPolicy
+    listKind: DestinationPolicyList
+    plural: destinationpolicies
+    singular: destinationpolicy
+  scope: Namespaced
+  version: v1alpha2
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: egressrules.config.istio.io
+  labels:
+    app: istio-pilot
+spec:
+  group: config.istio.io
+  names:
+    kind: EgressRule
+    listKind: EgressRuleList
+    plural: egressrules
+    singular: egressrule
+  scope: Namespaced
+  version: v1alpha2
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: routerules.config.istio.io
+  labels:
+    app: istio-pilot
+spec:
+  group: config.istio.io
+  names:
+    kind: RouteRule
+    listKind: RouteRuleList
+    plural: routerules
+    singular: routerule
+  scope: Namespaced
+  version: v1alpha2
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: virtualservices.networking.istio.io
+  labels:
+    app: istio-pilot
+spec:
+  group: networking.istio.io
+  names:
+    kind: VirtualService
+    listKind: VirtualServiceList
+    plural: virtualservices
+    singular: virtualservice
+  scope: Namespaced
+  version: v1alpha3
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: destinationrules.networking.istio.io
+  labels:
+    app: istio-pilot
+spec:
+  group: networking.istio.io
+  names:
+    kind: DestinationRule
+    listKind: DestinationRuleList
+    plural: destinationrules
+    singular: destinationrule
+  scope: Namespaced
+  version: v1alpha3
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: serviceentries.networking.istio.io
+  labels:
+    app: istio-pilot
+spec:
+  group: networking.istio.io
+  names:
+    kind: ServiceEntry
+    listKind: ServiceEntryList
+    plural: serviceentries
+    singular: serviceentry
+  scope: Namespaced
+  version: v1alpha3
+
+
+---
+# Source: istio/charts/mixer/templates/clusterrole.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: istio-mixer-istio-system
+  namespace: istio-system
+  labels:
+    app: mixer
+    chart: mixer-0.8.0
+    heritage: Tiller
+    release: RELEASE-NAME
+rules:
+- apiGroups: ["config.istio.io"] # istio CRD watcher
+  resources: ["*"]
+  verbs: ["create", "get", "list", "watch", "patch"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["configmaps", "endpoints", "pods", "services", "namespaces", "secrets"]
+  verbs: ["get", "list", "watch"]
+
+---
+# Source: istio/charts/pilot/templates/clusterrole.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: istio-pilot-istio-system
+  namespace: istio-system
+  labels:
+    app: istio-pilot
+    chart: pilot-0.8.0
+    heritage: Tiller
+    release: RELEASE-NAME
+rules:
+- apiGroups: ["config.istio.io"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["networking.istio.io"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["authentication.istio.io"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["*"]
+- apiGroups: ["extensions"]
+  resources: ["thirdpartyresources", "thirdpartyresources.extensions", "ingresses", "ingresses/status"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["create", "get", "list", "watch", "update"]
+- apiGroups: [""]
+  resources: ["endpoints", "pods", "services"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["namespaces", "nodes", "secrets"]
+  verbs: ["get", "list", "watch"]
+
+---
+# Source: istio/charts/prometheus/templates/clusterrole.yaml
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: prometheus-istio-system
+  namespace: istio-system
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  - nodes/proxy
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-istio-system
+  namespace: istio-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-istio-system
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: istio-system
+---
+
+
+---
+# Source: istio/charts/security/templates/clusterrole.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: istio-citadel-istio-system
+  namespace: istio-system
+  labels:
+    app: security
+    chart: security-0.8.0
+    heritage: Tiller
+    release: RELEASE-NAME
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create", "get", "watch", "list", "update", "delete"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "watch", "list"]
+
+---
+# Source: istio/charts/sidecar-injector/templates/clusterrole.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: istio-sidecar-injector-istio-system
+  labels:
+    app: istio-sidecar-injector
+    chart: sidecar-injector-0.8.0
+    heritage: Tiller
+    release: RELEASE-NAME
+rules:
+- apiGroups: ["*"]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations"]
+  verbs: ["get", "list", "watch", "patch"]
+
+---
+# Source: istio/charts/mixer/templates/clusterrolebinding.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-mixer-admin-role-binding-istio-system
+  labels:
+    app: mixer
+    chart: mixer-0.8.0
+    heritage: Tiller
+    release: RELEASE-NAME
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-mixer-istio-system
+subjects:
+  - kind: ServiceAccount
+    name: istio-mixer-service-account
+    namespace: istio-system
+
+---
+# Source: istio/charts/pilot/templates/clusterrolebinding.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-pilot-istio-system
+  labels:
+    app: istio-pilot
+    chart: pilot-0.8.0
+    heritage: Tiller
+    release: RELEASE-NAME
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-pilot-istio-system
+subjects:
+  - kind: ServiceAccount
+    name: istio-pilot-service-account
+    namespace: istio-system
+
+---
+# Source: istio/charts/security/templates/clusterrolebinding.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-citadel-istio-system
+  labels:
+    app: security
+    chart: security-0.8.0
+    heritage: Tiller
+    release: RELEASE-NAME
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-citadel-istio-system
+subjects:
+  - kind: ServiceAccount
+    name: istio-citadel-service-account
+    namespace: istio-system
+
+---
+# Source: istio/charts/sidecar-injector/templates/clusterrolebinding.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-sidecar-injector-admin-role-binding-istio-system
+  labels:
+    app: istio-sidecar-injector
+    chart: sidecar-injector-0.8.0
+    heritage: Tiller
+    release: RELEASE-NAME
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-sidecar-injector-istio-system
+subjects:
+  - kind: ServiceAccount
+    name: istio-sidecar-injector-service-account
+    namespace: istio-system
+---
+# Source: istio/charts/egressgateway/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-egressgateway
+  namespace: istio-system
+  labels:
+    chart: egressgateway-0.8.0
+    release: RELEASE-NAME
+    heritage: Tiller
+    istio: egressgateway
+spec:
+  type: ClusterIP
+  selector:
+    istio: egressgateway
+  ports:
+    -
+      name: http
+      port: 80
+    -
+      name: https
+      port: 443
+
+---
+# Source: istio/charts/grafana/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: istio-system
+  annotations:
+    auth.istio.io/3000: NONE
+  labels:
+    app: grafana
+    chart: grafana-0.1.0
+    release: RELEASE-NAME
+    heritage: Tiller
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: 3000
+      protocol: TCP
+      name: http
+  selector:
+    app: grafana
+
+---
+# Source: istio/charts/ingressgateway/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-ingressgateway
+  namespace: istio-system
+  labels:
+    chart: ingressgateway-0.8.0
+    release: RELEASE-NAME
+    heritage: Tiller
+    istio: ingressgateway
+spec:
+  type: LoadBalancer
+  selector:
+    istio: ingressgateway
+  ports:
+    -
+      name: http
+      nodePort: 31380
+      port: 80
+    -
+      name: https
+      nodePort: 31390
+      port: 443
+    -
+      name: tcp
+      nodePort: 31400
+      port: 31400
+
+---
+# Source: istio/charts/mixer/templates/service.yaml
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-policy
+  namespace: istio-system
+  labels:
+    chart: mixer-0.8.0
+    release: RELEASE-NAME
+    istio: mixer
+spec:
+  ports:
+  - name: grpc-mixer
+    port: 9091
+  - name: grpc-mixer-mtls
+    port: 15004
+  - name: http-monitoring
+    port: 9093
+  selector:
+    istio: mixer
+    istio-mixer-type: policy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-telemetry
+  namespace: istio-system
+  labels:
+    chart: mixer-0.8.0
+    release: RELEASE-NAME
+    istio: mixer
+spec:
+  ports:
+  - name: grpc-mixer
+    port: 9091
+  - name: grpc-mixer-mtls
+    port: 15004
+  - name: http-monitoring
+    port: 9093
+  - name: prometheus
+    port: 42422
+  selector:
+    istio: mixer
+    istio-mixer-type: telemetry
+---
+
+---
+# Source: istio/charts/mixer/templates/statsdtoprom.yaml
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-statsd-prom-bridge
+  namespace: istio-system
+  labels:
+    chart: mixer-0.8.0
+    release: RELEASE-NAME
+    istio: statsd-prom-bridge
+spec:
+  ports:
+  - name: statsd-prom
+    port: 9102
+  - name: statsd-udp
+    port: 9125
+    protocol: UDP
+  selector:
+    istio: statsd-prom-bridge
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-statsd-prom-bridge
+  namespace: istio-system
+  labels:
+    chart: mixer-0.8.0
+    release: RELEASE-NAME
+    istio: mixer
+spec:
+  template:
+    metadata:
+      labels:
+        istio: statsd-prom-bridge
+        zgroup: istio
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: istio-mixer-service-account
+      volumes:
+      - name: config-volume
+        configMap:
+          name: istio-statsd-prom-bridge
+      containers:
+      - name: statsd-prom-bridge
+        image: "prom/statsd-exporter:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9102
+        - containerPort: 9125
+          protocol: UDP
+        args:
+        - '-statsd.mapping-config=/etc/statsd/mapping.conf'
+        resources:
+            {}
+
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/statsd
+
+---
+# Source: istio/charts/pilot/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-pilot
+  namespace: istio-system
+  labels:
+    app: istio-pilot
+    chart: pilot-0.8.0
+    release: RELEASE-NAME
+    heritage: Tiller
+spec:
+  ports:
+  - port: 15003
+    name: http-old-discovery # mTLS or non-mTLS depending on auth setting
+  - port: 15005
+    name: https-discovery # always mTLS
+  - port: 15007
+    name: http-discovery # always plain-text
+  - port: 15010
+    name: grpc-xds # direct
+  - port: 15011
+    name: https-xds # mTLS
+  - port: 8080
+    name: http-legacy-discovery # direct
+  - port: 9093
+    name: http-monitoring
+  selector:
+    istio: pilot
+
+---
+# Source: istio/charts/prometheus/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: istio-system
+  annotations:
+    prometheus.io/scrape: 'true'
+  labels:
+    name: prometheus
+spec:
+  selector:
+    app: prometheus
+  ports:
+  - name: http-prometheus
+    protocol: TCP
+    port: 9090
+
+---
+# Source: istio/charts/security/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  # we use the normal name here (e.g. 'prometheus')
+  # as grafana is configured to use this as a data source
+  name: istio-citadel
+  namespace: istio-system
+  labels:
+    app: istio-citadel
+spec:
+  ports:
+    - name: grpc-citadel
+      port: 8060
+      targetPort: 8060
+      protocol: TCP
+    - name: http-monitoring
+      port: 9093
+  selector:
+    istio: citadel
+
+---
+# Source: istio/charts/servicegraph/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: servicegraph
+  namespace: istio-system
+  labels:
+    app: servicegraph
+    chart: servicegraph-0.1.0
+    release: RELEASE-NAME
+    heritage: Tiller
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8088
+      targetPort: 8088
+      protocol: TCP
+      name: http
+  selector:
+    app: servicegraph
+
+---
+# Source: istio/charts/sidecar-injector/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-sidecar-injector
+  namespace: istio-system
+  labels:
+    istio: sidecar-injector
+spec:
+  ports:
+  - port: 443
+  selector:
+    istio: sidecar-injector
+
+---
+# Source: istio/charts/egressgateway/templates/deployment.yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-egressgateway
+  namespace: istio-system
+  labels:
+    app: egressgateway
+    chart: egressgateway-0.8.0
+    release: RELEASE-NAME
+    heritage: Tiller
+    istio: egressgateway
+spec:
+  replicas:
+  template:
+    metadata:
+      labels:
+        istio: egressgateway
+        zgroup: istio
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: istio-egressgateway-service-account
+      containers:
+        - name: egressgateway
+          image: "gcr.io/istio-release/proxyv2:release-0.8-20180521-15-16"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+            - containerPort: 443
+          args:
+          - proxy
+          - router
+          - -v
+          - "2"
+          - --discoveryRefreshDelay
+          - '1s' #discoveryRefreshDelay
+          - --drainDuration
+          - '45s' #drainDuration
+          - --parentShutdownDuration
+          - '1m0s' #parentShutdownDuration
+          - --connectTimeout
+          - '10s' #connectTimeout
+          - --serviceCluster
+          - istio-egressgateway
+          - --zipkinAddress
+          - zipkin:9411
+          - --statsdUdpAddress
+          - istio-statsd-prom-bridge:9125
+          - --proxyAdminPort
+          - "15000"
+          - --controlPlaneAuthPolicy
+          - MUTUAL_TLS
+          - --discoveryAddress
+          - istio-pilot:15005
+          resources:
+            {}
+
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: INSTANCE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: ISTIO_META_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          volumeMounts:
+          - name: istio-certs
+            mountPath: /etc/certs
+            readOnly: true
+      volumes:
+      - name: istio-certs
+        secret:
+          secretName: "istio.default"
+          optional: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - s390x
+
+---
+# Source: istio/charts/grafana/templates/deployment.yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: istio-system
+  labels:
+    app: grafana
+    chart: grafana-0.1.0
+    release: RELEASE-NAME
+    heritage: Tiller
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: grafana
+        zgroup: istio
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+        - name: grafana
+          image: "gcr.io/istio-release/grafana:release-0.8-20180521-15-16"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+          readinessProbe:
+            httpGet:
+              path: /login
+              port: 3000
+          env:
+          - name: GRAFANA_PORT
+            value: "3000"
+          - name: GF_AUTH_BASIC_ENABLED
+            value: "false"
+          - name: GF_AUTH_ANONYMOUS_ENABLED
+            value: "true"
+          - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+            value: Admin
+          - name: GF_PATHS_DATA
+            value: /data/grafana
+          resources:
+            {}
+
+          volumeMounts:
+          - name: data
+            mountPath: /data/grafana
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - s390x
+      volumes:
+      - name: data
+        emptyDir: {}
+---
+# Source: istio/charts/ingressgateway/templates/deployment.yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-ingressgateway
+  namespace: istio-system
+  labels:
+    app: ingressgateway
+    chart: ingressgateway-0.8.0
+    release: RELEASE-NAME
+    heritage: Tiller
+    istio: ingressgateway
+spec:
+  replicas:
+  template:
+    metadata:
+      labels:
+        istio: ingressgateway
+        zgroup: istio
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: istio-ingressgateway-service-account
+      containers:
+        - name: ingressgateway
+          image: "gcr.io/istio-release/proxyv2:release-0.8-20180521-15-16"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+            - containerPort: 443
+            - containerPort: 31400
+          args:
+          - proxy
+          - router
+          - -v
+          - "2"
+          - --discoveryRefreshDelay
+          - '1s' #discoveryRefreshDelay
+          - --drainDuration
+          - '45s' #drainDuration
+          - --parentShutdownDuration
+          - '1m0s' #parentShutdownDuration
+          - --connectTimeout
+          - '10s' #connectTimeout
+          - --serviceCluster
+          - istio-ingressgateway
+          - --zipkinAddress
+          - zipkin:9411
+          - --statsdUdpAddress
+          - istio-statsd-prom-bridge:9125
+          - --proxyAdminPort
+          - "15000"
+          - --controlPlaneAuthPolicy
+          - MUTUAL_TLS
+          - --discoveryAddress
+          - istio-pilot:15005
+          resources:
+            {}
+
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: INSTANCE_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: ISTIO_META_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          volumeMounts:
+          - name: istio-certs
+            mountPath: /etc/certs
+            readOnly: true
+          - name: ingressgateway-certs
+            mountPath: "/etc/istio/ingressgateway-certs"
+            readOnly: true
+      volumes:
+      - name: istio-certs
+        secret:
+          secretName: "istio.default"
+          optional: true
+      - name: ingressgateway-certs
+        secret:
+          secretName: "istio-ingressgateway-certs"
+          optional: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - s390x
+
+---
+# Source: istio/charts/mixer/templates/deployment.yaml
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-policy
+  namespace: istio-system
+  labels:
+    chart: mixer-0.8.0
+    release: RELEASE-NAME
+    istio: mixer
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        istio: mixer
+        istio-mixer-type: policy
+        zgroup: istio
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: istio-mixer-service-account
+      volumes:
+      - name: istio-certs
+        secret:
+          secretName: istio.istio-mixer-service-account
+          optional: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - s390x
+      containers:
+      - name: mixer
+        image: "gcr.io/istio-release/mixer:release-0.8-20180521-15-16"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9092
+        - containerPort: 9093
+        - containerPort: 42422
+        args:
+          - --address
+          - tcp://127.0.0.1:9092
+          - --configStoreURL=k8s://
+          - --configDefaultNamespace=istio-system
+          - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
+        resources:
+            {}
+
+      - name: istio-proxy
+        image: "gcr.io/istio-release/proxyv2:release-0.8-20180521-15-16"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9091
+        - containerPort: 15004
+        args:
+        - proxy
+        - --serviceCluster
+        - istio-policy
+        - --templateFile
+        - /etc/istio/proxy/envoy_policy.yaml.tmpl
+        - --controlPlaneAuthPolicy
+        - MUTUAL_TLS
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+
+        volumeMounts:
+        - name: istio-certs
+          mountPath: /etc/certs
+          readOnly: true
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-telemetry
+  namespace: istio-system
+  labels:
+    chart: mixer-0.8.0
+    release: RELEASE-NAME
+    istio: mixer
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        istio: mixer
+        istio-mixer-type: telemetry
+        zgroup: istio
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: istio-mixer-service-account
+      volumes:
+      - name: istio-certs
+        secret:
+          secretName: istio.istio-mixer-service-account
+          optional: true
+      containers:
+      - name: mixer
+        image: "gcr.io/istio-release/mixer:release-0.8-20180521-15-16"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9092
+        - containerPort: 9093
+        - containerPort: 42422
+        args:
+          - --address
+          - tcp://127.0.0.1:9092
+          - --configStoreURL=k8s://
+          - --configDefaultNamespace=istio-system
+          - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
+        resources:
+            {}
+
+      - name: istio-proxy
+        image: "gcr.io/istio-release/proxyv2:release-0.8-20180521-15-16"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9091
+        - containerPort: 15004
+        args:
+        - proxy
+        - --serviceCluster
+        - istio-telemetry
+        - --templateFile
+        - /etc/istio/proxy/envoy_telemetry.yaml.tmpl
+        - --controlPlaneAuthPolicy
+        - MUTUAL_TLS
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+
+        volumeMounts:
+        - name: istio-certs
+          mountPath: /etc/certs
+          readOnly: true
+
+---
+
+---
+# Source: istio/charts/pilot/templates/deployment.yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-pilot
+  namespace: istio-system
+  # TODO: default tempate doesn't have this, which one is right ?
+  labels:
+    app: istio-pilot
+    chart: pilot-0.8.0
+    release: RELEASE-NAME
+    heritage: Tiller
+    istio: pilot
+  annotations:
+    checksum/config-volume: f8da08b6b8c170dde721efd680270b2901e750d4aa186ebb6c22bef5b78a43f9
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        istio: pilot
+        zgroup: istio
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: istio-pilot-service-account
+      containers:
+        - name: discovery
+          image: "docker.io/cilium/istio_pilot:release-0.8-20180521-15-16"
+          imagePullPolicy: IfNotPresent
+          args:
+          - "discovery"
+# TODO(sdake) remove when secrets are automagically registered
+          ports:
+          - containerPort: 8080
+          - containerPort: 15010
+          readinessProbe:
+            httpGet:
+              path: /v1/registration
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: PILOT_THROTTLE
+            value: "500"
+          - name: PILOT_CACHE_SQUASH
+            value: "5"
+          resources:
+            {}
+
+          volumeMounts:
+          - name: config-volume
+            mountPath: /etc/istio/config
+          - name: istio-certs
+            mountPath: /etc/certs
+            readOnly: true
+        - name: istio-proxy
+          image: "gcr.io/istio-release/proxyv2:release-0.8-20180521-15-16"
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 15003
+          - containerPort: 15005
+          - containerPort: 15007
+          - containerPort: 15011
+          args:
+          - proxy
+          - --serviceCluster
+          - istio-pilot
+          - --templateFile
+          - /etc/istio/proxy/envoy_pilot.yaml.tmpl
+          - --controlPlaneAuthPolicy
+          - MUTUAL_TLS
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: INSTANCE_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+
+          volumeMounts:
+          - name: istio-certs
+            mountPath: /etc/certs
+            readOnly: true
+      volumes:
+      - name: config-volume
+        configMap:
+          name: istio
+      - name: istio-certs
+        secret:
+          secretName: "istio.istio-pilot-service-account"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - s390x
+
+---
+# Source: istio/charts/prometheus/templates/deployment.yaml
+# TODO: the original template has service account, roles, etc
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: istio-system
+  labels:
+    app: prometheus
+    chart: prometheus-0.1.0
+    release: RELEASE-NAME
+    heritage: Tiller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+        zgroup: istio
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: prometheus
+
+      containers:
+        - name: prometheus
+          image: "docker.io/prom/prometheus:latest"
+          imagePullPolicy: IfNotPresent
+          args:
+            - '--storage.tsdb.retention=6h'
+            - '--config.file=/etc/prometheus/prometheus.yml'
+          ports:
+            - containerPort: 9090
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 9090
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9090
+          resources:
+            {}
+
+          volumeMounts:
+          - name: config-volume
+            mountPath: /etc/prometheus
+      volumes:
+      - name: config-volume
+        configMap:
+          name: prometheus
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - s390x
+
+---
+# Source: istio/charts/security/templates/deployment.yaml
+# istio CA watching all namespaces
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-citadel
+  namespace: istio-system
+  labels:
+    app: security
+    chart: security-0.8.0
+    release: RELEASE-NAME
+    heritage: Tiller
+    istio: citadel
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        istio: citadel
+        zgroup: istio
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: istio-citadel-service-account
+      containers:
+        - name: citadel
+          image: "gcr.io/istio-release/citadel:release-0.8-20180521-15-16"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --append-dns-names=true
+            - --grpc-port=8060
+            - --grpc-hostname=citadel
+            - --self-signed-ca=true
+            - --citadel-storage-namespace=istio-system
+          resources:
+            {}
+
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - s390x
+
+---
+# Source: istio/charts/servicegraph/templates/deployment.yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: servicegraph
+  namespace: istio-system
+  labels:
+    app: servicegraph
+    chart: servicegraph-0.1.0
+    release: RELEASE-NAME
+    heritage: Tiller
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: servicegraph
+        zgroup: istio
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+        - name: servicegraph
+          image: "gcr.io/istio-release/servicegraph:release-0.8-20180521-15-16"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8088
+          args:
+          - --prometheusAddr=http://prometheus:9090
+#          livenessProbe:
+#            httpGet:
+#              path: /
+#              port: 8088
+#          readinessProbe:
+#            httpGet:
+#              path: /
+#              port: 8088
+          resources:
+            {}
+
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - s390x
+
+---
+# Source: istio/charts/sidecar-injector/templates/deployment.yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-sidecar-injector
+  namespace: istio-system
+  labels:
+    app: sidecar-injector
+    chart: sidecar-injector-0.8.0
+    release: RELEASE-NAME
+    heritage: Tiller
+    istio: sidecar-injector
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        istio: sidecar-injector
+        zgroup: istio
+    spec:
+      serviceAccountName: istio-sidecar-injector-service-account
+      containers:
+        - name: sidecar-injector-webhook
+          image: "gcr.io/istio-release/sidecar_injector:release-0.8-20180521-15-16"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --caCertFile=/etc/istio/certs/root-cert.pem
+            - --tlsCertFile=/etc/istio/certs/cert-chain.pem
+            - --tlsKeyFile=/etc/istio/certs/key.pem
+            - --injectConfig=/etc/istio/inject/config
+            - --meshConfig=/etc/istio/config/mesh
+            - --healthCheckInterval=2s
+            - --healthCheckFile=/health
+          volumeMounts:
+          - name: config-volume
+            mountPath: /etc/istio/config
+            readOnly: true
+          - name: certs
+            mountPath: /etc/istio/certs
+            readOnly: true
+          - name: inject-config
+            mountPath: /etc/istio/inject
+            readOnly: true
+          livenessProbe:
+            exec:
+              command:
+                - /usr/local/bin/sidecar-injector
+                - probe
+                - --probe-path=/health
+                - --interval=2s
+            initialDelaySeconds: 4
+            periodSeconds: 4
+          readinessProbe:
+            exec:
+              command:
+                - /usr/local/bin/sidecar-injector
+                - probe
+                - --probe-path=/health
+                - --interval=2s
+            initialDelaySeconds: 4
+            periodSeconds: 4
+      volumes:
+      - name: config-volume
+        configMap:
+          name: istio
+      - name: certs
+        secret:
+          secretName: istio.istio-sidecar-injector-service-account
+      - name: inject-config
+        configMap:
+          name: istio-sidecar-injector
+          items:
+          - key: config
+            path: config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - s390x
+
+---
+# Source: istio/charts/mixer/templates/create-custom-resources-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: istio-mixer-create-cr
+  namespace: istio-system
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+  labels:
+    app: mixer
+    chart: mixer-0.8.0
+    release: RELEASE-NAME
+    heritage: Tiller
+spec:
+  template:
+    metadata:
+      name: istio-mixer-create-cr
+      labels:
+        app: mixer
+        release: RELEASE-NAME
+    spec:
+      serviceAccountName: istio-mixer-service-account
+      containers:
+        - name: hyperkube
+          image: "quay.io/coreos/hyperkube:v1.7.6_coreos.0"
+          command:
+            - ./kubectl
+            - apply
+            - -f
+            - /tmp/mixer/custom-resources.yaml
+          volumeMounts:
+            - mountPath: "/tmp/mixer"
+              name: tmp-configmap-mixer
+      volumes:
+        - name: tmp-configmap-mixer
+          configMap:
+            name: istio-mixer-custom-resources
+      restartPolicy: Never # CRD might take some time till they are available to consume
+
+---
+# Source: istio/charts/egressgateway/templates/autoscale.yaml
+
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+    name: istio-egressgateway
+    namespace: istio-system
+spec:
+    maxReplicas: 1
+    minReplicas: 1
+    scaleTargetRef:
+      apiVersion: apps/v1beta1
+      kind: Deployment
+      name: istio-egressgateway
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          targetAverageUtilization: 80
+
+
+---
+# Source: istio/charts/ingressgateway/templates/autoscale.yaml
+
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+    name: istio-ingressgateway
+    namespace: istio-system
+spec:
+    maxReplicas: 1
+    minReplicas: 1
+    scaleTargetRef:
+      apiVersion: apps/v1beta1
+      kind: Deployment
+      name: istio-ingressgateway
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          targetAverageUtilization: 80
+
+
+---
+# Source: istio/charts/sidecar-injector/templates/mutatingwebhook.yaml
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: istio-sidecar-injector
+  namespace: istio-system
+  labels:
+    app: istio-sidecar-injector
+    chart: sidecar-injector-0.8.0
+    release: RELEASE-NAME
+    heritage: Tiller
+webhooks:
+  - name: sidecar-injector.istio.io
+    clientConfig:
+      service:
+        name: istio-sidecar-injector
+        namespace: istio-system
+        path: "/inject"
+      caBundle: ""
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchLabels:
+        istio-injection: enabled
+
+---
+# Source: istio/charts/grafana/templates/ingress.yaml
+
+---
+# Source: istio/charts/mixer/templates/config.yaml
+
+
+---
+# Source: istio/charts/prometheus/templates/ingress.yaml
+
+---
+# Source: istio/charts/servicegraph/templates/ingress.yaml
+

--- a/test/k8sT/manifests/istio-kube-inject-template.yaml
+++ b/test/k8sT/manifests/istio-kube-inject-template.yaml
@@ -1,0 +1,152 @@
+policy: enabled
+template: |2
+
+  initContainers:
+  - name: istio-init
+    image: gcr.io/istio-release/proxy_init:release-0.8-20180521-15-16
+    args:
+    - "-p"
+    - [[ .MeshConfig.ProxyListenPort ]]
+    - "-u"
+    - 1337
+    - "-m"
+    - [[ or (index .ObjectMeta.Annotations "sidecar.istio.io/interceptionMode") .ProxyConfig.InterceptionMode.String ]]
+    - "-i"
+    [[ if (isset .ObjectMeta.Annotations "traffic.sidecar.istio.io/includeOutboundIPRanges") -]]
+    - "[[ index .ObjectMeta.Annotations "traffic.sidecar.istio.io/includeOutboundIPRanges"]]"
+    [[ else -]]
+    - "*"
+    [[ end -]]
+    - "-x"
+    [[ if (isset .ObjectMeta.Annotations "traffic.sidecar.istio.io/excludeOutboundIPRanges") -]]
+    - "[[ index .ObjectMeta.Annotations "traffic.sidecar.istio.io/excludeOutboundIPRanges" ]]"
+    [[ else -]]
+    - ""
+    [[ end -]]
+    - "-b"
+    [[ if (isset .ObjectMeta.Annotations "traffic.sidecar.istio.io/includeInboundPorts") -]]
+    - "[[ index .ObjectMeta.Annotations "traffic.sidecar.istio.io/includeInboundPorts" ]]"
+    [[ else -]]
+    - [[ range .Spec.Containers -]]
+        [[ range .Ports -]]
+          [[ .ContainerPort -]],
+        [[ end -]]
+      [[ end -]]
+    [[ end ]]
+    - "-d"
+    [[ if (isset .ObjectMeta.Annotations "traffic.sidecar.istio.io/excludeInboundPorts") -]]
+    - "[[ index .ObjectMeta.Annotations "traffic.sidecar.istio.io/excludeInboundPorts" ]]"
+    [[ else -]]
+    - ""
+    [[ end -]]
+    imagePullPolicy: IfNotPresent
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+      privileged: true
+      restartPolicy: Always
+  - args:
+    - -c
+    - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
+    command:
+    - /bin/sh
+    image: gcr.io/istio-release/proxy_init:release-0.8-20180521-15-16
+    imagePullPolicy: IfNotPresent
+    name: enable-core-dump
+    resources: {}
+    securityContext:
+      privileged: true
+  containers:
+  - name: istio-proxy
+    image: [[ if (isset .ObjectMeta.Annotations "sidecar.istio.io/proxyImage") -]]
+    "[[ index .ObjectMeta.Annotations "sidecar.istio.io/proxyImage" ]]"
+    [[ else -]]
+    docker.io/cilium/istio_proxy_debug:release-0.8-20180521-15-16
+    [[ end -]]
+    args:
+    - proxy
+    - sidecar
+    - --configPath
+    - [[ .ProxyConfig.ConfigPath ]]
+    - --binaryPath
+    - [[ .ProxyConfig.BinaryPath ]]
+    - --serviceCluster
+    [[ if ne "" (index .ObjectMeta.Labels "app") -]]
+    - [[ index .ObjectMeta.Labels "app" ]]
+    [[ else -]]
+    - "istio-proxy"
+    [[ end -]]
+    - --drainDuration
+    - [[ formatDuration .ProxyConfig.DrainDuration ]]
+    - --parentShutdownDuration
+    - [[ formatDuration .ProxyConfig.ParentShutdownDuration ]]
+    - --discoveryAddress
+    - [[ .ProxyConfig.DiscoveryAddress ]]
+    - --discoveryRefreshDelay
+    - [[ formatDuration .ProxyConfig.DiscoveryRefreshDelay ]]
+    - --zipkinAddress
+    - [[ .ProxyConfig.ZipkinAddress ]]
+    - --connectTimeout
+    - [[ formatDuration .ProxyConfig.ConnectTimeout ]]
+    - --statsdUdpAddress
+    - [[ .ProxyConfig.StatsdUdpAddress ]]
+    - --proxyAdminPort
+    - [[ .ProxyConfig.ProxyAdminPort ]]
+    - --controlPlaneAuthPolicy
+    - [[ .ProxyConfig.ControlPlaneAuthPolicy ]]
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: INSTANCE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: ISTIO_META_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: ISTIO_META_INTERCEPTION_MODE
+      value: [[ or (index .ObjectMeta.Annotations "sidecar.istio.io/interceptionMode") .ProxyConfig.InterceptionMode.String ]]
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    securityContext:
+      privileged: true
+      readOnlyRootFilesystem: false
+      [[ if ne (or (index .ObjectMeta.Annotations "sidecar.istio.io/interceptionMode") .ProxyConfig.InterceptionMode.String) "TPROXY" -]]
+      runAsUser: 1337
+      [[ end -]]
+    restartPolicy: Always
+    volumeMounts:
+    - mountPath: /var/run/cilium
+      name: cilium-unix-sock-dir
+    - mountPath: /etc/istio/proxy
+      name: istio-envoy
+    - mountPath: /etc/certs/
+      name: istio-certs
+      readOnly: true
+  volumes:
+  - hostPath:
+      path: /var/run/cilium
+    name: cilium-unix-sock-dir
+  - emptyDir:
+      medium: Memory
+    name: istio-envoy
+  - name: istio-certs
+    secret:
+      optional: true
+      [[ if eq .Spec.ServiceAccountName "" -]]
+      secretName: istio.default
+      [[ else -]]
+      secretName: [[ printf "istio.%s" .Spec.ServiceAccountName ]]
+      [[ end -]]
+

--- a/test/k8sT/manifests/istio-sidecar-init-policy.yaml
+++ b/test/k8sT/manifests/istio-sidecar-init-policy.yaml
@@ -1,0 +1,21 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: istio-sidecar
+specs:
+  - endpointSelector:
+      matchLabels:
+        "reserved:init": ""
+    ingress:
+    - fromEntities:
+      - host
+    egress:
+    - toEntities:
+      - all
+      toPorts:
+      - ports:
+        - port: "53"
+          protocol: UDP
+    - toEndpoints:
+      - matchLabels:
+          "k8s:io.kubernetes.pod.namespace": "istio-system"

--- a/test/k8sT/manifests/istio-sidecar-injector-configmap-release.yaml
+++ b/test/k8sT/manifests/istio-sidecar-injector-configmap-release.yaml
@@ -1,0 +1,1 @@
+../../../examples/kubernetes-istio/istio-sidecar-injector-configmap-release.yaml

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -147,6 +147,11 @@ sudo rm -rfv /var/lib/kubelet
 # Allow iptables forwarding so kube-dns can function.
 sudo iptables --policy FORWARD ACCEPT
 
+# Istio configurations
+
+sudo mkdir -p /etc/certs
+sudo chmod 777 /etc/certs
+
 #check hostname to know if is kubernetes or runtime test
 if [[ "${HOST}" == "k8s1" ]]; then
 


### PR DESCRIPTION
Hi,

This is an RFC pull request to automate the work in Istio e2e testing. The
current is an example of how to run Istio testing on top of Cilium.

I think that the following topics need to be tested:
- [ ] Configure a request routing with a single and multiple pods.
- [ ] Traffic Shifting with different pods (Httpd1, Httpd2)
- [ ] Request timeouts
- [ ] Mirroring
- [ ] Egress traffic.
- [ ] Rate limits
- [ ] TLS.

I find quite difficult to test these scenarios with the current `demo.yaml`, on
the other hand, I think that using Bookinfo application is not a good idea
either.

I propose to write a small HTTPd service, where we can get the number of
requests processed, the hostname of destination pod, where we can have
timeouts, etc.. That allows us to validate that the rate-limits works, the
traffic shifting with a real numbers, TCP timeouts, etc..  The httpd service
will be something like this:

```go
package main

import (
	"encoding/json"
	"fmt"
	"log"
	"net/http"
	"os"
	"time"
)

var request = 0

func SimpleHandler(w http.ResponseWriter, r *http.Request) {
	request++
	hostname, _ := os.Hostname()

	var result = map[string]string{
		"request":  fmt.Sprintf("%d", request),
		"hostname": hostname,
	}
	b, err := json.Marshal(result)
	if err != nil {
		fmt.Fprintf(w, "Error: %s", err)
		w.WriteHeader(http.StatusInternalServerError)
		return
	}
	fmt.Fprintf(w, "%s", b) 
        return
}

func ResetHandler(w http.ResponseWriter, r *http.Request) {
	request = 0
	return
}

func TimeoutHandler(w http.ResponseWriter, r *http.Request) {
	time.Sleep(10 * time.Second)
	return
}

func main() {
	http.HandleFunc("/", SimpleHandler)
	http.HandleFunc("/reset", ResetHandler)
	http.HandleFunc("/timeout", TimeoutHandler)

	err := http.ListenAndServe(":9090", nil)
	if err != nil {
		log.Fatal("ListenAndServe: ", err)
	}
}
```


With the following service, we can use good asserts that bookinfo do not allow
at all and test will be simpler.

The test from my POV will be:

- `It("Request routing all to HTTPD1")` #validate the requests number and hostname.
- `It("Traffic shaping 50% to httpd[1|2]")` # where requests output are in use.
- `It("Test timeout requests works on httpd1")` # use timeout/ target.
- `It("Rate limit number of requests")`

If you want to use Bookinfo manifest I'm happy with that, but I think that it's
not the right application to run these e2e.

Waiting for your feedback.

PS: The way of how Cillium is installed will change as soon the #4219 is
merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4266)
<!-- Reviewable:end -->
