### PR TITLE
Inter cluster connectivity (ClusterMesh)

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -21,7 +21,9 @@ cilium-agent
       --allow-localhost string                      Policy when to allow local stack to reach local endpoints { auto | always | policy }  (default "auto")
       --auto-ipv6-node-routes                       Automatically adds IPv6 L3 routes to reach other nodes for non-overlay mode (--device) (BETA)
       --bpf-root string                             Path to BPF filesystem
+      --cluster-id int                              Unique identifier of the cluster
       --cluster-name string                         Name of the cluster (default "default")
+      --clustermesh-config string                   Path to the ClusterMesh configuration directory
       --config string                               Configuration file (default "$HOME/ciliumd.yaml")
       --conntrack-garbage-collector-interval uint   Garbage collection interval for the connection tracking table (in seconds) (default 60)
       --container-runtime stringSlice               Sets the container runtime(s) used by Cilium { containerd | crio | docker | none | auto } ( "auto" uses the container runtime found in the order: "docker", "containerd", "crio" ) (default [auto])

--- a/Documentation/install/guides/clustermesh.rst
+++ b/Documentation/install/guides/clustermesh.rst
@@ -1,0 +1,130 @@
+****************************
+Setting up the Cluster Mesh
+****************************
+
+This is a step-by-step guide on how to build a mesh of Kubernetes clusters by
+connecting them together and enabling pod-to-pod connectivity across all
+clusters while providing label-based security policies.
+
+.. note::
+
+    This is a beta feature introduced in Cilium 1.2.
+
+Prerequisites
+#############
+
+* All nodes in all clusters must have IP connectivity. This requirement is
+  typically met by establishing peering between the networks of the machines
+  forming each cluster.
+
+* No encryption is performed by Cilium for the connectivity between nodes.
+  The feature is on the roadmap (`details
+  <https://github.com/cilium/cilium/issues/504>`) but not implemented yet.  It
+  is however possible to set up IPSec-based encryption between all nodes using
+  a standard guide. It is also possible and common to establish VPNs between
+  networks if clusters are connected across untrusted networks.
+
+* All worker nodes must have connectivity to the etcd clusters of all remote
+  clusters. Security is implemented by connecting to etcd using TLS/SSL
+  certificates.
+
+* Cilium must be configured to use etcd as the kvstore. Consul is not supported
+  by cluster mesh.
+
+Getting Started
+###############
+
+Step 1: Prepare the individual clusters
+=======================================
+
+Setting the cluster name and ID
+-------------------------------
+
+Each cluster must be assigned a unique human-readable name. The name will be
+used to group nodes of a cluster. The cluster name is specified with the
+``--cluster-name=NAME`` argument or ``cluster-name`` ConfigMap option.
+
+To ensure scalability of identity allocation and policy enforcement, each
+cluster continues to manage its own identity allocation. In order to guarantee
+compatibility with identities across clusters, each cluster is configured with
+a unique cluster ID configured with the ``--cluster-id=ID`` argument or
+``cluster-id`` ConfigMap option.
+
+.. code:: bash
+
+   $ kubectl -n kube-system edit cm cilium-config
+   [ add/edit ]
+   cluster-name: default
+   cluster-id: 1
+
+Provide unique values for the cluster name and ID for each cluster.
+
+Step 2: Create Secret to provide access to remote etcd
+------------------------------------------------------
+
+Clusters are connected together by providing connectivity information to the
+etcd key-value store to each individual cluster. This allows Cilium to
+synchronize state between clusters and provide cross-cluster connectivity and
+policy enforcement.
+
+The connectivity details of a remote etcd typically includes certificates to
+enable use of TLS which is why the entire ClusterMesh configuration is stored
+in a Kubernetes Secret.
+
+1. Create an etcd configuration file for each remote cluster you want to
+   connect to. The syntax is that the official etcd configuration file and
+   identical to the syntax used in the ``cilium-config`` ConfigMap.
+
+2. Create a secret ``cilium-clustermesh`` from all configuration files you have
+   created:
+
+   .. code:: bash
+
+       $ ks create secret generic cilium-clustermesh --from-file=./cluster5 --from-file=./cluster7
+
+   Cilium will automatically ignore any configuration referring to its own
+   cluster so you can create a single secret and import it into all your
+   clusters to establish connectivity between all clusters.
+
+   .. code:: bash
+
+       cluster 1:
+       $ kubectl -n kube-system get secret cilium-clustermesh -o yaml > clustermesh.yaml
+
+       cluster 2:
+       $ kubectl apply -f clustermesh.yaml
+
+Step 3: Restart the cilium agent
+--------------------------------
+
+Restart Cilium in each cluster to pick up the new cluster name, cluster id and
+clustermesh secret configuration. Cilium will automatically establish
+connectivity between the clusters.
+
+.. code:: bash
+
+    $ kubectl -n kube-system delete -l k8s-app=cilium
+
+Step 4: Test the connectivity between clusters
+----------------------------------------------
+
+Run ``cilium node list`` to see the full list of nodes discovered. You can run
+this command inside any Cilium pod in any cluster:
+
+.. code:: bash
+
+    $ kubectl -n kube-system exec -ti cilium-g6btl cilium node list
+    Name                                                   IPv4 Address    Endpoint CIDR   IPv6 Address   Endpoint CIDR
+    cluster5/ip-172-0-117-60.us-west-2.compute.internal    172.0.117.60    10.2.2.0/24     <nil>          f00d::a02:200:0:0/112
+    cluster5/ip-172-0-186-231.us-west-2.compute.internal   172.0.186.231   10.2.3.0/24     <nil>          f00d::a02:300:0:0/112
+    cluster5/ip-172-0-50-227.us-west-2.compute.internal    172.0.50.227    10.2.0.0/24     <nil>          f00d::a02:0:0:0/112
+    cluster5/ip-172-0-51-175.us-west-2.compute.internal    172.0.51.175    10.2.1.0/24     <nil>          f00d::a02:100:0:0/112
+    cluster7/ip-172-0-121-242.us-west-2.compute.internal   172.0.121.242   10.4.2.0/24     <nil>          f00d::a04:200:0:0/112
+    cluster7/ip-172-0-58-194.us-west-2.compute.internal    172.0.58.194    10.4.1.0/24     <nil>          f00d::a04:100:0:0/112
+    cluster7/ip-172-0-60-118.us-west-2.compute.internal    172.0.60.118    10.4.0.0/24     <nil>          f00d::a04:0:0:0/112
+
+
+.. code:: bash
+
+    $ kubectl exec -ti pod-cluster5-xxx curl <pod-ip-cluster7>
+    [...]

