### PR TITLE
docs, bpf: Add BTF (BPF Type Format) description

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -45,6 +45,7 @@ breakpoint
 Brenden
 Brouer
 browsable
+btf
 bugfix
 bugfixes
 bugtool
@@ -124,6 +125,7 @@ eBPF
 ec
 elasticsearch
 Elasticsearch
+elfutils
 endian
 endianness
 endpointSelector
@@ -334,6 +336,7 @@ opcodes
 orchestrator
 org
 osx
+pahole
 pc
 pem
 Pepelnjak
@@ -365,6 +368,7 @@ qdisc
 qdiscs
 qede
 queueing
+readelf
 rebase
 rebased
 recompiles


### PR DESCRIPTION
This explains how to build **BTF  (BPF Type Format) supported** bpf program
using recent `llc` with `-mattr=dwarfris` and `pahole -J <bpf prog>`.

I'd appreciate it, if you review this
 @borkmann @iamkafai

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5006)
<!-- Reviewable:end -->
