### PR TITLE
Test: Fix Upgrade clean callbacks

### DIFF
--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -433,8 +433,9 @@ var _ = Describe("NightlyExamples", func() {
 
 					err := kubectl.CiliumEndpointWaitReady()
 					Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
-
-					cleanupCallback = ValidateCiliumUpgrades(kubectl)
+					var assertUpgradeSuccessful func()
+					assertUpgradeSuccessful, cleanupCallback = ValidateCiliumUpgrades(kubectl)
+					assertUpgradeSuccessful()
 				})
 			}(image)
 		}

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -84,20 +84,23 @@ var _ = Describe("K8sUpdates", func() {
 	})
 
 	It("Updating Cilium stable to master", func() {
-		cleanupCallback = ValidateCiliumUpgrades(kubectl)
+		var assertUpgradeSuccessful func()
+		assertUpgradeSuccessful, cleanupCallback = ValidateCiliumUpgrades(kubectl)
+		assertUpgradeSuccessful()
 	})
 })
 
 // ValidateCiliumUpgrades it test that the given cilium master is installed
-// correctly and the policies are correctly. It returns a callback with the
+// correctly and the policies are correctly. It returns two callbacks, the
+// first one is the assertfunction that need to run, and the second one are the
 // cleanup actions
-func ValidateCiliumUpgrades(kubectl *helpers.Kubectl) (cleanupCallback func()) {
+func ValidateCiliumUpgrades(kubectl *helpers.Kubectl) (func(), func()) {
 	demoPath := helpers.ManifestGet("demo.yaml")
 	l7Policy := helpers.ManifestGet("l7-policy.yaml")
 	apps := []string{helpers.App1, helpers.App2, helpers.App3}
 	app1Service := "app1-service"
 
-	cleanupCallback = func() {
+	cleanupCallback := func() {
 		kubectl.Delete(l7Policy)
 		kubectl.Delete(demoPath)
 
@@ -108,112 +111,113 @@ func ValidateCiliumUpgrades(kubectl *helpers.Kubectl) (cleanupCallback func()) {
 			"ds", fmt.Sprintf("-n %s cilium", helpers.KubeSystemNamespace))
 	}
 
-	validatedImage := func(image string) {
-		By("Checking that installed image is %q", image)
+	testfunc := func() {
+		validatedImage := func(image string) {
+			By("Checking that installed image is %q", image)
 
-		filter := `{.items[*].status.containerStatuses[0].image}`
-		data, err := kubectl.GetPods(
-			helpers.KubeSystemNamespace, "-l k8s-app=cilium").Filter(filter)
-		ExpectWithOffset(1, err).To(BeNil(), "Cannot get cilium pods")
+			filter := `{.items[*].status.containerStatuses[0].image}`
+			data, err := kubectl.GetPods(
+				helpers.KubeSystemNamespace, "-l k8s-app=cilium").Filter(filter)
+			ExpectWithOffset(1, err).To(BeNil(), "Cannot get cilium pods")
 
-		for _, val := range strings.Split(data.String(), " ") {
-			ExpectWithOffset(1, val).To(Equal(image), "Cilium image didn't update correctly")
+			for _, val := range strings.Split(data.String(), " ") {
+				ExpectWithOffset(1, val).To(Equal(image), "Cilium image didn't update correctly")
+			}
 		}
-	}
 
-	By("Installing kube-dns")
-	kubectl.Apply(helpers.DNSDeployment()).ExpectSuccess("Kube-dns cannot be installed")
+		By("Installing kube-dns")
+		kubectl.Apply(helpers.DNSDeployment()).ExpectSuccess("Kube-dns cannot be installed")
 
-	By("Creating some endpoints and L7 policy")
-	kubectl.Apply(demoPath).ExpectSuccess()
+		By("Creating some endpoints and L7 policy")
+		kubectl.Apply(demoPath).ExpectSuccess()
 
-	err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", timeout)
-	Expect(err).Should(BeNil())
+		err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", timeout)
+		Expect(err).Should(BeNil(), "Test pods are not ready after timeout")
 
-	ExpectKubeDNSReady(kubectl)
+		ExpectKubeDNSReady(kubectl)
 
-	_, err = kubectl.CiliumPolicyAction(
-		helpers.KubeSystemNamespace, l7Policy, helpers.KubectlApply, timeout)
-	Expect(err).Should(BeNil(), "cannot import l7 policy: %v", l7Policy)
+		_, err = kubectl.CiliumPolicyAction(
+			helpers.KubeSystemNamespace, l7Policy, helpers.KubectlApply, timeout)
+		Expect(err).Should(BeNil(), "cannot import l7 policy: %v", l7Policy)
 
-	err = kubectl.CiliumEndpointWaitReady()
-	Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
+		err = kubectl.CiliumEndpointWaitReady()
+		Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 
-	appPods := helpers.GetAppPods(apps, helpers.DefaultNamespace, kubectl, "id")
+		appPods := helpers.GetAppPods(apps, helpers.DefaultNamespace, kubectl, "id")
 
-	err = kubectl.WaitForKubeDNSEntry(app1Service, helpers.DefaultNamespace)
-	Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
+		err = kubectl.WaitForKubeDNSEntry(app1Service, helpers.DefaultNamespace)
+		Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
 
-	res := kubectl.ExecPodCmd(
-		helpers.DefaultNamespace, appPods[helpers.App2],
-		helpers.CurlFail("http://%s/public", app1Service))
-	res.ExpectSuccess("Cannot curl app1-service")
+		res := kubectl.ExecPodCmd(
+			helpers.DefaultNamespace, appPods[helpers.App2],
+			helpers.CurlFail("http://%s/public", app1Service))
+		res.ExpectSuccess("Cannot curl app1-service")
 
-	res = kubectl.ExecPodCmd(
-		helpers.DefaultNamespace, appPods[helpers.App2],
-		helpers.CurlWithHTTPCode("http://%s/private", app1Service))
-	res.ExpectContains("403", "Expect 403 in the result")
+		res = kubectl.ExecPodCmd(
+			helpers.DefaultNamespace, appPods[helpers.App2],
+			helpers.CurlWithHTTPCode("http://%s/private", app1Service))
+		res.ExpectContains("403", "Expect 403 in the result")
 
-	By("Updating cilium to master image")
+		By("Updating cilium to master image")
 
-	localImage := "k8s1:5000/cilium/cilium-dev:latest"
-	resource := "daemonset/cilium"
+		localImage := "k8s1:5000/cilium/cilium-dev:latest"
+		resource := "daemonset/cilium"
 
-	kubectl.Exec(fmt.Sprintf("%s -n %s set image %s cilium-agent=%s",
-		helpers.KubectlCmd, helpers.KubeSystemNamespace,
-		resource, localImage)).ExpectSuccess(
-		"Cannot update image")
+		kubectl.Exec(fmt.Sprintf("%s -n %s set image %s cilium-agent=%s",
+			helpers.KubectlCmd, helpers.KubeSystemNamespace,
+			resource, localImage)).ExpectSuccess(
+			"Cannot update image")
 
-	waitForUpdateImage := func() bool {
-		pods, err := kubectl.GetCiliumPods(helpers.KubeSystemNamespace)
-		if err != nil {
+		waitForUpdateImage := func() bool {
+			pods, err := kubectl.GetCiliumPods(helpers.KubeSystemNamespace)
+			if err != nil {
+				return false
+			}
+
+			filter := `{.items[*].status.containerStatuses[0].image}`
+			data, err := kubectl.GetPods(
+				helpers.KubeSystemNamespace, "-l k8s-app=cilium").Filter(filter)
+			if err != nil {
+				return false
+			}
+			number := strings.Count(data.String(), localImage)
+			if number == len(pods) {
+				return true
+			}
+			log.Infof("Only '%v' of '%v' cilium pods updated to the new image",
+				number, len(pods))
 			return false
 		}
 
-		filter := `{.items[*].status.containerStatuses[0].image}`
-		data, err := kubectl.GetPods(
-			helpers.KubeSystemNamespace, "-l k8s-app=cilium").Filter(filter)
-		if err != nil {
-			return false
-		}
-		number := strings.Count(data.String(), localImage)
-		if number == len(pods) {
-			return true
-		}
-		log.Infof("Only '%v' of '%v' cilium pods updated to the new image",
-			number, len(pods))
-		return false
+		err = helpers.WithTimeout(
+			waitForUpdateImage,
+			"Cilium Pods are not updating correctly",
+			&helpers.TimeoutConfig{Timeout: timeout})
+		Expect(err).To(BeNil(), "Pods are not updating")
+
+		err = kubectl.WaitforPods(
+			helpers.KubeSystemNamespace, "-l k8s-app=cilium", timeout)
+		Expect(err).Should(BeNil(), "Cilium is not ready after timeout")
+
+		validatedImage(localImage)
+
+		err = kubectl.CiliumEndpointWaitReady()
+		Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
+
+		ExpectKubeDNSReady(kubectl)
+
+		err = kubectl.WaitForKubeDNSEntry(app1Service, helpers.DefaultNamespace)
+		Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
+
+		res = kubectl.ExecPodCmd(
+			helpers.DefaultNamespace, appPods[helpers.App2],
+			helpers.CurlFail("http://%s/public", app1Service))
+		res.ExpectSuccess("Cannot curl app1-service")
+
+		res = kubectl.ExecPodCmd(
+			helpers.DefaultNamespace, appPods[helpers.App2],
+			helpers.CurlWithHTTPCode("http://%s/private", app1Service))
+		res.ExpectContains("403", "Expect 403 in the result")
 	}
-
-	err = helpers.WithTimeout(
-		waitForUpdateImage,
-		"Cilium Pods are not updating correctly",
-		&helpers.TimeoutConfig{Timeout: timeout})
-	Expect(err).To(BeNil(), "Pods are not updating")
-
-	err = kubectl.WaitforPods(
-		helpers.KubeSystemNamespace, "-l k8s-app=cilium", timeout)
-	Expect(err).Should(BeNil(), "Cilium is not ready after timeout")
-
-	validatedImage(localImage)
-
-	err = kubectl.CiliumEndpointWaitReady()
-	Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
-
-	ExpectKubeDNSReady(kubectl)
-
-	err = kubectl.WaitForKubeDNSEntry(app1Service, helpers.DefaultNamespace)
-	Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
-
-	res = kubectl.ExecPodCmd(
-		helpers.DefaultNamespace, appPods[helpers.App2],
-		helpers.CurlFail("http://%s/public", app1Service))
-	res.ExpectSuccess("Cannot curl app1-service")
-
-	res = kubectl.ExecPodCmd(
-		helpers.DefaultNamespace, appPods[helpers.App2],
-		helpers.CurlWithHTTPCode("http://%s/private", app1Service))
-	res.ExpectContains("403", "Expect 403 in the result")
-
-	return
+	return testfunc, cleanupCallback
 }


### PR DESCRIPTION
In case of Upgrade test fails into the `ValidateCiliumUpgrades`  the
callbacks were never reached and test keeps in a bad state. With this
change `ValidateCiliumUpgrades` will return test and callbacks, so in
case of a fail it'll cleanup correctly

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5187)
<!-- Reviewable:end -->
