### PR TITLE
test/k8sT: wait for DNS to be ready in Kafka pods

### DIFF
--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -87,6 +87,20 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 			return err
 		}
 
+		waitForDNSResolution := func(pod, service string) error {
+			body := func() bool {
+				dnsLookupCmd := fmt.Sprintf("nslookup %s", service)
+				res := kubectl.ExecPodCmd(helpers.DefaultNamespace, pod, dnsLookupCmd)
+
+				if !res.WasSuccessful() {
+					return false
+				}
+				return true
+			}
+			err := helpers.WithTimeout(body, fmt.Sprintf("unable to resolve DNS for service %s in pod %s", service, pod), &helpers.TimeoutConfig{Timeout: 30})
+			return err
+		}
+
 		JustBeforeEach(func() {
 			microscopeErr, microscopeCancel = kubectl.MicroscopeStart()
 			Expect(microscopeErr).To(BeNil(), "Microscope cannot be started")
@@ -142,6 +156,12 @@ var _ = Describe("K8sValidatedKafkaPolicyTest", func() {
 			By("Creating new kafka topic %s", topicDeathstarPlans)
 			err = createTopic(topicDeathstarPlans, appPods[empireHqApp])
 			Expect(err).Should(BeNil(), "Failed to create topic deathstar-plans")
+
+			By("Waiting for DNS to resolve within pods for kafka-service")
+			err = waitForDNSResolution(appPods[empireHqApp], "kafka-service")
+			Expect(err).Should(BeNil(), "Failed to resolve kafka-service DNS entry in pod %s", appPods[empireHqApp])
+			err = waitForDNSResolution(appPods[outpostApp], "kafka-service")
+			Expect(err).Should(BeNil(), "Failed to resolve kafka-service DNS entry in pod %s", appPods[outpostApp])
 
 			By("Testing basic Kafka Produce and Consume")
 			// We need to produce first, since consumer script waits for


### PR DESCRIPTION
We have observed that while DNS lookups succeed from the host for the various
services used in the Kafka Policies test, the CI has failed with errors like the
following:

"Removing server kafka-service:9092 from bootstrap.servers as DNS resolution
failed for kafka-service"

To prevent this issue, ensure that "nslookup" succeeds within each Kafka pod
itself for "kafka-service".

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #4951

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4958)
<!-- Reviewable:end -->
