### PR TITLE
pkg/identity: Wait For Initial Identities for endpoints without fixed…

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -836,7 +836,6 @@ func runDaemon() {
 	go func() {
 		log.Info("Waiting until all pre-existing resources related to policy have been received")
 		d.k8sResourceSyncWaitGroup.Wait()
-		identity.WaitForInitialIdentities()
 		cachesSynced <- struct{}{}
 	}()
 

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -175,6 +175,12 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) {
 				scopedLog.WithError(err).Warn("Unable to restore endpoint")
 				epRegenerated <- false
 			}
+			// Wait for initial identities from the kvstore before
+			// doing any policy calculation for endpoints that don't have
+			// a fixed identity.
+			if !identity.IsFixed() {
+				identityPkg.WaitForInitialIdentities()
+			}
 
 			if err := ep.LockAlive(); err != nil {
 				scopedLog.Warn("Endpoint to restore has been deleted")

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -112,6 +112,12 @@ func (id *Identity) IsReserved() bool {
 	return LookupReservedIdentity(id.ID) != nil
 }
 
+// IsFixed returns whether the identity represents a fixed identity
+// (true), or not (false).
+func (id *Identity) IsFixed() bool {
+	return LookupReservedIdentity(id.ID) != nil && IsUserReservedIdentity(id.ID)
+}
+
 // NewIdentity creates a new identity
 func NewIdentity(id NumericIdentity, lbls labels.Labels) *Identity {
 	var lblArray labels.LabelArray


### PR DESCRIPTION
… identity

By waiting for the initial set of identities without creating the daemon
socket, Cilium would remain unavailable for kubelet to create endpoints,
breaking the etcd-operator integration.

Fixes: a6d3a5daa4c2 ("identity: Wait for initial set of security identities before restoring endpoints")
Signed-off-by: André Martins <andre@cilium.io>

Feel free to merge it if https://github.com/cilium/cilium/pull/5334 passes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5385)
<!-- Reviewable:end -->
