### PR TITLE
pkg/lock: use Mutex instead of RWMutex for internalMutex

### DIFF
--- a/pkg/lock/lock_debug.go
+++ b/pkg/lock/lock_debug.go
@@ -1,6 +1,6 @@
 // +build lockdebug
 
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,5 +31,5 @@ type internalRWMutex struct {
 }
 
 type internalMutex struct {
-	deadlock.RWMutex
+	deadlock.Mutex
 }


### PR DESCRIPTION
Fixes: 941c8c06f635 ("New lock package to allow for simple deadlock debugging")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5218)
<!-- Reviewable:end -->
