### PR TITLE
CI: Revert to working Vagrant box and cilium-builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM quay.io/cilium/cilium-builder:2018-06-05 as builder
+FROM quay.io/cilium/cilium-builder:2018-05-22 as builder
 LABEL maintainer="maintainer@cilium.io"
 WORKDIR /go/src/github.com/cilium/cilium
 COPY . ./

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -126,7 +126,7 @@ Vagrant.configure(2) do |config|
         vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
         vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
         config.vm.box = "cilium/ubuntu"
-        config.vm.box_version = "83"
+        config.vm.box_version = "77"
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i
         if ENV["NFS"] then

--- a/envoy/WORKSPACE
+++ b/envoy/WORKSPACE
@@ -7,7 +7,7 @@ workspace(name = "cilium")
 #
 # No other line in this file may have ENVOY_SHA followed by an equals sign!
 #
-ENVOY_SHA = "c2baf348055284ac761d94e9a06bc37ebf8a3532"
+ENVOY_SHA = "12c470e666d23f1cedaea92cdae6c747d6081dfe"
 
 http_archive(
     name = "envoy",
@@ -42,7 +42,7 @@ go_register_toolchains()
 # Dependencies for Istio filters.
 # Cf. https://github.com/istio/proxy.
 
-ISTIO_PROXY_SHA = "456ad786f902fb61b167043d2914544cf4cabdef"
+ISTIO_PROXY_SHA = "c05a6fc5c23b46345ba57f19cc014b72649b8dfa"
 
 http_archive(
     name = "istio_proxy",

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -8,7 +8,7 @@ $K8S_VERSION = ENV['K8S_VERSION'] || "1.10"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 $NFS = ENV['NFS']=="1"? true : false
 $SERVER_BOX= "cilium/ubuntu"
-$SERVER_VERSION="83"
+$SERVER_VERSION="77"
 $IPv6=(ENV['IPv6'] || "0")
 $CONTAINER_RUNTIME=(ENV['CONTAINER_RUNTIME'] || "docker")
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - consul
       - etcd
-    image: "quay.io/cilium/cilium-builder:2018-06-05"
+    image: "quay.io/cilium/cilium-builder:2018-05-22"
     command: "bash -c 'cd /go/src/github.com/cilium/cilium/; make tests-ginkgo-real'"
     privileged: true
     volumes:


### PR DESCRIPTION
Revert also the changes to update Envoy to the version used in
Istio 0.8.0 to prevent the CI build from timing out.

Relates to: https://github.com/cilium/cilium/issues/4429
Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4430)
<!-- Reviewable:end -->
