### PR TITLE
CI: Be more verbose in unit tests output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ BPF_SRCFILES=$(subst ../,,$(BPF_FILES))
 SWAGGER_VERSION = 0.12.0
 SWAGGER = $(QUIET)docker run --rm -v $(CURDIR):$(CURDIR) -w $(CURDIR) -e GOPATH=$(GOPATH) --entrypoint swagger quay.io/goswagger/swagger:$(SWAGGER_VERSION)
 
-GOTEST_OPTS = -test.v -check.v
+GOTEST_OPTS = -test.v -check.vv
 
 UTC_DATE=$(shell date -u "+%Y-%m-%d")
 


### PR DESCRIPTION
Mark the beginning and end of unit tests

Example:
```
START: config_test.go:54: ClusterMeshTestSuite.TestWatchConfigDirectory
level=debug msg="Shutting down controller" name=etcd-lease-keepalive-0xc42027f9a0 subsys=controller uuid=0f195da3-8fb5-11e8-838a-08002714a01b
[...]
level=debug msg="Shutting down controller" name=clustermesh-config-fsnotify subsys=controller uuid=1510377c-8fb5-11e8-838a-08002714a01b
PASS: config_test.go:54: ClusterMeshTestSuite.TestWatchConfigDirectory	0.174s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4983)
<!-- Reviewable:end -->
