### PR TITLE
Improve MTU upgrade notes to use mtu-update

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -298,6 +298,7 @@ mlx
 Monnet
 mountd
 mov
+mtu
 mul
 Multi
 multi


### PR DESCRIPTION
The new mtu-update tool (https://github.com/cilium/mtu-update) provides
a DaemonSet that allows users to deploy and upgrade all of their
existing pods in-place without restarting them to receive the new MTU
behaviour, when upgrading from Cilium 1.0. Update the documentation to
recommend users to use this.

Note that this will default to MTU 1500 (route MTU 1450), it doesn't currently make use of the newer Cilium MTU detection logic. We may want to consider implementing https://github.com/cilium/mtu-update/issues/3 before merging this documentation update.

Fixes: #4759 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4780)
<!-- Reviewable:end -->
