### PR TITLE
service: Fix local service ID restore

### DIFF
--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -573,9 +573,7 @@ func (d *Daemon) SyncLBMap() error {
 	// are modifying the BPF maps, and calling Dump on a Map RLocks the maps.
 	log.Debug("iterating over services read from BPF LB Map and seeing if they have the same ID set in the KV store")
 	for _, svc := range newSVCList {
-		// Check if the services read from the lbmap have the same ID set in the
-		// KVStore.
-		kvL3n4AddrID, err := service.AcquireID(svc.FE.L3n4Addr, 0)
+		kvL3n4AddrID, err := service.RestoreID(svc.FE.L3n4Addr, uint32(svc.FE.ID))
 		if err != nil {
 			log.WithError(err).WithFields(logrus.Fields{
 				logfields.L3n4Addr: logfields.Repr(svc.FE.L3n4Addr),

--- a/pkg/service/id.go
+++ b/pkg/service/id.go
@@ -30,6 +30,20 @@ func AcquireID(l3n4Addr types.L3n4Addr, baseID uint32) (*types.L3n4AddrID, error
 	return acquireLocalID(l3n4Addr, baseID)
 }
 
+// RestoreID restores  previously used service ID
+func RestoreID(l3n4Addr types.L3n4Addr, baseID uint32) (*types.L3n4AddrID, error) {
+	log.WithField(logfields.L3n4Addr, logfields.Repr(l3n4Addr)).Debug("Restoring service")
+
+	if enableGlobalServiceIDs {
+		// global service IDs do not require to pass in the existing
+		// service ID. The global state will guarantee that the same
+		// service will resolve to the same service ID again.
+		return acquireGlobalID(l3n4Addr, 0)
+	}
+
+	return acquireLocalID(l3n4Addr, baseID)
+}
+
 // GetID returns the L3n4AddrID that belongs to the given id.
 func GetID(id uint32) (*types.L3n4AddrID, error) {
 	if enableGlobalServiceIDs {


### PR DESCRIPTION
Ensuring that the service ID is restored was taken care of by the state in the
kvstore. When using local service ID allocation, IDs were always allocated from
scratch as the existing service ID was not passed in as desired service ID.

Fixes: 3e19bde8a73 ("service: Introduce local service ID allocation")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4721)
<!-- Reviewable:end -->
