### PR TITLE
allocator: Increase allocator list timeout to 2 minutes

### DIFF
--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -49,7 +49,7 @@ const (
 
 	// listTimeout is the time to wait for the initial list operation to
 	// succeed when creating a new allocator
-	listTimeout = 60 * time.Second
+	listTimeout = 2 * time.Minute
 
 	// gcInterval is the interval in which allocator identities are
 	// attempted to be expired from the kvstore


### PR DESCRIPTION
It has been observed that if etcd is under heavy load, the time to list all
identity keys can surpass 60 seconds.

Reported-by: Amey Bhide <amey@covalent.io>
Signed-off-by: Thomas Graf <thomas@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4527)
<!-- Reviewable:end -->
