### PR TITLE
Test: Using locks on read/write operations

### DIFF
--- a/test/helpers/buffer.go
+++ b/test/helpers/buffer.go
@@ -1,0 +1,79 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"bytes"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// A Buffer is a variable-sized buffer of bytes with Read and Write methods.
+// The zero value for Buffer is an empty buffer ready to use.
+type Buffer struct {
+	buffer bytes.Buffer
+	mutex  lock.Mutex
+}
+
+// Write appends the contents of p to the buffer, growing the buffer as
+// needed. The return value n is the length of p; err is always nil. If the
+// buffer becomes too large, Write will panic with ErrTooLarge.
+func (buf *Buffer) Write(p []byte) (n int, err error) {
+	buf.mutex.Lock()
+	r, err := buf.buffer.Write(p)
+	buf.mutex.Unlock()
+	return r, err
+}
+
+// String returns the contents of the unread portion of the buffer
+// as a string. If the Buffer is a nil pointer, it returns "<nil>".
+//
+// To build strings more efficiently, see the strings.Builder type.
+func (buf *Buffer) String() string {
+	buf.mutex.Lock()
+	r := buf.buffer.String()
+	buf.mutex.Unlock()
+	return r
+}
+
+// Reset resets the buffer to be empty,
+// but it retains the underlying storage for use by future writes.
+// Reset is the same as Truncate(0).
+func (buf *Buffer) Reset() {
+	buf.mutex.Lock()
+	buf.buffer.Reset()
+	buf.mutex.Unlock()
+}
+
+// Len returns the number of bytes of the unread portion of the buffer;
+// b.Len() == len(b.Bytes()).
+func (buf *Buffer) Len() int {
+	buf.mutex.Lock()
+	r := buf.buffer.Len()
+	buf.mutex.Unlock()
+	return r
+}
+
+// Bytes returns a slice of length b.Len() holding the unread portion of the buffer.
+// The slice is valid for use only until the next buffer modification (that is,
+// only until the next call to a method like Read, Write, Reset, or Truncate).
+// The slice aliases the buffer content at least until the next buffer modification,
+// so immediate changes to the slice will affect the result of future reads.
+func (buf *Buffer) Bytes() []byte {
+	buf.mutex.Lock()
+	r := buf.buffer.Bytes()
+	buf.mutex.Unlock()
+	return r
+}

--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -35,8 +35,8 @@ import (
 type CmdRes struct {
 	cmd      string        // Command to run
 	params   []string      // Parameters to provide to command
-	stdout   *bytes.Buffer // Stdout from running cmd
-	stderr   *bytes.Buffer // Stderr from running cmd
+	stdout   *Buffer       // Stdout from running cmd
+	stderr   *Buffer       // Stderr from running cmd
 	success  bool          // Whether command successfully executed
 	exitcode int           // The exit code of cmd
 	duration time.Duration // Is the representation of the the time that command took to execute.
@@ -209,7 +209,7 @@ func (res *CmdRes) KVOutput() map[string]string {
 }
 
 // Output returns res's stdout.
-func (res *CmdRes) Output() *bytes.Buffer {
+func (res *CmdRes) Output() *Buffer {
 	return res.stdout
 }
 


### PR DESCRIPTION
As discussed on #5295 the CMDRes was not safe to use in concurrent
environments.

This commit address the following:

- In Context use a pointer to make sure that it's the correct variable.
- Create a new type buffer that uses locks.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5319)
<!-- Reviewable:end -->
