### PR TITLE
examples: add registry address to all container images

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -59,7 +59,7 @@ version.
 
 ::
 
-    kubectl set image daemonset/cilium -n kube-system cilium-agent=cilium/cilium:vX.Y.Z
+    kubectl set image daemonset/cilium -n kube-system cilium-agent=docker.io/cilium/cilium:vX.Y.Z
 
 To monitor the rollout and confirm it is complete, run: 
 

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   cilium:
     container_name: cilium
-    image: cilium/cilium:stable
+    image: docker.io/cilium/cilium:stable
     command: cilium-agent --debug -d ${IFACE} --kvstore consul --kvstore-opt consul.address=127.0.0.1:8500
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -18,7 +18,7 @@ services:
 
   cilium_docker:
     container_name: cilium-docker-plugin
-    image: cilium/cilium:stable
+    image: docker.io/cilium/cilium:stable
     command: cilium-docker -D
     volumes:
       - /var/run/cilium:/var/run/cilium
@@ -36,6 +36,6 @@ services:
       - "8500:8500"
     environment:
       - "CONSUL_LOCAL_CONFIG={\"skip_leave_on_interrupt\": true, \"disable_update_check\": true}"
-    image: consul:0.8.3
+    image: docker.io/library/consul:0.8.3
     command: agent -client=0.0.0.0 -server -bootstrap-expect 1
 

--- a/examples/elk/README.md
+++ b/examples/elk/README.md
@@ -31,7 +31,7 @@ previous step.
 version: '2'
 services:
   cilium:
