### PR TITLE
Test: Use BeforeAll on External services test

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -215,7 +215,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 			servicePath       = helpers.ManifestGet("external_service.yaml")
 		)
 
-		BeforeEach(func() {
+		BeforeAll(func() {
 			kubectl.Apply(servicePath).ExpectSuccess("cannot install external service")
 			kubectl.Apply(podPath).ExpectSuccess("cannot install pod path")
 
@@ -226,6 +226,11 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 		AfterEach(func() {
 			_ = kubectl.Delete(policyPath)
 			_ = kubectl.Delete(endpointPath)
+
+			kubectl.WaitCleanAllTerminatingPods()
+		})
+
+		AfterAll(func() {
 			_ = kubectl.Delete(servicePath)
 			_ = kubectl.Delete(podPath)
 


### PR DESCRIPTION
Use BeforeAll to deploy external_pod.yaml once in all the test.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4735)
<!-- Reviewable:end -->
