### PR TITLE
endpoint: Fix deadlock and missing lock during syncPolicyMap()

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2537,3 +2537,14 @@ func (e *Endpoint) syncPolicyMapController() {
 		},
 	)
 }
+
+// IsDisconnecting returns true if the endpoint is being disconnected or
+// already disconnected
+//
+// This function must be called after re-aquiring the endpoint mutex to verify
+// that the endpoint has not been removed in the meantime.
+//
+// endpoint.Mutex must be held
+func (e *Endpoint) IsDisconnecting() bool {
+	return e.state == StateDisconnected || e.state == StateDisconnecting
+}


### PR DESCRIPTION
Fixes a deadlock in the error path of regenerateBPF() and fixes a missing lock
on the endpoint while e.syncPolicyMap() is called which writes to the endpoint
structure.

Fixes: #4821
Fixes: ea62a6b2eb2 ("endpoint: Fix sidecar proxy deadlock during BPF generation")

No backport is needed as this regression was never released.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4822)
<!-- Reviewable:end -->
