### PR TITLE
Improve the upgrade documentation

### DIFF
--- a/Documentation/install/upgrade-1.0.rst
+++ b/Documentation/install/upgrade-1.0.rst
@@ -14,3 +14,24 @@ Upgrading to Cilium 1.0.x from older versions
 Versions of Cilium older than 1.0.0 are unsupported for upgrade. The
 :ref:`upgrade_general` may work, however it may be more reliable to start
 again from the :ref:`install_guide`.
+
+Downgrading to Cilium 1.0.x from Cilium 1.1.y
+"""""""""""""""""""""""""""""""""""""""""""""
+
+#. Check whether you have any CIDR policy rules installed:
+
+   .. code-block:: shell-session
+
+     $ kubectl get cnp --all-namespaces -o yaml | grep "/0"
+
+   If any CIDR rules match on the CIDR prefix ``/0``, these must be removed
+   prior to downgrade as these rules are not supported by Cilium 1.0.
+
+#.
+
+  .. include:: upgrade-minor.rst
+
+Downgrading to Cilium 1.0.x from Cilium 1.0.y
+"""""""""""""""""""""""""""""""""""""""""""""
+
+.. include:: upgrade-micro.rst

--- a/Documentation/install/upgrade-1.0.rst
+++ b/Documentation/install/upgrade-1.0.rst
@@ -1,0 +1,14 @@
+Upgrading to the Cilium 1.0 series
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Upgrading to Cilium 1.0.x from Cilium 1.0.y
+"""""""""""""""""""""""""""""""""""""""""""
+
+Set the version to the desired release per :ref:`upgrade_version`.
+
+Upgrading to Cilium 1.0.x from older versions
+"""""""""""""""""""""""""""""""""""""""""""""
+
+Versions of Cilium older than 1.0.0 are unsupported for upgrade. The
+:ref:`upgrade_general` may work, however it may be more reliable to start
+again from the :ref:`install_guide`.

--- a/Documentation/install/upgrade-1.0.rst
+++ b/Documentation/install/upgrade-1.0.rst
@@ -1,10 +1,12 @@
 Upgrading to the Cilium 1.0 series
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+The latest version in the Cilium 1.0 series can be found `here <https://raw.githubusercontent.com/cilium/cilium/v1.0/VERSION>`__
+
 Upgrading to Cilium 1.0.x from Cilium 1.0.y
 """""""""""""""""""""""""""""""""""""""""""
 
-Set the version to the desired release per :ref:`upgrade_version`.
+.. include:: upgrade-micro.rst
 
 Upgrading to Cilium 1.0.x from older versions
 """""""""""""""""""""""""""""""""""""""""""""

--- a/Documentation/install/upgrade-1.1.rst
+++ b/Documentation/install/upgrade-1.1.rst
@@ -33,3 +33,27 @@ Upgrading to Cilium 1.1.x from Cilium 1.0.y
 #.
 
   .. include:: upgrade-minor.rst
+
+Downgrading to Cilium 1.1.x from Cilium 1.2.y
+"""""""""""""""""""""""""""""""""""""""""""""
+
+When downgrading from Cilium 1.2, the target version **must** be Cilium 1.1.3
+or later.
+
+#. Check whether you have any DNS policy rules installed:
+
+   .. code-block:: shell-session
+
+     $ kubectl get cnp --all-namespaces -o yaml | grep "fqdn"
+
+   If any DNS rules exist, these must be removed prior to downgrade as these
+   rules are not supported by Cilium 1.1.
+
+#.
+
+  .. include:: upgrade-minor.rst
+
+Downgrading to Cilium 1.1.x from Cilium 1.1.y
+"""""""""""""""""""""""""""""""""""""""""""""
+
+.. include:: upgrade-micro.rst

--- a/Documentation/install/upgrade-1.1.rst
+++ b/Documentation/install/upgrade-1.1.rst
@@ -1,10 +1,12 @@
 Upgrading to the Cilium 1.1 series
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+The latest version in the Cilium 1.1 series can be found `here <https://raw.githubusercontent.com/cilium/cilium/v1.1/VERSION>`__
+
 Upgrading to Cilium 1.1.x from Cilium 1.1.y
 """""""""""""""""""""""""""""""""""""""""""
 
-Set the version to the desired release per :ref:`upgrade_version`.
+.. include:: upgrade-micro.rst
 
 Upgrading to Cilium 1.1.x from Cilium 1.0.y
 """""""""""""""""""""""""""""""""""""""""""
@@ -28,4 +30,6 @@ Upgrading to Cilium 1.1.x from Cilium 1.0.y
    <https://raw.githubusercontent.com/cilium/cilium/v1.1/examples/kubernetes/templates/v1/cilium-cm.yaml>`__
    for more details.
 
-#. :ref:`upgrade_ds`.
+#.
+
+  .. include:: upgrade-minor.rst

