### PR TITLE
metrics: Check IPAM field for nil

### DIFF
--- a/pkg/metrics/status.go
+++ b/pkg/metrics/status.go
@@ -111,20 +111,22 @@ func (s *statusCollector) Collect(ch chan<- prometheus.Metric) {
 		float64(controllersFailing),
 	)
 
-	// Address count
-	ch <- prometheus.MustNewConstMetric(
-		s.ipAddressesDesc,
-		prometheus.GaugeValue,
-		float64(len(statusResponse.Payload.IPAM.IPV4)),
-		"ipv4",
-	)
+	if statusResponse.Payload.IPAM != nil {
+		// Address count
+		ch <- prometheus.MustNewConstMetric(
+			s.ipAddressesDesc,
+			prometheus.GaugeValue,
+			float64(len(statusResponse.Payload.IPAM.IPV4)),
+			"ipv4",
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		s.ipAddressesDesc,
-		prometheus.GaugeValue,
-		float64(len(statusResponse.Payload.IPAM.IPV6)),
-		"ipv6",
-	)
+		ch <- prometheus.MustNewConstMetric(
+			s.ipAddressesDesc,
+			prometheus.GaugeValue,
+			float64(len(statusResponse.Payload.IPAM.IPV6)),
+			"ipv6",
+		)
+	}
 
 	healthStatusResponse, err := s.healthClient.Connectivity.GetStatus(nil)
 	if err != nil {


### PR DESCRIPTION
Fixes:
```
goroutine 1704 [running]:
github.com/cilium/cilium/pkg/metrics.(*statusCollector).Collect(0xc42038adb0, 0xc423baa6c0)
    /go/src/github.com/cilium/cilium/pkg/metrics/status.go:118 +0x13a
github.com/cilium/cilium/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func2(0xc423484d10, 0xc423baa6c0, 0x3bdeca0, 0xc42038adb0)
    /go/src/github.com/cilium/cilium/vendor/github.com/prometheus/client_golang/prometheus/registry.go:383 +0x61
created by github.com/cilium/cilium/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).Gather
    /go/src/github.com/cilium/cilium/vendor/github.com/prometheus/client_golang/prometheus/registry.go:381 +0x2e1
level=fatal msg="Agent pipe unexpectedly closed, shutting down"
```

Related: #4490

Signed-off-by: Thomas Graf <thomas@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4493)
<!-- Reviewable:end -->
