### PR TITLE
Test: Add the cilium.TestScope option

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -683,14 +683,16 @@ framework in the ``test/`` directory and interact with ginkgo directly:
     $ ginkgo . -- --help | grep -A 1 cilium
       -cilium.SSHConfig string
             Specify a custom command to fetch SSH configuration (eg: 'vagrant ssh-config')
+      -cilium.dsManifest string
+            Cilium daemon set manifest to use for running the test (only Kubernetes)
       -cilium.holdEnvironment
             On failure, hold the environment in its current state
       -cilium.provision
             Provision Vagrant boxes and Cilium before running test (default true)
       -cilium.showCommands
             Output which commands are ran to stdout
-      -cilium.dsManifest
-            Cilium daemon set manifest to use for running the test (only Kubernetes)
+      -cilium.testScope string
+            Specifies scope of test to be ran (k8s, Nightly, runtime)
     $ ginkgo --focus "Policies*" -- --cilium.provision=false
 
 For more information about other built-in options to Ginkgo, consult the

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -23,6 +23,7 @@ type CiliumTestConfigType struct {
 	SSHConfig        string
 	ShowCommands     bool
 	CiliumDSManifest string
+	TestScope        string
 }
 
 // CiliumTestConfig holds the global configuration of commandline flags
@@ -41,5 +42,6 @@ func (c *CiliumTestConfigType) ParseFlags() {
 		"Output which commands are ran to stdout")
 	flag.StringVar(&c.CiliumDSManifest, "cilium.dsManifest", "",
 		"Cilium daemon set manifest to use for running the test (only Kubernetes)")
-
+	flag.StringVar(&c.TestScope, "cilium.testScope", "",
+		"Specifies scope of test to be ran (k8s, Nightly, runtime)")
 }

--- a/test/helpers/scope.go
+++ b/test/helpers/scope.go
@@ -1,32 +1,43 @@
 package helpers
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	ginkgoconfig "github.com/onsi/ginkgo/config"
 )
 
+// UserDefinedScope in case that the test scope is defined by the user instead
+// of the focus string.
+var UserDefinedScope string
+
 // GetScope returns the scope for the currently running test.
-func GetScope() string {
+func GetScope() (string, error) {
+	if UserDefinedScope != "" {
+		return UserDefinedScope, nil
+	}
+
 	focusString := strings.TrimSpace(strings.ToLower(ginkgoconfig.GinkgoConfig.FocusString))
 	switch {
 	case strings.HasPrefix(focusString, "run"):
-		return Runtime
+		return Runtime, nil
 	case strings.HasPrefix(focusString, K8s):
-		return K8s
+		return K8s, nil
 	case strings.Contains(focusString, "nightly"):
 		// Nightly tests run in a Kubernetes environment.
-		return K8s
+		return K8s, nil
 	default:
-		return Runtime
+		return "", errors.New("Scope cannot be set")
 	}
 }
 
 // GetScopeWithVersion returns the scope of the running test. If the scope is
 // k8s, then it returns k8s scope along with the version of k8s that is running.
 func GetScopeWithVersion() string {
-	result := GetScope()
+	// No errors check here, test never reach here because test should fail
+	// before.
+	result, _ := GetScope()
 	if result != K8s {
 		return result
 	}


### PR DESCRIPTION
On the test suite the scope (k8s, Nightly or Runtime) was defined by the
ginkgo.focus option. Over the time that was a bad approach because some
devs runs only the last test name, not all the test name and vagrant VM
didn't provision correctly.

With this change developers can choose the scope that they want.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4926)
<!-- Reviewable:end -->
