### PR TITLE
docs: use Documentation context to avoid longer image builds

### DIFF
--- a/Documentation/.gitignore
+++ b/Documentation/.gitignore
@@ -1,1 +1,2 @@
 _build
+_api

--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -1,11 +1,11 @@
 FROM alpine:3.7
 
-LABEL "author"="Cilium"
+LABEL maintainer="maintainer@cilium.io"
 
 ENV DOCS_DIR=/srv/Documentation
 ENV API_DIR=/srv/api
 
-ADD Documentation/requirements.txt $DOCS_DIR/requirements.txt
+ADD ./requirements.txt $DOCS_DIR/requirements.txt
 
 ENV PACKAGES="\
     bash \
@@ -23,5 +23,5 @@ RUN apk add --no-cache --virtual --update $PACKAGES && \
     pip install -r $DOCS_DIR/requirements.txt
 
 WORKDIR $DOCS_DIR
-ADD api $API_DIR
-ADD Documentation $DOCS_DIR
+ADD _api $API_DIR
+ADD . $DOCS_DIR

--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,9 @@ update-authors:
 docs-container:
 	grep -v -E "(SOURCE|GIT)_VERSION" .gitignore >.dockerignore
 	echo ".*" >>.dockerignore # .git pruned out
-	docker image build -t cilium/docs-builder -f Documentation/Dockerfile .
+	cp -r ./api ./Documentation/_api
+	docker image build -t cilium/docs-builder -f Documentation/Dockerfile ./Documentation; \
+	  (ret=$$?; rm -r ./Documentation/_api && exit $$ret)
 
 
 render-docs: docs-container


### PR DESCRIPTION
Instead of using the project root as the docker context to build the
documentation image, copy the api directory into `_api` and use the
Documentation directory as docker context for faster builds.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4543)
<!-- Reviewable:end -->
