### PR TITLE
CEP: Added custom columns on list

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -41,7 +41,7 @@ const (
 
 	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
 	// Used to determine if CRD needs to be updated in cluster
-	CustomResourceDefinitionSchemaVersion = "1.9"
+	CustomResourceDefinitionSchemaVersion = "1.10"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"
@@ -192,6 +192,44 @@ func createCEPCRD(clientset apiextensionsclient.Interface) error {
 				Singular:   CustomResourceDefinitionSingularName,
 				ShortNames: CustomResourceDefinitionShortNames,
 				Kind:       CustomResourceDefinitionKind,
+			},
+			AdditionalPrinterColumns: []apiextensionsv1beta1.CustomResourceColumnDefinition{
+				{
+					Name:        "Endpoint ID",
+					Type:        "integer",
+					Description: "Cilium endpoint id",
+					JSONPath:    ".status.id",
+				},
+				{
+					Name:        "Identity ID",
+					Type:        "integer",
+					Description: "Cilium identity id",
+					JSONPath:    ".status.status.identity.id",
+				},
+				{
+					Name:        "Policy Enforcement",
+					Type:        "string",
+					Description: "Policy enforcement in the endpoint",
+					JSONPath:    ".status.status.policy.realized.policy-enabled",
+				},
+				{
+					Name:        "Endpoint State",
+					Type:        "string",
+					Description: "Endpoint current state",
+					JSONPath:    ".status.status.state",
+				},
+				{
+					Name:        "IPv4",
+					Type:        "string",
+					Description: "Endpoint IPv4 address",
+					JSONPath:    ".status.status.networking.addressing[0].ipv4",
+				},
+				{
+					Name:        "IPv6",
+					Type:        "string",
+					Description: "Endpoint IPv6 address",
+					JSONPath:    ".status.status.networking.addressing[0].ipv6",
+				},
 			},
 			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
 				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},


### PR DESCRIPTION
On CEP the default list is not enough for a quick view and it does not
provide a lot of information to the users.

Kubernetes 1.11 added a new option to have custom list on the Custom
Resources definition, so the list provides to the users more
information.

This commit change the CEP list output to the following:

- Kubernetes 1.11
```
vagrant@k8s1:~$ kubectl get cep --all-namespaces
NAMESPACE     NAME                      ENDPOINT ID   IDENTITY ID  POLICY ENFORCEMENT   ENDPOINT STATE   IPV4          IPV6
default       app1-5d79fbc474-fkvxq     24637         37263        none                 ready            10.10.0.54    f00d::a0a:0:0:603d
default       app1-5d79fbc474-n4g2f     17467         37263        none                 ready            10.10.0.247   f00d::a0a:0:0:443b
default       app2-56fbc4b964-gwp6j     9386          22676        none                 ready            10.10.0.39    f00d::a0a:0:0:24aa
default       app3-5d9895d6ff-cwj2q     46066         11397        none                 ready            10.10.0.3     f00d::a0a:0:0:b3f2
kube-system   coredns-b9476b976-zkp9x   54975         30138        none                 ready            10.10.0.220   f00d::a0a:0:0:d6bf
```

- Kubernetes 1.7
```
vagrant@k8s1:~$ kubectl get pods
NAME                    READY     STATUS    RESTARTS   AGE
app1-1879020049-2sb9c   1/1       Running   0          1m
app1-1879020049-vb1z9   1/1       Running   0          1m
app2-2809035625-htqm4   1/1       Running   0          1m
app3-753781860-f1wj9    1/1       Running   0          1m
vagrant@k8s1:~$ kubectl get nodes
NAME      STATUS    AGE       VERSION
k8s1      Ready     12m       v1.7.15
vagrant@k8s1:~$ kubectl get cep
NAME                    KIND
app1-1879020049-2sb9c   CiliumEndpoint.v2.cilium.io
app1-1879020049-vb1z9   CiliumEndpoint.v2.cilium.io
app2-2809035625-htqm4   CiliumEndpoint.v2.cilium.io
app3-753781860-f1wj9    CiliumEndpoint.v2.cilium.io
```

Related to #3334

This PR works, but if https://github.com/cilium/cilium/pull/5100 is merged, this PR need to be updated. 

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5161)
<!-- Reviewable:end -->
