### PR TITLE
endpoint: Avoid policy sync error in log when endpoint disconnects

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2637,8 +2637,10 @@ func (e *Endpoint) syncPolicyMapController() {
 	e.controllers.UpdateController(ctrlName,
 		controller.ControllerParams{
 			DoFunc: func() (reterr error) {
+				// Failure to lock is not an error, it means
+				// that the endpoint was disconnected and we
+				// should exit gracefully.
 				if err := e.LockAlive(); err != nil {
-					e.LogDisconnectedMutexAction(err, "before syncing policy maps in controller")
 					return nil
 				}
 				defer e.Unlock()


### PR DESCRIPTION
The following error was found regularly in logs. The event this happens is not
an error. It is a regular incident that the controller keeps running while the
endpoint is marked to be disconnected. The endpoint is first stopped and
removed before the controllers are removed. The log message can be safely
removed.

```
msg="before syncing policy maps in controller" containerID=4fb21d6b1d datapathPolicyRevision=0 endpointID=1133 error="lock failed: endpoint is in the process of being removed" ipv4=10.10.0.167 ipv6="f00d::a0a:0:0:46d" k8sPodName=default/spaceship-589d768cc4-ccc87 policyRevision=8
```

Only 1.2 backport needed as this change is not present in 1.1 or 1.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5370)
<!-- Reviewable:end -->
