### PR TITLE
Test: Fix issues on false positive controllers

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1019,7 +1019,7 @@ func (kub *Kubectl) CiliumCheckReport() {
 		for name, data := range result.KVOutput() {
 			total++
 			status := strings.Split(data, "::")
-			if status[0] != "0" {
+			if status[0] != "" {
 				failed++
 				prefix = "⚠️  "
 				failedControllers += fmt.Sprintf("controller %s failure %q\n", name, status[1])


### PR DESCRIPTION
Due that the jsonpath is executed after the json is getted, the output
of the array will be an empty string instead of 0.

This fixes the false povsitives controllers seen in the last day.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5050)
<!-- Reviewable:end -->
