### PR TITLE
Tweak RTD theme for better representation of versions

### DIFF
--- a/Documentation/_themes/sphinx_rtd_theme/sphinx_rtd_theme/layout.html
+++ b/Documentation/_themes/sphinx_rtd_theme/sphinx_rtd_theme/layout.html
@@ -114,7 +114,11 @@
             {% endif %}
             {% if nav_version %}
               <div class="version">
+                {% if nav_version == 'stable' %}
+                {{ nav_version }} ({{ release }})
+                {% else %}
                 {{ nav_version }}
+                {% endif %}
               </div>
             {% endif %}
           {% endif %}

--- a/Documentation/_themes/sphinx_rtd_theme/sphinx_rtd_theme/versions.html
+++ b/Documentation/_themes/sphinx_rtd_theme/sphinx_rtd_theme/versions.html
@@ -3,7 +3,7 @@
   <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
       <span class="fa fa-book"> Read the Docs</span>
-      v: {{ current_version }}
+      version: {{ current_version }}
       <span class="fa fa-caret-down"></span>
     </span>
     <div class="rst-other-versions">

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -112,6 +112,9 @@ todo_include_todos = False
 html_theme = "sphinx_rtd_theme"
 html_theme_path = ["_themes/sphinx_rtd_theme", ]
 html_style = "static/css/theme.css"
+html_context = {
+        'release': release
+}
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -110,7 +110,8 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 html_theme = "sphinx_rtd_theme"
-html_theme_path = ["_themes", ]
+html_theme_path = ["_themes/sphinx_rtd_theme", ]
+html_style = "static/css/theme.css"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -121,7 +122,7 @@ html_theme_path = ["_themes", ]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['images', '_static']
+html_static_path = ['images', '_static', '_themes/sphinx_rtd_theme/sphinx_rtd_theme']
 
 # -- Options for HTMLHelp output ------------------------------------------
 


### PR DESCRIPTION
* Update the configuration for the sphinx theme so that the version of the theme is picked up from the Cilium tree
* Customize the version text in the upper left corner for stable releases to show the specific version of Cilium that the docs are generated from
* Reduce the redundancy of the "v: v1.1" text in the version navigation bar in the bottom right

See a preview here:
https://joestringercilium.readthedocs.io/en/stable/

Needs to be backported into:
* Each active branch so that the theme will be consistent between all branches
* A tagged release on github to make the stable docs consistent with the rest

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5206)
<!-- Reviewable:end -->
