### PR TITLE
monitor: Fix spin loop when reading stdout from monitor fails

### DIFF
--- a/pkg/launcher/launcher.go
+++ b/pkg/launcher/launcher.go
@@ -37,7 +37,7 @@ type Launcher struct {
 }
 
 // Run starts the daemon.
-func (launcher *Launcher) Run() {
+func (launcher *Launcher) Run() error {
 	targetName := launcher.GetTarget()
 	cmd := exec.Command(targetName, launcher.GetArgs()...)
 	cmd.Stderr = os.Stderr
@@ -45,10 +45,13 @@ func (launcher *Launcher) Run() {
 	if err := cmd.Start(); err != nil {
 		cmdStr := fmt.Sprintf("%s %s", targetName, launcher.GetArgs())
 		log.WithError(err).WithField("cmd", cmdStr).Error("cmd.Start()")
+		return fmt.Errorf("unable to launch process %s: %s", cmdStr, err)
 	}
 
 	launcher.setProcess(cmd.Process)
 	launcher.setStdout(stdout)
+
+	return nil
 }
 
 // Restart stops the launcher which will trigger a rerun.


### PR DESCRIPTION
The following pprof cpu trace was observed:
```
      flat  flat%   sum%        cum   cum%
    6670ms 32.97% 32.97%     7650ms 37.82%  syscall.Syscall
    2270ms 11.22% 44.19%     3290ms 16.26%  runtime.scanobject
    1690ms  8.35% 52.55%     4300ms 21.26%  runtime.mallocgc
     910ms  4.50% 57.04%      910ms  4.50%  runtime.heapBitsForObject
     680ms  3.36% 60.41%      680ms  3.36%  runtime.greyobject
     560ms  2.77% 63.17%      560ms  2.77%  runtime.memclrNoHeapPointers
     460ms  2.27% 65.45%      460ms  2.27%  runtime.heapBitsSetType
     430ms  2.13% 67.57%      490ms  2.42%  runtime.ifaceeq
     300ms  1.48% 69.06%    10450ms 51.66%  bufio.(*Reader).ReadSlice
     300ms  1.48% 70.54%      300ms  1.48%  runtime.casgstatus
```

The cause seems lack of error handling of `ReadBytes()` so an EOF on the pipe
will result in the for loop spinning forever.

Also fix up invalid calls to Fatalf() and instead restart the monitor when
creation of the pipe fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5074)
<!-- Reviewable:end -->
