### PR TITLE
k8s: Recreate CEP on update errors

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -601,20 +601,27 @@ func (e *Endpoint) RunK8sCiliumEndpointSync() {
 				case err == nil:
 					// Update the copy of the cep
 					k8sMdl.DeepCopyInto(&cep.Status)
-					var err2 error
 					switch {
 					case ciliumUpdateStatusVerConstr.Check(k8sServerVer):
-						_, err2 = ciliumClient.CiliumEndpoints(namespace).UpdateStatus(cep)
+						_, err = ciliumClient.CiliumEndpoints(namespace).UpdateStatus(cep)
 					default:
-						_, err2 = ciliumClient.CiliumEndpoints(namespace).Update(cep)
-					}
-					if err2 != nil {
-						scopedLog.WithError(err2).Error("Cannot update CEP")
-						return err2
+						_, err = ciliumClient.CiliumEndpoints(namespace).Update(cep)
 					}
 
-					lastMdl = mdl
-					return nil
+					// successfully updated CEP. Return
+					if err == nil {
+						lastMdl = mdl
+						return nil
+					}
+
+					// something went wrong with the update. Delete and fall through to
+					// the create below.
+					scopedLog.WithError(err).Debug("Deleting CEP due to error on update")
+					err = ciliumClient.CiliumEndpoints(namespace).Delete(podName, &meta_v1.DeleteOptions{})
+					if err != nil {
+						scopedLog.WithError(err).Warn("Error deleting CEP")
+						return err
+					}
 				}
 
 				// The CEP was not found, this is the first creation of the endpoint


### PR DESCRIPTION
This is a different approach to https://github.com/cilium/cilium/issues/4979 than https://github.com/cilium/cilium/pull/4981, which proved a little annoying to work out.

We sometimes see errors updating CEPs. These are updated from a single
source (a single controller in a single cilium-agent per pod) and so
these errors here are not update races, but something more fundamental
and can be deleted as a way to reset things

Signed-off-by: Ray Bejjani <ray@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5068)
<!-- Reviewable:end -->
