### PR TITLE
Test: MicroscopeStart return callback if error.

### DIFF
--- a/test/k8sT/microscope.go
+++ b/test/k8sT/microscope.go
@@ -49,6 +49,10 @@ var _ = Describe(microscopeTestName, func() {
 			"cilium endpoint list")
 	})
 
+	AfterAll(func() {
+		ExpectAllPodsTerminated(kubectl)
+	})
+
 	It("Runs microscope", func() {
 		microscopeErr, microscopeCancel := kubectl.MicroscopeStart()
 		Expect(microscopeErr).To(BeNil(), "Microscope cannot be started")


### PR DESCRIPTION
If the Microscope pod is not ready in the given timeout, it returned
`nil` callback that will fail when it is called on JustAfterEach, so no
logs were gathered correctly.

Related to #4644

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4648)
<!-- Reviewable:end -->
