### PR TITLE
Document how to configure ConfigMap with etcd certificates

### DIFF
--- a/Documentation/kubernetes/install.rst
+++ b/Documentation/kubernetes/install.rst
@@ -286,44 +286,172 @@ Deploying the DaemonSet
     .. parsed-literal::
 
       $ wget \ |SCM_WEB|\/examples/kubernetes/1.7/cilium.yaml
-      $ vim cilium.yaml
-      [adjust the etcd address]
 
   .. group-tab:: K8s 1.8
 
     .. parsed-literal::
 
       $ wget \ |SCM_WEB|\/examples/kubernetes/1.8/cilium.yaml
-      $ vim cilium.yaml
-      [adjust the etcd address]
 
   .. group-tab:: K8s 1.9
 
     .. parsed-literal::
 
       $ wget \ |SCM_WEB|\/examples/kubernetes/1.9/cilium.yaml
-      $ vim cilium.yaml
-      [adjust the etcd address]
 
   .. group-tab:: K8s 1.10
 
     .. parsed-literal::
 
       $ wget \ |SCM_WEB|\/examples/kubernetes/1.10/cilium.yaml
-      $ vim cilium.yaml
-      [adjust the etcd address]
 
   .. group-tab:: K8s 1.11
 
     .. parsed-literal::
 
       $ wget \ |SCM_WEB|\/examples/kubernetes/1.11/cilium.yaml
-      $ vim cilium.yaml
-      [adjust the etcd address]
+
+Adjusting the ConfigMap
+-----------------------
+
+After downloading the ``cilium.yaml`` file, open it with your text editor and
+change the `ConfigMap` based on the following instructions.
+
+Adjusting etcd-config
+~~~~~~~~~~~~~~~~~~~~~
+
+First, make sure the ``etcd-config`` endpoints have the correct addresses of
+your etcd nodes.
+
+If you are running more than one node simply specify the complete of endpoints.
+The list of endpoints can accept both domain names or IP addresses.
+Make sure you specify the correct port used in your etcd node.
+
+If etcd is running with `TLS <https://coreos.com/etcd/docs/latest/op-guide/security.html>`_,
+there are a couple of changes that you need to do.
+
+#. Make sure you have ``https`` in all endpoints;
+
+#. Uncomment the line ``#ca-file: '/var/lib/etcd-secrets/etcd-ca'`` so that the
+   certificate authority of the servers are known to Cilium;
+
+#. Create a kubernetes secret with certificate authority file in kubernetes;
+
+    #. Use certificate authority file, with the name ``ca.crt``, used to create in `etcd <https://coreos.com/etcd/docs/latest/op-guide/security.html#example-1-client-to-server-transport-security-with-https>`_;
+
+    #. Create the secret by executing:
+
+        .. code-block:: bash
+
+            $ kubectl create secret generic -n kube-system cilium-etcd-secrets \
+                --from-file=etcd-ca=ca.crt
 
 
-After configuring the ``cilium`` `ConfigMap` it is time to deploy it using
-``kubectl``:
+If etcd is running with
+`client to server authentication <https://coreos.com/etcd/docs/latest/op-guide/security.html#example-2-client-to-server-authentication-with-https-client-certificates>`_,
+you need make more changes to the `ConfigMap`:
+
+#. Uncomment both lines ``#key-file: '/var/lib/etcd-secrets/etcd-client-key'``
+   and ``#cert-file: '/var/lib/etcd-secrets/etcd-client-crt'``;
+
+#. Create a kubernetes secret with ``client.key`` and ``client.crt`` files in
+   kubernetes.
+
+    #. Use the file with the name ``client.key`` that contains the client key;
+
+    #. Use the file with the name ``client.crt`` that contains the client
+       certificate;
+
+    #. Create the secret by executing:
+
+        .. code-block:: bash
+
+            $ kubectl create secret generic -n kube-system cilium-etcd-secrets \
+                --from-file=etcd-ca=ca.crt \
+                --from-file=etcd-client-key=client.key \
+                --from-file=etcd-client-crt=client.crt
+
+
+.. note::
+
+    If you have set up the secret before you might see the error
+    ``Error from server (AlreadyExists): secrets "cilium-etcd-secrets" already exists``
+    you can simply delete it with
+    ``kubectl delete secret -n kube-system cilium-etcd-secrets``
+    and re-create it again.
+
+
+.. note::
+
+    When creating the kubernetes secrets just make sure you create it with
+    all necessary files, ``ca.crt``, ``client.key`` and ``client.crt`` in a
+    single ``kubectl create``.
+
+Regarding the etcd configuration that is all you need to change in the
+`ConfigMap`.
+
+Adjusting Cilium Options
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+In the `ConfigMap` there are a couple of options that can be changed
+accordingly with your changes.
+
+* ``debug`` - Sets to run Cilium in full debug mode, it can be changed at
+  runtime;
+
+* ``disable-ipv4`` - Disables IPv4 in Cilium and endpoints managed by Cilium;
+
+* ``clean-cilium-state`` - Removes any Cilium state, e.g. BPF policy maps,
+  before starting the Cilium agent;
+
+* ``legacy-host-allows-world`` - If true, the policy with the entity
+  ``reserved:host`` allows traffic from ``world``. If false, the policy needs
+  to explicitly have the entity ``reserved:world`` to allow traffic from
+  ``world``. It is recommended to set it to false. This option provides
+  compatibility with Cilium 1.0 which was not able to differentiate between
+  NodePort traffic and traffic from the host.
+
+Any changes that you perform in the Cilium `ConfigMap` and in
+``cilium-etcd-secrets`` ``Secret`` will require you to restart any existing
+Cilium pods in order for them to pick the latest configuration.
+
+The following `ConfigMap` is an example where the etcd cluster is running in 2
+nodes, ``node-1`` and ``node-2`` with TLS, and client to server authentication
+enabled.
+
+.. code:: yaml
+
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cilium-config
+      namespace: kube-system
+    data:
+        endpoints:
+        - https://node-1:31079
+        - https://node-2:31079
+        #
+        # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+        # and create a kubernetes secret by following the tutorial in
+        # https://cilium.link/etcd-config
+        ca-file: '/var/lib/etcd-secrets/etcd-ca'
+        #
+        # In case you want client to server authentication, uncomment the following
+        # lines and create a kubernetes secret by following the tutorial in
+        # https://cilium.link/etcd-config
+        key-file: '/var/lib/etcd-secrets/etcd-client-key'
+        cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+
+      # If you want to run cilium in debug mode change this value to true
+      debug: "false"
+      disable-ipv4: "false"
+      # If you want to clean cilium state; change this value to true
+      clean-cilium-state: "false"
+      legacy-host-allows-world: "false"
+
+
+After configuring the `ConfigMap` in ``cilium.yaml`` it is time to deploy it
+using ``kubectl``:
 
 .. code:: bash
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -445,6 +445,7 @@ Tu
 Twilio
 udp
 ui
