### PR TITLE
Test: CoreDNS using only one replicaset

### DIFF
--- a/test/provision/manifest/coredns_deployment.yaml
+++ b/test/provision/manifest/coredns_deployment.yaml
@@ -13,7 +13,7 @@ metadata:
   namespace: kube-system
 spec:
   progressDeadlineSeconds: 600
-  replicas: 2
+  replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:


### PR DESCRIPTION
A few builds has problems with DNS, where we wait until the service is
ready but after that pod can't resolve.

With this change we make sure that only one pod is in there to avoid
false negatives

Related to #4977

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5001)
<!-- Reviewable:end -->
