### PR TITLE
Test: extend validate on errors on Runtime

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -648,11 +648,11 @@ func (s *SSHMeta) ValidateNoErrorsOnLogs(duration time.Duration) {
 			return
 		}
 		err = ioutil.WriteFile(
-			fmt.Sprintf("%s/cilium_test.log", testPath),
+			fmt.Sprintf("%s/%s", testPath, CiliumTestLog),
 			[]byte(logs), LogPerm)
 
 		if err != nil {
-			s.logger.WithError(err).Error("Cannot create cilium_test.log")
+			s.logger.WithError(err).Errorf("Cannot create %s", CiliumTestLog)
 		}
 	}()
 

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -169,6 +169,10 @@ const (
 	MonitorLogFileName = "monitor.log"
 	microscopeManifest = "microscope.yaml"
 
+	// CiliumTestLog is the filename where the cilium logs that happens during
+	// the test are saved.
+	CiliumTestLog = "cilium-test.log"
+
 	// IPv4Host is an IP which is used in some datapath tests for simulating external IPv4 connectivity.
 	IPv4Host = "192.168.254.254"
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1061,11 +1061,11 @@ func (kub *Kubectl) ValidateNoErrorsOnLogs(duration time.Duration) {
 			return
 		}
 		err = ioutil.WriteFile(
-			fmt.Sprintf("%s/cilium_test.log", testPath),
+			fmt.Sprintf("%s/%s", testPath, CiliumTestLog),
 			[]byte(logs), LogPerm)
 
 		if err != nil {
-			kub.logger.WithError(err).Error("Cannot create cilium_test.log")
+			kub.logger.WithError(err).Errorf("Cannot create %s", CiliumTestLog)
 		}
 	}()
 


### PR DESCRIPTION
Currently the runtime test does not have the full validation of logs
messages as Kubernetes test. This adds al the methods for fail and
checks.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5086)
<!-- Reviewable:end -->
