### PR TITLE
pkg/endpoint: do not serialize LabelsMap in Endpoint

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -352,8 +352,9 @@ type Endpoint struct {
 	// TODO: Currently this applies only to HTTP L7 rules. Kafka L7 rules are still enforced by Cilium's node-wide Kafka proxy.
 	hasSidecarProxy bool
 
-	// LabelsMap is the Set of all security labels used in the last policy computation
-	LabelsMap *identityPkg.IdentityCache
+	// prevIdentityCache is the set of all security identities used in the
+	// previous policy computation
+	prevIdentityCache *identityPkg.IdentityCache
 
 	// Iteration policy of the Endpoint
 	// TODO: update documentation; description is not clear, and needs to be


### PR DESCRIPTION
There is no reason to serialize this field; it is a cache of security identities
that were last used during policy computation for the endpoint.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #4912

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4984)
<!-- Reviewable:end -->
