### PR TITLE
test: Disable --verbose-debug flow by default

### DIFF
--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -280,7 +280,7 @@ function write_cilium_cfg() {
     ipv6_addr="${3}"
     filename="${4}"
 
-    cilium_options="--auto-ipv6-node-routes --debug-verbose flow"
+    cilium_options="--auto-ipv6-node-routes"
 
     if [[ "${IPV4}" -eq "1" ]]; then
         if [[ -z "${K8S}" ]]; then

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -891,7 +891,7 @@ func (s *SSHMeta) ServiceDelAll() *CmdRes {
 func (s *SSHMeta) SetUpCilium() error {
 	template := `
 PATH=/usr/lib/llvm-3.8/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
-CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug --debug-verbose flow --pprof=true
+CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug --pprof=true
 INITSYSTEM=SYSTEMD`
 
 	err := RenderTemplateToFile("cilium", template, os.ModePerm)

--- a/test/k8sT/manifests/cilium-ds-patch-auto-routing.yaml
+++ b/test/k8sT/manifests/cilium-ds-patch-auto-routing.yaml
@@ -13,4 +13,3 @@ spec:
         - "--kvstore=etcd"
         - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
         - "--disable-ipv4=$(DISABLE_IPV4)"
-        - "--debug-verbose=flow"

--- a/test/k8sT/manifests/cilium-ds-patch-geneve.yaml
+++ b/test/k8sT/manifests/cilium-ds-patch-geneve.yaml
@@ -12,6 +12,5 @@ spec:
         - "--kvstore=etcd"
         - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
         - "--disable-ipv4=$(DISABLE_IPV4)"
-        - "--debug-verbose=flow"
         - "--k8s-require-ipv4-pod-cidr"
         - "--pprof=true"

--- a/test/k8sT/manifests/cilium-ds-patch.yaml
+++ b/test/k8sT/manifests/cilium-ds-patch.yaml
@@ -12,6 +12,5 @@ spec:
         - "--kvstore=etcd"
         - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
         - "--disable-ipv4=$(DISABLE_IPV4)"
-        - "--debug-verbose=flow"
         - "--k8s-require-ipv4-pod-cidr"
         - "--pprof=true"


### PR DESCRIPTION
This leads to the creation of *a lot* of log files which are not needed in most
cases. When needed, it can be enabled on the failing PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5338)
<!-- Reviewable:end -->
