### PR TITLE
Test: K8s/Tunnels install demo_ds on AfterAll

### DIFF
--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -39,7 +39,6 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 		demoDSPath = helpers.ManifestGet("demo_ds.yaml")
 
 		kubectl.Exec("kubectl -n kube-system delete ds cilium")
-		// Expect(res.Correct()).Should(BeTrue())
 
 		waitToDeleteCilium(kubectl, logger)
 	})
@@ -50,10 +49,7 @@ var _ = Describe("K8sValidatedTunnelTest", func() {
 	})
 
 	AfterEach(func() {
-		_ = kubectl.Delete(demoDSPath)
-	})
-
-	AfterAll(func() {
+		kubectl.Delete(demoDSPath)
 		ExpectAllPodsTerminated(kubectl)
 	})
 


### PR DESCRIPTION
Have seen in a PR that the pods are deleted on the `AfterEach` but never
wait until it was terminated, the next test started installing the pods
and it was still present.

With this change demo_ds application will be installed using BeforeAll
and AfterAll helpers.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4868)
<!-- Reviewable:end -->
