### PR TITLE
doc: more tooling and examples in CI failure triage section

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -218,6 +218,8 @@ ixgbevf
 Jakub
 Jenkinsfiles
 jeq
+jenkins
+Jenkins
 Jenkinsfiles
 Jesper
 jge
@@ -401,6 +403,8 @@ Sidious
 Sith
 skb
 Spectre
+Stacktrace
+stacktrace
 stap
 stapbpf
 Starovoitov
@@ -458,8 +462,11 @@ ui
 Uncomment
 underrepresents
 uninline
+unix
+Unix
 unmanaged
 unmounting
+untriaged
 untrusted
 uprobes
 upstreamed


### PR DESCRIPTION
This PR includes instructions on using the `jenkins-failures.sh` script (formerly jenkins-status.sh) to help find failures to triage. The instructions are more explicit on what to include in issues to help find them later.
Sadly, I couldn't find a way to automate adding issues to the CI project so that remains a manual step.

Once this is merged I can update the jenkins hat instructions. They will basically say:
Do the Triage steps in the docs once a day.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4833)
<!-- Reviewable:end -->
