### PR TITLE
Test: Skip Kube-dns if the Kubernetes version is 1.11

### DIFF
--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -23,6 +23,7 @@ export KUBEADM_CRI_SOCKET="unix:///var/run/docker.sock"
 export KUBEADM_SLAVE_OPTIONS=""
 export KUBEADM_OPTIONS=""
 export K8S_FULL_VERSION=""
+export INSTALL_KUBEDNS=1
 
 source ${PROVISIONSRC}/helpers.bash
 
@@ -99,6 +100,7 @@ case $K8S_VERSION in
         K8S_FULL_VERSION="1.11.0-beta.0"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri"
+        INSTALL_KUBEDNS=0
         ;;
 esac
 
@@ -160,9 +162,10 @@ if [[ "${HOST}" == "k8s1" ]]; then
     kubectl taint nodes --all node-role.kubernetes.io/master-
 
     sudo systemctl start etcd
-
-    kubectl -n kube-system delete svc,deployment,sa,cm kube-dns || true
-    kubectl -n kube-system apply -f ${PROVISIONSRC}/manifest/dns_deployment.yaml
+    if [[ $INSTALL_KUBEDNS -eq 1 ]]; then
+        kubectl -n kube-system delete svc,deployment,sa,cm kube-dns || true
+        kubectl -n kube-system apply -f ${PROVISIONSRC}/manifest/dns_deployment.yaml
+    fi
 
     $PROVISIONSRC/compile.sh
 else


### PR DESCRIPTION
On Kubernetes 1.11 the dns engine is Coredns instead of Kube-dns. With
this change we avoid to have two DNS services installed when the
Coredns is in place.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4479)
<!-- Reviewable:end -->
