### PR TITLE
Test: Precheck use the same docker-compose image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,7 @@ $(SUBDIRS): force
 
 
 jenkins-precheck:
-	docker-compose -f test/precheck.yml -p $$JOB_BASE_NAME-$$BUILD_NUMBER run --rm precheck
-
-clean-jenkins-precheck:
-	docker-compose -f test/precheck.yml -p $$JOB_BASE_NAME-$$BUILD_NUMBER down
-	docker-compose -f test/precheck.yml -p $$JOB_BASE_NAME-$$BUILD_NUMBER rm
+	docker-compose -f test/docker-compose.yml -p $$JOB_BASE_NAME-$$BUILD_NUMBER run --rm precheck
 
 # invoked from ginkgo Jenkinsfile
 tests-ginkgo: force

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             }
             post {
                always {
-                   sh "cd ${TESTDIR}; make clean-jenkins-precheck || true"
+                   sh "cd ${TESTDIR}; make clean-ginkgo-tests || true"
                }
             }
         }

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -11,12 +11,19 @@ services:
     hostname: "etcd"
     command: "etcd -name etcd0 -advertise-client-urls http://0.0.0.0:4002 -listen-client-urls http://0.0.0.0:4002 -initial-cluster-token etcd-cluster-1 -initial-cluster-state new"
     privileged: true
+  base_image:
+    image: "quay.io/cilium/cilium-builder:2018-06-21"
+    volumes:
+      - "./../:/go/src/github.com/cilium/cilium/"
+    privileged: true
   test:
+    extends:
+      service: base_image
     depends_on:
       - consul
       - etcd
-    image: "quay.io/cilium/cilium-builder:2018-06-21"
     command: "bash -c 'cd /go/src/github.com/cilium/cilium/; make tests-ginkgo-real'"
-    privileged: true
-    volumes:
-      - "./../:/go/src/github.com/cilium/cilium/"
+  precheck:
+    extends:
+      service: base_image
+    command: "bash -c 'cd /go/src/github.com/cilium/cilium/; make precheck || exit 1'"

--- a/test/precheck.yml
+++ b/test/precheck.yml
@@ -1,8 +1,0 @@
-version: "2"
-services:
-  precheck:
-    image: "quay.io/cilium/cilium-builder:2018-06-14"
-    command: "bash -c 'cd /go/src/github.com/cilium/cilium/; make precheck || exit 1'"
-    privileged: true
-    volumes:
-      - "./../:/go/src/github.com/cilium/cilium/"


### PR DESCRIPTION
Remove test/precheck.yaml and add another service based on the base
image service to run the precheck in the container.

This change allows us to use the same docker-compose file and only
update the dependencies once.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4701)
<!-- Reviewable:end -->
