### PR TITLE
endpoint: fix deadlock in writeHeaderfile

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -75,7 +75,7 @@ func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 		}
 	}
 	if err != nil {
-		e.LogStatus(BPF, Warning, fmt.Sprintf("Unable to create a base64: %s", err))
+		e.logStatusLocked(BPF, Warning, fmt.Sprintf("Unable to create a base64: %s", err))
 	}
 
 	if e.DockerID == "" {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1499,8 +1499,6 @@ func (e *Endpoint) LogStatus(typ StatusType, code StatusCode, msg string) {
 	defer e.Mutex.Unlock()
 	// FIXME GH2323 instead of a mutex we could use a channel to send the status
 	// log message to a single writer?
-	e.Status.indexMU.Lock()
-	defer e.Status.indexMU.Unlock()
 	e.logStatusLocked(typ, code, msg)
 }
 
@@ -1512,12 +1510,12 @@ func (e *Endpoint) LogStatusOK(typ StatusType, msg string) {
 // given msg string.
 // must be called with endpoint.Mutex held
 func (e *Endpoint) LogStatusOKLocked(typ StatusType, msg string) {
-	e.Status.indexMU.Lock()
-	defer e.Status.indexMU.Unlock()
 	e.logStatusLocked(typ, OK, msg)
 }
 
 func (e *Endpoint) logStatusLocked(typ StatusType, code StatusCode, msg string) {
+	e.Status.indexMU.Lock()
+	defer e.Status.indexMU.Unlock()
 	sts := &statusLogMsg{
 		Status: Status{
 			Code:  code,


### PR DESCRIPTION
writeHeaderfile is called with the endpoint Mutex is held. LogStatus tries to acquire the endpoint Mutex, and is called within writeHeaderfile. This is a deadlock scenario. Fix by calling logStatusLocked instead, which assumes the endpoint Mutex is held.

Also, some functions within pkg/endpoint called this function without the aforementioned mutex being locked, which should be done as we are updating the object which it protects. Move the locking logic into logStatusLocked, which is called when the endpoint Mutex is held.

Fixes: #4772 

Signed-off-by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4774)
<!-- Reviewable:end -->
