### PR TITLE
Support parallel deployment of etcd operator and Cilium

### DIFF
--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -164,29 +164,3 @@ func (ds *DaemonSuite) TestReadEPsFromDirNames(c *C) {
 	eps := readEPsFromDirNames(tmpDir, epsNames)
 	c.Assert(len(eps), Equals, len(epsWanted))
 }
-
-func (ds *DaemonSuite) TestSyncLabels(c *C) {
-	epsWanted, _ := createEndpoints()
-
-	ep1 := epsWanted[0]
-	ep1.SecurityIdentity = nil
-	err := ds.d.syncLabels(ep1)
-	// Endpoint doesn't have a security label but it has some operational labels
-	// so endpoint will have a new identity assigned
-	c.Assert(err, IsNil)
-	c.Assert(ep1.SecurityIdentity, NotNil)
-
-	// Let's make sure we delete all labels from the kv store first
-	ep2 := epsWanted[1]
-	ep2.SecurityIdentity.Release()
-
-	err = ds.d.syncLabels(ep2)
-	c.Assert(err, IsNil)
-
-	// let's change the ep2 security identity and see if sync labels properly sets
-	// it with the one from kv store
-	ep2.SecurityIdentity.ID = identity.NumericIdentity(1)
-
-	err = ds.d.syncLabels(ep2)
-	c.Assert(err, IsNil)
-}

--- a/examples/kubernetes/addons/etcd-operator/cilium-etcd-cluster.yaml
+++ b/examples/kubernetes/addons/etcd-operator/cilium-etcd-cluster.yaml
@@ -1,0 +1,17 @@
+apiVersion: "etcd.database.coreos.com/v1beta2"
+kind: "EtcdCluster"
+metadata:
+  name: "cilium-etcd"
+  namespace: kube-system
+spec:
+  size: 3
+  version: "3.2.22"
+  TLS:
+    static:
+      member:
+        peerSecret: cilium-etcd-peer-tls
+        serverSecret: cilium-etcd-server-tls
+      operatorSecret: cilium-etcd-client-tls
+  pod:
+    labels:
+      "io.cilium.fixed-identity": "kv-store"

--- a/examples/kubernetes/addons/etcd-operator/cilium-etcd-sa.yaml
+++ b/examples/kubernetes/addons/etcd-operator/cilium-etcd-sa.yaml
@@ -1,0 +1,5 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-etcd-sa
+  namespace: kube-system

--- a/examples/kubernetes/addons/etcd-operator/cluster-role-binding-template.yaml
+++ b/examples/kubernetes/addons/etcd-operator/cluster-role-binding-template.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-etcd-sa
+  namespace: kube-system

--- a/examples/kubernetes/addons/etcd-operator/cluster-role-template.yaml
+++ b/examples/kubernetes/addons/etcd-operator/cluster-role-template.yaml
@@ -1,0 +1,43 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: etcd-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - etcd.database.coreos.com
+  resources:
+  - etcdclusters
+  - etcdbackups
+  - etcdrestores
+  verbs:
+  - "*"
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"
+# The following permissions can be removed if not using S3 backup and TLS
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get

--- a/examples/kubernetes/addons/etcd-operator/deployment.yaml
+++ b/examples/kubernetes/addons/etcd-operator/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: etcd-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: etcd-operator
+        io.cilium.fixed-identity: "kv-store"
+    spec:
+      serviceAccountName: cilium-etcd-sa
+      containers:
+      - name: etcd-operator
+        image: quay.io/coreos/etcd-operator:v0.9.2
+        command:
+        - etcd-operator
+        # Uncomment to act for resources in all namespaces. More information in doc/clusterwide.md
+        #- -cluster-wide
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name

--- a/examples/kubernetes/addons/etcd-operator/tls/certs/.gitignore
+++ b/examples/kubernetes/addons/etcd-operator/tls/certs/.gitignore
@@ -1,0 +1,3 @@
+*.crt
+*.key
+peer.json

--- a/examples/kubernetes/addons/etcd-operator/tls/certs/ca-config.json
+++ b/examples/kubernetes/addons/etcd-operator/tls/certs/ca-config.json
@@ -1,0 +1,34 @@
+{
+    "signing": {
+        "default": {
+            "expiry": "43800h"
+        },
+        "profiles": {
+            "server": {
+                "expiry": "43800h",
+                "usages": [
+                    "signing",
+                    "key encipherment",
+                    "server auth"
+                ]
+            },
+            "client": {
+                "expiry": "43800h",
+                "usages": [
+                    "signing",
+                    "key encipherment",
+                    "client auth"
+                ]
+            },
+            "peer": {
+                "expiry": "43800h",
+                "usages": [
+                    "signing",
+                    "key encipherment",
+                    "server auth",
+                    "client auth"
+                ]
+            }
+        }
+    }
+}

