### PR TITLE
allocator: Support watching allocations in arbitrary kvstore connections

### DIFF
--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -21,7 +21,6 @@ import (
 	"path"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/cilium/cilium/pkg/backoff"
@@ -67,12 +66,6 @@ type ID uint64
 func (i ID) String() string {
 	return strconv.FormatUint(uint64(i), 10)
 }
-
-// IDMap provides mapping from ID to an AllocatorKey
-type IDMap map[ID]AllocatorKey
-
-// KeyMap provides mapping from AllocatorKey to ID
-type KeyMap map[string]ID
 
 // Allocator is a distributed ID allocator backed by a KVstore. It maps
 // arbitrary keys to identifiers. Multiple users on different cluster nodes can
@@ -145,28 +138,6 @@ type Allocator struct {
 	// keyType is an instance of the type to be used as allocator key.
 	keyType AllocatorKey
 
-	// mute protects the id to key mapping cache
-	mutex lock.RWMutex
-
-	// cache is a local cache of all IDs allocated in the kvstore. It is
-	// being maintained by watching for kvstore events and can thus lag
-	// behind.
-	cache IDMap
-
-	// keyCache shadows cache and allows access by key
-	keyCache KeyMap
-
-	// nextCache is the cache is constantly being filled by startWatch(),
-	// when startWatch has successfully performed the initial fill using
-	// ListPrefix, the cache above will be pointed to nextCache. If the
-	// startWatch() fails to perform the initial list, then the cache is
-	// never pointed to nextCache. This guarantees that a valid cache is
-	// kept at all times.
-	nextCache IDMap
-
-	// nextKeyCache follows the same logic as nextCache but for keyCache
-	nextKeyCache KeyMap
-
 	// basePrefix is the prefix in the kvstore that all keys share which
 	// are being managed by this allocator. The basePrefix typically
 	// consists of something like: "space/project/allocatorName"
@@ -208,9 +179,16 @@ type Allocator struct {
 	// backoffTemplate is the backoff configuration while allocating
 	backoffTemplate backoff.Exponential
 
-	// idWatcherStop is the channel used to stop the kvstore watcher
-	idWatcherStop chan struct{}
-	idWatcherWg   sync.WaitGroup
+	// mainCache is the main cache, representing the allocator contents of
+	// the primary kvstore connection
+	mainCache cache
+
+	// remoteCachesMutex protects accesse to remoteCaches
+	remoteCachesMutex lock.RWMutex
+
+	// remoteCaches is the list of additional remote caches being watched
+	// in addition to the main cache
+	remoteCaches map[*RemoteCache]struct{}
 
 	// stopGC is the channel used to stop the garbage collector
 	stopGC chan struct{}
@@ -247,19 +225,18 @@ func NewAllocator(basePath string, typ AllocatorKey, opts ...AllocatorOption) (*
 	}
 
 	a := &Allocator{
-		keyType:     typ,
-		basePrefix:  basePath,
-		idPrefix:    path.Join(basePath, "id"),
-		valuePrefix: path.Join(basePath, "value"),
-		lockPrefix:  path.Join(basePath, "locks"),
-		min:         1,
-		max:         ID(^uint64(0)),
-		localKeys:   newLocalKeys(),
-		stopGC:      make(chan struct{}, 0),
-		suffix:      uuid.NewUUID().String()[:10],
-		cache:       IDMap{},
-		keyCache:    KeyMap{},
-		lockless:    locklessCapability(),
+		keyType:      typ,
+		basePrefix:   basePath,
+		idPrefix:     path.Join(basePath, "id"),
+		valuePrefix:  path.Join(basePath, "value"),
+		lockPrefix:   path.Join(basePath, "locks"),
+		min:          1,
+		max:          ID(^uint64(0)),
+		localKeys:    newLocalKeys(),
+		stopGC:       make(chan struct{}, 0),
+		suffix:       uuid.NewUUID().String()[:10],
+		lockless:     locklessCapability(),
+		remoteCaches: map[*RemoteCache]struct{}{},
 		backoffTemplate: backoff.Exponential{
 			Min:    time.Duration(20) * time.Millisecond,
 			Factor: 2.0,
@@ -269,6 +246,11 @@ func NewAllocator(basePath string, typ AllocatorKey, opts ...AllocatorOption) (*
 	for _, fn := range opts {
 		fn(a)
 	}
+
+	a.mainCache = newCache(kvstore.Client(), a.idPrefix)
+
+	// invalid prefixes are only deleted from the main cache
+	a.mainCache.deleteInvalidPrefixes = true
 
 	if a.suffix == "<nil>" {
 		return nil, errors.New("Allocator suffix is <nil> and unlikely unique")
@@ -283,8 +265,8 @@ func NewAllocator(basePath string, typ AllocatorKey, opts ...AllocatorOption) (*
 	}
 
 	go func() {
-		if err := a.startWatchAndWait(); err != nil {
-			log.WithError(err).Fatalf("Unable to initialize identity allocator")
+		if err := a.mainCache.startAndWait(a); err != nil {
+			log.WithError(err).Fatalf("Unable to watch allocation prefix")
 		}
 
 		a.startGC()
@@ -321,7 +303,7 @@ func WithMax(id ID) AllocatorOption {
 // Delete deletes an allocator and stops the garbage collector
 func (a *Allocator) Delete() {
 	close(a.stopGC)
-	a.stopWatch()
+	a.mainCache.stop()
 
 	if a.events != nil {
 		close(a.events)
@@ -345,11 +327,13 @@ type RangeFunc func(ID, AllocatorKey)
 // ForeachCache iterates over the allocator cache and calls RangeFunc on each
 // cached entry
 func (a *Allocator) ForeachCache(cb RangeFunc) {
-	a.mutex.RLock()
-	for k, v := range a.cache {
-		cb(k, v)
+	a.mainCache.foreach(cb)
+
+	a.remoteCachesMutex.RLock()
+	for rc := range a.remoteCaches {
+		rc.cache.foreach(cb)
 	}
-	a.mutex.RUnlock()
+	a.remoteCachesMutex.RUnlock()
 }
 
 func invalidKey(key, prefix string, deleteInvalid bool) {
@@ -358,26 +342,6 @@ func invalidKey(key, prefix string, deleteInvalid bool) {
 	if deleteInvalid {
 		kvstore.Delete(key)
 	}
-}
-
-func (a *Allocator) keyToID(key string, deleteInvalid bool) ID {
-	if !strings.HasPrefix(key, a.idPrefix) {
-		invalidKey(key, a.idPrefix, deleteInvalid)
-		return NoID
-	}
-
-	suffix := strings.TrimPrefix(key, a.idPrefix)
-	if suffix[0] == '/' {
-		suffix = suffix[1:]
-	}
-
-	id, err := strconv.ParseUint(suffix, 10, 64)
-	if err != nil {
-		invalidKey(key, a.idPrefix, deleteInvalid)
-		return NoID
-	}
-
-	return ID(id)
 }
 
 var (
@@ -393,10 +357,10 @@ func (a *Allocator) newRandomIDs() {
 
 // Naive ID allocation mechanism.
 func (a *Allocator) selectAvailableID() (ID, string) {
-	a.mutex.RLock()
-	defer a.mutex.RUnlock()
+	a.mainCache.mutex.RLock()
+	defer a.mainCache.mutex.RUnlock()
 
-	// Perform two attempts to select an available identity:
+	// Perform two attempts to select an available ID:
 	// 1. The first attempt walks through the remaining IDs in the current
 	//    random sequence. This attempt represents the likely available IDs
 	//    but does not include IDs that may have been released again since
@@ -410,7 +374,7 @@ func (a *Allocator) selectAvailableID() (ID, string) {
 	for attempt := 0; attempt < 2; attempt++ {
 		for i, r := range a.randomIDs {
 			id := ID(r) + a.min
-			if _, ok := a.cache[id]; !ok && a.localKeys.lookupID(id) == "" {
+			if _, ok := a.mainCache.cache[id]; !ok && a.localKeys.lookupID(id) == "" {
 				// remove the previously tried IDs that are already in
 				// use from the list of IDs to attempt allocation
 				a.randomIDs = a.randomIDs[i+1:]
@@ -568,10 +532,7 @@ func (a *Allocator) Allocate(key AllocatorKey) (ID, bool, error) {
 	// operation was performed for this allocation
 	if val := a.localKeys.use(k); val != NoID {
 		kvstore.Trace("Reusing local id", nil, logrus.Fields{fieldID: val, fieldKey: key})
-		a.mutex.Lock()
-		a.nextCache[val] = key
-		a.nextKeyCache[k] = val
-		a.mutex.Unlock()
+		a.mainCache.insert(key, val)
 		return val, false, nil
 	}
 
@@ -585,10 +546,7 @@ func (a *Allocator) Allocate(key AllocatorKey) (ID, bool, error) {
 		// FIXME: Add non-locking variant
 		value, isNew, err = a.lockedAllocate(key)
 		if err == nil {
-			a.mutex.Lock()
-			a.nextCache[value] = key
-			a.nextKeyCache[k] = value
-			a.mutex.Unlock()
+			a.mainCache.insert(key, value)
 			return value, isNew, nil
 		}
 
@@ -603,7 +561,7 @@ func (a *Allocator) Allocate(key AllocatorKey) (ID, bool, error) {
 		//
 		// To prevent the stale local ache
 		if attempt == allocAttemptsWatermark {
-			if err := a.cleanCache(); err != nil {
+			if err := a.mainCache.restart(a); err != nil {
 				log.WithError(err).Warning("Unable to clear and refill allocator cache")
 			}
 		}
@@ -617,12 +575,9 @@ func (a *Allocator) Allocate(key AllocatorKey) (ID, bool, error) {
 // Get returns the ID which is allocated to a key. Returns an ID of NoID if no ID
 // has been allocated to this key yet.
 func (a *Allocator) Get(key AllocatorKey) (ID, error) {
-	a.mutex.RLock()
-	if id, ok := a.keyCache[key.GetKey()]; ok {
-		a.mutex.RUnlock()
+	if id := a.mainCache.get(key.GetKey()); id != NoID {
 		return id, nil
 	}
-	a.mutex.RUnlock()
 
 	return a.GetNoCache(key)
 }
@@ -647,12 +602,9 @@ func (a *Allocator) GetNoCache(key AllocatorKey) (ID, error) {
 // GetByID returns the key associated with an ID. Returns nil if no key is
 // associated with the ID.
 func (a *Allocator) GetByID(id ID) (AllocatorKey, error) {
-	a.mutex.RLock()
-	if v, ok := a.cache[id]; ok {
-		a.mutex.RUnlock()
-		return v, nil
+	if key := a.mainCache.getByID(id); key != nil {
+		return key, nil
 	}
-	a.mutex.RUnlock()
 
 	v, err := kvstore.Get(path.Join(a.idPrefix, id.String()))
 	if err != nil {
@@ -761,138 +713,40 @@ type AllocatorEvent struct {
 	Key AllocatorKey
 }
 
-type waitChan chan bool
-
-func (a *Allocator) cleanCache() error {
-	// stop the watcher and wait for it to exit
-	a.stopWatch()
-
-	return a.startWatchAndWait()
+// RemoteCache represents the cache content of an additional kvstore managing
+// identities. The contents are not directly accessible but will be merged into
+// the ForeachCache() function.
+type RemoteCache struct {
+	cache     cache
+	allocator *Allocator
 }
 
-// startWatch requests a LIST operation from the kvstore and starts watching
-// the prefix in a go subroutine.
-func (a *Allocator) startWatch() waitChan {
-	successChan := make(waitChan)
-
-	a.mutex.Lock()
-	a.idWatcherStop = make(chan struct{}, 0)
-
-	// start with a fresh nextCache
-	a.nextCache = IDMap{}
-	a.nextKeyCache = KeyMap{}
-	a.mutex.Unlock()
-
-	a.idWatcherWg.Add(1)
-
-	go func(a *Allocator) {
-		watcher := kvstore.ListAndWatch(a.idPrefix, a.idPrefix, 512)
-
-		for {
-			select {
-			case event, ok := <-watcher.Events:
-				if !ok {
-					goto abort
-				}
-				if event.Typ == kvstore.EventTypeListDone {
-					a.mutex.Lock()
-					// nextCache is valid, point the live cache to it
-					a.cache = a.nextCache
-					a.keyCache = a.nextKeyCache
-					a.mutex.Unlock()
-
-					// report that the list operation has
-					// been completed and the allocator is
-					// ready to use
-					successChan <- true
-					continue
-				}
-
-				id := a.keyToID(event.Key, true)
-				if id != 0 {
-					a.mutex.Lock()
-
-					var key AllocatorKey
-
-					if len(event.Value) > 0 {
-						var err error
-						key, err = a.keyType.PutKey(string(event.Value))
-						if err != nil {
-							log.WithError(err).WithFields(logrus.Fields{fieldKey: event.Value}).
-								Warning("Unable to unmarshal allocator key")
-						}
-					}
-
-					switch event.Typ {
-					case kvstore.EventTypeCreate:
-						kvstore.Trace("Adding id to cache", nil, logrus.Fields{fieldKey: key, fieldID: id})
-						a.nextCache[id] = key
-						if key != nil {
-							a.nextKeyCache[key.GetKey()] = id
-						}
-
-					case kvstore.EventTypeModify:
-						kvstore.Trace("Modifying id in cache", nil, logrus.Fields{fieldKey: key, fieldID: id})
-						if k, ok := a.nextCache[id]; ok {
-							delete(a.nextKeyCache, k.GetKey())
-						}
-
-						a.nextCache[id] = key
-						if key != nil {
-							a.nextKeyCache[key.GetKey()] = id
-						}
-
-					case kvstore.EventTypeDelete:
-						kvstore.Trace("Removing id from cache", nil, logrus.Fields{fieldID: id})
-
-						if k, ok := a.nextCache[id]; ok {
-							delete(a.nextKeyCache, k.GetKey())
-						}
-
-						delete(a.nextCache, id)
-					}
-					a.mutex.Unlock()
-
-					if a.events != nil {
-						a.events <- AllocatorEvent{
-							Typ: event.Typ,
-							ID:  ID(id),
-							Key: key,
-						}
-					}
-				}
-
-			case <-a.idWatcherStop:
-				goto abort
-			}
-		}
-
-	abort:
-		watcher.Stop()
-		// Signal that watcher is done
-		a.idWatcherWg.Done()
-	}(a)
-
-	return successChan
-}
-
-func (a *Allocator) startWatchAndWait() error {
-	waitWatch := a.startWatch()
-
-	// Wait for watcher to be started and for list operation to succeed
-	select {
-	case <-waitWatch:
-	case <-time.After(listTimeout):
-		return fmt.Errorf("Time out while waiting for list operation to complete")
+// WatchRemoteKVStore starts watching an allocator base prefix the kvstore
+// represents by the provided backend. A local cache of all identities of that
+// kvstore will be maintained in the RemoteCache structure returned and will
+// start being reported in the identities returned by the ForeachCache()
+// function.
+func (a *Allocator) WatchRemoteKVStore(backend kvstore.BackendOperations, prefix string) *RemoteCache {
+	rc := &RemoteCache{
+		cache:     newCache(backend, path.Join(prefix, "id")),
+		allocator: a,
 	}
 
-	return nil
+	a.remoteCachesMutex.Lock()
+	a.remoteCaches[rc] = struct{}{}
+	a.remoteCachesMutex.Unlock()
+
+	rc.cache.start(a)
+
+	return rc
 }
 
-func (a *Allocator) stopWatch() {
-	close(a.idWatcherStop)
+// Close stops watching for identities in the kvstore associated with the
+// remote cache and will clear the local cache.
+func (rc *RemoteCache) Close() {
+	rc.allocator.remoteCachesMutex.Lock()
+	delete(rc.allocator.remoteCaches, rc)
+	rc.allocator.remoteCachesMutex.Unlock()
 
-	// wait for all watcher to stop
-	a.idWatcherWg.Wait()
-
+	rc.cache.stop()
 }

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -89,7 +90,7 @@ func (s *AllocatorSuite) TestSelectID(c *C) {
 		id, val := a.selectAvailableID()
 		c.Assert(id, Not(Equals), NoID)
 		c.Assert(val, Equals, id.String())
-		a.cache[id] = TestType(fmt.Sprintf("key-%d", i))
+		a.mainCache.cache[id] = TestType(fmt.Sprintf("key-%d", i))
 	}
 
 	// we should be out of IDs
@@ -224,9 +225,66 @@ func (s *AllocatorSuite) TestKeyToID(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(a, Not(IsNil))
 
-	c.Assert(a.keyToID(path.Join(allocatorName, "invalid"), false), Equals, NoID)
-	c.Assert(a.keyToID(path.Join(a.idPrefix, "invalid"), false), Equals, NoID)
-	c.Assert(a.keyToID(path.Join(a.idPrefix, "10"), false), Equals, ID(10))
+	c.Assert(a.mainCache.keyToID(path.Join(allocatorName, "invalid"), false), Equals, NoID)
+	c.Assert(a.mainCache.keyToID(path.Join(a.idPrefix, "invalid"), false), Equals, NoID)
+	c.Assert(a.mainCache.keyToID(path.Join(a.idPrefix, "10"), false), Equals, ID(10))
+}
+
+func (s *AllocatorSuite) TestRemoteCache(c *C) {
+	testName := randomTestName()
+	allocator, err := NewAllocator(testName, TestType(""), WithMax(ID(256)), WithSuffix("a"))
+	c.Assert(err, IsNil)
+	c.Assert(allocator, Not(IsNil))
+
+	// remove any keys which might be leftover
+	allocator.DeleteAllKeys()
+
+	// allocate all available IDs
+	for i := ID(1); i <= ID(4); i++ {
+		key := TestType(fmt.Sprintf("key%04d", i))
+		_, _, err := allocator.Allocate(key)
+		c.Assert(err, IsNil)
+	}
+
+	// wait for main cache to be populated
+	c.Assert(testutils.WaitUntil(func() bool { return len(allocator.mainCache.cache) == 4 }, 5*time.Second), IsNil)
+
+	// count identical allocations returned
+	cache := map[ID]int{}
+	allocator.ForeachCache(func(id ID, val AllocatorKey) {
+		cache[id]++
+	})
+
+	// ForeachCache must have returned 4 allocations all unique
+	c.Assert(len(cache), Equals, 4)
+	for i := range cache {
+		c.Assert(cache[i], Equals, 1)
+	}
+
+	// watch the prefix in the same kvstore via a 2nd watcher
+	rc := allocator.WatchRemoteKVStore(kvstore.Client(), testName)
+	c.Assert(rc, Not(IsNil))
+
+	// wait for remote cache to be populated
+	c.Assert(testutils.WaitUntil(func() bool { return len(rc.cache.cache) == 4 }, 5*time.Second), IsNil)
+
+	// count the allocations in the main cache *AND* the remote cache
+	cache = map[ID]int{}
+	allocator.ForeachCache(func(id ID, val AllocatorKey) {
+		cache[id]++
+	})
+
+	// Foreach must have returned 4 allocations each duplicated, once in
+	// the main cache, once in the remote cache
+	c.Assert(len(cache), Equals, 4)
+	for i := range cache {
+		c.Assert(cache[i], Equals, 2)
+	}
+
+	rc.Close()
+
+	allocator.DeleteAllKeys()
+	allocator.Delete()
 }
 
 // The following tests are currently disabled as they are not 100% reliable in

--- a/pkg/kvstore/allocator/cache.go
+++ b/pkg/kvstore/allocator/cache.go
@@ -1,0 +1,285 @@
+// Copyright 2016-2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package allocator
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/lock"
+
+	"github.com/sirupsen/logrus"
+)
+
+// idMap provides mapping from ID to an AllocatorKey
+type idMap map[ID]AllocatorKey
+
+// keyMap provides mapping from AllocatorKey to ID
+type keyMap map[string]ID
+
+type cache struct {
+	backend  kvstore.BackendOperations
+	prefix   string
+	stopChan chan bool
+
+	// mutex protects all cache data structures
+	mutex lock.RWMutex
+
+	// cache is a local cache of all IDs allocated in the kvstore. It is
+	// being maintained by watching for kvstore events and can thus lag
+	// behind.
+	cache idMap
+
+	// keyCache shadows cache and allows access by key
+	keyCache keyMap
+
+	// nextCache is the cache is constantly being filled by startWatch(),
+	// when startWatch has successfully performed the initial fill using
+	// ListPrefix, the cache above will be pointed to nextCache. If the
+	// startWatch() fails to perform the initial list, then the cache is
+	// never pointed to nextCache. This guarantees that a valid cache is
+	// kept at all times.
+	nextCache idMap
+
+	// nextKeyCache follows the same logic as nextCache but for keyCache
+	nextKeyCache keyMap
+
+	// stopWatchWg is a wait group that gets conditions added when a
+	// watcher is started with the conditions marked as done when the
+	// watcher has exited
+	stopWatchWg sync.WaitGroup
+
+	// deleteInvalid enables deletion of identities outside of the valid
+	// prefix
+	deleteInvalidPrefixes bool
+}
+
+func newCache(backend kvstore.BackendOperations, prefix string) cache {
+	return cache{
+		backend:  backend,
+		prefix:   prefix,
+		cache:    idMap{},
+		keyCache: keyMap{},
+		stopChan: make(chan bool, 1),
+	}
+}
+
+type waitChan chan bool
+
+func (c *cache) getLogger() *logrus.Entry {
+	status, err := c.backend.Status()
+
+	return log.WithFields(logrus.Fields{
+		"kvstoreStatus": status,
+		"kvstoreErr":    err,
+		"prefix":        c.prefix,
+	})
+}
+
+func (c *cache) restart(a *Allocator) error {
+	c.stop()
+	return c.startAndWait(a)
+}
+
+func (c *cache) keyToID(key string, deleteInvalid bool) ID {
+	if !strings.HasPrefix(key, c.prefix) {
+		invalidKey(key, c.prefix, deleteInvalid)
+		return NoID
+	}
+
+	suffix := strings.TrimPrefix(key, c.prefix)
+	if suffix[0] == '/' {
+		suffix = suffix[1:]
+	}
+
+	id, err := strconv.ParseUint(suffix, 10, 64)
+	if err != nil {
+		invalidKey(key, c.prefix, deleteInvalid)
+		return NoID
+	}
+
+	return ID(id)
+}
+
+// start requests a LIST operation from the kvstore and starts watching the
+// prefix in a go subroutine.
+func (c *cache) start(a *Allocator) waitChan {
+	listDone := make(waitChan)
+
+	logger := c.getLogger()
+	logger.Info("Starting to watch allocation changes")
+
+	c.mutex.Lock()
+
+	// start with a fresh nextCache
+	c.nextCache = idMap{}
+	c.nextKeyCache = keyMap{}
+	c.mutex.Unlock()
+
+	c.stopWatchWg.Add(1)
+
+	go func() {
+		watcher := c.backend.ListAndWatch(c.prefix, c.prefix, 512)
+
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					goto abort
+				}
+				if event.Typ == kvstore.EventTypeListDone {
+					c.mutex.Lock()
+					// nextCache is valid, point the live cache to it
+					c.cache = c.nextCache
+					c.keyCache = c.nextKeyCache
+					c.mutex.Unlock()
+
+					// report that the list operation has
+					// been completed and the allocator is
+					// ready to use
+					close(listDone)
+					continue
+				}
+
+				id := c.keyToID(event.Key, c.deleteInvalidPrefixes)
+				if id != 0 {
+					c.mutex.Lock()
+
+					var key AllocatorKey
+
+					if len(event.Value) > 0 {
+						var err error
+						key, err = a.keyType.PutKey(string(event.Value))
+						if err != nil {
+							logger.WithError(err).WithField(fieldKey, event.Value).
+								Warning("Unable to unmarshal allocator key")
+						}
+					}
+					debugFields := logger.WithFields(logrus.Fields{fieldKey: key, fieldID: id})
+
+					switch event.Typ {
+					case kvstore.EventTypeCreate:
+						kvstore.Trace("Adding id to cache", nil, debugFields.Data)
+						c.nextCache[id] = key
+						if key != nil {
+							c.nextKeyCache[key.GetKey()] = id
+						}
+
+					case kvstore.EventTypeModify:
+						kvstore.Trace("Modifying id in cache", nil, debugFields.Data)
+						if k, ok := c.nextCache[id]; ok {
+							delete(c.nextKeyCache, k.GetKey())
+						}
+
+						c.nextCache[id] = key
+						if key != nil {
+							c.nextKeyCache[key.GetKey()] = id
+						}
+
+					case kvstore.EventTypeDelete:
+						kvstore.Trace("Removing id from cache", nil, debugFields.Data)
+
+						if k, ok := c.nextCache[id]; ok {
+							delete(c.nextKeyCache, k.GetKey())
+						}
+
+						delete(c.nextCache, id)
+					}
+					c.mutex.Unlock()
+
+					if a.events != nil {
+						a.events <- AllocatorEvent{
+							Typ: event.Typ,
+							ID:  ID(id),
+							Key: key,
+						}
+					}
+				}
+
+			case <-c.stopChan:
+				goto abort
+			}
+		}
+
+	abort:
+		watcher.Stop()
+		// Signal that watcher is done
+		c.stopWatchWg.Done()
+	}()
+
+	return listDone
+}
+
+func (c *cache) startAndWait(a *Allocator) error {
+	listDone := c.start(a)
+
+	// Wait for watcher to be started and for list operation to succeed
+	select {
+	case <-listDone:
+	case <-time.After(listTimeout):
+		return fmt.Errorf("Time out while waiting for list operation to complete")
+	}
+
+	return nil
+}
+
+func (c *cache) stop() {
+	select {
+	case c.stopChan <- true:
+	default:
+	}
+	c.stopWatchWg.Wait()
+}
+
+func (c *cache) get(key string) ID {
+	c.mutex.RLock()
+	if id, ok := c.keyCache[key]; ok {
+		c.mutex.RUnlock()
+		return id
+	}
+	c.mutex.RUnlock()
+
+	return NoID
+}
+
+func (c *cache) getByID(id ID) AllocatorKey {
+	c.mutex.RLock()
+	if v, ok := c.cache[id]; ok {
+		c.mutex.RUnlock()
+		return v
+	}
+	c.mutex.RUnlock()
+
+	return nil
+}
+
+func (c *cache) foreach(cb RangeFunc) {
+	c.mutex.RLock()
+	for k, v := range c.cache {
+		cb(k, v)
+	}
+	c.mutex.RUnlock()
+}
+
+func (c *cache) insert(key AllocatorKey, val ID) {
+	c.mutex.Lock()
+	c.nextCache[val] = key
+	c.nextKeyCache[key.GetKey()] = val
+	c.mutex.Unlock()
+}


### PR DESCRIPTION
* Move the local cache of allocations to cache.go into a separate abstraction.
* Maintain a main cache of the allocator which represents the allocation pool
  used for local allocations and releases.
* Add a new function WatchRemoteKVstore() to add additional kvstore connections
  and watch allocations.
* Combine all allocations via the ForeachCache() function
* Add test to verify correctness of remote cache watching

Required by #4727

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4934)
<!-- Reviewable:end -->