--- a/Documentation/install/guides/index.rst
+++ b/Documentation/install/guides/index.rst
@@ -22,4 +22,5 @@ experiment, we highly recommend trying out the :ref:`gs_guide` instead.
    from_source
    advanced_options
    kops
+   clustermesh
    kube-router

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -68,6 +68,7 @@ classid
 cli
 cloudcity
 Cloudflare
+clustermesh
 cls
 cni
 committer

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/counter"
@@ -138,6 +139,8 @@ type Daemon struct {
 	// prefixLengths tracks a mapping from CIDR prefix length to the count
 	// of rules that refer to that prefix length.
 	prefixLengths *counter.PrefixLengthCounter
+
+	clustermesh *clustermesh.ClusterMesh
 }
 
 // UpdateProxyRedirect updates the redirect rules in the proxy for a particular
@@ -1261,6 +1264,8 @@ func NewDaemon() (*Daemon, error) {
 		log.WithError(err).Fatal("postinit failed")
 	}
 	log.Info("Addressing information:")
+	log.Infof("  Cluster-Name: %s", option.Config.ClusterName)
+	log.Infof("  Cluster-ID: %d", option.Config.ClusterID)
 	log.Infof("  Local node-name: %s", node.GetName())
 	log.Infof("  Node-IPv6: %s", node.GetIPv6())
 	log.Infof("  External-Node IPv4: %s", node.GetExternalIPv4())
