### PR TITLE
Metrics: Added Endpoint BPF compilation time.

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -34,8 +34,9 @@ Endpoint
 * ``endpoint_count``: Number of endpoints managed by this agent
 * ``endpoint_regenerating``: Number of endpoints currently regenerating. Deprecated. Use endpoint_state with proper labels instead
 * ``endpoint_regenerations``: Count of all endpoint regenerations that have completed, tagged by outcome
-* ``endpoint_regeneration_seconds_total``: Total sum of successful endpoint regeneration times
-* ``endpoint_regeneration_square_seconds_total``: Total sum of squares of successful endpoint regeneration times
+* ``endpoint_regeneration_seconds_total``: Total sum of successful endpoint regeneration times (Deprecated)
+* ``endpoint_regeneration_square_seconds_total``: Total sum of squares of successful endpoint regeneration times (Deprecated)
+* ``endpoint_regeneration_time_stats_seconds``: Endpoint regeneration time stats labeled by scope.
 * ``endpoint_state``: Count of all endpoints, tagged by different endpoint states
 
 Datapath

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -45,7 +45,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
-	"github.com/cilium/cilium/pkg/spanstat"
 	"github.com/cilium/cilium/pkg/version"
 
 	"github.com/sirupsen/logrus"
@@ -429,19 +428,6 @@ func (e *Endpoint) removeOldRedirects(owner Owner, desiredRedirects map[string]b
 			e.proxyStatisticsMutex.Unlock()
 		}
 	}
-}
-
-type regenerationStatistics struct {
-	totalTime              spanstat.SpanStat
-	waitingForLock         spanstat.SpanStat
-	waitingForCTClean      spanstat.SpanStat
-	policyCalculation      spanstat.SpanStat
-	proxyConfiguration     spanstat.SpanStat
-	proxyPolicyCalculation spanstat.SpanStat
-	proxyWaitForAck        spanstat.SpanStat
-	bpfCompilation         spanstat.SpanStat
-	mapSync                spanstat.SpanStat
-	prepareBuild           spanstat.SpanStat
 }
 
 // regenerateBPF rewrites all headers and updates all BPF maps to reflect the

--- a/pkg/endpoint/metrics.go
+++ b/pkg/endpoint/metrics.go
@@ -1,0 +1,76 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"math"
+	"time"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/spanstat"
+)
+
+type regenerationStatistics struct {
+	success                bool
+	totalTime              spanstat.SpanStat
+	waitingForLock         spanstat.SpanStat
+	waitingForCTClean      spanstat.SpanStat
+	policyCalculation      spanstat.SpanStat
+	proxyConfiguration     spanstat.SpanStat
+	proxyPolicyCalculation spanstat.SpanStat
+	proxyWaitForAck        spanstat.SpanStat
+	bpfCompilation         spanstat.SpanStat
+	mapSync                spanstat.SpanStat
+	prepareBuild           spanstat.SpanStat
+}
+
+// SendMetrics sends the regeneration statistics for this endpoint to
+// Prometheus.
+func (s *regenerationStatistics) SendMetrics() {
+
+	metrics.EndpointCountRegenerating.Dec()
+
+	if !s.success {
+		// Endpoint regeneration failed, increase on failed metrics
+		metrics.EndpointRegenerationCount.WithLabelValues(metrics.LabelValueOutcomeFail).Inc()
+		return
+	}
+
+	metrics.EndpointRegenerationCount.WithLabelValues(metrics.LabelValueOutcomeSuccess).Inc()
+	regenerateTimeSec := s.totalTime.Total().Seconds()
+	metrics.EndpointRegenerationTime.Add(regenerateTimeSec)
+	metrics.EndpointRegenerationTimeSquare.Add(math.Pow(regenerateTimeSec, 2))
+
+	for scope, value := range s.GetMap() {
+		metrics.EndpointRegenerationTimeStats.WithLabelValues(scope).Observe(value.Seconds())
+	}
+}
+
+// GetMap returns a map where the key is the stats name and the value is the duration of the stat.
+func (s *regenerationStatistics) GetMap() map[string]time.Duration {
+	return map[string]time.Duration{
+		"waitingForLock":         s.waitingForLock.Total(),
+		"waitingForCTClean":      s.waitingForCTClean.Total(),
+		"policyCalculation":      s.policyCalculation.Total(),
+		"proxyConfiguration":     s.proxyConfiguration.Total(),
+		"proxyPolicyCalculation": s.proxyPolicyCalculation.Total(),
+		"proxyWaitForAck":        s.proxyWaitForAck.Total(),
+		"bpfCompilation":         s.bpfCompilation.Total(),
+		"mapSync":                s.mapSync.Total(),
+		"prepareBuild":           s.prepareBuild.Total(),
+		logfields.BuildDuration:  s.totalTime.Total(),
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -74,6 +74,12 @@ var (
 	// LabelStatus the label from completed task
 	LabelStatus = "status"
 
+	// LabelScope is the label used to defined multiples scopes in the same
+	// metric. For example, one counter may measure a metric over the scope of
+	// the entire event (scope=global), or just part of an event
+	// (scope=slow_path)
+	LabelScope = "scope"
+
 	// Endpoint
 
 	// EndpointCount is a function used to collect this metric.
@@ -96,19 +102,21 @@ var (
 	},
 		[]string{"outcome"})
 
+	// Deprecated: this metric will be removed in Cilium 1.4
 	// EndpointRegenerationTime is the total time taken to regenerate endpoint
 	EndpointRegenerationTime = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "endpoint_regeneration_seconds_total",
-		Help:      "Total sum of successful endpoint regeneration times",
+		Help:      "Total sum of successful endpoint regeneration times (Deprecated)",
 	})
 
+	// Deprecated: this metric will be removed in Cilium 1.4
 	// EndpointRegenerationTimeSquare is the sum of squares of total time taken
 	// to regenerate endpoint.
 	EndpointRegenerationTimeSquare = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "endpoint_regeneration_square_seconds_total",
-		Help:      "Total sum of squares of successful endpoint regeneration times",
+		Help:      "Total sum of squares of successful endpoint regeneration times (Deprecated)",
 	})
 
 	// EndpointStateCount is the total count of the endpoints in various states.
@@ -120,6 +128,13 @@ var (
 		},
 		[]string{"endpoint_state"},
 	)
+
+	// EndpointRegenerationTimeStats is the total time taken to regenerate endpoint
+	EndpointRegenerationTimeStats = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: Namespace,
+		Name:      "endpoint_regeneration_time_stats_seconds",
+		Help:      "Endpoint regeneration time stats labeled by the scope",
+	}, []string{LabelScope})
 
 	// Policy
 
@@ -305,6 +320,7 @@ func init() {
 	MustRegister(EndpointRegenerationTime)
 	MustRegister(EndpointRegenerationTimeSquare)
 	MustRegister(EndpointStateCount)
+	MustRegister(EndpointRegenerationTimeStats)
 
 	MustRegister(PolicyCount)
 	MustRegister(PolicyRegenerationCount)


### PR DESCRIPTION
Things to consider in this PR: 

- Should `EndpointRegenerationTime` be an `histogramVec` instead of `CounterVec`?
- How do we document the labels on metrics? Is there any pattern in the doc or should I  make something?
- I added logfields.Subsys, I think that make sense, but I'm not sure is the correct one. Please share your thoughts
- I also added the endpointID label, not sure if we don't add because any reason, or it's ok to have in it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5329)
<!-- Reviewable:end -->
