### PR TITLE
Fix API breakage for host vs world behaviour in Cilium 1.1 release candidates

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -71,6 +71,7 @@ committer
 committers
 conf
 config
+ConfigMap
 containerd
 contributing
 CoreOS
@@ -352,6 +353,7 @@ rebased
 recompiles
 regenerations
 regex
+remediate
 reparsing
 repo
 repos

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -73,6 +73,7 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/mattn/go-shellwords"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 	"github.com/vishvananda/netlink"
 )
 
@@ -1071,6 +1072,15 @@ func NewDaemon() (*Daemon, error) {
 		if option.Config.AllowLocalhost == option.AllowLocalhostAuto {
 			option.Config.AllowLocalhost = option.AllowLocalhostAlways
 			log.Info("k8s mode: Allowing localhost to reach local endpoints")
+		}
+
+		// In Cilium 1.0, due to limitations on the data path, traffic
+		// from the outside world on ingress was treated as though it
+		// was from the host for policy purposes. In order to not break
+		// existing policies, this option retains the behavior.
+		if viper.GetString("k8s-legacy-host-allows-world") != "false" {
+			option.Config.HostAllowsWorld = true
+			log.Warn("k8s mode: Configuring ingress policy for host to also allow from world. For more information, see https://cilium.link/host-vs-world")
 		}
 
 		if !singleClusterRoute {

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -358,6 +358,7 @@ func init() {
 		"k8s-api-server", "", "Kubernetes api address server (for https use --k8s-kubeconfig-path instead)")
 	flags.StringVar(&k8sKubeConfigPath,
 		"k8s-kubeconfig-path", "", "Absolute path of the kubernetes kubeconfig file")
+	viper.BindEnv("k8s-legacy-host-allows-world", "CILIUM_LEGACY_HOST_ALLOWS_WORLD")
 	flags.BoolVar(&option.Config.KeepConfig,
 		"keep-config", false, "When restoring state, keeps containers' configuration in place")
 	flags.BoolVar(&option.Config.KeepTemplates,

--- a/examples/kubernetes/1.10/cilium-cm.yaml
+++ b/examples/kubernetes/1.10/cilium-cm.yaml
@@ -28,6 +28,7 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
+  legacy-host-allows-world: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -101,6 +101,12 @@ spec:
                 name: cilium-metrics-config
                 optional: true
                 key: prometheus-serve-addr
+          - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: legacy-host-allows-world
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -28,6 +28,7 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
+  legacy-host-allows-world: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret
@@ -148,6 +149,12 @@ spec:
                 name: cilium-metrics-config
                 optional: true
                 key: prometheus-serve-addr
+          - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: legacy-host-allows-world
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.11/cilium-cm.yaml
+++ b/examples/kubernetes/1.11/cilium-cm.yaml
@@ -28,6 +28,7 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
+  legacy-host-allows-world: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -101,6 +101,12 @@ spec:
                 name: cilium-metrics-config
                 optional: true
                 key: prometheus-serve-addr
+          - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: legacy-host-allows-world
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -28,6 +28,7 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
+  legacy-host-allows-world: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret
@@ -148,6 +149,12 @@ spec:
                 name: cilium-metrics-config
                 optional: true
                 key: prometheus-serve-addr
+          - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: legacy-host-allows-world
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.7/cilium-cm.yaml
+++ b/examples/kubernetes/1.7/cilium-cm.yaml
@@ -28,6 +28,7 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
+  legacy-host-allows-world: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -101,6 +101,12 @@ spec:
                 name: cilium-metrics-config
                 optional: true
                 key: prometheus-serve-addr
+          - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: legacy-host-allows-world
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -28,6 +28,7 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
+  legacy-host-allows-world: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret
@@ -148,6 +149,12 @@ spec:
                 name: cilium-metrics-config
                 optional: true
                 key: prometheus-serve-addr
+          - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: legacy-host-allows-world
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.8/cilium-cm.yaml
+++ b/examples/kubernetes/1.8/cilium-cm.yaml
@@ -28,6 +28,7 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
+  legacy-host-allows-world: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -101,6 +101,12 @@ spec:
                 name: cilium-metrics-config
                 optional: true
                 key: prometheus-serve-addr
+          - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: legacy-host-allows-world
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -28,6 +28,7 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
+  legacy-host-allows-world: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret
@@ -148,6 +149,12 @@ spec:
                 name: cilium-metrics-config
                 optional: true
                 key: prometheus-serve-addr
+          - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: legacy-host-allows-world
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.9/cilium-cm.yaml
+++ b/examples/kubernetes/1.9/cilium-cm.yaml
@@ -28,6 +28,7 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
+  legacy-host-allows-world: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -101,6 +101,12 @@ spec:
                 name: cilium-metrics-config
                 optional: true
                 key: prometheus-serve-addr
+          - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: legacy-host-allows-world
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -28,6 +28,7 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
+  legacy-host-allows-world: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret
@@ -148,6 +149,12 @@ spec:
                 name: cilium-metrics-config
                 optional: true
                 key: prometheus-serve-addr
+          - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: legacy-host-allows-world
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/cilium.yaml
+++ b/examples/kubernetes/cilium.yaml
@@ -25,6 +25,7 @@ data:
   # If you want to run cilium in debug mode change this value to true
   debug: "false"
   disable-ipv4: "false"
+  legacy-host-allows-world: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret
@@ -142,6 +143,12 @@ spec:
                 name: cilium-metrics-config
                 optional: true
                 key: prometheus-serve-addr
+          - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: legacy-host-allows-world
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/templates/v1/cilium-cm.yaml
+++ b/examples/kubernetes/templates/v1/cilium-cm.yaml
@@ -28,6 +28,7 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
+  legacy-host-allows-world: "false"
 ---
 # The etcd secrets can be populated in kubernetes.
 # For more information see: https://kubernetes.io/docs/concepts/configuration/secret

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -101,6 +101,12 @@ spec:
                 name: cilium-metrics-config
                 optional: true
                 key: prometheus-serve-addr
+          - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: legacy-host-allows-world
         livenessProbe:
           exec:
             command:

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -84,6 +84,10 @@ type daemonConfig struct {
 	// values: { auto | always | policy }
 	AllowLocalhost string
 
+	// HostAllowsWorld applies the same policy to world-sourced traffic as
+	// host-sourced traffic, to provide compatibility with Cilium 1.0.
+	HostAllowsWorld bool
+
 	// StateDir is the directory where runtime state of endpoints is stored
 	StateDir string
 

--- a/test/k8sT/manifests/cilium_ds.template
+++ b/test/k8sT/manifests/cilium_ds.template
@@ -12,6 +12,7 @@
         "etcd-config": "---\nendpoints:\n- http://" + $.etcdEndpoint + "\n#\n# In case you want to use TLS in etcd, uncomment the following line\n# and add the certificate as explained in the comment labeled \"ETCD-CERT\"\n#ca-file: '/var/lib/etcd-secrets/etcd-ca'\n#\n# In case you want client to server authentication, uncomment the following\n# lines and add the certificate and key in cilium-etcd-secrets below\n#key-file: '/var/lib/etcd-secrets/etcd-client-key'\n#cert-file: '/var/lib/etcd-secrets/etcd-client-crt'",
         "debug": "true",
         "disable-ipv4": "false",
+        "legacy-host-allows-world": "false",
         "sidecar-http-proxy": "false",
         "clean-cilium-state": "false"
       }
@@ -173,6 +174,16 @@
                         "name": "cilium-metrics-config",
                         "optional": true,
                         "key": "prometheus-serve-addr"
+                      }
+                    }
+                  },
+                  {
+                    "name": "CILIUM_LEGACY_HOST_ALLOWS_WORLD",
+                    "valueFrom": {
+                      "configMapKeyRef": {
+                        "name": "cilium-config",
+                        "key": "legacy-host-allows-world",
+                        "optional": true
                       }
                     }
                   }


### PR DESCRIPTION
This PR fixes the API breakage caused by #3988 by retaining existing behaviour for users upgrading from an earlier release, while defaulting new users to the new behaviour. It also documents the behaviour in the upgrade notes section. For more information, see #4297.

Related: #3988
Fixes: #4297 
Fixes: #4345

Todo:
* [x] Add link for `https://cilium.link/host-vs-world`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4360)
<!-- Reviewable:end -->
