### PR TITLE
ToFQDN bugfixes

### DIFF
--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
-	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -199,7 +198,7 @@ func (d *Daemon) PolicyAdd(rules policyAPI.Rules, opts *AddOptions) (uint64, err
 
 	// These must be marked before actually adding them to the repository since a
 	// copy may be made and we won't be able to add the ToFQDN tracking labels
-	fqdn.MarkToFQDNRules(rules)
+	d.dnsPoller.MarkToFQDNRules(rules)
 
 	prefixes := policy.GetCIDRPrefixes(rules)
 	log.WithField("prefixes", prefixes).Debug("Policy imported via API, found CIDR prefixes...")

--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -107,6 +107,16 @@ func generateRuleFromSource(sourceRule *api.Rule, updatedDNSNames map[string][]n
 	return outputRule, namesMissingIPs
 }
 
+// stripeToCIDRSet ensures no ToCIDRSet is nil when ToFQDNs is non-nil
+func stripToCIDRSet(rule *api.Rule) {
+	for i := range rule.Egress {
+		egressRule := &rule.Egress[i]
+		if len(egressRule.ToFQDNs) > 0 {
+			egressRule.ToCIDRSet = nil
+		}
+	}
+}
+
 // ipsToRules generates CIDRRules for the IPs passed in.
 func ipsToRules(ips []net.IP) (cidrRules []api.CIDRRule) {
 	for _, ip := range ips {


### PR DESCRIPTION
This PR is best reviewed commit by commit.

A few bugs have cropped up:
1. A race can happen between deleting/updating a rule and the poller generating it. This brings rules back from the dead or reverts changes to them since the poller has an older copy from earlier in its run.
2. Updating a rule overwrites it in the policy repo, but it might regenerate before the poller fills in the IP data. For a policy with existing toFQDNs rules, this would result in interrupted connectivity.
3. Updating toFQDNs rule to remove one of the matchNames isn't handled correctly. We don't remove the older references and may use older version of the rule (the result is similar to (1) above but for different reasons).

The fixes for (1) and (3) are related, and are in 
* fqdn: Strip toCIDRSet rules to be more resilient
* fqdn: Use UUIDs to manage rules 

The fix for (2) is 
* fqdn: Inject IPs on initial rule insert

```release-note/bug
Correct toFQDNs being incorrectly recreated if a rule update coincides with a DNS poll iteration.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5306)
<!-- Reviewable:end -->
