### PR TITLE
[wip]testing: no CPU/mem limits on kubedns

### DIFF
--- a/test/provision/manifest/dns_deployment.yaml
+++ b/test/provision/manifest/dns_deployment.yaml
@@ -94,16 +94,6 @@ spec:
       containers:
       - name: kubedns
         image: k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.10
-        resources:
-          # TODO: Set memory limits when we've profiled the container for large
-          # clusters, then set request = limit to keep this container in
-          # guaranteed class. Currently, this container falls into the
-          # "burstable" category so the kubelet doesn't backoff from restarting it.
-          limits:
-            memory: 170Mi
-          requests:
-            cpu: 100m
-            memory: 70Mi
         livenessProbe:
           httpGet:
             path: /healthcheck/kubedns
@@ -175,10 +165,6 @@ spec:
           name: dns-tcp
           protocol: TCP
         # see: https://github.com/kubernetes/kubernetes/issues/29055 for details
-        resources:
-          requests:
-            cpu: 150m
-            memory: 20Mi
         volumeMounts:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
@@ -202,9 +188,5 @@ spec:
         - containerPort: 10054
           name: metrics
           protocol: TCP
-        resources:
-          requests:
-            memory: 20Mi
-            cpu: 10m
       dnsPolicy: Default  # Don't use cluster DNS.
       serviceAccountName: kube-dns


### PR DESCRIPTION
_Note: I'll be running tests many times, since we're proving a negative. If you see this PR and it isn't running tests (but has passed the last run), run it again!_

kubedns seems to freeze up in tests, triggering flakes. In case that's
related to these limits, we removed them. Generally, since this isn't a
production system it might be simpler to let kubedns hog memory when
something goes wrong than have test flakes.

Related to the never ending https://github.com/cilium/cilium/issues/3878

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4403)
<!-- Reviewable:end -->
