### PR TITLE
kubernetes: Simple connectivity check demo app

### DIFF
--- a/examples/kubernetes/connectivity-check/README.md
+++ b/examples/kubernetes/connectivity-check/README.md
@@ -1,0 +1,22 @@
+# Connectivity Checker App
+
+Deploys a simple echo REST API with multiple replicas. Probe pods with multiple
+replicas checks connectivity to echo pods with a ClusterIP service. Readiness
+and liveness probe of probes will fail if connectivity to echo pods are
+unhealthy.
+
+```
+$ kubectl create -f connectivity-check.yaml
+$ kubectl get pods
+NAME                    READY     STATUS    RESTARTS   AGE
+echo-7d9f9564df-2hkhp   1/1       Running   0          37s
+echo-7d9f9564df-jr87s   1/1       Running   0          37s
+echo-7d9f9564df-lk6dl   1/1       Running   0          37s
+echo-7d9f9564df-q5dpb   1/1       Running   0          37s
+echo-7d9f9564df-zwhtw   1/1       Running   0          37s
+probe-8689f6579-899hc   1/1       Running   0          37s
+probe-8689f6579-9wzz7   1/1       Running   0          37s
+probe-8689f6579-k8ggp   1/1       Running   0          37s
+probe-8689f6579-sqdfb   1/1       Running   0          37s
+probe-8689f6579-thv7j   1/1       Running   0          37s
+```

--- a/examples/kubernetes/connectivity-check/connectivity-check.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -1,0 +1,72 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: probe
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        name: probe
+    spec:
+      containers:
+      - name: probe-container
+        image: docker.io/cilium/json-mock
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - -o
+            - /dev/null
+            - echo.default.svc.cluster.local
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - -o
+            - /dev/null
+            - echo.default.svc.cluster.local
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+  selector:
+    name: echo
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: echo
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        name: echo
+    spec:
+      containers:
+      - name: echo-container
+        image: docker.io/cilium/json-mock
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - -o
+            - /dev/null
+            - localhost
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - -o
+            - /dev/null
+            - localhost


### PR DESCRIPTION
Deploys a simple echo REST api with multiple replicas. Probe pods with multiple
replicas checks connectivity to echo pods with a ClusterIP service. Readiness
and liveness probe of probes will fail if connectivity to echo pods are
unhealthy.

```
$ kubectl create -f connectivity-check.yaml
$ kubectl get pods
NAME                    READY     STATUS    RESTARTS   AGE
echo-7d9f9564df-2hkhp   1/1       Running   0          37s
echo-7d9f9564df-jr87s   1/1       Running   0          37s
echo-7d9f9564df-lk6dl   1/1       Running   0          37s
echo-7d9f9564df-q5dpb   1/1       Running   0          37s
echo-7d9f9564df-zwhtw   1/1       Running   0          37s
probe-8689f6579-899hc   1/1       Running   0          37s
probe-8689f6579-9wzz7   1/1       Running   0          37s
probe-8689f6579-k8ggp   1/1       Running   0          37s
probe-8689f6579-sqdfb   1/1       Running   0          37s
probe-8689f6579-thv7j   1/1       Running   0          37s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4600)
<!-- Reviewable:end -->
