### PR TITLE
daemon: do not add endpoints until all existing policies have synced from Kubernetes

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -142,6 +142,14 @@ type Daemon struct {
 	prefixLengths *counter.PrefixLengthCounter
 
 	clustermesh *clustermesh.ClusterMesh
+
+	// k8sResourceSyncWaitGroup is used to block the starting of the daemon,
+	// including regenerating restored endpoints (if specified) until all
+	// policies stored in Kubernetes are plumbed into the local Cilium
+	// repository.
+	// This prevents regeneration of endpoints before all policy rules in
+	// Kubernetes are consumed by Cilium. See GH-5038.
+	k8sResourceSyncWaitGroup sync.WaitGroup
 }
 
 // UpdateProxyRedirect updates the redirect rules in the proxy for a particular

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -27,6 +27,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -1094,14 +1095,14 @@ func createPrefixLengthCounter() *counter.PrefixLengthCounter {
 }
 
 // NewDaemon creates and returns a new Daemon with the parameters set in c.
-func NewDaemon() (*Daemon, error) {
+func NewDaemon() (*Daemon, *endpointRestoreState, error) {
 	// Validate the daemon specific global options
 	if err := option.Config.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid daemon configuration: %s", err)
+		return nil, nil, fmt.Errorf("invalid daemon configuration: %s", err)
 	}
 
 	if err := workloads.Setup(option.Config.Workloads, map[string]string{}); err != nil {
-		return nil, fmt.Errorf("unable to setup workload: %s", err)
+		return nil, nil, fmt.Errorf("unable to setup workload: %s", err)
 	}
 
 	lb := loadbalancer.NewLoadBalancer()
@@ -1283,7 +1284,7 @@ func NewDaemon() (*Daemon, error) {
 		// Allocate IPv4 service loopback IP
 		loopbackIPv4, _, err := ipam.AllocateNext("ipv4")
 		if err != nil {
-			return nil, fmt.Errorf("Unable to reserve IPv4 loopback address: %s", err)
+			return nil, restoredEndpoints, fmt.Errorf("Unable to reserve IPv4 loopback address: %s", err)
 		}
 		node.SetIPv4Loopback(loopbackIPv4)
 		log.Infof("  Loopback IPv4: %s", node.GetIPv4Loopback().String())
@@ -1317,7 +1318,7 @@ func NewDaemon() (*Daemon, error) {
 
 	if err = d.init(); err != nil {
 		log.WithError(err).Error("Error while initializing daemon")
-		return nil, err
+		return nil, restoredEndpoints, err
 	}
 
 	// Start watcher for endpoint IP --> identity mappings in key-value store.
@@ -1328,45 +1329,6 @@ func NewDaemon() (*Daemon, error) {
 	// FIXME: Make the port range configurable.
 	d.l7Proxy = proxy.StartProxySupport(10000, 20000, option.Config.RunDir,
 		option.Config.AccessLog, &d, option.Config.AgentLabels)
-
-	if option.Config.RestoreState {
-		d.regenerateRestoredEndpoints(restoredEndpoints)
-
-		go func() {
-			if err := d.SyncLBMap(); err != nil {
-				log.WithError(err).Warn("Error while recovering endpoints")
-			}
-		}()
-	} else {
-		log.Info("No previous state to restore. Cilium will not manage existing containers")
-		// We need to read all docker containers so we know we won't
-		// going to allocate the same IP addresses and we will ignore
-		// these containers from reading.
-		workloads.IgnoreRunningWorkloads()
-	}
-
-	d.collectStaleMapGarbage()
-
-	// Allocate health endpoint IPs after restoring state
-	log.Info("Building health endpoint")
-	health4, health6, err := ipam.AllocateNext("")
-	if err != nil {
-		log.WithError(err).Fatal("Error while allocating cilium-health IP")
-	}
-
-	err = node.SetIPv4HealthIP(health4)
-	if err != nil {
-		log.WithError(err).Fatal("Error while set health IPv4 ip on the local node.")
-	}
-
-	err = node.SetIPv6HealthIP(health6)
-	if err != nil {
-		log.WithError(err).Fatal("Error while set health IPv6 ip on the local node.")
-	}
-
-	log.Debugf("IPv4 health endpoint address: %s", node.GetIPv4HealthIP())
-	log.Debugf("IPv6 health endpoint address: %s", node.GetIPv6HealthIP())
-	node.NotifyLocalNodeUpdated()
 
 	d.startStatusCollector()
 	d.dnsPoller = fqdn.NewDNSPoller(fqdn.DNSPollerConfig{
@@ -1380,7 +1342,7 @@ func NewDaemon() (*Daemon, error) {
 		}})
 	fqdn.StartDNSPoller(d.dnsPoller)
 
-	return &d, nil
+	return &d, restoredEndpoints, nil
 }
 
 func (d *Daemon) validateExistingMaps() error {

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -102,7 +102,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	// state left on disk.
 	option.Config.EnableHostIPRestore = false
 
-	d, err := NewDaemon()
+	d, _, err := NewDaemon()
 	c.Assert(err, IsNil)
 	ds.d = d
 

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -74,6 +74,7 @@ const (
 	k8sAPIGroupNetworkingV1Core = "networking.k8s.io/v1::NetworkPolicy"
 	k8sAPIGroupIngressV1Beta1   = "extensions/v1beta1::Ingress"
 	k8sAPIGroupCiliumV2         = "cilium/v2::CiliumNetworkPolicy"
+	cacheSyncTimeout            = time.Duration(3 * time.Minute)
 )
 
 var (
@@ -289,7 +290,19 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 				},
 			},
 		)
+		d.k8sResourceSyncWaitGroup.Add(1)
 		go policyController.Run(wait.NeverStop)
+		go func() {
+			completed := make(<-chan struct{})
+			log.Debug("waiting for cache to synchronize for NetworkPolicies")
+			if ok := cache.WaitForCacheSync(completed, policyController.HasSynced); !ok {
+				// If we can't get NetworkPolicies for K8s, fatally exit.
+				log.Fatalf("failed to wait for cache to sync for NetworkPolicies")
+			}
+			log.Debug("caches synced for NetworkPolicies")
+			d.k8sResourceSyncWaitGroup.Done()
+		}()
+
 		d.k8sAPIGroups.addAPI(k8sAPIGroupNetworkingV1Core)
 	}
 
@@ -452,6 +465,18 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 				}
 			},
 		})
