### PR TITLE
Fix up environment binding and k8s YAMLs for monitor-aggregation-level

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -426,7 +426,7 @@ func init() {
 		"masquerade", true, "Masquerade packets from endpoints leaving the host")
 	flags.String(option.MonitorAggregationName, "None",
 		"Level of monitor aggregation for traces from the datapath")
-	viper.BindEnv(option.MonitorAggregationName, "MONITOR_AGGREGATION_LEVEL")
+	viper.BindEnv(option.MonitorAggregationName, "CILIUM_MONITOR_AGGREGATION_LEVEL")
 	flags.IntVar(&option.Config.MTU,
 		option.MTUName, mtu.AutoDetect(), "Overwrite auto-detected MTU of underlying network")
 	flags.StringVar(&v6Address,

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -103,7 +103,6 @@ var (
 	logstashAddr          string
 	logstashProbeTimer    uint32
 	masquerade            bool
-	monitorAggregation    string
 	nat46prefix           string
 	prometheusServeAddr   string
 	socketPath            string
@@ -425,8 +424,8 @@ func init() {
 		"nat46-range", node.DefaultNAT46Prefix, "IPv6 prefix to map IPv4 addresses to")
 	flags.BoolVar(&masquerade,
 		"masquerade", true, "Masquerade packets from endpoints leaving the host")
-	flags.StringVar(&monitorAggregation, option.MonitorAggregationName,
-		fmt.Sprintf("None"), "Level of monitor aggregation for traces from the datapath")
+	flags.String(option.MonitorAggregationName, "None",
+		"Level of monitor aggregation for traces from the datapath")
 	viper.BindEnv(option.MonitorAggregationName, "MONITOR_AGGREGATION_LEVEL")
 	flags.IntVar(&option.Config.MTU,
 		option.MTUName, mtu.AutoDetect(), "Overwrite auto-detected MTU of underlying network")
@@ -668,7 +667,7 @@ func initEnv(cmd *cobra.Command) {
 	option.Config.Opts.SetBool(option.ConntrackAccounting, !disableConntrack)
 	option.Config.Opts.SetBool(option.ConntrackLocal, false)
 
-	monitorAggregationLevel, err := option.ParseMonitorAggregationLevel(monitorAggregation)
+	monitorAggregationLevel, err := option.ParseMonitorAggregationLevel(viper.GetString(option.MonitorAggregationName))
 	if err != nil {
 		log.WithError(err).Fatal("Failed to parse %s: %s",
 			option.MonitorAggregationName, err)

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -112,7 +112,7 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
-          - name: "MONITOR_AGGREGATION_LEVEL"
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
             valueFrom:
               configMapKeyRef:
                 key: monitor-aggregation-level

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -159,7 +159,7 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
-          - name: "MONITOR_AGGREGATION_LEVEL"
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
             valueFrom:
               configMapKeyRef:
                 key: monitor-aggregation-level

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -112,7 +112,7 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
-          - name: "MONITOR_AGGREGATION_LEVEL"
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
             valueFrom:
               configMapKeyRef:
                 key: monitor-aggregation-level

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -159,7 +159,7 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
-          - name: "MONITOR_AGGREGATION_LEVEL"
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
             valueFrom:
               configMapKeyRef:
                 key: monitor-aggregation-level

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -112,7 +112,7 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
-          - name: "MONITOR_AGGREGATION_LEVEL"
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
             valueFrom:
               configMapKeyRef:
                 key: monitor-aggregation-level

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -159,7 +159,7 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
-          - name: "MONITOR_AGGREGATION_LEVEL"
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
             valueFrom:
               configMapKeyRef:
                 key: monitor-aggregation-level

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -112,7 +112,7 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
-          - name: "MONITOR_AGGREGATION_LEVEL"
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
             valueFrom:
               configMapKeyRef:
                 key: monitor-aggregation-level

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -159,7 +159,7 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
-          - name: "MONITOR_AGGREGATION_LEVEL"
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
             valueFrom:
               configMapKeyRef:
                 key: monitor-aggregation-level

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -112,7 +112,7 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
-          - name: "MONITOR_AGGREGATION_LEVEL"
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
             valueFrom:
               configMapKeyRef:
                 key: monitor-aggregation-level

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -159,7 +159,7 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
-          - name: "MONITOR_AGGREGATION_LEVEL"
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
             valueFrom:
               configMapKeyRef:
                 key: monitor-aggregation-level

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -112,7 +112,7 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
-          - name: "MONITOR_AGGREGATION_LEVEL"
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
             valueFrom:
               configMapKeyRef:
                 key: monitor-aggregation-level

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -159,7 +159,7 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
-          - name: "MONITOR_AGGREGATION_LEVEL"
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
             valueFrom:
               configMapKeyRef:
                 key: monitor-aggregation-level

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -112,7 +112,7 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
-          - name: "MONITOR_AGGREGATION_LEVEL"
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
             valueFrom:
               configMapKeyRef:
                 key: monitor-aggregation-level


### PR DESCRIPTION
The `monitor-aggregation-level` argument was not being respected if provided as an argument, and furthermore the environment variable name was inconsistent with other cilium environment variables (ie, not prefixed with `CILIUM_`). This PR fixes both of these issues.

Tested locally using minikube.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4890)
<!-- Reviewable:end -->