@@ -1284,6 +1289,24 @@ func NewDaemon() (*Daemon, error) {
 
 	if err := node.ConfigureLocalNode(); err != nil {
 		log.WithError(err).Fatal("Unable to initialize local node")
+	}
+
+	if path := option.Config.ClusterMeshConfig; path != "" {
+		if option.Config.ClusterID == 0 {
+			log.Info("Cluster-ID is not specified, skipping ClusterMesh initialization")
+		} else {
+			log.WithField("path", path).Info("Initializing ClusterMesh routing")
+			clustermesh, err := clustermesh.NewClusterMesh(clustermesh.Configuration{
+				Name:            "clustermesh",
+				ConfigDirectory: path,
+				NodeKeyCreator:  node.KeyCreator,
+			})
+			if err != nil {
+				log.WithError(err).Fatal("Unable to initialize ClusterMesh")
+			}
+
+			d.clustermesh = clustermesh
+		}
 	}
 
 	// This needs to be done after the node addressing has been configured

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -341,8 +341,12 @@ func init() {
 		option.AutoIPv6NodeRoutesName, false, "Automatically adds IPv6 L3 routes to reach other nodes for non-overlay mode (--device) (BETA)")
 	flags.StringVar(&bpfRoot,
 		"bpf-root", "", "Path to BPF filesystem")
+	flags.Int(option.ClusterIDName, 0, "Unique identifier of the cluster")
+	viper.BindEnv(option.ClusterIDName, option.ClusterIDEnv)
 	flags.String(option.ClusterName, defaults.ClusterName, "Name of the cluster")
 	viper.BindEnv(option.ClusterName, option.ClusterNameEnv)
+	flags.String(option.ClusterMeshConfigName, "", "Path to the ClusterMesh configuration directory")
+	viper.BindEnv(option.ClusterMeshConfigName, option.ClusterMeshConfigNameEnv)
 	flags.StringVar(&cfgFile,
 		"config", "", `Configuration file (default "$HOME/ciliumd.yaml")`)
 	flags.Uint("conntrack-garbage-collector-interval", 60, "Garbage collection interval for the connection tracking table (in seconds)")

--- a/examples/kubernetes/1.10/cilium-cm.yaml
+++ b/examples/kubernetes/1.10/cilium-cm.yaml
@@ -45,3 +45,10 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -120,6 +120,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -155,6 +169,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -195,6 +212,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -45,6 +45,13 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -167,6 +174,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -202,6 +223,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -242,6 +266,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -119,6 +119,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -154,6 +168,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -194,6 +211,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -45,6 +45,13 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -166,6 +173,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -201,6 +222,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -241,6 +265,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.11/cilium-cm.yaml
+++ b/examples/kubernetes/1.11/cilium-cm.yaml
@@ -45,3 +45,10 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -120,6 +120,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -155,6 +169,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -195,6 +212,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -45,6 +45,13 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -167,6 +174,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -202,6 +223,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -242,6 +266,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -119,6 +119,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -154,6 +168,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -194,6 +211,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -45,6 +45,13 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -166,6 +173,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -201,6 +222,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -241,6 +265,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:

--- a/examples/kubernetes/1.12/cilium-cm.yaml
+++ b/examples/kubernetes/1.12/cilium-cm.yaml
@@ -45,3 +45,10 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -120,6 +120,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -155,6 +169,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -195,6 +212,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -45,6 +45,13 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -167,6 +174,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -202,6 +223,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -242,6 +266,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -119,6 +119,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -154,6 +168,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -194,6 +211,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -45,6 +45,13 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -166,6 +173,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -201,6 +222,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -241,6 +265,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:

--- a/examples/kubernetes/1.7/cilium-cm.yaml
+++ b/examples/kubernetes/1.7/cilium-cm.yaml
@@ -45,3 +45,10 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1

--- a/examples/kubernetes/1.7/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-crio-ds.yaml
@@ -120,6 +120,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -155,6 +169,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -195,6 +212,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.7/cilium-crio.yaml
+++ b/examples/kubernetes/1.7/cilium-crio.yaml
@@ -45,6 +45,13 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -167,6 +174,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -202,6 +223,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -242,6 +266,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -119,6 +119,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -154,6 +168,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -194,6 +211,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -45,6 +45,13 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -166,6 +173,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -201,6 +222,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -241,6 +265,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.8/cilium-cm.yaml
+++ b/examples/kubernetes/1.8/cilium-cm.yaml
@@ -45,3 +45,10 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -120,6 +120,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -155,6 +169,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -195,6 +212,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -45,6 +45,13 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1
 ---
 apiVersion: apps/v1beta2
 kind: DaemonSet
@@ -167,6 +174,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -202,6 +223,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -242,6 +266,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -119,6 +119,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -154,6 +168,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -194,6 +211,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -45,6 +45,13 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1
 ---
 apiVersion: apps/v1beta2
 kind: DaemonSet
@@ -166,6 +173,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -201,6 +222,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -241,6 +265,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.9/cilium-cm.yaml
+++ b/examples/kubernetes/1.9/cilium-cm.yaml
@@ -45,3 +45,10 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -120,6 +120,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -155,6 +169,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -195,6 +212,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -45,6 +45,13 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -167,6 +174,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -202,6 +223,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -242,6 +266,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -119,6 +119,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -154,6 +168,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -194,6 +211,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -45,6 +45,13 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -166,6 +173,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -201,6 +222,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -241,6 +265,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/templates/v1/cilium-cm.yaml
+++ b/examples/kubernetes/templates/v1/cilium-cm.yaml
@@ -45,3 +45,10 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -120,6 +120,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -155,6 +169,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -195,6 +212,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -119,6 +119,20 @@ spec:
                   key: monitor-aggregation-level
                   name: cilium-config
                   optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
           livenessProbe:
             exec:
               command:
@@ -154,6 +168,9 @@ spec:
               readOnly: true
             - name: etcd-secrets
               mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
               readOnly: true
           securityContext:
             capabilities:
@@ -194,6 +211,12 @@ spec:
           secret:
             secretName: cilium-etcd-secrets
             optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -1,0 +1,164 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clustermesh
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+const (
+	// configNotificationsChannelSize is the size of the channel used to
+	// notify a clustermesh of configuration changes
+	configNotificationsChannelSize = 512
+)
+
+// Configuration is the configuration that must be provided to
+// NewClusterMesh()
+type Configuration struct {
+	// Name is the name of the remote cluster cache. This is for logging
+	// purposes only
+	Name string
+
+	// ConfigDirectory is the path to the directory that will be watched for etcd
+	// configuration files to appear
+	ConfigDirectory string
+
+	// NodeKeyCreator is the function used to create node instances as
+	// nodes are being discovered in remote clusters
+	NodeKeyCreator store.KeyCreator
+}
+
+// ClusterMesh is a cache of multiple remote clusters
+type ClusterMesh struct {
+	// conf is the configuration, it is immutable after NewClusterMesh()
+	conf Configuration
+
+	mutex         lock.RWMutex
+	clusters      map[string]*remoteCluster
+	controllers   *controller.Manager
+	configWatcher *configDirectoryWatcher
+}
+
+// NewClusterMesh creates a new remote cluster cache based on the
+// provided configuration
+func NewClusterMesh(c Configuration) (*ClusterMesh, error) {
+	cm := &ClusterMesh{
+		conf:        c,
+		clusters:    map[string]*remoteCluster{},
+		controllers: controller.NewManager(),
+	}
+
+	w, err := createConfigDirectoryWatcher(c.ConfigDirectory, cm)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create config directory watcher: %s", err)
+	}
+
+	cm.configWatcher = w
+
+	controllerName := fmt.Sprintf("clustermesh-%s-config-fsnotify", c.Name)
+	cm.controllers.UpdateController(controllerName,
+		controller.ControllerParams{
+			DoFunc: func() error { return cm.configWatcher.watch() },
+		},
+	)
+
+	return cm, nil
+}
+
+// Close stops watching for remote cluster configuration files to appear and
+// will close all connections to remote clusters
+func (cm *ClusterMesh) Close() {
+	cm.mutex.Lock()
+	defer cm.mutex.Unlock()
+
+	if cm.configWatcher != nil {
+		cm.configWatcher.close()
+	}
+
+	for name, cluster := range cm.clusters {
+		cluster.onRemove()
+		delete(cm.clusters, name)
+	}
+
+	cm.controllers.RemoveAll()
+}
+
+func (cm *ClusterMesh) newRemoteCluster(name, path string) *remoteCluster {
+	return &remoteCluster{
+		name:        name,
+		configPath:  path,
+		mesh:        cm,
+		changed:     make(chan bool, configNotificationsChannelSize),
+		controllers: controller.NewManager(),
+	}
+}
+
+func (cm *ClusterMesh) add(name, path string) {
+	if name == option.Config.ClusterName {
+		log.WithField(fieldClusterName, name).Debug("Ignoring configuration for own cluster")
+		return
+	}
+
+	inserted := false
+	cm.mutex.Lock()
+	cluster, ok := cm.clusters[name]
+	if !ok {
+		cluster = cm.newRemoteCluster(name, path)
+		cm.clusters[name] = cluster
+		inserted = true
+	}
+	cm.mutex.Unlock()
+
+	log.WithField(fieldClusterName, name).Debug("Remote cluster configuration added")
+
+	if inserted {
+		cluster.onInsert()
+	} else {
+		// signal a change in configuration
+		cluster.changed <- true
+	}
+}
+
+func (cm *ClusterMesh) remove(name string) {
+	cm.mutex.Lock()
+	if cluster, ok := cm.clusters[name]; ok {
+		cluster.onRemove()
+		delete(cm.clusters, name)
+	}
+	cm.mutex.Unlock()
+
+	log.WithField(fieldClusterName, name).Debug("Remote cluster configuration removed")
+}
+
+// NumReadyClusters returns the number of remote clusters to which a connection
+// has been established
+func (cm *ClusterMesh) NumReadyClusters() int {
+	cm.mutex.RLock()
+	defer cm.mutex.RUnlock()
+
+	nready := 0
+	for _, cm := range cm.clusters {
+		if cm.isReady() {
+			nready++
+		}
+	}
+
+	return nready
+}

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -1,0 +1,182 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clustermesh
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/testutils"
+
+	"github.com/sirupsen/logrus"
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type ClusterMeshTestSuite struct{}
+
+var _ = Suite(&ClusterMeshTestSuite{})
+
+var (
+	nodes      = map[string]*testNode{}
+	nodesMutex lock.RWMutex
+)
+
+type testNode struct {
+	// Name is the name of the node. This is typically the hostname of the node.
+	Name string
+
+	// Cluster is the name of the cluster the node is associated with
+	Cluster string
+}
+
+func (n *testNode) GetKeyName() string {
+	return path.Join(n.Name, n.Cluster)
+}
+
+func (n *testNode) OnUpdate() {
+	nodesMutex.Lock()
+	nodes[n.GetKeyName()] = n
+	nodesMutex.Unlock()
+}
+
+func (n *testNode) OnDelete() {
+	nodesMutex.Lock()
+	delete(nodes, n.GetKeyName())
+	nodesMutex.Unlock()
+}
+
+func (n *testNode) Marshal() ([]byte, error) {
+	return json.Marshal(n)
+}
+
+func (n *testNode) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, n)
+}
+
+var testNodeCreator = func() store.Key {
+	n := testNode{}
+	return &n
+}
+
+type identityAllocatorOwnerMock struct{}
+
+func (i *identityAllocatorOwnerMock) TriggerPolicyUpdates(force bool) *sync.WaitGroup {
+	return nil
+}
+
+func (i *identityAllocatorOwnerMock) GetNodeSuffix() string {
+	return "foo"
+}
+
+func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
+	kvstore.SetupDummy("etcd")
+	defer kvstore.Close()
+
+	logging.DefaultLogger.SetLevel(logrus.DebugLevel)
+
+	identity.InitIdentityAllocator(&identityAllocatorOwnerMock{})
+
+	dir, err := ioutil.TempDir("", "multicluster")
+	c.Assert(err, IsNil)
+	defer os.RemoveAll(dir)
+
+	etcdConfig := []byte(fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddress()))
+
+	config1 := path.Join(dir, "cluster1")
+	err = ioutil.WriteFile(config1, etcdConfig, 0644)
+	c.Assert(err, IsNil)
+
+	config2 := path.Join(dir, "cluster2")
+	err = ioutil.WriteFile(config2, etcdConfig, 0644)
+	c.Assert(err, IsNil)
+
+	cm, err := NewClusterMesh(Configuration{
+		Name:            "test2",
+		ConfigDirectory: dir,
+		NodeKeyCreator:  testNodeCreator,
+	})
+	c.Assert(err, IsNil)
+	c.Assert(cm, Not(IsNil))
+
+	nodeNames := []string{"foo", "bar", "baz"}
+
+	// wait for both clusters to appear in the list of cm clusters
+	c.Assert(testutils.WaitUntil(func() bool {
+		return cm.NumReadyClusters() == 2
+	}, 10*time.Second), IsNil)
+
+	cm.mutex.RLock()
+	for _, rc := range cm.clusters {
+		rc.mutex.RLock()
+		for _, name := range nodeNames {
+			err = rc.remoteNodes.UpdateLocalKeySync(&testNode{Name: name, Cluster: rc.name})
+			c.Assert(err, IsNil)
+		}
+		rc.mutex.RUnlock()
+	}
+	cm.mutex.RUnlock()
+
+	// wait for all cm nodes in both clusters to appear in the node list
+	c.Assert(testutils.WaitUntil(func() bool {
+		nodesMutex.RLock()
+		defer nodesMutex.RUnlock()
+		return len(nodes) == 2*len(nodeNames)
+	}, 10*time.Second), IsNil)
+
+	os.RemoveAll(config2)
+
+	// wait for the removed cluster to disappear
+	c.Assert(testutils.WaitUntil(func() bool {
+		return cm.NumReadyClusters() == 1
+	}, 5*time.Second), IsNil)
+
+	// wait for the nodes of the removed cluster to disappear
+	c.Assert(testutils.WaitUntil(func() bool {
+		nodesMutex.RLock()
+		defer nodesMutex.RUnlock()
+		return len(nodes) == len(nodeNames)
+	}, 10*time.Second), IsNil)
+
+	os.RemoveAll(config1)
+
+	// wait for the removed cluster to disappear
+	c.Assert(testutils.WaitUntil(func() bool {
+		return cm.NumReadyClusters() == 0
+	}, 5*time.Second), IsNil)
+
+	// wait for the nodes of the removed cluster to disappear
+	c.Assert(testutils.WaitUntil(func() bool {
+		nodesMutex.RLock()
+		defer nodesMutex.RUnlock()
+		return len(nodes) == 0
+	}, 10*time.Second), IsNil)
+
+	cm.Close()
+}