--- a/examples/kubernetes/addons/etcd-operator/tls/certs/ca-csr.json
+++ b/examples/kubernetes/addons/etcd-operator/tls/certs/ca-csr.json
@@ -1,0 +1,16 @@
+{
+    "CN": "Cilium-ETCD CA",
+    "key": {
+        "algo": "rsa",
+        "size": 2048
+    },
+    "names": [
+        {
+            "C": "US",
+            "L": "CA",
+            "O": "My Company Name",
+            "ST": "San Francisco",
+            "OU": "Org Unit 1"
+        }
+    ]
+}

--- a/examples/kubernetes/addons/etcd-operator/tls/certs/etcd-client.json
+++ b/examples/kubernetes/addons/etcd-operator/tls/certs/etcd-client.json
@@ -1,0 +1,16 @@
+{
+    "CN": "etcd client",
+    "hosts": [""],
+    "key": {
+        "algo": "rsa",
+        "size": 2048
+    },
+    "names": [
+        {
+            "C": "US",
+            "L": "CA",
+            "ST": "San Francisco"
+        }
+    ]
+}
+

--- a/examples/kubernetes/addons/etcd-operator/tls/certs/gen-cert.sh
+++ b/examples/kubernetes/addons/etcd-operator/tls/certs/gen-cert.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+if [ -z "$(which cfssl)" ]; then
+    echo "Please install the cfssl utility"
+    exit -1
+fi
+
+if [ -z "$(which cfssljson)" ]; then
+    echo "Please install the cfssljson utility"
+    exit -1
+fi
+
+cluster_domain="${1:-"${CLUSTER_DOMAIN}"}"
+if [ -z "${cluster_domain}" ]; then
+    echo "Please provide your cluster domain ./gen-cert.sh <cluster-domain>"
+    echo "You can find it by checking the config map of core-dns by running"
+    echo "kubectl get ConfigMap --namespace kube-system coredns -o yaml | grep kubernetes"
+    echo "or by checking the kube-dns deployment and grepping for 'domain'"
+    echo "kubectl get Deployment --namespace kube-system kube-dns -o yaml | grep domain"
+    echo "For reference, the cluster domain used in Kubernetes clusters by default is 'cluster.local'"
+    exit -1
+fi
+
+cd "${dir}"
+
+echo "generating CA certs ==="
+cfssl gencert -initca ca-csr.json | cfssljson -bare ca
+
+echo "generating etcd peer.json for cluster domain ${cluster_domain} ==="
+
+sed -e "s/CLUSTER_DOMAIN/${cluster_domain}/" peer.json.sed > peer.json
+
+echo "generating etcd peer certs ==="
+cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -profile=peer peer.json | cfssljson -bare peer
+
+echo "generating etcd server certs ==="
+cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -profile=server server.json | cfssljson -bare server
+
+echo "generating etcd client certs ==="
+cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -profile=client etcd-client.json | cfssljson -bare etcd-client
+
+mv etcd-client.pem etcd-client.crt
+mv etcd-client-key.pem etcd-client.key
+cp ca.pem etcd-client-ca.crt
+
+mv server.pem server.crt
+mv server-key.pem server.key
+cp ca.pem server-ca.crt
+
+mv peer.pem peer.crt
+mv peer-key.pem peer.key
+mv ca.pem peer-ca.crt
+
+rm *.csr ca-key.pem
+
+cd -

--- a/examples/kubernetes/addons/etcd-operator/tls/certs/peer.json.sed
+++ b/examples/kubernetes/addons/etcd-operator/tls/certs/peer.json.sed
@@ -1,0 +1,19 @@
+{
+    "CN": "etcd peer",
+    "hosts": [
+        "*.cilium-etcd.kube-system.svc",
+        "*.cilium-etcd.kube-system.svc.CLUSTER_DOMAIN"
+    ],
+    "key": {
+        "algo": "rsa",
+        "size": 2048
+    },
+    "names": [
+        {
+            "C": "US",
+            "L": "CA",
+            "ST": "San Francisco"
+        }
+    ]
+}
+

