### PR TITLE
envoy: use local_resources parameter during bazel build

### DIFF
--- a/envoy/Makefile
+++ b/envoy/Makefile
@@ -43,11 +43,11 @@ else
 # Dockerfile builds require special options
 ifdef PKG_BUILD
 BAZEL_OPTS ?= --batch
-BAZEL_BUILD_OPTS = --spawn_strategy=standalone --genrule_strategy=standalone
+BAZEL_BUILD_OPTS = --spawn_strategy=standalone --genrule_strategy=standalone --local_resources 2048,2.0,1.0
 all: clean-bins release
 else
 BAZEL_OPTS ?=
-BAZEL_BUILD_OPTS = --experimental_strict_action_env
+BAZEL_BUILD_OPTS = --experimental_strict_action_env --local_resources 2048,2.0,1.0
 all: clean-bins envoy-default api
 endif
 


### PR DESCRIPTION
This sets the resources for memory, CPU, and I/O for the bazel build.
This avoids errors like the following when building Envoy:

```
23:27:39     virtualbox-iso: ERROR: /home/vagrant/.cache/bazel/_bazel_vagrant/502ef5068e38073dd9828a920a71f484/external/envoy/source/server/http/BUILD:11:1: C++ compilation of rule '@envoy//source/server/http:admin_lib' failed (Exit 4)
23:27:39     virtualbox-iso: gcc: internal compiler error: Killed (program cc1plus)
23:27:39     virtualbox-iso: Please submit a full bug report,
23:27:39     virtualbox-iso: with preprocessed source if appropriate.
23:27:39     virtualbox-iso: See <file:///usr/share/doc/gcc-7/README.Bugs> for instructions.
23:27:39     virtualbox-iso: Target //:envoy failed to build
23:27:39     virtualbox-iso: Use --verbose_failures to see the command lines of failed build steps.
23:27:39     virtualbox-iso: INFO: Elapsed time: 444.469s, Critical Path: 74.62s
23:27:39     virtualbox-iso: INFO: 1544 processes, local.
23:27:39     virtualbox-iso: FAILED: Build did NOT complete successfully
23:27:39     virtualbox-iso: FAILED: Build did NOT complete successfully
23:27:40     virtualbox-iso: make: *** [envoy-release] Error 1
23:27:40     virtualbox-iso: Makefile:68: recipe for target 'envoy-release' failed
23:27:41 ==> virtualbox-iso: Deregistering and deleting VM...
23:27:41 ==> virtualbox-iso: Deleting output directory...
23:27:41 Build 'virtualbox-iso' errored: Script exited with non-zero exit status: 2
```

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #4740

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4744)
<!-- Reviewable:end -->
