### PR TITLE
Backport 1.1 2018 08 20

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -102,7 +102,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	// state left on disk.
 	option.Config.EnableHostIPRestore = false
 
-	d, err := NewDaemon()
+	d, _, err := NewDaemon()
 	c.Assert(err, IsNil)
 	ds.d = d
 

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -745,7 +745,7 @@ func runCiliumHealthEndpoint(d *Daemon) error {
 
 func runDaemon() {
 	log.Info("Initializing daemon")
-	d, err := NewDaemon()
+	d, _, err := NewDaemon()
 	if err != nil {
 		log.WithError(err).Fatal("Error while creating daemon")
 		return

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -745,14 +745,16 @@ func runCiliumHealthEndpoint(d *Daemon) error {
 
 func runDaemon() {
 	log.Info("Initializing daemon")
-	d, _, err := NewDaemon()
+	d, restoredEndpoints, err := NewDaemon()
 	if err != nil {
 		log.WithError(err).Fatal("Error while creating daemon")
 		return
 	}
 
 	log.Info("Starting connection tracking garbage collector")
-	endpointmanager.EnableConntrackGC(!option.Config.IPv4Disabled, true)
+	endpointmanager.EnableConntrackGC(!option.Config.IPv4Disabled, true,
+		endpointmanager.GcInterval,
+		restoredEndpoints.restored)
 
 	if enableLogstash {
 		log.Info("Enabling Logstash")

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1748,6 +1748,13 @@ func (e *Endpoint) LeaveLocked(owner Owner) []error {
 	e.controllers.RemoveAll()
 	e.cleanPolicySignals()
 
+	e.GarbageCollectConntrack(&ctmap.GCFilter{
+		MatchIPs: map[string]struct{}{
+			e.IPv4.String(): {},
+			e.IPv6.String(): {},
+		},
+	})
+
 	e.SetStateLocked(StateDisconnected, "Endpoint removed")
 
 	e.getLogger().Info("Removed endpoint")
@@ -2553,4 +2560,37 @@ func (e *Endpoint) syncPolicyMapController() {
 			RunInterval: 1 * time.Minute,
 		},
 	)
+}
+
+// garbageCollectConntrack is usd by GarbageCollectConntrack and should not be
+// called directly.
+func (e *Endpoint) garbageCollectConntrack(isIPv6 bool, filter *ctmap.GCFilter) {
+	var file, mapType string
+
+	if e.Opts != nil && e.Opts.IsEnabled(option.ConntrackLocal) {
+		mapType, file = ctmap.GetMapTypeAndPath(e, isIPv6)
+	} else {
+		mapType, file = ctmap.GetMapTypeAndPath(nil, isIPv6)
+	}
+
+	m, err := bpf.OpenMap(file)
+	if err != nil {
+		log.WithError(err).WithField(logfields.Path, file).Warn("Unable to open map")
+		return
+	}
+	defer m.Close()
+
+	ctmap.GC(m, mapType, filter)
+}
+
+// GarbageCollectConntrack will run the ctmap.GC() on either the endpoint's
+// local conntrack table or the global conntrack table.
+//
+// The endponit lock must be held
+func (e *Endpoint) GarbageCollectConntrack(filter *ctmap.GCFilter) {
+	if !option.Config.IPv4Disabled {
+		e.garbageCollectConntrack(false, filter)
+	}
+
+	e.garbageCollectConntrack(true, filter)
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -455,6 +455,10 @@ type Endpoint struct {
 	// This set of keys is updated upon regeneration of policy for an endpoint.
 	// All fields within the PolicyKey should be in host byte-order.
 	desiredMapState map[policymap.PolicyKey]struct{}
+
+	// ctCleaned indicates whether the conntrack table has already been
+	// cleaned when this endpoint was first created
+	ctCleaned bool
 }
 
 // WaitForProxyCompletions blocks until all proxy changes have been completed.
@@ -1748,12 +1752,7 @@ func (e *Endpoint) LeaveLocked(owner Owner) []error {
 	e.controllers.RemoveAll()
 	e.cleanPolicySignals()
 
-	e.GarbageCollectConntrack(&ctmap.GCFilter{
-		MatchIPs: map[string]struct{}{
-			e.IPv4.String(): {},
-			e.IPv6.String(): {},
-		},
-	})
+	e.scrubIPsInConntrackTableLocked()
 
 	e.SetStateLocked(StateDisconnected, "Endpoint removed")
 
@@ -2562,9 +2561,9 @@ func (e *Endpoint) syncPolicyMapController() {
 	)
 }
 
-// garbageCollectConntrack is usd by GarbageCollectConntrack and should not be
+// doGarbageCollectConntrack is usd by garbageCollectConntrack and should not be
 // called directly.
-func (e *Endpoint) garbageCollectConntrack(isIPv6 bool, filter *ctmap.GCFilter) {
+func (e *Endpoint) doGarbageCollectConntrack(isIPv6 bool, filter *ctmap.GCFilter) {
 	var file, mapType string
 
 	if e.Opts != nil && e.Opts.IsEnabled(option.ConntrackLocal) {
@@ -2583,14 +2582,29 @@ func (e *Endpoint) garbageCollectConntrack(isIPv6 bool, filter *ctmap.GCFilter) 
 	ctmap.GC(m, mapType, filter)
 }
 
-// GarbageCollectConntrack will run the ctmap.GC() on either the endpoint's
+// garbageCollectConntrack will run the ctmap.GC() on either the endpoint's
 // local conntrack table or the global conntrack table.
 //
 // The endponit lock must be held
-func (e *Endpoint) GarbageCollectConntrack(filter *ctmap.GCFilter) {
+func (e *Endpoint) garbageCollectConntrack(filter *ctmap.GCFilter) {
 	if !option.Config.IPv4Disabled {
-		e.garbageCollectConntrack(false, filter)
+		e.doGarbageCollectConntrack(false, filter)
 	}
 
-	e.garbageCollectConntrack(true, filter)
+	e.doGarbageCollectConntrack(true, filter)
+}
+
+func (e *Endpoint) scrubIPsInConntrackTableLocked() {
+	e.garbageCollectConntrack(&ctmap.GCFilter{
+		MatchIPs: map[string]struct{}{
+			e.IPv4.String(): {},
+			e.IPv6.String(): {},
+		},
+	})
+}
+
+func (e *Endpoint) scrubIPsInConntrackTable() {
+	e.Mutex.Lock()
+	e.scrubIPsInConntrackTableLocked()
+	e.Mutex.Unlock()
 }

--- a/pkg/endpointmanager/conntrack.go
+++ b/pkg/endpointmanager/conntrack.go
@@ -65,15 +65,16 @@ func runGC(e *endpoint.Endpoint, isIPv6 bool, filter *ctmap.GCFilter) {
 
 	if deleted > 0 {
 		log.WithFields(logrus.Fields{
-			logfields.Path:  file,
-			"ctFilter.type": filter.TypeString(),
-			"count":         deleted,
+			logfields.Path: file,
+			"count":        deleted,
 		}).Debug("Deleted filtered entries from map")
 	}
 }
 
 func createGCFilter(ipv6, initialScan bool, restoredEndpoints []*endpoint.Endpoint) *ctmap.GCFilter {
-	filter := ctmap.NewGCFilterBy(ctmap.GCFilterByTime)
+	filter := &ctmap.GCFilter{
+		RemoveExpired: true,
+	}
 
 	// On the initial scan, scrub all IPs from the conntrack table which do
 	// not belong to IPs of any endpoint that has been restored. No new
@@ -117,10 +118,10 @@ func EnableConntrackGC(ipv4, ipv6 bool, gcinterval int, restoredEndpoints []*end
 					continue
 				}
 				if ipv6 {
-					runGC(e, true, ctmap.NewGCFilterBy(ctmap.GCFilterByTime))
+					runGC(e, true, &ctmap.GCFilter{RemoveExpired: true})
 				}
 				if ipv4 {
-					runGC(e, false, ctmap.NewGCFilterBy(ctmap.GCFilterByTime))
+					runGC(e, false, &ctmap.GCFilter{RemoveExpired: true})
 				}
 			}
 

--- a/pkg/endpointmanager/conntrack.go
+++ b/pkg/endpointmanager/conntrack.go
@@ -72,18 +72,43 @@ func runGC(e *endpoint.Endpoint, isIPv6 bool, filter *ctmap.GCFilter) {
 	}
 }
 
+func createGCFilter(ipv6, initialScan bool, restoredEndpoints []*endpoint.Endpoint) *ctmap.GCFilter {
+	filter := ctmap.NewGCFilterBy(ctmap.GCFilterByTime)
+
+	// On the initial scan, scrub all IPs from the conntrack table which do
+	// not belong to IPs of any endpoint that has been restored. No new
+	// endpoints can appear yet so we can assume that any other entry not
+	// belonging to a restored endpoint has become stale.
+	if initialScan {
+		filter.ValidIPs = map[string]struct{}{}
+		for _, ep := range restoredEndpoints {
+			if ipv6 {
+				filter.ValidIPs[ep.IPv6.String()] = struct{}{}
+			} else {
+				filter.ValidIPs[ep.IPv4.String()] = struct{}{}
+			}
+		}
+	}
+
+	return filter
+}
+
 // EnableConntrackGC enables the connection tracking garbage collection.
-func EnableConntrackGC(ipv4, ipv6 bool) {
+func EnableConntrackGC(ipv4, ipv6 bool, gcinterval int, restoredEndpoints []*endpoint.Endpoint) {
+	initialScan := true
+	initialScanComplete := make(chan struct{})
+
 	go func() {
 		sleepTime := time.Duration(GcInterval) * time.Second
 		for {
 			eps := GetEndpoints()
-			if len(eps) > 0 {
+			if len(eps) > 0 || initialScan {
 				if ipv6 {
-					runGC(nil, true, ctmap.NewGCFilterBy(ctmap.GCFilterByTime))
+					runGC(nil, true, createGCFilter(true, initialScan, restoredEndpoints))
 				}
+
 				if ipv4 {
-					runGC(nil, false, ctmap.NewGCFilterBy(ctmap.GCFilterByTime))
+					runGC(nil, false, createGCFilter(false, initialScan, restoredEndpoints))
 				}
 			}
 			for _, e := range eps {
@@ -98,7 +123,20 @@ func EnableConntrackGC(ipv4, ipv6 bool) {
 					runGC(e, false, ctmap.NewGCFilterBy(ctmap.GCFilterByTime))
 				}
 			}
+
+			if initialScan {
+				close(initialScanComplete)
+				initialScan = false
+			}
+
 			time.Sleep(sleepTime)
 		}
 	}()
+
+	select {
+	case <-initialScanComplete:
+		log.Info("Initial scan of connection tracking completed")
+	case <-time.After(30 * time.Second):
+		log.Fatal("Timeout while waiting for initial conntrack scan")
+	}
 }

--- a/pkg/endpointmanager/conntrack.go
+++ b/pkg/endpointmanager/conntrack.go
@@ -31,7 +31,7 @@ const (
 	GcInterval int = 60
 )
 
-// RunGC run CT's garbage collector for the given endpoint. `isLocal` refers if
+// runGC run CT's garbage collector for the given endpoint. `isLocal` refers if
 // the CT map is set to local. If `isIPv6` is set specifies that is the IPv6
 // map. `filter` represents the filter type to be used while looping all CT
 // entries.
@@ -39,7 +39,7 @@ const (
 // The provided endpoint is optional; if it is provided, then its map will be
 // garbage collected and any failures will be logged to the endpoint log.
 // Otherwise it will garbage-collect the global map and use the global log.
-func RunGC(e *endpoint.Endpoint, isIPv6 bool, filter *ctmap.GCFilter) {
+func runGC(e *endpoint.Endpoint, isIPv6 bool, filter *ctmap.GCFilter) {
 	var file string
 	var mapType string
 
@@ -80,10 +80,10 @@ func EnableConntrackGC(ipv4, ipv6 bool) {
 			eps := GetEndpoints()
 			if len(eps) > 0 {
 				if ipv6 {
-					RunGC(nil, true, ctmap.NewGCFilterBy(ctmap.GCFilterByTime))
+					runGC(nil, true, ctmap.NewGCFilterBy(ctmap.GCFilterByTime))
 				}
 				if ipv4 {
-					RunGC(nil, false, ctmap.NewGCFilterBy(ctmap.GCFilterByTime))
+					runGC(nil, false, ctmap.NewGCFilterBy(ctmap.GCFilterByTime))
 				}
 			}
 			for _, e := range eps {
@@ -92,10 +92,10 @@ func EnableConntrackGC(ipv4, ipv6 bool) {
 					continue
 				}
 				if ipv6 {
-					RunGC(e, true, ctmap.NewGCFilterBy(ctmap.GCFilterByTime))
+					runGC(e, true, ctmap.NewGCFilterBy(ctmap.GCFilterByTime))
 				}
 				if ipv4 {
-					RunGC(e, false, ctmap.NewGCFilterBy(ctmap.GCFilterByTime))
+					runGC(e, false, ctmap.NewGCFilterBy(ctmap.GCFilterByTime))
 				}
 			}
 			time.Sleep(sleepTime)

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -1566,6 +1566,26 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "peer-with-allow-all-ns-selector",
+			args: args{
+				namespace: "foo-namespace",
+				peer: &networkingv1.NetworkPolicyPeer{
+					NamespaceSelector: &metav1.LabelSelector{},
+				},
+			},
+			want: &api.EndpointSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{},
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      fmt.Sprintf("%s.%s", labels.LabelSourceK8s, k8sConst.PodNamespaceLabel),
+							Operator: metav1.LabelSelectorOpExists,
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -84,6 +84,9 @@ const (
 	// StartTime is the start time of an event
 	StartTime = "startTime"
 
+	// Duration is the duration of a measured operation
+	Duration = "duration"
+
 	// V4HealthIP is an address used to contact the cilium-health endpoint
 	V4HealthIP = "v4healthIP.IPv4"
 

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"time"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -26,6 +27,8 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
+
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -293,24 +296,122 @@ func dumpToSlice(m *bpf.Map, mapType string) ([]CtEntryDump, error) {
 	return entries, nil
 }
 
+type gcStats struct {
+	// started is the timestamp when the gc run was started
+	started time.Time
+
+	// finishedis the timestamp when the gc run completed
+	finished time.Time
+
+	// lookup is the number of key lookups performed
+	lookup uint32
+
+	// lookupFailed is the number of key lookups that failed
+	lookupFailed uint32
+
+	// prevKeyUnavailable is the number of times the previous key was not
+	// available
+	prevKeyUnavailable uint32
+
+	// deleted is the number of keys deleted
+	deleted uint32
+
+	// keyFallback is the number of times the current key became invalid
+	// while traversing and we had to fall back to the previous key
+	keyFallback uint32
+
+	// count is number of lookups performed on the map
+	count uint32
+
+	// maxEntries is the maximum number of entries in the gc table
+	maxEntries uint32
+
+	// family is the address family
+	family gcFamily
+
+	// completed is true when the gc run has been completed
+	completed bool
+
+	// interrupted is the number of times the gc run was interrupted and
+	// had to start from scratch
+	interrupted uint32
+
+	// aliveEntries is the number of scanned entries that are still alive
+	aliveEntries uint32
+}
+
+type gcFamily int
+
+const (
+	gcFamilyIPv4 = iota
+	gcFamilyIPv6
+)
+
+func (g gcFamily) String() string {
+	switch g {
+	case gcFamilyIPv4:
+		return "ipv4"
+	case gcFamilyIPv6:
+		return "ipv6"
+	default:
+		return "unknown"
+	}
+}
+
+func statStartGc(m *bpf.Map, family gcFamily) gcStats {
+	return gcStats{
+		started:    time.Now(),
+		count:      1,
+		maxEntries: m.MapInfo.MaxEntries,
+		family:     family,
+	}
+}
+
+func (s *gcStats) finish() {
+	s.finished = time.Now()
+
+	switch s.family {
+	case gcFamilyIPv6:
+		metrics.DatapathErrors.With(labelIPv6CTDumpInterrupts).Add(float64(s.interrupted))
+	case gcFamilyIPv4:
+		metrics.DatapathErrors.With(labelIPv4CTDumpInterrupts).Add(float64(s.interrupted))
+	}
+
+	if !s.completed {
+		log.WithField("interrupted", s.interrupted).Warningf(
+			"Garbage collection on IPv6 CT map failed to finish")
+	}
+
+	log.WithFields(logrus.Fields{
+		logfields.StartTime: s.started,
+		logfields.Duration:  s.finished.Sub(s.started),
+		"numDeleted":        s.deleted,
+		"numLookups":        s.count,
+		"numLookupsFailed":  s.lookupFailed,
+		"numKeyFallbacks":   s.keyFallback,
+		"completed":         s.completed,
+		"maxEntries":        s.maxEntries,
+	}).Infof("%s Conntrack garbage collection statistics", s.family)
+}
+
 // doGC6 iterates through a CTv6 map and drops entries based on the given
 // filter.
-func doGC6(m *bpf.Map, filter *GCFilter) int {
-	var (
-		action, deleted, interrupted int
-		prevKey, currentKey, nextKey CtKey6Global
-	)
+func doGC6(m *bpf.Map, filter *GCFilter) gcStats {
+	var prevKey, currentKey, nextKey CtKey6Global
+
+	stats := statStartGc(m, gcFamilyIPv6)
+	defer stats.finish()
 
 	// prevKey is initially invalid, causing GetNextKey to return the first key in the map as currentKey.
 	prevKeyValid := false
 	err := m.GetNextKey(&prevKey, &currentKey)
 	if err != nil {
 		// Map is empty, nothing to clean up.
-		return 0
+		stats.completed = true
+		return stats
 	}
 
-	var count uint32
-	for count = 1; count <= m.MapInfo.MaxEntries; count++ {
+	for stats.count = 1; stats.count <= m.MapInfo.MaxEntries; stats.count++ {
 		// currentKey was returned by GetNextKey() so we know it existed in the map, but it may have been
 		// deleted by a concurrent map operation. If currentKey is no longer in the map, nextKey will be
 		// the first key in the map again. Use the nextKey only if we still find currentKey in the Lookup()
@@ -318,6 +419,8 @@ func doGC6(m *bpf.Map, filter *GCFilter) int {
 		nextKeyValid := m.GetNextKey(&currentKey, &nextKey)
 		entryMap, err := m.Lookup(&currentKey)
 		if err != nil {
+			stats.lookupFailed++
+
 			// Restarting from a invalid key starts the iteration again from the beginning.
 			// If we have a previously found key, try to restart from there instead
 			if prevKeyValid {
@@ -325,11 +428,12 @@ func doGC6(m *bpf.Map, filter *GCFilter) int {
 				// Restart from a given previous key only once, otherwise if the prevKey is
 				// concurrently deleted we might loop forever trying to look it up.
 				prevKeyValid = false
+				stats.keyFallback++
 			} else {
 				// Depending on exactly when currentKey was deleted from the map, nextKey may be the actual
 				// keyelement after the deleted one, or the first element in the map.
 				currentKey = nextKey
-				interrupted++
+				stats.interrupted++
 			}
 			continue
 		}
@@ -339,7 +443,7 @@ func doGC6(m *bpf.Map, filter *GCFilter) int {
 		// In CT entries, the source address of the conntrack entry (`saddr`) is
 		// the destination of the packet received, therefore it's the packet's
 		// destination IP
-		action = filter.doFiltering(currentKey.daddr.IP(), currentKey.saddr.IP(), currentKey.sport,
+		action := filter.doFiltering(currentKey.daddr.IP(), currentKey.saddr.IP(), currentKey.sport,
 			uint8(currentKey.nexthdr), currentKey.flags, entry)
 
 		switch action {
@@ -348,8 +452,10 @@ func doGC6(m *bpf.Map, filter *GCFilter) int {
 			if err != nil {
 				log.WithError(err).Errorf("Unable to delete CT entry %s", currentKey.String())
 			} else {
-				deleted++
+				stats.deleted++
 			}
+		default:
+			stats.aliveEntries++
 		}
 
 		if nextKeyValid != nil {
@@ -362,33 +468,27 @@ func doGC6(m *bpf.Map, filter *GCFilter) int {
 		currentKey = nextKey
 	}
 
-	metrics.DatapathErrors.With(labelIPv6CTDumpInterrupts).Add(float64(interrupted))
-	if count > m.MapInfo.MaxEntries {
-		log.WithError(err).WithField("interrupted", interrupted).Warning(
-			"Garbage collection on IPv6 CT map failed to finish")
-	}
-
-	return deleted
+	return stats
 }
 
 // doGC4 iterates through a CTv4 map and drops entries based on the given
 // filter.
-func doGC4(m *bpf.Map, filter *GCFilter) int {
-	var (
-		action, deleted, interrupted int
-		prevKey, currentKey, nextKey CtKey4Global
-	)
+func doGC4(m *bpf.Map, filter *GCFilter) gcStats {
+	var prevKey, currentKey, nextKey CtKey4Global
+
+	stats := statStartGc(m, gcFamilyIPv4)
+	defer stats.finish()
 
 	// prevKey is initially invalid, causing GetNextKey to return the first key in the map as currentKey.
 	prevKeyValid := false
 	err := m.GetNextKey(&prevKey, &currentKey)
 	if err != nil {
 		// Map is empty, nothing to clean up.
-		return 0
+		stats.completed = true
+		return stats
 	}
 
-	var count uint32
-	for count = 1; count <= m.MapInfo.MaxEntries; count++ {
+	for stats.count = 1; stats.count <= m.MapInfo.MaxEntries; stats.count++ {
 		// currentKey was returned by GetNextKey() so we know it existed in the map, but it may have been
 		// deleted by a concurrent map operation. If currentKey is no longer in the map, nextKey will be
 		// the first key in the map again. Use the nextKey only if we still find currentKey in the Lookup()
@@ -396,6 +496,8 @@ func doGC4(m *bpf.Map, filter *GCFilter) int {
 		nextKeyValid := m.GetNextKey(&currentKey, &nextKey)
 		entryMap, err := m.Lookup(&currentKey)
 		if err != nil {
+			stats.lookupFailed++
+
 			// Restarting from a invalid key starts the iteration again from the beginning.
 			// If we have a previously found key, try to restart from there instead
 			if prevKeyValid {
@@ -403,11 +505,12 @@ func doGC4(m *bpf.Map, filter *GCFilter) int {
 				// Restart from a given previous key only once, otherwise if the prevKey is
 				// concurrently deleted we might loop forever trying to look it up.
 				prevKeyValid = false
+				stats.keyFallback++
 			} else {
 				// Depending on exactly when currentKey was deleted from the map, nextKey may be the actual
 				// keyelement after the deleted one, or the first element in the map.
 				currentKey = nextKey
-				interrupted++
+				stats.interrupted++
 			}
 			continue
 		}
@@ -417,7 +520,7 @@ func doGC4(m *bpf.Map, filter *GCFilter) int {
 		// In CT entries, the source address of the conntrack entry (`saddr`) is
 		// the destination of the packet received, therefore it's the packet's
 		// destination IP
-		action = filter.doFiltering(currentKey.daddr.IP(), currentKey.saddr.IP(), currentKey.sport,
+		action := filter.doFiltering(currentKey.daddr.IP(), currentKey.saddr.IP(), currentKey.sport,
 			uint8(currentKey.nexthdr), currentKey.flags, entry)
 
 		switch action {
@@ -426,11 +529,14 @@ func doGC4(m *bpf.Map, filter *GCFilter) int {
 			if err != nil {
 				log.WithError(err).Errorf("Unable to delete CT entry %s", currentKey.String())
 			} else {
-				deleted++
+				stats.deleted++
 			}
+		default:
+			stats.aliveEntries++
 		}
 
 		if nextKeyValid != nil {
+			stats.completed = true
 			break
 		}
 		// remember the last found key
@@ -440,13 +546,7 @@ func doGC4(m *bpf.Map, filter *GCFilter) int {
 		currentKey = nextKey
 	}
 
-	metrics.DatapathErrors.With(labelIPv4CTDumpInterrupts).Add(float64(interrupted))
-	if count > m.MapInfo.MaxEntries {
-		log.WithError(err).WithField("interrupted", interrupted).Warning(
-			"Garbage collection on IPv4 CT map failed to finish")
-	}
-
-	return deleted
+	return stats
 }
 
 func (f *GCFilter) doFiltering(srcIP net.IP, dstIP net.IP, dstPort uint16, nextHdr, flags uint8, entry *CtEntry) (action int) {
@@ -456,6 +556,19 @@ func (f *GCFilter) doFiltering(srcIP net.IP, dstIP net.IP, dstPort uint16, nextH
 	}
 
 	return noAction
+}
+
+func doGC(m *bpf.Map, mapType string, filter *GCFilter) int {
+	switch mapType {
+	case MapName6, MapName6Global:
+		return int(doGC6(m, filter).deleted)
+	case MapName4, MapName4Global:
+		return int(doGC4(m, filter).deleted)
+	default:
+		log.Fatalf("Unsupported ct map type: %s", mapType)
+	}
+
+	return 0
 }
 
 // GC runs garbage collection for map m with name mapType with the given filter.
@@ -472,16 +585,7 @@ func GC(m *bpf.Map, mapType string, filter *GCFilter) int {
 		filter.Time = uint32(tsec)
 	}
 
-	switch mapType {
-	case MapName6, MapName6Global:
-		return doGC6(m, filter)
-	case MapName4, MapName4Global:
-		return doGC4(m, filter)
-	default:
-		log.Fatalf("Unsupported ct map type: %s", mapType)
-	}
-
-	return 0
+	return doGC(m, mapType, filter)
 }
 
 // Flush runs garbage collection for map m with the name mapType, deleting all
@@ -490,16 +594,7 @@ func Flush(m *bpf.Map, mapType string) int {
 	filter := NewGCFilterBy(GCFilterByTime)
 	filter.Time = MaxTime
 
-	switch mapType {
-	case MapName6, MapName6Global:
-		return doGC6(m, filter)
-	case MapName4, MapName4Global:
-		return doGC4(m, filter)
-	default:
-		log.Fatalf("Unsupported ct map type: %s", mapType)
-	}
-
-	return 0
+	return doGC(m, mapType, filter)
 }
 
 // checkAndUpgrade determines whether the ctmap on the filesystem has different

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -458,9 +458,9 @@ func (f *GCFilter) doFiltering(srcIP net.IP, dstIP net.IP, dstPort uint16, nextH
 	return noAction
 }
 
-// GC runs garbage collection for map m with name mapName with the given filter.
+// GC runs garbage collection for map m with name mapType with the given filter.
 // It returns how many items were deleted from m.
-func GC(m *bpf.Map, mapName string, filter *GCFilter) int {
+func GC(m *bpf.Map, mapType string, filter *GCFilter) int {
 	if filter.Type == GCFilterByTime {
 		// If LRUHashtable, no need to garbage collect as LRUHashtable cleans itself up.
 		// FIXME: GH-3239 LRU logic is not handling timeouts gracefully enough
@@ -472,30 +472,34 @@ func GC(m *bpf.Map, mapName string, filter *GCFilter) int {
 		filter.Time = uint32(tsec)
 	}
 
-	switch mapName {
+	switch mapType {
 	case MapName6, MapName6Global:
 		return doGC6(m, filter)
 	case MapName4, MapName4Global:
 		return doGC4(m, filter)
 	default:
-		return 0
+		log.Fatalf("Unsupported ct map type: %s", mapType)
 	}
+
+	return 0
 }
 
-// Flush runs garbage collection for map m with the name mapName, deleting all
+// Flush runs garbage collection for map m with the name mapType, deleting all
 // entries. The specified map must be already opened using bpf.OpenMap().
-func Flush(m *bpf.Map, mapName string) int {
+func Flush(m *bpf.Map, mapType string) int {
 	filter := NewGCFilterBy(GCFilterByTime)
 	filter.Time = MaxTime
 
-	switch mapName {
+	switch mapType {
 	case MapName6, MapName6Global:
 		return doGC6(m, filter)
 	case MapName4, MapName4Global:
 		return doGC4(m, filter)
 	default:
-		return 0
+		log.Fatalf("Unsupported ct map type: %s", mapType)
 	}
+
+	return 0
 }
 
 // checkAndUpgrade determines whether the ctmap on the filesystem has different

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -193,6 +193,11 @@ type GCFilter struct {
 	Time       uint32
 	EndpointID uint16
 	EndpointIP net.IP
+
+	// ValidIPs is the list of valid IPs to scrub all entries for which the
+	// source or destination IP is *not* matching one of the valid IPs.
+	// The key is the IP in string form: net.IP.String()
+	ValidIPs map[string]struct{}
 }
 
 // NewGCFilterBy creates a new GCFilter of the given type.
@@ -553,6 +558,14 @@ func (f *GCFilter) doFiltering(srcIP net.IP, dstIP net.IP, dstPort uint16, nextH
 	// Delete all entries with a lifetime smaller than f timestamp.
 	if f.Type == GCFilterByTime && entry.lifetime < f.Time {
 		return deleteEntry
+	}
+
+	if f.ValidIPs != nil {
+		_, srcIPExists := f.ValidIPs[srcIP.String()]
+		_, dstIPExists := f.ValidIPs[dstIP.String()]
+		if !srcIPExists && !dstIPExists {
+			return deleteEntry
+		}
 	}
 
 	return noAction

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -175,48 +175,22 @@ type CtEntryDump struct {
 	Value CtEntry
 }
 
-const (
-	// GCFilterNone doesn't filter the CT entries
-	GCFilterNone = iota
-	// GCFilterByTime filters CT entries by time
-	GCFilterByTime
-)
-
-// GCFilterType is the type of a filter.
-type GCFilterType uint
-
 // GCFilter contains the necessary fields to filter the CT maps.
 // Filtering by endpoint requires both EndpointID to be > 0 and
 // EndpointIP to be not nil.
 type GCFilter struct {
-	Type       GCFilterType
-	Time       uint32
-	EndpointID uint16
-	EndpointIP net.IP
+	// RemoveExpired enables removal of all entries that have expired
+	RemoveExpired bool
+
+	// Time is the reference timestamp to reomove expired entries. If
+	// RemoveExpired is true and lifetime is lesser than Time, the entry is
+	// removed
+	Time uint32
 
 	// ValidIPs is the list of valid IPs to scrub all entries for which the
 	// source or destination IP is *not* matching one of the valid IPs.
 	// The key is the IP in string form: net.IP.String()
 	ValidIPs map[string]struct{}
-}
-
-// NewGCFilterBy creates a new GCFilter of the given type.
-func NewGCFilterBy(filterType GCFilterType) *GCFilter {
-	return &GCFilter{
-		Type: filterType,
-	}
-}
-
-// TypeString returns the filter type in human readable way.
-func (f *GCFilter) TypeString() string {
-	switch f.Type {
-	case GCFilterNone:
-		return "none"
-	case GCFilterByTime:
-		return "timeout"
-	default:
-		return "(unknown)"
-	}
 }
 
 // ToString iterates through Map m and writes the values of the ct entries in m
@@ -555,8 +529,7 @@ func doGC4(m *bpf.Map, filter *GCFilter) gcStats {
 }
 
 func (f *GCFilter) doFiltering(srcIP net.IP, dstIP net.IP, dstPort uint16, nextHdr, flags uint8, entry *CtEntry) (action int) {
-	// Delete all entries with a lifetime smaller than f timestamp.
-	if f.Type == GCFilterByTime && entry.lifetime < f.Time {
+	if f.RemoveExpired && entry.lifetime < f.Time {
 		return deleteEntry
 	}
 
@@ -587,7 +560,7 @@ func doGC(m *bpf.Map, mapType string, filter *GCFilter) int {
 // GC runs garbage collection for map m with name mapType with the given filter.
 // It returns how many items were deleted from m.
 func GC(m *bpf.Map, mapType string, filter *GCFilter) int {
-	if filter.Type == GCFilterByTime {
+	if filter.RemoveExpired {
 		// If LRUHashtable, no need to garbage collect as LRUHashtable cleans itself up.
 		// FIXME: GH-3239 LRU logic is not handling timeouts gracefully enough
 		// if m.MapInfo.MapType == bpf.MapTypeLRUHash {
@@ -604,10 +577,10 @@ func GC(m *bpf.Map, mapType string, filter *GCFilter) int {
 // Flush runs garbage collection for map m with the name mapType, deleting all
 // entries. The specified map must be already opened using bpf.OpenMap().
 func Flush(m *bpf.Map, mapType string) int {
-	filter := NewGCFilterBy(GCFilterByTime)
-	filter.Time = MaxTime
-
-	return doGC(m, mapType, filter)
+	return doGC(m, mapType, &GCFilter{
+		RemoveExpired: true,
+		Time:          MaxTime,
+	})
 }
 
 // checkAndUpgrade determines whether the ctmap on the filesystem has different

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -191,6 +191,9 @@ type GCFilter struct {
 	// source or destination IP is *not* matching one of the valid IPs.
 	// The key is the IP in string form: net.IP.String()
 	ValidIPs map[string]struct{}
+
+	// MatchIPs is the list of IPs to remove from the conntrack table
+	MatchIPs map[string]struct{}
 }
 
 // ToString iterates through Map m and writes the values of the ct entries in m
@@ -537,6 +540,14 @@ func (f *GCFilter) doFiltering(srcIP net.IP, dstIP net.IP, dstPort uint16, nextH
 		_, srcIPExists := f.ValidIPs[srcIP.String()]
 		_, dstIPExists := f.ValidIPs[dstIP.String()]
 		if !srcIPExists && !dstIPExists {
+			return deleteEntry
+		}
+	}
+
+	if f.MatchIPs != nil {
+		_, srcIPExists := f.MatchIPs[srcIP.String()]
+		_, dstIPExists := f.MatchIPs[dstIP.String()]
+		if srcIPExists || dstIPExists {
 			return deleteEntry
 		}
 	}


### PR DESCRIPTION
This is a backport of
* PR: 5243 -- Fix conntrack entry removal on endpoint leave and agent restart (@tgraf) -- https://github.com/cilium/cilium/pull/5243
* PR: 5234 -- Provide conntrack GC stastistics (@tgraf) -- https://github.com/cilium/cilium/pull/5234
 * PR: 5250 -- pkg/k8s: properly handle empty NamespaceSelector (@ianvernon) -- https://github.com/cilium/cilium/pull/5250

@tgraf I pulled in #5234 to clear conflicts in #5243. The main dependency was the GC -> doGC refactor. I also had to include a new commit (https://github.com/cilium/cilium/commit/08e3e6c00d72fc5f1a080e7e0954b9e6d411ee89) that relied on changes from https://github.com/cilium/cilium/pull/5115 (68d19bf19adc442f52e6dca18dbfe265bd35f1e4) but #5115 had it's own conflicts and wasn't sure if we wanted those changes backported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5262)
<!-- Reviewable:end -->
