### PR TITLE
Test: Added duration field on CMDRes

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cilium/cilium/test/config"
 
@@ -38,6 +39,7 @@ type CmdRes struct {
 	stderr   *bytes.Buffer // Stderr from running cmd
 	success  bool          // Whether command successfully executed
 	exitcode int           // The exit code of cmd
+	duration time.Duration // Is the representation of the the time that command took to execute.
 }
 
 // GetCmd returns res's cmd.
@@ -65,13 +67,13 @@ func (res *CmdRes) GetStdErr() string {
 // the exitcode.
 func (res *CmdRes) SendToLog(quietMode bool) {
 	if quietMode {
-		logformat := "cmd: %q exitCode: %d"
-		fmt.Fprintf(&config.TestLogWriter, logformat, res.cmd, res.GetExitCode())
+		logformat := "cmd: %q exitCode: %d duration: %s\n"
+		fmt.Fprintf(&config.TestLogWriter, logformat, res.cmd, res.GetExitCode(), res.duration)
 		return
 	}
 
-	logformat := "cmd: %q exitCode: %d stdout:\n%s\n"
-	log := fmt.Sprintf(logformat, res.cmd, res.GetExitCode(), res.stdout.String())
+	logformat := "cmd: %q exitCode: %d duration: %s stdout:\n%s\n"
+	log := fmt.Sprintf(logformat, res.cmd, res.GetExitCode(), res.duration, res.stdout.String())
 	if res.stderr.Len() > 0 {
 		log = fmt.Sprintf("%sstderr:\n%s\n", log, res.stderr.String())
 	}

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/cilium/cilium/test/config"
 	ginkgoext "github.com/cilium/cilium/test/ginkgo-ext"
@@ -159,13 +160,15 @@ func (s *SSHMeta) Exec(cmd string, options ...ExecOptions) *CmdRes {
 	log.Debugf("running command: %s", cmd)
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
+	start := time.Now()
 	err := s.Execute(cmd, stdout, stderr)
 
 	res := CmdRes{
-		cmd:     cmd,
-		stdout:  stdout,
-		stderr:  stderr,
-		success: true, // this may be toggled when err != nil below
+		cmd:      cmd,
+		stdout:   stdout,
+		stderr:   stderr,
+		success:  true, // this may be toggled when err != nil below
+		duration: time.Since(start),
 	}
 
 	if err != nil {
@@ -242,9 +245,11 @@ func (s *SSHMeta) ExecContext(ctx context.Context, cmd string, options ...ExecOp
 	}
 
 	go func() {
+		start := time.Now()
 		if err := s.sshClient.RunCommandContext(ctx, command); err != nil {
 			log.WithError(err).Error("Error running context")
 		}
+		res.duration = time.Since(start)
 		res.SendToLog(ops.SkipLog)
 	}()
 


### PR DESCRIPTION
Added a new field on CMDRes struct for the duration. Each time that the
node.Exec is executed it'll log the duration of the given command in the
log.

The main reason of this change is to know with a quick look how long a
command took and to help debugging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5126)
<!-- Reviewable:end -->
