### PR TITLE
CI: Run netperf test on master

### DIFF
--- a/kubernetes-upstream.Jenkinsfile
+++ b/kubernetes-upstream.Jenkinsfile
@@ -68,8 +68,9 @@ pipeline {
         }
 
         stage('Netperf tests'){
+
             when {
-                branch 'master'
+                environment name: 'GIT_BRANCH', value: 'origin/master'
             }
 
             options {


### PR DESCRIPTION
The current conditional was incorrent because the `branch` only can be
used on multibranch jobs. With the current job configuration the
validation need to happens using the ENV variables.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5022)
<!-- Reviewable:end -->
