### PR TITLE
Jenkins: Update timeout on Nightly builds

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -40,7 +40,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 500, unit: 'MINUTES')
+        timeout(time: 700, unit: 'MINUTES')
         timestamps()
         ansiColor('xterm')
     }
@@ -77,10 +77,15 @@ pipeline {
                 CPU=4
                 FAILFAST=setIfLabel("ci/fail-fast", "true", "false")
             }
+
+            options {
+                timeout(time: 460, unit: 'MINUTES')
+            }
+
             steps {
                 parallel(
                     "Nightly":{
-                        sh 'cd ${TESTDIR}; ginkgo --focus="Nightly*" -v --timeout 390m --failFast=${FAILFAST}'
+                        sh 'cd ${TESTDIR}; ginkgo --focus="Nightly*" -v --timeout 450m --failFast=${FAILFAST}'
                     },
                 )
             }


### PR DESCRIPTION
Increase the timeout for Nightly builds that are dying now because of
timeouts.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5000)
<!-- Reviewable:end -->
