### PR TITLE
daemon: Delete deprecated code to remove older cilium-envoy.log at startup

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -772,12 +772,6 @@ func runDaemon() {
 		log.WithError(err).Fatal("Unable to establish connection to Kubernetes apiserver")
 	}
 
-	// This block is deprecated and will be removed later (GH-3050)
-	logPath := filepath.Join(viper.GetString("state-dir"), "cilium-envoy.log")
-	if err := os.Remove(logPath); !os.IsNotExist(err) && err != nil {
-		log.WithError(err).Warn("Error deleting cilium-envoy.log")
-	}
-
 	swaggerSpec, err := loads.Analyzed(server.SwaggerJSON, "")
 	if err != nil {
 		log.WithError(err).Fatal("Cannot load swagger spec")


### PR DESCRIPTION
We had added a one time `cilium-envoy.log` removal, pre-1.0 stage to remove the cilium log in
older location on user machines running cilium-envoy setup.
This code simply removes this deprecated code to do this one-time cleanup since we are post
1.1 at this point, and have given enough time for this code to bake.

Fixes: #3050
Signed-Off-By: Manali Bhutiyani <manali@covalent.io>


```release-note
Don't remove old (pre-1.0) cilium-envoy.log on startup
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4518)
<!-- Reviewable:end -->