### PR TITLE
Test: Add cep output on Kubernetes report

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1200,6 +1200,7 @@ func (kub *Kubectl) GatherLogs() {
 		"kubectl get nodes -o json":                                    "nodes.txt",
 		"kubectl get ds --all-namespaces -o json":                      "ds.txt",
 		"kubectl get cnp --all-namespaces -o json":                     "cnp.txt",
+		"kubectl get cep --all-namespaces -o json":                     "cep.txt",
 		"kubectl get netpol --all-namespaces -o json":                  "netpol.txt",
 		"kubectl describe pods --all-namespaces":                       "pods_status.txt",
 		"kubectl get replicationcontroller --all-namespaces -o json":   "replicationcontroller.txt",


### PR DESCRIPTION
Added `kubectl get cep` output on reportDump helper.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4331)
<!-- Reviewable:end -->
