### PR TITLE
Move Nightly-Docker-Image stage to front

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -55,6 +55,20 @@ pipeline {
                 checkout scm
             }
         }
+        stage('Nightly-Docker-Image') {
+            when {
+                branch 'master'
+            }
+            steps {
+                withDockerRegistry([ credentialsId: "NIGHTLY_DOCKER_HUB_CRED", url: "" ]) {
+                    sh 'make docker-image'
+                    sh 'docker tag cilium/cilium:latest cilium/nightly:latest'
+                    sh 'docker tag cilium/nightly:latest cilium/nightly:${NIGHTLY_TAG}'
+                    sh 'docker push cilium/nightly:${NIGHTLY_TAG}'
+                    sh 'docker push cilium/nightly:latest'
+                }
+            }
+        }
         stage('Nightly-Tests') {
             environment {
                 K8S_NODES=4
@@ -108,20 +122,6 @@ pipeline {
             post {
                 always {
                     sh "cd ${TESTDIR}; vagrant destroy -f || true"
-                }
-            }
-        }
-        stage('Nightly-Docker-Image') {
-            when {
-                branch 'master'
-            }
-            steps {
-                withDockerRegistry([ credentialsId: "NIGHTLY_DOCKER_HUB_CRED", url: "" ]) {
-                    sh 'make docker-image'
-                    sh 'docker tag cilium/cilium:latest cilium/nightly:latest'
-                    sh 'docker tag cilium/nightly:latest cilium/nightly:${NIGHTLY_TAG}'
-                    sh 'docker push cilium/nightly:${NIGHTLY_TAG}'
-                    sh 'docker push cilium/nightly:latest'
                 }
             }
         }


### PR DESCRIPTION
Since we want nightly images also for failed nightly builds, stage
building it is moved to front of Nightly pipeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4861)
<!-- Reviewable:end -->
