### PR TITLE
Fix l7 redirects for host / world flows with AllowsLocalhost=always, HostAllowsWorld options 

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -221,14 +221,6 @@ func (e *Endpoint) determineAllowLocalhost(desiredPolicyKeys map[policymap.Polic
 	}
 
 	if option.Config.AlwaysAllowLocalhost() || (e.DesiredL4Policy != nil && e.DesiredL4Policy.HasRedirect()) {
-		// Remove eventual existing ingress L4 localhost restrictions
-		for key := range desiredPolicyKeys {
-			if key.Identity == identityPkg.ReservedIdentityHost.Uint32() &&
-				key.TrafficDirection == policymap.Ingress.Uint8() {
-				delete(desiredPolicyKeys, key)
-			}
-		}
-
 		desiredPolicyKeys[localHostKey] = struct{}{}
 	}
 }
@@ -249,14 +241,6 @@ func (e *Endpoint) determineAllowFromWorld(desiredPolicyKeys map[policymap.Polic
 
 	_, localHostAllowed := desiredPolicyKeys[localHostKey]
 	if option.Config.HostAllowsWorld && localHostAllowed {
-		// Remove eventual existing ingress L4 world restrictions
-		for key := range desiredPolicyKeys {
-			if key.Identity == identityPkg.ReservedIdentityWorld.Uint32() &&
-				key.TrafficDirection == policymap.Ingress.Uint8() {
-				delete(desiredPolicyKeys, key)
-			}
-		}
-
 		desiredPolicyKeys[worldKey] = struct{}{}
 	}
 }

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -132,15 +132,6 @@ func (n EndpointSelector) HasKey(key string) bool {
 	return false
 }
 
-// newWildcardEndpointSelector returns a selector that matches on all endpoints
-func newWildcardEndpointSelector() EndpointSelector {
-	return EndpointSelector{&metav1.LabelSelector{MatchLabels: map[string]string{}}}
-}
-
-// WildcardEndpointSelector is a wildcard endpoint selector matching all
-// endpoints that can be described with labels.
-var WildcardEndpointSelector = newWildcardEndpointSelector()
-
 // NewESFromLabels creates a new endpoint selector from the given labels.
 func NewESFromLabels(lbls ...*labels.Label) EndpointSelector {
 	ml := map[string]string{}
@@ -153,6 +144,26 @@ func NewESFromLabels(lbls ...*labels.Label) EndpointSelector {
 		},
 	}
 }
+
+// newReservedEndpointSelector returns a selector that matches on all
+// endpoints with the specified reserved label.
+func newReservedEndpointSelector(ID string) EndpointSelector {
+	reservedLabels := labels.NewLabel(ID, "", labels.LabelSourceReserved)
+	return NewESFromLabels(reservedLabels)
+}
+
+var (
+	// WildcardEndpointSelector is a wildcard endpoint selector matching
+	// all endpoints that can be described with labels.
+	WildcardEndpointSelector = NewESFromLabels()
+
+	// ReservedEndpointSelectors map reserved labels to EndpointSelectors
+	// that will match those endpoints.
+	ReservedEndpointSelectors = map[string]EndpointSelector{
+		labels.IDNameHost:  newReservedEndpointSelector(labels.IDNameHost),
+		labels.IDNameWorld: newReservedEndpointSelector(labels.IDNameWorld),
+	}
+)
 
 // NewESFromK8sLabelSelector returns a new endpoint selector from the label
 // where it the given srcPrefix will be encoded in the label's keys.

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -75,7 +75,7 @@ func (s *PolicyTestSuite) TestCreateL4Filter(c *C) {
 		// Regardless of ingress/egress, we should end up with
 		// a single L7 rule whether the selector is wildcarded
 		// or if it is based on specific labels.
-		filter := CreateL4IngressFilter(eps, portrule, tuple, tuple.Protocol, nil)
+		filter := CreateL4IngressFilter(eps, nil, portrule, tuple, tuple.Protocol, nil)
 		c.Assert(len(filter.L7RulesPerEp), Equals, 1)
 
 		filter = CreateL4EgressFilter(eps, portrule, tuple, tuple.Protocol, nil)


### PR DESCRIPTION
If the daemon options AllowsLocalhost=always (default with k8s) and/or
LegacyHostAllowsWorld are set, and any L7 rules are created that might
match traffic from host / world, then these L3 sources should be wildcarded
at L7 to ensure that proxies will not restrict the traffic from these sources.

This was previously not done, but instead the l4 redirects were removed
later during policymap entry generation. This prevented such traffic from
even reaching the proxy, which is counter to how the API for such a rule
combination is described.

This PR teaches the policy logic about these options so that L7 can be
appropriately wildcarded depending on the mode, and reinstates the
redirects when L7 policy is applied.

Fixes: #4401

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4435)
<!-- Reviewable:end -->
