### PR TITLE
endpointmanager: Fix WaitForEndpointsAtPolicyRev's timeout handling

### DIFF
--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -375,6 +375,9 @@ func WaitForEndpointsAtPolicyRev(ctx context.Context, rev uint64) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-eps[i].WaitForPolicyRevision(ctx, rev):
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
A channel returned by `WaitForPolicyRevision` may be closed for two reasons: when the endpoint has reached the desired policy revision, or when the context has timed out.
Check in `WaitForEndpointsAtPolicyRev` whether the context has timed out in case a channel is closed, to avoid missing timeouts.

Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5242)
<!-- Reviewable:end -->
