### PR TITLE
policy: Fix policy unit tests in context of new identity garbage coll…

### DIFF
--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -123,22 +123,27 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := identity.AllocateIdentity(qaBarLbls)
 	c.Assert(err, Equals, nil)
+	defer qaBarSecLblsCtx.Release()
 
 	prodBarLbls := labels.Labels{lblBar.Key: lblBar, lblProd.Key: lblProd}
 	prodBarSecLblsCtx, _, err := identity.AllocateIdentity(prodBarLbls)
 	c.Assert(err, Equals, nil)
+	defer prodBarSecLblsCtx.Release()
 
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
 	qaFooSecLblsCtx, _, err := identity.AllocateIdentity(qaFooLbls)
 	c.Assert(err, Equals, nil)
+	defer qaFooSecLblsCtx.Release()
 
 	prodFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblProd.Key: lblProd}
 	prodFooSecLblsCtx, _, err := identity.AllocateIdentity(prodFooLbls)
 	c.Assert(err, Equals, nil)
+	defer prodFooSecLblsCtx.Release()
 
 	prodFooJoeLbls := labels.Labels{lblFoo.Key: lblFoo, lblProd.Key: lblProd, lblJoe.Key: lblJoe}
 	prodFooJoeSecLblsCtx, _, err := identity.AllocateIdentity(prodFooJoeLbls)
 	c.Assert(err, Equals, nil)
+	defer prodFooJoeSecLblsCtx.Release()
 
 	e := endpoint.NewEndpointWithState(1, endpoint.StateWaitingForIdentity)
 	e.IfName = "dummy1"
@@ -423,6 +428,7 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := identity.AllocateIdentity(qaBarLbls)
 	c.Assert(err, Equals, nil)
+	defer qaBarSecLblsCtx.Release()
 
 	// Create the endpoint and generate its policy.
 	e := endpoint.NewEndpointWithState(1, endpoint.StateWaitingForIdentity)


### PR DESCRIPTION
…ector

Commit 10e50bef7b6 has revelead a bug in the policy tests where identities are
allocated but never released. By not releasing the identities can re-appear in
another unit test and be included in the policy calculation which leads to
false negatives.

Example of failed test:
```
---------------------------------------------------------------------
FAIL: <autogenerated>:1: DaemonConsulSuite.TestUpdateConsumerMap

policy_test.go:252:
    c.Assert(qaBarNetworkPolicy, comparator.DeepEquals, expectedNetworkPolicy)
... obtained *cilium.NetworkPolicy = &cilium.NetworkPolicy{Name:"10.11.12.13", Policy:0xee10, IngressPerPortPolicies:[]*cilium.PortNetworkPolicy{(*cilium.PortNetworkPolicy)(0xc433171940)}, EgressPerPortPolicies:[]*cilium.PortNetworkPolicy{(*cilium.PortNetworkPolicy)(0x39bf0a0), (*cilium.PortNetworkPolicy)(0x3923000)}, XXX_NoUnkeyedLiteral:struct {}{}, XXX_unrecognized:[]uint8(nil), XXX_sizecache:0} ("name:\"10.11.12.13\" policy:60944 ingress_per_port_policies:<port:80 rules:<remote_policies:22814 remote_policies:45960 http_rules:<http_rules:<> > > rules:<remote_policies:22814 remote_policies:45960 http_rules:<http_rules:<headers:<name:\":method\" regex_match:\"GET\" > headers:<name:\":path\" regex_match:\"/bar\" > > > > > egress_per_port_policies:<> egress_per_port_policies:<protocol:UDP > ")
... expected *cilium.NetworkPolicy = &cilium.NetworkPolicy{Name:"10.11.12.13", Policy:0xee10, IngressPerPortPolicies:[]*cilium.PortNetworkPolicy{(*cilium.PortNetworkPolicy)(0xc4331b5480)}, EgressPerPortPolicies:[]*cilium.PortNetworkPolicy{(*cilium.PortNetworkPolicy)(0xc4331b54c0), (*cilium.PortNetworkPolicy)(0xc4331b5500)}, XXX_NoUnkeyedLiteral:struct {}{}, XXX_unrecognized:[]uint8(nil), XXX_sizecache:0} ("name:\"10.11.12.13\" policy:60944 ingress_per_port_policies:<port:80 rules:<remote_policies:45960 http_rules:<http_rules:<> > > rules:<remote_policies:45960 http_rules:<http_rules:<headers:<name:\":method\" regex_match:\"GET\" > headers:<name:\":path\" regex_match:\"/bar\" > > > > > egress_per_port_policies:<> egress_per_port_policies:<protocol:UDP > ")
```

Fixes: 10e50bef7b6 ("allocator: Periodically re-create master keys for local allocations")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5413)
<!-- Reviewable:end -->
