### PR TITLE
Curl helpers improvements. 

### DIFF
--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -66,7 +66,8 @@ func CurlWithHTTPCode(endpoint string, optionalValues ...interface{}) string {
 		endpoint = fmt.Sprintf(endpoint, optionalValues...)
 	}
 
-	return fmt.Sprintf(`curl -s --output /dev/stderr -w '%%{http_code}' --connect-timeout %d %s`,
+	return fmt.Sprintf(
+		`curl -s --fail --output /dev/stderr -w '%%{http_code}' --connect-timeout %d %s`,
 		CurlConnectTimeout, endpoint)
 }
 

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -46,12 +46,15 @@ func Ping6(endpoint string) string {
 // variadic optinalValues argument. This is passed on to fmt.Sprintf() and uses
 // into the curl message
 func CurlFail(endpoint string, optionalValues ...interface{}) string {
+	statsInfo := `time-> DNS: '%{time_namelookup}', Connect: '%{time_connect}',` +
+		`Transfer '%{time_starttransfer}', total '%{time_total}'`
+
 	if len(optionalValues) > 0 {
 		endpoint = fmt.Sprintf(endpoint, optionalValues...)
 	}
 	return fmt.Sprintf(
-		"curl -s -D /dev/stderr --fail --connect-timeout %[1]d --max-time %[1]d %[2]s",
-		CurlConnectTimeout, endpoint)
+		`curl -s -D /dev/stderr --fail --connect-timeout %[1]d --max-time %[1]d %[2]s -w "%[3]s"`,
+		CurlConnectTimeout, endpoint, statsInfo)
 }
 
 // CurlWithHTTPCode retunrs the string representation of the curl command which

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -537,12 +537,12 @@ var _ = Describe("K8sPolicyTest", func() {
 			By("Testing connectivity with ingress default-allow policy loaded")
 			res := kubectl.ExecPodCmd(
 				helpers.DefaultNamespace, appPods[helpers.App2],
-				helpers.CurlWithHTTPCode("http://%s/public", clusterIP))
+				helpers.CurlFail("http://%s/public", clusterIP))
 			res.ExpectSuccess("Ingress connectivity should be allowed by policy")
 
 			res = kubectl.ExecPodCmd(
 				helpers.DefaultNamespace, appPods[helpers.App3],
-				helpers.CurlWithHTTPCode("http://%s/public", clusterIP))
+				helpers.CurlFail("http://%s/public", clusterIP))
 			res.ExpectSuccess("Ingress connectivity should be allowed by policy")
 		})
 
