### PR TITLE
Test: Fix GRPC issue on Kubernetes

### DIFF
--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -448,7 +448,7 @@ var _ = Describe("NightlyExamples", func() {
 
 			By("Testing with L7 policy")
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.DefaultNamespace, PolicyManifest,
+				helpers.KubeSystemNamespace, PolicyManifest,
 				helpers.KubectlApply, 300)
 			Expect(err).To(BeNil(), "Cannot import GPRC policy")
 


### PR DESCRIPTION
The namespaces that are waiting for Cilium was `default` so the
CiliumPolicyAction didn't work correctly and didn't wait until policy
was OK.

Fix #4784

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4956)
<!-- Reviewable:end -->
