### PR TITLE
daemon: Remove health-ep before deleting its devices

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -133,22 +133,28 @@ func PingEndpoint() error {
 	return err
 }
 
-// CleanupEndpoint attempts to kill any existing cilium-health endpoint and
-// clean up its devices and pidfiles. If any existing cilium-health endpoint
-// exists in Cilium, it is removed from the endpoint manager.
+// KillEndpoint attempts to kill any existing cilium-health endpoint if it
+// exists.
 //
 // This is intended to be invoked in multiple situations:
 // * The health endpoint has never been run before
 // * The health endpoint was run during a previous run of the Cilium agent
 // * The health endpoint crashed during the current run of the Cilium agent
 //   and needs to be cleaned up before it is restarted.
-func CleanupEndpoint(owner endpoint.Owner) {
+func KillEndpoint() {
 	path := filepath.Join(option.Config.StateDir, healthPidfile)
 	if err := pidfile.Kill(path); err != nil {
 		scopedLog := log.WithField(logfields.Path, path).WithError(err)
 		scopedLog.Info("Failed to kill previous cilium-health instance")
 	}
+}
 
+// CleanupEndpoint cleans up remaining resources associated with the health
+// endpoint.
+//
+// This is expected to be called after the process is killed and the endpoint
+// is removed from the endpointmanager.
+func CleanupEndpoint() {
 	scopedLog := log.WithField(logfields.Veth, vethName)
 	if link, err := netlink.LinkByName(vethName); err == nil {
 		err = netlink.LinkDel(link)

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -828,7 +828,7 @@ func runDaemon() {
 			},
 			StopFunc: func() error {
 				err = health.PingEndpoint()
-				health.CleanupEndpoint(d)
+				cleanupHealthEndpoint(d)
 				return err
 			},
 			RunInterval: 30 * time.Second,

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -767,7 +767,7 @@ func initEnv(cmd *cobra.Command) {
 
 func cleanupHealthEndpoint(d *Daemon) {
 	// Delete the process
-	health.CleanupEndpoint(d)
+	health.KillEndpoint()
 	// Clean up agent resources
 	ip6 := node.GetIPv6HealthIP()
 	id := addressing.CiliumIPv6(ip6).EndpointID()
@@ -781,6 +781,7 @@ func cleanupHealthEndpoint(d *Daemon) {
 			log.WithError(err).Debug("Error occurred while deleting cilium-health endpoint")
 		}
 	}
+	health.CleanupEndpoint()
 }
 
 // runCiliumHealthEndpoint attempts to contact the cilium-health endpoint, and


### PR DESCRIPTION
Previously, the health endpoint's veth devices would be removed before
it was removed from the endpointmanager. This meant that it was possible
for the health-ep controller to check (and fail to connect to) the health
endpoint then interrupt an ongoing regeneration for the health endpoint.
To avoid this, separate the veth cleanup step from the killing of the
process such that this ordering should be followed when the health
endpoint becomes unresponsive:

* Kill the process
* Remove the endpoint
* Delete the devices
* Re-launch the endpoint

Fixes: a722e79bd553 ("daemon: Controllerize cilium-health endpoint")
Fixes: #5152

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5157)
<!-- Reviewable:end -->
