### PR TITLE
test: Increase connect timeout to 3 seconds

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -131,7 +131,7 @@ const (
 	StateRunning     = "Running"
 
 	PingCount          = 5
-	CurlConnectTimeout = 1
+	CurlConnectTimeout = 3
 
 	DefaultNamespace    = "default"
 	KubeSystemNamespace = "kube-system"


### PR DESCRIPTION
1 second is very optimistic. Bump it to 3 seconds. The impact on the CI
duration is limited as this only impacts timeout of requests that depend on
dropped packets. It is better to run connectivity tests in parallel if we want
to speed up CI runs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4806)
<!-- Reviewable:end -->
