### PR TITLE
Correctly restore router IPs from cilium_host interface

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -98,6 +98,10 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	option.Config.Opts.Set(option.DropNotify, true)
 	option.Config.Opts.Set(option.TraceNotify, true)
 
+	// Disable restore of host IPs for unit tests. There can be arbitrary
+	// state left on disk.
+	option.Config.EnableHostIPRestore = false
+
 	d, err := NewDaemon()
 	c.Assert(err, IsNil)
 	ds.d = d

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -62,4 +62,8 @@ const (
 
 	// EventsPipe is the name of the named pipe for agent <=> monitor events
 	EventsPipe = "events.sock"
+
+	// EnableHostIPRestore controls whether the host IP should be restored
+	// from previous state automatically
+	EnableHostIPRestore = true
 )

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -68,8 +68,15 @@ type daemonConfig struct {
 
 	Tunnel string // Tunnel mode
 
-	DryMode       bool // Do not create BPF maps, devices, ..
-	RestoreState  bool // RestoreState restores the state from previous running daemons.
+	DryMode bool // Do not create BPF maps, devices, ..
+
+	// RestoreState enables restoring the state from previous running daemons.
+	RestoreState bool
+
+	// EnableHostIPRestore enables restoring the host IPs based on state
+	// left behind by previous Cilium runs.
+	EnableHostIPRestore bool
+
 	KeepConfig    bool // Keep configuration of existing endpoints when starting up.
 	KeepTemplates bool // Do not overwrite the template files
 
@@ -113,6 +120,7 @@ var (
 		Monitor:                  &models.MonitorStatus{Cpus: int64(runtime.NumCPU()), Npages: 64, Pagesize: int64(os.Getpagesize()), Lost: 0, Unknown: 0},
 		IPv6ClusterAllocCIDR:     defaults.IPv6ClusterAllocCIDR,
 		IPv6ClusterAllocCIDRBase: defaults.IPv6ClusterAllocCIDRBase,
+		EnableHostIPRestore:      defaults.EnableHostIPRestore,
 	}
 )
 


### PR DESCRIPTION
Fixes restore from node_config.h. Requires this functionality to be disabled
for unit tests as random state can be found in development environments.

Signed-off-by: Thomas Graf <thomas@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4327)
<!-- Reviewable:end -->
