### PR TITLE
[wip] Rename CEP.status field to .details

### DIFF
--- a/Documentation/cheatsheet.rst
+++ b/Documentation/cheatsheet.rst
@@ -374,7 +374,7 @@ resource can be used.
 
     $ kubectl get cep 700e0976-6cb50b02 -o json
 
-    $ kubectl get cep -o jsonpath='{range .items[*]}{@.status.id}{"="}{@.status.status.policy.spec.policy-enabled}{"\n"}{end}'
+    $ kubectl get cep -o jsonpath='{range .items[*]}{@.status.id}{"="}{@.details.status.policy.spec.policy-enabled}{"\n"}{end}'
     30391=ingress
     5766=ingress
     51796=none

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -207,7 +207,7 @@ func RunK8sCiliumEndpointSyncGC() {
 					if _, found := clusterPodSet[cepFullName]; !found {
 						// delete
 						scopedLog = scopedLog.WithFields(logrus.Fields{
-							logfields.EndpointID: cep.Status.ID,
+							logfields.EndpointID: cep.Details.ID,
 							logfields.K8sPodName: cepFullName,
 						})
 						scopedLog.Debug("Orphaned CiliumEndpoint is being garbage collected")
@@ -617,7 +617,7 @@ func (e *Endpoint) RunK8sCiliumEndpointSync() {
 				// do an update
 				case err == nil:
 					// Update the copy of the cep
-					k8sMdl.DeepCopyInto(&cep.Status)
+					k8sMdl.DeepCopyInto(&cep.Details)
 					var err2 error
 					switch {
 					case ciliumUpdateStatusVerConstr.Check(k8sServerVer):
@@ -639,7 +639,7 @@ func (e *Endpoint) RunK8sCiliumEndpointSync() {
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name: podName,
 					},
-					Status: *k8sMdl,
+					Details: *k8sMdl,
 				}
 
 				_, err = ciliumClient.CiliumEndpoints(namespace).Create(cep)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -82,12 +82,6 @@ var (
 	// controller via getCiliumClient and the sync.Once is used to avoid race.
 	ciliumEndpointSyncControllerOnce      sync.Once
 	ciliumEndpointSyncControllerK8sClient clientset.Interface
-
-	// ciliumUpdateStatusVerConstr is the minimal version supported for
-	// to perform a CRD UpdateStatus.
-	ciliumUpdateStatusVerConstr, _ = go_version.NewConstraint(">= 1.11.0")
-
-	k8sServerVer *go_version.Version
 )
 
 // getCiliumClient builds and returns a k8s auto-generated client for cilium
@@ -516,21 +510,20 @@ func (e *Endpoint) RunK8sCiliumEndpointSync() {
 		endpointID     = e.ID
 		controllerName = fmt.Sprintf("sync-to-k8s-ciliumendpoint (%v)", endpointID)
 		scopedLog      = e.getLogger().WithField("controller", controllerName)
-		err            error
 	)
 
 	if !k8s.IsEnabled() {
 		scopedLog.Debug("Not starting controller because k8s is disabled")
 		return
 	}
-	k8sServerVer, err = k8s.GetServerVersion()
+	sv, err := k8s.GetServerVersion()
 	if err != nil {
 		scopedLog.WithError(err).Error("unable to retrieve kubernetes serverversion")
 		return
 	}
-	if !ciliumEPControllerLimit.Check(k8sServerVer) {
+	if !ciliumEPControllerLimit.Check(sv) {
 		scopedLog.WithFields(logrus.Fields{
-			"expected": k8sServerVer,
+			"expected": sv,
 			"found":    ciliumEPControllerLimit,
 		}).Warn("cannot run with this k8s version")
 		return
@@ -618,16 +611,9 @@ func (e *Endpoint) RunK8sCiliumEndpointSync() {
 				case err == nil:
 					// Update the copy of the cep
 					k8sMdl.DeepCopyInto(&cep.Details)
-					var err2 error
-					switch {
-					case ciliumUpdateStatusVerConstr.Check(k8sServerVer):
-						_, err2 = ciliumClient.CiliumEndpoints(namespace).UpdateStatus(cep)
-					default:
-						_, err2 = ciliumClient.CiliumEndpoints(namespace).Update(cep)
-					}
-					if err2 != nil {
-						scopedLog.WithError(err2).Error("Cannot update CEP")
-						return err2
+					if _, err = ciliumClient.CiliumEndpoints(namespace).Update(cep); err != nil {
+						scopedLog.WithError(err).Error("Cannot update CEP")
+						return err
 					}
 
 					lastMdl = mdl

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -183,6 +183,9 @@ func createCEPCRD(clientset apiextensionsclient.Interface) error {
 	res := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: CRDName,
+			Labels: map[string]string{
+				CustomResourceDefinitionSchemaVersionKey: CustomResourceDefinitionSchemaVersion,
+			},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   SchemeGroupVersion.Group,

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -41,7 +41,7 @@ const (
 
 	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
 	// Used to determine if CRD needs to be updated in cluster
-	CustomResourceDefinitionSchemaVersion = "1.9"
+	CustomResourceDefinitionSchemaVersion = "1.10"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -217,7 +217,7 @@ type CiliumEndpoint struct {
 	// +k8s:openapi-gen=false
 	metav1.ObjectMeta `json:"metadata"`
 
-	Status CiliumEndpointDetail `json:"status"`
+	Details CiliumEndpointDetail `json:"details"`
 }
 
 // CiliumEndpointDetail is the status of a Cilium policy rule

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -207,6 +207,7 @@ type CiliumNetworkPolicyList struct {
 }
 
 // +genclient
+// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CiliumEndpoint is the status of a Cilium policy rule

--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepcopy.go
@@ -28,7 +28,7 @@ func (in *CiliumEndpoint) DeepCopyInto(out *CiliumEndpoint) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	in.Status.DeepCopyInto(&out.Status)
+	in.Details.DeepCopyInto(&out.Details)
 	return
 }
 

--- a/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2/ciliumendpoint.go
+++ b/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2/ciliumendpoint.go
@@ -35,7 +35,6 @@ type CiliumEndpointsGetter interface {
 type CiliumEndpointInterface interface {
 	Create(*v2.CiliumEndpoint) (*v2.CiliumEndpoint, error)
 	Update(*v2.CiliumEndpoint) (*v2.CiliumEndpoint, error)
-	UpdateStatus(*v2.CiliumEndpoint) (*v2.CiliumEndpoint, error)
 	Delete(name string, options *v1.DeleteOptions) error
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v2.CiliumEndpoint, error)
@@ -113,22 +112,6 @@ func (c *ciliumEndpoints) Update(ciliumEndpoint *v2.CiliumEndpoint) (result *v2.
 		Namespace(c.ns).
 		Resource("ciliumendpoints").
 		Name(ciliumEndpoint.Name).
-		Body(ciliumEndpoint).
-		Do().
-		Into(result)
-	return
-}
-
-// UpdateStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-
-func (c *ciliumEndpoints) UpdateStatus(ciliumEndpoint *v2.CiliumEndpoint) (result *v2.CiliumEndpoint, err error) {
-	result = &v2.CiliumEndpoint{}
-	err = c.client.Put().
-		Namespace(c.ns).
-		Resource("ciliumendpoints").
-		Name(ciliumEndpoint.Name).
-		SubResource("status").
 		Body(ciliumEndpoint).
 		Do().
 		Into(result)

--- a/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2/fake/fake_ciliumendpoint.go
+++ b/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2/fake/fake_ciliumendpoint.go
@@ -98,18 +98,6 @@ func (c *FakeCiliumEndpoints) Update(ciliumEndpoint *v2.CiliumEndpoint) (result 
 	return obj.(*v2.CiliumEndpoint), err
 }
 
-// UpdateStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeCiliumEndpoints) UpdateStatus(ciliumEndpoint *v2.CiliumEndpoint) (*v2.CiliumEndpoint, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(ciliumendpointsResource, "status", c.ns, ciliumEndpoint), &v2.CiliumEndpoint{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v2.CiliumEndpoint), err
-}
-
 // Delete takes name of the ciliumEndpoint and deletes it. Returns an error if one occurs.
 func (c *FakeCiliumEndpoints) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -96,7 +96,7 @@ func (kub *Kubectl) CepGet(namespace string, pod string) *models.Endpoint {
 		"cep":       pod,
 		"namespace": namespace})
 
-	cmd := fmt.Sprintf("%s -n %s get cep %s -o json | jq '.status'", KubectlCmd, namespace, pod)
+	cmd := fmt.Sprintf("%s -n %s get cep %s -o json | jq '.details'", KubectlCmd, namespace, pod)
 	res := kub.Exec(cmd)
 	if !res.WasSuccessful() {
 		log.Debug("cep is not present")
@@ -121,7 +121,7 @@ func (kub *Kubectl) WaitCEPReady() error {
 	body := func() bool {
 		// Created a map of .id and IPv4 because endpoint id can be the same in different nodes.
 		endpointFilter := `{range [*]}{@.id}{"_"}{@.status.networking.addressing[0].ipv4}{"="}{@.status.policy.spec.policy-revision}{"\n"}{end}`
-		cepFilter := `{range .items[*]}{@.status.id}{"_"}{@.status.status.networking.addressing[0].ipv4}{"="}{@.status.status.policy.spec.policy-revision}{"\n"}{end}`
+		cepFilter := `{range .items[*]}{@.details.id}{"_"}{@.details.status.networking.addressing[0].ipv4}{"="}{@.details.status.policy.spec.policy-revision}{"\n"}{end}`
 		endpoints := map[string]string{}
 		for _, ciliumPod := range pods {
 			res := kub.ExecPodCmd(
@@ -994,7 +994,7 @@ func (kub *Kubectl) CiliumCheckReport() {
 		KubectlCmd, policiesFilter))
 	fmt.Fprintf(CheckLogs, "CiliumNetworkPolicies loaded: %v\n", cnp.Output())
 
-	cepFilter := `{range .items[*]}{.metadata.name}{"="}{.status.status.policy.realized.policy-enabled}{"\n"}{end}`
+	cepFilter := `{range .items[*]}{.metadata.name}{"="}{.details.status.policy.realized.policy-enabled}{"\n"}{end}`
 	cepStatus := kub.Exec(fmt.Sprintf(
 		"%s get cep -o jsonpath='%s' --all-namespaces",
 		KubectlCmd, cepFilter))

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -237,7 +237,7 @@ var _ = Describe("K8sServicesTest", func() {
 					helpers.DefaultNamespace,
 					podName))
 				res.ExpectSuccess("cannot get Cilium Endpoint")
-				data, err := res.Filter(`{.status.status.policy.realized.cidr-policy.egress}`)
+				data, err := res.Filter(`{.details.status.policy.realized.cidr-policy.egress}`)
 				ExpectWithOffset(1, err).To(BeNil(), "unable to get endpoint %s metadata", podName)
 				return data.String()
 			}, 5*time.Minute, 10*time.Second).Should(ContainSubstring(expectedCIDR))


### PR DESCRIPTION
We crashed kubeapiserver (https://github.com/cilium/cilium/issues/5085) so apparently something is wrong. This is a first attempt at renaming the field. I need to test:
- upgrade and downgrade for all supported k8s version
- GC of older/newer style CEP objects

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5100)
<!-- Reviewable:end -->
