### PR TITLE
Fix warning message during successful endpoint delete

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -497,8 +497,8 @@ func (d *Daemon) deleteEndpointQuiet(ep *endpoint.Endpoint, releaseIP bool) []er
 
 	// If dry mode is enabled, no changes to BPF maps are performed
 	if !d.DryModeEnabled() {
-		if err := lxcmap.DeleteElement(ep); err != nil {
-			errors = append(errors, fmt.Errorf("unable to delete element %d from map %s: %v", ep.ID, ep.PolicyMapPathLocked(), err))
+		if errs := lxcmap.DeleteElement(ep); errs != nil {
+			errors = append(errors, errs...)
 		}
 
 		// Remove policy BPF map

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -199,7 +199,7 @@ func DeleteElement(f EndpointFrontend) []error {
 	errors := []error{}
 	for _, k := range f.GetBPFKeys() {
 		if err := LXCMap.Delete(k); err != nil {
-			errors = append(errors, fmt.Errorf("Unable to delete key %v in endpoint BPF map: %s", k, err))
+			errors = append(errors, fmt.Errorf("Unable to delete key %v from %s: %s", k, bpf.MapPath(MapName), err))
 		}
 	}
 

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -196,7 +196,7 @@ func DeleteEntry(ip net.IP) error {
 // DeleteElement deletes the endpoint using all keys which represent the
 // endpoint. It returns the number of errors encountered during deletion.
 func DeleteElement(f EndpointFrontend) []error {
-	errors := []error{}
+	var errors []error
 	for _, k := range f.GetBPFKeys() {
 		if err := LXCMap.Delete(k); err != nil {
 			errors = append(errors, fmt.Errorf("Unable to delete key %v from %s: %s", k, bpf.MapPath(MapName), err))


### PR DESCRIPTION
Previously, the `errors` variable that would be returned from `lxcmap.DeleteElement()` was always initialized to a non-nil empty slice, which would ensure that if the caller checked it against nil that it would appear to always fail, leading to the following false positive warning message in the logs:                        

```
2018-08-02T23:18:29.600824917Z level=warning msg="Ignoring error while deleting endpoint" endpointID=13279 error="unable to delete element 13279 from map /sys/fs/bpf/tc/globals/cilium_policy_13279: []" subsys=daemon
```

This would occur when the delete was successful.

Furthermore, if there was a real error in this path, the warning message would include a lot of redundant "unable to ....". Reduce this.

Fixes: #5089

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5284)
<!-- Reviewable:end -->
