### PR TITLE
test/k8sT: disable microscope test temporarily

### DIFF
--- a/test/k8sT/microscope.go
+++ b/test/k8sT/microscope.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	microscopeTestName = "K8sValidatedMicroscope"
+	microscopeTestName = "K8sDisabledValidatedMicroscope"
 )
 
 var _ = Describe(microscopeTestName, func() {


### PR DESCRIPTION
There is an issue on the microscope side that is causing CI to fail. This is
tracked by #4879, and is actively being fixed. This is purely related to
microscope, and not Cilium, so it does not make sense for Cilium CI to be
blocked by the microscope test failing. Temporarily disable the test.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #4965

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4966)
<!-- Reviewable:end -->
