### PR TITLE
agent: Fix periodic agent unhealthiness due to CompilationLock contention

### DIFF
--- a/daemon/status.go
+++ b/daemon/status.go
@@ -71,9 +71,6 @@ func checkLocks(d *Daemon) {
 
 	option.Config.ConfigPatchMutex.Lock()
 	option.Config.ConfigPatchMutex.Unlock()
-
-	d.GetCompilationLock().Lock()
-	d.GetCompilationLock().Unlock()
 }
 
 func (d *Daemon) getNodeStatus() *models.ClusterStatus {


### PR DESCRIPTION
The agent status report acquires the CompilationLock in attempt to detect
deadlocks. This lock can receive a lot of contention as it is being held
throughout entire compilation cycles. At times, when many endpoints need to be
rebuilt. Waiting for this lock can potentially take a minute or longer.

There is no point in acquiring this lock with the motivation to detect
deadlocks as this lock may be held for a long time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5388)
<!-- Reviewable:end -->
