### PR TITLE
ipcache: Fix handling of endpoint IP events

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -850,8 +850,8 @@ func (h *putEndpointIDLabels) Handle(params PatchEndpointIDLabelsParams) middlew
 // 'oldIPIDPair' is ignored here, because in the BPF maps an update for the
 // IP->ID mapping will replace any existing contents; knowledge of the old pair
 // is not required to upsert the new pair.
-func (d *Daemon) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidr net.IPNet, hostIP net.IP,
-	oldID *identity.NumericIdentity, newID identity.NumericIdentity) {
+func (d *Daemon) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidr net.IPNet,
+	oldHostIP, newHostIP net.IP, oldID *identity.NumericIdentity, newID identity.NumericIdentity) {
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.IPAddr:       cidr,
 		logfields.Identity:     newID,
@@ -874,8 +874,8 @@ func (d *Daemon) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidr
 			SecurityIdentity: uint32(newID),
 		}
 
-		if hostIP != nil {
-			if ip4 := hostIP.To4(); ip4 != nil {
+		if newHostIP != nil {
+			if ip4 := newHostIP.To4(); ip4 != nil {
 				copy(value.TunnelEndpoint[:], ip4)
 			}
 		}

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1674,16 +1674,16 @@ func (d *Daemon) updateK8sNodeTunneling(k8sNodeOld, k8sNodeNew *v1.Node) error {
 		}
 		hostIP := node.GetNodeIP(false)
 		if ip4 := hostIP.To4(); ip4 == nil {
-			return "", nil, fmt.Errorf("HostIP is not an IPv4 address %s", hostIP)
+			return "", nil, fmt.Errorf("HostIP is not an IPv4 address: %s", hostIP)
 		}
 
 		ciliumIPStr := k8sNode.GetAnnotations()[annotation.CiliumHostIP]
 		ciliumIP := net.ParseIP(ciliumIPStr)
 		if ciliumIP == nil {
-			return "", nil, fmt.Errorf("no/invalid Cilium-Host IP: %s", ciliumIPStr)
+			return "", nil, fmt.Errorf("no/invalid Cilium-Host IP for host %s: %s", hostIP, ciliumIPStr)
 		}
 
-		return ciliumIPStr, ciliumIP, nil
+		return ciliumIPStr, hostIP, nil
 	}
 
 	ciliumIPStrNew, hostIPNew, err := getIDs(nodeNew, k8sNodeNew)

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -62,8 +62,8 @@ func (cache *NPHDSCache) OnIPIdentityCacheGC() {
 
 // OnIPIdentityCacheChange pushes modifications to the IP<->Identity mapping
 // into the Network Policy Host Discovery Service (NPHDS).
-func (cache *NPHDSCache) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidr net.IPNet, hostIP net.IP,
-	oldID *identity.NumericIdentity, newID identity.NumericIdentity) {
+func (cache *NPHDSCache) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidr net.IPNet,
+	oldHostIP, newHostIP net.IP, oldID *identity.NumericIdentity, newID identity.NumericIdentity) {
 	// An upsert where an existing pair exists should translate into a
 	// delete (for the old Identity) followed by an upsert (for the new).
 	if oldID != nil && modType == ipcache.Upsert {
@@ -72,7 +72,7 @@ func (cache *NPHDSCache) OnIPIdentityCacheChange(modType ipcache.CacheModificati
 			return
 		}
 
-		cache.OnIPIdentityCacheChange(ipcache.Delete, cidr, nil, nil, *oldID)
+		cache.OnIPIdentityCacheChange(ipcache.Delete, cidr, nil, nil, nil, *oldID)
 	}
 
 	cidrStr := cidr.String()

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -45,7 +45,7 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	// Deletion of key that doesn't exist doesn't cause panic.
 	IPIdentityCache.Delete(endpointIP)
 
-	IPIdentityCache.Upsert(endpointIP, Identity{
+	IPIdentityCache.Upsert(endpointIP, nil, Identity{
 		ID:     identity,
 		Source: FromKVStore,
 	})
@@ -60,13 +60,13 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	c.Assert(cachedIdentity.Source, Equals, FromKVStore)
 
 	// kubernetes source cannot update kvstore source
-	updated := IPIdentityCache.Upsert(endpointIP, Identity{
+	updated := IPIdentityCache.Upsert(endpointIP, nil, Identity{
 		ID:     identity,
 		Source: FromKubernetes,
 	})
 	c.Assert(updated, Equals, false)
 
-	IPIdentityCache.Upsert(endpointIP, Identity{
+	IPIdentityCache.Upsert(endpointIP, nil, Identity{
 		ID:     identity,
 		Source: FromKVStore,
 	})
@@ -85,13 +85,13 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 
 	c.Assert(exists, Equals, false)
 
-	IPIdentityCache.Upsert(endpointIP, Identity{
+	IPIdentityCache.Upsert(endpointIP, nil, Identity{
 		ID:     identity,
 		Source: FromKVStore,
 	})
 
 	newIdentity := identityPkg.NumericIdentity(69)
-	IPIdentityCache.Upsert(endpointIP, Identity{
+	IPIdentityCache.Upsert(endpointIP, nil, Identity{
 		ID:     newIdentity,
 		Source: FromKVStore,
 	})
@@ -118,7 +118,7 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	identities := []identityPkg.NumericIdentity{5, 67, 29, 29, 29}
 
 	for index := range endpointIPs {
-		IPIdentityCache.Upsert(endpointIPs[index], Identity{
+		IPIdentityCache.Upsert(endpointIPs[index], nil, Identity{
 			ID:     identities[index],
 			Source: FromKVStore,
 		})

--- a/pkg/ipcache/listener.go
+++ b/pkg/ipcache/listener.go
@@ -15,6 +15,8 @@
 package ipcache
 
 import (
+	"net"
+
 	"github.com/cilium/cilium/pkg/identity"
 )
 
@@ -33,9 +35,12 @@ const (
 // learning about IP to Identity mapping events.
 type IPIdentityMappingListener interface {
 	// OnIPIdentityCacheChange will be called whenever there the state of the
-	// IPCache has changed. If an existing IP->ID mapping is updated, then
-	// the old IPIdentityPair will be provided; otherwise it is nil.
-	OnIPIdentityCacheChange(modType CacheModification, oldIPIDPair *identity.IPIdentityPair, newIPIDPair identity.IPIdentityPair)
+	// IPCache has changed. If an existing CIDR->ID mapping is updated, then
+	// oldID is not nil; otherwise it is nil.
+	// hostIP is the IP address of the location of the cidr.
+	// hostIP is optional and may only be non-nil for an Upsert modification.
+	OnIPIdentityCacheChange(modType CacheModification, cidr net.IPNet, hostIP net.IP,
+		oldID *identity.NumericIdentity, newID identity.NumericIdentity)
 
 	// OnIPIdentityCacheGC will be called to sync other components which are
 	// reliant upon the IPIdentityCache with the IPIdentityCache.

--- a/pkg/ipcache/listener.go
+++ b/pkg/ipcache/listener.go
@@ -39,7 +39,7 @@ type IPIdentityMappingListener interface {
 	// oldID is not nil; otherwise it is nil.
 	// hostIP is the IP address of the location of the cidr.
 	// hostIP is optional and may only be non-nil for an Upsert modification.
-	OnIPIdentityCacheChange(modType CacheModification, cidr net.IPNet, hostIP net.IP,
+	OnIPIdentityCacheChange(modType CacheModification, cidr net.IPNet, oldHostIP, newHostIP net.IP,
 		oldID *identity.NumericIdentity, newID identity.NumericIdentity)
 
 	// OnIPIdentityCacheGC will be called to sync other components which are


### PR DESCRIPTION
Move the slice of ipcache listeners from `Daemon` into `IPCache`.
Factorize and encapsulate the handling of listeners into `IPCache`'s `Upsert` and `Delete` methods to reduce the complexity of callers.

Modify the signature of the `OnIPIdentityCacheChange` method in the `IPIdentityMappingListener` interface.
Specify that the given IP is always in CIDR form, with a prefix length, even when it represents an endpoint IP.
Use stronger types in the signature to clarify that only the identity and host IP associated with the CIDR may be modified.

Fix the `Upsert` and `Delete` to handle all cases of CIDR shadowing by endpoint IP:

- If inserting a new CIDR that is shadowed by an existing endpoint IP, don't callback the listeners about the insert.
- If inserting a new endpoint IP that is shadowing an existing CIDR, notify the listeners of an update of the identity associated with the CIDR, instead of an insert. If the shadowed CIDR and the endpoint IP are associated with the same identity, don't callback.
- If deleting a CIDR that was shadowed by an endpoint IP, don't callback the listeners about the delete.
- If deleting an endpoint IP that was shadowing a CIDR, notify the listeners of an update of the identity associated with the CIDR, instead of a delete. If the shadowed CIDR and the endpoint IP were associated with the same identity, don't callback.

In `Upsert`, when updating an IP's identity, delete the old identity from the identity-to-IP map.

Cache the mappings from endpoint IP / CIDR to host IP (maybe `nil`), in order to detect when the host IP for an endpoint changes.
Don't bypass the ipcache listener notifications when the host IP changes but the identity is identical.

Fixes: https://github.com/cilium/cilium/issues/4803
Fixes: https://github.com/cilium/cilium/issues/4798
Fixes: #3976

Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4810)
<!-- Reviewable:end -->
