### PR TITLE
v1.0 backports 2018-08-03

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1391,6 +1391,32 @@ func (d *Daemon) syncExternalLB(newSN, modSN, delSN *types.K8sServiceNamespace) 
 	return nil
 }
 
+// getUpdatedCNPFromStore gets the most recent version of cnp from the store
+// ciliumV2Store, which is updated by the Kubernetes watcher. This reduces
+// the possibility of Cilium trying to update cnp in Kubernetes which has
+// been updated between the time the watcher in this Cilium instance has
+// received cnp, and when this function is called. This still may occur, though
+// and users of the returned CiliumNetworkPolicy may not be able to update
+// the cnp because it may become out-of-date. Returns an error if the CNP cannot
+// be retrieved from the store, or the object retrieved from the store is not of
+// the expected type.
+func getUpdatedCNPFromStore(ciliumV2Store cache.Store, cnp *cilium_v2.CiliumNetworkPolicy) (*cilium_v2.CiliumNetworkPolicy, error) {
+	serverRuleStore, exists, err := ciliumV2Store.Get(cnp)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find v2.CiliumNetworkPolicy in local cache: %s", err)
+	}
+	if !exists {
+		return nil, errors.New("v2.CiliumNetworkPolicy does not exist in local cache")
+	}
+
+	serverRule, ok := serverRuleStore.(*cilium_v2.CiliumNetworkPolicy)
+	if !ok {
+		return nil, errors.New("Received object of unknown type from API server, expecting v2.CiliumNetworkPolicy")
+	}
+
+	return serverRule, nil
+}
+
 func (d *Daemon) addCiliumNetworkPolicyV2(ciliumV2Store cache.Store, cnp *cilium_v2.CiliumNetworkPolicy) {
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.CiliumNetworkPolicyName: cnp.ObjectMeta.Name,
@@ -1402,18 +1428,18 @@ func (d *Daemon) addCiliumNetworkPolicyV2(ciliumV2Store cache.Store, cnp *cilium
 
 	var rev uint64
 
-	rules, err := cnp.Parse()
-	if err == nil && len(rules) > 0 {
+	rules, policyImportErr := cnp.Parse()
+	if policyImportErr == nil && len(rules) > 0 {
 		d.loadBalancer.K8sMU.Lock()
-		err = k8s.PreprocessRules(rules, d.loadBalancer.K8sEndpoints, d.loadBalancer.K8sServices)
+		policyImportErr = k8s.PreprocessRules(rules, d.loadBalancer.K8sEndpoints, d.loadBalancer.K8sServices)
 		d.loadBalancer.K8sMU.Unlock()
-		if err == nil {
-			rev, err = d.PolicyAdd(rules, &AddOptions{Replace: true})
+		if policyImportErr == nil {
+			rev, policyImportErr = d.PolicyAdd(rules, &AddOptions{Replace: true})
 		}
 	}
 
-	if err != nil {
-		scopedLog.WithError(err).Warn("Unable to add CiliumNetworkPolicy")
+	if policyImportErr != nil {
+		scopedLog.WithError(policyImportErr).Warn("Unable to add CiliumNetworkPolicy")
 	} else {
 		scopedLog.Info("Imported CiliumNetworkPolicy")
 	}
@@ -1427,69 +1453,91 @@ func (d *Daemon) addCiliumNetworkPolicyV2(ciliumV2Store cache.Store, cnp *cilium
 
 				waitForEPsErr := endpointmanager.WaitForEndpointsAtPolicyRev(ctx, rev)
 
-				serverRuleStore, exists, err2 := ciliumV2Store.Get(cnp)
-				if err2 != nil {
-					return fmt.Errorf("unable to find v2.CiliumNetworkPolicy in local cache: %s", err2)
-				}
-				if !exists {
-					return errors.New("v2.CiliumNetworkPolicy does not exist in local cache")
+				serverRule, fromStoreErr := getUpdatedCNPFromStore(ciliumV2Store, cnp)
+				if fromStoreErr != nil {
+					scopedLog.WithError(fromStoreErr).Error("error getting updated CNP from store")
+					return fromStoreErr
 				}
 
-				serverRule, ok := serverRuleStore.(*cilium_v2.CiliumNetworkPolicy)
-				if !ok {
-					scopedLog.WithFields(logrus.Fields{
-						logfields.CiliumNetworkPolicy: logfields.Repr(serverRuleStore),
-					}).Warn("Received object of unknown type from API server, expecting v2.CiliumNetworkPolicy")
-					return errors.New("Received object of unknown type from API server, expecting v2.CiliumNetworkPolicy")
-				}
-
+				// Make a copy since the rule is a pointer, and any of its fields
+				// which are also pointers could be modified outside of this
+				// function.
 				serverRuleCpy := serverRule.DeepCopy()
-				_, err2 = serverRuleCpy.Parse()
-				if err2 != nil {
+				_, ruleCopyParseErr := serverRuleCpy.Parse()
+				if ruleCopyParseErr != nil {
 					// If we can't parse the rule then we should signalize
 					// it in the status
-					log.WithError(err2).WithField(logfields.Object, logfields.Repr(serverRuleCpy)).
+					log.WithError(ruleCopyParseErr).WithField(logfields.Object, logfields.Repr(serverRuleCpy)).
 						Warn("Error parsing new CiliumNetworkPolicy rule")
 				}
 
-				cnpns := cilium_v2.CiliumNetworkPolicyNodeStatus{
-					OK: true,
-					// If the deadline was reached then not all endpoints are enforcing
-					// the given policy.
-					Enforcing:   waitForEPsErr == nil,
-					Revision:    rev,
-					LastUpdated: cilium_v2.NewTimestamp(),
+				var err3 error
+
+				// Update the status of whether the rule is enforced on this node.
+				// If we are unable to parse the CNP retrieved from the store,
+				// or if endpoints did not reach the desired policy revision
+				// after 30 seconds, then mark the rule as not being enforced.
+				if policyImportErr != nil {
+					// OK is false here because the policy wasn't imported into
+					// cilium on this node; since it wasn't imported, it also
+					// isn't enforced.
+					err3 = updateCNPNodeStatus(serverRuleCpy, false, false, policyImportErr, rev, cnp.Annotations)
+				} else if ruleCopyParseErr != nil {
+					// This handles the case where the initial instance of this
+					// rule was imported into the policy repository successfully
+					// (policyImportErr == nil), but, the rule has been updated
+					// in the store soon after, and is now invalid. As such,
+					// the rule is not OK because it cannot be imported due
+					// to parsing errors, and cannot be enforced because it is
+					// not OK.
+					err3 = updateCNPNodeStatus(serverRuleCpy, false, false, ruleCopyParseErr, rev, cnp.Annotations)
+				} else {
+					// If the deadline by the above context, then not all
+					// endpoints are enforcing the given policy, and
+					// waitForEpsErr will be non-nil.
+					err3 = updateCNPNodeStatus(serverRuleCpy, waitForEPsErr == nil, true, waitForEPsErr, rev, cnp.Annotations)
 				}
 
-				// Most important is the error while adding the CNP
-				if err != nil {
-					cnpns = cilium_v2.CiliumNetworkPolicyNodeStatus{
-						Error:       err.Error(),
-						OK:          false,
-						LastUpdated: cilium_v2.NewTimestamp(),
-					}
-				} else if err2 != nil {
-					cnpns = cilium_v2.CiliumNetworkPolicyNodeStatus{
-						Error:       err2.Error(),
-						OK:          false,
-						LastUpdated: cilium_v2.NewTimestamp(),
-					}
-				}
-
-				nodeName := node.GetName()
-				serverRuleCpy.SetPolicyStatus(nodeName, cnpns)
-				ns := k8sUtils.ExtractNamespace(&serverRuleCpy.ObjectMeta)
-
-				_, err2 = ciliumNPClient.CiliumV2().CiliumNetworkPolicies(ns).Update(serverRuleCpy)
-				if err2 == nil {
+				if err3 == nil {
 					scopedLog.WithField("status", serverRuleCpy.Status).Debug("successfully updated with status")
 				} else {
-					return err2
+					return err3
 				}
+
 				return waitForEPsErr
 			},
 		},
 	)
+}
+
+func updateCNPNodeStatus(cnp *cilium_v2.CiliumNetworkPolicy, enforcing, ok bool, err error, rev uint64, annotations map[string]string) error {
+	var (
+		cnpns cilium_v2.CiliumNetworkPolicyNodeStatus
+		err2  error
+	)
+
+	if err != nil {
+		cnpns = cilium_v2.CiliumNetworkPolicyNodeStatus{
+			Enforcing:   enforcing,
+			Error:       err.Error(),
+			OK:          ok,
+			LastUpdated: cilium_v2.NewTimestamp(),
+		}
+	} else {
+		cnpns = cilium_v2.CiliumNetworkPolicyNodeStatus{
+			Enforcing:   enforcing,
+			Revision:    rev,
+			OK:          ok,
+			LastUpdated: cilium_v2.NewTimestamp(),
+		}
+	}
+
+	nodeName := node.GetName()
+	cnp.SetPolicyStatus(nodeName, cnpns)
+	ns := k8sUtils.ExtractNamespace(&cnp.ObjectMeta)
+
+	_, err2 = ciliumNPClient.CiliumV2().CiliumNetworkPolicies(ns).Update(cnp)
+	return err2
 }
 
 func (d *Daemon) deleteCiliumNetworkPolicyV2(cnp *cilium_v2.CiliumNetworkPolicy) {
@@ -1525,6 +1573,38 @@ func (d *Daemon) deleteCiliumNetworkPolicyV2(cnp *cilium_v2.CiliumNetworkPolicy)
 	}
 }
 
+func updateRuleAnnotations(ciliumV2Store cache.Store, cnp *cilium_v2.CiliumNetworkPolicy) error {
+
+	updatedCNPFromStore, err := getUpdatedCNPFromStore(ciliumV2Store, cnp)
+	if err != nil {
+		return err
+	}
+
+	// Make a copy since the rule is a pointer, and any of its fields
+	// which are also pointers could be modified outside of this
+	// function.
+	updatedCNPFromStoreCopy := updatedCNPFromStore.DeepCopy()
+
+	// Only update annotations for node on which this agent is running.
+	nodeName := node.GetName()
+	cnpNodeStatus := cnp.GetPolicyStatus(nodeName)
+
+	var cnpErr error
+	if cnpNodeStatus.Error != "" {
+		cnpErr = fmt.Errorf(cnpNodeStatus.Error)
+	}
+
+	// Update server with updated rule with new annotations.
+	err = updateCNPNodeStatus(updatedCNPFromStoreCopy, cnpNodeStatus.Enforcing, cnpNodeStatus.OK, cnpErr, cnpNodeStatus.Revision, cnp.Annotations)
+	if err != nil {
+		return err
+	}
+
+	log.WithField("rule", logfields.Repr(updatedCNPFromStoreCopy)).Debug("rule had no policy changes, but had annotation changes; successfully updated annotations of rule")
+
+	return nil
+}
+
 func (d *Daemon) updateCiliumNetworkPolicyV2(ciliumV2Store cache.Store,
 	oldRuleCpy, newRuleCpy *cilium_v2.CiliumNetworkPolicy) {
 
@@ -1541,17 +1621,49 @@ func (d *Daemon) updateCiliumNetworkPolicyV2(ciliumV2Store cache.Store,
 		return
 	}
 
-	// Ignore updates of the spec remains unchanged.
+	// Do not add rule into policy repository if the spec remains unchanged, as
+	// policy recalculation is not needed.
 	if oldRuleCpy.SpecEquals(newRuleCpy) {
+		// If the annotations differ between the rules, but the specs are the same,
+		// just update the annotations within the CNP new rule directly, but
+		// only if the policy has already been realized for all endpoints.
+		if !oldRuleCpy.AnnotationsEquals(newRuleCpy) {
+
+			// Update annotations within a controller so the status of the update
+			// is trackable from the list of running controllers, and so we do
+			// not block subsequent policy lifecycle operations from Kubernetes
+			// until the update is complete.
+			oldCtrlName := oldRuleCpy.GetControllerName()
+			newCtrlName := newRuleCpy.GetControllerName()
+
+			// In case the controller name changes between copies of rules,
+			// remove old controller so we do not leak goroutines.
+			if oldCtrlName != newCtrlName {
+				err := k8sCM.RemoveController(oldCtrlName)
+				if err != nil {
+					log.Debugf("Unable to remove controller %s: %s", oldCtrlName, err)
+				}
+			}
+
+			k8sCM.UpdateController(newCtrlName,
+				controller.ControllerParams{
+					DoFunc: func() error {
+						return updateRuleAnnotations(ciliumV2Store, newRuleCpy)
+					},
+				},
+			)
+		}
+
 		return
+
 	}
 
 	log.WithFields(logrus.Fields{
 		logfields.K8sAPIVersion:                    oldRuleCpy.TypeMeta.APIVersion,
 		logfields.CiliumNetworkPolicyName + ".old": oldRuleCpy.ObjectMeta.Name,
 		logfields.K8sNamespace + ".old":            oldRuleCpy.ObjectMeta.Namespace,
-		logfields.CiliumNetworkPolicyName + ".new": newRuleCpy.ObjectMeta.Name,
-		logfields.K8sNamespace + ".new":            newRuleCpy.ObjectMeta.Namespace,
+		logfields.CiliumNetworkPolicyName:          newRuleCpy.ObjectMeta.Name,
+		logfields.K8sNamespace:                     newRuleCpy.ObjectMeta.Namespace,
 	}).Debug("Modified CiliumNetworkPolicy")
 
 	d.addCiliumNetworkPolicyV2(ciliumV2Store, newRuleCpy)

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -713,7 +713,7 @@ func runDaemon() {
 	}
 
 	log.Info("Launching node monitor daemon")
-	go d.nodeMonitor.Run(path.Join(defaults.RuntimePath, defaults.EventsPipe))
+	go d.nodeMonitor.Run(path.Join(defaults.RuntimePath, defaults.EventsPipe), bpf.GetMapRoot())
 
 	// Launch cilium-health in the same namespace as cilium.
 	log.Info("Launching Cilium health daemon")

--- a/monitor/launch/launcher.go
+++ b/monitor/launch/launcher.go
@@ -75,7 +75,7 @@ func (nm *NodeMonitor) GetPid() int {
 }
 
 // Run starts the node monitor.
-func (nm *NodeMonitor) Run(sockPath string) {
+func (nm *NodeMonitor) Run(sockPath, bpfRoot string) {
 	nm.SetTarget(targetName)
 	for {
 		os.Remove(sockPath)
@@ -94,6 +94,7 @@ func (nm *NodeMonitor) Run(sockPath string) {
 		nm.pipe = pipe
 		nm.Mutex.Unlock()
 
+		nm.Launcher.SetArgs([]string{"--bpf-root", bpfRoot})
 		nm.Launcher.Run()
 
 		r := bufio.NewReader(nm.GetStdout())

--- a/monitor/launch/launcher.go
+++ b/monitor/launch/launcher.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/monitor/payload"
+	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/launcher"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
@@ -38,9 +39,6 @@ const (
 
 	// queueSize is the size of the message queue
 	queueSize = 524288
-
-	// restartInterval is the delay between attempts to restart node-monitor
-	restartInterval = time.Second
 )
 
 // NodeMonitor is used to wrap the node executable binary.
@@ -74,43 +72,65 @@ func (nm *NodeMonitor) GetPid() int {
 	return nm.GetProcess().Pid
 }
 
-// Run starts the node monitor.
+// run creates a FIFO at sockPath, launches the monitor as sub process and then
+// reads stdout from the monitor and updates nm.state accordingly. The function
+// returns with an error if the FIFO cannot be created, opened or if the an
+// error was encountered while reading stdout from the monitor. The FIFO is always
+// removed again when the function returns.
+func (nm *NodeMonitor) run(sockPath, bpfRoot string) error {
+	os.Remove(sockPath)
+	if err := syscall.Mkfifo(sockPath, 0600); err != nil {
+		return fmt.Errorf("Unable to create named pipe %s: %s", sockPath, err)
+	}
+
+	defer os.Remove(sockPath)
+
+	pipe, err := os.OpenFile(sockPath, os.O_RDWR, 0600)
+	if err != nil {
+		return fmt.Errorf("Unable to open named pipe for writing: %s", err)
+	}
+
+	defer pipe.Close()
+
+	nm.pipeLock.Lock()
+	nm.pipe = pipe
+	nm.pipeLock.Unlock()
+
+	nm.Launcher.SetArgs([]string{"--bpf-root", bpfRoot})
+	if err := nm.Launcher.Run(); err != nil {
+		return err
+	}
+
+	r := bufio.NewReader(nm.GetStdout())
+	for nm.GetProcess() != nil {
+		l, err := r.ReadBytes('\n') // this is a blocking read
+		if err != nil {
+			return fmt.Errorf("Unable to read stdout from monitor: %s", err)
+		}
+
+		var tmp *models.MonitorStatus
+		if err := json.Unmarshal(l, &tmp); err != nil {
+			return fmt.Errorf("Unable to unmarshal stdout from monitor: %s", err)
+		}
+
+		nm.setState(tmp)
+	}
+
+	return fmt.Errorf("Monitor process quit unexepctedly")
+}
+
+// Run starts the node monitor and keeps on restarting it. The function will
+// never return.
 func (nm *NodeMonitor) Run(sockPath, bpfRoot string) {
+	backoffConfig := backoff.Exponential{Min: time.Second, Max: 2 * time.Minute}
+
 	nm.SetTarget(targetName)
 	for {
-		os.Remove(sockPath)
-		if err := syscall.Mkfifo(sockPath, 0600); err != nil {
-			log.WithError(err).Fatalf("Unable to create named pipe %s", sockPath)
-			time.Sleep(time.Duration(5) * time.Second)
+		if err := nm.run(sockPath, bpfRoot); err != nil {
+			log.WithError(err).Warning("Error while running monitor")
 		}
 
-		pipe, err := os.OpenFile(sockPath, os.O_RDWR, 0600)
-		if err != nil {
-			log.WithError(err).Fatal("Unable to open named pipe for writing")
-			time.Sleep(time.Duration(5) * time.Second)
-		}
-
-		nm.Mutex.Lock()
-		nm.pipe = pipe
-		nm.Mutex.Unlock()
-
-		nm.Launcher.SetArgs([]string{"--bpf-root", bpfRoot})
-		nm.Launcher.Run()
-
-		r := bufio.NewReader(nm.GetStdout())
-		for nm.GetProcess() != nil {
-			l, _ := r.ReadBytes('\n') // this is a blocking read
-			var tmp *models.MonitorStatus
-			if err := json.Unmarshal(l, &tmp); err != nil {
-				continue
-			}
-			nm.setState(tmp)
-		}
-
-		pipe.Close()
-
-		// throttle breakage loops
-		time.Sleep(restartInterval)
+		backoffConfig.Wait()
 	}
 }
 

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/daemon/defaults"
 	"github.com/cilium/cilium/pkg/apisocket"
+	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
@@ -49,10 +50,15 @@ var (
 		},
 	}
 	npages int
+
+	// bpfRoot is the path to the BPF mount. This can be non-default if
+	// cilium-agent mounts bpf at an alternate location.
+	bpfRoot string
 )
 
 func init() {
 	rootCmd.Flags().IntVar(&npages, "num-pages", 64, "Number of pages for ring buffer")
+	rootCmd.Flags().StringVar(&bpfRoot, "bpf-root", "/sys/fs/bpf", "Path to the root of the bpf mount")
 }
 
 func execute() {
@@ -67,6 +73,8 @@ func main() {
 }
 
 func runNodeMonitor() {
+	bpf.SetMapRoot(bpfRoot)
+
 	eventSockPath := path.Join(defaults.RuntimePath, defaults.EventsPipe)
 	pipe, err := os.OpenFile(eventSockPath, os.O_RDONLY, 0600)
 	if err != nil {

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -71,10 +71,13 @@ type CiliumNetworkPolicyStatus struct {
 // CiliumNetworkPolicyNodeStatus is the status of a Cilium policy rule for a
 // specific node
 type CiliumNetworkPolicyNodeStatus struct {
-	// OK is true when the policy has been installed successfully
+	// OK is true when the policy has been parsed and imported successfully
+	// into the in-memory policy repository on the node.
 	OK bool `json:"ok,omitempty"`
 
-	// Error describes the error condition if OK is false
+	// Error describes any error that occurred when parsing or importing the
+	// policy, or realizing the policy for the endpoints to which it applies
+	// on the node.
 	Error string `json:"error,omitempty"`
 
 	// LastUpdated contains the last time this status was updated
@@ -107,6 +110,16 @@ func (t *Timestamp) DeepCopyInto(out *Timestamp) {
 	*out = *t
 }
 
+// GetPolicyStatus returns the CiliumNetworkPolicyNodeStatus corresponding to
+// nodeName in the provided CiliumNetworkPolicy. If Nodes within the rule's
+// Status is nil, returns an empty CiliumNetworkPolicyNodeStatus.
+func (r *CiliumNetworkPolicy) GetPolicyStatus(nodeName string) CiliumNetworkPolicyNodeStatus {
+	if r.Status.Nodes == nil {
+		return CiliumNetworkPolicyNodeStatus{}
+	}
+	return r.Status.Nodes[nodeName]
+}
+
 // SetPolicyStatus sets the given policy status for the given nodes' map
 func (r *CiliumNetworkPolicy) SetPolicyStatus(nodeName string, cnpns CiliumNetworkPolicyNodeStatus) {
 	if r.Status.Nodes == nil {
@@ -122,6 +135,16 @@ func (r *CiliumNetworkPolicy) SpecEquals(o *CiliumNetworkPolicy) bool {
 	}
 	return reflect.DeepEqual(r.Spec, o.Spec) &&
 		reflect.DeepEqual(r.Specs, o.Specs)
+}
+
+// AnnotationsEquals returns true if ObjectMeta.Annotations of each
+// CiliumNetworkPolicy are equivalent (i.e., they contain equivalent key-value
+// pairs).
+func (r *CiliumNetworkPolicy) AnnotationsEquals(o *CiliumNetworkPolicy) bool {
+	if o == nil {
+		return r == nil
+	}
+	return reflect.DeepEqual(r.ObjectMeta.Annotations, o.ObjectMeta.Annotations)
 }
 
 // Parse parses a CiliumNetworkPolicy and returns a list of cilium policy

--- a/pkg/launcher/launcher.go
+++ b/pkg/launcher/launcher.go
@@ -36,7 +36,7 @@ type Launcher struct {
 }
 
 // Run starts the daemon.
-func (launcher *Launcher) Run() {
+func (launcher *Launcher) Run() error {
 	targetName := launcher.GetTarget()
 	cmd := exec.Command(targetName, launcher.GetArgs()...)
 	cmd.Stderr = os.Stderr
@@ -44,10 +44,13 @@ func (launcher *Launcher) Run() {
 	if err := cmd.Start(); err != nil {
 		cmdStr := fmt.Sprintf("%s %s", targetName, launcher.GetArgs())
 		log.WithError(err).WithField("cmd", cmdStr).Error("cmd.Start()")
+		return fmt.Errorf("unable to launch process %s: %s", cmdStr, err)
 	}
 
 	launcher.setProcess(cmd.Process)
 	launcher.setStdout(stdout)
+
+	return nil
 }
 
 // Restart stops the launcher which will trigger a rerun.


### PR DESCRIPTION
* #4492
  * Conflicts again @ianvernon, details below
  * See also the backport approach taken in #5081
* #5074
  * Depended on #4286 , so I backported this to resolve the conflict.


Conflict for  ab77b79b4c38 ("daemon: refactor updating of CNP Node Status"):

```
diff --cc daemon/k8s_watcher.go
index 59d966bcd6cd,942f2d4b6ee5..000000000000
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@@ -1452,40 -1477,39 +1471,72 @@@ func (d *Daemon) addCiliumNetworkPolicy
                                                Warn("Error parsing new CiliumNetworkPolicy rule")
                                }
  
++<<<<<<< HEAD
 +                              cnpns := cilium_v2.CiliumNetworkPolicyNodeStatus{
 +                                      OK: true,
 +                                      // If the deadline was reached then not all endpoints are enforcing
 +                                      // the given policy.
 +                                      Enforcing:   waitForEPsErr == nil,
 +                                      Revision:    rev,
 +                                      LastUpdated: cilium_v2.NewTimestamp(),
 +                              }
 +
 +                              // Most important is the error while adding the CNP
 +                              if err != nil {
 +                                      cnpns = cilium_v2.CiliumNetworkPolicyNodeStatus{
 +                                              Error:       err.Error(),
 +                                              OK:          false,
 +                                              LastUpdated: cilium_v2.NewTimestamp(),
 +                                      }
 +                              } else if err2 != nil {
 +                                      cnpns = cilium_v2.CiliumNetworkPolicyNodeStatus{
 +                                              Error:       err2.Error(),
 +                                              OK:          false,
 +                                              LastUpdated: cilium_v2.NewTimestamp(),
 +                                      }
 +                              }
 +
 +                              nodeName := node.GetName()
 +                              serverRuleCpy.SetPolicyStatus(nodeName, cnpns)
 +                              ns := k8sUtils.ExtractNamespace(&serverRuleCpy.ObjectMeta)
 +
 +                              _, err2 = ciliumNPClient.CiliumV2().CiliumNetworkPolicies(ns).Update(serverRuleCpy)
 +                              if err2 == nil {
++=======
+                               var err3 error
+ 
+                               // Update the status of whether the rule is enforced on this node.
+                               // If we are unable to parse the CNP retrieved from the store,
+                               // or if endpoints did not reach the desired policy revision
+                               // after 30 seconds, then mark the rule as not being enforced.
+                               if policyImportErr != nil {
+                                       // OK is false here because the policy wasn't imported into
+                                       // cilium on this node; since it wasn't imported, it also
+                                       // isn't enforced.
+                                       err3 = updateCNPNodeStatus(serverRuleCpy, false, false, policyImportErr, rev, cnp.Annotations)
+                               } else if ruleCopyParseErr != nil {
+                                       // This handles the case where the initial instance of this
+                                       // rule was imported into the policy repository successfully
+                                       // (policyImportErr == nil), but, the rule has been updated
+                                       // in the store soon after, and is now invalid. As such,
+                                       // the rule is not OK because it cannot be imported due
+                                       // to parsing errors, and cannot be enforced because it is
+                                       // not OK.
+                                       err3 = updateCNPNodeStatus(serverRuleCpy, false, false, ruleCopyParseErr, rev, cnp.Annotations)
+                               } else {
+                                       // If the deadline by the above context, then not all
+                                       // endpoints are enforcing the given policy, and
+                                       // waitForEpsErr will be non-nil.
+                                       err3 = updateCNPNodeStatus(serverRuleCpy, waitForEPsErr == nil, true, waitForEPsErr, rev, cnp.Annotations)
+                               }
+ 
+                               if err3 == nil {
++>>>>>>> daemon: refactor updating of CNP Node Status
                                        scopedLog.WithField("status", serverRuleCpy.Status).Debug("successfully updated with status")
                                } else {
-                                       return err2
+                                       return err3
                                }
+ 
                                return waitForEPsErr
                        },
                },
@@@ -1550,10 -1675,13 +1702,17 @@@ func (d *Daemon) updateCiliumNetworkPol
                logfields.K8sAPIVersion:                    oldRuleCpy.TypeMeta.APIVersion,
                logfields.CiliumNetworkPolicyName + ".old": oldRuleCpy.ObjectMeta.Name,
                logfields.K8sNamespace + ".old":            oldRuleCpy.ObjectMeta.Namespace,
++<<<<<<< HEAD
 +              logfields.CiliumNetworkPolicyName + ".new": newRuleCpy.ObjectMeta.Name,
 +              logfields.K8sNamespace + ".new":            newRuleCpy.ObjectMeta.Namespace,
++=======
+               logfields.CiliumNetworkPolicyName:          newRuleCpy.ObjectMeta.Name,
+               logfields.K8sNamespace:                     newRuleCpy.ObjectMeta.Namespace,
+               "annotations.old":                          oldRuleCpy.ObjectMeta.Annotations,
+               "annotations":                              newRuleCpy.ObjectMeta.Annotations,
++>>>>>>> daemon: refactor updating of CNP Node Status
        }).Debug("Modified CiliumNetworkPolicy")
  
 -      d.deleteCiliumNetworkPolicyV2(oldRuleCpy)
        d.addCiliumNetworkPolicyV2(ciliumV2Store, newRuleCpy)
  }
 
```

Applied this additional diff to fix merge conflicts:

```
diff --cc daemon/k8s_watcher.go
index 59d966bcd6cd,5583fb40f57a..000000000000
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1441,12 +1442,7 @@ func updateCNPNodeStatus(cnp *cilium_v2.CiliumNetworkPolicy, enforcing, ok bool,
        cnp.SetPolicyStatus(nodeName, cnpns)
        ns := k8sUtils.ExtractNamespace(&cnp.ObjectMeta)
 
-       switch {
-       case ciliumUpdateStatusVerConstr.Check(k8sServerVer):
-               _, err2 = ciliumNPClient.CiliumV2().CiliumNetworkPolicies(ns).UpdateStatus(cnp)
-       default:
-               _, err2 = ciliumNPClient.CiliumV2().CiliumNetworkPolicies(ns).Update(cnp)
-       }
+       _, err2 = ciliumNPClient.CiliumV2().CiliumNetworkPolicies(ns).Update(cnp)
        return err2
 }
 
@@@ -1492,6 -1414,38 +1510,36 @@@ func (d *Daemon) addCiliumNetworkPolicy
        )
  }

+ func updateCNPNodeStatus(cnp *cilium_v2.CiliumNetworkPolicy, enforcing, ok bool, err error, rev uint64, annotations map[string]string) error {
+       var (
+               cnpns cilium_v2.CiliumNetworkPolicyNodeStatus
+               err2  error
+       )
+ 
+       if err != nil {
+               cnpns = cilium_v2.CiliumNetworkPolicyNodeStatus{
+                       Enforcing:   enforcing,
+                       Error:       err.Error(),
+                       OK:          ok,
+                       LastUpdated: cilium_v2.NewTimestamp(),
 -                      Annotations: annotations,
+               }
+       } else {
+               cnpns = cilium_v2.CiliumNetworkPolicyNodeStatus{
+                       Enforcing:   enforcing,
+                       Revision:    rev,
+                       OK:          ok,
+                       LastUpdated: cilium_v2.NewTimestamp(),
 -                      Annotations: annotations,
+               }
+       }
+ 
+       nodeName := node.GetName()
+       cnp.SetPolicyStatus(nodeName, cnpns)
+       ns := k8sUtils.ExtractNamespace(&cnp.ObjectMeta)
+ 
+       _, err2 = ciliumNPClient.CiliumV2().CiliumNetworkPolicies(ns).Update(cnp)
+       return err2
+ }
+ 
  func (d *Daemon) deleteCiliumNetworkPolicyV2(cnp *cilium_v2.CiliumNetworkPolicy) {
        scopedLog := log.WithFields(logrus.Fields{
                logfields.CiliumNetworkPolicyName: cnp.ObjectMeta.Name,
@@@ -1550,8 -1568,10 +1662,8 @@@ func (d *Daemon) updateCiliumNetworkPol
                logfields.K8sAPIVersion:                    oldRuleCpy.TypeMeta.APIVersion,
                logfields.CiliumNetworkPolicyName + ".old": oldRuleCpy.ObjectMeta.Name,
                logfields.K8sNamespace + ".old":            oldRuleCpy.ObjectMeta.Namespace,
-               logfields.CiliumNetworkPolicyName + ".new": newRuleCpy.ObjectMeta.Name,
-               logfields.K8sNamespace + ".new":            newRuleCpy.ObjectMeta.Namespace,
+               logfields.CiliumNetworkPolicyName:          newRuleCpy.ObjectMeta.Name,
+               logfields.K8sNamespace:                     newRuleCpy.ObjectMeta.Namespace,
 -              "annotations.old":                          oldRuleCpy.ObjectMeta.Annotations,
 -              "annotations":                              newRuleCpy.ObjectMeta.Annotations,
        }).Debug("Modified CiliumNetworkPolicy")

        d.addCiliumNetworkPolicyV3(ciliumV2Store, newRuleCpy)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5091)
<!-- Reviewable:end -->
