### PR TITLE
metrics: Expose endpoint and policy computation time metrics

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -34,6 +34,9 @@ Endpoint
 * ``endpoint_count``: Number of endpoints managed by this agent
 * ``endpoint_regenerating``: Number of endpoints currently regenerating
 * ``endpoint_regenerations``: Count of all endpoint regenerations that have completed, tagged by outcome
+* ``endpoint_regeneration_seconds_total``: Total sum of successful endpoint regeneration times
+* ``endpoint_regeneration_square_seconds_total``: Total sum of squares of successful endpoint regeneration times
+
 
 Datapath
 --------
@@ -50,6 +53,9 @@ Policy Imports
 --------------
 
 * ``policy_count``: Number of policies currently loaded
+* ``policy_regeneration_total``: Total number of policies regenerated successfully
+* ``policy_regeneration_seconds_total``: Total sum of successful policy regeneration times
+* ``policy_regeneration_square_seconds_total``: Total sum of squares of successful policy regeneration times
 * ``policy_max_revision``: Highest policy revision number in the agent
 * ``policy_import_errors``: Number of times a policy import has failed
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -84,6 +84,12 @@ const (
 	// BuildDuration is the time elapsed to build a BPF program
 	BuildDuration = "buildDuration"
 
+	// PolicyRegenerationTime is the time elapsed to generate a policy
+	PolicyRegenerationTime = "policyRegenerationTime"
+
+	// EndpointRegenerationTime is the time elapsed to generate an endpoint
+	EndpointRegenerationTime = "endpointRegenerationTime"
+
 	// StartTime is the start time of an event
 	StartTime = "startTime"
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -92,6 +92,21 @@ var (
 	},
 		[]string{"outcome"})
 
+	// EndpointRegenerationTime is the total time taken to regenerate endpoint
+	EndpointRegenerationTime = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "endpoint_regeneration_seconds_total",
+		Help:      "Total sum of successful endpoint regeneration times",
+	})
+
+	// EndpointRegenerationTimeSquare is the sum of squares of total time taken
+	// to regenerate endpoint.
+	EndpointRegenerationTimeSquare = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "endpoint_regeneration_square_seconds_total",
+		Help:      "Total sum of squares of successful endpoint regeneration times",
+	})
+
 	// Policy
 
 	// PolicyCount is the number of policies loaded into the agent
@@ -99,6 +114,29 @@ var (
 		Namespace: Namespace,
 		Name:      "policy_count",
 		Help:      "Number of policies currently loaded",
+	})
+
+	// PolicyRegenerationCount is the total number of successful policy
+	// regenerations.
+	PolicyRegenerationCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "policy_regeneration_total",
+		Help:      "Total number of successful policy regenerations",
+	})
+
+	// PolicyRegenerationTime is the total time taken to generate policies
+	PolicyRegenerationTime = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "policy_regeneration_seconds_total",
+		Help:      "Total sum of successful policy regeneration times",
+	})
+
+	// PolicyRegenerationTimeSquare is the sum of squares of total time taken
+	// to generate policies
+	PolicyRegenerationTimeSquare = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "policy_regeneration_square_seconds_total",
+		Help:      "Total sum of squares of successful policy regeneration times",
 	})
 
 	// PolicyRevision is the current policy revision number for this agent
@@ -215,8 +253,13 @@ func init() {
 
 	MustRegister(EndpointCountRegenerating)
 	MustRegister(EndpointRegenerationCount)
+	MustRegister(EndpointRegenerationTime)
+	MustRegister(EndpointRegenerationTimeSquare)
 
 	MustRegister(PolicyCount)
+	MustRegister(PolicyRegenerationCount)
+	MustRegister(PolicyRegenerationTime)
+	MustRegister(PolicyRegenerationTimeSquare)
 	MustRegister(PolicyRevision)
 	MustRegister(PolicyImportErrors)
 


### PR DESCRIPTION
metrics: Expose endpoint and policy computation time metrics
This commit adds changes to export endpoint and policy computation time
metrics to prometheus. To have an idea of the distribution, assuming a normal form, we need all 3:
    
1. count of regenerations
2. sum of time taken to regenerate
3. sum of squares of time taken to regenerate

Policy and Endpoint count are already exposed as follows:
1. EndpointRegenerationCount gives endpoint regenerations that have completed.
2. PolicyCount and PolicyImportErrors gives total successful policies imported.
    
This commit adds sum of time taken to regenerate and sum of squares of time taken to regenerate
for policy generation/computation and endpoint regeneration.
    
Fixes: #4396
Signed-Off-By: Manali Bhutiyani <manali@covalent.io>
```release-note
Expose endpoint and policy computation time metrics
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4684)
<!-- Reviewable:end -->
