### PR TITLE
Ginkgo logs enhancements

### DIFF
--- a/test/ginkgo-ext/scopes.go
+++ b/test/ginkgo-ext/scopes.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/config"
@@ -229,10 +230,12 @@ func runAllAfterFail(cs *scope, testName string) {
 	}
 
 	hasFailed, _ := afterEachFailed[testName]
-	for _, body := range cs.afterFail {
-		if ginkgo.CurrentGinkgoTestDescription().Failed || hasFailed {
+	if (ginkgo.CurrentGinkgoTestDescription().Failed || hasFailed) && len(cs.afterFail) > 0 {
+		GinkgoPrint("===================== TEST FAILED =====================")
+		for _, body := range cs.afterFail {
 			body()
 		}
+		GinkgoPrint("===================== Existing AfterFailed =====================")
 	}
 
 	if cs.parent != nil {
@@ -407,6 +410,7 @@ func wrapTest(f interface{}) interface{} {
 			atomic.AddInt32(&cs.counter, -1)
 			cs = cs.parent
 		}
+		GinkgoPrint("=== Test Finished at %s====", time.Now().Format(time.RFC3339))
 	}
 	return applyAdvice(f, nil, after)
 }

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -619,7 +619,6 @@ func (s *SSHMeta) ReportFailed(commands ...string) {
 
 	// Log the following line to both the log file, and to console to delineate
 	// when log gathering begins.
-	ginkgoext.GinkgoPrint("===================== TEST FAILED =====================")
 	res := s.ExecCilium("endpoint list") // save the output in the logs
 	ginkgoext.GinkgoPrint(res.GetDebugMessage())
 
@@ -632,9 +631,6 @@ func (s *SSHMeta) ReportFailed(commands ...string) {
 	s.GatherLogs()
 	s.GatherDockerLogs()
 	s.CheckLogsForDeadlock()
-	// Log the following line to both the log file, and to console to delineate
-	// when log gathering begins.
-	ginkgoext.GinkgoPrint("===================== EXITING REPORT GENERATION =====================")
 }
 
 // ValidateNoErrorsOnLogs checks in cilium logs since the given duration (By

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -623,7 +623,7 @@ func (s *SSHMeta) ReportFailed(commands ...string) {
 	ginkgoext.GinkgoPrint(res.GetDebugMessage())
 
 	for _, cmd := range commands {
-		res = s.ExecWithSudo(fmt.Sprintf("%s", cmd))
+		res = s.ExecWithSudo(fmt.Sprintf("%s", cmd), ExecOptions{SkipLog: true})
 		ginkgoext.GinkgoPrint(res.GetDebugMessage())
 	}
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -265,9 +265,9 @@ func (kub *Kubectl) ExecKafkaPodCmd(namespace string, pod string, arg string) er
 
 // ExecPodCmd executes command cmd in the specified pod residing in the specified
 // namespace. It returns a pointer to CmdRes with all the output
-func (kub *Kubectl) ExecPodCmd(namespace string, pod string, cmd string) *CmdRes {
+func (kub *Kubectl) ExecPodCmd(namespace string, pod string, cmd string, options ...ExecOptions) *CmdRes {
 	command := fmt.Sprintf("%s exec -n %s %s -- %s", KubectlCmd, namespace, pod, cmd)
-	return kub.Exec(command)
+	return kub.Exec(command, options...)
 }
 
 // ExecPodCmd executes command cmd in background in the specified pod residing
@@ -1035,7 +1035,7 @@ func (kub *Kubectl) CiliumReport(namespace string, commands ...string) {
 
 	for _, pod := range pods {
 		for _, cmd := range commands {
-			res = kub.ExecPodCmd(namespace, pod, cmd)
+			res = kub.ExecPodCmd(namespace, pod, cmd, ExecOptions{SkipLog: true})
 			ginkgoext.GinkgoPrint(res.GetDebugMessage())
 		}
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1030,8 +1030,6 @@ func (kub *Kubectl) CiliumReport(namespace string, commands ...string) {
 		kub.logger.WithError(err).Error("cannot retrieve cilium pods on ReportDump")
 		return
 	}
-	ginkgoext.GinkgoPrint("===================== TEST FAILED =====================")
-	// Dump a human readable view of pods in the test-output log
 	res := kub.Exec(fmt.Sprintf("%s get pods -o wide --all-namespaces", KubectlCmd))
 	ginkgoext.GinkgoPrint(res.GetDebugMessage())
 
@@ -1044,7 +1042,6 @@ func (kub *Kubectl) CiliumReport(namespace string, commands ...string) {
 
 	kub.DumpCiliumCommandOutput(namespace)
 	kub.GatherLogs()
-	ginkgoext.GinkgoPrint("===================== EXITING REPORT GENERATION =====================")
 }
 
 // ValidateNoErrorsOnLogs checks in cilium logs since the given duration (By


### PR DESCRIPTION
- Avoid the duplicated test-output on CiliumReport
- Print time when the test finished. 
- Move log lines for AfterFailed to ginkgo-ext package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4586)
<!-- Reviewable:end -->
