### PR TITLE
test: Use latest stable etcd and consul images

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,13 +1,13 @@
 version: "2"
 services:
   consul:
-    image: "consul:0.8.3"
+    image: "docker.io/library/consul:1.1.0"
     hostname: "consul"
     environment:
       - 'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true, "disable_update_check": true}'
     privileged: true
   etcd:
-    image: "quay.io/coreos/etcd:v3.1.0"
+    image: "quay.io/coreos/etcd:v3.2.17"
     hostname: "etcd"
     command: "etcd -name etcd0 -advertise-client-urls http://0.0.0.0:4002 -listen-client-urls http://0.0.0.0:4002 -initial-cluster-token etcd-cluster-1 -initial-cluster-state new"
     privileged: true


### PR DESCRIPTION
Change the real etcd and consul docker image tags that are used in the
unit tests run in the CI.

Fixes: ab999f126278 ("test: Use latest stable etcd and consul images")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4655)
<!-- Reviewable:end -->
