### PR TITLE
daemon: skip health endpoint on restore

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -80,7 +80,7 @@ func (d *Daemon) restoreOldEndpoints(dir string, clean bool) (*endpointRestoreSt
 
 		// On each restart, the health endpoint is supposed to be recreated.
 		// Hence we need to clean health endpoint state unconditionally.
-		if ep.SecurityIdentity.ID == identityPkg.ReservedIdentityHealth {
+		if ep.HasLabels(labels.LabelHealth) {
 			skipRestore = true
 		} else {
 			if _, err := netlink.LinkByName(ep.IfName); err != nil {

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -53,6 +53,11 @@ const (
 	IDNameUnknown = "unknown"
 )
 
+var (
+	// LabelHealth is the label used for health.
+	LabelHealth = Labels{IDNameHealth: NewLabel(IDNameHealth, "", LabelSourceReserved)}
+)
+
 // OpLabels represents the the possible types.
 // +k8s:openapi-gen=false
 type OpLabels struct {


### PR DESCRIPTION
When restoring health endpoint, Cilium should check for the existing
labels in order to skip the health endpoint otherwise when already set
with a wrong security ID, the health endpoint is not skipped.

Fixes: 403a2ec16de6 "agent: Reserve existing endpoint IPs before allocating auxiliary IPs"
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4591)
<!-- Reviewable:end -->
