### PR TITLE
Automatically detect MTU of network

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -61,6 +61,7 @@ cilium-agent
       --logstash-agent string                       Logstash agent address (default "127.0.0.1:8080")
       --logstash-probe-timer uint32                 Logstash probe timer (seconds) (default 10)
       --masquerade                                  Masquerade packets from endpoints leaving the host (default true)
+      --mtu int                                     Overwrite auto-detected MTU of underlying network (default 1500)
       --nat46-range string                          IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
       --pprof                                       Enable serving the pprof debugging API
       --prefilter-device string                     Device facing external network for XDP prefiltering (default "undefined")

--- a/Documentation/kubernetes/install.rst
+++ b/Documentation/kubernetes/install.rst
@@ -248,15 +248,13 @@ environment variables can be specified in the `DaemonSet` file like this:
 .. code:: bash
 
     env:
-      - name: "MTU"
-        value: "8950"
+      - name: "CNI_CONF_NAME"
+        value: "00-cilium.conf"
 
 The following variables are supported:
 
 +---------------------+--------------------------------------+------------------------+
 | Option              | Description                          | Default                |
-+---------------------+--------------------------------------+------------------------+
-| MTU                 | Pod MTU to be configured             | 1450                   |
 +---------------------+--------------------------------------+------------------------+
 | HOST_PREFIX         | Path prefix of all host mounts       | /host                  |
 +---------------------+--------------------------------------+------------------------+
@@ -273,8 +271,7 @@ the CNI configuration ``/etc/cni/net.d/00-cilium.conf`` manually:
     sudo mkdir -p /etc/cni/net.d
     sudo sh -c 'echo "{
         "name": "cilium",
-        "type": "cilium-cni",
-        "mtu": 1450
+        "type": "cilium-cni"
     }
     " > /etc/cni/net.d/00-cilium.conf'
 

--- a/Documentation/kubernetes/quickinstall.rst
+++ b/Documentation/kubernetes/quickinstall.rst
@@ -66,15 +66,6 @@ chapter.
       [adjust the etcd address]
 
 
-**Optional:** If you want to adjust the MTU of the pods, define the ``MTU`` environment
-variable in the ``env`` section:
-
-.. code:: bash
-
-    env:
-      - name: "MTU"
-        value: "8950"
-
 3. Deploy ``cilium`` with your local changes
 
 .. code:: bash