+
+		d.k8sResourceSyncWaitGroup.Add(1)
+		go func() {
+			completed := make(<-chan struct{})
+			log.Debug("waiting for cache to synchronize for CiliumNetworkPolicies")
+			if ok := cache.WaitForCacheSync(completed, ciliumV2Controller.HasSynced); !ok {
+				// If we can't get CiliumNetworkPolicies for K8s, fatally exit.
+				log.Fatalf("failed to wait for cache to sync for CiliumNetworkPolicies")
+			}
+			log.Debug("caches synced for CiliumNetworkPolicies")
+			d.k8sResourceSyncWaitGroup.Done()
+		}()
 	}
 
 	si.Start(wait.NeverStop)


### PR DESCRIPTION
This PR consists of two changes: 

* daemon: move restoring of endpoints to start after Kubernetes watcher starts

This change in the order of operations for bootstrapping the daemon is changed
so restoration of endpoints can only begin occurring once all known
CiliumNetworkPolicy and NetworkPolicy objects in Kubernetes have been listed.
Such detection logic is present in a forthcoming commit. It also ensures that the
watching of workloads is done after restoring of endpoints.

* daemon: block until initial policy list

Previously, when Cilium was bootstrapped, endpoints were restored before the
Kubernetes watcher was started. Since Cilium does not maintain state on disk
about the policy which applied to the endpoints which are being restored, the
restore operation would regenerate endpoints without any policy rules present in
the policy repository. Soon after, the Kubernetes watcher would be started, and
policy would get sent to the Cilium policy repository; eventually, endpoints
would have the correct policy. However, in the window between when the endpoints
were restored and when the watcher was started, the lack of rules in the
repository would result in the computed policy being a default-allow for said
endpoints. This patch fixes that, by using the prior commit (restoring endpoints
after the watchers are started),  to block restoration of endpoints until the
initial list of all CiliumNetworkPolicy and NetworkPolicy resources is completed
from Kubernetes. This ensures that the restored endpoints will always have their
policy computed against the set of rules that are in Kubernetes at all times
when Cilium is ran with Kubernetes. It also ensures that no endpoints can be
created in Cilium until the initial list of policy provided to Kubernetes is
received.

Signed-off : Ian Vernon <ian@cilium.io>

Fixes: #5038 

**Testing performed**

