### PR TITLE
apipanic: Log stack as string

### DIFF
--- a/pkg/apipanic/apipanic.go
+++ b/pkg/apipanic/apipanic.go
@@ -40,7 +40,7 @@ func (h *APIPanicHandler) ServeHTTP(r http.ResponseWriter, req *http.Request) {
 				"client":        req.RemoteAddr,
 			}
 			logging.DefaultLogger.WithFields(fields).Warn("Cilium API handler panicked")
-			logging.DefaultLogger.Debug(debug.Stack())
+			logging.DefaultLogger.Debugf("%s", debug.Stack())
 		}
 	}()
 	h.Next.ServeHTTP(r, req)


### PR DESCRIPTION
On commmit 8f7f7ab1effc826bc300ea6ca01b432f5b663170 a new debug
message was added, but when the message was triggered the output is a
`[]byte` type, so no data can't be read. This commit format the
stacktrace as string.

Fail example:

```
2018-06-17T15:48:48.954797858Z level=warning msg="Cilium API handler panicked" client=@ method=GET panic_message="write unix /var/run/cilium/cilium.sock->@: write: broken pipe" url=/v1/debuginfo
2018-06-17T15:48:48.954880714Z level=debug msg="[103 111 114 111 117 116 105 110 101 32 49 49 55 49 54 48 32 91 114 .....
```

Related-to: #4540

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4542)
<!-- Reviewable:end -->
