### PR TITLE
apipanic: Log stack at debug level

### DIFF
--- a/pkg/apipanic/apipanic.go
+++ b/pkg/apipanic/apipanic.go
@@ -16,6 +16,7 @@ package apipanic
 
 import (
 	"net/http"
+	"runtime/debug"
 
 	"github.com/sirupsen/logrus"
 
@@ -39,6 +40,7 @@ func (h *APIPanicHandler) ServeHTTP(r http.ResponseWriter, req *http.Request) {
 				"client":        req.RemoteAddr,
 			}
 			logging.DefaultLogger.WithFields(fields).Warn("Cilium API handler panicked")
+			logging.DefaultLogger.Debug(debug.Stack())
 		}
 	}()
 	h.Next.ServeHTTP(r, req)


### PR DESCRIPTION
Previously, it was difficult to debug issues when the API panicked
because only a single line like the following was printed:

level=warning msg="Cilium API handler panicked" client=@ method=GET
panic_message="write unix /var/run/cilium/cilium.sock->@: write: broken
pipe"

This patch logs the stack at this point at debug level so that it can at
least be determined in developer environments.

Fixes: #4191

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4525)
<!-- Reviewable:end -->
