### PR TITLE
pkg/endpoint: attempt to restore failed endpoints regenerations from previous life

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1219,11 +1219,14 @@ func (e *Endpoint) GetIdentity() identityPkg.NumericIdentity {
 	return identityPkg.InvalidIdentity
 }
 
-func (e *Endpoint) directoryPath() string {
+// DirectoryPath returns the directory name for this endpoint bpf program.
+func (e *Endpoint) DirectoryPath() string {
 	return filepath.Join(".", fmt.Sprintf("%d", e.ID))
 }
 
-func (e *Endpoint) failedDirectoryPath() string {
+// FailedDirectoryPath returns the directory name for this endpoint bpf program
+// failed builds.
+func (e *Endpoint) FailedDirectoryPath() string {
 	return filepath.Join(".", fmt.Sprintf("%d%s", e.ID, "_next_fail"))
 }
 
@@ -1360,7 +1363,8 @@ func FilterEPDir(dirFiles []os.FileInfo) []string {
 	eptsID := []string{}
 	for _, file := range dirFiles {
 		if file.IsDir() {
-			if _, err := strconv.ParseUint(file.Name(), 10, 16); err == nil {
+			_, err := strconv.ParseUint(file.Name(), 10, 16)
+			if err == nil || strings.HasSuffix(file.Name(), "_next_fail") {
 				eptsID = append(eptsID, file.Name())
 			}
 		}
@@ -1784,11 +1788,11 @@ func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup
 }
 
 func (e *Endpoint) removeDirectory() {
-	os.RemoveAll(e.directoryPath())
+	os.RemoveAll(e.DirectoryPath())
 }
 
 func (e *Endpoint) removeFailedDirectory() {
-	os.RemoveAll(e.failedDirectoryPath())
+	os.RemoveAll(e.FailedDirectoryPath())
 }
 
 func (e *Endpoint) RemoveDirectory() {
@@ -1803,7 +1807,7 @@ func (e *Endpoint) CreateDirectory() error {
 		return err
 	}
 	defer e.Unlock()
-	lxcDir := e.directoryPath()
+	lxcDir := e.DirectoryPath()
 	if err := os.MkdirAll(lxcDir, 0777); err != nil {
 		return fmt.Errorf("unable to create endpoint directory: %s", err)
 	}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -730,7 +730,7 @@ func (e *Endpoint) regenerate(owner Owner, reason string) (retErr error) {
 
 	// If generation fails, keep the directory around. If it ever succeeds
 	// again, clean up the XXX_next_fail copy.
-	failDir := e.failedDirectoryPath()
+	failDir := e.FailedDirectoryPath()
 	os.RemoveAll(failDir) // Most likely will not exist; ignore failure.
 	if err != nil {
 		scopedLog.WithFields(logrus.Fields{


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

Fixes: https://github.com/cilium/cilium/issues/4769

```release-note
Attempt to restore failed endpoint regenerations from a previous cilium-agent execution
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5182)
<!-- Reviewable:end -->
