### PR TITLE
pkg/endpoint: close and reopen policy map if dump fails

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -622,7 +622,6 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 		}
 	}()
 
-	// Create the policymap on the first pass
 	if e.PolicyMap == nil {
 		e.PolicyMap, createdPolicyMap, err = policymap.OpenMap(e.PolicyMapPathLocked())
 		if err != nil {
@@ -630,7 +629,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 			return 0, err
 		}
 		// Clean up map contents
-		log.Debugf("Flushing old policies map")
+		e.getLogger().Debug("flushing old PolicyMap")
 		err = e.PolicyMap.Flush()
 		if err != nil {
 			e.Mutex.Unlock()

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -253,4 +253,10 @@ const (
 
 	// BPFHeaderHash is the hash of the BPF header.
 	BPFHeaderfileHash = "bpfHeaderfileHash"
+
+	// BPFMapPath is the path of a BPF map in the filesystem.
+	BPFMapPath = "bpfMapPath"
+
+	// BPFMapFD is the file descriptor for a BPF map.
+	BPFMapFD = "bpfMapFileDescriptor"
 )


### PR DESCRIPTION
Sometimes, policy map updates for endpoints fail in CI with errors like the following:

"Unable to update element: bad file descriptor"

It is not known why this occurs; to mitigate this, try to close the existing map, and then reopen the PolicyMap for the endpoint again upon the first access of it in syncPolicyMap,
which is the dumping of the map into a slice of PolicyKey entries. After reopening the map, attempt to dump again.

Furthermore, this PR sets the file descriptor of the PolicyMap to be 0 once the `Close()` operation is performed upon it. It also logs when `Close()` is called for easier debugging of the lifecycle of a `PolicyMap`.

Fixes: #4229

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4299)
<!-- Reviewable:end -->
