### PR TITLE
test/helpers: Fix WaitForKubeDNSEntry function on timeout

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -589,7 +589,7 @@ func (kub *Kubectl) WaitForKubeDNSEntry(name string) error {
 		name = fmt.Sprintf("%s.%s", name, svcSuffix)
 	}
 	// https://bugs.launchpad.net/ubuntu/+source/bind9/+bug/854705
-	digCMD := "dig +short %s @%s | grep -v -e '^$'"
+	digCMD := "dig +short %s @%s | grep -v -e '^;'"
 
 	// If it fails we want to know if it's because of connection cannot be
 	// established or DNS does not exist.


### PR DESCRIPTION
As the dig request can timeout, the regex used in grep was selecting
the timeout string which caused grep to have an exit code of 0.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4371)
<!-- Reviewable:end -->
