### PR TITLE
daemon: Refactor BPF IPcache listener

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -74,6 +74,7 @@ pkg/components/ @cilium/agent
 pkg/controller @cilium/agent
 pkg/counter @cilium/bpf
 pkg/datapath @cilium/bpf
+pkg/datapath/ipcache/ @cilium/ipcache
 pkg/debugdetection @cilium/agent
 pkg/defaults @cilium/agent
 pkg/endpoint/ @cilium/endpoint

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/counter"
+	bpfIPCache "github.com/cilium/cilium/pkg/datapath/ipcache"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -849,7 +850,9 @@ func (d *Daemon) init() error {
 		// Set up the list of IPCache listeners in the daemon, to be
 		// used by syncLXCMap().
 		ipcache.IPIdentityCache.SetListeners([]ipcache.IPIdentityMappingListener{
-			&envoy.NetworkPolicyHostsCache, d})
+			&envoy.NetworkPolicyHostsCache,
+			bpfIPCache.NewListener(),
+		})
 
 		// Insert local host entries to bpf maps
 		if err := d.syncLXCMap(); err != nil {

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"net"
 	"os"
 	"sync"
 	"time"
@@ -26,20 +25,14 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/endpoint"
 	"github.com/cilium/cilium/pkg/api"
-	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/completion"
-	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpointmanager"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipam"
-	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	ipCacheBPF "github.com/cilium/cilium/pkg/maps/ipcache"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
-	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/uuid"
 	"github.com/cilium/cilium/pkg/workloads"
@@ -861,122 +854,4 @@ func (h *putEndpointIDLabels) Handle(params PatchEndpointIDLabelsParams) middlew
 		return api.Error(code, err)
 	}
 	return NewPatchEndpointIDLabelsOK()
