### PR TITLE
bpffs: Fix panic when root directory does not exist

### DIFF
--- a/pkg/bpf/bpffs.go
+++ b/pkg/bpf/bpffs.go
@@ -118,14 +118,14 @@ func mountFS() error {
 	mapRootStat, err := os.Stat(mapRoot)
 	if err != nil {
 		if os.IsNotExist(err) {
-			os.MkdirAll(mapRoot, 0755)
+			if err := os.MkdirAll(mapRoot, 0755); err != nil {
+				return fmt.Errorf("unable to create bpf mount directory: %s", err)
+			}
 		} else {
 			return fmt.Errorf("failed to stat the mount path %s: %s", mapRoot, err)
 
 		}
-	}
-
-	if !mapRootStat.IsDir() {
+	} else if !mapRootStat.IsDir() {
 		return fmt.Errorf("%s is a file which is not a directory", mapRoot)
 	}
 


### PR DESCRIPTION
Code used results of os.Stat() even when it failed. Also check the error
returned to Mkdir() in case the root directory had to be created.

Fixes: #4466

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4474)
<!-- Reviewable:end -->
