### PR TITLE
Test: Upgrade wait until endpoints are ready

### DIFF
--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -70,6 +70,9 @@ var _ = Describe("K8sValidatedUpdates", func() {
 		kubectl.DeleteResource("ds", fmt.Sprintf("-n %s cilium", helpers.KubeSystemNamespace))
 		helpers.InstallExampleCilium(kubectl)
 
+		err := kubectl.CiliumEndpointWaitReady()
+		Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
+
 		ExpectKubeDNSReady(kubectl)
 	})
 
@@ -159,13 +162,13 @@ var _ = Describe("K8sValidatedUpdates", func() {
 
 		validatedImage(localImage)
 
+		err = kubectl.CiliumEndpointWaitReady()
+		Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
+
 		ExpectKubeDNSReady(kubectl)
 
 		err = kubectl.WaitForKubeDNSEntry(app1Service)
 		Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
-
-		err = kubectl.CiliumEndpointWaitReady()
-		Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 
 		res = kubectl.ExecPodCmd(
 			helpers.DefaultNamespace, appPods[helpers.App2],


### PR DESCRIPTION
On Upgrade test wait untils all the endpoints are in ready state. The
Cilium pods are in ready state, but the endpoints maybe are not in ready
state.

With this change we have the endpoint state over the time and we can do
deeper debug before DNS resolution fails.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4572)
<!-- Reviewable:end -->
