### PR TITLE
V1.0 backports 18 07 05

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -70,7 +70,7 @@ get_prs () {
 
   label_opt="%20label:$label"
   label_exclude_opt="%20-label:$label_exclude"
-  url="https://api.github.com/search/issues?per_page=1&q=is:pr%20repo:cilium/cilium%20is:closed$label_opt$label_exclude_opt"
+  url="${CILIUM_GITHUB_SEARCHAPI}$label_opt$label_exclude_opt"
   total="$($GHCURL $url | jq -r '.total_count')"
 
   # Calculate number of pages, rounding up

--- a/contrib/release/lib/gitlib.sh
+++ b/contrib/release/lib/gitlib.sh
@@ -25,7 +25,7 @@ JCURL="curl -g -s --fail --retry 10"
 CILIUM_GITHUB_API='https://api.github.com/repos/cilium/cilium'
 CILIUM_GITHUB_RAW_ORG='https://raw.githubusercontent.com/cilium'
 
-CILIUM_GITHUB_SEARCHAPI='https://api.github.com/search/issues?per_page=100&q=is:pr%20is:closed%20repo:cilium/cilium%20'
+CILIUM_GITHUB_SEARCHAPI='https://api.github.com/search/issues?per_page=100&q=is:pr%20is:merged%20repo:cilium/cilium%20'
 CILIUM_GITHUB_URL='https://github.com/cilium/cilium'
 CILIUM_GITHUB_SSH='git@github.com:cilium/cilium.git'
 

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 120, unit: 'MINUTES')
+        timeout(time: 210, unit: 'MINUTES')
         timestamps()
         ansiColor('xterm')
     }
