### PR TITLE
pkg/endpoint: Keep BPF object files if compilation is skipped.

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -121,4 +122,30 @@ func RequireRootPrivilege(cmd string) {
 		fmt.Fprintf(os.Stderr, "Please run %q command(s) with root privileges.\n", cmd)
 		os.Exit(1)
 	}
+}
+
+// MoveNewFilesTo copies all files, that do not exist in newDir, from oldDir.
+func MoveNewFilesTo(oldDir, newDir string) error {
+	oldFiles, err := ioutil.ReadDir(oldDir)
+	if err != nil {
+		return err
+	}
+	newFiles, err := ioutil.ReadDir(newDir)
+	if err != nil {
+		return err
+	}
+
+	for _, oldFile := range oldFiles {
+		exists := false
+		for _, newFile := range newFiles {
+			if oldFile.Name() == newFile.Name() {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			os.Rename(filepath.Join(oldDir, oldFile.Name()), filepath.Join(newDir, oldFile.Name()))
+		}
+	}
+	return nil
 }

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -18,6 +18,9 @@ import (
 	"testing"
 
 	"gopkg.in/check.v1"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -58,4 +61,69 @@ func (s *CommonSuite) TestFmtDefineAddress(c *check.C) {
 func (s *CommonSuite) TestFmtDefineArray(c *check.C) {
 	c.Assert(FmtDefineArray("foo", []byte{1, 2, 3}), check.Equals, "#define foo { 0x1, 0x2, 0x3 }\n")
 	c.Assert(FmtDefineArray("foo", []byte{}), check.Equals, "#define foo {  }\n")
+}
+
+func (s *CommonSuite) TestMoveNewFilesTo(c *check.C) {
+	oldDir := c.MkDir()
+	newDir := c.MkDir()
+	f1, err := ioutil.TempFile(oldDir, "")
+	c.Assert(err, check.IsNil)
+	f2, err := ioutil.TempFile(oldDir, "")
+	c.Assert(err, check.IsNil)
+	f3, err := ioutil.TempFile(newDir, "")
+	c.Assert(err, check.IsNil)
+
+	// Copy the same f4 file in both directories to make sure the same files
+	// are not moved from the old directory into the new directory.
+	err = ioutil.WriteFile(filepath.Join(oldDir, "foo"), []byte(""), os.FileMode(0644))
+	c.Assert(err, check.IsNil)
+	err = ioutil.WriteFile(filepath.Join(newDir, "foo"), []byte(""), os.FileMode(0644))
+	c.Assert(err, check.IsNil)
+
+	compareDir := func(dir string, wantedFiles []string) {
+		files, err := ioutil.ReadDir(dir)
+		c.Assert(err, check.IsNil)
+		filesNames := make([]string, 0, len(wantedFiles))
+		for _, file := range files {
+			filesNames = append(filesNames, file.Name())
+		}
+		c.Assert(wantedFiles, check.DeepEquals, filesNames)
+	}
+
+	type args struct {
+		oldDir string
+		newDir string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantErr    bool
+		wantOldDir []string
+		wantNewDir []string
+	}{
+		{
+			name: "copying from one directory to the other",
+			args: args{
+				oldDir: oldDir,
+				newDir: newDir,
+			},
+			wantErr: false,
+			wantOldDir: []string{
+				"foo",
+			},
+			wantNewDir: []string{
+				f1.Name(),
+				f2.Name(),
+				f3.Name(),
+				"foo",
+			},
+		},
+	}
+	for _, tt := range tests {
+		if err := MoveNewFilesTo(tt.args.oldDir, tt.args.newDir); (err != nil) != tt.wantErr {
+			c.Assert(err != nil, check.Equals, tt.wantErr)
+			compareDir(tt.args.oldDir, tt.wantOldDir)
+			compareDir(tt.args.newDir, tt.wantNewDir)
+		}
+	}
 }

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -522,8 +522,13 @@ func (e *Endpoint) removeOldRedirects(owner Owner, desiredRedirects map[string]b
 // regenerateBPF rewrites all headers and updates all BPF maps to reflect the
 // specified endpoint.
 // Must be called with endpoint.Mutex not held and endpoint.BuildMutex held.
-func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, error) {
-	var err error
+// Returns the policy revision number when the regeneration has called, a
+// boolean if the BPF compilation was executed and an error in case of an error.
+func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, bool, error) {
+	var (
+		err                 error
+		compilationExecuted bool
+	)
 
 	// Make sure that owner is not compiling base programs while we are
 	// regenerating an endpoint.
@@ -551,7 +556,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 
 		e.getLogger().WithField(logfields.EndpointState, e.state).Debug("Skipping build due to invalid state")
 		e.Mutex.Unlock()
-		return 0, fmt.Errorf("Skipping build due to invalid state: %s", e.state)
+		return 0, compilationExecuted, fmt.Errorf("Skipping build due to invalid state: %s", e.state)
 	}
 
 	// If dry mode is enabled, no further changes to BPF maps are performed
@@ -562,21 +567,21 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 		// policy change.
 		// Note that PolicyMap is not initialized!
 		if _, err = e.regeneratePolicy(owner, nil); err != nil {
-			return 0, fmt.Errorf("Unable to regenerate policy: %s", err)
+			return 0, compilationExecuted, fmt.Errorf("Unable to regenerate policy: %s", err)
 		}
 
 		// Dry mode needs Network Policy Updates, but e.ProxyWaitGroup must not
 		// be initialized, as there is no proxy ACKing the changes.
 		if err = e.updateNetworkPolicy(owner); err != nil {
-			return 0, err
+			return 0, compilationExecuted, err
 		}
 
 		if err = e.writeHeaderfile(epdir, owner); err != nil {
-			return 0, fmt.Errorf("Unable to write header file: %s", err)
+			return 0, compilationExecuted, fmt.Errorf("Unable to write header file: %s", err)
 		}
 
 		log.WithField(logfields.EndpointID, e.ID).Debug("Skipping bpf updates due to dry mode")
-		return e.nextPolicyRevision, nil
+		return e.nextPolicyRevision, compilationExecuted, nil
 	}
 
 	completionCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -627,14 +632,14 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 		e.PolicyMap, createdPolicyMap, err = policymap.OpenMap(e.PolicyMapPathLocked())
 		if err != nil {
 			e.Mutex.Unlock()
-			return 0, err
+			return 0, compilationExecuted, err
 		}
 		// Clean up map contents
 		log.Debugf("Flushing old policies map")
 		err = e.PolicyMap.Flush()
 		if err != nil {
 			e.Mutex.Unlock()
-			return 0, err
+			return 0, compilationExecuted, err
 		}
 	}
 
@@ -648,7 +653,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 		_, err = e.regeneratePolicy(owner, nil)
 		if err != nil {
 			e.Mutex.Unlock()
-			return 0, fmt.Errorf("unable to regenerate policy for '%s': %s", e.PolicyMap.String(), err)
+			return 0, compilationExecuted, fmt.Errorf("unable to regenerate policy for '%s': %s", e.PolicyMap.String(), err)
 		}
 
 		// Synchronously try to update PolicyMap for this endpoint. If any
@@ -660,7 +665,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 		err := e.syncPolicyMap()
 		if err != nil {
 			e.Mutex.Unlock()
-			return 0, fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
+			return 0, compilationExecuted, fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
 		}
 
 		// Walk the L4Policy for ports that require
@@ -669,14 +674,14 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 			desiredRedirects, err = e.addNewRedirects(owner, e.DesiredL4Policy)
 			if err != nil {
 				e.Mutex.Unlock()
-				return 0, err
+				return 0, compilationExecuted, err
 			}
 		}
 		// Update policies after adding redirects, otherwise we will not wait for
 		// acks for the first policy upates for the first added redirects.
 		if err = e.updateNetworkPolicy(owner); err != nil {
 			e.Mutex.Unlock()
-			return 0, err
+			return 0, compilationExecuted, err
 		}
 	}
 
