### PR TITLE
Test: Upgrade test wait until pods are terminated.

### DIFF
--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -87,6 +87,8 @@ var _ = Describe("K8sValidatedUpdates", func() {
 		// Making sure that we deleted the  cilium ds. No assert message
 		// because maybe is not present
 		kubectl.DeleteResource("ds", fmt.Sprintf("-n %s cilium", helpers.KubeSystemNamespace))
+		ExpectAllPodsTerminated(kubectl)
+
 		helpers.InstallExampleCilium(kubectl)
 
 		err := kubectl.CiliumEndpointWaitReady()


### PR DESCRIPTION
I saw in the build [0] that pods are not ready after the timeout, but
the test itself didn't wait until cilium is uninstalled, so the system
fails because no pods at all.

With this change make sure that all terminated containers are deleted.

[0] https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/3343/testReport/junit/k8s-1/7/K8sValidatedUpdates_Updating_Cilium_stable_to_master/

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4895)
<!-- Reviewable:end -->
