### PR TITLE
Use local service ID allocation when DSR is disabled

### DIFF
--- a/common/types/loadbalancer.go
+++ b/common/types/loadbalancer.go
@@ -400,6 +400,13 @@ func (a *L3n4Addr) String() string {
 	return fmt.Sprintf("%s:%d", a.IP.String(), a.Port)
 }
 
+// StringID returns the L3n4Addr as string to be used for unique identification
+func (a *L3n4Addr) StringID() string {
+	// This does not include the protocol right now as the datapath does
+	// not include the protocol in the lookup of the service IP.
+	return a.String()
+}
+
 // DeepCopy returns a DeepCopy of the given L3n4Addr.
 func (a *L3n4Addr) DeepCopy() *L3n4Addr {
 	copyIP := make(net.IP, len(a.IP))

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/serializer"
+	"github.com/cilium/cilium/pkg/service"
 
 	go_version "github.com/hashicorp/go-version"
 	"github.com/sirupsen/logrus"
@@ -873,7 +874,7 @@ func (d *Daemon) delK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 		repPorts[svcPort.Port] = false
 
 		if svcPort.ID != 0 {
-			if err := DeleteL3n4AddrIDByUUID(uint32(svcPort.ID)); err != nil {
+			if err := service.DeleteL3n4AddrIDByUUID(uint32(svcPort.ID)); err != nil {
 				scopedLog.WithError(err).Warn("Error while cleaning service ID")
 			}
 		}
@@ -944,7 +945,7 @@ func (d *Daemon) addK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 				}).Error("Error while creating a new L3n4Addr. Ignoring service...")
 				continue
 			}
