### PR TITLE
Restore ability to run ginkgo on OSX

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -177,6 +177,13 @@ const (
 
 )
 
+// Re-definitions of stable constants in the API. The re-definition is on
+// purpose to validate these values in the API. They may never change
+const (
+	// ReservedIdentityHealth is equivalent to pkg/identity.ReservedIdentityHealth
+	ReservedIdentityHealth = 4
+)
+
 // CiliumDSPath is the default Cilium DaemonSet path to use in all test.
 var CiliumDSPath = "cilium_ds.jsonnet"
 

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cilium/cilium/pkg/identity"
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 
@@ -71,7 +70,7 @@ var _ = Describe("RuntimeValidatedChaos", func() {
 		// We don't use -o jsonpath... here due to GH-2395.
 		//
 		// jq 'map(select(.status.identity.id != 4), del(.status.controllers, ..., (.status.identity.labels | sort)))'
-		filterHealthEP := fmt.Sprintf("select(.status.identity.id != %d)", identity.GetReservedID("health"))
+		filterHealthEP := fmt.Sprintf("select(.status.identity.id != %d)", helpers.ReservedIdentityHealth)
 		nonPersistentEndpointFields := strings.Join([]string{
 			".status.controllers",     // Timestamps, UUIDs
 			".status.labels",          // Slice ordering


### PR DESCRIPTION
This restores the ability to run ginkgo and the integration tests on OSX by removing Linux specific go packages from the path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4443)
<!-- Reviewable:end -->
