### PR TITLE
policy: Introduce rate limiting for TriggerPolicyUpdates()

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -143,6 +143,8 @@ func (ds *DaemonSuite) TearDownTest(c *C) {
 	// Release the identity allocator reference created by NewDaemon. This
 	// is done manually here as we have no Close() function daemon
 	cache.Close()
+
+	ds.d.Close()
 }
 
 type DaemonEtcdSuite struct {

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -44,8 +44,7 @@ import (
 // This may be called in a variety of situations: after policy changes, changes
 // in agent configuration, changes in endpoint labels, and change of security
 // identities.
-// Returns a waiting group which signals when all endpoints are regenerated.
-func (d *Daemon) TriggerPolicyUpdates(force bool, reason string) *sync.WaitGroup {
+func (d *Daemon) TriggerPolicyUpdates(force bool, reason string) {
 	if force {
 		d.policy.BumpRevision() // force policy recalculation
 		log.Debugf("Forced policy recalculation triggered")
@@ -53,7 +52,7 @@ func (d *Daemon) TriggerPolicyUpdates(force bool, reason string) *sync.WaitGroup
 		log.Debugf("Full policy recalculation triggered")
 	}
 	regenerationMetadata := &endpoint.ExternalRegenerationMetadata{Reason: reason}
-	return endpointmanager.RegenerateAllEndpoints(d, regenerationMetadata)
+	endpointmanager.RegenerateAllEndpoints(d, regenerationMetadata)
 }
 
 type getPolicyResolve struct {

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"sync"
 	"testing"
 	"time"
 
@@ -93,8 +92,7 @@ func (o *testObserver) OnDelete(k store.Key) {
 
 type identityAllocatorOwnerMock struct{}
 
-func (i *identityAllocatorOwnerMock) TriggerPolicyUpdates(force bool, reason string) *sync.WaitGroup {
-	return nil
+func (i *identityAllocatorOwnerMock) TriggerPolicyUpdates(force bool, reason string) {
 }
 
 func (i *identityAllocatorOwnerMock) GetNodeSuffix() string {

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -17,8 +17,6 @@
 package cache
 
 import (
-	"sync"
-
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -102,8 +100,7 @@ func (e *IdentityAllocatorConsulSuite) SetUpTest(c *C) {
 
 type dummyOwner struct{}
 
-func (d dummyOwner) TriggerPolicyUpdates(force bool, reason string) *sync.WaitGroup {
-	return nil
+func (d dummyOwner) TriggerPolicyUpdates(force bool, reason string) {
 }
 
 func (d dummyOwner) GetNodeSuffix() string {

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -17,7 +17,6 @@ package cache
 import (
 	"fmt"
 	"path"
-	"sync"
 
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/idpool"
@@ -73,7 +72,7 @@ var (
 type IdentityAllocatorOwner interface {
 	// TriggerPolicyUpdates will be called whenever a policy recalculation
 	// must be triggered
-	TriggerPolicyUpdates(force bool, reason string) *sync.WaitGroup
+	TriggerPolicyUpdates(force bool, reason string)
 
 	// GetSuffix must return the node specific suffix to use
 	GetNodeSuffix() string

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -506,6 +506,16 @@ func MustRegister(c prometheus.Collector) {
 	registry.MustRegister(c)
 }
 
+// Register registers a collector
+func Register(c prometheus.Collector) error {
+	return registry.Register(c)
+}
+
+// Unregister unregisters a collector
+func Unregister(c prometheus.Collector) bool {
+	return registry.Unregister(c)
+}
+
 // Enable begins serving prometheus metrics on the address passed in. Addresses
 // of the form ":8080" will bind the port on all interfaces.
 func Enable(addr string) <-chan error {

--- a/pkg/trigger/trigger_test.go
+++ b/pkg/trigger/trigger_test.go
@@ -61,8 +61,8 @@ func (s *TriggerTestSuite) TestMinInterval(c *C) {
 		triggered int
 	)
 
-	t := NewTrigger(Parameters{
-		TriggerFunc: func() {
+	t, err := NewTrigger(Parameters{
+		TriggerFunc: func(reasons []string) {
 			mutex.Lock()
 			triggered++
 			mutex.Unlock()
@@ -70,6 +70,7 @@ func (s *TriggerTestSuite) TestMinInterval(c *C) {
 		MinInterval:   time.Millisecond * 500,
 		sleepInterval: time.Millisecond,
 	})
+	c.Assert(err, IsNil)
 	c.Assert(t, Not(IsNil))
 
 	// Trigger multiple times and sleep in between to guarantee that the
@@ -95,8 +96,8 @@ func (s *TriggerTestSuite) TestLongTrigger(c *C) {
 		triggered int
 	)
 
-	t := NewTrigger(Parameters{
-		TriggerFunc: func() {
+	t, err := NewTrigger(Parameters{
+		TriggerFunc: func(reasons []string) {
 			mutex.Lock()
 			triggered++
 			mutex.Unlock()
@@ -104,6 +105,7 @@ func (s *TriggerTestSuite) TestLongTrigger(c *C) {
 		},
 		sleepInterval: time.Millisecond,
 	})
+	c.Assert(err, IsNil)
 	c.Assert(t, Not(IsNil))
 
 	// Trigger multiple times and sleep in between to guarantee that the


### PR DESCRIPTION
TriggerPolicyUpdates() is called when policy recalculation is required. It can
be called subsequently in short intervals on mass policy imports. On such
occasions, it makes sense to batch updates together and limit calls to
TriggerPolicyUpdates() to a certain rate.

The pkg/trigger package is extended to understand trigger reasons. Metrics are
added to provide visibility into the trigger reasons, the effectiveness of the
batching, and the latency in form of a histogram on how long the policy update
is being delayed.

By introducing rate limiting at TriggerPolicyUpdates(), the existing rate
limiter in pkg/identity/cache/ can be removed.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5077)
<!-- Reviewable:end -->
