### PR TITLE
Test add custom errors on helpers

### DIFF
--- a/test/helpers/errors.go
+++ b/test/helpers/errors.go
@@ -1,0 +1,32 @@
+package helpers
+
+import "fmt"
+
+// NewSSHMetaError returns a new SSHMetaError with the given string and a
+// callback function
+func NewSSHMetaError(errorString string, callback func() string) *SSHMetaError {
+	if callback == nil {
+		callback = func() string { return "Invalid callback" }
+	}
+	return &SSHMetaError{
+		errorString:   errorString,
+		errorCallBack: callback,
+	}
+}
+
+// SSHMetaError is a custom error that executes a callback function when its
+// Error() function is invoked
+type SSHMetaError struct {
+	errorString   string
+	errorCallBack func() string
+}
+
+func (e *SSHMetaError) String() string {
+	return fmt.Sprintf(
+		"Error: %s\nExtended info: %s\n",
+		e.errorString, e.errorCallBack())
+}
+
+func (e *SSHMetaError) Error() string {
+	return e.String()
+}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -840,12 +840,11 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 	}
 
 	if status := kub.Action(action, filepath); !status.WasSuccessful() {
-		return "", fmt.Errorf("cannot perform %q on resource %q", action, filepath)
+		return "", fmt.Errorf("cannot perform %q on resource %q: %s", action, filepath, status.OutputPrettyPrint())
 	}
-
 	body := func() bool {
-		waitingRev := map[string]int{}
 
+		waitingRev := map[string]int{}
 		valid := true
 		for _, v := range pods {
 			revi, err := kub.CiliumPolicyRevision(v)
@@ -880,7 +879,26 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 		"cannot change state of resource correctly; command timed out",
 		&TimeoutConfig{Timeout: timeout})
 	if err != nil {
-		return "", err
+		callback := func() string {
+			result := new(bytes.Buffer)
+			fmt.Fprintln(result, "Policy version when cilium start")
+
+			for _, v := range pods {
+				revi, err := kub.CiliumPolicyRevision(v)
+				if err != nil {
+					fmt.Fprintf(result, "Cilium-agent %q is not responding\n", v)
+				}
+
+				fmt.Fprintf(result,
+					"Cilium-agent %q started with policy revision '%d' and finished with '%d' \n",
+					v, revisions[v], revi)
+				if revi <= revisions[v] {
+					fmt.Fprintf(result, "Cilium-agent %q restarted during policy import\n", v)
+				}
+			}
+			return result.String()
+		}
+		return "", NewSSHMetaError(err.Error(), callback)
 	}
 	return "", nil
 }

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -34,6 +34,8 @@ import (
 	ginkgoconfig "github.com/onsi/ginkgo/config"
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
+
+	"github.com/onsi/gomega/format"
 	"github.com/sirupsen/logrus"
 )
 
@@ -62,6 +64,8 @@ func init() {
 	config.CiliumTestConfig.ParseFlags()
 
 	os.RemoveAll(helpers.TestResultsPath)
+
+	format.UseStringerRepresentation = true
 }
 
 func configLogsOutput() {


### PR DESCRIPTION
Added a new helper error message, that has a callback function that can be called when the Ginkgo trigger an error, so the errors dump to users are more powerful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4859)
<!-- Reviewable:end -->
