### PR TITLE
option: Add unit tests

### DIFF
--- a/pkg/option/monitor_test.go
+++ b/pkg/option/monitor_test.go
@@ -1,0 +1,85 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package option
+
+import (
+	"strconv"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *OptionSuite) TestVerifyMonitorAggregationLevel(c *C) {
+	c.Assert(VerifyMonitorAggregationLevel("", ""), IsNil)
+	c.Assert(VerifyMonitorAggregationLevel("", "none"), IsNil)
+	c.Assert(VerifyMonitorAggregationLevel("", "disabled"), IsNil)
+	c.Assert(VerifyMonitorAggregationLevel("", "lowest"), IsNil)
+	c.Assert(VerifyMonitorAggregationLevel("", "low"), IsNil)
+	c.Assert(VerifyMonitorAggregationLevel("", "medium"), IsNil)
+	c.Assert(VerifyMonitorAggregationLevel("", "max"), IsNil)
+	c.Assert(VerifyMonitorAggregationLevel("", "maximum"), IsNil)
+	c.Assert(VerifyMonitorAggregationLevel("", "LoW"), IsNil)
+	c.Assert(VerifyMonitorAggregationLevel("", "disable"), NotNil)
+}
+
+func (s *OptionSuite) TestParseMonitorAggregationLevel(c *C) {
+	level, err := ParseMonitorAggregationLevel("2")
+	c.Assert(err, IsNil)
+	c.Assert(level, Equals, MonitorAggregationLevelLow)
+
+	level, err = ParseMonitorAggregationLevel(strconv.Itoa(MonitorAggregationLevelMax + 1))
+	c.Assert(err, NotNil)
+
+	level, err = ParseMonitorAggregationLevel("-1")
+	c.Assert(err, NotNil)
+
+	level, err = ParseMonitorAggregationLevel("foo")
+	c.Assert(err, NotNil)
+
+	level, err = ParseMonitorAggregationLevel("")
+	c.Assert(err, IsNil)
+	c.Assert(level, Equals, MonitorAggregationLevelNone)
+
+	level, err = ParseMonitorAggregationLevel("none")
+	c.Assert(err, IsNil)
+	c.Assert(level, Equals, MonitorAggregationLevelNone)
+
+	level, err = ParseMonitorAggregationLevel("disabled")
+	c.Assert(err, IsNil)
+	c.Assert(level, Equals, MonitorAggregationLevelNone)
+
+	level, err = ParseMonitorAggregationLevel("lowest")
+	c.Assert(err, IsNil)
+	c.Assert(level, Equals, MonitorAggregationLevelLowest)
+
+	level, err = ParseMonitorAggregationLevel("low")
+	c.Assert(err, IsNil)
+	c.Assert(level, Equals, MonitorAggregationLevelLow)
+
+	level, err = ParseMonitorAggregationLevel("medium")
+	c.Assert(err, IsNil)
+	c.Assert(level, Equals, MonitorAggregationLevelMedium)
+
+	level, err = ParseMonitorAggregationLevel("max")
+	c.Assert(err, IsNil)
+	c.Assert(level, Equals, MonitorAggregationLevelMax)
+
+	level, err = ParseMonitorAggregationLevel("maximum")
+	c.Assert(err, IsNil)
+	c.Assert(level, Equals, MonitorAggregationLevelMax)
+
+	level, err = ParseMonitorAggregationLevel("LOW")
+	c.Assert(err, IsNil)
+	c.Assert(level, Equals, MonitorAggregationLevelLow)
+}

--- a/pkg/option/option_test.go
+++ b/pkg/option/option_test.go
@@ -15,8 +15,10 @@
 package option
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/cilium/cilium/api/v1/models"
 	. "gopkg.in/check.v1"
 )
 
