### PR TITLE
add '[bB]log and Ubuntu to the spelling list. This fixes the issue when creating an ePub out of the docs

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -30,11 +30,13 @@ Bertin
 bgpd
 bindata
 Blanco
+blog
 bnxt
 bookinfo
 Bookinfo
 bootstrapper
 Borkmann
+Blog
 bpf
 BPF
 bpftool
@@ -453,6 +455,7 @@ uretprobes
 url
 username
 Userspace
+Ubuntu
 vader
 Vader
 Vagrantfile


### PR DESCRIPTION
add missing words to the `spelling_wordlist.txt`. This fixes the issue when doing a `make epub` for the documentation.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4524)
<!-- Reviewable:end -->
