### PR TITLE
Test: Add remoteIP on Curl statistics.

### DIFF
--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -46,7 +46,7 @@ func Ping6(endpoint string) string {
 // variadic optinalValues argument. This is passed on to fmt.Sprintf() and uses
 // into the curl message
 func CurlFail(endpoint string, optionalValues ...interface{}) string {
-	statsInfo := `time-> DNS: '%{time_namelookup}', Connect: '%{time_connect}',` +
+	statsInfo := `time-> DNS: '%{time_namelookup}(%{remote_ip})', Connect: '%{time_connect}',` +
 		`Transfer '%{time_starttransfer}', total '%{time_total}'`
 
 	if len(optionalValues) > 0 {


### PR DESCRIPTION
In build [0] the DNS was resolved correctly but can't ping to the right
place, we don't know the IP that try to connect, so with this change the
remote_ip will be printed in the stadistics variables.

Example invalid output:

```
/home/jenkins/workspace/cilium-ginkgo_cilium_master-QVKDPVJ2A6E272IRUX7X6DCB5FBLCQDKRTOMHPZS7ZECX3RM5C3A/src/github.com/cilium/cilium/test/ginkgo-ext/scopes.go:376
Cannot curl app1-service
Expected command: kubectl exec -n default app2-69f6b59665-wmbtf -- curl -s -D /dev/stderr --fail --connect-timeout 3 --max-time 3 http://app1-service/public -w "time-> DNS: '%{time_namelookup}', Connect: '%{time_connect}',Transfer '%{time_starttransfer}', total '%{time_total}'"
To succeed, but it failed:
Exitcode: 28
Stdout:
 	 time-> DNS: '0.004106', Connect: '0.000000',Transfer '0.000000', total '3.002199'
Stderr:
 	 command terminated with exit code 28
```

Example output with the change:

```
$ curl -s -D /dev/stderr --fail --connect-timeout 3 --max-time 3 http://www.google.com -w "time-> DNS: '%{time_namelookup}(%{remote_ip})', Connect: '%{time_connect}',Transfer '%{time_starttransfer}', total '%{time_total}'"  --output /dev/null
HTTP/1.1 200 OK
Date: Mon, 27 Aug 2018 14:13:09 GMT
Expires: -1
Cache-Control: private, max-age=0
Content-Type: text/html; charset=ISO-8859-1
P3P: CP="This is not a P3P policy! See g.co/p3phelp for more info."
Server: gws
X-XSS-Protection: 1; mode=block
X-Frame-Options: SAMEORIGIN
Set-Cookie: 1P_JAR=2018-08-27-14; expires=Wed, 26-Sep-2018 14:13:09 GMT; path=/; domain=.google.com
Set-Cookie: NID=137=FbstBR54y-ieOyR7VGSMrpO0AGryFFOg7Hz3NvAmTG0bjJafIP8lgslyBkNougRmXeduBDkGmxh45GtLOdIGi4QZx5bep1Dyx6GFMQDBraxl3aD0j_y_-7OJH1ahF-ll; expires=Tue, 26-Feb-2019 14:13:09 GMT; path=/; domain=.google.com; HttpOnly
Accept-Ranges: none
Vary: Accept-Encoding
Transfer-Encoding: chunked

time-> DNS: '0.004345(216.58.201.196)', Connect: '0.055171',Transfer '0.189131', total '0.203262'%                                                                                                                                                                                                                            breo.acalustra.com ➜  cilium git:(CurlRemoteIP) ✗

```

[0] https://jenkins.cilium.io/job/cilium-ginkgo/job/cilium/job/master/1495/testReport/junit/k8s-1/11/K8sUpdates_Updating_Cilium_stable_to_master/

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5380)
<!-- Reviewable:end -->
