### PR TITLE
Allocate ipcache mappings for service backends

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -35,6 +35,7 @@ import (
 	informer "github.com/cilium/cilium/pkg/k8s/client/informers/externalversions"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	bpfIPCache "github.com/cilium/cilium/pkg/maps/ipcache"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
@@ -745,7 +746,7 @@ func (d *Daemon) addK8sEndpointV1(ep *v1.Endpoints) {
 
 	svc, ok := d.loadBalancer.K8sServices[svcns]
 	if ok && svc.IsExternal() {
-		translator := k8s.NewK8sTranslator(svcns, *newSvcEP, false, svc.Labels)
+		translator := k8s.NewK8sTranslator(svcns, *newSvcEP, false, svc.Labels, bpfIPCache.IPCache)
 		err := d.policy.TranslateRules(translator)
 		if err != nil {
 			log.Errorf("Unable to repopulate egress policies from ToService rules: %v", err)
@@ -787,7 +788,7 @@ func (d *Daemon) deleteK8sEndpointV1(ep *v1.Endpoints) {
 	if endpoint, ok := d.loadBalancer.K8sEndpoints[svcns]; ok {
 		svc, ok := d.loadBalancer.K8sServices[svcns]
 		if ok && svc.IsExternal() {
-			translator := k8s.NewK8sTranslator(svcns, *endpoint, true, svc.Labels)
+			translator := k8s.NewK8sTranslator(svcns, *endpoint, true, svc.Labels, bpfIPCache.IPCache)
 			err := d.policy.TranslateRules(translator)
 			if err != nil {
 				log.Errorf("Unable to depopulate egress policies from ToService rules: %v", err)

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -258,6 +258,7 @@ func (d *Daemon) PolicyAdd(rules api.Rules, opts *AddOptions) (uint64, error) {
 	rev, err := d.policyAdd(rules, opts)
 	if err != nil {
 		// Don't leak identities allocated above.
+		ipcache.DeleteIPNetsFromKVStore(prefixes)
 		identity.ReleaseSlice(prefixIdentities)
 
 		return 0, apierror.Error(PutPolicyFailureCode, err)

--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -1,0 +1,51 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ip
+
+import (
+	"net"
+)
+
+// ParseCIDRs fetches all CIDRs referred to by the specified slice and returns
+// them as regular golang CIDR objects.
+func ParseCIDRs(cidrs []string) (valid []*net.IPNet, invalid []string) {
+	valid = make([]*net.IPNet, 0, len(cidrs))
+	invalid = make([]string, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, prefix, err := net.ParseCIDR(cidr)
+		if err != nil {
+			// Likely the CIDR is specified in host format.
+			ip := net.ParseIP(cidr)
+			if ip == nil {
+				invalid = append(invalid, cidr)
+				continue
+			} else {
+				bits := net.IPv6len * 8
+				if ip.To4() != nil {
+					ip = ip.To4()
+					bits = net.IPv4len * 8
+				}
+				prefix = &net.IPNet{
+					IP:   ip,
+					Mask: net.CIDRMask(bits, bits),
+				}
+			}
+		}
+		if prefix != nil {
+			valid = append(valid, prefix)
+		}
+	}
+	return valid, invalid
+}

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -1,0 +1,87 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipcache
+
+import (
+	"net"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cidr"
+
+	"github.com/sirupsen/logrus"
+)
+
+// AllocateCIDRs attempts to allocate identities and IP<->Identity mappings for
+// the specified CIDR prefixes. If any allocation fails, all allocations are
+// rolled back and the error is returned. Returns nil on success.
+func AllocateCIDRs(impl Implementation, prefixes []*net.IPNet) error {
+	// First, if the implementation will complain, exit early.
+	if err := checkPrefixes(impl, prefixes); err != nil {
+		return err
+	}
+
+	// Next, allocate labels -> ID mappings in KVstore (for policy)
+	prefixIdentities, err := cidr.AllocateCIDRIdentities(prefixes)
+	if err != nil {
+		return err
+	}
+
+	// Finally, allocate CIDR -> ID mappings in KVstore (for ipcache)
+	err = upsertIPNetsToKVStore(prefixes, prefixIdentities)
+	if err != nil {
+		if err2 := identity.ReleaseSlice(prefixIdentities); err2 != nil {
+			log.WithError(err2).WithFields(logrus.Fields{
+				fieldIdentities: prefixIdentities,
+			}).Warn("Failed to release CIDRs during CIDR->ID mapping")
+		}
+	}
+
+	return err
+}
+
+// ReleaseCIDRs attempts to release identities and IP<->Identity mappings for
+// the specified CIDR prefixes. If any release fails, all remaining prefixes
+// will be attempted to be rolled back and an error is returned representing
+// the most recent error. Returns nil if no errors occur.
+func ReleaseCIDRs(prefixes []*net.IPNet) (err error) {
+	scopedLog := log.WithField("prefixes", prefixes)
+	if prefixes != nil {
+		if err = deleteIPNetsFromKVStore(prefixes); err != nil {
+			scopedLog.WithError(err).Debug(
+				"Failed to release CIDR->Identity mappings")
+		}
+	}
+
+	prefixIdentities, err2 := cidr.LookupCIDRIdentities(prefixes)
+	if err2 != nil {
+		if err == nil {
+			err = err2
+		}
+		scopedLog.WithError(err2).Debug(
+			"Could not find identities for CIDRs during release")
+	}
+	if prefixIdentities != nil {
+		if err2 = identity.ReleaseSlice(prefixIdentities); err2 != nil {
+			if err == nil {
+				err = err2
+			}
+			log.WithError(err2).WithFields(logrus.Fields{
+				fieldIdentities: prefixIdentities,
+			}).Debug("Failed to release Identities for CIDRs")
+		}
+	}
+
+	return err
+}

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -106,10 +106,10 @@ func checkPrefixLengthsAgainstMap(impl Implementation, prefixes []*net.IPNet, ex
 	return nil
 }
 
-// CheckPrefixes ensures that we will reject rules if the import of those
+// checkPrefixes ensures that we will reject rules if the import of those
 // rules would cause the underlying implementation of the ipcache to exceed
 // the maximum number of supported CIDR prefix lengths.
-func CheckPrefixes(impl Implementation, prefixes []*net.IPNet) (err error) {
+func checkPrefixes(impl Implementation, prefixes []*net.IPNet) (err error) {
 	IPIdentityCache.RLock()
 	defer IPIdentityCache.RUnlock()
 

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -63,7 +63,7 @@ type store interface {
 	release(key string) error
 }
 
-// kvstoreImplementation is provided to mock out the kvstore for unit testing.
+// kvstoreImplementation is a store implementation backed by the kvstore.
 type kvstoreImplementation struct{}
 
 // upsert places the mapping of {key, value} into the kvstore, optionally with
@@ -80,8 +80,8 @@ func (k kvstoreImplementation) release(key string) error {
 // kvReferenceCounter provides a thin wrapper around the kvstore which adds
 // reference tracking for all entries being updated. When the first key is
 // updated, it adds a reference to the kvstore and tracks the reference
-// internally. Subsequent updates also update the kvstore, and add a referenc.
-// Deletes from the referenceCounter are only propagated to the kvstore when
+// internally. Subsequent updates also update the kvstore, and add a reference.
+// Deletes from the kvReferenceCounter are only propagated to the kvstore when
 // the final reference is released.
 //
 // This has some small overlap with the pkg/kvstore/allocator but this is only
@@ -95,8 +95,8 @@ type kvReferenceCounter struct {
 	keys map[string]uint64
 }
 
-// newKVReferenceCounter creates a new reference counter using the global
-// kvstore package as the underlying store.
+// newKVReferenceCounter creates a new reference counter using the specified
+// store as the underlying location for key/value pairs to be stored.
 func newKVReferenceCounter(s store) *kvReferenceCounter {
 	return &kvReferenceCounter{
 		store: s,

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -165,10 +165,10 @@ func UpsertIPToKVStore(IP net.IP, ID identity.NumericIdentity, metadata string) 
 	return globalMap.upsert(ipKey, ipIDPair)
 }
 
-// UpsertIPNetToKVStore updates / inserts the provided CIDR->Identity mapping
+// upsertIPNetToKVStore updates / inserts the provided CIDR->Identity mapping
 // into the kvstore, which will subsequently trigger an event in
 // ipIdentityWatcher().
-func UpsertIPNetToKVStore(prefix *net.IPNet, ID *identity.Identity) error {
+func upsertIPNetToKVStore(prefix *net.IPNet, ID *identity.Identity) error {
 	// Reserved identities are handled locally, don't push them to kvstore.
 	if ID.IsReserved() {
 		return nil
@@ -219,7 +219,7 @@ func keyToIPNet(key string) (parsedPrefix *net.IPNet, host bool, err error) {
 	return
 }
 
-// UpsertIPNetsToKVStore inserts a CIDR->Identity mapping into the kvstore
+// upsertIPNetsToKVStore inserts a CIDR->Identity mapping into the kvstore
 // ipcache for each of the specified prefixes and identities. That is to say,
 // prefixes[0] is mapped to identities[0].
 //
@@ -228,13 +228,13 @@ func keyToIPNet(key string) (parsedPrefix *net.IPNet, host bool, err error) {
 //
 // The caller should check the prefix lengths against the underlying IPCache
 // implementation using CheckPrefixLengths prior to upserting to the kvstore.
-func UpsertIPNetsToKVStore(prefixes []*net.IPNet, identities []*identity.Identity) (err error) {
+func upsertIPNetsToKVStore(prefixes []*net.IPNet, identities []*identity.Identity) (err error) {
 	if len(prefixes) != len(identities) {
 		return fmt.Errorf("Invalid []Prefix->[]Identity ipcache mapping requested: prefixes=%d identities=%d", len(prefixes), len(identities))
 	}
 	for i, prefix := range prefixes {
 		id := identities[i]
-		err = UpsertIPNetToKVStore(prefix, id)
+		err = upsertIPNetToKVStore(prefix, id)
 		if err != nil {
 			for j := 0; j < i; j++ {
 				ipKey := path.Join(IPIdentitiesPath, AddressSpace, prefix.String())
@@ -259,10 +259,10 @@ func DeleteIPFromKVStore(ip string) error {
 	return globalMap.release(ipKey)
 }
 
-// DeleteIPNetsFromKVStore removes the Prefix->Identity mappings for the
+// deleteIPNetsFromKVStore removes the Prefix->Identity mappings for the
 // specified slice of prefixes from the kvstore, which will subsequently
 // trigger an event in ipIdentityWatcher().
-func DeleteIPNetsFromKVStore(prefixes []*net.IPNet) (err error) {
+func deleteIPNetsFromKVStore(prefixes []*net.IPNet) (err error) {
 	for _, prefix := range prefixes {
 		ipKey := path.Join(IPIdentitiesPath, AddressSpace, prefix.String())
 		if err2 := globalMap.release(ipKey); err2 != nil {

--- a/pkg/ipcache/kvstore_test.go
+++ b/pkg/ipcache/kvstore_test.go
@@ -60,7 +60,7 @@ func (s *IPCacheTestSuite) TestKVReferenceCounter(c *C) {
 	err = refcnt.release(key1)
 	c.Assert(err, IsNil)
 	c.Assert(ts[key1], Equals, 2)
-	// Remove the second referenc, "foo" should be deleted from the store.
+	// Remove the second reference, "foo" should be deleted from the store.
 	err = refcnt.release(key1)
 	c.Assert(err, IsNil)
 	_, ok := ts[key1]

--- a/pkg/ipcache/logfields.go
+++ b/pkg/ipcache/logfields.go
@@ -1,0 +1,19 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipcache
+
+const (
+	fieldIdentities = "identities"
+)

--- a/pkg/k8s/rule_translate.go
+++ b/pkg/k8s/rule_translate.go
@@ -18,11 +18,13 @@ import (
 	"fmt"
 	"net"
 
-	"k8s.io/apimachinery/pkg/labels"
-
 	"github.com/cilium/cilium/common/types"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 var _ policy.Translator = RuleTranslator{}
@@ -35,6 +37,7 @@ type RuleTranslator struct {
 	Endpoint      types.K8sServiceEndpoint
 	ServiceLabels map[string]string
 	Revert        bool
+	IPCache       ipcache.Implementation
 }
 
 // Translate calls TranslateEgress on all r.Egress rules
@@ -67,7 +70,7 @@ func (k RuleTranslator) TranslateEgress(r *api.EgressRule) error {
 func (k RuleTranslator) populateEgress(r *api.EgressRule) error {
 	for _, service := range r.ToServices {
 		if k.serviceMatches(service) {
-			if err := generateToCidrFromEndpoint(r, k.Endpoint); err != nil {
+			if err := generateToCidrFromEndpoint(r, k.Endpoint, k.IPCache); err != nil {
 				return err
 			}
 			// TODO: generateToPortsFromEndpoint when ToPorts and ToCIDR are compatible
@@ -79,7 +82,7 @@ func (k RuleTranslator) populateEgress(r *api.EgressRule) error {
 func (k RuleTranslator) depopulateEgress(r *api.EgressRule) error {
 	for _, service := range r.ToServices {
 		if k.serviceMatches(service) {
-			if err := deleteToCidrFromEndpoint(r, k.Endpoint); err != nil {
+			if err := deleteToCidrFromEndpoint(r, k.Endpoint, k.IPCache); err != nil {
 				return err
 			}
 			// TODO: generateToPortsFromEndpoint when ToPorts and ToCIDR are compatible
@@ -106,7 +109,23 @@ func (k RuleTranslator) serviceMatches(service api.Service) bool {
 // generateToCidrFromEndpoint takes an egress rule and populates it with
 // ToCIDR rules based on provided endpoint object
 func generateToCidrFromEndpoint(
-	egress *api.EgressRule, endpoint types.K8sServiceEndpoint) error {
+	egress *api.EgressRule,
+	endpoint types.K8sServiceEndpoint,
+	impl ipcache.Implementation) error {
+
+	// Non-nil implementation here implies that this translation is
+	// occurring after policy import. This means that the CIDRs were not
+	// known at that time, so the IPCache hasn't been informed about them.
+	// In this case, it's the job of this Translator to notify the IPCache.
+	if impl != nil {
+		prefixes, err := endpoint.CIDRPrefixes()
+		if err != nil {
+			return err
+		}
+		if err := ipcache.AllocateCIDRs(impl, prefixes); err != nil {
+			return err
+		}
+	}
 
 	// This will generate one-address CIDRs consisting of endpoint backend ip
 	mask := net.CIDRMask(128, 128)
@@ -138,12 +157,21 @@ func generateToCidrFromEndpoint(
 	return nil
 }
 
-// deleteToCidrFromEndpoint takes an egress rule and removes
-// ToCIDR rules matching endpoint
+// deleteToCidrFromEndpoint takes an egress rule and removes ToCIDR rules
+// matching endpoint. Returns an error if any of the backends are malformed.
+//
+// If all backends are valid, attempts to remove any ipcache CIDR mappings (and
+// CIDR Identities) from the kvstore for backends in 'endpoint' that are being
+// removed from the policy. On failure to release such kvstore mappings, errors
+// will be logged but this function will return nil to allow subsequent
+// processing to proceed.
 func deleteToCidrFromEndpoint(
-	egress *api.EgressRule, endpoint types.K8sServiceEndpoint) error {
+	egress *api.EgressRule,
+	endpoint types.K8sServiceEndpoint,
+	impl ipcache.Implementation) error {
 
 	newToCIDR := make([]api.CIDRRule, 0, len(egress.ToCIDRSet))
+	deleted := make([]api.CIDRRule, 0, len(egress.ToCIDRSet))
 
 	for ip := range endpoint.BEIPs {
 		epIP := net.ParseIP(ip)
@@ -160,11 +188,23 @@ func deleteToCidrFromEndpoint(
 			// generated it's ok to retain it
 			if !cidr.Contains(epIP) || !c.Generated {
 				newToCIDR = append(newToCIDR, c)
+			} else {
+				deleted = append(deleted, c)
 			}
 		}
 	}
 
 	egress.ToCIDRSet = newToCIDR
+	if impl != nil {
+		prefixes := policy.GetPrefixesFromCIDRSet(deleted)
+		if err := ipcache.ReleaseCIDRs(prefixes); err != nil {
+			// Don't pass this up to the caller, as it would prevent the
+			// deletion of other services or the setup of new ones!
+			log.WithError(err).WithFields(logrus.Fields{
+				"prefixes": prefixes,
+			}).Debugf("Failed to release prefixes while deleting k8s backend")
+		}
+	}
 
 	return nil
 }
@@ -175,11 +215,16 @@ func PreprocessRules(
 	endpoints map[types.K8sServiceNamespace]*types.K8sServiceEndpoint,
 	services map[types.K8sServiceNamespace]*types.K8sServiceInfo) error {
 
+	// Headless services are translated prior to policy import, so the
+	// policy will contain all of the CIDRs and can handle ipcache
+	// interactions when the policy is imported. Ignore the IPCache
+	// interaction here and just set the implementation to nil.
+	ipcache := ipcache.Implementation(nil)
 	for _, rule := range r {
 		for ns, ep := range endpoints {
 			svc, ok := services[ns]
 			if ok && svc.IsHeadless {
-				t := NewK8sTranslator(ns, *ep, false, svc.Labels)
+				t := NewK8sTranslator(ns, *ep, false, svc.Labels, ipcache)
 				err := t.Translate(rule)
 				if err != nil {
 					return err
@@ -195,7 +240,8 @@ func NewK8sTranslator(
 	serviceInfo types.K8sServiceNamespace,
 	endpoint types.K8sServiceEndpoint,
 	revert bool,
-	labels map[string]string) RuleTranslator {
+	labels map[string]string,
+	ipcache ipcache.Implementation) RuleTranslator {
 
-	return RuleTranslator{serviceInfo, endpoint, labels, revert}
+	return RuleTranslator{serviceInfo, endpoint, labels, revert, ipcache}
 }

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -63,7 +63,7 @@ func (s *K8sSuite) TestTranslatorDirect(c *C) {
 		Labels: tag1,
 	}
 
-	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, map[string]string{})
+	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, map[string]string{}, nil)
 
 	_, err := repo.Add(rule1)
 	c.Assert(err, IsNil)
@@ -76,7 +76,7 @@ func (s *K8sSuite) TestTranslatorDirect(c *C) {
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
 
-	translator = NewK8sTranslator(serviceInfo, endpointInfo, true, map[string]string{})
+	translator = NewK8sTranslator(serviceInfo, endpointInfo, true, map[string]string{}, nil)
 	err = repo.TranslateRules(translator)
 
 	rule = repo.SearchRLocked(tag1)[0].Egress[0]
@@ -116,7 +116,7 @@ func (s *K8sSuite) TestServiceMatches(c *C) {
 		},
 	}
 
-	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, svcLabels)
+	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, svcLabels, nil)
 	c.Assert(translator.serviceMatches(service), Equals, true)
 }
 
@@ -162,7 +162,7 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 		Labels: tag1,
 	}
 
-	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, svcLabels)
+	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, svcLabels, nil)
 
 	_, err := repo.Add(rule1)
 	c.Assert(err, IsNil)
@@ -175,7 +175,7 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
 
-	translator = NewK8sTranslator(serviceInfo, endpointInfo, true, svcLabels)
+	translator = NewK8sTranslator(serviceInfo, endpointInfo, true, svcLabels, nil)
 	err = repo.TranslateRules(translator)
 
 	rule = repo.SearchRLocked(tag1)[0].Egress[0]
@@ -201,20 +201,20 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 		},
 	}
 
-	err := generateToCidrFromEndpoint(rule, endpointInfo)
+	err := generateToCidrFromEndpoint(rule, endpointInfo, nil)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
 
 	// second run, to make sure there are no duplicates added
-	err = generateToCidrFromEndpoint(rule, endpointInfo)
+	err = generateToCidrFromEndpoint(rule, endpointInfo, nil)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
 
-	err = deleteToCidrFromEndpoint(rule, endpointInfo)
+	err = deleteToCidrFromEndpoint(rule, endpointInfo, nil)
 	c.Assert(err, IsNil)
 	c.Assert(len(rule.ToCIDRSet), Equals, 0)
 }
@@ -300,20 +300,20 @@ func (s *K8sSuite) TestDontDeleteUserRules(c *C) {
 		},
 	}
 
-	err := generateToCidrFromEndpoint(rule, endpointInfo)
+	err := generateToCidrFromEndpoint(rule, endpointInfo, nil)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule.ToCIDRSet), Equals, 2)
 	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP+"/32")
 
 	// second run, to make sure there are no duplicates added
-	err = generateToCidrFromEndpoint(rule, endpointInfo)
+	err = generateToCidrFromEndpoint(rule, endpointInfo, nil)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule.ToCIDRSet), Equals, 2)
 	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP+"/32")
 
-	err = deleteToCidrFromEndpoint(rule, endpointInfo)
+	err = deleteToCidrFromEndpoint(rule, endpointInfo, nil)
 	c.Assert(err, IsNil)
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, string(userCIDR))

--- a/pkg/policy/api/cidr.go
+++ b/pkg/policy/api/cidr.go
@@ -80,6 +80,15 @@ func (s CIDRSlice) GetAsEndpointSelectors() EndpointSelectorSlice {
 	return slice
 }
 
+// StringSlice returns the CIDR slice as a slice of strings.
+func (s CIDRSlice) StringSlice() []string {
+	result := make([]string, 0, len(s))
+	for _, c := range s {
+		result = append(result, string(c))
+	}
+	return result
+}
+
 // CIDRRuleSlice is a slice of CIDRRules. It allows receiver methods to be
 // defined for transforming the slice into other convenient forms such as
 // EndpointSelectorSlice.

--- a/pkg/policy/cidr.go
+++ b/pkg/policy/cidr.go
@@ -17,35 +17,15 @@ package policy
 import (
 	"net"
 
+	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
 
 // getPrefixesFromCIDR fetches all CIDRs referred to by the specified slice
 // and returns them as regular golang CIDR objects.
 func getPrefixesFromCIDR(cidrs api.CIDRSlice) []*net.IPNet {
-	res := make([]*net.IPNet, 0, len(cidrs))
-	for _, cidr := range cidrs {
-		_, prefix, err := net.ParseCIDR(string(cidr))
-		if err != nil {
-			// Likely the CIDR is specified in host format.
-			ip := net.ParseIP(string(cidr))
-			if ip != nil {
-				bits := net.IPv6len * 8
-				if ip.To4() != nil {
-					ip = ip.To4()
-					bits = net.IPv4len * 8
-				}
-				prefix = &net.IPNet{
-					IP:   ip,
-					Mask: net.CIDRMask(bits, bits),
-				}
-			}
-		}
-		if prefix != nil {
-			res = append(res, prefix)
-		}
-	}
-	return res
+	result, _ := ip.ParseCIDRs(cidrs.StringSlice())
+	return result
 }
 
 // getPrefixesFromCIDRSet fetches all CIDRs referred to by the specified slice

--- a/pkg/policy/cidr.go
+++ b/pkg/policy/cidr.go
@@ -28,9 +28,11 @@ func getPrefixesFromCIDR(cidrs api.CIDRSlice) []*net.IPNet {
 	return result
 }
 
-// getPrefixesFromCIDRSet fetches all CIDRs referred to by the specified slice
+// GetPrefixesFromCIDRSet fetches all CIDRs referred to by the specified slice
 // and returns them as regular golang CIDR objects.
-func getPrefixesFromCIDRSet(rules api.CIDRRuleSlice) []*net.IPNet {
+//
+// Assumes that validation already occurred on 'rules'.
+func GetPrefixesFromCIDRSet(rules api.CIDRRuleSlice) []*net.IPNet {
 	cidrs := api.ComputeResultantCIDRSet(rules)
 	return getPrefixesFromCIDR(cidrs)
 }
@@ -52,7 +54,7 @@ func GetCIDRPrefixes(rules api.Rules) []*net.IPNet {
 				res = append(res, getPrefixesFromCIDR(ir.FromCIDR)...)
 			}
 			if len(ir.FromCIDRSet) > 0 {
-				res = append(res, getPrefixesFromCIDRSet(ir.FromCIDRSet)...)
+				res = append(res, GetPrefixesFromCIDRSet(ir.FromCIDRSet)...)
 			}
 		}
 		for _, er := range r.Egress {
@@ -60,7 +62,7 @@ func GetCIDRPrefixes(rules api.Rules) []*net.IPNet {
 				res = append(res, getPrefixesFromCIDR(er.ToCIDR)...)
 			}
 			if len(er.ToCIDRSet) > 0 {
-				res = append(res, getPrefixesFromCIDRSet(er.ToCIDRSet)...)
+				res = append(res, GetPrefixesFromCIDRSet(er.ToCIDRSet)...)
 			}
 		}
 	}


### PR DESCRIPTION
```release-note
Fix regression that caused policies with `ToServices` rules to not allow traffic to services with external backends
```

If adding a policy failed, then we previously would release the                                                                                                                          
identities that were allocated, but leave the ipcache mappings in the           
kvstore for those CIDR->ID pairs. Release the ipcache mappings as well.         
                                                                                
If some of the identities cannot be located in the kvstore, then none of        
the identities or ipcache entries would be deleted when removing a              
policy. Fix this up to instead attempt to locate as many of the entries         
as possible, then free as many as can be located.                               
                                                                                
When generating CIDR rules in k8s translation, allocate identities for          
the new CIDRs (for service backends) and create CIDR->Identity mappings         
in the IPCache.                                                                 
                                                                                
Fixes: 4692732a789f ("daemon: Allocate identities for CIDRs")                   
Fixes: #4570

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4587)
<!-- Reviewable:end -->
