### PR TITLE
Improve endpoint regeneration logging with detailed breakdown

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/spanstat"
 	"github.com/cilium/cilium/pkg/version"
 
 	"github.com/sirupsen/logrus"
@@ -430,6 +431,19 @@ func (e *Endpoint) removeOldRedirects(owner Owner, desiredRedirects map[string]b
 	}
 }
 
+type regenerationStatistics struct {
+	totalTime              spanstat.SpanStat
+	waitingForLock         spanstat.SpanStat
+	waitingForCTClean      spanstat.SpanStat
+	policyCalculation      spanstat.SpanStat
+	proxyConfiguration     spanstat.SpanStat
+	proxyPolicyCalculation spanstat.SpanStat
+	proxyWaitForAck        spanstat.SpanStat
+	bpfCompilation         spanstat.SpanStat
+	mapSync                spanstat.SpanStat
+	prepareBuild           spanstat.SpanStat
+}
+
 // regenerateBPF rewrites all headers and updates all BPF maps to reflect the
 // specified endpoint.
 // Must be called with endpoint.Mutex not held and endpoint.BuildMutex held.
@@ -441,26 +455,22 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 		compilationExecuted bool
 	)
 
+	stats := &regenContext.Stats
+	stats.waitingForLock.Start()
+
 	// Make sure that owner is not compiling base programs while we are
 	// regenerating an endpoint.
 	owner.GetCompilationLock().RLock()
 	defer owner.GetCompilationLock().RUnlock()
-
-	buildStart := time.Now()
 
 	ctCleaned := make(chan struct{})
 
 	if err = e.LockAlive(); err != nil {
 		return 0, compilationExecuted, err
 	}
+	stats.waitingForLock.End()
 
 	epID := e.StringID()
-
-	e.getLogger().WithField(logfields.StartTime, time.Now()).Info("Regenerating BPF program")
-	defer func() {
-		e.getLogger().WithField(logfields.BuildDuration, time.Since(buildStart).String()).
-			Info("Regeneration of BPF program has completed")
-	}()
 
 	// In the first ever regeneration of the endpoint, the conntrack table
 	// is cleaned from the new endpoint IPs as it is guaranteed that any
@@ -540,11 +550,13 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 	// Only generate & populate policy map if a security identity is set up for
 	// this endpoint.
 	if e.SecurityIdentity != nil {
+		stats.policyCalculation.Start()
 		_, err = e.regeneratePolicy(owner)
 		if err != nil {
 			e.Unlock()
 			return 0, compilationExecuted, fmt.Errorf("unable to regenerate policy for '%s': %s", e.PolicyMap.String(), err)
 		}
+		stats.policyCalculation.End()
 
 		_ = e.updateAndOverrideEndpointOptions(owner, nil)
 
@@ -554,18 +566,24 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 		// state with the current program (if it exists) for this endpoint.
 		// GH-3897 would fix this by creating a new map to do an atomic swap
 		// with the old one.
+		stats.mapSync.Start()
 		err := e.syncPolicyMap()
 		if err != nil {
 			e.Unlock()
 			return 0, compilationExecuted, fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
 		}
+		stats.mapSync.End()
 
 		// Configure the new network policy with the proxies.
+		stats.proxyPolicyCalculation.Start()
 		if err = e.updateNetworkPolicy(owner, proxyWaitGroup); err != nil {
 			e.Unlock()
 			return 0, compilationExecuted, err
 		}
+		stats.proxyPolicyCalculation.End()
 	}
+
+	stats.proxyConfiguration.Start()
 
 	// Walk the L4Policy to add new redirects and update the desired policy map
 	// state to set the newly allocated proxy ports.
@@ -581,6 +599,9 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 	// now-obsolete redirects, since we synced the updated policy map above.
 	// It's now safe to remove the redirects from the proxy's configuration.
 	e.removeOldRedirects(owner, desiredRedirects, proxyWaitGroup)
+	stats.proxyConfiguration.End()
+
+	stats.prepareBuild.Start()
 
 	// Generate header file specific to this endpoint for use in compiling
 	// BPF programs for this endpoint.
@@ -625,18 +646,18 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 	rundir := owner.GetStateDir()
 	debug := strconv.FormatBool(viper.GetBool(option.BPFCompileDebugName))
 
