### PR TITLE
bugtool: get list of open file descriptors

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -78,6 +78,8 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		fmt.Sprintf("gops memstats $(pidof %s)", helpers.AgentDaemon),
 		fmt.Sprintf("gops stack $(pidof %s)", helpers.AgentDaemon),
 		fmt.Sprintf("gops stats $(pidof %s)", helpers.AgentDaemon),
+		// Get list of open file descriptors managed by the agent
+		fmt.Sprintf("ls -la /proc/$(pidof %s)/fd", helpers.AgentDaemon),
 	}
 
 	// Commands that require variables and / or more configuration are added


### PR DESCRIPTION
As part of cilium-bugtool, run `ls -la /proc/$(pidof %s)/fd`. This will help
in triaging issues where maps are unable to be accessed within the agent with
errors like 'bad file descriptor'.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #4333
Related-to: #4229 

**How to test (optional)**:
1. Compile Cilium
2. Run `cilium-bugtool`, and decompress the created archive.
3. Open the file ` cmd/ls--la--proc-\$\(pidof-cilium-agent\)-fd.md `. It will have output like the following:

# ls -la /proc/$(pidof cilium-agent)/fd

```
total 0
dr-x------ 2 root root  0 Jun  4 17:52 .
dr-xr-xr-x 9 root root  0 Jun  4 17:52 ..
lr-x------ 1 root root 64 Jun  4 17:52 0 -> /dev/null
lrwx------ 1 root root 64 Jun  4 17:52 1 -> socket:[59878]
lrwx------ 1 root root 64 Jun  4 17:52 10 -> anon_inode:bpf-map
lrwx------ 1 root root 64 Jun  4 17:52 11 -> socket:[59973]
lrwx------ 1 root root 64 Jun  4 17:52 12 -> anon_inode:bpf-map
lrwx------ 1 root root 64 Jun  4 17:52 13 -> anon_inode:bpf-map
lrwx------ 1 root root 64 Jun  4 17:52 14 -> anon_inode:bpf-map
lrwx------ 1 root root 64 Jun  4 17:52 15 -> socket:[65241]
lrwx------ 1 root root 64 Jun  4 17:52 16 -> anon_inode:bpf-map
lrwx------ 1 root root 64 Jun  4 17:52 17 -> anon_inode:bpf-map
lrwx------ 1 root root 64 Jun  4 17:52 18 -> anon_inode:bpf-map
lrwx------ 1 root root 64 Jun  4 17:52 19 -> anon_inode:bpf-map
lrwx------ 1 root root 64 Jun  4 17:52 2 -> socket:[59878]
lrwx------ 1 root root 64 Jun  4 17:52 20 -> anon_inode:bpf-map
lrwx------ 1 root root 64 Jun  4 17:52 21 -> socket:[61135]
lrwx------ 1 root root 64 Jun  4 17:52 22 -> anon_inode:bpf-map
lrwx------ 1 root root 64 Jun  4 17:52 23 -> socket:[61133]
lrwx------ 1 root root 64 Jun  4 17:52 24 -> socket:[64329]
lr-x------ 1 root root 64 Jun  4 17:52 25 -> pipe:[61181]
lrwx------ 1 root root 64 Jun  4 17:52 26 -> socket:[60255]
lrwx------ 1 root root 64 Jun  4 17:52 27 -> /run/cilium/events.sock
lr-x------ 1 root root 64 Jun  4 17:52 28 -> pipe:[60112]
lr-x------ 1 root root 64 Jun  4 17:52 29 -> pipe:[61182]
lrwx------ 1 root root 64 Jun  4 17:52 3 -> socket:[60644]
lrwx------ 1 root root 64 Jun  4 17:52 30 -> socket:[60253]
lrwx------ 1 root root 64 Jun  4 17:52 31 -> anon_inode:bpf-map
lrwx------ 1 root root 64 Jun  4 17:52 32 -> socket:[60254]
lrwx------ 1 root root 64 Jun  4 17:52 33 -> socket:[61384]
lrwx------ 1 root root 64 Jun  4 17:52 34 -> socket:[60258]
lr-x------ 1 root root 64 Jun  4 17:52 35 -> pipe:[60260]
lrwx------ 1 root root 64 Jun  4 17:52 36 -> socket:[60269]
lrwx------ 1 root root 64 Jun  4 17:52 37 -> socket:[61408]
lrwx------ 1 root root 64 Jun  4 17:52 4 -> anon_inode:[eventpoll]
lrwx------ 1 root root 64 Jun  4 17:52 5 -> anon_inode:bpf-map
lrwx------ 1 root root 64 Jun  4 17:52 6 -> anon_inode:bpf-map
lrwx------ 1 root root 64 Jun  4 17:52 7 -> anon_inode:bpf-map
lrwx------ 1 root root 64 Jun  4 17:52 8 -> anon_inode:bpf-map
lrwx------ 1 root root 64 Jun  4 17:52 9 -> anon_inode:bpf-map

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4358)
<!-- Reviewable:end -->
