### PR TITLE
test: Validate kubectl exec command in Policies AfterEach

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -165,7 +165,8 @@ var _ = Describe("K8sValidatedPolicyTest", func() {
 
 		AfterEach(func() {
 			cmd := fmt.Sprintf("%s delete --all cnp,netpol", helpers.KubectlCmd)
-			_ = kubectl.Exec(cmd)
+			res := kubectl.Exec(cmd)
+			res.ExpectSuccess("Cilium CNP / Network policy cannot be deleted")
 		})
 
 		It("checks all kind of Kubernetes policies", func() {


### PR DESCRIPTION
In a PR, I observed that a test failed near the start of the execution, and it appears that there's no validation that the deletion of the policies was successful.

I saw that some other `AfterEach()` functions performed assertions like this, so perhaps we should add something like this?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4920)
<!-- Reviewable:end -->
