### PR TITLE
Test: Fix panic on microscope callback

### DIFF
--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -27,22 +27,21 @@ import (
 
 var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 
-	var microscopeErr error
-	var microscopeCancel func() error
-	var kubectl *helpers.Kubectl
-	var ciliumPod string
-
 	var (
-		logger      = log.WithFields(logrus.Fields{"testName": "K8sValidatedKafkaPolicyTest"})
-		l7Policy    = helpers.ManifestGet("kafka-sw-security-policy.yaml")
-		demoPath    = helpers.ManifestGet("kafka-sw-app.yaml")
-		kafkaApp    = "kafka"
-		zookApp     = "zook"
-		backupApp   = "empire-backup"
-		empireHqApp = "empire-hq"
-		outpostApp  = "empire-outpost"
-		apps        = []string{kafkaApp, zookApp, backupApp, empireHqApp, outpostApp}
-		appPods     = map[string]string{}
+		kubectl          *helpers.Kubectl
+		ciliumPod        string
+		microscopeErr    error
+		microscopeCancel = func() error { return nil }
+		logger           = log.WithFields(logrus.Fields{"testName": "K8sValidatedKafkaPolicyTest"})
+		l7Policy         = helpers.ManifestGet("kafka-sw-security-policy.yaml")
+		demoPath         = helpers.ManifestGet("kafka-sw-app.yaml")
+		kafkaApp         = "kafka"
+		zookApp          = "zook"
+		backupApp        = "empire-backup"
+		empireHqApp      = "empire-hq"
+		outpostApp       = "empire-outpost"
+		apps             = []string{kafkaApp, zookApp, backupApp, empireHqApp, outpostApp}
+		appPods          = map[string]string{}
 
 		prodHqAnnounce    = `-c "echo 'Happy 40th Birthday to General Tagge' | ./kafka-produce.sh --topic empire-announce"`
 		conOutpostAnnoune = `-c "./kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1"`

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -41,7 +41,7 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 		logger               *logrus.Entry
 		app1Service          = "app1-service"
 		microscopeErr        error
-		microscopeCancel     func() error
+		microscopeCancel     = func() error { return nil }
 
 		podFilter = "k8s:zgroup=testapp"
 		apps      = []string{helpers.App1, helpers.App2, helpers.App3}
@@ -914,7 +914,7 @@ var _ = Describe("K8sValidatedPolicyTestAcrossNamespaces", func() {
 		cnpL7Stresstest  = helpers.ManifestGet("cnp-l7-stresstest.yaml")
 		cnpAnyNamespace  = helpers.ManifestGet("cnp-any-namespace.yaml")
 		microscopeErr    error
-		microscopeCancel func() error
+		microscopeCancel = func() error { return nil }
 	)
 
 	namespaceAction := func(ns string, action string) {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -30,13 +30,14 @@ import (
 )
 
 var _ = Describe("K8sValidatedServicesTest", func() {
-
-	var kubectl *helpers.Kubectl
-	var logger *logrus.Entry
-	var serviceName = "app1-service"
-	var microscopeErr error
-	var microscopeCancel func() error
-	var ciliumPodK8s1 string
+	var (
+		kubectl          *helpers.Kubectl
+		logger           *logrus.Entry
+		serviceName      = "app1-service"
+		microscopeErr    error
+		microscopeCancel = func() error { return nil }
+		ciliumPodK8s1    string
+	)
 
 	applyPolicy := func(path string) {
 		_, err := kubectl.CiliumPolicyAction(helpers.KubeSystemNamespace, path, helpers.KubectlApply, helpers.HelperTimeout)

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -42,7 +42,7 @@ var _ = Describe(demoTestName, func() {
 		kubectl          *helpers.Kubectl
 		logger           *logrus.Entry
 		microscopeErr    error
-		microscopeCancel func() error
+		microscopeCancel = func() error { return nil }
 
 		deathStarYAMLLink = getStarWarsResourceLink("02-deathstar.yaml")
 		l4PolicyYAMLLink  = getStarWarsResourceLink("policy/l4_policy.yaml")


### PR DESCRIPTION
In case of a fail on BeforeEach, JustBeforeEach was not executed, so
MicroscopeCancel will be nil. When ginkgo run the JustAfterEach function
the call to MicroscopeCancel() panics and Ginkgo stop the process in the
thread.

This is a bad behaviour from Ginkgo Test, need to be fixed upstream to
run the JustBeforeEach on a test.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4478)
<!-- Reviewable:end -->
