### PR TITLE
Periodically sweep the IPCache map on kernels that don't support delete operation by recreating the map with the desired entries

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -851,7 +851,7 @@ func (d *Daemon) init() error {
 		// used by syncLXCMap().
 		ipcache.IPIdentityCache.SetListeners([]ipcache.IPIdentityMappingListener{
 			&envoy.NetworkPolicyHostsCache,
-			bpfIPCache.NewListener(),
+			bpfIPCache.NewListener(d),
 		})
 
 		// Insert local host entries to bpf maps
@@ -1462,16 +1462,17 @@ func mapValidateWalker(path string) error {
 	return nil
 }
 
-// ReloadBPF triggers whatever datapath synchronization logic is necessary to
-// reload BPF programs and maps. It first attempts to recompile the base
-// programs, and if this fails will return an error. Otherwise, it subsequently
-// triggers regeneration of all endpoints and returns a waitgroup that may be
-// used by the caller to wait for all endpoint regeneration to complete.
+// TriggerReloadWithoutCompile causes all BPF programs and maps to be reloaded,
+// without recompiling the datapath logic for each endpoint. It first attempts
+// to recompile the base programs, and if this fails returns an error. If base
+// program load is successful, it subsequently triggers regeneration of all
+// endpoints and returns a waitgroup that may be used by the caller to wait for
+// all endpoint regeneration to complete.
 //
 // If an error is returned, then no regeneration was successful. If no error
 // is returned, then the base programs were successfully regenerated, but
 // endpoints may or may not have successfully regenerated.
-func (d *Daemon) ReloadBPF(reason string) (*sync.WaitGroup, error) {
+func (d *Daemon) TriggerReloadWithoutCompile(reason string) (*sync.WaitGroup, error) {
 	log.Debugf("BPF reload triggered from %s", reason)
 	if err := d.compileBase(); err != nil {
 		return nil, fmt.Errorf("Unable to recompile base programs from %s: %s", reason, err)

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -51,7 +51,8 @@ func (d *Daemon) TriggerPolicyUpdates(force bool, reason string) *sync.WaitGroup
 	} else {
 		log.Debugf("Full policy recalculation triggered")
 	}
-	return endpointmanager.RegenerateAllEndpoints(d, reason)
+	regenContext := endpoint.NewRegenerationContext(reason)
+	return endpointmanager.RegenerateAllEndpoints(d, regenContext)
 }
 
 // UpdateEndpointPolicyEnforcement returns whether policy enforcement needs to be

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,6 +40,8 @@ var (
 	ProdHardAddr    = mac.MAC{0x01, 0x07, 0x08, 0x09, 0x0a, 0x0b}
 	ProdIPv6Addr, _ = addressing.NewCiliumIPv6("cafe:cafe:cafe:cafe:aaaa:aaaa:1111:1112")
 	ProdIPv4Addr, _ = addressing.NewCiliumIPv4("10.11.12.14")
+
+	regenContext = endpoint.NewRegenerationContext("test")
 )
 
 // getXDSNetworkPolicies returns the representation of the xDS network policies
@@ -158,7 +160,7 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 	ready := e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
 	e.Unlock()
 	c.Assert(ready, Equals, true)
-	buildSuccess := <-e.Regenerate(ds.d, "test")
+	buildSuccess := <-e.Regenerate(ds.d, regenContext)
 	c.Assert(buildSuccess, Equals, true)
 	c.Assert(e.Allows(qaBarSecLblsCtx.ID), Equals, false)
 	c.Assert(e.Allows(prodBarSecLblsCtx.ID), Equals, false)
@@ -176,7 +178,7 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 	ready = e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
 	e.Unlock()
 	c.Assert(ready, Equals, true)
-	buildSuccess = <-e.Regenerate(ds.d, "test")
+	buildSuccess = <-e.Regenerate(ds.d, regenContext)
 	c.Assert(buildSuccess, Equals, true)
 	c.Assert(e.Allows(0), Equals, false)
 	c.Assert(e.Allows(qaBarSecLblsCtx.ID), Equals, false)
@@ -442,7 +444,7 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 	ready := e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
 	e.Unlock()
 	c.Assert(ready, Equals, true)
-	buildSuccess := <-e.Regenerate(ds.d, "test")
+	buildSuccess := <-e.Regenerate(ds.d, regenContext)
 	c.Assert(buildSuccess, Equals, true)
 
 	// Check that the policy has been updated in the xDS cache for the L7

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -202,7 +202,9 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) {
 				epRegenerated <- false
 				return
 			}
-			if buildSuccess := <-ep.Regenerate(d, "syncing state to host"); !buildSuccess {
+			regenContext := endpoint.NewRegenerationContext(
+				"syncing state to host")
+			if buildSuccess := <-ep.Regenerate(d, regenContext); !buildSuccess {
 				scopedLog.Warn("Failed while regenerating endpoint")
 				epRegenerated <- false
 				return

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -147,7 +147,7 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 		ready := ep.SetStateLocked(e.StateWaitingToRegenerate, "test")
 		ep.Unlock()
 		if ready {
-			<-ep.Regenerate(ds, "test")
+			<-ep.Regenerate(ds, regenContext)
 		}
 
 		switch ep.ID {
@@ -170,7 +170,7 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 				ready := ep.SetStateLocked(e.StateWaitingToRegenerate, "test")
 				ep.Unlock()
 				if ready {
-					<-ep.Regenerate(ds, "test")
+					<-ep.Regenerate(ds, regenContext)
 				}
 				epsNames = append(epsNames, ep.DirectoryPath())
 			}

--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -454,6 +454,12 @@ func (m *Map) Close() error {
 	return nil
 }
 
+// Reopen attempts to close and re-open the received map.
+func (m *Map) Reopen() error {
+	m.Close()
+	return m.Open()
+}
+
 type DumpParser func(key []byte, value []byte) (MapKey, MapValue, error)
 type DumpCallback func(key MapKey, value MapValue)
 type MapValidator func(path string) (bool, error)

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -148,18 +148,20 @@ func (l *BPFListener) garbageCollect() error {
 	ipcache.IPIdentityCache.RLock()
 	defer ipcache.IPIdentityCache.RUnlock()
 
-	keysToRemove := map[string]*ipcacheMap.Key{}
-	if err := l.bpfMap.DumpWithCallback(updateStaleEntriesFunction(keysToRemove)); err != nil {
-		return fmt.Errorf("error dumping ipcache BPF map: %s", err)
-	}
+	if true {
+		keysToRemove := map[string]*ipcacheMap.Key{}
+		if err := l.bpfMap.DumpWithCallback(updateStaleEntriesFunction(keysToRemove)); err != nil {
+			return fmt.Errorf("error dumping ipcache BPF map: %s", err)
+		}
 
-	// Remove all keys which are not in in-memory cache from BPF map
-	// for consistency.
-	for _, k := range keysToRemove {
-		log.WithFields(logrus.Fields{logfields.BPFMapKey: k}).
-			Debug("deleting from ipcache BPF map")
-		if err := l.bpfMap.Delete(k); err != nil {
-			return fmt.Errorf("error deleting key %s from ipcache BPF map: %s", k, err)
+		// Remove all keys which are not in in-memory cache from BPF map
+		// for consistency.
+		for _, k := range keysToRemove {
+			log.WithFields(logrus.Fields{logfields.BPFMapKey: k}).
+				Debug("deleting from ipcache BPF map")
+			if err := l.bpfMap.Delete(k); err != nil {
+				return fmt.Errorf("error deleting key %s from ipcache BPF map: %s", k, err)
+			}
 		}
 	}
 	return nil

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -435,7 +435,7 @@ func (e *Endpoint) removeOldRedirects(owner Owner, desiredRedirects map[string]b
 // Must be called with endpoint.Mutex not held and endpoint.BuildMutex held.
 // Returns the policy revision number when the regeneration has called, a
 // boolean if the BPF compilation was executed and an error in case of an error.
-func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (revnum uint64, compiled bool, reterr error) {
+func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *RegenerationContext) (revnum uint64, compiled bool, reterr error) {
 	var (
 		err                 error
 		compilationExecuted bool
@@ -479,7 +479,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (revnum uint
 	// When building the initial drop policy in waiting-for-identity state
 	// the state remains unchanged
 	if e.GetStateLocked() != StateWaitingForIdentity &&
-		!e.BuilderSetStateLocked(StateRegenerating, "Regenerating Endpoint BPF: "+reason) {
+		!e.BuilderSetStateLocked(StateRegenerating, "Regenerating Endpoint BPF: "+regenContext.Reason) {
 
 		e.getLogger().WithField(logfields.EndpointState, e.state).Debug("Skipping build due to invalid state")
 		e.Unlock()

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -640,7 +640,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 	rundir := owner.GetStateDir()
 	debug := strconv.FormatBool(viper.GetBool(option.BPFCompileDebugName))
 
-	if bpfHeaderfilesChanged {
+	if bpfHeaderfilesChanged || regenContext.ReloadDatapath {
 		closeChan := loadinfo.LogPeriodicSystemLoad(log.WithFields(logrus.Fields{logfields.EndpointID: epID}).Debugf, time.Second)
 
 		start := time.Now()

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1695,7 +1695,7 @@ func (e *Endpoint) Update(owner Owner, cfg *models.EndpointConfigurationSpec) er
 				stateTransitionSucceeded := e.SetStateLocked(StateWaitingToRegenerate, reason)
 				if stateTransitionSucceeded {
 					e.Unlock()
-					e.Regenerate(owner, reason)
+					e.Regenerate(owner, NewRegenerationContext(reason))
 					return nil
 				}
 				e.Unlock()
@@ -1874,7 +1874,7 @@ func (e *Endpoint) CreateDirectory() error {
 // RegenerateWait should only be called when endpoint's state has successfully
 // been changed to "waiting-to-regenerate"
 func (e *Endpoint) RegenerateWait(owner Owner, reason string) error {
-	if !<-e.Regenerate(owner, reason) {
+	if !<-e.Regenerate(owner, NewRegenerationContext(reason)) {
 		return fmt.Errorf("error while regenerating endpoint."+
 			" For more info run: 'cilium endpoint get %d'", e.ID)
 	}
@@ -2501,7 +2501,7 @@ func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
 	e.Unlock()
 
 	if readyToRegenerate {
-		e.Regenerate(owner, "updated security labels")
+		e.Regenerate(owner, NewRegenerationContext("updated security labels"))
 	}
 
 	return nil

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -74,6 +74,10 @@ type RegenerationContext struct {
 	// Reason provides context to source for the regeneration, which is
 	// used to generate useful log messages.
 	Reason string
+
+	// ReloadDatapath forces the datapath programs to be reloaded. It does
+	// not guarantee recompilation of the programs.
+	ReloadDatapath bool
 }
 
 // NewRegenerationContext returns a new context for regeneration that does not

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -209,3 +209,9 @@ func init() {
 		log.WithError(err).Error("unable to open map")
 	}
 }
+
+// Reopen attempts to close and re-open the IPCache map at the standard path
+// on the filesystem.
+func Reopen() error {
+	return IPCache.Map.Reopen()
+}


### PR DESCRIPTION
Add detection of the case where Linux kernels 4.11 to 4.14 inclusive don't support delete operations on IPCache (LPM) maps.

When this case is detected, change the IPCache garbage collection to instead:
* Grab a readlock on the IPCache
* Create a brand new map on the filesystem
* Populate the new map based on the current IPCache state
* Move the old map out of the way
* Move the new map into the standard IPCache location
* Reload BPF programs (Should not require recompilation, but it performs recompilation for now)
* When successful, delete the old map from the filesystem.
  * If not successful, attempt to roll back

This should be safe, because when a BPF program is loaded, it reads the filesystem at that point and takes a reference on the map that is pinned to the standard location. It continues to use this reference to the map that was loaded and pinned to that location for the remainder of the lifetime of the BPF program.

When we prepare the new map, even when we move it into the same location as the previous map, the existing BPF programs continue to use the old map based on the reference from load time. By placing it into the location that was previously used, the path does not need to change in the existing BPF ELF binary so no recompilation is necessary. When the BPF program is reloaded from the same ELF, it looks into the filesystem and gets a reference to the new map, and we discard the reference to the old map when replacing the previous program's attachment. Finally, we reload the IPCache map from the Cilium userspace side (at the same path again) to remove the final reference to the old IPCache map.

Fixes: #4896

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5303)
<!-- Reviewable:end -->
