### PR TITLE
ipcache: Fall back to update based delete

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -883,7 +883,7 @@ func (d *Daemon) OnIPIdentityCacheChange(modType ipcache.CacheModification, oldI
 				Warning("unable to update bpf map")
 		}
 	case ipcache.Delete:
-		err := ipCacheBPF.IPCache.Delete(&key)
+		err := ipCacheBPF.Delete(&key)
 		if err != nil {
 			log.WithError(err).WithFields(logrus.Fields{"key": key.String()}).
 				Warning("unable to delete from bpf map")
@@ -943,7 +943,7 @@ func (d *Daemon) OnIPIdentityCacheGC() {
 				for _, k := range keysToRemove {
 					log.WithFields(logrus.Fields{logfields.BPFMapKey: k}).
 						Debug("deleting from ipcache BPF map")
-					if err := ipCacheBPF.IPCache.Delete(k); err != nil {
+					if err := ipCacheBPF.Delete(k); err != nil {
 						return fmt.Errorf("error deleting key %s from ipcache BPF map: %s", k, err)
 					}
 				}


### PR DESCRIPTION
Older kernels do not support the delete operation on LPM maps. Fall back to an
update based deletion by reseting the value portion of the map entry to all
zeroes.

Entries will show up like this in `cilium map get cilium_ipcache`
```
10.4.0.237/32              4       sync
10.4.1.162/32              4       sync
10.4.1.131/32              0       sync
10.4.0.62/32               0       sync
```

Signed-off-by: Thomas Graf <thomas@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4891)
<!-- Reviewable:end -->
