### PR TITLE
Documentation: Multiple fixes

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -956,6 +956,10 @@ configuration options that can be passed as environment variables:
 +----------------------+-------------------+--------------+------------------------------------------------------------------+
 | SERVER\_BOX          | cilium/ubuntu-dev | *            | Vagrantcloud base image                                          |
 +----------------------+-------------------+--------------+------------------------------------------------------------------+
+| CPU                  | 2                 | 0..100       | Number of CPUs that need to have the VM                          |
++----------------------+-------------------+--------------+------------------------------------------------------------------+
+| MEMORY               | 4096              | \d+          | RAM size in Megabytes                                            |
++----------------------+-------------------+--------------+------------------------------------------------------------------+
 
 Further Assistance
 ~~~~~~~~~~~~~~~~~~
@@ -976,7 +980,7 @@ Getting Started
 #. Clone the cilium repository
 
    ::
-  
+
       go get -d github.com/cilium/cilium
       cd $GOPATH/src/github.com/cilium/cilium
 
@@ -1030,7 +1034,7 @@ requirements have been met:
         Signed-off-by: Joe Stringer <joe@covalent.io>
 
    .. note:
-   
+
        Make sure to include a blank line in between commit title and commit
        description.
 
@@ -1123,7 +1127,7 @@ Getting a pull request merged
    One of the reviewers will start a CI run by replying with a comment
    ``test-me-please`` as described in :ref:`trigger_phrases``. If you are a
    core team member, you may trigger the CI run yourself.
-  
+
    #. Hound: basic ``golang/lint`` static code analyzer. You need to make the
       puppy happy.
    #. :ref:`ci_jenkins`: Will run a series of tests:
@@ -1669,7 +1673,7 @@ If you intent to release a new minor release, see the
 #. Create a branch for the release pull request:
 
    ::
-   
+
        git checkout -b pr/prepare-v1.0.3
 
 #. Update the ``VERSION`` file to represent ``X.Y.Z+1``
@@ -1679,7 +1683,7 @@ If you intent to release a new minor release, see the
 #. Update the image tag versions in the examples:
 
    ::
-   
+
        make -C examples/kubernetes clean all
 
 #. Update the ``cilium_version`` and ``cilium_tag`` variables in
@@ -1688,13 +1692,13 @@ If you intent to release a new minor release, see the
 #. Update the ``AUTHORS file``
 
    ::
-   
+
        make update-authors
 
 #. Generate the ``NEWS.rst`` addition:
 
    ::
-   
+
        git shortlog v1.0.2.. > add-to-NEWS.rst
 
 #. Add a new section to ``NEWS.rst``:
@@ -1719,7 +1723,7 @@ If you intent to release a new minor release, see the
        Make sure to create the PR against the desired stable branch. In this
        case ``v1.0``
 
-#. Follow standard procedures to get the 
+#. Follow standard procedures to get the
 #. Checkout out the stable branch and pull your merged changes:
 
    ::
@@ -1830,7 +1834,7 @@ On Freeze date
    the pull request merged
 
    ::
-   
+
        git checkout -b pr/prepare-v1.2
        git add [...]
        git commit

--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-      http://docs.cilium.io
+    http://docs.cilium.io
 
 .. _dev_guide:
 
@@ -31,7 +31,7 @@ contribute to Cilium:
 +==================================================================================+==========================+===============================================================================+
 | git                                                                              | latest                   | N/A (OS-specific)                                                             |
 +----------------------------------------------------------------------------------+--------------------------+-------------------------------------------------------------------------------+
-| `go <https://golang.org/dl/>`_                                                   | 1.10                      | N/A (OS-specific)                                                             |
+| `go <https://golang.org/dl/>`_                                                   | 1.10                      | N/A (OS-specific)                                                            |
 +----------------------------------------------------------------------------------+--------------------------+-------------------------------------------------------------------------------+
 | `dep <https://github.com/golang/dep/>`_                                          | >= v0.4.1                | ``curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh``  |
 +----------------------------------------------------------------------------------+--------------------------+-------------------------------------------------------------------------------+
