### PR TITLE
Fix PolicyRevision of endpoint bumped prematurely

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -583,9 +583,6 @@ func (e *Endpoint) regeneratePolicy(owner Owner, opts models.ConfigurationMap) (
 	// already running the latest revision, otherwise we have to wait for
 	// the regeneration of the endpoint to complete.
 	policyChanged := l3PolicyChanged || l4PolicyChanged
-	if !policyChanged && !optsChanged {
-		e.setPolicyRevision(revision)
-	}
 
 	e.getLogger().WithFields(logrus.Fields{
 		"policyChanged":       policyChanged,
@@ -787,6 +784,11 @@ func (e *Endpoint) TriggerPolicyUpdatesLocked(owner Owner, opts models.Configura
 	needToRegenerateBPF, err := e.regeneratePolicy(owner, opts)
 	if err != nil {
 		return false, fmt.Errorf("%s: %s", e.StringID(), err)
+	}
+	// If it does not need datapath regeneration then we should set the policy
+	// revision with nextPolicyRevision.
+	if !needToRegenerateBPF {
+		e.setPolicyRevision(e.nextPolicyRevision)
 	}
 
 	// CurrentStatus will be not OK when we have an uncleared error in BPF,


### PR DESCRIPTION
**Summary of changes**: pkg/endpoint: set policy revision if there is no datapath changes

```
As cilium calls regeneratePolicy inside regenerateBPF, it could end up
setting up the policy revision before enforcing the changes in the
datapath.

This bug could be triggered by TriggerPolicyUpdates where the trace call
could be the following:

1 - endpoint.TriggerPolicyUpdates
  2 - endpoint.TriggerPolicyUpdatesLocked
    3 - endpoint.regeneratePolicy
       returns (true, nil)
     returns (true, nil)
  4 - endpoint.Regenerate
    5 - endpoint.regeneratePolicy
        6 - endpoint.setPolicyRevision(y) # -> WRONG!
    7 - endpoint.regenerateBPF
      8 - endpoint.setPolicyRevision(y) # -> 'y' was already wrongly set in step 6
```
Fixes: #4462

@tgraf does this need backport to 1.0? If yes, I need to create a new PR without 670c5e5a26408827abe5abf2d33d1c36db6ce63c

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4636)
<!-- Reviewable:end -->
