### PR TITLE
backport for v1.1: revert incomplete re-enabling of microscope

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -427,46 +427,47 @@ func (kub *Kubectl) Logs(namespace string, pod string) *CmdRes {
 // a timeout. Also it returns a callback function to stop the monitor and save
 // the output to `helpers.monitorLogFileName` file.
 func (kub *Kubectl) MicroscopeStart() (error, func() error) {
-	microscope := "microscope"
-	var microscopeCmd = microscope + "| ts '[%Y-%m-%d %H:%M:%S]'"
-	var cb = func() error { return nil }
-	cmd := fmt.Sprintf("%[1]s -ti -n %[2]s exec %[3]s -- %[4]s",
-		KubectlCmd, KubeSystemNamespace, microscope, microscopeCmd)
-	_ = kub.Apply(microscopeManifest)
+	/*
+		TODO: re-enable microscope in CI. See GH-4011.
+		microscope := "microscope"
+		cmd := fmt.Sprintf("%[1]s -n %[2]s exec %[3]s -- %[3]s",
+			KubectlCmd, KubeSystemNamespace, microscope)
+		_ = kub.Apply(microscopeManifest)
 
-	err := kub.WaitforPods(
-		KubeSystemNamespace,
-		fmt.Sprintf("-l k8s-app=%s", microscope),
-		300)
-	if err != nil {
-		return err, cb
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	res := kub.ExecContext(ctx, cmd, ExecOptions{SkipLog: true})
-
-	cb = func() error {
-		cancel()
-		<-ctx.Done()
-		testPath, err := CreateReportDirectory()
+		_, err := kub.WaitforPods(
+			KubeSystemNamespace,
+			fmt.Sprintf("-l k8s-app=%s", microscope),
+			300)
 		if err != nil {
-			kub.logger.WithError(err).Errorf(
-				"cannot create test results path '%s'", testPath)
-			return err
+			return err, nil
 		}
 
-		err = ioutil.WriteFile(
-			filepath.Join(testPath, monitorLogFileName),
-			res.CombineOutput().Bytes(),
-			LogPerm)
-		if err != nil {
-			log.WithError(err).Errorf("cannot create monitor log file")
-			return err
+		ctx, cancel := context.WithCancel(context.Background())
+		res := kub.ExecContext(ctx, cmd, ExecOptions{SkipLog: true})
+
+		cb := func() error {
+			cancel()
+			testPath, err := CreateReportDirectory()
+			if err != nil {
+				kub.logger.WithError(err).Errorf(
+					"cannot create test results path '%s'", testPath)
+				return err
+			}
+
+			err = ioutil.WriteFile(
+				filepath.Join(testPath, monitorLogFileName),
+				res.CombineOutput().Bytes(),
+				LogPerm)
+			if err != nil {
+				log.WithError(err).Errorf("cannot create monitor log file")
+			}
+			return nil
 		}
-		kub.Delete(microscopeManifest)
+	*/
+
+	cb := func() error {
 		return nil
 	}
-
 	return nil, cb
 }
 


### PR DESCRIPTION
To get the v1.1. branch stable, this PR *reverts* the following backported PRs:

* #4648

This is being reverted because it re-enabled microscope in the K8s CI, without fixing the issue of leftover microscope processes being left behind, and eating up tons of memory in the nodes, which eventually caused timeouts / test failures. This was fixed by #4452, but there are also other PRs which added fixes on top of that as well; given that microscope integration in the CI has no effect on the Cilium binary that is shipped, in order to unblock backports for v1.1 and to get the next fix version out, just revert this commit.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4860)
<!-- Reviewable:end -->
