### PR TITLE
pkg/endpoint: annotate pod with numeric identity

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -886,7 +886,7 @@ func (e *Endpoint) runIdentityToK8sPodSync() {
 
 				e.Mutex.RLock()
 				if e.SecurityIdentity != nil {
-					id = e.SecurityIdentity.ID.String()
+					id = e.SecurityIdentity.ID.StringID()
 				}
 				e.Mutex.RUnlock()
 


### PR DESCRIPTION
As the pod annotation value is expected to be numeric, Cilium should
always set that value with a numeric one instead of the string
representation.

Fixes: e2d08b5ba510 ("endpoint: Use controller pattern to sync identity to k8s pod")
Signed-off-by: André Martins <andre@cilium.io>

Fixes: https://github.com/cilium/cilium/issues/5013

```release-note
pkg/endpoint: annotate pod with the numeric representation of an identity
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5019)
<!-- Reviewable:end -->
