### PR TITLE
daemon: do not TriggerPolicyUpdates if Kubernetes Endpoints have not changed

### DIFF
--- a/pkg/k8s/rule_translate.go
+++ b/pkg/k8s/rule_translate.go
@@ -225,7 +225,7 @@ func PreprocessRules(
 	for _, rule := range r {
 		for ns, ep := range endpoints {
 			svc, ok := services[ns]
-			if ok && svc.IsHeadless {
+			if ok && svc.IsExternal() {
 				t := NewK8sTranslator(ns, *ep, false, svc.Labels, ipcache)
 				err := t.Translate(rule)
 				if err != nil {


### PR DESCRIPTION
Before this commit, `TriggerPolicyUpdates` was invoked every 5 minutes because
when Kubernetes will send a list of all objects to their corresponding
Kubernetes watchers in Cilium regardless of if they have changed or not. This is
because Kubernetes Informers list at the specified \`resyncPeriod\`.

Per the Kubernetes code:
```
// resyncPeriod: if non-zero, will re-list this often (you will get OnUpdate
//    calls, even if nothing changed). Otherwise, re-list will be delayed as
//    long as possible (until the upstream source closes the watch or times out,
//    or you stop the controller).
```

Invoking policy updates every five minutes regardless of if the Kubernetes
Endpoint has actually changed means that we trigger regeneration for all
endpoints every five minutes for each and every Kubernetes Endpoint which
corresponds to an external service. This is a waste of resources, and is not scalable. This commit
adds logic to detect if the Kubernetes Endpoint has changed. If it has changed,
then trigger policy updates for all Cilium endpoints like before.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #3673 

<!--  Thanks for contributing to Cilium!

If this is your first time contributing, then please see the following
guidelines for detailed instructions on how to contribute:
https://github.com/cilium/cilium/blob/master/CONTRIBUTING.md for detailed instructions 

Fixes: #3673 

```release-note
Do not regenerate all endpoints every five minutes for each Kubernetes endpoint corresponding to a headless service
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5359)
<!-- Reviewable:end -->
