### PR TITLE
metricsmap: Fix index out of range error

### DIFF
--- a/pkg/maps/metricsmap/metricsmap.go
+++ b/pkg/maps/metricsmap/metricsmap.go
@@ -167,7 +167,7 @@ func updatePrometheusMetrics(key *Key, val *Value) {
 // aggregating it into drops (by drop reason and direction) and
 // forwards (by direction) with the prometheus server.
 func SyncMetricsMap() error {
-	var entry [possibleCPUsFileLength]Value
+	entry := make([]Value, possibleCpus)
 	file := bpf.MapPath(MapName)
 	metricsmap, err := bpf.OpenMap(file)
 
@@ -182,7 +182,7 @@ func SyncMetricsMap() error {
 		if err != nil {
 			break
 		}
-		err = bpf.LookupElement(metricsmap.GetFd(), unsafe.Pointer(&nextKey), unsafe.Pointer(&entry))
+		err = bpf.LookupElement(metricsmap.GetFd(), unsafe.Pointer(&nextKey), unsafe.Pointer(&entry[0]))
 		if err != nil {
 			return fmt.Errorf("unable to lookup metrics map: %s", err)
 		}


### PR DESCRIPTION
This function was declaring an array of length `possibleCPUsFileLength`
then reading indexes of up to `possibleCpus` out of the array. When the
number of possible CPUs is large, this would cause the following error:

    panic: runtime error: index out of range

    goroutine 236 [running]:
    github.com/cilium/cilium/pkg/maps/metricsmap.SyncMetricsMap(0x0, 0x0)
            /go/src/github.com/cilium/cilium/pkg/maps/metricsmap/metricsmap.go:194 +0x33b
    created by github.com/cilium/cilium/pkg/controller.(*Manager).UpdateController
            /go/src/github.com/cilium/cilium/pkg/controller/manager.go:82 +0x30c

To fix this, declare a slice of size `possibleCpus` and use the pointer to the
first element to pass to the kernel. This should point to a contiguous memory
location of the appropriate length for the kernel to write the results into,             
according to the following documentation:                                       
                                                                                
https://blog.golang.org/go-slices-usage-and-internals

Fixes: #4622

Signed-off-by: Joe Stringer <joe@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4623)
<!-- Reviewable:end -->
