### PR TITLE
WIP: V1.0 backports 18 07 02

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM cilium/cilium-builder:2018-03-29 as builder
+FROM quay.io/cilium/cilium-builder:2018-06-21 as builder
 LABEL maintainer="maintainer@cilium.io"
 WORKDIR /go/src/github.com/cilium/cilium
 ADD . ./
@@ -29,7 +29,7 @@ RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 DESTDIR=/tmp/install clean-container b
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2018-06-04
+FROM quay.io/cilium/cilium-runtime:2018-06-21
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /tmp/install /
 ADD plugins/cilium-cni/cni-install.sh /cni-install.sh

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -54,7 +54,7 @@ pipeline {
         stage('Nightly-Tests') {
             environment {
                 K8S_NODES=4
-                K8S_VERSION=1.9
+                K8S_VERSION=1.11
                 MEMORY=4096
                 CPU=4
                 FAILFAST=setIfPR("true", "false")
@@ -112,7 +112,7 @@ pipeline {
         always {
             sh "cd ${TESTDIR}; K8S_VERSION=1.8 vagrant destroy -f || true"
             sh "cd ${TESTDIR}; K8S_VERSION=1.7 vagrant destroy -f || true"
-            sh "cd ${TESTDIR}; K8S_VERSION=1.9 vagrant destroy -f || true"
+            sh "cd ${TESTDIR}; K8S_VERSION=1.11 vagrant destroy -f || true"
             sh "cd ${TESTDIR}; vagrant destroy -f || true"
             sh 'cd ${TEST_DIR}; ./post_build_agent.sh || true'
             cleanWs()

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -70,7 +70,7 @@ get_prs () {
 
   label_opt="%20label:$label"
   label_exclude_opt="%20-label:$label_exclude"
-  url="https://api.github.com/search/issues?per_page=1&q=is:pr%20repo:cilium/cilium%20is:closed$label_opt$label_exclude_opt"
+  url="${CILIUM_GITHUB_SEARCHAPI}$label_opt$label_exclude_opt"
   total="$($GHCURL $url | jq -r '.total_count')"
 
   # Calculate number of pages, rounding up

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -73,7 +73,7 @@ apt-get clean
 #
 # Go-based tools we need at runtime
 #
-FROM golang:1.10.2 as runtime-gobuild
+FROM golang:1.10.3 as runtime-gobuild
 WORKDIR /tmp
 RUN go get -u github.com/cilium/go-bindata/... && \
 go get -u github.com/google/gops && \

--- a/contrib/release/lib/gitlib.sh
+++ b/contrib/release/lib/gitlib.sh
@@ -25,7 +25,7 @@ JCURL="curl -g -s --fail --retry 10"
 CILIUM_GITHUB_API='https://api.github.com/repos/cilium/cilium'
 CILIUM_GITHUB_RAW_ORG='https://raw.githubusercontent.com/cilium'
 
-CILIUM_GITHUB_SEARCHAPI='https://api.github.com/search/issues?per_page=100&q=is:pr%20is:closed%20repo:cilium/cilium%20'
+CILIUM_GITHUB_SEARCHAPI='https://api.github.com/search/issues?per_page=100&q=is:pr%20is:merged%20repo:cilium/cilium%20'
 CILIUM_GITHUB_URL='https://github.com/cilium/cilium'
 CILIUM_GITHUB_SSH='git@github.com:cilium/cilium.git'
 

--- a/examples/kubernetes/1.12/cilium-cm.yaml
+++ b/examples/kubernetes/1.12/cilium-cm.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+  # This etcd-config contains the etcd endpoints of your cluster. If you use
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
+  etcd-config: |-
+    ---
+    endpoints:
+    - http://127.0.0.1:31079
+    #
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
+    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
+    #
+    # In case you want client to server authentication, uncomment the following
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
+    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  disable-ipv4: "false"
+  # If you want to clean cilium state; change this value to true
+  clean-cilium-state: "false"
+  legacy-host-allows-world: "false"

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -1,0 +1,189 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  updateStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
+      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
+      maxUnavailable: "100%"
+  selector:
+    matchLabels:
+      k8s-app: cilium
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
+      annotations:
+        # This annotation plus the CriticalAddonsOnly toleration makes
+        # cilium to be a critical pod in the cluster, which ensures cilium
+        # gets priority scheduling.
+        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: >-
+          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+    spec:
+      serviceAccountName: cilium
+      initContainers:
+      - name: clean-cilium-state
+        image: docker.io/library/busybox:1.28.4
+        imagePullPolicy: IfNotPresent
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+        env:
+          - name: "CLEAN_CILIUM_STATE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: clean-cilium-state
+      containers:
+      - image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        name: cilium-agent
+        command: [ "cilium-agent" ]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "-t=vxlan"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+          - "--disable-ipv4=$(DISABLE_IPV4)"
+          - "--container-runtime=crio"
+        ports:
+          - name: prometheus
+            containerPort: 9090
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - "/cni-install.sh"
+          preStop:
+            exec:
+              command:
+                - "/cni-uninstall.sh"
+        env:
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+          - name: "DISABLE_IPV4"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: disable-ipv4
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+          - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-metrics-config
+                optional: true
+                key: prometheus-serve-addr
+          - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: legacy-host-allows-world
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          failureThreshold: 10
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+          - name: cni-path
+            mountPath: /host/opt/cni/bin
+          - name: etc-cni-netd
+            mountPath: /host/etc/cni/net.d
+          - name: crio-socket
+            mountPath: /var/run/crio.sock
+            readOnly: true
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+        securityContext:
+          capabilities:
+            add:
+              - "NET_ADMIN"
+          privileged: true
+      hostNetwork: true
+      volumes:
+          # To keep state between restarts / upgrades
+        - name: cilium-run
+          hostPath:
+            path: /var/run/cilium
+          # To keep state between restarts / upgrades
+        - name: bpf-maps
+          hostPath:
+            path: /sys/fs/bpf
+          # To read labels from CRI-O containers running in the host
+        - name: crio-socket
+          hostPath:
+            path: /var/run/crio.sock
+          # To install cilium cni plugin in the host
+        - name: cni-path
+          hostPath:
+            path: /opt/cni/bin
+          # To install cilium cni configuration in the host
+        - name: etc-cni-netd
+          hostPath:
+              path: /etc/cni/net.d
+          # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+            - key: etcd-config
+              path: etcd.config
+          # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+      restartPolicy: Always
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+      # Mark cilium's pod as critical for rescheduling
+      - key: CriticalAddonsOnly
+        operator: "Exists"

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -1,0 +1,306 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+  # This etcd-config contains the etcd endpoints of your cluster. If you use
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
+  etcd-config: |-
+    ---
+    endpoints:
+    - http://127.0.0.1:31079
+    #
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
+    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
+    #
+    # In case you want client to server authentication, uncomment the following
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
+    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  disable-ipv4: "false"
+  # If you want to clean cilium state; change this value to true
+  clean-cilium-state: "false"
+  legacy-host-allows-world: "false"
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  updateStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
+      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
+      maxUnavailable: "100%"
+  selector:
+    matchLabels:
+      k8s-app: cilium
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
+      annotations:
+        # This annotation plus the CriticalAddonsOnly toleration makes
+        # cilium to be a critical pod in the cluster, which ensures cilium
+        # gets priority scheduling.
+        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: >-
+          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+    spec:
+      serviceAccountName: cilium
+      initContainers:
+      - name: clean-cilium-state
+        image: docker.io/library/busybox:1.28.4
+        imagePullPolicy: IfNotPresent
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+        env:
+          - name: "CLEAN_CILIUM_STATE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: clean-cilium-state
+      containers:
+      - image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        name: cilium-agent
+        command: [ "cilium-agent" ]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "-t=vxlan"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+          - "--disable-ipv4=$(DISABLE_IPV4)"
+          - "--container-runtime=crio"
+        ports:
+          - name: prometheus
+            containerPort: 9090
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - "/cni-install.sh"
+          preStop:
+            exec:
+              command:
+                - "/cni-uninstall.sh"
+        env:
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+          - name: "DISABLE_IPV4"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: disable-ipv4
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+          - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-metrics-config
+                optional: true
+                key: prometheus-serve-addr
+          - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: legacy-host-allows-world
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          failureThreshold: 10
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+          - name: cni-path
+            mountPath: /host/opt/cni/bin
+          - name: etc-cni-netd
+            mountPath: /host/etc/cni/net.d
+          - name: crio-socket
+            mountPath: /var/run/crio.sock
+            readOnly: true
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+        securityContext:
+          capabilities:
+            add:
+              - "NET_ADMIN"
+          privileged: true
+      hostNetwork: true
+      volumes:
+          # To keep state between restarts / upgrades
+        - name: cilium-run
+          hostPath:
+            path: /var/run/cilium
+          # To keep state between restarts / upgrades
+        - name: bpf-maps
+          hostPath:
+            path: /sys/fs/bpf
+          # To read labels from CRI-O containers running in the host
+        - name: crio-socket
+          hostPath:
+            path: /var/run/crio.sock
+          # To install cilium cni plugin in the host
+        - name: cni-path
+          hostPath:
+            path: /opt/cni/bin
+          # To install cilium cni configuration in the host
+        - name: etc-cni-netd
+          hostPath:
+              path: /etc/cni/net.d
+          # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+            - key: etcd-config
+              path: etcd.config
+          # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+      restartPolicy: Always
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+      # Mark cilium's pod as critical for rescheduling
+      - key: CriticalAddonsOnly
+        operator: "Exists"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- kind: Group
+  name: system:nodes
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
+  - thirdpartyresources
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumendpoints
+  verbs:
+  - "*"
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium
+  namespace: kube-system
+---

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -1,0 +1,188 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  updateStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
+      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
+      maxUnavailable: "100%"
+  selector:
+    matchLabels:
+      k8s-app: cilium
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
+      annotations:
+        # This annotation plus the CriticalAddonsOnly toleration makes
+        # cilium to be a critical pod in the cluster, which ensures cilium
+        # gets priority scheduling.
+        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: >-
+          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+    spec:
+      serviceAccountName: cilium
+      initContainers:
+      - name: clean-cilium-state
+        image: docker.io/library/busybox:1.28.4
+        imagePullPolicy: IfNotPresent
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+        env:
+          - name: "CLEAN_CILIUM_STATE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: clean-cilium-state
+      containers:
+      - image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        name: cilium-agent
+        command: [ "cilium-agent" ]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "-t=vxlan"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+          - "--disable-ipv4=$(DISABLE_IPV4)"
+        ports:
+          - name: prometheus
+            containerPort: 9090
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - "/cni-install.sh"
+          preStop:
+            exec:
+              command:
+                - "/cni-uninstall.sh"
+        env:
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+          - name: "DISABLE_IPV4"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: disable-ipv4
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+          - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-metrics-config
+                optional: true
+                key: prometheus-serve-addr
+          - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: legacy-host-allows-world
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          failureThreshold: 10
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+          - name: cni-path
+            mountPath: /host/opt/cni/bin
+          - name: etc-cni-netd
+            mountPath: /host/etc/cni/net.d
+          - name: docker-socket
+            mountPath: /var/run/docker.sock
+            readOnly: true
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+        securityContext:
+          capabilities:
+            add:
+              - "NET_ADMIN"
+          privileged: true
+      hostNetwork: true
+      volumes:
+          # To keep state between restarts / upgrades
+        - name: cilium-run
+          hostPath:
+            path: /var/run/cilium
+          # To keep state between restarts / upgrades
+        - name: bpf-maps
+          hostPath:
+            path: /sys/fs/bpf
+          # To read docker events from the node
+        - name: docker-socket
+          hostPath:
+            path: /var/run/docker.sock
+          # To install cilium cni plugin in the host
+        - name: cni-path
+          hostPath:
+            path: /opt/cni/bin
+          # To install cilium cni configuration in the host
+        - name: etc-cni-netd
+          hostPath:
+              path: /etc/cni/net.d
+          # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+            - key: etcd-config
+              path: etcd.config
+          # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+      restartPolicy: Always
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+      # Mark cilium's pod as critical for rescheduling
+      - key: CriticalAddonsOnly
+        operator: "Exists"

--- a/examples/kubernetes/1.12/cilium-rbac.yaml
+++ b/examples/kubernetes/1.12/cilium-rbac.yaml
@@ -1,0 +1,78 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- kind: Group
+  name: system:nodes
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
+  - thirdpartyresources
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumendpoints
+  verbs:
+  - "*"

--- a/examples/kubernetes/1.12/cilium-sa.yaml
+++ b/examples/kubernetes/1.12/cilium-sa.yaml
@@ -1,0 +1,5 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium
+  namespace: kube-system

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -1,0 +1,305 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+  # This etcd-config contains the etcd endpoints of your cluster. If you use
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
+  etcd-config: |-
+    ---
+    endpoints:
+    - http://127.0.0.1:31079
+    #
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
+    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
+    #
+    # In case you want client to server authentication, uncomment the following
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
+    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  disable-ipv4: "false"
+  # If you want to clean cilium state; change this value to true
+  clean-cilium-state: "false"
+  legacy-host-allows-world: "false"
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  updateStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
+      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
+      maxUnavailable: "100%"
+  selector:
+    matchLabels:
+      k8s-app: cilium
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
+      annotations:
+        # This annotation plus the CriticalAddonsOnly toleration makes
+        # cilium to be a critical pod in the cluster, which ensures cilium
+        # gets priority scheduling.
+        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: >-
+          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+    spec:
+      serviceAccountName: cilium
+      initContainers:
+      - name: clean-cilium-state
+        image: docker.io/library/busybox:1.28.4
+        imagePullPolicy: IfNotPresent
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+        env:
+          - name: "CLEAN_CILIUM_STATE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: clean-cilium-state
+      containers:
+      - image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        name: cilium-agent
+        command: [ "cilium-agent" ]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "-t=vxlan"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+          - "--disable-ipv4=$(DISABLE_IPV4)"
+        ports:
+          - name: prometheus
+            containerPort: 9090
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - "/cni-install.sh"
+          preStop:
+            exec:
+              command:
+                - "/cni-uninstall.sh"
+        env:
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+          - name: "DISABLE_IPV4"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: disable-ipv4
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+          - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-metrics-config
+                optional: true
+                key: prometheus-serve-addr
+          - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                optional: true
+                key: legacy-host-allows-world
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          failureThreshold: 10
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+          - name: bpf-maps
+            mountPath: /sys/fs/bpf
+          - name: cilium-run
+            mountPath: /var/run/cilium
+          - name: cni-path
+            mountPath: /host/opt/cni/bin
+          - name: etc-cni-netd
+            mountPath: /host/etc/cni/net.d
+          - name: docker-socket
+            mountPath: /var/run/docker.sock
+            readOnly: true
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+        securityContext:
+          capabilities:
+            add:
+              - "NET_ADMIN"
+          privileged: true
+      hostNetwork: true
+      volumes:
+          # To keep state between restarts / upgrades
+        - name: cilium-run
+          hostPath:
+            path: /var/run/cilium
+          # To keep state between restarts / upgrades
+        - name: bpf-maps
+          hostPath:
+            path: /sys/fs/bpf
+          # To read docker events from the node
+        - name: docker-socket
+          hostPath:
+            path: /var/run/docker.sock
+          # To install cilium cni plugin in the host
+        - name: cni-path
+          hostPath:
+            path: /opt/cni/bin
+          # To install cilium cni configuration in the host
+        - name: etc-cni-netd
+          hostPath:
+              path: /etc/cni/net.d
+          # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+            - key: etcd-config
+              path: etcd.config
+          # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+      restartPolicy: Always
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+      # Mark cilium's pod as critical for rescheduling
+      - key: CriticalAddonsOnly
+        operator: "Exists"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- kind: Group
+  name: system:nodes
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
+  - thirdpartyresources
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumendpoints
+  verbs:
+  - "*"
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium
+  namespace: kube-system
+---

--- a/examples/kubernetes/1.12/transforms2sed.sed
+++ b/examples/kubernetes/1.12/transforms2sed.sed
@@ -1,0 +1,2 @@
+s+__DS_API_VERSION__+apps/v1+g
+s+__RBAC_API_VERSION__+rbac.authorization.k8s.io/v1+g

--- a/examples/kubernetes/Makefile
+++ b/examples/kubernetes/Makefile
@@ -4,7 +4,7 @@ ifeq ($(CILIUM_VERSION),)
     CILIUM_VERSION = "v$(shell cat ../../VERSION)"
 endif
 
-K8S_VERSIONS = 1.7 1.8 1.9 1.10 1.11
+K8S_VERSIONS = 1.7 1.8 1.9 1.10 1.11 1.12
 
 # make_concat creates a concatenated YAML file specific for a K8s version.
 # $(1) is the K8s version. $(2) is the concatenated file.

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -92,6 +92,7 @@ pipeline {
             }
             steps {
                 sh 'cd ${TESTDIR}; K8S_VERSION=1.11 vagrant up --no-provision'
+                sh 'cd ${TESTDIR}; K8S_VERSION=1.12 vagrant up --no-provision'
             }
         }
         stage('Non-release-k8s-versions') {
@@ -104,6 +105,9 @@ pipeline {
                 parallel(
                     "K8s-1.11":{
                         sh 'cd ${TESTDIR}; K8S_VERSION=1.11 ginkgo --focus=" K8s*" --failFast=${FAILFAST}'
+                    },
+                    "K8s-1.12":{
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.12 ginkgo --focus=" K8s*" --failFast=${FAILFAST}'
                     },
                 )
             }
@@ -123,6 +127,7 @@ pipeline {
             sh "cd ${TESTDIR}; K8S_VERSION=1.9 vagrant destroy -f || true"
             sh "cd ${TESTDIR}; K8S_VERSION=1.10 vagrant destroy -f || true"
             sh "cd ${TESTDIR}; K8S_VERSION=1.11 vagrant destroy -f || true"
+            sh "cd ${TESTDIR}; K8S_VERSION=1.12 vagrant destroy -f || true"
             sh "cd ${TESTDIR}; ./post_build_agent.sh || true"
             cleanWs()
         }

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -57,10 +57,9 @@ pipeline {
             steps {
                 sh 'cd ${TESTDIR}; K8S_VERSION=1.8 vagrant up --no-provision'
                 sh 'cd ${TESTDIR}; K8S_VERSION=1.9 vagrant up --no-provision'
-                sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant up --no-provision'
             }
         }
-        stage('BDD-Test-k8s') {
+        stage('BDD-Test-k8s-1.8-and-1.9') {
             environment {
                 FAILFAST=setIfPR("true", "false")
             }
@@ -74,9 +73,6 @@ pipeline {
                     },
                     "K8s-1.9":{
                         sh 'cd ${TESTDIR}; K8S_VERSION=1.9 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST}'
-                    },
-                    "K8s-1.10":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST}'
                     },
                 )
             }
@@ -95,10 +91,11 @@ pipeline {
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
             }
             steps {
+                sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant up --no-provision'
                 sh 'cd ${TESTDIR}; K8S_VERSION=1.12 vagrant up --no-provision'
             }
         }
-        stage('Non-release-k8s-versions') {
+        stage('BDD-Test-k8s-1.10-and-1.12') {
             environment {
                 FAILFAST=setIfPR("true", "false")
             options {
@@ -106,6 +103,9 @@ pipeline {
             }
             steps {
                 parallel(
+                    "K8s-1.10":{
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST}'
+                    },
                     "K8s-1.12":{
                         sh 'cd ${TESTDIR}; K8S_VERSION=1.12 ginkgo --focus=" K8s*" --failFast=${FAILFAST}'
                     },

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -57,6 +57,7 @@ pipeline {
             steps {
                 sh 'cd ${TESTDIR}; K8S_VERSION=1.8 vagrant up --no-provision'
                 sh 'cd ${TESTDIR}; K8S_VERSION=1.9 vagrant up --no-provision'
+                sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant up --no-provision'
             }
         }
         stage('BDD-Test-k8s') {
@@ -73,6 +74,9 @@ pipeline {
                     },
                     "K8s-1.9":{
                         sh 'cd ${TESTDIR}; K8S_VERSION=1.9 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST}'
+                    },
+                    "K8s-1.10":{
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST}'
                     },
                 )
             }
@@ -91,7 +95,6 @@ pipeline {
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
             }
             steps {
-                sh 'cd ${TESTDIR}; K8S_VERSION=1.11 vagrant up --no-provision'
                 sh 'cd ${TESTDIR}; K8S_VERSION=1.12 vagrant up --no-provision'
             }
         }
@@ -103,9 +106,6 @@ pipeline {
             }
             steps {
                 parallel(
-                    "K8s-1.11":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.11 ginkgo --focus=" K8s*" --failFast=${FAILFAST}'
-                    },
                     "K8s-1.12":{
                         sh 'cd ${TESTDIR}; K8S_VERSION=1.12 ginkgo --focus=" K8s*" --failFast=${FAILFAST}'
                     },
@@ -126,7 +126,6 @@ pipeline {
             sh "cd ${TESTDIR}; K8S_VERSION=1.8 vagrant destroy -f || true"
             sh "cd ${TESTDIR}; K8S_VERSION=1.9 vagrant destroy -f || true"
             sh "cd ${TESTDIR}; K8S_VERSION=1.10 vagrant destroy -f || true"
-            sh "cd ${TESTDIR}; K8S_VERSION=1.11 vagrant destroy -f || true"
             sh "cd ${TESTDIR}; K8S_VERSION=1.12 vagrant destroy -f || true"
             sh "cd ${TESTDIR}; ./post_build_agent.sh || true"
             cleanWs()

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
             }
             steps {
                 sh 'cd ${TESTDIR}; K8S_VERSION=1.7 vagrant up --no-provision'
-                sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant up --no-provision'
+                sh 'cd ${TESTDIR}; K8S_VERSION=1.11 vagrant up --no-provision'
             }
         }
         stage('BDD-Test-PR') {
@@ -72,8 +72,8 @@ pipeline {
                     "K8s-1.7":{
                         sh 'cd ${TESTDIR}; K8S_VERSION=1.7 ginkgo --focus=" K8sValidated*" -v --failFast=${FAILFAST}'
                     },
-                    "K8s-1.10":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --focus=" K8sValidated*" -v --failFast=${FAILFAST}'
+                    "K8s-1.11":{
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.11 ginkgo --focus=" K8sValidated*" -v --failFast=${FAILFAST}'
                     },
                     failFast: true
                 )
@@ -93,7 +93,7 @@ pipeline {
     post {
         always {
             sh 'cd ${TESTDIR}/test/; K8S_VERSION=1.7 vagrant destroy -f || true'
-            sh 'cd ${TESTDIR}/test/; K8S_VERSION=1.10 vagrant destroy -f || true'
+            sh 'cd ${TESTDIR}/test/; K8S_VERSION=1.11 vagrant destroy -f || true'
             cleanWs()
         }
         success {

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 120, unit: 'MINUTES')
+        timeout(time: 210, unit: 'MINUTES')
         timestamps()
         ansiColor('xterm')
     }
@@ -61,7 +61,7 @@ pipeline {
             }
 
             options {
-                timeout(time: 90, unit: 'MINUTES')
+                timeout(time: 120, unit: 'MINUTES')
             }
 
             steps {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -871,9 +871,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner, opts models.ConfigurationMap) (
 	// If no policy or options change occurred for this endpoint then the endpoint is
 	// already running the latest revision, otherwise we have to wait for
 	// the regeneration of the endpoint to complete.
-	if !policyChanged && !optsChanged {
-		e.setPolicyRevision(revision)
-	}
+	policyChanged := l3PolicyChanged || l4PolicyChanged
 
 	e.getLogger().WithFields(logrus.Fields{
 		"policyChanged":       policyChanged,
@@ -1048,6 +1046,11 @@ func (e *Endpoint) TriggerPolicyUpdatesLocked(owner Owner, opts models.Configura
 	needToRegenerateBPF, _, _, err := e.regeneratePolicy(owner, opts)
 	if err != nil {
 		return false, ctCleaned, fmt.Errorf("%s: %s", e.StringID(), err)
+	}
+	// If it does not need datapath regeneration then we should set the policy
+	// revision with nextPolicyRevision.
+	if !needToRegenerateBPF {
+		e.setPolicyRevision(e.nextPolicyRevision)
 	}
 
 	// CurrentStatus will be not OK when we have an uncleared error in BPF,

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -205,6 +205,25 @@ func (n *EndpointSelector) IsWildcard() bool {
 		len(n.LabelSelector.MatchLabels)+len(n.LabelSelector.MatchExpressions) == 0
 }
 
+// ConvertToLabelSelectorRequirementSlice converts the MatchLabels and
+// MatchExpressions within the specified EndpointSelector into a list of
+// LabelSelectorRequirements.
+func (n *EndpointSelector) ConvertToLabelSelectorRequirementSlice() []metav1.LabelSelectorRequirement {
+	requirements := make([]metav1.LabelSelectorRequirement, 0, len(n.MatchExpressions)+len(n.MatchLabels))
+	// Append already existing match expressions.
+	requirements = append(requirements, n.MatchExpressions...)
+	// Convert each MatchLables to LabelSelectorRequirement.
+	for key, value := range n.MatchLabels {
+		requirementFromMatchLabels := metav1.LabelSelectorRequirement{
+			Key:      key,
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{value},
+		}
+		requirements = append(requirements, requirementFromMatchLabels)
+	}
+	return requirements
+}
+
 // EndpointSelectorSlice is a slice of EndpointSelectors that can be sorted.
 type EndpointSelectorSlice []EndpointSelector
 

--- a/pkg/policy/l4Filter_test.go
+++ b/pkg/policy/l4Filter_test.go
@@ -170,7 +170,7 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndShadowedL7(c *C) {
 	ctx.Logging = logging.NewLogBackend(buffer, "", 0)
 
 	ingressState := traceState{}
-	res, err := rule1.resolveL4IngressPolicy(&ctx, &ingressState, NewL4Policy())
+	res, err := rule1.resolveL4IngressPolicy(&ctx, &ingressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
@@ -303,7 +303,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7HTTP(c *C)
 	c.Log(buffer)
 
 	state := traceState{}
-	res, err := identicalHTTPRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err := identicalHTTPRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -311,7 +311,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7HTTP(c *C)
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = identicalHTTPRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = identicalHTTPRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -376,7 +376,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7Kafka(c *C
 	}
 
 	state := traceState{}
-	res, err := identicalKafkaRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err := identicalKafkaRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -384,7 +384,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7Kafka(c *C
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = identicalKafkaRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = identicalKafkaRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -436,7 +436,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndMismatchingParsers(c *
 	c.Log(buffer)
 
 	state := traceState{}
-	res, err := conflictingParsersRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err := conflictingParsersRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
 
@@ -480,7 +480,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndMismatchingParsers(c *
 	c.Log(buffer)
 
 	state = traceState{}
-	res, err = conflictingParsersRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err = conflictingParsersRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
 }
@@ -531,7 +531,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 	}
 
 	state := traceState{}
-	res, err := shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err := shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -539,7 +539,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -586,7 +586,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 	}
 
 	state = traceState{}
-	res, err = shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err = shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -594,7 +594,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -666,7 +666,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 	}
 
 	state := traceState{}
-	res, err := shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err := shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -674,7 +674,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -733,7 +733,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 	}
 
 	state = traceState{}
-	res, err = shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err = shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -741,7 +741,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -816,7 +816,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 	}
 
 	state := traceState{}
-	res, err := case8Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err := case8Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -824,7 +824,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = case8Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = case8Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -892,7 +892,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 	}
 
 	state = traceState{}
-	res, err = case8Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err = case8Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -900,7 +900,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = case8Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = case8Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -952,12 +952,12 @@ func (ds *PolicyTestSuite) TestL3SelectingEndpointAndL3AllowAllMergeConflictingL
 	c.Log(buffer)
 
 	state := traceState{}
-	res, err := conflictingL7Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err := conflictingL7Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
 
 	state = traceState{}
-	res, err = conflictingL7Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = conflictingL7Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -1003,12 +1003,12 @@ func (ds *PolicyTestSuite) TestL3SelectingEndpointAndL3AllowAllMergeConflictingL
 	c.Log(buffer)
 
 	state = traceState{}
-	res, err = conflictingL7Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err = conflictingL7Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
 
 	state = traceState{}
-	res, err = conflictingL7Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = conflictingL7Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -1077,7 +1077,7 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointsSelectedAllowSameL7(
 	}
 
 	state := traceState{}
-	res, err := selectDifferentEndpointsRestrictL7.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err := selectDifferentEndpointsRestrictL7.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -1090,7 +1090,7 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointsSelectedAllowSameL7(
 	c.Log(buffer)
 
 	state = traceState{}
-	res, err = selectDifferentEndpointsRestrictL7.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = selectDifferentEndpointsRestrictL7.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -1141,7 +1141,7 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointSelectedAllowAllL7(c 
 	}
 
 	state := traceState{}
-	res, err := selectDifferentEndpointsAllowAllL7.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err := selectDifferentEndpointsAllowAllL7.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -1154,7 +1154,84 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointSelectedAllowAllL7(c 
 	c.Log(buffer)
 
 	state = traceState{}
-	res, err = selectDifferentEndpointsAllowAllL7.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = selectDifferentEndpointsAllowAllL7.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
+	c.Assert(err, IsNil)
+	c.Assert(res, IsNil)
+	c.Assert(state.selectedRules, Equals, 0)
+	c.Assert(state.matchedRules, Equals, 0)
+}
+
+// Case 12: allow all at L3 in one rule with restrictions at L7. Determine that
+//          the host should always be allowed. From Host should go to proxy
+//          allow all; other L3 should restrict at L7 in a separate filter.
+func (ds *PolicyTestSuite) TestAllowingLocalhostShadowsL7(c *C) {
+
+	// This test checks that when the AllowLocalhost=always option is
+	// enabled, we always wildcard the host at L7. That means we need to
+	// set the option in the config, and of course clean up afterwards so
+	// that this test doesn't affect subsequent tests.
+	oldLocalhostOpt := option.Config.AllowLocalhost
+	option.Config.AllowLocalhost = option.AllowLocalhostAlways
+	defer func() { option.Config.AllowLocalhost = oldLocalhostOpt }()
+
+	rule := &rule{
+		Rule: api.Rule{
+			EndpointSelector: endpointSelectorA,
+			Ingress: []api.IngressRule{
+				{
+					FromEndpoints: []api.EndpointSelector{api.WildcardEndpointSelector},
+					ToPorts: []api.PortRule{{
+						Ports: []api.PortProtocol{
+							{Port: "80", Protocol: api.ProtoTCP},
+						},
+						Rules: &api.L7Rules{
+							HTTP: []api.PortRuleHTTP{
+								{Method: "GET", Path: "/"},
+							},
+						},
+					}},
+				},
+			},
+		}}
+
+	buffer := new(bytes.Buffer)
+	ctxToA := SearchContext{To: labelsA, Trace: TRACE_VERBOSE}
+	ctxToA.Logging = logging.NewLogBackend(buffer, "", 0)
+	c.Log(buffer)
+
+	expected := NewL4Policy()
+	expected.Ingress["80/TCP"] = L4Filter{
+		Port:      80,
+		Protocol:  api.ProtoTCP,
+		U8Proto:   6,
+		Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
+		L7Parser:  ParserTypeHTTP,
+		L7RulesPerEp: L7DataMap{
+			api.WildcardEndpointSelector: api.L7Rules{
+				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
+			},
+			hostSelector: api.L7Rules{}, // Empty => Allow all
+		},
+		Ingress:          true,
+		DerivedFromRules: labels.LabelArrayList{nil},
+	}
+
+	state := traceState{}
+	res, err := rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
+	c.Assert(err, IsNil)
+	c.Assert(res, Not(IsNil))
+	c.Assert(*res, comparator.DeepEquals, *expected)
+	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 0)
+
+	// Endpoints not selected by the rule should not match the rule.
+	buffer = new(bytes.Buffer)
+	ctxToC := SearchContext{To: labelsC, Trace: TRACE_VERBOSE}
+	ctxToC.Logging = logging.NewLogBackend(buffer, "", 0)
+	c.Log(buffer)
+
+	state = traceState{}
+	res, err = rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/op/go-logging"
 	. "gopkg.in/check.v1"
 )
@@ -558,6 +560,137 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
 				},
 			},
 			DerivedFromRules: labels.LabelArrayList{labelsL3, labelsKafka, labelsL3},
+		},
+	}
+	c.Assert((*policy), comparator.DeepEquals, expectedPolicy)
+}
+
+func (ds *PolicyTestSuite) TestL3DependentL4IngressFromRequires(c *C) {
+	repo := NewPolicyRepository()
+
+	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
+	selBar1 := api.NewESFromLabels(labels.ParseSelectLabel("id=bar1"))
+	selBar2 := api.NewESFromLabels(labels.ParseSelectLabel("id=bar2"))
+
+	l480Rule := api.Rule{
+		EndpointSelector: selFoo,
+		Ingress: []api.IngressRule{
+			{
+				FromEndpoints: []api.EndpointSelector{
+					selBar1,
+				},
+				ToPorts: []api.PortRule{{
+					Ports: []api.PortProtocol{
+						{Port: "80", Protocol: api.ProtoTCP},
+					},
+				}},
+			},
+			{
+				FromRequires: []api.EndpointSelector{selBar2},
+			},
+		},
+	}
+	l480Rule.Sanitize()
+	_, err := repo.Add(l480Rule)
+	c.Assert(err, IsNil)
+
+	ctx := &SearchContext{
+		To: labels.ParseSelectLabelArray("id=foo"),
+	}
+
+	repo.Mutex.RLock()
+	defer repo.Mutex.RUnlock()
+
+	policy, err := repo.ResolveL4IngressPolicy(ctx)
+	c.Assert(err, IsNil)
+
+	expectedPolicy := L4PolicyMap{
+		"80/TCP": L4Filter{
+			Port:     80,
+			Protocol: api.ProtoTCP,
+			U8Proto:  0x6,
+			Endpoints: api.EndpointSelectorSlice{
+				api.EndpointSelector{
+					LabelSelector: &v1.LabelSelector{
+						MatchLabels: map[string]string{"any.id": "bar1"},
+						MatchExpressions: []v1.LabelSelectorRequirement{
+							{
+								Key:      "any.id",
+								Operator: v1.LabelSelectorOpIn,
+								Values:   []string{"bar2"},
+							},
+						},
+					},
+				},
+			},
+			L7RulesPerEp:     L7DataMap{},
+			Ingress:          true,
+			DerivedFromRules: labels.LabelArrayList{nil},
+		},
+	}
+	c.Assert((*policy), comparator.DeepEquals, expectedPolicy)
+}
+
+func (ds *PolicyTestSuite) TestL3DependentL4EgressFromRequires(c *C) {
+	repo := NewPolicyRepository()
+
+	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
+	selBar1 := api.NewESFromLabels(labels.ParseSelectLabel("id=bar1"))
+	selBar2 := api.NewESFromLabels(labels.ParseSelectLabel("id=bar2"))
+
+	l480Rule := api.Rule{
+		EndpointSelector: selFoo,
+		Egress: []api.EgressRule{
+			{
+				ToEndpoints: []api.EndpointSelector{
+					selBar1,
+				},
+				ToPorts: []api.PortRule{{
+					Ports: []api.PortProtocol{
+						{Port: "80", Protocol: api.ProtoTCP},
+					},
+				}},
+			},
+			{
+				ToRequires: []api.EndpointSelector{selBar2},
+			},
+		},
+	}
+	l480Rule.Sanitize()
+	_, err := repo.Add(l480Rule)
+	c.Assert(err, IsNil)
+
+	ctx := &SearchContext{
+		From: labels.ParseSelectLabelArray("id=foo"),
+	}
+
+	repo.Mutex.RLock()
+	defer repo.Mutex.RUnlock()
+
+	policy, err := repo.ResolveL4EgressPolicy(ctx)
+	c.Assert(err, IsNil)
+
+	expectedPolicy := L4PolicyMap{
+		"80/TCP": L4Filter{
+			Port:     80,
+			Protocol: api.ProtoTCP,
+			U8Proto:  0x6,
+			Endpoints: api.EndpointSelectorSlice{
+				api.EndpointSelector{
+					LabelSelector: &v1.LabelSelector{
+						MatchLabels: map[string]string{"any.id": "bar1"},
+						MatchExpressions: []v1.LabelSelectorRequirement{
+							{
+								Key:      "any.id",
+								Operator: v1.LabelSelectorOpIn,
+								Values:   []string{"bar2"},
+							},
+						},
+					},
+				},
+			},
+			L7RulesPerEp:     L7DataMap{},
+			DerivedFromRules: labels.LabelArrayList{nil},
 		},
 	}
 	c.Assert((*policy), comparator.DeepEquals, expectedPolicy)

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -22,6 +22,8 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/policy/api"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type rule struct {
@@ -177,7 +179,7 @@ func (state *traceState) unSelectRule(ctx *SearchContext, labels labels.LabelArr
 }
 
 // resolveL4IngressPolicy determines whether (TODO ianvernon)
-func (r *rule) resolveL4IngressPolicy(ctx *SearchContext, state *traceState, result *L4Policy) (*L4Policy, error) {
+func (r *rule) resolveL4IngressPolicy(ctx *SearchContext, state *traceState, result *L4Policy, requirements []v1.LabelSelectorRequirement) (*L4Policy, error) {
 	if !r.EndpointSelector.Matches(ctx.To) {
 		state.unSelectRule(ctx, ctx.To, r)
 		return nil, nil
@@ -190,7 +192,25 @@ func (r *rule) resolveL4IngressPolicy(ctx *SearchContext, state *traceState, res
 		ctx.PolicyTrace("    No L4 ingress rules\n")
 	}
 	for _, ingressRule := range r.Ingress {
-		cnt, err := mergeL4Ingress(ctx, ingressRule, r.Rule.Labels.DeepCopy(), result.Ingress)
+		ruleCopy := ingressRule
+
+		// For each FromEndpoints in each ingress rule, add requirements, which
+		// is a flattened list of all EndpointSelectors from all FromRequires
+		// from rules which select the labels in ctx.To. This ensures that
+		// FromRequires is taken into account even if it isn't part of the current
+		// rule over which we are iterating.
+		if len(requirements) > 0 {
+			// Create a deep copy of the rule, as we are going to modify FromEndpoints
+			// with requirementsSelector. We don't want to modify the rule itself
+			// in the policy repository.
+			ruleCopy = *ingressRule.DeepCopy()
+			// Update each EndpointSelector in FromEndpoints to contain requirements.
+			for _, fromEndpoint := range ruleCopy.FromEndpoints {
+				fromEndpoint.MatchExpressions = append(fromEndpoint.MatchExpressions, requirements...)
+			}
+		}
+
+		cnt, err := mergeL4Ingress(ctx, ruleCopy, r.Rule.Labels.DeepCopy(), result.Ingress)
 		if err != nil {
 			return nil, err
 		}
@@ -511,7 +531,7 @@ func mergeL4EgressPort(ctx *SearchContext, endpoints []api.EndpointSelector, r a
 	return 1, nil
 }
 
-func (r *rule) resolveL4EgressPolicy(ctx *SearchContext, state *traceState, result *L4Policy) (*L4Policy, error) {
+func (r *rule) resolveL4EgressPolicy(ctx *SearchContext, state *traceState, result *L4Policy, requirements []v1.LabelSelectorRequirement) (*L4Policy, error) {
 
 	if !r.EndpointSelector.Matches(ctx.From) {
 		state.unSelectRule(ctx, ctx.From, r)
@@ -525,7 +545,24 @@ func (r *rule) resolveL4EgressPolicy(ctx *SearchContext, state *traceState, resu
 		ctx.PolicyTrace("    No L4 rules\n")
 	}
 	for _, egressRule := range r.Egress {
-		cnt, err := mergeL4Egress(ctx, egressRule, r.Rule.Labels.DeepCopy(), result.Egress)
+		ruleCopy := egressRule
+		// For each ToEndpoints in each egress rule, add the requirements, which
+		// is a flattened list of all EndpointSelectors from all ToRequires
+		// from rules which select the labels in ctx.From. This ensures that
+		// ToRequires is taken into account even if it isn't part of the current
+		// rule over which we are iterating.
+		if len(requirements) > 0 {
+			// Create a deep copy of the rule, as we are going to modify
+			// ToEndpoints with requirements; we don't want to modify the rule
+			// in the repository.
+			ruleCopy = *egressRule.DeepCopy()
+			for _, toEndpoint := range ruleCopy.ToEndpoints {
+				// Update each EndpointSelector in ToEndpoints to contain
+				// requirements.
+				toEndpoint.MatchExpressions = append(toEndpoint.MatchExpressions, requirements...)
+			}
+		}
+		cnt, err := mergeL4Egress(ctx, ruleCopy, r.Rule.Labels.DeepCopy(), result.Egress)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -177,11 +177,11 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 
 	ingressState := traceState{}
 	egressState := traceState{}
-	res, err := rule1.resolveL4IngressPolicy(toBar, &ingressState, NewL4Policy())
+	res, err := rule1.resolveL4IngressPolicy(toBar, &ingressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
-	res2, err := rule1.resolveL4EgressPolicy(fromBar, &egressState, NewL4Policy())
+	res2, err := rule1.resolveL4EgressPolicy(fromBar, &egressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res2, Not(IsNil))
 
@@ -198,9 +198,9 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	ingressState = traceState{}
 	egressState = traceState{}
 
-	res, err = rule1.resolveL4IngressPolicy(toFoo, &ingressState, NewL4Policy())
+	res, err = rule1.resolveL4IngressPolicy(toFoo, &ingressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
-	res2, err = rule1.resolveL4EgressPolicy(fromFoo, &ingressState, NewL4Policy())
+	res2, err = rule1.resolveL4EgressPolicy(fromFoo, &ingressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 
 	c.Assert(res, IsNil)
@@ -278,11 +278,11 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 
 	ingressState = traceState{}
 	egressState = traceState{}
-	res, err = rule2.resolveL4IngressPolicy(toBar, &ingressState, NewL4Policy())
+	res, err = rule2.resolveL4IngressPolicy(toBar, &ingressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
-	res2, err = rule2.resolveL4EgressPolicy(fromBar, &egressState, NewL4Policy())
+	res2, err = rule2.resolveL4EgressPolicy(fromBar, &egressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res2, Not(IsNil))
 
@@ -299,11 +299,11 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	ingressState = traceState{}
 	egressState = traceState{}
 
-	res, err = rule2.resolveL4IngressPolicy(toFoo, &ingressState, NewL4Policy())
+	res, err = rule2.resolveL4IngressPolicy(toFoo, &ingressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 
-	res2, err = rule2.resolveL4EgressPolicy(fromFoo, &egressState, NewL4Policy())
+	res2, err = rule2.resolveL4EgressPolicy(fromFoo, &egressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 
@@ -353,7 +353,7 @@ func (ds *PolicyTestSuite) TestMergeL4PolicyIngress(c *C) {
 	}
 
 	state := traceState{}
-	res, err := rule1.resolveL4IngressPolicy(toBar, &state, NewL4Policy())
+	res, err := rule1.resolveL4IngressPolicy(toBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -407,7 +407,7 @@ func (ds *PolicyTestSuite) TestMergeL4PolicyEgress(c *C) {
 	}
 
 	state := traceState{}
-	res, err := rule1.resolveL4EgressPolicy(fromBar, &state, NewL4Policy())
+	res, err := rule1.resolveL4EgressPolicy(fromBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -484,7 +484,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	}
 
 	state := traceState{}
-	res, err := rule1.resolveL4IngressPolicy(toBar, &state, NewL4Policy())
+	res, err := rule1.resolveL4IngressPolicy(toBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -492,7 +492,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = rule1.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = rule1.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -547,7 +547,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	}
 
 	state = traceState{}
-	res, err = rule2.resolveL4IngressPolicy(toBar, &state, NewL4Policy())
+	res, err = rule2.resolveL4IngressPolicy(toBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -555,19 +555,19 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = rule2.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = rule2.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
 	c.Assert(state.matchedRules, Equals, 0)
 
 	// Resolve rule1's policy, then try to add rule2.
-	res, err = rule1.resolveL4IngressPolicy(toBar, &state, NewL4Policy())
+	res, err = rule1.resolveL4IngressPolicy(toBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
 	state = traceState{}
-	_, err = rule2.resolveL4IngressPolicy(toBar, &state, res)
+	_, err = rule2.resolveL4IngressPolicy(toBar, &state, res, nil)
 
 	c.Assert(err, Not(IsNil))
 
@@ -629,7 +629,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	}
 
 	state = traceState{}
-	res, err = rule3.resolveL4IngressPolicy(toBar, &state, NewL4Policy())
+	res, err = rule3.resolveL4IngressPolicy(toBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -702,7 +702,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	}
 
 	state := traceState{}
-	res, err := rule1.resolveL4EgressPolicy(fromBar, &state, NewL4Policy())
+	res, err := rule1.resolveL4EgressPolicy(fromBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -710,7 +710,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = rule1.resolveL4EgressPolicy(fromFoo, &state, NewL4Policy())
+	res, err = rule1.resolveL4EgressPolicy(fromFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -773,7 +773,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	}
 
 	state = traceState{}
-	res, err = rule2.resolveL4EgressPolicy(fromBar, &state, NewL4Policy())
+	res, err = rule2.resolveL4EgressPolicy(fromBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -781,14 +781,14 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = rule2.resolveL4EgressPolicy(fromFoo, &state, NewL4Policy())
+	res, err = rule2.resolveL4EgressPolicy(fromFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
 	c.Assert(state.matchedRules, Equals, 0)
 
 	// Resolve rule1's policy, then try to add rule2.
-	res, err = rule1.resolveL4EgressPolicy(fromBar, &state, NewL4Policy())
+	res, err = rule1.resolveL4EgressPolicy(fromBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
@@ -847,7 +847,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	}
 
 	state = traceState{}
-	res, err = rule3.resolveL4EgressPolicy(fromBar, &state, NewL4Policy())
+	res, err = rule3.resolveL4EgressPolicy(fromBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -1450,8 +1450,8 @@ func (ds *PolicyTestSuite) TestL4RuleLabels(c *C) {
 
 			rule := &rule{Rule: apiRule}
 
-			rule.resolveL4IngressPolicy(toBar, &traceState{}, finalPolicy)
-			rule.resolveL4EgressPolicy(fromBar, &traceState{}, finalPolicy)
+			rule.resolveL4IngressPolicy(toBar, &traceState{}, finalPolicy, nil)
+			rule.resolveL4EgressPolicy(fromBar, &traceState{}, finalPolicy, nil)
 		}
 
 		c.Assert(len(finalPolicy.Ingress), Equals, len(test.expectedIngressLabels), Commentf(test.description))

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,13 +1,13 @@
 version: "2"
 services:
   consul:
-    image: "consul:0.8.3"
+    image: "docker.io/library/consul:1.1.0"
     hostname: "consul"
     environment:
       - 'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true, "disable_update_check": true}'
     privileged: true
   etcd:
-    image: "quay.io/coreos/etcd:v3.1.0"
+    image: "quay.io/coreos/etcd:v3.2.17"
     hostname: "etcd"
     command: "etcd -name etcd0 -advertise-client-urls http://0.0.0.0:4002 -listen-client-urls http://0.0.0.0:4002 -initial-cluster-token etcd-cluster-1 -initial-cluster-state new"
     privileged: true

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - consul
       - etcd
-    image: "cilium/cilium-builder:2018-03-29"
+    image: "quay.io/cilium/cilium-builder:2018-06-21"
     command: "bash -c 'cd /go/src/github.com/cilium/cilium/; make tests-ginkgo-real'"
     privileged: true
     volumes:

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -57,7 +57,7 @@ case $K8S_VERSION in
         ;;
     "1.8")
         KUBERNETES_CNI_VERSION="0.5.1-00"
-        K8S_FULL_VERSION="1.8.13"
+        K8S_FULL_VERSION="1.8.14"
         ;;
     "1.9")
         KUBERNETES_CNI_VERSION="0.6.0-00"
@@ -67,12 +67,12 @@ case $K8S_VERSION in
         ;;
     "1.10")
         KUBERNETES_CNI_VERSION="0.6.0-00"
-        K8S_FULL_VERSION="1.10.3"
+        K8S_FULL_VERSION="1.10.4"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri"
         ;;
     "1.11")
-        KUBERNETES_CNI_VERSION="v0.6.0"
-        K8S_FULL_VERSION="1.11.0-beta.0"
+        KUBERNETES_CNI_VERSION="0.6.0-00"
+        K8S_FULL_VERSION="1.11.0"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri"
         ;;
@@ -87,14 +87,14 @@ esac
 
 #Install kubernetes
 case $K8S_VERSION in
-    "1.7"|"1.8"|"1.9"|"1.10")
+    "1.7"|"1.8"|"1.9"|"1.10"|"1.11")
         install_k8s_using_packages \
             kubernetes-cni=${KUBERNETES_CNI_VERSION} \
             kubelet=${K8S_FULL_VERSION}* \
             kubeadm=${K8S_FULL_VERSION}* \
             kubectl=${K8S_FULL_VERSION}*
         ;;
-    "1.11"|"1.12")
+    "1.12")
         install_k8s_using_binary "v${K8S_FULL_VERSION}" "${KUBERNETES_CNI_VERSION}"
         ;;
 esac

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -12,6 +12,18 @@ MOUNT_SYSTEMD="sys-fs-bpf.mount"
 NODE=$1
 IP=$2
 K8S_VERSION=$3
+IPv6=$4
+CONTAINER_RUNTIME=$5
+
+# Kubeadm default parameters
+export KUBEADM_ADDR='192.168.36.11'
+export KUBEADM_POD_NETWORK='10.10.0.0'
+export KUBEADM_POD_CIDR='16'
+export KUBEADM_CRI_SOCKET="/var/run/dockershim.sock"
+export KUBEADM_SLAVE_OPTIONS=""
+export KUBEADM_OPTIONS=""
+export K8S_FULL_VERSION=""
+export INSTALL_KUBEDNS=1
 
 source ${PROVISIONSRC}/helpers.bash
 
@@ -69,6 +81,7 @@ case $K8S_VERSION in
         KUBERNETES_CNI_VERSION="0.6.0-00"
         K8S_FULL_VERSION="1.10.4"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri"
+        KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
         ;;
     "1.11")
         KUBERNETES_CNI_VERSION="0.6.0-00"

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -76,6 +76,13 @@ case $K8S_VERSION in
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri"
         ;;
+    "1.12")
+        KUBERNETES_CNI_VERSION="v0.6.0"
+        K8S_FULL_VERSION="1.12.0-alpha.0"
+        KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
+        KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri"
+        INSTALL_KUBEDNS=0
+        ;;
 esac
 
 #Install kubernetes
@@ -87,7 +94,7 @@ case $K8S_VERSION in
             kubeadm=${K8S_FULL_VERSION}* \
             kubectl=${K8S_FULL_VERSION}*
         ;;
-    "1.11")
+    "1.11"|"1.12")
         install_k8s_using_binary "v${K8S_FULL_VERSION}" "${KUBERNETES_CNI_VERSION}"
         ;;
 esac

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -38,7 +38,7 @@ import (
 var (
 	log             = logging.DefaultLogger
 	DefaultSettings = map[string]string{
-		"K8S_VERSION": "1.10",
+		"K8S_VERSION": "1.11",
 	}
 	k8sNodesEnv         = "K8S_NODES"
 	commandsLogFileName = "cmds.log"


### PR DESCRIPTION
List of back ports:
PR: #4682 -- pkg/policy: take into account To / FromRequires when computing L4 policy (@ianvernon)
PR: #4678 -- endpoint: Fix restored endpoints not showing up in ipcache (@tgraf)
PR: #4663 -- backport: Only check merged PRs (@raybejjani) 
PR: #4655 -- test: Use latest stable etcd and consul images (@aanm) 
PR: #4653 -- tests: Update cilium-builder in unit tests to 2018-06-21 (@aanm) 
PR: #4636 -- Fix PolicyRevision of endpoint bumped prematurely (@aanm) 
PR: #4635 -- update cilium to golang 1.10.3 (@aanm)
PR: #4634 -- test: update k8s to 1.8.14, 1.10.4 and 1.11.0 (@aanm)
PR: #4633 -- test: update k8s to 1.8.14, 1.10.4 and 1.11.0-rc.1 (@aanm) 
PR: #4602 -- update cilium to golang 1.10.3 (@aanm)
PR: #4538 -- test: update k8s to 1.8.14, 1.10.4 and 1.11.0-rc.1 (@aanm)
PR: #4265 -- test: add k8s 1.12 test framework (@aanm)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4712)
<!-- Reviewable:end -->
