### PR TITLE
CI: Check external access before policies test

### DIFF
--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1182,6 +1182,10 @@ var _ = Describe("RuntimePolicies", func() {
 		It("Tests egress with CIDR+L4 policy to external https service", func() {
 			cloudFlare := "1.1.1.1"
 
+			By("Checking connectivity to %q without policy", cloudFlare)
+			res := vm.ContainerExec(helpers.App1, helpers.Ping(cloudFlare))
+			res.ExpectSuccess("Expected to be able to connect to cloudflare (%q); external connectivity not available", cloudFlare)
+
 			By("Importing policy which allows egress to %q from %q", otherHostIP, helpers.App1)
 			policy := fmt.Sprintf(`
 			[{


### PR DESCRIPTION
To get a good sense for whether connectivity to the remote host is
working correctly, attempt to ping it prior to running the test. This
should highlight eg when running the test locally that the failure
is due to a generic external access problem rather than test issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4469)
<!-- Reviewable:end -->
