### PR TITLE
pkg/k8s: enable CRD Status by default

### DIFF
--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -316,7 +316,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.10/cilium-rbac.yaml
+++ b/examples/kubernetes/1.10/cilium-rbac.yaml
@@ -73,6 +73,8 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -315,7 +315,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -317,7 +317,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.11/cilium-rbac.yaml
+++ b/examples/kubernetes/1.11/cilium-rbac.yaml
@@ -73,6 +73,8 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -316,7 +316,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -317,7 +317,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.12/cilium-rbac.yaml
+++ b/examples/kubernetes/1.12/cilium-rbac.yaml
@@ -73,6 +73,8 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -316,7 +316,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.7/cilium-crio.yaml
+++ b/examples/kubernetes/1.7/cilium-crio.yaml
@@ -316,7 +316,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.7/cilium-rbac.yaml
+++ b/examples/kubernetes/1.7/cilium-rbac.yaml
@@ -73,6 +73,8 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -315,7 +315,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -316,7 +316,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.8/cilium-rbac.yaml
+++ b/examples/kubernetes/1.8/cilium-rbac.yaml
@@ -73,6 +73,8 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -315,7 +315,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -316,7 +316,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.9/cilium-rbac.yaml
+++ b/examples/kubernetes/1.9/cilium-rbac.yaml
@@ -73,6 +73,8 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -315,7 +315,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/templates/v1/cilium-rbac.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-rbac.yaml.sed
@@ -73,6 +73,8 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -41,7 +41,7 @@ const (
 
 	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
 	// Used to determine if CRD needs to be updated in cluster
-	CustomResourceDefinitionSchemaVersion = "1.8"
+	CustomResourceDefinitionSchemaVersion = "1.9"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"
@@ -150,6 +150,9 @@ func createCNPCRD(clientset apiextensionsclient.Interface) error {
 				ShortNames: CustomResourceDefinitionShortNames,
 				Kind:       CustomResourceDefinitionKind,
 			},
+			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
+				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
+			},
 			Scope:      apiextensionsv1beta1.NamespaceScoped,
 			Validation: &cnpCRV,
 		},
@@ -189,6 +192,9 @@ func createCEPCRD(clientset apiextensionsclient.Interface) error {
 				Singular:   CustomResourceDefinitionSingularName,
 				ShortNames: CustomResourceDefinitionShortNames,
 				Kind:       CustomResourceDefinitionKind,
+			},
+			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
+				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
 			},
 			Scope:      apiextensionsv1beta1.NamespaceScoped,
 			Validation: &cepCRV,

--- a/test/k8sT/manifests/cilium_ds.template
+++ b/test/k8sT/manifests/cilium_ds.template
@@ -424,7 +424,9 @@
           ],
           "resources": [
             "ciliumnetworkpolicies",
-            "ciliumendpoints"
+            "ciliumnetworkpolicies/status",
+            "ciliumendpoints",
+            "ciliumendpoints/status"
           ],
           "verbs": [
             "*"


### PR DESCRIPTION
This change will only take effect in envionments that hve k8s CRD Status
enabled. It's only enabled by default since k8s 1.11.

Fixes: 8d15cc962c44 ("k8s: Use UpdateStatus for kubernetes server version >=1.11")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4836)
<!-- Reviewable:end -->
