### PR TITLE
envoy: Make the log level computation thread-safe

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1464,7 +1464,7 @@ func changedOption(key string, value int, data interface{}) {
 		// Set the debug toggle (this can be a no-op)
 		logging.ToggleDebugLogs(d.DebugEnabled())
 		// Reflect log level change to proxies
-		proxy.ChangeLogLevel(log.Level)
+		proxy.ChangeLogLevel(logging.GetLevel(logging.DefaultLogger))
 	}
 	d.policy.BumpRevision() // force policy recalculation
 }

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -180,7 +180,8 @@ func StartEnvoy(adminPort uint32, stateDir, logPath string, baseID uint64) *Envo
 		defer logWriter.Close()
 
 		for {
-			cmd := exec.Command("cilium-envoy", "-l", mapLogLevel(log.Level), "-c", bootstrapPath, "--base-id", strconv.FormatUint(baseID, 10), "--log-format", logFormat)
+			logLevel := logging.GetLevel(logging.DefaultLogger)
+			cmd := exec.Command("cilium-envoy", "-l", mapLogLevel(logLevel), "-c", bootstrapPath, "--base-id", strconv.FormatUint(baseID, 10), "--log-format", logFormat)
 			cmd.Stderr = logWriter
 			cmd.Stdout = logWriter
 

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -341,5 +341,10 @@ func MultiLine(logFn func(args ...interface{}), output string) {
 // CanLogAt returns whether a log message at the given level would be
 // logged by the given logger.
 func CanLogAt(logger *logrus.Logger, level logrus.Level) bool {
-	return logrus.Level(atomic.LoadUint32((*uint32)(&logger.Level))) >= level
+	return GetLevel(logger) >= level
+}
+
+// GetLevel returns the log level of the given logger.
+func GetLevel(logger *logrus.Logger) logrus.Level {
+	return logrus.Level(atomic.LoadUint32((*uint32)(&logger.Level)))
 }


### PR DESCRIPTION
The previous logic was reading the Level of a Logger and an Entry
in a non-threadsafe manner. Also, using an Entry's Level was not
reliable since that is not set until the Entry's first log
statement.

Fixes: https://github.com/cilium/cilium/pull/4937
Fixes: https://github.com/cilium/cilium/commit/d5345cf282f219e05f91b2581b100711c95892ae
Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5221)
<!-- Reviewable:end -->
