### PR TITLE
pkg/endpoint: always ForcePolicyCompute if endpoint assigned new identity

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2306,14 +2306,15 @@ func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
 
 	e.SetIdentity(identity)
 
-	ready := e.SetStateLocked(StateWaitingToRegenerate, "Triggering regeneration due to new identity")
-	if ready {
-		e.ForcePolicyCompute()
-	}
+	readyToRegenerate := e.SetStateLocked(StateWaitingToRegenerate, "Triggering regeneration due to new identity")
+
+	// Unconditionally force policy recomputation after a new identity has been
+	// assigned.
+	e.ForcePolicyCompute()
 
 	e.Mutex.Unlock()
 
-	if ready {
+	if readyToRegenerate {
 		e.Regenerate(owner, "updated security labels")
 	}
 


### PR DESCRIPTION
Previously, if an endpoint was already in waiting-to-regenerate state, and it received a new identity, policy would not be forcibly computed for the endpoint after receiving its new identity, and the policy regeneration optimizations for the endpoint would prematurely exit, resulting in policy not being computed after identity change.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #3993 

AFAICT this is the smallest change possible to fix this issue, which has been affecting CI stability considerably. I think we need to re-engineer how we handle multiple build requests for a given endpoint at the same time with some type of queue per endpoint which manages building endpoints and setting state accordingly for rebuilding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4378)
<!-- Reviewable:end -->
