### PR TITLE
metrics: Add cilium-health metrics about latency

### DIFF
--- a/Documentation/cmdref/cilium-health.md
+++ b/Documentation/cmdref/cilium-health.md
@@ -16,16 +16,17 @@ cilium-health
 ### Options
 
 ```
-      --admin string             Expose resources over 'unix' socket, 'any' socket (default "unix")
-  -c, --cilium string            URI to Cilium server API
-  -d, --daemon                   Run as a daemon
-  -D, --debug                    Enable debug messages
-  -H, --host string              URI to cilium-health server API
-  -i, --interval uint            Interval (in seconds) for periodic connectivity probes (default 60)
-      --log-driver stringSlice   Logging endpoints to use for example syslog, fluentd
-      --log-opt map              Log driver options for cilium-health (default map[])
-  -p, --passive                  Only respond to HTTP health checks
-      --pidfile string           Write the PID to the specified file
+      --admin string                   Expose resources over 'unix' socket, 'any' socket (default "unix")
+  -c, --cilium string                  URI to Cilium server API
+  -d, --daemon                         Run as a daemon
+  -D, --debug                          Enable debug messages
+  -H, --host string                    URI to cilium-health server API
+  -i, --interval uint                  Interval (in seconds) for periodic connectivity probes (default 60)
+      --log-driver stringSlice         Logging endpoints to use for example syslog, fluentd
+      --log-opt map                    Log driver options for cilium-health (default map[])
+  -p, --passive                        Only respond to HTTP health checks
+      --pidfile string                 Write the PID to the specified file
+      --prometheus-serve-addr string   IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_get.md
+++ b/Documentation/cmdref/cilium-health_get.md
@@ -22,16 +22,17 @@ cilium-health get
 ### Options inherited from parent commands
 
 ```
-      --admin string             Expose resources over 'unix' socket, 'any' socket (default "unix")
-  -c, --cilium string            URI to Cilium server API
-  -d, --daemon                   Run as a daemon
-  -D, --debug                    Enable debug messages
-  -H, --host string              URI to cilium-health server API
-  -i, --interval uint            Interval (in seconds) for periodic connectivity probes (default 60)
-      --log-driver stringSlice   Logging endpoints to use for example syslog, fluentd
-      --log-opt map              Log driver options for cilium-health (default map[])
-  -p, --passive                  Only respond to HTTP health checks
-      --pidfile string           Write the PID to the specified file
+      --admin string                   Expose resources over 'unix' socket, 'any' socket (default "unix")
+  -c, --cilium string                  URI to Cilium server API
+  -d, --daemon                         Run as a daemon
+  -D, --debug                          Enable debug messages
+  -H, --host string                    URI to cilium-health server API
+  -i, --interval uint                  Interval (in seconds) for periodic connectivity probes (default 60)
+      --log-driver stringSlice         Logging endpoints to use for example syslog, fluentd
+      --log-opt map                    Log driver options for cilium-health (default map[])
+  -p, --passive                        Only respond to HTTP health checks
+      --pidfile string                 Write the PID to the specified file
+      --prometheus-serve-addr string   IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_ping.md
+++ b/Documentation/cmdref/cilium-health_ping.md
@@ -16,16 +16,17 @@ cilium-health ping
 ### Options inherited from parent commands
 
 ```
-      --admin string             Expose resources over 'unix' socket, 'any' socket (default "unix")
-  -c, --cilium string            URI to Cilium server API
-  -d, --daemon                   Run as a daemon
-  -D, --debug                    Enable debug messages
-  -H, --host string              URI to cilium-health server API
-  -i, --interval uint            Interval (in seconds) for periodic connectivity probes (default 60)
-      --log-driver stringSlice   Logging endpoints to use for example syslog, fluentd
-      --log-opt map              Log driver options for cilium-health (default map[])
-  -p, --passive                  Only respond to HTTP health checks
-      --pidfile string           Write the PID to the specified file
+      --admin string                   Expose resources over 'unix' socket, 'any' socket (default "unix")
+  -c, --cilium string                  URI to Cilium server API
+  -d, --daemon                         Run as a daemon
+  -D, --debug                          Enable debug messages
+  -H, --host string                    URI to cilium-health server API
+  -i, --interval uint                  Interval (in seconds) for periodic connectivity probes (default 60)
+      --log-driver stringSlice         Logging endpoints to use for example syslog, fluentd
+      --log-opt map                    Log driver options for cilium-health (default map[])
+  -p, --passive                        Only respond to HTTP health checks
+      --pidfile string                 Write the PID to the specified file
+      --prometheus-serve-addr string   IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_status.md
+++ b/Documentation/cmdref/cilium-health_status.md
@@ -25,16 +25,17 @@ cilium-health status
 ### Options inherited from parent commands
 
 ```
