### PR TITLE
Test: Fix Kafka nslookup checker

### DIFF
--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -17,6 +17,7 @@ package k8sTest
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/test/ginkgo-ext"
@@ -90,6 +91,9 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 				res := kubectl.ExecPodCmd(helpers.DefaultNamespace, pod, dnsLookupCmd)
 
 				if !res.WasSuccessful() {
+					return false
+				}
+				if strings.Contains(res.GetStdErr(), "can't resolve") {
 					return false
 				}
 				return true


### PR DESCRIPTION
During the triage of [0] I found a log message where nslookup check on
kafka test was not doing the correct on the `waitForDNSResolution`
function.

```
STEP: Waiting for DNS to resolve within pods for kafka-service
time="2018-08-09T23:10:13Z" level=debug msg="running command: kubectl exec -n default empire-hq-2917507631-kq0pg -- nslookup kafka-service"
cmd: "kubectl exec -n default empire-hq-2917507631-kq0pg -- nslookup kafka-service" exitCode: 0 duration: 2.309678164s stdout:

Name:      kafka-service
Address 1: 10.10.0.19

stderr:
nslookup: can't resolve '(null)': Name does not resolve
```

This commit check that the nslookup works correct and resolve correctly.

[0] https://github.com/cilium/cilium/issues/5164

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5166)
<!-- Reviewable:end -->
