### PR TITLE
CI: Archive artifacts with the stage name.

### DIFF
--- a/test/archive_test_results.sh
+++ b/test/archive_test_results.sh
@@ -3,7 +3,7 @@
 cd ${WORKSPACE}/test
 
 TEST_RESULTS="test_results"
-ARCHIVE_NAME="${TEST_RESULTS}_${JOB_BASE_NAME}_${BUILD_NUMBER}.zip"
+ARCHIVE_NAME="${TEST_RESULTS}_${JOB_BASE_NAME}_${BUILD_NUMBER}_${STAGE_NAME/ /}.zip"
 
 find $TEST_RESULTS/  -name "*.zip" | xargs -I '{}' mv '{}' ../
 


### PR DESCRIPTION
On multiple stages that creates multiple artifacts (Ginkgo kubernetes
all) the artifacts are not updating correctly because the zip file has
the same output name. With this change all artifacts has the stage name
in there too.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4811)
<!-- Reviewable:end -->
