### PR TITLE
Test: Delete all with Timeout.

### DIFF
--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -230,7 +230,10 @@ func (t *Target) CreateApplyManifest(spec *TestSpec) error {
 		"apiVersion": "v1",
 		"kind": "Service",
 		"metadata": {
-			"name": "{{ .targetName }}"
+			"name": "{{ .targetName }}",
+			"labels": {
+				"test": "policygen"
+			}
 		},
 		"spec": {
 			"ports": [
@@ -255,7 +258,10 @@ func (t *Target) CreateApplyManifest(spec *TestSpec) error {
 		  "apiVersion": "v1",
 		  "kind": "Service",
 		  "metadata": {
-			"name": "{{ .targetName }}"
+			"name": "{{ .targetName }}",
+			"labels": {
+				"test": "policygen"
+			}
 		  },
 		  "spec": {
 			"type": "NodePort",
@@ -448,6 +454,7 @@ metadata:
   labels:
     id: "%[3]s"
     zgroup: "%[1]s"
+    test: "policygen"
 spec:
   containers:
   - name: web
@@ -529,7 +536,9 @@ func (t *TestSpec) CreateCiliumNetworkPolicy() (string, error) {
 	  "kind": "CiliumNetworkPolicy",
 	  "metadata": {
 		"name": "%[1]s",
-		"test": "%[3]s"
+		"labels": {
+			"test": "policygen"
+		}
 	  },
 	  "specs": %[2]s}`)
 
@@ -626,7 +635,7 @@ func (t *TestSpec) CreateCiliumNetworkPolicy() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf(string(metadata), t.Prefix, jsonOutput, t), nil
+	return fmt.Sprintf(string(metadata), t.Prefix, jsonOutput), nil
 }
 
 // NetworkPolicyName returns the name of the NetworkPolicy

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -55,10 +55,12 @@ var _ = Describe("NightlyPolicies", func() {
 	AfterAll(func() {
 		// Delete all pods created
 		kubectl.Exec(fmt.Sprintf(
-			"%s delete --all pods,svc,cnp -n %s", helpers.KubectlCmd, helpers.DefaultNamespace))
+			"%s delete pods,svc,cnp -n %s -l test=policygen",
+			helpers.KubectlCmd, helpers.DefaultNamespace))
 
 		ExpectAllPodsTerminated(kubectl)
 	})
+
 	Context("PolicyEnforcement default", func() {
 		createTests := func() {
 			testSpecs := policygen.GeneratedTestSpec()


### PR DESCRIPTION
Had seen in the nightly builds that the delete all has failed and hang
until the Jenkins timeout. Tested locally and pods were all deleted but
the kubectl was still hung.

With this change we delete all resources with a timeout.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5056)
<!-- Reviewable:end -->
