### PR TITLE
daemon: Return from sync endpoint creation after 1st regeneration

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -276,15 +276,10 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder 
 				if err := e.RLockAlive(); err != nil {
 					return api.Error(PutEndpointIDFailedCode, fmt.Errorf("error locking endpoint: %s", err.Error()))
 				}
-				epState := e.GetStateLocked()
 				hasSidecarProxy := e.HasSidecarProxy()
 				e.RUnlock()
 
-				if epState == endpoint.StateDisconnected || epState == endpoint.StateDisconnecting {
-					// Short circuit in case a call to delete the endpoint is
-					// made while we are waiting.
-					return api.Error(PutEndpointIDFailedCode, fmt.Errorf("endpoint %d went into state %s while waiting for regeneration to succeed", e.ID, epState))
-				} else if hasSidecarProxy {
+				if hasSidecarProxy {
 					// If the endpoint is determined to have a sidecar proxy,
 					// return immediately to let the sidecar container start,
 					// in case it is required to enforce L7 rules.

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -34,13 +34,16 @@ type Repository struct {
 	rules []*rule
 
 	// revision is the revision of the policy repository. It will be
-	// incremented whenever the policy repository is changed
+	// incremented whenever the policy repository is changed.
+	// Always positive (>0).
 	revision uint64
 }
 
 // NewPolicyRepository allocates a new policy repository
 func NewPolicyRepository() *Repository {
-	return &Repository{}
+	return &Repository{
+		revision: 1,
+	}
 }
 
 // traceState is an internal structure used to collect information

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -32,7 +32,7 @@ func (ds *PolicyTestSuite) TestAddSearchDelete(c *C) {
 	// cannot add empty rule
 	rev, err := repo.Add(api.Rule{})
 	c.Assert(err, Not(IsNil))
-	c.Assert(rev, Equals, uint64(0))
+	c.Assert(rev, Equals, uint64(1))
 
 	lbls1 := labels.LabelArray{
 		labels.ParseLabel("tag1"),
@@ -52,7 +52,7 @@ func (ds *PolicyTestSuite) TestAddSearchDelete(c *C) {
 		Labels:           lbls2,
 	}
 
-	nextRevision := uint64(0)
+	nextRevision := uint64(1)
 
 	c.Assert(repo.GetRevision(), Equals, nextRevision)
 	nextRevision++


### PR DESCRIPTION
A synchronous endpoint creation API call was waiting for the endpoint to get to the `ready` state before returning. However, in the case when many endpoints are starting at the same time, an endpoint may go through several regenerations immediately before getting `ready`.
It is sufficient to return after the 1st regeneration since the endpoint has network connectivity at that point.

This will reduce the probability of API timeouts under load, and improve the pod start times.

The recently added call to `e.RLockAlive` was already checking whether the endpoint is disconnecting. Remove the explicit state check, which was now dead code.

Start the repository policy revision from 1 instead of 0.
Starting from 1 allows identifying when an `Endpoint` has had a successful BPF regeneration (`policyRevision` > 0).

Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5240)
<!-- Reviewable:end -->
