### PR TITLE
pkg/endpoint: check for regenerateBPF error earlier

### DIFF
--- a/pkg/endpoint/directory.go
+++ b/pkg/endpoint/directory.go
@@ -17,11 +17,29 @@ package endpoint
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/sirupsen/logrus"
 )
+
+// DirectoryPath returns the directory name for this endpoint bpf program.
+func (e *Endpoint) DirectoryPath() string {
+	return filepath.Join(".", fmt.Sprintf("%d", e.ID))
+}
+
+// FailedDirectoryPath returns the directory name for this endpoint bpf program
+// failed builds.
+func (e *Endpoint) FailedDirectoryPath() string {
+	return filepath.Join(".", fmt.Sprintf("%d%s", e.ID, "_next_fail"))
+}
+
+// NextDirectoryPath returns the directory name for this endpoint bpf program
+// next bpf builds.
+func (e *Endpoint) NextDirectoryPath() string {
+	return filepath.Join(".", fmt.Sprintf("%d%s", e.ID, "_next"))
+}
 
 // synchronizeDirectories moves the files related to endpoint BPF program
 // compilation to their according directories if compilation of BPF was

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -23,7 +23,6 @@ import (
 	"math/rand"
 	"net"
 	"os"
-	"path/filepath"
 	"reflect"
 	"runtime"
 	"sort"
@@ -1267,17 +1266,6 @@ func (e *Endpoint) GetIdentity() identityPkg.NumericIdentity {
 	}
 
 	return identityPkg.InvalidIdentity
-}
-
-// DirectoryPath returns the directory name for this endpoint bpf program.
-func (e *Endpoint) DirectoryPath() string {
-	return filepath.Join(".", fmt.Sprintf("%d", e.ID))
-}
-
-// FailedDirectoryPath returns the directory name for this endpoint bpf program
-// failed builds.
-func (e *Endpoint) FailedDirectoryPath() string {
-	return filepath.Join(".", fmt.Sprintf("%d%s", e.ID, "_next_fail"))
 }
 
 func (e *Endpoint) Allows(id identityPkg.NumericIdentity) bool {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -773,7 +773,7 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 	// This is the temporary directory to store the generated headers,
 	// the original existing directory is not overwritten until the
 	// entire generation process has succeeded.
-	tmpDir := getTempEndpointDirectory(origDir)
+	tmpDir := e.NextDirectoryPath()
 
 	// Create temporary endpoint directory if it does not exist yet
 	if err := os.MkdirAll(tmpDir, 0777); err != nil {
@@ -799,11 +799,19 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 	}()
 
 	revision, compilationExecuted, err = e.regenerateBPF(owner, tmpDir, context)
+	if err != nil {
+		failDir := e.FailedDirectoryPath()
+		e.getLogger().WithFields(logrus.Fields{
+			logfields.Path: failDir,
+		}).Warn("generating BPF for endpoint failed, keeping stale directory.")
+		os.Rename(tmpDir, failDir)
+		return err
+	}
 
-	// Depending upon result of BPF regeneration (compilation executed, or
-	// error occurred), shift endpoint directories to match said BPF regeneration
+	// Depending upon result of BPF regeneration (compilation executed),
+	// shift endpoint directories to match said BPF regeneration
 	// results.
-	err = e.synchronizeDirectories(origDir, compilationExecuted, err)
+	err = e.synchronizeDirectories(origDir, compilationExecuted)
 	if err != nil {
 		return fmt.Errorf("error synchronizing endpoint BPF program directories: %s", err)
 	}


### PR DESCRIPTION
It's confusing to send an error to a function and not checking it
earlier closer to the function that returned that error. Made some
changes to make the code easier for readability.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5377)
<!-- Reviewable:end -->
