### PR TITLE
pkg/endpoint: set state ready if endpoint labels are the same

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2328,6 +2328,10 @@ func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
 	}
 
 	if e.SecurityIdentity != nil && e.SecurityIdentity.Labels.Equals(newLabels) {
+		// Sets endpoint state to ready if was waiting for identity
+		if e.GetStateLocked() == StateWaitingForIdentity {
+			e.SetStateLocked(StateReady, "Set identity for this endpoint")
+		}
 		e.Mutex.RUnlock()
 		elog.Debug("Endpoint labels unchanged, skipping resolution of identity")
 		return nil


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>


```release-note
Fix deadlock for endpoint state when endpoint is in StateWaitingForIdentity when no labels were changed
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4840)
<!-- Reviewable:end -->
