### PR TITLE
Automatically re-create master keys for local allocations

### DIFF
--- a/pkg/identity/allocator.go
+++ b/pkg/identity/allocator.go
@@ -87,6 +87,7 @@ func InitIdentityAllocator(owner IdentityAllocatorOwner) {
 			allocator.WithMax(maxID), allocator.WithMin(minID),
 			allocator.WithSuffix(owner.GetNodeSuffix()),
 			allocator.WithEvents(events),
+			allocator.WithMasterKeyProtection(),
 			allocator.WithPrefixMask(allocator.ID(option.Config.ClusterID<<option.ClusterIDShift)))
 		if err != nil {
 			log.WithError(err).Fatal("Unable to initialize identity allocator")

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -53,6 +53,10 @@ const (
 	// attempted to be expired from the kvstore
 	gcInterval = time.Duration(10) * time.Minute
 
+	// localKeySyncInterval is the interval in which local keys are being
+	// synced to the kvstore in case master keys get lost
+	localKeySyncInterval = 1 * time.Minute
+
 	// NoID is a special ID that represents "no ID available"
 	NoID ID = 0
 )
@@ -202,6 +206,10 @@ type Allocator struct {
 
 	// idPool maintains a pool of available ids for allocation.
 	idPool *idPool
+
+	// enableMasterKeyProtection if true, causes master keys that are still in
+	// local use to be automatically re-created
+	enableMasterKeyProtection bool
 }
 
 func locklessCapability() bool {
@@ -317,6 +325,12 @@ func WithMax(id ID) AllocatorOption {
 // min..max.
 func WithPrefixMask(mask ID) AllocatorOption {
 	return func(a *Allocator) { a.prefixMask = mask }
+}
+
+// WithMasterKeyProtection will watch for delete events on master keys and
+// re-created them if local usage suggests that the key is still in use
+func WithMasterKeyProtection() AllocatorOption {
+	return func(a *Allocator) { a.enableMasterKeyProtection = true }
 }
 
 // Delete deletes an allocator and stops the garbage collector
@@ -689,6 +703,34 @@ func (a *Allocator) runGC() error {
 	return nil
 }
 
+func (a *Allocator) recreateMasterKey(id ID, value string) {
+	keyPath := path.Join(a.idPrefix, id.String())
+
+	// Use of CreateOnly() ensures that any existing potentially
+	// conflicting key is never overwritten.
+	if err := kvstore.CreateOnly(keyPath, []byte(value), false); err == nil {
+		log.WithField(fieldKey, keyPath).Warning("Re-created missing master key")
+	}
+}
+
+// syncLocalKeys checks the kvstore and verifies that a master key exists for
+// all locally used allocations. This will restore master keys if deleted for
+// some reason.
+func (a *Allocator) syncLocalKeys() error {
+	// Create a local copy of all local allocations to not require to hold
+	// any locks while performing kvstore operations. Local use can
+	// disappear while we perform the sync but that is fine as worst case,
+	// a master key is created for a slave key that no longer exists. The
+	// garbage collector will remove it again.
+	ids := a.localKeys.getIDs()
+
+	for id, value := range ids {
+		a.recreateMasterKey(id, value)
+	}
+
+	return nil
+}
+
 func (a *Allocator) startGC() {
 	go func(a *Allocator) {
 		for {
@@ -705,6 +747,23 @@ func (a *Allocator) startGC() {
 			case <-time.After(gcInterval):
 			}
 
+		}
+	}(a)
+
+	go func(a *Allocator) {
+		for {
+			if err := a.syncLocalKeys(); err != nil {
+				log.WithError(err).WithFields(logrus.Fields{fieldPrefix: a.idPrefix}).
+					Warning("Unable to run local key sync routine")
+			}
+
+			select {
+			case <-a.stopGC:
+				log.WithFields(logrus.Fields{fieldPrefix: a.idPrefix}).
+					Debug("Stopped master key sync routine")
+				return
+			case <-time.After(localKeySyncInterval):
+			}
 		}
 	}(a)
 }

--- a/pkg/kvstore/allocator/cache.go
+++ b/pkg/kvstore/allocator/cache.go
@@ -198,6 +198,13 @@ func (c *cache) start(a *Allocator) waitChan {
 					case kvstore.EventTypeDelete:
 						kvstore.Trace("Removing id from cache", nil, debugFields.Data)
 
+						if a.enableMasterKeyProtection {
+							if value := a.localKeys.lookupID(id); value != "" {
+								a.recreateMasterKey(id, value)
+								break
+							}
+						}
+
 						if k, ok := c.nextCache[id]; ok && k != nil {
 							delete(c.nextKeyCache, k.GetKey())
 						}

--- a/pkg/kvstore/allocator/localkeys.go
+++ b/pkg/kvstore/allocator/localkeys.go
@@ -134,3 +134,14 @@ func (lk *localKeys) release(key string) (lastUse bool, err error) {
 
 	return false, fmt.Errorf("unable to find key in local cache")
 }
+
+func (lk *localKeys) getIDs() map[ID]string {
+	ids := map[ID]string{}
+	lk.RLock()
+	for id, localKey := range lk.ids {
+		ids[id] = localKey.key
+	}
+	lk.RUnlock()
+
+	return ids
+}

--- a/pkg/kvstore/allocator/localkeys_test.go
+++ b/pkg/kvstore/allocator/localkeys_test.go
@@ -44,6 +44,9 @@ func (s *AllocatorSuite) TestLocalKeys(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(v, Equals, val2)
 
+	ids := k.getIDs()
+	c.Assert(len(ids), Equals, 2)
+
 	// allocate with different value must fail
 	_, err = k.allocate(key2, val)
 	c.Assert(err, Not(IsNil))


### PR DESCRIPTION
Add a new master key protection mode of the allocator which will cause any node
to immediately re-create master keys of locally used allocations.

Also, run a background routine to periodically re-create all master keys of
locally used allocations.

This fixes #5397 while we are not entirely sure what caused the master keys to
be deleted.

This also indirectly improves the behavior of #5399 but does not directly fix it.

Fixes: #5397

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5400)
<!-- Reviewable:end -->
