### PR TITLE
pkg/policy/api: handle multiple CIDRs in CIDRSlice when adding reserved:world EndpointSelector

### DIFF
--- a/pkg/policy/api/cidr.go
+++ b/pkg/policy/api/cidr.go
@@ -68,11 +68,16 @@ type CIDRSlice []CIDR
 // GetAsEndpointSelectors returns the provided CIDR slice as a slice of
 // endpoint selectors
 func (s CIDRSlice) GetAsEndpointSelectors() EndpointSelectorSlice {
+	// If multiple CIDRs representing reserved:world are in this CIDRSlice,
+	// we only have to add the EndpointSelector representing reserved:world
+	// once.
+	var hasWorldBeenAdded bool
 	slice := EndpointSelectorSlice{}
-	if len(s) == 1 && s[0].MatchesAll() {
-		slice = append(slice, ReservedEndpointSelectors[labels.IDNameWorld])
-	}
 	for _, cidr := range s {
+		if cidr.MatchesAll() && !hasWorldBeenAdded {
+			hasWorldBeenAdded = true
+			slice = append(slice, ReservedEndpointSelectors[labels.IDNameWorld])
+		}
 		lbl := labels.IPStringToLabel(string(cidr))
 		slice = append(slice, NewESFromLabels(lbl))
 	}


### PR DESCRIPTION
If multiple CIDRs are provided in a CIDR rule, CIDRs corresponding to the world
(0.0.0.0/0 and ::/0) are not correctly converted to the reserved:world
EndpointSelector. The net effect of this is that policy does not allow traffic
to the world when rules are provided that select multiple CIDRs, if any of the
CIDRs within the CIDRSlice in the rule correspond to reserved:world.
This commit fixes that bug, and adds additional unit tests.

Signed-off-by: Ian Vernon <ian@cilium.io>

Fixes: #4845 

```release-note
correctly convert CIDRs within a single CIDR policy rule which allow access to the world to reserved:world identity when rule contains multiple CIDRs
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4846)
<!-- Reviewable:end -->
