### PR TITLE
kubernetes: Add CILIUM_MONITOR_AGGREGATION_LEVEL to crio-o DaemonSet

### DIFF
--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -113,6 +113,12 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
+            valueFrom:
+              configMapKeyRef:
+                key: monitor-aggregation-level
+                name: cilium-config
+                optional: true
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -160,6 +160,12 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
+            valueFrom:
+              configMapKeyRef:
+                key: monitor-aggregation-level
+                name: cilium-config
+                optional: true
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -113,6 +113,12 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
+            valueFrom:
+              configMapKeyRef:
+                key: monitor-aggregation-level
+                name: cilium-config
+                optional: true
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -160,6 +160,12 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
+            valueFrom:
+              configMapKeyRef:
+                key: monitor-aggregation-level
+                name: cilium-config
+                optional: true
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -113,6 +113,12 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
+            valueFrom:
+              configMapKeyRef:
+                key: monitor-aggregation-level
+                name: cilium-config
+                optional: true
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -160,6 +160,12 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
+            valueFrom:
+              configMapKeyRef:
+                key: monitor-aggregation-level
+                name: cilium-config
+                optional: true
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.7/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-crio-ds.yaml
@@ -113,6 +113,12 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
+            valueFrom:
+              configMapKeyRef:
+                key: monitor-aggregation-level
+                name: cilium-config
+                optional: true
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.7/cilium-crio.yaml
+++ b/examples/kubernetes/1.7/cilium-crio.yaml
@@ -160,6 +160,12 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
+            valueFrom:
+              configMapKeyRef:
+                key: monitor-aggregation-level
+                name: cilium-config
+                optional: true
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -113,6 +113,12 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
+            valueFrom:
+              configMapKeyRef:
+                key: monitor-aggregation-level
+                name: cilium-config
+                optional: true
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -160,6 +160,12 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
+            valueFrom:
+              configMapKeyRef:
+                key: monitor-aggregation-level
+                name: cilium-config
+                optional: true
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -113,6 +113,12 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
+            valueFrom:
+              configMapKeyRef:
+                key: monitor-aggregation-level
+                name: cilium-config
+                optional: true
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -160,6 +160,12 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
+            valueFrom:
+              configMapKeyRef:
+                key: monitor-aggregation-level
+                name: cilium-config
+                optional: true
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -113,6 +113,12 @@ spec:
                 key: tunnel
                 name: cilium-config
                 optional: true
+          - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
+            valueFrom:
+              configMapKeyRef:
+                key: monitor-aggregation-level
+                name: cilium-config
+                optional: true
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
Fixes: 25edcda4931d ("examples: Add MONITOR_AGGREGATION_LEVEL option")

Signed-off-by: Thomas Graf <thomas@cilium.io>

This is a new feature in 1.2 and thus does not need any backports

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4990)
<!-- Reviewable:end -->
