### PR TITLE
Pr/v1.1 backport 18 07 30

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -1927,9 +1927,13 @@ Cilium PRs that are marked with label ``stable/needs-backport`` need to be backp
     and clear the ``stable/needs-backport`` label.  Note that using
     the GitHub web interface it is better to add new labels first so
     that you can still find the PRs using either the new or old label!
+    You can also do this with
+    ``contrib/backporting/set-labels.py <original PR ID> pending <version(defaults to 1.0)>``.
 14. After the backport PR is merged, mark all backported PRs with
     ``stable/backport-done`` label and clear the
     ``stable/backport-pending`` label.
+    This can be achieved by
+    ``contrib/backporting/set-labels.py <original PR ID> done <version(defaults to 1.0)>``.
 
 Update cilium-builder and cilium-runtime images
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cilium/cmd/endpoint_get.go
+++ b/cilium/cmd/endpoint_get.go
@@ -22,6 +22,7 @@ import (
 
 	endpointApi "github.com/cilium/cilium/api/v1/client/endpoint"
 	"github.com/cilium/cilium/api/v1/models"
+	api "github.com/cilium/cilium/pkg/apisocket"
 	"github.com/cilium/cilium/pkg/command"
 
 	"github.com/spf13/cobra"
@@ -43,7 +44,7 @@ var endpointGetCmd = &cobra.Command{
 		var endpointInst []*models.Endpoint
 
 		if len(lbls) > 0 {
-			params := endpointApi.NewGetEndpointParams().WithLabels(lbls)
+			params := endpointApi.NewGetEndpointParams().WithLabels(lbls).WithTimeout(api.ClientTimeout)
 			result, err := client.Endpoint.GetEndpoint(params)
 			if err != nil {
 				Fatalf("Cannot get endpoints for given list of labels %s: %s\n", lbls, err)

--- a/cilium/cmd/identity_get.go
+++ b/cilium/cmd/identity_get.go
@@ -21,6 +21,7 @@ import (
 
 	identityApi "github.com/cilium/cilium/api/v1/client/policy"
 	"github.com/cilium/cilium/api/v1/models"
+	api "github.com/cilium/cilium/pkg/apisocket"
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/labels"
 
@@ -63,7 +64,7 @@ var identityGetCmd = &cobra.Command{
 	Short: "Retrieve information about an identity",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(lookupLabels) > 0 {
-			params := identityApi.NewGetIdentityParams().WithLabels(lookupLabels)
+			params := identityApi.NewGetIdentityParams().WithLabels(lookupLabels).WithTimeout(api.ClientTimeout)
 			if id, err := client.Policy.GetIdentity(params); err != nil {
 				Fatalf("Cannot get identity for labels %s: %s\n", lookupLabels, err)
 			} else {
@@ -74,7 +75,7 @@ var identityGetCmd = &cobra.Command{
 				Usagef(cmd, "Invalid identity ID")
 			}
 
-			params := identityApi.NewGetIdentityIDParams().WithID(args[0])
+			params := identityApi.NewGetIdentityIDParams().WithID(args[0]).WithTimeout(api.ClientTimeout)
 			if id, err := client.Policy.GetIdentityID(params); err != nil {
 				Fatalf("Cannot get identity for given ID %s: %s\n", id, err)
 			} else {

--- a/cilium/cmd/identity_list.go
+++ b/cilium/cmd/identity_list.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	identityApi "github.com/cilium/cilium/api/v1/client/policy"
 	"github.com/cilium/cilium/api/v1/models"
+	api "github.com/cilium/cilium/pkg/apisocket"
 	pkg "github.com/cilium/cilium/pkg/client"
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/identity"
@@ -46,9 +47,9 @@ func listIdentities(args []string) {
 		reserved = append(reserved, identity.NewIdentity(v, labels.NewLabelsFromModel([]string{"reserved:" + k})).GetModel())
 	}
 
-	var params *identityApi.GetIdentityParams
+	params := identityApi.NewGetIdentityParams().WithTimeout(api.ClientTimeout)
 	if len(args) != 0 {
-		params = identityApi.NewGetIdentityParams().WithLabels(args)
+		params = params.WithLabels(args)
 	}
 
 	identities, err := client.Policy.GetIdentity(params)

--- a/cilium/cmd/policy_trace.go
+++ b/cilium/cmd/policy_trace.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/cilium/cilium/api/v1/client/policy"
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/common"
+	api "github.com/cilium/cilium/pkg/apisocket"
 	"github.com/cilium/cilium/pkg/command"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/identity"
@@ -169,7 +170,7 @@ If multiple sources and / or destinations are provided, each source is tested wh
 					Verbose: verbose,
 				}
 
-				params := NewGetPolicyResolveParams().WithTraceSelector(&search)
+				params := NewGetPolicyResolveParams().WithTraceSelector(&search).WithTimeout(api.ClientTimeout)
 				if scr, err := client.Policy.GetPolicyResolve(params); err != nil {
 					Fatalf("Error while retrieving policy assessment result: %s\n", err)
 				} else if command.OutputJSON() {

--- a/contrib/backporting/set-labels.py
+++ b/contrib/backporting/set-labels.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+"""
+This script requires PyGithub to be installed
+`pip install pygithub`
+
+GITHUB_TOKEN env variable is used to access GH API
+"""
+
+import argparse
+import os
+import sys
+
+from github import Github
+
+parser = argparse.ArgumentParser()
+parser.add_argument('pr_number', type=int)
+actions = ["pending", "done"]
+parser.add_argument('action', type=str, choices=actions)
+parser.add_argument('version', type=str, default="1.0", nargs='?')
+
+args = parser.parse_args()
+
+token = os.environ["GITHUB_TOKEN"]
+pr_number = args.pr_number
+action = args.action
+version = args.version
+
+g = Github(token)
+cilium = g.get_repo("cilium/cilium")
+pr = cilium.get_pull(pr_number)
+pr_labels = list(pr.get_labels())
+old_label_len = len(pr_labels)
+
+cilium_labels = cilium.get_labels()
+
+if action == "pending":
+    pr_labels = [l for l in pr_labels
+                 if l.name != "needs-backport/"+version]
+    if old_label_len - 1 != len(pr_labels):
+        print("needs-backport/"+version+" label not found in PR, exiting")
+        sys.exit(1)
+
+    pr_labels.append(
+        [l for l in cilium_labels if l.name == "backport-pending/"+version][0])
+
+    if old_label_len != len(pr_labels):
+        print("error adding backport-pending/"+version+" label to PR, exiting")
+        sys.exit(2)
+    pr.set_labels(*pr_labels)
+    sys.exit(0)
+
+if action == "done":
+    pr_labels = [l for l in pr_labels
+                 if l.name != "backport-pending/"+version]
+    if old_label_len - 1 != len(pr_labels):
+        print("backport-pending/"+version+" label not found in PR, exiting")
+        sys.exit(1)
+
+    pr_labels.append(
+        [l for l in cilium_labels if l.name == "backport-done/"+version][0])
+
+    if old_label_len != len(pr_labels):
+        print("error adding backport-done/"+version+" label to PR, exiting")
+        sys.exit(2)
+    pr.set_labels(*pr_labels)
+    sys.exit(0)

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -232,16 +232,12 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder 
 
 		log.Debug("synchronously waiting for endpoint %d to be in %s state", e.ID, endpoint.StateReady)
 
-		// Default timeout for PUT /endpoint/{id} is 30 seconds, so put timeout
+		// Default timeout for PUT /endpoint/{id} is 60 seconds, so put timeout
 		// in this function a bit below that timeout. If the timeout for clients
 		// in API is below this value, they will get a message containing
 		// "context deadline exceeded" if the operation takes longer than the
 		// client's configured timeout value.
-		stateChangeTimeout := time.Duration(25 * time.Second)
-
-		// Check up until stateChangeTimeout seconds for endpoint state before
-		// waiting for endpoint to be in ready state.
-		timeout := time.After(stateChangeTimeout)
+		timeout := time.After(endpoint.EndpointGenerationTimeout)
 
 		// Check for endpoint state every second.
 		ticker := time.NewTicker(1 * time.Second)

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1459,7 +1459,6 @@ func (d *Daemon) updateCiliumNetworkPolicyV2(ciliumV2Store cache.Store,
 		logfields.K8sNamespace:                     newRuleCpy.ObjectMeta.Namespace,
 	}).Debug("Modified CiliumNetworkPolicy")
 
-	d.deleteCiliumNetworkPolicyV2(oldRuleCpy)
 	d.addCiliumNetworkPolicyV2(ciliumV2Store, newRuleCpy)
 }
 

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -76,6 +76,8 @@ const (
 	argDebugVerboseFlow    = "flow"
 	argDebugVerboseKvstore = "kvstore"
 	argDebugVerboseEnvoy   = "envoy"
+
+	apiTimeout = 60 * time.Second
 )
 
 var (
@@ -877,6 +879,8 @@ func runDaemon() {
 	server := server.NewServer(api)
 	server.EnabledListeners = []string{"unix"}
 	server.SocketPath = flags.Filename(socketPath)
+	server.ReadTimeout = apiTimeout
+	server.WriteTimeout = apiTimeout
 	defer server.Shutdown()
 
 	server.ConfigureAPI()

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -43,9 +43,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -43,9 +43,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -43,9 +43,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -43,9 +43,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -43,9 +43,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -43,9 +43,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.7/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-crio-ds.yaml
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.7/cilium-crio.yaml
+++ b/examples/kubernetes/1.7/cilium-crio.yaml
@@ -43,9 +43,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -43,9 +43,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -43,9 +43,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -43,9 +43,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -43,9 +43,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -43,9 +43,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/pkg/apisocket/const.go
+++ b/pkg/apisocket/const.go
@@ -14,7 +14,10 @@
 
 package apisocket
 
-import "os"
+import (
+	"os"
+	"time"
+)
 
 const (
 	// GroupFilePath is the unix group file path.
@@ -23,4 +26,6 @@ const (
 	CiliumGroupName = "cilium"
 	// SocketFileMode is the default file mode for the sockets.
 	SocketFileMode os.FileMode = 0660
+	//ClientTimeout specifies timeout to be used by clients
+	ClientTimeout = 90 * time.Second
 )

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -17,6 +17,7 @@ package client
 import (
 	"github.com/cilium/cilium/api/v1/client/daemon"
 	"github.com/cilium/cilium/api/v1/models"
+	api "github.com/cilium/cilium/pkg/apisocket"
 )
 
 // ConfigGet returns a daemon configuration.
@@ -42,7 +43,7 @@ func (c *Client) ConfigPatch(cfg models.DaemonConfigurationSpec) error {
 		fullCfg.Spec.PolicyEnforcement = cfg.PolicyEnforcement
 	}
 
-	params := daemon.NewPatchConfigParams().WithConfiguration(fullCfg.Spec)
+	params := daemon.NewPatchConfigParams().WithConfiguration(fullCfg.Spec).WithTimeout(api.ClientTimeout)
 	_, err = c.Daemon.PatchConfig(params)
 	return Hint(err)
 }

--- a/pkg/client/identity.go
+++ b/pkg/client/identity.go
@@ -17,11 +17,12 @@ package client
 import (
 	"github.com/cilium/cilium/api/v1/client/policy"
 	"github.com/cilium/cilium/api/v1/models"
+	api "github.com/cilium/cilium/pkg/apisocket"
 )
 
 // IdentityGet returns a security identity.
 func (c *Client) IdentityGet(id string) (*models.Identity, error) {
-	params := policy.NewGetIdentityIDParams().WithID(id)
+	params := policy.NewGetIdentityIDParams().WithID(id).WithTimeout(api.ClientTimeout)
 
 	resp, err := c.Policy.GetIdentityID(params)
 	if err != nil {

--- a/pkg/client/ipam.go
+++ b/pkg/client/ipam.go
@@ -17,6 +17,7 @@ package client
 import (
 	"github.com/cilium/cilium/api/v1/client/ipam"
 	"github.com/cilium/cilium/api/v1/models"
+	api "github.com/cilium/cilium/pkg/apisocket"
 )
 
 const (
@@ -26,7 +27,7 @@ const (
 
 // IPAMAllocate allocates an IP address out of address family specific pool.
 func (c *Client) IPAMAllocate(family string) (*models.IPAMResponse, error) {
-	params := ipam.NewPostIPAMParams()
+	params := ipam.NewPostIPAMParams().WithTimeout(api.ClientTimeout)
 
 	if family != "" {
 		params.SetFamily(&family)
@@ -41,14 +42,14 @@ func (c *Client) IPAMAllocate(family string) (*models.IPAMResponse, error) {
 
 // IPAMAllocateIP tries to allocate a particular IP address.
 func (c *Client) IPAMAllocateIP(ip string) error {
-	params := ipam.NewPostIPAMIPParams().WithIP(ip)
+	params := ipam.NewPostIPAMIPParams().WithIP(ip).WithTimeout(api.ClientTimeout)
 	_, err := c.IPAM.PostIPAMIP(params)
 	return Hint(err)
 }
 
 // IPAMReleaseIP releases a IP address back to the pool.
 func (c *Client) IPAMReleaseIP(ip string) error {
-	params := ipam.NewDeleteIPAMIPParams().WithIP(ip)
+	params := ipam.NewDeleteIPAMIPParams().WithIP(ip).WithTimeout(api.ClientTimeout)
 	_, err := c.IPAM.DeleteIPAMIP(params)
 	return Hint(err)
 }

--- a/pkg/client/policy.go
+++ b/pkg/client/policy.go
@@ -17,11 +17,12 @@ package client
 import (
 	"github.com/cilium/cilium/api/v1/client/policy"
 	"github.com/cilium/cilium/api/v1/models"
+	api "github.com/cilium/cilium/pkg/apisocket"
 )
 
 // PolicyPut inserts the `policyJSON`
 func (c *Client) PolicyPut(policyJSON string) (*models.Policy, error) {
-	params := policy.NewPutPolicyParams().WithPolicy(&policyJSON)
+	params := policy.NewPutPolicyParams().WithPolicy(&policyJSON).WithTimeout(api.ClientTimeout)
 	resp, err := c.Policy.PutPolicy(params)
 	if err != nil {
 		return nil, Hint(err)
@@ -31,7 +32,7 @@ func (c *Client) PolicyPut(policyJSON string) (*models.Policy, error) {
 
 // PolicyGet returns policy rules
 func (c *Client) PolicyGet(labels []string) (*models.Policy, error) {
-	params := policy.NewGetPolicyParams().WithLabels(labels)
+	params := policy.NewGetPolicyParams().WithLabels(labels).WithTimeout(api.ClientTimeout)
 	resp, err := c.Policy.GetPolicy(params)
 	if err != nil {
 		return nil, Hint(err)
@@ -41,7 +42,7 @@ func (c *Client) PolicyGet(labels []string) (*models.Policy, error) {
 
 // PolicyDelete deletes policy rules
 func (c *Client) PolicyDelete(labels []string) (*models.Policy, error) {
-	params := policy.NewDeletePolicyParams().WithLabels(labels)
+	params := policy.NewDeletePolicyParams().WithLabels(labels).WithTimeout(api.ClientTimeout)
 	resp, err := c.Policy.DeletePolicy(params)
 	if err != nil {
 		return nil, Hint(err)
@@ -51,7 +52,7 @@ func (c *Client) PolicyDelete(labels []string) (*models.Policy, error) {
 
 // PolicyResolveGet resolves policy for a Trace Selector with source and destination identity.
 func (c *Client) PolicyResolveGet(traceSelector *models.TraceSelector) (*models.PolicyTraceResult, error) {
-	params := policy.NewGetPolicyResolveParams().WithTraceSelector(traceSelector)
+	params := policy.NewGetPolicyResolveParams().WithTraceSelector(traceSelector).WithTimeout(api.ClientTimeout)
 	resp, err := c.Policy.GetPolicyResolve(params)
 	if err != nil {
 		return nil, Hint(err)

--- a/pkg/client/prefilter.go
+++ b/pkg/client/prefilter.go
@@ -17,6 +17,7 @@ package client
 import (
 	"github.com/cilium/cilium/api/v1/client/prefilter"
 	"github.com/cilium/cilium/api/v1/models"
+	api "github.com/cilium/cilium/pkg/apisocket"
 )
 
 // GetPrefilter returns a list of all CIDR prefixes
@@ -30,7 +31,7 @@ func (c *Client) GetPrefilter() (*models.Prefilter, error) {
 
 // PatchPrefilter sets a list of CIDR prefixes
 func (c *Client) PatchPrefilter(spec *models.PrefilterSpec) (*models.Prefilter, error) {
-	params := prefilter.NewPatchPrefilterParams().WithPrefilterSpec(spec)
+	params := prefilter.NewPatchPrefilterParams().WithPrefilterSpec(spec).WithTimeout(api.ClientTimeout)
 	resp, err := c.Prefilter.PatchPrefilter(params)
 	if err != nil {
 		return nil, Hint(err)

--- a/pkg/client/service.go
+++ b/pkg/client/service.go
@@ -17,6 +17,7 @@ package client
 import (
 	"github.com/cilium/cilium/api/v1/client/service"
 	"github.com/cilium/cilium/api/v1/models"
+	api "github.com/cilium/cilium/pkg/apisocket"
 )
 
 // GetServices returns a list of all services.
@@ -30,7 +31,7 @@ func (c *Client) GetServices() ([]*models.Service, error) {
 
 // GetServiceID returns a service by ID.
 func (c *Client) GetServiceID(id int64) (*models.Service, error) {
-	params := service.NewGetServiceIDParams().WithID(id)
+	params := service.NewGetServiceIDParams().WithID(id).WithTimeout(api.ClientTimeout)
 	resp, err := c.Service.GetServiceID(params)
 	if err != nil {
 		return nil, Hint(err)
@@ -41,14 +42,14 @@ func (c *Client) GetServiceID(id int64) (*models.Service, error) {
 // PutServiceID creates or updates a service. Returns true if service was created.
 func (c *Client) PutServiceID(id int64, svc *models.ServiceSpec) (bool, error) {
 	svc.ID = id
-	params := service.NewPutServiceIDParams().WithID(id).WithConfig(svc)
+	params := service.NewPutServiceIDParams().WithID(id).WithConfig(svc).WithTimeout(api.ClientTimeout)
 	_, created, err := c.Service.PutServiceID(params)
 	return created != nil, Hint(err)
 }
 
 // DeleteServiceID deletes a service by ID.
 func (c *Client) DeleteServiceID(id int64) error {
-	params := service.NewDeleteServiceIDParams().WithID(id)
+	params := service.NewDeleteServiceIDParams().WithID(id).WithTimeout(api.ClientTimeout)
 	_, err := c.Service.DeleteServiceID(params)
 	return Hint(err)
 }

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -51,6 +51,9 @@ import (
 const (
 	// ExecTimeout is the execution timeout to use in join_ep.sh executions
 	ExecTimeout = 300 * time.Second
+
+	// EndpointGenerationTimeout specifies timeout for proxy completion context
+	EndpointGenerationTimeout = 55 * time.Second
 )
 
 // lookupRedirectPortBE returns the redirect L4 proxy port for the given L4
@@ -671,7 +674,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, boo
 
 		// Now that policy has been regenerated, set up a context to
 		// wait for proxy completions.
-		completionCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		completionCtx, cancel := context.WithTimeout(context.Background(), EndpointGenerationTimeout)
 		e.ProxyWaitGroup = completion.NewWaitGroup(completionCtx)
 		defer func() {
 			cancel()
@@ -779,7 +782,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (uint64, boo
 	// To avoid traffic loss, wait for the policy to be pushed into BPF before
 	// deleting obsolete redirects, to make sure no packets are redirected to
 	// those ports.
-	completionCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	completionCtx, cancel := context.WithTimeout(context.Background(), EndpointGenerationTimeout)
 	e.ProxyWaitGroup = completion.NewWaitGroup(completionCtx)
 	defer cancel()
 	e.Mutex.Lock()

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1583,15 +1583,11 @@ func (e *Endpoint) Update(owner Owner, cfg *models.EndpointConfigurationSpec) er
 
 		// TODO / FIXME: GH-3281: need ways to queue up regenerations per-endpoint.
 
-		// Default timeout for PATCH /endpoint/{id}/config is 30 seconds, so put
+		// Default timeout for PATCH /endpoint/{id}/config is 60 seconds, so put
 		// timeout in this function a bit below that timeout. If the timeout
 		// for clients in API is below this value, they will get a message containing
 		// "context deadline exceeded".
-		stateChangeTimeout := time.Duration(25 * time.Second)
-
-		// Check up until stateChangeTimeout seconds for endpoint state before
-		// trying to update configuration.
-		timeout := time.After(stateChangeTimeout)
+		timeout := time.After(EndpointGenerationTimeout)
 
 		// Check for endpoint state every second.
 		ticker := time.NewTicker(1 * time.Second)

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -811,7 +811,7 @@ func (e *Endpoint) runIdentityToK8sPodSync() {
 
 				e.Mutex.RLock()
 				if e.SecurityIdentity != nil {
-					id = e.SecurityIdentity.ID.String()
+					id = e.SecurityIdentity.ID.StringID()
 				}
 				e.Mutex.RUnlock()
 

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -161,4 +161,12 @@ type BackendOperations interface {
 
 	// Decodes a key previously encoded back into the original binary slice
 	Decode(in string) ([]byte, error)
+
+	// ListAndWatch creates a new watcher which will watch the specified
+	// prefix for changes. Before doing this, it will list the current keys
+	// matching the prefix and report them as new keys. Name can be set to
+	// anything and is used for logging messages. The Events channel is
+	// created with the specified sizes. Upon every change observed, a
+	// KeyValueEvent will be sent to the Events channel
+	ListAndWatch(name, prefix string, chanSize int) *Watcher
 }

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -382,7 +382,9 @@ func (c *consulClient) Watch(w *Watcher) {
 	localState := map[string]consulAPI.KVPair{}
 	nextIndex := uint64(0)
 
-	qo := consulAPI.QueryOptions{}
+	qo := consulAPI.QueryOptions{
+		WaitTime: time.Second,
+	}
 
 	for {
 		// Initialize sleep time to a millisecond as we don't

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -460,6 +460,7 @@ func (c *consulClient) Watch(w *Watcher) {
 		case <-time.After(sleepTime):
 		case <-w.stopWatch:
 			close(w.Events)
+			w.stopWait.Done()
 			return
 		}
 	}

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -651,3 +651,14 @@ func (c *consulClient) Encode(in []byte) string {
 func (c *consulClient) Decode(in string) ([]byte, error) {
 	return base64.URLEncoding.DecodeString(in)
 }
+
+// ListAndWatch implements the BackendOperations.ListAndWatch using consul
+func (c *consulClient) ListAndWatch(name, prefix string, chanSize int) *Watcher {
+	w := newWatcher(name, prefix, chanSize)
+
+	log.WithField(fieldWatcher, w).Debug("Starting watcher...")
+
+	go c.Watch(w)
+
+	return w
+}

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -558,6 +558,7 @@ reList:
 			select {
 			case <-w.stopWatch:
 				close(w.Events)
+				w.stopWait.Done()
 				return
 
 			case r, ok := <-etcdWatch:

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -872,3 +872,14 @@ func (e *etcdClient) Encode(in []byte) string {
 func (e *etcdClient) Decode(in string) ([]byte, error) {
 	return []byte(in), nil
 }
+
+// ListAndWatch implements the BackendOperations.ListAndWatch using etcd
+func (e *etcdClient) ListAndWatch(name, prefix string, chanSize int) *Watcher {
+	w := newWatcher(name, prefix, chanSize)
+
+	log.WithField(fieldWatcher, w).Debug("Starting watcher...")
+
+	go e.Watch(w)
+
+	return w
+}

--- a/pkg/kvstore/events.go
+++ b/pkg/kvstore/events.go
@@ -14,6 +14,10 @@
 
 package kvstore
 
+import (
+	"sync"
+)
+
 // EventType defines the type of watch event that occurred
 type EventType int
 
@@ -75,16 +79,24 @@ type Watcher struct {
 	prefix    string
 	stopWatch stopChan
 
-	stopped bool
+	// stopOnce guarantees that Stop() is only called once
+	stopOnce sync.Once
+
+	// stopWait is the wait group to wait for watchers to exit gracefully
+	stopWait sync.WaitGroup
 }
 
 func newWatcher(name, prefix string, chanSize int) *Watcher {
-	return &Watcher{
+	w := &Watcher{
 		name:      name,
 		prefix:    prefix,
 		Events:    make(EventChan, chanSize),
 		stopWatch: make(stopChan, 0),
 	}
+
+	w.stopWait.Add(1)
+
+	return w
 }
 
 // String returns the name of the wather
@@ -107,11 +119,9 @@ func ListAndWatch(name, prefix string, chanSize int) *Watcher {
 
 // Stop stops a watcher previously created and started with Watch()
 func (w *Watcher) Stop() {
-	if w.stopped {
-		return
-	}
-
-	close(w.stopWatch)
-	log.WithField(fieldWatcher, w).Debug("Stopped watcher...")
-	w.stopped = true
+	w.stopOnce.Do(func() {
+		close(w.stopWatch)
+		log.WithField(fieldWatcher, w).Debug("Stopped watcher")
+		w.stopWait.Wait()
+	})
 }

--- a/pkg/kvstore/events.go
+++ b/pkg/kvstore/events.go
@@ -78,6 +78,15 @@ type Watcher struct {
 	stopped bool
 }
 
+func newWatcher(name, prefix string, chanSize int) *Watcher {
+	return &Watcher{
+		name:      name,
+		prefix:    prefix,
+		Events:    make(EventChan, chanSize),
+		stopWatch: make(stopChan, 0),
+	}
+}
+
 // String returns the name of the wather
 func (w *Watcher) String() string {
 	return w.name
@@ -93,18 +102,7 @@ func (w *Watcher) String() string {
 // Returns a watcher structure plus a channel that is closed when the initial
 // list operation has been completed
 func ListAndWatch(name, prefix string, chanSize int) *Watcher {
-	w := &Watcher{
-		name:      name,
-		prefix:    prefix,
-		Events:    make(EventChan, chanSize),
-		stopWatch: make(stopChan, 0),
-	}
-
-	log.WithField(fieldWatcher, w).Debug("Starting watcher...")
-
-	go Client().Watch(w)
-
-	return w
+	return Client().ListAndWatch(name, prefix, chanSize)
 }
 
 // Stop stops a watcher previously created and started with Watch()

--- a/pkg/kvstore/store/store_test.go
+++ b/pkg/kvstore/store/store_test.go
@@ -103,6 +103,13 @@ func (s *StoreSuite) TestStoreCreation(c *C) {
 	c.Assert(store, Not(IsNil))
 	c.Assert(store.conf.SynchronizationInterval, Equals, synchronizationIntervalDefault)
 	store.Close()
+
+	// Test with kvstore client specified
+	store, err = JoinSharedStore(Configuration{Prefix: testutils.RandomRune(), KeyCreator: newTestType, Backend: kvstore.Client()})
+	c.Assert(err, IsNil)
+	c.Assert(store, Not(IsNil))
+	c.Assert(store.conf.SynchronizationInterval, Equals, synchronizationIntervalDefault)
+	store.Close()
 }
 
 func expect(check func() bool) error {


### PR DESCRIPTION
* #4945                                                                         
  * Required #4768 to cleanly apply                                             
* #4998                                                                         
  * Did not cleanly apply - @nebril please review
    * `pkg/endpoint/bpf.go`
    * `pkg/api` changes autoapplied to `pkg/apisocket` during cherry-pick, so I imported `apisocket` as `api` to minimize diff from original patches
* #5019                                                                         
* #5021                                                                         
* #5024                                                                         
* #5029

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5042)
<!-- Reviewable:end -->
