### PR TITLE
pkg/policy/api: allow ToPorts coupled with ToServices

### DIFF
--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -131,7 +131,7 @@ func (e *EgressRule) sanitize() error {
 		"ToCIDRSet":   true,
 		"ToEndpoints": true,
 		"ToEntities":  true,
-		"ToServices":  false,
+		"ToServices":  true,
 	}
 	for m1 := range l3Members {
 		for m2 := range l3Members {

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -236,3 +236,36 @@ func (s *PolicyAPITestSuite) TestCIDRsanitize(c *C) {
 	_, err = cidr.sanitize()
 	c.Assert(err, NotNil)
 }
+
+func (s *PolicyAPITestSuite) TestToServicesSanitize(c *C) {
+
+	svcLabels := map[string]string{
+		"app": "tested-service",
+	}
+	selector := ServiceSelector(NewESFromMatchRequirements(svcLabels, nil))
+	toServicesL3L4 := Rule{
+		EndpointSelector: WildcardEndpointSelector,
+		Egress: []EgressRule{
+			{
+				ToServices: []Service{
+					{
+						K8sServiceSelector: &K8sServiceSelectorNamespace{
+							Selector:  selector,
+							Namespace: "",
+						},
+					},
+				},
+				ToPorts: []PortRule{{
+					Ports: []PortProtocol{
+						{Port: "80", Protocol: ProtoTCP},
+						{Port: "81", Protocol: ProtoTCP},
+					},
+				}},
+			},
+		},
+	}
+
+	err := toServicesL3L4.Sanitize()
+	c.Assert(err, IsNil)
+
+}


### PR DESCRIPTION
This functionality is supported in the datapath, because Cilium now supports
CIDR-dependent L4, and ToServices rules are translated into CIDR rules within
Cilium.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #4713

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4805)
<!-- Reviewable:end -->
