### PR TITLE
Improve error logging in CIDR identity release

### DIFF
--- a/pkg/identity/allocator.go
+++ b/pkg/identity/allocator.go
@@ -165,10 +165,11 @@ func (id *Identity) Release() error {
 func ReleaseSlice(identities []*Identity) error {
 	var err error
 	for _, id := range identities {
-		if err = id.Release(); err != nil {
-			log.WithFields(logrus.Fields{
+		if err2 := id.Release(); err2 != nil {
+			log.WithError(err2).WithFields(logrus.Fields{
 				logfields.Identity: id,
 			}).Error("Failed to release identity")
+			err = err2
 		}
 	}
 	return err


### PR DESCRIPTION
If ReleaseSlice() failed during one identity release, then succeeded on
the next, then no error would be returned because it was overwriting the
error that was being returned.

Use a separate err variable for the inner loop and just update the outer
error variable when it fails. This should ensure the actual error can
be forwarded out and caught.

While we're at it, add the error to the log message in this function.

Related: #4174

Signed-off-by: Joe Stringer <joe@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4434)
<!-- Reviewable:end -->
