### PR TITLE
Test: Fix top command

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1086,7 +1086,7 @@ func (kub *Kubectl) GatherLogs() {
 		vm := GetVagrantSSHMeta(node)
 		reportCmds := map[string]string{
 			"journalctl --no-pager -au kubelet": fmt.Sprintf("kubelet-%s.log", node),
-			"sudo top -n 1":                     fmt.Sprintf("top-%s.log", node),
+			"sudo top -n 1 -b":                  fmt.Sprintf("top-%s.log", node),
 			"sudo ps aux":                       fmt.Sprintf("ps-%s.log", node),
 		}
 		reportMap(testPath, reportCmds, vm)


### PR DESCRIPTION
The result of a `top` command was always Unknown because top uses ncurses
and can't get the information in the terminal. With this change no
ncurses are in place and it works ok.

Example of the change results:

```
breo.acalustra.com ➜  head test_results/110-/K8sValidatedServicesTest_Eloy/top-k8s*
==> test_results/110-/K8sValidatedServicesTest_Eloy/top-k8s1-1.10.log <==
top - 23:30:03 up 7 min,  0 users,  load average: 0.98, 1.01, 0.56
Tasks: 165 total,   1 running, 164 sleeping,   0 stopped,   0 zombie
%Cpu(s): 12.3 us,  6.2 sy,  0.0 ni, 79.4 id,  1.4 wa,  0.0 hi,  0.7 si,  0.0 st
KiB Mem :  4044512 total,  1767468 free,  1213760 used,  1063284 buff/cache
KiB Swap:        0 total,        0 free,        0 used.  2596492 avail Mem

  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND
 1992 root      20   0  139488  90676  45940 S   6.2  2.2   0:17.21 kube-contr+
 2019 root      20   0  470348 345852  55036 S   6.2  8.6   0:30.22 kube-apise+
12556 root      20   0   42096   3524   2964 R   6.2  0.1   0:00.01 top

==> test_results/110-/K8sValidatedServicesTest_Eloy/top-k8s2-1.10.log <==
top - 23:30:05 up 7 min,  0 users,  load average: 0.68, 0.51, 0.27
Tasks: 160 total,   2 running, 158 sleeping,   0 stopped,   0 zombie
%Cpu(s):  8.5 us,  4.1 sy,  0.0 ni, 85.9 id,  0.9 wa,  0.0 hi,  0.6 si,  0.0 st
KiB Mem :  4044512 total,  2147000 free,   846072 used,  1051440 buff/cache
KiB Swap:        0 total,        0 free,        0 used.  2953896 avail Mem

  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND
  620 root      20   0 1030836  92980  51260 S   6.2  2.3   0:14.52 kubelet
  903 root      20   0 1042648  97948  38088 S   6.2  2.4   0:16.64 dockerd
10229 root      20   0   42092   3520   2960 R   6.2  0.1   0:00.02 top
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4873)
<!-- Reviewable:end -->
