### PR TITLE
RFC: Test: Compiling using docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG LOCKDEBUG
 # Please do not add any dependency updates before the 'make install' here,
 # as that will mess with caching for incremental builds!
 #
-RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 DESTDIR=/tmp/install clean-container build install
+RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 DESTDIR=/tmp/install build install
 
 #
 # Cilium runtime install.

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,9 @@ GIT_VERSION: .git
 envoy/SOURCE_VERSION: .git
 	git rev-parse HEAD >envoy/SOURCE_VERSION
 
-docker-image: clean GIT_VERSION envoy/SOURCE_VERSION
+docker-image: clean docker-image-dev
+
+docker-image-dev: GIT_VERSION envoy/SOURCE_VERSION
 	grep -v -E "(SOURCE|GIT)_VERSION" .gitignore >.dockerignore
 	echo ".*" >>.dockerignore # .git pruned out
 	echo "Documentation" >>.dockerignore # Not needed

--- a/envoy/Makefile
+++ b/envoy/Makefile
@@ -70,6 +70,7 @@ $(CILIUM_ENVOY_BIN) envoy-release: force
 	@$(ECHO_BAZEL)
 	-rm -f bazel-out/k8-opt/bin/_objs/envoy/external/envoy/source/common/common/version_linkstamp.o
 	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) -c opt //:envoy $(BAZEL_FILTER)
+	- cp $(CILIUM_ENVOY_BIN) cilium-envoy
 
 # Allow root build for release
 $(ISTIO_ENVOY_BIN) $(ISTIO_ENVOY_RELEASE_BIN): force
@@ -97,7 +98,7 @@ $(CHECK_FORMAT): force-non-root
 
 install: force-root
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m 0755 -T $(CILIUM_ENVOY_BIN) $(DESTDIR)$(BINDIR)/cilium-envoy
+	$(INSTALL) -m 0755 -T cilium-envoy $(DESTDIR)$(BINDIR)/cilium-envoy
 # Strip only non-debug builds
 ifeq "$(findstring -dbg,$(realpath bazel-bin))" ""
 	$(STRIP) $(DESTDIR)$(BINDIR)/cilium-envoy

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -61,7 +61,14 @@ pipeline {
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/"
             }
             steps {
-                sh "cd ${TESTDIR}; make tests-ginkgo"
+                parallel(
+                    "Test": {
+                        sh "cd ${TESTDIR}; make tests-ginkgo"
+                    },
+                    "Compilation": {
+                        sh "docker-compose -f test/docker-compose.yml run --rm compile"
+                    }
+                )
             }
             post {
                 always {

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -27,3 +27,7 @@ services:
     extends:
       service: base_image
     command: "bash -c 'cd /go/src/github.com/cilium/cilium/; make precheck || exit 1'"
+  compile:
+    extends:
+      service: base_image
+    command: "bash -c 'cd /go/src/github.com/cilium/cilium/; make build LOCKDEBUG=1 PKG_BUILD=1'"

--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -17,7 +17,7 @@ if echo $(hostname) | grep "k8s" -q;
 then
     if [[ "$(hostname)" == "k8s1" ]]; then
         echo "building cilium/cilium container image..."
-        make LOCKDEBUG=1 docker-image
+        make LOCKDEBUG=1 docker-image-dev
         echo "pushing container image to k8s1:5000/cilium/cilium-dev..."
         docker tag cilium/cilium k8s1:5000/cilium/cilium-dev
         docker push k8s1:5000/cilium/cilium-dev
@@ -28,7 +28,7 @@ then
     fi
 else
     echo "compiling cilium..."
-    sudo -u vagrant -H -E make LOCKDEBUG=1
+    docker-compose -f test/docker-compose.yml run compile
     echo "installing cilium..."
     make install
     mkdir -p /etc/sysconfig/


### PR DESCRIPTION
At the moment in 1.0 branch if we update the base box the envoy
dependencies will complain. With this change runtime box will use
docker-compose to compile, so it'll be use the correct cilium-builder
image and it'll be easy to mantain over time.

Related to #4789

@aanm @ianvernon this what I mentioned in the issue, with this change does not matter what is the base box. 

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4831)
<!-- Reviewable:end -->
