### PR TITLE
examples/kubernetes: add "system-node-critical" priorityClass

### DIFF
--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -178,6 +178,7 @@ spec:
             secretName: cilium-etcd-secrets
             optional: true
       restartPolicy: Always
+      priorityClassName: system-node-critical
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -209,6 +209,7 @@ spec:
             secretName: cilium-etcd-secrets
             optional: true
       restartPolicy: Always
+      priorityClassName: system-node-critical
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -177,6 +177,7 @@ spec:
             secretName: cilium-etcd-secrets
             optional: true
       restartPolicy: Always
+      priorityClassName: system-node-critical
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -208,6 +208,7 @@ spec:
             secretName: cilium-etcd-secrets
             optional: true
       restartPolicy: Always
+      priorityClassName: system-node-critical
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/examples/kubernetes/1.11/transforms2sed.sed
+++ b/examples/kubernetes/1.11/transforms2sed.sed
@@ -1,2 +1,3 @@
 s+__DS_API_VERSION__+apps/v1+g
 s+__RBAC_API_VERSION__+rbac.authorization.k8s.io/v1+g
+s+restartPolicy: Always+restartPolicy: Always\n      priorityClassName: system-node-critical+g

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -178,6 +178,7 @@ spec:
             secretName: cilium-etcd-secrets
             optional: true
       restartPolicy: Always
+      priorityClassName: system-node-critical
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -209,6 +209,7 @@ spec:
             secretName: cilium-etcd-secrets
             optional: true
       restartPolicy: Always
+      priorityClassName: system-node-critical
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -177,6 +177,7 @@ spec:
             secretName: cilium-etcd-secrets
             optional: true
       restartPolicy: Always
+      priorityClassName: system-node-critical
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -208,6 +208,7 @@ spec:
             secretName: cilium-etcd-secrets
             optional: true
       restartPolicy: Always
+      priorityClassName: system-node-critical
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/examples/kubernetes/1.12/transforms2sed.sed
+++ b/examples/kubernetes/1.12/transforms2sed.sed
@@ -1,2 +1,3 @@
 s+__DS_API_VERSION__+apps/v1+g
 s+__RBAC_API_VERSION__+rbac.authorization.k8s.io/v1+g
+s+restartPolicy: Always+restartPolicy: Always\n      priorityClassName: system-node-critical+g


### PR DESCRIPTION
More info: https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#marking-pod-as-critical-when-priorites-are-enabled

Signed-off-by: André Martins <andre@cilium.io>

```release-note
set Cilium DaemonSet priorityClass to "system-node-critical"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4690)
<!-- Reviewable:end -->
