### PR TITLE
daemon: fix minimum number of work threads unit test

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -178,7 +178,7 @@ func (e *DaemonConsulSuite) TearDownTest(c *C) {
 }
 
 func (ds *DaemonSuite) TestMinimumWorkerThreadsIsSet(c *C) {
-	c.Assert(numWorkerThreads() >= 4, Equals, true)
+	c.Assert(numWorkerThreads() >= 2, Equals, true)
 	c.Assert(numWorkerThreads() >= runtime.NumCPU(), Equals, true)
 }
 


### PR DESCRIPTION
The test failed with the following output when ran locally:

```
----------------------------------------------------------------------
FAIL: <autogenerated>:1: DaemonConsulSuite.TestMinimumWorkerThreadsIsSet

daemon_test.go:181:
    c.Assert(numWorkerThreads() >= 4, Equals, true)
... obtained bool = false
... expected bool = true

```

Fixes: 25f898609888 ("daemon: change minimal worker thread to 2")

Signed-off-by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4685)
<!-- Reviewable:end -->
