### PR TITLE
Split plugin logic into pkg/datapath/(link|route) and pkg/endpoint/connector

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -26,8 +26,9 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/common/addressing"
-	"github.com/cilium/cilium/common/plugins"
+	"github.com/cilium/cilium/pkg/datapath/route"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpoint/connector"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	healthPkg "github.com/cilium/cilium/pkg/health/client"
@@ -84,14 +85,14 @@ func logFromCommand(cmd *exec.Cmd, netns string) error {
 }
 
 func configureHealthRouting(netns, dev string, addressing *models.NodeAddressing) error {
-	routes := []plugins.Route{}
-	v4Routes, err := plugins.IPv4Routes(addressing, mtu.GetRouteMTU())
+	routes := []route.Route{}
+	v4Routes, err := connector.IPv4Routes(addressing, mtu.GetRouteMTU())
 	if err == nil {
 		routes = append(routes, v4Routes...)
 	} else {
 		log.Debugf("Couldn't get IPv4 routes for health routing")
 	}
-	v6Routes, err := plugins.IPv6Routes(addressing, mtu.GetRouteMTU())
+	v6Routes, err := connector.IPv6Routes(addressing, mtu.GetRouteMTU())
 	if err != nil {
 		return fmt.Errorf("Failed to get IPv6 routes")
 	}
@@ -183,7 +184,7 @@ func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressin
 		},
 	}
 
-	if _, _, err := plugins.SetupVethWithNames(vethName, vethPeerName, mtu.GetDeviceMTU(), info); err != nil {
+	if _, _, err := connector.SetupVethWithNames(vethName, vethPeerName, mtu.GetDeviceMTU(), info); err != nil {
 		return fmt.Errorf("Error while creating veth: %s", err)
 	}
 

--- a/pkg/datapath/link/doc.go
+++ b/pkg/datapath/link/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package link provides the Cilium specific abstraction and useful helpers to
+// manage network interfaces
+package link

--- a/pkg/datapath/link/link.go
+++ b/pkg/datapath/link/link.go
@@ -1,0 +1,45 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package link
+
+import (
+	"fmt"
+
+	"github.com/vishvananda/netlink"
+)
+
+// DeleteByName deletes the interface with the name ifName.
+func DeleteByName(ifName string) error {
+	iface, err := netlink.LinkByName(ifName)
+	if err != nil {
+		return fmt.Errorf("failed to lookup %q: %v", ifName, err)
+	}
+
+	if err = netlink.LinkDel(iface); err != nil {
+		return fmt.Errorf("failed to delete %q: %v", ifName, err)
+	}
+
+	return nil
+}
+
+// Rename renames a network link
+func Rename(curName, newName string) error {
+	link, err := netlink.LinkByName(curName)
+	if err != nil {
+		return err
+	}
+
+	return netlink.LinkSetName(link, newName)
+}

--- a/pkg/datapath/route/doc.go
+++ b/pkg/datapath/route/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,24 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plugins
-
-import (
-	"fmt"
-
-	"github.com/vishvananda/netlink"
-)
-
-// DelLinkByName deletes the interface with the name ifName.
-func DelLinkByName(ifName string) error {
-	iface, err := netlink.LinkByName(ifName)
-	if err != nil {
-		return fmt.Errorf("failed to lookup %q: %v", ifName, err)
-	}
-
-	if err = netlink.LinkDel(iface); err != nil {
-		return fmt.Errorf("failed to delete %q: %v", ifName, err)
-	}
-
-	return nil
-}
+// Package route provides the Cilium specific abstraction and useful helpers to
+// manage network routes
+package route

--- a/pkg/datapath/route/route.go
+++ b/pkg/datapath/route/route.go
@@ -1,0 +1,60 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package route
+
+import (
+	"fmt"
+	"net"
+)
+
+type Route struct {
+	Prefix  net.IPNet
+	Nexthop *net.IP
+	MTU     int
+}
+
+// ToIPCommand converts the route into a full "ip route ..." command
+func (r *Route) ToIPCommand(dev string) []string {
+	res := []string{"ip"}
+	if r.Prefix.IP.To4() == nil {
+		res = append(res, "-6")
+	}
+	res = append(res, "route", "add", r.Prefix.String())
+	if r.Nexthop != nil {
+		res = append(res, "via", r.Nexthop.String())
+	}
+	if r.MTU != 0 {
+		res = append(res, "mtu", fmt.Sprintf("%d", r.MTU))
+	}
+	res = append(res, "dev", dev)
+	return res
+}
+
+// ByMask is used to sort an array of routes by mask, narrow first.
+type ByMask []Route
+
+func (a ByMask) Len() int {
+	return len(a)
+}
+
+func (a ByMask) Less(i, j int) bool {
+	lenA, _ := a[i].Prefix.Mask.Size()
+	lenB, _ := a[j].Prefix.Mask.Size()
+	return lenA > lenB
+}
+
+func (a ByMask) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}

--- a/pkg/datapath/route/route_test.go
+++ b/pkg/datapath/route/route_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plugins
+package route
 
 import (
 	"fmt"
@@ -26,16 +26,16 @@ import (
 // Hook up gocheck into the "go test" runner.
 func Test(t *testing.T) { TestingT(t) }
 
-type PluginsSuite struct{}
+type RouteSuite struct{}
 
-var _ = Suite(&PluginsSuite{})
+var _ = Suite(&RouteSuite{})
 
 func parseIP(ip string) *net.IP {
 	result := net.ParseIP(ip)
 	return &result
 }
 
-func (p *PluginsSuite) TestToIPCommand(c *C) {
+func (p *RouteSuite) TestToIPCommand(c *C) {
 	routes := []*Route{
 		{
 			Prefix: net.IPNet{

--- a/pkg/endpoint/connector/add.go
+++ b/pkg/endpoint/connector/add.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plugins
+package connector
 
 import (
 	"fmt"

--- a/pkg/endpoint/connector/doc.go
+++ b/pkg/endpoint/connector/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package connector is responsible for the datapath specific plumbing to
+// connect an endpoint to the network
+package connector


### PR DESCRIPTION
This moves common/plugins into separate packages under pkg/. No code change is
being performed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4705)
<!-- Reviewable:end -->
