### PR TITLE
doc: better text in basic-rules k8s link

### DIFF
--- a/Documentation/policy/intro.rst
+++ b/Documentation/policy/intro.rst
@@ -128,9 +128,9 @@ egress
 
 labels
   Labels are used to identify the rule. Rules can be listed and deleted by
-  labels. Policy rules which are imported via :ref:`k8s_policy` automatically
-  get the label ``io.cilium.k8s.policy.name=NAME`` assigned where ``NAME``
-  corresponds to the name specified in the `NetworkPolicy` or
+  labels. Policy rules which are imported via :ref:`kubernetes<k8s_policy>`
+  automatically get the label ``io.cilium.k8s.policy.name=NAME`` assigned where
+  ``NAME`` corresponds to the name specified in the `NetworkPolicy` or
   `CiliumNetworkPolicy` resource.
 
 description


### PR DESCRIPTION
The :ref: to the k8s policy section inherited its title, and this made
no sense at the source. We now better text but link to the same place.

Signed-off-by: Ray Bejjani <ray@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4554)
<!-- Reviewable:end -->
