### PR TITLE
daemon: change minimal worker thread to 2

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1568,7 +1568,7 @@ func (d *Daemon) clearCiliumVeths() error {
 // numWorkerThreads returns the number of worker threads with a minimum of 4.
 func numWorkerThreads() int {
 	ncpu := runtime.NumCPU()
-	minWorkerThreads := 4
+	minWorkerThreads := 2
 
 	if ncpu < minWorkerThreads {
 		return minWorkerThreads


### PR DESCRIPTION
As all of your CI was running with 2 CPUs, it was creating some
scalibility issues in cilium-agent while building the BPF programs.

For this reason we should decrease the minimal worker threads to 2 so we
can make sure Cilium won't take too much time to regenerate BPF
programs in nodes that only have 2 CPUs.

Signed-off-by: André Martins <andre@cilium.io>

```release-note
change the minimal number of BPF regeneration builders from 4 to 2
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4670)
<!-- Reviewable:end -->
