### PR TITLE
vagrant: update Vagrantfiles to use vm v97

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -127,7 +127,7 @@ Vagrant.configure(2) do |config|
         vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
 
         config.vm.box = "cilium/ubuntu-dev"
-        config.vm.box_version = "92"
+        config.vm.box_version = "97"
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i
         if ENV["NFS"] then

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -8,7 +8,7 @@ $K8S_VERSION = ENV['K8S_VERSION'] || "1.10"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 $NFS = ENV['NFS']=="1"? true : false
 $SERVER_BOX = (ENV['SERVER_BOX'] || "cilium/ubuntu-dev")
-$SERVER_VERSION="92"
+$SERVER_VERSION="97"
 $IPv6=(ENV['IPv6'] || "0")
 $CONTAINER_RUNTIME=(ENV['CONTAINER_RUNTIME'] || "docker")
 


### PR DESCRIPTION
This VM image is built with Ubuntu 18.04 LTS as a base.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4766)
<!-- Reviewable:end -->
