### PR TITLE
docs: Map stable RTD version to VERSION

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -66,10 +66,14 @@ author = u'Cilium Authors'
 # The short X.Y version.
 release = open("../VERSION", "r").read().strip()
 
-# Fetch the docs version from an environment variable. Map latest -> master.
+# Fetch the docs version from an environment variable.
+# Map latest -> master.
+# Map stable -> current version number.
 branch = os.environ.get('READTHEDOCS_VERSION')
 if branch == None or branch == 'latest':
     branch = 'HEAD'
+elif branch == 'stable':
+    branch = release
 githubusercontent = 'https://raw.githubusercontent.com/cilium/cilium/'
 scm_web = githubusercontent + branch
 


### PR DESCRIPTION
When readthedocs requests to build the "stable" build, configure the
links into GitHub to search for the release version specified in the
root of the repository. This fixes the links for examples in the Cilium
github repository for the stable version of the docs, such as those used
in the kubernetes getting started guide.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4809)
<!-- Reviewable:end -->
