### PR TITLE
endpoint: Remove unnecessary locks around logging

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -660,10 +660,8 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 		compilationExecuted = true
 		e.bpfHeaderfileHash = bpfHeaderfilesHash
 	} else {
-		e.UnconditionalRLock()
 		e.getLogger().WithField(logfields.BPFHeaderfileHash, bpfHeaderfilesHash).
 			Debug("BPF header file unchanged, skipping BPF compilation and installation")
-		e.RUnlock()
 	}
 
 	err = e.WaitForProxyCompletions(proxyWaitGroup)

--- a/pkg/endpoint/lock.go
+++ b/pkg/endpoint/lock.go
@@ -62,8 +62,5 @@ func (e *Endpoint) UnconditionalRLock() {
 
 // LogDisconnectedMutexAction gets the logger and logs given error with context
 func (e *Endpoint) LogDisconnectedMutexAction(err error, context string) {
-	e.mutex.Lock()
-	logger := e.getLogger()
-	logger.WithError(err).Error(context)
-	e.mutex.Unlock()
+	e.getLogger().WithError(err).Error(context)
 }


### PR DESCRIPTION
e.getLogger() uses an atomic pointer now, no need to lock to fetch the
logger. Remove lock occurrences that assume they can unconditionally
grab the endpoint mutex, if the lock was only used to protect logger
access.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5398)
<!-- Reviewable:end -->
