### PR TITLE
backport-1.2-2018-08-23

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -671,7 +671,7 @@ func (e *Endpoint) regenerate(owner Owner, reason string) (retErr error) {
 	regenerateStart := time.Now()
 	defer func() {
 		metrics.EndpointCountRegenerating.Dec()
-		if retErr == nil && compilationExecuted {
+		if retErr == nil {
 			metrics.EndpointRegenerationCount.
 				WithLabelValues(metrics.LabelValueOutcomeSuccess).Inc()
 

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -439,6 +439,7 @@ func doGC6(m *bpf.Map, filter *GCFilter) gcStats {
 		}
 
 		if nextKeyValid != nil {
+			stats.completed = true
 			break
 		}
 		// remember the last found key

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -478,7 +478,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		log.WithError(err).Warn("Deletion of endpoint failed")
 	}
 
-	return ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
-		return link.DeleteByName(args.IfName)
+	return ns.WithNetNSPath(args.Netns, func(netNs ns.NetNS) error {
+		return removeIfFromNSIfExists(netNs, args.IfName)
 	})
 }


### PR DESCRIPTION
* PR: 5315 -- Fix warning message about IPv6 CT map garbage collection failing (@joestringer) -- https://github.com/cilium/cilium/pull/5315
 * PR: 5311 -- Ignore non-existing link error in cni del (@nebril) -- https://github.com/cilium/cilium/pull/5311
 * PR: 5316 -- Fix endpoint regeneration failure metric by not counting skipped compiles (@joestringer) -- https://github.com/cilium/cilium/pull/5316


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5318)
<!-- Reviewable:end -->
