### PR TITLE
daemon: Use pkg/versioncheck to expose compile errors

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/serializer"
 	"github.com/cilium/cilium/pkg/service"
+	"github.com/cilium/cilium/pkg/versioncheck"
 
 	go_version "github.com/hashicorp/go-version"
 	"github.com/sirupsen/logrus"
@@ -84,10 +85,10 @@ var (
 
 	ciliumNPClient clientset.Interface
 
-	networkPolicyV1VerConstr, _ = go_version.NewConstraint(">= 1.7.0")
+	networkPolicyV1VerConstr = versioncheck.MustCompile(">= 1.7.0")
 
-	ciliumv2VerConstr, _           = go_version.NewConstraint(">= 1.7.0")
-	ciliumUpdateStatusVerConstr, _ = go_version.NewConstraint(">= 1.11.0")
+	ciliumv2VerConstr           = versioncheck.MustCompile(">= 1.7.0")
+	ciliumUpdateStatusVerConstr = versioncheck.MustCompile(">= 1.11.0")
 
 	k8sCM = controller.NewManager()
 )

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -53,6 +53,7 @@ import (
 	"github.com/cilium/cilium/pkg/pprof"
 	"github.com/cilium/cilium/pkg/service"
 	"github.com/cilium/cilium/pkg/version"
+	"github.com/cilium/cilium/pkg/versioncheck"
 	"github.com/cilium/cilium/pkg/workloads"
 
 	"github.com/go-openapi/loads"
@@ -66,11 +67,11 @@ import (
 )
 
 var (
-	minKernelVer, _ = go_version.NewConstraint(">= 4.8.0")
-	minClangVer, _  = go_version.NewConstraint(">= 3.8.0")
+	minKernelVer = versioncheck.MustCompile(">= 4.8.0")
+	minClangVer  = versioncheck.MustCompile(">= 3.8.0")
 
-	recKernelVer, _ = go_version.NewConstraint(">= 4.9.0")
-	recClangVer, _  = go_version.NewConstraint(">= 3.9.0")
+	recKernelVer = versioncheck.MustCompile(">= 4.9.0")
+	recClangVer  = versioncheck.MustCompile(">= 3.9.0")
 )
 
 const (

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -57,6 +57,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/u8proto"
+	"github.com/cilium/cilium/pkg/versioncheck"
 
 	go_version "github.com/hashicorp/go-version"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -75,7 +76,7 @@ var (
 
 	// ciliumEPControllerLimit is the range of k8s versions with which we are
 	// willing to run the EndpointCRD controllers
-	ciliumEPControllerLimit, _ = go_version.NewConstraint("> 1.6")
+	ciliumEPControllerLimit = versioncheck.MustCompile("> 1.6")
 
 	// ciliumEndpointSyncControllerK8sClient is a k8s client shared by the
 	// RunK8sCiliumEndpointSync and RunK8sCiliumEndpointSyncGC. They obtain the
@@ -85,7 +86,7 @@ var (
 
 	// ciliumUpdateStatusVerConstr is the minimal version supported for
 	// to perform a CRD UpdateStatus.
-	ciliumUpdateStatusVerConstr, _ = go_version.NewConstraint(">= 1.11.0")
+	ciliumUpdateStatusVerConstr = versioncheck.MustCompile(">= 1.11.0")
 
 	k8sServerVer *go_version.Version
 )

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -24,8 +24,8 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/versioncheck"
 
-	go_version "github.com/hashicorp/go-version"
 	"github.com/sirupsen/logrus"
 )
 
@@ -87,7 +87,7 @@ func retrieveNodeInformation(nodeName string) (*node.Node, error) {
 // Init initializes the Kubernetes package. It is required to call Configure()
 // beforehand.
 func Init() error {
-	compatibleVersions, err := go_version.NewConstraint(compatibleK8sVersions)
+	compatibleVersions, err := versioncheck.Compile(compatibleK8sVersions)
 	if err != nil {
 		return fmt.Errorf("unable to parse compatible k8s verions: %s", err)
 	}

--- a/pkg/versioncheck/check.go
+++ b/pkg/versioncheck/check.go
@@ -1,0 +1,41 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package versioncheck provides utility wrappers for go-version, allowing the
+// constraints to be used as global variables.
+package versioncheck
+
+import (
+	"fmt"
+
+	go_version "github.com/hashicorp/go-version"
+)
+
+// MustCompile wraps go-version.NewConstraint, panicing when an error is
+// returns (this occurs when the constraint cannot be parsed).
+// It is intended to be use similar to re.MustCompile, to ensure unparseable
+// constraints are caught in testing.
+func MustCompile(constraint string) go_version.Constraints {
+	verCheck, err := Compile(constraint)
+	if err != nil {
+		panic(fmt.Errorf("Cannot compile go-version constraint '%s' %s", constraint, err))
+	}
+	return verCheck
+}
+
+// Compile trivially wraps go-version.NewConstraint, returning the constraint
+// and error
+func Compile(constraint string) (go_version.Constraints, error) {
+	return go_version.NewConstraint(constraint)
+}


### PR DESCRIPTION
We use some versions as global constants, but do not check the error of
their return. We now panic on startup, exposing this very clearly during
testing.

Fixes https://github.com/cilium/cilium/issues/5084

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5113)
<!-- Reviewable:end -->
