### PR TITLE
Vagrantfiles: Update base image to 77

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -126,7 +126,7 @@ Vagrant.configure(2) do |config|
         vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
         vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
         config.vm.box = "cilium/ubuntu"
-        config.vm.box_version = "75"
+        config.vm.box_version = "77"
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i
         if ENV["NFS"] then

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -8,7 +8,7 @@ $K8S_VERSION = ENV['K8S_VERSION'] || "1.10"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 $NFS = ENV['NFS']=="1"? true : false
 $SERVER_BOX= "cilium/ubuntu"
-$SERVER_VERSION="75"
+$SERVER_VERSION="77"
 $IPv6=(ENV['IPv6'] || "0")
 $CONTAINER_RUNTIME=(ENV['CONTAINER_RUNTIME'] || "docker")
 

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -157,7 +157,7 @@ func InstallExampleCilium(kubectl *Kubectl) {
 
 	var path = filepath.Join("..", "examples", "kubernetes", GetCurrentK8SEnv(), "cilium.yaml")
 	var result bytes.Buffer
-	timeout := time.Duration(300)
+	timeout := time.Duration(800)
 
 	newCiliumDSName := fmt.Sprintf("cilium_ds_%s.json", MakeUID())
 

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -35,9 +35,6 @@ if [[ -f  "/etc/provision_finished" ]]; then
     exit 0
 fi
 
-go get github.com/subfuzion/envtpl
-mv ~/go/bin/envtpl /usr/local/bin/
-
 $PROVISIONSRC/dns.sh
 
 cat <<EOF > /etc/hosts

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -8,23 +8,5 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 source "${PROVISIONSRC}/helpers.bash"
 
-echo "editing journald configuration"
-sudo bash -c "echo RateLimitIntervalSec=1s >> /etc/systemd/journald.conf"
-sudo bash -c "echo RateLimitBurst=1000 >> /etc/systemd/journald.conf"
-echo "restarting systemd-journald"
-sudo systemctl restart systemd-journald
-echo "getting status of systemd-journald"
-sudo service systemd-journald status
-echo "done configuring journald"
-
-# Delete this section when the new server is ready
-# https://github.com/cilium/cilium/pull/3023/files
-export GOPATH="/home/vagrant/go"
-sudo -E /usr/local/go/bin/go get -d github.com/lyft/protoc-gen-validate
-
-cd ${GOPATH}/src/github.com/lyft/protoc-gen-validate
-sudo git checkout 930a67cf7ba41b9d9436ad7a1be70a5d5ff6e1fc
-make build
-
 "${PROVISIONSRC}"/dns.sh
 "${PROVISIONSRC}"/compile.sh


### PR DESCRIPTION
Update to new image that has the following changes:

- Kernel bump to 4.9.17
- Some 3-party libraries already installed.
- Journald limits increased.
- Cleanup CI provision scripts
- Increase Cilium Example timeout limits because Cilium images are not
longer cached in base box.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4269)
<!-- Reviewable:end -->
