### PR TITLE
conntrack: Increase conntrack interval to 1 minute

### DIFF
--- a/pkg/endpointmanager/conntrack.go
+++ b/pkg/endpointmanager/conntrack.go
@@ -30,9 +30,7 @@ import (
 
 const (
 	// GcInterval is the garbage collection interval.
-	// #FIXME find a way to change this value otherwise we'll have lots of tests flakes
-	// Change to be a flag
-	GcInterval int = 10
+	GcInterval int = 60
 )
 
 // RunGC run CT's garbage collector for the given endpoint. `isLocal` refers if


### PR DESCRIPTION
The existing conntrack garbage collector interval is 10 seconds. In
environments that are operating at the upper limit of the conntrack table (1M
entries), this can put considerable stress on the CPU. Increase the interval
to 1 minute to reduce the stress and find a better balance between resource
consumption and aggressive cleanup.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4408)
<!-- Reviewable:end -->
