### PR TITLE
test: add microscope YAML to manifests directory

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -161,7 +161,7 @@ const (
 	daemonSet   = "DaemonSet"
 
 	MonitorLogFileName = "monitor.log"
-	microscopeManifest = `https://raw.githubusercontent.com/cilium/microscope/master/ci/microscope.yaml`
+	microscopeManifest = "microscope.yaml"
 
 	// IPv4Host is an IP which is used in some datapath tests for simulating external IPv4 connectivity.
 	IPv4Host = "192.168.254.254"

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -342,7 +342,8 @@ func (kub *Kubectl) MicroscopeStart() (error, func() error) {
 	var cb = func() error { return nil }
 	cmd := fmt.Sprintf("%[1]s -ti -n %[2]s exec %[3]s -- %[4]s",
 		KubectlCmd, KubeSystemNamespace, microscope, microscopeCmd)
-	_ = kub.Apply(microscopeManifest)
+	microscopePath := ManifestGet(microscopeManifest)
+	_ = kub.Apply(microscopePath)
 
 	err := kub.WaitforPods(
 		KubeSystemNamespace,
@@ -373,7 +374,7 @@ func (kub *Kubectl) MicroscopeStart() (error, func() error) {
 			log.WithError(err).Errorf("cannot create monitor log file")
 			return err
 		}
-		kub.Delete(microscopeManifest)
+		kub.Delete(microscopePath)
 		return nil
 	}
 

--- a/test/k8sT/manifests/microscope.yaml
+++ b/test/k8sT/manifests/microscope.yaml
@@ -1,0 +1,74 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: microscope
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: microscope
+subjects:
+- kind: ServiceAccount
+  name: microscope
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: microscope
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumendpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: microscope
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: microscope
+  namespace: kube-system
+  labels:
+    k8s-app: microscope
+spec:
+  serviceAccountName: microscope
+  containers:
+  - args:
+    - sleep
+    - "100000"
+    image: docker.io/cilium/microscope:1.0.1
+    imagePullPolicy: IfNotPresent
+    name: microscope


### PR DESCRIPTION
This ensures that changes to microscope outside of the Cilium repo do not affect
test stability, which is what spurred this change; the YAML for microscope was
pointed to a version which did not exist, and broke the CI. If the YAML is part
of the Cilium repository, this will not happen.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #4855

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4856)
<!-- Reviewable:end -->
