### PR TITLE
Fix sidecar proxy deadlock during BPF generation

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -331,26 +331,33 @@ func (e *Endpoint) addNewRedirectsFromMap(owner Owner, m policy.L4PolicyMap, des
 
 	for _, l4 := range m {
 		if l4.IsRedirect() {
-			// Ignore the redirect if the proxy is running in a sidecar container.
-			if l4.L7Parser == policy.ParserTypeHTTP && e.hasSidecarProxy {
-				continue
+			var redirectPort uint16
+			var err error
+			// Only create a redirect if the proxy is NOT running in a sidecar
+			// container. If running in a sidecar container, just allow traffic
+			// to the port at L4 by setting the proxy port to 0.
+			if !e.hasSidecarProxy || l4.L7Parser != policy.ParserTypeHTTP {
+				redirectPort, err = owner.UpdateProxyRedirect(e, &l4, proxyWaitGroup)
+				if err != nil {
+					return err
+				}
+
+				proxyID := e.ProxyID(&l4)
+				if e.realizedRedirects == nil {
+					e.realizedRedirects = make(map[string]uint16)
+				}
+				e.realizedRedirects[proxyID] = redirectPort
+				desiredRedirects[proxyID] = true
+
+				// Update the endpoint API model to report that Cilium manages a
+				// redirect for that port.
+				e.proxyStatisticsMutex.Lock()
+				proxyStats := e.getProxyStatisticsLocked(string(l4.L7Parser), uint16(l4.Port), l4.Ingress)
+				proxyStats.AllocatedProxyPort = int64(redirectPort)
+				e.proxyStatisticsMutex.Unlock()
 			}
 
-			redirectPort, err := owner.UpdateProxyRedirect(e, &l4, proxyWaitGroup)
-			if err != nil {
-				return err
-			}
-
-			proxyID := e.ProxyID(&l4)
-			if e.realizedRedirects == nil {
-				e.realizedRedirects = make(map[string]uint16)
-			}
-			e.realizedRedirects[proxyID] = redirectPort
-			desiredRedirects[proxyID] = true
-
-			// Update the proxy port in the policy map.
-			// This may override proxy ports written by
-			// e.computeDesiredPolicyMapState.
+			// Set the proxy port in the policy map.
 			var direction policymap.TrafficDirection
 			if l4.Ingress {
 				direction = policymap.Ingress
@@ -361,13 +368,6 @@ func (e *Endpoint) addNewRedirectsFromMap(owner Owner, m policy.L4PolicyMap, des
 			for _, keyFromFilter := range keysFromFilter {
 				e.desiredMapState[keyFromFilter] = PolicyMapStateEntry{ProxyPort: redirectPort}
 			}
-
-			// Update the endpoint API model to report that Cilium manages a
-			// redirect for that port.
-			e.proxyStatisticsMutex.Lock()
-			proxyStats := e.getProxyStatisticsLocked(string(l4.L7Parser), uint16(l4.Port), l4.Ingress)
-			proxyStats.AllocatedProxyPort = int64(redirectPort)
-			e.proxyStatisticsMutex.Unlock()
 		}
 	}
 	return nil
@@ -388,22 +388,6 @@ func (e *Endpoint) addNewRedirects(owner Owner, m *policy.L4Policy, proxyWaitGro
 		return desiredRedirects, fmt.Errorf("Unable to allocate egress redirects: %s", err)
 	}
 	return desiredRedirects, nil
-}
-
-func (e *Endpoint) removeOldRedirectPolicyMapEntries(desiredRedirects map[string]bool) {
-	for id, redirectPort := range e.realizedRedirects {
-		// Remove only the redirects that are not required.
-		if desiredRedirects[id] {
-			continue
-		}
-		// Clear all occurrences of this proxy port in the policy map.
-		for k, v := range e.desiredMapState {
-			if v.ProxyPort == redirectPort {
-				v.ProxyPort = 0
-				e.desiredMapState[k] = v
-			}
-		}
-	}
 }
 
 // Must be called with endpoint.Mutex held.
@@ -509,10 +493,6 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, boo
 		return e.nextPolicyRevision, compilationExecuted, nil
 	}
 
-	// The set of IDs of proxy redirects that are required to implement the
-	// policy.
-	var desiredRedirects map[string]bool
-
 	// Anything below this point must be reverted upon failure as we are
 	// changing live BPF maps
 	createdPolicyMap := false
@@ -547,6 +527,11 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, boo
 		}
 	}
 
+	// Set up a context to wait for proxy completions.
+	completionCtx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	proxyWaitGroup := completion.NewWaitGroup(completionCtx)
+	defer cancel()
+
 	// Only generate & populate policy map if a security identity is set up for
 	// this endpoint.
 	if e.SecurityIdentity != nil {
@@ -560,53 +545,22 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, boo
 			return 0, compilationExecuted, fmt.Errorf("unable to regenerate policy for '%s': %s", e.PolicyMap.String(), err)
 		}
 
