### PR TITLE
Test: Dump Vagrant output to Jenkins console

### DIFF
--- a/test/helpers/vagrant.go
+++ b/test/helpers/vagrant.go
@@ -57,11 +57,10 @@ func CreateVM(scope string) error {
 		return fmt.Errorf("error getting stderr: %s", err)
 	}
 
-	go io.Copy(ginkgoext.GinkgoWriter, stderr)
-	go io.Copy(ginkgoext.GinkgoWriter, stdout)
+	globalWriter := ginkgoext.NewWriter(ginkgo.GinkgoWriter)
 
-	go io.Copy(ginkgo.GinkgoWriter, stderr)
-	go io.Copy(ginkgo.GinkgoWriter, stdout)
+	go io.Copy(globalWriter, stderr)
+	go io.Copy(globalWriter, stdout)
 
 	if err := cmd.Start(); err != nil {
 		log.WithFields(logrus.Fields{
@@ -70,7 +69,9 @@ func CreateVM(scope string) error {
 		}).Fatalf("Create error on start")
 		return err
 	}
-	return cmd.Wait()
+	result := cmd.Wait()
+	io.Copy(ginkgoext.GinkgoWriter, globalWriter.Buffer)
+	return result
 }
 
 // GetVagrantSSHMetadata returns a string containing the output of `vagrant ssh-config`


### PR DESCRIPTION
The `io.Copy` does not  work correctly when the source is the same
buffer. With this change all is stremed to Jenkins terminal,and it's
dump to `test-output.log` at the end of the provision.

Fix #4170

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4284)
<!-- Reviewable:end -->
