### PR TITLE
Count references to CIDR prefix lengths and generate bpf_netdev config based on it

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -298,6 +298,7 @@ func (d *Daemon) writeNetdevHeader(dir string) error {
 	fw.WriteString(option.Config.Opts.GetFmtList())
 	fw.WriteString(d.fmtPolicyEnforcementIngress())
 	fw.WriteString(d.fmtPolicyEnforcementEgress())
+	endpoint.WriteIPCachePrefixes(fw, d.prefixLengths.ToBPFData)
 
 	return fw.Flush()
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/counter"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -133,6 +134,10 @@ type Daemon struct {
 	// Used to synchronize generation of daemon's BPF programs and endpoint BPF
 	// programs.
 	compilationMutex *lock.RWMutex
+
+	// prefixLengths tracks a mapping from CIDR prefix length to the count
+	// of rules that refer to that prefix length.
+	prefixLengths *counter.PrefixLengthCounter
 }
 
 // UpdateProxyRedirect updates the redirect rules in the proxy for a particular
@@ -1049,6 +1054,37 @@ func (d *Daemon) syncLXCMap() error {
 	return nil
 }
 
+func createIPNet(ones, bits int) *net.IPNet {
+	return &net.IPNet{
+		Mask: net.CIDRMask(ones, bits),
+	}
+}
+
+// createPrefixLengthCounter wraps around the counter library, providing
+// references to prefix lengths that will always be present.
+func createPrefixLengthCounter() *counter.PrefixLengthCounter {
+	counter := counter.NewPrefixLengthCounter(ipcachemap.IPCache.GetMaxPrefixLengths())
+
+	// This is a bit ugly, but there's not a great way to define an IPNet
+	// without parsing strings, etc.
+	defaultPrefixes := []*net.IPNet{
+		// IPv4
+		createIPNet(0, net.IPv4len*8),                     // world
+		createIPNet(v4ClusterCidrMaskSize, net.IPv4len*8), // cluster
+		createIPNet(net.IPv4len*8, net.IPv4len*8),         // hosts
+
+		// IPv6
+		createIPNet(0, net.IPv6len*8), // world
+		createIPNet(node.DefaultIPv6ClusterPrefixLen, net.IPv6len*8),
+		createIPNet(net.IPv6len*8, net.IPv6len*8), // hosts
+	}
+	_, err := counter.Add(defaultPrefixes)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to create default prefix lengths")
+	}
+	return counter
+}
+
 // NewDaemon creates and returns a new Daemon with the parameters set in c.
 func NewDaemon() (*Daemon, error) {
 	// Validate the daemon specific global options
@@ -1063,10 +1099,11 @@ func NewDaemon() (*Daemon, error) {
 	lb := types.NewLoadBalancer()
 
 	d := Daemon{
-		loadBalancer: lb,
-		policy:       policy.NewPolicyRepository(),
-		uniqueID:     map[uint64]bool{},
-		nodeMonitor:  monitorLaunch.NewNodeMonitor(),
+		loadBalancer:  lb,
+		policy:        policy.NewPolicyRepository(),
+		uniqueID:      map[uint64]bool{},
+		nodeMonitor:   monitorLaunch.NewNodeMonitor(),
+		prefixLengths: createPrefixLengthCounter(),
 
 		// FIXME
 		// The channel size has to be set to the maximum number of

--- a/pkg/counter/doc.go
+++ b/pkg/counter/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package counter provides generic reference counter objects
+package counter

--- a/pkg/counter/integer.go
+++ b/pkg/counter/integer.go
@@ -1,0 +1,67 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package counter
+
+import (
+	"sort"
+)
+
+// IntCounter tracks references for integers with an optional limiter.
+//
+// No threadsafety is provided within this structure, the user is expected to
+// handle concurrent access to this structure if it is used from multiple
+// threads.
+type IntCounter map[int]int
+
+// DeepCopy makes a new copy of the received IntCounter.
+func (i IntCounter) DeepCopy() IntCounter {
+	result := make(IntCounter, len(i))
+	for k, v := range i {
+		result[k] = v
+	}
+	return result
+}
+
+// Add increments the reference count for the specified integer key.
+func (i IntCounter) Add(key int) (changed bool) {
+	value, exists := i[key]
+	if !exists {
+		changed = true
+	}
+	i[key] = value + 1
+	return changed
+}
+
+// Delete decrements the reference count for the specified integer key.
+func (i IntCounter) Delete(key int) bool {
+	value, _ := i[key]
+	if value <= 1 {
+		delete(i, key)
+		return true
+	}
+	i[key] = value - 1
+	return false
+}
+
+// ToBPFData returns the keys as a slice, sorted from high to low.
+func (i IntCounter) ToBPFData() []int {
+	result := make([]int, 0, len(i))
+
+	for key := range i {
+		result = append(result, key)
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(result)))
+	return result
+}

--- a/pkg/counter/prefixes.go
+++ b/pkg/counter/prefixes.go
@@ -1,0 +1,139 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package counter
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// PrefixLengthCounter tracks references to prefix lengths, limited by the
+// maxUniquePrefixes count. Neither of the IPv4 or IPv6 counters nested within
+// may contain more keys than the specified maximum number of unique prefixes.
+type PrefixLengthCounter struct {
+	lock.RWMutex
+
+	v4 IntCounter
+	v6 IntCounter
+
+	maxUniquePrefixes int
+}
+
+// NewPrefixLengthCounter returns a new PrefixLengthCounter which limits
+// insertions to the specified maximum number of unique prefix lengths.
+func NewPrefixLengthCounter(maxUniquePrefixes int) *PrefixLengthCounter {
+	return &PrefixLengthCounter{
+		v4:                make(IntCounter),
+		v6:                make(IntCounter),
+		maxUniquePrefixes: maxUniquePrefixes,
+	}
+}
+
+// checkLimits checks whether the specified new count of prefixes would exceed
+// the specified limit on the maximum number of unique keys, and returns an
+// error if it would exceed the limit.
+func (p *PrefixLengthCounter) checkLimits(current, newCount int) error {
+	if newCount > p.maxUniquePrefixes {
+		return fmt.Errorf("Adding specified prefixes would result in too many prefix lengths (current: %d, result: %d, max: %d)",
+			current, newCount, p.maxUniquePrefixes)
+	}
+	return nil
+}
+
+// Add increments references to prefix lengths for the specified IPNets to the
+// counter. If the maximum number of unique prefix lengths would be exceeded,
+// returns an error.
+//
+// Returns true if adding these prefixes results in an increase in the total
+// number of unique prefix lengths in the counter.
+func (p *PrefixLengthCounter) Add(prefixes []*net.IPNet) (bool, error) {
+	p.Lock()
+	defer p.Unlock()
+
+	// Assemble a map of references that need to be added
+	newV4Counter := p.v4.DeepCopy()
+	newV6Counter := p.v6.DeepCopy()
+	newV4Prefixes := false
+	newV6Prefixes := false
+	for _, prefix := range prefixes {
+		ones, bits := prefix.Mask.Size()
+
+		switch bits {
+		case net.IPv4len * 8:
+			if newV4Counter.Add(ones) {
+				newV4Prefixes = true
+			}
+		case net.IPv6len * 8:
+			if newV6Counter.Add(ones) {
+				newV6Prefixes = true
+			}
+		default:
+			return false, fmt.Errorf("Unsupported IPAddr bitlength %d", bits)
+		}
+	}
+
+	// Check if they can be added given the limit in place
+	if newV4Prefixes {
+		if err := p.checkLimits(len(p.v4), len(newV4Counter)); err != nil {
+			return false, err
+		}
+	}
+	if newV6Prefixes {
+		if err := p.checkLimits(len(p.v6), len(newV6Counter)); err != nil {
+			return false, err
+		}
+	}
+
+	// Set and return whether anything changed
+	p.v4 = newV4Counter
+	p.v6 = newV6Counter
+	return newV4Prefixes || newV6Prefixes, nil
+}
+
+// Delete reduces references to prefix lengths in the the specified IPNets from
+// the counter. Returns true if removing references to these prefix lengths
+// would result in a decrese in the total number of unique prefix lengths in
+// the counter.
+func (p *PrefixLengthCounter) Delete(prefixes []*net.IPNet) (changed bool) {
+	p.Lock()
+	defer p.Unlock()
+
+	for _, prefix := range prefixes {
+		ones, bits := prefix.Mask.Size()
+		switch bits {
+		case net.IPv4len * 8:
+			if p.v4.Delete(ones) {
+				changed = true
+			}
+		case net.IPv6len * 8:
+			if p.v6.Delete(ones) {
+				changed = true
+			}
+		}
+	}
+
+	return changed
+}
+
+// ToBPFData converts the counter into a set of prefix lengths that the BPF
+// datapath can use for LPM lookup.
+func (p *PrefixLengthCounter) ToBPFData() (s6, s4 []int) {
+	p.RLock()
+	defer p.RUnlock()
+
+	return p.v6.ToBPFData(), p.v4.ToBPFData()
+}

--- a/pkg/counter/prefixes_test.go
+++ b/pkg/counter/prefixes_test.go
@@ -1,0 +1,202 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package counter
+
+import (
+	"net"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/comparator"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+type CounterTestSuite struct{}
+
+var _ = Suite(&CounterTestSuite{})
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+func (cs *CounterTestSuite) TestReferenceTracker(c *C) {
+	v4Prefixes := []*net.IPNet{
+		{Mask: net.CIDRMask(0, 32)},
+		{Mask: net.CIDRMask(15, 32)},
+		{Mask: net.CIDRMask(15, 32)},
+		{Mask: net.CIDRMask(31, 32)},
+		{Mask: net.CIDRMask(32, 32)},
+	}
+	v4PrefixesLengths := map[int]int{
+		0:  1,
+		15: 2,
+		31: 1,
+		32: 1,
+	}
+
+	result := NewPrefixLengthCounter(128)
+
+	// Expected output is the combination of defaults and the above prefixes.
+	expectedPrefixLengths := make(IntCounter, len(v4PrefixesLengths))
+	for k, v := range v4PrefixesLengths {
+		expectedPrefixLengths[k] += v
+	}
+	// New prefixes are added (return true)
+	changed, err := result.Add(v4Prefixes)
+	c.Assert(err, IsNil)
+	c.Assert(changed, Equals, true)
+	c.Assert(result.v4, comparator.DeepEquals, expectedPrefixLengths)
+
+	// When we add the prefixes again, we should increase the reference
+	// counts appropriately
+	for k, v := range v4PrefixesLengths {
+		expectedPrefixLengths[k] += v
+	}
+	// This time, there are no new prefix lengths (return false).
+	changed, err = result.Add(v4Prefixes)
+	c.Assert(err, IsNil)
+	c.Assert(changed, Equals, false)
+	c.Assert(result.v4, comparator.DeepEquals, expectedPrefixLengths)
+
+	// Delete the /15 prefix and see that it is removed and doesn't affect
+	// other counts
+	prefixes15 := []*net.IPNet{
+		{Mask: net.CIDRMask(15, 32)},
+	}
+	expectedPrefixLengths[15]--
+	c.Assert(result.Delete(prefixes15), Equals, false)
+	c.Assert(result.v4, comparator.DeepEquals, expectedPrefixLengths)
+
+	// Delete some prefix lengths
+	for k, v := range v4PrefixesLengths {
+		expectedPrefixLengths[k] -= v
+	}
+	// No change in prefix lengths; each 'prefixes' was referenced twice.
+	c.Assert(result.Delete(v4Prefixes), Equals, false)
+	c.Assert(result.v4, comparator.DeepEquals, expectedPrefixLengths)
+
+	// Re-add the /32 prefix and see that it is added back properly.
+	expectedPrefixLengths[15]++
+	changed, err = result.Add(prefixes15)
+	c.Assert(err, IsNil)
+	c.Assert(changed, Equals, false)
+	c.Assert(result.v4, comparator.DeepEquals, expectedPrefixLengths)
+
+	// When removing the 'prefixes' again, return true and the set of
+	// prefixes should be empty
+	c.Assert(result.Delete(v4Prefixes), Equals, true)
+	c.Assert(result.v4, comparator.DeepEquals, IntCounter{})
+
+	// Add back the v4 prefixes while we add v6 prefixes.
+	changed, err = result.Add(v4Prefixes)
+	c.Assert(err, IsNil)
+	c.Assert(changed, Equals, true)
+	c.Assert(result.v4, comparator.DeepEquals, expectedPrefixLengths)
+
+	v6Prefixes := []*net.IPNet{
+		{Mask: net.CIDRMask(0, 128)},
+		{Mask: net.CIDRMask(76, 128)},
+		{Mask: net.CIDRMask(96, 128)},
+		{Mask: net.CIDRMask(120, 128)},
+	}
+	v6PrefixesLengths := map[int]int{
+		0:   1,
+		76:  1,
+		96:  1,
+		120: 1,
+	}
+
+	expectedPrefixLengths = make(IntCounter, len(v6PrefixesLengths))
+
+	// Add the v6 prefixes (changed: true)
+	for k, v := range v6PrefixesLengths {
+		expectedPrefixLengths[k] = v
+	}
+	changed, err = result.Add(v6Prefixes)
+	c.Assert(err, IsNil)
+	c.Assert(changed, Equals, true)
+	c.Assert(result.v6, comparator.DeepEquals, expectedPrefixLengths)
+
+	// Add the v6 prefixes again (changed: false)
+	for k, v := range v6PrefixesLengths {
+		expectedPrefixLengths[k] += v
+	}
+	changed, err = result.Add(v6Prefixes)
+	c.Assert(err, IsNil)
+	c.Assert(changed, Equals, false)
+	c.Assert(result.v6, comparator.DeepEquals, expectedPrefixLengths)
+
+	// Now, remove them (changed: false)
+	for k, v := range v6PrefixesLengths {
+		expectedPrefixLengths[k] -= v
+	}
+	c.Assert(result.Delete(v6Prefixes), Equals, false)
+	c.Assert(result.v6, comparator.DeepEquals, expectedPrefixLengths)
+
+	// Delete them again (changed: true)
+	c.Assert(result.Delete(v6Prefixes), Equals, true)
+	c.Assert(result.v6, comparator.DeepEquals, IntCounter{})
+
+	// Our v4 prefixes should still be here, unchanged
+	expectedPrefixLengths = make(map[int]int, len(v4PrefixesLengths))
+	for k, v := range v4PrefixesLengths {
+		expectedPrefixLengths[k] += v
+	}
+	c.Assert(result.v4, comparator.DeepEquals, expectedPrefixLengths)
+}
+
+func (cs *CounterTestSuite) TestCheckLimits(c *C) {
+	result := NewPrefixLengthCounter(4)
+	c.Assert(result.checkLimits(0, 4), IsNil)
+	c.Assert(result.checkLimits(0, 5), NotNil)
+
+	prefixes := []*net.IPNet{
+		{Mask: net.CIDRMask(0, 32)},
+		{Mask: net.CIDRMask(15, 32)},
+		{Mask: net.CIDRMask(31, 32)},
+		{Mask: net.CIDRMask(32, 32)},
+	}
+	changed, err := result.Add(prefixes)
+	c.Assert(err, IsNil)
+	c.Assert(changed, Equals, true)
+
+	changed, err = result.Add([]*net.IPNet{{Mask: net.CIDRMask(8, 32)}})
+	c.Assert(err, NotNil)
+	c.Assert(changed, Equals, false)
+}
+
+func (cs *CounterTestSuite) TestToBPFData(c *C) {
+	result := NewPrefixLengthCounter(42)
+
+	prefixes := []string{
+		"192.0.2.0/24",
+		"192.0.2.0/32",
+		"192.0.64.0/20",
+	}
+	prefixesToAdd := []*net.IPNet{}
+	for _, prefix := range prefixes {
+		_, net, err := net.ParseCIDR(prefix)
+		c.Assert(err, IsNil)
+		prefixesToAdd = append(prefixesToAdd, net)
+	}
+
+	_, err := result.Add(prefixesToAdd)
+	c.Assert(err, IsNil)
+
+	s6, s4 := result.ToBPFData()
+	c.Assert(s6, comparator.DeepEquals, []int{})
+	c.Assert(s4, comparator.DeepEquals, []int{32, 24, 20})
+}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -52,6 +52,34 @@ const (
 	ExecTimeout = 300 * time.Second
 )
 
+type getBPFDataCallback func() (s6, s4 []int)
+
+// WriteIPCachePrefixes fetches the set of prefixes that should be used from
+// the specified getBPFData function, and writes the IPCache prefixes to the
+// given writer in the format that the datapath expects.
+func WriteIPCachePrefixes(fw *bufio.Writer, getBPFData getBPFDataCallback) {
+	// In case the Linux kernel doesn't support LPM map type, pass the set of
+	// prefix length for the datapath to lookup the map.
+	if ipcache.IPCache.MapType != bpf.BPF_MAP_TYPE_LPM_TRIE {
+		ipcachePrefixes6, ipcachePrefixes4 := policy.GetDefaultPrefixLengths()
+		if getBPFData != nil {
+			// This will include the default prefix lengths from above.
+			ipcachePrefixes6, ipcachePrefixes4 = getBPFData()
+		}
+
+		fw.WriteString("#define IPCACHE6_PREFIXES ")
+		for _, prefix := range ipcachePrefixes6 {
+			fmt.Fprintf(fw, "%d,", prefix)
+		}
+		fw.WriteString("\n")
+		fw.WriteString("#define IPCACHE4_PREFIXES ")
+		for _, prefix := range ipcachePrefixes4 {
+			fmt.Fprintf(fw, "%d,", prefix)
+		}
+		fw.WriteString("\n")
+	}
+}
+
 func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 	headerPath := filepath.Join(prefix, common.CHeaderFileName)
 	f, err := os.Create(headerPath)
@@ -169,25 +197,10 @@ func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 		fmt.Fprintf(fw, "#define HAVE_L4_POLICY\n")
 	}
 
-	// In case the Linux kernel doesn't support LPM map type, pass the set of
-	// prefix length for the datapath to lookup the map.
-	if ipcache.IPCache.MapType != bpf.BPF_MAP_TYPE_LPM_TRIE {
-		ipcachePrefixes6, ipcachePrefixes4 := policy.GetDefaultPrefixLengths()
-		if e.L3Policy != nil {
-			// This will include the default prefix lengths from above.
-			ipcachePrefixes6, ipcachePrefixes4 = e.L3Policy.ToBPFData()
-		}
-
-		fw.WriteString("#define IPCACHE6_PREFIXES ")
-		for _, prefix := range ipcachePrefixes6 {
-			fmt.Fprintf(fw, "%d,", prefix)
-		}
-		fw.WriteString("\n")
-		fw.WriteString("#define IPCACHE4_PREFIXES ")
-		for _, prefix := range ipcachePrefixes4 {
-			fmt.Fprintf(fw, "%d,", prefix)
-		}
-		fw.WriteString("\n")
+	if e.L3Policy == nil {
+		WriteIPCachePrefixes(fw, nil)
+	} else {
+		WriteIPCachePrefixes(fw, e.L3Policy.ToBPFData)
 	}
 
 	return fw.Flush()

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -179,6 +179,12 @@ func (m *Map) GetMaxPrefixLengths() (count int) {
 	return maxPrefixLengths
 }
 
+// BackedByLPM returns true if the IPCache is backed by a proper LPM
+// implementation (provided by Linux kernels 4.11 or later), false otherwise.
+func BackedByLPM() bool {
+	return IPCache.MapType == bpf.BPF_MAP_TYPE_LPM_TRIE
+}
+
 var (
 	// IPCache is a mapping of all endpoint IPs in the cluster which this
 	// Cilium agent is a part of to their corresponding security identities.

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -174,7 +174,7 @@ func Delete(k bpf.MapKey) error {
 // simultaneously based on the underlying BPF map type in use.
 func (m *Map) GetMaxPrefixLengths() (count int) {
 	if IPCache.MapType == bpf.BPF_MAP_TYPE_LPM_TRIE {
-		return net.IPv6len * 8
+		return net.IPv6len*8 + 1
 	}
 	return maxPrefixLengths
 }


### PR DESCRIPTION
Commit bfdfc3dea6b7 ("bpf: Shift ingress ipcache source lookup to netdev") shifted the IPCache on ingress from the ingress LXC program into the bpf_netdev program. This inadvertently set the set of prefixes to be used for IPCache lookup to `{}`, because the `netdev_config.h` file doesn't specify which prefixes should be used. As a result, the IPCache is rendered useless on Linux versions earlier than 4.11.

To fix this, create a new package `pkg/counter` which reference-counts prefix lengths, and use this to generate the headerfile config for the IPCache prefixes in the `netdev_config.h` file.

Future work can look at removing the existing reference-counting of prefix lengths from the IPCache as it should no longer be necessary.

Fixes: #4892

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4910)
<!-- Reviewable:end -->