-		// Now that policy has been regenerated, set up a context to
-		// wait for proxy completions.
-		completionCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		proxyWaitGroup := completion.NewWaitGroup(completionCtx)
-		defer func() {
-			cancel()
-		}()
-
-		// Walk the L4Policy for ports that require
-		// an L7 redirect and add them to the endpoint.
-		// Also update the desired policy map state to set the newly allocated proxy ports.
-		if e.DesiredL4Policy != nil {
-			desiredRedirects, err = e.addNewRedirects(owner, e.DesiredL4Policy, proxyWaitGroup)
-			if err != nil {
-				e.Mutex.Unlock()
-				return 0, compilationExecuted, err
-			}
-		}
-
-		// Update policies after adding redirects, otherwise we will not wait for
-		// acks for the first policy updates for the first added redirects.
-		if err = e.updateNetworkPolicy(owner, proxyWaitGroup); err != nil {
-			e.Mutex.Unlock()
-			return 0, compilationExecuted, err
-		}
-
-		// To avoid traffic loss, wait for the proxy to be ready to accept
-		// traffic on new redirect ports, before we update the policy map that
-		// will redirect traffic to those ports.
-		err = e.WaitForProxyCompletions(proxyWaitGroup)
-		if err != nil {
-			return 0, compilationExecuted, fmt.Errorf("Error while configuring proxy redirects: %s", err)
-		}
-
 		// Synchronously try to update PolicyMap for this endpoint. If any
 		// part of updating the PolicyMap fails, bail out and do not generate
 		// BPF. Unfortunately, this means that the map will be in an inconsistent
 		// state with the current program (if it exists) for this endpoint.
 		// GH-3897 would fix this by creating a new map to do an atomic swap
 		// with the old one.
-		//
-		// This must be done after adding the new redirects, because the newly
-		// allocated proxy ports have to be updated in the policy map.
 		err := e.syncPolicyMap()
 		if err != nil {
 			e.Mutex.Unlock()
 			return 0, compilationExecuted, fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
+		}
+
+		// Configure the new network policy with the proxies.
+		if err = e.updateNetworkPolicy(owner, proxyWaitGroup); err != nil {
+			e.Mutex.Unlock()
+			return 0, compilationExecuted, err
 		}
 	}
 
@@ -667,8 +621,26 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, boo
 		e.Mutex.RUnlock()
 	}
 
-	// Remove all obsolete redirects from the desired policy map.
-	e.removeOldRedirectPolicyMapEntries(desiredRedirects)
+	e.Mutex.Lock()
+	// Walk the L4Policy to add new redirects and update the desired policy map
+	// state to set the newly allocated proxy ports.
+	var desiredRedirects map[string]bool
+	if e.DesiredL4Policy != nil {
+		desiredRedirects, err = e.addNewRedirects(owner, e.DesiredL4Policy, proxyWaitGroup)
+		if err != nil {
+			e.Mutex.Unlock()
+			return 0, compilationExecuted, err
+		}
+	}
+	// At this point, traffic is no longer redirected to the proxy for
+	// now-obsolete redirects, since we synced the updated policy map above.
+	// It's now safe to remove the redirects from the proxy's configuration.
+	e.removeOldRedirects(owner, desiredRedirects, proxyWaitGroup)
+	e.Mutex.Unlock()
+	err = e.WaitForProxyCompletions(proxyWaitGroup)
+	if err != nil {
+		return 0, compilationExecuted, fmt.Errorf("Error while configuring proxy redirects: %s", err)
+	}
 
 	// Synchronously try to update PolicyMap for this endpoint. If any
 	// part of updating the PolicyMap fails, bail out and do not generate
@@ -677,26 +649,12 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, boo
 	// GH-3897 would fix this by creating a new map to do an atomic swap
 	// with the old one.
 	//
