### PR TITLE
cilium-docker: pass default cilium url when cilium-api is not provided

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -39,6 +39,19 @@ type Client struct {
 	clientapi.Cilium
 }
 
+// DefaultSockPath returns deafult UNIX domain socket path or
+// path set using CILIUM_SOCK env variable
+func DefaultSockPath() string {
+	// Check if environment variable points to socket
+	e := os.Getenv(defaults.SockPathEnv)
+	if e == "" {
+		// If unset, fall back to default value
+		e = defaults.SockPath
+	}
+	return "unix://" + e
+
+}
+
 func configureTransport(tr *http.Transport, proto, addr string) *http.Transport {
 	if tr == nil {
 		tr = &http.Transport{}
@@ -64,15 +77,11 @@ func NewDefaultClient() (*Client, error) {
 }
 
 // NewClient creates a client for the given `host`.
+// If host is nil then use SockPath provided by CILIUM_SOCK
+// or the cilium default SockPath
 func NewClient(host string) (*Client, error) {
 	if host == "" {
-		// Check if environment variable points to socket
-		e := os.Getenv(defaults.SockPathEnv)
-		if e == "" {
-			// If unset, fall back to default value
-			e = defaults.SockPath
-		}
-		host = "unix://" + e
+		host = DefaultSockPath()
 	}
 	tmp := strings.SplitN(host, "://", 2)
 	if len(tmp) != 2 {

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -77,8 +77,15 @@ func newLibnetworkRoute(route plugins.Route) api.StaticRoute {
 	return rt
 }
 
-// NewDriver creates and returns a new Driver for the given API URL
+// NewDriver creates and returns a new Driver for the given API URL.
+// If url is nil then use SockPath provided by CILIUM_SOCK
+// or the cilium default SockPath
 func NewDriver(url string) (Driver, error) {
+
+	if url == "" {
+		url = client.DefaultSockPath()
+	}
+
 	scopedLog := log.WithField("url", url)
 	c, err := client.NewClient(url)
 	if err != nil {


### PR DESCRIPTION
Fixes: #4308

Signed-off-by: Nirmoy Das <ndas@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4309)
<!-- Reviewable:end -->
