### PR TITLE
check-complexity: Print individual prog insn count

### DIFF
--- a/test/bpf/check-complexity.sh
+++ b/test/bpf/check-complexity.sh
@@ -20,7 +20,7 @@ TESTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 BPFDIR="$TESTDIR/../../bpf/"
 
 function get_insn_cnt {
-	grep -e "^Prog" -e processed -e "Proccessed" -e "^=>"
+	grep -e "^Prog" -e processed -e "Proccessed" -e "^=>" -e "over limit"
 }
 
 # These are derived from bpf/lib/common.h CILIUM_CALL_*.


### PR DESCRIPTION
Print the complexity of individual programs in the output of the
check-complexity.sh script, for better understanding of how changes
impact the complexity.

(Previously, only the complexity output after loading the program into the kernel would be printed, which traced the maximum complexity from the root program through various tail calls)

No CI run should be necessary as these changes do not yet get run by CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5129)
<!-- Reviewable:end -->
