### PR TITLE
metrics: Add metrics to report count of current endpoints tagged by states

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -32,7 +32,7 @@ Endpoint
 --------
 
 * ``endpoint_count``: Number of endpoints managed by this agent
-* ``endpoint_regenerating``: Number of endpoints currently regenerating
+* ``endpoint_regenerating``: Number of endpoints currently regenerating. Deprecated. Use endpoint_state with proper labels instead
 * ``endpoint_regenerations``: Count of all endpoint regenerations that have completed, tagged by outcome
 * ``endpoint_regeneration_seconds_total``: Total sum of successful endpoint regeneration times
 * ``endpoint_regeneration_square_seconds_total``: Total sum of squares of successful endpoint regeneration times

--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -36,7 +36,7 @@ Endpoint
 * ``endpoint_regenerations``: Count of all endpoint regenerations that have completed, tagged by outcome
 * ``endpoint_regeneration_seconds_total``: Total sum of successful endpoint regeneration times
 * ``endpoint_regeneration_square_seconds_total``: Total sum of squares of successful endpoint regeneration times
-
+* ``endpoint_state``: Count of all endpoints, tagged by different endpoint states
 
 Datapath
 --------

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -80,7 +80,7 @@ var (
 	EndpointCountRegenerating = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "endpoint_regenerating",
-		Help:      "Number of endpoints currently regenerating",
+		Help:      "Number of endpoints currently regenerating. Deprecated. Use endpoint_state with proper labels instead",
 	})
 
 	// EndpointRegenerationCount is a count of the number of times any endpoint

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -107,6 +107,16 @@ var (
 		Help:      "Total sum of squares of successful endpoint regeneration times",
 	})
 
+	// EndpointStateCount is the total count of the endpoints in various states.
+	EndpointStateCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "endpoint_state",
+			Help:      "Count of all endpoints, tagged by different endpoint states",
+		},
+		[]string{"endpoint_state"},
+	)
+
 	// Policy
 
 	// PolicyCount is the number of policies loaded into the agent
@@ -255,6 +265,7 @@ func init() {
 	MustRegister(EndpointRegenerationCount)
 	MustRegister(EndpointRegenerationTime)
 	MustRegister(EndpointRegenerationTimeSquare)
+	MustRegister(EndpointStateCount)
 
 	MustRegister(PolicyCount)
 	MustRegister(PolicyRegenerationCount)


### PR DESCRIPTION
This change adds a new prometheus gauge metrics to expose the
count of current endpoints labelled by various endpoint states.

Fixes: #3863
Signed-Off-By: Manali Bhutiyani <manali@covalent.io>


```release-note
Metrics to report count of current endpoints tagged by endpoint states
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4376)
<!-- Reviewable:end -->