--- a/pkg/clustermesh/config.go
+++ b/pkg/clustermesh/config.go
@@ -1,0 +1,105 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clustermesh
+
+import (
+	"io/ioutil"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// clusterLifecycle is the interface to implement in order to receive cluster
+// configuration lifecycle events. This is implemented by the ClusterMesh.
+type clusterLifecycle interface {
+	add(clusterName, clusterConfigPath string)
+	remove(clusterName string)
+}
+
+type configDirectoryWatcher struct {
+	watcher   *fsnotify.Watcher
+	lifecycle clusterLifecycle
+	path      string
+	stop      chan struct{}
+}
+
+func createConfigDirectoryWatcher(path string, lifecycle clusterLifecycle) (*configDirectoryWatcher, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := watcher.Add(path); err != nil {
+		watcher.Close()
+		return nil, err
+	}
+
+	return &configDirectoryWatcher{
+		watcher:   watcher,
+		path:      path,
+		lifecycle: lifecycle,
+		stop:      make(chan struct{}, 0),
+	}, nil
+}
+
+func (cdw *configDirectoryWatcher) watch() error {
+	log.WithField(fieldConfig, cdw.path).Debug("Starting config directory watcher")
+
+	files, err := ioutil.ReadDir(cdw.path)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range files {
+		// A typical directory will look like this:
+		// lrwxrwxrwx. 1 root root 12 Jul 21 16:32 test5 -> ..data/test5
+		// lrwxrwxrwx. 1 root root 12 Jul 21 16:32 test7 -> ..data/test7
+		//
+		// Ignore all backing files and only read the symlinks
+		if strings.HasPrefix(f.Name(), "..") {
+			continue
+		}
+
+		log.WithField(fieldClusterName, f.Name()).WithField("mode", f.Mode()).Debugf("Found configuration in initial scan")
+		cdw.lifecycle.add(f.Name(), path.Join(cdw.path, f.Name()))
+	}
+
+	for {
+		select {
+		case event := <-cdw.watcher.Events:
+			name := filepath.Base(event.Name)
+			log.WithField(fieldClusterName, name).Debugf("Received fsnotify event: %+v", event)
+			switch event.Op {
+			case fsnotify.Create, fsnotify.Write, fsnotify.Chmod:
+				cdw.lifecycle.add(name, event.Name)
+			case fsnotify.Remove, fsnotify.Rename:
+				cdw.lifecycle.remove(name)
+			}
+
+		case err := <-cdw.watcher.Errors:
+			return err
+
+		case <-cdw.stop:
+			return nil
+		}
+	}
+}
+
+func (cdw *configDirectoryWatcher) close() {
+	close(cdw.stop)
+	cdw.watcher.Close()
+}

--- a/pkg/clustermesh/config_test.go
+++ b/pkg/clustermesh/config_test.go
@@ -1,0 +1,125 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clustermesh
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"time"
+
+	"github.com/cilium/cilium/pkg/testutils"
+
+	. "gopkg.in/check.v1"
+)
+
+func createFile(c *C, name string) {
+	f, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE, 0666)
+	c.Assert(err, IsNil)
+	f.Sync()
+	f.Close()
+}
+
+func expectExists(c *C, cm *ClusterMesh, name string) {
+	c.Assert(cm.clusters[name], Not(IsNil))
+}
+
+func expectChange(c *C, cm *ClusterMesh, name string) {
+	cluster := cm.clusters[name]
+	c.Assert(cluster, Not(IsNil))
+
+	select {
+	case <-cluster.changed:
+	case <-time.After(time.Second):
+		c.Fatal("timeout while waiting for changed event")
+	}
+}
+
+func expectNotExist(c *C, cm *ClusterMesh, name string) {
+	c.Assert(cm.clusters[name], IsNil)
+}
+
+func (s *ClusterMeshTestSuite) TestWatchConfigDirectory(c *C) {
+	skipKvstoreConnection = true
+
+	dir, err := ioutil.TempDir("", "multicluster")
+	c.Assert(err, IsNil)
+	defer os.RemoveAll(dir)
+
+	file1 := path.Join(dir, "cluster1")
+	file2 := path.Join(dir, "cluster2")
+	file3 := path.Join(dir, "cluster3")
+
+	createFile(c, file1)
+	createFile(c, file2)
+
+	cm, err := NewClusterMesh(Configuration{
+		Name:            "test1",
+		ConfigDirectory: dir,
+		NodeKeyCreator:  testNodeCreator,
+	})
+	c.Assert(err, IsNil)
+	c.Assert(cm, Not(IsNil))
+	defer cm.Close()
+
+	// wait for cluster1 and cluster2 to appear
+	c.Assert(testutils.WaitUntil(func() bool { return len(cm.clusters) == 2 }, time.Second), IsNil)
+	expectExists(c, cm, "cluster1")
+	expectExists(c, cm, "cluster2")
+	expectNotExist(c, cm, "cluster3")
+
+	err = os.RemoveAll(file1)
+	c.Assert(err, IsNil)
+
+	// wait for cluster1 to disappear
+	c.Assert(testutils.WaitUntil(func() bool { return len(cm.clusters) == 1 }, time.Second), IsNil)
+
+	createFile(c, file3)
+
+	// wait for cluster3 to appear
+	c.Assert(testutils.WaitUntil(func() bool { return len(cm.clusters) == 2 }, time.Second), IsNil)
+	expectNotExist(c, cm, "cluster1")
+	expectExists(c, cm, "cluster2")
+	expectExists(c, cm, "cluster3")
+
+	// Test renaming of file from cluster3 to cluster1
+	err = os.Rename(file3, file1)
+	c.Assert(err, IsNil)
+
+	// wait for cluster1 to appear
+	c.Assert(testutils.WaitUntil(func() bool { return cm.clusters["cluster1"] != nil }, time.Second), IsNil)
+	expectExists(c, cm, "cluster2")
+	expectNotExist(c, cm, "cluster3")
+
+	// touch file
+	err = os.Chtimes(file1, time.Now(), time.Now())
+	c.Assert(err, IsNil)
+
+	// give time for events to be processed
+	time.Sleep(100 * time.Millisecond)
+	expectChange(c, cm, "cluster1")
+
+	err = os.RemoveAll(file1)
+	c.Assert(err, IsNil)
+	err = os.RemoveAll(file2)
+	c.Assert(err, IsNil)
+
+	// wait for all clusters to disappear
+	c.Assert(testutils.WaitUntil(func() bool { return len(cm.clusters) == 0 }, time.Second), IsNil)
+	expectNotExist(c, cm, "cluster1")
+	expectNotExist(c, cm, "cluster2")
+	expectNotExist(c, cm, "cluster3")
+
+}

