### PR TITLE
Refactor EndpointSelector usage into helper functions

### DIFF
--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -65,34 +65,45 @@ func GetPolicyLabels(ns, name string) labels.LabelArray {
 	}
 }
 
+// getEndpointSelector converts the provided labelSelector into an EndpointSelector,
+// adding the relevant matches for namespaces based on the provided options.
+func getEndpointSelector(namespace string, labelSelector *metav1.LabelSelector, addK8sPrefix, matchesInit bool) api.EndpointSelector {
+	es := api.NewESFromK8sLabelSelector("", labelSelector)
+
+	// There's no need to prefixed K8s
+	// prefix for reserved labels
+	if addK8sPrefix && es.HasKeyPrefix(labels.LabelSourceReservedKeyPrefix) {
+		return es
+	}
+
+	// The user can explicitly specify the namespace in the
+	// FromEndpoints selector. If omitted, we limit the
+	// scope to the namespace the policy lives in.
+	//
+	// Policies applying on initializing pods are a special case.
+	// Those pods don't have any labels, so they don't have a namespace label either.
+	// Don't add a namespace label to those endpoint selectors, or we wouldn't be
+	// able to match on those pods.
+	if !matchesInit && !es.HasKey(podPrefixLbl) {
+		if es.MatchLabels == nil {
+			es.MatchLabels = map[string]string{}
+		}
+		es.MatchLabels[podPrefixLbl] = namespace
+	}
+
+	return es
+}
+
 func parseToCiliumIngressRule(namespace string, inRule, retRule *api.Rule) {
+	matchesInit := retRule.EndpointSelector.HasKey(podInitLbl)
+
 	if inRule.Ingress != nil {
 		retRule.Ingress = make([]api.IngressRule, len(inRule.Ingress))
 		for i, ing := range inRule.Ingress {
 			if ing.FromEndpoints != nil {
 				retRule.Ingress[i].FromEndpoints = make([]api.EndpointSelector, len(ing.FromEndpoints))
 				for j, ep := range ing.FromEndpoints {
-					retRule.Ingress[i].FromEndpoints[j] = api.NewESFromK8sLabelSelector("", ep.LabelSelector)
-					if retRule.Ingress[i].FromEndpoints[j].MatchLabels == nil {
-						retRule.Ingress[i].FromEndpoints[j].MatchLabels = map[string]string{}
-					}
-					// There's no need to prefixed K8s
-					// prefix for reserved labels
-					if retRule.Ingress[i].FromEndpoints[j].HasKeyPrefix(labels.LabelSourceReservedKeyPrefix) {
-						continue
-					}
-					// The user can explicitly specify the namespace in the
-					// FromEndpoints selector. If omitted, we limit the
-					// scope to the namespace the policy lives in.
-					//
-					// Policies applying on initializing pods are a special case.
-					// Those pods don't have any labels, so they don't have a namespace label either.
-					// Don't add a namespace label to those endpoint selectors, or we wouldn't be
-					// able to match on those pods.
-					if _, ok := retRule.EndpointSelector.LabelSelector.MatchLabels[podInitLbl]; !ok &&
-						!retRule.Ingress[i].FromEndpoints[j].HasKey(podPrefixLbl) {
-						retRule.Ingress[i].FromEndpoints[j].MatchLabels[podPrefixLbl] = namespace
-					}
+					retRule.Ingress[i].FromEndpoints[j] = getEndpointSelector(namespace, ep.LabelSelector, true, matchesInit)
 				}
 			}
 
@@ -113,22 +124,7 @@ func parseToCiliumIngressRule(namespace string, inRule, retRule *api.Rule) {
 			if ing.FromRequires != nil {
 				retRule.Ingress[i].FromRequires = make([]api.EndpointSelector, len(ing.FromRequires))
 				for j, ep := range ing.FromRequires {
-					retRule.Ingress[i].FromRequires[j] = api.NewESFromK8sLabelSelector("", ep.LabelSelector)
-					if retRule.Ingress[i].FromRequires[j].MatchLabels == nil {
-						retRule.Ingress[i].FromRequires[j].MatchLabels = map[string]string{}
-					}
-					// The user can explicitly specify the namespace in the
-					// FromEndpoints selector. If omitted, we limit the
-					// scope to the namespace the policy lives in.
-					//
-					// Policies applying on initializing pods are a special case.
-					// Those pods don't have any labels, so they don't have a namespace label either.
-					// Don't add a namespace label to those endpoint selectors, or we wouldn't be
-					// able to match on those pods.
-					if _, ok := retRule.EndpointSelector.LabelSelector.MatchLabels[podInitLbl]; !ok &&
-						!retRule.Ingress[i].FromRequires[j].HasKey(podPrefixLbl) {
-						retRule.Ingress[i].FromRequires[j].MatchLabels[podPrefixLbl] = namespace
-					}
+					retRule.Ingress[i].FromRequires[j] = getEndpointSelector(namespace, ep.LabelSelector, false, matchesInit)
 				}
 			}
 
@@ -141,6 +137,8 @@ func parseToCiliumIngressRule(namespace string, inRule, retRule *api.Rule) {
 }
 
 func parseToCiliumEgressRule(namespace string, inRule, retRule *api.Rule) {
+	matchesInit := retRule.EndpointSelector.HasKey(podInitLbl)
+
 	if inRule.Egress != nil {
 		retRule.Egress = make([]api.EgressRule, len(inRule.Egress))
 
@@ -148,26 +146,7 @@ func parseToCiliumEgressRule(namespace string, inRule, retRule *api.Rule) {
 			if egr.ToEndpoints != nil {
 				retRule.Egress[i].ToEndpoints = make([]api.EndpointSelector, len(egr.ToEndpoints))
 				for j, ep := range egr.ToEndpoints {
-					retRule.Egress[i].ToEndpoints[j] = api.NewESFromK8sLabelSelector("", ep.LabelSelector)
-					if retRule.Egress[i].ToEndpoints[j].MatchLabels == nil {
-						retRule.Egress[i].ToEndpoints[j].MatchLabels = map[string]string{}
-					}
-					// There's no need to add K8s prefix for reserved labels
-					if retRule.Egress[i].ToEndpoints[j].HasKeyPrefix(labels.LabelSourceReservedKeyPrefix) {
-						continue
-					}
-					// The user can explicitly specify the namespace in the
-					// ToEndpoints selector. If omitted, we limit the
-					// scope to the namespace the policy lives in.
-					//
-					// Policies applying on initializing pods are a special case.
-					// Those pods don't have any labels, so they don't have a namespace label either.
-					// Don't add a namespace label to those endpoint selectors, or we wouldn't be
-					// able to match on those pods.
-					if _, ok := retRule.EndpointSelector.LabelSelector.MatchLabels[podInitLbl]; !ok &&
-						!retRule.Egress[i].ToEndpoints[j].HasKey(podPrefixLbl) {
-						retRule.Egress[i].ToEndpoints[j].MatchLabels[podPrefixLbl] = namespace
-					}
+					retRule.Egress[i].ToEndpoints[j] = getEndpointSelector(namespace, ep.LabelSelector, true, matchesInit)
 				}
 			}
 
@@ -188,22 +167,7 @@ func parseToCiliumEgressRule(namespace string, inRule, retRule *api.Rule) {
 			if egr.ToRequires != nil {
 				retRule.Egress[i].ToRequires = make([]api.EndpointSelector, len(egr.ToRequires))
 				for j, ep := range egr.ToRequires {
-					retRule.Egress[i].ToRequires[j] = api.NewESFromK8sLabelSelector("", ep.LabelSelector)
-					if retRule.Egress[i].ToRequires[j].MatchLabels == nil {
-						retRule.Egress[i].ToRequires[j].MatchLabels = map[string]string{}
-					}
-					// The user can explicitly specify the namespace in the
-					// ToEndpoints selector. If omitted, we limit the
-					// scope to the namespace the policy lives in.
-					//
-					// Policies applying on initializing pods are a special case.
-					// Those pods don't have any labels, so they don't have a namespace label either.
-					// Don't add a namespace label to those endpoint selectors, or we wouldn't be
-					// able to match on those pods.
-					if _, ok := retRule.EndpointSelector.LabelSelector.MatchLabels[podInitLbl]; !ok &&
-						!retRule.Egress[i].ToRequires[j].HasKey(podPrefixLbl) {
-						retRule.Egress[i].ToRequires[j].MatchLabels[podPrefixLbl] = namespace
-					}
+					retRule.Egress[i].ToRequires[j] = getEndpointSelector(namespace, ep.LabelSelector, false, matchesInit)
 				}
 			}
 

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -16,6 +16,7 @@ package v2
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/comparator"
@@ -254,11 +255,16 @@ var (
 )
 
 func (s *CiliumV2Suite) TestParseSpec(c *C) {
-
-	es := api.NewESFromLabels(labels.ParseSelectLabel("role=backend"))
-	es.MatchExpressions = []metav1.LabelSelectorRequirement{
-		{Key: "any.role", Operator: "NotIn", Values: []string{"production"}},
-	}
+	es := api.NewESFromMatchRequirements(
+		map[string]string{
+			fmt.Sprintf("%s.role", labels.LabelSourceAny): "backend",
+		},
+		[]metav1.LabelSelectorRequirement{{
+			Key:      fmt.Sprintf("%s.role", labels.LabelSourceAny),
+			Operator: "NotIn",
+			Values:   []string{"production"},
+		}},
+	)
 
 	apiRule.EndpointSelector = es
 
@@ -278,9 +284,17 @@ func (s *CiliumV2Suite) TestParseSpec(c *C) {
 		Spec: &apiRuleWithLabels,
 	}
 
-	expectedES := api.NewESFromLabels(labels.ParseSelectLabel("role=backend"), labels.ParseSelectLabel("k8s:"+k8sConst.PodNamespaceLabel+"=default"))
-	expectedES.MatchExpressions = []metav1.LabelSelectorRequirement{{Key: "any.role", Operator: "NotIn", Values: []string{"production"}}}
-
+	expectedES := api.NewESFromMatchRequirements(
+		map[string]string{
+			fmt.Sprintf("%s.role", labels.LabelSourceAny):                           "backend",
+			fmt.Sprintf("%s.%s", labels.LabelSourceK8s, k8sConst.PodNamespaceLabel): "default",
+		},
+		[]metav1.LabelSelectorRequirement{{
+			Key:      fmt.Sprintf("%s.role", labels.LabelSourceAny),
+			Operator: "NotIn",
+			Values:   []string{"production"},
+		}},
+	)
 	expectedSpecRule.EndpointSelector = expectedES
 
 	rules, err := expectedPolicyRule.Parse()
@@ -302,8 +316,16 @@ func (s *CiliumV2Suite) TestParseSpec(c *C) {
 }
 
 func (s *CiliumV2Suite) TestParseRules(c *C) {
-	es := api.NewESFromLabels(labels.ParseSelectLabel("role=backend"))
-	es.MatchExpressions = []metav1.LabelSelectorRequirement{{Key: "any.role", Operator: "NotIn", Values: []string{"production"}}}
+	es := api.NewESFromMatchRequirements(
+		map[string]string{
+			fmt.Sprintf("%s.role", labels.LabelSourceAny): "backend",
+		},
+		[]metav1.LabelSelectorRequirement{{
+			Key:      fmt.Sprintf("%s.role", labels.LabelSourceAny),
+			Operator: "NotIn",
+			Values:   []string{"production"},
+		}},
+	)
 
 	apiRule.EndpointSelector = es
 
@@ -323,11 +345,18 @@ func (s *CiliumV2Suite) TestParseRules(c *C) {
 		Specs: api.Rules{&apiRuleWithLabels, &apiRuleWithLabels},
 	}
 
-	expectedES := api.NewESFromLabels(labels.ParseSelectLabel("role=backend"), labels.ParseSelectLabel("k8s:"+k8sConst.PodNamespaceLabel+"=default"))
-	expectedES.MatchExpressions = []metav1.LabelSelectorRequirement{{Key: "any.role", Operator: "NotIn", Values: []string{"production"}}}
-
+	expectedES := api.NewESFromMatchRequirements(
+		map[string]string{
+			fmt.Sprintf("%s.role", labels.LabelSourceAny):                           "backend",
+			fmt.Sprintf("%s.%s", labels.LabelSourceK8s, k8sConst.PodNamespaceLabel): "default",
+		},
+		[]metav1.LabelSelectorRequirement{{
+			Key:      fmt.Sprintf("%s.role", labels.LabelSourceAny),
+			Operator: "NotIn",
+			Values:   []string{"production"},
+		}},
+	)
 	expectedSpecRule.EndpointSelector = expectedES
-
 	expectedSpecRules := api.Rules{&expectedSpecRule, &expectedSpecRule}
 
 	rules, err := expectedPolicyRuleList.Parse()

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -16,7 +16,6 @@ package k8s
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -158,17 +157,7 @@ func (s *K8sSuite) TestParseNetworkPolicyIngress(c *C) {
 	repo.AddList(rules)
 	c.Assert(repo.AllowsIngressRLocked(&ctx), Equals, api.Denied)
 
-	matchLabels := make(map[string]string)
-	for _, v := range fromEndpoints {
-		matchLabels[fmt.Sprintf("%s.%s", v.Source, v.Key)] = v.Value
-	}
-	lblSelector := metav1.LabelSelector{
-		MatchLabels: matchLabels,
-	}
-	epSelector := api.EndpointSelector{
-		LabelSelector: &lblSelector,
-	}
-
+	epSelector := api.NewESFromLabels(fromEndpoints...)
 	ingressL4Policy, err := repo.ResolveL4IngressPolicy(&ctx)
 	c.Assert(ingressL4Policy, Not(IsNil))
 	c.Assert(err, IsNil)
@@ -247,17 +236,7 @@ func (s *K8sSuite) TestParseNetworkPolicyNoSelectors(c *C) {
 		labels.NewLabel("role", "backend", labels.LabelSourceK8s),
 	}
 
-	matchLabels := make(map[string]string)
-	for _, v := range fromEndpoints {
-		matchLabels[fmt.Sprintf("%s.%s", v.Source, v.Key)] = v.Value
-	}
-	lblSelector := metav1.LabelSelector{
-		MatchLabels: matchLabels,
-	}
-	epSelector := api.EndpointSelector{
-		LabelSelector: &lblSelector,
-	}
-
+	epSelector := api.NewESFromLabels(fromEndpoints...)
 	np := networkingv1.NetworkPolicy{}
 	err := json.Unmarshal(ex1, &np)
 	c.Assert(err, IsNil)
@@ -354,17 +333,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEgress(c *C) {
 	// expected.
 	c.Assert(repo.AllowsEgressRLocked(&ctx), Equals, api.Denied)
 
-	matchLabels := make(map[string]string)
-	for _, v := range toEndpoints {
-		matchLabels[fmt.Sprintf("%s.%s", v.Source, v.Key)] = v.Value
-	}
-	lblSelector := metav1.LabelSelector{
-		MatchLabels: matchLabels,
-	}
-	epSelector := api.EndpointSelector{
-		LabelSelector: &lblSelector,
-	}
-
+	epSelector := api.NewESFromLabels(toEndpoints...)
 	egressL4Policy, err := repo.ResolveL4EgressPolicy(&ctx)
 	c.Assert(egressL4Policy, Not(IsNil))
 	c.Assert(err, IsNil)
@@ -1427,6 +1396,10 @@ func (s *K8sSuite) TestCIDRPolicyExamples(c *C) {
 
 }
 
+func getSelectorPointer(sel api.EndpointSelector) *api.EndpointSelector {
+	return &sel
+}
+
 func Test_parseNetworkPolicyPeer(t *testing.T) {
 	type args struct {
 		namespace string
@@ -1456,21 +1429,21 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					},
 				},
 			},
-			want: &api.EndpointSelector{
-				LabelSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
+			want: getSelectorPointer(
+				api.NewESFromMatchRequirements(
+					map[string]string{
 						"k8s.foo":                         "bar",
 						"k8s.io.kubernetes.pod.namespace": "foo-namespace",
 					},
-					MatchExpressions: []metav1.LabelSelectorRequirement{
+					[]metav1.LabelSelectorRequirement{
 						{
 							Key:      "k8s.foo",
 							Operator: metav1.LabelSelectorOpIn,
 							Values:   []string{"bar", "baz"},
 						},
 					},
-				},
-			},
+				),
+			),
 		},
 		{
 			name: "peer-nil",
@@ -1510,13 +1483,13 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					},
 				},
 			},
-			want: &api.EndpointSelector{
-				LabelSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
+			want: getSelectorPointer(
+				api.NewESFromMatchRequirements(
+					map[string]string{
 						"k8s.foo": "bar",
 						"k8s.io.cilium.k8s.namespace.labels.ns-foo": "ns-bar",
 					},
-					MatchExpressions: []metav1.LabelSelectorRequirement{
+					[]metav1.LabelSelectorRequirement{
 						{
 							Key:      "k8s.io.cilium.k8s.namespace.labels.ns-foo-expression",
 							Operator: metav1.LabelSelectorOpExists,
@@ -1528,8 +1501,8 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 							Values:   []string{"bar", "baz"},
 						},
 					},
-				},
-			},
+				),
+			),
 		},
 		{
 			name: "peer-with-ns-selector",
@@ -1550,20 +1523,20 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					},
 				},
 			},
-			want: &api.EndpointSelector{
-				LabelSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
+			want: getSelectorPointer(
+				api.NewESFromMatchRequirements(
+					map[string]string{
 						"k8s.io.cilium.k8s.namespace.labels.ns-foo": "ns-bar",
 					},
-					MatchExpressions: []metav1.LabelSelectorRequirement{
+					[]metav1.LabelSelectorRequirement{
 						{
 							Key:      "k8s.io.cilium.k8s.namespace.labels.ns-foo-expression",
 							Operator: metav1.LabelSelectorOpExists,
 							Values:   []string{"bar", "baz"},
 						},
 					},
-				},
-			},
+				),
+			),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -17,7 +17,6 @@ package k8s
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -1569,8 +1568,11 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := parseNetworkPolicyPeer(tt.args.namespace, tt.args.peer); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("parseNetworkPolicyPeer() = \n%v, want \n%v", got, tt.want)
+			got := parseNetworkPolicyPeer(tt.args.namespace, tt.args.peer)
+			args := []interface{}{got, tt.want}
+			names := []string{"obtained", "expected"}
+			if equal, err := comparator.DeepEquals.Check(args, names); !equal {
+				t.Errorf("Failed to parseNetworkPolicyPeer():\n%s", err)
 			}
 		})
 	}

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -15,8 +15,6 @@
 package k8s
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/cilium/cilium/common/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
@@ -113,12 +111,7 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 		},
 	}
 
