### PR TITLE
examples/kubernetes: add missing generated spec for k8s 1.7

### DIFF
--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -159,6 +159,12 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
+          - name: "MONITOR_AGGREGATION_LEVEL"
+            valueFrom:
+              configMapKeyRef:
+                key: monitor-aggregation-level
+                name: cilium-config
+                optional: true
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
Fixes: 25edcda4931d ("examples: Add MONITOR_AGGREGATION_LEVEL option")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4887)
<!-- Reviewable:end -->
