### PR TITLE
Test: Dump Cilium Logs for the test in a separate file.

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -1034,6 +1035,21 @@ func (kub *Kubectl) ValidateNoErrorsOnLogs(duration time.Duration) {
 	if res.WasSuccessful() {
 		logs += res.Output().String()
 	}
+	defer func() {
+		// Keep the cilium logs for the given test in a separate file.
+		testPath, err := CreateReportDirectory()
+		if err != nil {
+			kub.logger.WithError(err).Error("Cannot create report directory")
+			return
+		}
+		err = ioutil.WriteFile(
+			fmt.Sprintf("%s/cilium_test.log", testPath),
+			[]byte(logs), LogPerm)
+
+		if err != nil {
+			kub.logger.WithError(err).Error("Cannot create cilium_test.log")
+		}
+	}()
 
 	for _, message := range checkLogsMessages {
 		if strings.Contains(logs, message) {
@@ -1051,6 +1067,7 @@ func (kub *Kubectl) ValidateNoErrorsOnLogs(duration time.Duration) {
 		}
 		fmt.Fprintf(CheckLogs, "%sNumber of %q in logs: %d\n", prefix, message, result)
 	}
+
 }
 
 // GatherCiliumCoreDumps copies core dumps if are present in the /tmp folder


### PR DESCRIPTION
Just dump all Cilium logs for the test time in a separate file so it is
easy to figure it out what happens during the test.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4964)
<!-- Reviewable:end -->
