### PR TITLE
pkg/workloads: check if Client() is nil to avoid nil pointer dereference

### DIFF
--- a/pkg/workloads/client.go
+++ b/pkg/workloads/client.go
@@ -52,12 +52,18 @@ func IsRunning(ep *endpoint.Endpoint) bool {
 
 // Status returns the status of the workload runtime
 func Status() *models.Status {
+	if Client() == nil {
+		return &models.Status{State: models.StatusStateDisabled}
+	}
 	return Client().Status()
 }
 
 // EnableEventListener watches for docker events. Performs the plumbing for the
 // containers started or dead.
 func EnableEventListener() (eventsCh chan<- *EventMessage, err error) {
+	if Client() == nil {
+		return nil, nil
+	}
 	return Client().EnableEventListener()
 }
 
@@ -65,5 +71,8 @@ func EnableEventListener() (eventsCh chan<- *EventMessage, err error) {
 // their IP address, then adds the containers to the list of ignored containers
 // and allocates the IPs they are using to prevent future collisions.
 func IgnoreRunningWorkloads() {
+	if Client() == nil {
+		return
+	}
 	Client().IgnoreRunningWorkloads()
 }


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Fix nil pointer dereference when running with --container-runtime=none
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4812)
<!-- Reviewable:end -->
