### PR TITLE
daemon: Delete old ID mapping when updating the IP for a reserved ID

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -991,27 +991,44 @@ func (d *Daemon) syncLXCMap() error {
 		},
 	}
 
-	for _, pair := range specialIdentities {
-		isHost := pair.ID == identity.ReservedIdentityHost
+	for _, ipIDPair := range specialIdentities {
+		isHost := ipIDPair.ID == identity.ReservedIdentityHost
 		if isHost {
-			added, err := lxcmap.SyncHostEntry(pair.IP)
+			added, err := lxcmap.SyncHostEntry(ipIDPair.IP)
 			if err != nil {
 				return fmt.Errorf("Unable to add host entry to endpoint map: %s", err)
 			}
 			if added {
-				log.WithField(logfields.IPAddr, pair.IP).Debugf("Added local ip to endpoint map")
+				log.WithField(logfields.IPAddr, ipIDPair.IP).Debugf("Added local ip to endpoint map")
 			}
 		}
-		prefix := pair.PrefixString()
-		id, exists := ipcache.IPIdentityCache.LookupByIP(prefix)
-		if !exists || id != pair.ID {
+		prefix := ipIDPair.PrefixString()
+		cachedIdentity, exists := ipcache.IPIdentityCache.LookupByIP(prefix)
+		if !exists || cachedIdentity != ipIDPair.ID {
 			// Upsert will not propagate (reserved:foo->ID) mappings across the cluster,
 			// and we specifically don't want to do so.
 			// Manually push it into each IPIdentityMappingListener.
-			log.WithField(logfields.IPAddr, prefix).Debug("Adding special identity to ipcache")
-			ipcache.IPIdentityCache.Upsert(prefix, pair.ID)
+			log.WithFields(logrus.Fields{
+				logfields.IPAddr:       ipIDPair.IP,
+				logfields.IPMask:       ipIDPair.Mask,
+				logfields.OldIdentity:  cachedIdentity,
+				logfields.Identity:     ipIDPair.ID,
+				logfields.Modification: ipcache.Upsert,
+			}).Debug("Adding special identity to ipcache")
+			ipcache.IPIdentityCache.Upsert(prefix, ipIDPair.ID)
+
+			var oldIPIDPair *identity.IPIdentityPair
+			if cachedIdentity != ipIDPair.ID {
+				// If an existing mapping is updated,
+				// provide the existing mapping to the
+				// listener so it can easily clean up
+				// the old mapping.
+				pair := ipIDPair
+				pair.ID = cachedIdentity
+				oldIPIDPair = &pair
+			}
 			for _, listener := range d.ipcacheListeners {
-				listener.OnIPIdentityCacheChange(ipcache.Upsert, nil, pair)
+				listener.OnIPIdentityCacheChange(ipcache.Upsert, oldIPIDPair, ipIDPair)
 			}
 		}
 	}

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -580,7 +580,7 @@ func ipIdentityWatcher(listeners []IPIdentityMappingListener) {
 				log.WithFields(logrus.Fields{
 					logfields.IPAddr:       ipIDPair.IP,
 					logfields.IPMask:       ipIDPair.Mask,
-					"cached-identity":      cachedIdentity,
+					logfields.OldIdentity:  cachedIdentity,
 					logfields.Identity:     ipIDPair.ID,
 					logfields.Modification: cacheModification,
 				}).Debugf("endpoint IP cache state change")


### PR DESCRIPTION
Fix logging.
Homogenize the code calling OnIPIdentityCacheChange to make it
easier to maintain.

Fixes: https://github.com/cilium/cilium/issues/4277
Fixes: https://github.com/cilium/cilium/pull/4172
Fixes: https://github.com/cilium/cilium/commit/8b64ca827b78a9787015f29cd075d04906068f0c
Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4365)
<!-- Reviewable:end -->
