### PR TITLE
backports: v1.0 backports 2018-07-18

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2274,6 +2274,10 @@ func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
 	if e.SecurityIdentity != nil &&
 		string(e.SecurityIdentity.Labels.SortedList()) == string(newLabels.SortedList()) {
 
+		// Sets endpoint state to ready if was waiting for identity
+		if e.GetStateLocked() == StateWaitingForIdentity {
+			e.SetStateLocked(StateReady, "Set identity for this endpoint")
+		}
 		e.Mutex.RUnlock()
 		elog.Debug("Endpoint labels unchanged, skipping resolution of identity")
 		return nil

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -302,7 +302,9 @@ func (e *etcdClient) LockPath(path string) (kvLocker, error) {
 	mu := concurrency.NewMutex(e.session, path)
 	e.RUnlock()
 
-	err := mu.Lock(ctx.Background())
+	ctx, cancel := ctx.WithTimeout(ctx.Background(), 1*time.Minute)
+	defer cancel()
+	err := mu.Lock(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Backports PRs: 

* #4788
* #4840

Does *not* backport PRs:

* #4635 ; this was intentionally not backported before due to issues it caused with Envoy compilation. 
* #4675 ; this is purely a CI change. It was also avoided in prior backport PRs.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4872)
<!-- Reviewable:end -->
