### PR TITLE
Test: Validate that endpoints are ready after Cilium restart

### DIFF
--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -114,6 +114,8 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 		res.ExpectSuccess()
 
 		ExpectCiliumReady(kubectl)
+		err = kubectl.CiliumEndpointWaitReady()
+		Expect(err).To(BeNil(), "Endpoints are not ready after Cilium restarts")
 
 		PingService()
 


### PR DESCRIPTION
On Chaos, wait until endpoint are ready to validate that all
connectivity is working as expected.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

Fix Build: https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/2992/testReport/junit/k8s-1/10/K8sValidatedChaosTest_Endpoint_can_still_connect_while_Cilium_is_not_running/
```
Stacktrace

/home/jenkins/workspace/Ginkgo-CI-Tests-Pipeline/src/github.com/cilium/cilium/test/ginkgo-ext/scopes.go:373
Cannot ping from "testclient-v4gj6" to "10.10.1.48"
Expected command: kubectl exec -n default testclient-v4gj6 -- ping -W 2 -c 5 10.10.1.48 
To succeed, but it failed:
Exitcode: 1 
Stdout:
 	 PING 10.10.1.48 (10.10.1.48) 56(84) bytes of data.
	 
	 --- 10.10.1.48 ping statistics ---
	 5 packets transmitted, 0 received, 100% packet loss, time 4079ms
	 
	 
Stderr:
 	 command terminated with exit code 1
	 

/home/jenkins/workspace/Ginkgo-CI-Tests-Pipeline/src/github.com/cilium/cilium/test/k8sT/Chaos.go:118

Standard Output

STEP: Deleting cilium pods
===================== TEST FAILED =====================
cmd: kubectl get pods -o wide --all-namespaces
NAMESPACE     NAME                               READY     STATUS    RESTARTS   AGE       IP              NODE
default       testclient-4bjq4                   1/1       Running   0          2m        10.10.0.240     k8s1
default       testclient-v4gj6                   1/1       Running   0          2m        10.10.1.110     k8s2
default       testds-hkf92                       1/1       Running   0          2m        10.10.1.48      k8s2
default       testds-q5jsc                       1/1       Running   0          2m        10.10.0.12      k8s1
kube-system   cilium-k8gzc                       1/1       Running   0          1m        192.168.36.11   k8s1
kube-system   cilium-xdwjb                       1/1       Running   0          46s       192.168.36.12   k8s2
kube-system   etcd-k8s1                          1/1       Running   0          13m       192.168.36.11   k8s1
kube-system   kube-apiserver-k8s1                1/1       Running   0          13m       192.168.36.11   k8s1
kube-system   kube-controller-manager-k8s1       1/1       Running   0          13m       192.168.36.11   k8s1
kube-system   kube-dns-f4d788bb7-b2ptv           3/3       Running   0          14m       10.10.1.6       k8s2
kube-system   kube-proxy-6q2lb                   1/1       Running   0          6m        192.168.36.12   k8s2
kube-system   kube-proxy-qggcp                   1/1       Running   0          14m       192.168.36.11   k8s1
kube-system   kube-scheduler-k8s1                1/1       Running   0          13m       192.168.36.11   k8s1
kube-system   microscope                         1/1       Running   0          5m        10.10.0.65      k8s1
prometheus    prometheus-core-84677d797f-6sfvk   1/1       Running   0          6m        10.10.1.83      k8s2

cmd: kubectl exec -n kube-system cilium-k8gzc -- cilium service list
ID   Frontend              Backend                   
1    10.96.0.10:53         1 => 10.10.1.6:53         
2    10.102.255.101:9090   1 => 10.10.1.83:9090      
3    10.96.0.1:443         1 => 192.168.36.11:6443   
5    10.111.251.30:80      1 => 10.10.0.12:80        
                           2 => 10.10.1.48:80        
6    10.100.42.135:10080   1 => 10.10.0.12:80        
                           2 => 10.10.1.48:80        

cmd: kubectl exec -n kube-system cilium-k8gzc -- cilium endpoint list
ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                          IPv6                 IPv4          STATUS   
           ENFORCEMENT        ENFORCEMENT                                                                                                          
23041      Disabled           Disabled          22640      k8s:io.cilium.k8s.policy.serviceaccount=microscope   f00d::a0a:0:0:5a01   10.10.0.65    ready   
                                                           k8s:io.kubernetes.pod.namespace=kube-system                                                     
                                                           k8s:k8s-app=microscope                                                                          
31783      Disabled           Disabled          4          reserved:health                                      f00d::a0a:0:0:7c27   10.10.0.131   ready   
49845      Disabled           Disabled          48163      k8s:io.cilium.k8s.policy.serviceaccount=default      f00d::a0a:0:0:c2b5   10.10.0.240   ready   
                                                           k8s:io.kubernetes.pod.namespace=default                                                         
                                                           k8s:zgroup=testDSClient                                                                         
59367      Disabled           Disabled          35344      k8s:io.cilium.k8s.policy.serviceaccount=default      f00d::a0a:0:0:e7e7   10.10.0.12    ready   
                                                           k8s:io.kubernetes.pod.namespace=default                                                         
                                                           k8s:zgroup=testDS                                                                               

cmd: kubectl exec -n kube-system cilium-xdwjb -- cilium service list
ID   Frontend              Backend                   
1    10.96.0.10:53         1 => 10.10.1.6:53         
2    10.102.255.101:9090   1 => 10.10.1.83:9090      
3    10.96.0.1:443         1 => 192.168.36.11:6443   
5    10.111.251.30:80      1 => 10.10.0.12:80        
                           2 => 10.10.1.48:80        
6    10.100.42.135:10080   1 => 10.10.0.12:80        
                           2 => 10.10.1.48:80        

cmd: kubectl exec -n kube-system cilium-xdwjb -- cilium endpoint list
ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                              IPv6                   IPv4          STATUS   
           ENFORCEMENT        ENFORCEMENT                                                                                                                
3169       Disabled           Disabled          48163      k8s:io.cilium.k8s.policy.serviceaccount=default          f00d::a0a:100:0:c61    10.10.1.110   not-ready   
                                                           k8s:io.kubernetes.pod.namespace=default                                                                   
                                                           k8s:zgroup=testDSClient                                                                                   
12163      Disabled           Disabled          59915      k8s:io.cilium.k8s.policy.serviceaccount=kube-dns         f00d::a0a:100:0:2f83   10.10.1.6     ready       
                                                           k8s:io.kubernetes.pod.namespace=kube-system                                                               
                                                           k8s:k8s-app=kube-dns                                                                                      
33532      Disabled           Disabled          35344      k8s:io.cilium.k8s.policy.serviceaccount=default          f00d::a0a:100:0:82fc   10.10.1.48    ready       
                                                           k8s:io.kubernetes.pod.namespace=default                                                                   
                                                           k8s:zgroup=testDS                                                                                         
36491      Disabled           Disabled          4          reserved:health                                          f00d::a0a:100:0:8e8b   10.10.1.91    ready       
62566      Disabled           Disabled          30266      k8s:app=prometheus                                       f00d::a0a:100:0:f466   10.10.1.83    ready       
                                                           k8s:component=core                                                                                        
                                                           k8s:io.cilium.k8s.policy.serviceaccount=prometheus-k8s                                                    
                                                           k8s:io.kubernetes.pod.namespace=prometheus                                                                
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4571)
<!-- Reviewable:end -->
