### PR TITLE
ipache: Skip Upsert() if IP is already mapped to given identity

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -188,6 +188,11 @@ func (ipc *IPCache) Upsert(IP string, identity Identity) bool {
 		if !allowOverwrite(existingIdentity.Source, identity.Source) {
 			return false
 		}
+
+		// Skip update if IP is already mapped to the given identity
+		if existingIdentity == identity {
+			return false
+		}
 	}
 
 	// An update is treated as a deletion and then an insert.


### PR DESCRIPTION
The envoy filter bails out when receiving an hostIP to identity mapping that already exists in the local cache. This causes a NACK to be sent.

The behavior of the Envoy filter is not ideal as it should be able to handle an update for an existing mapping. As an immediate workaround, protect the ipcache from no-op updates by adding a check to the `Upsert()` function.

Fixes: #4803
Fixes: 82a7ce9bad0a ("ipcache: Populate ipcache based on Pod events")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4804)
<!-- Reviewable:end -->
