### PR TITLE
cmd: Detect BPF map root properly

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -1,0 +1,33 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package components
+
+import (
+	"os"
+	"strings"
+)
+
+const (
+	// CiliumAgentName is the name of cilium-agent (daemon) process name.
+	CiliumAgentName = "cilium-agent"
+	// CiliumDaemonTestName is the name of test binary for daemon package.
+	CiliumDaemonTestName = "daemon.test"
+)
+
+// IsCiliumAgent checks whether the current process is cilium-agent (daemon).
+func IsCiliumAgent() bool {
+	binaryName := os.Args[0]
+	return binaryName == CiliumAgentName || strings.Contains(binaryName, CiliumDaemonTestName)
+}


### PR DESCRIPTION
Cilium CLI should detect the map root on its own, using the
mountinfo package, because there is no way to get the information
from daemon process.

Fixes #4521

Signed-off-by: Michal Rostecki <mrostecki@suse.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4545)
<!-- Reviewable:end -->
