### PR TITLE
k8s: Fix auto-generated deepycopy functions

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepcopy.go
@@ -168,6 +168,13 @@ func (in *CiliumNetworkPolicyList) DeepCopyObject() runtime.Object {
 func (in *CiliumNetworkPolicyNodeStatus) DeepCopyInto(out *CiliumNetworkPolicyNodeStatus) {
 	*out = *in
 	in.LastUpdated.DeepCopyInto(&out.LastUpdated)
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
Run `make generate-k8s-api`.

Fixes: #4412
Fixes: ad437706dd4e ("GH-4248: Return Annotations in CNP NodeStatus")

Signed-off-by: Joe Stringer <joe@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4565)
<!-- Reviewable:end -->
