### PR TITLE
add external peer configuration to cilium + kube-router docs

### DIFF
--- a/Documentation/install/guides/kube-router.rst
+++ b/Documentation/install/guides/kube-router.rst
@@ -47,6 +47,17 @@ for more information.
     - --advertise-external-ip=true
     - --advertise-loadbalancer-ip=true
 
+The following arguments are **optional** and should be set if you want BGP peering
+with an external router. This is useful if you want externally routable Kubernetes
+Pod and Service IPs. Note the values used here should be changed to
+whatever IPs and ASNs are configured on your external router.
+
+.. code:: bash
+
+    - --cluster-asn=65001
+    - --peer-router-ips=10.0.0.1,10.0.2
+    - --peer-router-asns=65000,65000
+
 Apply the DaemonSet file to deploy kube-router and verify it has come up
 correctly:
 


### PR DESCRIPTION
**Summary of changes**:
Improves kube-router + Cilium docs to include examples for configuring eBGP peer. Related: https://github.com/cilium/cilium/issues/2463

```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4819)
<!-- Reviewable:end -->
