### PR TITLE
Test: Refactor CiliumEndpointWait

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -800,46 +800,59 @@ func (kub *Kubectl) CiliumEndpointsListByLabel(pod, label string) (EndpointMap, 
 	return result, nil
 }
 
-// CiliumEndpointWait waits until all endpoints managed by the specified Cilium
-// pod are ready. Returns false if the command to retrieve the state of the
-// endpoints times out.
-func (kub *Kubectl) CiliumEndpointWait(pod string) bool {
+// CiliumEndpointWaitReady waits until all endpoints managed by all Cilium pod
+// are ready. Returns an error if the Cilium pods cannot be retrieved via
+// Kubernetes, or endpoints are not ready after a specified timeout
+func (kub *Kubectl) CiliumEndpointWaitReady() error {
+	ciliumPods, err := kub.GetCiliumPods(KubeSystemNamespace)
+	if err != nil {
+		kub.logger.WithError(err).Error("cannot get Cilium pods")
+		return err
+	}
 
 	body := func() bool {
-		status, err := kub.CiliumEndpointsList(pod).Filter("{range [*]}{.status.state},{.status.identity.id} {end}")
-		if err != nil {
-			return false
-		}
+		for _, pod := range ciliumPods {
+			logCtx := kub.logger.WithField("pod", pod)
+			status, err := kub.CiliumEndpointsList(pod).Filter(`{range [*]}{.status.state}{"="}{.status.identity.id}{"\n"}{end}`)
+			if err != nil {
+				logCtx.WithError(err).Errorf("cannot get endpoints states on Cilium pod")
+				return false
+			}
+			total := 0
+			invalid := 0
+			for _, line := range strings.Split(status.String(), "\n") {
+				if line == "" {
+					continue
+				}
+				// each line is like status=identityID.
+				// IdentityID is needed because the reserved:init identity
+				// means that the pod is not ready to accept traffic.
+				total++
+				vals := strings.Split(line, "=")
+				if len(vals) != 2 {
+					logCtx.Errorf("Endpoint list does not have a correct output '%s'", line)
+					return false
+				}
+				if vals[0] != "ready" {
+					invalid++
+				}
+				// Consider an endpoint with reserved identity 5 (reserved:init) as not ready.
+				if vals[1] == "5" {
+					invalid++
+				}
+			}
+			logCtx.WithFields(logrus.Fields{
+				"total":   total,
+				"invalid": invalid,
+			}).Info("Waiting for cilium endpoints to be ready")
 
-		var valid, invalid int
-		for _, endpoint := range strings.Split(strings.TrimRight(status.String(), " "), " ") {
-			fields := strings.Split(endpoint, ",")
-			state := fields[0]
-			secID := fields[1]
-			// Consider an endpoint with reserved identity 5 (reserved:init) as not ready.
-			if state != "ready" || secID == "5" {
-				invalid++
-			} else {
-				valid++
+			if invalid != 0 {
+				return false
 			}
 		}
-		if invalid == 0 {
-			return true
-		}
-
-		kub.logger.WithFields(logrus.Fields{
-			"pod":     pod,
-			"valid":   valid,
-			"invalid": invalid,
-		}).Info("Waiting for cilium endpoints")
-		return false
+		return true
 	}
-
-	err := WithTimeout(body, "cannot retrieve endpoints", &TimeoutConfig{Timeout: HelperTimeout})
-	if err != nil {
-		return false
-	}
-	return true
+	return WithTimeout(body, "cannot retrieve endpoints", &TimeoutConfig{Timeout: HelperTimeout})
 }
 
 // CiliumEndpointPolicyVersion returns a mapping of each endpoint's ID to its

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -233,7 +233,8 @@ func (kubectl *Kubectl) WaitCiliumEndpointReady(podFilter string, k8sNode string
 	status := kubectl.CiliumExec(ciliumPod, fmt.Sprintf("cilium config %s=%s", PolicyEnforcement, PolicyEnforcementDefault))
 	status.ExpectSuccess()
 
-	kubectl.CiliumEndpointWait(ciliumPod)
+	err = kubectl.CiliumEndpointWaitReady()
+	Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 
 	epsStatus := WithTimeout(func() bool {
 		endpoints, err := kubectl.CiliumEndpointsListByLabel(ciliumPod, podFilter)

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -103,6 +103,9 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 			fmt.Sprintf("-l zgroup=testDSClient"), 300)
 		Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 
+		err = kubectl.CiliumEndpointWaitReady()
+		Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
+
 		PingService()
 
 		By("Deleting cilium pods")
@@ -130,6 +133,9 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 		Expect(err).To(BeNil(), "Cilium cannot be installed")
 
 		ExpectCiliumReady(kubectl)
+
+		err = kubectl.CiliumEndpointWaitReady()
+		Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 
 		PingService()
 	})

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -125,9 +125,11 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 				ciliumPod, fmt.Sprintf("cilium config %s=%s",
 					helpers.PolicyEnforcement, helpers.PolicyEnforcementDefault))
 			status.ExpectSuccess()
-			kubectl.CiliumEndpointWait(ciliumPod)
 
-			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", 300)
+			err := kubectl.CiliumEndpointWaitReady()
+			Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
+
+			err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", 300)
 			Expect(err).Should(BeNil())
 
 		})
@@ -162,9 +164,10 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 					helpers.PolicyEnforcement, helpers.PolicyEnforcementAlways))
 			status.ExpectSuccess()
 
