### PR TITLE
kvstore/allocator: Optimize ID allocation

### DIFF
--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -87,15 +87,17 @@ func (s *AllocatorSuite) TestSelectID(c *C) {
 
 	// allocate all available IDs
 	for i := minID; i <= maxID; i++ {
-		id, val := a.selectAvailableID()
+		id, val, unmaskedID := a.selectAvailableID()
 		c.Assert(id, Not(Equals), NoID)
 		c.Assert(val, Equals, id.String())
+		c.Assert(id, Equals, unmaskedID)
 		a.mainCache.cache[id] = TestType(fmt.Sprintf("key-%d", i))
 	}
 
 	// we should be out of IDs
-	id, val := a.selectAvailableID()
+	id, val, unmaskedID := a.selectAvailableID()
 	c.Assert(id, Equals, ID(0))
+	c.Assert(id, Equals, unmaskedID)
 	c.Assert(val, Equals, "")
 }
 
@@ -109,9 +111,10 @@ func (s *AllocatorSuite) TestPrefixMask(c *C) {
 
 	// allocate all available IDs
 	for i := minID; i <= maxID; i++ {
-		id, val := a.selectAvailableID()
+		id, val, unmaskedID := a.selectAvailableID()
 		c.Assert(id, Not(Equals), NoID)
 		c.Assert(id>>16, Equals, ID(1))
+		c.Assert(id, Not(Equals), unmaskedID)
 		c.Assert(val, Equals, id.String())
 	}
 

--- a/pkg/kvstore/allocator/cache.go
+++ b/pkg/kvstore/allocator/cache.go
@@ -131,6 +131,7 @@ func (c *cache) start(a *Allocator) waitChan {
 	c.nextCache = idMap{}
 	c.nextKeyCache = keyMap{}
 	c.mutex.Unlock()
+	a.idPool.StartRefresh()
 
 	c.stopWatchWg.Add(1)
 
@@ -149,6 +150,7 @@ func (c *cache) start(a *Allocator) waitChan {
 					c.cache = c.nextCache
 					c.keyCache = c.nextKeyCache
 					c.mutex.Unlock()
+					a.idPool.FinishRefresh()
 
 					// report that the list operation has
 					// been completed and the allocator is
@@ -180,6 +182,7 @@ func (c *cache) start(a *Allocator) waitChan {
 						if key != nil {
 							c.nextKeyCache[key.GetKey()] = id
 						}
+						a.idPool.Remove(id)
 
 					case kvstore.EventTypeModify:
 						kvstore.Trace("Modifying id in cache", nil, debugFields.Data)
@@ -200,6 +203,7 @@ func (c *cache) start(a *Allocator) waitChan {
 						}
 
 						delete(c.nextCache, id)
+						a.idPool.Insert(id)
 					}
 					c.mutex.Unlock()
 

--- a/pkg/kvstore/allocator/idpool.go
+++ b/pkg/kvstore/allocator/idpool.go
@@ -1,0 +1,277 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package allocator
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// idPool represents a pool of IDs that can be managed concurrently
+// via local usage and external events.
+//
+// An intermediate state (leased) is introduced to the life cycle
+// of an ID in the pool, in order to prevent lost updates to the
+// pool that can occur as a result of employing both management schemes
+// simultaneously.
+// Local usage of an ID becomes a two stage process of leasing
+// the ID from the pool, and later, Use()ing or Release()ing the ID on
+// the pool upon successful or unsuccessful usage respectively,
+//
+// The table below shows the state transitions in the ID's life cycle.
+// In the case of LeaseAvailableID() the ID is returned rather
+// than provided as an input to the operation.
+// All ID's begin in the available state.
+/*
+---------------------------------------------------------------------
+|state\event   | LeaseAvailableID | Release | Use | Insert | Remove |
+---------------------------------------------------------------------
+|1 available   |        2         |    *    |  *  |   *    |   3    |
+---------------------------------------------------------------------
+|2 leased      |        **        |    1    |  3  |   *    |   3    |
+---------------------------------------------------------------------
+|3 unavailable |        **        |    *    |  *  |   1    |   *    |
+---------------------------------------------------------------------
+*  The event has no effect.
+** This is guaranteed never to occur.
+*/
+type idPool struct {
+	// mutex protects all idPool data structures
+	mutex lock.Mutex
+
+	// min is the lower limit when leasing IDs. The pool will never
+	// return an ID lesser than this value.
+	minID ID
+
+	// max is the upper limit when leasing IDs. The pool will never
+	// return an ID greater than this value.
+	maxID ID
+
+	// idCache is a cache of IDs backing the pool.
+	idCache *idCache
+
+	// Upon a refresh of the pool, idCache will be pointed to
+	// nextIDCache.
+	nextIDCache *idCache
+}
+
+func newIDPool(minID ID, maxID ID) *idPool {
+	p := &idPool{
+		minID: minID,
+		maxID: maxID,
+	}
+	p.StartRefresh()
+	p.FinishRefresh()
+
+	return p
+}
+
+// StartRefresh creates a new cache backing the pool.
+// This cache becomes live when FinishRefresh() is called.
+func (p *idPool) StartRefresh() {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	p.nextIDCache = newIDCache(p.minID, p.maxID)
+}
+
+// FinishRefresh makes the most recent cache created by the pool live.
+func (p *idPool) FinishRefresh() {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	p.idCache = p.nextIDCache
+}
+
+// LeaseAvailableID returns an available ID at random from the pool.
+// Returns an ID of NoID if no there is no available ID in the pool.
+func (p *idPool) LeaseAvailableID() ID {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	return p.idCache.leaseAvailableID()
+}
+
+// Release returns a leased ID back to the pool.
+// This operation accounts for IDs that were previously leased
+// from the pool but were unused, e.g if allocation was unsuccessful.
+// Thus, it has no effect if the ID is not currently leased in the
+// pool, or the pool has since been refreshed.
+//
+// Returns true if the ID was returned back to the pool as
+// a result of this call.
+func (p *idPool) Release(id ID) bool {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	return p.idCache.release(id)
+}
+
+// Use makes a leased ID unavailable in the pool and has no effect
+// otherwise. Returns true if the ID was made unavailable
+// as a result of this call.
+func (p *idPool) Use(id ID) bool {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	return p.idCache.use(id)
+}
+
+// Insert makes an unavailable ID available in the pool
+// and has no effect otherwise. Returns true if the ID
+// was added back to the pool.
+func (p *idPool) Insert(id ID) bool {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	return p.nextIDCache.insert(id)
+}
+
+// Remove makes an ID unavailable in the pool.
+// Returns true if the ID was previously available in the pool.
+func (p *idPool) Remove(id ID) bool {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	return p.nextIDCache.remove(id)
+}
+
+type idCache struct {
+
+	// ids is a slice of IDs available in this idCache.
+	ids []ID
+
+	// index tracks the position of IDs in the above ids slice.
+	index map[ID]int
+
+	// leased is the set of IDs that are leased in this idCache.
+	leased map[ID]struct{}
+}
+
+func newIDCache(minID ID, maxID ID) *idCache {
+	n := int(maxID - minID + 1)
+	if n < 0 {
+		n = 0
+	}
+
+	c := &idCache{
+		ids:    make([]ID, n),
+		index:  make(map[ID]int, n),
+		leased: make(map[ID]struct{}, n),
+	}
+
+	for i := 0; i < n; i++ {
+		id := ID(i) + minID
+		c.ids[i] = id
+		c.index[id] = i
+	}
+
+	return c
+}
+
+var random = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+// leaseAvailableID returns a random available ID.
+func (c *idCache) leaseAvailableID() ID {
+	if len(c.ids) == 0 {
+		return NoID
+	}
+
+	id := c.ids[random.Intn(len(c.ids))]
+	c.doRemove(id)
+	// Mark the ID as leased.
+	c.leased[id] = struct{}{}
+
+	return id
+}
+
+// release makes the ID available again if it is currently
+// leased and has no effect otherwise. Returns true if the
+// ID was made available as a result of this call.
+func (c *idCache) release(id ID) bool {
+	if _, exists := c.leased[id]; !exists {
+		return false
+	}
+
+	delete(c.leased, id)
+	c.insert(id)
+
+	return true
+}
+
+// use makes the ID unavailable if it is currently
+// leased and has no effect otherwise. Returns true if the
+// ID was made unavailable as a result of this call.
+func (c *idCache) use(id ID) bool {
+	if _, exists := c.leased[id]; !exists {
+		return false
+	}
+
+	delete(c.leased, id)
+	return true
+}
+
+// insert adds the ID into the cache if it is currently unavailable.
+// Returns true if the ID was added to the cache.
+func (c *idCache) insert(id ID) bool {
+	if _, exists := c.index[id]; exists {
+		return false
+	}
+
+	if _, exists := c.leased[id]; exists {
+		return false
+	}
+
+	c.ids = append(c.ids, id)
+	c.index[id] = len(c.ids) - 1
+
+	return true
+}
+
+// remove removes the ID from the cache.
+// Returns true if the ID was available in the cache.
+func (c *idCache) remove(id ID) bool {
+	removed := c.doRemove(id)
+	// If the id is leased, update it.
+	delete(c.leased, id)
+
+	return removed
+}
+
+func (c *idCache) doRemove(id ID) bool {
+	i, exists := c.index[id]
+	if !exists {
+		return false
+	}
+
+	delete(c.index, id)
+
+	N := len(c.ids)
+	tmp := c.ids[N-1]
+	c.ids[i] = tmp
+	if N > 1 {
+		c.ids = c.ids[:N-1]
+	} else {
+		c.ids = c.ids[:0]
+	}
+
+	if id != tmp {
+		c.index[tmp] = i
+	}
+
+	return true
+}

--- a/pkg/kvstore/allocator/idpool_test.go
+++ b/pkg/kvstore/allocator/idpool_test.go
@@ -1,0 +1,315 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package allocator
+
+import (
+	"sort"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *AllocatorSuite) TestLeaseAvailableID(c *C) {
+	minID, maxID := 1, 5
+	p := newIDPool(ID(minID), ID(maxID))
+
+	leaseAllIDs(p, minID, maxID, c)
+}
+
+func (s *AllocatorSuite) TestInsertIDs(c *C) {
+	minID, maxID := 2, 6
+	p := newIDPool(ID(minID), ID(maxID))
+
+	// Insert IDs beyond minID, maxID range.
+	for i := minID - 1; i <= maxID+1; i++ {
+		c.Assert(p.Insert(ID(i)), Equals, i < minID || i > maxID)
+		c.Assert(p.Insert(ID(i)), Equals, false)
+	}
+
+	leaseAllIDs(p, minID-1, maxID+1, c)
+}
+
+func (s *AllocatorSuite) TestInsertRemoveIDs(c *C) {
+	minID, maxID := 1, 5
+	p := newIDPool(ID(minID), ID(maxID))
+
+	// Remove all IDs.
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p.Remove(ID(i)), Equals, true)
+		c.Assert(p.Remove(ID(i)), Equals, false)
+	}
+	// We should be out of IDs.
+	id := p.LeaseAvailableID()
+	c.Assert(id, Equals, NoID)
+
+	// Re-insert all IDs.
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p.Insert(ID(i)), Equals, true)
+		c.Assert(p.Insert(ID(i)), Equals, false)
+	}
+
+	// Remove odd-numbered IDs.
+	for i := minID; i <= maxID; i++ {
+		if i%2 != 0 {
+			c.Assert(p.Remove(ID(i)), Equals, true)
+		}
+	}
+
+	// Only even-numbered IDs should be left.
+	evenIDs := make([]int, 0)
+	actualIDs := make([]int, 0)
+	for i := minID; i <= maxID; i++ {
+		if i%2 == 0 {
+			id := p.LeaseAvailableID()
+			c.Assert(id, Not(Equals), NoID)
+			actualIDs = append(actualIDs, int(id))
+			evenIDs = append(evenIDs, i)
+		}
+	}
+	// We should be out of IDs.
+	id = p.LeaseAvailableID()
+	c.Assert(id, Equals, NoID)
+
+	sort.Ints(actualIDs)
+	c.Assert(actualIDs, DeepEquals, evenIDs)
+}
+
+func (s *AllocatorSuite) TestRefresh(c *C) {
+	minID, maxID := 1, 5
+	p := newIDPool(ID(minID), ID(maxID))
+
+	p.StartRefresh()
+
+	// Lease all ids from the current cache.
+	for i := minID; i <= maxID; i++ {
+		id := p.LeaseAvailableID()
+		c.Assert(id, Not(Equals), NoID)
+	}
+
+	// Delete even-numbered ids from the next cache.
+	for i := minID; i <= maxID; i++ {
+		if i%2 == 0 {
+			c.Assert(p.Remove(ID(i)), Equals, true)
+		}
+	}
+
+	// We should be out of IDs until we finish the refresh.
+	id := p.LeaseAvailableID()
+	c.Assert(id, Equals, NoID)
+
+	p.FinishRefresh()
+
+	// Check we can only lease the remaining
+	// odd-numbered ids from the current cache.
+	expected := make([]int, 0)
+	actual := make([]int, 0)
+	for i := minID; i <= maxID; i++ {
+		if i%2 != 0 {
+			id := p.LeaseAvailableID()
+			c.Assert(id, Not(Equals), NoID)
+			actual = append(actual, int(id))
+			expected = append(expected, int(i))
+		}
+	}
+	// We should be out of IDs.
+	id = p.LeaseAvailableID()
+	c.Assert(id, Equals, NoID)
+
+	sort.Ints(actual)
+	c.Assert(actual, DeepEquals, expected)
+}
+
+func (s *AllocatorSuite) TestReleaseID(c *C) {
+	minID, maxID := 1, 5
+	p := newIDPool(ID(minID), ID(maxID))
+
+	// Lease all ids and release them.
+	for i := minID; i <= maxID; i++ {
+		id := p.LeaseAvailableID()
+		c.Assert(id, Not(Equals), NoID)
+	}
+	// We should be out of IDs.
+	id := p.LeaseAvailableID()
+	c.Assert(id, Equals, NoID)
+
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p.Release(ID(i)), Equals, true)
+		c.Assert(p.Release(ID(i)), Equals, false)
+	}
+
+	// Lease all ids. This time, remove them before
+	// releasing them.
+	leaseAllIDs(p, minID, maxID, c)
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p.Remove(ID(i)), Equals, false)
+	}
+	// Release should not have any effect.
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p.Release(ID(i)), Equals, false)
+	}
+}
+
+func (s *AllocatorSuite) TestOperationsOnAvailableIDs(c *C) {
+	minID, maxID := 1, 5
+
+	// Leasing available IDs should move its state to leased.
+	p0 := newIDPool(ID(minID), ID(maxID))
+	leaseAllIDs(p0, minID, maxID, c)
+	// Check all IDs are in leased state.
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p0.Release(ID(i)), Equals, true)
+	}
+	leaseAllIDs(p0, minID, maxID, c)
+
+	// Releasing available IDs should not have any effect.
+	p1 := newIDPool(ID(minID), ID(maxID))
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p1.Release(ID(i)), Equals, false)
+	}
+	leaseAllIDs(p1, minID, maxID, c)
+
+	// Using available IDs should not have any effect.
+	p2 := newIDPool(ID(minID), ID(maxID))
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p2.Use(ID(i)), Equals, false)
+	}
+	leaseAllIDs(p2, minID, maxID, c)
+
+	// Inserting available IDs should not have any effect.
+	p3 := newIDPool(ID(minID), ID(maxID))
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p3.Insert(ID(i)), Equals, false)
+	}
+	leaseAllIDs(p3, minID, maxID, c)
+
+	// Removing available IDs should make them unavailable.
+	p4 := newIDPool(ID(minID), ID(maxID))
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p4.Remove(ID(i)), Equals, true)
+	}
+	leaseAllIDs(p4, minID, minID-1, c)
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p4.Release(ID(i)), Equals, false)
+	}
+}
+
+func (s *AllocatorSuite) TestOperationsOnLeasedIDs(c *C) {
+	minID, maxID := 1, 5
+	var poolWithAllIDsLeased = func() *idPool {
+		p := newIDPool(ID(minID), ID(maxID))
+		leaseAllIDs(p, minID, maxID, c)
+		return p
+	}
+
+	// Releasing leased IDs should make it available again.
+	p0 := poolWithAllIDsLeased()
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p0.Release(ID(i)), Equals, true)
+	}
+	leaseAllIDs(p0, minID, maxID, c)
+
+	// Using leased IDs should make it unavailable again.
+	p1 := poolWithAllIDsLeased()
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p1.Use(ID(i)), Equals, true)
+		// It should no longer be leased.
+		c.Assert(p1.Use(ID(i)), Equals, false)
+	}
+	leaseAllIDs(p1, minID, minID-1, c)
+
+	// Inserting leased IDs should not have any effect.
+	p2 := poolWithAllIDsLeased()
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p2.Insert(ID(i)), Equals, false)
+	}
+	// The IDs should still be leased.
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p2.Release(ID(i)), Equals, true)
+	}
+	leaseAllIDs(p2, minID, maxID, c)
+
+	// Removing leased IDs should make them unavailable.
+	p3 := poolWithAllIDsLeased()
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p3.Remove(ID(i)), Equals, false)
+	}
+	// The IDs should not be leased anymore.
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p3.Use(ID(i)), Equals, false)
+	}
+	// They should be unavailable.
+	leaseAllIDs(p3, minID, minID-1, c)
+}
+
+func (s *AllocatorSuite) TestOperationsOnUnavailableIDs(c *C) {
+	minID, maxID := 1, 5
+	var poolWithAllIDsUnavailable = func() *idPool {
+		p := newIDPool(ID(minID), ID(maxID))
+		for i := minID; i <= maxID; i++ {
+			c.Assert(p.Remove(ID(i)), Equals, true)
+		}
+		return p
+	}
+
+	// Releasing unavailable IDs should not have any effect.
+	p1 := poolWithAllIDsUnavailable()
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p1.Release(ID(i)), Equals, false)
+	}
+	leaseAllIDs(p1, minID, minID-1, c)
+
+	// Using unavailable IDs should not have any effect.
+	p2 := poolWithAllIDsUnavailable()
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p2.Use(ID(i)), Equals, false)
+	}
+	leaseAllIDs(p2, minID, minID-1, c)
+
+	// Inserting unavailable IDs should make them available.
+	p3 := poolWithAllIDsUnavailable()
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p3.Insert(ID(i)), Equals, true)
+	}
+	// They should not be leased.
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p3.Use(ID(i)), Equals, false)
+		c.Assert(p3.Release(ID(i)), Equals, false)
+	}
+	leaseAllIDs(p3, minID, maxID, c)
+
+	// Removing unavailable IDs should not have any effect.
+	p4 := poolWithAllIDsUnavailable()
+	for i := minID; i <= maxID; i++ {
+		c.Assert(p4.Remove(ID(i)), Equals, false)
+	}
+	leaseAllIDs(p4, minID, minID-1, c)
+}
+
+func leaseAllIDs(p *idPool, minID int, maxID int, c *C) {
+	expected := make([]int, 0)
+	actual := make([]int, 0)
+	for i := minID; i <= maxID; i++ {
+		id := p.LeaseAvailableID()
+		c.Assert(id, Not(Equals), NoID)
+		actual = append(actual, int(id))
+		expected = append(expected, i)
+	}
+	// We should be out of IDs.
+	id := p.LeaseAvailableID()
+	c.Assert(id, Equals, NoID)
+
+	// Unique ids must have been leased.
+	sort.Ints(actual)
+	c.Assert(actual, DeepEquals, expected)
+}


### PR DESCRIPTION
This patch improves on the current brute-force mechanism by maintaining
a pool of IDs that accounts for both local ID usages and incoming
identity events, and uses this information to allocate IDs.

* Add idpool.go backing ID allocation.
* Add idpool_test.go to verify correctness of idpool.
* Update allocator.go and cache.go to use idpool.
* Update test cases that use selectAvailableID() in allocator_test.go

Fixes #4574

Happy to change anything that isn't right!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5036)
<!-- Reviewable:end -->
