### PR TITLE
Revert "start.sh: set RELOAD=1 if VM already exists"

### DIFF
--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -53,16 +53,6 @@ export 'CILIUM_TEMP'="${dir}"
 # Required bazel version
 export 'BAZEL_VERSION'=$(<envoy/BAZEL_VERSION)
 
-# Sets the RELOAD env variable with 1 if there is any VM printed by
-# vagrant status.
-function set_reload_if_vm_exists(){
-    if [ -z "${RELOAD}" ]; then
-        if [[ $(vagrant status 2>/dev/null | wc -l) -gt 1 ]]; then
-            RELOAD=1
-        fi
-    fi
-}
-
 # split_ipv4 splits an IPv4 address into a bash array and assigns it to ${1}.
 # Exits if ${2} is an invalid IPv4 address.
 function split_ipv4(){
@@ -561,8 +551,6 @@ ipv6_public_workers_addrs=()
 
 split_ipv4 ipv4_array "${MASTER_IPV4}"
 MASTER_IPV6="${IPV6_INTERNAL_CIDR}$(printf '%02X' ${ipv4_array[3]})"
-
-set_reload_if_vm_exists
 
 create_master
 create_workers


### PR DESCRIPTION
Commit cf96c958ae19376001e2ad441128f8b2a8c07fc2 broke vagrant usage on OSX

This is because of vagrant status output:
```
$ vagrant status 2>/dev/null
Current machine states:

runtime1                  not created (virtualbox)

The environment has not yet been created. Run `vagrant up` to
create the environment. If a machine is not created, only the
default provider will be shown. So if a provider is not listed,
then the machine is not created for that environment.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4657)
<!-- Reviewable:end -->
