### PR TITLE
test/k8sT: use specific commit for cilium/star-wars-demo YAMLs

### DIFF
--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	starWarsDemoLinkRoot = "https://raw.githubusercontent.com/cilium/star-wars-demo/master/v1"
+	starWarsDemoLinkRoot = "https://raw.githubusercontent.com/cilium/star-wars-demo/b1d18870758af7cec713a4b5e4c3f013afe8c4bf/v1"
 )
 
 func getStarWarsResourceLink(file string) string {


### PR DESCRIPTION
A recent commit moved location of files in the cilium/star-wars-demo repository.
This broke the CI tests because they assumed the files were at a specific
location. Hardcode the base link to GitHub to a specific commit to get the files
for running the test instead of pointing to master.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #5251 

**How to test (optional)**:

1. Run the Demos test:

```
cd test;  K8S_VERSION=1.11 ginkgo --focus="K8sDemosTest" -v
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5252)
<!-- Reviewable:end -->
