### PR TITLE
Makefile: add jenkins-precheck Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,14 @@ build: $(SUBDIRS)
 $(SUBDIRS): force
 	@ $(MAKE) -C $@ all
 
+
+jenkins-precheck:
+	docker-compose -f test/precheck.yml -p $$JOB_BASE_NAME-$$BUILD_NUMBER run --rm precheck
+
+clean-jenkins-precheck:
+	docker-compose -f test/precheck.yml -p $$JOB_BASE_NAME-$$BUILD_NUMBER down
+	docker-compose -f test/precheck.yml -p $$JOB_BASE_NAME-$$BUILD_NUMBER rm
+
 # invoked from ginkgo Jenkinsfile
 tests-ginkgo: force
 	# Make the bindata to run the unittest

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -29,6 +29,19 @@ pipeline {
                 checkout scm
             }
         }
+        stage('Precheck') {
+            environment {
+                TESTDIR="${WORKSPACE}/${PROJ_PATH}/"
+            }
+            steps {
+               sh "cd ${TESTDIR}; make jenkins-precheck"
+            }
+            post {
+               always {
+                   sh "cd ${TESTDIR}; make clean-jenkins-precheck || true"
+               }
+            }
+        }
         stage('UnitTesting') {
             environment {
                 GOPATH="${WORKSPACE}"

--- a/test/precheck.yml
+++ b/test/precheck.yml
@@ -1,0 +1,8 @@
+version: "2"
+services:
+  precheck:
+    image: "quay.io/cilium/cilium-builder:2018-05-22"
+    command: "bash -c 'cd /go/src/github.com/cilium/cilium/; make precheck || exit 1'"
+    privileged: true
+    volumes:
+      - "./../:/go/src/github.com/cilium/cilium/"


### PR DESCRIPTION
Add a wrapper around `make precheck` which runs via docker-compose with
`make jenkins-precheck`. This is used in a new stage in `ginkgo.Jenkinsfile`,
which runs the precheck quite early in the build process, so as to quickly exit
and fail the build if the precheck fails. Previously, `make precheck` was ran
as part of the VM provisioning, which could occur almost 15 minutes into the
build process. Since this can be done without provisioning VMs, do so.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #4487 

Testing done locally:

```
$ JOB_BASE_NAME=foo BUILD_NUMBER=bar make jenkins-precheck
can't load package: package github.com/cilium/cilium/test/bpf: C source files not allowed when not using cgo or SWIG: bpf-event-test.c unit-test.c
docker-compose -f test/precheck.yml -p $JOB_BASE_NAME-$BUILD_NUMBER run --rm precheck
can't load package: package github.com/cilium/cilium/test/bpf: C source files not allowed when not using cgo or SWIG: bpf-event-test.c unit-test.c
go tool vet envoy plugins bpf cilium daemon monitor cilium-health bugtool
contrib/scripts/check-fmt.sh

$ JOB_BASE_NAME=foo BUILD_NUMBER=bar make clean-jenkins-precheck
can't load package: package github.com/cilium/cilium/test/bpf: C source files not allowed when not using cgo or SWIG: bpf-event-test.c unit-test.c
docker-compose -f test/precheck.yml -p $JOB_BASE_NAME-$BUILD_NUMBER down
Removing network foobar_default
docker-compose -f test/precheck.yml -p $JOB_BASE_NAME-$BUILD_NUMBER rm
No stopped containers
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4497)
<!-- Reviewable:end -->
