### PR TITLE
Test: Update kubernetes upstream test to 1.11

### DIFF
--- a/kubernetes-upstream.Jenkinsfile
+++ b/kubernetes-upstream.Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
         PROJ_PATH = "src/github.com/cilium/cilium"
         TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
         MEMORY = "4096"
-        K8S_VERSION="1.10"
+        K8S_VERSION="1.11"
         SERVER_BOX = "cilium/ubuntu"
     }
 


### PR DESCRIPTION
Commit `9f979bbb42d6611159211f58f963be3ac3a11528` updated all our
kubernetes instances to 1.11 but did not update the Kubernetes Upstream
test.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5172)
<!-- Reviewable:end -->
