### PR TITLE
CI: Different random seed on each run

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -38,6 +38,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
+func init() {
+	// ensure that our random numbers are seeded differently on each run
+	rand.Seed(time.Now().UnixNano())
+}
+
 // IsRunningOnJenkins detects if the currently running Ginkgo application is
 // most likely running in a Jenkins environment. Returns true if certain
 // environment variables that are present in Jenkins jobs are set, false

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -19,12 +19,18 @@ import (
 	"fmt"
 	"math/rand"
 	"strings"
+	"time"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 
 	. "github.com/onsi/gomega"
 )
+
+func init() {
+	// ensure that our random numbers are seeded differently on each run
+	rand.Seed(time.Now().UnixNano())
+}
 
 const (
 	// MonitorDropNotification represents the DropNotification configuration


### PR DESCRIPTION
We didn't explicitly seed the random package during tests. The default
seed is 1, resulting in the same UIDs etc. when running tests. We now
use the current time to nanosecond percision which, for a whole test
run, should be adequate to ensure some uniqueness. Note that package
math/rand indicates that the seed is 31 bits (so many of the bits here
are wasted).

I'm not sure if it was intentional, but the UIDs we generate are used for some debug files and the names keep colliding when I download/unpack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/4993)
<!-- Reviewable:end -->