-}
-
-// OnIPIdentityCacheChange is called whenever there is a change of state in the
-// IPCache (pkg/ipcache).
-// TODO (FIXME): GH-3161.
-//
-// 'oldIPIDPair' is ignored here, because in the BPF maps an update for the
-// IP->ID mapping will replace any existing contents; knowledge of the old pair
-// is not required to upsert the new pair.
-func (d *Daemon) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidr net.IPNet,
-	oldHostIP, newHostIP net.IP, oldID *identity.NumericIdentity, newID identity.NumericIdentity) {
-	scopedLog := log.WithFields(logrus.Fields{
-		logfields.IPAddr:       cidr,
-		logfields.Identity:     newID,
-		logfields.Modification: modType,
-	})
-
-	scopedLog.Debug("Daemon notified of IP-Identity cache state change")
-
-	// TODO - see if we can factor this into an interface under something like
-	// pkg/datapath instead of in the daemon directly so that the code is more
-	// logically located.
-
-	// Update BPF Maps.
-
-	key := ipCacheBPF.NewKey(cidr.IP, cidr.Mask)
-
-	switch modType {
-	case ipcache.Upsert:
-		value := ipCacheBPF.RemoteEndpointInfo{
-			SecurityIdentity: uint32(newID),
-		}
-
-		if newHostIP != nil {
-			// If the hostIP is specified and it doesn't point to
-			// the local host, then the ipcache should be populated
-			// with the hostIP so that this traffic can be guided
-			// to a tunnel endpoint destination.
-			externalIP := node.GetExternalIPv4()
-			if ip4 := newHostIP.To4(); ip4 != nil && !ip4.Equal(externalIP) {
-				copy(value.TunnelEndpoint[:], ip4)
-			}
-		}
-		err := ipCacheBPF.IPCache.Update(&key, &value)
-		if err != nil {
-			scopedLog.WithError(err).WithFields(logrus.Fields{"key": key.String(),
-				"value": value.String()}).
-				Warning("unable to update bpf map")
-		}
-	case ipcache.Delete:
-		err := ipCacheBPF.Delete(&key)
-		if err != nil {
-			scopedLog.WithError(err).WithFields(logrus.Fields{"key": key.String()}).
-				Warning("unable to delete from bpf map")
-		}
-	default:
-		scopedLog.Warning("cache modification type not supported")
-	}
-}
-
-// OnIPIdentityCacheGC spawns a controller which synchronizes the BPF IPCache Map
-// with the in-memory IP-Identity cache.
-func (d *Daemon) OnIPIdentityCacheGC() {
-
-	// This controller ensures that the in-memory IP-identity cache is in-sync
-	// with the BPF map on disk. These can get out of sync if the cilium-agent
-	// is offline for some time, as the maps persist on the BPF filesystem.
-	// In the case that there is some loss of event history in the key-value
-	// store (e.g., compaction in etcd), we cannot rely upon the key-value store
-	// fully to give us the history of all events. As such, periodically check
-	// for inconsistencies in the data-path with that in the agent to ensure
-	// consistent state.
-	controller.NewManager().UpdateController("ipcache-bpf-garbage-collection",
-		controller.ControllerParams{
-			DoFunc: func() error {
-
-				// Since controllers run asynchronously, need to make sure
-				// IPIdentityCache is not being updated concurrently while we do
-				// GC;
-				ipcache.IPIdentityCache.RLock()
-				defer ipcache.IPIdentityCache.RUnlock()
-
-				keysToRemove := map[string]*ipCacheBPF.Key{}
-
-				// Add all keys which are in BPF map but not in in-memory cache
-				// to set of keys to remove from BPF map.
-				cb := func(key bpf.MapKey, value bpf.MapValue) {
-					k := key.(*ipCacheBPF.Key)
-					keyToIP := k.String()
-
-					// Don't RLock as part of the same goroutine.
-					if i, exists := ipcache.IPIdentityCache.LookupByPrefixRLocked(keyToIP); !exists {
-						switch i.Source {
-						case ipcache.FromKVStore, ipcache.FromAgentLocal:
-							// Cannot delete from map during callback because DumpWithCallback
-							// RLocks the map.
-							keysToRemove[keyToIP] = k
-						}
-					}
-				}
-
-				if err := ipCacheBPF.IPCache.DumpWithCallback(cb); err != nil {
-					return fmt.Errorf("error dumping ipcache BPF map: %s", err)
-				}
-
-				// Remove all keys which are not in in-memory cache from BPF map
-				// for consistency.
-				for _, k := range keysToRemove {
-					log.WithFields(logrus.Fields{logfields.BPFMapKey: k}).
-						Debug("deleting from ipcache BPF map")
-					if err := ipCacheBPF.Delete(k); err != nil {
-						return fmt.Errorf("error deleting key %s from ipcache BPF map: %s", k, err)
-					}
-				}
-				return nil
-			},
-			RunInterval: time.Duration(5) * time.Minute,
-		})
 }

--- a/pkg/datapath/ipcache/doc.go
+++ b/pkg/datapath/ipcache/doc.go
@@ -1,0 +1,20 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ipcache provides a BPF datapath implementation of the IPCache store.
+// It depends on details from pkg/ipcache (which handles IPCache events), as
+// well as (indirectly) details such as the KVstore. It is kept distinct from
+// pkg/maps/ipcache, which only deals with low-level BPF details of the
+// underlying map.
+package ipcache

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -100,10 +100,64 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 	}
 }
 
