### PR TITLE
endpoint: Ignore delete requests if endpoint is already deleted

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -476,9 +476,11 @@ func (d *Daemon) deleteEndpointQuiet(ep *endpoint.Endpoint, releaseIP bool) []er
 	// Lock out any other writers to the endpoint
 	ep.UnconditionalLock()
 
-	// In case multiple delete requests have been enqueued, have all of them
-	// except the first return here.
-	if ep.GetStateLocked() == endpoint.StateDisconnecting {
+	// In case multiple delete requests have been enqueued, have all of
+	// them except the first return here. Ignore the request if the
+	// endpoint is already disconnected.
+	switch ep.GetStateLocked() {
+	case endpoint.StateDisconnecting, endpoint.StateDisconnected:
 		ep.Unlock()
 		ep.BuildMutex.Unlock()
 		return []error{}


### PR DESCRIPTION
There is a small race window in which the endpoint may have been disconnected
already and another deletion would be scheduled and then attempt deletion a
second time, resulting in errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5374)
<!-- Reviewable:end -->