@@ -684,7 +689,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 	// BPF programs for this endpoint.
 	if err = e.writeHeaderfile(epdir, owner); err != nil {
 		e.Mutex.Unlock()
-		return 0, fmt.Errorf("unable to write header file: %s", err)
+		return 0, compilationExecuted, fmt.Errorf("unable to write header file: %s", err)
 	}
 
 	// Avoid BPF program compilation and installation if the headerfile for the endpoint
@@ -707,7 +712,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 	if epInfoCache == nil {
 		e.Mutex.Unlock()
 		err = fmt.Errorf("Unable to cache endpoint information")
-		return 0, err
+		return 0, compilationExecuted, err
 	}
 
 	// Populate maps used for CIDR-based policy. If the maps would be empty,
@@ -743,15 +748,16 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 	// traffic to those ports.
 	err = e.WaitForProxyCompletions()
 	if err != nil {
-		return 0, fmt.Errorf("Error while configuring proxy redirects: %s", err)
+		return 0, compilationExecuted, fmt.Errorf("Error while configuring proxy redirects: %s", err)
 	}
 
 	if bpfHeaderfilesChanged {
 		// Compile and install BPF programs for this endpoint
 		err = e.runInit(libdir, rundir, epdir, epInfoCache.ifName, debug)
 		if err != nil {
-			return epInfoCache.revision, err
+			return epInfoCache.revision, compilationExecuted, err
 		}
+		compilationExecuted = true
 		e.bpfHeaderfileHash = bpfHeaderfilesHash
 	} else {
 		e.Mutex.RLock()
@@ -771,7 +777,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 	e.Mutex.Unlock()
 	err = e.WaitForProxyCompletions()
 	if err != nil {
-		return 0, fmt.Errorf("Error while deleting obsolete proxy redirects: %s", err)
+		return 0, compilationExecuted, fmt.Errorf("Error while deleting obsolete proxy redirects: %s", err)
 	}
 
 	// The last operation hooks the endpoint into the endpoint table and exposes it
@@ -780,5 +786,5 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, err
 		log.WithField(logfields.EndpointID, e.ID).WithError(err).Error("Exposing new bpf failed")
 	}
 
-	return epInfoCache.revision, err
+	return epInfoCache.revision, compilationExecuted, err
 }


### PR DESCRIPTION
Since we optmized the BPF compilation by skipping it if the lxc_header.h
was not different, we still need to keep the object files from the
previous successful build.

Fixes: a5d98cc5eb01 ("endpoint: Skip BPF compilation if headerfile is unchanged")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4372)
<!-- Reviewable:end -->
