### PR TITLE
Test: Fix assert line on CMDRes.Expect*

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -76,14 +76,14 @@ func (res *CmdRes) WasSuccessful() bool {
 // ExpectFail asserts whether res failed to execute. It accepts an optional
 // parameter that can be used to annotate failure messages.
 func (res *CmdRes) ExpectFail(optionalDescription ...interface{}) bool {
-	return gomega.ExpectWithOffset(1, res).ShouldNot(
+	return gomega.ExpectWithOffset(2, res).ShouldNot(
 		CMDSuccess(), optionalDescription...)
 }
 
 // ExpectSuccess asserts whether res executed successfully. It accepts an optional
 // parameter that can be used to annotate failure messages.
 func (res *CmdRes) ExpectSuccess(optionalDescription ...interface{}) bool {
-	return gomega.ExpectWithOffset(1, res).Should(
+	return gomega.ExpectWithOffset(2, res).Should(
 		CMDSuccess(), optionalDescription...)
 }
 


### PR DESCRIPTION
When the new assert was added the ExpectSucess was not correctly updated
to trigger the correct line. With this change the fail message will
point to the test line instead of the helper library.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4285)
<!-- Reviewable:end -->
