### PR TITLE
CI: Add Kafka specific tests to make sure kafka cluster is up correctly.

### DIFF
--- a/examples/kubernetes-kafka/kafka-sw-app.yaml
+++ b/examples/kubernetes-kafka/kafka-sw-app.yaml
@@ -25,9 +25,9 @@ spec:
         - name: KAFKA_CREATE_TOPICS
           value: "empire-announce:1:1,deathstar-plans:1:1"
         - name: KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS
-          value: "20000"
+          value: "60000"
         - name: KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS
-          value: "20000"
+          value: "60000"
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/test/k8sT/manifests/kafka-sw-app.yaml
+++ b/test/k8sT/manifests/kafka-sw-app.yaml
@@ -23,9 +23,9 @@ spec:
         - name: KAFKA_BROKER_ID
           value: "1"
         - name: KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS
-          value: "20000"
+          value: "60000"
         - name: KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS
-          value: "20000"
+          value: "60000"
         livenessProbe:
           tcpSocket:
             port: 9092

--- a/test/k8sT/manifests/kafka-sw-app.yaml
+++ b/test/k8sT/manifests/kafka-sw-app.yaml
@@ -22,8 +22,6 @@ spec:
           value: zook:2181
         - name: KAFKA_BROKER_ID
           value: "1"
-        - name: KAFKA_CREATE_TOPICS
-          value: "empire-announce:1:1,deathstar-plans:1:1"
         - name: KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS
           value: "20000"
         - name: KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -56,7 +56,7 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 			Expect(err).Should(BeNil())
 
 			vm.ContainerCreate("kafka", "wurstmeister/kafka", helpers.CiliumDockerNetwork, fmt.Sprintf(
-				"-l id.kafka -e KAFKA_ZOOKEEPER_CONNECT=%s:2181 -e KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS=20000 -e KAFKA_LISTENERS=PLAINTEXT://:9092 -e KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS=20000", zook["IPv4"]))
+				"-l id.kafka -e KAFKA_ZOOKEEPER_CONNECT=%s:2181 -e KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS=60000 -e KAFKA_LISTENERS=PLAINTEXT://:9092 -e KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS=60000", zook["IPv4"]))
 
 		case "delete":
 			for k := range images {

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -148,7 +148,7 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 	})
 
 	It("Kafka Policy Ingress", func() {
-		_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-kafka.json"), 300)
+		_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-kafka.json"), helpers.HelperTimeout)
 		Expect(err).Should(BeNil())
 
 		endPoints, err := vm.PolicyEndpointsSummary()
@@ -182,7 +182,7 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 	})
 
 	It("Kafka Policy Role Ingress", func() {
-		_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-kafka-Role.json"), 300)
+		_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-kafka-Role.json"), helpers.HelperTimeout)
 		Expect(err).Should(BeNil(), "Expected nil got %s while importing policy Policies-kafka-Role.json", err)
 
 		endPoints, err := vm.PolicyEndpointsSummary()


### PR DESCRIPTION
These changes add kafka specific tests to ensure that the broker is up correctly before trying to create topics/produce/consume to it.

It also increases the session and connection timeout from 20 sec from 60 sec, due to logs observed
https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-K8s/350/ 
which cause the kafka broker to timeout since zookeeper has not responded for 20 sec.


Fixes: #4431
Signed-Off-By: Manali Bhutiyani <manali@covalent.io>

```release-note
Add Kafka specific CI test checks to make sure kafka cluster is up correctly.
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4488)
<!-- Reviewable:end -->