### PR TITLE
envoy: Sanitize HTTP headers

### DIFF
--- a/envoy/cilium_integration_test.cc
+++ b/envoy/cilium_integration_test.cc
@@ -613,6 +613,11 @@ TEST_P(CiliumIntegrationTest, AllowedPathPrefix) {
   Accepted({{":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}});
 }
 
+TEST_P(CiliumIntegrationTest, AllowedPathPrefixStrippedHeader) {
+  Accepted({{":method", "GET"}, {":path", "/allowed"}, {":authority", "host"},
+            {"x-envoy-original-dst-host", "1.1.1.1:9999"}});
+}
+
 TEST_P(CiliumIntegrationTest, AllowedPathRegex) {
   Accepted({{":method", "GET"}, {":path", "/maybe/public"}, {":authority", "host"}});
 }

--- a/envoy/cilium_l7policy.cc
+++ b/envoy/cilium_l7policy.cc
@@ -125,6 +125,7 @@ void Config::Log(AccessLog::Entry &entry, ::cilium::EntryType type) {
 void AccessFilter::onDestroy() {}
 
 Http::FilterHeadersStatus AccessFilter::decodeHeaders(Http::HeaderMap& headers, bool) {
+  headers.remove(Http::Headers::get().EnvoyOriginalDstHost);
   const auto& conn = callbacks_->connection();
   bool ingress = false;
   bool allowed = false;


### PR DESCRIPTION
Remove HTTP headers that might interfere with the original destination processing.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5083)
<!-- Reviewable:end -->