--- a/api/v1/models/daemon_configuration_status.go
+++ b/api/v1/models/daemon_configuration_status.go
@@ -23,6 +23,9 @@ type DaemonConfigurationStatus struct {
 	// addressing
 	Addressing *NodeAddressing `json:"addressing,omitempty"`
 
+	// MTU on workload facing devices
+	DeviceMTU int64 `json:"deviceMTU,omitempty"`
+
 	// Immutable configuration (read-only)
 	Immutable ConfigurationMap `json:"immutable,omitempty"`
 
@@ -40,9 +43,14 @@ type DaemonConfigurationStatus struct {
 
 	// Currently applied configuration
 	Realized *DaemonConfigurationSpec `json:"realized,omitempty"`
+
+	// MTU for network facing routes
+	RouteMTU int64 `json:"routeMTU,omitempty"`
 }
 
 /* polymorph DaemonConfigurationStatus addressing false */
+
+/* polymorph DaemonConfigurationStatus deviceMTU false */
 
 /* polymorph DaemonConfigurationStatus immutable false */
 
@@ -55,6 +63,8 @@ type DaemonConfigurationStatus struct {
 /* polymorph DaemonConfigurationStatus nodeMonitor false */
 
 /* polymorph DaemonConfigurationStatus realized false */
+
+/* polymorph DaemonConfigurationStatus routeMTU false */
 
 // Validate validates this daemon configuration status
 func (m *DaemonConfigurationStatus) Validate(formats strfmt.Registry) error {

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1341,6 +1341,12 @@ definitions:
         "$ref": "#/definitions/MonitorStatus"
       kvstoreConfiguration:
         "$ref": "#/definitions/KVstoreConfiguration"
+      deviceMTU:
+        description: MTU on workload facing devices
+        type: integer
+      routeMTU:
+        description: MTU for network facing routes
+        type: integer
   EndpointConfigurationSpec:
     description: An endpoint's configuration
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1168,6 +1168,10 @@ func init() {
         "addressing": {
           "$ref": "#/definitions/NodeAddressing"
         },
+        "deviceMTU": {
+          "description": "MTU on workload facing devices",
+          "type": "integer"
+        },
         "immutable": {
           "description": "Immutable configuration (read-only)",
           "$ref": "#/definitions/ConfigurationMap"
@@ -1188,6 +1192,10 @@ func init() {
         "realized": {
           "description": "Currently applied configuration",
           "$ref": "#/definitions/DaemonConfigurationSpec"
+        },
+        "routeMTU": {
+          "description": "MTU for network facing routes",
+          "type": "integer"
         }
       }
     },

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -85,13 +85,13 @@ func logFromCommand(cmd *exec.Cmd, netns string) error {
 
 func configureHealthRouting(netns, dev string, addressing *models.NodeAddressing) error {
 	routes := []plugins.Route{}
-	v4Routes, err := plugins.IPv4Routes(addressing, mtu.StandardMTU)
+	v4Routes, err := plugins.IPv4Routes(addressing, mtu.GetRouteMTU())
 	if err == nil {
 		routes = append(routes, v4Routes...)
 	} else {
 		log.Debugf("Couldn't get IPv4 routes for health routing")
 	}
-	v6Routes, err := plugins.IPv6Routes(addressing, mtu.StandardMTU)
+	v6Routes, err := plugins.IPv6Routes(addressing, mtu.GetRouteMTU())
 	if err != nil {
 		return fmt.Errorf("Failed to get IPv6 routes")
 	}
@@ -183,7 +183,7 @@ func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressin
 		},
 	}
 
-	if _, _, err := plugins.SetupVethWithNames(vethName, vethPeerName, mtu.StandardMTU, info); err != nil {
+	if _, _, err := plugins.SetupVethWithNames(vethName, vethPeerName, mtu.GetDeviceMTU(), info); err != nil {
 		return fmt.Errorf("Error while creating veth: %s", err)
 	}
 

--- a/common/plugins/ipam.go
+++ b/common/plugins/ipam.go
@@ -19,7 +19,6 @@ import (
 	"net"
 
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node"
 )
 
@@ -91,7 +90,7 @@ func IPv6Routes(addr *models.NodeAddressing, linkMTU int) ([]Route, error) {
 		{
 			Prefix:  node.IPv6DefaultRoute,
 			Nexthop: &ip,
-			MTU:     linkMTU - mtu.TunnelOverhead,
+			MTU:     linkMTU,
 		},
 	}, nil
 }
@@ -112,7 +111,7 @@ func IPv4Routes(addr *models.NodeAddressing, linkMTU int) ([]Route, error) {
 		{
 			Prefix:  node.IPv4DefaultRoute,
 			Nexthop: &ip,
-			MTU:     linkMTU - mtu.TunnelOverhead,
+			MTU:     linkMTU,
 		},
 	}, nil
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -681,7 +681,7 @@ func (d *Daemon) compileBase() error {
 	args[initArgRundir] = option.Config.StateDir
 	args[initArgIPv4NodeIP] = node.GetInternalIPv4().String()
 	args[initArgIPv6NodeIP] = node.GetIPv6().String()
-	args[initArgMTU] = fmt.Sprintf("%d", mtu.StandardMTU)
+	args[initArgMTU] = fmt.Sprintf("%d", mtu.GetDeviceMTU())
 
 	if option.Config.Device != "undefined" {
 		_, err := netlink.LinkByName(option.Config.Device)
@@ -1510,7 +1510,9 @@ func (h *getConfig) Handle(params GetConfigParams) middleware.Responder {
 			Type:    kvStore,
 			Options: kvStoreOpts,
 		},
-		Realized: spec,
+		Realized:  spec,
+		DeviceMTU: int64(mtu.GetDeviceMTU()),
+		RouteMTU:  int64(mtu.GetRouteMTU()),
 	}
 
 	cfg := &models.DaemonConfiguration{

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/monitor"
+	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pidfile"
@@ -397,6 +398,8 @@ func init() {
 		"nat46-range", node.DefaultNAT46Prefix, "IPv6 prefix to map IPv4 addresses to")
 	flags.BoolVar(&masquerade,
 		"masquerade", true, "Masquerade packets from endpoints leaving the host")
+	flags.IntVar(&option.Config.MTU,
+		option.MTUName, mtu.AutoDetect(), "Overwrite auto-detected MTU of underlying network")
 	flags.StringVar(&v6Address,
 		"ipv6-node", "auto", "IPv6 address of node")
 	flags.StringVar(&v4Address,
@@ -540,6 +543,10 @@ func initEnv(cmd *cobra.Command) {
 
 	if viper.GetBool("pprof") {
 		pprof.Enable()
+	}
+
+	if configuredMTU := viper.GetInt(option.MTUName); configuredMTU != 0 {
+		mtu.UseMTU(configuredMTU)
 	}
 
 	scopedLog := log.WithFields(logrus.Fields{

--- a/pkg/mtu/detect.go
+++ b/pkg/mtu/detect.go
@@ -1,0 +1,69 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mtu
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/cilium/cilium/pkg/logging"
+
+	"github.com/vishvananda/netlink"
+)
+
+var log = logging.DefaultLogger
+
+const (
+	externalProbe = "1.1.1.1"
+)
+
+func autoDetect() (int, error) {
+	ip := net.ParseIP(externalProbe)
+	if ip == nil {
+		return 0, fmt.Errorf("unable to parse IP %s", externalProbe)
+	}
+
+	routes, err := netlink.RouteGet(ip)
+	if err != nil {
+		return 0, fmt.Errorf("unable to lookup route to %s: %s", externalProbe, err)
+	}
+
+	if len(routes) == 0 {
+		return 0, fmt.Errorf("no route to %s", externalProbe)
+	}
+
+	link, err := netlink.LinkByIndex(routes[0].LinkIndex)
+	if err != nil {
+		return 0, fmt.Errorf("unable to find interface of default route: %s", err)
+	}
+
+	if mtu := link.Attrs().MTU; mtu != 0 {
+		log.Infof("Detected MTU %d", mtu)
+		return mtu, nil
+	}
+
+	return StandardMTU, nil
+}
+
+// AutoDetect tries to automatically detect the MTU of the underlying network
+func AutoDetect() int {
+	mtu, err := autoDetect()
+	if err != nil {
+		log.WithError(err).Warning("Unable to automatically detect MTU")
+		return StandardMTU
+	}
+
+	return mtu
+}

--- a/pkg/mtu/mtu.go
+++ b/pkg/mtu/mtu.go
@@ -63,3 +63,14 @@ func UseMTU(mtu int) {
 	StandardMTU = mtu
 	TunnelMTU = mtu - TunnelOverhead
 }
+
+// GetRouteMTU returns the MTU to be used on the network. When running in
+// tunneling mode, this will have tunnel overhead accounted for.
+func GetRouteMTU() int {
+	return TunnelMTU
+}
+
+// GetDeviceMTU returns the MTU to be used on workload facing devices.
+func GetDeviceMTU() int {
+	return StandardMTU
+}

--- a/pkg/node/manager.go
+++ b/pkg/node/manager.go
@@ -196,8 +196,10 @@ func replaceNodeRoute(ip *net.IPNet) {
 	// If the route includes the local address, then the route is for
 	// local containers and we can use a high MTU for transmit. Otherwise,
 	// it needs to be able to fit within the MTU of tunnel devices.
-	if !ip.Contains(local) {
-		route.MTU = mtu.TunnelMTU
+	if ip.Contains(local) {
+		route.MTU = mtu.GetDeviceMTU()
+	} else {
+		route.MTU = mtu.GetRouteMTU()
 	}
 	scopedLog := log.WithField(logfields.Route, route)
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -58,6 +58,9 @@ const (
 
 	// AutoIPv6NodeRoutesName is the name of the AutoIPv6NodeRoutes option
 	AutoIPv6NodeRoutesName = "auto-ipv6-node-routes"
+
+	// MTUName is the name of the MTU option
+	MTUName = "mtu"
 )
 
 // daemonConfig is the configuration used by Daemon.
@@ -139,6 +142,9 @@ type daemonConfig struct {
 	// AutoIPv6NodeRoutes enables automatic route injection of IPv6
 	// endpoint routes based on node discovery information
 	AutoIPv6NodeRoutes bool
+
+	// MTU is the maximum transmission unit of the underlying network
+	MTU int
 }
 
 var (
@@ -208,6 +214,10 @@ func (c *daemonConfig) Validate() error {
 	if err := c.validateIPv6ClusterAllocCIDR(); err != nil {
 		return fmt.Errorf("unable to parse CIDR value '%s' of option --%s: %s",
 			c.IPv6ClusterAllocCIDR, IPv6ClusterAllocCIDRName, err)
+	}
+
+	if c.MTU <= 0 {
+		return fmt.Errorf("MTU '%d' cannot be 0 or negative", c.MTU)
 	}
 
 	return nil

--- a/plugins/cilium-cni/00-cilium-cni.conf
+++ b/plugins/cilium-cni/00-cilium-cni.conf
@@ -1,5 +1,4 @@
 {
     "name": "cilium",
     "type": "cilium-cni",
-    "mtu": 1450
 }

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/mtu"
 
 	"github.com/docker/libnetwork/drivers/remote/api"
 	lnTypes "github.com/docker/libnetwork/types"
@@ -135,7 +134,7 @@ func (driver *driver) updateRoutes(addressing *models.NodeAddressing) {
 	driver.routes = []api.StaticRoute{}
 
 	if driver.conf.Addressing.IPV6 != nil {
-		if routes, err := plugins.IPv6Routes(driver.conf.Addressing, mtu.StandardMTU); err != nil {
+		if routes, err := plugins.IPv6Routes(driver.conf.Addressing, int(driver.conf.RouteMTU)); err != nil {
 			log.Fatalf("Unable to generate IPv6 routes: %s", err)
 		} else {
 			for _, r := range routes {
@@ -147,7 +146,7 @@ func (driver *driver) updateRoutes(addressing *models.NodeAddressing) {
 	}
 
 	if driver.conf.Addressing.IPV4 != nil {
-		if routes, err := plugins.IPv4Routes(driver.conf.Addressing, mtu.StandardMTU); err != nil {
+		if routes, err := plugins.IPv4Routes(driver.conf.Addressing, int(driver.conf.RouteMTU)); err != nil {
 			log.Fatalf("Unable to generate IPv4 routes: %s", err)
 		} else {
 			for _, r := range routes {
@@ -323,7 +322,7 @@ func (driver *driver) createEndpoint(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	veth, _, _, err := plugins.SetupVeth(create.EndpointID, mtu.StandardMTU, endpoint)
+	veth, _, _, err := plugins.SetupVeth(create.EndpointID, int(driver.conf.DeviceMTU), endpoint)
 	if err != nil {
 		sendError(w, "Error while setting up veth pair: "+err.Error(), http.StatusBadRequest)
 		return


### PR DESCRIPTION
Introduces a device MTU to guarantee ability to receive of arbitrarily big
frames. Existing MTU is renamed to RouteMTU and used for all configured routes.

Provide both the route and device MTU via the API so all plugins can use the
MTU configured via the cilium-agent.

Use the MTU of the device of which the default route points to as an indication
of the network MTU. The user can overwrite this using a new --mtu=INT option.

Example:
```
level=info msg="Detected MTU 9001"
level=info msg="Adding route" command="ip route add 0.0.0.0/0 via 10.2.2.172 mtu 8951 dev cilium" netns=cilium-health
level=info msg="Adding route" command="ip -6 route add ::/0 via f00d::a02:200:0:815b mtu 8951 dev cilium" netns=cilium-health
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4687)
<!-- Reviewable:end -->
