### PR TITLE
proxy: Re-create redirect if L7 type has changed

### DIFF
--- a/test/k8sT/manifests/l7-policy-kafka.yaml
+++ b/test/k8sT/manifests/l7-policy-kafka.yaml
@@ -1,0 +1,21 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+description: "L7 policy to test HTTP -> Kafka type change"
+metadata:
+  name: "l7-policy"
+spec:
+  endpointSelector:
+    matchLabels:
+      id: app1
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        id: app2
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+      rules:
+        kafka:
+        - apiKey: "apiversions"
+        - apiKey: "metadata"


### PR DESCRIPTION
The existing code errored out when a port was already configured with a
redirect of a different kind. Add the ability to change the parser type.  A new
redirect will be recreated and a new port will be allocated. Existing
connections will receive an RST as the port is closed.

Fixes: #5202

Signed-off-by: Thomas Graf <thomas@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5210)
<!-- Reviewable:end -->
