### PR TITLE
    monitor: cilium-agent passes along BPF mount path

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -706,7 +706,7 @@ func runDaemon() {
 	}
 
 	log.Info("Launching node monitor daemon")
-	go d.nodeMonitor.Run(path.Join(defaults.RuntimePath, defaults.EventsPipe))
+	go d.nodeMonitor.Run(path.Join(defaults.RuntimePath, defaults.EventsPipe), bpf.GetMapRoot())
 
 	// Launch cilium-health in the same namespace as cilium.
 	log.Info("Launching Cilium health daemon")

--- a/monitor/launch/launcher.go
+++ b/monitor/launch/launcher.go
@@ -75,7 +75,7 @@ func (nm *NodeMonitor) GetPid() int {
 }
 
 // Run starts the node monitor.
-func (nm *NodeMonitor) Run(sockPath string) {
+func (nm *NodeMonitor) Run(sockPath, bpfRoot string) {
 	nm.SetTarget(targetName)
 	for {
 		os.Remove(sockPath)
@@ -94,6 +94,7 @@ func (nm *NodeMonitor) Run(sockPath string) {
 		nm.pipe = pipe
 		nm.Mutex.Unlock()
 
+		nm.Launcher.SetArgs([]string{"--bpf-root", bpfRoot})
 		nm.Launcher.Run()
 
 		r := bufio.NewReader(nm.GetStdout())

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/daemon/defaults"
 	"github.com/cilium/cilium/pkg/apisocket"
+	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
@@ -49,10 +50,15 @@ var (
 		},
 	}
 	npages int
+
+	// bpfRoot is the path to the BPF mount. This can be non-default if
+	// cilium-agent mounts bpf at an alternate location.
+	bpfRoot string
 )
 
 func init() {
 	rootCmd.Flags().IntVar(&npages, "num-pages", 64, "Number of pages for ring buffer")
+	rootCmd.Flags().StringVar(&bpfRoot, "bpf-root", "/sys/fs/bpf", "Path to the root of the bpf mount")
 }
 
 func execute() {
@@ -67,6 +73,8 @@ func main() {
 }
 
 func runNodeMonitor() {
+	bpf.SetMapRoot(bpfRoot)
+
 	eventSockPath := path.Join(defaults.RuntimePath, defaults.EventsPipe)
 	pipe, err := os.OpenFile(eventSockPath, os.O_RDONLY, 0600)
 	if err != nil {


### PR DESCRIPTION
_This PR should wait for any other fixes relating to https://github.com/cilium/cilium/pull/4280. In particular, we should include the correct fixes reference for the unreverted commits._

cilium-agent may mount BPFFS at a non-default location. In those cases this information is stored in the bpf package. Unfortunately, cilium-node-monitor is a separate process and doesn't see this change. cilium-agent now passes the path along always, allowing cilium-node-monitor to be oblivious to changes in the mount logic.

fixes https://github.com/cilium/cilium/issues/4274

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4286)
<!-- Reviewable:end -->
