### PR TITLE
pkg/endpoint: fix endpoint.logger race condition

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -689,9 +689,9 @@ func (e *Endpoint) regenerate(owner Owner, reason string) (retErr error) {
 	e.BuildMutex.Lock()
 	defer e.BuildMutex.Unlock()
 
-	e.Mutex.RLock()
+	e.Mutex.Lock()
 	e.getLogger().Debug("Regenerating endpoint...")
-	e.Mutex.RUnlock()
+	e.Mutex.Unlock()
 
 	origDir := filepath.Join(owner.GetStateDir(), e.StringID())
 


### PR DESCRIPTION
pkg/endpoint: fix endpoint.logger race condition

As getLogger specifies the endpoint.Mutex needs to be held,
endpoint.getLogger() after a mutex.Lock()

Fixes: 6a8b48951470 ("endpoint: Limit proxy completion timeout to proxy updates")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4942)
<!-- Reviewable:end -->
