### PR TITLE
metrics: Represent errors and warnings as counters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,11 @@ ineffassign:
 	@$(ECHO_CHECK) contrib/scripts/check-ineffassign.sh
 	$(QUIET) contrib/scripts/check-ineffassign.sh
 
-precheck: govet ineffassign
+logging-subsys-field:
+	@$(ECHO_CHECK) contrib/scripts/check-logging-subsys-field.sh
+	$(QUIET) contrib/scripts/check-logging-subsys-field.sh
+
+precheck: govet ineffassign logging-subsys-field
 	@$(ECHO_CHECK) contrib/scripts/check-fmt.sh
 	$(QUIET) contrib/scripts/check-fmt.sh
 	@$(ECHO_CHECK) contrib/scripts/check-log-newlines.sh

--- a/contrib/scripts/check-logging-subsys-field.sh
+++ b/contrib/scripts/check-logging-subsys-field.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# check-logging-subsys-field.sh checks whether all logging entry instancs
+# created from DefaultLogger contain the LogSubsys field. This is required for
+# proper labeling of error/warning Prometheus metric and helpful for debugging.
+# If any entry which writes any message doesn't contaion the 'subsys' field,
+# Prometheus metric logging hook (`pkg/metrics/logging_hook.go`) is going to
+# fail.
+
+# Directories:
+# - pkg/debugdetection
+# - test/
+# - vendor/
+# are excluded, because instances of DefaultLogger in those modules have their
+# specific usage which doesn't break the Prometheus logging hook.
+
+set -eu
+
+if grep -IPRns '(?!.*LogSubsys)log[ ]*= logging\.DefaultLogger.*' \
+        --exclude-dir=test/ \
+        --exclude-dir=pkg/debugdetection/ \
+        --exclude-dir=vendor/ \
+        --include=*.go .; then
+    echo "Logging entry instances have to contain the LogSubsys field. Example of"
+    echo "properly configured entry instance:"
+    echo
+    echo -e "\timport ("
+    echo -e "\t\t\"github.com/cilium/cilium/pkg/logging\""
+    echo -e "\t\t\"github.com/cilium/cilium/pkg/logging/logfields\""
+    echo -e "\t)"
+    echo
+    echo -e "\tvar log = logging.DefaultLogger.WithField(logfields.LogSubsys, \"my-subsystem\")"
+    echo
+    exit 1
+fi

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -162,6 +163,10 @@ var (
 		},
 	}
 )
+
+func init() {
+	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook(components.CiliumAgentName))
+}
 
 func main() {
 

--- a/pkg/metrics/logging_hook.go
+++ b/pkg/metrics/logging_hook.go
@@ -1,0 +1,82 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/cilium/cilium/pkg/components"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+// LoggingHook is a hook for logrus which counts error and warning messages as a
+// Prometheus metric.
+type LoggingHook struct {
+	metric *prometheus.CounterVec
+}
+
+// NewLoggingHook returns a new instance of LoggingHook for the given Cilium
+// component.
+func NewLoggingHook(component string) *LoggingHook {
+	// NOTE(mrostecki): For now errors and warning metric exists only for Cilium
+	// daemon, but support of Prometheus metrics in some other components (i.e.
+	// cilium-health - GH-4268) is planned.
+
+	// Pick a metric for the component.
+	var metric *prometheus.CounterVec
+	switch component {
+	case components.CiliumAgentName:
+		metric = ErrorsWarnings
+	default:
+		panic(fmt.Sprintf("component %s is unsupported by LoggingHook", component))
+	}
+
+	return &LoggingHook{metric: metric}
+}
+
+// Levels returns the list of logging levels on which the hook is triggered.
+func (h *LoggingHook) Levels() []logrus.Level {
+	return []logrus.Level{
+		logrus.ErrorLevel,
+		logrus.WarnLevel,
+	}
+}
+
+// Fire is the main method which is called every time when logger has an error
+// or warning message.
+func (h *LoggingHook) Fire(entry *logrus.Entry) error {
+	// Get information about subsystem from logging entry field.
+	iSubsystem, ok := entry.Data[logfields.LogSubsys]
+	if !ok {
+		serializedEntry, err := entry.String()
+		if err != nil {
+			return fmt.Errorf("log entry cannot be serialized and doesn't contain 'subsys' field")
+		}
+		return fmt.Errorf("log entry doesn't contain 'subsys' field: %s", serializedEntry)
+	}
+	subsystem, ok := iSubsystem.(string)
+	if !ok {
+		return fmt.Errorf("type of the 'subsystem' log entry field is not string but %s", reflect.TypeOf(iSubsystem))
+	}
+
+	// Increment the metric.
+	h.metric.WithLabelValues(entry.Level.String(), subsystem).Inc()
+
+	return nil
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import (
 	"os"
 
 	"github.com/cilium/cilium/api/v1/models"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	dto "github.com/prometheus/client_model/go"
@@ -307,6 +308,15 @@ var (
 		Help: "Duration in seconds of the garbage collector process " +
 			"labeled by datapath family and completion status",
 	}, []string{LabelDatapathFamily, LabelStatus})
+
+	// Errors and warnings
+
+	// ErrorsWarnings is the number of errors and warnings in cilium-agent instances
+	ErrorsWarnings = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "errors_warnings_total",
+		Help:      "Number of total errors in cilium-agent instances",
+	}, []string{"level", "subsystem"})
 )
 
 func init() {
@@ -347,6 +357,8 @@ func init() {
 	MustRegister(ConntrackGCKeyFallbacks)
 	MustRegister(ConntrackGCSize)
 	MustRegister(ConntrackGCDuration)
+
+	MustRegister(ErrorsWarnings)
 }
 
 // MustRegister adds the collector to the registry, exposing this metric to


### PR DESCRIPTION
Add counters representing errors and warnings occuring in
cilium-agent.

Fixes #4268

Signed-off-by: Michal Rostecki <mrostecki@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5286)
<!-- Reviewable:end -->
