### PR TITLE
docs: point users to docs.cilium.io in GH docs

### DIFF
--- a/Documentation/api.rst
+++ b/Documentation/api.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _api_ref:
 
 #############

--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _bpf_guide:
 
 ***************************

--- a/Documentation/cheatsheet.rst
+++ b/Documentation/cheatsheet.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 ******************
 Command Cheatsheet
 ******************

--- a/Documentation/cmdref/cli_index.rst
+++ b/Documentation/cmdref/cli_index.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 cilium
 ======
 

--- a/Documentation/cmdref/index.rst
+++ b/Documentation/cmdref/index.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 Command Reference
 =================
 

--- a/Documentation/cmdref/kvstore.rst
+++ b/Documentation/cmdref/kvstore.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _install_kvstore:
 
 Key-Value Store

--- a/Documentation/commit-access.rst
+++ b/Documentation/commit-access.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 ..       This has been bluntly copied from the excellent committer guidelines
          written for the Open vSwitch project and has then been adapted. It is
          based on the following files:

--- a/Documentation/concepts.rst
+++ b/Documentation/concepts.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _arch_guide:
 
 ########

--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _metrics:
 
 ********************

--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _dev_guide:
 
 Developer / Contributor Guide

--- a/Documentation/docker/index.rst
+++ b/Documentation/docker/index.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 ******
 Docker
 ******

--- a/Documentation/further_reading.rst
+++ b/Documentation/further_reading.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 ###############
 Further Reading
 ###############

--- a/Documentation/gettinghelp.rst
+++ b/Documentation/gettinghelp.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _getting_help:
 
 ############

--- a/Documentation/gettingstarted/cilium_install.rst
+++ b/Documentation/gettingstarted/cilium_install.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 Step 1: Install Cilium
 ======================
 

--- a/Documentation/gettingstarted/cilium_install_crio.rst
+++ b/Documentation/gettingstarted/cilium_install_crio.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _install_cilium_crio:
 
 Cilium, Kubernetes and CRI-O

--- a/Documentation/gettingstarted/cilium_install_docker.rst
+++ b/Documentation/gettingstarted/cilium_install_docker.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _install_cilium_docker:
 
 Cilium, Kubernetes and Docker

--- a/Documentation/gettingstarted/docker.rst
+++ b/Documentation/gettingstarted/docker.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 ***************************************
 Getting Started Using `Docker Compose`_
 ***************************************

--- a/Documentation/gettingstarted/elasticsearch.rst
+++ b/Documentation/gettingstarted/elasticsearch.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 **************************************
 Getting Started Securing Elasticsearch
 **************************************

--- a/Documentation/gettingstarted/grpc.rst
+++ b/Documentation/gettingstarted/grpc.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 *****************************
 Getting Started Securing gRPC
 *****************************

