### PR TITLE
etcd: Fix and relax during recreate watcher loop

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -566,7 +566,6 @@ func (e *etcdClient) DeletePrefix(path string) error {
 
 // Watch starts watching for changes in a prefix
 func (e *etcdClient) Watch(w *Watcher) {
-	var lastRev int64
 	localCache := watcherCache{}
 	listSignalSent := false
 
@@ -576,20 +575,15 @@ func (e *etcdClient) Watch(w *Watcher) {
 	})
 
 reList:
-	// Retrieve latest revision
-	lastRev = 0
-
 	for {
 		res, err := e.client.Get(ctx.Background(), w.prefix, client.WithPrefix(),
-			client.WithRev(lastRev), client.WithSerializable())
+			client.WithSerializable())
 		if err != nil {
-			scopedLog.WithField(fieldRev, lastRev).WithError(err).Warn("Unable to list keys before starting watcher")
+			scopedLog.WithError(err).Warn("Unable to list keys before starting watcher")
 			continue
 		}
 
-		lastRev := res.Header.Revision
-
-		scopedLog = scopedLog.WithField(fieldRev, lastRev)
+		nextRev := res.Header.Revision + 1
 		scopedLog.Debugf("List response from etcd len=%d: %+v", res.Count, res)
 
 		if res.Count > 0 {
@@ -635,11 +629,9 @@ reList:
 		}
 
 	recreateWatcher:
-		lastRev++
-
-		scopedLog.WithField(fieldRev, lastRev).Debug("Starting to watch a prefix")
+		scopedLog.WithField(fieldRev, nextRev).Debug("Starting to watch a prefix")
 		etcdWatch := e.client.Watch(ctx.Background(), w.prefix,
-			client.WithPrefix(), client.WithRev(lastRev))
+			client.WithPrefix(), client.WithRev(nextRev))
 		for {
 			select {
 			case <-w.stopWatch:
@@ -648,6 +640,7 @@ reList:
 
 			case r, ok := <-etcdWatch:
 				if !ok {
+					time.Sleep(50 * time.Millisecond)
 					goto recreateWatcher
 				}
 
@@ -670,7 +663,7 @@ reList:
 					goto reList
 				}
 
-				lastRev = r.Header.Revision
+				nextRev = r.Header.Revision + 1
 				scopedLog.Debugf("Received event from etcd: %+v", r)
 
 				for _, ev := range r.Events {


### PR DESCRIPTION
I can't think of a reason why the revision to watch should be bumped when
Watch() returns a closed channel. We have also observed occasions where etcd
returns a closed channel on calling Watch(). The problem typically resolves
itself quickly but we should sleep for a while to relax the CPU.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4943)
<!-- Reviewable:end -->
