### PR TITLE
[WIP] pkg/bpf: Ignore nested /ip and /xdp mounts

### DIFF
--- a/pkg/bpf/bpffs.go
+++ b/pkg/bpf/bpffs.go
@@ -175,11 +175,16 @@ func hasMultipleMounts() (bool, error) {
 	}
 	defer scanner.Close()
 
-	newmapRoot := mapRoot + " " // Append space to ignore /sys/fs/bpf/xdp and /sys/fs/bpf/ip mountpoints.
+	// Clean the last trailing / character from map root
+	cleanMapRoot := filepath.Clean(mapRoot)
 
 	num := 0
 	for scanner.Scan() {
-		if strings.Contains(scanner.Text(), newmapRoot) {
+		mountinfo := strings.Split(scanner.Text(), " ")
+		if len(mountinfo) < 2 {
+			return false, fmt.Errorf("incorrect entry in /proc/mounts")
+		}
+		if mountinfo[1] == cleanMapRoot {
 			num++
 		}
 	}


### PR DESCRIPTION
`hasMultipleMounts` should look only for the main maproot mounts
(i.e. /sys/fs/bpf), not nested mounts (i.e. /sys/fs/bpf/ip,
/sys/fs/bpf/xdp).

Fixes #4278

Signed-off-by: Michal Rostecki <mrostecki@suse.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4279)
<!-- Reviewable:end -->
