### PR TITLE
daemon: sync BPF maps with in-memory K8s service maps

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -145,10 +145,11 @@ type Daemon struct {
 
 	// k8sResourceSyncWaitGroup is used to block the starting of the daemon,
 	// including regenerating restored endpoints (if specified) until all
-	// policies stored in Kubernetes are plumbed into the local Cilium
-	// repository.
-	// This prevents regeneration of endpoints before all policy rules in
-	// Kubernetes are consumed by Cilium. See GH-5038.
+	// policies, services, ingresses, and endpoints stored in Kubernetes at the
+	// time of bootstrapping of the agent are consumed by Cilium.
+	// This prevents regeneration of endpoints, restoring of loadbalancer BPF
+	// maps, etc. being performed without crucial information in securing said
+	// components. See GH-5038 and GH-4457.
 	k8sResourceSyncWaitGroup sync.WaitGroup
 }
 

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -374,14 +374,8 @@ func (d *Daemon) RevNATDelete(id loadbalancer.ServiceID) error {
 		return nil
 	}
 
-	var revNATK lbmap.RevNatKey
-	if !revNAT.IsIPv6() {
-		revNATK = lbmap.NewRevNat4Key(uint16(id))
-	} else {
-		revNATK = lbmap.NewRevNat6Key(uint16(id))
-	}
+	err := lbmap.DeleteRevNATBPF(id, revNAT.IsIPv6())
 