--- a/pkg/clustermesh/logfields.go
+++ b/pkg/clustermesh/logfields.go
@@ -1,0 +1,30 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clustermesh
+
+import (
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "clustermesh")
+
+const (
+	fieldName          = "name"
+	fieldClusterName   = "clusterName"
+	fieldConfig        = "config"
+	fieldKVStoreStatus = "kvstoreStatus"
+	fieldKVStoreErr    = "kvstoreErr"
+)

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -1,0 +1,202 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clustermesh
+
+import (
+	"fmt"
+	"path"
+	"time"
+
+	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/kvstore/allocator"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/node"
+
+	"github.com/sirupsen/logrus"
+)
+
+// remoteCluster represents another cluster other than the cluster the agent is
+// running in
+type remoteCluster struct {
+	// name is the name of the cluster
+	name string
+
+	// configPath is the path to the etcd configuration to be used to
+	// connect to the etcd cluster of the remote cluster
+	configPath string
+
+	// changed receives an event when the remote cluster configuration has
+	// changed and is closed when the configuration file was removed
+	changed chan bool
+
+	// mesh is the cluster mesh this remote cluster belongs to
+	mesh *ClusterMesh
+
+	controllers *controller.Manager
+
+	// remoteConnectionControllerName is the name of the backing controller
+	// that maintains the remote connection
+	remoteConnectionControllerName string
+
+	// mutex protects the following variables
+	// - store
+	// - remoteNodes
+	// - ipCacheWatcher
+	// - remoteIdentityCache
+	mutex lock.RWMutex
+
+	// store is the shared store representing all nodes in the remote cluster
+	remoteNodes *store.SharedStore
+
+	// ipCacheWatcher is the watcher that notifies about IP<->identity
+	// changes in the remote cluster
+	ipCacheWatcher *ipcache.IPIdentityWatcher
+
+	// remoteIdentityCache is a locally cached copy of the identity
+	// allocations in the remote cluster
+	remoteIdentityCache *allocator.RemoteCache
+
+	// backend is the kvstore backend being used
+	backend kvstore.BackendOperations
+}
+
+var (
+	// skipKvstoreConnection skips the etcd connection, used for testing
+	skipKvstoreConnection bool
+)
+
+func (rc *remoteCluster) getLogger() *logrus.Entry {
+	var (
+		status string
+		err    error
+	)
+
+	if rc.backend != nil {
+		status, err = rc.backend.Status()
+	}
+
+	return log.WithFields(logrus.Fields{
+		fieldClusterName:   rc.name,
+		fieldConfig:        rc.configPath,
+		fieldKVStoreStatus: status,
+		fieldKVStoreErr:    err,
+	})
+}
+
+func (rc *remoteCluster) restartRemoteConnection() {
+	rc.controllers.UpdateController(rc.remoteConnectionControllerName,
+		controller.ControllerParams{
+			DoFunc: func() error {
+				backend, err := kvstore.NewClient(kvstore.EtcdBackendName,
+					map[string]string{
+						kvstore.EtcdOptionConfig: rc.configPath,
+					})
+				if err != nil {
+					return err
+				}
+
+				remoteNodes, err := store.JoinSharedStore(store.Configuration{
+					Prefix:                  path.Join(node.NodeStorePrefix, rc.name),
+					KeyCreator:              rc.mesh.conf.NodeKeyCreator,
+					SynchronizationInterval: time.Minute,
+					Backend:                 backend,
+				})
+				if err != nil {
+					backend.Close()
+					return err
+				}
+
+				ipCacheWatcher := ipcache.NewIPIdentityWatcher(backend)
+				go ipCacheWatcher.Watch()
+
+				remoteIdentityCache := identity.WatchRemoteIdentities(backend)
+
+				rc.mutex.Lock()
+				rc.remoteNodes = remoteNodes
+				rc.backend = backend
+				rc.ipCacheWatcher = ipCacheWatcher
+				rc.remoteIdentityCache = remoteIdentityCache
+				rc.mutex.Unlock()
+
+				rc.getLogger().Info("Established connection to remote etcd")
+
+				return nil
+			},
+			StopFunc: func() error {
+				rc.mutex.Lock()
+				if rc.ipCacheWatcher != nil {
+					rc.ipCacheWatcher.Close()
+				}
+
+				if rc.remoteNodes != nil {
+					rc.remoteNodes.Close()
+				}
+				if rc.backend != nil {
+					rc.backend.Close()
+				}
+				if rc.remoteIdentityCache != nil {
+					rc.remoteIdentityCache.Close()
+				}
+				rc.mutex.Unlock()
+
+				rc.getLogger().Info("All resources of remote cluster cleaned up")
+
+				return nil
+			},
+		},
+	)
+}
+
+func (rc *remoteCluster) onInsert() {
+	rc.getLogger().Info("New remote cluster discovered")
+
+	if skipKvstoreConnection {
+		return
+	}
+
+	rc.remoteConnectionControllerName = fmt.Sprintf("remote-etcd-%s", rc.name)
+	rc.restartRemoteConnection()
+
+	go func() {
+		for {
+			val := <-rc.changed
+			if val {
+				rc.getLogger().Info("etcd configuration has changed, re-creating connection")
+				rc.restartRemoteConnection()
+			} else {
+				rc.getLogger().Info("Closing connection to remote etcd")
+				return
+			}
+		}
+	}()
+}
+
+func (rc *remoteCluster) onRemove() {
+	rc.controllers.RemoveAll()
+	close(rc.changed)
+
+	rc.getLogger().Info("Remote cluster disconnected")
+}
+
+func (rc *remoteCluster) isReady() bool {
+	rc.mutex.RLock()
+	defer rc.mutex.RUnlock()
+
+	return rc.backend != nil && rc.remoteNodes != nil && rc.ipCacheWatcher != nil
+}

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -168,6 +168,11 @@ func (id NumericIdentity) IsReservedIdentity() bool {
 	return isReservedIdentity
 }
 
