### PR TITLE
proxy: Make NACK cancel the WaitGroup and pass NACK detail in ProxyError

### DIFF
--- a/pkg/completion/completion.go
+++ b/pkg/completion/completion.go
@@ -25,6 +25,9 @@ type WaitGroup struct {
 	// ctx is the context of all the Completions in the wait group.
 	ctx context.Context
 
+	// cancel is the function to call if any pending operation fails
+	cancel context.CancelFunc
+
 	// counterLocker locks all calls to AddCompletion and Wait, which must not
 	// be called concurrently.
 	counterLocker lock.Mutex
@@ -36,7 +39,8 @@ type WaitGroup struct {
 
 // NewWaitGroup returns a new WaitGroup using the given context.
 func NewWaitGroup(ctx context.Context) *WaitGroup {
-	return &WaitGroup{ctx: ctx}
+	ctx2, cancel := context.WithCancel(ctx)
+	return &WaitGroup{ctx: ctx2, cancel: cancel}
 }
 
 // Context returns the context of all the Completions in the wait group.
@@ -46,14 +50,11 @@ func (wg *WaitGroup) Context() context.Context {
 
 // AddCompletionWithCallback creates a new completion, adds it to the wait
 // group, and returns it. The callback will be called upon completion.
-func (wg *WaitGroup) AddCompletionWithCallback(callback func()) *Completion {
+// Completion can complete in a failure (err != nil)
+func (wg *WaitGroup) AddCompletionWithCallback(callback func(err error)) *Completion {
 	wg.counterLocker.Lock()
 	defer wg.counterLocker.Unlock()
-	c := &Completion{
-		ctx:       wg.ctx,
-		completed: make(chan struct{}),
-		callback:  callback,
-	}
+	c := NewCompletion(wg.cancel, callback)
 	wg.pendingCompletions = append(wg.pendingCompletions, c)
 	return c
 }
@@ -64,36 +65,66 @@ func (wg *WaitGroup) AddCompletion() *Completion {
 	return wg.AddCompletionWithCallback(nil)
 }
 
+// updateError updates the error value to be returned from Wait()
+// so that we return the most severe or consequential error
+// encountered. The order of importance of error values is (from
+// highest to lowest):
+// 1. Non-context errors
+// 2. context.Canceled
+// 3. context.DeadlineExceeded
+// 4. nil
+func updateError(old, new error) error {
+	if new == nil {
+		return old
+	}
+	// 'old' error is overridden by a non-nil 'new' error value if
+	// 1. 'old' is nil, or
+	// 2. 'old' is a timeout, or
+	// 3. 'old' is a cancel and the 'new' error value is not a timeout
+	if old == nil || old == context.DeadlineExceeded || (old == context.Canceled && new != context.DeadlineExceeded) {
+		return new
+	}
+	return old
+}
+
 // Wait blocks until all completions added by calling AddCompletion are
 // completed, or the context is canceled, whichever happens first.
 // Returns the context's error if it is cancelled, nil otherwise.
+// No callbacks of the completions in this wait group will be called after
+// this returns.
+// Returns the error value of one of the completions, if available, or the
+// error value of the Context otherwise.
 func (wg *WaitGroup) Wait() error {
 	wg.counterLocker.Lock()
 	defer wg.counterLocker.Unlock()
 
+	var err error
 Loop:
 	for i, comp := range wg.pendingCompletions {
 		select {
 		case <-comp.Completed():
+			err = updateError(err, comp.Err()) // Keep the most severe error value we encounter
 			continue Loop
 		case <-wg.ctx.Done():
-			// Complete the remaining completions to make sure their completed
+			// Complete the remaining completions (if any) to make sure their completed
 			// channels are closed.
 			for _, comp := range wg.pendingCompletions[i:] {
-				comp.complete(false)
+				// 'comp' may have already completed on a different error
+				compErr := comp.Complete(wg.ctx.Err())
+				err = updateError(err, compErr) // Keep the most severe error value we encounter
 			}
 			break Loop
 		}
 	}
 	wg.pendingCompletions = nil
-	return wg.ctx.Err()
+	return err
 }
 
 // Completion provides the Complete callback to be called when an asynchronous
 // computation is completed.
 type Completion struct {
-	// ctx is the context of the wait group.
-	ctx context.Context
+	// cancel is used to cancel the WaitGroup the completion belongs in case of an error
+	cancel context.CancelFunc
 
 	// lock is used to check and close the completed channel atomically.
 	lock lock.Mutex
@@ -103,39 +134,44 @@ type Completion struct {
 	completed chan struct{}
 
 	// callback is called when Complete is called the first time.
-	callback func()
+	callback func(err error)
+
+	// err is the error the completion completed with
+	err error
 }
 
-// Context returns the context of the asynchronous computation.
-// If the context is cancelled, e.g. if it times out, the computation must be
-// cancelled.
-func (c *Completion) Context() context.Context {
-	return c.ctx
+// Err returns a non-nil error if the completion ended in error
+func (c *Completion) Err() error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.err
 }
 
 // Complete notifies of the completion of the asynchronous computation.
 // Idempotent.
-func (c *Completion) Complete() {
-	c.complete(true)
-}
-
-// Complete notifies of the completion of the asynchronous computation.
-// If this is the first time this method is called, runCallback is true, and
-// the Completion was created by calling WaitGroup.AddCompletionWithCallback or
-// NewCallback with a non-nil callback, that callback is called.
-// Idempotent.
-func (c *Completion) complete(runCallback bool) {
+// If the operation completed successfully 'err' is passed as nil.
+// Returns the error state the completion completed with, which is
+// gnerally different from 'err' if already completed.
+func (c *Completion) Complete(err error) error {
 	c.lock.Lock()
 	select {
 	case <-c.completed:
-		c.lock.Unlock()
+		err = c.err // return the error 'c' completed with
 	default:
-		close(c.completed)
-		c.lock.Unlock()
-		if runCallback && c.callback != nil {
-			c.callback()
+		c.err = err
+		if c.callback != nil {
+			// We must call the callbacks synchronously to guarantee
+			// that they are actually called before Wait() returns.
+			c.callback(err)
 		}
+		// Cancel the WaitGroup on failure
+		if err != nil && c.cancel != nil {
+			c.cancel()
+		}
+		close(c.completed)
 	}
+	c.lock.Unlock()
+	return err
 }
 
 // Completed returns a channel that's closed when the completion is completed,
@@ -145,10 +181,11 @@ func (c *Completion) Completed() <-chan struct{} {
 	return c.completed
 }
 
-// NewCallback creates a Completion which calls a function upon Complete().
-func NewCallback(ctx context.Context, callback func()) *Completion {
+// NewCompletion creates a Completion which calls a function upon Complete().
+// 'cancel' is called if the associated operation fails for any reason.
+func NewCompletion(cancel context.CancelFunc, callback func(err error)) *Completion {
 	return &Completion{
-		ctx:       ctx,
+		cancel:    cancel,
 		completed: make(chan struct{}),
 		callback:  callback,
 	}

--- a/pkg/envoy/envoy_test.go
+++ b/pkg/envoy/envoy_test.go
@@ -168,7 +168,7 @@ func (s *EnvoySuite) TestEnvoyNACK(c *C) {
 
 	err = s.waitForProxyCompletion()
 	c.Assert(err, Not(IsNil))
-	c.Assert(err, Equals, xds.ErrNackReceived)
+	c.Assert(err, DeepEquals, &xds.ProxyError{Err: xds.ErrNackReceived, Detail: "Error adding/updating listener listener:22: cannot bind '[::]:22': Permission denied"})
 
 	s.waitGroup = completion.NewWaitGroup(ctx)
 	// Remove listener1

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -724,7 +724,7 @@ func (s *XDSServer) RemoveAllNetworkPolicies() {
 // the given names.
 // If resourceNames is empty, all resources are returned.
 func (s *XDSServer) GetNetworkPolicies(resourceNames []string) (map[string]*cilium.NetworkPolicy, error) {
-	resources, err := s.networkPolicyCache.GetResources(context.Background(), NetworkPolicyTypeURL, nil, nil, resourceNames)
+	resources, err := s.networkPolicyCache.GetResources(context.Background(), NetworkPolicyTypeURL, 0, nil, resourceNames)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -37,7 +37,7 @@ type ResourceVersionAckObserver interface {
 	// HandleResourceVersionAck notifies that the node with the given Node ID
 	// has acknowledged having applied the resources.
 	// Calls to this function must not block.
-	HandleResourceVersionAck(ackVersion *uint64, nackVersion uint64, node *envoy_api_v2_core.Node, resourceNames []string, typeURL string)
+	HandleResourceVersionAck(ackVersion uint64, nackVersion uint64, node *envoy_api_v2_core.Node, resourceNames []string, typeURL string)
 }
 
 // AckingResourceMutator is a variant of ResourceMutator which calls back a
@@ -188,7 +188,7 @@ func (m *AckingResourceMutatorWrapper) Delete(typeURL string, resourceName strin
 }
 
 // 'ackVersion' is the last version that was acked. 'nackVersion', if greater than 'nackVersion', is the last version that was NACKed.
-func (m *AckingResourceMutatorWrapper) HandleResourceVersionAck(ackVersion *uint64, nackVersion uint64, node *envoy_api_v2_core.Node, resourceNames []string, typeURL string) {
+func (m *AckingResourceMutatorWrapper) HandleResourceVersionAck(ackVersion uint64, nackVersion uint64, node *envoy_api_v2_core.Node, resourceNames []string, typeURL string) {
 	ackLog := log.WithFields(logrus.Fields{
 		logfields.XDSVersionInfo: ackVersion,
 		logfields.XDSNonce:       nackVersion,
@@ -231,7 +231,7 @@ func (m *AckingResourceMutatorWrapper) HandleResourceVersionAck(ackVersion *uint
 					}
 					if len(pending.remainingNodesResources) == 0 {
 						// Completed. Notify and remove from pending list.
-						if ackVersion != nil && pending.version <= *ackVersion {
+						if pending.version <= ackVersion {
 							ackLog.Debugf("completing ACK: %v", pending)
 							comp.Complete(nil)
 						} else {

--- a/pkg/envoy/xds/ack_test.go
+++ b/pkg/envoy/xds/ack_test.go
@@ -40,7 +40,7 @@ var nodes = map[string]*envoy_api_v2_core.Node{
 	node2: {Id: "sidecar~10.0.0.2~node2~bar"},
 }
 
-// IsCompletedChecker checks that a Completion is completed.
+// IsCompletedChecker checks that a Completion is completed without errors.
 type IsCompletedChecker struct {
 	*CheckerInfo
 }
@@ -56,7 +56,7 @@ func (c *IsCompletedChecker) Check(params []interface{}, names []string) (result
 
 	select {
 	case <-comp.Completed():
-		return true, ""
+		return comp.Err() == nil, ""
 	default:
 		return false, ""
 	}
@@ -79,25 +79,27 @@ func (s *AckSuite) TestUpsertSingleNode(c *C) {
 
 	// Create version 1 with resource 0.
 	comp := wg.AddCompletion()
-	defer comp.Complete()
+	defer comp.Complete(nil)
 
 	acker.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, comp)
 	c.Assert(comp, Not(IsCompleted))
+	one := uint64(1)
+	zero := uint64(0)
 
 	// Ack the right version, for the right resource, from another node.
-	acker.HandleResourceVersionAck(1, nodes[node1], []string{resources[0].Name}, typeURL)
+	acker.HandleResourceVersionAck(&one, 1, nodes[node1], []string{resources[0].Name}, typeURL)
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack the right version, for another resource, from the right node.
-	acker.HandleResourceVersionAck(1, nodes[node0], []string{resources[1].Name}, typeURL)
+	acker.HandleResourceVersionAck(&one, 1, nodes[node0], []string{resources[1].Name}, typeURL)
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack an older version, for the right resource, from the right node.
-	acker.HandleResourceVersionAck(0, nodes[node0], []string{resources[0].Name}, typeURL)
+	acker.HandleResourceVersionAck(&zero, 0, nodes[node0], []string{resources[0].Name}, typeURL)
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack the right version, for the right resource, from the right node.
-	acker.HandleResourceVersionAck(1, nodes[node0], []string{resources[0].Name}, typeURL)
+	acker.HandleResourceVersionAck(&one, 1, nodes[node0], []string{resources[0].Name}, typeURL)
 	c.Assert(comp, IsCompleted)
 }
 
@@ -110,24 +112,26 @@ func (s *AckSuite) TestUpsertMultipleNodes(c *C) {
 	cache := NewCache()
 	acker := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
 
+	one := uint64(1)
+
 	// Create version 1 with resource 0.
 	comp := wg.AddCompletion()
-	defer comp.Complete()
+	defer comp.Complete(nil)
 
 	acker.Upsert(typeURL, resources[0].Name, resources[0], []string{node0, node1}, comp)
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack the right version, for the right resource, from another node.
-	acker.HandleResourceVersionAck(1, nodes[node2], []string{resources[0].Name}, typeURL)
+	acker.HandleResourceVersionAck(&one, 1, nodes[node2], []string{resources[0].Name}, typeURL)
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack the right version, for the right resource, from one of the nodes (node0).
 	// One of the nodes (node1) still needs to ACK.
-	acker.HandleResourceVersionAck(1, nodes[node0], []string{resources[0].Name}, typeURL)
+	acker.HandleResourceVersionAck(&one, 1, nodes[node0], []string{resources[0].Name}, typeURL)
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack the right version, for the right resource, from the last remaining node (node1).
-	acker.HandleResourceVersionAck(1, nodes[node1], []string{resources[0].Name}, typeURL)
+	acker.HandleResourceVersionAck(&one, 1, nodes[node1], []string{resources[0].Name}, typeURL)
 	c.Assert(comp, IsCompleted)
 }
 
@@ -139,21 +143,51 @@ func (s *AckSuite) TestUpsertMoreRecentVersion(c *C) {
 
 	cache := NewCache()
 	acker := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+	zero := uint64(0)
+	bigOne := uint64(123)
 
 	// Create version 1 with resource 0.
 	comp := wg.AddCompletion()
-	defer comp.Complete()
+	defer comp.Complete(nil)
 
 	acker.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, comp)
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack an older version, for the right resource, from the right node.
-	acker.HandleResourceVersionAck(0, nodes[node0], []string{resources[0].Name}, typeURL)
+	acker.HandleResourceVersionAck(&zero, 0, nodes[node0], []string{resources[0].Name}, typeURL)
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack a more recent version, for the right resource, from the right node.
-	acker.HandleResourceVersionAck(123, nodes[node0], []string{resources[0].Name}, typeURL)
+	acker.HandleResourceVersionAck(&bigOne, bigOne, nodes[node0], []string{resources[0].Name}, typeURL)
 	c.Assert(comp, IsCompleted)
+}
+
+func (s *AckSuite) TestUpsertMoreRecentVersionNack(c *C) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	typeURL := "type.googleapis.com/envoy.api.v2.DummyConfiguration"
+	wg := completion.NewWaitGroup(ctx)
+
+	cache := NewCache()
+	acker := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+
+	// Create version 1 with resource 0.
+	comp := wg.AddCompletion()
+	defer comp.Complete(nil)
+	zero := uint64(0)
+
+	acker.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, comp)
+	c.Assert(comp, Not(IsCompleted))
+
+	// Ack an older version, for the right resource, from the right node.
+	acker.HandleResourceVersionAck(&zero, 0, nodes[node0], []string{resources[0].Name}, typeURL)
+	c.Assert(comp, Not(IsCompleted))
+
+	// NAck a more recent version, for the right resource, from the right node.
+	acker.HandleResourceVersionAck(&zero, 1, nodes[node0], []string{resources[0].Name}, typeURL)
+	// IsCompleted is true only for completions without error
+	c.Assert(comp, Not(IsCompleted))
+	c.Assert(comp.Err(), Not(Equals), nil)
 }
 
 func (s *AckSuite) TestDeleteSingleNode(c *C) {
@@ -167,28 +201,30 @@ func (s *AckSuite) TestDeleteSingleNode(c *C) {
 
 	// Create version 1 with resource 0.
 	comp := wg.AddCompletion()
-	defer comp.Complete()
+	defer comp.Complete(nil)
+	one := uint64(1)
+	two := uint64(2)
 
 	acker.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, comp)
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack the right version, for the right resource, from the right node.
-	acker.HandleResourceVersionAck(1, nodes[node0], []string{resources[0].Name}, typeURL)
+	acker.HandleResourceVersionAck(&one, 1, nodes[node0], []string{resources[0].Name}, typeURL)
 	c.Assert(comp, IsCompleted)
 
 	// Create version 2 with no resources.
 	comp = wg.AddCompletion()
-	defer comp.Complete()
+	defer comp.Complete(nil)
 
 	acker.Delete(typeURL, resources[0].Name, []string{node0}, comp)
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack the right version, for another resource, from another node.
-	acker.HandleResourceVersionAck(2, nodes[node1], []string{resources[2].Name}, typeURL)
+	acker.HandleResourceVersionAck(&two, 2, nodes[node1], []string{resources[2].Name}, typeURL)
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack the right version, for another resource, from the right node.
-	acker.HandleResourceVersionAck(2, nodes[node0], []string{resources[2].Name}, typeURL)
+	acker.HandleResourceVersionAck(&two, 2, nodes[node0], []string{resources[2].Name}, typeURL)
 	// The resource name is ignored. For delete, we only consider the version.
 	c.Assert(comp, IsCompleted)
 }
@@ -201,31 +237,33 @@ func (s *AckSuite) TestDeleteMultipleNodes(c *C) {
 
 	cache := NewCache()
 	acker := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+	one := uint64(1)
+	two := uint64(2)
 
 	// Create version 1 with resource 0.
 	comp := wg.AddCompletion()
-	defer comp.Complete()
+	defer comp.Complete(nil)
 
 	acker.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, comp)
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack the right version, for the right resource, from the right node.
-	acker.HandleResourceVersionAck(1, nodes[node0], []string{resources[0].Name}, typeURL)
+	acker.HandleResourceVersionAck(&one, 1, nodes[node0], []string{resources[0].Name}, typeURL)
 	c.Assert(comp, IsCompleted)
 
 	// Create version 2 with no resources.
 	comp = wg.AddCompletion()
-	defer comp.Complete()
+	defer comp.Complete(nil)
 
 	acker.Delete(typeURL, resources[0].Name, []string{node0, node1}, comp)
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack the right version, for another resource, from one of the nodes.
-	acker.HandleResourceVersionAck(2, nodes[node1], []string{resources[2].Name}, typeURL)
+	acker.HandleResourceVersionAck(&two, 2, nodes[node1], []string{resources[2].Name}, typeURL)
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack the right version, for another resource, from the remaining node.
-	acker.HandleResourceVersionAck(2, nodes[node0], []string{resources[2].Name}, typeURL)
+	acker.HandleResourceVersionAck(&two, 2, nodes[node0], []string{resources[2].Name}, typeURL)
 	// The resource name is ignored. For delete, we only consider the version.
 	c.Assert(comp, IsCompleted)
 }

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -282,6 +282,11 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 					return ErrInvalidResponseNonce
 				}
 			}
+			var detail string
+			status := req.GetErrorDetail()
+			if status != nil {
+				detail = status.Message
+			}
 
 			typeURL := req.GetTypeUrl()
 			if defaultTypeURL == AnyTypeURL && typeURL == "" {
@@ -308,7 +313,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				// ACK versions up to the received versionInfo
 				if ackObserver != nil {
 					requestLog.Debug("notifying observers of ACKs")
-					ackObserver.HandleResourceVersionAck(versionInfo, nonce, req.GetNode(), state.resourceNames, typeURL)
+					ackObserver.HandleResourceVersionAck(versionInfo, nonce, req.GetNode(), state.resourceNames, typeURL, detail)
 					if versionInfo < nonce {
 						// versions after VersionInfo, upto and including ResponseNonce are NACKed
 						requestLog.Warningf("NACK received for versions after %s and up to %s; waiting for a version update before sending again", req.VersionInfo, req.ResponseNonce)

--- a/pkg/envoy/xds/set.go
+++ b/pkg/envoy/xds/set.go
@@ -33,7 +33,7 @@ type ResourceSource interface {
 	// changed since lastVersion, nil is returned.
 	// If resourceNames is empty, all resources are returned.
 	// Should not be blocking.
-	GetResources(ctx context.Context, typeURL string, lastVersion *uint64,
+	GetResources(ctx context.Context, typeURL string, lastVersion uint64,
 		node *envoy_api_v2_core.Node, resourceNames []string) (*VersionedResources, error)
 
 	// EnsureVersion increases this resource set's version to be at least the

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -72,11 +72,10 @@ type Proxy struct {
 	// ports out of the rangeMin-rangeMax range.
 	rangeMax uint16
 
-	// allocatedPorts is a map of all allocated proxy ports pointing
-	// to the redirect rules attached to that port
+	// allocatedPorts is the map of all allocated proxy ports
 	allocatedPorts map[uint16]struct{}
 
-	// redirects is a map of all redirect configurations indexed by
+	// redirects is the map of all redirect configurations indexed by
 	// the redirect identifier. Redirects may be implemented by different
 	// proxies.
 	redirects map[string]*Redirect

--- a/proxylib/npds/client_test.go
+++ b/proxylib/npds/client_test.go
@@ -15,7 +15,6 @@
 package npds
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 	"time"
@@ -52,13 +51,17 @@ var resources = []*cilium.NetworkPolicy{
 	{Name: "resource2"},
 }
 
-func ackCallback() {
-	log.Info("ACK Callback called")
+func ackCallback(err error) {
+	if err == nil {
+		log.Info("ACK Callback called")
+	} else {
+		log.Info("NACK Callback called")
+	}
 }
 
 // UpsertNetworkPolicy must only be used for testing!
 func UpsertNetworkPolicy(s *envoy.XDSServer, p *cilium.NetworkPolicy) {
-	c := completion.NewCallback(context.Background(), ackCallback)
+	c := completion.NewCompletion(nil, ackCallback)
 	s.NetworkPolicyMutator.Upsert(envoy.NetworkPolicyTypeURL, p.Name, p, []string{"127.0.0.1"}, c)
 }
 


### PR DESCRIPTION
Make received NACKs cancel the WaitGroup immediately.

Pass NACK error detail in a new error type (ProxyError).

Change xDS versioning start at 1, so that we can map the initial (no-)version ("") from Envoy to 0.

Fixes: #5649 
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4535)
<!-- Reviewable:end -->