-      --admin string             Expose resources over 'unix' socket, 'any' socket (default "unix")
-  -c, --cilium string            URI to Cilium server API
-  -d, --daemon                   Run as a daemon
-  -D, --debug                    Enable debug messages
-  -H, --host string              URI to cilium-health server API
-  -i, --interval uint            Interval (in seconds) for periodic connectivity probes (default 60)
-      --log-driver stringSlice   Logging endpoints to use for example syslog, fluentd
-      --log-opt map              Log driver options for cilium-health (default map[])
-  -p, --passive                  Only respond to HTTP health checks
-      --pidfile string           Write the PID to the specified file
+      --admin string                   Expose resources over 'unix' socket, 'any' socket (default "unix")
+  -c, --cilium string                  URI to Cilium server API
+  -d, --daemon                         Run as a daemon
+  -D, --debug                          Enable debug messages
+  -H, --host string                    URI to cilium-health server API
+  -i, --interval uint                  Interval (in seconds) for periodic connectivity probes (default 60)
+      --log-driver stringSlice         Logging endpoints to use for example syslog, fluentd
+      --log-opt map                    Log driver options for cilium-health (default map[])
+  -p, --passive                        Only respond to HTTP health checks
+      --pidfile string                 Write the PID to the specified file
+      --prometheus-serve-addr string   IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
 ```
 
 ### SEE ALSO

--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -162,7 +162,9 @@ directly and manually install Cilium:
         $ sudo make install
         $ sudo mkdir -p /etc/sysconfig/
         $ sudo cp contrib/systemd/cilium.service /etc/systemd/system/
-        $ sudo cp contrib/systemd/cilium  /etc/sysconfig/cilium
+        $ sudo cp contrib/systemd/cilium-health.service /etc/systemd/system/
+        $ sudo cp contrib/systemd/cilium /etc/sysconfig/cilium
+        $ sudo cp contrib/systemd/cilium-health /etc/sysconfig/cilium
         $ sudo usermod -a -G cilium vagrant
         $ sudo systemctl enable cilium
         $ sudo systemctl restart cilium

--- a/Documentation/install/guides/from_source.rst
+++ b/Documentation/install/guides/from_source.rst
@@ -62,5 +62,7 @@ You can also add it in your ``~/.bashrc`` file:
 
     sudo cp contrib/systemd/*.service /lib/systemd/system
     sudo cp contrib/systemd/sys-fs-bpf.mount /lib/systemd/system
-    sudo mkdir -p /etc/sysconfig/cilium && cp contrib/systemd/cilium /etc/sysconfig/cilium
+    sudo mkdir -p /etc/sysconfig
+    sudo cp contrib/systemd/cilium /etc/sysconfig/cilium
+    sudo cp contrib/systemd/cilium-health /etc/sysconfig/cilium
     service cilium start

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,7 +68,9 @@ sudo mkdir -p /etc/sysconfig
 sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/systemd/cilium-consul.service /lib/systemd/system
 sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/systemd/cilium-docker.service /lib/systemd/system
 sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/systemd/cilium-etcd.service /lib/systemd/system
+sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/systemd/cilium-health.service /lib/systemd/system
 sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/systemd/cilium.service /lib/systemd/system
+sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/systemd/cilium-health /etc/sysconfig
 sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/systemd/cilium /etc/sysconfig
 
 sudo usermod -a -G cilium vagrant

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/health/defaults"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node"
@@ -45,6 +46,8 @@ import (
 )
 
 var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "cilium-health")
+
 	// vethName is the host-side link device name for cilium-health EP.
 	vethName = "cilium_health"
 

--- a/contrib/systemd/cilium-health
+++ b/contrib/systemd/cilium-health
@@ -1,0 +1,22 @@
+### Configuration options for cilium-health
+
+## Path:                System/Management
+## Description:         Extra cli switches for cilium-health daemon
+## Type:                string
+## Default:             ""
+## ServiceRestart:      cilium-health
+
+# Run as a daemon:
+# --daemon
+#
+# Note: Check more cli options using cilium-health-h
+
+CILIUM_HEALTH_OPTS="--daemon"
+
+## Path:                System/Management
+## Description:         init system cilium-health is running on
+## Type:                string
+## Default:             ""
+## ServiceRestart:      cilium-health
+
+INITSYSTEM=SYSTEMD

--- a/contrib/systemd/cilium-health.service
+++ b/contrib/systemd/cilium-health.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=cilium-health
+Documentation=http://docs.cilium.io
+Requires=cilium.service
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/sysconfig/cilium-health
+ExecStart=/usr/bin/cilium-health $CILIUM_HEALTH_OPTS
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -229,7 +229,8 @@ export ETCD_CLEAN="${ETCD_CLEAN}"
 
 # Stop cilium before until we install kubelet. This prevents cilium from
 # allocating its own podCIDR without using the kubernetes allocated podCIDR.
-sudo service cilium stop
+sudo systemctl stop cilium-health
+sudo systemctl stop cilium
 EOF
     cat <<EOF >> "${filename}"
 if [[ "\$(hostname)" == "${VM_BASENAME}1" ]]; then
@@ -355,7 +356,8 @@ if [ -n "\${K8S}" ]; then
     done
 fi
 
-service cilium restart
+systemctl restart cilium-health
+systemctl restart cilium
 
 cilium_started=false
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
-	health "github.com/cilium/cilium/cilium-health/launch"
+	health "github.com/cilium/cilium/cilium-health/watch"
 	"github.com/cilium/cilium/common"
 	monitorLaunch "github.com/cilium/cilium/monitor/launch"
 	"github.com/cilium/cilium/pkg/api"

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -110,7 +110,6 @@ spec:
         scheduler.alpha.kubernetes.io/tolerations: >-
           [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
       initContainers:
@@ -280,6 +279,44 @@ spec:
               add:
                 - "NET_ADMIN"
             privileged: true
+        - image: docker.io/cilium/cilium:latest
+          imagePullPolicy: Always
+          name: cilium-health
+          command: [ "cilium-health" ]
+          args:
+            - "-d"
+          ports:
+            - name: metrics
+              containerPort: 9091
+              protocol: TCP
+          env:
+            - name: "CILIUM_HEALTH_PROMETHEUS_SERVE_ADDR"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-health-metrics-config
+                  optional: true
+                  key: prometheus-serve-addr
+          livenessProbe:
+            exec:
+              command:
+              - cilium-health
+              - status
+            # The initial delay for the liveness probe is intentionally large to
+            # avoid an endless kill & restart cycle if in the event that the initial
+            # bootstrapping takes longer than expected.
+            initialDelaySeconds: 120
+            failureThreshold: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+              - cilium-health
+              - status
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: cilium-run
+              mountPath: /var/run/cilium
       hostNetwork: true
       volumes:
         # To keep state between restarts / upgrades

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -28,7 +28,6 @@ spec:
         scheduler.alpha.kubernetes.io/tolerations: >-
           [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
       initContainers:
@@ -177,6 +176,44 @@ spec:
               add:
                 - "NET_ADMIN"
             privileged: true
+        - image: docker.io/cilium/cilium:latest
+          imagePullPolicy: Always
+          name: cilium-health
+          command: [ "cilium-health" ]
+          args:
+            - "-d"
+          ports:
+            - name: metrics
+              containerPort: 9091
+              protocol: TCP
+          env:
+            - name: "CILIUM_HEALTH_PROMETHEUS_SERVE_ADDR"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-health-metrics-config
+                  optional: true
+                  key: prometheus-serve-addr
+          livenessProbe:
+            exec:
+              command:
+              - cilium-health
+              - status
+            # The initial delay for the liveness probe is intentionally large to
+            # avoid an endless kill & restart cycle if in the event that the initial
+            # bootstrapping takes longer than expected.
+            initialDelaySeconds: 120
+            failureThreshold: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+              - cilium-health
+              - status
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: cilium-run
+              mountPath: /var/run/cilium
       hostNetwork: true
       volumes:
         # To keep state between restarts / upgrades

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -110,7 +110,6 @@ spec:
         scheduler.alpha.kubernetes.io/tolerations: >-
           [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
       initContainers:
@@ -259,6 +258,45 @@ spec:
               add:
                 - "NET_ADMIN"
             privileged: true
+        - image: docker.io/cilium/cilium:latest
+          imagePullPolicy: Always
+          name: cilium-health
+          command: [ "cilium-health" ]
+          args:
+            - "-d"
+          ports:
+            - name: metrics
+              containerPort: 9091
+              protocol: TCP
+          env:
+            - name: "CILIUM_HEALTH_PROMETHEUS_SERVE_ADDR"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-health-metrics-config
+                  optional: true
+                  key: prometheus-serve-addr
+          livenessProbe:
+            exec:
+              command:
+              - cilium-health
+              - status
+            # The initial delay for the liveness probe is intentionally large to
+            # avoid an endless kill & restart cycle if in the event that the initial
+            # bootstrapping takes longer than expected.
+            initialDelaySeconds: 120
+            failureThreshold: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+              - cilium-health
+              - status
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: cilium-run
+              mountPath: /var/run/cilium
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       volumes:
         # To keep state between restarts / upgrades

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -110,7 +110,6 @@ spec:
         scheduler.alpha.kubernetes.io/tolerations: >-
           [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
       initContainers:
@@ -280,6 +279,44 @@ spec:
               add:
                 - "NET_ADMIN"
             privileged: true
+        - image: docker.io/cilium/cilium:latest
+          imagePullPolicy: Always
+          name: cilium-health
+          command: [ "cilium-health" ]
+          args:
+            - "-d"
+          ports:
+            - name: metrics
+              containerPort: 9091
+              protocol: TCP
+          env:
+            - name: "CILIUM_HEALTH_PROMETHEUS_SERVE_ADDR"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-health-metrics-config
+                  optional: true
+                  key: prometheus-serve-addr
+          livenessProbe:
+            exec:
+              command:
+              - cilium-health
+              - status
+            # The initial delay for the liveness probe is intentionally large to
+            # avoid an endless kill & restart cycle if in the event that the initial
+            # bootstrapping takes longer than expected.
+            initialDelaySeconds: 120
+            failureThreshold: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+              - cilium-health
+              - status
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: cilium-run
+              mountPath: /var/run/cilium
       hostNetwork: true
       volumes:
         # To keep state between restarts / upgrades

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -110,7 +110,6 @@ spec:
         scheduler.alpha.kubernetes.io/tolerations: >-
           [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
       initContainers:
@@ -280,6 +279,44 @@ spec:
               add:
                 - "NET_ADMIN"
             privileged: true
+        - image: docker.io/cilium/cilium:latest
+          imagePullPolicy: Always
+          name: cilium-health
+          command: [ "cilium-health" ]
+          args:
+            - "-d"
+          ports:
+            - name: metrics
+              containerPort: 9091
+              protocol: TCP
+          env:
+            - name: "CILIUM_HEALTH_PROMETHEUS_SERVE_ADDR"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-health-metrics-config
+                  optional: true
+                  key: prometheus-serve-addr
+          livenessProbe:
+            exec:
+              command:
+              - cilium-health
+              - status
+            # The initial delay for the liveness probe is intentionally large to
+            # avoid an endless kill & restart cycle if in the event that the initial
+            # bootstrapping takes longer than expected.
+            initialDelaySeconds: 120
+            failureThreshold: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+              - cilium-health
+              - status
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: cilium-run
+              mountPath: /var/run/cilium
       hostNetwork: true
       volumes:
         # To keep state between restarts / upgrades

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -110,7 +110,6 @@ spec:
         scheduler.alpha.kubernetes.io/tolerations: >-
           [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
       initContainers:
@@ -263,6 +262,44 @@ spec:
               add:
                 - "NET_ADMIN"
             privileged: true
+        - image: docker.io/cilium/cilium:latest
+          imagePullPolicy: Always
+          name: cilium-health
+          command: [ "cilium-health" ]
+          args:
+            - "-d"
+          ports:
+            - name: metrics
+              containerPort: 9091
+              protocol: TCP
+          env:
+            - name: "CILIUM_HEALTH_PROMETHEUS_SERVE_ADDR"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-health-metrics-config
+                  optional: true
+                  key: prometheus-serve-addr
+          livenessProbe:
+            exec:
+              command:
+              - cilium-health
+              - status
+            # The initial delay for the liveness probe is intentionally large to
+            # avoid an endless kill & restart cycle if in the event that the initial
+            # bootstrapping takes longer than expected.
+            initialDelaySeconds: 120
+            failureThreshold: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+              - cilium-health
+              - status
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: cilium-run
+              mountPath: /var/run/cilium
       hostNetwork: true
       volumes:
         # To keep state between restarts / upgrades

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -110,7 +110,6 @@ spec:
         scheduler.alpha.kubernetes.io/tolerations: >-
           [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
       initContainers:
@@ -280,6 +279,44 @@ spec:
               add:
                 - "NET_ADMIN"
             privileged: true
+        - image: docker.io/cilium/cilium:latest
+          imagePullPolicy: Always
+          name: cilium-health
+          command: [ "cilium-health" ]
+          args:
+            - "-d"
+          ports:
+            - name: metrics
+              containerPort: 9091
+              protocol: TCP
+          env:
+            - name: "CILIUM_HEALTH_PROMETHEUS_SERVE_ADDR"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-health-metrics-config
+                  optional: true
+                  key: prometheus-serve-addr
+          livenessProbe:
+            exec:
+              command:
+              - cilium-health
+              - status
+            # The initial delay for the liveness probe is intentionally large to
+            # avoid an endless kill & restart cycle if in the event that the initial
+            # bootstrapping takes longer than expected.
+            initialDelaySeconds: 120
+            failureThreshold: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+              - cilium-health
+              - status
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: cilium-run
+              mountPath: /var/run/cilium
       hostNetwork: true
       volumes:
         # To keep state between restarts / upgrades

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -110,7 +110,6 @@ spec:
         scheduler.alpha.kubernetes.io/tolerations: >-
           [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
     spec:
       serviceAccountName: cilium
       initContainers:
@@ -280,6 +279,44 @@ spec:
               add:
                 - "NET_ADMIN"
             privileged: true
+        - image: docker.io/cilium/cilium:latest
+          imagePullPolicy: Always
+          name: cilium-health
+          command: [ "cilium-health" ]
+          args:
+            - "-d"
+          ports:
+            - name: metrics
+              containerPort: 9091
+              protocol: TCP
+          env:
+            - name: "CILIUM_HEALTH_PROMETHEUS_SERVE_ADDR"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-health-metrics-config
+                  optional: true
+                  key: prometheus-serve-addr
+          livenessProbe:
+            exec:
+              command:
+              - cilium-health
+              - status
+            # The initial delay for the liveness probe is intentionally large to
+            # avoid an endless kill & restart cycle if in the event that the initial
+            # bootstrapping takes longer than expected.
+            initialDelaySeconds: 120
+            failureThreshold: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+              - cilium-health
+              - status
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: cilium-run
+              mountPath: /var/run/cilium
       hostNetwork: true
       volumes:
         # To keep state between restarts / upgrades

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -55,7 +55,7 @@ func init() {
 	},
 		func() float64 { return float64(len(GetEndpoints())) },
 	)
-	metrics.MustRegister(metrics.EndpointCount)
+	metrics.AgentRegistry.MustRegister(metrics.EndpointCount)
 }
 
 // Insert inserts the endpoint into the global maps.

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -302,4 +302,7 @@ const (
 
 	// Debug is a boolean value for whether debug is set or not.
 	Debug = "debug"
+
+	// PrometheusServeAddr is the address for Prometheus metrics server
+	PrometheusServeAddr = "prometheusServeAddr"
 )


### PR DESCRIPTION
This change adds the Prometheus metrics server for cilium-health
daemon.

Currently supported metric is a histogram with information about
latency to nodes and endpoints.

Fixes #4267

Signed-off-by: Michal Rostecki <mrostecki@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4596)
<!-- Reviewable:end -->
