### PR TITLE
Test: Wait Kubedns ready when cilium updates

### DIFF
--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -159,6 +159,8 @@ var _ = Describe("K8sValidatedUpdates", func() {
 
 		validatedImage(localImage)
 
+		ExpectKubeDNSReady(kubectl)
+
 		err = kubectl.WaitForKubeDNSEntry(app1Service)
 		Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
 


### PR DESCRIPTION
When Cilium updates DNS pods are not ready and Cilium try to connect to
the service, but pod is not ready.

Related to #3878

Issue: 
On build https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/2733/testReport/k8s-1/10/K8sValidatedUpdates_Updating_Cilium_stable_to_master/

The host  cannot connect to the DNS service, and we received a TCP timeout.
```
time="2018-06-07T08:50:43Z" level=debug msg="running command: dig +short app1-service.default.svc.cluster.local @10.96.0.10 | grep -v -e '^;'"
cmd: "dig +short app1-service.default.svc.cluster.local @10.96.0.10 | grep -v -e '^;'" exitCode: 1 
 
time="2018-06-07T08:50:58Z" level=debug msg="running command: dig +tcp app1-service.default.svc.cluster.local @10.96.0.10"
cmd: "dig +tcp app1-service.default.svc.cluster.local @10.96.0.10" exitCode: 9 
 ;; Connection to 10.96.0.10#53(10.96.0.10) for app1-service.default.svc.cluster.local failed: connection refused.

time="2018-06-07T08:50:59Z" level=debug msg="running command: dig +short app1-service.default.svc.cluster.local @10.96.0.10 | grep -v -e '^;'"
cmd: "dig +short app1-service.default.svc.cluster.local @10.96.0.10 | grep -v -e '^;'" exitCode: 1 
 
time="2018-06-07T08:51:14Z" level=debug msg="running command: dig +tcp app1-service.default.svc.cluster.local @10.96.0.10"
cmd: "dig +tcp app1-service.default.svc.cluster.local @10.96.0.10" exitCode: 9 
 ;; Connection to 10.96.0.10#53(10.96.0.10) for app1-service.default.svc.cluster.local failed: connection refused.
```
Pod status: 
```
default       app1-c4954c58c-29mp5           1/1       Running   0          8m        10.10.0.32      k8s1
default       app1-c4954c58c-kqqxt           1/1       Running   0          8m        10.10.0.81      k8s1
default       app2-5b59d5764b-wjsc5          1/1       Running   0          8m        10.10.0.142     k8s1
default       app3-6d745c45f6-6fdfb          1/1       Running   0          8m        10.10.0.157     k8s1
kube-system   cilium-bf969                   1/1       Running   0          8m        192.168.36.12   k8s2
kube-system   cilium-gnxnx                   1/1       Running   0          8m        192.168.36.11   k8s1
kube-system   etcd-k8s1                      1/1       Running   0          35m       192.168.36.11   k8s1
kube-system   kube-apiserver-k8s1            1/1       Running   0          34m       192.168.36.11   k8s1
kube-system   kube-controller-manager-k8s1   1/1       Running   0          34m       192.168.36.11   k8s1
kube-system   kube-dns-59d8c5f9b5-qhjtc      2/3       Running   11         35m       10.10.1.108     k8s2
kube-system   kube-proxy-rm88p               1/1       Running   0          28m       192.168.36.12   k8s2
kube-system   kube-proxy-s4tzx               1/1       Running   0          35m       192.168.36.11   k8s1
kube-system   kube-scheduler-k8s1            1/1       Running   0          35m       192.168.36.11   k8s1
```

KubeDNS describe: 
```
Name:           kube-dns-59d8c5f9b5-qhjtc
Namespace:      kube-system
Node:           k8s2/192.168.36.12
Start Time:     Thu, 07 Jun 2018 08:30:54 +0000
Labels:         k8s-app=kube-dns
                pod-template-hash=1584719561
Annotations:    cilium.io/identity=48936
                scheduler.alpha.kubernetes.io/critical-pod=
Status:         Running
IP:             10.10.1.108
Controlled By:  ReplicaSet/kube-dns-59d8c5f9b5
Containers:
  kubedns:
    Container ID:  docker://d1ff8a3662b1d1e3834e9a99c67566ef86a1fac333f04edbfc9e54af91d47741
    Image:         k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.10
    Image ID:      docker-pullable://k8s.gcr.io/k8s-dns-kube-dns-amd64@sha256:b99fc3eee2a9f052f7eb4cc00f15eb12fc405fa41019baa2d6b79847ae7284a8
    Ports:         10053/UDP, 10053/TCP, 10055/TCP
    Host Ports:    0/UDP, 0/TCP, 0/TCP
    Args:
      --domain=cluster.local.
      --dns-port=10053
      --config-dir=/kube-dns-config
      --v=5
    State:          Running
      Started:      Thu, 07 Jun 2018 08:56:05 +0000
    Last State:     Terminated
      Reason:       Error
      Exit Code:    137
      Started:      Thu, 07 Jun 2018 08:53:56 +0000
      Finished:     Thu, 07 Jun 2018 08:56:05 +0000
    Ready:          False
    Restart Count:  3
    Limits:
      memory:  170Mi
    Requests:
      cpu:      100m
      memory:   70Mi
    Liveness:   http-get http://:10054/healthcheck/kubedns delay=60s timeout=5s period=10s #success=1 #failure=5
    Readiness:  http-get http://:8081/readiness delay=3s timeout=5s period=10s #success=1 #failure=3
    Environment:
      PROMETHEUS_PORT:  10055
    Mounts:
      /kube-dns-config from kube-dns-config (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-dns-token-t4ds6 (ro)
  dnsmasq:
    Container ID:  docker://798f1030a96ebc6a2b3a17c2052be5ef1d33dffd0f53d7ea0fe5486989639966
    Image:         k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.10
    Image ID:      docker-pullable://k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64@sha256:bbb2a290a568125b3b996028958eb773f33b5b87a6b37bf38a28f8b62dddb3c8
    Ports:         53/UDP, 53/TCP
    Host Ports:    0/UDP, 0/TCP
    Args:
      -v=5
      -logtostderr
      -configDir=/etc/k8s/dns/dnsmasq-nanny
      -restartDnsmasq=true
      --
      -k
      --cache-size=1000
      --no-negcache
      --log-facility=-
      --server=/cluster.local/127.0.0.1#10053
      --server=/in-addr.arpa/127.0.0.1#10053
      --server=/ip6.arpa/127.0.0.1#10053
    State:          Running
      Started:      Thu, 07 Jun 2018 08:57:41 +0000
    Last State:     Terminated
      Reason:       Error
      Exit Code:    137
      Started:      Thu, 07 Jun 2018 08:55:31 +0000
      Finished:     Thu, 07 Jun 2018 08:57:41 +0000
    Ready:          True
    Restart Count:  4
    Requests:
      cpu:        150m
      memory:     20Mi
    Liveness:     http-get http://:10054/healthcheck/dnsmasq delay=60s timeout=5s period=10s #success=1 #failure=5
    Environment:  <none>
    Mounts:
      /etc/k8s/dns/dnsmasq-nanny from kube-dns-config (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-dns-token-t4ds6 (ro)
  sidecar:
    Container ID:  docker://a44deb77c6d27c46897a81d0a656793f37433c58e39aa56e0364b01646590a1a
    Image:         k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
    Image ID:      docker-pullable://k8s.gcr.io/k8s-dns-sidecar-amd64@sha256:4f1ab957f87b94a5ec1edc26fae50da2175461f00afecf68940c4aa079bd08a4
    Port:          10054/TCP
    Host Port:     0/TCP
    Args:
      --v=2
      --logtostderr
      --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.cluster.local,5,SRV
      --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.cluster.local,5,SRV
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
      Reason:       Error
      Exit Code:    2
      Started:      Thu, 07 Jun 2018 08:56:27 +0000
      Finished:     Thu, 07 Jun 2018 08:57:42 +0000
    Ready:          False
    Restart Count:  5
    Requests:
      cpu:        10m
      memory:     20Mi
    Liveness:     http-get http://:10054/metrics delay=60s timeout=5s period=10s #success=1 #failure=5
    Environment:  <none>
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from kube-dns-token-t4ds6 (ro)
Conditions:
  Type           Status
  Initialized    True 
  Ready          False 
  PodScheduled   True 
Volumes:
  kube-dns-config:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      kube-dns
    Optional:  true
  kube-dns-token-t4ds6:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  kube-dns-token-t4ds6
    Optional:    false
QoS Class:       Burstable
Node-Selectors:  <none>
Tolerations:     CriticalAddonsOnly
                 node.kubernetes.io/not-ready:NoExecute for 300s
                 node.kubernetes.io/unreachable:NoExecute for 300s
Events:
  Type     Reason                  Age                 From               Message
  ----     ------                  ----                ----               -------
  Warning  FailedScheduling        29m (x26 over 35m)  default-scheduler  0/1 nodes are available: 1 node(s) were not ready.
  Normal   SuccessfulMountVolume   27m                 kubelet, k8s2      MountVolume.SetUp succeeded for volume "kube-dns-config"
  Normal   SuccessfulMountVolume   27m                 kubelet, k8s2      MountVolume.SetUp succeeded for volume "kube-dns-token-t4ds6"
  Warning  FailedCreatePodSandBox  26m (x12 over 27m)  kubelet, k8s2      Failed create pod sandbox: rpc error: code = Unknown desc = NetworkPlugin cni failed to set up pod "kube-dns-59d8c5f9b5-qhjtc_kube-system" network: failed to find plugin "cilium-cni" in path [/opt/cilium-cni/bin /opt/cni/bin]
  Normal   SandboxChanged          26m (x11 over 27m)  kubelet, k8s2      Pod sandbox changed, it will be killed and re-created.
  Warning  Unhealthy               9m                  kubelet, k8s2      Liveness probe failed: HTTP probe failed with statuscode: 503
  Warning  Unhealthy               8m                  kubelet, k8s2      Liveness probe failed: HTTP probe failed with statuscode: 503
  Warning  Unhealthy               8m                  kubelet, k8s2      Liveness probe failed: Get http://10.10.1.108:10054/metrics: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
  Warning  Unhealthy               2m (x36 over 8m)    kubelet, k8s2      Readiness probe failed: Get http://10.10.1.108:8081/readiness: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```

If you see the status of the pods, DNS only has 2 or 3 containers ready, and this is the reason why DNS is not ready. 

With this change, we always wait until DNS pods are ready after an upgrade.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4404)
<!-- Reviewable:end -->