+	stats.prepareBuild.End()
 	if bpfHeaderfilesChanged || regenContext.ReloadDatapath {
 		closeChan := loadinfo.LogPeriodicSystemLoad(log.WithFields(logrus.Fields{logfields.EndpointID: epID}).Debugf, time.Second)
 
-		start := time.Now()
+		stats.bpfCompilation.Start()
 		// Compile and install BPF programs for this endpoint
 		err = e.runInit(libdir, rundir, epdir, epInfoCache.ifName, debug)
+		stats.bpfCompilation.End()
 		close(closeChan)
 
-		compilationTime := time.Since(start)
-
 		e.getLogger().WithError(err).
-			WithField(logfields.BPFCompilationTime, compilationTime.String()).
+			WithField(logfields.BPFCompilationTime, stats.bpfCompilation.Total().String()).
 			Info("Recompiled endpoint BPF program")
 
 		if err != nil {
@@ -649,17 +670,23 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 			Debug("BPF header file unchanged, skipping BPF compilation and installation")
 	}
 
+	stats.proxyWaitForAck.Start()
 	err = e.WaitForProxyCompletions(proxyWaitGroup)
 	if err != nil {
 		return 0, compilationExecuted, fmt.Errorf("Error while configuring proxy redirects: %s", err)
 	}
+	stats.proxyWaitForAck.End()
 
 	// Wait for connection tracking cleaning to be complete
+	stats.waitingForCTClean.Start()
 	<-ctCleaned
+	stats.waitingForCTClean.End()
 
+	stats.waitingForLock.Start()
 	if err = e.LockAlive(); err != nil {
 		return 0, compilationExecuted, err
 	}
+	stats.waitingForLock.End()
 	defer e.Unlock()
 
 	e.ctCleaned = true
@@ -673,6 +700,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 	//
 	// This must be done after allocating the new redirects, to update the
 	// policy map with the new proxy ports.
+	stats.mapSync.Start()
 	err = e.syncPolicyMap()
 	if err != nil {
 		return 0, compilationExecuted, fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
@@ -683,6 +711,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 	if err != nil {
 		log.WithField(logfields.EndpointID, e.ID).WithError(err).Error("Exposing new bpf failed")
 	}
+	stats.mapSync.End()
 
 	return epInfoCache.revision, compilationExecuted, err
 }

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -79,6 +79,7 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 		logfields.EndpointID:             e.ID,
 		logfields.ContainerID:            e.getShortContainerID(),
 		logfields.DatapathPolicyRevision: e.policyRevision,
+		logfields.DesiredPolicyRevision:  e.nextPolicyRevision,
 		logfields.IPv4:                   e.IPv4.String(),
 		logfields.IPv6:                   e.IPv6.String(),
 		logfields.K8sPodName:             e.GetK8sNamespaceAndPodNameLocked(),

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -70,6 +70,10 @@ type RegenerationContext struct {
 	// ReloadDatapath forces the datapath programs to be reloaded. It does
 	// not guarantee recompilation of the programs.
 	ReloadDatapath bool
+
+	// Stats are collected during the endpoint regeneration and provided
+	// back to the caller
+	Stats regenerationStatistics
 }
 
 // NewRegenerationContext returns a new context for regeneration that does not
@@ -491,18 +495,6 @@ func (e *Endpoint) regeneratePolicy(owner Owner) (isPolicyComp bool, err error) 
 	}
 
 	regenerateStart := time.Now()
-	// Capture successful regeneration time
-	defer func() {
-		if err == nil && isPolicyComp {
-			regenerateTimeNs := time.Since(regenerateStart)
-			regenerateTimeSec := float64(regenerateTimeNs) / float64(time.Second)
-			e.getLogger().WithField(logfields.PolicyRegenerationTime, time.Since(regenerateStart).String()).
-				Info("Regeneration of policy has completed")
-			metrics.PolicyRegenerationCount.Inc()
-			metrics.PolicyRegenerationTime.Add(regenerateTimeSec)
-			metrics.PolicyRegenerationTimeSquare.Add(math.Pow(regenerateTimeSec, 2))
-		}
-	}()
 
 	// Use the old labelsMap instance if the new one is still the same.
 	// Later we can compare the pointers to figure out if labels have changed or not.
