### PR TITLE
Test: Cleanup runtime installation

### DIFF
--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -8,13 +8,5 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 source "${PROVISIONSRC}/helpers.bash"
 
-echo "editing journald configuration"
-sudo bash -c "sed -i 's/RateLimitBurst=1000/RateLimitBurst=10000/' /etc/systemd/journald.conf"
-echo "restarting systemd-journald"
-sudo systemctl restart systemd-journald
-echo "getting status of systemd-journald"
-sudo service systemd-journald status
-echo "done configuring journald"
-
 "${PROVISIONSRC}"/dns.sh
 "${PROVISIONSRC}"/compile.sh


### PR DESCRIPTION
With the current vagrant box the journal Ratelimits are set to 10000
instead of 1000, so no need to set it on the box.

Fix #4425

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4580)
<!-- Reviewable:end -->
