### PR TITLE
Enable Prometheus server by default

### DIFF
--- a/examples/kubernetes/1.10/cilium-cm.yaml
+++ b/examples/kubernetes/1.10/cilium-cm.yaml
@@ -28,3 +28,4 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
+  prometheus-serve-addr: ":9090"

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -93,7 +93,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -28,6 +28,7 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
+  prometheus-serve-addr: ":9090"
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -124,7 +125,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -92,7 +92,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -28,6 +28,7 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
+  prometheus-serve-addr: ":9090"
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -123,7 +124,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.11/cilium-cm.yaml
+++ b/examples/kubernetes/1.11/cilium-cm.yaml
@@ -28,3 +28,4 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
+  prometheus-serve-addr: ":9090"

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -93,7 +93,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -28,6 +28,7 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
+  prometheus-serve-addr: ":9090"
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -124,7 +125,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -92,7 +92,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -28,6 +28,7 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
+  prometheus-serve-addr: ":9090"
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -123,7 +124,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.12/cilium-cm.yaml
+++ b/examples/kubernetes/1.12/cilium-cm.yaml
@@ -28,3 +28,4 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
+  prometheus-serve-addr: ":9090"

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -93,7 +93,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -28,6 +28,7 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
+  prometheus-serve-addr: ":9090"
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -124,7 +125,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -92,7 +92,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -28,6 +28,7 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
+  prometheus-serve-addr: ":9090"
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -123,7 +124,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.7/cilium-cm.yaml
+++ b/examples/kubernetes/1.7/cilium-cm.yaml
@@ -28,3 +28,4 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
+  prometheus-serve-addr: ":9090"

--- a/examples/kubernetes/1.7/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-crio-ds.yaml
@@ -93,7 +93,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.7/cilium-crio.yaml
+++ b/examples/kubernetes/1.7/cilium-crio.yaml
@@ -28,6 +28,7 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
+  prometheus-serve-addr: ":9090"
 ---
 kind: DaemonSet
 apiVersion: extensions/v1beta1
@@ -124,7 +125,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -92,7 +92,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -28,6 +28,7 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
+  prometheus-serve-addr: ":9090"
 ---
 kind: DaemonSet
 apiVersion: extensions/v1beta1
@@ -123,7 +124,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.8/cilium-cm.yaml
+++ b/examples/kubernetes/1.8/cilium-cm.yaml
@@ -28,3 +28,4 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
+  prometheus-serve-addr: ":9090"

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -93,7 +93,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -28,6 +28,7 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
+  prometheus-serve-addr: ":9090"
 ---
 kind: DaemonSet
 apiVersion: apps/v1beta2
@@ -124,7 +125,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -92,7 +92,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -28,6 +28,7 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
+  prometheus-serve-addr: ":9090"
 ---
 kind: DaemonSet
 apiVersion: apps/v1beta2
@@ -123,7 +124,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.9/cilium-cm.yaml
+++ b/examples/kubernetes/1.9/cilium-cm.yaml
@@ -28,3 +28,4 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
+  prometheus-serve-addr: ":9090"

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -93,7 +93,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -28,6 +28,7 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
+  prometheus-serve-addr: ":9090"
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -124,7 +125,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -92,7 +92,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -28,6 +28,7 @@ data:
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
+  prometheus-serve-addr: ":9090"
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -123,7 +124,7 @@ spec:
           - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
             valueFrom:
               configMapKeyRef:
-                name: cilium-metrics-config
+                name: cilium-config
                 optional: true
                 key: prometheus-serve-addr
           - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"


### PR DESCRIPTION
Made `prometheus-serve-addr: ":9090"` part of the cilium-config map
Previously this was part of a config map in the Prometheus file
which unnecessarily requires users to restart Cilium

Note that Prometheus scrapes Cilium for metrics, so Prometheus is the client
and Cilium is the server for this interaction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4700)
<!-- Reviewable:end -->
