### PR TITLE
test/k8sT: wrap KafkaPolicies test within Context

### DIFF
--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -52,152 +52,154 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 		prodOutAnnounce   = `-c "echo 'Vader Booed at Empire Karaoke Party' | ./kafka-produce.sh --topic empire-announce"`
 	)
 
-	BeforeAll(func() {
-		logger = log.WithFields(logrus.Fields{"testName": "K8sValidatedKafkaPolicyTest"})
-		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-
-		err := kubectl.CiliumInstall(helpers.CiliumDSPath)
-		Expect(err).To(BeNil(), "Cilium cannot be installed")
-		ExpectCiliumReady(kubectl)
-		ExpectKubeDNSReady(kubectl)
-
-		kubectl.Apply(demoPath)
-		err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=kafkaTestApp", 300)
-		Expect(err).Should(BeNil(), "Kafka Pods are not ready after timeout")
-
-		appPods = helpers.GetAppPods(apps, helpers.DefaultNamespace, kubectl, "app")
-
-		ciliumPod, err = kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s2)
-		Expect(err).To(BeNil(), "Cannot get cilium Pod")
-
-	})
-
 	AfterFailed(func() {
 		kubectl.CiliumReport(helpers.KubeSystemNamespace,
 			"cilium service list",
 			"cilium endpoint list")
 	})
 
