### PR TITLE
pkg/endpoint: remove ProxyWaitGroup field from Endpoint

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -525,17 +525,16 @@ func (d *Daemon) deleteEndpointQuiet(ep *endpoint.Endpoint, releaseIP bool) []er
 	}
 
 	completionCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	ep.ProxyWaitGroup = completion.NewWaitGroup(completionCtx)
+	proxyWaitGroup := completion.NewWaitGroup(completionCtx)
 
-	errors = append(errors, ep.LeaveLocked(d)...)
+	errors = append(errors, ep.LeaveLocked(d, proxyWaitGroup)...)
 	ep.Mutex.Unlock()
 
-	err := ep.WaitForProxyCompletions()
+	err := ep.WaitForProxyCompletions(proxyWaitGroup)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("unable to remove proxy redirects: %s", err))
 	}
 	cancel()
-	ep.ProxyWaitGroup = nil
 
 	ep.BuildMutex.Unlock()
 

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -459,7 +459,7 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 
 	// Delete the endpoint.
 	e.Mutex.Lock()
-	e.LeaveLocked(ds.d)
+	e.LeaveLocked(ds.d, nil)
 	e.Mutex.Unlock()
 
 	// Check that the policy has been removed from the xDS cache.

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	"github.com/cilium/cilium/common/addressing"
+	"github.com/cilium/cilium/pkg/completion"
 	e "github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
@@ -126,7 +127,7 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 	}
 
 	ds.OnUpdateNetworkPolicy = func(e *e.Endpoint, policy *policy.L4Policy,
-		labelsMap identity.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool) error {
+		labelsMap identity.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool, proxyWaitGroup *completion.WaitGroup) error {
 		return nil
 	}
 

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -15,6 +15,7 @@
 package endpoint
 
 import (
+	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/monitor"
@@ -38,15 +39,15 @@ type Owner interface {
 	GetPolicyRepository() *policy.Repository
 
 	// UpdateProxyRedirect must update the redirect configuration of an endpoint in the proxy
-	UpdateProxyRedirect(e *Endpoint, l4 *policy.L4Filter) (uint16, error)
+	UpdateProxyRedirect(e *Endpoint, l4 *policy.L4Filter, proxyWaitGroup *completion.WaitGroup) (uint16, error)
 
 	// RemoveProxyRedirect must remove the redirect installed by UpdateProxyRedirect
-	RemoveProxyRedirect(e *Endpoint, id string) error
+	RemoveProxyRedirect(e *Endpoint, id string, proxyWaitGroup *completion.WaitGroup) error
 
 	// UpdateNetworkPolicy adds or updates a network policy in the set
 	// published to L7 proxies.
 	UpdateNetworkPolicy(e *Endpoint, policy *policy.L4Policy,
-		labelsMap identity.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool) error
+		labelsMap identity.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool, proxyWaitGroup *completion.WaitGroup) error
 
 	// RemoveNetworkPolicy removes a network policy from the set published to
 	// L7 proxies.


### PR DESCRIPTION
This field is only populated, and propagated in endpoint.regenerateBPF. Thus,
there is no point in exposing this field; it should only be accessible at the
time of regeneration of an endpoint. Update all users of the endpoint's
ProxyWaitGroup field to take in a *completion.WaitGroup parameter instead of
accessing the field from within the endpoint.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4697)
<!-- Reviewable:end -->
