### PR TITLE
Fix xDS completion timeout handling on cache update

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -592,6 +592,21 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (revnum uint
 		}
 	}
 
+	// Walk the L4Policy to add new redirects and update the desired policy map
+	// state to set the newly allocated proxy ports.
+	var desiredRedirects map[string]bool
+	if e.DesiredL4Policy != nil {
+		desiredRedirects, err = e.addNewRedirects(owner, e.DesiredL4Policy, proxyWaitGroup)
+		if err != nil {
+			e.Unlock()
+			return 0, compilationExecuted, err
+		}
+	}
+	// At this point, traffic is no longer redirected to the proxy for
+	// now-obsolete redirects, since we synced the updated policy map above.
+	// It's now safe to remove the redirects from the proxy's configuration.
+	e.removeOldRedirects(owner, desiredRedirects, proxyWaitGroup)
+
 	// Generate header file specific to this endpoint for use in compiling
 	// BPF programs for this endpoint.
 	if err = e.writeHeaderfile(epdir, owner); err != nil {
@@ -629,6 +644,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (revnum uint
 	os.RemoveAll(e.IPv4IngressMapPathLocked())
 
 	e.Unlock()
+
 	e.getLogger().WithField("bpfHeaderfilesChanged", bpfHeaderfilesChanged).Debug("Preparing to compile BPF")
 	libdir := owner.GetBpfDir()
 	rundir := owner.GetStateDir()
@@ -652,25 +668,6 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (revnum uint
 			Debug("BPF header file unchanged, skipping BPF compilation and installation")
 		e.RUnlock()
 	}
-
-	if err = e.LockAlive(); err != nil {
-		return 0, compilationExecuted, err
-	}
-	// Walk the L4Policy to add new redirects and update the desired policy map
-	// state to set the newly allocated proxy ports.
-	var desiredRedirects map[string]bool
-	if e.DesiredL4Policy != nil {
-		desiredRedirects, err = e.addNewRedirects(owner, e.DesiredL4Policy, proxyWaitGroup)
-		if err != nil {
-			e.Unlock()
-			return 0, compilationExecuted, err
-		}
-	}
-	// At this point, traffic is no longer redirected to the proxy for
-	// now-obsolete redirects, since we synced the updated policy map above.
-	// It's now safe to remove the redirects from the proxy's configuration.
-	e.removeOldRedirects(owner, desiredRedirects, proxyWaitGroup)
-	e.Unlock()
 
 	err = e.WaitForProxyCompletions(proxyWaitGroup)
 	if err != nil {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -483,11 +483,15 @@ func (e *Endpoint) WaitForProxyCompletions(proxyWaitGroup *completion.WaitGroup)
 		return nil
 	}
 
+	err := proxyWaitGroup.Context().Err()
+	if err != nil {
+		return fmt.Errorf("context cancelled before waiting for proxy updates: %s", err)
+	}
+
 	start := time.Now()
 
 	e.getLogger().Debug("Waiting for proxy updates to complete...")
-
-	err := proxyWaitGroup.Wait()
+	err = proxyWaitGroup.Wait()
 	if err != nil {
 		return fmt.Errorf("proxy state changes failed: %s", err)
 	}


### PR DESCRIPTION
Ignore completion timeouts on xDS resource cache upsert and delete.

In BPF regeneration, create/remove Envoy listeners earlier.
Create new listeners and remove obsolete listeners as early as possible, just after updating the policy map. This gives more time to Envoy to configure and ACK listener config updates, and reduces the probability of regeneration timeouts due to Envoy.
Also remove one endpoint mutex locking section after BPF compilation, in order to reduce the regeneration time.

In BPF regeneration, log a distinct regeneration error when it times out before even starting to wait for an Envoy ACK.

Related: https://github.com/cilium/cilium/issues/5317
Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5326)
<!-- Reviewable:end -->