-	JustBeforeEach(func() {
-		microscopeErr, microscopeCancel = kubectl.MicroscopeStart()
-		Expect(microscopeErr).To(BeNil(), "Microscope cannot be started")
-	})
+	// GH-4414: put test in a context so that if any failures occur in BeforeAll,
+	// logs will be gathered by the above "AfterFailed".
+	Context("Kafka Policy Tests", func() {
+		JustBeforeEach(func() {
+			microscopeErr, microscopeCancel = kubectl.MicroscopeStart()
+			Expect(microscopeErr).To(BeNil(), "Microscope cannot be started")
+		})
 
-	JustAfterEach(func() {
-		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
-		Expect(microscopeCancel()).To(BeNil(), "cannot stop microscope")
-	})
+		JustAfterEach(func() {
+			kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
+			Expect(microscopeCancel()).To(BeNil(), "cannot stop microscope")
+		})
 
-	AfterEach(func() {
-		// On aftereach don't make assertions to delete all.
-		_ = kubectl.Delete(demoPath)
-		_ = kubectl.Delete(l7Policy)
+		AfterEach(func() {
+			// On aftereach don't make assertions to delete all.
+			_ = kubectl.Delete(demoPath)
+			_ = kubectl.Delete(l7Policy)
 
-		ExpectAllPodsTerminated(kubectl)
+			ExpectAllPodsTerminated(kubectl)
+		})
 
-	})
+		BeforeAll(func() {
+			logger = log.WithFields(logrus.Fields{"testName": "K8sValidatedKafkaPolicyTest"})
+			kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
-	It("KafkaPolicies", func() {
+			err := kubectl.CiliumInstall(helpers.CiliumDSPath)
+			Expect(err).To(BeNil(), "Cilium cannot be installed")
+			ExpectCiliumReady(kubectl)
+			ExpectKubeDNSReady(kubectl)
 
-		By("Testing basic Kafka Produce and Consume")
-		// We need to produce first, since consumer script waits for
-		// some messages to be already there by the producer.
+			kubectl.Apply(demoPath)
+			err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=kafkaTestApp", 300)
+			Expect(err).Should(BeNil(), "Kafka Pods are not ready after timeout")
 
-		err := kubectl.ExecKafkaPodCmd(
-			helpers.DefaultNamespace, appPods[empireHqApp], fmt.Sprintf(prodHqAnnounce))
-		Expect(err).Should(BeNil(), "Failed to produce to empire-hq on topic empire-announce")
+			appPods = helpers.GetAppPods(apps, helpers.DefaultNamespace, kubectl, "app")
 
-		err = kubectl.ExecKafkaPodCmd(
-			helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(conOutpostAnnoune))
-		Expect(err).Should(BeNil(), "Failed to consume from outpost on topic empire-announce")
+			ciliumPod, err = kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s2)
+			Expect(err).To(BeNil(), "Cannot get cilium Pod")
+		})
 
-		err = kubectl.ExecKafkaPodCmd(
-			helpers.DefaultNamespace, appPods[empireHqApp], fmt.Sprintf(prodHqDeathStar))
-		Expect(err).Should(BeNil(), "Failed to produce to empire-hq on topic deathstar-plans")
+		It("KafkaPolicies", func() {
 
-		err = kubectl.ExecKafkaPodCmd(
-			helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(conOutDeathStar))
-		Expect(err).Should(BeNil(), "Failed to consume from outpost on topic deathstar-plans")
+			By("Testing basic Kafka Produce and Consume")
+			// We need to produce first, since consumer script waits for
+			// some messages to be already there by the producer.
 
-		err = kubectl.ExecKafkaPodCmd(
-			helpers.DefaultNamespace, appPods[backupApp], fmt.Sprintf(prodBackAnnounce))
-		Expect(err).Should(BeNil(), "Failed to produce to backup on topic empire-announce")
+			err := kubectl.ExecKafkaPodCmd(
+				helpers.DefaultNamespace, appPods[empireHqApp], fmt.Sprintf(prodHqAnnounce))
+			Expect(err).Should(BeNil(), "Failed to produce to empire-hq on topic empire-announce")
 
-		err = kubectl.ExecKafkaPodCmd(
-			helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(prodOutAnnounce))
-		Expect(err).Should(BeNil(), "Failed to produce to outpost on topic empire-announce")
+			err = kubectl.ExecKafkaPodCmd(
+				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(conOutpostAnnoune))
+			Expect(err).Should(BeNil(), "Failed to consume from outpost on topic empire-announce")
 
-		By("Apply L7 kafka policy and wait")
+			err = kubectl.ExecKafkaPodCmd(
+				helpers.DefaultNamespace, appPods[empireHqApp], fmt.Sprintf(prodHqDeathStar))
+			Expect(err).Should(BeNil(), "Failed to produce to empire-hq on topic deathstar-plans")
 
-		_, err = kubectl.CiliumPolicyAction(
-			helpers.KubeSystemNamespace, l7Policy,
-			helpers.KubectlApply, helpers.HelperTimeout)
-		Expect(err).To(BeNil(), "L7 policy cannot be imported correctly")
+			err = kubectl.ExecKafkaPodCmd(
+				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(conOutDeathStar))
+			Expect(err).Should(BeNil(), "Failed to consume from outpost on topic deathstar-plans")
 
-		ExpectCEPUpdates(kubectl)
+			err = kubectl.ExecKafkaPodCmd(
+				helpers.DefaultNamespace, appPods[backupApp], fmt.Sprintf(prodBackAnnounce))
+			Expect(err).Should(BeNil(), "Failed to produce to backup on topic empire-announce")
 
-		By("validate that the pods have the correct policy")
+			err = kubectl.ExecKafkaPodCmd(
+				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(prodOutAnnounce))
+			Expect(err).Should(BeNil(), "Failed to produce to outpost on topic empire-announce")
 
-		desiredPolicyStatus := map[string]models.EndpointPolicyEnabled{
-			backupApp:   models.EndpointPolicyEnabledNone,
-			empireHqApp: models.EndpointPolicyEnabledNone,
-			kafkaApp:    models.EndpointPolicyEnabledIngress,
-			outpostApp:  models.EndpointPolicyEnabledNone,
-			zookApp:     models.EndpointPolicyEnabledNone,
-		}
+			By("Apply L7 kafka policy and wait")
 
-		for app, policy := range desiredPolicyStatus {
-			cep := kubectl.CepGet(helpers.DefaultNamespace, appPods[app])
-			Expect(cep).ToNot(BeNil(), "cannot get cep for app %q and pod %s", app, appPods[app])
-			Expect(cep.Status.Policy.Spec.PolicyEnabled).To(Equal(policy), "Policy for %q mismatch", app)
-		}
+			_, err = kubectl.CiliumPolicyAction(
+				helpers.KubeSystemNamespace, l7Policy,
+				helpers.KubectlApply, helpers.HelperTimeout)
+			Expect(err).To(BeNil(), "L7 policy cannot be imported correctly")
 
-		By("Validating Policy trace")
-		trace := kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
-			"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 9092",
-			appPods[empireHqApp], appPods[kafkaApp]))
-		trace.ExpectSuccess("Cilium policy trace failed")
-		trace.ExpectContains("Final verdict: ALLOWED")
+			ExpectCEPUpdates(kubectl)
 
-		trace = kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
-			"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 9092",
-			appPods[backupApp], appPods[kafkaApp]))
-		trace.ExpectSuccess("Cilium policy trace failed")
-		trace.ExpectContains("Final verdict: ALLOWED")
+			By("validate that the pods have the correct policy")
 
-		trace = kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
-			"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 80",
-			appPods[empireHqApp], appPods[kafkaApp]))
-		trace.ExpectSuccess("Failed cilium policy trace")
-		trace.ExpectContains("Final verdict: DENIED")
+			desiredPolicyStatus := map[string]models.EndpointPolicyEnabled{
+				backupApp:   models.EndpointPolicyEnabledNone,
+				empireHqApp: models.EndpointPolicyEnabledNone,
+				kafkaApp:    models.EndpointPolicyEnabledIngress,
+				outpostApp:  models.EndpointPolicyEnabledNone,
+				zookApp:     models.EndpointPolicyEnabledNone,
+			}
 
