### PR TITLE
Test: CiliumEndpointsWaitReady ensure policy is latest

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -827,6 +827,19 @@ func (kub *Kubectl) CiliumEndpointWaitReady() error {
 				"invalid": invalid,
 			}).Info("Waiting for cilium endpoints to be ready")
 
+			ciliumPolicyRevision, err := kub.CiliumPolicyRevision(pod)
+			if err != nil {
+				logCtx.WithError(err).Errorf("cannot get policy revision")
+				return false
+			}
+			res := kub.CiliumExec(pod, fmt.Sprintf("cilium policy wait %d", ciliumPolicyRevision))
+			if !res.WasSuccessful() {
+				logCtx.WithFields(logrus.Fields{
+					"policyRevision": ciliumPolicyRevision,
+					"error":          res.CombineOutput(),
+				}).Errorf("Wait for policy revision failed")
+				return true
+			}
 			if invalid != 0 {
 				return false
 			}


### PR DESCRIPTION
To avoid weird collisions ensure that the endpoints on Wait until Ready
are all in the latest policy revision.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4530)
<!-- Reviewable:end -->
