### PR TITLE
kafka: Fix de/serialization of null arrays

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -666,7 +666,7 @@
     ".",
     "proto"
   ]
-  revision = "c411825615d9959fd44c0b455b86f8684f9c58b0"
+  revision = "01ce283b732b96914f62b1ff1bf5d8b90f7db86c"
   source = "https://github.com/cilium/kafka"
 
 [[projects]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -57,7 +57,7 @@ required = [
 [[constraint]]
   name = "github.com/optiopay/kafka"
   source = "https://github.com/cilium/kafka"
-  revision = "c411825615d9959fd44c0b455b86f8684f9c58b0"
+  revision = "01ce283b732b96914f62b1ff1bf5d8b90f7db86c"
 
 [[constraint]]
   name = "github.com/pmezard/go-difflib"

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -85,7 +85,7 @@ var _ = Describe("RuntimeChaos", func() {
 		originalEndpointList := vm.Exec(endpointListCmd)
 
 		err := vm.RestartCilium()
-		Expect(err).Should(BeNil())
+		Expect(err).Should(BeNil(), "restarting Cilium failed")
 
 		ips := vm.Exec(`
 		curl -s --unix-socket /var/run/cilium/cilium.sock \
@@ -108,7 +108,7 @@ var _ = Describe("RuntimeChaos", func() {
 		_ = vm.Exec("sudo ip link add lxc12345 type veth peer name tmp54321")
 
 		err = vm.RestartCilium()
-		Expect(err).Should(BeNil())
+		Expect(err).Should(BeNil(), "restarting Cilium failed")
 
 		status := vm.Exec("sudo ip link show lxc12345")
 		status.ExpectFail("leftover interface were not properly cleaned up")

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -51,7 +51,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 	AfterEach(func() {
 		containers(helpers.Delete)
 		err := vm.RestartCilium()
-		Expect(err).Should(BeNil())
+		Expect(err).Should(BeNil(), "restarting Cilium failed")
 	})
 
 	JustAfterEach(func() {

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -44,12 +44,14 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 	}
 
 	BeforeEach(func() {
-		vm.Exec("sudo systemctl stop cilium")
+		res := vm.ExecWithSudo("systemctl stop cilium")
+		res.ExpectSuccess()
 	}, 150)
 
 	AfterEach(func() {
 		containers(helpers.Delete)
-		vm.Exec("sudo systemctl start cilium")
+		err := vm.RestartCilium()
+		Expect(err).Should(BeNil())
 	})
 
 	JustAfterEach(func() {

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -304,7 +304,7 @@ var _ = Describe("RuntimeLB", func() {
 			Expect(err).Should(BeNil())
 
 			err = vm.RestartCilium()
-			Expect(err).Should(BeNil())
+			Expect(err).Should(BeNil(), "restarting Cilium failed")
 
 			By("Checking that the service was restored correctly")
 

--- a/test/runtime/verifier.go
+++ b/test/runtime/verifier.go
@@ -59,7 +59,7 @@ var _ = Describe("RuntimeVerifier", func() {
 
 	AfterAll(func() {
 		err := vm.RestartCilium()
-		Expect(err).Should(BeNil())
+		Expect(err).Should(BeNil(), "restarting Cilium failed")
 	})
 
 	It("runs the kernel verifier against the tree copy of the BPF datapath", func() {


### PR DESCRIPTION
Properly handle the de/serialization of arrays specified to be nullable, cf. the calls to `ArrayOf.nullable` in the Java client:
https://github.com/apache/kafka/tree/trunk/clients/src/main/java/org/apache/kafka/common/requests

Properly handle null arrays in the de/serialization of `RECORDS` arrays, since this type is nullable.

Properly set (non-)nullable arrays in responses synthesized by the Kafka proxy.

Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5125)
<!-- Reviewable:end -->
