### PR TITLE
Test: Curl Timeout to 1 second

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -131,7 +131,7 @@ const (
 	StateRunning     = "Running"
 
 	PingCount          = 5
-	CurlConnectTimeout = 5
+	CurlConnectTimeout = 1
 
 	DefaultNamespace    = "default"
 	KubeSystemNamespace = "kube-system"


### PR DESCRIPTION
To speed up a little bit the test, limit the connection timeout to 1
second instead of 5.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4706)
<!-- Reviewable:end -->
