### PR TITLE
Test: Fix PodCIDR issues on Kubernetes 1.7

### DIFF
--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -66,10 +66,6 @@ api:
 criSocket: "{{ .KUBEADM_CRI_SOCKET }}"
 kubernetesVersion: "v{{ .K8S_FULL_VERSION }}"
 token: "{{ .TOKEN }}"
-controllerManagerExtraArgs:
-  allocate-node-cidrs: "true"
-  cluster-cidr: "{{ .KUBEADM_POD_NETWORK }}/{{ .KUBEADM_POD_CIDR}}"
-  node-cidr-mask-size: "{{ .KUBEADM_POD_CIDR }}"
 networking:
   podSubnet: "{{ .KUBEADM_POD_NETWORK }}/{{ .KUBEADM_POD_CIDR}}"
 EOF


### PR DESCRIPTION
On Kubernetes 1.7 PodSubnet was not correctly applied, because the
controller arguments had two times the parameters configured.

As seen in the code[0], if the PodSubnet is configured, all ExtraArgs
are created by Kubeadm.

[0] Kubernetes 1.7: https://github.com/kubernetes/kubernetes/blob/release-1.7/cmd/kubeadm/app/master/manifests.go#L450-L454
[0] Kubernetes master: https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/phases/controlplane/manifests.go#L304-L309



Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4352)
<!-- Reviewable:end -->
