### PR TITLE
examples/kubernetes-ingress: fix development VM setup

### DIFF
--- a/examples/kubernetes-ingress/scripts/03-install-kubernetes-worker.sh
+++ b/examples/kubernetes-ingress/scripts/03-install-kubernetes-worker.sh
@@ -228,10 +228,9 @@ sudo cp ./cilium.kubeconfig /var/lib/kube-proxy/kube-proxy.kubeconfig
 
 sudo tee /etc/systemd/system/kube-proxy.service <<EOF
 [Unit]
-Description=Kubernetes kube-proxy
-Documentation=https://kubernetes.io/docs/home
-After=containerd.service
-Requires=containerd.service
+Description=Kubernetes Kube-Proxy Server
+Documentation=https://kubernetes.io/docs/concepts/overview/components/#kube-proxy https://kubernetes.io/docs/reference/generated/kube-proxy/
+After=network.target
 
 [Service]
 ExecStart=/usr/bin/kube-proxy \\


### PR DESCRIPTION
Changes made in the development VM v106 broke the kube-proxy setup. This
commit fixes the deployment by removing the unnecessary requires from
the systemd service.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5149)
<!-- Reviewable:end -->
