### PR TITLE
doc: Ensure no old k8s CEPs in kops install

### DIFF
--- a/Documentation/install/guides/kops.rst
+++ b/Documentation/install/guides/kops.rst
@@ -152,6 +152,7 @@ The default Cilium version deployed by ``kops`` is old. Upgrade the Cilium Daemo
 
 .. code:: bash
 
+        kubectl delete crd ciliumendpoints.cilium.io # this ensures older CEP objects do not persist
         kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/HEAD/examples/kubernetes/1.10/cilium-rbac.yaml
         kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/HEAD/examples/kubernetes/1.10/cilium-ds.yaml
         kubectl set image daemonset/cilium -n kube-system cilium-agent=docker.io/cilium/cilium:v1.0.3


### PR DESCRIPTION
I recently encountered a situation where someone followed our kops guide and saw CEP errors. The version of kops with a >1.0 version of cilium is still in beta and, until it ships, this is the best way to ensure the kops guide doesn't result in these errors.

kops still ships with an old cilium. This requires a cilium update at
the end of an install, and that will leave pre-1.0 k8s CEP objects
around.  Removing the CEP CRD will remove all CEP objects, allowing them
to be recreated by the updated cilium version.

Signed-off-by: Ray Bejjani <ray@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5067)
<!-- Reviewable:end -->
