### PR TITLE
envoy: Parse and log Envoy log messages at their actual level

### DIFF
--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -262,4 +262,7 @@ const (
 
 	// BPFMapFD is the file descriptor for a BPF map.
 	BPFMapFD = "bpfMapFileDescriptor"
+
+	// ThreadID is the Envoy thread ID.
+	ThreadID = "threadID"
 )


### PR DESCRIPTION
The logs from Envoy are now structured, with proper `subsys` and `threadID` fields:
```
Jun 21 00:24:50 runtime1 cilium-agent[18930]: level=debug msg="[external/envoy/source/server/lds_api.cc:75] lds: add/update listener '41619:ingress:TCP:8080' skipped" subsys=envoy-upstream threadID=20342
```

Log levels are properly mapped onto Cilium log levels:
```
Jun 21 00:17:56 runtime1 cilium-agent[8469]: level=warning msg="[external/envoy/source/server/server.cc:347] caught SIGTERM" subsys=envoy-main threadID=9919
...
Jun 21 00:24:50 runtime1 cilium-agent[18930]: level=info msg="[external/envoy/source/server/lds_api.cc:65] lds: remove listener '29389:ingress:TCP:80'" subsys=envoy-upstream threadID=20342
...
Jun 21 00:24:50 runtime1 cilium-agent[18930]: level=debug msg="[external/envoy/source/server/listener_manager_impl.cc:511] begin add/update listener: name=41619:ingress:TCP:80 hash=17342118622859091634" subsys=envoy-config threadID=20342
```

Multi-line log messages are properly logged with the same log level and fields:
```
Jun 21 00:24:50 runtime1 cilium-agent[18930]: level=debug msg="[bazel-out/k8-fastbuild/bin/external/envoy/source/common/config/_virtual_includes/grpc_mux_subscription_lib/common/config/grpc_mux_subscription_impl.h:60] gRPC config for type.googleapis.com/envoy.api.v2.Listener accepted with 2 resources: [name: \"41619:ingress:TCP:80\"" subsys=envoy-config threadID=20342
Jun 21 00:24:50 runtime1 cilium-agent[18930]: level=debug msg="address {" subsys=envoy-config threadID=20342
Jun 21 00:24:50 runtime1 cilium-agent[18930]: level=debug msg="  socket_address {" subsys=envoy-config threadID=20342
Jun 21 00:24:50 runtime1 cilium-agent[18930]: level=debug msg="    address: \"::\"" subsys=envoy-config threadID=20342
Jun 21 00:24:50 runtime1 cilium-agent[18930]: level=debug msg="    port_value: 15835" subsys=envoy-config threadID=20342
Jun 21 00:24:50 runtime1 cilium-agent[18930]: level=debug msg="    ipv4_compat: true" subsys=envoy-config threadID=20342
Jun 21 00:24:50 runtime1 cilium-agent[18930]: level=debug msg="  }" subsys=envoy-config threadID=20342
Jun 21 00:24:50 runtime1 cilium-agent[18930]: level=debug msg="}" subsys=envoy-config threadID=20342
```

Fixes: https://github.com/cilium/cilium/issues/4381
Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4589)
<!-- Reviewable:end -->
