### PR TITLE
Test: Removed CreateNewRuntimeHelper

### DIFF
--- a/test/helpers/runtime.go
+++ b/test/helpers/runtime.go
@@ -25,9 +25,6 @@ import (
 // on the provided VM target and using logger 'log'. It marks the test as Fail
 // if it cannot get the ssh meta information or cannot execute a `ls` on the
 // virtual machine.
-//
-// This function does not set up cilium, so it should only be run by the
-// test_suite; test writers should use CreateNewRuntimeHelper() instead.
 func InitRuntimeHelper(target string, log *logrus.Entry) *SSHMeta {
 	node := GetVagrantSSHMeta(target)
 	if node == nil {
@@ -46,24 +43,5 @@ func InitRuntimeHelper(target string, log *logrus.Entry) *SSHMeta {
 	}
 
 	node.logger = log
-	return node
-}
-
-// CreateNewRuntimeHelper returns SSHMeta helper for running the runtime tests
-// on the provided VM target and using logger log. It marks the test as Fail if
-// the framework is unable to gain SSH access to the VM and run commands.
-func CreateNewRuntimeHelper(target string, log *logrus.Entry) *SSHMeta {
-	node := InitRuntimeHelper(target, log)
-	node.WaitUntilReady(100)
-	node.NetworkCreate(CiliumDockerNetwork, "")
-
-	res := node.SetPolicyEnforcement(PolicyEnforcementDefault)
-	if !res.WasSuccessful() {
-		ginkgo.Fail(fmt.Sprintf(
-			"Cannot set default policy enforcement on target '%s'",
-			target), 1)
-		return nil
-	}
-
 	return node
 }

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -62,7 +62,10 @@ var _ = Describe("RuntimeValidatedPolicyEnforcement", func() {
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimePolicyEnforcement"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+
+		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+		ExpectCiliumReady(vm)
+
 		vm.ContainerCreate(appContainerName, helpers.HttpdImage, helpers.CiliumDockerNetwork, "-l id.app")
 		areEndpointsReady := vm.WaitEndpointsReady()
 		Expect(areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
@@ -251,7 +254,9 @@ var _ = Describe("RuntimeValidatedPolicies", func() {
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"test": "RunPolicies"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+
+		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+		ExpectCiliumReady(vm)
 
 		vm.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
 		vm.PolicyDelAll()
@@ -1382,7 +1387,9 @@ var _ = Describe("RuntimeValidatedPolicyImportTests", func() {
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"test": "RuntimeValidatedPolicyImportTests"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+
+		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+		ExpectCiliumReady(vm)
 
 		vm.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
 

--- a/test/runtime/assertionHelpers.go
+++ b/test/runtime/assertionHelpers.go
@@ -39,3 +39,16 @@ func ExpectEndpointSummary(vm *helpers.SSHMeta, policyEnforcementType string, nu
 	ExpectWithOffset(1, err).Should(BeNil(), "error getting endpoint summary")
 	ExpectWithOffset(1, endpoints[policyEnforcementType]).To(Equal(numWithPolicyEnforcementType), "number of endpoints with %s=%s does not match", helpers.PolicyEnforcement, policyEnforcementType)
 }
+
+// ExpectCiliumReady asserts that cilium status is ready
+func ExpectCiliumReady(vm *helpers.SSHMeta) {
+	err := vm.WaitUntilReady(100)
+	ExpectWithOffset(1, err).To(BeNil(), "Cilium-agent cannot be started")
+
+	vm.NetworkCreate(helpers.CiliumDockerNetwork, "")
+	res := vm.NetworkGet(helpers.CiliumDockerNetwork)
+	ExpectWithOffset(1, res).To(helpers.CMDSuccess(), "Cilium docker network is not created")
+
+	res = vm.SetPolicyEnforcement(helpers.PolicyEnforcementDefault)
+	ExpectWithOffset(1, res).To(helpers.CMDSuccess(), "Cannot set policy enforcement default")
+}

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -33,7 +33,9 @@ var _ = Describe("RuntimeValidatedChaos", func() {
 	BeforeAll(func() {
 		logger := log.WithFields(logrus.Fields{"testName": "RuntimeValidatedChaos"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+
+		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+		ExpectCiliumReady(vm)
 
 		vm.ContainerCreate(helpers.Client, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
 		vm.ContainerCreate(helpers.Server, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.server")

--- a/test/runtime/cli.go
+++ b/test/runtime/cli.go
@@ -34,7 +34,9 @@ var _ = Describe("RuntimeValidatedCLI", func() {
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimeCLI"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+		ExpectCiliumReady(vm)
+
 		areEndpointsReady := vm.WaitEndpointsReady()
 		Expect(areEndpointsReady).Should(BeTrue())
 	})

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -25,7 +25,8 @@ var _ = Describe("RuntimeValidatedConnectivityTest", func() {
 	initialize := func() {
 		logger = log.WithFields(logrus.Fields{"test": "RuntimeConnectivityTest"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+		ExpectCiliumReady(vm)
 	}
 
 	JustBeforeEach(func() {
@@ -320,7 +321,8 @@ var _ = Describe("RuntimeValidatedConntrackTest", func() {
 	initialize := func() {
 		logger = log.WithFields(logrus.Fields{"test": "RunConntrackTest"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+		ExpectCiliumReady(vm)
 
 		ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementAlways)
 	}

--- a/test/runtime/ct.go
+++ b/test/runtime/ct.go
@@ -105,10 +105,9 @@ var _ = Describe("DisabledRuntimeValidatedConntrackTable", func() {
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimeConntrack"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
-		err := vm.WaitUntilReady(100)
-		Expect(err).To(BeNil())
-		vm.NetworkCreate(helpers.CiliumDockerNetwork, "")
+
+		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+		ExpectCiliumReady(vm)
 
 		containers(helpers.Create)
 	})

--- a/test/runtime/examples.go
+++ b/test/runtime/examples.go
@@ -36,7 +36,9 @@ var _ = Describe("RuntimeValidatedPolicyValidationTests", func() {
 	initialize := func() {
 		logger = log.WithFields(logrus.Fields{"test": "RuntimeValidatedPolicyValidationTests"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+
+		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+		ExpectCiliumReady(vm)
 	}
 
 	BeforeEach(func() {

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -108,7 +108,9 @@ var _ = Describe("RuntimeValidatedKafka", func() {
 
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimeValidatedKafka"})
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+
+		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+		ExpectCiliumReady(vm)
 
 		containers("create")
 		epsReady := vm.WaitEndpointsReady()

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -34,8 +34,8 @@ var _ = Describe("RuntimeValidatedKVStoreTest", func() {
 	initialize := func() {
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimeKVStoreTest"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
-		logger.Info("done creating Cilium and Docker helpers")
+		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+		ExpectCiliumReady(vm)
 	}
 	containers := func(option string) {
 		switch option {

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -35,8 +35,9 @@ var _ = Describe("RuntimeValidatedLB", func() {
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"test": "RuntimeLB"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
-		vm.PolicyDelAll().ExpectSuccess()
+
+		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+		ExpectCiliumReady(vm)
 	})
 
 	AfterAll(func() {

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -49,7 +49,9 @@ var _ = Describe("RuntimeValidatedMonitorTest", func() {
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"testName": "RuntimeMonitorTest"})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+		ExpectCiliumReady(vm)
+
 		areEndpointsReady := vm.WaitEndpointsReady()
 		Expect(areEndpointsReady).Should(BeTrue())
 	})

--- a/test/runtime/verifier.go
+++ b/test/runtime/verifier.go
@@ -37,7 +37,9 @@ var _ = Describe(verifierTest, func() {
 	BeforeAll(func() {
 		logger = log.WithFields(logrus.Fields{"testName": verifierTest})
 		logger.Info("Starting")
-		vm = helpers.CreateNewRuntimeHelper(helpers.Runtime, logger)
+
+		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+		ExpectCiliumReady(vm)
 
 		By("Stopping Cilium")
 		res := vm.ExecWithSudo("systemctl stop cilium")


### PR DESCRIPTION
Delete `helpers.CreateNewRuntimeHelper` because if it fails no assert
that provides the error message in the correct way.

With this change Cilium Runtime test will be executed as Kubernetes
test and will provide more context to users in case of fails

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4770)
<!-- Reviewable:end -->
