### PR TITLE
monitor: revert agent -> monitor encoding

### DIFF
--- a/monitor/launch/launcher.go
+++ b/monitor/launch/launcher.go
@@ -202,8 +202,12 @@ func (nm *NodeMonitor) send(data []byte) error {
 	}
 
 	p := payload.Payload{Data: data, CPU: 0, Lost: nm.lostSinceLastTime(), Type: payload.EventSample}
+	buf, err := p.BuildMessage()
+	if err != nil {
+		return err
+	}
 
-	if err := p.WriteBinary(nm.pipe); err != nil {
+	if _, err := nm.pipe.Write(buf); err != nil {
 		nm.pipe.Close()
 		nm.pipe = nil
 		return fmt.Errorf("Unable to write message buffer to pipe: %s", err)

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -76,9 +76,9 @@ func (m *Monitor) agentPipeReader(ctx context.Context, agentPipe io.Reader) {
 	log.Info("Beginning to read cilium agent events")
 	defer log.Info("Stopped reading cilium agent events")
 
-	p := payload.Payload{}
 	for !isCtxDone(ctx) {
-		err := p.ReadBinary(agentPipe)
+		meta, p := payload.Meta{}, payload.Payload{}
+		err := payload.ReadMetaPayload(agentPipe, &meta, &p)
 		switch {
 		// this captures the case where we are shutting down and main closes the
 		// pipe socket


### PR DESCRIPTION
We "optimized" the encoding scheme for agent events. Unfortunately, this
resulted in partial reads of data that triggered errors. This patch
reverts the code to the older scheme that includes more framing. Note
that the old scheme is also susceptible to this but the problem is very
unlikely to manifest.

The problem here is around message framing. We use gob and it has no
inbuilt framing. Under load, the reads or write on the socket may result
in partial data. The functions we use to encode and decode constuct new
gob enc/decoders. This effectively interrupts the stream for the new
decoder causing an error.

The older scheme minimized this by encoding a length before the payload
object. This was done with another gob encode and is, itself,
susceptible as well. This object is much smaller, however, making it
very unlikely.

fixes b88afa221afc56b8ac34d304a7af64ac99e9f4b3

fixes https://github.com/cilium/cilium/issues/5229

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5236)
<!-- Reviewable:end -->
