### PR TITLE
daemon: add capability to wait for endpoint to be in "ready" state if specified via EndpointChangeRequest

### DIFF
--- a/api/v1/models/endpoint_change_request.go
+++ b/api/v1/models/endpoint_change_request.go
@@ -57,6 +57,10 @@ type EndpointChangeRequest struct {
 	// Current state of endpoint
 	// Required: true
 	State EndpointState `json:"state"`
+
+	// Whether to build an endpoint synchronously
+	//
+	SyncBuildEndpoint bool `json:"sync-build-endpoint,omitempty"`
 }
 
 /* polymorph EndpointChangeRequest addressing false */
@@ -84,6 +88,8 @@ type EndpointChangeRequest struct {
 /* polymorph EndpointChangeRequest policy-enabled false */
 
 /* polymorph EndpointChangeRequest state false */
+
+/* polymorph EndpointChangeRequest sync-build-endpoint false */
 
 // Validate validates this endpoint change request
 func (m *EndpointChangeRequest) Validate(formats strfmt.Registry) error {

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -782,6 +782,10 @@ definitions:
       policy-enabled:
         description: Whether policy enforcement is enabled or not
         type: boolean
+      sync-build-endpoint:
+        description: |
+          Whether to build an endpoint synchronously
+        type: boolean
   EndpointStatus:
     description: The current state and configuration of the endpoint, its policy & datapath, and subcomponents
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1308,6 +1308,10 @@ func init() {
         "state": {
           "description": "Current state of endpoint",
           "$ref": "#/definitions/EndpointState"
+        },
+        "sync-build-endpoint": {
+          "description": "Whether to build an endpoint synchronously\n",
+          "type": "boolean"
         }
       }
     },

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -211,6 +211,62 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder 
 	if err != nil {
 		apierror.Error(code, err)
 	}
+
+	// Wait for endpoint to be in "ready" state if specified in API call.
+	if params.Endpoint.SyncBuildEndpoint {
+
+		e, err := endpointmanager.Lookup(params.ID)
+		if err != nil {
+			// Delete endpoint if any operation that occurs during PUT, fails,
+			// so that endpoints in an unhealthy state are not left lying around.
+			if e != nil {
+				h.d.deleteEndpoint(e)
+			}
+			return apierror.Error(PutEndpointIDFailedCode, err)
+		}
+
+		if e == nil {
+			return apierror.Error(PutEndpointIDFailedCode, fmt.Errorf("error retrieving endpoint to check if it is in %s state", endpoint.StateReady))
+		}
+
+		log.Debug("synchronously waiting for endpoint %d to be in %s state", e.ID, endpoint.StateReady)
+
+		// Default timeout for PUT /endpoint/{id} is 30 seconds, so put timeout
+		// in this function a bit below that timeout. If the timeout for clients
+		// in API is below this value, they will get a message containing
+		// "context deadline exceeded" if the operation takes longer than the
+		// client's configured timeout value.
+		stateChangeTimeout := time.Duration(25 * time.Second)
+
+		// Check up until stateChangeTimeout seconds for endpoint state before
+		// waiting for endpoint to be in ready state.
+		timeout := time.After(stateChangeTimeout)
+
+		// Check for endpoint state every second.
+		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				e.Mutex.Lock()
+				epState := e.GetStateLocked()
+				e.Mutex.Unlock()
+				if epState == endpoint.StateReady {
+					return nil
+				} else if epState == endpoint.StateDisconnected || epState == endpoint.StateDisconnecting {
+					// Short circuit in case a call to delete the endpoint is
+					// made while we are waiting for it to be in "ready" state.
+					return apierror.Error(PutEndpointIDFailedCode, fmt.Errorf("endpoint %d went into state %s while waiting for it to be %s", e.ID, epState, endpoint.StateReady))
+				}
+			case <-timeout:
+				// Delete endpoint because PUT operation fails if timeout is
+				// exceeded.
+				h.d.deleteEndpoint(e)
+				return apierror.Error(PutEndpointIDFailedCode, fmt.Errorf("endpoint %d did not synchronously regenerate after timeout", e.ID))
+			}
+		}
+	}
 	return NewPutEndpointIDCreated()
 }
 

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -327,9 +327,9 @@ func AddEndpoint(owner endpoint.Owner, ep *endpoint.Endpoint, reason string) err
 	ep.Mutex.Lock()
 	build := false
 	state := ep.GetStateLocked()
-	// Note that the endpoint state can initially also be "creating", and the
-	// initial build will not be done yet in that case. A following PATCH
-	// request will be needed to change the state and trigger bpf build.
+
+	// We can only trigger regeneration of endpoints if the endpoint is in a
+	// state where it can regenerate. See endpoint.SetStateLocked().
 	if state == endpoint.StateReady {
 		ep.SetStateLocked(endpoint.StateWaitingToRegenerate, reason)
 		build = true

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -429,6 +429,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 		Sandbox: "/proc/" + args.Netns + "/ns/net",
 	})
 
+	// Specify that endpoint must be regenerated synchronously. See GH-4409.
+	ep.SyncBuildEndpoint = true
 	if err = client.EndpointCreate(ep); err != nil {
 		return fmt.Errorf("Unable to create endpoint: %s", err)
 	}


### PR DESCRIPTION
This allows for different behavior depending upon the orchestration system being used in tandem with Cilium for calls to /PUT for an endpoint. Different orchestration systems handle bootstrapping / initialization of container / endpoints differently, and as such whether API calls should synchronously wait for endpoint regeneration to occur must be configurable.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #4409

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4413)
<!-- Reviewable:end -->
