### PR TITLE
pkg/endpoint: check when policy proxy revision is set

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -512,6 +512,8 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, boo
 	defer func() {
 		e.Mutex.RLock()
 		e.getLogger().WithField(logfields.BuildDuration, time.Since(buildStart).String()).
+			WithField("nextPolicyRevision", e.nextPolicyRevision).
+			WithField("policyRevision", e.policyRevision).
 			Info("Regeneration of BPF program has completed")
 		e.Mutex.RUnlock()
 	}()

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2017,7 +2017,7 @@ func (e *Endpoint) bumpPolicyRevision(revision uint64) {
 func (e *Endpoint) OnProxyPolicyUpdate(revision uint64) {
 	e.Mutex.Lock()
 	if revision > e.proxyPolicyRevision {
-		e.proxyPolicyRevision = revision
+		e.setProxyPolicyRevision(revision)
 	}
 	e.Mutex.Unlock()
 }
@@ -2353,12 +2353,45 @@ func (e *Endpoint) setPolicyRevision(rev uint64) {
 			close(ps.ch)
 			delete(e.policyRevisionSignals, ps)
 		default:
-			if rev >= ps.wantedRev {
+			// We only close the channel when e.policyRevision >= ps.wantedRev
+			// and, if the endpoint has (or had) a proxy set up, when the
+			// e.proxyPolicyRevision >= ps.wantedRev.
+			if e.policyRevision >= ps.wantedRev &&
+				(!e.HasProxy() || e.proxyPolicyRevision >= ps.wantedRev) {
+
 				close(ps.ch)
 				delete(e.policyRevisionSignals, ps)
 			}
 		}
 	}
+}
+
+// setProxyPolicyRevision sets the policy wantedRev with the given revision.
+func (e *Endpoint) setProxyPolicyRevision(rev uint64) {
+	e.proxyPolicyRevision = rev
+	for ps := range e.policyRevisionSignals {
+		select {
+		case <-ps.ctx.Done():
+			close(ps.ch)
+			delete(e.policyRevisionSignals, ps)
+		default:
+			// We only close the channel when e.policyRevision >= ps.wantedRev
+			// and, if the endpoint has (or had) a proxy set up, when the
+			// e.proxyPolicyRevision >= ps.wantedRev.
+			if e.policyRevision >= ps.wantedRev &&
+				(!e.HasProxy() || e.proxyPolicyRevision >= ps.wantedRev) {
+
+				close(ps.ch)
+				delete(e.policyRevisionSignals, ps)
+			}
+		}
+	}
+}
+
+// HasProxy returns true if the given endpoint has a proxy redirect configured.
+// Must be called with e.RLock held
+func (e *Endpoint) HasProxy() bool {
+	return e.DesiredL4Policy.HasRedirect() || e.RealizedL4Policy.HasRedirect()
 }
 
 // cleanPolicySignals closes and removes all policy revision signals.


### PR DESCRIPTION
In WaitForPolicyRevision, the channel would only be closed when the
PolicyRevision was at the given revision. With this change we will also
take into account the proxy revision number only when the endpoint has a
proxy configured, otherwise it will only consider the policy revision.

Signed-off-by: André Martins <andre@cilium.io>

```release-note
In Kubernetes, set Cilium Endpoint Status policy enforcement as true when the L4 and L7 policy desired is configured in the proxy.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4743)
<!-- Reviewable:end -->
