### PR TITLE
Test: Policy namespaces fixes

### DIFF
--- a/test/k8sT/manifests/1.7/netpol-namespace-selector.yaml
+++ b/test/k8sT/manifests/1.7/netpol-namespace-selector.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: second
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          nslabel: second
+  podSelector:
+    matchLabels:
+      id: app1

--- a/test/k8sT/manifests/netpol-namespace-selector.yaml
+++ b/test/k8sT/manifests/netpol-namespace-selector.yaml
@@ -1,0 +1,15 @@
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: second
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          nslabel: second
+  podSelector:
+    matchLabels:
+      id: app1
+  policyTypes:
+  - Ingress


### PR DESCRIPTION
 - Move `Tests the same Policy in the different namespaces` into a new   
 context "Namespaces Policies"                                           
 - `Tests the same Policy in the different namespaces"                   
     - Moved to the namespace context.                                   
     - Use custom demo application instead of pods.                      
     - Move to `kubectl exec` instead of API pod creation that was       
     difficult to debug.                                                 

Related to #4292

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4304)
<!-- Reviewable:end -->
