### PR TITLE
[WIP] testing: restart kubedns in Policies tests

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -71,6 +71,10 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 	})
 
 	JustBeforeEach(func() {
+		// restart kubedns every time!
+		kubectl.Exec("kubectl delete pod -l k8s-app=kube-dns -n kube-system")
+		ExpectKubeDNSReady(kubectl)
+
 		microscopeErr, microscopeCancel = kubectl.MicroscopeStart()
 		Expect(microscopeErr).To(BeNil(), "Microscope cannot be started")
 	})


### PR DESCRIPTION
_Please don't merge this_

kubedns seems to break. This is intended to isolate if restarting it
fixes something.
It tests https://github.com/cilium/cilium/issues/3878#issuecomment-395135548

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4405)
<!-- Reviewable:end -->
