### PR TITLE
Test: Core-dns fix log issues

### DIFF
--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -185,7 +185,7 @@ if [[ "${HOST}" == "k8s1" ]]; then
 
     sudo systemctl start etcd
     if [[ $INSTALL_KUBEDNS -eq 1 ]]; then
-        kubectl -n kube-system delete svc,deployment,sa,cm -l k8s-app=kube-dns || true
+        kubectl -n kube-system delete -f ${PROVISIONSRC}/manifest/dns_deployment.yaml || true
         kubectl -n kube-system apply -f ${PROVISIONSRC}/manifest/dns_deployment.yaml
     fi
 


### PR DESCRIPTION
On provision Coredns the configMap provided by kubeadm does not have the
`k8s-app=kube-dns` so the configMap was not updated when apply the new
one.

With this change we deleted all resources related to the *-DNS and
install the new ones from scratch.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4957)
<!-- Reviewable:end -->