@@ -1125,7 +1125,7 @@ Getting a pull request merged
 
 #. As you submit the pull request as described in the section :ref:`submit_pr`.
    One of the reviewers will start a CI run by replying with a comment
-   ``test-me-please`` as described in :ref:`trigger_phrases``. If you are a
+   ``test-me-please`` as described in :ref:`trigger_phrases`. If you are a
    core team member, you may trigger the CI run yourself.
 
    #. Hound: basic ``golang/lint`` static code analyzer. You need to make the

--- a/Documentation/install/guides/kube-router.rst
+++ b/Documentation/install/guides/kube-router.rst
@@ -109,17 +109,17 @@ In the above example, we see three categories of routes that have been
 installed:
 
 * *Local PodCIDR:* This route points to all pods running on the host and makes
-  these pods available to 
-  * `10.2.0.0/24 via 10.2.0.172 dev cilium_host src 10.2.0.172`
+  these pods available to
+  * ``10.2.0.0/24 via 10.2.0.172 dev cilium_host src 10.2.0.172``
 * *BGP route:* This type of route is installed if kube-router determines that
   the remote PodCIDR can be reached via a router known to the local host. It
   will instruct pod to pod traffic to be forwarded directly to that router
   without requiring any encapsulation.
-  * `10.2.1.0/24 via 172.0.51.175 dev eth0 proto 17`
+  * ``10.2.1.0/24 via 172.0.51.175 dev eth0 proto 17``
 * *IPIP tunnel route:*  If no direct routing path exists, kube-router will fall
   back to using an overlay and establish an IPIP tunnel between the nodes.
-  * `10.2.2.0/24 dev tun-172011760 proto 17 src 172.0.50.227`
-  * `10.2.3.0/24 dev tun-1720186231 proto 17 src 172.0.50.227`
+  * ``10.2.2.0/24 dev tun-172011760 proto 17 src 172.0.50.227``
+  * ``10.2.3.0/24 dev tun-1720186231 proto 17 src 172.0.50.227``
 
 You can test connectivity by deploying the following connectivity checker pods:
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -363,6 +363,8 @@ queueing
 rebase
 rebased
 recompiles
+refactor
+refactoring
 regenerations
 regex
 remediate

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -95,8 +95,8 @@ of all nodes in the cluster:
 Logs
 ~~~~
 
-To retrieve log files of a cilium pod, run (replace `cilium-1234` with a pod
-name returned by `kubectl -n kube-system get pods -l k8s-app=cilium`)
+To retrieve log files of a cilium pod, run (replace ``cilium-1234`` with a pod
+name returned by ``kubectl -n kube-system get pods -l k8s-app=cilium``)
 
 .. code:: bash
 
@@ -181,7 +181,7 @@ Sometimes you may experience broken connectivity, which may be due to a
 number of different causes. A main cause can be unwanted packet drops on
 the networking level. The tool
 ``cilium monitor`` allows you to quickly inspect and see if and where packet
-drops happen. Following is an example output (use `kubectl exec` as in previous
+drops happen. Following is an example output (use ``kubectl exec`` as in previous
 examples if running with Kubernetes):
 
 .. code:: bash
@@ -303,9 +303,9 @@ When running in :ref:`arch_overlay` mode:
 4. If nodes are being populated correctly, run ``tcpdump -n -i cilium_vxlan`` on
    each node to verify whether cross node traffic is being forwarded correctly
    between nodes.
-   
+
    If packets are being dropped,
-   
+
    * verify that the node IP listed in ``cilium bpf tunnel list`` can reach each
      other.
    * verify that the firewall on each node allows UDP port 4789.
@@ -420,7 +420,7 @@ the tool can retrieve debugging information from all of them. The tool works by
 archiving a collection of command output and files from several places. By
 default, it writes to the ``tmp`` directory.
 
-Note that the command needs to be run from inside the Cilium pod/container. 
+Note that the command needs to be run from inside the Cilium pod/container.
 
 .. code:: bash
 


### PR DESCRIPTION
- Added missed ENV variables on test VMs that are not created. 
- Added miss-expelled words to the list. 
- Fix multiple warnings in Contributing, kube-router and troubleshooting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4813)
<!-- Reviewable:end -->
