### PR TITLE
CI: Update virtual CPUs to 4.

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -36,6 +36,7 @@ pipeline {
         GOPATH = "${WORKSPACE}"
         TESTDIR = "${WORKSPACE}/${PROJ_PATH}/test"
         SERVER_BOX = "cilium/ubuntu"
+        CPU = "4"
     }
 
     options {

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -34,6 +34,7 @@ pipeline {
     environment {
         PROJ_PATH = "src/github.com/cilium/cilium"
         MEMORY = "3072"
+        CPU = "4"
         TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
         GOPATH="${WORKSPACE}"
         SERVER_BOX = "cilium/ubuntu"

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
         PROJ_PATH = "src/github.com/cilium/cilium"
         TESTDIR = "${WORKSPACE}/${PROJ_PATH}/"
         MEMORY = "3072"
+        CPU = "4"
         SERVER_BOX = "cilium/ubuntu"
     }
 

--- a/kubernetes-upstream.Jenkinsfile
+++ b/kubernetes-upstream.Jenkinsfile
@@ -35,6 +35,7 @@ pipeline {
         PROJ_PATH = "src/github.com/cilium/cilium"
         TESTDIR = "${WORKSPACE}/${PROJ_PATH}/"
         MEMORY = "4096"
+        CPU = "4"
         K8S_VERSION="1.10"
         SERVER_BOX = "cilium/ubuntu"
     }


### PR DESCRIPTION
Increase the VCPUs to 4 in the test servers to try to reduce the issues
on BPF compilation timeouts on `/endpoint/put` from the CNI.

Related to: #4541

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4669)
<!-- Reviewable:end -->