--- a/examples/kubernetes/addons/etcd-operator/tls/certs/server.json
+++ b/examples/kubernetes/addons/etcd-operator/tls/certs/server.json
@@ -1,0 +1,20 @@
+{
+    "CN": "etcd server",
+    "hosts": [
+        "*.cilium-etcd.kube-system.svc",
+        "cilium-etcd-client.kube-system.svc",
+        "localhost"
+    ],
+    "key": {
+        "algo": "rsa",
+        "size": 2048
+    },
+    "names": [
+        {
+            "C": "US",
+            "L": "CA",
+            "ST": "San Francisco"
+        }
+    ]
+}
+

--- a/examples/kubernetes/addons/etcd-operator/tls/deploy-certs.sh
+++ b/examples/kubernetes/addons/etcd-operator/tls/deploy-certs.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+cd "${dir}/certs"
+
+# member.peerSecret
+kubectl create secret generic -n kube-system cilium-etcd-peer-tls --from-file=peer-ca.crt --from-file=peer.crt --from-file=peer.key
+
+# member.serverSecret
+kubectl create secret generic -n kube-system cilium-etcd-server-tls --from-file=server-ca.crt --from-file=server.crt --from-file=server.key
+
+# operatorSecret
+kubectl create secret generic -n kube-system cilium-etcd-client-tls --from-file=etcd-client-ca.crt --from-file=etcd-client.crt --from-file=etcd-client.key

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -301,10 +301,7 @@ func TriggerPolicyUpdates(owner endpoint.Owner, force bool) *sync.WaitGroup {
 func HasGlobalCT() bool {
 	eps := GetEndpoints()
 	for _, e := range eps {
-		e.RLock()
-		globalCT := !e.Options.IsEnabled(option.ConntrackLocal)
-		e.RUnlock()
-		if globalCT {
+		if !e.Options.IsEnabled(option.ConntrackLocal) {
 			return true
 		}
 	}

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -49,7 +49,7 @@ const (
 
 	// listTimeout is the time to wait for the initial list operation to
 	// succeed when creating a new allocator
-	listTimeout = 2 * time.Minute
+	listTimeout = 3 * time.Minute
 
 	// gcInterval is the interval in which allocator identities are
 	// attempted to be expired from the kvstore
@@ -282,11 +282,13 @@ func NewAllocator(basePath string, typ AllocatorKey, opts ...AllocatorOption) (*
 		return nil, errors.New("Maximum ID must be greater than minimum ID")
 	}
 
-	if err := a.startWatchAndWait(); err != nil {
-		return nil, err
-	}
+	go func() {
+		if err := a.startWatchAndWait(); err != nil {
+			log.WithError(err).Fatalf("Unable to initialize identity allocator")
+		}
 
-	a.startGC()
+		a.startGC()
+	}()
 
 	return a, nil
 }

--- a/pkg/kvstore/client.go
+++ b/pkg/kvstore/client.go
@@ -30,7 +30,7 @@ func initClient(module backendModule) error {
 	}
 
 	defaultClient = c
-	deleteLegacyPrefixes()
+	go deleteLegacyPrefixes()
 
 	return nil
 }

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -32,7 +32,7 @@ import (
 const (
 	// listTimeoutDefault is the default timeout to wait while performing
 	// the initial list operation of objects from the kvstore
-	listTimeoutDefault = 30 * time.Second
+	listTimeoutDefault = 3 * time.Minute
 
 	// synchronizationIntervalDefault is the default interval to
 	// synchronize keys with the kvstore


### PR DESCRIPTION
**Summary of changes**:

This PR enables Cilium without a kvstore connection for 3 minutes which might give enough time for a cluster to set up an etcd-operator.

Fixes: #4314 

```release-note
Add support for etcd-operator to ease Cilium deployment.
```

Will require documentation changes. 
TL;DR docs:
```
# create etcd-operator
kubectl create -f examples/kubernetes/addons/etcd-operator
# add arguments to cilium.yaml
--fixed-identity-mapping=128=kv-store
--fixed-identity-mapping=129=kube-dns
# point etcd configuration in cilium configmap to
---
endpoints:
- http://cilium-etcd.kube-system.svc.cluster.local:2379
# add label to kube-dns pod
kubectl label -n kube-system pod kube-dns-7dcc557ddd-k4jz6 io.cilium.fixed-identity=kube-dns
# install cilium
kubectl create -f cilium.yaml
# wait a couple minutes until all endpoints are up and running with a sec ID
# remove label from kube-dns pod
kubectl label -n kube-system pod kube-dns-7dcc557ddd-k4jz6 io.cilium.fixed-identity-
# done
```

Depends on #4797  and #4775

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4826)
<!-- Reviewable:end -->
