### PR TITLE
test: make K8s DNS checks more robust

### DIFF
--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -28,7 +28,7 @@ var _ = Describe("K8sChaosTest", func() {
 	var (
 		kubectl       *helpers.Kubectl
 		demoDSPath    = helpers.ManifestGet("demo_ds.yaml")
-		testDSService = "testds-service.default.svc.cluster.local"
+		testDSService = "testds-service"
 	)
 
 	BeforeAll(func() {
@@ -85,7 +85,7 @@ var _ = Describe("K8sChaosTest", func() {
 					"Cannot ping from %q to %q", pod, ip)
 
 				By("Waiting for kube-dns entry for service testds-service")
-				err = kubectl.WaitForKubeDNSEntry(testDSService)
+				err = kubectl.WaitForKubeDNSEntry(testDSService, helpers.DefaultNamespace)
 				ExpectWithOffset(1, err).To(BeNil(), "DNS entry is not ready after timeout")
 
 				By("Getting ClusterIP For testds-service")

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -77,24 +77,38 @@ var _ = Describe("K8sChaosTest", func() {
 
 		for _, pod := range pods {
 			for _, ip := range dsPods {
+				By("Pinging test-ds service pod with IP %q from client pod %q", ip, pod)
 				res := kubectl.ExecPodCmd(
 					helpers.DefaultNamespace, pod, helpers.Ping(ip))
 				log.Debugf("Pod %s ping %v", pod, ip)
 				ExpectWithOffset(1, res).To(helpers.CMDSuccess(),
 					"Cannot ping from %q to %q", pod, ip)
 
+				By("Waiting for kube-dns entry for service testds-service")
 				err = kubectl.WaitForKubeDNSEntry(testDSService)
 				ExpectWithOffset(1, err).To(BeNil(), "DNS entry is not ready after timeout")
 
+				By("Getting ClusterIP For testds-service")
+				host, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, "testds-service")
+				ExpectWithOffset(1, err).To(BeNil(), "unable to get ClusterIP and port for service testds-service")
+
+				By("Curling testds-service via ClusterIP %q", host)
+				res = kubectl.ExecPodCmd(
+					helpers.DefaultNamespace, pod, helpers.CurlFail("http://%s:80/", host))
+				ExpectWithOffset(1, res).To(helpers.CMDSuccess(),
+					"Cannot curl from %q to testds-service via ClusterIP", pod)
+
+				By("Curling testds-service via DNS hostname")
 				res = kubectl.ExecPodCmd(
 					helpers.DefaultNamespace, pod, helpers.CurlFail("http://%s:80/", testDSService))
 				ExpectWithOffset(1, res).To(helpers.CMDSuccess(),
-					"Cannot curl from %q to testds-service", pod)
+					"Cannot curl from %q to testds-service via DNS hostname", pod)
 			}
 		}
 	}
 
 	It("Endpoint can still connect while Cilium is not running", func() {
+		By("Waiting for deployed pods to be ready")
 		err := kubectl.WaitforPods(
 			helpers.DefaultNamespace,
 			fmt.Sprintf("-l zgroup=testDSClient"), 300)
@@ -103,6 +117,7 @@ var _ = Describe("K8sChaosTest", func() {
 		err = kubectl.CiliumEndpointWaitReady()
 		Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 
+		By("Checking connectivity before restarting Cilium")
 		PingService()
 
 		By("Deleting cilium pods")
@@ -116,6 +131,7 @@ var _ = Describe("K8sChaosTest", func() {
 		err = kubectl.CiliumEndpointWaitReady()
 		Expect(err).To(BeNil(), "Endpoints are not ready after Cilium restarts")
 
+		By("Checking connectivity after restarting Cilium")
 		PingService()
 
 		By("Uninstall cilium pods")
@@ -126,6 +142,7 @@ var _ = Describe("K8sChaosTest", func() {
 
 		ExpectAllPodsTerminated(kubectl)
 
+		By("Checking connectivity after uninstalling Cilium")
 		PingService()
 
 		By("Install cilium pods")
@@ -138,6 +155,7 @@ var _ = Describe("K8sChaosTest", func() {
 		err = kubectl.CiliumEndpointWaitReady()
 		Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 
+		By("Checking connectivity after reinstalling Cilium")
 		PingService()
 	})
 })

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -132,9 +132,9 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 			err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=kafkaTestApp", helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Kafka Pods are not ready after timeout")
 
-			err = kubectl.WaitForKubeDNSEntry("kafka-service." + helpers.DefaultNamespace)
+			err = kubectl.WaitForKubeDNSEntry("kafka-service", helpers.DefaultNamespace)
 			Expect(err).To(BeNil(), "DNS entry of kafka-service is not ready after timeout")
-			err = kubectl.WaitForKubeDNSEntry("zook." + helpers.DefaultNamespace)
+			err = kubectl.WaitForKubeDNSEntry("zook", helpers.DefaultNamespace)
 			Expect(err).To(BeNil(), "DNS entry of zook is not ready after timeout")
 
 			err = kubectl.CiliumEndpointWaitReady()

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -678,8 +678,8 @@ var _ = Describe("K8sPolicyTest", func() {
 
 			serviceIP, port, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, "redis-master")
 
-			serviceName := "redis-master.default.svc.cluster.local"
-			err = kubectl.WaitForKubeDNSEntry(serviceName)
+			serviceName := "redis-master"
+			err = kubectl.WaitForKubeDNSEntry(serviceName, helpers.DefaultNamespace)
 			Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
 
 			for pod := range webPods {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -390,7 +390,7 @@ var _ = Describe("K8sServicesTest", func() {
 			}
 			By("Validating DNS without Policy")
 			for _, name := range dnsChecks {
-				err = kubectl.WaitForKubeDNSEntry(fmt.Sprintf("%s.%s", name, helpers.DefaultNamespace))
+				err = kubectl.WaitForKubeDNSEntry(name, helpers.DefaultNamespace)
 				Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
 			}
 
@@ -421,7 +421,7 @@ var _ = Describe("K8sServicesTest", func() {
 
 			By("Validating DNS with Policy loaded")
 			for _, name := range dnsChecks {
-				err = kubectl.WaitForKubeDNSEntry(fmt.Sprintf("%s.%s", name, helpers.DefaultNamespace))
+				err = kubectl.WaitForKubeDNSEntry(name, helpers.DefaultNamespace)
 				Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
 			}
 

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -95,7 +95,7 @@ func ValidateCiliumUpgrades(kubectl *helpers.Kubectl) (cleanupCallback func()) {
 	demoPath := helpers.ManifestGet("demo.yaml")
 	l7Policy := helpers.ManifestGet("l7-policy.yaml")
 	apps := []string{helpers.App1, helpers.App2, helpers.App3}
-	app1Service := "app1-service.default.svc.cluster.local"
+	app1Service := "app1-service"
 
 	cleanupCallback = func() {
 		kubectl.Delete(l7Policy)
@@ -141,7 +141,7 @@ func ValidateCiliumUpgrades(kubectl *helpers.Kubectl) (cleanupCallback func()) {
 
 	appPods := helpers.GetAppPods(apps, helpers.DefaultNamespace, kubectl, "id")
 
-	err = kubectl.WaitForKubeDNSEntry(app1Service)
+	err = kubectl.WaitForKubeDNSEntry(app1Service, helpers.DefaultNamespace)
 	Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
 
 	res := kubectl.ExecPodCmd(
@@ -202,7 +202,7 @@ func ValidateCiliumUpgrades(kubectl *helpers.Kubectl) (cleanupCallback func()) {
 
 	ExpectKubeDNSReady(kubectl)
 
-	err = kubectl.WaitForKubeDNSEntry(app1Service)
+	err = kubectl.WaitForKubeDNSEntry(app1Service, helpers.DefaultNamespace)
 	Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
 
 	res = kubectl.ExecPodCmd(

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -95,9 +95,10 @@ var _ = Describe("K8sDemosTest", func() {
 	It("Tests Star Wars Demo", func() {
 
 		allianceLabel := "org=alliance"
-		deathstarServiceName := "deathstar.default.svc.cluster.local"
+		deathstarServiceName := "deathstar"
+		deathstarFQDN := fmt.Sprintf("%s.%s.svc.cluster.local", deathstarServiceName, helpers.DefaultNamespace)
 
-		exhaustPortPath := filepath.Join(deathstarServiceName, "/v1/exhaust-port")
+		exhaustPortPath := filepath.Join(deathstarFQDN, "/v1/exhaust-port")
 
 		By("Applying deployments")
 
@@ -130,12 +131,12 @@ var _ = Describe("K8sDemosTest", func() {
 
 		By("Showing how alliance can execute REST API call to main API endpoint")
 
-		err = kubectl.WaitForKubeDNSEntry(deathstarServiceName)
+		err = kubectl.WaitForKubeDNSEntry(deathstarServiceName, helpers.DefaultNamespace)
 		Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
 
 		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, xwingPod,
-			helpers.CurlWithHTTPCode("http://%s/v1", deathstarServiceName))
-		res.ExpectContains("200", "unable to curl %s/v1: %s", deathstarServiceName, res.Output())
+			helpers.CurlWithHTTPCode("http://%s/v1", deathstarFQDN))
+		res.ExpectContains("200", "unable to curl %s/v1: %s", deathstarFQDN, res.Output())
 
 		By("Importing L7 Policy which restricts access to %q", exhaustPortPath)
 		_, err = kubectl.CiliumPolicyAction(


### PR DESCRIPTION
This PR addresses flakiness in the CI that results from CoreDNS caching hostname entries for a long time. It addresses the following problem:

We have multiple tests which use the same YAML (`test/k8sT/manifests/demo_ds.yaml`) for creating resources in the CI:

* `test/k8sT/Tunnels.go`
* `test/k8sT/Chaos.go`
* `test/k8sT/Services.go`

These create services, which are referenced via hostnames in the CI. When CoreDNS is used in the CI (in Kubernetes >= 1.11 versions), hostname --> IP mappings are cached for some time, even after the service with the same name has been created in one test, and then re-created in another test shortly thereafter. This means that if any of the above tests run right after the other, there is a possibility that the IP returned by looking up a service name which was also used in the prior test which added a service with the same name would return the old IP for the service, which is not plumbed into the Cilium datapath, while the new service IP is. As a result, this means that tests which try to access services via hostname in the CI would fail because the DNS lookup would return the old IP for the service. This is odd behavior, considering that the `ConfigMap` for CoreDNS in the CI has the setting for cache (see https://coredns.io/plugins/cache/ ) to have a TTL of 3 seconds:

https://github.com/cilium/cilium/blob/1f7a845c49df4717bb1c62904abbaf5525a98cfb/test/provision/manifest/coredns_deployment.yaml#L88-L103

To alleviate the flakiness that results in the CI, this is addressed by the addition of functionality to wait for DNS entries to be ready by not only checking that `dig` returns an IP for the given service name, but that the IP that is returned by `dig` matches the `ClusterIP` for the service returned by Kubernetes. 

As part of debugging this, I also added some additional output / commands to make debugging such issues easier if they should arise in the future. The `WaitForKubeDNSEntry` helper function also runs `dig` for the given service name to provide additional information for debugging in the logs, and additional narration of the test in `test/k8sT/Chaos.go` to make it easier to determine how far the test has progressed while it runs. Finally, it also preforms a datapath check to not only the service name, but also the ClusterIP for the given service, to make it easier to see whether there is an issue with DNS resolution, or with the Cilium datapath itself in the test `test/k8sT/Chaos.go`.

Ideally, we should not see errors like the following in the CI any more after this is merged:

```
Cannot curl from "testclient-24crq" to testds-service
Expected command: kubectl exec -n default testclient-24crq -- curl -s -D /dev/stderr --fail --connect-timeout 3 --max-time 3 http://testds-service.default.svc.cluster.local:80/ 
To succeed, but it failed:
Exitcode: 28 
Stdout:
 	 
Stderr:
 	 command terminated with exit code 28
```

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #5122 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5133)
<!-- Reviewable:end -->
