### PR TITLE
Fix warning message about IPv6 CT map garbage collection failing

### DIFF
--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -439,6 +439,7 @@ func doGC6(m *bpf.Map, filter *GCFilter) gcStats {
 		}
 
 		if nextKeyValid != nil {
+			stats.completed = true
 			break
 		}
 		// remember the last found key


### PR DESCRIPTION
The IPv6 CT completed path was missing the update of the gcStats to mark
it as completed, which resulted in the following false warning every
time IPv6 CT GC was run:

    Garbage collection on IPv6 CT map failed to finish

Fixes: 4ae95ad4eb61 ("ctmap: Provide conntrack gc statistics")
Fixes: #5313

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5315)
<!-- Reviewable:end -->