-	selector := api.ServiceSelector{
-		LabelSelector: &metav1.LabelSelector{
-			MatchLabels: svcLabels,
-		},
-	}
-
+	selector := api.ServiceSelector(api.NewESFromMatchRequirements(svcLabels, nil))
 	rule1 := api.Rule{
 		EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("bar")),
 		Egress: []api.EgressRule{{

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -152,10 +152,20 @@ func NewESFromLabels(lbls ...*labels.Label) EndpointSelector {
 	for _, lbl := range lbls {
 		ml[lbl.GetExtendedKey()] = lbl.Value
 	}
+
+	return NewESFromMatchRequirements(ml, nil)
+}
+
+// NewESFromMatchRequirements creates a new endpoint selector from the given
+// match specifications: An optional set of labels that must match, and
+// an optional slice of LabelSelectorRequirements.
+func NewESFromMatchRequirements(matchLabels map[string]string, reqs []metav1.LabelSelectorRequirement) EndpointSelector {
+	labelSelector := &metav1.LabelSelector{
+		MatchLabels:      matchLabels,
+		MatchExpressions: reqs,
+	}
 	return EndpointSelector{
-		&metav1.LabelSelector{
-			MatchLabels: ml,
-		},
+		LabelSelector: labelSelector,
 	}
 }
 


### PR DESCRIPTION
Previously, the internal details of `EndpointSelector` were splayed out across the codebase, which made it impossible to modify the structure without first refactoring the code. This PR is intended to just refactor this usage so that a future PR may make some modifications to the `EndpointSelector`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4548)
<!-- Reviewable:end -->
