### PR TITLE
cilium-health: Fix issue where daemon continues to ping nodes that are no longer part of the cluster

### DIFF
--- a/pkg/health/server/node.go
+++ b/pkg/health/server/node.go
@@ -1,0 +1,72 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"github.com/cilium/cilium/api/v1/models"
+)
+
+type healthNode struct {
+	*models.NodeElement
+
+	// During setNodes(), we perform mark-and-sweep to get rid of IPs that
+	// should no longer be probed. If deletionMark is true after the set
+	// of nodes is updated, this node can be removed.
+	deletionMark bool
+}
+
+// NewHealthNode creates a new node structure based on the specified model.
+func NewHealthNode(elem *models.NodeElement) healthNode {
+	return healthNode{
+		NodeElement: elem,
+	}
+}
+
+// PrimaryIP returns the primary IP address of the node.
+func (n *healthNode) PrimaryIP() string {
+	if n.NodeElement.PrimaryAddress.IPV4.Enabled {
+		return n.NodeElement.PrimaryAddress.IPV4.IP
+	}
+	return n.NodeElement.PrimaryAddress.IPV6.IP
+}
+
+// HealthIP returns the IP address of the health endpoint for the node.
+func (n *healthNode) HealthIP() string {
+	if n.NodeElement.HealthEndpointAddress == nil {
+		return ""
+	}
+	if n.NodeElement.HealthEndpointAddress.IPV4.Enabled {
+		return n.NodeElement.HealthEndpointAddress.IPV4.IP
+	}
+	return n.NodeElement.HealthEndpointAddress.IPV6.IP
+}
+
+// Addresses returns a map of the node's addresses -> "primary" bool
+func (n *healthNode) Addresses() map[*models.NodeAddressingElement]bool {
+	addresses := map[*models.NodeAddressingElement]bool{}
+	if n.NodeElement.PrimaryAddress != nil {
+		addr := n.NodeElement.PrimaryAddress
+		addresses[addr.IPV4] = addr.IPV4.Enabled
+		addresses[addr.IPV6] = addr.IPV6.Enabled
+	}
+	if n.NodeElement.HealthEndpointAddress != nil {
+		addresses[n.NodeElement.HealthEndpointAddress.IPV4] = false
+		addresses[n.NodeElement.HealthEndpointAddress.IPV6] = false
+	}
+	for _, elem := range n.NodeElement.SecondaryAddresses {
+		addresses[elem] = false
+	}
+	return addresses
+}

--- a/pkg/health/server/server.go
+++ b/pkg/health/server/server.go
@@ -22,7 +22,6 @@ import (
 	healthModels "github.com/cilium/cilium/api/v1/health/models"
 	healthApi "github.com/cilium/cilium/api/v1/health/server"
 	"github.com/cilium/cilium/api/v1/health/server/restapi"
-	ciliumModels "github.com/cilium/cilium/api/v1/models"
 	ciliumPkg "github.com/cilium/cilium/pkg/client"
 	"github.com/cilium/cilium/pkg/health/defaults"
 	"github.com/cilium/cilium/pkg/lock"
@@ -74,9 +73,9 @@ type Config struct {
 // ipString is an IP address used as a more descriptive type name in maps.
 type ipString string
 
-// nodeMap maps IP addresses to NodeElements for convenient access to node
-// information.
-type nodeMap map[ipString]*ciliumModels.NodeElement
+// nodeMap maps IP addresses to healthNode objectss for convenient access to
+// node information.
+type nodeMap map[ipString]healthNode
 
 // Server is the cilium-health daemon that is in charge of performing health
 // and connectivity checks periodically, and serving the cilium-health API.
@@ -131,21 +130,21 @@ func (s *Server) getNodes() (nodeMap, error) {
 	for _, n := range resp.Payload.Cluster.Nodes {
 		if n.PrimaryAddress != nil {
 			if n.PrimaryAddress.IPV4 != nil {
-				nodes[ipString(n.PrimaryAddress.IPV4.IP)] = n
+				nodes[ipString(n.PrimaryAddress.IPV4.IP)] = NewHealthNode(n)
 			}
 			if n.PrimaryAddress.IPV6 != nil {
-				nodes[ipString(n.PrimaryAddress.IPV6.IP)] = n
+				nodes[ipString(n.PrimaryAddress.IPV6.IP)] = NewHealthNode(n)
 			}
 		}
 		for _, addr := range n.SecondaryAddresses {
-			nodes[ipString(addr.IP)] = n
+			nodes[ipString(addr.IP)] = NewHealthNode(n)
 		}
 		if n.HealthEndpointAddress != nil {
 			if n.HealthEndpointAddress.IPV4 != nil {
-				nodes[ipString(n.HealthEndpointAddress.IPV4.IP)] = n
+				nodes[ipString(n.HealthEndpointAddress.IPV4.IP)] = NewHealthNode(n)
 			}
 			if n.HealthEndpointAddress.IPV6 != nil {
-				nodes[ipString(n.HealthEndpointAddress.IPV6.IP)] = n
+				nodes[ipString(n.HealthEndpointAddress.IPV6.IP)] = NewHealthNode(n)
 			}
 		}
 	}


### PR DESCRIPTION
Cilium-health periodically (once every ProbeInterval) fetches the list of nodes from the Cilium daemon. Every time it fetched the list of nodes, if there were new nodes then those would be added to the list of peers to probe on a regular basis. However, we previously didn't garbage collect nodes or results in the cilium-health daemon if Cilium no longer reported them. As a result, when a node left the cluster, `cilium-health` would continue pinging that node forever (or at least, until pod restart).

This PR refactors a little code for easier understanding of the changes to locking and applying mark/sweep to remove nodes that are no longer reported by Cilium.

Tested manually by inserting fake node entries into the kvstore, performing a manual probe, then removing the fake node entry from the kvstore and performing a manual probe again, then running TCPdump on the `cilium_health` device to observe that other nodes are not being pinged on a regular basis.

Affected versions: 1.0, 1.1, 1.2. This issue is not major so it probably doesn't need a backport, though the original issue was reported in the community so we could consider at least putting it on the imminent 1.2 release.

Fixes: #4363

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5185)
<!-- Reviewable:end -->
