### PR TITLE
[wip] Test cilium-agent/monitor handling of non-default BPF paths

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -41,6 +41,9 @@ const (
 	// MaxRetries is the number of times that a loop should iterate until a
 	// specified condition is not met
 	MaxRetries = 30
+
+	// DefaultCiliumAgentCLIArgs are the basic parameters to run cilium-agent with during testing
+	DefaultCiliumAgentCLIArgs = `CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug --debug-verbose flow`
 )
 
 // BpfLBList returns the output of `cilium bpf lb list -o json` as a map
@@ -834,11 +837,13 @@ func (s *SSHMeta) ServiceDelAll() *CmdRes {
 
 // SetUpCilium sets up Cilium as a systemd service with a hardcoded set of options. It
 // returns an error if any of the operations needed to start Cilium fails.
-func (s *SSHMeta) SetUpCilium() error {
-	template := `
-PATH=/usr/lib/llvm-3.8/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
-CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug --debug-verbose flow
-INITSYSTEM=SYSTEMD`
+func (s *SSHMeta) SetUpCilium(cliArgs string) error {
+	template := strings.Join([]string{
+		`PATH=/usr/lib/llvm-3.8/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin`,
+		cliArgs,
+		`INITSYSTEM=SYSTEMD`,
+	},
+		"\n")
 
 	err := RenderTemplateToFile("cilium", template, os.ModePerm)
 	if err != nil {

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -49,7 +49,12 @@ var _ = Describe("RuntimeValidatedMonitorTest", func() {
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimeMonitorTest"})
 		logger.Info("Starting")
+
 		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+
+		err := vm.SetUpCilium(helpers.DefaultCiliumAgentCLIArgs + "--bpf-root /run/cilium/bpffs")
+		Expect(err).To(BeNil(), "Error launching cilium-agent with custom bpf mount path")
+
 		areEndpointsReady := vm.WaitEndpointsReady()
 		Expect(areEndpointsReady).Should(BeTrue())
 	})
@@ -78,6 +83,9 @@ var _ = Describe("RuntimeValidatedMonitorTest", func() {
 
 		AfterAll(func() {
 			vm.SampleContainersActions(helpers.Delete, helpers.CiliumDockerNetwork)
+			err := vm.SetUpCilium(helpers.DefaultCiliumAgentCLIArgs)
+			Expect(err).To(BeNil(), "Error restoring cilium-agent to default bpf mount path")
+
 		})
 
 		monitorConfig := func() {

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -53,6 +53,7 @@ var _ = Describe("RuntimeValidatedMonitorTest", func() {
 		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
 
 		err := vm.SetUpCilium(helpers.DefaultCiliumAgentCLIArgs + "--bpf-root /run/cilium/bpffs")
+		logger.Warn("FFF:" + err.Error())
 		Expect(err).To(BeNil(), "Error launching cilium-agent with custom bpf mount path")
 
 		areEndpointsReady := vm.WaitEndpointsReady()
@@ -84,6 +85,7 @@ var _ = Describe("RuntimeValidatedMonitorTest", func() {
 		AfterAll(func() {
 			vm.SampleContainersActions(helpers.Delete, helpers.CiliumDockerNetwork)
 			err := vm.SetUpCilium(helpers.DefaultCiliumAgentCLIArgs)
+			logger.Warn("FFF:" + err.Error())
 			Expect(err).To(BeNil(), "Error restoring cilium-agent to default bpf mount path")
 
 		})

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -166,7 +166,7 @@ var _ = BeforeAll(func() {
 
 		vm := helpers.InitRuntimeHelper(helpers.Runtime, log.WithFields(
 			logrus.Fields{"testName": "BeforeSuite"}))
-		err = vm.SetUpCilium()
+		err = vm.SetUpCilium(helpers.DefaultCiliumAgentCLIArgs)
 
 		if err != nil {
 			// AfterFailed function is not defined in this scope, fired the


### PR DESCRIPTION
A followup to https://github.com/cilium/cilium/pull/4286

I need to test this here because I can't run tests on my mac :/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4290)
<!-- Reviewable:end -->
