### PR TITLE
envoy: Disable http connection manager stream idle timeout.

### DIFF
--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -168,6 +168,7 @@ func StartXDSServer(stateDir string) *XDSServer {
 							"config": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{}}}},
 						}}}},
 					}}}},
+					"stream_idle_timeout": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{}}}},
 					"route_config": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
 						"virtual_hosts": {Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: []*structpb.Value{
 							{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{


### PR DESCRIPTION
The default stream idle timeout functionality has been recently added
to Envoy with a default of 5 minutes. This interferes with HTTP long
polling and gRPC streaming, so disable the timeout by configuring it
as 0 (empty Duration message).

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5401)
<!-- Reviewable:end -->
