### PR TITLE
loadinfo: Provide the cmdline arguments of high CPU processes

### DIFF
--- a/pkg/loadinfo/loadinfo.go
+++ b/pkg/loadinfo/loadinfo.go
@@ -77,6 +77,7 @@ func LogCurrentSystemLoad(logFunc LogFunc) {
 				name, _ := p.Name()
 				status, _ := p.Status()
 				memPercent, _ := p.MemoryPercent()
+				cmdline, _ := p.Cmdline()
 
 				memExt := ""
 				if memInfo, err := p.MemoryInfo(); memInfo != nil && err == nil {
@@ -85,8 +86,8 @@ func LogCurrentSystemLoad(logFunc LogFunc) {
 						toMB(memInfo.Stack), toMB(memInfo.Locked), toMB(memInfo.Swap))
 				}
 
-				logFunc("NAME %s STATUS %s PID %d CPU: %.2f%% MEM: %.2f%% %s",
-					name, status, p.Pid, cpuPercent, memPercent, memExt)
+				logFunc("NAME %s STATUS %s PID %d CPU: %.2f%% MEM: %.2f%% CMDLINE: %s MEM-EXT: %s",
+					name, status, p.Pid, cpuPercent, memPercent, cmdline, memExt)
 			}
 		}
 	}


### PR DESCRIPTION
```
msg="NAME cilium-agent STATUS S PID 20446 CPU: 10.79% MEM: 3.40% CMDLINE: /usr/bin/cilium-agent --debug --auto-ipv6-node-routes --debug-verbose flow --ipv4-range 10.11.0.0/16 --kvstore-opt consul.address=192.168.33.11:8500 --kvstore consul --container-runtime=docker --container-runtime-endpoint=unix:///var/run/docker.sock -t vxlan --access-log=/var/log/cilium-access.log --fixed-identity-mapping=128=kv-store --fixed-identity-mapping=129=kube-dns --pprof RSS: 102 VMS: 1088 Data: 0 Stack: 0 Locked: 0 Swap: 0" endpointID=49112 subsys=endpoint
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5375)
<!-- Reviewable:end -->
