### PR TITLE
Changed the prometheus yaml to deploy in monitoring namespace

### DIFF
--- a/Documentation/gettingstarted/gsg_starwars.rst
+++ b/Documentation/gettingstarted/gsg_starwars.rst
@@ -446,5 +446,4 @@ prometheus configuration. Navigate to the web ui with:
 
 ::
 
-   $ minikube service prometheus -n prometheus
-
+   $ minikube service prometheus -n monitoring 

--- a/examples/kubernetes/addons/prometheus/prometheus.yaml
+++ b/examples/kubernetes/addons/prometheus/prometheus.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: prometheus
+  name: monitoring
 
 # The prometheus service, deployment and config
 ---
@@ -10,7 +10,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus
-  namespace: prometheus
+  namespace: monitoring
   labels:
     app: prometheus
     component: core
@@ -31,7 +31,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: prometheus-core
-  namespace: prometheus
+  namespace: monitoring
   labels:
     app: prometheus
     component: core
@@ -75,7 +75,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus-core
-  namespace: prometheus
+  namespace: monitoring
 data:
   prometheus.yaml: |
     global:
@@ -129,7 +129,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-k8s
-  namespace: prometheus
+  namespace: monitoring
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -156,7 +156,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus-k8s
-  namespace: prometheus
+  namespace: monitoring
 ---
 kind: ConfigMap
 apiVersion: v1


### PR DESCRIPTION
Prometheus and grafana are commonly deployed in the monitoring ns
the change makes it easy to connect those services without
requiring a full domain name for service

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4699)
<!-- Reviewable:end -->
