### PR TITLE
controller: Log the DoFunc and update times

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -179,7 +179,9 @@ func (c *Controller) runController() {
 		if runFunc {
 			interval = params.RunInterval
 
+			start := time.Now()
 			err = params.DoFunc()
+			c.getLogger().Debug("Controller func execution time: ", time.Since(start))
 
 			c.mutex.Lock()
 

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/lock"
@@ -54,6 +55,8 @@ func GetGlobalStatus() models.ControllerStatuses {
 // immediately regardless of any previous conditions. It will also cause any
 // statistics to be reset.
 func (m *Manager) UpdateController(name string, params ControllerParams) *Controller {
+	start := time.Now()
+
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -81,6 +84,8 @@ func (m *Manager) UpdateController(name string, params ControllerParams) *Contro
 		case ctrl.update <- struct{}{}:
 		default:
 		}
+
+		ctrl.getLogger().Debug("Controller update time: ", time.Since(start))
 	} else {
 		ctrl = &Controller{
 			name:   name,


### PR DESCRIPTION
With https://github.com/cilium/cilium/pull/4683, controller updates are synchronous and may block for a long time if the func is executing and lasts a long time, which may cause timeouts in callers.
Log the func execution times and update times in order to identify such issues.

Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5159)
<!-- Reviewable:end -->
