### PR TITLE
Test: Waiting all pods to terminate on K8st/Policies.go

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -70,6 +70,10 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 			"cilium endpoint list")
 	})
 
+	AfterAll(func() {
+		_ = kubectl.WaitCleanAllTerminatingPods()
+	})
+
 	JustBeforeEach(func() {
 		microscopeErr, microscopeCancel = kubectl.MicroscopeStart()
 		Expect(microscopeErr).To(BeNil(), "Microscope cannot be started")
@@ -844,6 +848,7 @@ EOF`, k, v)
 		})
 
 		AfterAll(func() {
+			_ = kubectl.Delete(demoPath)
 			_ = kubectl.Delete(demoManifest)
 			_ = kubectl.NamespaceDelete(secondNS)
 			_ = kubectl.NamespaceDelete(cnpSecondNS)


### PR DESCRIPTION
- Waiting to all pods to terminate before continue to other test.
- Clean demo application on namespaces test.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4719)
<!-- Reviewable:end -->