-			feAddrID, err := PutL3n4Addr(*feAddr, 0)
+			feAddrID, err := service.PutL3n4Addr(*feAddr, 0)
 			if err != nil {
 				scopedLog.WithError(err).WithFields(logrus.Fields{
 					logfields.ServiceID: fePortName,
@@ -1146,7 +1147,7 @@ func (d *Daemon) updateIngressV1beta1(oldIngress, newIngress *v1beta1.Ingress) {
 				scopedLog.WithError(err).Error("Error while creating a new L3n4Addr. Ignoring ingress...")
 				continue
 			}
-			feAddrID, err := PutL3n4Addr(*feAddr, 0)
+			feAddrID, err := service.PutL3n4Addr(*feAddr, 0)
 			if err != nil {
 				scopedLog.WithError(err).Error("Error while getting a new service ID. Ignoring ingress...")
 				continue

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -874,7 +874,7 @@ func (d *Daemon) delK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 		repPorts[svcPort.Port] = false
 
 		if svcPort.ID != 0 {
-			if err := service.DeleteL3n4AddrIDByUUID(uint32(svcPort.ID)); err != nil {
+			if err := service.DeleteID(uint32(svcPort.ID)); err != nil {
 				scopedLog.WithError(err).Warn("Error while cleaning service ID")
 			}
 		}
@@ -945,7 +945,7 @@ func (d *Daemon) addK8sSVCs(svc types.K8sServiceNamespace, svcInfo *types.K8sSer
 				}).Error("Error while creating a new L3n4Addr. Ignoring service...")
 				continue
 			}
-			feAddrID, err := service.PutL3n4Addr(*feAddr, 0)
+			feAddrID, err := service.AcquireID(*feAddr, 0)
 			if err != nil {
 				scopedLog.WithError(err).WithFields(logrus.Fields{
 					logfields.ServiceID: fePortName,
@@ -1147,7 +1147,7 @@ func (d *Daemon) updateIngressV1beta1(oldIngress, newIngress *v1beta1.Ingress) {
 				scopedLog.WithError(err).Error("Error while creating a new L3n4Addr. Ignoring ingress...")
 				continue
 			}
-			feAddrID, err := service.PutL3n4Addr(*feAddr, 0)
+			feAddrID, err := service.AcquireID(*feAddr, 0)
 			if err != nil {
 				scopedLog.WithError(err).Error("Error while getting a new service ID. Ignoring ingress...")
 				continue

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -68,12 +68,12 @@ func (d *Daemon) SVCAdd(feL3n4Addr types.L3n4AddrID, be []types.LBBackEnd, addRe
 		return false, fmt.Errorf("invalid service ID 0")
 	}
 	// Check if the service is already registered with this ID.
-	feAddr, err := service.GetL3n4AddrID(uint32(feL3n4Addr.ID))
+	feAddr, err := service.GetID(uint32(feL3n4Addr.ID))
 	if err != nil {
 		return false, fmt.Errorf("unable to get service %d: %s", feL3n4Addr.ID, err)
 	}
 	if feAddr == nil {
-		feAddr, err = service.PutL3n4Addr(feL3n4Addr.L3n4Addr, uint32(feL3n4Addr.ID))
+		feAddr, err = service.AcquireID(feL3n4Addr.L3n4Addr, uint32(feL3n4Addr.ID))
 		if err != nil {
 			return false, fmt.Errorf("unable to store service %s in kvstore: %s", feL3n4Addr.String(), err)
 		}
@@ -206,7 +206,7 @@ func (h *deleteServiceID) Handle(params DeleteServiceIDParams) middleware.Respon
 	}
 
 	// FIXME: How to handle error?
-	err := service.DeleteL3n4AddrIDByUUID(uint32(params.ID))
+	err := service.DeleteID(uint32(params.ID))
 
 	if err != nil {
 		log.WithError(err).Warn("error, DeleteL3n4AddrIDByUUID failed")
@@ -570,7 +570,7 @@ func (d *Daemon) SyncLBMap() error {
 	for _, svc := range newSVCList {
 		// Check if the services read from the lbmap have the same ID set in the
 		// KVStore.
-		kvL3n4AddrID, err := service.PutL3n4Addr(svc.FE.L3n4Addr, 0)
+		kvL3n4AddrID, err := service.AcquireID(svc.FE.L3n4Addr, 0)
 		if err != nil {
 			log.WithError(err).WithFields(logrus.Fields{
 				logfields.L3n4Addr: logfields.Repr(svc.FE.L3n4Addr),

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cilium/cilium/pkg/pidfile"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/pprof"
+	"github.com/cilium/cilium/pkg/service"
 	"github.com/cilium/cilium/pkg/version"
 	"github.com/cilium/cilium/pkg/workloads"
 
@@ -547,6 +548,10 @@ func initEnv(cmd *cobra.Command) {
 		logfields.Path + ".RunDir": option.Config.RunDir,
 		logfields.Path + ".LibDir": option.Config.LibDir,
 	})
+
+	if option.Config.LBInterface != "" {
+		service.EnableGlobalServiceID(true)
+	}
 
 	option.Config.BpfDir = filepath.Join(option.Config.LibDir, defaults.BpfDir)
 	scopedLog = scopedLog.WithField(logfields.Path+".BPFDir", defaults.BpfDir)

--- a/pkg/service/config.go
+++ b/pkg/service/config.go
@@ -1,0 +1,27 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+var (
+	enableGlobalServiceIDs bool
+)
+
+// EnableGlobalServiceID enables or disables the use of global service IDs.
+// When global service IDs are enabled, a kvstore interaction is used to
+// allocate service IDs in the scope of the entire kvstore domain to enable
+// transfer of service ID context between nodes.
+func EnableGlobalServiceID(val bool) {
+	enableGlobalServiceIDs = val
+}

--- a/pkg/service/id.go
+++ b/pkg/service/id.go
@@ -15,153 +15,20 @@
 package service
 
 import (
-	"encoding/json"
-	"path"
-	"strconv"
-
-	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/common/types"
-	"github.com/cilium/cilium/pkg/kvstore"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
-func updateL3n4AddrIDRef(id types.ServiceID, l3n4AddrID types.L3n4AddrID) error {
-	key := path.Join(common.ServiceIDKeyPath, strconv.FormatUint(uint64(id), 10))
-	return kvstore.Client().SetValue(key, l3n4AddrID)
+// AcquireID acquires a service ID
+func AcquireID(l3n4Addr types.L3n4Addr, baseID uint32) (*types.L3n4AddrID, error) {
+	return acquireGlobalID(l3n4Addr, baseID)
 }
 
-// gasNewL3n4AddrID gets and sets a new L3n4Addr ID. If baseID is different than zero,
-// KVStore tries to assign that ID first.
-func gasNewL3n4AddrID(l3n4AddrID *types.L3n4AddrID, baseID uint32) error {
-	if baseID == 0 {
-		var err error
-		baseID, err = getMaxServiceID()
-		if err != nil {
-			return err
-		}
-	}
-
-	return kvstore.Client().GASNewL3n4AddrID(common.ServiceIDKeyPath, baseID, l3n4AddrID)
+// GetID returns the L3n4AddrID that belongs to the given id.
+func GetID(id uint32) (*types.L3n4AddrID, error) {
+	return getGlobalID(id)
 }
 
-// PutL3n4Addr stores the given service in the kvstore and returns the L3n4AddrID
-// created for the given l3n4Addr. If baseID is different than 0, it tries to acquire that
-// ID to the l3n4Addr.
-func PutL3n4Addr(l3n4Addr types.L3n4Addr, baseID uint32) (*types.L3n4AddrID, error) {
-	log.WithField(logfields.L3n4Addr, logfields.Repr(l3n4Addr)).Debug("Resolving service")
-
-	// Retrieve unique SHA256Sum for service
-	sha256Sum := l3n4Addr.SHA256Sum()
-	svcPath := path.Join(common.ServicesKeyPath, sha256Sum)
-
-	// Lock that sha256Sum
-	lockKey, err := kvstore.LockPath(svcPath)
-	if err != nil {
-		return nil, err
-	}
-	defer lockKey.Unlock()
-
-	// After lock complete, get svc's path
-	rmsg, err := kvstore.Client().GetValue(svcPath)
-	if err != nil {
-		return nil, err
-	}
-
-	sl4KV := types.L3n4AddrID{}
-	if rmsg != nil {
-		if err := json.Unmarshal(rmsg, &sl4KV); err != nil {
-			return nil, err
-		}
-	}
-	if sl4KV.ID == 0 {
-		sl4KV.L3n4Addr = l3n4Addr
-		if err := gasNewL3n4AddrID(&sl4KV, baseID); err != nil {
-			return nil, err
-		}
-		err = kvstore.Client().SetValue(svcPath, sl4KV)
-	}
-
-	return &sl4KV, err
-}
-
-func getL3n4AddrID(keyPath string) (*types.L3n4AddrID, error) {
-	rmsg, err := kvstore.Client().GetValue(keyPath)
-	if err != nil {
-		return nil, err
-	}
-	if rmsg == nil {
-		log.WithField("key", keyPath).Debug("no value mapped to key in KVStore")
-		return nil, nil
-	}
-
-	var l3n4AddrID types.L3n4AddrID
-	if err := json.Unmarshal(rmsg, &l3n4AddrID); err != nil || l3n4AddrID.ID == 0 {
-		return nil, err
-	}
-	return &l3n4AddrID, nil
-}
-
-// GetL3n4AddrID returns the L3n4AddrID that belongs to the given id.
-func GetL3n4AddrID(id uint32) (*types.L3n4AddrID, error) {
-	strID := strconv.FormatUint(uint64(id), 10)
-	log.WithField(logfields.L3n4AddrID, strID).Debug("getting L3n4AddrID for ID")
-
-	return getL3n4AddrID(path.Join(common.ServiceIDKeyPath, strID))
-}
-
-// DeleteL3n4AddrIDByUUID deletes the L3n4AddrID belonging to the given id from the kvstore.
-func DeleteL3n4AddrIDByUUID(id uint32) error {
-	log.WithField(logfields.L3n4AddrID, id).Debug("deleting L3n4Addr by ID")
-	l3n4AddrID, err := GetL3n4AddrID(id)
-	if err != nil {
-		return err
-	}
-	if l3n4AddrID == nil {
-		return nil
-	}
-
-	return deleteL3n4AddrIDBySHA256(l3n4AddrID.SHA256Sum())
-}
-
-// deleteL3n4AddrIDBySHA256 deletes the L3n4AddrID from the kvstore corresponding to the service's
-// sha256Sum.
-func deleteL3n4AddrIDBySHA256(sha256Sum string) error {
-	log.WithField(logfields.SHA, sha256Sum).Debug("deleting L3n4AddrID with SHA256")
-	if sha256Sum == "" {
-		return nil
-	}
-	svcPath := path.Join(common.ServicesKeyPath, sha256Sum)
-	// Lock that sha256Sum
-	lockKey, err := kvstore.LockPath(svcPath)
-	if err != nil {
-		return err
-	}
-	defer lockKey.Unlock()
-
-	// After lock complete, get label's path
-	rmsg, err := kvstore.Client().GetValue(svcPath)
-	if err != nil {
-		return err
-	}
-	if rmsg == nil {
-		return nil
-	}
-
-	var l3n4AddrID types.L3n4AddrID
-	if err := json.Unmarshal(rmsg, &l3n4AddrID); err != nil {
-		return err
-	}
-	oldL3n4ID := l3n4AddrID.ID
-	l3n4AddrID.ID = 0
-
-	// update the value in the kvstore
-	if err := updateL3n4AddrIDRef(oldL3n4ID, l3n4AddrID); err != nil {
-		return err
-	}
-	return kvstore.Client().SetValue(svcPath, l3n4AddrID)
-}
-
-// getMaxServiceID returns the maximum possible free UUID stored in the kvstore.
-func getMaxServiceID() (uint32, error) {
-	return kvstore.Client().GetMaxID(common.LastFreeServiceIDKeyPath, common.FirstFreeServiceID)
+// DeleteID deletes the L3n4AddrID belonging to the given id from the kvstore.
+func DeleteID(id uint32) error {
+	return deleteGlobalID(id)
 }

--- a/pkg/service/id.go
+++ b/pkg/service/id.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package service
 
 import (
 	"encoding/json"
@@ -35,7 +35,7 @@ func updateL3n4AddrIDRef(id types.ServiceID, l3n4AddrID types.L3n4AddrID) error 
 func gasNewL3n4AddrID(l3n4AddrID *types.L3n4AddrID, baseID uint32) error {
 	if baseID == 0 {
 		var err error
-		baseID, err = GetMaxServiceID()
+		baseID, err = getMaxServiceID()
 		if err != nil {
 			return err
 		}
@@ -109,11 +109,6 @@ func GetL3n4AddrID(id uint32) (*types.L3n4AddrID, error) {
 	return getL3n4AddrID(path.Join(common.ServiceIDKeyPath, strID))
 }
 
-// GetL3n4AddrIDBySHA256 returns the L3n4AddrID that have the given SHA256SUM.
-func GetL3n4AddrIDBySHA256(sha256sum string) (*types.L3n4AddrID, error) {
-	return getL3n4AddrID(path.Join(common.ServicesKeyPath, sha256sum))
-}
-
 // DeleteL3n4AddrIDByUUID deletes the L3n4AddrID belonging to the given id from the kvstore.
 func DeleteL3n4AddrIDByUUID(id uint32) error {
 	log.WithField(logfields.L3n4AddrID, id).Debug("deleting L3n4Addr by ID")
@@ -125,12 +120,12 @@ func DeleteL3n4AddrIDByUUID(id uint32) error {
 		return nil
 	}
 
-	return DeleteL3n4AddrIDBySHA256(l3n4AddrID.SHA256Sum())
+	return deleteL3n4AddrIDBySHA256(l3n4AddrID.SHA256Sum())
 }
 
-// DeleteL3n4AddrIDBySHA256 deletes the L3n4AddrID from the kvstore corresponding to the service's
+// deleteL3n4AddrIDBySHA256 deletes the L3n4AddrID from the kvstore corresponding to the service's
 // sha256Sum.
-func DeleteL3n4AddrIDBySHA256(sha256Sum string) error {
+func deleteL3n4AddrIDBySHA256(sha256Sum string) error {
 	log.WithField(logfields.SHA, sha256Sum).Debug("deleting L3n4AddrID with SHA256")
 	if sha256Sum == "" {
 		return nil
@@ -166,7 +161,7 @@ func DeleteL3n4AddrIDBySHA256(sha256Sum string) error {
 	return kvstore.Client().SetValue(svcPath, l3n4AddrID)
 }
 
-// GetMaxServiceID returns the maximum possible free UUID stored in the kvstore.
-func GetMaxServiceID() (uint32, error) {
+// getMaxServiceID returns the maximum possible free UUID stored in the kvstore.
+func getMaxServiceID() (uint32, error) {
 	return kvstore.Client().GetMaxID(common.LastFreeServiceIDKeyPath, common.FirstFreeServiceID)
 }

--- a/pkg/service/id_kvstore.go
+++ b/pkg/service/id_kvstore.go
@@ -1,0 +1,167 @@
+// Copyright 2016-2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"encoding/json"
+	"path"
+	"strconv"
+
+	"github.com/cilium/cilium/common"
+	"github.com/cilium/cilium/common/types"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+func updateL3n4AddrIDRef(id types.ServiceID, l3n4AddrID types.L3n4AddrID) error {
+	key := path.Join(common.ServiceIDKeyPath, strconv.FormatUint(uint64(id), 10))
+	return kvstore.Client().SetValue(key, l3n4AddrID)
+}
+
+// gasNewL3n4AddrID gets and sets a new L3n4Addr ID. If baseID is different than zero,
+// KVStore tries to assign that ID first.
+func gasNewL3n4AddrID(l3n4AddrID *types.L3n4AddrID, baseID uint32) error {
+	if baseID == 0 {
+		var err error
+		baseID, err = getMaxServiceID()
+		if err != nil {
+			return err
+		}
+	}
+
+	return kvstore.Client().GASNewL3n4AddrID(common.ServiceIDKeyPath, baseID, l3n4AddrID)
+}
+
+// acquireGlobalID stores the given service in the kvstore and returns the L3n4AddrID
+// created for the given l3n4Addr. If baseID is different than 0, it tries to acquire that
+// ID to the l3n4Addr.
+func acquireGlobalID(l3n4Addr types.L3n4Addr, baseID uint32) (*types.L3n4AddrID, error) {
+	log.WithField(logfields.L3n4Addr, logfields.Repr(l3n4Addr)).Debug("Resolving service")
+
+	// Retrieve unique SHA256Sum for service
+	sha256Sum := l3n4Addr.SHA256Sum()
+	svcPath := path.Join(common.ServicesKeyPath, sha256Sum)
+
+	// Lock that sha256Sum
+	lockKey, err := kvstore.LockPath(svcPath)
+	if err != nil {
+		return nil, err
+	}
+	defer lockKey.Unlock()
+
+	// After lock complete, get svc's path
+	rmsg, err := kvstore.Client().GetValue(svcPath)
+	if err != nil {
+		return nil, err
+	}
+
+	sl4KV := types.L3n4AddrID{}
+	if rmsg != nil {
+		if err := json.Unmarshal(rmsg, &sl4KV); err != nil {
+			return nil, err
+		}
+	}
+	if sl4KV.ID == 0 {
+		sl4KV.L3n4Addr = l3n4Addr
+		if err := gasNewL3n4AddrID(&sl4KV, baseID); err != nil {
+			return nil, err
+		}
+		err = kvstore.Client().SetValue(svcPath, sl4KV)
+	}
+
+	return &sl4KV, err
+}
+
+func getL3n4AddrID(keyPath string) (*types.L3n4AddrID, error) {
+	rmsg, err := kvstore.Client().GetValue(keyPath)
+	if err != nil {
+		return nil, err
+	}
+	if rmsg == nil {
+		log.WithField("key", keyPath).Debug("no value mapped to key in KVStore")
+		return nil, nil
+	}
+
+	var l3n4AddrID types.L3n4AddrID
+	if err := json.Unmarshal(rmsg, &l3n4AddrID); err != nil || l3n4AddrID.ID == 0 {
+		return nil, err
+	}
+	return &l3n4AddrID, nil
+}
+
+// getGlobalID returns the L3n4AddrID that belongs to the given id.
+func getGlobalID(id uint32) (*types.L3n4AddrID, error) {
+	strID := strconv.FormatUint(uint64(id), 10)
+	log.WithField(logfields.L3n4AddrID, strID).Debug("getting L3n4AddrID for ID")
+
+	return getL3n4AddrID(path.Join(common.ServiceIDKeyPath, strID))
+}
+
+// deleteGlobalID deletes the L3n4AddrID belonging to the given id from the kvstore.
+func deleteGlobalID(id uint32) error {
+	log.WithField(logfields.L3n4AddrID, id).Debug("deleting L3n4Addr by ID")
+	l3n4AddrID, err := getGlobalID(id)
+	if err != nil {
+		return err
+	}
+	if l3n4AddrID == nil {
+		return nil
+	}
+
+	return deleteL3n4AddrIDBySHA256(l3n4AddrID.SHA256Sum())
+}
+
+// deleteL3n4AddrIDBySHA256 deletes the L3n4AddrID from the kvstore corresponding to the service's
+// sha256Sum.
+func deleteL3n4AddrIDBySHA256(sha256Sum string) error {
+	log.WithField(logfields.SHA, sha256Sum).Debug("deleting L3n4AddrID with SHA256")
+	if sha256Sum == "" {
+		return nil
+	}
+	svcPath := path.Join(common.ServicesKeyPath, sha256Sum)
+	// Lock that sha256Sum
+	lockKey, err := kvstore.LockPath(svcPath)
+	if err != nil {
+		return err
+	}
+	defer lockKey.Unlock()
+
+	// After lock complete, get label's path
+	rmsg, err := kvstore.Client().GetValue(svcPath)
+	if err != nil {
+		return err
+	}
+	if rmsg == nil {
+		return nil
+	}
+
+	var l3n4AddrID types.L3n4AddrID
+	if err := json.Unmarshal(rmsg, &l3n4AddrID); err != nil {
+		return err
+	}
+	oldL3n4ID := l3n4AddrID.ID
+	l3n4AddrID.ID = 0
+
+	// update the value in the kvstore
+	if err := updateL3n4AddrIDRef(oldL3n4ID, l3n4AddrID); err != nil {
+		return err
+	}
+	return kvstore.Client().SetValue(svcPath, l3n4AddrID)
+}
+
+// getMaxServiceID returns the maximum possible free UUID stored in the kvstore.
+func getMaxServiceID() (uint32, error) {
+	return kvstore.Client().GetMaxID(common.LastFreeServiceIDKeyPath, common.FirstFreeServiceID)
+}

--- a/pkg/service/id_local.go
+++ b/pkg/service/id_local.go
@@ -1,0 +1,140 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/common"
+	"github.com/cilium/cilium/common/types"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+var (
+	// mutex protects servicesID, services, nextID and maxID
+	mutex lock.RWMutex
+
+	// servicesID is a map of all services indexed by service ID
+	servicesID = map[uint32]*types.L3n4AddrID{}
+
+	// services is a map of all services indexed by L3n4Addr.StringID()
+	services = map[string]uint32{}
+
+	// nextID is the next service ID to attempt to allocate
+	nextID = common.FirstFreeServiceID
+
+	// maxID is the maximum service ID available for allocation
+	maxID = common.MaxSetOfServiceID
+)
+
+func newServiceID(svc types.L3n4Addr, id uint32) *types.L3n4AddrID {
+	return &types.L3n4AddrID{
+		L3n4Addr: svc,
+		ID:       types.ServiceID(id),
+	}
+}
+
+func addServiceID(svc types.L3n4Addr, id uint32) *types.L3n4AddrID {
+	svcID := newServiceID(svc, id)
+	servicesID[id] = svcID
+	services[svc.StringID()] = id
+
+	return svcID
+}
+
+func acquireLocalID(svc types.L3n4Addr, desiredID uint32) (*types.L3n4AddrID, error) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	if svcID, ok := services[svc.StringID()]; ok {
+		if svc, ok := servicesID[svcID]; ok {
+			return svc, nil
+		}
+	}
+
+	if desiredID != 0 {
+		if _, ok := servicesID[desiredID]; !ok {
+			return addServiceID(svc, desiredID), nil
+		}
+	}
+
+	startingID := nextID
+	rollover := false
+	for {
+		if nextID == startingID && rollover {
+			break
+		} else if nextID == maxID {
+			nextID = common.FirstFreeServiceID
+			rollover = true
+		}
+
+		if _, ok := servicesID[nextID]; !ok {
+			svcID := addServiceID(svc, nextID)
+			nextID++
+			return svcID, nil
+		}
+
+		nextID++
+	}
+
+	return nil, fmt.Errorf("no service ID available")
+}
+
+func getLocalID(id uint32) (*types.L3n4AddrID, error) {
+	mutex.RLock()
+	defer mutex.RUnlock()
+
+	if svc, ok := servicesID[id]; ok {
+		return svc, nil
+	}
+
+	return nil, nil
+}
+
+func deleteLocalID(id uint32) error {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	if svc, ok := servicesID[id]; ok {
+		delete(servicesID, id)
+		delete(services, svc.StringID())
+	}
+
+	return nil
+}
+
+func setLocalIDSpace(next, max uint32) error {
+	mutex.Lock()
+	nextID = next
+	maxID = max
+	mutex.Unlock()
+
+	return nil
+}
+
+func getLocalMaxServiceID() (uint32, error) {
+	mutex.RLock()
+	defer mutex.RUnlock()
+	return nextID, nil
+}
+
+func resetLocalID() {
+	mutex.Lock()
+	servicesID = map[uint32]*types.L3n4AddrID{}
+	services = map[string]uint32{}
+	nextID = common.FirstFreeServiceID
+	maxID = common.MaxSetOfServiceID
+	mutex.Unlock()
+}

--- a/pkg/service/id_test.go
+++ b/pkg/service/id_test.go
@@ -53,82 +53,82 @@ func (ds *ServiceTestSuite) TestServices(c *C) {
 
 	ffsIDu16 := types.ServiceID(uint16(common.FirstFreeServiceID))
 
-	l3n4AddrID, err := PutL3n4Addr(l3n4Addr1, 0)
+	l3n4AddrID, err := AcquireID(l3n4Addr1, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(l3n4AddrID.ID, Equals, ffsIDu16)
 
-	l3n4AddrID, err = PutL3n4Addr(l3n4Addr1, 0)
+	l3n4AddrID, err = AcquireID(l3n4Addr1, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(l3n4AddrID.ID, Equals, ffsIDu16)
 
-	l3n4AddrID, err = PutL3n4Addr(l3n4Addr2, 0)
+	l3n4AddrID, err = AcquireID(l3n4Addr2, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(l3n4AddrID.ID, Equals, ffsIDu16+1)
 
 	// l3n4Addr3 should have the same ID as l3n4Addr2 since we are omitting the
 	// protocol type.
-	l3n4AddrID, err = PutL3n4Addr(l3n4Addr3, 0)
+	l3n4AddrID, err = AcquireID(l3n4Addr3, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(l3n4AddrID.ID, Equals, ffsIDu16+1)
 
-	gotL3n4AddrID, err := GetL3n4AddrID(common.FirstFreeServiceID)
+	gotL3n4AddrID, err := GetID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
 	wantL3n4AddrID.ID = ffsIDu16
 	wantL3n4AddrID.L3n4Addr = l3n4Addr1
 	c.Assert(gotL3n4AddrID, comparator.DeepEquals, wantL3n4AddrID)
 
-	err = DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID)
+	err = DeleteID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
-	gotL3n4AddrID, err = GetL3n4AddrID(common.FirstFreeServiceID)
+	gotL3n4AddrID, err = GetID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID, Equals, nilL3n4AddrID)
 
-	gotL3n4AddrID, err = GetL3n4AddrID(common.FirstFreeServiceID + 1)
+	gotL3n4AddrID, err = GetID(common.FirstFreeServiceID + 1)
 	c.Assert(err, Equals, nil)
 	wantL3n4AddrID.ID = types.ServiceID(common.FirstFreeServiceID + 1)
 	wantL3n4AddrID.L3n4Addr = l3n4Addr2
 	c.Assert(gotL3n4AddrID, comparator.DeepEquals, wantL3n4AddrID)
 
-	err = DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID)
+	err = DeleteID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
 
 	err = kvstore.Client().SetMaxID(common.LastFreeServiceIDKeyPath, common.FirstFreeServiceID, common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
 
-	err = DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID)
+	err = DeleteID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
-	gotL3n4AddrID, err = GetL3n4AddrID(common.FirstFreeServiceID)
+	gotL3n4AddrID, err = GetID(common.FirstFreeServiceID)
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID, Equals, nilL3n4AddrID)
 
-	gotL3n4AddrID, err = PutL3n4Addr(l3n4Addr2, 0)
+	gotL3n4AddrID, err = AcquireID(l3n4Addr2, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID.ID, Equals, types.ServiceID(common.FirstFreeServiceID+1))
 
 	sha256sum := l3n4Addr2.SHA256Sum()
 	err = deleteL3n4AddrIDBySHA256(sha256sum)
 	c.Assert(err, Equals, nil)
-	err = DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID + 1)
+	err = DeleteID(common.FirstFreeServiceID + 1)
 	c.Assert(err, Equals, nil)
-	err = DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID + 1)
+	err = DeleteID(common.FirstFreeServiceID + 1)
 	c.Assert(err, Equals, nil)
 
-	gotL3n4AddrID, err = PutL3n4Addr(l3n4Addr2, 0)
+	gotL3n4AddrID, err = AcquireID(l3n4Addr2, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID.ID, Equals, ffsIDu16)
 
-	gotL3n4AddrID, err = PutL3n4Addr(l3n4Addr1, 0)
+	gotL3n4AddrID, err = AcquireID(l3n4Addr1, 0)
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID.ID, Equals, types.ServiceID(common.FirstFreeServiceID+1))
 
-	gotL3n4AddrID, err = PutL3n4Addr(l3n4Addr1, 99)
+	gotL3n4AddrID, err = AcquireID(l3n4Addr1, 99)
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID.ID, Equals, types.ServiceID(common.FirstFreeServiceID+1))
 
-	err = DeleteL3n4AddrIDByUUID(uint32(common.FirstFreeServiceID + 1))
+	err = DeleteID(uint32(common.FirstFreeServiceID + 1))
 	c.Assert(err, Equals, nil)
 
-	gotL3n4AddrID, err = PutL3n4Addr(l3n4Addr1, 99)
+	gotL3n4AddrID, err = AcquireID(l3n4Addr1, 99)
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID.ID, Equals, types.ServiceID(99))
 }

--- a/pkg/service/id_test.go
+++ b/pkg/service/id_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package service
 
 import (
 	"net"
@@ -44,10 +44,10 @@ var (
 	}
 )
 
-func (ds *DaemonSuite) TestServices(c *C) {
+func (ds *ServiceTestSuite) TestServices(c *C) {
 	var nilL3n4AddrID *types.L3n4AddrID
 	// Set up last free ID with zero
-	id, err := GetMaxServiceID()
+	id, err := getMaxServiceID()
 	c.Assert(err, Equals, nil)
 	c.Assert(id, Equals, common.FirstFreeServiceID)
 
@@ -106,11 +106,7 @@ func (ds *DaemonSuite) TestServices(c *C) {
 	c.Assert(gotL3n4AddrID.ID, Equals, types.ServiceID(common.FirstFreeServiceID+1))
 
 	sha256sum := l3n4Addr2.SHA256Sum()
-	gotL3n4AddrID, err = GetL3n4AddrIDBySHA256(sha256sum)
-	c.Assert(err, Equals, nil)
-	c.Assert(gotL3n4AddrID, comparator.DeepEquals, wantL3n4AddrID)
-
-	err = DeleteL3n4AddrIDBySHA256(sha256sum)
+	err = deleteL3n4AddrIDBySHA256(sha256sum)
 	c.Assert(err, Equals, nil)
 	err = DeleteL3n4AddrIDByUUID(common.FirstFreeServiceID + 1)
 	c.Assert(err, Equals, nil)
@@ -137,12 +133,12 @@ func (ds *DaemonSuite) TestServices(c *C) {
 	c.Assert(gotL3n4AddrID.ID, Equals, types.ServiceID(99))
 }
 
-func (ds *DaemonSuite) TestGetMaxServiceID(c *C) {
+func (ds *ServiceTestSuite) TestGetMaxServiceID(c *C) {
 	lastID := uint32(common.MaxSetOfServiceID - 1)
 	err := kvstore.Client().SetValue(common.LastFreeServiceIDKeyPath, lastID)
 	c.Assert(err, Equals, nil)
 
-	id, err := GetMaxServiceID()
+	id, err := getMaxServiceID()
 	c.Assert(err, Equals, nil)
 	c.Assert(id, Equals, (common.MaxSetOfServiceID - 1))
 }

--- a/pkg/service/logfields.go
+++ b/pkg/service/logfields.go
@@ -1,0 +1,22 @@
+// Copyright 2016-2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "service")

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -1,0 +1,65 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/common"
+	"github.com/cilium/cilium/pkg/kvstore"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type ServiceTestSuite struct{}
+
+type ServiceEtcdSuite struct {
+	ServiceTestSuite
+}
+
+var _ = Suite(&ServiceEtcdSuite{})
+
+func (e *ServiceEtcdSuite) SetUpTest(c *C) {
+	kvstore.SetupDummy("etcd")
+	kvstore.DeletePrefix(common.OperationalPath)
+	kvstore.DeletePrefix(kvstore.BaseKeyPrefix)
+}
+
+func (e *ServiceEtcdSuite) TearDownTest(c *C) {
+	// FIXME: Cleanup test prefix
+	kvstore.Close()
+}
+
+type ServiceConsulSuite struct {
+	ServiceTestSuite
+}
+
+var _ = Suite(&ServiceConsulSuite{})
+
+func (e *ServiceConsulSuite) SetUpTest(c *C) {
+	kvstore.SetupDummy("consul")
+	kvstore.DeletePrefix(common.OperationalPath)
+	kvstore.DeletePrefix(kvstore.BaseKeyPrefix)
+}
+
+func (e *ServiceConsulSuite) TearDownTest(c *C) {
+	// FIXME: Cleanup test prefix
+	kvstore.Close()
+}

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -17,7 +17,6 @@ package service
 import (
 	"testing"
 
-	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/kvstore"
 
 	. "gopkg.in/check.v1"
@@ -37,13 +36,13 @@ type ServiceEtcdSuite struct {
 var _ = Suite(&ServiceEtcdSuite{})
 
 func (e *ServiceEtcdSuite) SetUpTest(c *C) {
+	EnableGlobalServiceID(true)
 	kvstore.SetupDummy("etcd")
-	kvstore.DeletePrefix(common.OperationalPath)
-	kvstore.DeletePrefix(kvstore.BaseKeyPrefix)
+	kvstore.DeletePrefix(serviceKvstorePrefix)
 }
 
 func (e *ServiceEtcdSuite) TearDownTest(c *C) {
-	// FIXME: Cleanup test prefix
+	kvstore.DeletePrefix(serviceKvstorePrefix)
 	kvstore.Close()
 }
 
@@ -54,12 +53,27 @@ type ServiceConsulSuite struct {
 var _ = Suite(&ServiceConsulSuite{})
 
 func (e *ServiceConsulSuite) SetUpTest(c *C) {
+	EnableGlobalServiceID(true)
 	kvstore.SetupDummy("consul")
-	kvstore.DeletePrefix(common.OperationalPath)
-	kvstore.DeletePrefix(kvstore.BaseKeyPrefix)
+	kvstore.DeletePrefix(serviceKvstorePrefix)
 }
 
 func (e *ServiceConsulSuite) TearDownTest(c *C) {
-	// FIXME: Cleanup test prefix
+	kvstore.DeletePrefix(serviceKvstorePrefix)
 	kvstore.Close()
+}
+
+type ServiceLocalSuite struct {
+	ServiceTestSuite
+}
+
+var _ = Suite(&ServiceLocalSuite{})
+
+func (e *ServiceLocalSuite) SetUpTest(c *C) {
+	EnableGlobalServiceID(false)
+	resetLocalID()
+}
+
+func (e *ServiceLocalSuite) TearDownTest(c *C) {
+	resetLocalID()
 }


### PR DESCRIPTION
Global service ID allocation is only required when we perform load-balancing
with DSR (direct server return). We currently pay the cost of global service ID
allocation for all services. This introduces a new local service ID allocation
layer which becomes the new default. Global service ID allocation is only
enabled when the --lb flag is provided to the agent which indicates use of DSR.

Future versions can enable/disable this on a per service basis as well.

This dramatically reduces the cost of service ID allocation and removes the
requirement of a kvstore for normal load-balancing operations.

PASS: <autogenerated>:1: ServiceEtcdSuite.BenchmarkAllocation       1000           2822479 ns/op
PASS: <autogenerated>:1: ServiceConsulSuite.BenchmarkAllocation      200          10702444 ns/op
PASS: <autogenerated>:1: ServiceLocalSuite.BenchmarkAllocation   1000000              2625 ns/op

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4664)
<!-- Reviewable:end -->
