### PR TITLE
Test: PolicyGen wait until CNP has status.

### DIFF
--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -699,10 +699,13 @@ func (t *TestSpec) InvalidNetworkPolicyApply() (*cnpv2.CiliumNetworkPolicy, erro
 	}
 	body := func() bool {
 		cnp := t.Kub.GetCNP(helpers.DefaultNamespace, t.Prefix)
-		if cnp != nil {
-			return true
+		if cnp == nil {
+			return false
 		}
-		return false
+		if len(cnp.Status.Nodes) == 0 {
+			return false
+		}
+		return true
 	}
 	err = helpers.WithTimeout(
 		body,

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -420,6 +420,7 @@ var _ = Describe("NightlyExamples", func() {
 
 		AfterEach(func() {
 			cleanupCallback()
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		AfterAll(func() {


### PR DESCRIPTION
Found in the nightly build[0] that the CNP does not have status, and test
fails.

This commit make sure that the status is in place on invalid policies
combinations.

[0]
```
time="2018-08-10T08:18:33Z" level=debug msg="running command: kubectl -n default get cnp 305f67ae -o json"
cmd: "kubectl -n default get cnp 305f67ae -o json" exitCode: 0 duration: 168.698244ms stdout:
{
    "apiVersion": "cilium.io/v2",
    "kind": "CiliumNetworkPolicy",
    "metadata": {
        "annotations": {
            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"cilium.io/v2\",\"kind\":\"CiliumNetworkPolicy\",\"metadata\":{\"annotations\":{},\"labels\":{\"test\":\"policygen\"},\"name\":\"305f67ae\",\"namespace\":\"default\"},\"specs\":[{\"endpointSelector\":{\"matchLabels\":{\"any:id\":\"305f67ae-65c18f43\"}},\"ingress\":[{\"fromEndpoints\":[{}]}]},{\"egress\":[{\"toPorts\":[{\"ports\":[{\"port\":\"80\",\"protocol\":\"UDP\"}],\"rules\":{\"http\":[{\"method\":\"GET\",\"path\":\"/private\"}]}}]}],\"endpointSelector\":{\"matchLabels\":{\"any:id\":\"305f67ae-894ccb82\"}}}]}\n"
        },
        "creationTimestamp": "2018-08-10T08:18:33Z",
        "generation": 1,
        "labels": {
            "test": "policygen"
        },
        "name": "305f67ae",
        "namespace": "default",
        "resourceVersion": "20621",
        "selfLink": "/apis/cilium.io/v2/namespaces/default/ciliumnetworkpolicies/305f67ae",
        "uid": "f91051ad-9c75-11e8-a260-0800275579e8"
    },
    "specs": [
        {
            "endpointSelector": {
                "matchLabels": {
                    "any:id": "305f67ae-65c18f43"
                }
            },
            "ingress": [
                {
                    "fromEndpoints": [
                        {}
                    ]
                }
            ]
        },
        {
            "egress": [
                {
                    "toPorts": [
                        {
                            "ports": [
                                {
                                    "port": "80",
                                    "protocol": "UDP"
                                }
                            ],
                            "rules": {
                                "http": [
                                    {
                                        "method": "GET",
                                        "path": "/private"
                                    }
                                ]
                            }
                        }
                    ]
                }
            ],
            "endpointSelector": {
                "matchLabels": {
                    "any:id": "305f67ae-894ccb82"
                }
            }
        }
    ]
}
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5169)
<!-- Reviewable:end -->
