### PR TITLE
pkg/lock: add detector if a lock was held for more than n seconds

### DIFF
--- a/pkg/lock/lock_debug.go
+++ b/pkg/lock/lock_debug.go
@@ -17,19 +17,127 @@
 package lock
 
 import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"runtime/debug"
 	"time"
 
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+
 	"github.com/sasha-s/go-deadlock"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// selfishThresholdSec is the number of seconds that should be used when
+	// detecting if a lock was held for more than the specified time.
+	selfishThresholdSec = 0.1
+
+	// Waiting for a lock for longer than DeadlockTimeout is considered a deadlock.
+	// Ignored is DeadlockTimeout <= 0.
+	deadLockTimeout = 310 * time.Second
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "lock-lib")
+
+	// selfishThresholdMsg is the message that will be printed when a lock was
+	// held for more than selfishThresholdSec.
+	selfishThresholdMsg = fmt.Sprintf("Goroutine took lock for more than %.2f seconds", selfishThresholdSec)
 )
 
 func init() {
-	deadlock.Opts.DeadlockTimeout = time.Second * 310
+	deadlock.Opts.DeadlockTimeout = deadLockTimeout
 }
 
 type internalRWMutex struct {
 	deadlock.RWMutex
+	time.Time
+}
+
+func (i *internalRWMutex) Lock() {
+	i.RWMutex.Lock()
+	i.Time = time.Now()
+}
+
+func (i *internalRWMutex) Unlock() {
+	if sec := time.Since(i.Time).Seconds(); sec >= selfishThresholdSec {
+		printStackTo(sec, debug.Stack(), os.Stderr)
+	}
+	i.RWMutex.Unlock()
+}
+
+func (i *internalRWMutex) UnlockIgnoreTime() {
+	i.RWMutex.Unlock()
+}
+
+func (i *internalRWMutex) RLock() {
+	i.RWMutex.Lock()
+	i.Time = time.Now()
+}
+
+func (i *internalRWMutex) RUnlock() {
+	if sec := time.Since(i.Time).Seconds(); sec >= selfishThresholdSec {
+		printStackTo(sec, debug.Stack(), os.Stderr)
+	}
+	i.RWMutex.Unlock()
+}
+
+func (i *internalRWMutex) RUnlockIgnoreTime() {
+	i.RWMutex.Unlock()
 }
 
 type internalMutex struct {
 	deadlock.Mutex
+	time.Time
+}
+
+func (i *internalMutex) Lock() {
+	i.Mutex.Lock()
+	i.Time = time.Now()
+}
+
+func (i *internalMutex) Unlock() {
+	if sec := time.Since(i.Time).Seconds(); sec >= selfishThresholdSec {
+		printStackTo(sec, debug.Stack(), os.Stderr)
+	}
+	i.Mutex.Unlock()
+}
+
+func (i *internalMutex) UnlockIgnoreTime() {
+	i.Mutex.Unlock()
+}
+
+func printStackTo(sec float64, stack []byte, writer io.Writer) {
+	goRoutineNumber := []byte("0")
+	newLines := 0
+
+	if bytes.Equal([]byte("goroutine"), stack[:len("goroutine")]) {
+		newLines = bytes.Count(stack, []byte{'\n'})
+		goroutineLine := bytes.IndexRune(stack, '[')
+		goRoutineNumber = stack[:goroutineLine]
+	}
+
+	log.WithFields(logrus.Fields{
+		"seconds":   sec,
+		"goroutine": string(goRoutineNumber[len("goroutine") : len(goRoutineNumber)-1]),
+	}).Debug(selfishThresholdMsg)
+
+	// A stack trace is usually in the following format:
+	// goroutine 1432 [running]:
+	// runtime/debug.Stack(0xc424c4a370, 0xc421f7f750, 0x1)
+	//   /usr/local/go/src/runtime/debug/stack.go:24 +0xa7
+	//   ...
+	// To know which trace belongs to which go routine we will append the
+	// go routine number to every line of the stack trace.
+	writer.Write(bytes.Replace(
+		stack,
+		[]byte{'\n'},
+		append([]byte{'\n'}, goRoutineNumber...),
+		// Don't replace the last '\n'
+		newLines-1),
+	)
 }

--- a/pkg/lock/lock_fast.go
+++ b/pkg/lock/lock_fast.go
@@ -24,6 +24,18 @@ type internalRWMutex struct {
 	sync.RWMutex
 }
 
+func (i *internalRWMutex) UnlockIgnoreTime() {
+	i.RWMutex.Unlock()
+}
+
+func (i *internalRWMutex) RUnlockIgnoreTime() {
+	i.RWMutex.Unlock()
+}
+
 type internalMutex struct {
 	sync.Mutex
+}
+
+func (i *internalMutex) UnlockIgnoreTime() {
+	i.Mutex.Unlock()
 }

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -181,11 +181,12 @@ const (
 	IPv6Host = "fdff::ff"
 
 	// Logs messages that should not be in the cilium logs.
-	panicMessage      = "panic:"
-	deadLockHeader    = "POTENTIAL DEADLOCK:"               // from github.com/sasha-s/go-deadlock/deadlock.go:header
-	segmentationFault = "segmentation fault"                // from https://github.com/cilium/cilium/issues/3233
-	NACKreceived      = "NACK received for version"         // from https://github.com/cilium/cilium/issues/4003
-	RunInitFailed     = "RunInit: Command execution failed" // from https://github.com/cilium/cilium/pull/5052
+	panicMessage        = "panic:"
+	deadLockHeader      = "POTENTIAL DEADLOCK:"               // from github.com/sasha-s/go-deadlock/deadlock.go:header
+	segmentationFault   = "segmentation fault"                // from https://github.com/cilium/cilium/issues/3233
+	NACKreceived        = "NACK received for version"         // from https://github.com/cilium/cilium/issues/4003
+	RunInitFailed       = "RunInit: Command execution failed" // from https://github.com/cilium/cilium/pull/5052
+	selfishThresholdMsg = "Goroutine took lock for more than" // from https://github.com/cilium/cilium/pull/5268
 
 	contextDeadlineExceeded = "context deadline exceeded"
 	ErrorLogs               = "level=error"
@@ -207,7 +208,7 @@ var NightlyStableUpgradesFrom = []string{"docker.io/cilium/cilium:v1.0.5"}
 var CiliumDSPath = "cilium_ds.jsonnet"
 
 var checkLogsMessages = []string{panicMessage, deadLockHeader, segmentationFault, NACKreceived, RunInitFailed}
-var countLogsMessages = []string{contextDeadlineExceeded, ErrorLogs, WarningLogs, APIPanicked}
+var countLogsMessages = []string{contextDeadlineExceeded, ErrorLogs, WarningLogs, APIPanicked, selfishThresholdMsg}
 
 var ciliumCLICommands = map[string]string{
 	"cilium endpoint list -o json":          "endpoint_list.txt",


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

This PR adds a new debug functionality that prints the stack trace of goroutines that hold a lock for more than 0.1 seconds.

This should only affect systems that are compiled with `LOCKDEBUG=1`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5268)
<!-- Reviewable:end -->
