### PR TITLE
Documentation: Fix warnings

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -30,7 +30,7 @@ Endpoint
 * ``endpoint_regenerations``: Count of all endpoint regenerations that have completed, tagged by outcome
 
 Drops/Forwards (L3/L4)
----------------------
+----------------------
 
 * ``drop_count_total``: Total dropped packets, tagged by drop reason and ingress/egress direction
 * ``forward_count_total``: Total forwarded packets, tagged by ingress/egress direction

--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -127,7 +127,7 @@ brought up by vagrant:
 * ``RUNTIME=x``: Sets up the container runtime to be used inside a kubernetes
   cluster. Valid options are: ``docker``, ``containerd`` and ``crio``. If not
   set, it defaults to ``docker``.
-* ``VAGRANT_DEFAULT_PROVIDER``={virtualbox \| libvirt \| ...}
+* ``VAGRANT_DEFAULT_PROVIDER={virtualbox \| libvirt \| ...}``
 
 If you want to start the VM with cilium enabled with ``containerd``, with
 kubernetes installed and plus a worker, run:


### PR DESCRIPTION
```
WARNING: /home/vagrant/go/src/github.com/cilium/cilium/Documentation/configuration/metrics.rst:33: (WARNING/2) Title underline too short.

Drops/Forwards (L3/L4)
---------------------
WARNING: /home/vagrant/go/src/github.com/cilium/cilium/Documentation/configuration/metrics.rst:33: (WARNING/2) Title underline too short.

Drops/Forwards (L3/L4)
---------------------
/home/vagrant/go/src/github.com/cilium/cilium/Documentation/contributing.rst:130: WARNING: Inline literal start-string without end-string.
```

Signed-off-by: Thomas Graf <thomas@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4305)
<!-- Reviewable:end -->
