### PR TITLE
Endpoint: Added logs for BPF compilation time

### DIFF
--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -87,6 +87,9 @@ const (
 	// BuildDuration is the time elapsed to build a BPF program
 	BuildDuration = "buildDuration"
 
+	// BPFCompilationTime is the time elapsed to build a BPF endpoint program
+	BPFCompilationTime = "BPFCompilationTime"
+
 	// PolicyRegenerationTime is the time elapsed to generate a policy
 	PolicyRegenerationTime = "policyRegenerationTime"
 


### PR DESCRIPTION
Had seen in the GH-4947 that the BPF compilation or the Unlock take 20
seconds. To know if the problem is the Unlock or the BPF compilation
time added the two new log messages to help triage this issues.

Related to #4947

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4972)
<!-- Reviewable:end -->