@@ -570,7 +570,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			for _, pod := range []string{appPods[helpers.App2], appPods[helpers.App3]} {
 				res := kubectl.ExecPodCmd(
 					helpers.DefaultNamespace, pod,
-					helpers.CurlWithHTTPCode("http://www.google.com/"))
+					helpers.CurlFail("http://www.google.com/"))
 				res.ExpectSuccess("Egress connectivity should be allowed for pod %q", pod)
 
 				res = kubectl.ExecPodCmd(

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -155,8 +155,8 @@ func ValidateCiliumUpgrades(kubectl *helpers.Kubectl) (func(), func()) {
 
 		res = kubectl.ExecPodCmd(
 			helpers.DefaultNamespace, appPods[helpers.App2],
-			helpers.CurlWithHTTPCode("http://%s/private", app1Service))
-		res.ExpectContains("403", "Expect 403 in the result")
+			helpers.CurlFail("http://%s/private", app1Service))
+		res.ExpectFail("Expect a 403 from app1-service")
 
 		By("Updating cilium to master image")
 
@@ -216,8 +216,9 @@ func ValidateCiliumUpgrades(kubectl *helpers.Kubectl) (func(), func()) {
 
 		res = kubectl.ExecPodCmd(
 			helpers.DefaultNamespace, appPods[helpers.App2],
-			helpers.CurlWithHTTPCode("http://%s/private", app1Service))
-		res.ExpectContains("403", "Expect 403 in the result")
+			helpers.CurlFail("http://%s/private", app1Service))
+		res.ExpectFail("Expect a 403 from app1-service")
+
 	}
 	return testfunc, cleanupCallback
 }

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -135,8 +135,8 @@ var _ = Describe("K8sDemosTest", func() {
 		Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
 
 		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, xwingPod,
-			helpers.CurlWithHTTPCode("http://%s/v1", deathstarFQDN))
-		res.ExpectContains("200", "unable to curl %s/v1: %s", deathstarFQDN, res.Output())
+			helpers.CurlFail("http://%s/v1", deathstarFQDN))
+		res.ExpectSuccess("unable to curl %s/v1: %s", deathstarFQDN, res.Output())
 
 		By("Importing L7 Policy which restricts access to %q", exhaustPortPath)
 		_, err = kubectl.CiliumPolicyAction(
@@ -154,12 +154,14 @@ var _ = Describe("K8sDemosTest", func() {
 		By("Showing how alliance cannot access %q without force header in API request after importing L7 Policy", exhaustPortPath)
 		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, xwingPod,
 			helpers.CurlWithHTTPCode("-X PUT http://%s", exhaustPortPath))
+		res.ExpectFail("Able to access %q when policy disallows it", exhaustPortPath)
 		res.ExpectContains("403", "able to access %s when policy disallows it; %s", exhaustPortPath, res.Output())
 
 		By("Showing how alliance can access %q with force header in API request to attack the deathstar", exhaustPortPath)
 		res = kubectl.ExecPodCmd(helpers.DefaultNamespace, xwingPod,
 			helpers.CurlWithHTTPCode("-X PUT -H 'X-Has-Force: True' http://%s", exhaustPortPath))
 		By("Expecting 503 to be returned when using force header to attack the deathstar")
+		res.ExpectFail("unable to access %s when policy allows it", exhaustPortPath)
 		res.ExpectContains("503", "unable to access %s when policy allows it; %s", exhaustPortPath, res.Output())
 	})
 })

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1171,8 +1171,8 @@ var _ = Describe("RuntimePolicies", func() {
 			// Docker container running with host networking is accessible via
 			// the host's IP address. See https://docs.docker.com/network/host/.
 			By("Accessing /public using Docker container using host networking from %q (should work)", helpers.App1)
-			successCurl := vm.ContainerExec(helpers.App1, helpers.CurlWithHTTPCode("http://%s/public", hostIP))
-			successCurl.ExpectContains("200", "Expected to be able to access /public in host Docker container")
+			successCurl := vm.ContainerExec(helpers.App1, helpers.CurlFail("http://%s/public", hostIP))
+			successCurl.ExpectSuccess("Expected to be able to access /public in host Docker container")
 
 			By("Pinging %s from %s (shouldn't work)", helpers.App2, helpers.App1)
 			failPing := vm.ContainerExec(helpers.App1, helpers.Ping(helpers.App2))
@@ -1203,17 +1203,17 @@ var _ = Describe("RuntimePolicies", func() {
 			// Docker container running with host networking is accessible via
 			// the docker bridge's IP address. See https://docs.docker.com/network/host/.
 			By("Accessing index.html using Docker container using host networking from %q (should work)", helpers.App1)
-			res = vm.ContainerExec(helpers.App1, helpers.CurlWithHTTPCode("%s://%s/index.html", proto, dstIP))
-			ExpectWithOffset(1, res.Output().String()).To(ContainSubstring("200"),
+			res = vm.ContainerExec(helpers.App1, helpers.CurlFail("%s://%s/index.html", proto, dstIP))
+			ExpectWithOffset(1, res).To(helpers.CMDSuccess(),
 				"Expected to be able to access /public in host Docker container")
 
 			By("Accessing %q on wrong port from %q should fail", dstIP, helpers.App1)
-			res = vm.ContainerExec(helpers.App1, helpers.CurlWithHTTPCode("http://%s:8080/public", dstIP))
+			res = vm.ContainerExec(helpers.App1, helpers.CurlFail("http://%s:8080/public", dstIP))
 			ExpectWithOffset(1, res).ShouldNot(helpers.CMDSuccess(),
 				"unexpectedly able to access %q when access should only be allowed to CIDR", dstIP)
 
 			By("Accessing port 80 on wrong destination from %q should fail", helpers.App1)
-			res = vm.ContainerExec(helpers.App1, helpers.CurlWithHTTPCode("%s://%s/public", proto, hostIP))
+			res = vm.ContainerExec(helpers.App1, helpers.CurlFail("%s://%s/public", proto, hostIP))
 			ExpectWithOffset(1, res).ShouldNot(helpers.CMDSuccess(),
 				"unexpectedly able to access %q when access should only be allowed to CIDR", hostIP)
 
@@ -1299,6 +1299,7 @@ var _ = Describe("RuntimePolicies", func() {
 
 			By("Accessing /private on %q from %q should fail", otherHostIP, helpers.App1)
 			res := vm.ContainerExec(helpers.App1, helpers.CurlWithHTTPCode("http://%s/private", otherHostIP))
+			res.ExpectFail("unexpectedly able to access http://%q:80/private when access should only be allowed to /index.html", otherHostIP)
 			res.ExpectContains("403", "unexpectedly able to access http://%q:80/private when access should only be allowed to /index.html", otherHostIP)
 		})
 	})


### PR DESCRIPTION
Changes: 

- Added curl stadistics, so it's easy to debug what happens. 
- Added --fail on CurlWithHTTPCode and  use it correctly, before we wait until ExpectSuccess but without --fail never fails.


The output for the stats:
```
STEP: Making ten HTTP requests from "testclient-4fnsx" to "http://10.99.183.79:10080"
cmd: "kubectl exec -n default testclient-4fnsx -- curl -s -D /dev/stderr --fail --connect-timeout 3 --max-time 3 http://10.99.183.79:10080 -w \"time-> DNS: '%!{(MISSING)time_namelookup}', Connect: '%!{(MISSING)time_connect}',Transfer '%!{(MISSING)time_starttransfer}', total '%!{(MISSING)time_total}'\"" exitCode: 0 duration: 187.902266ms stdout:
<html><body><h1>It works!</h1></body></html>
time-> DNS: '0.000025', Connect: '0.000513',Transfer '0.002978', total '0.003021'
stderr:
HTTP/1.1 200 OK
Date: Mon, 20 Aug 2018 07:22:14 GMT
Server: Apache/2.4.25 (Unix)
Last-Modified: Mon, 11 Jun 2007 18:53:14 GMT
ETag: "2d-432a5e4a73a80"
Accept-Ranges: bytes
Content-Length: 45
Content-Type: text/html
```
That statistics are: 

- DNS: Time to resolve the DNS name. 
- Connect: Time to connect to the endpoint. 
- Transfer: The time, in seconds, it took from the start until the first byte was just about to be transferred.
- Total: the total time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5247)
<!-- Reviewable:end -->
