### PR TITLE
endpoint: use options stored in endpoint configuration for determining endpoint policy enforcement for ingress and egress

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -169,8 +169,7 @@ func (d *Daemon) UpdateNetworkPolicy(e *endpoint.Endpoint, policy *policy.L4Poli
 	if d.l7Proxy == nil {
 		return fmt.Errorf("can't update network policy, proxy disabled")
 	}
-	ingressPolicyEnforced, egressPolicyEnforced := d.EnableEndpointPolicyEnforcement(e)
-	return d.l7Proxy.UpdateNetworkPolicy(e, policy, ingressPolicyEnforced, egressPolicyEnforced,
+	return d.l7Proxy.UpdateNetworkPolicy(e, policy, e.Opts.IsEnabled(option.IngressPolicy), e.Opts.IsEnabled(option.EgressPolicy),
 		labelsMap, deniedIngressIdentities, deniedEgressIdentities, e.ProxyWaitGroup)
 }
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -266,8 +266,6 @@ func (e *Endpoint) computeDesiredL3PolicyMapEntries(owner Owner, identityCache *
 		egressCtx.Trace = policy.TRACE_ENABLED
 	}
 
-	enableIngressEnforcement, enableEgressEnforcement := owner.EnableEndpointPolicyEnforcement(e)
-
 	// Only L3 (label-based) policy apply.
 	// Complexity increases linearly by the number of identities in the map.
 	for identity, labels := range *identityCache {
@@ -275,7 +273,7 @@ func (e *Endpoint) computeDesiredL3PolicyMapEntries(owner Owner, identityCache *
 		egressCtx.To = labels
 
 		var ingressAccess api.Decision
-		if enableIngressEnforcement {
+		if e.Opts.IsEnabled(option.IngressPolicy) {
 			ingressAccess = repo.AllowsIngressLabelAccess(&ingressCtx)
 		} else {
 			// If policy enforcement is disabled, set the policy to an
@@ -294,7 +292,7 @@ func (e *Endpoint) computeDesiredL3PolicyMapEntries(owner Owner, identityCache *
 		}
 
 		var egressAccess api.Decision
-		if enableEgressEnforcement {
+		if e.Opts.IsEnabled(option.EgressPolicy) {
 			egressAccess = repo.AllowsEgressLabelAccess(&egressCtx)
 		} else {
 			// If policy enforcement is disabled, set the policy to an


### PR DESCRIPTION
In `pkg/endpoint/policy.go:regeneratePolicy()`, we determine the policy enforcement mode for the endpoint (enabled or disabled). The endpoint configuration is updated accordingly. The determination of the policy enforcement mode for the endpoint is made with a call to `owner.EnableEndpointPolicyEnforcement`. `EnableEndpointPolicyEnforcement` is a costly operation, because it iterates over all the rules in the repository and determines if the rules select the endpoint if the cilium-agent is running in `default` enforcement mode (which is the most common mode used). We only have to do this once upon initial policy calculation per endpoint; there is no need to do it multiple times, per endpoint regeneration.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4609)
<!-- Reviewable:end -->
