### PR TITLE
start.sh: fix RELOAD=1 if VM is not created

### DIFF
--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -57,7 +57,8 @@ export 'BAZEL_VERSION'=$(<envoy/BAZEL_VERSION)
 # vagrant status.
 function set_reload_if_vm_exists(){
     if [ -z "${RELOAD}" ]; then
-        if [[ $(vagrant status 2>/dev/null | wc -l) -gt 1 ]]; then
+        if [[ $(vagrant status 2>/dev/null | wc -l) -gt 1 && \
+                ! $(vagrant status 2>/dev/null | grep "not created") ]]; then
             RELOAD=1
         fi
     fi


### PR DESCRIPTION
Fixes: cf96c958ae ("start.sh: set RELOAD=1 if VM already exists")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4662)
<!-- Reviewable:end -->
