### PR TITLE
policy: DNS Poller initializes error map on poll

### DIFF
--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -33,6 +33,8 @@ import (
 // It is used by DNSPoller when no alternative LookupDNSNames is provided
 func DNSLookupDefaultResolver(dnsNames []string) (DNSIPs map[string][]net.IP, DNSErrors map[string]error) {
 	DNSIPs = make(map[string][]net.IP)
+	DNSErrors = make(map[string]error)
+
 	for _, dnsName := range dnsNames {
 		lookupIPs, err := net.LookupIP(dnsName)
 		if err != nil {


### PR DESCRIPTION
The DNS poller didn't initialize the dnsName -> error map used during a
DNS poll. This would cause it to assign values to a nil map on error,
crashing the daemon.

fixes 92243feb5df4956e87874b94ba77278d67ba3206

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4903)
<!-- Reviewable:end -->
