### PR TITLE
Fix golang 1.10 build on Ubuntu with snap packages

### DIFF
--- a/bugtool/Makefile
+++ b/bugtool/Makefile
@@ -18,7 +18,7 @@ TARGET=cilium-bugtool
 SOURCES := $(shell find ../common . -name '*.go')
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
-	$(GO) build -i $(GOBUILD) -o $(TARGET)
+	$(GO) build $(GOBUILD) -o $(TARGET)
 
 all: $(TARGET)
 

--- a/cilium-health/Makefile
+++ b/cilium-health/Makefile
@@ -4,7 +4,7 @@ TARGET=cilium-health
 SOURCES := $(shell find ../api/v1/health ../pkg/health cmd . \( -name '*.go' ! -name '*_test.go' \))
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
-	$(GO) build -i $(GOBUILD) -o $(TARGET)
+	$(GO) build $(GOBUILD) -o $(TARGET)
 
 all: $(TARGET)
 

--- a/cilium/Makefile
+++ b/cilium/Makefile
@@ -5,7 +5,7 @@ TARGET=cilium
 SOURCES := $(shell find ../api ../daemon ../common ../pkg cmd . \( -name '*.go' ! -name '*_test.go' \))
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
-	$(GO) build -i $(GOBUILD) -o $(TARGET)
+	$(GO) build $(GOBUILD) -o $(TARGET)
 
 all: $(TARGET)
 

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -11,7 +11,7 @@ TARGET=cilium-agent
 SOURCES := $(shell find ../api ../common ../daemon ../pkg ../monitor . \( -name '*.go'  ! -name '*_test.go' \))
 $(TARGET): $(SOURCES) check-bindata
 	@$(ECHO_GO)
-	$(GO) build -i $(GOBUILD) -o $(TARGET)
+	$(GO) build $(GOBUILD) -o $(TARGET)
 
 GO_BINDATA := $(QUIET) go-bindata -prefix ../ -mode 0640 -modtime 1450269211 \
 	-ignore Makefile -ignore bpf_features.h -ignore lxc_config.h \

--- a/monitor/Makefile
+++ b/monitor/Makefile
@@ -18,7 +18,7 @@ TARGET=cilium-node-monitor
 SOURCES := $(shell find ../monitor ../common ../pkg ../api . \( -name '*.go' ! -name '*_test.go' \))
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
-	$(GO) build -i $(GOBUILD) -o $(TARGET)
+	$(GO) build $(GOBUILD) -o $(TARGET)
 
 all: $(TARGET)
 

--- a/plugins/cilium-cni/Makefile
+++ b/plugins/cilium-cni/Makefile
@@ -13,7 +13,7 @@ SOURCES := $(shell find ../../api/v1/models ../../common ../../pkg/client ../../
 
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
-	$(GO) build -i $(GOBUILD) -o $(TARGET) ./cilium-cni.go
+	$(GO) build $(GOBUILD) -o $(TARGET) ./cilium-cni.go
 
 install:
 	$(INSTALL) -m 0755 -d $(DESTDIR)/etc/cni/net.d

--- a/plugins/cilium-docker/Makefile
+++ b/plugins/cilium-docker/Makefile
@@ -8,7 +8,7 @@ SOURCES := $(shell find ../../api/v1 ../../common ../../pkg/client ../../pkg/end
 
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
-	$(GO) build -i $(GOBUILD) -o $(TARGET)
+	$(GO) build $(GOBUILD) -o $(TARGET)
 
 run:
 	./cilium-docker -d

--- a/test/bpf/Makefile
+++ b/test/bpf/Makefile
@@ -14,7 +14,7 @@ all: $(TARGETS)
 
 perf-event-test: perf-event-test.go
 	@$(ECHO_GO)
-	$(GO) build -i $(GOBUILD) -o $@ $<
+	$(GO) build $(GOBUILD) -o $@ $<
 
 bpf-event-test.o: bpf-event-test.c
 	@$(ECHO_CC)


### PR DESCRIPTION
Using `-i` in the "go build" arguments with Golang 1.10 on Ubuntu using
a snap package results in this error:

    $ make -C daemon
      CHECK contrib/scripts/bindata.sh
      GO    daemon/cilium-agent
    go build runtime/cgo: open /snap/go/2130/pkg/linux_amd64/runtime/cgo.a: read-only file system

According to the upstream issue, this is because it's attempting to rebuild
the core Golang packages on the system, and snap is preventing this via a
read-only file system to ensure consistency for the base Golang version.

The workaround suggested in the following issue is to remove `-i`.

https://github.com/golang/go/issues/24674

For more information, see the Golang 1.10 release notes:
https://golang.org/doc/go1.10#build

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4620)
<!-- Reviewable:end -->
