### PR TITLE
pkg/k8s: properly handle empty NamespaceSelector

### DIFF
--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -16,6 +16,7 @@ package k8s
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -1534,6 +1535,26 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 							Key:      "k8s.io.cilium.k8s.namespace.labels.ns-foo-expression",
 							Operator: metav1.LabelSelectorOpExists,
 							Values:   []string{"bar", "baz"},
+						},
+					},
+				),
+			),
+		},
+		{
+			name: "peer-with-allow-all-ns-selector",
+			args: args{
+				namespace: "foo-namespace",
+				peer: &networkingv1.NetworkPolicyPeer{
+					NamespaceSelector: &metav1.LabelSelector{},
+				},
+			},
+			want: getSelectorPointer(
+				api.NewESFromMatchRequirements(
+					map[string]string{},
+					[]metav1.LabelSelectorRequirement{
+						{
+							Key:      fmt.Sprintf("%s.%s", labels.LabelSourceK8s, k8sConst.PodNamespaceLabel),
+							Operator: metav1.LabelSelectorOpExists,
 						},
 					},
 				),


### PR DESCRIPTION
If a rule is passed with an empty NamespaceSelector, this means that all traffic should be
allowed to/from all pods in all namespaces. However, Cilium was improperly treating this as
allowing all traffic to/from all destinations/sources accordingly.

Signed-off by: Ian Vernon <ian@cilium.io>

```release-note
properly handle empty NamespaceSelector in Kubernetes NetworkPolicy
```

Fixes: #4513

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5250)
<!-- Reviewable:end -->
