### PR TITLE
Jenkins: Increase timeouts for stages

### DIFF
--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 240, unit: 'MINUTES')
+        timeout(time: 300, unit: 'MINUTES')
         timestamps()
         ansiColor('xterm')
     }
@@ -74,7 +74,7 @@ pipeline {
                 CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
             }
             options {
-                timeout(time: 90, unit: 'MINUTES')
+                timeout(time: 120, unit: 'MINUTES')
             }
             steps {
                 script {
@@ -118,7 +118,7 @@ pipeline {
                 CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
             }
             options {
-                timeout(time: 90, unit: 'MINUTES')
+                timeout(time: 120, unit: 'MINUTES')
             }
             steps {
                 script {

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 210, unit: 'MINUTES')
+        timeout(time: 240, unit: 'MINUTES')
         timestamps()
         ansiColor('xterm')
     }
@@ -90,7 +90,7 @@ pipeline {
             }
 
             options {
-                timeout(time: 120, unit: 'MINUTES')
+                timeout(time: 140, unit: 'MINUTES')
             }
 
             steps {


### PR DESCRIPTION
Due the new test the build duration will be a bit bigger, increase the
timeout a little bit to no trigger timeouts.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5232)
<!-- Reviewable:end -->
