### PR TITLE
Add metric for interrupts during conntrack dump / garbage collection

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -29,6 +29,11 @@ Endpoint
 * ``endpoint_regenerating``: Number of endpoints currently regenerating
 * ``endpoint_regenerations``: Count of all endpoint regenerations that have completed, tagged by outcome
 
+Datapath
+--------
+
+* ``datapath_errors_total``: Total number of errors occurred in datapath management, labelled by area, name and address family.
+
 Drops/Forwards (L3/L4)
 ----------------------
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -39,6 +39,10 @@ var (
 	// names and separated with a '_'
 	Namespace = "cilium"
 
+	// Datapath is the subsystem to scope metrics related to management of
+	// the datapath. It is prepended to metric names and separated with a '_'.
+	Datapath = "datapath"
+
 	// Labels
 
 	// LabelValueOutcomeSuccess is used as a successful outcome of an operation
@@ -55,6 +59,16 @@ var (
 
 	// LabelEventSourceContainerd marks event-related metrics that come from docker
 	LabelEventSourceContainerd = "docker"
+
+	// LabelDatapathArea marks which area the metrics are related to (eg, which BPF map)
+	LabelDatapathArea = "area"
+
+	// LabelDatapathName marks a unique identifier for this metric.
+	// The name should be defined once for a given type of error.
+	LabelDatapathName = "name"
+
+	// LabelDatapathFamily marks which protocol family (IPv4, IPV6) the metric is related to.
+	LabelDatapathFamily = "family"
 
 	// Endpoint
 
@@ -180,6 +194,18 @@ var (
 		Help:      "Total forwarded packets, tagged by ingress/egress direction",
 	},
 		[]string{"direction"})
+
+	// Datapath statistics
+
+	// DatapathErrors is the number of errors managing datapath components
+	// such as BPF maps.
+	DatapathErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: Datapath,
+		Name:      "errors_total",
+		Help:      "Number of errors that occurred in the datapath or datapath management",
+	},
+		[]string{LabelDatapathArea, LabelDatapathName, LabelDatapathFamily})
 )
 
 func init() {
@@ -207,6 +233,8 @@ func init() {
 	MustRegister(ForwardCount)
 
 	MustRegister(newStatusCollector())
+
+	MustRegister(DatapathErrors)
 }
 
 // MustRegister adds the collector to the registry, exposing this metric to


### PR DESCRIPTION
```release-note
Add metric "cilium_datapath_errors_total" for tracking errors in the datapath.
```

Add a metric for counting datapath errors. This should cover all possible errors in datapath management or the datapath itself, however to allow identification of which kind of error it is, the user should mix in labels identifying the area, name and address family for the metric.         
                                                                                                                                                                                         
Use this metric to count the rate of errors that occur while attempting to dump the conntrack table. Curry the gauge with specific labels to identify this particular failure condition.
                                                                      
We can use this to determine how important it is to improve the CT map iteration logic.
          
These metrics will show up as:
```
# HELP cilium_datapath_errors_total Number of errors that occurred in the datapath or datapath management
# TYPE cilium_datapath_errors_total counter
cilium_datapath_errors_total{area="conntrack",family="ipv4",name="dump_reset"} 0
cilium_datapath_errors_total{area="conntrack",family="ipv6",name="dump_reset"} 0
```

I ran these against `promtool` and it doesn't complain about the naming convention.

Related: #4496 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4507)
<!-- Reviewable:end -->