+// ClusterID returns the cluster ID associated with the identity
+func (id NumericIdentity) ClusterID() int {
+	return int((uint32(id) >> 16) & 0xFF)
+}
+
 // GetAllReservedIdentities returns a list of all reserved numeric identities.
 func GetAllReservedIdentities() []NumericIdentity {
 	reservedIdentitiesMutex.RLock()

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -99,6 +99,25 @@ func (s *AllocatorSuite) TestSelectID(c *C) {
 	c.Assert(val, Equals, "")
 }
 
+func (s *AllocatorSuite) TestPrefixMask(c *C) {
+	allocatorName := randomTestName()
+	minID, maxID := ID(1), ID(5)
+	a, err := NewAllocator(allocatorName, TestType(""), WithMin(minID),
+		WithMax(maxID), WithSuffix("a"), WithPrefixMask(1<<16))
+	c.Assert(err, IsNil)
+	c.Assert(a, Not(IsNil))
+
+	// allocate all available IDs
+	for i := minID; i <= maxID; i++ {
+		id, val := a.selectAvailableID()
+		c.Assert(id, Not(Equals), NoID)
+		c.Assert(id>>16, Equals, ID(1))
+		c.Assert(val, Equals, id.String())
+	}
+
+	a.Delete()
+}
+
 func (s *AllocatorSuite) BenchmarkAllocate(c *C) {
 	allocatorName := randomTestName()
 	maxID := ID(256 + c.N)

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -39,10 +39,11 @@ import (
 )
 
 const (
-	etcdName = "etcd"
+	// EtcdBackendName is the backend name fo etcd
+	EtcdBackendName = "etcd"
 
-	addrOption = "etcd.address"
-	cfgOption  = "etcd.config"
+	addrOption       = "etcd.address"
+	EtcdOptionConfig = "etcd.config"
 )
 
 type etcdModule struct {
@@ -82,12 +83,16 @@ var (
 			addrOption: &backendOption{
 				description: "Addresses of etcd cluster",
 			},
-			cfgOption: &backendOption{
+			EtcdOptionConfig: &backendOption{
 				description: "Path to etcd configuration file",
 			},
 		},
 	}
 )
+
+func EtcdDummyAddress() string {
+	return etcdDummyAddress
+}
 
 func (e *etcdModule) createInstance() backendModule {
 	cpy := *etcdInstance
@@ -95,7 +100,7 @@ func (e *etcdModule) createInstance() backendModule {
 }
 
 func (e *etcdModule) getName() string {
-	return etcdName
+	return EtcdBackendName
 }
 
 func (e *etcdModule) setConfigDummy() {
@@ -113,12 +118,13 @@ func (e *etcdModule) getConfig() map[string]string {
 
 func (e *etcdModule) newClient() (BackendOperations, error) {
 	endpointsOpt, endpointsSet := e.opts[addrOption]
-	configPathOpt, configSet := e.opts[cfgOption]
+	configPathOpt, configSet := e.opts[EtcdOptionConfig]
 	configPath := ""
 
 	if e.config == nil {
 		if !endpointsSet && !configSet {
-			return nil, fmt.Errorf("invalid etcd configuration, %s or %s must be specified", cfgOption, addrOption)
+			return nil, fmt.Errorf("invalid etcd configuration, %s or %s must be specified",
+				EtcdOptionConfig, addrOption)
 		}
 
 		e.config = &client.Config{}
@@ -137,7 +143,7 @@ func (e *etcdModule) newClient() (BackendOperations, error) {
 
 func init() {
 	// register etcd module for use
-	registerBackend(etcdName, etcdInstance)
+	registerBackend(EtcdBackendName, etcdInstance)
 }
 
 type etcdClient struct {

--- a/pkg/node/local_node.go
+++ b/pkg/node/local_node.go
@@ -46,6 +46,7 @@ func ConfigureLocalNode() error {
 		IPv6AllocCIDR: GetIPv6AllocRange(),
 		IPv4HealthIP:  GetIPv4HealthIP(),
 		IPv6HealthIP:  GetIPv6HealthIP(),
+		ClusterID:     option.Config.ClusterID,
 	}
 
 	UpdateNode(&localNode, TunnelRoute, nil)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -65,6 +65,9 @@ type Node struct {
 	// cilium-health endpoint located on the node.
 	IPv6HealthIP net.IP
 
+	// ClusterID is the unique identifier of the cluster
+	ClusterID int
+
 	// cluster membership
 	cluster *clusterConfiguation
 }

--- a/pkg/node/store.go
+++ b/pkg/node/store.go
@@ -24,11 +24,17 @@ import (
 )
 
 var (
-	// nodesStorePrefix is the kvstore prefix of the shared store
+	// NodeStorePrefix is the kvstore prefix of the shared store
 	//
 	// WARNING - STABLE API: Changing the structure or values of this will
 	// break backwards compatibility
-	nodeStorePrefix = path.Join(kvstore.BaseKeyPrefix, "state", "nodes", "v1")
+	NodeStorePrefix = path.Join(kvstore.BaseKeyPrefix, "state", "nodes", "v1")
+
+	// KeyCreator creates a node for a shared store
+	KeyCreator = func() store.Key {
+		n := Node{}
+		return &n
+	}
 
 	nodeStore *store.SharedStore
 )
@@ -56,11 +62,8 @@ func registerNode() error {
 
 	// Join the shared store holding node information of entire cluster
 	store, err := store.JoinSharedStore(store.Configuration{
-		Prefix: nodeStorePrefix,
-		KeyCreator: func() store.Key {
-			n := Node{}
-			return &n
-		},
+		Prefix:                  NodeStorePrefix,
+		KeyCreator:              KeyCreator,
 		SynchronizationInterval: time.Minute,
 	})
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -85,8 +85,33 @@ const (
 	// ClusterName is the name of the ClusterName option
 	ClusterName = "cluster-name"
 
-	// ClusterNameEnv is the name of the environment variable of the ClusterName option
+	// ClusterNameEnv is the name of the environment variable of the
+	// ClusterName option
 	ClusterNameEnv = "CILIUM_CLUSTER_NAME"
+
+	// ClusterIDName is the name of the ClusterID option
+	ClusterIDName = "cluster-id"
+
+	// ClusterIDEnv is the name of the environment variable of the
+	// ClusterID option
+	ClusterIDEnv = "CILIUM_CLUSTER_ID"
+
+	// ClusterIDMin is the minimum value of the cluster ID
+	ClusterIDMin = 0
+
+	// ClusterIDMax is the maximum value of the cluster ID
+	ClusterIDMax = 255
+
+	// ClusterIDShift specifies the number of bits the cluster ID will be
+	// shifted
+	ClusterIDShift = 16
+
+	// ClusterMeshConfigName is the name of the ClusterMeshConfig option
+	ClusterMeshConfigName = "clustermesh-config"
+
+	// ClusterMeshConfigNameEnv is the name of the environment variable of
+	// the ClusterMeshConfig option
+	ClusterMeshConfigNameEnv = "CILIUM_CLUSTERMESH_CONFIG"
 )
 
 // Available option for daemonConfig.Tunnel
@@ -191,6 +216,12 @@ type daemonConfig struct {
 
 	// ClusterName is the name of the cluster
 	ClusterName string
+
+	// ClusterID is the unique identifier of the cluster
+	ClusterID int
+
+	// ClusterMeshConfig is the path to the clustermesh configuration directory
+	ClusterMeshConfig string
 }
 
 var (
@@ -279,6 +310,20 @@ func (c *daemonConfig) Validate() error {
 	}
 
 	c.ClusterName = viper.GetString(ClusterName)
+	c.ClusterID = viper.GetInt(ClusterIDName)
+	c.ClusterMeshConfig = viper.GetString(ClusterMeshConfigName)
+
+	if c.ClusterID < ClusterIDMin || c.ClusterID > ClusterIDMax {
+		return fmt.Errorf("invalid cluster id %d: must be in range %d..%d",
+			c.ClusterID, ClusterIDMin, ClusterIDMax)
+	}
+
+	if c.ClusterID != 0 {
+		if c.ClusterName == defaults.ClusterName {
+			return fmt.Errorf("cannot use default cluster name (%s) with option %s",
+				defaults.ClusterName, ClusterIDName)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
This commit introduces connectivity between endpoints in multiple clusters.
The feature requires basic connectivity between all cluster nodes of all
clusters.

Two new options are added to unique identify clusters:

`--cluster-name=NAME`

   Human-readable, unique name to identify the cluster.

`--cluster-id=ID`

   Unique identifier for the cluster. Must be in the range of 1..255. The
   unique cluster ID is utilized to make per cluster security identities unique
   across multiple clusters without requiring co-ordination when allocating
   security identities.

`CLUSTERMESH_CONFIG_PATH`

  Path to a directory with individual configuration files pointing to remote
  clusters. Cilium monitors the directory using fsnotify to detect file
  changes.  Each file is interpreted as an etcd configuration and a connection
  is attempted. Each configuration represents a remote cluster. If the
  connection is successful, the nodes and ipache will be synchronized to the
  local instance, thus making the cluster reachable from the individual agent.

  This option is set to a default value in the DaemonSet file and populated by
  an Kubernetes secret. If present, the files stores in the secret are
  automatically mounted into the Cilium pod.

Upon successful connection to a remote etcd. All nodes in all remote clusters
are discovered to either build a tunnel mesh between all clusters or to
establish direct routing.

The IP cache of all clusters are synchronized to establish egress policy
enforcement. Ingress policy enforcement is provided by relying on the identity
based mechanism with a fall back to IP based security.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4738)
<!-- Reviewable:end -->
