### PR TITLE
kvstore: Wait for kvstore watcher to exit 

### DIFF
--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -416,7 +416,9 @@ func (c *consulClient) Watch(w *Watcher) {
 	localState := map[string]consulAPI.KVPair{}
 	nextIndex := uint64(0)
 
-	qo := consulAPI.QueryOptions{}
+	qo := consulAPI.QueryOptions{
+		WaitTime: time.Second,
+	}
 
 	for {
 		// Initialize sleep time to a millisecond as we don't

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -494,6 +494,7 @@ func (c *consulClient) Watch(w *Watcher) {
 		case <-time.After(sleepTime):
 		case <-w.stopWatch:
 			close(w.Events)
+			w.stopWait.Done()
 			return
 		}
 	}

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -634,6 +634,7 @@ reList:
 			select {
 			case <-w.stopWatch:
 				close(w.Events)
+				w.stopWait.Done()
 				return
 
 			case r, ok := <-etcdWatch:

--- a/pkg/kvstore/events.go
+++ b/pkg/kvstore/events.go
@@ -14,6 +14,10 @@
 
 package kvstore
 
+import (
+	"sync"
+)
+
 // EventType defines the type of watch event that occurred
 type EventType int
 
@@ -75,16 +79,24 @@ type Watcher struct {
 	prefix    string
 	stopWatch stopChan
 
-	stopped bool
+	// stopOnce guarantees that Stop() is only called once
+	stopOnce sync.Once
+
+	// stopWait is the wait group to wait for watchers to exit gracefully
+	stopWait sync.WaitGroup
 }
 
 func newWatcher(name, prefix string, chanSize int) *Watcher {
-	return &Watcher{
+	w := &Watcher{
 		name:      name,
 		prefix:    prefix,
 		Events:    make(EventChan, chanSize),
 		stopWatch: make(stopChan, 0),
 	}
+
+	w.stopWait.Add(1)
+
+	return w
 }
 
 // String returns the name of the wather
@@ -107,11 +119,9 @@ func ListAndWatch(name, prefix string, chanSize int) *Watcher {
 
 // Stop stops a watcher previously created and started with Watch()
 func (w *Watcher) Stop() {
-	if w.stopped {
-		return
-	}
-
-	close(w.stopWatch)
-	log.WithField(fieldWatcher, w).Debug("Stopped watcher...")
-	w.stopped = true
+	w.stopOnce.Do(func() {
+		close(w.stopWatch)
+		log.WithField(fieldWatcher, w).Debug("Stopped watcher")
+		w.stopWait.Wait()
+	})
 }


### PR DESCRIPTION
This fixes an overall watcher problem where kvstore watchers can continue running with events being emited and acted upon even after logic in code has decided to stop watching.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4945)
<!-- Reviewable:end -->
