### PR TITLE
Metrics: KVStore usage metrics.

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -38,6 +38,12 @@ Endpoint
 * ``endpoint_regeneration_square_seconds_total``: Total sum of squares of successful endpoint regeneration times
 * ``endpoint_state``: Count of all endpoints, tagged by different endpoint states
 
+KVStore
+-------
+
+* ``kvstore_operations_total``: Number of interactions with the Key-Value Store,
+  labeled by subsystem and event type
+
 Datapath
 --------
 

--- a/pkg/identity/cache.go
+++ b/pkg/identity/cache.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/allocator"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/trigger"
 )
 
@@ -87,6 +88,10 @@ func identityWatcher(owner IdentityAllocatorOwner, events allocator.AllocatorEve
 		case kvstore.EventTypeModify:
 			// Ignore modify events
 		}
+		metrics.KVStoreOperationsTotal.With(map[string]string{
+			metrics.LabelScope: subsystem,
+			metrics.LabelType:  event.Typ.String(),
+		}).Inc()
 	}
 }
 

--- a/pkg/identity/config.go
+++ b/pkg/identity/config.go
@@ -19,6 +19,10 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
+const (
+	subsystem = "identity"
+)
+
 var (
-	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "identity")
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, subsystem)
 )

--- a/pkg/ipcache/config.go
+++ b/pkg/ipcache/config.go
@@ -19,6 +19,10 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
+const (
+	subsystem = "ipcache"
+)
+
 var (
-	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ipcache")
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, subsystem)
 )

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 
 	"github.com/sirupsen/logrus"
 )
@@ -317,6 +318,11 @@ restart:
 
 			scopedLog := log.WithFields(logrus.Fields{"kvstore-event": event.Typ.String(), "key": event.Key})
 			scopedLog.Debug("Received event")
+
+			metrics.KVStoreOperationsTotal.With(map[string]string{
+				metrics.LabelScope: subsystem,
+				metrics.LabelType:  event.Typ.String(),
+			}).Inc()
 
 			// Synchronize local caching of endpoint IP to ipIDPair mapping with
 			// operation key-value store has informed us about.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -74,6 +74,9 @@ var (
 	// LabelStatus the label from completed task
 	LabelStatus = "status"
 
+	// LabelType marks the type label for various metrics.
+	LabelType = "type"
+
 	// Endpoint
 
 	// EndpointCount is a function used to collect this metric.
@@ -197,6 +200,16 @@ var (
 		ConstLabels: prometheus.Labels{"source": LabelEventSourceAPI},
 	})
 
+	LabelScope = "scope" // @TODO to delete when PR-5296 is merged.
+
+	// Key Value Store statistics
+
+	// KVStoreOperationsTotal are the number of iteractions in kvstore per subsystem and type
+	KVStoreOperationsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "kvstore_operations_total",
+		Help: "Number of interactions with the Key-Value Store, labeled by subsystem and event type",
+	}, []string{LabelScope, LabelType})
+
 	// L7 statistics
 
 	// ProxyParseErrors is a count of failed parse errors on proxy
@@ -316,6 +329,8 @@ func init() {
 	MustRegister(EventTSK8s)
 	MustRegister(EventTSContainerd)
 	MustRegister(EventTSAPI)
+
+	MustRegister(KVStoreOperationsTotal)
 
 	MustRegister(ProxyParseErrors)
 	MustRegister(ProxyForwarded)


### PR DESCRIPTION
There are few cases when Kvstore is used (Ipcache, identity, and node)
this PR creates some metrics about the use of the KVStore usage and the
event types.

The reason to do in the watcher is because it's easy to count the types,
instead of monkey patching all the methods to increase the numbers.

The metrics add are the following:

- kvstore_usage_total

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5412)
<!-- Reviewable:end -->
