### PR TITLE
CmdRes.Unmarshal silent fail for non-pointer fix

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -243,7 +243,7 @@ func (res *CmdRes) SingleOut() string {
 // Unmarshal unmarshalls res's stdout into data. It assumes that the stdout of
 // res is in JSON format. Returns an error if the unmarshalling fails.
 func (res *CmdRes) Unmarshal(data interface{}) error {
-	err := json.Unmarshal(res.stdout.Bytes(), &data)
+	err := json.Unmarshal(res.stdout.Bytes(), data)
 	return err
 }
 


### PR DESCRIPTION
If the reference was passed to CmdRes.Unmarshal instead of a pointer,
json.Unmarshal received a pointer to the interface argument anyway and
failed silently without any marshalling.

This bug did not manifest in any existing tests yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4876)
<!-- Reviewable:end -->
