### PR TITLE
bpf: Remove misleading MaxIdentity const

### DIFF
--- a/pkg/identity/allocator.go
+++ b/pkg/identity/allocator.go
@@ -27,11 +27,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	// MaxIdentity is the maximum identity value
-	MaxIdentity = ^uint16(0)
-)
-
 // globalIdentity is the structure used to store an identity in the kvstore
 type globalIdentity struct {
 	labels.Labels

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -39,9 +38,8 @@ const (
 
 	// ProgArrayMaxEntries is the upper limit of entries in the program
 	// array for the tail calls to jump into the endpoint specific policy
-	// programs. This number *MUST* be identical to the maximum number of
-	// allowed identities.
-	ProgArrayMaxEntries = identity.MaxIdentity
+	// programs. This number *MUST* be identical to the maximum endponit ID.
+	ProgArrayMaxEntries = ^uint16(0)
 
 	// AllPorts is used to ignore the L4 ports in PolicyMap lookups; all ports
 	// are allowed. In the datapath, this is represented with the value 0 in the


### PR DESCRIPTION
The MaxIdentity const was incorrectly used to define the BPF map size for the
policy tail call. The value should be the maximum endpoint ID. Fortunately the
value was the same but as we grow the identity space, the BPF maps would become
unnecessarily big.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4930)
<!-- Reviewable:end -->
