### PR TITLE
Check endpoint status before modifying identity labels

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2131,6 +2131,11 @@ func (e *Endpoint) SetIdentityLabels(owner Owner, l pkgLabels.Labels) {
 func (e *Endpoint) ModifyIdentityLabels(owner Owner, addLabels, delLabels pkgLabels.Labels) error {
 	e.Mutex.Lock()
 
+	switch e.GetStateLocked() {
+	case StateDisconnected, StateDisconnecting:
+		return nil
+	}
+
 	newLabels := e.OpLabels.DeepCopy()
 
 	for k := range delLabels {


### PR DESCRIPTION

pkg/endpoint: check endpoint's state before modifying identity labels
    
ModifyIdentityLabels() can potentially be invoked on an endpoint that is already disconnecting and the state transition can incorrectly revive it.


Fixes: https://github.com/cilium/cilium/issues/4734

Should this be backported to 1.1?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4739)
<!-- Reviewable:end -->
