### PR TITLE
Kubernetes: Add pod labels metadata on CEP metadata

### DIFF
--- a/api/v1/models/labels.go
+++ b/api/v1/models/labels.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"strings"
+
 	strfmt "github.com/go-openapi/strfmt"
 
 	"github.com/go-openapi/errors"
@@ -24,4 +26,23 @@ func (m Labels) Validate(formats strfmt.Registry) error {
 		return errors.CompositeValidationError(res...)
 	}
 	return nil
+}
+
+// GetMap returns a map with the Labels in key-value format. If one label
+// cannot be in the key-value format will be skipped on the output.
+func (m Labels) GetMap() map[string]string {
+	var result = map[string]string{}
+
+	for _, label := range m {
+		lbl := strings.Split(label, ":")
+		if len(lbl) != 2 {
+			continue
+		}
+		values := strings.Split(lbl[1], "=")
+		if len(values) < 2 {
+			continue
+		}
+		result[values[0]] = strings.Join(values[1:], "=")
+	}
+	return result
 }

--- a/api/v1/models/labels_test.go
+++ b/api/v1/models/labels_test.go
@@ -1,0 +1,33 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/api/v1/models"
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type LabelSuite struct{}
+
+var _ = Suite(&LabelSuite{})
+
+func (b *LabelSuite) TestsLabelsGetMap(c *C) {
+	labels := models.Labels{
+		"k8s:zgroup=testapp",
+		"k8s:appSecond=true",
+		"k8s:testNew=mynewvalue=true",
+	}
+	lblMap := labels.GetMap()
+
+	expectedOutPut := map[string]string{
+		"zgroup":    "testapp",
+		"appSecond": "true",
+		"testNew":   "mynewvalue=true",
+	}
+	c.Assert(lblMap, DeepEquals, expectedOutPut)
+}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -620,7 +620,8 @@ func (e *Endpoint) RunK8sCiliumEndpointSync() {
 				// The CEP was not found, this is the first creation of the endpoint
 				cep = &cilium_v2.CiliumEndpoint{
 					ObjectMeta: meta_v1.ObjectMeta{
-						Name: podName,
+						Name:   podName,
+						Labels: k8sMdl.Status.Identity.Labels.GetMap(),
 					},
 					Status: *k8sMdl,
 				}


### PR DESCRIPTION
At the moment the cilium endpoints resource does not set the pod labels
in the metadata, this commit added that labels into the metadata.

The reason is to allow users and e2e testing to filter by labels, like
`kubectl get cep -l zgroup=testapp`

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5075)
<!-- Reviewable:end -->
