### PR TITLE
daemon: check if dry mode is enabled for misc. BPF map-related operations

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1296,6 +1296,9 @@ func (d *Daemon) validateExistingMaps() error {
 }
 
 func (d *Daemon) collectStaleMapGarbage() {
+	if d.DryModeEnabled() {
+		return
+	}
 	walker := func(path string, _ os.FileInfo, _ error) error {
 		return d.staleMapWalker(path)
 	}

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -443,6 +443,11 @@ func (d *Daemon) RevNATDump() ([]types.L3n4AddrID, error) {
 // KVStore's ID, that entry will be updated on the bpf map accordingly with the new ID
 // retrieved from the KVStore.
 func (d *Daemon) SyncLBMap() error {
+	// Don't bother syncing if we are in dry mode.
+	if d.DryModeEnabled() {
+		return nil
+	}
+
 	log.Info("Syncing BPF LBMaps with daemon's LB maps...")
 	d.loadBalancer.BPFMapMU.Lock()
 	defer d.loadBalancer.BPFMapMU.Unlock()


### PR DESCRIPTION
The following warnings always appeared when running the unit tests for the
daemon:

```
level=warning msg="Error while deleting stale map file" error="remove /sys/fs/bpf/tc/globals/cilium_calls_23073: permission denied" file-path=/sys/fs/bpf/tc/globals/cilium_calls_23073
```

and

```
level=warning msg="error dumping Service4Map" error="Unable to get object /sys/fs/bpf/tc/globals/cilium_lb4_services: operation not permitted"
```

DryMode is a configuration option which, when true, is used to specify when BPF
maps and devices should not be created. This is useful for unit / component
testing of the daemon, i.e. when the datapath itself is not being used or
tested. Add some checks for drymode for syncing the LB maps, as well as for
collecting stale map garbage, as these are BPF map-related operations, and thus
should not be performed when the daemon is running in dry mode. This results in
the above errors not appearing in the daemon unit test output.

Signed-off-by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4695)
<!-- Reviewable:end -->
