### PR TITLE
CI: Delete bugtool files correctly

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1174,7 +1174,7 @@ func (kub *Kubectl) DumpCiliumCommandOutput(namespace string) {
 				continue
 			}
 			//Remove bugtool artifact, so it'll be not used if any other fail test
-			_ = kub.ExecPodCmd(KubeSystemNamespace, pod, fmt.Sprintf("rm %s", line))
+			_ = kub.ExecPodCmd(KubeSystemNamespace, pod, fmt.Sprintf("rm /tmp/%s", line))
 		}
 	}
 


### PR DESCRIPTION
On fail, the `kubectl.DumpCiliumCommandOutput` command creates some
bugtool outputs and are saved on the test_result folder,but it was not
deleted correctly from the pod, and it was in there if any other test
fails it'll be in there and we dump old information.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4654)
<!-- Reviewable:end -->
