### PR TITLE
daemon: add parameter indicating why TriggerPolicyUpdates is called

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1540,7 +1540,7 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 			msg := fmt.Errorf("Unable to recompile base programs: %s", err)
 			return api.Error(PatchConfigFailureCode, msg)
 		}
-		d.TriggerPolicyUpdates(true)
+		d.TriggerPolicyUpdates(true, "agent configuration update")
 	}
 
 	return NewPatchConfigOK()

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -936,7 +936,7 @@ func (d *Daemon) addK8sEndpointV1(ep *v1.Endpoints) {
 		if err != nil {
 			log.Errorf("Unable to repopulate egress policies from ToService rules: %v", err)
 		} else {
-			d.TriggerPolicyUpdates(true)
+			d.TriggerPolicyUpdates(true, "Kubernetes service endpoint added")
 		}
 	}
 }
@@ -978,7 +978,7 @@ func (d *Daemon) deleteK8sEndpointV1(ep *v1.Endpoints) {
 			if err != nil {
 				log.Errorf("Unable to depopulate egress policies from ToService rules: %v", err)
 			} else {
-				d.TriggerPolicyUpdates(true)
+				d.TriggerPolicyUpdates(true, "Kubernetes service endpoint deleted")
 			}
 		}
 	}

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -87,7 +87,7 @@ var testNodeCreator = func() store.Key {
 
 type identityAllocatorOwnerMock struct{}
 
-func (i *identityAllocatorOwnerMock) TriggerPolicyUpdates(force bool) *sync.WaitGroup {
+func (i *identityAllocatorOwnerMock) TriggerPolicyUpdates(force bool, reason string) *sync.WaitGroup {
 	return nil
 }
 

--- a/pkg/identity/allocator.go
+++ b/pkg/identity/allocator.go
@@ -62,7 +62,7 @@ var (
 type IdentityAllocatorOwner interface {
 	// TriggerPolicyUpdates will be called whenever a policy recalculation
 	// must be triggered
-	TriggerPolicyUpdates(force bool) *sync.WaitGroup
+	TriggerPolicyUpdates(force bool, reason string) *sync.WaitGroup
 
 	// GetSuffix must return the node specific suffix to use
 	GetNodeSuffix() string

--- a/pkg/identity/cache.go
+++ b/pkg/identity/cache.go
@@ -75,7 +75,7 @@ func identityWatcher(owner IdentityAllocatorOwner, events allocator.AllocatorEve
 	policyTrigger := trigger.NewTrigger(trigger.Parameters{
 		MinInterval: time.Second,
 		TriggerFunc: func() {
-			owner.TriggerPolicyUpdates(true)
+			owner.TriggerPolicyUpdates(true, "one or more identities created or deleted")
 		},
 	})
 

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -146,7 +146,7 @@ func (e *IdentityAllocatorConsulSuite) SetUpTest(c *C) {
 
 type dummyOwner struct{}
 
-func (d dummyOwner) TriggerPolicyUpdates(force bool) *sync.WaitGroup {
+func (d dummyOwner) TriggerPolicyUpdates(force bool, reason string) *sync.WaitGroup {
 	return nil
 }
 


### PR DESCRIPTION
This function triggers regeneration for all endpoints, which can potentially be
very costly. To get more visibility into why it is called, add a string
parameter to it for callers to indicate the reason for calling it.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5341)
<!-- Reviewable:end -->