--- a/Documentation/install/upgrade-1.1.rst
+++ b/Documentation/install/upgrade-1.1.rst
@@ -1,0 +1,31 @@
+Upgrading to the Cilium 1.1 series
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Upgrading to Cilium 1.1.x from Cilium 1.1.y
+"""""""""""""""""""""""""""""""""""""""""""
+
+Set the version to the desired release per :ref:`upgrade_version`.
+
+Upgrading to Cilium 1.1.x from Cilium 1.0.y
+"""""""""""""""""""""""""""""""""""""""""""
+
+#. Follow the guide in :ref:`err_low_mtu` to update the MTU of existing
+   endpoints.
+
+#. :ref:`upgrade_cm`.
+
+   New options in Cilium 1.1:
+
+   * ``legacy-host-allows-world``: This is recommended to be set to false. For
+     more information, see :ref:`host_vs_world`.
+   * ``sidecar-istio-proxy-image``
+
+   Deprecated options in Cilium 1.1:
+
+   * ``sidecar-http-proxy``
+
+   See the `example Cilium 1.1 ConfigMap
+   <https://raw.githubusercontent.com/cilium/cilium/v1.1/examples/kubernetes/templates/v1/cilium-cm.yaml>`__
+   for more details.
+
+#. :ref:`upgrade_ds`.

--- a/Documentation/install/upgrade-1.2.rst
+++ b/Documentation/install/upgrade-1.2.rst
@@ -1,10 +1,12 @@
 Upgrading to the Cilium 1.2 series
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+The latest version in the Cilium 1.2 series can be found `here <https://raw.githubusercontent.com/cilium/cilium/v1.2/VERSION>`__
+
 Upgrading to Cilium 1.2.x from Cilium 1.2.y
 """""""""""""""""""""""""""""""""""""""""""
 
