### PR TITLE
endpoint: Set Regenerating state in regenerate()

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -474,19 +474,6 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 		close(ctCleaned)
 	}
 
-	// If endpoint was marked as disconnected then
-	// it won't be regenerated.
-	// When building the initial drop policy in waiting-for-identity state
-	// the state remains unchanged
-	if e.GetStateLocked() != StateWaitingForIdentity &&
-		!e.BuilderSetStateLocked(StateRegenerating, "Regenerating Endpoint BPF: "+regenContext.Reason) {
-
-		e.getLogger().WithField(logfields.EndpointState, e.state).Debug("Skipping build due to invalid state")
-		e.Unlock()
-
-		return 0, compilationExecuted, fmt.Errorf("Skipping build due to invalid state: %s", e.state)
-	}
-
 	// If dry mode is enabled, no further changes to BPF maps are performed
 	if owner.DryModeEnabled() {
 		defer e.Unlock()

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -678,10 +678,23 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 	defer e.BuildMutex.Unlock()
 
 	// Check if endpoints is still alive before doing any build
-	if err = e.RLockAlive(); err != nil {
+	if err = e.LockAlive(); err != nil {
 		return err
 	}
-	e.RUnlock()
+
+	// When building the initial drop policy in waiting-for-identity state
+	// the state remains unchanged
+	//
+	// GH-5350: Remove this special case to require checking for StateWaitingForIdentity
+	if e.GetStateLocked() != StateWaitingForIdentity &&
+		!e.BuilderSetStateLocked(StateRegenerating, "Regenerating endpoint: "+context.Reason) {
+		e.getLogger().WithField(logfields.EndpointState, e.state).Debug("Skipping build due to invalid state")
+		e.Unlock()
+
+		return fmt.Errorf("Skipping build due to invalid state: %s", e.state)
+	}
+
+	e.Unlock()
 
 	scopedLog := e.getLogger()
 	scopedLog.Debug("Regenerating endpoint...")


### PR DESCRIPTION
This is a more logical place and ensures that the regenerating state is set
from the beginning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5406)
<!-- Reviewable:end -->
