### PR TITLE
Test: WithTimeout executed on start

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -117,7 +117,9 @@ func WithTimeout(body func() bool, msg string, config *TimeoutConfig) error {
 	done := time.After(config.Timeout * time.Second)
 	ticker := time.NewTicker(config.Ticker * time.Second)
 	defer ticker.Stop()
-
+	if body() {
+		return nil
+	}
 	for {
 		select {
 		case <-ticker.C:

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -113,6 +113,8 @@ var _ = Describe("K8sValidatedChaosTest", func() {
 			helpers.KubectlCmd, helpers.KubeSystemNamespace))
 		res.ExpectSuccess()
 
+		ExpectAllPodsTerminated(kubectl)
+
 		ExpectCiliumReady(kubectl)
 		err = kubectl.CiliumEndpointWaitReady()
 		Expect(err).To(BeNil(), "Endpoints are not ready after Cilium restarts")


### PR DESCRIPTION
WithTimeout was not executed on start, so the first run was after
`config.Ticker` value (default to 5) With this change always will
executed on first run, if fail will executed each config.Ticker.

This change should make test a bit faster.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4710)
<!-- Reviewable:end -->