@@ -530,7 +522,8 @@ func (e *Endpoint) regeneratePolicy(owner Owner) (isPolicyComp bool, err error) 
 			"policyRevision.next": e.nextPolicyRevision,
 			"policyRevision.repo": revision,
 			"policyChanged":       e.nextPolicyRevision > e.policyRevision,
-		}).Debug("skipping policy recalculation")
+		}).Debug("Skipping unnecessary endpoint policy recalculation")
+
 		// This revision already computed, but may still need to be applied to BPF
 		return e.nextPolicyRevision > e.policyRevision, nil
 	}
@@ -592,20 +585,27 @@ func (e *Endpoint) regeneratePolicy(owner Owner) (isPolicyComp bool, err error) 
 	// the regeneration of the endpoint to complete.
 	policyChanged := l3PolicyChanged || l4PolicyChanged
 
-	e.getLogger().WithFields(logrus.Fields{
-		"policyChanged":      policyChanged,
-		"forcedRegeneration": forceRegeneration,
-	}).Debug("Done calculating policy")
-
 	// If the policy changed, or the revision of the policy repository has changed
 	// we return true. It is possible that the endpoint's next policy revision
 	// is the same as the endpoint's current policy revision; this indicates
 	// that no new rules have been added in the policy repository; if policy
 	// hasn't changed, and no new rules were added, and we haven't forced
 	// regeneration for the endpoint, then return false.
-	policyChanged = policyChanged || e.nextPolicyRevision > e.policyRevision || forceRegeneration
+	bpfCompilationRequired := policyChanged || e.nextPolicyRevision > e.policyRevision || forceRegeneration
 
-	return policyChanged, nil
+	e.getLogger().WithFields(logrus.Fields{
+		"policyChanged":                  policyChanged,
+		"forcedRegeneration":             forceRegeneration,
+		logfields.PolicyRegenerationTime: time.Since(regenerateStart).String(),
+		"bpfCompilationRequired":         bpfCompilationRequired,
+	}).Info("Completed endpoint policy recalculation")
+
+	regenerateTimeSec := float64(time.Since(regenerateStart)) / float64(time.Second)
+	metrics.PolicyRegenerationCount.Inc()
+	metrics.PolicyRegenerationTime.Add(regenerateTimeSec)
+	metrics.PolicyRegenerationTimeSquare.Add(math.Pow(regenerateTimeSec, 2))
+
+	return bpfCompilationRequired, nil
 }
 
 // updateAndOverrideEndpointOptions updates the boolean configuration options for the endpoint
@@ -637,21 +637,49 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 	var compilationExecuted bool
 	var err error
 
+	context.Stats = regenerationStatistics{}
+	stats := &context.Stats
+
 	metrics.EndpointCountRegenerating.Inc()
