### PR TITLE
Do not regenerate policy on TriggerPolicyUpdates

### DIFF
--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -40,7 +40,7 @@ import (
 	"github.com/op/go-logging"
 )
 
-// TriggerPolicyUpdates triggers policy updates for every daemon's endpoint.
+// RegenerateAllEndpoints triggers policy updates for every daemon's endpoint.
 // This is called after policy changes, but also after some changes in daemon
 // configuration and endpoint labels.
 // Returns a waiting group which signalizes when all endpoints are regenerated.
@@ -51,7 +51,7 @@ func (d *Daemon) TriggerPolicyUpdates(force bool) *sync.WaitGroup {
 	} else {
 		log.Debugf("Full policy recalculation triggered")
 	}
-	return endpointmanager.TriggerPolicyUpdates(d, force)
+	return endpointmanager.RegenerateAllEndpoints(d)
 }
 
 // UpdateEndpointPolicyEnforcement returns whether policy enforcement needs to be

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -151,7 +151,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) {
 		}
 
 		// Insert into endpoint manager so it can be regenerated when calls to
-		// TriggerPolicyUpdates() are made. This must be done synchronously (i.e.,
+		// RegenerateAllEndpoints() are made. This must be done synchronously (i.e.,
 		// not in a goroutine) because regenerateRestoredEndpoints must guarantee
 		// upon returning that endpoints are exposed to other subsystems via
 		// endpointmanager.

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -258,12 +258,12 @@ func updateReferences(ep *endpoint.Endpoint) {
 	}
 }
 
-// TriggerPolicyUpdates calls TriggerPolicyUpdatesLocked for each endpoint and
-// regenerates as required. During this process, the endpoint list is locked
-// and cannot be modified.
+// RegenerateAllEndpoints calls a SetStateLocked for each endpoint and
+// regenerates if state transaction is valid. During this process, the endpoint
+// list is locked and cannot be modified.
 // Returns a waiting group that can be used to know when all the endpoints are
 // regenerated.
-func TriggerPolicyUpdates(owner endpoint.Owner, force bool) *sync.WaitGroup {
+func RegenerateAllEndpoints(owner endpoint.Owner) *sync.WaitGroup {
 	var wg sync.WaitGroup
 
 	eps := GetEndpoints()
@@ -271,31 +271,16 @@ func TriggerPolicyUpdates(owner endpoint.Owner, force bool) *sync.WaitGroup {
 
 	for _, ep := range eps {
 		go func(ep *endpoint.Endpoint, wg *sync.WaitGroup) {
-			var err error
-			var regen, policyChanges bool
-			if err = ep.LockAlive(); err != nil {
+			if err := ep.LockAlive(); err != nil {
 				log.WithError(err).Warn("Error while handling policy updates for endpoint")
 				ep.LogStatus(endpoint.Policy, endpoint.Failure, "Error while handling policy updates for endpoint: "+err.Error())
 			} else {
-				policyChanges, err = ep.TriggerPolicyUpdatesLocked(owner, nil)
-				regen = false
-				if err == nil && (policyChanges || force) {
-					// Regenerate only if state transition succeeds
-					regen = ep.SetStateLocked(endpoint.StateWaitingToRegenerate, "Triggering endpoint regeneration due to policy updates")
-				}
+				regen := ep.SetStateLocked(endpoint.StateWaitingToRegenerate, "Triggering endpoint regeneration due to policy updates")
 				ep.Unlock()
-			}
-
-			if err != nil {
-				log.WithError(err).Warn("Error while handling policy updates for endpoint")
-				ep.LogStatus(endpoint.Policy, endpoint.Failure, "Error while handling policy updates for endpoint: "+err.Error())
-			} else {
-				if !policyChanges && !force {
-					ep.LogStatusOK(endpoint.Policy, "Endpoint policy update skipped because no changes were needed")
-				} else if regen {
+				if regen {
 					// Regenerate logs status according to the build success/failure
 					<-ep.Regenerate(owner, "endpoint policy updated & changes were needed")
-				} // else policy changed, but can't regenerate => do not change status
+				}
 			}
 			wg.Done()
 		}(ep, &wg)


### PR DESCRIPTION
This seems to be counter-intuitive but as we are also regenerating
policy inside the endpoint regeneration we can remove the policy
regeneration in the TriggerPolicyUpdates.

This is proven to decrease the average policy regeneration time of
100 rules and 50 endpoints, 2 rules per endpoint, from 180ms to
17ms.

Signed-off-by: André Martins <andre@cilium.io>


```release-note
Decreased average policy regeneration time by 10x
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5272)
<!-- Reviewable:end -->
