### PR TITLE
docs: Use absolute paths for iptables diagram

### DIFF
--- a/Documentation/concepts.rst
+++ b/Documentation/concepts.rst
@@ -788,5 +788,5 @@ Kubernetes Integration
 The following diagram shows the integration of iptables rules as installed by
 kube-proxy and the iptables rules as installed by Cilium.
 
-.. image:: _static/kubernetes_iptables.svg
-   :target: _static/kubernetes_iptables.svg
+.. image:: /_static/kubernetes_iptables.svg
+   :target: /_static/kubernetes_iptables.svg


### PR DESCRIPTION
Fixes the issue that the iptables diagram image could not be expanded by clicking on it

Fixes: #4125

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4397)
<!-- Reviewable:end -->
