### PR TITLE
Test: KafkaExec to use node.Exec

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -163,15 +163,15 @@ func (kub *Kubectl) WaitCEPReady() error {
 // function needs to also take into account the stderr messages returned.
 func (kub *Kubectl) ExecKafkaPodCmd(namespace string, pod string, arg string) error {
 	command := fmt.Sprintf("%s exec -n %s %s sh -- %s", KubectlCmd, namespace, pod, arg)
-	stdout := new(bytes.Buffer)
-	stderr := new(bytes.Buffer)
-	err := kub.Execute(command, stdout, stderr)
-	if err != nil {
-		return fmt.Errorf("ExecKafkaPodCmd: command '%s' failed '%s' || '%s'", command, stdout.String(), stderr.String())
+	res := kub.Exec(command)
+	if !res.WasSuccessful() {
+		return fmt.Errorf("ExecKafkaPodCmd: command '%s' failed %s",
+			res.GetCmd(), res.OutputPrettyPrint())
 	}
 
-	if strings.Contains(stderr.String(), "ERROR") {
-		return fmt.Errorf("ExecKafkaPodCmd: command '%s' failed '%s' || '%s'", command, stdout.String(), stderr.String())
+	if strings.Contains(res.GetStdErr(), "ERROR") {
+		return fmt.Errorf("ExecKafkaPodCmd: command '%s' failed '%s'",
+			res.GetCmd(), res.OutputPrettyPrint())
 	}
 	return nil
 }


### PR DESCRIPTION
At the moment the kubectl.KafkaExec is not using node.Exec and commands
are not logged into the test-output.log

With this change all commands will be logged in the test-output.log to
help debugging.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5127)
<!-- Reviewable:end -->