+Uncomment
 underrepresents
 uninline
 unmounting

--- a/examples/kubernetes/1.10/cilium-cm.yaml
+++ b/examples/kubernetes/1.10/cilium-cm.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,19 +28,3 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -176,6 +176,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,22 +28,6 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -223,6 +207,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -175,6 +175,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,22 +28,6 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -222,6 +206,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.11/cilium-cm.yaml
+++ b/examples/kubernetes/1.11/cilium-cm.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,19 +28,3 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -176,6 +176,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,22 +28,6 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -223,6 +207,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -175,6 +175,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,22 +28,6 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -222,6 +206,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.7/cilium-cm.yaml
+++ b/examples/kubernetes/1.7/cilium-cm.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,19 +28,3 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""

--- a/examples/kubernetes/1.7/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-crio-ds.yaml
@@ -176,6 +176,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.7/cilium-crio.yaml
+++ b/examples/kubernetes/1.7/cilium-crio.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,22 +28,6 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
 ---
 kind: DaemonSet
 apiVersion: extensions/v1beta1
@@ -223,6 +207,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -175,6 +175,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,22 +28,6 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
 ---
 kind: DaemonSet
 apiVersion: extensions/v1beta1
@@ -222,6 +206,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.8/cilium-cm.yaml
+++ b/examples/kubernetes/1.8/cilium-cm.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,19 +28,3 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -176,6 +176,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,22 +28,6 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
 ---
 kind: DaemonSet
 apiVersion: apps/v1beta2
@@ -223,6 +207,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -175,6 +175,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,22 +28,6 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
 ---
 kind: DaemonSet
 apiVersion: apps/v1beta2
@@ -222,6 +206,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.9/cilium-cm.yaml
+++ b/examples/kubernetes/1.9/cilium-cm.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,19 +28,3 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -176,6 +176,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,22 +28,6 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -223,6 +207,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -175,6 +175,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,22 +28,6 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -222,6 +206,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/templates/v1/cilium-cm.yaml
+++ b/examples/kubernetes/templates/v1/cilium-cm.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,19 +28,3 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -176,6 +176,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -175,6 +175,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule


### PR DESCRIPTION
@tgraf I need a URL that points https://cilium.link/etcd-config to https://docs.cilium.io/en/latest/kubernetes/install#adjusting-etcd-config

The etcd secrets are no longer present in the `cilium-cm.yaml`!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4520)
<!-- Reviewable:end -->
