### PR TITLE
Fix index out of range error in ParseToCiliumRule

### DIFF
--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -197,7 +197,7 @@ func ParseToCiliumRule(namespace, name string, r *api.Rule) *api.Rule {
 		// able to match on those pods.
 		if !retRule.EndpointSelector.HasKey(podInitLbl) {
 			userNamespace, ok := retRule.EndpointSelector.GetMatch(podPrefixLbl)
-			if ok && (len(userNamespace) > 1 || (len(userNamespace) == 1 && userNamespace[1] != namespace)) {
+			if ok && (len(userNamespace) > 1 || (len(userNamespace) == 1 && userNamespace[0] != namespace)) {
 				log.WithFields(logrus.Fields{
 					logfields.K8sNamespace:              namespace,
 					logfields.CiliumNetworkPolicyName:   name,

--- a/pkg/k8s/apis/cilium.io/utils/utils_test.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils_test.go
@@ -32,9 +32,16 @@ func Test(t *testing.T) {
 	TestingT(t)
 }
 
-type CiliumV2Suite struct{}
+type CiliumUtilsSuite struct{}
 
-var _ = Suite(&CiliumV2Suite{})
+var _ = Suite(&CiliumUtilsSuite{})
+
+func (s *CiliumUtilsSuite) Test_namespacesAreValid(c *C) {
+	c.Assert(namespacesAreValid("default", []string{}), Equals, true)
+	c.Assert(namespacesAreValid("default", []string{"default"}), Equals, true)
+	c.Assert(namespacesAreValid("default", []string{"foo"}), Equals, false)
+	c.Assert(namespacesAreValid("default", []string{"default", "foo"}), Equals, false)
+}
 
 func Test_ParseToCiliumRule(t *testing.T) {
 	role := fmt.Sprintf("%s.role", labels.LabelSourceAny)

--- a/pkg/k8s/apis/cilium.io/utils/utils_test.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils_test.go
@@ -1,0 +1,178 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/comparator"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/api"
+
+	. "gopkg.in/check.v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type CiliumV2Suite struct{}
+
+var _ = Suite(&CiliumV2Suite{})
+
+func Test_ParseToCiliumRule(t *testing.T) {
+	role := fmt.Sprintf("%s.role", labels.LabelSourceAny)
+	namespace := fmt.Sprintf("%s.%s", labels.LabelSourceK8s, k8sConst.PodNamespaceLabel)
+	type args struct {
+		namespace string
+		rule      *api.Rule
+	}
+	tests := []struct {
+		name string
+		args args
+		want *api.Rule
+	}{
+		{
+			// When the rule has no namespace match, the namespace
+			// is inherited from the namespace where the rule is
+			// added.
+			name: "parse-in-namespace",
+			args: args{
+				namespace: metav1.NamespaceDefault,
+				rule: &api.Rule{
+					EndpointSelector: api.NewESFromMatchRequirements(
+						map[string]string{
+							role: "backend",
+						},
+						nil,
+					),
+				},
+			},
+			want: &api.Rule{
+				EndpointSelector: api.NewESFromMatchRequirements(
+					map[string]string{
+						role:      "backend",
+						namespace: "default",
+					},
+					nil,
+				),
+				Labels: labels.LabelArray{
+					{
+						Key:    "io.cilium.k8s.policy.name",
+						Value:  "parse-in-namespace",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.namespace",
+						Value:  "default",
+						Source: labels.LabelSourceK8s,
+					},
+				},
+			},
+		},
+		{
+			// When the rule specifies a namespace, it is overridden
+			// by the namespace where the rule was inserted.
+			name: "parse-in-namespace-with-ns-selector",
+			args: args{
+				namespace: metav1.NamespaceDefault,
+				rule: &api.Rule{
+					EndpointSelector: api.NewESFromMatchRequirements(
+						map[string]string{
+							role:      "backend",
+							namespace: "foo",
+						},
+						nil,
+					),
+				},
+			},
+			want: &api.Rule{
+				EndpointSelector: api.NewESFromMatchRequirements(
+					map[string]string{
+						role:      "backend",
+						namespace: "default",
+					},
+					nil,
+				),
+				Labels: labels.LabelArray{
+					{
+						Key:    "io.cilium.k8s.policy.name",
+						Value:  "parse-in-namespace-with-ns-selector",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.namespace",
+						Value:  "default",
+						Source: labels.LabelSourceK8s,
+					},
+				},
+			},
+		},
+		{
+			// Don't insert a namespace selection when the rule
+			// is for init policies.
+			name: "parse-init-policy",
+			args: args{
+				namespace: metav1.NamespaceDefault,
+				rule: &api.Rule{
+					EndpointSelector: api.NewESFromMatchRequirements(
+						map[string]string{
+							role:       "backend",
+							podInitLbl: "",
+						},
+						nil,
+					),
+				},
+			},
+			want: &api.Rule{
+				EndpointSelector: api.NewESFromMatchRequirements(
+					map[string]string{
+						role:       "backend",
+						podInitLbl: "",
+						// No namespace because it's init.
+						// namespace: "default",
+					},
+					nil,
+				),
+				Labels: labels.LabelArray{
+					{
+						Key:    "io.cilium.k8s.policy.name",
+						Value:  "parse-init-policy",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.namespace",
+						Value:  "default",
+						Source: labels.LabelSourceK8s,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseToCiliumRule(tt.args.namespace, tt.name, tt.args.rule)
+			args := []interface{}{got, tt.want}
+			names := []string{"obtained", "expected"}
+			if equal, err := comparator.DeepEquals.Check(args, names); !equal {
+				t.Errorf("Failed to ParseToCiliumRule():\n%s", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Recent refactoring introduced an indexing error:
    
    panic: runtime error: index out of range
    
    goroutine 743 [running]:
    github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils.ParseToCiliumRule(...)
            /go/src/github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils/utils.go:200 +0x9ee
    github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2.(*CiliumNetworkPolicy).Parse(...)
            /go/src/github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2/types.go:161 +0x1b9
    main.(*Daemon).addCiliumNetworkPolicyV2(...)
            /go/src/github.com/cilium/cilium/daemon/k8s_watcher.go:1308 +0x2d3
    main.(*Daemon).EnableK8sWatcher.func13.1(...)
            /go/src/github.com/cilium/cilium/daemon/k8s_watcher.go:414 +0x45
    github.com/cilium/cilium/pkg/serializer.(*functionQueue).run(...)
            /go/src/github.com/cilium/cilium/pkg/serializer/func_queue.go:65 +0x70
    created by github.com/cilium/cilium/pkg/serializer.NewFunctionQueue
            /go/src/github.com/cilium/cilium/pkg/serializer/func_queue.go:45 +0xca
    
Fix the issue and introduce unit tests to catch this in future.
    
Fixes: #4548
Fixes: 86c5ac2a32e9 ("utils: Refactor reaching into EndpointSelector")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4562)
<!-- Reviewable:end -->
