### PR TITLE
docs: Mention LB -> conntrack dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,8 @@ external services. The loadbalancing is implemented using BPF using efficient
 hashtables allowing for almost unlimited scale and supports direct server
 return (DSR) if the loadbalancing operation is not performed on the source
 host.
+*Note: load balancing requires connection tracking to be enabled. This is the
+default.*
 
 Monitoring and Troubleshooting
 ------------------------------


### PR DESCRIPTION
LB doesn't work when `--disable-contrack` is passed in. We don't have a
proper documentation section for load-balancing but we now at least
mention it.

Signed-off-by: Ray Bejjani <ray@covalent.io>

Fixes #4814

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5053)
<!-- Reviewable:end -->
