### PR TITLE
endpoint: policy calculation simplifications and cleanups

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -496,7 +496,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 			return 0, compilationExecuted, fmt.Errorf("Unable to regenerate policy: %s", err)
 		}
 
-		_ = e.updateAndOverrideEndpointOptions(owner, nil)
+		_ = e.updateAndOverrideEndpointOptions(nil)
 
 		// Dry mode needs Network Policy Updates, but the proxy wait group must
 		// not be initialized, as there is no proxy ACKing the changes.
@@ -559,7 +559,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 			return 0, compilationExecuted, fmt.Errorf("unable to regenerate policy for '%s': %s", e.PolicyMap.String(), err)
 		}
 
-		_ = e.updateAndOverrideEndpointOptions(owner, nil)
+		_ = e.updateAndOverrideEndpointOptions(nil)
 
 		// Synchronously try to update PolicyMap for this endpoint. If any
 		// part of updating the PolicyMap fails, bail out and do not generate

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -317,6 +317,14 @@ func (e *Endpoint) computeDesiredL3PolicyMapEntries(repo *policy.Repository, des
 	ingressPolicyEnabled := e.ingressPolicyEnabled
 	egressPolicyEnabled := e.egressPolicyEnabled
 
+	if !ingressPolicyEnabled {
+		e.getLogger().Debug("ingress policy is disabled, which equates to allow-all; allowing all identities")
+	}
+
+	if !egressPolicyEnabled {
+		e.getLogger().Debug("egress policy is disabled, which equates to allow-all; allowing all identities")
+	}
+
 	// Only L3 (label-based) policy apply.
 	// Complexity increases linearly by the number of identities in the map.
 	for identity, labels := range *e.prevIdentityCache {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -804,45 +804,6 @@ func (e *Endpoint) Regenerate(owner Owner, context *RegenerationContext) <-chan 
 	return newReq.ExternalDone
 }
 
-// TriggerPolicyUpdatesLocked indicates that a policy change is likely to
-// affect this endpoint. Will update all required endpoint configuration and
-// state to reflect new policy.
-//
-// Returns true if policy was changed and the endpoint needs to be rebuilt
-func (e *Endpoint) TriggerPolicyUpdatesLocked(owner Owner, opts option.OptionMap) (bool, error) {
-
-	if e.SecurityIdentity == nil {
-		return false, nil
-	}
-
-	policyChanged, err := e.regeneratePolicy(owner)
-	if err != nil {
-		return false, fmt.Errorf("%s: %s", e.StringID(), err)
-	}
-
-	// Note that this *must* be called after regeneratePolicy because options
-	// can be changed based on the endpoint's desired state for policy.
-	optionsChanged := e.updateAndOverrideEndpointOptions(opts)
-	needToRegenerateBPF := optionsChanged || policyChanged
-
-	// If it does not need datapath regeneration then we should set the policy
-	// revision with nextPolicyRevision.
-	if !needToRegenerateBPF {
-		e.setPolicyRevision(e.nextPolicyRevision)
-	}
-
-	// CurrentStatus will be not OK when we have an uncleared error in BPF,
-	// policy or Other. We should keep trying to regenerate in the hopes of
-	// suceeding.
-	// Note: This "retry" behaviour is better suited to a controller, and can be
-	// moved there once we have an endpoint regeneration controller.
-	needToRegenerateBPF = needToRegenerateBPF || (e.Status.CurrentStatus() != OK)
-
-	e.getLogger().Debugf("TriggerPolicyUpdatesLocked: changed: %t", needToRegenerateBPF)
-
-	return needToRegenerateBPF, nil
-}
-
 func (e *Endpoint) runIdentityToK8sPodSync() {
 	e.controllers.UpdateController(fmt.Sprintf("sync-identity-to-k8s-pod (%d)", e.ID),
 		controller.ControllerParams{

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -565,6 +565,8 @@ func (e *Endpoint) regeneratePolicy(owner Owner) (isPolicyComp bool, err error) 
 		e.getLogger().Debug("regeneration of L3 (CIDR) policy caused policy change")
 	}
 
+	// no failures after this point
+	// Note - endpoint policy enforcement must be determined BEFORE this function!
 	e.computeDesiredPolicyMapState(repo)
 
 	// If we are in this function, then policy has been calculated.
@@ -615,7 +617,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner) (isPolicyComp bool, err error) 
 // to the endpoint, as well as the daemon's policy enforcement, may override
 // configuration changes which were made via the API that were provided in opts.
 // Must be called with endpoint mutex held.
-func (e *Endpoint) updateAndOverrideEndpointOptions(owner Owner, opts option.OptionMap) (optsChanged bool) {
+func (e *Endpoint) updateAndOverrideEndpointOptions(opts option.OptionMap) (optsChanged bool) {
 	if opts == nil {
 		opts = make(option.OptionMap)
 	}
@@ -818,7 +820,9 @@ func (e *Endpoint) TriggerPolicyUpdatesLocked(owner Owner, opts option.OptionMap
 		return false, fmt.Errorf("%s: %s", e.StringID(), err)
 	}
 
-	optionsChanged := e.updateAndOverrideEndpointOptions(owner, opts)
+	// Note that this *must* be called after regeneratePolicy because options
+	// can be changed based on the endpoint's desired state for policy.
+	optionsChanged := e.updateAndOverrideEndpointOptions(opts)
 	needToRegenerateBPF := optionsChanged || policyChanged
 
 	// If it does not need datapath regeneration then we should set the policy


### PR DESCRIPTION
Now that PR #5324, which separated out configuration updates from policy recalculation, has been merged, we can now remove policy calculation from occurring during calls to `endpoint.Update`. Now, in `endpoint.Update`, regeneration of the endpoint itself is only done if the configuration was indeed updated, or if the endpoint's status indicates it is in a bad state. This allows for removal of the `TriggerPolicyUpdatesLocked` function.

Cleaned up some function definitions as a result of doing this cleanup, and also short-circuited the L4 Policy regeneration code in the case that ingress or egress policy are disabled for the given endpoint.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5410)
<!-- Reviewable:end -->
