### PR TITLE
test: Change CPU environment variable to CPUS

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -14,7 +14,7 @@ $CONTAINER_RUNTIME=(ENV['CONTAINER_RUNTIME'] || "docker")
 
 # RAM and CPU settings
 $MEMORY = (ENV['MEMORY'] || "4096").to_i
-$CPU = (ENV['CPU'] || "2").to_i
+$CPU = (ENV['CPUS'] || "2").to_i
 
 ENV["VAGRANT_DEFAULT_PROVIDER"] = "virtualbox"
 Vagrant.configure("2") do |config|


### PR DESCRIPTION
On openSUSE, the CPU environment variable usually contains info
about the architecture of processor. That's why using CPU (instead
of CPUS) to configure number of vCPUs wasn't working.

Fixes #4786

Signed-off-by: Michal Rostecki <mrostecki@suse.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4787)
<!-- Reviewable:end -->
