### PR TITLE
test: Do not treat log lines as format strings

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -77,7 +77,7 @@ func (res *CmdRes) SendToLog(quietMode bool) {
 	if res.stderr.Len() > 0 {
 		log = fmt.Sprintf("%sstderr:\n%s\n", log, res.stderr.String())
 	}
-	fmt.Fprintf(&config.TestLogWriter, log)
+	fmt.Fprint(&config.TestLogWriter, log)
 }
 
 // WasSuccessful returns true if cmd completed successfully.


### PR DESCRIPTION
When we log anything with a % in it the Fprintf would re-interpret it
and write out an ugly string. This is common when logging curl commands,
which often have `-w %{http}` arguments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5264)
<!-- Reviewable:end -->
