### PR TITLE
More efficient monitor event encoding (v1.2)

### DIFF
--- a/monitor/launch/launcher.go
+++ b/monitor/launch/launcher.go
@@ -203,12 +203,7 @@ func (nm *NodeMonitor) send(data []byte) error {
 
 	p := payload.Payload{Data: data, CPU: 0, Lost: nm.lostSinceLastTime(), Type: payload.EventSample}
 
-	buf, err := p.BuildMessage()
-	if err != nil {
-		return err
-	}
-
-	if _, err := nm.pipe.Write(buf); err != nil {
+	if err := p.WriteBinary(nm.pipe); err != nil {
 		nm.pipe.Close()
 		nm.pipe = nil
 		return fmt.Errorf("Unable to write message buffer to pipe: %s", err)

--- a/monitor/listener.go
+++ b/monitor/listener.go
@@ -1,0 +1,71 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"net"
+	"os"
+	"syscall"
+)
+
+type monitorListener struct {
+	conn      net.Conn
+	queue     chan []byte
+	cleanupFn func(*monitorListener)
+}
+
+func newMonitorListener(c net.Conn, queueSize int, cleanupFn func(*monitorListener)) *monitorListener {
+	ml := &monitorListener{
+		conn:      c,
+		queue:     make(chan []byte, queueSize),
+		cleanupFn: cleanupFn,
+	}
+
+	go ml.drainQueue()
+
+	return ml
+}
+
+func (ml *monitorListener) enqueue(msg []byte) {
+	select {
+	case ml.queue <- msg:
+	default:
+		log.Debugf("Per listener queue is full, dropping message")
+	}
+}
+
+func (ml *monitorListener) drainQueue() {
+	defer func() {
+		ml.conn.Close()
+		ml.cleanupFn(ml)
+	}()
+
+	for msgBuf := range ml.queue {
+		if _, err := ml.conn.Write(msgBuf); err != nil {
+			if op, ok := err.(*net.OpError); ok {
+				if syscerr, ok := op.Err.(*os.SyscallError); ok {
+					if errn, ok := syscerr.Err.(syscall.Errno); ok {
+						if errn == syscall.EPIPE {
+							log.Info("Listener disconnected")
+							return
+						}
+					}
+				}
+			}
+			log.WithError(err).Warn("Removing listener due to write failure")
+			return
+		}
+	}
+}

--- a/monitor/listener/listener.go
+++ b/monitor/listener/listener.go
@@ -18,6 +18,8 @@ import (
 	"net"
 	"os"
 	"syscall"
+
+	"github.com/cilium/cilium/monitor/payload"
 )
 
 // Version is the version of a node-monitor listener client. There are
@@ -36,6 +38,17 @@ const (
 	// Version1_0 is the API 1.0 version of the protocol (see above).
 	Version1_0 = Version("1.0")
 )
+
+// MonitorListener is a generic consumer of monitor events. Implementers are
+// expected to handle errors as needed, including exiting.
+type MonitorListener interface {
+	// Enqueue adds this payload to the send queue. Any errors should be logged
+	// and handled appropriately.
+	Enqueue(pl *payload.Payload)
+
+	// Version returns the API version of this listener
+	Version() Version
+}
 
 // IsDisconnected is a convenience function that wraps the absurdly long set of
 // checks for a disconnect.

--- a/monitor/listener/listener.go
+++ b/monitor/listener/listener.go
@@ -37,6 +37,9 @@ const (
 
 	// Version1_0 is the API 1.0 version of the protocol (see above).
 	Version1_0 = Version("1.0")
+
+	// Version1_2 is the API 1.0 version of the protocol (see above).
+	Version1_2 = Version("1.2")
 )
 
 // MonitorListener is a generic consumer of monitor events. Implementers are

--- a/monitor/listener1_2.go
+++ b/monitor/listener1_2.go
@@ -1,0 +1,80 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/gob"
+	"net"
+
+	"github.com/cilium/cilium/monitor/listener"
+	"github.com/cilium/cilium/monitor/payload"
+)
+
+// listenerv1_2 implements the ciliim-node-monitor API protocol compatible with
+// cilium 1.2
+// cleanupFn is called on exit
+type listenerv1_2 struct {
+	conn      net.Conn
+	queue     chan *payload.Payload
+	cleanupFn func(listener.MonitorListener)
+}
+
+func newListenerv1_2(c net.Conn, queueSize int, cleanupFn func(listener.MonitorListener)) *listenerv1_2 {
+	ml := &listenerv1_2{
+		conn:      c,
+		queue:     make(chan *payload.Payload, queueSize),
+		cleanupFn: cleanupFn,
+	}
+
+	go ml.drainQueue()
+
+	return ml
+}
+
+func (ml *listenerv1_2) Enqueue(pl *payload.Payload) {
+	select {
+	case ml.queue <- pl:
+	default:
+		log.Debugf("Per listener queue is full, dropping message")
+	}
+}
+
+// drainQueue encodes and sends monitor payloads to the listener. It is
+// intended to be a goroutine.
+func (ml *listenerv1_2) drainQueue() {
+	defer func() {
+		ml.conn.Close()
+		ml.cleanupFn(ml)
+	}()
+
+	enc := gob.NewEncoder(ml.conn)
+	for pl := range ml.queue {
+		if err := pl.EncodeBinary(enc); err != nil {
+			switch {
+			case listener.IsDisconnected(err):
+				log.Info("Listener disconnected")
+				return
+
+			default:
+				log.WithError(err).Warn("Removing listener due to write failure")
+				return
+			}
+		}
+	}
+}
+
+func (ml *listenerv1_2) Version() listener.Version {
+	return listener.Version1_2
+}

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -114,9 +114,13 @@ func runNodeMonitor() {
 	defer server1_0.Close() // Stop accepting new v1.0 connections
 	log.Infof("Serving cilium node monitor v1.0 API at unix://%s", defaults.MonitorSockPath1_0)
 
+	server1_2 := buildServerOrExit(defaults.MonitorSockPath1_2)
+	defer server1_2.Close() // Stop accepting new v1.2 connections
+	log.Infof("Serving cilium node monitor v1.2 API at unix://%s", defaults.MonitorSockPath1_2)
+
 	mainCtx, mainCtxCancel := context.WithCancel(context.Background())
 
-	monitorSingleton, err = NewMonitor(mainCtx, npages, pipe, server1_0)
+	monitorSingleton, err = NewMonitor(mainCtx, npages, pipe, server1_0, server1_2)
 	if err != nil {
 		log.WithError(err).Fatal("Error initialising monitor handlers")
 	}

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -271,18 +271,12 @@ func (m *Monitor) connectionHandler1_0(parentCtx context.Context, server net.Lis
 	}
 }
 
-// send writes the payload.Meta and the actual payload to the active
-// connections.
+// send enqueues the payload to all listeners.
 func (m *Monitor) send(pl *payload.Payload) {
-	buf, err := pl.BuildMessage()
-	if err != nil {
-		log.WithError(err).Error("Unable to send notification to listeners")
-	}
-
 	m.Lock()
 	defer m.Unlock()
 	for ml := range m.listeners {
-		ml.enqueue(buf)
+		ml.enqueue(pl)
 	}
 }
 

--- a/monitor/payload/monitor_payload.go
+++ b/monitor/payload/monitor_payload.go
@@ -91,13 +91,23 @@ func (pl *Payload) Encode() ([]byte, error) {
 // ReadBinary reads the payload from its binary representation.
 func (pl *Payload) ReadBinary(r io.Reader) error {
 	dec := gob.NewDecoder(r)
-	return dec.Decode(pl)
+	return pl.DecodeBinary(dec)
 }
 
 // WriteBinary writes the payload into its binary representation.
 func (pl *Payload) WriteBinary(w io.Writer) error {
 	enc := gob.NewEncoder(w)
+	return pl.EncodeBinary(enc)
+}
+
+// EncodeBinary writes the payload into its binary representation.
+func (pl *Payload) EncodeBinary(enc *gob.Encoder) error {
 	return enc.Encode(pl)
+}
+
+// DecodeBinary reads the payload from its binary representation.
+func (pl *Payload) DecodeBinary(dec *gob.Decoder) error {
+	return dec.Decode(pl)
 }
 
 // ReadMetaPayload reads a Meta and Payload from a Cilium monitor connection.

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -49,9 +49,10 @@ const (
 	// SockPathEnv is the environment variable to overwrite SockPath
 	SockPathEnv = "CILIUM_SOCK"
 
-	// MonitorSockPath is the path to the UNIX domain socket used to distribute events
-	// between multiple monitors.
-	MonitorSockPath = RuntimePath + "/monitor.sock"
+	// MonitorSockPath1_0 is the path to the UNIX domain socket used to
+	// distribute BPF and agent events to listeners.
+	// This is the 1.0 protocol version.
+	MonitorSockPath1_0 = RuntimePath + "/monitor.sock"
 
 	// PidFilePath is the path to the pid file for the agent.
 	PidFilePath = RuntimePath + "/cilium.pid"

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -54,6 +54,11 @@ const (
 	// This is the 1.0 protocol version.
 	MonitorSockPath1_0 = RuntimePath + "/monitor.sock"
 
+	// MonitorSockPath1_2 is the path to the UNIX domain socket used to
+	// distribute BPF and agent events to listeners.
+	// This is the 1.2 protocol version.
+	MonitorSockPath1_2 = RuntimePath + "/monitor1_2.sock"
+
 	// PidFilePath is the path to the pid file for the agent.
 	PidFilePath = RuntimePath + "/cilium.pid"
 


### PR DESCRIPTION
I've changed how node-monitor encodes events that it transmits. This is now labelled as the 1.2 version, and the older scheme is 1.0. In type names the `.` is replaced with a`_` (this is ugly). The numbers are intended to follow cilium releases.
Version 1.0 created a new gob encoder per `payload`. This meant that the encoder also included a type preamble in the output. It prepended a similarly encoded `meta` object (this includes a length field).
Version 1.2 uses a single gob encoder per connected monitor listener client. Thus, it sends the type preamble the first time it sends an event `payload`. There is no meta object in this version.

Note: each version is served on a different socket, `monitor.sock` for v1.0 and `monitor1_2.sock` for v1.2.

The general steps, in almost as few PRs
1- Reuse the gob encoder when sending data to listeners. A naive benchmark on my dev VM shows a 6x improvement. This isn't representative of the real pipeline, however. Gob will only send the type information to each listener once, the first time it sends data, and then should only send the actual data (I suspect this is similar to how protobuf encodes data, a tag-length-value style scheme with field numbers).
2- Begin tracking API version in the CLI client and in node-monitor.
3- Support multiple versions of listener. Newer listeners prefer the newer encoding scheme but can read from older node-monitor instances. v1.2 node-monitor instances present the old and new API sockets and can handle both
4- Ensure the endpoint/policy events from cilium-agent are still working

*Questions & Concerns*
1- To keep it simple, I naively moved the v1.0 encoding into the listener class. This is dangerous. Previously, we did the inefficient encoding once, then sent the bytes directly. We now repeat the inefficient encoding per listener. This can be fixed but the number of older listeners is likely to be low. Note that the CLI `cilium monitor` is bundled with cilium-agent (ideally) and would use the new version always.
2- This is more a simplification of the current protocol. It still retains it's original problem: listeners cannot push any data when they connect, including what data they are interested in.
3- If we're doing this anyway, should we just jump to a more robust scheme like grpc? I'm not sure what the overhead is for something like that but after handling the initial request, cilium-node-monitor would just stream data the way it does now without handling new requests on that listener connection. Another reason to go further is that v1.2 is still no upgradeable without yet another socket being created. This isn't very ideal.

```release-note
Updated cilium-monitor internal API v1.2 uses less CPU and I/O when streaming data
```

Fixes #5110 


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4581)
<!-- Reviewable:end -->
