### PR TITLE
envoy: Set route reply policy to retry on "5xx"

### DIFF
--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -184,6 +184,10 @@ func StartXDSServer(stateDir string) *XDSServer {
 										"route": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
 											"cluster":          {Kind: &structpb.Value_StringValue{StringValue: "cluster1"}},
 											"max_grpc_timeout": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{}}}},
+											"retry_policy": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
+												"retry_on":    {Kind: &structpb.Value_StringValue{StringValue: "5xx"}},
+												"num_retries": {Kind: &structpb.Value_NumberValue{NumberValue: 3}},
+											}}}},
 										}}}},
 									}}}},
 								}}}},


### PR DESCRIPTION
On "5xx" policy "Envoy will attempt a retry if the upstream server
responds with any 5xx response code, or does not respond at all
(disconnect/reset/read timeout). (Includes connect-failure and
refused-stream)."

This fixes issues due to broken connections due to policy changes that
either insert or remove a proxy redirect on a the path of the
connection.

The max number of retries is set to 3, as I found out in local testing
that sometimes the first retry would end up also re-using a connection
broken by a policy change.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5403)
<!-- Reviewable:end -->
