### PR TITLE
pkg/bpf: include map file descriptor in error messages

### DIFF
--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -158,7 +158,7 @@ func UpdateElement(fd int, key, value unsafe.Pointer, flags uint64) error {
 	)
 
 	if ret != 0 || err != 0 {
-		return fmt.Errorf("Unable to update element: %s", err)
+		return fmt.Errorf("Unable to update element for map with file descriptor %d: %s", fd, err)
 	}
 
 	return nil
@@ -181,7 +181,7 @@ func LookupElement(fd int, key, value unsafe.Pointer) error {
 	)
 
 	if ret != 0 || err != 0 {
-		return fmt.Errorf("Unable to lookup element: %s", err)
+		return fmt.Errorf("Unable to lookup element in map with file descriptor %d: %s", fd, err)
 	}
 
 	return nil
@@ -201,7 +201,7 @@ func DeleteElement(fd int, key unsafe.Pointer) error {
 	)
 
 	if ret != 0 || err != 0 {
-		return fmt.Errorf("Unable to delete element: %s", err)
+		return fmt.Errorf("Unable to delete element from map with file descriptor %d: %s", fd, err)
 	}
 
 	return nil
@@ -222,7 +222,7 @@ func GetNextKey(fd int, key, nextKey unsafe.Pointer) error {
 	)
 
 	if ret != 0 || err != 0 {
-		return fmt.Errorf("Unable to get next key: %s", err)
+		return fmt.Errorf("Unable to get next key from map with file descriptor %d: %s", fd, err)
 	}
 
 	return nil
@@ -253,7 +253,7 @@ func ObjPin(fd int, pathname string) error {
 	)
 
 	if ret != 0 || err != 0 {
-		return fmt.Errorf("Unable to pin object to %s: %s", pathname, err)
+		return fmt.Errorf("Unable to pin object with file descriptor %d to %s: %s", fd, pathname, err)
 	}
 
 	return nil


### PR DESCRIPTION
Issues like #3621 occasionally appear saying that map updates failed due to bad file descriptors. But, the errors do not contain what the file descriptor which is supposedly bad, is. Return this in the error for map lifecycle operations for easier debugging.

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #3666

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4341)
<!-- Reviewable:end -->
