### PR TITLE
Fix conntrack entry removal on endpoint leave and agent restart

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -808,7 +808,9 @@ func runDaemon() {
 	}
 
 	log.Info("Starting connection tracking garbage collector")
-	endpointmanager.EnableConntrackGC(!option.Config.IPv4Disabled, true, viper.GetInt("conntrack-garbage-collector-interval"))
+	endpointmanager.EnableConntrackGC(!option.Config.IPv4Disabled, true,
+		viper.GetInt("conntrack-garbage-collector-interval"),
+		restoredEndpoints.restored)
 
 	if enableLogstash {
 		log.Info("Enabling Logstash")

--- a/pkg/endpointmanager/conntrack.go
+++ b/pkg/endpointmanager/conntrack.go
@@ -65,15 +65,16 @@ func runGC(e *endpoint.Endpoint, isIPv6 bool, filter *ctmap.GCFilter) {
 
 	if deleted > 0 {
 		log.WithFields(logrus.Fields{
-			logfields.Path:  file,
-			"ctFilter.type": filter.TypeString(),
-			"count":         deleted,
+			logfields.Path: file,
+			"count":        deleted,
 		}).Debug("Deleted filtered entries from map")
 	}
 }
 
 func createGCFilter(ipv6, initialScan bool, restoredEndpoints []*endpoint.Endpoint) *ctmap.GCFilter {
-	filter := ctmap.NewGCFilterBy(ctmap.GCFilterByTime)
+	filter := &ctmap.GCFilter{
+		RemoveExpired: true,
+	}
 
 	// On the initial scan, scrub all IPs from the conntrack table which do
 	// not belong to IPs of any endpoint that has been restored. No new
@@ -121,10 +122,10 @@ func EnableConntrackGC(ipv4, ipv6 bool, gcinterval int, restoredEndpoints []*end
 					continue
 				}
 				if ipv6 {
-					runGC(e, true, ctmap.NewGCFilterBy(ctmap.GCFilterByTime))
+					runGC(e, true, &ctmap.GCFilter{RemoveExpired: true})
 				}
 				if ipv4 {
-					runGC(e, false, ctmap.NewGCFilterBy(ctmap.GCFilterByTime))
+					runGC(e, false, &ctmap.GCFilter{RemoveExpired: true})
 				}
 			}
 

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -189,6 +189,9 @@ type GCFilter struct {
 	// source or destination IP is *not* matching one of the valid IPs.
 	// The key is the IP in string form: net.IP.String()
 	ValidIPs map[string]struct{}
+
+	// MatchIPs is the list of IPs to remove from the conntrack table
+	MatchIPs map[string]struct{}
 }
 
 // ToString iterates through Map m and writes the values of the ct entries in m
@@ -535,6 +538,14 @@ func (f *GCFilter) doFiltering(srcIP net.IP, dstIP net.IP, dstPort uint16, nextH
 		_, srcIPExists := f.ValidIPs[srcIP.String()]
 		_, dstIPExists := f.ValidIPs[dstIP.String()]
 		if !srcIPExists && !dstIPExists {
+			return deleteEntry
+		}
+	}
+
+	if f.MatchIPs != nil {
+		_, srcIPExists := f.MatchIPs[srcIP.String()]
+		_, dstIPExists := f.MatchIPs[dstIP.String()]
+		if srcIPExists || dstIPExists {
 			return deleteEntry
 		}
 	}


### PR DESCRIPTION
So far, no scrubbing was performed and all entries in the conntrack table have
been subject to regular expiration cycles. When starting the agent, the agent
restores all previous endpoints. The IPs of all those endpoints are known. We
can thus scrub the conntrack table from all entries that cannot be associated
with one of the restored endpoints.

Testing:

Old table
```
$ sudo cilium bpf ct list global
ICMPv6 IN [f00d::a0f:0:0:fbac]:0 -> [fd01::b]:0 related  expires=98121 rx_packets=1 rx_bytes=142 tx_packets=0 tx_bytes=0 flags=10 revnat=0 src_sec_id=1
TCP OUT [2a00:1450:400a:801::2004]:80 -> [f00d::a0f:0:0:fbac]:43232  expires=98121 rx_packets=0 rx_bytes=0 tx_packets=1 tx_bytes=94 flags=0 revnat=0 src_sec_id=63927
ICMPv6 OUT [2a00:1450:400a:801::2004]:0 -> [f00d::a0f:0:0:fbac]:0 related  expires=98121 rx_packets=0 rx_bytes=0 tx_packets=1 tx_bytes=94 flags=10 revnat=0 src_sec_id=63927

TCP OUT 172.217.168.68:80 -> 10.11.248.28:41732  expires=119587 rx_packets=10 rx_bytes=13101 tx_packets=11 tx_bytes=692 flags=10 revnat=0 src_sec_id=63927
TCP OUT 216.58.215.228:80 -> 10.11.248.28:58144  expires=119661 rx_packets=13 rx_bytes=13303 tx_packets=14 tx_bytes=854 flags=10 revnat=0 src_sec_id=63927
ICMP OUT 8.8.8.8:0 -> 10.11.248.28:0 related  expires=98121 rx_packets=0 rx_bytes=0 tx_packets=1 tx_bytes=74 flags=10 revnat=0 src_sec_id=63927
ICMP OUT 216.58.215.228:0 -> 10.11.248.28:0 related  expires=98121 rx_packets=0 rx_bytes=0 tx_packets=1 tx_bytes=74 flags=10 revnat=0 src_sec_id=63927
UDP OUT 8.8.8.8:53 -> 10.11.248.28:52753  expires=98121 rx_packets=1 rx_bytes=102 tx_packets=1 tx_bytes=74 flags=0 revnat=0 src_sec_id=63927
UDP OUT 8.8.8.8:53 -> 10.11.248.28:52597  expires=98121 rx_packets=1 rx_bytes=90 tx_packets=1 tx_bytes=74 flags=0 revnat=0 src_sec_id=63927
```

[restart agent]

New table:
```
sudo cilium bpf ct list global
```

When an endpoint is removed, all conntrack entries of that endpoint are
guaranteed to become invalid. Use the opportunity to remove all such entries.

Testing:
```
$ sudo cilium bpf ct list global
ICMPv6 IN [f00d::a0f:0:0:3adc]:0 -> [fd01::b]:0 related  expires=100021 rx_packets=1 rx_bytes=142 tx_packets=0 tx_bytes=0 flags=10 revnat=0 src_sec_id=1
ICMPv6 OUT [2a00:1450:400a:803::200e]:0 -> [f00d::a0f:0:0:3adc]:0 related  expires=100021 rx_packets=0 rx_bytes=0 tx_packets=1 tx_bytes=94 flags=10 revnat=0 src_sec_id=1031
TCP OUT [2a00:1450:400a:803::200e]:80 -> [f00d::a0f:0:0:3adc]:37958  expires=100021 rx_packets=0 rx_bytes=0 tx_packets=1 tx_bytes=94 flags=0 revnat=0 src_sec_id=1031

UDP OUT 8.8.8.8:53 -> 10.11.246.180:48671  expires=100021 rx_packets=1 rx_bytes=98 tx_packets=1 tx_bytes=70 flags=0 revnat=0 src_sec_id=1031
ICMP IN 10.11.224.225:0 -> 10.11.0.1:0 related  expires=100022 rx_packets=1 rx_bytes=74 tx_packets=0 tx_bytes=0 flags=10 revnat=0 src_sec_id=1
TCP IN 10.11.224.225:4240 -> 10.11.0.1:54450  expires=121562 rx_packets=5 rx_bytes=475 tx_packets=5 tx_bytes=464 flags=10 revnat=0 src_sec_id=1
ICMP OUT 8.8.8.8:0 -> 10.11.246.180:0 related  expires=100021 rx_packets=0 rx_bytes=0 tx_packets=1 tx_bytes=70 flags=10 revnat=0 src_sec_id=1031
UDP OUT 8.8.8.8:53 -> 10.11.246.180:40772  expires=100021 rx_packets=1 rx_bytes=86 tx_packets=1 tx_bytes=70 flags=0 revnat=0 src_sec_id=1031
ICMP OUT 172.217.168.78:0 -> 10.11.246.180:0 related  expires=100021 rx_packets=0 rx_bytes=0 tx_packets=1 tx_bytes=74 flags=10 revnat=0 src_sec_id=1031
TCP OUT 172.217.168.78:80 -> 10.11.246.180:36166  expires=121561 rx_packets=5 rx_bytes=814 tx_packets=6 tx_bytes=418 flags=10 revnat=0 src_sec_id=1031

$ docker rm -f 98a611fb2d4f

$ sudo cilium bpf ct list global
ICMP IN 10.11.224.225:0 -> 10.11.0.1:0 related  expires=100022 rx_packets=1 rx_bytes=74 tx_packets=0 tx_bytes=0 flags=10 revnat=0 src_sec_id=1
TCP IN 10.11.224.225:4240 -> 10.11.0.1:54450  expires=121562 rx_packets=5 rx_bytes=475 tx_packets=5 tx_bytes=464 flags=10 revnat=0 src_sec_id=1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5243)
<!-- Reviewable:end -->
