### PR TITLE
 option: remove IngressPolicy and EgressPolicy endpoint options

### DIFF
--- a/pkg/option/endpoint.go
+++ b/pkg/option/endpoint.go
@@ -25,8 +25,6 @@ var (
 		TraceNotify:         &specTraceNotify,
 		MonitorAggregation:  &specMonitorAggregation,
 		NAT46:               &specNAT46,
-		IngressPolicy:       &IngressSpecPolicy,
-		EgressPolicy:        &EgressSpecPolicy,
 	}
 )
 

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -178,14 +178,20 @@ func (o *IntOptions) GetMutableModel() *models.ConfigurationMap {
 	o.optsMU.RLock()
 	for k, v := range o.Opts {
 		_, config := o.Library.Lookup(k)
-		if config.Format == nil {
-			if v == OptionDisabled {
-				mutableCfg[k] = fmt.Sprintf("Disabled")
+
+		// It's possible that an option has since been removed and thus has
+		// no corresponding configuration; need to check if configuration is
+		// nil accordingly.
+		if config != nil {
+			if config.Format == nil {
+				if v == OptionDisabled {
+					mutableCfg[k] = fmt.Sprintf("Disabled")
+				} else {
+					mutableCfg[k] = fmt.Sprintf("Enabled")
+				}
 			} else {
-				mutableCfg[k] = fmt.Sprintf("Enabled")
+				mutableCfg[k] = config.Format(v)
 			}
-		} else {
-			mutableCfg[k] = config.Format(v)
 		}
 	}
 	o.optsMU.RUnlock()

--- a/pkg/option/runtime_options.go
+++ b/pkg/option/runtime_options.go
@@ -29,8 +29,6 @@ const (
 	TraceNotify         = "TraceNotification"
 	MonitorAggregation  = "MonitorAggregationLevel"
 	NAT46               = "NAT46"
-	IngressPolicy       = "IngressPolicy"
-	EgressPolicy        = "EgressPolicy"
 	AlwaysEnforce       = "always"
 	NeverEnforce        = "never"
 	DefaultEnforcement  = "default"


### PR DESCRIPTION
These options are no longer configurable. Remove them from the list of configurable options for endpoint accordingly.

When I removed these options, when I restored endpoints, I discovered a nil-pointer deference bug in `pkg/option`. Fixed that as well.

Fixes: 05f6441ade8b ("endpoint: remove POLICY_*GRESS ifdefs")

 Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5409)
<!-- Reviewable:end -->
