### PR TITLE
endpointmanager: Fix conntrack GC

### DIFF
--- a/pkg/endpointmanager/conntrack.go
+++ b/pkg/endpointmanager/conntrack.go
@@ -47,9 +47,9 @@ func RunGC(e *endpoint.Endpoint, isIPv6 bool, filter *ctmap.GCFilter) {
 	// that receives an interface doesn't pass the nil through, so to avoid
 	// a segfault we check the pointer and directly pass nil here.
 	if e == nil {
-		file = ctmap.GetMapPath(nil, isIPv6)
+		mapType, file = ctmap.GetMapTypeAndPath(nil, isIPv6)
 	} else {
-		file = ctmap.GetMapPath(e, isIPv6)
+		mapType, file = ctmap.GetMapTypeAndPath(e, isIPv6)
 	}
 	m, err := bpf.OpenMap(file)
 	if err != nil {

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -72,9 +72,9 @@ type CtEndpoint interface {
 	StringID() string
 }
 
-// GetMapPath returns the path for the CT map for the specified endpoint.
-// Returns the global map path if e is nil.
-func GetMapPath(e CtEndpoint, isIPv6 bool) string {
+// GetMapTypeAndPath returns the map type and path for the CT map for the
+// specified endpoint. Returns the global map path if e is nil.
+func GetMapTypeAndPath(e CtEndpoint, isIPv6 bool) (string, string) {
 	var (
 		file    string
 		mapType string
@@ -97,7 +97,12 @@ func GetMapPath(e CtEndpoint, isIPv6 bool) string {
 		file = bpf.MapPath(mapType)
 	}
 
-	return file
+	return mapType, file
+}
+
+func getMapPath(e CtEndpoint, isIPv6 bool) string {
+	_, path := GetMapTypeAndPath(e, isIPv6)
+	return path
 }
 
 // getMaps fetches all paths for conntrack maps associated with the specified
@@ -105,8 +110,8 @@ func GetMapPath(e CtEndpoint, isIPv6 bool) string {
 // map.
 func getMapPathsToKeySize(e CtEndpoint) map[string]uint32 {
 	return map[string]uint32{
-		GetMapPath(e, true):  uint32(unsafe.Sizeof(CtKey6{})),
-		GetMapPath(e, false): uint32(unsafe.Sizeof(CtKey4{})),
+		getMapPath(e, true):  uint32(unsafe.Sizeof(CtKey6{})),
+		getMapPath(e, false): uint32(unsafe.Sizeof(CtKey4{})),
 	}
 }
 


### PR DESCRIPTION
Commit 61759e706c6b ("ctmap: Add accessor method for path per endpoint")
inadvertently hid the map type (IPv4 or IPv6) from the endpointmanager,
which was relying on this map type to call the correct ctmap garbage
collection function.

This commit does a quick fix to fetch the maptype so that it can be used
in the same way as it was in previous releases. A followup commit will
refactor this to avoid leaking CT map details into the callers.

Fixes: 61759e706c6b ("ctmap: Add accessor method for path per endpoint")

Fixes PR #5118.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5230)
<!-- Reviewable:end -->
