### PR TITLE
cilium-health: Fix issue where older health probes overwrite newer health probes

### DIFF
--- a/pkg/health/server/server.go
+++ b/pkg/health/server/server.go
@@ -153,11 +153,16 @@ func (s *Server) getNodes() (nodeMap, error) {
 }
 
 // updateCluster makes the specified health report visible to the API.
+//
+// It only updates the server's API-visible health report if the provided
+// report started after the current report.
 func (s *Server) updateCluster(report *healthReport) {
 	s.Lock()
 	defer s.Unlock()
 
-	s.connectivity = report
+	if s.connectivity.startTime.Before(report.startTime) {
+		s.connectivity = report
+	}
 }
 
 // GetStatusResponse returns the most recent cluster connectivity status.


### PR DESCRIPTION
Previously, we would unconditionally update the API-visible cluster                                                                                                                                                                                            
health report in the server, even if the probe was performed earlier            
than the currently visible report. This could happen if, for instance, a        
periodic probe began and was unable to complete, then a manual probe was        
invoked via the API (which succeeds and updates the server's cache),            
then finally the periodic probe completes.                                      
                                                                                
Check the start time of the probe and only overwrite if the probe is newer.     
                                                                                
Fixes: #2956

Note on backporting: While this affects 1.0, it only applies to users using `cilium-health status --probe`, which is fairly uncommon and primarily applicable to our CI environment. Hence not proposing for backports. This is of course open to debate if someone feels we should backport the fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4484)
<!-- Reviewable:end -->
