### PR TITLE
kubernetes: Add missing parenthesis to only fail on invalid version

### DIFF
--- a/examples/kubernetes/Makefile
+++ b/examples/kubernetes/Makefile
@@ -21,7 +21,7 @@ define make_yaml
 $(1)/$(patsubst templates/v1/%,%,$(patsubst %.yaml.sed,%.yaml,$(2))):
 	@$(ECHO_GEN)$$@
 	@echo "$(CILIUM_VERSION)" | egrep -Eq 'v\d+\.\d+\.\d+(-.+)?' || \
-	echo "\"$(CILIUM_VERSION)\" is not a valid version. Must match regexp 'v\d+\.\d+\.\d+(-.+)?'. Please fix VERSION file" && false
+	(echo "\"$(CILIUM_VERSION)\" is not a valid version. Must match regexp 'v\d+\.\d+\.\d+(-.+)?'. Please fix VERSION file" && false)
 	-$(QUIET)sed -f $(1)/transforms2sed.sed -e s+__CILIUM_VERSION__+$$(CILIUM_VERSION)+ <$$< >$$@
 endef
 


### PR DESCRIPTION
Previous logic always failed when generating YAML files. Fix logic to only fail
if version check fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4494)
<!-- Reviewable:end -->
