### PR TITLE
Change kafka docker image to point to a more stable tag 1.1.0

### DIFF
--- a/examples/kubernetes-kafka/kafka-sw-app.yaml
+++ b/examples/kubernetes-kafka/kafka-sw-app.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: docker.io/wurstmeister/kafka
+        image: docker.io/wurstmeister/kafka:1.1.0
         ports:
         - containerPort: 9092
         env:

--- a/test/k8sT/manifests/kafka-sw-app.yaml
+++ b/test/k8sT/manifests/kafka-sw-app.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: docker.io/wurstmeister/kafka
+        image: docker.io/wurstmeister/kafka:1.1.0
         ports:
         - containerPort: 9092
         env:


### PR DESCRIPTION
Fixes: #4481
Related-to: #4431
Signed-Off-By: Manali Bhutiyani <manali@covalent.io>


```release-note
Change kafka docker image to point to a more stable tag 1.1.0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4464)
<!-- Reviewable:end -->