-	// This must be done before removing the old redirects below, because the
-	// allocated proxy ports are to be cleared from the policy map first.
+	// This must be done after allocating the new redirects, to update the
+	// policy map with the new proxy ports.
 	err = e.syncPolicyMap()
 	if err != nil {
 		e.Mutex.Unlock()
 		return 0, compilationExecuted, fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
-	}
-
-	// To avoid traffic loss, wait for the policy map to be updated before
-	// deleting obsolete redirects, to make sure no packets are redirected to
-	// those ports.
-	completionCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	proxyWaitGroup := completion.NewWaitGroup(completionCtx)
-	defer cancel()
-	e.Mutex.Lock()
-	e.removeOldRedirects(owner, desiredRedirects, proxyWaitGroup)
-	e.Mutex.Unlock()
-	err = e.WaitForProxyCompletions(proxyWaitGroup)
-	if err != nil {
-		return 0, compilationExecuted, fmt.Errorf("Error while deleting obsolete proxy redirects: %s", err)
 	}
 
 	// The last operation hooks the endpoint into the endpoint table and exposes it

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -135,20 +135,40 @@ func (e *Endpoint) computeDesiredL4PolicyMapEntries(keysToAdd PolicyMapState) {
 	for _, filter := range e.DesiredL4Policy.Ingress {
 		keysFromFilter := e.convertL4FilterToPolicyMapKeys(&filter, policymap.Ingress)
 		for _, keyFromFilter := range keysFromFilter {
-			// This proxy port may get overwritten later by
-			// e.addNewRedirectsFromMap. We don't know at this point about new
-			// redirect ports that are to be allocated.
-			keysToAdd[keyFromFilter] = PolicyMapStateEntry{ProxyPort: e.lookupRedirectPort(&filter)}
+			var proxyPort uint16
+			// Preserve the already-allocated proxy ports for redirects that
+			// already exist.
+			if filter.IsRedirect() {
+				proxyPort = e.lookupRedirectPort(&filter)
+				// If the currently allocated proxy port is 0, this is a new
+				// redirect, for which no port has been allocated yet. Ignore
+				// it for now. This will be configured by
+				// e.addNewRedirectsFromMap once the port has been allocated.
+				if proxyPort == 0 {
+					continue
+				}
+			}
+			keysToAdd[keyFromFilter] = PolicyMapStateEntry{ProxyPort: proxyPort}
 		}
 	}
 
 	for _, filter := range e.DesiredL4Policy.Egress {
 		keysFromFilter := e.convertL4FilterToPolicyMapKeys(&filter, policymap.Egress)
 		for _, keyFromFilter := range keysFromFilter {
-			// This proxy port may get overwritten later by
-			// e.addNewRedirectsFromMap. We don't know at this point about new
-			// redirect ports that are to be allocated.
-			keysToAdd[keyFromFilter] = PolicyMapStateEntry{ProxyPort: e.lookupRedirectPort(&filter)}
+			var proxyPort uint16
+			// Preserve the already-allocated proxy ports for redirects that
+			// already exist.
+			if filter.IsRedirect() {
+				proxyPort = e.lookupRedirectPort(&filter)
+				// If the currently allocated proxy port is 0, this is a new
+				// redirect, for which no port has been allocated yet. Ignore
+				// it for now. This will be configured by
+				// e.addNewRedirectsFromMap once the port has been allocated.
+				if proxyPort == 0 {
+					continue
+				}
+			}
+			keysToAdd[keyFromFilter] = PolicyMapStateEntry{ProxyPort: proxyPort}
 		}
 	}
 	return

--- a/tests/10-proxy.sh
+++ b/tests/10-proxy.sh
@@ -78,6 +78,12 @@ function proxy_init {
   wait_for_docker_ipv6_addr server2
   wait_for_docker_ipv6_addr client
 
+  log "waiting for all 4 endpoints to get an identity"
+  while [ `cilium endpoint list -o jsonpath='{range [*]}{.status.identity.id}{"\n"}{end}' | grep '^[0-9]' | grep -v '^5$' | wc -l` -ne 4 ] ; do
+    log "waiting..."
+    sleep 1
+  done
+
   monitor_start
   log "finished proxy_init"
 }


### PR DESCRIPTION
In some cases, the HTTP proxy in sidecar mode can't connect to Istio Pilot to be configured during regeneration, even if the policy whitelists that traffic.

This can happen especially when the first policy being applied on an endpoint contains HTTP rules. In this case, BPF generation waits for the sidecar proxy to configure the Cilium filters and to ACK the policy configuration, before the endpoint's BPF program has been installed for this endpoint. Because no BPF program is installed, all traffic keeps getting dropped, which results in the sidecar proxy not being able to connect to Istio Pilot and to get configured. The endpoint remains in this state, with all its traffic being dropped, until it the endpoint deleted or the HTTP rules are deleted from the policy.

Specifying an init policy that whitelists traffic to Istio services at L3/L4 normally solves that problem. Such an init policy allows the sidecar proxy to get configured before the endpoint's actual policy is generated. However, in some cases, the identity of an endpoint is resolved before its init policy is generated, so the first policy to be generated is the endpoint's actual policy and the init policy is ignored.

To solve this problem, refactor the BPF regeneration to configure L3+L4 connectivity and generate the BPF program first, before configuring the L7 proxies and configuring L7 policies. This way, if the policy to be enforced allows connectivity at L3/L4 to Istio services, the sidecar proxy can always get configured by Istio Pilot before L7 policies are configured.

The new BPF regeneration process is now:

1. generate the policy as done currently
2. do the complete generation, incl.:
  - modify the BPF policy map, **but do not configure any new proxy redirect (i.e. any new L4 port that is to be redirected to an L7 proxy)**; this includes removing any obsolete redirects from the BPF policy map, in effect dropping all traffic to obsolete redirects
  - send the new network policy to Envoy
  - generate the BPF program
3. delete the obsolete redirects from the Envoy + Kafka proxies
4. create the new redirects to the Envoy + Kafka proxies
5. wait for Envoy to ACK all the changes; may require to increase the proxy wait timeout because that may require waiting for the BPF policy map to be configured in order for Envoy to get configured in case it's in a sidecar container
6. modify the BPF policy map to configure the new L4 ports with proxy redirects

This requires that the BPF datapath looks up redirect ports from the BPF policy map entries (https://github.com/cilium/cilium/pull/2918) and for the Cilium agent to populate the redirect ports in policy map entries (https://github.com/cilium/cilium/issues/4711).

Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4610)
<!-- Reviewable:end -->
