### PR TITLE
endpoint: Fix logger when updating DatapathPolicyRevision

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2464,7 +2464,7 @@ func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
 func (e *Endpoint) setPolicyRevision(rev uint64) {
 	e.policyRevision = rev
 	e.UpdateLogger(map[string]interface{}{
-		logfields.PolicyRevision: e.policyRevision,
+		logfields.DatapathPolicyRevision: e.policyRevision,
 	})
 	for ps := range e.policyRevisionSignals {
 		select {


### PR DESCRIPTION
Commit 0c9728feab4 missed to change the field name on the call to UpdateLogger()

No backport needed as 0c9728feab4 was not yet released.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5364)
<!-- Reviewable:end -->
