### PR TITLE
Test: Update policies names with the file name

### DIFF
--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -34,7 +34,7 @@ import (
 var (
 	endpointTimeout  = (60 * time.Second)
 	timeout          = time.Duration(300)
-	netcatDsManifest = "netcat_ds.yaml"
+	netcatDsManifest = "netcat-ds.yaml"
 )
 
 var _ = Describe("NightlyEpsMeasurement", func() {
@@ -331,8 +331,8 @@ var _ = Describe("NightlyExamples", func() {
 		apps = []string{helpers.App1, helpers.App2, helpers.App3}
 
 		demoPath = helpers.ManifestGet("demo.yaml")
-		l3Policy = helpers.ManifestGet("l3_l4_policy.yaml")
-		l7Policy = helpers.ManifestGet("l7_policy.yaml")
+		l3Policy = helpers.ManifestGet("l3-l4-policy.yaml")
+		l7Policy = helpers.ManifestGet("l7-policy.yaml")
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -29,9 +29,9 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 	var (
 		kubectl              *helpers.Kubectl
 		demoPath             = helpers.ManifestGet("demo.yaml")
-		l3Policy             = helpers.ManifestGet("l3_l4_policy.yaml")
-		l7Policy             = helpers.ManifestGet("l7_policy.yaml")
-		serviceAccountPolicy = helpers.ManifestGet("service_account.yaml")
+		l3Policy             = helpers.ManifestGet("l3-l4-policy.yaml")
+		l7Policy             = helpers.ManifestGet("l7-policy.yaml")
+		serviceAccountPolicy = helpers.ManifestGet("service-account.yaml")
 		knpDenyIngress       = helpers.ManifestGet("knp-default-deny-ingress.yaml")
 		knpDenyEgress        = helpers.ManifestGet("knp-default-deny-egress.yaml")
 		knpDenyIngressEgress = helpers.ManifestGet("knp-default-deny-ingress-egress.yaml")
@@ -604,11 +604,11 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 			deployment                = "guestbook_deployment.json"
 			groupLabel                = "zgroup=guestbook"
 			redisPolicy               = "guestbook-policy-redis.json"
-			redisPolicyName           = "guestbook-redis"
+			redisPolicyName           = "guestbook-policy-redis"
 			redisPolicyDeprecated     = "guestbook-policy-redis-deprecated.json"
 			redisPolicyDeprecatedName = "guestbook-redis-deprecated"
 			webPolicy                 = "guestbook-policy-web.yaml"
-			webPolicyName             = "guestbook-web"
+			webPolicyName             = "guestbook-policy-web"
 		)
 
 		var ciliumPod, ciliumPod2 string
@@ -762,7 +762,7 @@ EOF`, k, v)
 			secondNSclusterIP string
 
 			demoPath           = helpers.ManifestGet("demo.yaml")
-			l3L4Policy         = helpers.ManifestGet("l3_l4_policy.yaml")
+			l3L4Policy         = helpers.ManifestGet("l3-l4-policy.yaml")
 			cnpSecondNS        = helpers.ManifestGet("cnp-second-namespaces.yaml")
 			netpolNsSelector   = fmt.Sprintf("%s -n %s", helpers.ManifestGet("netpol-namespace-selector.yaml"), secondNS)
 			l3l4PolicySecondNS = fmt.Sprintf("%s -n %s", l3L4Policy, secondNS)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -210,8 +210,8 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 
 			endpointPath      = helpers.ManifestGet("external_endpoint.yaml")
 			podPath           = helpers.ManifestGet("external_pod.yaml")
-			policyPath        = helpers.ManifestGet("external_policy.yaml")
-			policyLabeledPath = helpers.ManifestGet("external_policy_labeled.yaml")
+			policyPath        = helpers.ManifestGet("external-policy.yaml")
+			policyLabeledPath = helpers.ManifestGet("external-policy-labeled.yaml")
 			servicePath       = helpers.ManifestGet("external_service.yaml")
 		)
 
@@ -412,7 +412,7 @@ var _ = Describe("K8sValidatedServicesTest", func() {
 			shouldConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, health))
 			shouldConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, ratingsPath))
 
-			policyCmd := "cilium policy get io.cilium.k8s.policy.name=multi-rules"
+			policyCmd := "cilium policy get io.cilium.k8s.policy.name=cnp-specs"
 
 			By("Importing policy")
 

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -41,8 +41,8 @@ var _ = Describe("K8sValidatedUpdates", func() {
 		apps = []string{helpers.App1, helpers.App2, helpers.App3}
 
 		demoPath = helpers.ManifestGet("demo.yaml")
-		l3Policy = helpers.ManifestGet("l3_l4_policy.yaml")
-		l7Policy = helpers.ManifestGet("l7_policy.yaml")
+		l3Policy = helpers.ManifestGet("l3-l4-policy.yaml")
+		l7Policy = helpers.ManifestGet("l7-policy.yaml")
 
 		// Sometimes PolicyGen has a lot of pods running around without delete
 		// it. Using this we are sure that we delete before this test start

--- a/test/k8sT/manifests/cnp-default-deny-egress.yaml
+++ b/test/k8sT/manifests/cnp-default-deny-egress.yaml
@@ -1,7 +1,7 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  name: "default-deny-all-egress"
+  name: "cnp-default-deny-egress"
 spec:
   endpointSelector: {}
   egress:

--- a/test/k8sT/manifests/cnp-default-deny-ingress.yaml
+++ b/test/k8sT/manifests/cnp-default-deny-ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  name: "default-deny-all-ingress"
+  name: "cnp-default-deny-ingress"
 spec:
   endpointSelector: {}
   ingress:

--- a/test/k8sT/manifests/cnp-matchexpressions.yaml
+++ b/test/k8sT/manifests/cnp-matchexpressions.yaml
@@ -2,7 +2,7 @@ apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 description: "Policy to test matchExpressions key"
 metadata:
-  name: "l7-match-expressions"
+  name: "cnp-matchexpressions"
 spec:
   endpointSelector:
     matchLabels:

--- a/test/k8sT/manifests/cnp-specs.yaml
+++ b/test/k8sT/manifests/cnp-specs.yaml
@@ -2,7 +2,7 @@ apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 description: "Policy to test multiple rules in a single file"
 metadata:
-  name: "multi-rules"
+  name: "cnp-specs"
 specs:
   - endpointSelector:
       matchLabels:

--- a/test/k8sT/manifests/external-policy-labeled.yaml
+++ b/test/k8sT/manifests/external-policy-labeled.yaml
@@ -1,7 +1,7 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  name: "rule-to-services"
+  name: "external-policy-labeled"
 spec:
   endpointSelector:
     matchLabels:

--- a/test/k8sT/manifests/external-policy.yaml
+++ b/test/k8sT/manifests/external-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  name: "rule-to-services"
+  name: "external-policy"
 spec:
   endpointSelector:
     matchLabels:

--- a/test/k8sT/manifests/guestbook-policy-redis.json
+++ b/test/k8sT/manifests/guestbook-policy-redis.json
@@ -2,7 +2,7 @@
   "apiVersion": "networking.k8s.io/v1",
   "kind": "NetworkPolicy",
   "metadata": {
-    "name": "guestbook-redis"
+    "name": "guestbook-policy-redis"
   },
   "spec": {
     "podSelector": {

--- a/test/k8sT/manifests/guestbook-policy-web.yaml
+++ b/test/k8sT/manifests/guestbook-policy-web.yaml
@@ -1,7 +1,7 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  name: "guestbook-web"
+  name: "guestbook-policy-web"
 spec:
   endpointSelector:
     matchLabels:

--- a/test/k8sT/manifests/kafka-sw-security-policy.yaml
+++ b/test/k8sT/manifests/kafka-sw-security-policy.yaml
@@ -2,7 +2,7 @@ apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 description: "Allow only permitted Kafka requests to empire Kafka broker"
 metadata:
-  name: "secure-empire-kafka"
+  name: "kafka-sw-security-policy"
 specs:
   - endpointSelector:
       matchLabels:

--- a/test/k8sT/manifests/knp-default-allow-egress.yaml
+++ b/test/k8sT/manifests/knp-default-allow-egress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-all-egress
+  name: "knp-default-allow-egress"
 spec:
   podSelector: {}
   egress:

--- a/test/k8sT/manifests/knp-default-allow-ingress.yaml
+++ b/test/k8sT/manifests/knp-default-allow-ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-all-ingress
+  name: "knp-default-allow-ingress"
 spec:
   podSelector: {}
   ingress:

--- a/test/k8sT/manifests/knp-default-deny-egress.yaml
+++ b/test/k8sT/manifests/knp-default-deny-egress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: default-deny-egress
+  name: "knp-default-deny-egress"
 spec:
   podSelector: {}
   policyTypes:

--- a/test/k8sT/manifests/knp-default-deny-ingress-egress.yaml
+++ b/test/k8sT/manifests/knp-default-deny-ingress-egress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: default-deny
+  name: "knp-default-deny-ingress-egress"
 spec:
   podSelector: {}
   policyTypes:

--- a/test/k8sT/manifests/knp-default-deny-ingress.yaml
+++ b/test/k8sT/manifests/knp-default-deny-ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: default-deny-ingress
+  name: "knp-default-deny-ingress"
 spec:
   podSelector: {}
   policyTypes:

--- a/test/k8sT/manifests/l3-l4-policy.yaml
+++ b/test/k8sT/manifests/l3-l4-policy.yaml
@@ -2,7 +2,7 @@ apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 description: "L3-L4 policy"
 metadata:
-  name: "rule1"
+  name: "l3-l4-policy"
 spec:
   endpointSelector:
     matchLabels:

--- a/test/k8sT/manifests/l7-policy.yaml
+++ b/test/k8sT/manifests/l7-policy.yaml
@@ -1,16 +1,21 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
+description: "L7 policy for getting started using Kubernetes guide"
 metadata:
-  name: "k8s-svc-account"
+  name: "l7-policy"
 spec:
   endpointSelector:
     matchLabels:
-      io.cilium.k8s.policy.serviceaccount: app1-account
+      id: app1
   ingress:
   - fromEndpoints:
     - matchLabels:
-        io.cilium.k8s.policy.serviceaccount: app2-account
+        id: app2
     toPorts:
     - ports:
       - port: "80"
         protocol: TCP
+      rules:
+        http:
+        - method: "GET"
+          path: "/public"

--- a/test/k8sT/manifests/netcat-ds.yaml
+++ b/test/k8sT/manifests/netcat-ds.yaml
@@ -29,7 +29,7 @@ apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 description: "L7 policy for incoming http "
 metadata:
-  name: "netcatds"
+  name: "netcat-ds"
 spec:
   endpointSelector:
     matchLabels:

--- a/test/k8sT/manifests/netpol-namespace-selector.yaml
+++ b/test/k8sT/manifests/netpol-namespace-selector.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
-  name: second
+  name: "netpol-namespace-selector"
 spec:
   ingress:
   - from:

--- a/test/k8sT/manifests/service-account.yaml
+++ b/test/k8sT/manifests/service-account.yaml
@@ -1,21 +1,16 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
-description: "L7 policy for getting started using Kubernetes guide"
 metadata:
-  name: "rule1"
+  name: "service-account"
 spec:
   endpointSelector:
     matchLabels:
-      id: app1
+      io.cilium.k8s.policy.serviceaccount: app1-account
   ingress:
   - fromEndpoints:
     - matchLabels:
-        id: app2
+        io.cilium.k8s.policy.serviceaccount: app2-account
     toPorts:
     - ports:
       - port: "80"
         protocol: TCP
-      rules:
-        http:
-        - method: "GET"
-          path: "/public"


### PR DESCRIPTION
It was a bit hard to debug cnp/netpol when something fails because the
name of the policies sometimes are not the same as the file and some of
them overlap.

With this change all the Kubernetes policies have the same name as the
filename.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4894)
<!-- Reviewable:end -->
