### PR TITLE
Fix and further quieten build targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,12 @@ LABEL maintainer="maintainer@cilium.io"
 WORKDIR /go/src/github.com/cilium/cilium
 COPY . ./
 ARG LOCKDEBUG
+ARG V
 #
 # Please do not add any dependency updates before the 'make install' here,
 # as that will mess with caching for incremental builds!
 #
-RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 DESTDIR=/tmp/install clean-container build install
+RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V DESTDIR=/tmp/install clean-container build install
 
 #
 # Cilium runtime install.

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -6,7 +6,9 @@ BINDIR?=$(PREFIX)/bin
 RUNDIR?=/var/run
 CONFDIR?=/etc
 
-GO = $(QUIET)go
+# GO_NOQUIET should not have any Makefile directives.
+GO_NOQUIET = go
+GO = $(QUIET)$(GO_NOQUIET)
 INSTALL = $(QUIET)install
 
 VERSION = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/VERSION)

--- a/contrib/scripts/check-ineffassign.sh
+++ b/contrib/scripts/check-ineffassign.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eux
+set -eu
 
 TOPDIR=$(git rev-parse --show-toplevel)
 

--- a/plugins/cilium-cni/Makefile
+++ b/plugins/cilium-cni/Makefile
@@ -14,7 +14,7 @@ SOURCES := $(shell find ../../api/v1/models ../../common ../../pkg/client ../../
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
 	# Compile without cgo to allow use of cilium-cni on non-glibc platforms - see GH-5055
-	CGO_ENABLED=0 $(GO) build $(GOBUILD) -o $(TARGET) ./cilium-cni.go
+	$(QUIET)CGO_ENABLED=0 $(GO_NOQUIET) build $(GOBUILD) -o $(TARGET) ./cilium-cni.go
 
 install:
 	$(INSTALL) -m 0755 -d $(DESTDIR)/etc/cni/net.d


### PR DESCRIPTION
A recent commit broke the "make V=0" quiet build, fix that. While we're
at it, extend the quiet options to some other areas that are currently
lacking it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5331)
<!-- Reviewable:end -->
