### PR TITLE
policy: Handle empty L7Rules in ToPorts

### DIFF
--- a/pkg/policy/api/l4.go
+++ b/pkg/policy/api/l4.go
@@ -73,3 +73,17 @@ type L7Rules struct {
 	// +optional
 	Kafka []PortRuleKafka `json:"kafka,omitempty"`
 }
+
+// Len returns the total number of rules inside `L7Rules`.
+// Returns 0 if nil.
+func (rules *L7Rules) Len() int {
+	if rules == nil {
+		return 0
+	}
+	return len(rules.HTTP) + len(rules.Kafka)
+}
+
+// IsEmpty returns whether the `L7Rules` is nil or contains nil rules.
+func (rules *L7Rules) IsEmpty() bool {
+	return rules == nil || (rules.HTTP == nil && rules.Kafka == nil)
+}

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -276,13 +276,13 @@ func (pr *PortRule) sanitize() error {
 		if err := pr.Ports[i].sanitize(); err != nil {
 			return err
 		}
-		if pr.Rules != nil && pr.Ports[i].Protocol != ProtoTCP {
+		if !pr.Rules.IsEmpty() && pr.Ports[i].Protocol != ProtoTCP {
 			return fmt.Errorf("L7 rules can only apply exclusively to TCP, not %s", pr.Ports[i].Protocol)
 		}
 	}
 
 	// Sanitize L7 rules
-	if pr.Rules != nil {
+	if !pr.Rules.IsEmpty() {
 		if err := pr.Rules.sanitize(); err != nil {
 			return err
 		}

--- a/pkg/policy/api/utils.go
+++ b/pkg/policy/api/utils.go
@@ -19,11 +19,6 @@ import (
 	"strings"
 )
 
-// Len returns the total number of rules inside `L7Rules`.
-func (rules *L7Rules) Len() int {
-	return len(rules.HTTP) + len(rules.Kafka)
-}
-
 // Exists returns true if the HTTP rule already exists in the list of rules
 func (h *PortRuleHTTP) Exists(rules L7Rules) bool {
 	for _, existingRule := range rules.HTTP {
@@ -78,15 +73,6 @@ func (l4 L4Proto) Validate() error {
 	}
 
 	return nil
-}
-
-// NumRules returns the total number of L7Rules configured in this PortRule
-func (r *PortRule) NumRules() int {
-	if r.Rules == nil {
-		return 0
-	}
-
-	return r.Rules.Len()
 }
 
 // ParseL4Proto parses a string as layer 4 protocol

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -172,7 +172,7 @@ func CreateL4Filter(peerEndpoints api.EndpointSelectorSlice, rule api.PortRule, 
 		Ingress:          ingress,
 	}
 
-	if protocol == api.ProtoTCP && rule.Rules != nil {
+	if protocol == api.ProtoTCP && !rule.Rules.IsEmpty() {
 		switch {
 		case len(rule.Rules.HTTP) > 0:
 			l4.L7Parser = ParserTypeHTTP
@@ -199,7 +199,7 @@ func CreateL4IngressFilter(fromEndpoints api.EndpointSelectorSlice, endpointsWit
 
 	// If the filter would apply L7 rules for endpointsWithL3Override,
 	// then wildcard those specific endpoints at L7.
-	if rule.Rules != nil && rule.Rules.Len() > 0 {
+	if !rule.Rules.IsEmpty() {
 		for _, selector := range endpointsWithL3Override {
 			filter.L7RulesPerEp[selector] = api.L7Rules{}
 		}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -182,7 +182,7 @@ func (p *Repository) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Polic
 				} else {
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
-						if toPort.Rules == nil {
+						if toPort.Rules.IsEmpty() {
 							for _, p := range toPort.Ports {
 								// Already validated via PortRule.Validate().
 								port, _ := strconv.ParseUint(p.Port, 0, 16)
@@ -212,7 +212,7 @@ func (p *Repository) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Polic
 				} else {
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
-						if toPort.Rules == nil {
+						if toPort.Rules.IsEmpty() {
 							for _, p := range toPort.Ports {
 								// Already validated via PortRule.Validate().
 								port, _ := strconv.ParseUint(p.Port, 0, 16)

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -153,7 +153,7 @@ func mergeL4Ingress(ctx *SearchContext, rule api.IngressRule, ruleLabels labels.
 
 	for _, r := range rule.ToPorts {
 		ctx.PolicyTrace("    Allows %s port %v from endpoints %v\n", policymap.Ingress, r.Ports, fromEndpoints)
-		if r.Rules != nil {
+		if !r.Rules.IsEmpty() {
 			for _, l7 := range r.Rules.HTTP {
 				ctx.PolicyTrace("        %+v\n", l7)
 			}
@@ -422,7 +422,7 @@ func mergeL4Egress(ctx *SearchContext, rule api.EgressRule, ruleLabels labels.La
 	for _, r := range rule.ToPorts {
 		ctx.PolicyTrace("    Allows %s port %v to endpoints %v\n", policymap.Egress, r.Ports, toEndpoints)
 
-		if r.Rules != nil {
+		if !r.Rules.IsEmpty() {
 			for _, l7 := range r.Rules.HTTP {
 				ctx.PolicyTrace("        %+v\n", l7)
 			}


### PR DESCRIPTION
Consistently respect the API spec in handling an empty `L7Rules`
like a `nil` `L7Rules`.  Fix the merging and wildcarding of rules with
empty `L7Rules`.

Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5216)
<!-- Reviewable:end -->
