### PR TITLE
daemon: Warn on too-old status data

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -106,8 +106,9 @@ type Daemon struct {
 	// Only used for CRI-O since it does not support events.
 	workloadsEventsCh chan<- *workloads.EventMessage
 
-	statusCollectMutex lock.RWMutex
-	statusResponse     models.StatusResponse
+	statusCollectMutex      lock.RWMutex
+	statusResponse          models.StatusResponse
+	statusResponseTimestamp time.Time
 
 	uniqueIDMU lock.Mutex
 	uniqueID   map[uint64]bool


### PR DESCRIPTION
We switched to collecting status data asyncronously but we don't account
for deadlocks, despite checking for them explicitly. The status
collector records the time when it recorded the status, allowing us to
mark stale statuses with a warning.

This is a redo of https://github.com/cilium/cilium/pull/3690 (itself an extension of https://github.com/cilium/cilium/pull/3607).  I found https://github.com/cilium/cilium/pull/3690 to be too long and complicated for such a simple goal. The one downside this PR has is that it can't distinguish which subsystem is slow/deadlocked but that's probably fine in the end.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4273)
<!-- Reviewable:end -->
