### PR TITLE
Test: Delete Kube-dns on upgrade test

### DIFF
--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -71,6 +71,9 @@ var _ = Describe("K8sUpdates", func() {
 		kubectl.Delete(l3Policy)
 		kubectl.Delete(demoPath)
 
+		// make sure that Kubedns is deleted correctly
+		_ = kubectl.Delete(helpers.DNSDeployment())
+
 		_ = kubectl.DeleteResource(
 			"ds", fmt.Sprintf("-n %s cilium", helpers.KubeSystemNamespace))
 


### PR DESCRIPTION
On delete delete the Kube-dns pods to make sure that the new services
are picked correctly by Kube-DNS.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5054)
<!-- Reviewable:end -->