-Set the version to the desired release per :ref:`upgrade_version`.
+.. include:: upgrade-micro.rst
 
 Upgrading to Cilium 1.2.x from Cilium 1.1.y or 1.0.z
 """"""""""""""""""""""""""""""""""""""""""""""""""""

--- a/Documentation/install/upgrade-1.2.rst
+++ b/Documentation/install/upgrade-1.2.rst
@@ -1,0 +1,25 @@
+Upgrading to the Cilium 1.2 series
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Upgrading to Cilium 1.2.x from Cilium 1.2.y
+"""""""""""""""""""""""""""""""""""""""""""
+
+Set the version to the desired release per :ref:`upgrade_version`.
+
+Upgrading to Cilium 1.2.x from Cilium 1.1.y or 1.0.z
+""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+#. Upgrade to Cilium ``1.1.3`` or later using the instructions below.
+
+#. :ref:`upgrade_cm`.
+
+   New options in Cilium 1.2:
+
+   * ``cluster-name``
+   * ``cluster-id``
+   * ``monitor-aggregation-level``
+
+   See the :git-tree:`example ConfigMap
+   <examples/kubernetes/templates/v1/cilium-cm.yaml>` for more details.
+
+#. :ref:`upgrade_ds`.

--- a/Documentation/install/upgrade-micro.rst
+++ b/Documentation/install/upgrade-micro.rst
@@ -1,0 +1,1 @@
+Set the version to the desired release per :ref:`upgrade_version`.

--- a/Documentation/install/upgrade-minor.rst
+++ b/Documentation/install/upgrade-minor.rst
@@ -1,0 +1,3 @@
+
+Follow the instructions for :ref:`upgrade_ds`, using the desired version rather
+than "\ |SCM_BRANCH|".

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -324,18 +324,25 @@ To monitor the rollout and confirm it is complete, run:
 
     $ kubectl rollout status daemonset/cilium -n kube-system
 
-To undo the rollout via rollback, run:
-
-.. code-block:: shell-session
-
-    $ kubectl rollout undo daemonset/cilium -n kube-system
-
 During the upgrade roll-out, Cilium will typically continue to forward traffic
 at L3/L4, and all endpoints and their configuration will be preserved across
 the upgrade. However, because the L7 proxies implementing HTTP, gRPC, and
 Kafka-aware filtering currently reside in the same Pod as Cilium, they are
 removed and re-installed as part of the rollout. As a result, any proxied
 connections will be lost and clients must reconnect.
+
+Rolling back the upgrade (Typically unnecessary)
+""""""""""""""""""""""""""""""""""""""""""""""""
+
+Occasionally, it may be necessary to undo the rollout because a step was missed
+or something went wrong during upgrade. To undo the rollout via rollback, run:
+
+.. code-block:: shell-session
+
+    $ kubectl rollout undo daemonset/cilium -n kube-system
+
+This will revert the latest changes to the Cilium ``DaemonSet`` and return
+Cilium to the state it was in prior to the upgrade.
 
 .. _specific_upgrade:
 

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -403,7 +403,9 @@ also disable the usage of the feature.
 +==============================================+===================+==============================================+===========================================================+
 | CIDR policies matching on IPv6 prefix ranges | ``v1.0.2``        | Remove policies that contain IPv6 CIDR rules | `PR 4004 <https://github.com/cilium/cilium/pull/4004>`_   |
 +----------------------------------------------+-------------------+----------------------------------------------+-----------------------------------------------------------+
-+ CIDR policies matching on default prefix     | ``v1.1.0``        | Remove policies that match a ``/0`` prefix   | `PR 4458 <https://github.com/cilium/cilium/pull/4458>`_   |
+| CIDR policies matching on default prefix     | ``v1.1.0``        | Remove policies that match a ``/0`` prefix   | `PR 4458 <https://github.com/cilium/cilium/pull/4458>`_   |
++----------------------------------------------+-------------------+----------------------------------------------+-----------------------------------------------------------+
+| Monitor Aggregation                          | ``v1.2.0``        | Re-install ``DaemonSet`` from target version | `PR 5118 <https://github.com/cilium/cilium/pull/5118>`_   |
 +----------------------------------------------+-------------------+----------------------------------------------+-----------------------------------------------------------+
 
 .. _upgrade_notes:

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -224,6 +224,23 @@ As the `ConfigMap` is successfully upgraded we can start upgrading Cilium
 Upgrading Cilium DaemonSet and RBAC
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+There are two methods to upgrade the Cilium `DaemonSet`:
+
+* Full upgrade of the ``RBAC`` and ``DaemonSet`` resources: This is the safest
+  option, and typically should be used when upgrading to a new minor release,
+  for example from ``1.0.x`` to ``1.1.y``. This pulls in the latest
+  configuration options for the Cilium daemon.
+
+* Set the version in the existing ``DaemonSet``: A simpler upgrade procedure
+  which does not update the Daemon options. Typically only safe when upgrading
+  to a new micro release, for example from ``1.0.0`` to ``1.0.1``.
+
+The following sections describe how to upgrade using either of the above
+approaches, then how to monitor (and if necessary, roll back) the upgrade
+process.
+
+**Full RBAC and DaemonSet upgrade**
+
 Simply pick your Kubernetes version and run ``kubectl apply`` for the ``RBAC``
 and the ``DaemonSet``.
 
@@ -265,32 +282,37 @@ Both files are dedicated to "\ |SCM_BRANCH|" for each Kubernetes version.
       $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.11/cilium-rbac.yaml
       $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.11/cilium-ds.yaml
 
+**Direct version upgrade**
 
-You can also substitute the desired Cilium version number for vX.Y.Z in the
-command below, but be aware that copy of the spec file stored in Kubernetes
-might run out-of-sync with the CLI flags, or options, specified by each Cilium
-version.
+You can alternatively substitute the version ``vX.Y.Z`` for the desired Cilium
+version number in the command below, but be aware that copy of the spec file
+stored in Kubernetes might run out-of-sync with the CLI flags, or options,
+specified by each Cilium version.
 
-::
+.. code-block:: shell-session
 
-    kubectl set image daemonset/cilium -n kube-system cilium-agent=docker.io/cilium/cilium:vX.Y.Z
+    $ kubectl set image daemonset/cilium -n kube-system cilium-agent=docker.io/cilium/cilium:vX.Y.Z
+
+**Monitor the upgrade procedure**
 
 To monitor the rollout and confirm it is complete, run:
 
-::
+.. code-block:: shell-session
 
-    kubectl rollout status daemonset/cilium -n kube-system
+    $ kubectl rollout status daemonset/cilium -n kube-system
 
 To undo the rollout via rollback, run:
 
-::
+.. code-block:: shell-session
 
-    kubectl rollout undo daemonset/cilium -n kube-system
+    $ kubectl rollout undo daemonset/cilium -n kube-system
 
-Cilium will continue to forward traffic at L3/L4 during the roll-out, and all endpoints and their configuration will be preserved across
-the upgrade rollout.   However, because the L7 proxies implementing HTTP, gRPC, and Kafka-aware filtering currently reside in the
-same Pod as Cilium, they are removed and re-installed as part of the rollout.   As a result, any proxied connections will be lost and
-clients must reconnect.
+During the upgrade roll-out, Cilium will typically continue to forward traffic
+at L3/L4, and all endpoints and their configuration will be preserved across
+the upgrade. However, because the L7 proxies implementing HTTP, gRPC, and
+Kafka-aware filtering currently reside in the same Pod as Cilium, they are
+removed and re-installed as part of the rollout. As a result, any proxied
+connections will be lost and clients must reconnect.
 
 Downgrade
 =========


### PR DESCRIPTION
Improve the upgrade documentation by:

* Adding an overview to describe what happens during upgrade, what the different files are, etc.
* Adding version-specific notes about what needs to occur to upgrade from Cilium version X to version Y.

Outstanding tasks, could be achieved in follow-up PR:
* [x] Update the 1.2 upgrade steps to document the potential issue with #5052 (limited prefix lengths on Linux < 4.11
* [x] Review `upgrade-impact` labelled issues for any additional known upgrade constraints:
  https://github.com/cilium/cilium/issues?utf8=%E2%9C%93&q=label%3Aupgrade-impact+

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5162)
<!-- Reviewable:end -->
