### PR TITLE
Fix downgrade from Cilium 1.2 to earlier versions

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -461,6 +461,16 @@ type Endpoint struct {
 	// Proxy port 0 indicates no proxy redirection.
 	// All fields within the PolicyKey and the proxy port must be in host byte-order.
 	desiredMapState PolicyMapState
+
+	///////////////////////
+	// DEPRECATED FIELDS //
+	///////////////////////
+
+	// DeprecatedOpts represents the mutable options for the endpoint, in
+	// the format understood by Cilium 1.1 or earlier.
+	//
+	// Deprecated: Use Options instead.
+	DeprecatedOpts deprecatedOptions `json:"Opts"`
 }
 
 // WaitForProxyCompletions blocks until all proxy changes have been completed.
@@ -1335,6 +1345,7 @@ func (e *Endpoint) base64() (string, error) {
 		err       error
 	)
 
+	transformEndpointForDowngrade(e)
 	jsonBytes, err = json.Marshal(e)
 	if err != nil {
 		return "", err

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -1,0 +1,53 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// deprecatedOptions represents the 'Opts' field in the Endpoint structure from
+// Cilium 1.1 or earlier.
+type deprecatedOptions struct {
+	Opts map[string]bool `json:"map"`
+}
+
+// convertOptions handles backwards compatibility for the 'Opts' field.
+//
+// In Cilium 1.2, the ep.Opts became ep.Options and its internal storage type
+// was converted from map[string]bool to map[string]int. To allow downgrade, we
+// must populate the older Opts field based on the newer Options field.
+//
+// Consider deprecating in the Cilium 1.5 cycle or later.
+func convertOptions(opts option.OptionMap) map[string]bool {
+	result := make(map[string]bool, len(opts))
+	for k, v := range opts {
+		switch v {
+		case option.OptionDisabled:
+			result[k] = false
+		case option.OptionEnabled:
+			result[k] = true
+		}
+	}
+	return result
+}
+
+// transformEndpointForDowngrade modifies the specified endpoint to populate
+// deprecated fields so that when the endpoint is serialized, an older version
+// of Cilium will understand the format. This allows safe downgrade from this
+// version to an older version.
+func transformEndpointForDowngrade(ep *Endpoint) {
+	ep.DeprecatedOpts.Opts = convertOptions(ep.Options.Opts)
+}

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -1,0 +1,34 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+func (s *EndpointSuite) TesttransformEndpointForDowngrade(c *C) {
+	/* Cilium 1.2 converted BoolOptions -> IntOptions. */
+	e := NewEndpointWithState(42, StateReady)
+	e.Options.Opts["foo"] = 0
+	e.Options.Opts["bar"] = 1
+	e.Options.Opts["baz"] = 2
+
+	transformEndpointForDowngrade(e)
+
+	c.Assert(e.DeprecatedOpts.Opts["foo"], Equals, false)
+	c.Assert(e.DeprecatedOpts.Opts["bar"], Equals, true)
+	_, exists := e.DeprecatedOpts.Opts["baz"]
+	c.Assert(exists, Equals, false)
+}


### PR DESCRIPTION
Commits 607b8179ff7a ("option: Refactor BoolOptions into IntOptions")
and 8f0279e3788e ("endpoint: Rename Opts -> Options") reworked the
options for an endpoint to be based on integers rather than booleans. To
avoid introducing upgrade problems, the field was renamed. However, this
introduced downgrade problems: If an endpoint is created when running
Cilium 1.2 or later, then the Cilium version is set to 1.1 or earlier,
then the earlier version of Cilium will attempt to restore the endpoints
that were serialized to the `lxc_config.h` from Cilium 1.2.

Since Cilium 1.2 doesn't serialize the `Opts` field (as map[string]bool)
the earlier version of Cilium can't restore the options correctly, and
as a result may dereference the options field of such restored endpoints
and even crash.

To avoid this, on newer versions of Cilium we will always serialize both
forms of the options: the `Opts` (map[string]bool) from earlier
versions, and `Options` (map[string]int) from newer versions. This means
that older versions can restore using `Opts`, and newer versions can
restore using `Options`.

In a subsequent Cilium release, perhaps 1.5 or later, we can consider
dropping support for downgrade to 1.1 or earlier and remove this code.

Fixes: #4899

Manually tested via `cilium/cilium:fix-options-downgrade` image on DockerHub, then following v1.0 upgrade instructions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4917)
<!-- Reviewable:end -->
