### PR TITLE
ToFQDN Runtime test waits for DNS policy to take effect

### DIFF
--- a/pkg/fqdn/dnspoller.go
+++ b/pkg/fqdn/dnspoller.go
@@ -29,9 +29,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// generatedLabelNameUUID is the label key for policy rules that contain a
-// ToFQDN section and need to be updated
-const generatedLabelNameUUID = "ToFQDN-UUID"
+const (
+	// generatedLabelNameUUID is the label key for policy rules that contain a
+	// ToFQDN section and need to be updated
+	generatedLabelNameUUID = "ToFQDN-UUID"
+
+	// DNSPollerInterval is the time between 2 complete DNS lookup runs of the
+	// DNSPoller controller
+	DNSPollerInterval = 5 * time.Second
+)
 
 // uuidLabelSearchKey is an *extended* label key. This is because .Has
 // expects the source:key delimiter to be the labels.PathDelimiter
@@ -44,7 +50,7 @@ var uuidLabelSearchKey = generateUUIDLabel(nil).GetExtendedKey()
 func StartDNSPoller(poller *DNSPoller) {
 	log.Debug("Starting DNS poller for ToFQDN rules")
 	controller.NewManager().UpdateController("dns-poller", controller.ControllerParams{
-		RunInterval: 5 * time.Second,
+		RunInterval: DNSPollerInterval,
 		DoFunc:      poller.LookupUpdateDNS,
 		StopFunc: func() error {
 			log.Debug("Stopping DNS poller for ToFQDN rules")

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -900,20 +900,20 @@ var _ = Describe("RuntimePolicies", func() {
 		_, err := vm.PolicyRenderAndImport(fqdnPolicy)
 		Expect(err).To(BeNil(), "Unable to import policy: %s", err)
 
-		By("Denying egress to IPs of non-ToFQDN DNS names that are looked up")
+		By("Denying egress to IPs of DNS names not in ToFQDNs, and normal IPs")
 		// www.cilium.io has a different IP than cilium.io (it is CNAMEd as well!),
 		// and so should be blocked.
 		// cilium.io.cilium.io doesn't exist.
 		// 1.1.1.1, amusingly, serves HTTP.
 		for _, blockedTarget := range []string{"www.cilium.io", "cilium.io.cilium.io", "1.1.1.1"} {
 			res := vm.ContainerExec(helpers.App1, helpers.CurlFail(blockedTarget))
-			res.ExpectFail("Curl succeeded against blocked DNS name " + blockedTarget)
+			res.ExpectFail("Curl succeeded against blocked DNS name %s" + blockedTarget)
 		}
 
 		By("Allowing egress to IPs of specified ToFQDN DNS names")
 		allowedTarget := "cilium.io"
 		res := vm.ContainerExec(helpers.App1, helpers.CurlWithHTTPCode(allowedTarget))
-		res.ExpectContains("301", "Cannot access ", allowedTarget, res.OutputPrettyPrint())
+		res.ExpectContains("301", "Cannot access %s %s", allowedTarget, res.OutputPrettyPrint())
 	})
 
 	It("Extended HTTP Methods tests", func() {


### PR DESCRIPTION
Fixes #5071 

The test didn't wait for the second regeneration of policy, and so it would race. This meant it failed. I've added a more correct wait that ensures the DNS lookup has added IPs to the policy and regenerated.

Note: if this misses the 1.2 merge deadline, it should be backported to avoid this flake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5092)
<!-- Reviewable:end -->
