### PR TITLE
CNI: Set correctly the log level.

### DIFF
--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -50,7 +50,7 @@ var (
 )
 
 func init() {
-	log.Level = logrus.DebugLevel
+	logging.SetLogLevel(logrus.DebugLevel)
 	runtime.LockOSThread()
 }
 


### PR DESCRIPTION
The current log level was not set correctly due it was set for log
instead for the logging object.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5080)
<!-- Reviewable:end -->
