### PR TITLE
envoy: Update Envoy dependency to release 1.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM quay.io/cilium/cilium-builder:2018-06-21 as builder
+FROM quay.io/cilium/cilium-builder:2018-06-29 as builder
 LABEL maintainer="maintainer@cilium.io"
 WORKDIR /go/src/github.com/cilium/cilium
 COPY . ./

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -127,7 +127,7 @@ Vagrant.configure(2) do |config|
         vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
 
         config.vm.box = "cilium/ubuntu-dev"
-        config.vm.box_version = "91"
+        config.vm.box_version = "92"
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i
         if ENV["NFS"] then

--- a/envoy/WORKSPACE
+++ b/envoy/WORKSPACE
@@ -7,7 +7,7 @@ workspace(name = "cilium")
 #
 # No other line in this file may have ENVOY_SHA followed by an equals sign!
 #
-ENVOY_SHA = "7f800115ba2b8d7a053872f1f852d4ba5996ae4d"
+ENVOY_SHA = "3f59fb5c0f6554f8b3f2e73ab4c1437a63d42668"
 
 http_archive(
     name = "envoy",

--- a/pkg/envoy/envoy/api/v2/core/address.pb.go
+++ b/pkg/envoy/envoy/api/v2/core/address.pb.go
@@ -42,7 +42,7 @@ func (x SocketAddress_Protocol) String() string {
 	return proto.EnumName(SocketAddress_Protocol_name, int32(x))
 }
 func (SocketAddress_Protocol) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_address_f4d4ccf656e6b43c, []int{1, 0}
+	return fileDescriptor_address_db08d0ef9ed44b0d, []int{1, 0}
 }
 
 type Pipe struct {
@@ -60,7 +60,7 @@ func (m *Pipe) Reset()         { *m = Pipe{} }
 func (m *Pipe) String() string { return proto.CompactTextString(m) }
 func (*Pipe) ProtoMessage()    {}
 func (*Pipe) Descriptor() ([]byte, []int) {
-	return fileDescriptor_address_f4d4ccf656e6b43c, []int{0}
+	return fileDescriptor_address_db08d0ef9ed44b0d, []int{0}
 }
 func (m *Pipe) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Pipe.Unmarshal(m, b)
@@ -90,14 +90,16 @@ func (m *Pipe) GetPath() string {
 type SocketAddress struct {
 	Protocol SocketAddress_Protocol `protobuf:"varint,1,opt,name=protocol,proto3,enum=envoy.api.v2.core.SocketAddress_Protocol" json:"protocol,omitempty"`
 	// The address for this socket. :ref:`Listeners <config_listeners>` will bind
-	// to the address or outbound connections will be made. An empty address is
-	// not allowed, specify ``0.0.0.0`` or ``::`` to bind any. It's still possible to
-	// distinguish on an address via the prefix/suffix matching in
-	// FilterChainMatch after connection. For :ref:`clusters
-	// <config_cluster_manager_cluster>`, an address may be either an IP or
-	// hostname to be resolved via DNS. If it is a hostname, :ref:`resolver_name
-	// <envoy_api_field_core.SocketAddress.resolver_name>` should be set unless default
-	// (i.e. DNS) resolution is expected.
+	// to the address. An empty address is not allowed. Specify ``0.0.0.0`` or ``::``
+	// to bind to any address. [#comment:TODO(zuercher) reinstate when implemented:
+	// It is possible to distinguish a Listener address via the prefix/suffix matching
+	// in :ref:`FilterChainMatch <envoy_api_msg_listener.FilterChainMatch>`.] When used
+	// within an upstream :ref:`BindConfig <envoy_api_msg_core.BindConfig>`, the address
+	// controls the source address of outbound connections. For :ref:`clusters
+	// <config_cluster_manager_cluster>`, the cluster type determines whether the
+	// address must be an IP (*STATIC* or *EDS* clusters) or a hostname resolved by DNS
+	// (*STRICT_DNS* or *LOGICAL_DNS* clusters). Address resolution can be customized
+	// via :ref:`resolver_name <envoy_api_field_core.SocketAddress.resolver_name>`.
 	Address string `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty"`
 	// Types that are valid to be assigned to PortSpecifier:
 	//	*SocketAddress_PortValue
@@ -122,7 +124,7 @@ func (m *SocketAddress) Reset()         { *m = SocketAddress{} }
 func (m *SocketAddress) String() string { return proto.CompactTextString(m) }
 func (*SocketAddress) ProtoMessage()    {}
 func (*SocketAddress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_address_f4d4ccf656e6b43c, []int{1}
+	return fileDescriptor_address_db08d0ef9ed44b0d, []int{1}
 }
 func (m *SocketAddress) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SocketAddress.Unmarshal(m, b)
@@ -291,7 +293,7 @@ func (m *TcpKeepalive) Reset()         { *m = TcpKeepalive{} }
 func (m *TcpKeepalive) String() string { return proto.CompactTextString(m) }
 func (*TcpKeepalive) ProtoMessage()    {}
 func (*TcpKeepalive) Descriptor() ([]byte, []int) {
-	return fileDescriptor_address_f4d4ccf656e6b43c, []int{2}
+	return fileDescriptor_address_db08d0ef9ed44b0d, []int{2}
 }
 func (m *TcpKeepalive) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TcpKeepalive.Unmarshal(m, b)
@@ -352,7 +354,7 @@ func (m *BindConfig) Reset()         { *m = BindConfig{} }
 func (m *BindConfig) String() string { return proto.CompactTextString(m) }
 func (*BindConfig) ProtoMessage()    {}
 func (*BindConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_address_f4d4ccf656e6b43c, []int{3}
+	return fileDescriptor_address_db08d0ef9ed44b0d, []int{3}
 }
 func (m *BindConfig) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_BindConfig.Unmarshal(m, b)
@@ -403,7 +405,7 @@ func (m *Address) Reset()         { *m = Address{} }
 func (m *Address) String() string { return proto.CompactTextString(m) }
 func (*Address) ProtoMessage()    {}
 func (*Address) Descriptor() ([]byte, []int) {
-	return fileDescriptor_address_f4d4ccf656e6b43c, []int{4}
+	return fileDescriptor_address_db08d0ef9ed44b0d, []int{4}
 }
 func (m *Address) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Address.Unmarshal(m, b)
@@ -548,7 +550,7 @@ func (m *CidrRange) Reset()         { *m = CidrRange{} }
 func (m *CidrRange) String() string { return proto.CompactTextString(m) }
 func (*CidrRange) ProtoMessage()    {}
 func (*CidrRange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_address_f4d4ccf656e6b43c, []int{5}
+	return fileDescriptor_address_db08d0ef9ed44b0d, []int{5}
 }
 func (m *CidrRange) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CidrRange.Unmarshal(m, b)
@@ -593,10 +595,10 @@ func init() {
 }
 
 func init() {
-	proto.RegisterFile("envoy/api/v2/core/address.proto", fileDescriptor_address_f4d4ccf656e6b43c)
+	proto.RegisterFile("envoy/api/v2/core/address.proto", fileDescriptor_address_db08d0ef9ed44b0d)
 }
 
-var fileDescriptor_address_f4d4ccf656e6b43c = []byte{
+var fileDescriptor_address_db08d0ef9ed44b0d = []byte{
 	// 644 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x53, 0xc1, 0x6e, 0xd3, 0x4a,
 	0x14, 0xcd, 0x24, 0x6e, 0x9b, 0xdc, 0x36, 0x79, 0xe9, 0xe8, 0x49, 0xb5, 0xa2, 0xf7, 0xda, 0x28,

--- a/pkg/envoy/envoy/api/v2/endpoint/endpoint.pb.go
+++ b/pkg/envoy/envoy/api/v2/endpoint/endpoint.pb.go
@@ -28,7 +28,7 @@ type Endpoint struct {
 	//
 	// .. attention::
 	//
-	//   The form of host address depends on the given cluster type. For STATIC,
+	//   The form of host address depends on the given cluster type. For STATIC or EDS,
 	//   it is expected to be a direct IP address (or something resolvable by the
 	//   specified :ref:`resolver <envoy_api_field_core.SocketAddress.resolver_name>`
 	//   in the Address). For LOGICAL or STRICT DNS, it is expected to be hostname,
@@ -51,7 +51,7 @@ func (m *Endpoint) Reset()         { *m = Endpoint{} }
 func (m *Endpoint) String() string { return proto.CompactTextString(m) }
 func (*Endpoint) ProtoMessage()    {}
 func (*Endpoint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_endpoint_ac874e8927bdf21f, []int{0}
+	return fileDescriptor_endpoint_3de14644fb025da9, []int{0}
 }
 func (m *Endpoint) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Endpoint.Unmarshal(m, b)
@@ -103,7 +103,7 @@ func (m *Endpoint_HealthCheckConfig) Reset()         { *m = Endpoint_HealthCheck
 func (m *Endpoint_HealthCheckConfig) String() string { return proto.CompactTextString(m) }
 func (*Endpoint_HealthCheckConfig) ProtoMessage()    {}
 func (*Endpoint_HealthCheckConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_endpoint_ac874e8927bdf21f, []int{0, 0}
+	return fileDescriptor_endpoint_3de14644fb025da9, []int{0, 0}
 }
 func (m *Endpoint_HealthCheckConfig) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Endpoint_HealthCheckConfig.Unmarshal(m, b)
@@ -167,7 +167,7 @@ func (m *LbEndpoint) Reset()         { *m = LbEndpoint{} }
 func (m *LbEndpoint) String() string { return proto.CompactTextString(m) }
 func (*LbEndpoint) ProtoMessage()    {}
 func (*LbEndpoint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_endpoint_ac874e8927bdf21f, []int{1}
+	return fileDescriptor_endpoint_3de14644fb025da9, []int{1}
 }
 func (m *LbEndpoint) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_LbEndpoint.Unmarshal(m, b)
@@ -260,7 +260,7 @@ func (m *LocalityLbEndpoints) Reset()         { *m = LocalityLbEndpoints{} }
 func (m *LocalityLbEndpoints) String() string { return proto.CompactTextString(m) }
 func (*LocalityLbEndpoints) ProtoMessage()    {}
 func (*LocalityLbEndpoints) Descriptor() ([]byte, []int) {
-	return fileDescriptor_endpoint_ac874e8927bdf21f, []int{2}
+	return fileDescriptor_endpoint_3de14644fb025da9, []int{2}
 }
 func (m *LocalityLbEndpoints) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_LocalityLbEndpoints.Unmarshal(m, b)
@@ -316,10 +316,10 @@ func init() {
 }
 
 func init() {
-	proto.RegisterFile("envoy/api/v2/endpoint/endpoint.proto", fileDescriptor_endpoint_ac874e8927bdf21f)
+	proto.RegisterFile("envoy/api/v2/endpoint/endpoint.proto", fileDescriptor_endpoint_3de14644fb025da9)
 }
 
-var fileDescriptor_endpoint_ac874e8927bdf21f = []byte{
+var fileDescriptor_endpoint_3de14644fb025da9 = []byte{
 	// 500 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x52, 0xc1, 0x6e, 0xd3, 0x40,
 	0x10, 0xc5, 0x49, 0x4b, 0xc3, 0x26, 0xad, 0xd4, 0x0d, 0x15, 0x91, 0x29, 0x0d, 0x44, 0x3d, 0x44,

--- a/pkg/envoy/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.pb.go
+++ b/pkg/envoy/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.pb.go
@@ -59,7 +59,7 @@ func (x HttpConnectionManager_CodecType) String() string {
 	return proto.EnumName(HttpConnectionManager_CodecType_name, int32(x))
 }
 func (HttpConnectionManager_CodecType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_http_connection_manager_9e73ff4987361af4, []int{0, 0}
+	return fileDescriptor_http_connection_manager_a2df6c7fde28b52f, []int{0, 0}
 }
 
 // How to handle the :ref:`config_http_conn_man_headers_x-forwarded-client-cert` (XFCC) HTTP
@@ -102,7 +102,7 @@ func (x HttpConnectionManager_ForwardClientCertDetails) String() string {
 	return proto.EnumName(HttpConnectionManager_ForwardClientCertDetails_name, int32(x))
 }
 func (HttpConnectionManager_ForwardClientCertDetails) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_http_connection_manager_9e73ff4987361af4, []int{0, 1}
+	return fileDescriptor_http_connection_manager_a2df6c7fde28b52f, []int{0, 1}
 }
 
 type HttpConnectionManager_Tracing_OperationName int32
@@ -127,7 +127,7 @@ func (x HttpConnectionManager_Tracing_OperationName) String() string {
 	return proto.EnumName(HttpConnectionManager_Tracing_OperationName_name, int32(x))
 }
 func (HttpConnectionManager_Tracing_OperationName) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_http_connection_manager_9e73ff4987361af4, []int{0, 0, 0}
+	return fileDescriptor_http_connection_manager_a2df6c7fde28b52f, []int{0, 0, 0}
 }
 
 // [#comment:next free field: 23]
@@ -250,7 +250,7 @@ func (m *HttpConnectionManager) Reset()         { *m = HttpConnectionManager{} }
 func (m *HttpConnectionManager) String() string { return proto.CompactTextString(m) }
 func (*HttpConnectionManager) ProtoMessage()    {}
 func (*HttpConnectionManager) Descriptor() ([]byte, []int) {
-	return fileDescriptor_http_connection_manager_9e73ff4987361af4, []int{0}
+	return fileDescriptor_http_connection_manager_a2df6c7fde28b52f, []int{0}
 }
 func (m *HttpConnectionManager) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_HttpConnectionManager.Unmarshal(m, b)
@@ -560,7 +560,7 @@ func (m *HttpConnectionManager_Tracing) Reset()         { *m = HttpConnectionMan
 func (m *HttpConnectionManager_Tracing) String() string { return proto.CompactTextString(m) }
 func (*HttpConnectionManager_Tracing) ProtoMessage()    {}
 func (*HttpConnectionManager_Tracing) Descriptor() ([]byte, []int) {
-	return fileDescriptor_http_connection_manager_9e73ff4987361af4, []int{0, 0}
+	return fileDescriptor_http_connection_manager_a2df6c7fde28b52f, []int{0, 0}
 }
 func (m *HttpConnectionManager_Tracing) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_HttpConnectionManager_Tracing.Unmarshal(m, b)
@@ -644,7 +644,7 @@ func (m *HttpConnectionManager_SetCurrentClientCertDetails) String() string {
 }
 func (*HttpConnectionManager_SetCurrentClientCertDetails) ProtoMessage() {}
 func (*HttpConnectionManager_SetCurrentClientCertDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_http_connection_manager_9e73ff4987361af4, []int{0, 1}
+	return fileDescriptor_http_connection_manager_a2df6c7fde28b52f, []int{0, 1}
 }
 func (m *HttpConnectionManager_SetCurrentClientCertDetails) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_HttpConnectionManager_SetCurrentClientCertDetails.Unmarshal(m, b)
@@ -717,7 +717,7 @@ func (m *Rds) Reset()         { *m = Rds{} }
 func (m *Rds) String() string { return proto.CompactTextString(m) }
 func (*Rds) ProtoMessage()    {}
 func (*Rds) Descriptor() ([]byte, []int) {
-	return fileDescriptor_http_connection_manager_9e73ff4987361af4, []int{1}
+	return fileDescriptor_http_connection_manager_a2df6c7fde28b52f, []int{1}
 }
 func (m *Rds) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Rds.Unmarshal(m, b)
@@ -765,6 +765,7 @@ type HttpFilter struct {
 	// * :ref:`envoy.grpc_json_transcoder <config_http_filters_grpc_json_transcoder>`
 	// * :ref:`envoy.grpc_web <config_http_filters_grpc_web>`
 	// * :ref:`envoy.health_check <config_http_filters_health_check>`
+	// * :ref:`envoy.header_to_metadata <config_http_filters_header_to_metadata>`
 	// * :ref:`envoy.ip_tagging <config_http_filters_ip_tagging>`
 	// * :ref:`envoy.lua <config_http_filters_lua>`
 	// * :ref:`envoy.rate_limit <config_http_filters_rate_limit>`
@@ -786,7 +787,7 @@ func (m *HttpFilter) Reset()         { *m = HttpFilter{} }
 func (m *HttpFilter) String() string { return proto.CompactTextString(m) }
 func (*HttpFilter) ProtoMessage()    {}
 func (*HttpFilter) Descriptor() ([]byte, []int) {
-	return fileDescriptor_http_connection_manager_9e73ff4987361af4, []int{2}
+	return fileDescriptor_http_connection_manager_a2df6c7fde28b52f, []int{2}
 }
 func (m *HttpFilter) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_HttpFilter.Unmarshal(m, b)
@@ -841,7 +842,7 @@ func (m *HttpFilter_DeprecatedV1) Reset()         { *m = HttpFilter_DeprecatedV1
 func (m *HttpFilter_DeprecatedV1) String() string { return proto.CompactTextString(m) }
 func (*HttpFilter_DeprecatedV1) ProtoMessage()    {}
 func (*HttpFilter_DeprecatedV1) Descriptor() ([]byte, []int) {
-	return fileDescriptor_http_connection_manager_9e73ff4987361af4, []int{2, 0}
+	return fileDescriptor_http_connection_manager_a2df6c7fde28b52f, []int{2, 0}
 }
 func (m *HttpFilter_DeprecatedV1) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_HttpFilter_DeprecatedV1.Unmarshal(m, b)
@@ -881,10 +882,10 @@ func init() {
 }
 
 func init() {
-	proto.RegisterFile("envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto", fileDescriptor_http_connection_manager_9e73ff4987361af4)
+	proto.RegisterFile("envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto", fileDescriptor_http_connection_manager_a2df6c7fde28b52f)
 }
 
-var fileDescriptor_http_connection_manager_9e73ff4987361af4 = []byte{
+var fileDescriptor_http_connection_manager_a2df6c7fde28b52f = []byte{
 	// 1441 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x56, 0x4f, 0x6f, 0x1b, 0x45,
 	0x14, 0xcf, 0xda, 0xce, 0x1f, 0x3f, 0xdb, 0x89, 0x33, 0x49, 0xda, 0x25, 0x85, 0xc6, 0x8a, 0x04,

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -8,7 +8,7 @@ $K8S_VERSION = ENV['K8S_VERSION'] || "1.10"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 $NFS = ENV['NFS']=="1"? true : false
 $SERVER_BOX = (ENV['SERVER_BOX'] || "cilium/ubuntu-dev")
-$SERVER_VERSION="91"
+$SERVER_VERSION="92"
 $IPv6=(ENV['IPv6'] || "0")
 $CONTAINER_RUNTIME=(ENV['CONTAINER_RUNTIME'] || "docker")
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     command: "etcd -name etcd0 -advertise-client-urls http://0.0.0.0:4002 -listen-client-urls http://0.0.0.0:4002 -initial-cluster-token etcd-cluster-1 -initial-cluster-state new"
     privileged: true
   base_image:
-    image: "quay.io/cilium/cilium-builder:2018-06-21"
+    image: "quay.io/cilium/cilium-builder:2018-06-29"
     volumes:
       - "./../:/go/src/github.com/cilium/cilium/"
     privileged: true


### PR DESCRIPTION
The previous Envoy master commit we depended on had crashing regressions that have been fixed in the release 1.7.0.

CI VM image (box version 92) as well as docker cilium-builder image (tag '2018-06-29') have been regenerated using the updated dependencies.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4698)
<!-- Reviewable:end -->
