### PR TITLE
examples/kubernetes: fix default crio mounting path

### DIFF
--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -161,7 +161,7 @@ spec:
           # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
-            path: /var/run/crio.sock
+            path: /var/run/crio/crio.sock
           # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -199,7 +199,7 @@ spec:
           # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
-            path: /var/run/crio.sock
+            path: /var/run/crio/crio.sock
           # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -161,7 +161,7 @@ spec:
           # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
-            path: /var/run/crio.sock
+            path: /var/run/crio/crio.sock
           # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -199,7 +199,7 @@ spec:
           # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
-            path: /var/run/crio.sock
+            path: /var/run/crio/crio.sock
           # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -56,7 +56,6 @@ spec:
         command: [ "cilium-agent" ]
         args:
           - "--debug=$(CILIUM_DEBUG)"
-          - "-t=vxlan"
           - "--kvstore=etcd"
           - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
           - "--disable-ipv4=$(DISABLE_IPV4)"
@@ -156,7 +155,7 @@ spec:
           # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
-            path: /var/run/crio.sock
+            path: /var/run/crio/crio.sock
           # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -187,7 +187,7 @@ spec:
           # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
-            path: /var/run/crio.sock
+            path: /var/run/crio/crio.sock
           # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:

--- a/examples/kubernetes/1.7/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-crio-ds.yaml
@@ -161,7 +161,7 @@ spec:
           # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
-            path: /var/run/crio.sock
+            path: /var/run/crio/crio.sock
           # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:

--- a/examples/kubernetes/1.7/cilium-crio.yaml
+++ b/examples/kubernetes/1.7/cilium-crio.yaml
@@ -199,7 +199,7 @@ spec:
           # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
-            path: /var/run/crio.sock
+            path: /var/run/crio/crio.sock
           # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -161,7 +161,7 @@ spec:
           # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
-            path: /var/run/crio.sock
+            path: /var/run/crio/crio.sock
           # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -199,7 +199,7 @@ spec:
           # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
-            path: /var/run/crio.sock
+            path: /var/run/crio/crio.sock
           # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -161,7 +161,7 @@ spec:
           # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
-            path: /var/run/crio.sock
+            path: /var/run/crio/crio.sock
           # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -199,7 +199,7 @@ spec:
           # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
-            path: /var/run/crio.sock
+            path: /var/run/crio/crio.sock
           # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -161,7 +161,7 @@ spec:
           # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
-            path: /var/run/crio.sock
+            path: /var/run/crio/crio.sock
           # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Change default "CRI-o" mounting path to "/var/run/crio/crio.sock"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4753)
<!-- Reviewable:end -->
