### PR TITLE
endpoint: extract endpoint configuration update from `regeneratePolicy` 

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -553,10 +553,6 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 	// Only generate & populate policy map if a security identity is set up for
 	// this endpoint.
 	if e.SecurityIdentity != nil {
-
-		// Regenerate policy and apply any options resulting in the
-		// policy change.
-		// This also populates e.PolicyMap.
 		_, err = e.regeneratePolicy(owner)
 		if err != nil {
 			e.Unlock()

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -450,31 +450,20 @@ func (e *Endpoint) updateNetworkPolicy(owner Owner, proxyWaitGroup *completion.W
 	return nil
 }
 
-// regeneratePolicy regenerates endpoint's policy if needed and returns
-// whether the BPF for the given endpoint should be regenerated.
+// regeneratePolicy regenerates endpoint's policy if needed and returns whether
+// the policy for the endpoint changed.
 //
-// In a typical workflow this is first called to regenerate the policy
-// (if needed), and second time when the BPF program is
-// regenerated. The second step is usually unnecessary and may be
-// optimized away by the revision checks.  However, if there has been
-// a further policy update between the first and second calls, the
-// second call will update the policy just before regenerating the BPF
-// programs to avoid needing to regenerate BPF programs again right
-// after.
-//
-// Policy changes are tracked so that only endpoints affected by the
-// policy change need to have their BPF programs regenerated.
-//
-// Policy generation may fail, and in that case we exit before
-// actually changing the policy in any way, so that the last policy
-// remains fully in effect if the new policy can not be
-// implemented. This is done on a per endpoint-basis, however, and it is
-// possible that policy update succeeds for some endpoints, while it
-// fails for other endpoints.
+// Policy generation may fail, and in that case we exit before actually changing
+// the policy in any way, so that the last policy remains fully in effect if the
+// new policy can not be implemented. This is done on a per endpoint-basis,
+// however, and it is possible that policy update succeeds for some endpoints,
+// while it fails for other endpoints.
 //
 // Returns:
-//  - changed: true if the policy was changed for this endpoint;
-//  - err: error in case of an error.
+//  - isPolicyComp: true if the policy was changed for this endpoint;
+//  - err: any error in obtaining information for computing policy, or if
+// policy could not be generated given the current set of rules in the
+// repository.
 // Must be called with endpoint mutex held.
 func (e *Endpoint) regeneratePolicy(owner Owner) (isPolicyComp bool, err error) {
 	var labelsMap *identityPkg.IdentityCache

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -482,24 +482,6 @@ func (e *Endpoint) updateNetworkPolicy(owner Owner, proxyWaitGroup *completion.W
 // Must be called with endpoint mutex held.
 func (e *Endpoint) regeneratePolicy(owner Owner, opts option.OptionMap) (isPolicyComp bool, err error) {
 	var labelsMap *identityPkg.IdentityCache
-	// Dry mode does not regenerate policy via bpf regeneration, so we let it pass
-	// through. Some bpf/redirect updates are skipped in that case.
-	//
-	// This can be cleaned up once we shift all bpf updates to regenerateBPF().
-	if e.PolicyMap == nil && !owner.DryModeEnabled() {
-		// First run always results in bpf generation
-		// L4 policy generation assumes e.PolicyMap to exist, but it is only created
-		// when bpf is generated for the first time. Until then we can't really compute
-		// the policy. Bpf generation calls us again after PolicyMap is created.
-		// In dry mode we are called with a nil PolicyMap.
-
-		// We still need to apply any options if given.
-		if opts != nil {
-			e.applyOptsLocked(opts)
-		}
-		e.getLogger().Debug("marking policy as changed to trigger bpf generation as part of first build")
-		return true, nil
-	}
 
 	e.getLogger().Debug("Starting regenerate...")
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -603,10 +603,6 @@ func (e *Endpoint) regeneratePolicy(owner Owner, opts option.OptionMap) (isPolic
 
 	e.nextPolicyRevision = revision
 
-	if !owner.DryModeEnabled() {
-		e.syncPolicyMapController()
-	}
-
 	// If no policy or options change occurred for this endpoint then the endpoint is
 	// already running the latest revision, otherwise we have to wait for
 	// the regeneration of the endpoint to complete.
@@ -730,6 +726,11 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 	// performed in endpoint.syncPolicyMap().
 	if err = e.LockAlive(); err != nil {
 		return err
+	}
+
+	// Keep PolicyMap for this endpoint in sync with desired / realized state.
+	if !owner.DryModeEnabled() {
+		e.syncPolicyMapController()
 	}
 
 	e.RealizedL4Policy = e.DesiredL4Policy


### PR DESCRIPTION
Decoupling policy updates from configuration updates allows for policy computation to be entirely separate from endpoint configuration. As a result, policy generation for an endpoint is now based only upon the endpoint's identity / set of labels in relation to the policy repository. This will make testing endpoint policy generation much easier in the future.

Signed-off by: Ian Vernon <ian@cilium.io>


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5324)
<!-- Reviewable:end -->
