### PR TITLE
Pr/v1.0 backport 18 07 30

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -1312,9 +1312,13 @@ Cilium PRs that are marked with label ``stable/needs-backport`` need to be backp
     and clear the ``stable/needs-backport`` label.  Note that using
     the GitHub web interface it is better to add new labels first so
     that you can still find the PRs using either the new or old label!
+    You can also do this with
+    ``contrib/backporting/set-labels.py <original PR ID> pending <version(defaults to 1.0)>``.
 14. After the backport PR is merged, mark all backported PRs with
     ``stable/backport-done`` label and clear the
     ``stable/backport-pending`` label.
+    This can be achieved by
+    ``contrib/backporting/set-labels.py <original PR ID> done <version(defaults to 1.0)>``.
 
 Stable branches
 ~~~~~~~~~~~~~~~

--- a/contrib/backporting/set-labels.py
+++ b/contrib/backporting/set-labels.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+"""
+This script requires PyGithub to be installed
+`pip install pygithub`
+
+GITHUB_TOKEN env variable is used to access GH API
+"""
+
+import argparse
+import os
+import sys
+
+from github import Github
+
+parser = argparse.ArgumentParser()
+parser.add_argument('pr_number', type=int)
+actions = ["pending", "done"]
+parser.add_argument('action', type=str, choices=actions)
+parser.add_argument('version', type=str, default="1.0", nargs='?')
+
+args = parser.parse_args()
+
+token = os.environ["GITHUB_TOKEN"]
+pr_number = args.pr_number
+action = args.action
+version = args.version
+
+g = Github(token)
+cilium = g.get_repo("cilium/cilium")
+pr = cilium.get_pull(pr_number)
+pr_labels = list(pr.get_labels())
+old_label_len = len(pr_labels)
+
+cilium_labels = cilium.get_labels()
+
+if action == "pending":
+    pr_labels = [l for l in pr_labels
+                 if l.name != "needs-backport/"+version]
+    if old_label_len - 1 != len(pr_labels):
+        print("needs-backport/"+version+" label not found in PR, exiting")
+        sys.exit(1)
+
+    pr_labels.append(
+        [l for l in cilium_labels if l.name == "backport-pending/"+version][0])
+
+    if old_label_len != len(pr_labels):
+        print("error adding backport-pending/"+version+" label to PR, exiting")
+        sys.exit(2)
+    pr.set_labels(*pr_labels)
+    sys.exit(0)
+
+if action == "done":
+    pr_labels = [l for l in pr_labels
+                 if l.name != "backport-pending/"+version]
+    if old_label_len - 1 != len(pr_labels):
+        print("backport-pending/"+version+" label not found in PR, exiting")
+        sys.exit(1)
+
+    pr_labels.append(
+        [l for l in cilium_labels if l.name == "backport-done/"+version][0])
+
+    if old_label_len != len(pr_labels):
+        print("error adding backport-done/"+version+" label to PR, exiting")
+        sys.exit(2)
+    pr.set_labels(*pr_labels)
+    sys.exit(0)

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1554,7 +1554,6 @@ func (d *Daemon) updateCiliumNetworkPolicyV2(ciliumV2Store cache.Store,
 		logfields.K8sNamespace + ".new":            newRuleCpy.ObjectMeta.Namespace,
 	}).Debug("Modified CiliumNetworkPolicy")
 
-	d.deleteCiliumNetworkPolicyV2(oldRuleCpy)
 	d.addCiliumNetworkPolicyV2(ciliumV2Store, newRuleCpy)
 }
 

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -55,9 +55,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -55,9 +55,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -55,9 +55,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -55,9 +55,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -55,9 +55,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -55,9 +55,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/kubernetes/cilium.yaml
+++ b/examples/kubernetes/cilium.yaml
@@ -73,9 +73,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   template:
     metadata:
       labels:

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -8,9 +8,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium

--- a/examples/minikube/cilium-ds.yaml
+++ b/examples/minikube/cilium-ds.yaml
@@ -77,9 +77,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 2
   template:
     metadata:
       labels:

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1072,7 +1072,7 @@ func (e *Endpoint) runIdentityToK8sPodSync() {
 
 				e.Mutex.RLock()
 				if e.SecurityIdentity != nil {
-					id = e.SecurityIdentity.ID.String()
+					id = e.SecurityIdentity.ID.StringID()
 				}
 				e.Mutex.RUnlock()
 


### PR DESCRIPTION
* Skipped: #4945                                                                
  * Significant refactors make this less than trivial to backport to 1.0.       

Backported:
* #5019                                                                         
* #5021                                                                                                                                                                                  
* #5024                                                                         
* #5029                                                                         
  * Had to remove the CRI-O YAMLs from the examples during backport as 1.0 doesn't support CRI-O.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5043)
<!-- Reviewable:end -->
