### PR TITLE
Test:Guestbook wait for pods to be ready

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -687,6 +687,12 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 		})
 
 		waitforPods := func() {
+
+			err = kubectl.WaitforPods(
+				helpers.DefaultNamespace,
+				fmt.Sprintf("-l %s", groupLabel), 300)
+			ExpectWithOffset(1, err).Should(BeNil(), "Bookinfo pods are not ready after timeout")
+
 			port := "6379"
 			err := kubectl.WaitForServiceEndpoints(
 				helpers.DefaultNamespace, "", "redis-master", port, helpers.HelperTimeout)
@@ -696,10 +702,6 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 				helpers.DefaultNamespace, "", "redis-slave", port, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "error waiting for redis-slave service to be ready on port %s", port)
 
-			err = kubectl.WaitforPods(
-				helpers.DefaultNamespace,
-				fmt.Sprintf("-l %s", groupLabel), 300)
-			ExpectWithOffset(1, err).Should(BeNil())
 		}
 
 		testConnectivitytoRedis := func() {


### PR DESCRIPTION
Wait until all pods are ready before wait for endpoints to be ready.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4539)
<!-- Reviewable:end -->
