### PR TITLE
k8s: Add --k8s-require-ipv4-pod-cidr and --k8s-require-ipv6-pod-cidr option

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -44,6 +44,8 @@ cilium-agent
       --ipv6-service-range string         Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
       --k8s-api-server string             Kubernetes api address server (for https use --k8s-kubeconfig-path instead)
       --k8s-kubeconfig-path string        Absolute path of the kubernetes kubeconfig file
+      --k8s-require-ipv4-pod-cidr         Require IPv4 PodCIDR to be specified in node resource
+      --k8s-require-ipv6-pod-cidr         Require IPv6 PodCIDR to be specified in node resource
       --keep-bpf-templates                Do not restore BPF template files from binary
       --keep-config                       When restoring state, keeps containers' configuration in place
       --kvstore string                    Key-value store type

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -359,6 +359,10 @@ func init() {
 	flags.StringVar(&k8sKubeConfigPath,
 		"k8s-kubeconfig-path", "", "Absolute path of the kubernetes kubeconfig file")
 	viper.BindEnv("k8s-legacy-host-allows-world", "CILIUM_LEGACY_HOST_ALLOWS_WORLD")
+	flags.BoolVar(&option.Config.K8sRequireIPv4PodCIDR,
+		option.K8sRequireIPv4PodCIDRName, false, "Require IPv4 PodCIDR to be specified in node resource")
+	flags.BoolVar(&option.Config.K8sRequireIPv6PodCIDR,
+		option.K8sRequireIPv6PodCIDRName, false, "Require IPv6 PodCIDR to be specified in node resource")
 	flags.BoolVar(&option.Config.KeepConfig,
 		"keep-config", false, "When restoring state, keeps containers' configuration in place")
 	flags.BoolVar(&option.Config.KeepTemplates,

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,13 +18,71 @@ package k8s
 import (
 	"fmt"
 	"os"
+	"time"
 
+	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
 
 	go_version "github.com/hashicorp/go-version"
 	"github.com/sirupsen/logrus"
 )
+
+const (
+	nodeRetrievalMaxRetries = 15
+)
+
+func waitForNodeInformation(nodeName string) *node.Node {
+	backoff := backoff.Exponential{
+		Min:    time.Duration(200) * time.Millisecond,
+		Factor: 2.0,
+		Name:   "k8s-node-retrieval",
+	}
+
+	for retry := 0; retry < nodeRetrievalMaxRetries; retry++ {
+		n, err := retrieveNodeInformation(nodeName)
+		if err != nil {
+			log.WithError(err).Warning("Waiting for k8s node information")
+			backoff.Wait()
+			continue
+		}
+
+		return n
+	}
+
+	return nil
+}
+
+func retrieveNodeInformation(nodeName string) (*node.Node, error) {
+	requireIPv4CIDR := option.Config.K8sRequireIPv4PodCIDR
+	requireIPv6CIDR := option.Config.K8sRequireIPv6PodCIDR
+
+	k8sNode, err := GetNode(Client(), nodeName)
+	if err != nil {
+		// If no CIDR is required, retrieving the node information is
+		// optional
+		if !requireIPv4CIDR && !requireIPv6CIDR {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("unable to retrieve k8s node information: %s", err)
+
+	}
+
+	n := ParseNode(k8sNode)
+	log.WithField(logfields.NodeName, n.Name).Info("Retrieved node information from kubernetes")
+
+	if requireIPv4CIDR && n.IPv4AllocCIDR == nil {
+		return nil, fmt.Errorf("Required IPv4 pod CIDR not present in node resource")
+	}
+
+	if requireIPv6CIDR && n.IPv6AllocCIDR == nil {
+		return nil, fmt.Errorf("Required IPv6 pod CIDR not present in node resource")
+	}
+
+	return n, nil
+}
 
 // Init initializes the Kubernetes package. It is required to call Configure()
 // beforehand.
@@ -51,31 +109,32 @@ func Init() error {
 		// automatically derived
 		node.SetName(nodeName)
 
-		k8sNode, err := GetNode(Client(), nodeName)
-		if err != nil {
-			log.WithError(err).Warning("Unable to retrieve k8s node information, skipping...")
-			return nil
-		}
+		if n := waitForNodeInformation(nodeName); n != nil {
+			log.WithFields(logrus.Fields{
+				logfields.NodeName:         n.Name,
+				logfields.IPAddr + ".ipv4": n.GetNodeIP(false),
+				logfields.IPAddr + ".ipv6": n.GetNodeIP(true),
+			}).Info("Received own node information from API server")
 
-		n := ParseNode(k8sNode)
-		log.WithField(logfields.NodeName, n.Name).Info("Retrieved node information from kubernetes")
+			if err := node.UseNodeCIDR(n); err != nil {
+				return fmt.Errorf("unable to use k8s node CIDRs: %s", err)
+			}
 
-		log.WithFields(logrus.Fields{
-			logfields.NodeName:         n.Name,
-			logfields.IPAddr + ".ipv4": n.GetNodeIP(false),
-			logfields.IPAddr + ".ipv6": n.GetNodeIP(true),
-		}).Info("Received own node information from API server")
-
-		if err := node.UseNodeCIDR(n); err != nil {
-			return fmt.Errorf("unable to retrieve k8s node CIDR: %s", err)
-		}
-
-		if err := node.UseNodeAddresses(n); err != nil {
-			return fmt.Errorf("unable to use k8s node addresses: %s", err)
+			if err := node.UseNodeAddresses(n); err != nil {
+				return fmt.Errorf("unable to use k8s node addresses: %s", err)
+			}
+		} else {
+			// if node resource could not be received, fail if
+			// PodCIDR requirement has been requested
+			if option.Config.K8sRequireIPv4PodCIDR || option.Config.K8sRequireIPv6PodCIDR {
+				log.Fatal("Unable to derive PodCIDR from Kubernetes node resource, giving up")
+			}
 		}
 
 		// Annotate addresses will occur later since the user might
 		// want to specify them manually
+	} else if option.Config.K8sRequireIPv4PodCIDR || option.Config.K8sRequireIPv6PodCIDR {
+		return fmt.Errorf("node name must be specified via environment variable '%s' to retrieve Kubernetes PodCIDR range", EnvNodeNameSpec)
 	}
 
 	return nil

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -49,6 +49,12 @@ const (
 
 	// IPv6ClusterAllocCIDRName is the name of the IPv6ClusterAllocCIDR option
 	IPv6ClusterAllocCIDRName = "ipv6-cluster-alloc-cidr"
+
+	// K8sRequireIPv4PodCIDRName is the name of the K8sRequireIPv4PodCIDR option
+	K8sRequireIPv4PodCIDRName = "k8s-require-ipv4-pod-cidr"
+
+	// K8sRequireIPv6PodCIDRName is the name of the K8sRequireIPv6PodCIDR option
+	K8sRequireIPv6PodCIDRName = "k8s-require-ipv6-pod-cidr"
 )
 
 // daemonConfig is the configuration used by Daemon.
@@ -116,6 +122,16 @@ type daemonConfig struct {
 	// This variable should never be written to, it is initialized via
 	// daemonConfig.Validate()
 	IPv6ClusterAllocCIDRBase string
+
+	// K8sRequireIPv4PodCIDR requires the k8s node resource to specify the
+	// IPv4 PodCIDR. Cilium will block bootstrapping until the information
+	// is available.
+	K8sRequireIPv4PodCIDR bool
+
+	// K8sRequireIPv6PodCIDR requires the k8s node resource to specify the
+	// IPv6 PodCIDR. Cilium will block bootstrapping until the information
+	// is available.
+	K8sRequireIPv6PodCIDR bool
 }
 
 var (

--- a/test/k8sT/manifests/cilium_ds.jsonnet
+++ b/test/k8sT/manifests/cilium_ds.jsonnet
@@ -9,6 +9,7 @@ deploy {
         "--kvstore=etcd",
         "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config",
         "--disable-ipv4=$(DISABLE_IPV4)",
-        "--debug-verbose=flow"
+        "--debug-verbose=flow",
+        "--k8s-require-ipv4-pod-cidr"
     ]
 }

--- a/test/k8sT/manifests/cilium_ds_geneve.jsonnet
+++ b/test/k8sT/manifests/cilium_ds_geneve.jsonnet
@@ -9,6 +9,7 @@ deploy {
         "--kvstore=etcd",
         "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config",
         "--disable-ipv4=$(DISABLE_IPV4)",
-        "--debug-verbose=flow"
+        "--debug-verbose=flow",
+        "--k8s-require-ipv4-pod-cidr"
     ]
 }


### PR DESCRIPTION
Kubernetes is capable of allocating pod CIDRs to nodes and distributing them
via the node resource. Cilium is capable of deriving and using the allocated
pod CIDRS. However, Kubernetes only allocates pod CIDRs once the node has been
declared ready. The deployment of Cilium itself can be required for the node to
become ready. This creates a chicken-egg problem.

Introduce new flags which put Cilium into a mode where Cilium waits for the
IPv4 and/or the IPv6 pod CIDR to be distributed via the node resource. This
allows to reliably derive the pod CIDR from Kubernetes and refuse to start up
otherwise.

Fixes: #4324

Signed-off-by: Thomas Graf <thomas@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4330)
<!-- Reviewable:end -->
