### PR TITLE
doc: Add missing indices to spelling list

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -183,6 +183,7 @@ hvm
 Hypercalls
 hypervisors
 ie
+indices
 ImageLocation
 imm
 incrementing


### PR DESCRIPTION
Fixes:  dfa8a34466d9 ("revised elasticsearch getting started guide")

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4441)
<!-- Reviewable:end -->
