### PR TITLE
docker: Fix logging of endpoint ID in handleCreateWorkload

### DIFF
--- a/pkg/workloads/docker.go
+++ b/pkg/workloads/docker.go
@@ -428,6 +428,8 @@ func (d *dockerClient) handleCreateWorkload(id string, retry bool) {
 			if ciliumID != 0 {
 				ep = endpointmanager.LookupCiliumID(ciliumID)
 			}
+		} else {
+			ciliumID = ep.ID
 		}
 
 		retryLog.WithFields(logrus.Fields{


### PR DESCRIPTION
The `endpointID` field's value was always `0` in logs from `handleCreateWorkload` when the endpoint already exists, e.g.:
```
2018-08-22T18:22:55.80825952Z level=debug msg="Trying to associate container with existing endpoint" containerID=8a5bf4540a containerName=/k8s_POD_app1-7c5785f7f7-78vm9_default_ce57342d-a635-11e8-b11a-0800275579e8_0 endpointID=0 identityLabels="k8s:id=app1,k8s:io.cilium.k8s.policy.serviceaccount=app1-account,k8s:io.kubernetes.pod.namespace=default,k8s:zgroup=testapp" maxRetry=20 retry=1 subsys=workload-watcher willRetry=false
```

Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5386)
<!-- Reviewable:end -->
