### PR TITLE
policy: Improve L4Filter tests

### DIFF
--- a/pkg/policy/l4Filter_test.go
+++ b/pkg/policy/l4Filter_test.go
@@ -201,6 +201,11 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndShadowedL7(c *C) {
 
 	c.Log(buffer)
 
+	// The expected policy contains the L7 Rules below, but in practice
+	// when the policy is being resolved and sent to the proxy, it actually
+	// allows all at L7, based on the first API rule imported above. We
+	// just set the expected set of L7 rules below to include this to match
+	// the current implementation.
 	expected := NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
 		Port:      80,

--- a/pkg/policy/l4Filter_test.go
+++ b/pkg/policy/l4Filter_test.go
@@ -57,11 +57,6 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndAllowAllL7(c *C) {
 					Ports: []api.PortProtocol{
 						{Port: "80", Protocol: api.ProtoTCP},
 					},
-					Rules: &api.L7Rules{
-						HTTP: []api.PortRuleHTTP{
-							{Method: "GET", Path: "/"},
-						},
-					},
 				}},
 			},
 		},
@@ -83,15 +78,15 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndAllowAllL7(c *C) {
 
 	c.Assert(filter.Endpoints.SelectsAllEndpoints(), Equals, true)
 
-	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
-	c.Assert(len(filter.L7RulesPerEp), Equals, 1)
+	c.Assert(filter.L7Parser, Equals, ParserTypeNone)
+	c.Assert(len(filter.L7RulesPerEp), Equals, 0)
 
 	// Case1B: implicitly wildcard all endpoints.
 	repo = parseAndAddRules(c, api.Rules{&api.Rule{
 		EndpointSelector: endpointSelectorA,
 		Ingress: []api.IngressRule{
 			{
-				FromEndpoints: []api.EndpointSelector{api.WildcardEndpointSelector},
+				FromEndpoints: []api.EndpointSelector{},
 				ToPorts: []api.PortRule{{
 					Ports: []api.PortProtocol{
 						{Port: "80", Protocol: api.ProtoTCP},
@@ -99,15 +94,10 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndAllowAllL7(c *C) {
 				}},
 			},
 			{
-				FromEndpoints: []api.EndpointSelector{api.WildcardEndpointSelector},
+				FromEndpoints: []api.EndpointSelector{},
 				ToPorts: []api.PortRule{{
 					Ports: []api.PortProtocol{
 						{Port: "80", Protocol: api.ProtoTCP},
-					},
-					Rules: &api.L7Rules{
-						HTTP: []api.PortRuleHTTP{
-							{Method: "GET", Path: "/"},
-						},
 					},
 				}},
 			},
@@ -130,8 +120,8 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndAllowAllL7(c *C) {
 
 	c.Assert(filter.Endpoints.SelectsAllEndpoints(), Equals, true)
 
-	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
-	c.Assert(len(filter.L7RulesPerEp), Equals, 1)
+	c.Assert(filter.L7Parser, Equals, ParserTypeNone)
+	c.Assert(len(filter.L7RulesPerEp), Equals, 0)
 }
 
 // Case 2: allow all at L3 in both rules. Allow all in one L7 rule, but second

--- a/pkg/policy/l4Filter_test.go
+++ b/pkg/policy/l4Filter_test.go
@@ -491,7 +491,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndMismatchingParsers(c *
 // in another rule. Should resolve to just allowing all on L3/L7 (first rule
 // shadows the second).
 func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
-	// Case 1A: Specify WildcardEndpointSelector explicitly.
+	// Case 6A: Specify WildcardEndpointSelector explicitly.
 	shadowRule := &rule{
 		Rule: api.Rule{
 			EndpointSelector: endpointSelectorA,
@@ -547,6 +547,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 	c.Assert(state.selectedRules, Equals, 0)
 	c.Assert(state.matchedRules, Equals, 0)
 
+	// Case 6B: Reverse the ordering of the rules. Result should be the same.
 	shadowRule = &rule{
 		Rule: api.Rule{
 			EndpointSelector: endpointSelectorA,

--- a/pkg/policy/l4Filter_test.go
+++ b/pkg/policy/l4Filter_test.go
@@ -331,7 +331,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7Kafka(c *C
 					FromEndpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
 					ToPorts: []api.PortRule{{
 						Ports: []api.PortProtocol{
-							{Port: "80", Protocol: api.ProtoTCP},
+							{Port: "9092", Protocol: api.ProtoTCP},
 						},
 						Rules: &api.L7Rules{
 							Kafka: []api.PortRuleKafka{
@@ -344,7 +344,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7Kafka(c *C
 					FromEndpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
 					ToPorts: []api.PortRule{{
 						Ports: []api.PortProtocol{
-							{Port: "80", Protocol: api.ProtoTCP},
+							{Port: "9092", Protocol: api.ProtoTCP},
 						},
 						Rules: &api.L7Rules{
 							Kafka: []api.PortRuleKafka{
@@ -362,8 +362,8 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7Kafka(c *C
 	c.Log(buffer)
 
 	expected := NewL4Policy()
-	expected.Ingress["80/TCP"] = L4Filter{
-		Port:      80,
+	expected.Ingress["9092/TCP"] = L4Filter{
+		Port:      9092,
 		Protocol:  api.ProtoTCP,
 		U8Proto:   6,
 		Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},


### PR DESCRIPTION
Improve the descriptions for the L4Filter tests, and document them further. These were various changes I picked up while preparing #4416.

The only functional change is simplifying case 1, which was previously the same as case 2.

I manually verified that the policy behaviour is correct for the rules that overlap where one wildcards L7 and the other does not. The policy appears to work as one would expect, despite the strange representation when generating the L4Filter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4473)
<!-- Reviewable:end -->
