### PR TITLE
CI: Disable fail-fast on Jenkins if no label.

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -60,7 +60,7 @@ pipeline {
                 K8S_VERSION=1.9
                 MEMORY=4096
                 CPU=4
-                FAILFAST=setIfPR("true", "false")
+                FAILFAST=setIfLabel("ci/fail-fast", "true", "false")
             }
             steps {
                 parallel(

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -37,6 +37,7 @@ pipeline {
         TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
         GOPATH="${WORKSPACE}"
         SERVER_BOX = "cilium/ubuntu"
+        FAILFAST=setIfLabel("ci/fail-fast", "true", "false")
     }
 
     options {
@@ -70,21 +71,23 @@ pipeline {
         }
         stage('BDD-Test-k8s') {
             environment {
-                FAILFAST=setIfPR("true", "false")
                 CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
             }
             options {
                 timeout(time: 90, unit: 'MINUTES')
             }
             steps {
-                parallel(
-                    "K8s-1.8":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.8 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST}'
-                    },
-                    "K8s-1.9":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.9 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST}'
-                    },
-                )
+                script {
+                    parallel(
+                        "K8s-1.8":{
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.8 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST}'
+                        },
+                        "K8s-1.9":{
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.9 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST}'
+                        },
+                        failFast: "${FAILFAST}".toBoolean()
+                    )
+                }
             }
             post {
                 always {
@@ -113,21 +116,23 @@ pipeline {
         }
         stage('Non-release-k8s-versions') {
             environment {
-                FAILFAST=setIfPR("true", "false")
                 CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
             }
             options {
                 timeout(time: 90, unit: 'MINUTES')
             }
             steps {
-                parallel(
-                    "K8s-1.11":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.11 ginkgo --focus=" K8s*" --failFast=${FAILFAST}'
-                    },
-                    "K8s-1.12":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.12 ginkgo --focus=" K8s*" --failFast=${FAILFAST}'
-                    },
-                )
+                script {
+                    parallel(
+                        "K8s-1.11":{
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.11 ginkgo --focus=" K8s*" --failFast=${FAILFAST}'
+                        },
+                        "K8s-1.12":{
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.12 ginkgo --focus=" K8s*" --failFast=${FAILFAST}'
+                        },
+                        failFast: "${FAILFAST}".toBoolean()
+                    )
+                }
             }
             post {
                 always {

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -85,7 +85,7 @@ pipeline {
             environment {
                 GOPATH="${WORKSPACE}"
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
-                FAILFAST=setIfPR("true", "false")
+                FAILFAST=setIfLabel("ci/fail-fast", "true", "false")
                 CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
             }
 
@@ -94,18 +94,20 @@ pipeline {
             }
 
             steps {
-                parallel(
-                    "Runtime":{
-                        sh 'cd ${TESTDIR}; ginkgo --focus=" RuntimeValidated*" -v --failFast=${FAILFAST}'
-                    },
-                    "K8s-1.7":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.7 ginkgo --focus=" K8sValidated*" -v --failFast=${FAILFAST}'
-                    },
-                    "K8s-1.10":{
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --focus=" K8sValidated*" -v --failFast=${FAILFAST}'
-                    },
-                    failFast: true
-                )
+                script {
+                    parallel(
+                        "Runtime":{
+                            sh 'cd ${TESTDIR}; ginkgo --focus=" RuntimeValidated*" -v --failFast=${FAILFAST}'
+                        },
+                        "K8s-1.7":{
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.7 ginkgo --focus=" K8sValidated*" -v --failFast=${FAILFAST}'
+                        },
+                        "K8s-1.10":{
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --focus=" K8sValidated*" -v --failFast=${FAILFAST}'
+                        },
+                        failFast: "${FAILFAST}".toBoolean()
+                    )
+                }
             }
             post {
                 always {


### PR DESCRIPTION
By default now test with fail-fast is disabled and will only be enabled
if the ci/fail-fast label is present in the PR.

This is a consecuence of the CI meeting:
https://docs.google.com/document/d/1BDX6g9mhQqiVYxdYn6wPk6wv9clJrcaGmRlrxvSTiLo/edit

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4796)
<!-- Reviewable:end -->
