### PR TITLE
bpf: add cocci script to find wrong null checks

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -28,6 +28,7 @@ all: $(BPF) $(TARGET)
 
 check:
 	@$(ECHO_CHECK) bpf/*.c
+	$(QUIET) spatch --sp-file ../contrib/coccinelle/null.cocci --dir . --include-headers
 	$(QUIET) sparse -Wsparse-all ${FLAGS} *.c
 	$(QUIET) $(CLANG) ${CLANG_FLAGS} --analyze *.c
 

--- a/contrib/coccinelle/null.cocci
+++ b/contrib/coccinelle/null.cocci
@@ -1,0 +1,24 @@
+// spatch --sp-file null.cocci lib/*.h *.c *.h
+//
+// This script finds undefined behavior in BPF C code which LLVM
+// does not warn about but optimizes instead. See GH PR #4881.
+
+@r exists@
+expression E;
+identifier f;
+position p;
+@@
+
+if (E == NULL)
+{
+  ...
+  E@p->f
+  ...
+}
+
+@script:python@
+E << r.E;
+p << r.p;
+@@
+
+print "* file: %s deref of NULL value %s on line %s" % (p[0].file,E,p[0].line)


### PR DESCRIPTION
Since we recently had a case where a map null check went wrong and
LLVM instead of warning about it optimized the check away entirely
due to being undefined behavior (commit 848d41d1909b (" bpf: Fix
ipcache lookup in bpf_netdev ")), add a cocci script to detect such
situations. Example run on pre 848d41d1909b:

```
  # make check
  spatch --sp-file ../contrib/coccinelle/null.cocci --dir . --include-headers
  init_defs_builtins: /usr/lib/coccinelle/standard.h
  HANDLING: ./bpf_features.h
  HANDLING: ./include/elf/elf.h
  HANDLING: ./include/elf/libelf.h
  HANDLING: ./include/elf/gelf.h
  HANDLING: ./include/bpf/api.h
  HANDLING: ./include/iproute2/bpf_elf.h
  HANDLING: ./include/linux/byteorder/little_endian.h
  HANDLING: ./include/linux/byteorder/big_endian.h
  HANDLING: ./include/linux/in.h
  HANDLING: ./include/linux/if_ether.h
  HANDLING: ./include/linux/if_arp.h
  HANDLING: ./include/linux/ioctl.h
  HANDLING: ./include/linux/icmpv6.h
  HANDLING: ./include/linux/byteorder.h
  HANDLING: ./include/linux/swab.h
  HANDLING: ./include/linux/in6.h
  HANDLING: ./include/linux/ipv6.h
  HANDLING: ./include/linux/bpf_common.h
  HANDLING: ./include/linux/icmp.h
  HANDLING: ./include/linux/type_mapper.h
  HANDLING: ./include/linux/ip.h
  HANDLING: ./include/linux/udp.h
  HANDLING: ./include/linux/bpf.h
  HANDLING: ./include/linux/tcp.h
  HANDLING: ./include/linux/perf_event.h
  HANDLING: ./netdev_config.h
  HANDLING: ./node_config.h
  HANDLING: ./probes/raw_main.c
  HANDLING: ./probes/raw_insn.h
  HANDLING: ./lib/drop.h
  HANDLING: ./lib/maps.h
  HANDLING: ./lib/eth.h
  HANDLING: ./lib/nat46.h
  HANDLING: ./lib/common.h
  HANDLING: ./lib/arp.h
  HANDLING: ./lib/dbg.h
  HANDLING: ./lib/utils.h
  HANDLING: ./lib/ipv4.h
  HANDLING: ./lib/metrics.h
  HANDLING: ./lib/trace.h
  HANDLING: ./lib/l4.h
  HANDLING: ./lib/encap.h
  HANDLING: ./lib/l3.h
  HANDLING: ./lib/xdp.h
  HANDLING: ./lib/csum.h
  HANDLING: ./lib/events.h
  HANDLING: ./lib/icmp6.h
  HANDLING: ./lib/eps.h
  HANDLING: ./lib/ipv6.h
  HANDLING: ./lib/conntrack.h
  HANDLING: ./lib/policy.h
  HANDLING: ./lib/lxc.h
  HANDLING: ./lib/lb.h
  HANDLING: ./filter_config.h
  HANDLING: ./bpf_netdev.c
  * file: ./bpf_netdev.c deref of NULL value info on line 374
  * file: ./bpf_netdev.c deref of NULL value info on line 207
  HANDLING: ./bpf_lb.c
  HANDLING: ./cilium-map-migrate.c
  HANDLING: ./bpf_lxc.c
  HANDLING: ./bpf_xdp.c
  HANDLING: ./lxc_config.h
  HANDLING: ./bpf_overlay.c
  [...]
```

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4900)
<!-- Reviewable:end -->
