### PR TITLE
examples/kubernetes: add volume types

### DIFF
--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -184,22 +184,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
             path: /var/run/crio/crio.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -238,22 +238,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
             path: /var/run/crio/crio.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -183,22 +183,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read docker events from the node
         - name: docker-socket
           hostPath:
             path: /var/run/docker.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -237,22 +237,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read docker events from the node
         - name: docker-socket
           hostPath:
             path: /var/run/docker.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -184,22 +184,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
             path: /var/run/crio/crio.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -238,22 +238,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
             path: /var/run/crio/crio.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -183,22 +183,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read docker events from the node
         - name: docker-socket
           hostPath:
             path: /var/run/docker.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -237,22 +237,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read docker events from the node
         - name: docker-socket
           hostPath:
             path: /var/run/docker.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -184,22 +184,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
             path: /var/run/crio/crio.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -238,22 +238,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
             path: /var/run/crio/crio.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -183,22 +183,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read docker events from the node
         - name: docker-socket
           hostPath:
             path: /var/run/docker.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -237,22 +237,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read docker events from the node
         - name: docker-socket
           hostPath:
             path: /var/run/docker.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -184,22 +184,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
             path: /var/run/crio/crio.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -238,22 +238,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
             path: /var/run/crio/crio.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -183,22 +183,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read docker events from the node
         - name: docker-socket
           hostPath:
             path: /var/run/docker.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -237,22 +237,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read docker events from the node
         - name: docker-socket
           hostPath:
             path: /var/run/docker.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -184,22 +184,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
             path: /var/run/crio/crio.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -238,22 +238,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
             path: /var/run/crio/crio.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -183,22 +183,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read docker events from the node
         - name: docker-socket
           hostPath:
             path: /var/run/docker.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -237,22 +237,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read docker events from the node
         - name: docker-socket
           hostPath:
             path: /var/run/docker.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -184,22 +184,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:
             path: /var/run/crio/crio.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -183,22 +183,27 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
+            type: "DirectoryOrCreate"
         # To keep state between restarts / upgrades
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
         # To read docker events from the node
         - name: docker-socket
           hostPath:
             path: /var/run/docker.sock
+            type: "Socket"
         # To install cilium cni plugin in the host
         - name: cni-path
           hostPath:
             path: /opt/cni/bin
+            type: "DirectoryOrCreate"
         # To install cilium cni configuration in the host
         - name: etc-cni-netd
           hostPath:
             path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
         # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:


### PR DESCRIPTION
Volume Types allows to fail fast in case the volume type does not exist
on a specific node, for example if a specific path is not a Unix Socket,
or create a directory for a volume path if it does not exist on the node.

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Add volume types for volumes in kubernetes Cilium DaemonSet.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4755)
<!-- Reviewable:end -->
