### PR TITLE
CI: Cilium Pre flight checks

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -158,7 +158,7 @@ func (res *CmdRes) FindResults(filter string) ([]reflect.Value, error) {
 // Filter returns the contents of res's stdout filtered using the provided
 // JSONPath filter in a buffer. Returns an error if the unmarshalling of the
 // contents of res's stdout fails.
-func (res *CmdRes) Filter(filter string) (*bytes.Buffer, error) {
+func (res *CmdRes) Filter(filter string) (*FilterBuffer, error) {
 	var data interface{}
 	result := new(bytes.Buffer)
 
@@ -173,7 +173,7 @@ func (res *CmdRes) Filter(filter string) (*bytes.Buffer, error) {
 	if err != nil {
 		return nil, err
 	}
-	return result, nil
+	return &FilterBuffer{result}, nil
 }
 
 // ByLines returns res's stdout split by the newline character .

--- a/test/helpers/filterBuffer.go
+++ b/test/helpers/filterBuffer.go
@@ -1,0 +1,47 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"bytes"
+	"strings"
+)
+
+// FilterBuffer structs that extends buffer methods
+type FilterBuffer struct {
+	*bytes.Buffer
+}
+
+// ByLines returns buf string plit by the newline characters
+func (buf *FilterBuffer) ByLines() []string {
+	return strings.Split(buf.String(), "\n")
+}
+
+// KVOutput returns a map of the buff string split based on
+// the separator '='.
+// For example, the following strings would be split as follows:
+// 		a=1
+// 		b=2
+// 		c=3
+func (buf *FilterBuffer) KVOutput() map[string]string {
+	result := make(map[string]string)
+	for _, line := range buf.ByLines() {
+		vals := strings.Split(line, "=")
+		if len(vals) == 2 {
+			result[vals[0]] = vals[1]
+		}
+	}
+	return result
+}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1130,3 +1130,102 @@ func (kub *Kubectl) GetCiliumPodOnNode(namespace string, node string) (string, e
 
 	return res.Output().String(), nil
 }
+
+// CiliumPreFlightCheck specify that it checks that various subsystems within
+// Cilium are in a good state. If one of the multiple preflight fails it'll
+// return an error.
+func (kub *Kubectl) CiliumPreFlightCheck() error {
+	// Doing this withTimeout because the Status can be ready, but the other
+	// nodes cannot be show up yet, and the cilium-health can fail as a false positive.
+	var err error
+	body := func() bool {
+		err = kub.CiliumControllersPreFlightCheck()
+		if err != nil {
+			return false
+		}
+		err = kub.CiliumHealthPreFlightCheck()
+		if err != nil {
+			return false
+		}
+		return true
+	}
+	timeoutErr := WithTimeout(body, "PreflightCheck failed", &TimeoutConfig{Timeout: HelperTimeout})
+	if timeoutErr != nil {
+		return fmt.Errorf("CiliumPreFlightCheck error: %s: %s", timeoutErr, err)
+	}
+	return nil
+}
+
+// CiliumControllersPreFlightCheck validates that all controllers are not
+// failing. If any of the controllers fails will return an error.
+func (kub *Kubectl) CiliumControllersPreFlightCheck() error {
+	var controllersFilter = `{range .controllers[*]}{.name}{"="}{.status.consecutive-failure-count}{"\n"}{end}`
+	ciliumPods, err := kub.GetCiliumPods(KubeSystemNamespace)
+	if err != nil {
+		return err
+	}
+	for _, pod := range ciliumPods {
+		status := kub.CiliumExec(pod, fmt.Sprintf(
+			"cilium status --all-controllers -o jsonpath='%s'", controllersFilter))
+		if !status.WasSuccessful() {
+			return fmt.Errorf("cilium-agent %q: Cannot run cilium status: %s",
+				pod, status.OutputPrettyPrint())
+		}
+		for controller, status := range status.KVOutput() {
+			if status != "0" {
+				failmsg := kub.CiliumExec(pod, "cilium status --all-controllers")
+				return fmt.Errorf(
+					"cilium-agent %q: controller %s is failing: %s",
+					pod, controller, failmsg.OutputPrettyPrint())
+			}
+		}
+	}
+	return nil
+}
+
+// CiliumHealthPreFlightCheck checks that the health status is working
+// correctly and the number of nodes does not mistmatch with the running pods.
+// It return an error if health mark a node as failed.
+func (kub *Kubectl) CiliumHealthPreFlightCheck() error {
+	var nodesFilter = `{.nodes[*].name}`
+	var statusFilter = `{range .nodes[*]}{.name}{"="}{.host.primary-address.http.status}{"\n"}{end}`
+
+	ciliumPods, err := kub.GetCiliumPods(KubeSystemNamespace)
+	if err != nil {
+		return err
+	}
+	for _, pod := range ciliumPods {
+		status := kub.CiliumExec(pod, "cilium-health status -o json --probe")
+		if !status.WasSuccessful() {
+			return fmt.Errorf(
+				"Cluster connectivity is unhealthy on %q: %s",
+				pod, status.OutputPrettyPrint())
+		}
+
+		// By Checking that the node list is the same
+		nodes, err := status.Filter(nodesFilter)
+		if err != nil {
+			return fmt.Errorf("Cannot unmarshal health status: %s", err)
+		}
+
+		nodeCount := strings.Split(nodes.String(), " ")
+		if len(ciliumPods) != len(nodeCount) {
+			return fmt.Errorf(
+				"cilium-agent %q: Only %d/%d nodes appeared in cilium-health status. nodes = '%+v'",
+				pod, len(nodeCount), len(ciliumPods), nodeCount)
+		}
+
+		healthStatus, err := status.Filter(statusFilter)
+		if err != nil {
+			return fmt.Errorf("Cannot unmarshal health status: %s", err)
+		}
+
+		for node, status := range healthStatus.KVOutput() {
+			if status != "" {
+				return fmt.Errorf("cilium-agent %q: connectivity to node %q is unhealthy: %q",
+					pod, node, status)
+			}
+		}
+	}
+	return nil
+}

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -32,6 +32,9 @@ func ExpectKubeDNSReady(vm *helpers.Kubectl) {
 func ExpectCiliumReady(vm *helpers.Kubectl) {
 	err := vm.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
 	ExpectWithOffset(1, err).Should(BeNil(), "cilium was not able to get into ready state")
+
+	err = vm.CiliumPreFlightCheck()
+	ExpectWithOffset(1, err).Should(BeNil(), "cilium pre flight checks has failed")
 }
 
 // ExpectAllPodsTerminated is a wrapper around helpers/WaitCleanAllTerminatingPods.


### PR DESCRIPTION
- Added  a new helper on `cmd.Filter`
- Add two pre-checks on the ExpectCiliumReady. 
- Dump controller failure count in the json file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4733)
<!-- Reviewable:end -->