+// updateStaleEntriesFunction returns a DumpCallback that will update the
+// specified "keysToRemove" map with entries that exist in the BPF map which
+// do not exist in the in-memory ipcache.
+//
+// Must be called while holding ipcache.IPIdentityCache.Lock for reading.
+func updateStaleEntriesFunction(keysToRemove map[string]*ipcacheMap.Key) bpf.DumpCallback {
+	return func(key bpf.MapKey, value bpf.MapValue) {
+		k := key.(*ipcacheMap.Key)
+		keyToIP := k.String()
+
+		// Don't RLock as part of the same goroutine.
+		if i, exists := ipcache.IPIdentityCache.LookupByPrefixRLocked(keyToIP); !exists {
+			switch i.Source {
+			case ipcache.FromKVStore, ipcache.FromAgentLocal:
+				// Cannot delete from map during callback because DumpWithCallback
+				// RLocks the map.
+				keysToRemove[keyToIP] = k
+			}
+		}
+	}
+}
+
+// garbageCollect implements GC of the ipcache map.
+//
+//   Periodically sweep through every element in the BPF map and check it
+//   against the in-memory copy of the map. If it doesn't exist in memory,
+//   delete the entry.
+//
+// Returns an error if garbage collection failed to occur.
+func (l *BPFListener) garbageCollect() error {
+	log.Debug("Running garbage collection for BPF IPCache")
+
+	// Since controllers run asynchronously, need to make sure
+	// IPIdentityCache is not being updated concurrently while we do
+	// GC;
+	ipcache.IPIdentityCache.RLock()
+	defer ipcache.IPIdentityCache.RUnlock()
+
+	keysToRemove := map[string]*ipcacheMap.Key{}
+	if err := ipcacheMap.IPCache.DumpWithCallback(updateStaleEntriesFunction(keysToRemove)); err != nil {
+		return fmt.Errorf("error dumping ipcache BPF map: %s", err)
+	}
+
+	// Remove all keys which are not in in-memory cache from BPF map
+	// for consistency.
+	for _, k := range keysToRemove {
+		log.WithFields(logrus.Fields{logfields.BPFMapKey: k}).
+			Debug("deleting from ipcache BPF map")
+		if err := ipcacheMap.Delete(k); err != nil {
+			return fmt.Errorf("error deleting key %s from ipcache BPF map: %s", k, err)
+		}
+	}
+	return nil
+}
+
 // OnIPIdentityCacheGC spawns a controller which synchronizes the BPF IPCache Map
 // with the in-memory IP-Identity cache.
 func (l *BPFListener) OnIPIdentityCacheGC() {
-
 	// This controller ensures that the in-memory IP-identity cache is in-sync
 	// with the BPF map on disk. These can get out of sync if the cilium-agent
 	// is offline for some time, as the maps persist on the BPF filesystem.
@@ -114,48 +168,8 @@ func (l *BPFListener) OnIPIdentityCacheGC() {
 	// consistent state.
 	controller.NewManager().UpdateController("ipcache-bpf-garbage-collection",
 		controller.ControllerParams{
-			DoFunc: func() error {
-
-				// Since controllers run asynchronously, need to make sure
-				// IPIdentityCache is not being updated concurrently while we do
-				// GC;
-				ipcache.IPIdentityCache.RLock()
-				defer ipcache.IPIdentityCache.RUnlock()
-
-				keysToRemove := map[string]*ipcacheMap.Key{}
-
-				// Add all keys which are in BPF map but not in in-memory cache
-				// to set of keys to remove from BPF map.
-				cb := func(key bpf.MapKey, value bpf.MapValue) {
-					k := key.(*ipcacheMap.Key)
-					keyToIP := k.String()
-
-					// Don't RLock as part of the same goroutine.
-					if i, exists := ipcache.IPIdentityCache.LookupByPrefixRLocked(keyToIP); !exists {
-						switch i.Source {
-						case ipcache.FromKVStore, ipcache.FromAgentLocal:
-							// Cannot delete from map during callback because DumpWithCallback
-							// RLocks the map.
-							keysToRemove[keyToIP] = k
-						}
-					}
-				}
-
-				if err := ipcacheMap.IPCache.DumpWithCallback(cb); err != nil {
-					return fmt.Errorf("error dumping ipcache BPF map: %s", err)
-				}
-
-				// Remove all keys which are not in in-memory cache from BPF map
-				// for consistency.
-				for _, k := range keysToRemove {
-					log.WithFields(logrus.Fields{logfields.BPFMapKey: k}).
-						Debug("deleting from ipcache BPF map")
-					if err := ipcacheMap.Delete(k); err != nil {
-						return fmt.Errorf("error deleting key %s from ipcache BPF map: %s", k, err)
-					}
-				}
-				return nil
-			},
+			DoFunc:      l.garbageCollect,
 			RunInterval: 5 * time.Minute,
-		})
+		},
+	)
 }

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -1,0 +1,161 @@
+// Copyright 2016-2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipcache
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	ipcacheMap "github.com/cilium/cilium/pkg/maps/ipcache"
+	"github.com/cilium/cilium/pkg/node"
+
+	"github.com/sirupsen/logrus"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "datapath-ipcache")
+
+// BPFListener implements the ipcache.IPIdentityMappingBPFListener
+// interface with an IPCache store that is backed by BPF maps.
+type BPFListener struct{}
+
+// NewListener returns a new listener to push IPCache entries into BPF maps.
+func NewListener() *BPFListener {
+	return &BPFListener{}
+}
+
+// OnIPIdentityCacheChange is called whenever there is a change of state in the
+// IPCache (pkg/ipcache).
+// TODO (FIXME): GH-3161.
+//
+// 'oldIPIDPair' is ignored here, because in the BPF maps an update for the
+// IP->ID mapping will replace any existing contents; knowledge of the old pair
+// is not required to upsert the new pair.
+func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidr net.IPNet,
+	oldHostIP, newHostIP net.IP, oldID *identity.NumericIdentity, newID identity.NumericIdentity) {
+	scopedLog := log.WithFields(logrus.Fields{
+		logfields.IPAddr:       cidr,
+		logfields.Identity:     newID,
+		logfields.Modification: modType,
+	})
+
+	scopedLog.Debug("Daemon notified of IP-Identity cache state change")
+
+	// TODO - see if we can factor this into an interface under something like
+	// pkg/datapath instead of in the daemon directly so that the code is more
+	// logically located.
+
+	// Update BPF Maps.
+
+	key := ipcacheMap.NewKey(cidr.IP, cidr.Mask)
+
+	switch modType {
+	case ipcache.Upsert:
+		value := ipcacheMap.RemoteEndpointInfo{
+			SecurityIdentity: uint32(newID),
+		}
+
+		if newHostIP != nil {
+			// If the hostIP is specified and it doesn't point to
+			// the local host, then the ipcache should be populated
+			// with the hostIP so that this traffic can be guided
+			// to a tunnel endpoint destination.
+			externalIP := node.GetExternalIPv4()
+			if ip4 := newHostIP.To4(); ip4 != nil && !ip4.Equal(externalIP) {
+				copy(value.TunnelEndpoint[:], ip4)
+			}
+		}
+		err := ipcacheMap.IPCache.Update(&key, &value)
+		if err != nil {
+			scopedLog.WithError(err).WithFields(logrus.Fields{"key": key.String(),
+				"value": value.String()}).
+				Warning("unable to update bpf map")
+		}
+	case ipcache.Delete:
+		err := ipcacheMap.Delete(&key)
+		if err != nil {
+			scopedLog.WithError(err).WithFields(logrus.Fields{"key": key.String()}).
+				Warning("unable to delete from bpf map")
+		}
+	default:
+		scopedLog.Warning("cache modification type not supported")
+	}
+}
+
+// OnIPIdentityCacheGC spawns a controller which synchronizes the BPF IPCache Map
+// with the in-memory IP-Identity cache.
+func (l *BPFListener) OnIPIdentityCacheGC() {
+
+	// This controller ensures that the in-memory IP-identity cache is in-sync
+	// with the BPF map on disk. These can get out of sync if the cilium-agent
+	// is offline for some time, as the maps persist on the BPF filesystem.
+	// In the case that there is some loss of event history in the key-value
+	// store (e.g., compaction in etcd), we cannot rely upon the key-value store
+	// fully to give us the history of all events. As such, periodically check
+	// for inconsistencies in the data-path with that in the agent to ensure
+	// consistent state.
+	controller.NewManager().UpdateController("ipcache-bpf-garbage-collection",
+		controller.ControllerParams{
+			DoFunc: func() error {
+
+				// Since controllers run asynchronously, need to make sure
+				// IPIdentityCache is not being updated concurrently while we do
+				// GC;
+				ipcache.IPIdentityCache.RLock()
+				defer ipcache.IPIdentityCache.RUnlock()
+
+				keysToRemove := map[string]*ipcacheMap.Key{}
+
+				// Add all keys which are in BPF map but not in in-memory cache
+				// to set of keys to remove from BPF map.
+				cb := func(key bpf.MapKey, value bpf.MapValue) {
+					k := key.(*ipcacheMap.Key)
+					keyToIP := k.String()
+
+					// Don't RLock as part of the same goroutine.
+					if i, exists := ipcache.IPIdentityCache.LookupByPrefixRLocked(keyToIP); !exists {
+						switch i.Source {
+						case ipcache.FromKVStore, ipcache.FromAgentLocal:
+							// Cannot delete from map during callback because DumpWithCallback
+							// RLocks the map.
+							keysToRemove[keyToIP] = k
+						}
+					}
+				}
+
+				if err := ipcacheMap.IPCache.DumpWithCallback(cb); err != nil {
+					return fmt.Errorf("error dumping ipcache BPF map: %s", err)
+				}
+
+				// Remove all keys which are not in in-memory cache from BPF map
+				// for consistency.
+				for _, k := range keysToRemove {
+					log.WithFields(logrus.Fields{logfields.BPFMapKey: k}).
+						Debug("deleting from ipcache BPF map")
+					if err := ipcacheMap.Delete(k); err != nil {
+						return fmt.Errorf("error deleting key %s from ipcache BPF map: %s", k, err)
+					}
+				}
+				return nil
+			},
+			RunInterval: 5 * time.Minute,
+		})
+}

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -34,6 +34,9 @@ const (
 	// RemoteEndpointMap.
 	MaxEntries = 512000
 
+	// Name is the canonical name for the IPCache map on the filesystem.
+	Name = "cilium_ipcache"
+
 	// maxPrefixLengths is an approximation of how many different CIDR
 	// prefix lengths may be supported by the BPF datapath without causing
 	// BPF code generation to exceed the verifier instruction limit.
@@ -138,10 +141,10 @@ type Map struct {
 }
 
 // NewMap instantiates a Map.
-func NewMap() *Map {
+func NewMap(name string) *Map {
 	return &Map{
 		Map: *bpf.NewMap(
-			"cilium_ipcache",
+			name,
 			bpf.BPF_MAP_TYPE_LPM_TRIE,
 			int(unsafe.Sizeof(Key{})),
 			int(unsafe.Sizeof(RemoteEndpointInfo{})),
@@ -197,7 +200,7 @@ var (
 	// IPCache is a mapping of all endpoint IPs in the cluster which this
 	// Cilium agent is a part of to their corresponding security identities.
 	// It is a singleton; there is only one such map per agent.
-	IPCache = NewMap()
+	IPCache = NewMap(Name)
 )
 
 func init() {

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -160,12 +160,12 @@ func NewMap() *Map {
 }
 
 // Delete removes a key from the ipcache BPF map
-func Delete(k bpf.MapKey) error {
+func (m *Map) Delete(k bpf.MapKey) error {
 	// Older kernels do not support deletion of LPM map entries so zero out
 	// the entry instead of attempting a deletion
-	err, errno := IPCache.DeleteWithErrno(k)
+	err, errno := m.DeleteWithErrno(k)
 	if errno == unix.ENOSYS {
-		return IPCache.Update(k, &RemoteEndpointInfo{})
+		return m.Update(k, &RemoteEndpointInfo{})
 	}
 
 	return err


### PR DESCRIPTION
This splits out some code from daemon/ and factors out to make it easier
to introduce a new way of performing garbage collection of the BPF
IPCache maps.

No functional changes intended.

Related: #5303

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5346)
<!-- Reviewable:end -->
