### PR TITLE
Test: Add Custom Junit reporter

### DIFF
--- a/test/ginkgo-ext/junit_reporter.go
+++ b/test/ginkgo-ext/junit_reporter.go
@@ -1,0 +1,152 @@
+package ginkgoext
+
+/*
+
+JUnit XML Reporter for Ginkgo
+
+For usage instructions: http://onsi.github.io/ginkgo/#generating_junit_xml_output
+
+*/
+
+import (
+	"encoding/xml"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/types"
+)
+
+type JUnitTestSuite struct {
+	XMLName   xml.Name        `xml:"testsuite"`
+	TestCases []JUnitTestCase `xml:"testcase"`
+	Name      string          `xml:"name,attr"`
+	Tests     int             `xml:"tests,attr"`
+	Failures  int             `xml:"failures,attr"`
+	Errors    int             `xml:"errors,attr"`
+	Time      float64         `xml:"time,attr"`
+}
+
+type JUnitTestCase struct {
+	Name           string               `xml:"name,attr"`
+	ClassName      string               `xml:"classname,attr"`
+	FailureMessage *JUnitFailureMessage `xml:"failure,omitempty"`
+	Skipped        *JUnitSkipped        `xml:"skipped,omitempty"`
+	Time           float64              `xml:"time,attr"`
+	SystemOut      string               `xml:"system-out,omitempty"`
+}
+
+type JUnitFailureMessage struct {
+	Type    string `xml:"type,attr"`
+	Message string `xml:",chardata"`
+}
+
+type JUnitSkipped struct {
+	XMLName xml.Name `xml:"skipped"`
+}
+
+type JUnitReporter struct {
+	suite         JUnitTestSuite
+	filename      string
+	testSuiteName string
+}
+
+//NewJUnitReporter creates a new JUnit XML reporter.  The XML will be stored in the passed in filename.
+func NewJUnitReporter(filename string) *JUnitReporter {
+	return &JUnitReporter{
+		filename: filename,
+	}
+}
+
+func (reporter *JUnitReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
+	reporter.suite = JUnitTestSuite{
+		Name:      summary.SuiteDescription,
+		TestCases: []JUnitTestCase{},
+	}
+	reporter.testSuiteName = summary.SuiteDescription
+}
+
+func (reporter *JUnitReporter) SpecWillRun(specSummary *types.SpecSummary) {
+}
+
+func (reporter *JUnitReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {
+	reporter.handleSetupSummary("BeforeSuite", setupSummary)
+}
+
+func (reporter *JUnitReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {
+	reporter.handleSetupSummary("AfterSuite", setupSummary)
+}
+
+func failureMessage(failure types.SpecFailure) string {
+	return fmt.Sprintf("%s\n%s\n%s", failure.ComponentCodeLocation.String(), failure.Message, failure.Location.String())
+}
+
+func (reporter *JUnitReporter) handleSetupSummary(name string, setupSummary *types.SetupSummary) {
+	if setupSummary.State != types.SpecStatePassed {
+		testCase := JUnitTestCase{
+			Name:      name,
+			ClassName: reporter.testSuiteName,
+		}
+
+		testCase.FailureMessage = &JUnitFailureMessage{
+			Type:    reporter.failureTypeForState(setupSummary.State),
+			Message: failureMessage(setupSummary.Failure),
+		}
+		testCase.SystemOut = setupSummary.CapturedOutput
+		testCase.Time = setupSummary.RunTime.Seconds()
+		reporter.suite.TestCases = append(reporter.suite.TestCases, testCase)
+	}
+}
+
+func (reporter *JUnitReporter) SpecDidComplete(specSummary *types.SpecSummary) {
+	testCase := JUnitTestCase{
+		Name:      strings.Join(specSummary.ComponentTexts[1:], " "),
+		ClassName: reporter.testSuiteName,
+	}
+	if specSummary.State == types.SpecStateFailed || specSummary.State == types.SpecStateTimedOut || specSummary.State == types.SpecStatePanicked {
+		testCase.FailureMessage = &JUnitFailureMessage{
+			Type:    reporter.failureTypeForState(specSummary.State),
+			Message: failureMessage(specSummary.Failure),
+		}
+		testCase.SystemOut = specSummary.CapturedOutput
+	}
+	if specSummary.State == types.SpecStateSkipped || specSummary.State == types.SpecStatePending {
+		testCase.Skipped = &JUnitSkipped{}
+	}
+	testCase.Time = specSummary.RunTime.Seconds()
+	reporter.suite.TestCases = append(reporter.suite.TestCases, testCase)
+}
+
+func (reporter *JUnitReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
+	reporter.suite.Tests = summary.NumberOfSpecsThatWillBeRun
+	reporter.suite.Time = math.Trunc(summary.RunTime.Seconds() * 1000 / 1000)
+	reporter.suite.Failures = summary.NumberOfFailedSpecs
+	reporter.suite.Errors = 0
+	file, err := os.Create(reporter.filename)
+	if err != nil {
+		fmt.Printf("Failed to create JUnit report file: %s\n\t%s", reporter.filename, err.Error())
+	}
+	defer file.Close()
+	file.WriteString(xml.Header)
+	encoder := xml.NewEncoder(file)
+	encoder.Indent("  ", "    ")
+	err = encoder.Encode(reporter.suite)
+	if err != nil {
+		fmt.Printf("Failed to generate JUnit report\n\t%s", err.Error())
+	}
+}
+
+func (reporter *JUnitReporter) failureTypeForState(state types.SpecState) string {
+	switch state {
+	case types.SpecStateFailed:
+		return "Failure"
+	case types.SpecStateTimedOut:
+		return "Timeout"
+	case types.SpecStatePanicked:
+		return "Panic"
+	default:
+		return ""
+	}
+}

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -15,11 +15,13 @@
 package helpers
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"time"
 
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	ginkgoext "github.com/cilium/cilium/test/ginkgo-ext"
 )
 
 var (
@@ -29,6 +31,8 @@ var (
 	// BasePath is the path in the Vagrant VMs to which the test directory
 	// is mounted
 	BasePath = "/home/vagrant/go/src/github.com/cilium/cilium/test"
+
+	CheckLogs = ginkgoext.NewWriter(new(bytes.Buffer))
 )
 
 const (

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -179,6 +179,9 @@ const (
 	segmentationFault = "segmentation fault"        // from https://github.com/cilium/cilium/issues/3233
 	NACKreceived      = "NACK received for version" // from https://github.com/cilium/cilium/issues/4003
 
+	contextDeadlineExceeded = "context deadline exceeded"
+	ErrorLogs               = "level=error"
+	WarningLogs             = "level=warning"
 )
 
 // Re-definitions of stable constants in the API. The re-definition is on
@@ -192,6 +195,7 @@ const (
 var CiliumDSPath = "cilium_ds.jsonnet"
 
 var checkLogsMessages = []string{panicMessage, deadLockHeader, segmentationFault, NACKreceived}
+var countLogsMessages = []string{contextDeadlineExceeded, ErrorLogs, WarningLogs}
 
 var ciliumCLICommands = map[string]string{
 	"cilium endpoint list -o json":          "endpoint_list.txt",

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -31,7 +31,9 @@ var (
 	// BasePath is the path in the Vagrant VMs to which the test directory
 	// is mounted
 	BasePath = "/home/vagrant/go/src/github.com/cilium/cilium/test"
-
+	// CheckLogs newtes a new buffer where all the warnings and checks that
+	// happens during the test are saved. This buffer will be printed in the
+	// test output inside <checks> labels.
 	CheckLogs = ginkgoext.NewWriter(new(bytes.Buffer))
 )
 
@@ -40,7 +42,7 @@ const (
 	//CiliumPath is the path where cilium test code is located.
 	CiliumPath = "/src/github.com/cilium/cilium/test"
 
-	// ManifestBase tells ginkgo suite where to look for manifests
+	// K8sManifestBase tells ginkgo suite where to look for manifests
 	K8sManifestBase = "k8sT/manifests"
 
 	// VM / Test suite constants.

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -989,9 +989,19 @@ func (kub *Kubectl) ValidateNoErrorsOnLogs(duration time.Duration) {
 
 	for _, message := range checkLogsMessages {
 		if strings.Contains(logs, message) {
-			fmt.Fprintf(CheckLogs, "Found a %q in logs", message)
+			fmt.Fprintf(CheckLogs, "⚠️  Found a %q in logs\n", message)
 			ginkgoext.Fail(fmt.Sprintf("Found a %q in Cilium Logs", message))
 		}
+	}
+	// Count part
+	for _, message := range countLogsMessages {
+		var prefix = ""
+		result := strings.Count(logs, message)
+		if result > 5 {
+			// Added a warning emoji just in case that are more than 5 warning in the logs.
+			prefix = "⚠️  "
+		}
+		fmt.Fprintf(CheckLogs, "%sNumber of %q in logs: %d\n", prefix, message, result)
 	}
 }
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -931,7 +931,8 @@ func (kub *Kubectl) ValidateNoErrorsOnLogs(duration time.Duration) {
 
 	for _, message := range checkLogsMessages {
 		if strings.Contains(logs, message) {
-			ginkgoext.Fail("Found a %q in Cilium Logs")
+			fmt.Fprintf(CheckLogs, "Found a %q in logs", message)
+			ginkgoext.Fail(fmt.Sprintf("Found a %q in Cilium Logs", message))
 		}
 	}
 }

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -180,7 +180,7 @@ func (kub *Kubectl) ExecPodCmd(namespace string, pod string, cmd string, options
 	return kub.Exec(command, options...)
 }
 
-// ExecPodCmd executes command cmd in background in the specified pod residing
+// ExecPodCmdContext executes command cmd in background in the specified pod residing
 // in the specified namespace. It returns a pointer to CmdRes with all the
 // output
 func (kub *Kubectl) ExecPodCmdContext(ctx context.Context, namespace string, pod string, cmd string) *CmdRes {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/asaskevich/govalidator"
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 )
@@ -918,32 +917,22 @@ func (kub *Kubectl) CiliumReport(namespace string, commands ...string) {
 // `deadlocks` or `segmentation faults` messages. In case of any of these
 // messages, it'll mark the test as failed.
 func (kub *Kubectl) ValidateNoErrorsOnLogs(duration time.Duration) {
+	var logs string
 	cmd := fmt.Sprintf("%s -n %s logs --timestamps=true -l k8s-app=cilium --since=%vs",
 		KubectlCmd, KubeSystemNamespace, duration.Seconds())
 	res := kub.Exec(fmt.Sprintf("%s --previous", cmd), ExecOptions{SkipLog: true})
-	if !res.WasSuccessful() {
-		res = kub.Exec(cmd, ExecOptions{SkipLog: true})
+	if res.WasSuccessful() {
+		logs += res.Output().String()
 	}
-	logs := res.Output().String()
-	for _, message := range checkLogsMessages {
-		gomega.ExpectWithOffset(1, logs).ToNot(gomega.ContainSubstring(message),
-			"Found a %q in Cilium logs", message)
+	res = kub.Exec(cmd, ExecOptions{SkipLog: true})
+	if res.WasSuccessful() {
+		logs += res.Output().String()
 	}
-}
 
-// CheckLogsForDeadlock checks if the logs for Cilium log messages that signify
-// that a deadlock has occurred.
-func (kub *Kubectl) CheckLogsForDeadlock() {
-	deadlockCheckCmd := fmt.Sprintf("%s -n %s logs --timestamps=true -l k8s-app=cilium | grep -qi -B 5 -A 5 deadlock", KubectlCmd, KubeSystemNamespace)
-	res := kub.Exec(deadlockCheckCmd)
-	if res.WasSuccessful() {
-		log.Errorf("Deadlock during test run detected, check Cilium logs for context")
-	}
-	// Also check for previous container
-	deadlockCheckCmd = fmt.Sprintf("%s -n %s logs --timestamps=true --previous -l k8s-app=cilium | grep -qi -B 5 -A 5 deadlock", KubectlCmd, KubeSystemNamespace)
-	res = kub.Exec(deadlockCheckCmd)
-	if res.WasSuccessful() {
-		log.Errorf("Deadlock during test run detected, check Cilium logs for context")
+	for _, message := range checkLogsMessages {
+		if strings.Contains(logs, message) {
+			ginkgoext.Fail("Found a %q in Cilium Logs")
+		}
 	}
 }
 

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -255,6 +255,10 @@ func getOrSetEnvVar(key, value string) {
 
 var _ = AfterEach(func() {
 
+	// Send the Checks output to Junit report to be render on Jenkins.
+	defer helpers.CheckLogs.Reset()
+	GinkgoPrint("<Checks>\n%s\n</Checks>\n", helpers.CheckLogs.Buffer.String())
+
 	defer config.TestLogWriterReset()
 	err := helpers.CreateLogFile(config.TestLogFileName, config.TestLogWriter.Bytes())
 	if err != nil {

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -32,7 +32,6 @@ import (
 	gops "github.com/google/gops/agent"
 	"github.com/onsi/ginkgo"
 	ginkgoconfig "github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 )
@@ -96,7 +95,7 @@ func TestTest(t *testing.T) {
 	} else {
 		RegisterFailHandler(Fail)
 	}
-	junitReporter := reporters.NewJUnitReporter(fmt.Sprintf(
+	junitReporter := ginkgoext.NewJUnitReporter(fmt.Sprintf(
 		"%s.xml", helpers.GetScopeWithVersion()))
 	RunSpecsWithDefaultAndCustomReporters(
 		t, helpers.GetScopeWithVersion(), []ginkgo.Reporter{junitReporter})


### PR DESCRIPTION
Hi, 

This PR introduces a new way of report some checks on a failed test. The idea is to provide more context to users when a test failed, so this introduce a Cilium status summary. how many policies are loaded, endpoints and their policy enforcement, cilium status, controllers and if any deadlock,panic or how many times the error/warning/context deadline are present in the logs. 

The summary of changes: 
- New Junit reporter that support system-err and system-out
- Added the Checks buffer per test and dump to stdout using <checks> labels. 
- Extend ValidateNoErrorsOnLogs to check logs and make warnings. 
- Added CiliumCheckReport

The output on Jenkins will be similar to this: 

```

Number of "context deadline exceeded" in logs: 0
Number of "level=error" in logs: 0
Number of "level=warning" in logs: 0
Cilium pods: [cilium-8nrxq cilium-czqxs]
Netpols loaded: default::second
CiliumNetworkPolicies loaded: default::rule1
Cilium CEP status:
        cilium-health-k8s2=> none
        kube-dns-f4d788bb7-htj44=> none
        microscope=> none
        app1-78b4c7b56c-6jfcd=> ingress
        app1-78b4c7b56c-gdg4v=> ingress
        app2-6db56c7d8f-2hbbv=> none
        app3-6d745c45f6-8dldc=> none
Cilium agent "cilium-8nrxq": Status: Ok  Health: Ok Nodes "k8s2 k8s1" ContinerRuntime: Ok Kubernetes: Ok KVstore: Ok Controllers: Total 39 Failed 0
Cilium agent "cilium-czqxs": Status: Ok  Health: Ok Nodes "k8s2 k8s1" ContinerRuntime: Ok Kubernetes: Ok KVstore: Ok Controllers: Total 27 Failed 0

```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4823)
<!-- Reviewable:end -->
