### PR TITLE
pkg/kvstore: set hard timeout for etcd lock path to 1 minute

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -339,7 +339,9 @@ func (e *etcdClient) LockPath(path string) (kvLocker, error) {
 	mu := concurrency.NewMutex(e.session, path)
 	e.RUnlock()
 
-	err := mu.Lock(ctx.Background())
+	ctx, cancel := ctx.WithTimeout(ctx.Background(), 1*time.Minute)
+	defer cancel()
+	err := mu.Lock(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Prevent Cilium from deadlock when interacting with etcd
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4788)
<!-- Reviewable:end -->
