### PR TITLE
test: Increase curl --max-time timeout

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -135,8 +135,18 @@ const (
 	StateTerminating = "Terminating"
 	StateRunning     = "Running"
 
-	PingCount          = 5
+	PingCount = 5
+
+	// CurlConnectTimeout is the timeout for the connect() call that curl
+	// invokes
 	CurlConnectTimeout = 3
+
+	// CurlMaxTimeout is the hard timeout. It starts when curl is invoked
+	// and interrupts curl regardless of whether curl is currently
+	// connecting or transferring data. CurlMaxTimeout should be at least 5
+	// seconds longer than CurlConnectTimeout to provide some time to
+	// actually transfer data.
+	CurlMaxTimeout = 8
 
 	DefaultNamespace    = "default"
 	KubeSystemNamespace = "kube-system"

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -53,8 +53,8 @@ func CurlFail(endpoint string, optionalValues ...interface{}) string {
 		endpoint = fmt.Sprintf(endpoint, optionalValues...)
 	}
 	return fmt.Sprintf(
-		`curl -s -D /dev/stderr --fail --connect-timeout %[1]d --max-time %[1]d %[2]s -w "%[3]s"`,
-		CurlConnectTimeout, endpoint, statsInfo)
+		`curl -s -D /dev/stderr --fail --connect-timeout %[1]d --max-time %[2]d %[3]s -w "%[4]s"`,
+		CurlConnectTimeout, CurlMaxTimeout, endpoint, statsInfo)
 }
 
 // CurlWithHTTPCode retunrs the string representation of the curl command which


### PR DESCRIPTION
CurlMaxTimeout is the hard timeout. It starts when curl is invoked and
interrupts curl regardless of whether curl is currently connecting or
transferring data. CurlMaxTimeout should be at least 5 seconds longer than
CurlConnectTimeout to provide some time to actually transfer data.

Related: #5384
Related: #4745
Related: #4384

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5411)
<!-- Reviewable:end -->
