### PR TITLE
Test: Use Kubecfg native options.

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -718,14 +718,22 @@ func (kub *Kubectl) ApplyNetworkPolicyUsingAPI(namespace string, networkPolicy *
 // and will be used in `kubecfg show` and applied to Kubernetes. It will return
 // a error if any action fails.
 func (kub *Kubectl) CiliumInstall(manifestName string) error {
-	manifestTmpPath := GetFilePath(fmt.Sprintf("%s_%s", MakeUID(), manifestName))
-	res := kub.Exec(fmt.Sprintf("kubecfg show %s | tee %s",
-		ManifestGet(manifestName), manifestTmpPath))
+	ciliumDSManifest := ManifestGet(manifestName)
+	// debugYaml only dumps the full created yaml file to the test output if
+	// the cilium manifest can not be created correctly.
+	debugYaml := func() {
+		_ = kub.Exec(fmt.Sprintf("kubecfg show %s", ciliumDSManifest))
+	}
+
+	res := kub.Exec(fmt.Sprintf("kubecfg validate %s", ciliumDSManifest))
 	if !res.WasSuccessful() {
+		debugYaml()
 		return fmt.Errorf(res.GetDebugMessage())
 	}
-	res = kub.Apply(manifestTmpPath)
+
+	res = kub.Exec(fmt.Sprintf("kubecfg update %s", ciliumDSManifest))
 	if !res.WasSuccessful() {
+		debugYaml()
 		return fmt.Errorf(res.GetDebugMessage())
 	}
 	return nil


### PR DESCRIPTION
Had seen some issues when the output yaml from `kubecfg show` was
correctly on the test output, but the apply is not working as expected.
Maybe it's related with some strange behaviour on flushing stdout to
`tee` and the file was not created correctly.

The only reason to have the `tee` in there is to have the output for
debugging purposes, so I change the logic to `kubecfg validate` and
`kubecfg update`, If one of the two fails, it'll log the `kubecfg show`
output.

Error:
```
Cilium cannot be installed
Expected
    <*errors.errorString | 0xc4203ee780>: {
        s: "cmd: kubectl apply -f  /home/vagrant/go/src/github.com/cilium/cilium/test/9acb0442_cilium_ds.jsonnet\nconfigmap \"cilium-config\" created\nsecret \"cilium-etcd-secrets\" created\nerror: error validating \"/home/vagrant/go/src/github.com/cilium/cilium/test/9acb0442_cilium_ds.jsonnet\": error validating data: ValidationError(DaemonSet.spec.template.spec.initContainers): unknown object type \"nil\" in DaemonSet.spec.template.spec.initContainers[0]; if you choose to ignore these errors, turn validation off with --validate=false\n",
    }
to be nil
/home/jenkins/workspace/Ginkgo-CI-Tests-Pipeline/src/github.com/cilium/cilium/vendor/github.com/onsi/gomega/internal/assertion/assertion.go:35
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4367)
<!-- Reviewable:end -->