-    image: cilium:cilium-ubuntu-16-04
+    image: docker.io/cilium:cilium-ubuntu-16-04
     command: cilium-agent --debug --logstash 192.168.33.21:9302
 ...
 ```

--- a/examples/elk/docker-compose.yml
+++ b/examples/elk/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   elastic:
-    image: elasticsearch:2.3.4
+    image: docker.io/library/elasticsearch:2.3.4
     command: elasticsearch -Des.network.bind_host=_non_loopback:ipv4_
     container_name: cilium-elastic
     ports:
@@ -9,7 +9,7 @@ services:
       - 9300:9300
 
   logstash:
-    image: logstash:2.3.4-1
+    image: docker.io/library/logstash:2.3.4-1
     command: -f /logstash.conf
     container_name: cilium-logstash
     volumes:
@@ -20,7 +20,7 @@ services:
       - 9302:9302
 
   kibana:
-    image: kibana:4.5.3
+    image: docker.io/library/kibana:4.5.3
     container_name: cilium-kibana
     environment:
       - ELASTICSEARCH_URL=http://elastic:9200

--- a/examples/getting-started/docker-compose.yml
+++ b/examples/getting-started/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   cilium:
     container_name: cilium
-    image: cilium/cilium:${CILIUM_TAG}
+    image: docker.io/cilium/cilium:${CILIUM_TAG}
     command: cilium-agent ${CILIUM_OPTS}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -18,7 +18,7 @@ services:
 
   cilium_docker:
     container_name: cilium-docker-plugin
-    image: cilium/cilium:${CILIUM_TAG}
+    image: docker.io/cilium/cilium:${CILIUM_TAG}
     command: cilium-docker
     volumes:
       - /var/run/cilium:/var/run/cilium
@@ -36,5 +36,5 @@ services:
       - "8500:8500"
     environment:
       - "CONSUL_LOCAL_CONFIG={\"skip_leave_on_interrupt\": true, \"disable_update_check\": true}"
-    image: consul:0.8.3
+    image: docker.io/library/consul:0.8.3
     command: agent -client=0.0.0.0 -server -bootstrap-expect 1

--- a/examples/kubernetes-es/es-sw-app.yaml
+++ b/examples/kubernetes-es/es-sw-app.yaml
@@ -38,7 +38,7 @@ spec:
       serviceAccount: elasticsearch
       initContainers:
       - name: init-sysctl
-        image: busybox
+        image: docker.io/library/busybox
         imagePullPolicy: IfNotPresent
         command: ["sysctl", "-w", "vm.max_map_count=262144"]
         securityContext:
@@ -116,7 +116,7 @@ metadata:
 spec:
   containers:
   - name: bookreader
-    image: cilium/esclient:v1 
+    image: docker.io/cilium/esclient:v1
 ---
 apiVersion: v1
 kind: Pod
@@ -128,4 +128,4 @@ metadata:
 spec:
   containers:
   - name: bookreader
-    image: cilium/esclient:v1 
+    image: docker.io/cilium/esclient:v1

--- a/examples/kubernetes-grpc/cc-door-app.yaml
+++ b/examples/kubernetes-grpc/cc-door-app.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: cc-door-mgr
-        image: cilium/cc-grpc-demo
+        image: docker.io/cilium/cc-grpc-demo
         command: ["python3"]
         args: ["/cloudcity/cc_door_server.py"]
         ports:
@@ -52,6 +52,6 @@ metadata:
 spec:
   containers:
   - name: cc-door-client
-    image: cilium/cc-grpc-demo
+    image: docker.io/cilium/cc-grpc-demo
     command: ["sleep"]
     args: ["300000"]

--- a/examples/kubernetes-istio/authaudit-logger-v1.yaml
+++ b/examples/kubernetes-istio/authaudit-logger-v1.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: authaudit-logger
-        image: spotify/kafka:latest
+        image: docker.io/spotify/kafka:latest
         command:
         - /opt/kafka_2.11-0.10.1.0/bin/kafka-console-consumer.sh
         - --bootstrap-server=kafka:9092

--- a/examples/kubernetes-istio/bookinfo-details-v1.yaml
+++ b/examples/kubernetes-istio/bookinfo-details-v1.yaml
@@ -65,7 +65,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v1:0.2.8
+        image: docker.io/istio/examples-bookinfo-details-v1:0.2.8
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/examples/kubernetes-istio/bookinfo-productpage-v1.yaml
+++ b/examples/kubernetes-istio/bookinfo-productpage-v1.yaml
@@ -65,7 +65,7 @@ spec:
     spec:
       containers:
       - name: productpage
-        image: istio/examples-bookinfo-productpage-v1:0.2.8
+        image: docker.io/istio/examples-bookinfo-productpage-v1:0.2.8
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/examples/kubernetes-istio/bookinfo-productpage-v2.yaml
+++ b/examples/kubernetes-istio/bookinfo-productpage-v2.yaml
@@ -61,7 +61,7 @@ spec:
     spec:
       containers:
       - name: productpage
-        image: cilium/istio-examples-bookinfo-productpage-v2:0.3.0
+        image: docker.io/cilium/istio-examples-bookinfo-productpage-v2:0.3.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/examples/kubernetes-istio/bookinfo-ratings-v1.yaml
+++ b/examples/kubernetes-istio/bookinfo-ratings-v1.yaml
@@ -78,7 +78,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v1:0.2.8
+        image: docker.io/istio/examples-bookinfo-ratings-v1:0.2.8
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/examples/kubernetes-istio/bookinfo-reviews-v1.yaml
+++ b/examples/kubernetes-istio/bookinfo-reviews-v1.yaml
@@ -65,7 +65,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v1:0.2.8
+        image: docker.io/istio/examples-bookinfo-reviews-v1:0.2.8
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/examples/kubernetes-istio/bookinfo-reviews-v2.yaml
+++ b/examples/kubernetes-istio/bookinfo-reviews-v2.yaml
@@ -52,7 +52,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2:0.2.8
+        image: docker.io/istio/examples-bookinfo-reviews-v2:0.2.8
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/examples/kubernetes-istio/istio-sidecar-injector-configmap-debug.yaml
+++ b/examples/kubernetes-istio/istio-sidecar-injector-configmap-debug.yaml
@@ -34,7 +34,7 @@ data:
           unlimited
         command:
         - /bin/sh
-        image: alpine
+        image: docker.io/library/alpine
         imagePullPolicy: Always
         name: enable-core-dump
         resources: {}

--- a/examples/kubernetes-istio/kafka-v1.yaml
+++ b/examples/kubernetes-istio/kafka-v1.yaml
@@ -74,7 +74,7 @@ spec:
     spec:
       containers:
       - name:  kafka
-        image: spotify/kafka:latest
+        image: docker.io/spotify/kafka:latest
         ports:
         - containerPort: 9092
           name: kafka

--- a/examples/kubernetes-kafka/kafka-sw-app.yaml
+++ b/examples/kubernetes-kafka/kafka-sw-app.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: wurstmeister/kafka
+        image: docker.io/wurstmeister/kafka
         ports:
         - containerPort: 9092
         env:
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: zookeeper
-        image: digitalwonderland/zookeeper
+        image: docker.io/digitalwonderland/zookeeper
         ports:
         - containerPort: 2181
 ---
@@ -90,7 +90,7 @@ spec:
     spec:
       containers:
       - name: empire-hq
-        image: cilium/kafkaclient
+        image: docker.io/cilium/kafkaclient
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -106,7 +106,7 @@ spec:
     spec:
       containers:
       - name: empire-outpost-8888
-        image: cilium/kafkaclient
+        image: docker.io/cilium/kafkaclient
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -122,7 +122,7 @@ spec:
     spec:
       containers:
       - name: empire-outpost-9999
-        image: cilium/kafkaclient
+        image: docker.io/cilium/kafkaclient
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -137,4 +137,4 @@ spec:
     spec:
       containers:
       - name: empire-backup
-        image: cilium/kafkaclient
+        image: docker.io/cilium/kafkaclient

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -34,7 +34,8 @@ spec:
       serviceAccountName: cilium
       initContainers:
       - name: clean-cilium-state
-        image: busybox
+        image: docker.io/library/busybox:1.28.4
+        imagePullPolicy: IfNotPresent
         command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
         volumeMounts:
           - name: bpf-maps
@@ -44,12 +45,12 @@ spec:
         env:
           - name: "CLEAN_CILIUM_STATE"
             valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: clean-cilium-state
       containers:
-      - image: cilium/cilium:latest
+      - image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -81,7 +81,8 @@ spec:
       serviceAccountName: cilium
       initContainers:
       - name: clean-cilium-state
-        image: busybox
+        image: docker.io/library/busybox:1.28.4
+        imagePullPolicy: IfNotPresent
         command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
         volumeMounts:
           - name: bpf-maps
@@ -91,12 +92,12 @@ spec:
         env:
           - name: "CLEAN_CILIUM_STATE"
             valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: clean-cilium-state
       containers:
-      - image: cilium/cilium:latest
+      - image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -34,7 +34,8 @@ spec:
       serviceAccountName: cilium
       initContainers:
       - name: clean-cilium-state
-        image: busybox
+        image: docker.io/library/busybox:1.28.4
+        imagePullPolicy: IfNotPresent
         command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
         volumeMounts:
           - name: bpf-maps
@@ -44,12 +45,12 @@ spec:
         env:
           - name: "CLEAN_CILIUM_STATE"
             valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: clean-cilium-state
       containers:
-      - image: cilium/cilium:latest
+      - image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -81,7 +81,8 @@ spec:
       serviceAccountName: cilium
       initContainers:
       - name: clean-cilium-state
-        image: busybox
+        image: docker.io/library/busybox:1.28.4
+        imagePullPolicy: IfNotPresent
         command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
         volumeMounts:
           - name: bpf-maps
@@ -91,12 +92,12 @@ spec:
         env:
           - name: "CLEAN_CILIUM_STATE"
             valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: clean-cilium-state
       containers:
-      - image: cilium/cilium:latest
+      - image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -34,7 +34,8 @@ spec:
       serviceAccountName: cilium
       initContainers:
       - name: clean-cilium-state
-        image: busybox
+        image: docker.io/library/busybox:1.28.4
+        imagePullPolicy: IfNotPresent
         command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
         volumeMounts:
           - name: bpf-maps
@@ -44,12 +45,12 @@ spec:
         env:
           - name: "CLEAN_CILIUM_STATE"
             valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: clean-cilium-state
       containers:
-      - image: cilium/cilium:latest
+      - image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -81,7 +81,8 @@ spec:
       serviceAccountName: cilium
       initContainers:
       - name: clean-cilium-state
-        image: busybox
+        image: docker.io/library/busybox:1.28.4
+        imagePullPolicy: IfNotPresent
         command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
         volumeMounts:
           - name: bpf-maps
@@ -91,12 +92,12 @@ spec:
         env:
           - name: "CLEAN_CILIUM_STATE"
             valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: clean-cilium-state
       containers:
-      - image: cilium/cilium:latest
+      - image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -34,7 +34,8 @@ spec:
       serviceAccountName: cilium
       initContainers:
       - name: clean-cilium-state
-        image: busybox
+        image: docker.io/library/busybox:1.28.4
+        imagePullPolicy: IfNotPresent
         command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
         volumeMounts:
           - name: bpf-maps
@@ -44,12 +45,12 @@ spec:
         env:
           - name: "CLEAN_CILIUM_STATE"
             valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: clean-cilium-state
       containers:
-      - image: cilium/cilium:latest
+      - image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -81,7 +81,8 @@ spec:
       serviceAccountName: cilium
       initContainers:
       - name: clean-cilium-state
-        image: busybox
+        image: docker.io/library/busybox:1.28.4
+        imagePullPolicy: IfNotPresent
         command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
         volumeMounts:
           - name: bpf-maps
@@ -91,12 +92,12 @@ spec:
         env:
           - name: "CLEAN_CILIUM_STATE"
             valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: clean-cilium-state
       containers:
-      - image: cilium/cilium:latest
+      - image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -34,7 +34,8 @@ spec:
       serviceAccountName: cilium
       initContainers:
       - name: clean-cilium-state
-        image: busybox
+        image: docker.io/library/busybox:1.28.4
+        imagePullPolicy: IfNotPresent
         command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
         volumeMounts:
           - name: bpf-maps
@@ -44,12 +45,12 @@ spec:
         env:
           - name: "CLEAN_CILIUM_STATE"
             valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: clean-cilium-state
       containers:
-      - image: cilium/cilium:latest
+      - image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -81,7 +81,8 @@ spec:
       serviceAccountName: cilium
       initContainers:
       - name: clean-cilium-state
-        image: busybox
+        image: docker.io/library/busybox:1.28.4
+        imagePullPolicy: IfNotPresent
         command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
         volumeMounts:
           - name: bpf-maps
@@ -91,12 +92,12 @@ spec:
         env:
           - name: "CLEAN_CILIUM_STATE"
             valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: clean-cilium-state
       containers:
-      - image: cilium/cilium:latest
+      - image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/addons/prometheus/prometheus.yaml
+++ b/examples/kubernetes/addons/prometheus/prometheus.yaml
@@ -47,7 +47,7 @@ spec:
       serviceAccountName: prometheus-k8s
       containers:
       - name: prometheus
-        image: prom/prometheus:v1.7.0
+        image: docker.io/prom/prometheus:v1.7.0
         args:
           - '-storage.local.retention=12h'
           - '-storage.local.memory-chunks=500000'

--- a/examples/kubernetes/cilium.yaml
+++ b/examples/kubernetes/cilium.yaml
@@ -94,7 +94,7 @@ spec:
     spec:
       serviceAccountName: cilium
       containers:
-      - image: cilium/cilium:stable
+      - image: docker.io/cilium/cilium:stable
         imagePullPolicy: Always
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/kubernetes/prometheus.yaml
+++ b/examples/kubernetes/prometheus.yaml
@@ -47,7 +47,7 @@ spec:
       serviceAccountName: prometheus-k8s
       containers:
       - name: prometheus
-        image: prom/prometheus:v1.7.0
+        image: docker.io/prom/prometheus:v1.7.0
         args:
           - '-storage.local.retention=12h'
           - '-storage.local.memory-chunks=500000'

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -34,7 +34,8 @@ spec:
       serviceAccountName: cilium
       initContainers:
       - name: clean-cilium-state
-        image: busybox
+        image: docker.io/library/busybox:1.28.4
+        imagePullPolicy: IfNotPresent
         command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
         volumeMounts:
           - name: bpf-maps
@@ -44,12 +45,12 @@ spec:
         env:
           - name: "CLEAN_CILIUM_STATE"
             valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: clean-cilium-state
       containers:
-      - image: cilium/cilium:__CILIUM_VERSION__
+      - image: docker.io/cilium/cilium:__CILIUM_VERSION__
         imagePullPolicy: Always
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/minikube/cilium-ds.yaml
+++ b/examples/minikube/cilium-ds.yaml
@@ -98,7 +98,7 @@ spec:
     spec:
       serviceAccountName: cilium
       containers:
-      - image: cilium/cilium:stable
+      - image: docker.io/cilium/cilium:stable
         imagePullPolicy: Always
         name: cilium-agent
         command: [ "cilium-agent" ]

--- a/examples/minikube/http-sw-app.yaml
+++ b/examples/minikube/http-sw-app.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: deathstar
-        image: cilium/starwars
+        image: docker.io/cilium/starwars
 ---
 apiVersion: v1
 kind: Pod
@@ -41,7 +41,7 @@ metadata:
 spec:
   containers:
   - name: spaceship
-    image: tgraf/netperf
+    image: docker.io/tgraf/netperf
 ---
 apiVersion: v1
 kind: Pod
@@ -53,4 +53,4 @@ metadata:
 spec:
   containers:
   - name: spaceship
-    image: tgraf/netperf
+    image: docker.io/tgraf/netperf

--- a/test/k8sT/manifests/bookinfo-v1.yaml
+++ b/test/k8sT/manifests/bookinfo-v1.yaml
@@ -44,7 +44,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v1:1.6.0
+        image: docker.io/istio/examples-bookinfo-details-v1:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -81,7 +81,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v1:1.6.0
+        image: docker.io/istio/examples-bookinfo-reviews-v1:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -119,7 +119,7 @@ spec:
       containers:
       # Use v0.2.3 because it still contains 'wget', necessary for tests.
       - name: productpage
-        image: istio/examples-bookinfo-productpage-v1:0.2.3
+        image: docker.io/istio/examples-bookinfo-productpage-v1:0.2.3
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/test/k8sT/manifests/bookinfo-v2.yaml
+++ b/test/k8sT/manifests/bookinfo-v2.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v1:1.6.0
+        image: docker.io/istio/examples-bookinfo-ratings-v1:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -66,7 +66,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2:1.6.0
+        image: docker.io/istio/examples-bookinfo-reviews-v2:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/test/k8sT/manifests/client.yaml
+++ b/test/k8sT/manifests/client.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: app-frontend
-    image: cilium/connectivity-container:v1.0
+    image: docker.io/cilium/connectivity-container:v1.0
     command: [ "sleep" ]
     args:
       - "1000h"

--- a/test/k8sT/manifests/demo.yaml
+++ b/test/k8sT/manifests/demo.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: web
-        image: cilium/demo-httpd
+        image: docker.io/cilium/demo-httpd
         ports:
         - containerPort: 80
       nodeSelector:
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: app-frontend
-        image: cilium/demo-client
+        image: docker.io/cilium/demo-client
         command: [ "sleep" ]
         args:
           - "1000h"
@@ -64,7 +64,7 @@ spec:
     spec:
       containers:
       - name: app-frontend
-        image: cilium/demo-client
+        image: docker.io/cilium/demo-client
         command: [ "sleep" ]
         args:
           - "1000h"

--- a/test/k8sT/manifests/demo_ds.yaml
+++ b/test/k8sT/manifests/demo_ds.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: web
-        image: cilium/demo-httpd
+        image: docker.io/cilium/demo-httpd
         ports:
         - containerPort: 80
       tolerations:
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: web
-        image: cilium/demo-client
+        image: docker.io/cilium/demo-client
         command: [ "sleep" ]
         args:
           - "1000h"

--- a/test/k8sT/manifests/external_pod.yaml
+++ b/test/k8sT/manifests/external_pod.yaml
@@ -8,5 +8,5 @@ metadata:
 spec:
   containers:
   - name: app-reach-services
-    image: cilium/demo-client
+    image: docker.io/cilium/demo-client
     command: [ "bash", "-c", "while true; do sleep 5; done" ]

--- a/test/k8sT/manifests/kafka-sw-app.yaml
+++ b/test/k8sT/manifests/kafka-sw-app.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: wurstmeister/kafka
+        image: docker.io/wurstmeister/kafka
         ports:
         - containerPort: 9092
         env:
@@ -54,7 +54,7 @@ spec:
     spec:
       containers:
       - name: zookeeper
-        image: digitalwonderland/zookeeper
+        image: docker.io/digitalwonderland/zookeeper
         ports:
         - containerPort: 2181
 ---
@@ -103,7 +103,7 @@ spec:
     spec:
       containers:
       - name: empire-hq
-        image: cilium/kafkaclient
+        image: docker.io/cilium/kafkaclient
       nodeSelector:
         "kubernetes.io/hostname": k8s1
 ---
@@ -122,7 +122,7 @@ spec:
     spec:
       containers:
       - name: empire-outpost-8888
-        image: cilium/kafkaclient
+        image: docker.io/cilium/kafkaclient
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -139,7 +139,7 @@ spec:
     spec:
       containers:
       - name: empire-outpost-9999
-        image: cilium/kafkaclient
+        image: docker.io/cilium/kafkaclient
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -155,4 +155,4 @@ spec:
     spec:
       containers:
       - name: empire-backup
-        image: cilium/kafkaclient
+        image: docker.io/cilium/kafkaclient

--- a/test/k8sT/manifests/netcat_ds.yaml
+++ b/test/k8sT/manifests/netcat_ds.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: netcat
-        image: cilium/demo-client
+        image: docker.io/cilium/demo-client
         command: [ "sleep" ]
         args:
           - "1000h"

--- a/test/k8sT/manifests/server.yaml
+++ b/test/k8sT/manifests/server.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   containers:
   - name: web
-    image: cilium/connectivity-container:v1.0
+    image: docker.io/cilium/connectivity-container:v1.0
     ports:
     - containerPort: 80
     volumeMounts:


### PR DESCRIPTION
Since not all container runtimes use docker as the default image
registry it is necessary to specify the address for the correct
registry.

Signed-off-by: André Martins <andre@cilium.io>

```release-note
add container image registry for all examples and cilium yaml spec file.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4295)
<!-- Reviewable:end -->
