### PR TITLE
Manage cilium-health endpoint from a controller

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -105,7 +105,7 @@ func configureHealthRouting(netns, dev string, addressing *models.NodeAddressing
 // LaunchAsEndpoint launches the cilium-health agent in a nested network
 // namespace and attaches it to Cilium the same way as any other endpoint,
 // but with special reserved labels.
-func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressing, opts *option.BoolOptions) context.CancelFunc {
+func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressing) context.CancelFunc {
 	ip4 := node.GetIPv4HealthIP()
 	ip6 := node.GetIPv6HealthIP()
 
@@ -177,7 +177,7 @@ func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressin
 	if err != nil {
 		log.WithError(err).Fatal("Error while creating cilium-health endpoint")
 	}
-	ep.SetDefaultOpts(opts)
+	ep.SetDefaultOpts(option.Config.Opts)
 
 	// Add the endpoint
 	if err := endpointmanager.AddEndpoint(owner, ep, "Create cilium-health endpoint"); err != nil {

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -179,11 +179,6 @@ func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressin
 	}
 	ep.SetDefaultOpts(option.Config.Opts)
 
-	// Add the endpoint
-	if err := endpointmanager.AddEndpoint(owner, ep, "Create cilium-health endpoint"); err != nil {
-		log.WithError(err).Fatal("Error while adding cilium-health endpoint")
-	}
-
 	// Give the endpoint a security identity
 	lbls := labels.Labels{labels.IDNameHealth: labels.NewLabel(labels.IDNameHealth, "", labels.LabelSourceReserved)}
 	ep.SetIdentityLabels(owner, lbls)
@@ -205,6 +200,11 @@ func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressin
 	// Set up the endpoint routes
 	if err = configureHealthRouting(info.ContainerName, vethPeerName, hostAddressing); err != nil {
 		log.WithError(err).Fatal("Error while configuring cilium-health routes")
+	}
+
+	// Add the endpoint
+	if err := endpointmanager.AddEndpoint(owner, ep, "Create cilium-health endpoint"); err != nil {
+		log.WithError(err).Fatal("Error while adding cilium-health endpoint")
 	}
 
 	// Propagate health IPs to all other nodes

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -202,7 +202,7 @@ func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressin
 	ep.SetIdentityLabels(owner, lbls)
 
 	// Wait until the cilium-health endpoint is running before setting up routes
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(1 * time.Minute)
 	for {
 		if _, err := os.Stat(pidfile); err == nil {
 			log.WithField("pidfile", pidfile).Debug("cilium-health agent running")
@@ -210,7 +210,7 @@ func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressin
 		} else if time.Now().After(deadline) {
 			return fmt.Errorf("Endpoint failed to run: %s", err)
 		} else {
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(1 * time.Second)
 		}
 	}
 

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -719,7 +719,7 @@ func runDaemon() {
 	// Launch another cilium-health as an endpoint, managed by cilium.
 	log.Info("Launching Cilium health endpoint")
 	addressing := d.getNodeAddressing()
-	cancelHealth := health.LaunchAsEndpoint(d, addressing, option.Config.Opts)
+	cancelHealth := health.LaunchAsEndpoint(d, addressing)
 	defer cancelHealth()
 
 	eventsCh, err := workloads.EnableEventListener()

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -719,8 +719,10 @@ func runDaemon() {
 	// Launch another cilium-health as an endpoint, managed by cilium.
 	log.Info("Launching Cilium health endpoint")
 	addressing := d.getNodeAddressing()
-	cancelHealth := health.LaunchAsEndpoint(d, addressing)
-	defer cancelHealth()
+	if err = health.LaunchAsEndpoint(d, addressing); err != nil {
+		log.WithError(err).Fatal("Error while launching cilium-health endpoint")
+	}
+	defer health.CleanupEndpoint(d)
 
 	eventsCh, err := workloads.EnableEventListener()
 	if err != nil {

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -182,7 +182,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) {
 	}
 
 	for _, ep := range state.toClean {
-		go d.deleteEndpointQuiet(ep)
+		go d.deleteEndpointQuiet(ep, true)
 	}
 
 	go func() {


### PR DESCRIPTION
```release-note
Fix daemon crash on startup when cilium-health endpoint takes a long time to launch
```

The cilium-health endpoint's lifecycle was previously not handled particularly well: The main goroutine in Cilium would rush to get it up, providing it just five seconds to start before failing out and causing the main daemon to exit. Under high load situations, eg there's a lot of endpoints to restore on startup, this could be exceeded for no reason other than lack of CPU resources available to launch the health endpoint.

By splitting this out into a controller, it can be handled more gracefully and unblock the main goroutine to continue to (attempt to) serve the API. Furthermore, we can avoid using `log.Fatal()` with regards to the launching of the cilium-health endpoint but still represent failures to run this endpoint in a user-visible way, in the status output:

```
$ cilium status --all-controllers
KVStore:                Ok         Consul: 172.17.0.3:8300
ContainerRuntime:       Ok         docker daemon: OK
Kubernetes:             Disabled
Cilium:                 Ok         OK
NodeMonitor:            Disabled
Cilium health daemon:   Ok
IPv4 address pool:      3/65535 allocated
IPv6 address pool:      2/65535 allocated
Controller Status:      10/10 healthy
  Name                                 Last success   Last error   Count   Message
  cilium-health-ep                     6s ago         never        0       no error
...
```

Note that to reasonably introduce a controller to handle the lifecycle of the cilium-health endpoint, some amount of refactoring was required. I've prepared this PR with discrete patches for each functional or non-functional change, so it may assist to review this patch-by-patch rather than as a whole PR at once.

Fixes: #4242

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4498)
<!-- Reviewable:end -->
