### PR TITLE
Runtime test: Logs gathering fixes

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -28,9 +28,8 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/test/config"
-	ginkgoext "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/ginkgo-ext"
 
-	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 )
@@ -521,7 +520,7 @@ func (s *SSHMeta) PolicyGetRevision() (int, error) {
 // until the policy revision number increments. Returns an error if the policy
 // is invalid or could not be imported.
 func (s *SSHMeta) PolicyImportAndWait(path string, timeout time.Duration) (int, error) {
-	ginkgo.By(fmt.Sprintf("Setting up policy: %s", path))
+	ginkgoext.By(fmt.Sprintf("Setting up policy: %s", path))
 
 	revision, err := s.PolicyGetRevision()
 	if err != nil {
@@ -874,7 +873,7 @@ func (s *SSHMeta) WaitUntilReady(timeout time.Duration) error {
 // RestartCilium reloads cilium on this host, then waits for it to become
 // ready again.
 func (s *SSHMeta) RestartCilium() error {
-	ginkgo.By("Restarting Cilium")
+	ginkgoext.By("Restarting Cilium")
 
 	res := s.ExecWithSudo("systemctl restart cilium")
 	if !res.WasSuccessful() {

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -244,7 +244,7 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 	var (
 		logger        *logrus.Entry
 		vm            *helpers.SSHMeta
-		monitorStop   func() error
+		monitorStop   = func() error { return nil }
 		initContainer string
 	)
 

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -15,11 +15,12 @@ import (
 )
 
 var _ = Describe("RuntimeValidatedConnectivityTest", func() {
-
-	var once sync.Once
-	var logger *logrus.Entry
-	var vm *helpers.SSHMeta
-	var monitorStop func() error
+	var (
+		once        sync.Once
+		logger      *logrus.Entry
+		vm          *helpers.SSHMeta
+		monitorStop = func() error { return nil }
+	)
 
 	initialize := func() {
 		logger = log.WithFields(logrus.Fields{"test": "RuntimeConnectivityTest"})
@@ -299,14 +300,16 @@ var _ = Describe("RuntimeValidatedConnectivityTest", func() {
 })
 
 var _ = Describe("RuntimeValidatedConntrackTest", func() {
-	var logger *logrus.Entry
-	var vm *helpers.SSHMeta
-	var once sync.Once
-	var monitorStop func() error
+	var (
+		logger      *logrus.Entry
+		vm          *helpers.SSHMeta
+		once        sync.Once
+		monitorStop = func() error { return nil }
 
-	var curl1ContainerName = "curl"
-	var curl2ContainerName = "curl2"
-	var CTPolicyConntrackLocalDisabled = "ct-test-policy-conntrack-local-disabled.json"
+		curl1ContainerName             = "curl"
+		curl2ContainerName             = "curl2"
+		CTPolicyConntrackLocalDisabled = "ct-test-policy-conntrack-local-disabled.json"
+	)
 
 	type conntestCases struct {
 		from        string

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -27,18 +27,21 @@ import (
 
 var _ = Describe("RuntimeValidatedKafka", func() {
 
-	var logger *logrus.Entry
-	var vm *helpers.SSHMeta
-	var monitorStop func() error
+	var (
+		logger      *logrus.Entry
+		vm          *helpers.SSHMeta
+		monitorStop = func() error { return nil }
 
-	var allowedTopic string = "allowedTopic"
-	var disallowTopic string = "disallowTopic"
-	var produceCmd string = fmt.Sprintf(
-		"echo \"Message 0\" | docker exec -i client /opt/kafka/bin/kafka-console-producer.sh "+
-			"--broker-list kafka:9092 --topic %s", allowedTopic)
-	var listTopicsCmd string = "/opt/kafka/bin/kafka-topics.sh --list --zookeeper zook:2181"
-	var MaxMessages int = 6
-	var client string = "client"
+		allowedTopic  = "allowedTopic"
+		disallowTopic = "disallowTopic"
+		listTopicsCmd = "/opt/kafka/bin/kafka-topics.sh --list --zookeeper zook:2181"
+		MaxMessages   = 6
+		client        = "client"
+
+		produceCmd = fmt.Sprintf(
+			"echo \"Message 0\" | docker exec -i client /opt/kafka/bin/kafka-console-producer.sh "+
+				"--broker-list kafka:9092 --topic %s", allowedTopic)
+	)
 
 	containers := func(mode string) {
 

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -26,10 +26,11 @@ import (
 )
 
 var _ = Describe("RuntimeValidatedLB", func() {
-
-	var logger *logrus.Entry
-	var vm *helpers.SSHMeta
-	var monitorStop func() error
+	var (
+		logger      *logrus.Entry
+		vm          *helpers.SSHMeta
+		monitorStop = func() error { return nil }
+	)
 
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"test": "RuntimeLB"})


### PR DESCRIPTION
Three separate commits: 

1) Use BeforeAll/AfterAll in Kafka runtime. 
2) Fix a log message in the test/helpers/cilium.go
3) Fix the issue with the `BeforeEach` and logs gathering. 

Regards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4511)
<!-- Reviewable:end -->
