### PR TITLE
Fix endpoint regeneration failure metric by not counting skipped compiles

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -674,7 +674,7 @@ func (e *Endpoint) regenerate(owner Owner, reason string) (retErr error) {
 	regenerateStart := time.Now()
 	defer func() {
 		metrics.EndpointCountRegenerating.Dec()
-		if retErr == nil && compilationExecuted {
+		if retErr == nil {
 			metrics.EndpointRegenerationCount.
 				WithLabelValues(metrics.LabelValueOutcomeSuccess).Inc()
 


### PR DESCRIPTION
The endpoint regeneration metric was being considered "failed" if the
BPF compilation was not executed, even if the overall regeneration was
successful. Fix this by not taking into account whether BPF compilation
occurred when incrementing the metric.

We could in theory split this information out into a separate metric,
however I think that with the EndpointRegenerationTimeSquare we should
be able to tell which cases involved compilation and which did not, as
we should see a bimodal distribution of endpoint regeneration times.

Fixes: 70b82a69f914 ("metrics: Expose endpoint and policy computation time metrics")
Fixes: #5312

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5316)
<!-- Reviewable:end -->