-	regenerateStart := time.Now()
+	stats.totalTime.Start()
+	e.getLogger().WithFields(logrus.Fields{
+		logfields.StartTime: time.Now(),
+		logfields.Reason:    context.Reason,
+	}).Info("Regenerating endpoint")
+
 	defer func() {
+		stats.totalTime.End()
 		metrics.EndpointCountRegenerating.Dec()
+
+		scopedLog := e.getLogger().WithFields(logrus.Fields{
+			"waitingForLock":         stats.waitingForLock.Total(),
+			"waitingForCTClean":      stats.waitingForCTClean.Total(),
+			"policyCalculation":      stats.policyCalculation.Total(),
+			"proxyConfiguration":     stats.proxyConfiguration.Total(),
+			"proxyPolicyCalculation": stats.proxyPolicyCalculation.Total(),
+			"proxyWaitForAck":        stats.proxyWaitForAck.Total(),
+			"bpfCompilation":         stats.bpfCompilation.Total(),
+			"mapSync":                stats.mapSync.Total(),
+			"prepareBuild":           stats.prepareBuild.Total(),
+			logfields.BuildDuration:  stats.totalTime.Total(),
+			logfields.Reason:         context.Reason,
+		})
+
 		if retErr == nil {
+			scopedLog.Info("Completed endpoint regeneration")
+			e.LogStatusOK(BPF, "Successfully regenerated endpoint program (Reason: "+context.Reason+")")
+
 			metrics.EndpointRegenerationCount.
 				WithLabelValues(metrics.LabelValueOutcomeSuccess).Inc()
 
 			// Capture successful endpoint generation time
-			regenerateTimeNs := time.Since(regenerateStart)
-			regenerateTimeSec := float64(regenerateTimeNs) / float64(time.Second)
-			e.getLogger().WithField(logfields.EndpointRegenerationTime, time.Since(regenerateStart).String()).Info("Regeneration of endpoint has completed")
+			regenerateTimeSec := float64(stats.totalTime.Total()) / float64(time.Second)
 			metrics.EndpointRegenerationTime.Add(regenerateTimeSec)
 			metrics.EndpointRegenerationTimeSquare.Add(math.Pow(regenerateTimeSec, 2))
 		} else {
+			scopedLog.WithError(retErr).Warn("Regeneration of endpoint failed")
+			e.LogStatus(BPF, Failure, "Error regenerating endpoint: "+retErr.Error())
+
 			metrics.EndpointRegenerationCount.
 				WithLabelValues(metrics.LabelValueOutcomeFail).Inc()
 		}
@@ -660,10 +688,12 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 	e.BuildMutex.Lock()
 	defer e.BuildMutex.Unlock()
 
+	stats.waitingForLock.Start()
 	// Check if endpoints is still alive before doing any build
 	if err = e.LockAlive(); err != nil {
 		return err
 	}
+	stats.waitingForLock.End()
 
 	// When building the initial drop policy in waiting-for-identity state
 	// the state remains unchanged
@@ -679,9 +709,7 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 
 	e.Unlock()
 
-	scopedLog := e.getLogger()
-	scopedLog.Debug("Regenerating endpoint...")
-
+	stats.prepareBuild.Start()
 	origDir := filepath.Join(owner.GetStateDir(), e.StringID())
 
 	// This is the temporary directory to store the generated headers,
@@ -693,6 +721,7 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 	if err := os.MkdirAll(tmpDir, 0777); err != nil {
 		return fmt.Errorf("Failed to create endpoint directory: %s", err)
 	}
+	stats.prepareBuild.End()
 
 	defer func() {
 		if err := e.LockAlive(); err != nil {
@@ -724,9 +753,11 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 	// Update desired policy for endpoint because policy has now been realized
 	// in the datapath. PolicyMap state is not updated here, because that is
 	// performed in endpoint.syncPolicyMap().
+	stats.waitingForLock.Start()
 	if err = e.LockAlive(); err != nil {
 		return err
 	}
+	stats.waitingForLock.End()
 
 	// Keep PolicyMap for this endpoint in sync with desired / realized state.
 	if !owner.DryModeEnabled() {
@@ -738,8 +769,6 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 	// compiled for
 	e.bumpPolicyRevisionLocked(revision)
 	e.Unlock()
-
-	scopedLog.Info("Endpoint policy recalculated")
 
 	return nil
 }
@@ -785,14 +814,11 @@ func (e *Endpoint) Regenerate(owner Owner, context *RegenerationContext) <-chan 
 
 			if err != nil {
 				buildSuccess = false
-				scopedLog.WithError(err).Warn("Regeneration of endpoint program failed")
-				e.LogStatus(BPF, Failure, "Error regenerating endpoint: "+err.Error())
 				if reprerr == nil && !owner.DryModeEnabled() {
 					owner.SendNotification(monitor.AgentNotifyEndpointRegenerateFail, repr)
 				}
 			} else {
 				buildSuccess = true
-				e.LogStatusOK(BPF, "Successfully regenerated endpoint program due to "+context.Reason)
 				if reprerr == nil && !owner.DryModeEnabled() {
 					owner.SendNotification(monitor.AgentNotifyEndpointRegenerateSuccess, repr)
 				}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -450,6 +450,15 @@ func (e *Endpoint) updateNetworkPolicy(owner Owner, proxyWaitGroup *completion.W
 	return nil
 }
 
+// setNextPolicyRevision updates the desired policy revision field
+// Must be called with the endpoint lock held for at least reading
+func (e *Endpoint) setNextPolicyRevision(revision uint64) {
+	e.nextPolicyRevision = revision
+	e.UpdateLogger(map[string]interface{}{
+		logfields.DesiredPolicyRevision: e.nextPolicyRevision,
+	})
+}
+
 // regeneratePolicy regenerates endpoint's policy if needed and returns whether
 // the policy for the endpoint changed.
 //
@@ -576,7 +585,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner) (isPolicyComp bool, err error) 
 
 	// Set the revision of this endpoint to the current revision of the policy
 	// repository.
-	e.nextPolicyRevision = revision
+	e.setNextPolicyRevision(revision)
 
 	// If no policy or options change occurred for this endpoint then the endpoint is
 	// already running the latest revision, otherwise we have to wait for
@@ -584,9 +593,8 @@ func (e *Endpoint) regeneratePolicy(owner Owner) (isPolicyComp bool, err error) 
 	policyChanged := l3PolicyChanged || l4PolicyChanged
 
 	e.getLogger().WithFields(logrus.Fields{
-		"policyChanged":       policyChanged,
-		"policyRevision.next": e.nextPolicyRevision,
-		"forcedRegeneration":  forceRegeneration,
+		"policyChanged":      policyChanged,
+		"forcedRegeneration": forceRegeneration,
 	}).Debug("Done calculating policy")
 
 	// If the policy changed, or the revision of the policy repository has changed

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -64,6 +64,11 @@ const (
 	// the datapath
 	DatapathPolicyRevision = "datapathPolicyRevision"
 
+	// DesiredPolicyRevision is the latest policy revision as evaluated for
+	// an endpoint. It is the desired policy revision to be implemented
+	// into the datapath.
+	DesiredPolicyRevision = "desiredPolicyRevision"
+
 	// PolicyID is the identifier of a L3, L4 or L7 Policy. Ideally the .NumericIdentity
 	PolicyID = "policyID"
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -292,4 +292,8 @@ const (
 
 	// ThreadID is the Envoy thread ID.
 	ThreadID = "threadID"
+
+	// Reason is a human readable string describing why an operation was
+	// performed
+	Reason = "reason"
 )

--- a/pkg/spanstat/doc.go
+++ b/pkg/spanstat/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package spanstat provides a mechanism to measure duration of multiple spans
+// and add them up to a total duration
+package spanstat

--- a/pkg/spanstat/spanstat.go
+++ b/pkg/spanstat/spanstat.go
@@ -1,0 +1,46 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanstat
+
+import (
+	"time"
+)
+
+// SpanStat measures the total duration of all time spent in between Start()
+// and Stop() calls
+type SpanStat struct {
+	spanStart     time.Time
+	totalDuration time.Duration
+}
+
+// Start starts a new span
+func (s *SpanStat) Start() {
+	s.spanStart = time.Now()
+}
+
+// End ends the current span and adds the measured duration to the total
+func (s *SpanStat) End() {
+	s.totalDuration += time.Since(s.spanStart)
+}
+
+// Total returns the total duration of all spans measured
+func (s *SpanStat) Total() time.Duration {
+	return s.totalDuration
+}
+
+// Reset rests the duration measurement
+func (s *SpanStat) Reset() {
+	s.totalDuration = 0
+}


### PR DESCRIPTION
* Avoid complicated defer logic to log when the policy recalculation has completed

* Simplify the logging invocations, remove duplicated log messages and use
  consistent language. Also include the build reason.

* Fix the metric accounting for policy recalculation to not include skipped
  calculations to have real insight into how long calculations take. This can
  later be improved by using labels instead.

* Provides a detailed breakdown of individual operation durations:

  ```
  msg="Completed endpoint regeneration" bpfCompilation=1.230640282s buildDuration=1.236731263s containerID=6086b396cd datapathPolicyRevision=0 desiredPolicyRevision=2 endpointID=54912 ipv4=10.11.221.144 ipv6="f00d::a0f:0:0:d680" k8sPodName=/ mapSync="215.248µs" policyCalculation=2.651822ms policyRevision=2 prepareBuild="517.631µs" proxyConfiguration="1.225µs" proxyPolicyCalculation="215.838µs" proxyWaitForAck="322.373µs" reason="syncing state to host" waitingForCTClean=422ns waitingForLock="2.069µs"
  ```

* Add DesiredPolicyRevision to endpoint logger

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5358)
<!-- Reviewable:end -->
