### PR TITLE
daemon: do not add endpoints until all existing policies have synced from Kubernetes

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -142,6 +142,8 @@ type Daemon struct {
 	prefixLengths *counter.PrefixLengthCounter
 
 	clustermesh *clustermesh.ClusterMesh
+
+	k8sResourceSyncWaitGroup sync.WaitGroup
 }
 
 // UpdateProxyRedirect updates the redirect rules in the proxy for a particular

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -102,7 +102,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	// state left on disk.
 	option.Config.EnableHostIPRestore = false
 
-	d, err := NewDaemon()
+	d, _, err := NewDaemon()
 	c.Assert(err, IsNil)
 	ds.d = d
 

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
@@ -793,7 +794,7 @@ func runCiliumHealthEndpoint(d *Daemon) error {
 
 func runDaemon() {
 	log.Info("Initializing daemon")
-	d, err := NewDaemon()
+	d, restoredEndpoints, err := NewDaemon()
 	if err != nil {
 		log.WithError(err).Fatal("Error while creating daemon")
 		return
@@ -809,6 +810,51 @@ func runDaemon() {
 
 	log.Info("Launching node monitor daemon")
 	go d.nodeMonitor.Run(path.Join(defaults.RuntimePath, defaults.EventsPipe), bpf.GetMapRoot())
+
+	if err := d.EnableK8sWatcher(5 * time.Minute); err != nil {
+		log.WithError(err).Fatal("Unable to establish connection to Kubernetes apiserver")
+	}
+
+	if option.Config.RestoreState {
+
+		d.regenerateRestoredEndpoints(restoredEndpoints)
+
+		go func() {
+			if err := d.SyncLBMap(); err != nil {
+				log.WithError(err).Warn("Error while recovering endpoints")
+			}
+		}()
+	} else {
+		log.Info("No previous state to restore. Cilium will not manage existing containers")
+		// We need to read all docker containers so we know we won't
+		// going to allocate the same IP addresses and we will ignore
+		// these containers from reading.
+		workloads.IgnoreRunningWorkloads()
+	}
+
+	d.collectStaleMapGarbage()
+
+	// The workload event listener *must* be enabled *after* restored endpoints
+	// are added into the endpoint manager; otherwise, updates to important
+	// endpoint metadata, such as Kubernetes pod name and namespace, will not
+	// be performed on the endpoint.
+	eventsCh, err := workloads.EnableEventListener()
+	if err != nil {
+		log.WithError(err).Fatal("Error while enabling workload event watcher")
+	} else {
+		d.workloadsEventsCh = eventsCh
+	}
+
+	// Allocate health endpoint IPs after restoring state
+	log.Info("Building health endpoint")
+	health4, health6, err := ipam.AllocateNext("")
+	if err != nil {
+		log.WithError(err).Fatal("Error while allocating cilium-health IP")
+	}
+	node.SetIPv4HealthIP(health4)
+	node.SetIPv6HealthIP(health6)
+	log.Debugf("IPv4 health endpoint address: %s", node.GetIPv4HealthIP())
+	log.Debugf("IPv6 health endpoint address: %s", node.GetIPv6HealthIP())
 
 	// Launch cilium-health in the same namespace as cilium.
 	log.Info("Launching Cilium health daemon")
@@ -829,17 +875,6 @@ func runDaemon() {
 			},
 			RunInterval: 30 * time.Second,
 		})
-
-	eventsCh, err := workloads.EnableEventListener()
-	if err != nil {
-		log.WithError(err).Fatal("Error while enabling docker event watcher")
-	} else {
-		d.workloadsEventsCh = eventsCh
-	}
-
-	if err := d.EnableK8sWatcher(5 * time.Minute); err != nil {
-		log.WithError(err).Fatal("Unable to establish connection to Kubernetes apiserver")
-	}
 
 	swaggerSpec, err := loads.Analyzed(server.SwaggerJSON, "")
 	if err != nil {

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -815,8 +815,13 @@ func runDaemon() {
 		log.WithError(err).Fatal("Unable to establish connection to Kubernetes apiserver")
 	}
 
-	if option.Config.RestoreState {
+	log.Info("waiting to regenerate restored endpoints until all pre-existing policies have been received")
+	d.k8sResourceSyncWaitGroup.Wait()
+	log.Info("all pre-existing policies have been received; continuing")
 
+	if option.Config.RestoreState {
+		// Block on regenerating endpoints until we receive all policies from K8s
+		// if K8s is enabled.
 		d.regenerateRestoredEndpoints(restoredEndpoints)
 
 		go func() {


### PR DESCRIPTION
This PR consists of two changes: 

* daemon: move restoring of endpoints to start after Kubernetes watcher starts

This change in the order of operations for bootstrapping the daemon is changed
so restoration of endpoints can only begin occurring once all known
CiliumNetworkPolicy and NetworkPolicy objects in Kubernetes have been listed.
Such detection logic is present in a forthcoming commit. It also ensures that the
watching of workloads is done after restoring of endpoints.

* daemon: block until initial policy list

Previously, when Cilium was bootstrapped, endpoints were restored before the
Kubernetes watcher was started. Since Cilium does not maintain state on disk
about the policy which applied to the endpoints which are being restored, the
restore operation would regenerate endpoints without any policy rules present in
the policy repository. Soon after, the Kubernetes watcher would be started, and
policy would get sent to the Cilium policy repository; eventually, endpoints
would have the correct policy. However, in the window between when the endpoints
were restored and when the watcher was started, the lack of rules in the
repository would result in the computed policy being a default-allow for said
endpoints. This patch fixes that, by using the prior commit (restoring endpoints
after the watchers are started),  to block restoration of endpoints until the
initial list of all CiliumNetworkPolicy and NetworkPolicy resources is completed
from Kubernetes. This ensures that the restored endpoints will always have their
policy computed against the set of rules that are in Kubernetes at all times
when Cilium is ran with Kubernetes. It also ensures that no endpoints can be
created in Cilium until the initial list of policy provided to Kubernetes is
received.

Signed-off : Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5101)
<!-- Reviewable:end -->
