### PR TITLE
Prometheus metrics for connection tracking garbage

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -41,7 +41,17 @@ Endpoint
 Datapath
 --------
 
-* ``datapath_errors_total``: Total number of errors occurred in datapath management, labeled by area, name and address family.
+* ``datapath_errors_total``: Total number of errors occurred in datapath
+  management, labeled by area, name and address family.
+* ``datapath_conntrack_gc_runs_total``: Number of times that the conntrack
+  garbage collector process was run. It contains a label status that describes
+  if it was successful or not.
+* ``datapath_conntrack_gc_key_fallbacks_total``: Number of times that the Key fallback
+  was invalid.
+* ``datapath_conntrack_gc_entries``: The number of alive and deleted conntrack
+  entries at the end of a garbage collector run labeled by datapath family.
+* ``datapath_conntrack_gc_duration_seconds``: Duration in seconds of the garbage
+  collector process labeled by datapath and completation status.
 
 Drops/Forwards (L3/L4)
 ----------------------

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -71,6 +71,9 @@ var (
 	// LabelDatapathFamily marks which protocol family (IPv4, IPV6) the metric is related to.
 	LabelDatapathFamily = "family"
 
+	// LabelStatus the label from completed task
+	LabelStatus = "status"
+
 	// Endpoint
 
 	// EndpointCount is a function used to collect this metric.
@@ -253,8 +256,43 @@ var (
 		Subsystem: Datapath,
 		Name:      "errors_total",
 		Help:      "Number of errors that occurred in the datapath or datapath management",
-	},
-		[]string{LabelDatapathArea, LabelDatapathName, LabelDatapathFamily})
+	}, []string{LabelDatapathArea, LabelDatapathName, LabelDatapathFamily})
+
+	// ConntrackGCRuns is the number of times that the conntrack GC
+	// process was run.
+	ConntrackGCRuns = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: Datapath,
+		Name:      "conntrack_gc_runs_total",
+		Help: "Number of times that the conntrack garbage collector process was run " +
+			"labeled by completion status",
+	}, []string{LabelDatapathFamily, LabelStatus})
+
+	// ConntrackGCKeyFallbacks number of times that the conntrack key fallback was invalid.
+	ConntrackGCKeyFallbacks = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: Datapath,
+		Name:      "conntrack_gc_key_fallbacks_total",
+		Help:      "Number of times a key fallback was needed when iterating over the BPF map",
+	}, []string{LabelDatapathFamily})
+
+	// ConntrackGCSize the number of entries in the conntrack table
+	ConntrackGCSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Datapath,
+		Name:      "conntrack_gc_entries",
+		Help: "The number of alive and deleted conntrack entries at the end " +
+			"of a garbage collector run labeled by datapath family.",
+	}, []string{LabelDatapathFamily, LabelStatus})
+
+	// ConntrackGCDuration the duration of the conntrack GC process in milliseconds.
+	ConntrackGCDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: Namespace,
+		Subsystem: Datapath,
+		Name:      "conntrack_gc_duration_seconds",
+		Help: "Duration in seconds of the garbage collector process " +
+			"labeled by datapath family and completion status",
+	}, []string{LabelDatapathFamily, LabelStatus})
 )
 
 func init() {
@@ -290,6 +328,10 @@ func init() {
 	MustRegister(newStatusCollector())
 
 	MustRegister(DatapathErrors)
+	MustRegister(ConntrackGCRuns)
+	MustRegister(ConntrackGCKeyFallbacks)
+	MustRegister(ConntrackGCSize)
+	MustRegister(ConntrackGCDuration)
 }
 
 // MustRegister adds the collector to the registry, exposing this metric to


### PR DESCRIPTION
Hi, 

 Added the following metrics to the system:
                                           
 cilium_datapath_conntrack_gc_duration     
 cilium_datapath_conntrack_gc_expired_total
 cilium_datapath_conntrack_gc_key_fallbacks
 cilium_datapath_conntrack_gc_runs_total   
 cilium_datapath_conntrack_gc_size         
 cilium_datapath_errors_total              

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5296)
<!-- Reviewable:end -->
