### PR TITLE
test: Fix the semantics of WithTimeout's Timeout

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -518,7 +518,7 @@ func (s *SSHMeta) PolicyGetRevision() (int, error) {
 // PolicyImportAndWait validates and imports a new policy into Cilium and waits
 // until the policy revision number increments. Returns an error if the policy
 // is invalid or could not be imported.
-func (s *SSHMeta) PolicyImportAndWait(path string, timeout time.Duration) (int, error) {
+func (s *SSHMeta) PolicyImportAndWait(path string, timeout int64) (int, error) {
 	ginkgoext.By(fmt.Sprintf("Setting up policy: %s", path))
 
 	revision, err := s.PolicyGetRevision()
@@ -914,7 +914,7 @@ INITSYSTEM=SYSTEMD`
 // WaitUntilReady waits until the output of `cilium status` returns with code
 // zero. Returns an error if the output of `cilium status` returns a nonzero
 // return code after the specified timeout duration has elapsed.
-func (s *SSHMeta) WaitUntilReady(timeout time.Duration) error {
+func (s *SSHMeta) WaitUntilReady(timeout int64) error {
 
 	body := func() bool {
 		res := s.ExecCilium("status")

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -18,15 +18,14 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"time"
 
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
-	ginkgoext "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/ginkgo-ext"
 )
 
 var (
-	// HelperTimeout is a predefined timeout value for commands.
-	HelperTimeout time.Duration = 300 // WithTimeout helper translates it to seconds
+	// HelperTimeout is a predefined timeout value for commands, in seconds.
+	HelperTimeout int64 = 300
 
 	// BasePath is the path in the Vagrant VMs to which the test directory
 	// is mounted

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -53,7 +53,7 @@ const (
 	// needed this time to recover from a connection problem to kube-apiserver.
 	// The kubedns resyncPeriod is defined at
 	// https://github.com/kubernetes/dns/blob/80fdd88276adba36a87c4f424b66fdf37cd7c9a8/pkg/dns/dns.go#L53
-	DNSHelperTimeout time.Duration = 420 // WithTimeout helper translates it to seconds
+	DNSHelperTimeout int64 = 420
 )
 
 // GetCurrentK8SEnv returns the value of K8S_VERSION from the OS environment.
@@ -516,7 +516,7 @@ func (kub *Kubectl) NamespaceDelete(name string) *CmdRes {
 // containterStatuses equal to "ready". Returns true if all pods achieve
 // the aforementioned desired state within timeout seconds. Returns false and
 // an error if the command failed or the timeout was exceeded.
-func (kub *Kubectl) WaitforPods(namespace string, filter string, timeout time.Duration) error {
+func (kub *Kubectl) WaitforPods(namespace string, filter string, timeout int64) error {
 
 	data, err := kub.GetPods(namespace, filter).Filter("{.items[*].metadata.deletionTimestamp}")
 	if err != nil {
@@ -563,7 +563,7 @@ func (kub *Kubectl) WaitforPods(namespace string, filter string, timeout time.Du
 // to have their port equal to the provided port. Returns true if all pods achieve
 // the aforementioned desired state within timeout seconds. Returns false and
 // an error if the command failed or the timeout was exceeded.
-func (kub *Kubectl) WaitForServiceEndpoints(namespace string, filter string, service string, port string, timeout time.Duration) error {
+func (kub *Kubectl) WaitForServiceEndpoints(namespace string, filter string, service string, port string, timeout int64) error {
 	body := func() bool {
 		var jsonPath = fmt.Sprintf("{.items[?(@.metadata.name =='%s')].subsets[0].ports[0].port}", service)
 		data, err := kub.GetEndpoints(namespace, filter).Filter(jsonPath)
@@ -736,7 +736,7 @@ func (kub *Kubectl) WaitCleanAllTerminatingPods() error {
 	err := WithTimeout(
 		body,
 		"Pods are still not deleted after a timeout",
-		&TimeoutConfig{Timeout: HelperTimeout * time.Second})
+		&TimeoutConfig{Timeout: HelperTimeout})
 	return err
 }
 
@@ -1061,7 +1061,7 @@ type ResourceLifeCycleAction string
 // to be applied in all Cilium endpoints. Returns an error if the policy is not
 // imported before the timeout is
 // exceeded.
-func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action ResourceLifeCycleAction, timeout time.Duration) (string, error) {
+func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action ResourceLifeCycleAction, timeout int64) (string, error) {
 	revisions := map[string]int{}
 
 	kub.logger.Infof("Performing %s action on resource '%s'", action, filepath)

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -107,8 +107,8 @@ func RenderTemplateToFile(filename string, tmplt string, perm os.FileMode) error
 
 // TimeoutConfig represents the configuration for the timeout of a command.
 type TimeoutConfig struct {
-	Ticker  time.Duration // Check interval in duration.
-	Timeout time.Duration // Timeout definition
+	Ticker  int64 // Check interval in duration, in seconds.
+	Timeout int64 // Timeout definition, in seconds.
 }
 
 // WithTimeout executes body using the time interval specified in config until
@@ -119,8 +119,8 @@ func WithTimeout(body func() bool, msg string, config *TimeoutConfig) error {
 		config.Ticker = 5
 	}
 
-	done := time.After(config.Timeout * time.Second)
-	ticker := time.NewTicker(config.Ticker * time.Second)
+	done := time.After(time.Duration(config.Timeout) * time.Second)
+	ticker := time.NewTicker(time.Duration(config.Ticker) * time.Second)
 	defer ticker.Stop()
 	if body() {
 		return nil
@@ -164,7 +164,7 @@ func InstallExampleCilium(kubectl *Kubectl, version string) {
 
 	var path = filepath.Join("..", "examples", "kubernetes", GetCurrentK8SEnv(), "cilium.yaml")
 	var result bytes.Buffer
-	timeout := time.Duration(800)
+	var timeout int64 = 800
 
 	newCiliumDSName := fmt.Sprintf("cilium_ds_%s.json", MakeUID())
 

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -31,9 +31,9 @@ import (
 )
 
 var (
-	endpointTimeout  = (60 * time.Second)
-	timeout          = time.Duration(300)
-	netcatDsManifest = "netcat-ds.yaml"
+	endpointTimeout  int64 = 60
+	timeout          int64 = 300
+	netcatDsManifest       = "netcat-ds.yaml"
 )
 
 var _ = Describe("NightlyEpsMeasurement", func() {
@@ -41,7 +41,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 	var kubectl *helpers.Kubectl
 
 	endpointCount := 45
-	endpointsTimeout := endpointTimeout * time.Duration(endpointCount)
+	endpointsTimeout := endpointTimeout * int64(endpointCount)
 	manifestPath := "tmp.yaml"
 	vagrantManifestPath := path.Join(helpers.BasePath, manifestPath)
 	var lastServer int

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -913,7 +913,7 @@ var _ = Describe("RuntimePolicies", func() {
 		// increment it by 1 again. We can wait for two policy revisions to happen.
 		// Once we have an API to expose DNS->IP mappings we can also use that to
 		// ensure the lookup has completed more explicitly
-		timeout_s := 3 * fqdn.DNSPollerInterval / time.Second // convert to seconds
+		timeout_s := int64(3 * fqdn.DNSPollerInterval / time.Second) // convert to seconds
 		dnsWaitBody := func() bool {
 			return vm.PolicyWait(preImportPolicyRevision + 2).WasSuccessful()
 		}


### PR DESCRIPTION
The Go docs specify that a `time.Duration` "represents the elapsed time between two instants as an int64 nanosecond count."
However, `TimeoutConfig`'s `Ticker` and `Timeout` fields violated that semantics as they were defined as `time.Duration` while storing durations in `Seconds`.

Fix the timeout handling in `WaitForServiceEndpoints`, which converted timeouts into billions of seconds.

To prevent such bugs from occurring again, specify clearly that `Ticker` and `Timeout` contain seconds, and change their type to `int64`.

Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5369)
<!-- Reviewable:end -->
