### PR TITLE
Documentation: add step to bump version of Cilium used in upgrade tests

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -1886,6 +1886,11 @@ If you intent to release a new minor release, see the
 
 #. Announce the release in the ``#general`` channel on Slack
 
+#. Bump the version of Cilium used in the Cilium upgrade tests to use the new release
+
+   Please reach out on the ``#development`` channel on Slack for assistance with
+   this task.
+
 
 .. _minor_release_process:
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -106,6 +106,7 @@ deserialization
 dev
 Devel
 Dinan
+diff
 disassembly
 distros
 DMA


### PR DESCRIPTION
As part of a release, after the release is announced, upgrade the version of
Cilium used in the CI upgrade tests. This ensures that the CI tests do not lag
behind in testing upgrade from the most recently released version of Cilium to
HEAD.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #5014

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5016)
<!-- Reviewable:end -->
