### PR TITLE
v1.1 backports 18-08-17

### DIFF
--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	demoTestName         = "K8sValidatedDemosTest"
-	starWarsDemoLinkRoot = "https://raw.githubusercontent.com/cilium/star-wars-demo/master/v1"
+	starWarsDemoLinkRoot = "https://raw.githubusercontent.com/cilium/star-wars-demo/b1d18870758af7cec713a4b5e4c3f013afe8c4bf/v1"
 )
 
 func getStarWarsResourceLink(file string) string {


### PR DESCRIPTION
Backported PRs:

#5252 

PRs that were not backported due to merge conflicts

#5243 (@tgraf) - from my initial analysis, this will require #5234 and #5115. 

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5254)
<!-- Reviewable:end -->
