### PR TITLE
pkg/k8s: allow namespace specification in FromEndpoints without k8s source

### DIFF
--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -33,6 +33,10 @@ const (
 	// represent pods on the default namespace.
 	podPrefixLbl = labels.LabelSourceK8sKeyPrefix + k8sConst.PodNamespaceLabel
 
+	// podAnyPrefixLbl is the value of the prefix used in the label selector to
+	// represent pods in the default namespace for any source type.
+	podAnyPrefixLbl = labels.LabelSourceAnyKeyPrefix + k8sConst.PodNamespaceLabel
+
 	// podInitLbl is the label used in a label selector to match on
 	// initializing pods.
 	podInitLbl = labels.LabelSourceReservedKeyPrefix + labels.IDNameInit
@@ -84,7 +88,7 @@ func getEndpointSelector(namespace string, labelSelector *metav1.LabelSelector, 
 	// Those pods don't have any labels, so they don't have a namespace label either.
 	// Don't add a namespace label to those endpoint selectors, or we wouldn't be
 	// able to match on those pods.
-	if !matchesInit && !es.HasKey(podPrefixLbl) {
+	if !matchesInit && !es.HasKey(podPrefixLbl) && !es.HasKey(podAnyPrefixLbl) {
 		es.AddMatch(podPrefixLbl, namespace)
 	}
 

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -119,6 +119,9 @@ const (
 	// LabelSourceAny is a label that matches any source
 	LabelSourceAny = "any"
 
+	// LabelSourceAnyKeyPrefix is prefix of a "any" label
+	LabelSourceAnyKeyPrefix = LabelSourceAny + "."
+
 	// LabelSourceK8s is a label imported from Kubernetes
 	LabelSourceK8s = "k8s"
 


### PR DESCRIPTION
Allow users to specify a kubernetes namespace with "any" source.
With this changes it will no longer be required the CNP to have "k8s:"
prefix in "k8s:io.kubernetes.pod.namespace".

Example of a policy selecting the namespace "ns2":
```
apiVersion: "cilium.io/v2"
kind: CiliumNetworkPolicy
metadata:
  name: "k8s-expose-across-namespace"
spec:
  endpointSelector:
    matchLabels:
      name: leia
  ingress:
  - fromEndpoints:
    - matchLabels:
        io.kubernetes.pod.namespace: ns2
        name: luke
```
Signed-off-by: André Martins <andre@cilium.io>

Fixes: #4504 

```release-note
Allow selection of namespace without specifying any "source" type with label `io.kubernetes.pod.namespace`
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5188)
<!-- Reviewable:end -->
