### PR TITLE
Test: Service never get deleted.

### DIFF
--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package k8sTest
 
 import (
@@ -357,6 +356,11 @@ var _ = Describe("NightlyExamples", func() {
 
 	Context("Cilium DaemonSet from example", func() {
 		AfterEach(func() {
+
+			_ = kubectl.Delete(demoPath)
+			_ = kubectl.Delete(l3Policy)
+			_ = kubectl.Delete(l7Policy)
+
 			res := kubectl.DeleteResource(
 				"ds", fmt.Sprintf("-n %s cilium", helpers.KubeSystemNamespace))
 			res.ExpectSuccess("Cilium DS cannot be deleted")


### PR DESCRIPTION
When the service is deleted after Cilium is deleted, the service is not
deleted correctly.

This commit fix a leftover service in Nightly.

Fix #5256

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5257)
<!-- Reviewable:end -->
