### PR TITLE
bpf: print map name instead of nil

### DIFF
--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -643,7 +643,7 @@ func (m *Map) DeleteWithErrno(key MapKey) (error, syscall.Errno) {
 	_, errno = deleteElement(m.fd, key.GetKeyPtr())
 
 	if errno != 0 {
-		err = fmt.Errorf("Unable to delete element from map: %s", err)
+		err = fmt.Errorf("Unable to delete element from map %s: %s", m.name, errno.Error())
 	}
 
 	return err, errno


### PR DESCRIPTION
err will be always nil here.
Signed-off-by: Nirmoy Das <ndas@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5108)
<!-- Reviewable:end -->
