### PR TITLE
endpoint: Fix restored endpoints not showing up in ipcache

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -895,13 +895,6 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity) {
 		istioSidecarProxyLabel.Source == labels.LabelSourceK8s &&
 		strings.ToLower(istioSidecarProxyLabel.Value) == "true"
 
-	if e.SecurityIdentity != nil && identity.ID == e.SecurityIdentity.ID {
-		// Even if the numeric identity is the same, the order in which the
-		// labels are represented may change.
-		e.SecurityIdentity = identity
-		return
-	}
-
 	oldIdentity := "no identity"
 	if e.SecurityIdentity != nil {
 		oldIdentity = e.SecurityIdentity.StringID()


### PR DESCRIPTION
Due to leaving the SetIdentity() functione early, the controller to sync the
identity to the ipcache and to the k8s pod as annotation was never started
until the identity has changed again.

Fixes: 7448e41aa047 ("endpoint: sync endpoint IP-SecID map to kvstore")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4678)
<!-- Reviewable:end -->
