### PR TITLE
Bump journald log ratelimit to 10000/s

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,7 @@ export PATH=/home/vagrant/go/bin:/usr/local/clang/bin:/usr/local/sbin:/usr/local
 
 echo "editing journald configuration"
 sudo bash -c "echo RateLimitIntervalSec=1s >> /etc/systemd/journald.conf"
-sudo bash -c "echo RateLimitBurst=1000 >> /etc/systemd/journald.conf"
+sudo bash -c "echo RateLimitBurst=10000 >> /etc/systemd/journald.conf"
 echo "restarting systemd-journald"
 sudo systemctl restart systemd-journald
 echo "getting status of systemd-journald"

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -8,5 +8,13 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 source "${PROVISIONSRC}/helpers.bash"
 
+echo "editing journald configuration"
+sudo bash -c "sed -i 's/RateLimitBurst=1000/RateLimitBurst=10000/' /etc/systemd/journald.conf"
+echo "restarting systemd-journald"
+sudo systemctl restart systemd-journald
+echo "getting status of systemd-journald"
+sudo service systemd-journald status
+echo "done configuring journald"
+
 "${PROVISIONSRC}"/dns.sh
 "${PROVISIONSRC}"/compile.sh


### PR DESCRIPTION
In common test environments, it is easy for LDS + NPDS configuration for
~10 endpoints to generate more than 1000 lines of log messages within a
second. To prevent losing logs in test environments, bump this ratelimit
to 10000.

Related: #4417
Related: #4425 

[Inheriting priority from #4417, which we don't have enough logs to debug]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4426)
<!-- Reviewable:end -->
