### PR TITLE
Test: Fix PodCIDR on Kubeadm init.

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1197,6 +1197,7 @@ func (kub *Kubectl) GatherLogs() {
 	reportCmds := map[string]string{
 		"kubectl get pods --all-namespaces -o json":                    "pods.txt",
 		"kubectl get services --all-namespaces -o json":                "svc.txt",
+		"kubectl get nodes -o json":                                    "nodes.txt",
 		"kubectl get ds --all-namespaces -o json":                      "ds.txt",
 		"kubectl get cnp --all-namespaces -o json":                     "cnp.txt",
 		"kubectl get netpol --all-namespaces -o json":                  "netpol.txt",

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -70,6 +70,8 @@ controllerManagerExtraArgs:
   allocate-node-cidrs: "true"
   cluster-cidr: "{{ .KUBEADM_POD_NETWORK }}/{{ .KUBEADM_POD_CIDR}}"
   node-cidr-mask-size: "{{ .KUBEADM_POD_CIDR }}"
+networking:
+  podSubnet: "{{ .KUBEADM_POD_NETWORK }}/{{ .KUBEADM_POD_CIDR}}"
 EOF
 )
 


### PR DESCRIPTION
In the last days a few issues related with CIDR had been seen. The issue
is that PodCIDR was not set in the kubeadm config file.

Related to #4234

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4315)
<!-- Reviewable:end -->
