### PR TITLE
Test: Wait for Pods ensure that no deleted pods

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -418,6 +418,15 @@ func (kub *Kubectl) NamespaceDelete(name string) *CmdRes {
 // the aforementioned desired state within timeout seconds. Returns false and
 // an error if the command failed or the timeout was exceeded.
 func (kub *Kubectl) WaitforPods(namespace string, filter string, timeout time.Duration) error {
+
+	data, err := kub.GetPods(namespace, filter).Filter("{.items[*].metadata.deletionTimestamp}")
+	if err != nil {
+		return fmt.Errorf("Cannot get pods with filter '%s': %s", filter, err)
+	}
+	if data.String() != "" {
+		return fmt.Errorf(
+			"There are some pods with filter %s that are marked to be deleted", filter)
+	}
 	body := func() bool {
 		var jsonPath = "{.items[*].status.containerStatuses[*].ready}"
 		data, err := kub.GetPods(namespace, filter).Filter(jsonPath)
@@ -444,7 +453,10 @@ func (kub *Kubectl) WaitforPods(namespace string, filter string, timeout time.Du
 		}).Info("WaitforPods: pods are not ready")
 		return false
 	}
-	return WithTimeout(body, "could not get Pods", &TimeoutConfig{Timeout: timeout})
+	return WithTimeout(
+		body,
+		fmt.Sprintf("timed out waiting for pods with filter %s to be ready", filter),
+		&TimeoutConfig{Timeout: timeout})
 }
 
 // WaitForServiceEndpoints waits up until timeout seconds have elapsed for all


### PR DESCRIPTION
Have seen that pods are not ready because some pods are waiting to be
deleted and finally pods are not ready at all. Added a new checker to
validate that pods should not be deleted.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4902)
<!-- Reviewable:end -->
