### PR TITLE
policy: Support CIDRs in rules with zero length prefix

### DIFF
--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -105,6 +105,12 @@ func (id *Identity) GetModel() *models.Identity {
 	return ret
 }
 
+// IsReserved returns whether the identity represents a reserved identity
+// (true), or not (false).
+func (id *Identity) IsReserved() bool {
+	return reservedIdentityCache[id.ID] != nil
+}
+
 // NewIdentity creates a new identity
 func NewIdentity(id NumericIdentity, lbls labels.Labels) *Identity {
 	var lblArray labels.LabelArray

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -137,6 +137,11 @@ func UpsertIPToKVStore(IP net.IP, ID identity.NumericIdentity, metadata string) 
 // into the kvstore, which will subsequently trigger an event in
 // ipIdentityWatcher().
 func UpsertIPNetToKVStore(prefix *net.IPNet, ID *identity.Identity) error {
+	// Reserved identities are handled locally, don't push them to kvstore.
+	if ID.IsReserved() {
+		return nil
+	}
+
 	ipKey := path.Join(IPIdentitiesPath, AddressSpace, prefix.String())
 	ipIDPair := identity.IPIdentityPair{
 		IP:       prefix.IP,

--- a/pkg/labels/cidr/cidr.go
+++ b/pkg/labels/cidr/cidr.go
@@ -34,9 +34,15 @@ func GetCIDRLabels(cidr *net.IPNet) labels.Labels {
 	ones, bits := cidr.Mask.Size()
 	result := []string{}
 
-	for i := 0; i <= ones; i++ {
-		label := labels.MaskedIPNetToLabelString(cidr, i, bits)
-		result = append(result, label)
+	// If ones is zero, then it's the default CIDR prefix /0 which should
+	// just be regarded as reserved:world. In all other cases, we need
+	// to generate the set of prefixes starting from the /0 up to the
+	// specified prefix length.
+	if ones > 0 {
+		for i := 0; i <= ones; i++ {
+			label := labels.MaskedIPNetToLabelString(cidr, i, bits)
+			result = append(result, label)
+		}
 	}
 
 	var cluster *net.IPNet

--- a/pkg/labels/cidr/cidr_test.go
+++ b/pkg/labels/cidr/cidr_test.go
@@ -77,7 +77,7 @@ func (s *CIDRLabelsSuite) TestGetCIDRLabels(c *C) {
 	lblArray = lbls.LabelArray()
 	c.Assert(lblArray.Lacks(expected), comparator.DeepEquals, labels.LabelArray{})
 	// CIDRs that are covered by the prefix should not be in the labels
-	c.Assert(lblArray.Has("cidr:192.0.2.3/32"), Equals, false)
+	c.Assert(lblArray.Has("cidr.192.0.2.3/32"), Equals, false)
 
 	// Note that we convert the colons in IPv6 addresses into dashes when
 	// translating into labels, because endpointSelectors don't support
@@ -98,7 +98,7 @@ func (s *CIDRLabelsSuite) TestGetCIDRLabels(c *C) {
 	lblArray = lbls.LabelArray()
 	c.Assert(lblArray.Lacks(expected), comparator.DeepEquals, labels.LabelArray{})
 	// IPs should be masked as the labels are generated
-	c.Assert(lblArray.Has("cidr:2001-db8--1/24"), Equals, false)
+	c.Assert(lblArray.Has("cidr.2001-db8--1/24"), Equals, false)
 }
 
 // TestGetCIDRLabelsInCluster checks that the cluster label is properly added

--- a/pkg/labels/cidr/cidr_test.go
+++ b/pkg/labels/cidr/cidr_test.go
@@ -79,6 +79,18 @@ func (s *CIDRLabelsSuite) TestGetCIDRLabels(c *C) {
 	// CIDRs that are covered by the prefix should not be in the labels
 	c.Assert(lblArray.Has("cidr.192.0.2.3/32"), Equals, false)
 
+	// Zero-length prefix / default route should become reserved:world.
+	_, cidr, err = net.ParseCIDR("0.0.0.0/0")
+	c.Assert(err, IsNil)
+	expected = labels.ParseLabelArray(
+		"reserved:world",
+	)
+
+	lbls = GetCIDRLabels(cidr)
+	lblArray = lbls.LabelArray()
+	c.Assert(lblArray.Lacks(expected), comparator.DeepEquals, labels.LabelArray{})
+	c.Assert(lblArray.Has("cidr.0.0.0.0/0"), Equals, false)
+
 	// Note that we convert the colons in IPv6 addresses into dashes when
 	// translating into labels, because endpointSelectors don't support
 	// colons.

--- a/pkg/policy/api/cidr_test.go
+++ b/pkg/policy/api/cidr_test.go
@@ -1,0 +1,45 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"github.com/cilium/cilium/pkg/labels"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *PolicyAPITestSuite) TestCIDRMatchesAll(c *C) {
+	cidr := CIDR("0.0.0.0/0")
+	c.Assert(cidr.MatchesAll(), Equals, true)
+
+	cidr = CIDR("::/0")
+	c.Assert(cidr.MatchesAll(), Equals, true)
+
+	cidr = CIDR("192.0.2.0/24")
+	c.Assert(cidr.MatchesAll(), Equals, false)
+	cidr = CIDR("192.0.2.3/32")
+	c.Assert(cidr.MatchesAll(), Equals, false)
+}
+
+func (s *PolicyAPITestSuite) TestGetAsEndpointSelectors(c *C) {
+
+	// Special case: the 0.0.0.0/0 CIDR should match reserved:world.
+	world := labels.ParseLabelArray("reserved:world")
+	cidrs := CIDRSlice{
+		"0.0.0.0/0",
+	}
+	result := cidrs.GetAsEndpointSelectors()
+	c.Assert(result[0].Matches(world), Equals, true)
+}

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -334,7 +334,7 @@ func (c *CIDRRule) sanitize() (prefixLength int, err error) {
 	// the logic in api.CIDR.Sanitize().
 	_, cidrNet, err := net.ParseCIDR(string(c.Cidr))
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("Unable to parse CIDRRule %q: %s", c.Cidr, err)
 	}
 
 	// Returns the prefix length as zero if the mask is not continuous.

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -309,10 +309,11 @@ func (cidr CIDR) sanitize() (prefixLength int, err error) {
 
 	_, ipnet, err := net.ParseCIDR(strCIDR)
 	if err == nil {
-		// Returns the prefix length as zero if the mask is not continuous.
-		prefixLength, _ = ipnet.Mask.Size()
-		if prefixLength == 0 {
-			return 0, fmt.Errorf("Mask length can not be zero")
+		var bits int
+		prefixLength, bits = ipnet.Mask.Size()
+		if prefixLength == 0 && bits == 0 {
+			return 0, fmt.Errorf("CIDR cannot specify non-contiguous mask %s",
+				ipnet.Mask.String())
 		}
 	} else {
 		// Try to parse as a fully masked IP or an IP subnetwork
@@ -337,10 +338,11 @@ func (c *CIDRRule) sanitize() (prefixLength int, err error) {
 		return 0, fmt.Errorf("Unable to parse CIDRRule %q: %s", c.Cidr, err)
 	}
 
-	// Returns the prefix length as zero if the mask is not continuous.
-	prefixLength, _ = cidrNet.Mask.Size()
-	if prefixLength == 0 {
-		return 0, fmt.Errorf("Mask length can not be zero")
+	var bits int
+	prefixLength, bits = cidrNet.Mask.Size()
+	if prefixLength == 0 && bits == 0 {
+		return 0, fmt.Errorf("CIDR cannot specify non-contiguous mask %s",
+			cidrNet.Mask.String())
 	}
 
 	// Ensure that each provided exception CIDR prefix  is formatted correctly,

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -196,3 +196,43 @@ func (s *PolicyAPITestSuite) TestHTTPRuleRegexes(c *C) {
 	err = invalidHTTPRegexMethodRule.Sanitize()
 	c.Assert(err, Not(IsNil))
 }
+
+// Test the validation of CIDR rule prefix definitions
+func (s *PolicyAPITestSuite) TestCIDRsanitize(c *C) {
+	// IPv4
+	cidr := CIDRRule{Cidr: "0.0.0.0/0"}
+	length, err := cidr.sanitize()
+	c.Assert(err, IsNil)
+	c.Assert(length, Equals, 0)
+
+	cidr = CIDRRule{Cidr: "10.0.0.0/24"}
+	length, err = cidr.sanitize()
+	c.Assert(err, IsNil)
+	c.Assert(length, Equals, 24)
+
+	cidr = CIDRRule{Cidr: "192.0.2.3/32"}
+	length, err = cidr.sanitize()
+	c.Assert(err, IsNil)
+	c.Assert(length, Equals, 32)
+
+	// IPv6
+	cidr = CIDRRule{Cidr: "::/0"}
+	length, err = cidr.sanitize()
+	c.Assert(err, IsNil)
+	c.Assert(length, Equals, 0)
+
+	cidr = CIDRRule{Cidr: "ff02::/64"}
+	length, err = cidr.sanitize()
+	c.Assert(err, IsNil)
+	c.Assert(length, Equals, 64)
+
+	cidr = CIDRRule{Cidr: "2001:0db8:85a3:0000:0000:8a2e:0370:7334/128"}
+	length, err = cidr.sanitize()
+	c.Assert(err, IsNil)
+	c.Assert(length, Equals, 128)
+
+	// Non-contiguous mask.
+	cidr = CIDRRule{Cidr: "10.0.0.0/254.0.0.255"}
+	_, err = cidr.sanitize()
+	c.Assert(err, NotNil)
+}

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -997,11 +997,11 @@ func (ds *PolicyTestSuite) TestL3Policy(c *C) {
 	}.Sanitize()
 	c.Assert(err, Not(IsNil))
 
-	// Must have a mask, make sure Validate fails when not.
+	// Must have a contiguous mask, make sure Validate fails when not.
 	err = api.Rule{
 		EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("bar")),
 		Ingress: []api.IngressRule{{
-			FromCIDR: []api.CIDR{"10.0.1.0/0"},
+			FromCIDR: []api.CIDR{"10.0.1.0/128.0.0.128"},
 		}},
 	}.Sanitize()
 	c.Assert(err, Not(IsNil))
@@ -1018,18 +1018,8 @@ func (ds *PolicyTestSuite) TestL3Policy(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestL3PolicyRestrictions(c *C) {
-	// Check rejection of allow-all CIDRs
-	barSelector := api.NewESFromLabels(labels.ParseSelectLabel("bar"))
-	cidrs := []api.CIDR{"0.0.0.0/0"}
-	apiRule1 := api.Rule{
-		EndpointSelector: barSelector,
-		Ingress:          []api.IngressRule{{FromCIDR: cidrs}},
-	}
-	err := apiRule1.Sanitize()
-	c.Assert(err, Not(IsNil))
-
 	// Check rejection of too many prefix lengths
-	cidrs = []api.CIDR{}
+	cidrs := []api.CIDR{}
 	for i := 1; i < 42; i++ {
 		cidrs = append(cidrs, api.CIDR(fmt.Sprintf("%d::/%d", i, i)))
 	}
@@ -1037,7 +1027,7 @@ func (ds *PolicyTestSuite) TestL3PolicyRestrictions(c *C) {
 		EndpointSelector: barSelector,
 		Ingress:          []api.IngressRule{{FromCIDR: cidrs}},
 	}
-	err = apiRule2.Sanitize()
+	err := apiRule2.Sanitize()
 	c.Assert(err, Not(IsNil))
 	apiRule3 := api.Rule{
 		EndpointSelector: barSelector,

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -992,6 +992,20 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 
 		vm.PolicyDelAll().ExpectSuccess("Unable to delete all policies")
 
+		By("testing basic egress to 0.0.0.0/0")
+		policy = fmt.Sprintf(`
+		[{
+			"endpointSelector": {"matchLabels":{"%s":""}},
+			"egress": [{
+				"toCIDR": [
+					"0.0.0.0/0"
+				]
+			}]
+		}]`, app1Label)
+		setupPolicyAndTestEgressToWorld(policy)
+
+		vm.PolicyDelAll().ExpectSuccess("Unable to delete all policies")
+
 		By("testing that in-cluster L7 doesn't affect egress L3")
 		app2Label := fmt.Sprintf("id.%s", helpers.App2)
 		policy = fmt.Sprintf(`


### PR DESCRIPTION
There's no reason to disallow specifying 0.0.0.0/0 CIDRs in policies,           
they're as valid as any other CIDR. Make the /0 check more specific to          
deny non-contiguous masks, which is what we actually disallow.                  
                                                                                
Fixes: #3146                                                                    
Fixes: #3945

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4458)
<!-- Reviewable:end -->
