### PR TITLE
envoy: Generalize access logging.

### DIFF
--- a/envoy/accesslog.cc
+++ b/envoy/accesslog.cc
@@ -64,17 +64,17 @@ void AccessLog::Entry::InitFromRequest(
                           time.time_since_epoch())
                           .count());
 
-  ::cilium::Protocol proto;
+  ::cilium::HttpProtocol proto;
   switch (info.protocol() ? info.protocol().value() : Http::Protocol::Http11) {
   case Http::Protocol::Http10:
-    proto = ::cilium::Protocol::HTTP10;
+    proto = ::cilium::HttpProtocol::HTTP10;
     break;
   case Http::Protocol::Http11:
   default: // Just to make compiler happy
-    proto = ::cilium::Protocol::HTTP11;
+    proto = ::cilium::HttpProtocol::HTTP11;
     break;
   case Http::Protocol::Http2:
-    proto = ::cilium::Protocol::HTTP2;
+    proto = ::cilium::HttpProtocol::HTTP2;
     break;
   }
   entry.set_http_protocol(proto);
@@ -106,8 +106,8 @@ void AccessLog::Entry::InitFromRequest(
          void *entry_) -> Http::HeaderMap::Iterate {
         const Http::HeaderString &key = header.key();
         const char *value = header.value().c_str();
-        ::cilium::HttpLogEntry *entry =
-            static_cast<::cilium::HttpLogEntry *>(entry_);
+        ::cilium::LogEntry *entry =
+            static_cast<::cilium::LogEntry *>(entry_);
 
         if (key == ":path") {
           entry->set_path(value);
@@ -158,7 +158,7 @@ void AccessLog::Entry::UpdateFromResponse(
 
 void AccessLog::Log(AccessLog::Entry &entry_,
                     ::cilium::EntryType entry_type) {
-  ::cilium::HttpLogEntry &entry = entry_.entry;
+  ::cilium::LogEntry &entry = entry_.entry;
 
   entry.set_entry_type(entry_type);
 

--- a/envoy/accesslog.h
+++ b/envoy/accesslog.h
@@ -28,7 +28,7 @@ public:
                          const Http::HeaderMap &, const RequestInfo::RequestInfo &);
     void UpdateFromResponse(const Http::HeaderMap &, const RequestInfo::RequestInfo &);
 
-    ::cilium::HttpLogEntry entry{};
+    ::cilium::LogEntry entry{};
   };
   void Log(Entry &entry, ::cilium::EntryType);
 

--- a/envoy/cilium/accesslog.proto
+++ b/envoy/cilium/accesslog.proto
@@ -7,7 +7,7 @@ message KeyValue {
   string value = 2;
 }
 
-enum Protocol {
+enum HttpProtocol {
   HTTP10 = 0;
   HTTP11 = 1;
   HTTP2 = 2;
@@ -20,11 +20,29 @@ enum EntryType {
 }
 
 message HttpLogEntry {
+  HttpProtocol http_protocol = 1;
+
+  // Request info that is also retained for the response
+  string scheme = 2;      // Envoy "x-forwarded-proto", e.g., "http", "https"
+  string host = 3;        // Envoy ":authority" header
+  string path = 4;        // Envoy ":path" header
+  string method = 5;      // Envoy ":method" header
+
+  // Request headers not included above
+  repeated KeyValue headers = 6;
+
+  // Response info
+  uint32 status = 7;      // Envoy ":status" header, zero for request
+}
+
+message LogEntry {
   // The time that Cilium filter captured this log entry,
   // in, nanoseconds since 1/1/1970.
   uint64 timestamp = 1;
 
-  Protocol http_protocol = 2;
+  // 'true' if the request was received by an ingress listener,
+  // 'false' if received by an egress listener
+  bool is_ingress = 15;
 
   EntryType entry_type = 3;
 
@@ -34,27 +52,32 @@ message HttpLogEntry {
   // Cilium rule reference
   string cilium_rule_ref = 5;
   
-  // Cilium security ID of the source
+  // Cilium security ID of the source and destination
   uint32 source_security_id = 6;
+  uint32 destination_security_id = 16;
 
   // These fields record the original source and destination addresses,
   // stored in ipv4:port or [ipv6]:port format.
   string source_address = 7;
   string destination_address = 8;
 
-  // Request info that is also retained for the response
-  string scheme = 9;      // Envoy "x-forwarded-proto", e.g., "http", "https"
-  string host = 10;       // Envoy ":authority" header
-  string path = 11;       // Envoy ":path" header
-  string method = 12;     // Envoy ":method" header
+  oneof l7 {
+    HttpLogEntry http = 100;
+  }
 
-  // Response info
-  uint32 status = 13;     // Envoy ":status" header, zero for request
+  //
+  // Deprecated HTTP fields. Use the http field above instead.
+  //
+  HttpProtocol http_protocol = 2 [deprecated=true];
+
+  // Request info that is also retained for the response
+  string scheme = 9 [deprecated=true];      // Envoy "x-forwarded-proto", e.g., "http", "https"
+  string host = 10 [deprecated=true];       // Envoy ":authority" header
+  string path = 11 [deprecated=true];       // Envoy ":path" header
+  string method = 12 [deprecated=true];     // Envoy ":method" header
+
+  uint32 status = 13 [deprecated=true];     // Envoy ":status" header, zero for request
   
   // Request headers not included above
-  repeated KeyValue headers = 14;
-
-  // 'true' if the request was received by an ingress listener,
-  // 'false' if received by an egress listener
-  bool is_ingress = 15;
+  repeated KeyValue headers = 14 [deprecated=true];
 }

--- a/envoy/cilium_integration_test.cc
+++ b/envoy/cilium_integration_test.cc
@@ -1,3 +1,10 @@
+#include "accesslog.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
 #include <string>
 
 #include "envoy/network/listen_socket.h"
@@ -28,6 +35,120 @@
 #include "cilium/cilium_l7policy.pb.validate.h"
 
 namespace Envoy {
+
+class AccessLogServer : Logger::Loggable<Logger::Id::router> {
+public:
+  AccessLogServer(const char*path) : path_(path), fd2_(-1) {
+    ENVOY_LOG(critical, "Creating access log server: {}", path);
+    ::unlink(path);
+    fd_ = ::socket(AF_UNIX, SOCK_SEQPACKET, 0);
+    if (fd_ == -1) {
+      ENVOY_LOG(error, "Can't create socket: {}", strerror(errno));
+      return;
+    }
+
+    struct sockaddr_un addr = {.sun_family = AF_UNIX, .sun_path = {}};
+    strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
+    if (::bind(fd_, reinterpret_cast<struct sockaddr *>(&addr),
+	       sizeof(addr)) == -1) {
+      ENVOY_LOG(warn, "Bind to {} failed: {}", path, strerror(errno));
+      Close();
+      return;
+    }
+
+    if (::listen(fd_, 5) == -1) {
+      ENVOY_LOG(warn, "Listen on {} failed: {}", path, strerror(errno));
+      Close();
+      return;
+    }
+
+    ENVOY_LOG(critical, "Starting access log server thread fd: {}", fd_);
+
+    thread_.reset(new Thread::Thread([this]() -> void { threadRoutine(); }));
+  }
+
+  ~AccessLogServer() {
+    if (fd_ >= 0) {
+      Close();
+      ENVOY_LOG(warn, "Waiting on access log to close: {}", strerror(errno));
+      thread_->join();
+      thread_.reset();
+    }
+  }
+private:
+  void Close() {
+    ::shutdown(fd_, SHUT_RD);
+    ::shutdown(fd2_, SHUT_RD);
+    ::close(fd_);
+    fd_ = -1;
+    ::unlink(path_);
+  }
+
+  void threadRoutine() {
+    while (fd_ >= 0) {
+      ENVOY_LOG(critical, "Access Log thread started on fd: {}", fd_);
+      // Accept a new connection
+      struct sockaddr_un addr;
+      socklen_t addr_len;
+      ENVOY_LOG(warn, "Access log blocking accept on fd: {}", fd_);
+      fd2_ = ::accept(fd_, reinterpret_cast<sockaddr*>(&addr), &addr_len);
+      if (fd2_ < 0) {
+	ENVOY_LOG(critical, "Access log accept failed: {}", strerror(errno));
+      } else {
+	char buf[8192];
+	while (true) {
+	  ENVOY_LOG(warn, "Access log blocking recv on fd: {}", fd2_);
+	  ssize_t received = ::recv(fd2_, buf, sizeof(buf), 0);
+	  if (received < 0) {
+	    ENVOY_LOG(warn, "Access log recv failed: {}", strerror(errno));
+	    break;
+	  } else if (received == 0) {
+	    ENVOY_LOG(warn, "Access log recv got no data!");
+	    break;
+	  } else {
+	    std::string data(buf, received);
+	    ::cilium::LogEntry entry;
+	    if (!entry.ParseFromString(data)) {
+	      ENVOY_LOG(warn, "Access log parse failed!");
+	    } else {
+	      if (entry.method().length() > 0) {
+		ENVOY_LOG(warn, "Access log deprecated format detected");
+		// Deprecated format detected, map to the new one
+		auto http = entry.mutable_http();
+		http->set_http_protocol(entry.http_protocol());
+		entry.clear_http_protocol();
+		http->set_scheme(entry.scheme());
+		entry.clear_scheme();
+		http->set_host(entry.host());
+		entry.clear_host();
+		http->set_path(entry.path());
+		entry.clear_path();
+		http->set_method(entry.method());
+		entry.clear_method();
+		for (const auto& dep_hdr: entry.headers()) {
+		  auto hdr = http->add_headers();
+		  hdr->set_key(dep_hdr.key());
+		  hdr->set_value(dep_hdr.value());
+		}
+		entry.clear_headers();
+		http->set_status(entry.status());
+		entry.clear_status();
+	      }
+	      ENVOY_LOG(info, "Access log entry: {}", entry.DebugString());
+	    }
+	  }
+	}
+	::close(fd2_);
+	fd2_ = -1;
+      }
+    };
+  }
+
+  const char* path_;
+  std::atomic<int> fd_;
+  std::atomic<int> fd2_;
+  Thread::ThreadPtr thread_;
+};
 
 std::string host_map_config;
 std::shared_ptr<const Cilium::PolicyHostMap> hostmap{nullptr};
@@ -282,7 +403,7 @@ static_resources:
           http_filters:
           - name: test_l7policy
             config:
-              access_log_path: ""
+              access_log_path: "access_log.sock"
               policy_name: "173"
           - name: envoy.router
           route_config:
@@ -306,7 +427,8 @@ class CiliumIntegrationTestBase
 
 public:
   CiliumIntegrationTestBase(const std::string& config)
-    : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam(), config) {
+    : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam(), config),
+      accessLogServer_("access_log.sock") {
     // Undo legacy compat rename done by HttpIntegrationTest constructor.
     // config_helper_.renameListener("cilium");
     for (Logger::Logger& logger : Logger::Registry::loggers()) {
@@ -361,6 +483,8 @@ public:
     EXPECT_THROW_WITH_MESSAGE(hmap.onConfigUpdate(typed_resources, "1"), EnvoyException, exmsg);
     tls.shutdownGlobalThreading();
   }
+
+  AccessLogServer accessLogServer_;;
 };
 
 class CiliumIntegrationTest : public CiliumIntegrationTestBase {

--- a/pkg/envoy/accesslog_server_test.go
+++ b/pkg/envoy/accesslog_server_test.go
@@ -32,7 +32,7 @@ func (k *AccessLogServerSuite) TestParseURL(c *C) {
 	}
 
 	for _, l := range logs {
-		u := parseURL(&l)
+		u := l.ParseURL()
 		c.Assert(u.Scheme, Equals, "http")
 		c.Assert(u.Host, Equals, "foo")
 		c.Assert(u.Path, Equals, "/foo")

--- a/pkg/envoy/cilium/accesslog.pb.go
+++ b/pkg/envoy/cilium/accesslog.pb.go
@@ -18,30 +18,30 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
-type Protocol int32
+type HttpProtocol int32
 
 const (
-	Protocol_HTTP10 Protocol = 0
-	Protocol_HTTP11 Protocol = 1
-	Protocol_HTTP2  Protocol = 2
+	HttpProtocol_HTTP10 HttpProtocol = 0
+	HttpProtocol_HTTP11 HttpProtocol = 1
+	HttpProtocol_HTTP2  HttpProtocol = 2
 )
 
-var Protocol_name = map[int32]string{
+var HttpProtocol_name = map[int32]string{
 	0: "HTTP10",
 	1: "HTTP11",
 	2: "HTTP2",
 }
-var Protocol_value = map[string]int32{
+var HttpProtocol_value = map[string]int32{
 	"HTTP10": 0,
 	"HTTP11": 1,
 	"HTTP2":  2,
 }
 
-func (x Protocol) String() string {
-	return proto.EnumName(Protocol_name, int32(x))
+func (x HttpProtocol) String() string {
+	return proto.EnumName(HttpProtocol_name, int32(x))
 }
-func (Protocol) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_accesslog_1b41d6edb88c4826, []int{0}
+func (HttpProtocol) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_accesslog_149966dc1dc4329c, []int{0}
 }
 
 type EntryType int32
@@ -67,7 +67,7 @@ func (x EntryType) String() string {
 	return proto.EnumName(EntryType_name, int32(x))
 }
 func (EntryType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_accesslog_1b41d6edb88c4826, []int{1}
+	return fileDescriptor_accesslog_149966dc1dc4329c, []int{1}
 }
 
 type KeyValue struct {
@@ -82,7 +82,7 @@ func (m *KeyValue) Reset()         { *m = KeyValue{} }
 func (m *KeyValue) String() string { return proto.CompactTextString(m) }
 func (*KeyValue) ProtoMessage()    {}
 func (*KeyValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_accesslog_1b41d6edb88c4826, []int{0}
+	return fileDescriptor_accesslog_149966dc1dc4329c, []int{0}
 }
 func (m *KeyValue) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_KeyValue.Unmarshal(m, b)
@@ -117,33 +117,16 @@ func (m *KeyValue) GetValue() string {
 }
 
 type HttpLogEntry struct {
-	// The time that Cilium filter captured this log entry,
-	// in, nanoseconds since 1/1/1970.
-	Timestamp    uint64    `protobuf:"varint,1,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
-	HttpProtocol Protocol  `protobuf:"varint,2,opt,name=http_protocol,json=httpProtocol,proto3,enum=cilium.Protocol" json:"http_protocol,omitempty"`
-	EntryType    EntryType `protobuf:"varint,3,opt,name=entry_type,json=entryType,proto3,enum=cilium.EntryType" json:"entry_type,omitempty"`
-	// Cilium network policy resource name
-	PolicyName string `protobuf:"bytes,4,opt,name=policy_name,json=policyName,proto3" json:"policy_name,omitempty"`
-	// Cilium rule reference
-	CiliumRuleRef string `protobuf:"bytes,5,opt,name=cilium_rule_ref,json=ciliumRuleRef,proto3" json:"cilium_rule_ref,omitempty"`
-	// Cilium security ID of the source
-	SourceSecurityId uint32 `protobuf:"varint,6,opt,name=source_security_id,json=sourceSecurityId,proto3" json:"source_security_id,omitempty"`
-	// These fields record the original source and destination addresses,
-	// stored in ipv4:port or [ipv6]:port format.
-	SourceAddress      string `protobuf:"bytes,7,opt,name=source_address,json=sourceAddress,proto3" json:"source_address,omitempty"`
-	DestinationAddress string `protobuf:"bytes,8,opt,name=destination_address,json=destinationAddress,proto3" json:"destination_address,omitempty"`
+	HttpProtocol HttpProtocol `protobuf:"varint,1,opt,name=http_protocol,json=httpProtocol,proto3,enum=cilium.HttpProtocol" json:"http_protocol,omitempty"`
 	// Request info that is also retained for the response
-	Scheme string `protobuf:"bytes,9,opt,name=scheme,proto3" json:"scheme,omitempty"`
-	Host   string `protobuf:"bytes,10,opt,name=host,proto3" json:"host,omitempty"`
-	Path   string `protobuf:"bytes,11,opt,name=path,proto3" json:"path,omitempty"`
-	Method string `protobuf:"bytes,12,opt,name=method,proto3" json:"method,omitempty"`
-	// Response info
-	Status uint32 `protobuf:"varint,13,opt,name=status,proto3" json:"status,omitempty"`
+	Scheme string `protobuf:"bytes,2,opt,name=scheme,proto3" json:"scheme,omitempty"`
+	Host   string `protobuf:"bytes,3,opt,name=host,proto3" json:"host,omitempty"`
+	Path   string `protobuf:"bytes,4,opt,name=path,proto3" json:"path,omitempty"`
+	Method string `protobuf:"bytes,5,opt,name=method,proto3" json:"method,omitempty"`
 	// Request headers not included above
-	Headers []*KeyValue `protobuf:"bytes,14,rep,name=headers,proto3" json:"headers,omitempty"`
-	// 'true' if the request was received by an ingress listener,
-	// 'false' if received by an egress listener
-	IsIngress            bool     `protobuf:"varint,15,opt,name=is_ingress,json=isIngress,proto3" json:"is_ingress,omitempty"`
+	Headers []*KeyValue `protobuf:"bytes,6,rep,name=headers,proto3" json:"headers,omitempty"`
+	// Response info
+	Status               uint32   `protobuf:"varint,7,opt,name=status,proto3" json:"status,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -153,7 +136,7 @@ func (m *HttpLogEntry) Reset()         { *m = HttpLogEntry{} }
 func (m *HttpLogEntry) String() string { return proto.CompactTextString(m) }
 func (*HttpLogEntry) ProtoMessage()    {}
 func (*HttpLogEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_accesslog_1b41d6edb88c4826, []int{1}
+	return fileDescriptor_accesslog_149966dc1dc4329c, []int{1}
 }
 func (m *HttpLogEntry) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_HttpLogEntry.Unmarshal(m, b)
@@ -173,60 +156,11 @@ func (m *HttpLogEntry) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_HttpLogEntry proto.InternalMessageInfo
 
-func (m *HttpLogEntry) GetTimestamp() uint64 {
-	if m != nil {
-		return m.Timestamp
-	}
-	return 0
-}
-
-func (m *HttpLogEntry) GetHttpProtocol() Protocol {
+func (m *HttpLogEntry) GetHttpProtocol() HttpProtocol {
 	if m != nil {
 		return m.HttpProtocol
 	}
-	return Protocol_HTTP10
-}
-
-func (m *HttpLogEntry) GetEntryType() EntryType {
-	if m != nil {
-		return m.EntryType
-	}
-	return EntryType_Request
-}
-
-func (m *HttpLogEntry) GetPolicyName() string {
-	if m != nil {
-		return m.PolicyName
-	}
-	return ""
-}
-
-func (m *HttpLogEntry) GetCiliumRuleRef() string {
-	if m != nil {
-		return m.CiliumRuleRef
-	}
-	return ""
-}
-
-func (m *HttpLogEntry) GetSourceSecurityId() uint32 {
-	if m != nil {
-		return m.SourceSecurityId
-	}
-	return 0
-}
-
-func (m *HttpLogEntry) GetSourceAddress() string {
-	if m != nil {
-		return m.SourceAddress
-	}
-	return ""
-}
-
-func (m *HttpLogEntry) GetDestinationAddress() string {
-	if m != nil {
-		return m.DestinationAddress
-	}
-	return ""
+	return HttpProtocol_HTTP10
 }
 
 func (m *HttpLogEntry) GetScheme() string {
@@ -257,13 +191,6 @@ func (m *HttpLogEntry) GetMethod() string {
 	return ""
 }
 
-func (m *HttpLogEntry) GetStatus() uint32 {
-	if m != nil {
-		return m.Status
-	}
-	return 0
-}
-
 func (m *HttpLogEntry) GetHeaders() []*KeyValue {
 	if m != nil {
 		return m.Headers
@@ -271,51 +198,321 @@ func (m *HttpLogEntry) GetHeaders() []*KeyValue {
 	return nil
 }
 
-func (m *HttpLogEntry) GetIsIngress() bool {
+func (m *HttpLogEntry) GetStatus() uint32 {
+	if m != nil {
+		return m.Status
+	}
+	return 0
+}
+
+type LogEntry struct {
+	// The time that Cilium filter captured this log entry,
+	// in, nanoseconds since 1/1/1970.
+	Timestamp uint64 `protobuf:"varint,1,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	// 'true' if the request was received by an ingress listener,
+	// 'false' if received by an egress listener
+	IsIngress bool      `protobuf:"varint,15,opt,name=is_ingress,json=isIngress,proto3" json:"is_ingress,omitempty"`
+	EntryType EntryType `protobuf:"varint,3,opt,name=entry_type,json=entryType,proto3,enum=cilium.EntryType" json:"entry_type,omitempty"`
+	// Cilium network policy resource name
+	PolicyName string `protobuf:"bytes,4,opt,name=policy_name,json=policyName,proto3" json:"policy_name,omitempty"`
+	// Cilium rule reference
+	CiliumRuleRef string `protobuf:"bytes,5,opt,name=cilium_rule_ref,json=ciliumRuleRef,proto3" json:"cilium_rule_ref,omitempty"`
+	// Cilium security ID of the source and destination
+	SourceSecurityId      uint32 `protobuf:"varint,6,opt,name=source_security_id,json=sourceSecurityId,proto3" json:"source_security_id,omitempty"`
+	DestinationSecurityId uint32 `protobuf:"varint,16,opt,name=destination_security_id,json=destinationSecurityId,proto3" json:"destination_security_id,omitempty"`
+	// These fields record the original source and destination addresses,
+	// stored in ipv4:port or [ipv6]:port format.
+	SourceAddress      string `protobuf:"bytes,7,opt,name=source_address,json=sourceAddress,proto3" json:"source_address,omitempty"`
+	DestinationAddress string `protobuf:"bytes,8,opt,name=destination_address,json=destinationAddress,proto3" json:"destination_address,omitempty"`
+	// Types that are valid to be assigned to L7:
+	//	*LogEntry_Http
+	L7 isLogEntry_L7 `protobuf_oneof:"l7"`
+	//
+	// Deprecated HTTP fields. Use the http field above instead.
+	//
+	HttpProtocol HttpProtocol `protobuf:"varint,2,opt,name=http_protocol,json=httpProtocol,proto3,enum=cilium.HttpProtocol" json:"http_protocol,omitempty"` // Deprecated: Do not use.
+	// Request info that is also retained for the response
+	Scheme string `protobuf:"bytes,9,opt,name=scheme,proto3" json:"scheme,omitempty"`   // Deprecated: Do not use.
+	Host   string `protobuf:"bytes,10,opt,name=host,proto3" json:"host,omitempty"`      // Deprecated: Do not use.
+	Path   string `protobuf:"bytes,11,opt,name=path,proto3" json:"path,omitempty"`      // Deprecated: Do not use.
+	Method string `protobuf:"bytes,12,opt,name=method,proto3" json:"method,omitempty"`  // Deprecated: Do not use.
+	Status uint32 `protobuf:"varint,13,opt,name=status,proto3" json:"status,omitempty"` // Deprecated: Do not use.
+	// Request headers not included above
+	Headers              []*KeyValue `protobuf:"bytes,14,rep,name=headers,proto3" json:"headers,omitempty"` // Deprecated: Do not use.
+	XXX_NoUnkeyedLiteral struct{}    `json:"-"`
+	XXX_unrecognized     []byte      `json:"-"`
+	XXX_sizecache        int32       `json:"-"`
+}
+
+func (m *LogEntry) Reset()         { *m = LogEntry{} }
+func (m *LogEntry) String() string { return proto.CompactTextString(m) }
+func (*LogEntry) ProtoMessage()    {}
+func (*LogEntry) Descriptor() ([]byte, []int) {
+	return fileDescriptor_accesslog_149966dc1dc4329c, []int{2}
+}
+func (m *LogEntry) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_LogEntry.Unmarshal(m, b)
+}
+func (m *LogEntry) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_LogEntry.Marshal(b, m, deterministic)
+}
+func (dst *LogEntry) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LogEntry.Merge(dst, src)
+}
+func (m *LogEntry) XXX_Size() int {
+	return xxx_messageInfo_LogEntry.Size(m)
+}
+func (m *LogEntry) XXX_DiscardUnknown() {
+	xxx_messageInfo_LogEntry.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_LogEntry proto.InternalMessageInfo
+
+func (m *LogEntry) GetTimestamp() uint64 {
+	if m != nil {
+		return m.Timestamp
+	}
+	return 0
+}
+
+func (m *LogEntry) GetIsIngress() bool {
 	if m != nil {
 		return m.IsIngress
 	}
 	return false
 }
 
+func (m *LogEntry) GetEntryType() EntryType {
+	if m != nil {
+		return m.EntryType
+	}
+	return EntryType_Request
+}
+
+func (m *LogEntry) GetPolicyName() string {
+	if m != nil {
+		return m.PolicyName
+	}
+	return ""
+}
+
+func (m *LogEntry) GetCiliumRuleRef() string {
+	if m != nil {
+		return m.CiliumRuleRef
+	}
+	return ""
+}
+
+func (m *LogEntry) GetSourceSecurityId() uint32 {
+	if m != nil {
+		return m.SourceSecurityId
+	}
+	return 0
+}
+
+func (m *LogEntry) GetDestinationSecurityId() uint32 {
+	if m != nil {
+		return m.DestinationSecurityId
+	}
+	return 0
+}
+
+func (m *LogEntry) GetSourceAddress() string {
+	if m != nil {
+		return m.SourceAddress
+	}
+	return ""
+}
+
+func (m *LogEntry) GetDestinationAddress() string {
+	if m != nil {
+		return m.DestinationAddress
+	}
+	return ""
+}
+
+type isLogEntry_L7 interface {
+	isLogEntry_L7()
+}
+
+type LogEntry_Http struct {
+	Http *HttpLogEntry `protobuf:"bytes,100,opt,name=http,proto3,oneof"`
+}
+
+func (*LogEntry_Http) isLogEntry_L7() {}
+
+func (m *LogEntry) GetL7() isLogEntry_L7 {
+	if m != nil {
+		return m.L7
+	}
+	return nil
+}
+
+func (m *LogEntry) GetHttp() *HttpLogEntry {
+	if x, ok := m.GetL7().(*LogEntry_Http); ok {
+		return x.Http
+	}
+	return nil
+}
+
+// Deprecated: Do not use.
+func (m *LogEntry) GetHttpProtocol() HttpProtocol {
+	if m != nil {
+		return m.HttpProtocol
+	}
+	return HttpProtocol_HTTP10
+}
+
+// Deprecated: Do not use.
+func (m *LogEntry) GetScheme() string {
+	if m != nil {
+		return m.Scheme
+	}
+	return ""
+}
+
+// Deprecated: Do not use.
+func (m *LogEntry) GetHost() string {
+	if m != nil {
+		return m.Host
+	}
+	return ""
+}
+
+// Deprecated: Do not use.
+func (m *LogEntry) GetPath() string {
+	if m != nil {
+		return m.Path
+	}
+	return ""
+}
+
+// Deprecated: Do not use.
+func (m *LogEntry) GetMethod() string {
+	if m != nil {
+		return m.Method
+	}
+	return ""
+}
+
+// Deprecated: Do not use.
+func (m *LogEntry) GetStatus() uint32 {
+	if m != nil {
+		return m.Status
+	}
+	return 0
+}
+
+// Deprecated: Do not use.
+func (m *LogEntry) GetHeaders() []*KeyValue {
+	if m != nil {
+		return m.Headers
+	}
+	return nil
+}
+
+// XXX_OneofFuncs is for the internal use of the proto package.
+func (*LogEntry) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
+	return _LogEntry_OneofMarshaler, _LogEntry_OneofUnmarshaler, _LogEntry_OneofSizer, []interface{}{
+		(*LogEntry_Http)(nil),
+	}
+}
+
+func _LogEntry_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
+	m := msg.(*LogEntry)
+	// l7
+	switch x := m.L7.(type) {
+	case *LogEntry_Http:
+		b.EncodeVarint(100<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Http); err != nil {
+			return err
+		}
+	case nil:
+	default:
+		return fmt.Errorf("LogEntry.L7 has unexpected type %T", x)
+	}
+	return nil
+}
+
+func _LogEntry_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
+	m := msg.(*LogEntry)
+	switch tag {
+	case 100: // l7.http
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(HttpLogEntry)
+		err := b.DecodeMessage(msg)
+		m.L7 = &LogEntry_Http{msg}
+		return true, err
+	default:
+		return false, nil
+	}
+}
+
+func _LogEntry_OneofSizer(msg proto.Message) (n int) {
+	m := msg.(*LogEntry)
+	// l7
+	switch x := m.L7.(type) {
+	case *LogEntry_Http:
+		s := proto.Size(x.Http)
+		n += 2 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case nil:
+	default:
+		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
+	}
+	return n
+}
+
 func init() {
 	proto.RegisterType((*KeyValue)(nil), "cilium.KeyValue")
 	proto.RegisterType((*HttpLogEntry)(nil), "cilium.HttpLogEntry")
-	proto.RegisterEnum("cilium.Protocol", Protocol_name, Protocol_value)
+	proto.RegisterType((*LogEntry)(nil), "cilium.LogEntry")
+	proto.RegisterEnum("cilium.HttpProtocol", HttpProtocol_name, HttpProtocol_value)
 	proto.RegisterEnum("cilium.EntryType", EntryType_name, EntryType_value)
 }
 
-func init() { proto.RegisterFile("cilium/accesslog.proto", fileDescriptor_accesslog_1b41d6edb88c4826) }
+func init() { proto.RegisterFile("cilium/accesslog.proto", fileDescriptor_accesslog_149966dc1dc4329c) }
 
-var fileDescriptor_accesslog_1b41d6edb88c4826 = []byte{
-	// 459 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x4c, 0x92, 0x6f, 0x6b, 0xd4, 0x40,
-	0x10, 0xc6, 0x9b, 0xfb, 0x93, 0x4b, 0xe6, 0xfe, 0x34, 0x8e, 0x52, 0xf6, 0x85, 0xe2, 0x51, 0x50,
-	0x8e, 0x43, 0xaf, 0xed, 0x89, 0x1f, 0x40, 0x50, 0x68, 0x51, 0xa4, 0xac, 0x87, 0x6f, 0xc3, 0x9a,
-	0x4c, 0x2f, 0x8b, 0x49, 0x36, 0x66, 0x37, 0x42, 0x3e, 0x8d, 0x5f, 0x55, 0xb2, 0x9b, 0x5c, 0xfb,
-	0xee, 0x99, 0xdf, 0x3c, 0xcf, 0xec, 0x2e, 0xb3, 0x70, 0x91, 0xc8, 0x5c, 0x36, 0xc5, 0x95, 0x48,
-	0x12, 0xd2, 0x3a, 0x57, 0xc7, 0x5d, 0x55, 0x2b, 0xa3, 0xd0, 0x77, 0xfc, 0x72, 0x0f, 0xc1, 0x57,
-	0x6a, 0x7f, 0x8a, 0xbc, 0x21, 0x8c, 0x60, 0xfc, 0x9b, 0x5a, 0xe6, 0xad, 0xbd, 0x4d, 0xc8, 0x3b,
-	0x89, 0x2f, 0x60, 0xfa, 0xb7, 0x6b, 0xb1, 0x91, 0x65, 0xae, 0xb8, 0xfc, 0x37, 0x81, 0xc5, 0xad,
-	0x31, 0xd5, 0x37, 0x75, 0xfc, 0x52, 0x9a, 0xba, 0xc5, 0x97, 0x10, 0x1a, 0x59, 0x90, 0x36, 0xa2,
-	0xa8, 0x6c, 0x7c, 0xc2, 0x1f, 0x01, 0x7e, 0x84, 0x65, 0x66, 0x4c, 0x15, 0xdb, 0x83, 0x13, 0x95,
-	0xdb, 0x61, 0xab, 0x7d, 0xb4, 0x73, 0x57, 0xd8, 0xdd, 0xf7, 0x9c, 0x2f, 0x3a, 0xdb, 0x50, 0xe1,
-	0x35, 0x00, 0x75, 0xd3, 0x63, 0xd3, 0x56, 0xc4, 0xc6, 0x36, 0xf3, 0x6c, 0xc8, 0xd8, 0x73, 0x0f,
-	0x6d, 0x45, 0x3c, 0xa4, 0x41, 0xe2, 0x6b, 0x98, 0x57, 0x2a, 0x97, 0x49, 0x1b, 0x97, 0xa2, 0x20,
-	0x36, 0xb1, 0x77, 0x06, 0x87, 0xbe, 0x8b, 0x82, 0xf0, 0x2d, 0x9c, 0xbb, 0x7c, 0x5c, 0x37, 0x39,
-	0xc5, 0x35, 0x3d, 0xb0, 0xa9, 0x35, 0x2d, 0x1d, 0xe6, 0x4d, 0x4e, 0x9c, 0x1e, 0xf0, 0x1d, 0xa0,
-	0x56, 0x4d, 0x9d, 0x50, 0xac, 0x29, 0x69, 0x6a, 0x69, 0xda, 0x58, 0xa6, 0xcc, 0x5f, 0x7b, 0x9b,
-	0x25, 0x8f, 0x5c, 0xe7, 0x47, 0xdf, 0xb8, 0x4b, 0xf1, 0x0d, 0xac, 0x7a, 0xb7, 0x48, 0xd3, 0x9a,
-	0xb4, 0x66, 0x33, 0x37, 0xd4, 0xd1, 0x4f, 0x0e, 0xe2, 0x15, 0x3c, 0x4f, 0x49, 0x1b, 0x59, 0x0a,
-	0x23, 0x55, 0x79, 0xf2, 0x06, 0xd6, 0x8b, 0x4f, 0x5a, 0x43, 0xe0, 0x02, 0x7c, 0x9d, 0x64, 0x54,
-	0x10, 0x0b, 0xad, 0xa7, 0xaf, 0x10, 0x61, 0x92, 0x29, 0x6d, 0x18, 0x58, 0x6a, 0x75, 0xc7, 0x2a,
-	0x61, 0x32, 0x36, 0x77, 0xac, 0xd3, 0x5d, 0xbe, 0x20, 0x93, 0xa9, 0x94, 0x2d, 0x5c, 0xde, 0x55,
-	0x76, 0xae, 0x11, 0xa6, 0xd1, 0x6c, 0x69, 0x5f, 0xd4, 0x57, 0xb8, 0x85, 0x59, 0x46, 0x22, 0xa5,
-	0x5a, 0xb3, 0xd5, 0x7a, 0xbc, 0x99, 0x3f, 0x6e, 0x68, 0xf8, 0x21, 0x7c, 0x30, 0xe0, 0x2b, 0x00,
-	0xa9, 0x63, 0x59, 0x1e, 0xed, 0x1b, 0xce, 0xd7, 0xde, 0x26, 0xe0, 0xa1, 0xd4, 0x77, 0x0e, 0x6c,
-	0xdf, 0x43, 0x70, 0xda, 0x23, 0x80, 0x7f, 0x7b, 0x38, 0xdc, 0xdf, 0x5c, 0x47, 0x67, 0x27, 0x7d,
-	0x13, 0x79, 0x18, 0xc2, 0xb4, 0xd3, 0xfb, 0x68, 0xb4, 0xdd, 0x43, 0x78, 0x5a, 0x28, 0xce, 0x61,
-	0xc6, 0xe9, 0x4f, 0x43, 0xda, 0x44, 0x67, 0xb8, 0x80, 0x80, 0x93, 0xae, 0x54, 0xa9, 0x29, 0xf2,
-	0xba, 0xf8, 0x67, 0x2a, 0x25, 0xa5, 0xd1, 0xe8, 0x97, 0x6f, 0xbf, 0xd3, 0x87, 0xff, 0x01, 0x00,
-	0x00, 0xff, 0xff, 0xcc, 0xc0, 0x49, 0x3a, 0xe1, 0x02, 0x00, 0x00,
+var fileDescriptor_accesslog_149966dc1dc4329c = []byte{
+	// 578 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x93, 0x6d, 0x8b, 0xd3, 0x40,
+	0x10, 0xc7, 0x2f, 0xb9, 0x36, 0x6d, 0xa6, 0x0f, 0x17, 0xd7, 0xb3, 0x86, 0x43, 0xb1, 0x1c, 0x28,
+	0xa5, 0x48, 0xef, 0x1a, 0x41, 0xf1, 0x85, 0x2f, 0x3c, 0x14, 0x7a, 0x28, 0x72, 0xac, 0xc5, 0xb7,
+	0x21, 0x26, 0x73, 0xcd, 0x62, 0x9e, 0xcc, 0x6e, 0x84, 0x7c, 0x20, 0x3f, 0x9a, 0xdf, 0x43, 0x76,
+	0x37, 0x49, 0x7b, 0x87, 0xbe, 0x9b, 0xf9, 0xcf, 0xc3, 0xce, 0x4c, 0x7e, 0x81, 0x59, 0xc8, 0x12,
+	0x56, 0xa5, 0x17, 0x41, 0x18, 0x22, 0xe7, 0x49, 0xbe, 0x5b, 0x15, 0x65, 0x2e, 0x72, 0x62, 0x69,
+	0xfd, 0xdc, 0x83, 0xe1, 0x27, 0xac, 0xbf, 0x05, 0x49, 0x85, 0xc4, 0x81, 0xe3, 0x1f, 0x58, 0xbb,
+	0xc6, 0xdc, 0x58, 0xd8, 0x54, 0x9a, 0xe4, 0x14, 0xfa, 0xbf, 0x64, 0xc8, 0x35, 0x95, 0xa6, 0x9d,
+	0xf3, 0x3f, 0x06, 0x8c, 0x37, 0x42, 0x14, 0x9f, 0xf3, 0xdd, 0xc7, 0x4c, 0x94, 0x35, 0x79, 0x0b,
+	0x93, 0x58, 0x88, 0xc2, 0x57, 0xad, 0xc3, 0x3c, 0x51, 0x2d, 0xa6, 0xde, 0xe9, 0x4a, 0x3f, 0xb2,
+	0x92, 0xc9, 0x37, 0x4d, 0x8c, 0x8e, 0xe3, 0x03, 0x8f, 0xcc, 0xc0, 0xe2, 0x61, 0x8c, 0x69, 0xfb,
+	0x44, 0xe3, 0x11, 0x02, 0xbd, 0x38, 0xe7, 0xc2, 0x3d, 0x56, 0xaa, 0xb2, 0xa5, 0x56, 0x04, 0x22,
+	0x76, 0x7b, 0x5a, 0x93, 0xb6, 0xac, 0x4f, 0x51, 0xc4, 0x79, 0xe4, 0xf6, 0x75, 0xbd, 0xf6, 0xc8,
+	0x12, 0x06, 0x31, 0x06, 0x11, 0x96, 0xdc, 0xb5, 0xe6, 0xc7, 0x8b, 0x91, 0xe7, 0xb4, 0xc3, 0xb4,
+	0xeb, 0xd2, 0x36, 0x41, 0xcd, 0x20, 0x02, 0x51, 0x71, 0x77, 0x30, 0x37, 0x16, 0x13, 0xda, 0x78,
+	0xe7, 0xbf, 0xfb, 0x30, 0xec, 0x76, 0x7c, 0x02, 0xb6, 0x60, 0x29, 0x72, 0x11, 0xa4, 0x85, 0xda,
+	0xaf, 0x47, 0xf7, 0x02, 0x79, 0x0a, 0xc0, 0xb8, 0xcf, 0xb2, 0x5d, 0x89, 0x9c, 0xbb, 0x27, 0x73,
+	0x63, 0x31, 0xa4, 0x36, 0xe3, 0xd7, 0x5a, 0x20, 0x97, 0x00, 0x28, 0xbb, 0xf8, 0xa2, 0x2e, 0x50,
+	0xed, 0x34, 0xf5, 0x1e, 0xb4, 0x03, 0xa9, 0xfe, 0xdb, 0xba, 0x40, 0x6a, 0x63, 0x6b, 0x92, 0x67,
+	0x30, 0x2a, 0xf2, 0x84, 0x85, 0xb5, 0x9f, 0x05, 0x29, 0x36, 0x2b, 0x83, 0x96, 0xbe, 0x04, 0x29,
+	0x92, 0x17, 0x70, 0xa2, 0xeb, 0xfd, 0xb2, 0x4a, 0xd0, 0x2f, 0xf1, 0xb6, 0xb9, 0xc0, 0x44, 0xcb,
+	0xb4, 0x4a, 0x90, 0xe2, 0x2d, 0x79, 0x09, 0x84, 0xe7, 0x55, 0x19, 0xa2, 0xcf, 0x31, 0xac, 0x4a,
+	0x26, 0x6a, 0x9f, 0x45, 0xae, 0xa5, 0x16, 0x75, 0x74, 0xe4, 0x6b, 0x13, 0xb8, 0x8e, 0xc8, 0x6b,
+	0x78, 0x1c, 0x21, 0x17, 0x2c, 0x0b, 0x04, 0xcb, 0xb3, 0x3b, 0x25, 0x8e, 0x2a, 0x79, 0x74, 0x10,
+	0x3e, 0xa8, 0x7b, 0x0e, 0xd3, 0xe6, 0x95, 0x20, 0x8a, 0xd4, 0x0d, 0x06, 0x7a, 0x18, 0xad, 0xbe,
+	0xd7, 0x22, 0xb9, 0x80, 0x87, 0x87, 0xed, 0xdb, 0xdc, 0xa1, 0xca, 0x25, 0x07, 0xa1, 0xb6, 0x60,
+	0x09, 0x3d, 0x89, 0x8b, 0x1b, 0xcd, 0x8d, 0xc5, 0xe8, 0x2e, 0x50, 0xed, 0x97, 0xd9, 0x1c, 0x51,
+	0x95, 0x43, 0xde, 0xdd, 0xa7, 0xd0, 0xfc, 0x3f, 0x85, 0x57, 0xa6, 0x6b, 0xdc, 0x23, 0xf1, 0xac,
+	0x23, 0xd1, 0x96, 0xe3, 0xa8, 0x8c, 0x96, 0xc6, 0x59, 0x43, 0x23, 0x74, 0x11, 0x4d, 0xe4, 0xac,
+	0x21, 0x72, 0xb4, 0xd7, 0x15, 0x95, 0x67, 0x1d, 0x95, 0xe3, 0x7d, 0xaf, 0x86, 0xcc, 0xb3, 0x8e,
+	0xb6, 0x89, 0xbc, 0x68, 0xf3, 0x8e, 0x52, 0xc8, 0x6a, 0x4f, 0xed, 0xf4, 0xdf, 0xd4, 0xaa, 0xf4,
+	0x36, 0xe9, 0xaa, 0x07, 0x66, 0xf2, 0x66, 0xb9, 0xd6, 0xbf, 0x63, 0xb7, 0x09, 0x80, 0xb5, 0xd9,
+	0x6e, 0x6f, 0xd6, 0x97, 0xce, 0x51, 0x67, 0xaf, 0x1d, 0x83, 0xd8, 0xd0, 0x97, 0xb6, 0xe7, 0x98,
+	0x4b, 0x0f, 0xec, 0x0e, 0x3b, 0x32, 0x82, 0x01, 0xc5, 0x9f, 0x15, 0x72, 0xe1, 0x1c, 0x91, 0x31,
+	0x0c, 0x29, 0xf2, 0x22, 0xcf, 0x38, 0x3a, 0x86, 0x2c, 0xff, 0x80, 0x19, 0xc3, 0xc8, 0x31, 0xbf,
+	0x5b, 0xea, 0xb0, 0xaf, 0xfe, 0x06, 0x00, 0x00, 0xff, 0xff, 0x11, 0x8d, 0x6f, 0xe8, 0x53, 0x04,
+	0x00, 0x00,
 }

--- a/pkg/envoy/cilium/accesslog.pb.validate.go
+++ b/pkg/envoy/cilium/accesslog.pb.validate.go
@@ -87,21 +87,7 @@ func (m *HttpLogEntry) Validate() error {
 		return nil
 	}
 
-	// no validation rules for Timestamp
-
 	// no validation rules for HttpProtocol
-
-	// no validation rules for EntryType
-
-	// no validation rules for PolicyName
-
-	// no validation rules for CiliumRuleRef
-
-	// no validation rules for SourceSecurityId
-
-	// no validation rules for SourceAddress
-
-	// no validation rules for DestinationAddress
 
 	// no validation rules for Scheme
 
@@ -110,8 +96,6 @@ func (m *HttpLogEntry) Validate() error {
 	// no validation rules for Path
 
 	// no validation rules for Method
-
-	// no validation rules for Status
 
 	for idx, item := range m.GetHeaders() {
 		_, _ = idx, item
@@ -128,7 +112,7 @@ func (m *HttpLogEntry) Validate() error {
 
 	}
 
-	// no validation rules for IsIngress
+	// no validation rules for Status
 
 	return nil
 }
@@ -163,3 +147,105 @@ func (e HttpLogEntryValidationError) Error() string {
 }
 
 var _ error = HttpLogEntryValidationError{}
+
+// Validate checks the field values on LogEntry with the rules defined in the
+// proto definition for this message. If any rules are violated, an error is returned.
+func (m *LogEntry) Validate() error {
+	if m == nil {
+		return nil
+	}
+
+	// no validation rules for Timestamp
+
+	// no validation rules for IsIngress
+
+	// no validation rules for EntryType
+
+	// no validation rules for PolicyName
+
+	// no validation rules for CiliumRuleRef
+
+	// no validation rules for SourceSecurityId
+
+	// no validation rules for DestinationSecurityId
+
+	// no validation rules for SourceAddress
+
+	// no validation rules for DestinationAddress
+
+	// no validation rules for HttpProtocol
+
+	// no validation rules for Scheme
+
+	// no validation rules for Host
+
+	// no validation rules for Path
+
+	// no validation rules for Method
+
+	// no validation rules for Status
+
+	for idx, item := range m.GetHeaders() {
+		_, _ = idx, item
+
+		if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return LogEntryValidationError{
+					Field:  fmt.Sprintf("Headers[%v]", idx),
+					Reason: "embedded message failed validation",
+					Cause:  err,
+				}
+			}
+		}
+
+	}
+
+	switch m.L7.(type) {
+
+	case *LogEntry_Http:
+
+		if v, ok := interface{}(m.GetHttp()).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return LogEntryValidationError{
+					Field:  "Http",
+					Reason: "embedded message failed validation",
+					Cause:  err,
+				}
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// LogEntryValidationError is the validation error returned by
+// LogEntry.Validate if the designated constraints aren't met.
+type LogEntryValidationError struct {
+	Field  string
+	Reason string
+	Cause  error
+	Key    bool
+}
+
+// Error satisfies the builtin error interface
+func (e LogEntryValidationError) Error() string {
+	cause := ""
+	if e.Cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.Cause)
+	}
+
+	key := ""
+	if e.Key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sLogEntry.%s: %s%s",
+		key,
+		e.Field,
+		e.Reason,
+		cause)
+}
+
+var _ error = LogEntryValidationError{}


### PR DESCRIPTION
Define extensible layer 7 `oneof` for accesslog protobuf.  Deprecate
the old http fields in the main access log protobuf
message and convert to new format when received.

This change makes it clearer how to extend access logging for new L7
protocols while maintaining backwards compatibility with existing
pods.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5219)
<!-- Reviewable:end -->
