### PR TITLE
Make the Istio sidecar proxy image name regexp configurable

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -68,6 +68,7 @@ cilium-agent
       --prefilter-mode string                       Prefilter mode { native | generic } (default: native) (default "native")
       --prometheus-serve-addr string                IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
       --restore                                     Restores state, if possible, from previous daemon (default true)
+      --sidecar-istio-proxy-image string            Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
       --single-cluster-route                        Use a single cluster route instead of per node routes
       --socket-path string                          Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
       --state-dir string                            Directory path to store runtime state (default "/var/run/cilium")

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -408,6 +408,9 @@ func init() {
 	flags.Bool("sidecar-http-proxy", false, "Disable host HTTP proxy, assuming proxies in sidecar containers")
 	flags.MarkHidden("sidecar-http-proxy")
 	viper.BindEnv("sidecar-http-proxy", "CILIUM_SIDECAR_HTTP_PROXY")
+	flags.String("sidecar-istio-proxy-image", workloads.DefaultSidecarIstioProxyImageRegexp,
+		"Regular expression matching compatible Istio sidecar istio-proxy container image names")
+	viper.BindEnv("sidecar-istio-proxy-image", "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE")
 	flags.Bool(option.SingleClusterRouteName, false,
 		"Use a single cluster route instead of per node routes")
 	flags.StringVar(&socketPath,
@@ -703,6 +706,12 @@ func initEnv(cmd *cobra.Command) {
 
 	if viper.GetBool("sidecar-http-proxy") {
 		log.Warn(`"sidecar-http-proxy" flag is deprecated and has no effect`)
+	}
+
+	workloads.SidecarIstioProxyImageRegexp, err = regexp.Compile(viper.GetString("sidecar-istio-proxy-image"))
+	if err != nil {
+		log.WithError(err).Fatal("Invalid sidecar-istio-proxy-image regular expression")
+		return
 	}
 }
 

--- a/examples/kubernetes/1.10/cilium-cm.yaml
+++ b/examples/kubernetes/1.10/cilium-cm.yaml
@@ -29,6 +29,10 @@ data:
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
 
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -101,6 +101,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -29,6 +29,10 @@ data:
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
 
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
@@ -139,6 +143,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -100,6 +100,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -29,6 +29,10 @@ data:
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
 
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
@@ -138,6 +142,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.11/cilium-cm.yaml
+++ b/examples/kubernetes/1.11/cilium-cm.yaml
@@ -29,6 +29,10 @@ data:
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
 
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -101,6 +101,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -29,6 +29,10 @@ data:
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
 
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
@@ -139,6 +143,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -100,6 +100,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -29,6 +29,10 @@ data:
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
 
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
@@ -138,6 +142,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.12/cilium-cm.yaml
+++ b/examples/kubernetes/1.12/cilium-cm.yaml
@@ -29,6 +29,10 @@ data:
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
 
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -101,6 +101,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -29,6 +29,10 @@ data:
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
 
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
@@ -139,6 +143,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -100,6 +100,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -29,6 +29,10 @@ data:
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
 
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
@@ -138,6 +142,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.7/cilium-cm.yaml
+++ b/examples/kubernetes/1.7/cilium-cm.yaml
@@ -29,6 +29,10 @@ data:
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
 
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled

--- a/examples/kubernetes/1.7/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-crio-ds.yaml
@@ -101,6 +101,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.7/cilium-crio.yaml
+++ b/examples/kubernetes/1.7/cilium-crio.yaml
@@ -29,6 +29,10 @@ data:
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
 
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
@@ -139,6 +143,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -100,6 +100,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -29,6 +29,10 @@ data:
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
 
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
@@ -138,6 +142,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.8/cilium-cm.yaml
+++ b/examples/kubernetes/1.8/cilium-cm.yaml
@@ -29,6 +29,10 @@ data:
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
 
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -101,6 +101,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -29,6 +29,10 @@ data:
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
 
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
@@ -139,6 +143,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -100,6 +100,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -29,6 +29,10 @@ data:
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
 
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
@@ -138,6 +142,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.9/cilium-cm.yaml
+++ b/examples/kubernetes/1.9/cilium-cm.yaml
@@ -29,6 +29,10 @@ data:
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
 
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -101,6 +101,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -29,6 +29,10 @@ data:
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
 
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
@@ -139,6 +143,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -100,6 +100,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -29,6 +29,10 @@ data:
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
 
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled
@@ -138,6 +142,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/templates/v1/cilium-cm.yaml
+++ b/examples/kubernetes/templates/v1/cilium-cm.yaml
@@ -29,6 +29,10 @@ data:
   clean-cilium-state: "false"
   legacy-host-allows-world: "false"
 
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
   # Encapsulation mode for communication between nodes
   # Possible values:
   #   - disabled

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -101,6 +101,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -100,6 +100,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: legacy-host-allows-world
+          - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: sidecar-istio-proxy-image
+                optional: true
           - name: CILIUM_TUNNEL
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
Add a `sidecar-istio-proxy-image` flag to specify the regular expression matching compatible Istio sidecar `istio-proxy` container image names.

Add a corresponding `sidecar-istio-proxy-image` setting into the example k8s config map and daemon sets.

Fixes: https://github.com/cilium/cilium/issues/4760
Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4764)
<!-- Reviewable:end -->