--- a/Documentation/gettingstarted/gsg_intro.rst
+++ b/Documentation/gettingstarted/gsg_intro.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 If you haven't read the :ref:`intro` yet, we'd encourage you to do that first.
 
 The best way to get help if you get stuck is to ask a question on the `Cilium

--- a/Documentation/gettingstarted/gsg_starwars.rst
+++ b/Documentation/gettingstarted/gsg_starwars.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 
 
 Step 2: Deploy the Demo Application

--- a/Documentation/gettingstarted/index.rst
+++ b/Documentation/gettingstarted/index.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _gs_guide:
 
 Getting Started Guides

--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 ***************************
 Getting Started Using Istio
 ***************************

--- a/Documentation/gettingstarted/kafka.rst
+++ b/Documentation/gettingstarted/kafka.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 ******************************
 Getting Started Securing Kafka 
 ******************************

--- a/Documentation/gettingstarted/mesos.rst
+++ b/Documentation/gettingstarted/mesos.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 ************************************
 Getting Started Using Mesos/Marathon
 ************************************

--- a/Documentation/gettingstarted/minikube.rst
+++ b/Documentation/gettingstarted/minikube.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _gs_minikube:
 
 ******************************

--- a/Documentation/gettingstarted/minikube_intro.rst
+++ b/Documentation/gettingstarted/minikube_intro.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 Step 0: Install kubectl & minikube
 ==================================
 

--- a/Documentation/glossary.rst
+++ b/Documentation/glossary.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _glossary:
 
 Glossary

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 Welcome to Cilium's documentation!
 ==================================
 

--- a/Documentation/install/guides/advanced_options.rst
+++ b/Documentation/install/guides/advanced_options.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _admin_install_options:
 
 ****************

--- a/Documentation/install/guides/from_source.rst
+++ b/Documentation/install/guides/from_source.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _admin_install_source:
 
 *************************

--- a/Documentation/install/guides/index.rst
+++ b/Documentation/install/guides/index.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _install_guide:
 
 Installation Guides

--- a/Documentation/install/guides/kops.rst
+++ b/Documentation/install/guides/kops.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _kops_guide:
 
 **********************************

--- a/Documentation/install/guides/kubernetes.rst
+++ b/Documentation/install/guides/kubernetes.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 ***************************************
 Kubernetes Installation Guide (Generic)
 ***************************************

--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _admin_system_reqs:
 
 *******************

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _admin_upgrade:
 
 *************

--- a/Documentation/intro.rst
+++ b/Documentation/intro.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _intro:
 
 ######################

--- a/Documentation/istio/index.rst
+++ b/Documentation/istio/index.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 *****
 Istio
 *****

--- a/Documentation/kubernetes/ciliumendpoint.rst
+++ b/Documentation/kubernetes/ciliumendpoint.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 ******************************************
 Cilium Endpoint Custom Resource Definition
 ******************************************

--- a/Documentation/kubernetes/compatibility.rst
+++ b/Documentation/kubernetes/compatibility.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 :orphan:
 
 .. _k8scompatibility:

--- a/Documentation/kubernetes/index.rst
+++ b/Documentation/kubernetes/index.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _kubernetes:
 
 **********

--- a/Documentation/kubernetes/install.rst
+++ b/Documentation/kubernetes/install.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _admin_install_daemonset:
 
 ******************

--- a/Documentation/kubernetes/intro.rst
+++ b/Documentation/kubernetes/intro.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _k8s_intro:
 
 ************

--- a/Documentation/kubernetes/policy.rst
+++ b/Documentation/kubernetes/policy.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _k8s_policy:
 
 **************

--- a/Documentation/kubernetes/quickinstall.rst
+++ b/Documentation/kubernetes/quickinstall.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _k8s_quick:
 
 ***********

--- a/Documentation/kubernetes/troubleshooting.rst
+++ b/Documentation/kubernetes/troubleshooting.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _troubleshooting_k8s:
 
 ***************

--- a/Documentation/mesos/index.rst
+++ b/Documentation/mesos/index.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _mesos:
 
 *****

--- a/Documentation/policy/index.rst
+++ b/Documentation/policy/index.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _network_policy:
 .. _Network Policies:
 .. _Network Policy:

--- a/Documentation/policy/intro.rst
+++ b/Documentation/policy/intro.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _policy_guide:
 
 .. _policy_enforcement_modes:

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _policy_examples:
 
 Layer 3 Examples

--- a/Documentation/policy/lifecycle.rst
+++ b/Documentation/policy/lifecycle.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _endpoint_lifecycle:
 .. _Endpoint Lifecycle:
 

--- a/Documentation/policy/troubleshooting.rst
+++ b/Documentation/policy/troubleshooting.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _policy_tracing:
 .. _policy_troubleshooting:
 

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -1,3 +1,9 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+      http://docs.cilium.io
+
 .. _admin_guide:
 
 ###############


### PR DESCRIPTION
Since users might read the github docs we will provide them a warning
in the documentation, that will not show up in the generated html code
but it shows up in github, to point them into the stable documentation
in http://docs.cilium.io

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4627)
<!-- Reviewable:end -->