@@ -28,6 +30,191 @@ func Test(t *testing.T) {
 type OptionSuite struct{}
 
 var _ = Suite(&OptionSuite{})
+
+func (s *OptionSuite) TestGetValue(c *C) {
+	k1, k2 := "foo", "bar"
+	v1 := 7
+
+	o := IntOptions{
+		Opts: OptionMap{
+			k1: v1,
+			k2: OptionEnabled,
+		},
+	}
+
+	c.Assert(o.GetValue(k1), Equals, v1)
+	c.Assert(o.GetValue(k2), Equals, OptionEnabled)
+	c.Assert(o.GetValue("unknown"), Equals, OptionDisabled)
+}
+
+func (s *OptionSuite) TestIsEnabled(c *C) {
+	k1, k2 := "foo", "bar"
+
+	o := IntOptions{
+		Opts: OptionMap{
+			k1: OptionEnabled,
+			k2: OptionDisabled,
+		},
+	}
+
+	c.Assert(o.IsEnabled(k1), Equals, true)
+	c.Assert(o.IsEnabled(k2), Equals, false)
+	c.Assert(o.IsEnabled("unknown"), Equals, false)
+}
+
+func (s *OptionSuite) TestSetValidated(c *C) {
+	k1, k2 := "foo", "bar"
+
+	o := IntOptions{
+		Opts: OptionMap{
+			k1: OptionEnabled,
+		},
+	}
+
+	c.Assert(o.IsEnabled(k1), Equals, true)
+	c.Assert(o.IsEnabled(k2), Equals, false)
+
+	o.SetValidated(k1, OptionDisabled)
+	o.SetValidated(k2, OptionEnabled)
+	c.Assert(o.IsEnabled(k1), Equals, false)
+	c.Assert(o.IsEnabled(k2), Equals, true)
+}
+
+func (s *OptionSuite) TestSetBool(c *C) {
+	k1, k2, k3 := "foo", "bar", "baz"
+
+	o := IntOptions{
+		Opts: OptionMap{
+			k1: OptionEnabled,
+			k2: OptionDisabled,
+		},
+	}
+
+	o.SetBool(k1, false)
+	o.SetBool(k2, true)
+	o.SetBool(k3, true)
+	c.Assert(o.GetValue(k1), Equals, OptionDisabled)
+	c.Assert(o.GetValue(k2), Equals, OptionEnabled)
+	c.Assert(o.GetValue(k3), Equals, OptionEnabled)
+}
+
+func (s *OptionSuite) TestDelete(c *C) {
+	k1, k2 := "foo", "bar"
+
+	o := IntOptions{
+		Opts: OptionMap{
+			k1: OptionEnabled,
+			k2: OptionEnabled,
+		},
+	}
+
+	o.Delete(k1)
+	c.Assert(o.GetValue(k1), Equals, OptionDisabled)
+	c.Assert(o.GetValue(k2), Equals, OptionEnabled)
+}
+
+func (s *OptionSuite) TestSetIfUnset(c *C) {
+	k1, k2 := "foo", "bar"
+
+	o := IntOptions{
+		Opts: OptionMap{
+			k1: OptionDisabled,
+		},
+	}
+
+	o.SetIfUnset(k1, OptionEnabled)
+	o.SetIfUnset(k2, OptionEnabled)
+	c.Assert(o.GetValue(k1), Equals, OptionDisabled)
+	c.Assert(o.GetValue(k2), Equals, OptionEnabled)
+}
+
+func (s *OptionSuite) TestInheritDefault(c *C) {
+	k := "foo"
+
+	o := IntOptions{
+		Opts: OptionMap{},
+	}
+	parent := IntOptions{
+		Opts: OptionMap{
+			k: OptionEnabled,
+		},
+	}
+
+	c.Assert(o.GetValue(k), Equals, OptionDisabled)
+	o.InheritDefault(&parent, k)
+	c.Assert(o.GetValue(k), Equals, OptionEnabled)
+}
+
+func (s *OptionSuite) TestParseKeyValueWithDefaultParseFunc(c *C) {
+	k := "foo"
+
+	l := OptionLibrary{
+		k: &Option{
+			Define:      "TEST_DEFINE",
+			Description: "This is a test",
+		},
+	}
+
+	_, res, err := ParseKeyValue(&l, k, "on", OptionDisabled)
+	c.Assert(err, IsNil)
+	c.Assert(res, Equals, OptionEnabled)
+}
+
+func (s *OptionSuite) TestParseKeyValue(c *C) {
+	k := "foo"
+
+	l := OptionLibrary{
+		k: &Option{
+			Define:      "TEST_DEFINE",
+			Description: "This is a test",
+			Parse: func(value string) (int, error) {
+				if value == "yes" {
+					return OptionEnabled, nil
+				}
+				return OptionDisabled, fmt.Errorf("invalid option value %s", value)
+			},
+		},
+	}
+
+	_, _, err := ParseKeyValue(&l, k, "true", OptionDisabled)
+	c.Assert(err, NotNil)
+
+	_, res, err := ParseKeyValue(&l, k, "yes", OptionDisabled)
+	c.Assert(err, IsNil)
+	c.Assert(res, Equals, OptionEnabled)
+
+	_, _, err = ParseKeyValue(&l, "unknown", "yes", OptionDisabled)
+	c.Assert(err, NotNil)
+}
+
+func (s *OptionSuite) TestParseOption(c *C) {
+	k := "foo"
+	arg := k + "=enabled"
+
+	OptionTest := Option{
+		Define:      "TEST_DEFINE",
+		Description: "This is a test",
+	}
+
+	l := OptionLibrary{
+		k: &OptionTest,
+	}
+
+	_, res, err := ParseOption(k+":enabled", &l)
+	c.Assert(err, NotNil)
+
+	_, res, err = ParseOption(arg, &l)
+	c.Assert(err, IsNil)
+	c.Assert(res, Equals, OptionEnabled)
+
+	_, _, err = ParseOption("!"+arg, &l)
+	c.Assert(err, NotNil)
+
+	OptionTest.Immutable = true
+	_, _, err = ParseOption(arg, &l)
+	c.Assert(err, NotNil)
+	OptionTest.Immutable = false
+}
 
 func (s *OptionSuite) TestGetFmtOpts(c *C) {
 	OptionTest := Option{
@@ -95,4 +282,182 @@ func (s *OptionSuite) TestGetFmtOpt(c *C) {
 	c.Assert(o.getFmtOpt("BAZ"), Equals, "#undef BAZ")
 	c.Assert(o.getFmtOpt("alice"), Equals, "#define TEST_DEFINE 2")
 	o.optsMU.Unlock()
+}
+
+func (s *OptionSuite) TestGetImmutableModel(c *C) {
+	k := "foo"
+
+	OptionTest := Option{
+		Define:      "TEST_DEFINE",
+		Description: "This is a test",
+	}
+
+	o := IntOptions{
+		Opts: OptionMap{
+			k: OptionEnabled,
+		},
+		Library: &OptionLibrary{
+			k: &OptionTest,
+		},
+	}
+
+	cfg := o.GetImmutableModel()
+	c.Assert(cfg, NotNil)
+	c.Assert(cfg, DeepEquals, &models.ConfigurationMap{})
+}
+
+func (s *OptionSuite) TestGetMutableModel(c *C) {
+	k1, k2, k3 := "foo", "bar", "baz"
+
+	OptionDefaultFormat := Option{
+		Define:      "TEST_DEFINE",
+		Description: "This is a test",
+	}
+	OptionCustomFormat := Option{
+		Define:      "TEST_DEFINE",
+		Description: "This is a test",
+		Format: func(value int) string {
+			return "ok"
+		},
+	}
+
+	o := IntOptions{
+		Opts: OptionMap{
+			k1: OptionEnabled,
+			k2: OptionDisabled,
+			k3: OptionEnabled,
+		},
+		Library: &OptionLibrary{
+			k1: &OptionDefaultFormat,
+			k2: &OptionDefaultFormat,
+			k3: &OptionCustomFormat,
+		},
+	}
+
+	cfg := o.GetMutableModel()
+	c.Assert(cfg, NotNil)
+	c.Assert(cfg, DeepEquals, &models.ConfigurationMap{
+		k1: "Enabled",
+		k2: "Disabled",
+		k3: "ok",
+	})
+
+	o2 := IntOptions{}
+	cfg2 := o2.GetMutableModel()
+	c.Assert(cfg2, NotNil)
+	c.Assert(cfg2, DeepEquals, &models.ConfigurationMap{})
+}
+
+func (s *OptionSuite) TestValidate(c *C) {
+	k1, k2, k3, k4 := "foo", "bar", "baz", "qux"
+
+	OptionTest := Option{
+		Define:      "TEST_DEFINE",
+		Description: "This is a test",
+	}
+	OptionCustomVerify := Option{
+		Define:      "TEST_DEFINE",
+		Description: "This is a test",
+		Verify: func(key string, value string) error {
+			return fmt.Errorf("invalid key value %s %s", key, value)
+
+		},
+	}
+	OptionImmutable := Option{
+		Define:      "TEST_DEFINE",
+		Description: "This is a test",
+		Immutable:   true,
+	}
+
+	o := IntOptions{
+		Opts: OptionMap{
+			k1: OptionEnabled,
+			k2: OptionEnabled,
+			k3: OptionDisabled,
+			k4: OptionEnabled,
+		},
+		Library: &OptionLibrary{
+			k1: &OptionTest,
+			k2: &OptionCustomVerify,
+			k3: &OptionCustomVerify,
+			k4: &OptionImmutable,
+		},
+	}
+
+	c.Assert(o.Validate(models.ConfigurationMap{k1: "on"}), IsNil)
+	c.Assert(o.Validate(models.ConfigurationMap{"unknown": "on"}), NotNil)
+	c.Assert(o.Validate(models.ConfigurationMap{k4: "on"}), NotNil)
+	c.Assert(o.Validate(models.ConfigurationMap{k1: "on", k2: "on"}), IsNil)
+	c.Assert(o.Validate(models.ConfigurationMap{k1: "on", k3: "on"}), NotNil)
+}
+
+func (s *OptionSuite) TestApplyValidated(c *C) {
+	k1, k2, k3, k4, k5, k6 := "foo", "bar", "baz", "qux", "quux", "corge"
+
+	OptionDefault := Option{
+		Define:      "TEST_DEFINE",
+		Description: "This is a test",
+	}
+	Option2 := Option{
+		Define:      "TEST_DEFINE",
+		Description: "This is a test",
+		Requires:    []string{k1},
+	}
+	Option3 := Option{
+		Define:      "TEST_DEFINE",
+		Description: "This is a test",
+		Requires:    []string{k4},
+	}
+
+	o := IntOptions{
+		Opts: OptionMap{
+			k1: OptionEnabled,
+			k2: OptionEnabled,
+			k3: OptionDisabled,
+			k4: OptionDisabled,
+			k5: OptionDisabled,
+		},
+		Library: &OptionLibrary{
+			k1: &OptionDefault,
+			k2: &Option2,
+			k3: &Option3,
+			k4: &OptionDefault,
+			k5: &OptionDefault,
+			k6: &OptionDefault,
+		},
+	}
+
+	cfg := models.ConfigurationMap{
+		k1: "off",
+		k3: "on",
+		k5: "off",
+		k6: "on",
+	}
+	c.Assert(o.Validate(cfg), IsNil)
+
+	expectedChanges := map[string]int{
+		k1: OptionDisabled,
+		k3: OptionEnabled,
+		k6: OptionEnabled,
+	}
+	actualChanges := map[string]int{}
+	var changed ChangedFunc = func(key string, value int, data interface{}) {
+		c.Assert(data, Equals, &cfg)
+		actualChanges[key] = value
+	}
+
+	c.Assert(o.ApplyValidated(cfg, changed, &cfg), Equals, len(expectedChanges))
+	c.Assert(actualChanges, DeepEquals, expectedChanges)
+
+	expectedOpts := map[string]int{
+		k1: OptionDisabled,
+		k2: OptionDisabled,
+		k3: OptionEnabled,
+		k4: OptionEnabled,
+		k5: OptionDisabled,
+		k6: OptionEnabled,
+	}
+	for k, v := range expectedOpts {
+		c.Assert(o.GetValue(k), Equals, v)
+	}
 }


### PR DESCRIPTION
This patch improves unit testing coverage by adding tests to
the monitor and option modules.

Fixes: #4866

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4992)
<!-- Reviewable:end -->
