### PR TITLE
backport: Only check merged PRs

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -70,7 +70,7 @@ get_prs () {
 
   label_opt="%20label:$label"
   label_exclude_opt="%20-label:$label_exclude"
-  url="https://api.github.com/search/issues?per_page=1&q=is:pr%20repo:cilium/cilium%20is:closed$label_opt$label_exclude_opt"
+  url="${CILIUM_GITHUB_SEARCHAPI}$label_opt$label_exclude_opt"
   total="$($GHCURL $url | jq -r '.total_count')"
 
   # Calculate number of pages, rounding up

--- a/contrib/release/lib/gitlib.sh
+++ b/contrib/release/lib/gitlib.sh
@@ -25,7 +25,7 @@ JCURL="curl -g -s --fail --retry 10"
 CILIUM_GITHUB_API='https://api.github.com/repos/cilium/cilium'
 CILIUM_GITHUB_RAW_ORG='https://raw.githubusercontent.com/cilium'
 
-CILIUM_GITHUB_SEARCHAPI='https://api.github.com/search/issues?per_page=100&q=is:pr%20is:closed%20repo:cilium/cilium%20'
+CILIUM_GITHUB_SEARCHAPI='https://api.github.com/search/issues?per_page=100&q=is:pr%20is:merged%20repo:cilium/cilium%20'
 CILIUM_GITHUB_URL='https://github.com/cilium/cilium'
 CILIUM_GITHUB_SSH='git@github.com:cilium/cilium.git'
 


### PR DESCRIPTION
The script would surface closed PRs with the needs/backport label.
Instead of cleaning those up, clean up the script.

This will cause us to skip PRs that are closed but are actually merged. I'm not sure how often that happens.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4663)
<!-- Reviewable:end -->
