### PR TITLE
prometheus example edit

### DIFF
--- a/examples/kubernetes/prometheus.yaml
+++ b/examples/kubernetes/prometheus.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: prometheus
+  name: monitoring
 
 ---
 # The prometheus service, deployment and config
@@ -10,7 +10,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus
-  namespace: prometheus
+  namespace: monitoring
   labels:
     app: prometheus
     component: core
@@ -31,7 +31,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: prometheus-core
-  namespace: prometheus
+  namespace: monitoring
   labels:
     app: prometheus
     component: core
@@ -75,7 +75,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus-core
-  namespace: prometheus
+  namespace: monitoring
 data:
   prometheus.yaml: |
     global:
@@ -129,7 +129,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: prometheus-k8s
-    namespace: prometheus
+    namespace: monitoring
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -156,7 +156,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus-k8s
-  namespace: prometheus
+  namespace: monitoring
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Signed-off-by: Cynthia Thomas <cynthia@covalent.io>

**Summary of changes**:
Prometheus example provided in recent blog was missing the creation of monitoring namespace. Team opted to modify the prometheus yaml to use the same namespace for both Prometheus and Grafana deployments in the Prometheus blog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5124)
<!-- Reviewable:end -->