@@ -61,7 +61,7 @@ pipeline {
             }
 
             options {
-                timeout(time: 90, unit: 'MINUTES')
+                timeout(time: 120, unit: 'MINUTES')
             }
 
             steps {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -871,9 +871,6 @@ func (e *Endpoint) regeneratePolicy(owner Owner, opts models.ConfigurationMap) (
 	// If no policy or options change occurred for this endpoint then the endpoint is
 	// already running the latest revision, otherwise we have to wait for
 	// the regeneration of the endpoint to complete.
-	if !policyChanged && !optsChanged {
-		e.setPolicyRevision(revision)
-	}
 
 	e.getLogger().WithFields(logrus.Fields{
 		"policyChanged":       policyChanged,
@@ -1048,6 +1045,11 @@ func (e *Endpoint) TriggerPolicyUpdatesLocked(owner Owner, opts models.Configura
 	needToRegenerateBPF, _, _, err := e.regeneratePolicy(owner, opts)
 	if err != nil {
 		return false, ctCleaned, fmt.Errorf("%s: %s", e.StringID(), err)
+	}
+	// If it does not need datapath regeneration then we should set the policy
+	// revision with nextPolicyRevision.
+	if !needToRegenerateBPF {
+		e.setPolicyRevision(e.nextPolicyRevision)
 	}
 
 	// CurrentStatus will be not OK when we have an uncleared error in BPF,

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -205,6 +205,25 @@ func (n *EndpointSelector) IsWildcard() bool {
 		len(n.LabelSelector.MatchLabels)+len(n.LabelSelector.MatchExpressions) == 0
 }
 
+// ConvertToLabelSelectorRequirementSlice converts the MatchLabels and
+// MatchExpressions within the specified EndpointSelector into a list of
+// LabelSelectorRequirements.
+func (n *EndpointSelector) ConvertToLabelSelectorRequirementSlice() []metav1.LabelSelectorRequirement {
+	requirements := make([]metav1.LabelSelectorRequirement, 0, len(n.MatchExpressions)+len(n.MatchLabels))
+	// Append already existing match expressions.
+	requirements = append(requirements, n.MatchExpressions...)
+	// Convert each MatchLables to LabelSelectorRequirement.
+	for key, value := range n.MatchLabels {
+		requirementFromMatchLabels := metav1.LabelSelectorRequirement{
+			Key:      key,
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{value},
+		}
+		requirements = append(requirements, requirementFromMatchLabels)
+	}
+	return requirements
+}
+
 // EndpointSelectorSlice is a slice of EndpointSelectors that can be sorted.
 type EndpointSelectorSlice []EndpointSelector
 

--- a/pkg/policy/l4Filter_test.go
+++ b/pkg/policy/l4Filter_test.go
@@ -170,7 +170,7 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndShadowedL7(c *C) {
 	ctx.Logging = logging.NewLogBackend(buffer, "", 0)
 
 	ingressState := traceState{}
-	res, err := rule1.resolveL4IngressPolicy(&ctx, &ingressState, NewL4Policy())
+	res, err := rule1.resolveL4IngressPolicy(&ctx, &ingressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
@@ -303,7 +303,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7HTTP(c *C)
 	c.Log(buffer)
 
 	state := traceState{}
-	res, err := identicalHTTPRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err := identicalHTTPRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -311,7 +311,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7HTTP(c *C)
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = identicalHTTPRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = identicalHTTPRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -376,7 +376,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7Kafka(c *C
 	}
 
 	state := traceState{}
-	res, err := identicalKafkaRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err := identicalKafkaRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -384,7 +384,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7Kafka(c *C
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = identicalKafkaRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = identicalKafkaRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -436,7 +436,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndMismatchingParsers(c *
 	c.Log(buffer)
 
 	state := traceState{}
-	res, err := conflictingParsersRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err := conflictingParsersRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
 
@@ -480,7 +480,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndMismatchingParsers(c *
 	c.Log(buffer)
 
 	state = traceState{}
-	res, err = conflictingParsersRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err = conflictingParsersRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
 }
@@ -531,7 +531,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 	}
 
 	state := traceState{}
-	res, err := shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err := shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -539,7 +539,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -586,7 +586,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 	}
 
 	state = traceState{}
-	res, err = shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err = shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -594,7 +594,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -666,7 +666,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 	}
 
 	state := traceState{}
-	res, err := shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err := shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -674,7 +674,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -733,7 +733,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 	}
 
 	state = traceState{}
-	res, err = shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err = shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -741,7 +741,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -816,7 +816,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 	}
 
 	state := traceState{}
-	res, err := case8Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err := case8Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -824,7 +824,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = case8Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = case8Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -892,7 +892,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 	}
 
 	state = traceState{}
-	res, err = case8Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err = case8Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -900,7 +900,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = case8Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = case8Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -952,12 +952,12 @@ func (ds *PolicyTestSuite) TestL3SelectingEndpointAndL3AllowAllMergeConflictingL
 	c.Log(buffer)
 
 	state := traceState{}
-	res, err := conflictingL7Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err := conflictingL7Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
 
 	state = traceState{}
-	res, err = conflictingL7Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = conflictingL7Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -1003,12 +1003,12 @@ func (ds *PolicyTestSuite) TestL3SelectingEndpointAndL3AllowAllMergeConflictingL
 	c.Log(buffer)
 
 	state = traceState{}
-	res, err = conflictingL7Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err = conflictingL7Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
 
 	state = traceState{}
-	res, err = conflictingL7Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = conflictingL7Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -1077,7 +1077,7 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointsSelectedAllowSameL7(
 	}
 
 	state := traceState{}
-	res, err := selectDifferentEndpointsRestrictL7.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err := selectDifferentEndpointsRestrictL7.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -1090,7 +1090,7 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointsSelectedAllowSameL7(
 	c.Log(buffer)
 
 	state = traceState{}
-	res, err = selectDifferentEndpointsRestrictL7.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = selectDifferentEndpointsRestrictL7.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -1141,7 +1141,7 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointSelectedAllowAllL7(c 
 	}
 
 	state := traceState{}
-	res, err := selectDifferentEndpointsAllowAllL7.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy())
+	res, err := selectDifferentEndpointsAllowAllL7.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -1154,7 +1154,7 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointSelectedAllowAllL7(c 
 	c.Log(buffer)
 
 	state = traceState{}
-	res, err = selectDifferentEndpointsAllowAllL7.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = selectDifferentEndpointsAllowAllL7.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/op/go-logging"
 	. "gopkg.in/check.v1"
 )
@@ -558,6 +560,137 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
 				},
 			},
 			DerivedFromRules: labels.LabelArrayList{labelsL3, labelsKafka, labelsL3},
+		},
+	}
+	c.Assert((*policy), comparator.DeepEquals, expectedPolicy)
+}
+
+func (ds *PolicyTestSuite) TestL3DependentL4IngressFromRequires(c *C) {
+	repo := NewPolicyRepository()
+
+	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
+	selBar1 := api.NewESFromLabels(labels.ParseSelectLabel("id=bar1"))
+	selBar2 := api.NewESFromLabels(labels.ParseSelectLabel("id=bar2"))
+
+	l480Rule := api.Rule{
+		EndpointSelector: selFoo,
+		Ingress: []api.IngressRule{
+			{
+				FromEndpoints: []api.EndpointSelector{
+					selBar1,
+				},
+				ToPorts: []api.PortRule{{
+					Ports: []api.PortProtocol{
+						{Port: "80", Protocol: api.ProtoTCP},
+					},
+				}},
+			},
+			{
+				FromRequires: []api.EndpointSelector{selBar2},
+			},
+		},
+	}
+	l480Rule.Sanitize()
+	_, err := repo.Add(l480Rule)
+	c.Assert(err, IsNil)
+
+	ctx := &SearchContext{
+		To: labels.ParseSelectLabelArray("id=foo"),
+	}
+
+	repo.Mutex.RLock()
+	defer repo.Mutex.RUnlock()
+
+	policy, err := repo.ResolveL4IngressPolicy(ctx)
+	c.Assert(err, IsNil)
+
+	expectedPolicy := L4PolicyMap{
+		"80/TCP": L4Filter{
+			Port:     80,
+			Protocol: api.ProtoTCP,
+			U8Proto:  0x6,
+			Endpoints: api.EndpointSelectorSlice{
+				api.EndpointSelector{
+					LabelSelector: &v1.LabelSelector{
+						MatchLabels: map[string]string{"any.id": "bar1"},
+						MatchExpressions: []v1.LabelSelectorRequirement{
+							{
+								Key:      "any.id",
+								Operator: v1.LabelSelectorOpIn,
+								Values:   []string{"bar2"},
+							},
+						},
+					},
+				},
+			},
+			L7RulesPerEp:     L7DataMap{},
+			Ingress:          true,
+			DerivedFromRules: labels.LabelArrayList{nil},
+		},
+	}
+	c.Assert((*policy), comparator.DeepEquals, expectedPolicy)
+}
+
+func (ds *PolicyTestSuite) TestL3DependentL4EgressFromRequires(c *C) {
+	repo := NewPolicyRepository()
+
+	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
+	selBar1 := api.NewESFromLabels(labels.ParseSelectLabel("id=bar1"))
+	selBar2 := api.NewESFromLabels(labels.ParseSelectLabel("id=bar2"))
+
+	l480Rule := api.Rule{
+		EndpointSelector: selFoo,
+		Egress: []api.EgressRule{
+			{
+				ToEndpoints: []api.EndpointSelector{
+					selBar1,
+				},
+				ToPorts: []api.PortRule{{
+					Ports: []api.PortProtocol{
+						{Port: "80", Protocol: api.ProtoTCP},
+					},
+				}},
+			},
+			{
+				ToRequires: []api.EndpointSelector{selBar2},
+			},
+		},
+	}
+	l480Rule.Sanitize()
+	_, err := repo.Add(l480Rule)
+	c.Assert(err, IsNil)
+
+	ctx := &SearchContext{
+		From: labels.ParseSelectLabelArray("id=foo"),
+	}
+
+	repo.Mutex.RLock()
+	defer repo.Mutex.RUnlock()
+
+	policy, err := repo.ResolveL4EgressPolicy(ctx)
+	c.Assert(err, IsNil)
+
+	expectedPolicy := L4PolicyMap{
+		"80/TCP": L4Filter{
+			Port:     80,
+			Protocol: api.ProtoTCP,
+			U8Proto:  0x6,
+			Endpoints: api.EndpointSelectorSlice{
+				api.EndpointSelector{
+					LabelSelector: &v1.LabelSelector{
+						MatchLabels: map[string]string{"any.id": "bar1"},
+						MatchExpressions: []v1.LabelSelectorRequirement{
+							{
+								Key:      "any.id",
+								Operator: v1.LabelSelectorOpIn,
+								Values:   []string{"bar2"},
+							},
+						},
+					},
+				},
+			},
+			L7RulesPerEp:     L7DataMap{},
+			DerivedFromRules: labels.LabelArrayList{nil},
 		},
 	}
 	c.Assert((*policy), comparator.DeepEquals, expectedPolicy)

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -22,6 +22,8 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/policy/api"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type rule struct {
@@ -177,7 +179,7 @@ func (state *traceState) unSelectRule(ctx *SearchContext, labels labels.LabelArr
 }
 
 // resolveL4IngressPolicy determines whether (TODO ianvernon)
-func (r *rule) resolveL4IngressPolicy(ctx *SearchContext, state *traceState, result *L4Policy) (*L4Policy, error) {
+func (r *rule) resolveL4IngressPolicy(ctx *SearchContext, state *traceState, result *L4Policy, requirements []v1.LabelSelectorRequirement) (*L4Policy, error) {
 	if !r.EndpointSelector.Matches(ctx.To) {
 		state.unSelectRule(ctx, ctx.To, r)
 		return nil, nil
@@ -190,7 +192,25 @@ func (r *rule) resolveL4IngressPolicy(ctx *SearchContext, state *traceState, res
 		ctx.PolicyTrace("    No L4 ingress rules\n")
 	}
 	for _, ingressRule := range r.Ingress {
-		cnt, err := mergeL4Ingress(ctx, ingressRule, r.Rule.Labels.DeepCopy(), result.Ingress)
+		ruleCopy := ingressRule
+
+		// For each FromEndpoints in each ingress rule, add requirements, which
+		// is a flattened list of all EndpointSelectors from all FromRequires
+		// from rules which select the labels in ctx.To. This ensures that
+		// FromRequires is taken into account even if it isn't part of the current
+		// rule over which we are iterating.
+		if len(requirements) > 0 {
+			// Create a deep copy of the rule, as we are going to modify FromEndpoints
+			// with requirementsSelector. We don't want to modify the rule itself
+			// in the policy repository.
+			ruleCopy = *ingressRule.DeepCopy()
+			// Update each EndpointSelector in FromEndpoints to contain requirements.
+			for _, fromEndpoint := range ruleCopy.FromEndpoints {
+				fromEndpoint.MatchExpressions = append(fromEndpoint.MatchExpressions, requirements...)
+			}
+		}
+
+		cnt, err := mergeL4Ingress(ctx, ruleCopy, r.Rule.Labels.DeepCopy(), result.Ingress)
 		if err != nil {
 			return nil, err
 		}
@@ -511,7 +531,7 @@ func mergeL4EgressPort(ctx *SearchContext, endpoints []api.EndpointSelector, r a
 	return 1, nil
 }
 
-func (r *rule) resolveL4EgressPolicy(ctx *SearchContext, state *traceState, result *L4Policy) (*L4Policy, error) {
+func (r *rule) resolveL4EgressPolicy(ctx *SearchContext, state *traceState, result *L4Policy, requirements []v1.LabelSelectorRequirement) (*L4Policy, error) {
 
 	if !r.EndpointSelector.Matches(ctx.From) {
 		state.unSelectRule(ctx, ctx.From, r)
@@ -525,7 +545,24 @@ func (r *rule) resolveL4EgressPolicy(ctx *SearchContext, state *traceState, resu
 		ctx.PolicyTrace("    No L4 rules\n")
 	}
 	for _, egressRule := range r.Egress {
-		cnt, err := mergeL4Egress(ctx, egressRule, r.Rule.Labels.DeepCopy(), result.Egress)
+		ruleCopy := egressRule
+		// For each ToEndpoints in each egress rule, add the requirements, which
+		// is a flattened list of all EndpointSelectors from all ToRequires
+		// from rules which select the labels in ctx.From. This ensures that
+		// ToRequires is taken into account even if it isn't part of the current
+		// rule over which we are iterating.
+		if len(requirements) > 0 {
+			// Create a deep copy of the rule, as we are going to modify
+			// ToEndpoints with requirements; we don't want to modify the rule
+			// in the repository.
+			ruleCopy = *egressRule.DeepCopy()
+			for _, toEndpoint := range ruleCopy.ToEndpoints {
+				// Update each EndpointSelector in ToEndpoints to contain
+				// requirements.
+				toEndpoint.MatchExpressions = append(toEndpoint.MatchExpressions, requirements...)
+			}
+		}
+		cnt, err := mergeL4Egress(ctx, ruleCopy, r.Rule.Labels.DeepCopy(), result.Egress)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -177,11 +177,11 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 
 	ingressState := traceState{}
 	egressState := traceState{}
-	res, err := rule1.resolveL4IngressPolicy(toBar, &ingressState, NewL4Policy())
+	res, err := rule1.resolveL4IngressPolicy(toBar, &ingressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
-	res2, err := rule1.resolveL4EgressPolicy(fromBar, &egressState, NewL4Policy())
+	res2, err := rule1.resolveL4EgressPolicy(fromBar, &egressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res2, Not(IsNil))
 
@@ -198,9 +198,9 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	ingressState = traceState{}
 	egressState = traceState{}
 
-	res, err = rule1.resolveL4IngressPolicy(toFoo, &ingressState, NewL4Policy())
+	res, err = rule1.resolveL4IngressPolicy(toFoo, &ingressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
-	res2, err = rule1.resolveL4EgressPolicy(fromFoo, &ingressState, NewL4Policy())
+	res2, err = rule1.resolveL4EgressPolicy(fromFoo, &ingressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 
 	c.Assert(res, IsNil)
@@ -278,11 +278,11 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 
 	ingressState = traceState{}
 	egressState = traceState{}
-	res, err = rule2.resolveL4IngressPolicy(toBar, &ingressState, NewL4Policy())
+	res, err = rule2.resolveL4IngressPolicy(toBar, &ingressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
-	res2, err = rule2.resolveL4EgressPolicy(fromBar, &egressState, NewL4Policy())
+	res2, err = rule2.resolveL4EgressPolicy(fromBar, &egressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res2, Not(IsNil))
 
@@ -299,11 +299,11 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	ingressState = traceState{}
 	egressState = traceState{}
 
-	res, err = rule2.resolveL4IngressPolicy(toFoo, &ingressState, NewL4Policy())
+	res, err = rule2.resolveL4IngressPolicy(toFoo, &ingressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 
-	res2, err = rule2.resolveL4EgressPolicy(fromFoo, &egressState, NewL4Policy())
+	res2, err = rule2.resolveL4EgressPolicy(fromFoo, &egressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 
@@ -353,7 +353,7 @@ func (ds *PolicyTestSuite) TestMergeL4PolicyIngress(c *C) {
 	}
 
 	state := traceState{}
-	res, err := rule1.resolveL4IngressPolicy(toBar, &state, NewL4Policy())
+	res, err := rule1.resolveL4IngressPolicy(toBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -407,7 +407,7 @@ func (ds *PolicyTestSuite) TestMergeL4PolicyEgress(c *C) {
 	}
 
 	state := traceState{}
-	res, err := rule1.resolveL4EgressPolicy(fromBar, &state, NewL4Policy())
+	res, err := rule1.resolveL4EgressPolicy(fromBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -484,7 +484,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	}
 
 	state := traceState{}
-	res, err := rule1.resolveL4IngressPolicy(toBar, &state, NewL4Policy())
+	res, err := rule1.resolveL4IngressPolicy(toBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -492,7 +492,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = rule1.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = rule1.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -547,7 +547,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	}
 
 	state = traceState{}
-	res, err = rule2.resolveL4IngressPolicy(toBar, &state, NewL4Policy())
+	res, err = rule2.resolveL4IngressPolicy(toBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -555,19 +555,19 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = rule2.resolveL4IngressPolicy(toFoo, &state, NewL4Policy())
+	res, err = rule2.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
 	c.Assert(state.matchedRules, Equals, 0)
 
 	// Resolve rule1's policy, then try to add rule2.
-	res, err = rule1.resolveL4IngressPolicy(toBar, &state, NewL4Policy())
+	res, err = rule1.resolveL4IngressPolicy(toBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
 	state = traceState{}
-	_, err = rule2.resolveL4IngressPolicy(toBar, &state, res)
+	_, err = rule2.resolveL4IngressPolicy(toBar, &state, res, nil)
 
 	c.Assert(err, Not(IsNil))
 
@@ -629,7 +629,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	}
 
 	state = traceState{}
-	res, err = rule3.resolveL4IngressPolicy(toBar, &state, NewL4Policy())
+	res, err = rule3.resolveL4IngressPolicy(toBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -702,7 +702,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	}
 
 	state := traceState{}
-	res, err := rule1.resolveL4EgressPolicy(fromBar, &state, NewL4Policy())
+	res, err := rule1.resolveL4EgressPolicy(fromBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -710,7 +710,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = rule1.resolveL4EgressPolicy(fromFoo, &state, NewL4Policy())
+	res, err = rule1.resolveL4EgressPolicy(fromFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -773,7 +773,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	}
 
 	state = traceState{}
-	res, err = rule2.resolveL4EgressPolicy(fromBar, &state, NewL4Policy())
+	res, err = rule2.resolveL4EgressPolicy(fromBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -781,14 +781,14 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = rule2.resolveL4EgressPolicy(fromFoo, &state, NewL4Policy())
+	res, err = rule2.resolveL4EgressPolicy(fromFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
 	c.Assert(state.matchedRules, Equals, 0)
 
 	// Resolve rule1's policy, then try to add rule2.
-	res, err = rule1.resolveL4EgressPolicy(fromBar, &state, NewL4Policy())
+	res, err = rule1.resolveL4EgressPolicy(fromBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
@@ -847,7 +847,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	}
 
 	state = traceState{}
-	res, err = rule3.resolveL4EgressPolicy(fromBar, &state, NewL4Policy())
+	res, err = rule3.resolveL4EgressPolicy(fromBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, comparator.DeepEquals, *expected)
@@ -1450,8 +1450,8 @@ func (ds *PolicyTestSuite) TestL4RuleLabels(c *C) {
 
 			rule := &rule{Rule: apiRule}
 
-			rule.resolveL4IngressPolicy(toBar, &traceState{}, finalPolicy)
-			rule.resolveL4EgressPolicy(fromBar, &traceState{}, finalPolicy)
+			rule.resolveL4IngressPolicy(toBar, &traceState{}, finalPolicy, nil)
+			rule.resolveL4EgressPolicy(fromBar, &traceState{}, finalPolicy, nil)
 		}
 
 		c.Assert(len(finalPolicy.Ingress), Equals, len(test.expectedIngressLabels), Commentf(test.description))

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,13 +1,13 @@
 version: "2"
 services:
   consul:
-    image: "consul:0.8.3"
+    image: "docker.io/library/consul:1.1.0"
     hostname: "consul"
     environment:
       - 'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true, "disable_update_check": true}'
     privileged: true
   etcd:
-    image: "quay.io/coreos/etcd:v3.1.0"
+    image: "quay.io/coreos/etcd:v3.2.17"
     hostname: "etcd"
     command: "etcd -name etcd0 -advertise-client-urls http://0.0.0.0:4002 -listen-client-urls http://0.0.0.0:4002 -initial-cluster-token etcd-cluster-1 -initial-cluster-state new"
     privileged: true

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - consul
       - etcd
-    image: "cilium/cilium-builder:2018-03-29"
+    image: "quay.io/cilium/cilium-builder:2018-06-21"
     command: "bash -c 'cd /go/src/github.com/cilium/cilium/; make tests-ginkgo-real'"
     privileged: true
     volumes:

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -12,6 +12,18 @@ MOUNT_SYSTEMD="sys-fs-bpf.mount"
 NODE=$1
 IP=$2
 K8S_VERSION=$3
+IPv6=$4
+CONTAINER_RUNTIME=$5
+
+# Kubeadm default parameters
+export KUBEADM_ADDR='192.168.36.11'
+export KUBEADM_POD_NETWORK='10.10.0.0'
+export KUBEADM_POD_CIDR='16'
+export KUBEADM_CRI_SOCKET="/var/run/dockershim.sock"
+export KUBEADM_SLAVE_OPTIONS=""
+export KUBEADM_OPTIONS=""
+export K8S_FULL_VERSION=""
+export INSTALL_KUBEDNS=1
 
 source ${PROVISIONSRC}/helpers.bash
 
@@ -69,6 +81,7 @@ case $K8S_VERSION in
         KUBERNETES_CNI_VERSION="0.6.0-00"
         K8S_FULL_VERSION="1.10.3"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri"
+        KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
         ;;
     "1.11")
         KUBERNETES_CNI_VERSION="v0.6.0"


### PR DESCRIPTION
PR: #4634 -- test: update k8s to 1.8.14, 1.10.4 and 1.11.0 (@aanm)
PR: #4636 -- Fix PolicyRevision of endpoint bumped prematurely (@aanm)
PR: #4653 -- tests: Update cilium-builder in unit tests to 2018-06-21 (@aanm)
PR: #4655 -- test: Use latest stable etcd and consul images (@aanm)
PR: #4663 -- backport: Only check merged PRs (@raybejjani)
PR: #4682 -- pkg/policy: take into account To / FromRequires when computing L4 policy (@ianvernon)

Skipped:
@aanm I have skipped 3fa23d0 ("ginkgo-kubernetes-all.Jenkinsfile: move k8s 1.10 and 1.12 to same stage") and https://github.com/cilium/cilium/commit/1b882e4109f1b99f9f6c99124074aad6e619b49f (test: update k8s to 1.8.14, 1.10.4 and 1.11.0)
since these were reverted in master recently. Please let me know.

Also PR: #4635 -- update cilium to golang 1.10.3 (@aanm)
Because it was leading to envoy compilation errors 
Please check development channel on slack for reference as well as https://github.com/cilium/cilium/pull/4737

PR: #4265 -- test: add k8s 1.12 test framework (@aanm)
Discussed this offline with Andre and we felt its best to do this in a separate PR.
Andre already opened https://github.com/cilium/cilium/pull/4762

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4752)
<!-- Reviewable:end -->