### PR TITLE
test: 1.1.4 is required to up- and downgrade from 1.2.x

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -161,7 +161,7 @@ const (
 	KubectlPolicyNameLabel      = k8sConst.PolicyLabelName
 	KubectlPolicyNameSpaceLabel = k8sConst.PolicyLabelNamespace
 
-	StableImage = "docker.io/cilium/cilium:v1.1.1"
+	StableImage = "docker.io/cilium/cilium:v1.1.4"
 
 	configMap = "ConfigMap"
 	daemonSet = "DaemonSet"


### PR DESCRIPTION
This avoids testing an unsupported up and downgrade path from 1.1 to 1.2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5376)
<!-- Reviewable:end -->