1. Launched the Kubernetes VMs used  in the CI (`test/Vagrantfile`):
 `K8S_VERSION=1.7 vagrant up k8s1-1.7; K8S_VERSION=1.7 vagrant up k8s2-1.7` 
2.  Installed Cilium (`kubecfg update test/k8sT/manifests/cilium_ds.jsonnet` )
3. Installed a bunch of policies in the `test/k8sT/manifests/` directory:
```
$ for fl in <list of files>; do kubectl apply -f $fl; done
ciliumnetworkpolicy "cnp-default-deny-egress" created
ciliumnetworkpolicy "cnp-default-deny-ingress" created
ciliumnetworkpolicy "cnp-second-namespace" created
ciliumnetworkpolicy "cnp-matchexpressions" created
ciliumnetworkpolicy "cnp-specs" created
networkpolicy "guestbook-redis-deprecated" configured
networkpolicy "guestbook-policy-redis" configured
ciliumnetworkpolicy "guestbook-policy-web" created
ciliumnetworkpolicy "kafka-sw-security-policy" created
```

4. Checked the ordering of the statements in the logs; it confirms that the wait group appropriately waits until all workers have completed their tasks (and that the wait for cache sync works as expected):

```
$ kubectl logs cilium-v4qqj -n kube-system --timestamps | grep "waiting to regenerate restored endpoints\|all pre-existing policies\|ailed to wait for cache to sync\|caches synced\|Adding CiliumNetworkPolicy"
2018-08-06T22:38:49.483298002Z level=info msg="waiting to regenerate restored endpoints until all pre-existing policies have been received" subsys=daemon
2018-08-06T22:38:49.485870196Z level=debug msg="Adding CiliumNetworkPolicy" ciliumNetworkPolicyName=service-account k8sApiVersion=cilium.io/v2 k8sNamespace=default subsys=daemon
2018-08-06T22:38:49.497035322Z level=debug msg="Adding CiliumNetworkPolicy" ciliumNetworkPolicyName=cnp-default-deny-egress k8sApiVersion=cilium.io/v2 k8sNamespace=default subsys=daemon
2018-08-06T22:38:49.497857601Z level=debug msg="Adding CiliumNetworkPolicy" ciliumNetworkPolicyName=cnp-matchexpressions k8sApiVersion=cilium.io/v2 k8sNamespace=default subsys=daemon
2018-08-06T22:38:49.498880425Z level=debug msg="Adding CiliumNetworkPolicy" ciliumNetworkPolicyName=cnp-specs k8sApiVersion=cilium.io/v2 k8sNamespace=default subsys=daemon
2018-08-06T22:38:49.500293847Z level=debug msg="Adding CiliumNetworkPolicy" ciliumNetworkPolicyName=kafka-sw-security-policy k8sApiVersion=cilium.io/v2 k8sNamespace=default subsys=daemon
2018-08-06T22:38:49.503900067Z level=debug msg="Adding CiliumNetworkPolicy" ciliumNetworkPolicyName=l7-policy k8sApiVersion=cilium.io/v2 k8sNamespace=default subsys=daemon
2018-08-06T22:38:49.505354247Z level=debug msg="Adding CiliumNetworkPolicy" ciliumNetworkPolicyName=cnp-default-deny-ingress k8sApiVersion=cilium.io/v2 k8sNamespace=default subsys=daemon
2018-08-06T22:38:49.506504829Z level=debug msg="Adding CiliumNetworkPolicy" ciliumNetworkPolicyName=cnp-second-namespace k8sApiVersion=cilium.io/v2 k8sNamespace=default subsys=daemon
2018-08-06T22:38:49.508581205Z level=debug msg="Adding CiliumNetworkPolicy" ciliumNetworkPolicyName=guestbook-policy-web k8sApiVersion=cilium.io/v2 k8sNamespace=default subsys=daemon
2018-08-06T22:38:49.509912842Z level=debug msg="Adding CiliumNetworkPolicy" ciliumNetworkPolicyName=l3-l4-policy k8sApiVersion=cilium.io/v2 k8sNamespace=default subsys=daemon
2018-08-06T22:38:49.585607021Z level=debug msg="caches synced for NetworkPolicies" subsys=daemon
2018-08-06T22:38:49.585773182Z level=debug msg="caches synced for CiliumNetworkPolicies" subsys=daemon
2018-08-06T22:38:49.586075145Z level=info msg="all pre-existing policies have been received; continuing" subsys=daemon
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5115)
<!-- Reviewable:end -->