### PR TITLE
kubernetes: No CEP CRD for cilium-health EP

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1678,6 +1678,14 @@ func (e *Endpoint) Update(owner Owner, cfg *models.EndpointConfigurationSpec) er
 func (e *Endpoint) HasLabels(l pkgLabels.Labels) bool {
 	e.Mutex.RLock()
 	defer e.Mutex.RUnlock()
+
+	return e.hasLabelsRLocked(l)
+}
+
+// hasLabelsRLocked returns whether endpoint e contains all labels l. Will
+// return 'false' if any label in l is not in the endpoint's labels.
+// e.Mutex must be RLocked
+func (e *Endpoint) hasLabelsRLocked(l pkgLabels.Labels) bool {
 	allEpLabels := e.OpLabels.AllLabels()
 
 	for _, v := range l {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -120,7 +120,9 @@ func (kub *Kubectl) WaitCEPReady() error {
 	}
 	body := func() bool {
 		// Created a map of .id and IPv4 because endpoint id can be the same in different nodes.
-		endpointFilter := `{range [*]}{@.id}{"_"}{@.status.networking.addressing[0].ipv4}{"="}{@.status.policy.spec.policy-revision}{"\n"}{end}`
+		// Note: endpointFilter ignores the health endpoint because we don't create
+		// CEPs for them (via `?(@.status.identity.id != 4)`).
+		endpointFilter := `{range [?(@.status.identity.id != 4)]}{@.id}{"_"}{@.status.networking.addressing[0].ipv4}{"="}{@.status.policy.spec.policy-revision}{"\n"}{end}`
 		cepFilter := `{range .items[*]}{@.status.id}{"_"}{@.status.status.networking.addressing[0].ipv4}{"="}{@.status.status.policy.spec.policy-revision}{"\n"}{end}`
 		endpoints := map[string]string{}
 		for _, ciliumPod := range pods {


### PR DESCRIPTION
The cilium-health endpoint doesn't exist in kubernetes land, and we've
had random errors trying to maintain corresponding CEPs. Instead of
playing wack-a-mole with the errors, avoid creating the CEP to begin
with. Older, already created, cilium-health CEPs will be GCed.

Fixes #4979

```release-note/minor
cilium-agent no longer creates a CiliumEndpoint k8s CRD for internal cilium-health endpoints
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4981)
<!-- Reviewable:end -->