-		By("Testing Kafka L7 policy enforcement status")
-		err = kubectl.ExecKafkaPodCmd(
-			helpers.DefaultNamespace, appPods[empireHqApp], fmt.Sprintf(prodHqAnnounce))
-		Expect(err).Should(BeNil(), "Failed to produce to empire-hq on topic empire-announce")
+			for app, policy := range desiredPolicyStatus {
+				cep := kubectl.CepGet(helpers.DefaultNamespace, appPods[app])
+				Expect(cep).ToNot(BeNil(), "cannot get cep for app %q and pod %s", app, appPods[app])
+				Expect(cep.Status.Policy.Spec.PolicyEnabled).To(Equal(policy), "Policy for %q mismatch", app)
+			}
 
-		err = kubectl.ExecKafkaPodCmd(
-			helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(conOutpostAnnoune))
-		Expect(err).Should(BeNil(), "Failed to consume from outpost on topic empire-announce")
+			By("Validating Policy trace")
+			trace := kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
+				"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 9092",
+				appPods[empireHqApp], appPods[kafkaApp]))
+			trace.ExpectSuccess("Cilium policy trace failed")
+			trace.ExpectContains("Final verdict: ALLOWED")
 
-		err = kubectl.ExecKafkaPodCmd(
-			helpers.DefaultNamespace, appPods[empireHqApp], fmt.Sprintf(prodHqDeathStar))
-		Expect(err).Should(BeNil(), "Failed to produce from empire-hq on topic deathstar-plans")
+			trace = kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
+				"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 9092",
+				appPods[backupApp], appPods[kafkaApp]))
+			trace.ExpectSuccess("Cilium policy trace failed")
+			trace.ExpectContains("Final verdict: ALLOWED")
 
-		err = kubectl.ExecKafkaPodCmd(
-			helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(conOutpostAnnoune))
-		Expect(err).Should(BeNil(), "Failed to consume from outpost on topic empire-announce")
+			trace = kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
+				"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 80",
+				appPods[empireHqApp], appPods[kafkaApp]))
+			trace.ExpectSuccess("Failed cilium policy trace")
+			trace.ExpectContains("Final verdict: DENIED")
 
-		err = kubectl.ExecKafkaPodCmd(
-			helpers.DefaultNamespace, appPods[backupApp], fmt.Sprintf(prodBackAnnounce))
-		Expect(err).Should(HaveOccurred(), " Produce to backup on topic empire-announce should have been denied")
+			By("Testing Kafka L7 policy enforcement status")
+			err = kubectl.ExecKafkaPodCmd(
+				helpers.DefaultNamespace, appPods[empireHqApp], fmt.Sprintf(prodHqAnnounce))
+			Expect(err).Should(BeNil(), "Failed to produce to empire-hq on topic empire-announce")
 
-		err = kubectl.ExecKafkaPodCmd(
-			helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(conOutDeathStar))
-		Expect(err).Should(HaveOccurred(), " Consume from outpost on topic deathstar-plans should have been denied")
+			err = kubectl.ExecKafkaPodCmd(
+				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(conOutpostAnnoune))
+			Expect(err).Should(BeNil(), "Failed to consume from outpost on topic empire-announce")
 
-		err = kubectl.ExecKafkaPodCmd(
-			helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(prodOutAnnounce))
-		Expect(err).Should(HaveOccurred(), "Produce to outpost on topic empire-announce should have been denied")
+			err = kubectl.ExecKafkaPodCmd(
+				helpers.DefaultNamespace, appPods[empireHqApp], fmt.Sprintf(prodHqDeathStar))
+			Expect(err).Should(BeNil(), "Failed to produce from empire-hq on topic deathstar-plans")
+
+			err = kubectl.ExecKafkaPodCmd(
+				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(conOutpostAnnoune))
+			Expect(err).Should(BeNil(), "Failed to consume from outpost on topic empire-announce")
+
+			err = kubectl.ExecKafkaPodCmd(
+				helpers.DefaultNamespace, appPods[backupApp], fmt.Sprintf(prodBackAnnounce))
+			Expect(err).Should(HaveOccurred(), " Produce to backup on topic empire-announce should have been denied")
+
+			err = kubectl.ExecKafkaPodCmd(
+				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(conOutDeathStar))
+			Expect(err).Should(HaveOccurred(), " Consume from outpost on topic deathstar-plans should have been denied")
+
+			err = kubectl.ExecKafkaPodCmd(
+				helpers.DefaultNamespace, appPods[outpostApp], fmt.Sprintf(prodOutAnnounce))
+			Expect(err).Should(HaveOccurred(), "Produce to outpost on topic empire-announce should have been denied")
+		})
 	})
 })


### PR DESCRIPTION
Put all Ginkgo test constructs except `AfterFailed` into a `Context`. This allows for
logs to be gathered for all assertion failures in the test, including `BeforeAll`. There is no functional change in the test itself.

Related-to: #4414

Signed-off by: Ian Vernon <ian@cilium.io>

This is a quick fix that is necessary to RCA the issue necessitating the filing of #4414 . It is a workaround due to limitations in the Ginkgo framework that Cilium currently has w.r.t. log-gathering if an assertion in `Before*` constructs fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4427)
<!-- Reviewable:end -->
