### PR TITLE
Fix failure to apply xds NetworkPolicy due to "context deadline exceeded" with large policies

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -449,6 +449,10 @@ type Endpoint struct {
 // WaitForProxyCompletions blocks until all proxy changes have been completed.
 // Called with BuildMutex held.
 func (e *Endpoint) WaitForProxyCompletions() error {
+	if e.ProxyWaitGroup == nil {
+		return nil
+	}
+
 	start := time.Now()
 	e.getLogger().Debug("Waiting for proxy updates to complete...")
 	err := e.ProxyWaitGroup.Wait()


### PR DESCRIPTION
Previously, the endpoint's ProxyWaitGroup would be initialized with a
context that contains a timeout before any policy is computed. With a
very large policy, it was plausible for the context deadline to be
exceeded before any attempt was made to push NetworkPolicy into XDS or
out to the proxy.

In such settings, there would be a complaint like this in the logs:
```
level=warning msg="context cancelled: context deadline exceeded" xdsTypeURL=type.googleapis.com/cilium.NetworkPolicy
```

Shift the context initialization later so that the context should only
time out if it takes a long time to apply policy to the proxy, rather
than it taking a long time to generate the policy in the first place.

Signed-off-by: Joe Stringer <joe@covalent.io>

/cc @rlenglet I'm still concerned that `updateNetworkPolicy()` may take a long time to determine the deniedIdentities, but it should be an improvement on the existing implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4395)
<!-- Reviewable:end -->
