### PR TITLE
allocator: nextCache can hold a nil value for a id/key

### DIFF
--- a/pkg/kvstore/allocator/cache.go
+++ b/pkg/kvstore/allocator/cache.go
@@ -195,7 +195,7 @@ func (c *cache) start(a *Allocator) waitChan {
 					case kvstore.EventTypeDelete:
 						kvstore.Trace("Removing id from cache", nil, debugFields.Data)
 
-						if k, ok := c.nextCache[id]; ok {
+						if k, ok := c.nextCache[id]; ok && k != nil {
 							delete(c.nextKeyCache, k.GetKey())
 						}
 


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1626fbf]

goroutine 46 [running]:
github.com/cilium/cilium/pkg/kvstore/allocator.(*cache).start.func1(0xc4204b3ec0, 0xc421002000, 0xc4204b3e00, 0xc422edaaa0)
        /home/nirmoy/go/src/github.com/cilium/cilium/pkg/kvstore/allocator/cache.go:202 +0x6af
created by github.com/cilium/cilium/pkg/kvstore/allocator.(*cache).start
        /home/nirmoy/go/src/github.com/cilium/cilium/pkg/kvstore/allocator/cache.go:137 +0x16b
```

Signed-off-by: Nirmoy Das <ndas@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5109)
<!-- Reviewable:end -->
