### PR TITLE
Vagrant: Bump K8S_VERSION to 1.11

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -4,7 +4,7 @@ Vagrant.require_version ">= 2.0.0"
 
 $BUILD_NUMBER = ENV['BUILD_NUMBER'] || "0"
 $JOB_NAME = ENV['JOB_BASE_NAME'] || "LOCAL"
-$K8S_VERSION = ENV['K8S_VERSION'] || "1.10"
+$K8S_VERSION = ENV['K8S_VERSION'] || "1.11"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 $NFS = ENV['NFS']=="1"? true : false
 $SERVER_BOX = (ENV['SERVER_BOX'] || "cilium/ubuntu-dev")


### PR DESCRIPTION
With commit `9f979bbb42d6611159211f58f963be3ac3a11528` we updated the
test to 1.11 version, but VagrantFile was not updated correctly.

Fixes: 9f979bbb42d6611159211f58f963be3ac3a11528

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4955)
<!-- Reviewable:end -->
