### PR TITLE
agent: Require --bpf-compile-debug to enable keeping BPF compilation resources

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -20,6 +20,7 @@ cilium-agent
       --agent-labels stringSlice                    Additional labels to identify this agent
       --allow-localhost string                      Policy when to allow local stack to reach local endpoints { auto | always | policy }  (default "auto")
       --auto-ipv6-node-routes                       Automatically adds IPv6 L3 routes to reach other nodes for non-overlay mode (--device) (BETA)
+      --bpf-compile-debug                           Enable debugging of the BPF compilation process
       --bpf-root string                             Path to BPF filesystem
       --cluster-id int                              Unique identifier of the cluster
       --cluster-name string                         Name of the cluster (default "default")

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -347,6 +347,7 @@ func init() {
 		option.AutoIPv6NodeRoutesName, false, "Automatically adds IPv6 L3 routes to reach other nodes for non-overlay mode (--device) (BETA)")
 	flags.StringVar(&bpfRoot,
 		"bpf-root", "", "Path to BPF filesystem")
+	flags.Bool(option.BPFCompileDebugName, false, "Enable debugging of the BPF compilation process")
 	flags.Int(option.ClusterIDName, 0, "Unique identifier of the cluster")
 	viper.BindEnv(option.ClusterIDName, option.ClusterIDEnv)
 	flags.String(option.ClusterName, defaults.ClusterName, "Name of the cluster")

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -45,6 +45,8 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/version"
+
+	"github.com/spf13/viper"
 )
 
 const (
@@ -632,7 +634,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir, reason string) (revnum uint
 	e.getLogger().WithField("bpfHeaderfilesChanged", bpfHeaderfilesChanged).Debug("Preparing to compile BPF")
 	libdir := owner.GetBpfDir()
 	rundir := owner.GetStateDir()
-	debug := strconv.FormatBool(owner.DebugEnabled())
+	debug := strconv.FormatBool(viper.GetBool(option.BPFCompileDebugName))
 
 	if bpfHeaderfilesChanged {
 		start := time.Now()

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -65,9 +65,6 @@ type Owner interface {
 	// RemoveFromEndpointQueue removes all requests from the working queue
 	RemoveFromEndpointQueue(epID uint64)
 
-	// Returns true if debugging has been enabled
-	DebugEnabled() bool
-
 	// GetCompilationLock returns the mutex responsible for synchronizing compilation
 	// of BPF programs.
 	GetCompilationLock() *lock.RWMutex

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -112,6 +112,9 @@ const (
 	// ClusterMeshConfigNameEnv is the name of the environment variable of
 	// the ClusterMeshConfig option
 	ClusterMeshConfigNameEnv = "CILIUM_CLUSTERMESH_CONFIG"
+
+	// BPFCompileDebugName is the name of the option to enable BPF compiliation debugging
+	BPFCompileDebugName = "bpf-compile-debug"
 )
 
 // Available option for daemonConfig.Tunnel


### PR DESCRIPTION
With debugging enabled, each compilation invokes clang two additional times and
llc one additional time to save the preprocessor state and to store the
assembly state in clear text. These are very costly. Thus hide this behind a
flag

Signed-off-by: Thomas Graf <thomas@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5337)
<!-- Reviewable:end -->
