### PR TITLE
k8s: Updated LastUpdated after waiting for endpoint status

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1361,28 +1361,28 @@ func (d *Daemon) addCiliumNetworkPolicyV2(ciliumV2Store cache.Store, cnp *cilium
 					// the given policy.
 					Enforcing:   waitForEPsErr == nil,
 					Revision:    rev,
-					LastUpdated: cilium_v2.NewTimestamp(),
 					Annotations: cnp.Annotations,
 				}
 
 				// Most important is the error while adding the CNP
 				if err != nil {
 					cnpns = cilium_v2.CiliumNetworkPolicyNodeStatus{
-						Error:       err.Error(),
-						OK:          false,
-						LastUpdated: cilium_v2.NewTimestamp(),
+						Error: err.Error(),
+						OK:    false,
 					}
 				} else if err2 != nil {
 					cnpns = cilium_v2.CiliumNetworkPolicyNodeStatus{
-						Error:       err2.Error(),
-						OK:          false,
-						LastUpdated: cilium_v2.NewTimestamp(),
+						Error: err2.Error(),
+						OK:    false,
 					}
 				}
 
 				nodeName := node.GetName()
 				serverRuleCpy.SetPolicyStatus(nodeName, cnpns)
 				ns := k8sUtils.ExtractNamespace(&serverRuleCpy.ObjectMeta)
+
+				// Update LastUpdated last to have an accurate timestamp
+				cnpns.LastUpdated = cilium_v2.NewTimestamp()
 
 				_, err2 = ciliumNPClient.CiliumV2().CiliumNetworkPolicies(ns).Update(serverRuleCpy)
 				if err2 == nil {


### PR DESCRIPTION
Ensure that the LastUpdated timestamp is using the time-stamp after waiting for
the policy revision wait channel to be closed or timing out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4461)
<!-- Reviewable:end -->
