### PR TITLE
endpointmanager: Simplify Conntrack garbage collection launch code

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1252,6 +1252,19 @@ func (e *Endpoint) SetDefaultOpts(opts *option.BoolOptions) {
 	}
 }
 
+// ConntrackLocal determines whether this endpoint is currently using a local
+// table to handle connection tracking (true), or the global table (false).
+func (e *Endpoint) ConntrackLocal() bool {
+	e.Mutex.RLock()
+	defer e.Mutex.RUnlock()
+
+	if e.SecurityIdentity == nil || !e.Opts.IsEnabled(option.ConntrackLocal) {
+		return false
+	}
+
+	return true
+}
+
 type orderEndpoint func(e1, e2 *models.Endpoint) bool
 
 // OrderEndpointAsc orders the slice of Endpoint in ascending ID order.


### PR DESCRIPTION
This code used a confusing bool and triggering global map CT inside an
endpoint loop. Shuffle the code around to make it easier to understand.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4468)
<!-- Reviewable:end -->
