### PR TITLE
Revert "Test: Update Vagrant image to 107."

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -128,7 +128,7 @@ Vagrant.configure(2) do |config|
         vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
 
         config.vm.box = "cilium/ubuntu-dev"
-        config.vm.box_version = "107"
+        config.vm.box_version = "106"
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i
         if ENV["NFS"] then

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -8,7 +8,7 @@ $K8S_VERSION = ENV['K8S_VERSION'] || "1.11"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 $NFS = ENV['NFS']=="1"? true : false
 $SERVER_BOX = (ENV['SERVER_BOX'] || "cilium/ubuntu-dev")
-$SERVER_VERSION="107"
+$SERVER_VERSION="106"
 $IPv6=(ENV['IPv6'] || "0")
 $CONTAINER_RUNTIME=(ENV['CONTAINER_RUNTIME'] || "docker")
 


### PR DESCRIPTION
This reverts commit cd392a007fe8922cf1d4a770c35df1ef0ddd7fd3.

Some issues with envoy/Makefile where bazel is stopped before starting to collect the dependencies. 
Tracked on #5394

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5395)
<!-- Reviewable:end -->
