### PR TITLE
makefile: Run go tool vet on the api and pkg subdirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ gofmt:
 
 govet:
 	@$(ECHO_CHECK) vetting all GOFILES...
-	$(GO) tool vet $(SUBDIRS)
+	$(GO) tool vet api pkg $(SUBDIRS)
 
 precheck: govet
 	@$(ECHO_CHECK) contrib/scripts/check-fmt.sh

--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -32,6 +32,8 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
+	"github.com/cilium/cilium/pkg/comparator"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -751,6 +753,9 @@ func (m *Map) MetadataDiff(other *Map) bool {
 	case m == nil || other == nil:
 		return false
 	default:
+		if logging.CanLogAt(log, logrus.DebugLevel) {
+			logging.MultiLine(log.Debug, comparator.Compare(m, other))
+		}
 		return m.DeepEquals(other)
 	}
 }

--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -28,10 +28,8 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/byteorder"
-	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
 	"github.com/sirupsen/logrus"
@@ -747,21 +745,14 @@ func ConvertKeyValue(bKey []byte, bValue []byte, key interface{}, value interfac
 // MetadataDiff compares the metadata of the BPF maps and returns false if the
 // metadata does not match
 func (m *Map) MetadataDiff(other *Map) bool {
-	if m == nil || other == nil {
+	switch {
+	case m == other:
+		return true
+	case m == nil || other == nil:
 		return false
+	default:
+		return m.DeepEquals(other)
 	}
-
-	// create copies
-	m1 := *m
-	m2 := *other
-
-	// ignore fd in diff
-	m1.fd = 0
-	m2.fd = 0
-
-	logging.MultiLine(log.Debug, comparator.Compare(m1, m2))
-
-	return m1.DeepEquals(&m2)
 }
 
 // GetModel returns a BPF map in the representation served via the API

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -28,6 +28,7 @@ import (
 	"github.com/evalphobia/logrus_fluent"
 	"github.com/sirupsen/logrus"
 	logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
+	"sync/atomic"
 )
 
 const (
@@ -335,4 +336,10 @@ func MultiLine(logFn func(args ...interface{}), output string) {
 	for scanner.Scan() {
 		logFn(scanner.Text())
 	}
+}
+
+// CanLogAt returns whether a log message at the given level would be
+// logged by the given logger.
+func CanLogAt(logger *logrus.Logger, level logrus.Level) bool {
+	return logrus.Level(atomic.LoadUint32((*uint32)(&logger.Level))) >= level
 }

--- a/pkg/monitor/dissect.go
+++ b/pkg/monitor/dissect.go
@@ -183,7 +183,7 @@ type DissectSummary struct {
 	TCP      string `json:"tcp,omitempty"`
 	UDP      string `json:"udp,omitempty"`
 	ICMPv4   string `json:"icmpv4,omitempty"`
-	ICMPv6   string `json:"icmpv4,omitempty"`
+	ICMPv6   string `json:"icmpv6,omitempty"`
 	L2       *Flow  `json:"l2,omitempty"`
 	L3       *Flow  `json:"l3,omitempty"`
 	L4       *Flow  `json:"l4,omitempty"`

--- a/pkg/monitor/logrecord.go
+++ b/pkg/monitor/logrecord.go
@@ -97,7 +97,7 @@ type LogRecordNotifyVerbose struct {
 	SrcIdentity      uint64                     `json:"srcIdentity"`
 	DstEpID          uint64                     `json:"dstEpID"`
 	DstEpLabels      []string                   `json:"dstEpLabels"`
-	DstIdentity      uint64                     `json:dstIdentity`
+	DstIdentity      uint64                     `json:"dstIdentity"`
 	Verdict          accesslog.FlowVerdict      `json:"verdict"`
 	HTTP             *accesslog.LogRecordHTTP   `json:"http,omitempty"`
 	Kafka            *accesslog.LogRecordKafka  `json:"kafka,omitempty"`

--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -15,5 +15,5 @@
 package api
 
 type FQDNSelector struct {
-	MatchName string `json:"matchName",omitempty`
+	MatchName string `json:"matchName,omitempty"`
 }

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -36,7 +36,7 @@ type EndpointSelector struct {
 	// LabelSelector, which allows more efficient matching in Matches().
 	//
 	// Kept as a pointer to allow EndpointSelector to be used as a map key.
-	requirements *k8sLbls.Requirements `json:"-"`
+	requirements *k8sLbls.Requirements
 }
 
 // LabelSelectorString returns a user-friendly string representation of

--- a/pkg/workloads/runtimes_test.go
+++ b/pkg/workloads/runtimes_test.go
@@ -17,9 +17,20 @@ package workloads
 import (
 	"reflect"
 	"testing"
+
+	. "gopkg.in/check.v1"
 )
 
-func TestParseConfigEndpoint(t *testing.T) {
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type WorkloadsTestSuite struct{}
+
+var _ = Suite(&WorkloadsTestSuite{})
+
+func (s *WorkloadsTestSuite) TestParseConfigEndpoint(c *C) {
 	// backup registered workload since None will unregister them all
 	bakRegisteredWorkloads := map[workloadRuntimeType]workloadModule{}
 	for k, v := range registeredWorkloads {
@@ -58,18 +69,16 @@ func TestParseConfigEndpoint(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := ParseConfigEndpoint(tt.args.containerRuntimes, tt.args.containerRuntimesEPOpts); (err != nil) != tt.wantErr {
-				t.Errorf("ParseConfigEndpoint() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
+		if err := ParseConfigEndpoint(tt.args.containerRuntimes, tt.args.containerRuntimesEPOpts); (err != nil) != tt.wantErr {
+			c.Errorf("ParseConfigEndpoint() for %s error = %v, wantErr %v", tt.name, err, tt.wantErr)
+		}
 	}
 
 	if !reflect.DeepEqual(getWorkload(ContainerD).getConfig(), containerDOpts) {
-		t.Errorf("ParseConfigEndpoint() = %v, want %v", getWorkload(ContainerD).getConfig(), containerDOpts)
+		c.Errorf("ParseConfigEndpoint() = %v, want %v", getWorkload(ContainerD).getConfig(), containerDOpts)
 	}
 	if !reflect.DeepEqual(getWorkload(Docker).getConfig(), dockerOpts) {
-		t.Errorf("ParseConfigEndpoint() = %v, want %v", getWorkload(Docker).getConfig(), dockerOpts)
+		c.Errorf("ParseConfigEndpoint() = %v, want %v", getWorkload(Docker).getConfig(), dockerOpts)
 	}
 
 	// Since None will unregister the backends we need to execute it on a
@@ -98,15 +107,13 @@ func TestParseConfigEndpoint(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := ParseConfigEndpoint(tt.args.containerRuntimes, tt.args.containerRuntimesEPOpts); (err != nil) != tt.wantErr {
-				t.Errorf("ParseConfigEndpoint() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
+		if err := ParseConfigEndpoint(tt.args.containerRuntimes, tt.args.containerRuntimesEPOpts); (err != nil) != tt.wantErr {
+			c.Errorf("ParseConfigEndpoint() for %s error = %v, wantErr %v", tt.name, err, tt.wantErr)
+		}
 	}
 }
 
-func Test_parseRuntimeType(t *testing.T) {
+func (s *WorkloadsTestSuite) Test_parseRuntimeType(c *C) {
 	type args struct {
 		str string
 	}
@@ -166,20 +173,18 @@ func Test_parseRuntimeType(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseRuntimeType(tt.args.str)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("parseRuntimeType() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("parseRuntimeType() = %v, want %v", got, tt.want)
-			}
-		})
+		got, err := parseRuntimeType(tt.args.str)
+		if (err != nil) != tt.wantErr {
+			c.Errorf("parseRuntimeType() for %s error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			return
+		}
+		if got != tt.want {
+			c.Errorf("parseRuntimeType() for %s = %v, want %v", tt.name, got, tt.want)
+		}
 	}
 }
 
-func Test_unregisterWorkloads(t *testing.T) {
+func (s *WorkloadsTestSuite) Test_unregisterWorkloads(c *C) {
 	// backup registered workloads since they will unregistered
 	bakRegisteredWorkloads := map[workloadRuntimeType]workloadModule{}
 	for k, v := range registeredWorkloads {
@@ -189,28 +194,16 @@ func Test_unregisterWorkloads(t *testing.T) {
 		registeredWorkloads = bakRegisteredWorkloads
 	}()
 
-	tests := []struct {
-		name string
-	}{
-		{
-			name: "unregister backends",
-		},
-	}
-
 	if len(registeredWorkloads) == 0 {
-		t.Errorf("number of registeredWorkloads should not be 0")
+		c.Errorf("number of registeredWorkloads should not be 0")
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			unregisterWorkloads()
-		})
-	}
+	unregisterWorkloads()
 	if len(registeredWorkloads) != 0 {
-		t.Errorf("number of registeredWorkloads should be 0")
+		c.Errorf("number of registeredWorkloads should be 0")
 	}
 }
 
-func Test_getWorkload(t *testing.T) {
+func (s *WorkloadsTestSuite) Test_getWorkload(c *C) {
 	type args struct {
 		name workloadRuntimeType
 	}
@@ -228,15 +221,13 @@ func Test_getWorkload(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := getWorkload(tt.args.name); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getWorkload() = %v, want %v", got, tt.want)
-			}
-		})
+		if got := getWorkload(tt.args.name); !reflect.DeepEqual(got, tt.want) {
+			c.Errorf("getWorkload() fot %s = %v, want %v", tt.name, got, tt.want)
+		}
 	}
 }
 
-func TestGetRuntimeDefaultOpt(t *testing.T) {
+func (s *WorkloadsTestSuite) TestGetRuntimeDefaultOpt(c *C) {
 	type args struct {
 		crt workloadRuntimeType
 		opt string
@@ -262,15 +253,13 @@ func TestGetRuntimeDefaultOpt(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := GetRuntimeDefaultOpt(tt.args.crt, tt.args.opt); got != tt.want {
-				t.Errorf("GetRuntimeDefaultOpt() = %v, want %v", got, tt.want)
-			}
-		})
+		if got := GetRuntimeDefaultOpt(tt.args.crt, tt.args.opt); got != tt.want {
+			c.Errorf("GetRuntimeDefaultOpt() for %s = %v, want %v", tt.name, got, tt.want)
+		}
 	}
 }
 
-func TestGetRuntimeOptions(t *testing.T) {
+func (s *WorkloadsTestSuite) TestGetRuntimeOptions(c *C) {
 	tests := []struct {
 		name string
 		want string
@@ -283,15 +272,13 @@ func TestGetRuntimeOptions(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := GetRuntimeOptions(); got != tt.want {
-				t.Errorf("GetRuntimeOptions() = %v, want %v", got, tt.want)
-			}
-		})
+		if got := GetRuntimeOptions(); got != tt.want {
+			c.Errorf("GetRuntimeOptions() for %s = %v, want %v", tt.name, got, tt.want)
+		}
 	}
 }
 
-func TestGetDefaultEPOptsStringWithPrefix(t *testing.T) {
+func (s *WorkloadsTestSuite) TestGetDefaultEPOptsStringWithPrefix(c *C) {
 	type args struct {
 		prefix string
 	}
@@ -311,10 +298,8 @@ func TestGetDefaultEPOptsStringWithPrefix(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := GetDefaultEPOptsStringWithPrefix(tt.args.prefix); got != tt.want {
-				t.Errorf("GetDefaultEPOptsStringWithPrefix() = %v, want %v", got, tt.want)
-			}
-		})
+		if got := GetDefaultEPOptsStringWithPrefix(tt.args.prefix); got != tt.want {
+			c.Errorf("GetDefaultEPOptsStringWithPrefix() for %s = %v, want %v", tt.name, got, tt.want)
+		}
 	}
 }


### PR DESCRIPTION
Fix all go tool vet errors.
Fix unnecessary or incorrect json tags.
Remove map copies, which were also copying mutexes.

Fixes: https://github.com/cilium/cilium/issues/4906
Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4909)
<!-- Reviewable:end -->
