### PR TITLE
pkg/endpoint: add UpdateStatus functionality for CEP

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -184,7 +184,6 @@ type CiliumNetworkPolicyList struct {
 }
 
 // +genclient
-// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CiliumEndpoint is the status of a Cilium policy rule

--- a/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2/ciliumendpoint.go
+++ b/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2/ciliumendpoint.go
@@ -35,6 +35,7 @@ type CiliumEndpointsGetter interface {
 type CiliumEndpointInterface interface {
 	Create(*v2.CiliumEndpoint) (*v2.CiliumEndpoint, error)
 	Update(*v2.CiliumEndpoint) (*v2.CiliumEndpoint, error)
+	UpdateStatus(*v2.CiliumEndpoint) (*v2.CiliumEndpoint, error)
 	Delete(name string, options *v1.DeleteOptions) error
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v2.CiliumEndpoint, error)
@@ -112,6 +113,22 @@ func (c *ciliumEndpoints) Update(ciliumEndpoint *v2.CiliumEndpoint) (result *v2.
 		Namespace(c.ns).
 		Resource("ciliumendpoints").
 		Name(ciliumEndpoint.Name).
+		Body(ciliumEndpoint).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+
+func (c *ciliumEndpoints) UpdateStatus(ciliumEndpoint *v2.CiliumEndpoint) (result *v2.CiliumEndpoint, err error) {
+	result = &v2.CiliumEndpoint{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("ciliumendpoints").
+		Name(ciliumEndpoint.Name).
+		SubResource("status").
 		Body(ciliumEndpoint).
 		Do().
 		Into(result)

--- a/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2/fake/fake_ciliumendpoint.go
+++ b/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2/fake/fake_ciliumendpoint.go
@@ -98,6 +98,18 @@ func (c *FakeCiliumEndpoints) Update(ciliumEndpoint *v2.CiliumEndpoint) (result 
 	return obj.(*v2.CiliumEndpoint), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeCiliumEndpoints) UpdateStatus(ciliumEndpoint *v2.CiliumEndpoint) (*v2.CiliumEndpoint, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(ciliumendpointsResource, "status", c.ns, ciliumEndpoint), &v2.CiliumEndpoint{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v2.CiliumEndpoint), err
+}
+
 // Delete takes name of the ciliumEndpoint and deletes it. Returns an error if one occurs.
 func (c *FakeCiliumEndpoints) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Use UpdateStatus for Cilium Endpoint Status in k8s 1.11
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4877)
<!-- Reviewable:end -->
