### PR TITLE
Contrib: Backport script to use different versions

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -1379,10 +1379,12 @@ Cilium PRs that are marked with label ``stable/needs-backport`` need to be backp
 8. Run the ``check-stable`` script, referring to your Github access
    token, this will list the commits that need backporting, from the
    newest to oldest:
+9. ``check-stable`` has a optional argument that it's the target version to
+   backport.
 
 .. code-block:: bash
 
-        $ GITHUB_TOKEN=xxx contrib/backporting/check-stable
+        $ GITHUB_TOKEN=xxx contrib/backporting/check-stable 1.0
 
 9. Cherry-pick the commits using the master git SHAs listed, starting
    from the oldest (bottom), working your way up and fixing any merge

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -16,6 +16,8 @@
 #
 # Set PROGram name
 PROG=${0##*/}
+STABLE_BRANCH=${1:-1.0}
+echo "Checking for backports on branch '${STABLE_BRANCH}'"
 
 source $(dirname $(readlink -ne $BASH_SOURCE))/../release/lib/common.sh
 source $TOOL_LIB_PATH/gitlib.sh
@@ -165,7 +167,7 @@ MYLOG=/tmp/$PROG.log
 # Check token
 gitlib::github_api_token
 
-stable_prs=($(get_prs "stable/needs-backport" "stable/backport-done"))
+stable_prs=($(get_prs "needs-backport/${STABLE_BRANCH}" "backport-done/${STABLE_BRANCH}"))
 echo -e "PRs for stable backporting: ${#stable_prs[@]}\n"
 if [[ ${#stable_prs[@]} > 0 ]]; then
   for pr in "${stable_prs[@]}"; do


### PR DESCRIPTION
- Add a new argument on check-stable to be able to set the target branch
that we need to backport.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4552)
<!-- Reviewable:end -->
