### PR TITLE
remove DryModeEnabled requirement for endpoint Owner

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -281,10 +281,6 @@ func (d *Daemon) GetPolicyRepository() *policy.Repository {
 	return d.policy
 }
 
-func (d *Daemon) DryModeEnabled() bool {
-	return option.Config.DryMode
-}
-
 // PolicyEnforcement returns the type of policy enforcement for the daemon.
 func (d *Daemon) PolicyEnforcement() string {
 	return policy.GetPolicyEnabled()
@@ -831,7 +827,7 @@ func (d *Daemon) init() error {
 		return nil
 	}
 
-	if !d.DryModeEnabled() {
+	if !option.Config.DryMode {
 		// Validate existing map paths before attempting BPF compile.
 		if err = d.validateExistingMaps(); err != nil {
 			log.WithError(err).Error("Error while validating maps")
@@ -1366,7 +1362,7 @@ func (d *Daemon) validateExistingMaps() error {
 }
 
 func (d *Daemon) collectStaleMapGarbage() {
-	if d.DryModeEnabled() {
+	if option.Config.DryMode {
 		return
 	}
 	walker := func(path string, _ os.FileInfo, _ error) error {

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -52,7 +52,6 @@ type DaemonSuite struct {
 
 	// Owners interface mock
 	OnTracingEnabled                  func() bool
-	OnDryModeEnabled                  func() bool
 	OnEnableEndpointPolicyEnforcement func(e *e.Endpoint) (bool, bool)
 	OnPolicyEnforcement               func() string
 	OnAlwaysAllowLocalhost            func() bool
@@ -112,7 +111,6 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	identity.InitIdentityAllocator(d)
 
 	ds.OnTracingEnabled = nil
-	ds.OnDryModeEnabled = nil
 	ds.OnEnableEndpointPolicyEnforcement = nil
 	ds.OnPolicyEnforcement = nil
 	ds.OnAlwaysAllowLocalhost = nil
@@ -181,13 +179,6 @@ func (e *DaemonConsulSuite) TearDownTest(c *C) {
 func (ds *DaemonSuite) TestMinimumWorkerThreadsIsSet(c *C) {
 	c.Assert(numWorkerThreads() >= 2, Equals, true)
 	c.Assert(numWorkerThreads() >= runtime.NumCPU(), Equals, true)
-}
-
-func (ds *DaemonSuite) DryModeEnabled() bool {
-	if ds.OnDryModeEnabled != nil {
-		return ds.OnDryModeEnabled()
-	}
-	panic("DryModeEnabled should not have been called")
 }
 
 func (ds *DaemonSuite) EnableEndpointPolicyEnforcement(e *e.Endpoint) (bool, bool) {

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -492,7 +492,7 @@ func (d *Daemon) deleteEndpointQuiet(ep *endpoint.Endpoint, releaseIP bool) []er
 	endpointmanager.Remove(ep)
 
 	// If dry mode is enabled, no changes to BPF maps are performed
-	if !d.DryModeEnabled() {
+	if !option.Config.DryMode {
 		if errs := lxcmap.DeleteElement(ep); errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -437,7 +437,7 @@ func (d *Daemon) RevNATDump() ([]loadbalancer.L3n4AddrID, error) {
 // retrieved from the KVStore.
 func (d *Daemon) SyncLBMap() error {
 	// Don't bother syncing if we are in dry mode.
-	if d.DryModeEnabled() {
+	if option.Config.DryMode {
 		return nil
 	}
 

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -114,9 +114,6 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 	ds.OnEnableEndpointPolicyEnforcement = func(e *e.Endpoint) (bool, bool) {
 		return true, true
 	}
-	ds.OnDryModeEnabled = func() bool {
-		return true
-	}
 
 	ds.OnGetCompilationLock = func() *lock.RWMutex {
 		return ds.d.compilationMutex

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -328,7 +328,7 @@ func (ep *epInfoCache) GetBPFValue() (*lxcmap.EndpointInfo, error) {
 // problem that occurred while adding an l7 redirect for the specified policy.
 // Must be called with endpoint.Mutex held.
 func (e *Endpoint) addNewRedirectsFromMap(owner Owner, m policy.L4PolicyMap, desiredRedirects map[string]bool, proxyWaitGroup *completion.WaitGroup) error {
-	if owner.DryModeEnabled() {
+	if option.Config.DryMode {
 		return nil
 	}
 
@@ -395,7 +395,7 @@ func (e *Endpoint) addNewRedirects(owner Owner, m *policy.L4Policy, proxyWaitGro
 
 // Must be called with endpoint.Mutex held.
 func (e *Endpoint) removeOldRedirects(owner Owner, desiredRedirects map[string]bool, proxyWaitGroup *completion.WaitGroup) {
-	if owner.DryModeEnabled() {
+	if option.Config.DryMode {
 		return
 	}
 
@@ -485,7 +485,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 	}
 
 	// If dry mode is enabled, no further changes to BPF maps are performed
-	if owner.DryModeEnabled() {
+	if option.Config.DryMode {
 		defer e.Unlock()
 
 		// Compute policy for this endpoint.

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -25,9 +25,6 @@ import (
 // Owner is the interface defines the requirements for anybody owning policies.
 type Owner interface {
 
-	// Must return true if dry mode is enabled
-	DryModeEnabled() bool
-
 	// EnableEndpointPolicyEnforcement returns whether policy enforcement
 	// should be enabled for the specified endpoint.
 	EnableEndpointPolicyEnforcement(e *Endpoint) (bool, bool)

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -788,7 +788,7 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 	stats.waitingForLock.End()
 
 	// Keep PolicyMap for this endpoint in sync with desired / realized state.
-	if !owner.DryModeEnabled() {
+	if !option.Config.DryMode {
 		e.syncPolicyMapController()
 	}
 
@@ -842,12 +842,12 @@ func (e *Endpoint) Regenerate(owner Owner, context *RegenerationContext) <-chan 
 
 			if err != nil {
 				buildSuccess = false
-				if reprerr == nil && !owner.DryModeEnabled() {
+				if reprerr == nil && !option.Config.DryMode {
 					owner.SendNotification(monitor.AgentNotifyEndpointRegenerateFail, repr)
 				}
 			} else {
 				buildSuccess = true
-				if reprerr == nil && !owner.DryModeEnabled() {
+				if reprerr == nil && !option.Config.DryMode {
 					owner.SendNotification(monitor.AgentNotifyEndpointRegenerateSuccess, repr)
 				}
 			}


### PR DESCRIPTION
This field is accessible via `pkg/option`. Since we can access it from there, remove the
accessing of it via the Owner interface.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5414)
<!-- Reviewable:end -->
