### PR TITLE
Test: re-enable debug configuration in Cilium K8s tests

### DIFF
--- a/test/k8sT/manifests/cilium_ds.jsonnet
+++ b/test/k8sT/manifests/cilium_ds.jsonnet
@@ -8,6 +8,7 @@ deploy {
         "-t=vxlan",
         "--kvstore=etcd",
         "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config",
-        "--disable-ipv4=$(DISABLE_IPV4)"
+        "--disable-ipv4=$(DISABLE_IPV4)",
+        "--debug-verbose=flow"
     ]
 }

--- a/test/k8sT/manifests/cilium_ds.template
+++ b/test/k8sT/manifests/cilium_ds.template
@@ -10,7 +10,7 @@
       },
       "data": {
         "etcd-config": "---\nendpoints:\n- http://" + $.etcdEndpoint + "\n#\n# In case you want to use TLS in etcd, uncomment the following line\n# and add the certificate as explained in the comment labeled \"ETCD-CERT\"\n#ca-file: '/var/lib/etcd-secrets/etcd-ca'\n#\n# In case you want client to server authentication, uncomment the following\n# lines and add the certificate and key in cilium-etcd-secrets below\n#key-file: '/var/lib/etcd-secrets/etcd-client-key'\n#cert-file: '/var/lib/etcd-secrets/etcd-client-crt'",
-        "debug": "false",
+        "debug": "true",
         "disable-ipv4": "false",
         "sidecar-http-proxy": "false",
         "clean-cilium-state": "false"

--- a/test/k8sT/manifests/cilium_ds_autorouting.jsonnet
+++ b/test/k8sT/manifests/cilium_ds_autorouting.jsonnet
@@ -9,6 +9,7 @@ deploy {
         "--tunnel=disabled --auto-routing",
         "--kvstore=etcd",
         "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config",
-        "--disable-ipv4=$(DISABLE_IPV4)"
+        "--disable-ipv4=$(DISABLE_IPV4)",
+        "--debug-verbose=flow"
     ]
 }

--- a/test/k8sT/manifests/cilium_ds_geneve.jsonnet
+++ b/test/k8sT/manifests/cilium_ds_geneve.jsonnet
@@ -8,6 +8,7 @@ deploy {
         "-t=geneve",
         "--kvstore=etcd",
         "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config",
-        "--disable-ipv4=$(DISABLE_IPV4)"
+        "--disable-ipv4=$(DISABLE_IPV4)",
+        "--debug-verbose=flow"
     ]
 }


### PR DESCRIPTION
On `d8661e0bc62a824fdadfaa98d376db185a2c69e4` daemonset was updated and
the debug flag was not activated. Enable debug in all test.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4307)
<!-- Reviewable:end -->
