### PR TITLE
Daemon: Refactor PolicyAdd

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1345,7 +1345,7 @@ func NewDaemon() (*Daemon, *endpointRestoreState, error) {
 			// Insert the new rules into the policy repository. We need them to
 			// replace the previous set. This requires the labels to match (including
 			// the ToFQDN-UUID one).
-			_, err := d.PolicyAdd(generatedRules, &AddOptions{Replace: true})
+			_, err := d.PolicyAdd(generatedRules)
 			return err
 		}})
 	fqdn.StartDNSPoller(d.dnsPoller)

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -696,8 +696,7 @@ func (d *Daemon) addK8sNetworkPolicyV1(k8sNP *networkingv1.NetworkPolicy) {
 	}
 	scopedLog = scopedLog.WithField(logfields.K8sNetworkPolicyName, k8sNP.ObjectMeta.Name)
 
-	opts := AddOptions{Replace: true}
-	if _, err := d.PolicyAdd(rules, &opts); err != nil {
+	if _, err := d.PolicyAdd(rules); err != nil {
 		scopedLog.WithError(err).WithFields(logrus.Fields{
 			logfields.CiliumNetworkPolicy: logfields.Repr(rules),
 		}).Error("Unable to add NetworkPolicy rules to policy repository")
@@ -1466,7 +1465,7 @@ func (d *Daemon) addCiliumNetworkPolicyV2(ciliumV2Store cache.Store, cnp *cilium
 		policyImportErr = k8s.PreprocessRules(rules, d.loadBalancer.K8sEndpoints, d.loadBalancer.K8sServices)
 		d.loadBalancer.K8sMU.Unlock()
 		if policyImportErr == nil {
-			rev, policyImportErr = d.PolicyAdd(rules, &AddOptions{Replace: true})
+			rev, policyImportErr = d.PolicyAdd(rules)
 		}
 	}
 

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -115,7 +115,7 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 
 	ds.d.l7Proxy.RemoveAllNetworkPolicies()
 
-	_, err3 := ds.d.PolicyAdd(rules, nil)
+	_, err3 := ds.d.PolicyAdd(rules)
 	c.Assert(err3, Equals, nil)
 
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
@@ -338,12 +338,12 @@ func (ds *DaemonSuite) TestReplacePolicy(c *C) {
 		},
 	}
 
-	_, err := ds.d.PolicyAdd(rules, nil)
+	_, err := ds.d.PolicyAdd(rules)
 	c.Assert(err, IsNil)
 	ds.d.policy.Mutex.RLock()
 	c.Assert(len(ds.d.policy.SearchRLocked(lbls)), Equals, 2)
 	ds.d.policy.Mutex.RUnlock()
-	_, err = ds.d.PolicyAdd(rules, &AddOptions{Replace: true})
+	_, err = ds.d.PolicyAdd(rules)
 	c.Assert(err, IsNil)
 	ds.d.policy.Mutex.RLock()
 	c.Assert(len(ds.d.policy.SearchRLocked(lbls)), Equals, 2)
@@ -415,7 +415,7 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 
 	ds.d.l7Proxy.RemoveAllNetworkPolicies()
 
-	_, err3 := ds.d.PolicyAdd(rules, nil)
+	_, err3 := ds.d.PolicyAdd(rules)
 	c.Assert(err3, Equals, nil)
 
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -510,12 +510,12 @@ func (p *Repository) Add(r api.Rule) (uint64, error) {
 
 	newList := make([]*api.Rule, 1)
 	newList[0] = &r
-	return p.AddListLocked(newList)
+	return p.AddListLocked(newList), nil
 }
 
 // AddListLocked inserts a rule into the policy repository with the repository already locked
 // Expects that the entire rule list has already been sanitized.
-func (p *Repository) AddListLocked(rules api.Rules) (uint64, error) {
+func (p *Repository) AddListLocked(rules api.Rules) uint64 {
 	newList := make([]*rule, len(rules))
 	for i := range rules {
 		newList[i] = &rule{Rule: *rules[i]}
@@ -525,14 +525,14 @@ func (p *Repository) AddListLocked(rules api.Rules) (uint64, error) {
 	metrics.PolicyCount.Add(float64(len(newList)))
 	metrics.PolicyRevision.Inc()
 
-	return p.revision, nil
+	return p.revision
 }
 
 // AddList inserts a rule into the policy repository.
 // This is only used in unit tests.
 // TODO: this should be in a test_helpers.go file or something similar
 // so we can clearly delineate what helpers are for testing.
-func (p *Repository) AddList(rules api.Rules) (uint64, error) {
+func (p *Repository) AddList(rules api.Rules) uint64 {
 	p.Mutex.Lock()
 	defer p.Mutex.Unlock()
 	return p.AddListLocked(rules)


### PR DESCRIPTION
`daemon.policyAdd` never return a error, and some logic about replacing
old rules are in place where are never trigger.

This PR delete the function `policyAdd` and use Repository.AddList() and
remove the unused arguments for daemon.PolicyAdd (AddOptions)

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5199)
<!-- Reviewable:end -->
