### PR TITLE
identity: Move CIDR identity code into pkg/identity/cidr

### DIFF
--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cidr"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -237,7 +238,7 @@ func (d *Daemon) PolicyAdd(rules api.Rules, opts *AddOptions) (uint64, error) {
 	prefixes := policy.GetCIDRPrefixes(rules)
 	log.WithField("prefixes", prefixes).Debug("Policy imported via API, found CIDR prefixes...")
 
-	prefixIdentities, err := identity.AllocateCIDRIdentities(prefixes)
+	prefixIdentities, err := cidr.AllocateCIDRIdentities(prefixes)
 	if err != nil {
 		metrics.PolicyImportErrors.Inc()
 		return d.policy.GetRevision(), err
@@ -311,7 +312,7 @@ func (d *Daemon) PolicyDelete(labels labels.LabelArray) (uint64, error) {
 	prefixes := policy.GetCIDRPrefixes(rules)
 	log.WithField("prefixes", prefixes).Debug("Policy deleted via API, found prefixes...")
 
-	prefixIdentities, err := identity.LookupCIDRIdentities(prefixes)
+	prefixIdentities, err := cidr.LookupCIDRIdentities(prefixes)
 	if err == nil {
 		if err = identity.ReleaseSlice(prefixIdentities); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{


### PR DESCRIPTION
This removes the following dependency tree from pkg/identity:
```
-    ├ github.com/cilium/cilium/pkg/labels/cidr
-      ├ fmt
-      ├ net
-      ├ github.com/cilium/cilium/pkg/labels
-      └ github.com/cilium/cilium/pkg/node
-        ├ bufio
-        ├ bytes
-        ├ fmt
-        ├ net
-        ├ os
-        ├ os/exec
-        ├ strconv
-        ├ strings
-        ├ github.com/cilium/cilium/api/v1/models
-        ├ github.com/cilium/cilium/common
-        ├ github.com/cilium/cilium/pkg/byteorder
-          ├ encoding/binary
-          ├ fmt
-          ├ reflect
-          └ unsafe
-        ├ github.com/cilium/cilium/pkg/lock
-        ├ github.com/cilium/cilium/pkg/logging
-        ├ github.com/cilium/cilium/pkg/logging/logfields
-        ├ github.com/cilium/cilium/pkg/maps/tunnel
-          ├ net
-          ├ os
-          ├ path/filepath
-          ├ unsafe
-          ├ github.com/cilium/cilium/pkg/bpf
-            ├ bufio
-            ├ bytes
-            ├ encoding/binary
-            ├ fmt
-            ├ math
-            ├ net
-            ├ os
-            ├ path
-            ├ path/filepath
-            ├ runtime
-            ├ sync
-            ├ syscall
-            ├ unsafe
-            ├ C
-            ├ github.com/cilium/cilium/common/types
-            ├ github.com/cilium/cilium/pkg/byteorder
-            ├ github.com/cilium/cilium/pkg/comparator
-              ├ reflect
-              ├ github.com/cilium/cilium/vendor/github.com/kr/pretty
-                ├ fmt
-                ├ io
-                ├ log
-                ├ reflect
-                ├ strconv
-                ├ text/tabwriter
-                └ github.com/cilium/cilium/vendor/github.com/kr/text
-                  ├ bytes
-                  ├ io
-                  └ math
-              ├ github.com/cilium/cilium/vendor/github.com/pmezard/go-difflib/difflib
-                ├ bufio
-                ├ bytes
-                ├ fmt
-                ├ io
-                └ strings
-              └ github.com/cilium/cilium/vendor/gopkg.in/check.v1
-                ├ bufio
-                ├ bytes
-                ├ errors
-                ├ flag
-                ├ fmt
-                ├ go/ast
-                ├ go/parser
-                ├ go/printer
-                ├ go/token
-                ├ io
-                ├ math/rand
-                ├ os
-                ├ path
-                ├ path/filepath
-                ├ reflect
-                ├ regexp
-                ├ runtime
-                ├ strconv
-                ├ strings
-                ├ sync
-                ├ sync/atomic
-                ├ testing
-                └ time
-            ├ github.com/cilium/cilium/pkg/components
-              ├ os
-              └ strings
-            ├ github.com/cilium/cilium/pkg/defaults
-            ├ github.com/cilium/cilium/pkg/lock
-            ├ github.com/cilium/cilium/pkg/logging
-            ├ github.com/cilium/cilium/pkg/logging/logfields
-            ├ github.com/cilium/cilium/pkg/mountinfo
-              ├ bufio
-              ├ fmt
-              ├ os
-              ├ strconv
-              └ strings
-            ├ github.com/cilium/cilium/vendor/github.com/sirupsen/logrus
-            └ github.com/cilium/cilium/vendor/golang.org/x/sys/unix
-          ├ github.com/cilium/cilium/pkg/defaults
-          ├ github.com/cilium/cilium/pkg/logging
-          ├ github.com/cilium/cilium/pkg/logging/logfields
-          └ github.com/cilium/cilium/vendor/github.com/sirupsen/logrus
-        ├ github.com/cilium/cilium/pkg/mtu
-        ├ github.com/cilium/cilium/pkg/option
-        ├ github.com/cilium/cilium/vendor/github.com/sirupsen/logrus
-        ├ github.com/cilium/cilium/vendor/github.com/vishvananda/netlink
-          ├ encoding/binary
-          ├ errors
-          ├ fmt
-          ├ math
-          ├ net
-          ├ strings
-          ├ time
-          ├ github.com/cilium/cilium/vendor/github.com/vishvananda/netlink/nl
-            └ encoding/binary
-          ├ github.com/cilium/cilium/vendor/github.com/vishvananda/netns
-            ├ errors
-            ├ fmt
-            └ syscall
-          └ github.com/cilium/cilium/vendor/golang.org/x/sys/unix
-        ├ github.com/cilium/cilium/vendor/golang.org/x/sys/unix
-        └ github.com/cilium/cilium/vendor/k8s.io/api/core/v1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4595)
<!-- Reviewable:end -->
