### PR TITLE
Jenkins: Nightly run the conditional with env variable

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -57,7 +57,7 @@ pipeline {
         }
         stage('Nightly-Docker-Image') {
             when {
-                branch 'origin/master'
+                environment name: 'GIT_BRANCH', value: 'origin/master'
             }
             steps {
                 withDockerRegistry([ credentialsId: "NIGHTLY_DOCKER_HUB_CRED", url: "" ]) {


### PR DESCRIPTION
The current conditional use branch conditional, but the Jenkins docs [0]
notes that value only works in multibranch, something that we're not
using at all.

https://jenkins.io/doc/book/pipeline/syntax/#when

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4974)
<!-- Reviewable:end -->