-	err := lbmap.DeleteRevNat(revNATK)
 	// TODO should we delete even if err is != nil?
 	if err == nil {
 		delete(d.loadBalancer.RevNATMap, id)

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -845,6 +845,23 @@ func runDaemon() {
 		// is bootstrapped.
 		d.regenerateRestoredEndpoints(restoredEndpoints)
 		go func() {
+			if k8s.IsEnabled() {
+				// Start controller which removes any leftover Kubernetes
+				// services that may have been deleted while Cilium was not
+				// running. Once this controller succeeds, because it has no
+				// RunInterval specified, it will not run again unless updated
+				// elsewhere. This means that if, for instance, a user manually
+				// adds a service via the CLI into the BPF maps, that it will
+				// not be cleaned up by the daemon until it restarts.
+				controller.NewManager().UpdateController("sync-lb-maps-with-k8s-services",
+					controller.ControllerParams{
+						DoFunc: func() error {
+							return d.syncLBMapsWithK8s()
+						},
+					},
+				)
+				return
+			}
 			if err := d.SyncLBMap(); err != nil {
 				log.WithError(err).Warn("Error while recovering endpoints")
 			}

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -827,16 +827,16 @@ func runDaemon() {
 	cachesSynced := make(chan struct{})
 
 	go func() {
-		log.Info("Waiting until all pre-existing policies have been received")
+		log.Info("Waiting until all pre-existing resources related to policy have been received")
 		d.k8sResourceSyncWaitGroup.Wait()
 		cachesSynced <- struct{}{}
 	}()
 
 	select {
 	case <-cachesSynced:
-		log.Info("All pre-existing policies have been received; continuing")
+		log.Info("All pre-existing resources related to policy have been received; continuing")
 	case <-time.After(cacheSyncTimeout):
-		log.Fatalf("Timed out waiting for pre-existing policies to be received; exiting")
+		log.Fatalf("Timed out waiting for pre-existing resources related to policy to be received; exiting")
 	}
 
 	if option.Config.RestoreState {

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -391,13 +391,22 @@ func (b *LBBackEnd) GetBackendModel() *models.BackendAddress {
 	}
 }
 
-// String returns the L3n4Addr in the "IPv4:Port" format for IPv4 and "[IPv6]:Port" format
-// for IPv6.
+// String returns the L3n4Addr in the "IPv4:Port" format for IPv4 and
+// "[IPv6]:Port" format for IPv6.
 func (a *L3n4Addr) String() string {
 	if a.IsIPv6() {
 		return fmt.Sprintf("[%s]:%d", a.IP.String(), a.Port)
 	}
 	return fmt.Sprintf("%s:%d", a.IP.String(), a.Port)
+}
+
+// StringWithProtocol returns the L3n4Addr in the "IPv4:Port/Protocol" format
+// for IPv4 and "[IPv6]:Port/Protocol" format for IPv6.
+func (a *L3n4Addr) StringWithProtocol() string {
+	if a.IsIPv6() {
+		return fmt.Sprintf("[%s]:%d/%s", a.IP.String(), a.Port, a.Protocol)
+	}
+	return fmt.Sprintf("%s:%d/%s", a.IP.String(), a.Port, a.Protocol)
 }
 
 // StringID returns the L3n4Addr as string to be used for unique identification

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -548,3 +548,16 @@ func ServiceValue2LBBackEnd(svcKey ServiceKey, svcValue ServiceValue) (*loadbala
 
 	return loadbalancer.NewLBBackEnd(loadbalancer.TCP, feIP, fePort, feWeight)
 }
+
+// DeleteRevNATBPF deletes the revNAT entry from its corresponding BPF map
+// (IPv4 or IPv6) with ID id. Returns an error if the deletion operation failed.
+func DeleteRevNATBPF(id loadbalancer.ServiceID, isIPv6 bool) error {
+	var revNATK RevNatKey
+	if isIPv6 {
+		revNATK = NewRevNat6Key(uint16(id))
+	} else {
+		revNATK = NewRevNat4Key(uint16(id))
+	}
+	err := DeleteRevNat(revNATK)
+	return err
+}


### PR DESCRIPTION
This provides a fix for the following scenario when Cilium is running in tandem with Kubernetes:
    
* Cilium is running, and a service is added to Kubernetes. Cilium's Kubernetes watcher receives this event, and plumbs the service into its BPF service maps.
* Cilium is stopped / stops running.
* Aforementioned service is deleted from Kubernetes.
* Cilium is restarted, but the service is kept in the BPF maps because Cilium never received the deletion event for the service from Kubernetes.

Now, upon bootstrapping of the daemon, Cilium waits for all Kubernetes resources that exist upon startup of the Cilium agent that get plumbed into the BPF service maps (services, ingresses) to be consumed by Cilium. Once this is done, a controller is spawned which synchronizes the contents of the BPF service maps with the in-memory Kubernetes service maps maintained by Cilium. This ensures that any service which was deleted when Cilium was not running is cleaned up. Once this controller succeeds, it does not run again; this means that any service which is added manually, say by `cilium service add`, will not be deleted by Cilium if the controller has already completed successfully, or until Cilium is restarted again.

Along the way, did some tidying up and refactoring of some code to allow for reuse of it within this new controller.

Fixes: #4457

Signed-off by: Ian Vernon <ian@cilium.io>

Some comments: I most likely will refactor this in the future so we are doing this on a per-map basis to be in-line with #3161 . Eventually, I would like to factor out the code in such a way that we can spawn controllers on a per-map basis, but this wouldn't do much because we have to hold global locks in the loadbalancer in its current implementation to do this anyway, so I don't think there's not much of a performance benefit by doing this currently. Also would like to get comments regarding running the controller with a `RunInterval` of 0 (meaning it doesn't run again after succeeding) - should we run this consistently to ensure synchronicity between `cilium-agent` and the datapath? Such a change is trivial. I chose not to do it because when this controller is ran, it holds two global mutexes in the loadbalancer. 

```release-note
clean up BPF service map entries for services that were deleted from Kubernetes while Cilium wasn't running
```

**Testing-done**:

I ran this against two test cases in the developer VM:

`NFS=1 K8S=1 ./contrib/vagrant/start.sh`

The following examples were used for testing:

* svc.yaml:

```
apiVersion: v1
kind: Service
metadata:
  name: testds-service
spec:
  ports:
  - port: 80
  selector:
    zgroup: testDS
```

* ds.yaml:

```
apiVersion: extensions/v1beta1
kind: DaemonSet
metadata:
  name: testds
  namespace: default
spec:
  template:
    metadata:
      labels:
        zgroup: testDS
    spec:
      containers:
      - name: web
        image: docker.io/cilium/demo-httpd
        ports:
        - containerPort: 80
      tolerations:
      - effect: NoSchedule
        key: node-role.kubernetes.io/master
      - effect: NoSchedule
        key: node.cloudprovider.kubernetes.io/uninitialized
        value: "true"
```

*No corresponding backends for service exist*

1. List services in Cilium:

```
$ cilium service list
ID   Frontend             Backend                        
1    172.20.0.10:53/UDP   1 => 10.0.96.249:53/NONE       
2    172.20.0.1:443/TCP   1 => 192.168.33.11:6443/NONE 
```

2. BPF map contents match:
```
$ sudo cilium bpf lb list
SERVICE ADDRESS   BACKEND ADDRESS          
172.20.0.1:443    0.0.0.0:0 (0)            
                  192.168.33.11:6443 (2)   
172.20.0.10:53    10.0.96.249:53 (1)       
                  0.0.0.0:0 (0)   
```

3. While Cilium is still running, import the service:

```
$ kubectl apply -f svc.yaml 
service/testds-service created
```

4. Stop cilium:

```
$ sudo service cilium stop
$
```

5. While Cilium is stopped, delete the service:
```
$ kubectl delete -f svc.yaml 
service "testds-service" deleted
```

6. Confirm that service is deleted in K8s:
```
$ kubectl get svc --all-namespaces
NAMESPACE     NAME         TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)         AGE
default       kubernetes   ClusterIP   172.20.0.1    <none>        443/TCP         4h
kube-system   kube-dns     ClusterIP   172.20.0.10   <none>        53/UDP,53/TCP   4h
```

7. Confirm that `cilium bpf lb list` still shows the service as being in the BPF maps (this is expected because cilium isn't running):

```
$ sudo cilium bpf lb list
SERVICE ADDRESS   BACKEND ADDRESS          
172.20.0.10:53    10.0.96.249:53 (1)       
                  0.0.0.0:0 (0)            
172.20.0.43:80    0.0.0.0:0 (0)            
172.20.0.1:443    0.0.0.0:0 (0)            
                  192.168.33.11:6443 (2)
```

8. Start Cilium:
```
$ sudo service cilium start
```

9. Check that the service is removed from the the service list / BPF maps:
```
$ sudo cilium bpf lb list
SERVICE ADDRESS   BACKEND ADDRESS          
172.20.0.1:443    0.0.0.0:0 (0)            
                  192.168.33.11:6443 (1)   
172.20.0.10:53    10.0.96.249:53 (2)       
                  0.0.0.0:0 (0)       
```

```
$ cilium service list
ID   Frontend             Backend                        
1    172.20.0.1:443/TCP   1 => 192.168.33.11:6443/NONE   
2    172.20.0.10:53/UDP   1 => 10.0.96.249:53/NONE 
```

*Backends exist for service* 

1. Apply DaemonSet and service:

```
$ kubectl apply -f ds.yaml 
daemonset.extensions/testds created
$ kubectl apply -f svc.yaml 
service/testds-service created
```

2. Confirm service list and BPF map list show new service:
```
$ cilium service list
ID   Frontend             Backend                        
1    172.20.0.1:443/TCP   1 => 192.168.33.11:6443/NONE   
2    172.20.0.10:53/UDP   1 => 10.0.96.249:53/NONE       
3    172.20.0.75:80/TCP   1 => 10.0.174.167:80/NONE 
```

```
$ sudo cilium bpf lb list 
SERVICE ADDRESS   BACKEND ADDRESS          
172.20.0.1:443    0.0.0.0:0 (0)            
                  192.168.33.11:6443 (1)   
172.20.0.75:80    0.0.0.0:0 (0)            
                  10.0.174.167:80 (3)      
172.20.0.10:53    10.0.96.249:53 (2)       
                  0.0.0.0:0 (0)          
```

4. Stop Cilium

```
$ sudo service cilium stop
$
```

5. Delete service:
```
$ kubectl delete -f svc.yaml 
service "testds-service" deleted
```

6. Start CIlium:
```
$ sudo service cilium start
$
```

7.  Service is not in BPF lb list or in service list:

```
$ sudo cilium bpf lb list 
SERVICE ADDRESS   BACKEND ADDRESS          
172.20.0.1:443    0.0.0.0:0 (0)            
                  192.168.33.11:6443 (2)   
172.20.0.10:53    10.0.96.249:53 (1)       
                  0.0.0.0:0 (0)      
```

```
$ cilium service list
ID   Frontend             Backend                        
1    172.20.0.10:53/TCP   1 => 10.0.96.249:53/NONE       
2    172.20.0.1:443/TCP   1 => 192.168.33.11:6443/NONE 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5203)
<!-- Reviewable:end -->