-			kubectl.CiliumEndpointWait(ciliumPod)
+			err := kubectl.CiliumEndpointWaitReady()
+			Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 
-			endpoints, err := kubectl.CiliumEndpointsListByLabel(ciliumPod, podFilter)
+			endpoints, err = kubectl.CiliumEndpointsListByLabel(ciliumPod, podFilter)
 			Expect(err).Should(BeNil())
 			Expect(endpoints.AreReady()).Should(BeTrue())
 			policyStatus = endpoints.GetPolicyStatus()
@@ -181,7 +184,8 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 					helpers.PolicyEnforcement, helpers.PolicyEnforcementDefault))
 			status.ExpectSuccess()
 
-			kubectl.CiliumEndpointWait(ciliumPod)
+			err = kubectl.CiliumEndpointWaitReady()
+			Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 
 			endpoints, err = kubectl.CiliumEndpointsListByLabel(ciliumPod, podFilter)
 			Expect(err).Should(BeNil())
@@ -1022,15 +1026,13 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 			res.ExpectContains("403", "Unexpected response code,wanted HTTP 403")
 		}
 
-		ciliumPodK8s2, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s2)
-		Expect(err).Should(BeNil())
-
 		ciliumPods, err := kubectl.GetCiliumPods(helpers.KubeSystemNamespace)
 		Expect(err).To(BeNil(), "cannot get cilium pods")
 
-		By("Waiting for endpoints to be ready on k8s-2 node")
-		areEndpointsReady := kubectl.CiliumEndpointWait(ciliumPodK8s2)
-		Expect(areEndpointsReady).Should(BeTrue())
+		By("Waiting for endpoints to be ready on cilium")
+
+		err = kubectl.CiliumEndpointWaitReady()
+		Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 
 		err = kubectl.WaitForServiceEndpoints(
 			developmentNs, "", "backend", "80", helpers.HelperTimeout)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -265,8 +265,8 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 			ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, node)
 			ExpectWithOffset(1, err).Should(BeNil(), "was not able to retrieve Cilium pod on node %s", node)
 
-			status := kubectl.CiliumEndpointWait(ciliumPod)
-			ExpectWithOffset(1, status).To(BeTrue(), "timed out waiting for endpoints to be ready")
+			err = kubectl.CiliumEndpointWaitReady()
+			Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 
 			endpointIDs := kubectl.CiliumEndpointsIDs(ciliumPod)
 			endpointID := endpointIDs[fmt.Sprintf("%s:%s", helpers.DefaultNamespace, podName)]

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -88,6 +88,10 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 			ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
 			Expect(err).Should(BeNil())
 
+			By("Making sure all endpoints are in ready state")
+			err = kubectl.CiliumEndpointWaitReady()
+			Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
+
 			_, err = kubectl.CiliumNodesWait()
 			Expect(err).Should(BeNil())
 
@@ -126,6 +130,10 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 
 			_, err = kubectl.CiliumNodesWait()
 			Expect(err).Should(BeNil())
+
+			By("Making sure all endpoints are in ready state")
+			err = kubectl.CiliumEndpointWaitReady()
+			Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 
 			//Check that cilium detects a
 			By("Checking that BPF tunnels are in place")

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -97,10 +97,6 @@ var _ = Describe(demoTestName, func() {
 
 		exhaustPortPath := filepath.Join(deathstarServiceName, "/v1/exhaust-port")
 
-		By("Getting Cilium Pod on node %s", helpers.K8s2)
-		ciliumPod2, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s2)
-		Expect(err).Should(BeNil(), "unable to get Cilium pod on node %s", helpers.K8s2)
-
 		// Taint the node instead of adding a nodeselector in the file so that we
 		// don't have to customize the YAML for this test.
 		By("Tainting %s so that all pods run on %s", helpers.K8s1, helpers.K8s2)
@@ -117,7 +113,7 @@ var _ = Describe(demoTestName, func() {
 		res.ExpectSuccess("unable to apply %s: %s", deathStarYAMLLink, res.CombineOutput())
 
 		By("Waiting for deathstar deployment pods to be ready")
-		err = kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", empireLabel), 300)
+		err := kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", empireLabel), 300)
 		Expect(err).Should(BeNil(), "Empire pods are not ready after timeout")
 
 		By("Applying policy and waiting for policy revision to increase in Cilium pods")
@@ -141,8 +137,8 @@ var _ = Describe(demoTestName, func() {
 		xwingPod := xwingPods[0]
 
 		By("Making sure all endpoints are in ready state")
-		arePodsReady := kubectl.CiliumEndpointWait(ciliumPod2)
-		Expect(arePodsReady).To(BeTrue(), "pods running on k8s2 are not ready")
+		err = kubectl.CiliumEndpointWaitReady()
+		Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 
 		By("Showing how alliance can execute REST API call to main API endpoint")
 
@@ -159,8 +155,8 @@ var _ = Describe(demoTestName, func() {
 		res.ExpectSuccess("unable to apply %s: %s", l7PolicyYAMLLink, res.CombineOutput())
 
 		By("Waiting for endpoints to be ready after importing policy")
-		arePodsReady = kubectl.CiliumEndpointWait(ciliumPod2)
-		Expect(arePodsReady).To(BeTrue(), "pods running on k8s2 are not ready")
+		err = kubectl.CiliumEndpointWaitReady()
+		Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 
 		By("Showing how alliance cannot access %q without force header in API request after importing L7 Policy", exhaustPortPath)
 		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, xwingPod,


### PR DESCRIPTION
Refactor CiliumEndpointWait to CiliumEndpointWaitReady and avoid to use
CiliumPod per each call. Use of separate functions has been inefficient
now that we have CEP resource, the idea is to avoid the use of
CiliumPodk8s1 and CiliumPodk8s2 in the test.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4355)
<!-- Reviewable:end -->
