### PR TITLE
Add documentation on v1.0-stable Docker tag

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -1962,6 +1962,9 @@ On Freeze date
 #. Update the release branch on
     `Jenkins <https://jenkins.cilium.io/job/cilium-ginkgo/job/cilium/>`_ to be
     tested on every change and Nightly.
+#. (Only 1.0 minor releases) Tag newest 1.0.x Docker image as ``v1.0-stable``
+   and push it to Docker Hub. This will ensure that Kops uses latest 1.0 release by default.
+
 
 
 For the final release


### PR DESCRIPTION
This tag is used by Kops 1.10 by default. Future Kops releases will user
`v1.x` branch tags directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5260)
<!-- Reviewable:end -->
