### PR TITLE
doc: Add toFQDNs documentation and example

### DIFF
--- a/examples/policies/l3/fqdn/fqdn.json
+++ b/examples/policies/l3/fqdn/fqdn.json
@@ -1,0 +1,27 @@
+[
+  {
+    "endpointSelector": {
+      "matchLabels": {
+        "app": "test-app"
+      }
+    },
+    "egress": [
+      {
+        "toEndpoints": [
+          {
+            "matchLabels": {
+              "app-type": "dns"
+            }
+          }
+        ]
+      },
+      {
+        "toFQDNs": [
+          {
+            "matchName": "my-remote-service.com"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/examples/policies/l3/fqdn/fqdn.yaml
+++ b/examples/policies/l3/fqdn/fqdn.yaml
@@ -1,0 +1,16 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "to-fqdn"
+spec:
+  endpointSelector:
+    matchLabels:
+      app: test-app
+  egress:
+    - toEndpoints:
+      - matchLabels:
+          "k8s:io.cilium.k8s.policy.serviceaccount": kube-dns
+          "k8s:io.kubernetes.pod.namespace": kube-system
+          "k8s:k8s-app": kube-dns
+    - toFQDNs:
+        - matchName: "my-remote-service.com"


### PR DESCRIPTION
We now support toFQDNs egress rules. These now have documentation to
help end-users deploy the policy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4913)
<!-- Reviewable:end -->
