### PR TITLE
Re enable microscope in CI

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -377,7 +377,10 @@ func (kub *Kubectl) MicroscopeStart() (error, func() error) {
 			log.WithError(err).Errorf("cannot create monitor log file")
 			return err
 		}
-		kub.Delete(microscopePath)
+		res := kub.Exec(fmt.Sprintf("%s -n %s delete pod microscope", KubectlCmd, KubeSystemNamespace))
+		if !res.WasSuccessful() {
+			return fmt.Errorf("error deleting microscope pod: %s", res.OutputPrettyPrint())
+		}
 		return nil
 	}
 

--- a/test/k8sT/manifests/microscope.yaml
+++ b/test/k8sT/manifests/microscope.yaml
@@ -72,3 +72,13 @@ spec:
     image: docker.io/cilium/microscope:1.1.0-ci
     imagePullPolicy: IfNotPresent
     name: microscope
+    readinessProbe:
+      exec:
+        command:
+        - microscope
+        - --send-command
+        - "'echo test'"
+        - --timeout-monitors
+        - "2"
+      initialDelaySeconds: 0
+      periodSeconds: 3

--- a/test/k8sT/microscope.go
+++ b/test/k8sT/microscope.go
@@ -21,8 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("DisabledK8sMicroscope", func() {
-
+var _ = Describe("K8sMicroscope", func() {
 	var (
 		kubectl *helpers.Kubectl
 	)


### PR DESCRIPTION
Seems like microscope pod doesn't get all required RBAC immedietaly,
added readiness probe for microscope pod to check if it's able to list
pods.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4976)
<!-- Reviewable:end -->
