### PR TITLE
endpoint: move EnableEndpointPolicyEnforcement from Owner interface to pkg/endpoint

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -272,11 +272,6 @@ func (d *Daemon) GetPolicyRepository() *policy.Repository {
 	return d.policy
 }
 
-// PolicyEnforcement returns the type of policy enforcement for the daemon.
-func (d *Daemon) PolicyEnforcement() string {
-	return policy.GetPolicyEnabled()
-}
-
 // DebugEnabled returns if debug mode is enabled.
 func (d *Daemon) DebugEnabled() bool {
 	return option.Config.Opts.IsEnabled(option.Debug)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -51,22 +51,20 @@ type DaemonSuite struct {
 	kvstoreInit bool
 
 	// Owners interface mock
-	OnTracingEnabled                  func() bool
-	OnEnableEndpointPolicyEnforcement func(e *e.Endpoint) (bool, bool)
-	OnPolicyEnforcement               func() string
-	OnAlwaysAllowLocalhost            func() bool
-	OnGetCachedLabelList              func(id identity.NumericIdentity) (labels.LabelArray, error)
-	OnGetPolicyRepository             func() *policy.Repository
-	OnUpdateProxyRedirect             func(e *e.Endpoint, l4 *policy.L4Filter, proxyWaitGroup *completion.WaitGroup) (uint16, error)
-	OnRemoveProxyRedirect             func(e *e.Endpoint, id string, proxyWaitGroup *completion.WaitGroup) error
-	OnUpdateNetworkPolicy             func(e *e.Endpoint, policy *policy.L4Policy, labelsMap identity.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool, proxyWaitGroup *completion.WaitGroup) error
-	OnRemoveNetworkPolicy             func(e *e.Endpoint)
-	OnQueueEndpointBuild              func(r *e.Request)
-	OnRemoveFromEndpointQueue         func(epID uint64)
-	OnDebugEnabled                    func() bool
-	OnGetCompilationLock              func() *lock.RWMutex
-	OnSendNotification                func(typ monitor.AgentNotification, text string) error
-	OnNewProxyLogRecord               func(l *accesslog.LogRecord) error
+	OnTracingEnabled          func() bool
+	OnAlwaysAllowLocalhost    func() bool
+	OnGetCachedLabelList      func(id identity.NumericIdentity) (labels.LabelArray, error)
+	OnGetPolicyRepository     func() *policy.Repository
+	OnUpdateProxyRedirect     func(e *e.Endpoint, l4 *policy.L4Filter, proxyWaitGroup *completion.WaitGroup) (uint16, error)
+	OnRemoveProxyRedirect     func(e *e.Endpoint, id string, proxyWaitGroup *completion.WaitGroup) error
+	OnUpdateNetworkPolicy     func(e *e.Endpoint, policy *policy.L4Policy, labelsMap identity.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool, proxyWaitGroup *completion.WaitGroup) error
+	OnRemoveNetworkPolicy     func(e *e.Endpoint)
+	OnQueueEndpointBuild      func(r *e.Request)
+	OnRemoveFromEndpointQueue func(epID uint64)
+	OnDebugEnabled            func() bool
+	OnGetCompilationLock      func() *lock.RWMutex
+	OnSendNotification        func(typ monitor.AgentNotification, text string) error
+	OnNewProxyLogRecord       func(l *accesslog.LogRecord) error
 }
 
 func (ds *DaemonSuite) SetUpTest(c *C) {
@@ -109,8 +107,6 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	identity.InitIdentityAllocator(d)
 
 	ds.OnTracingEnabled = nil
-	ds.OnEnableEndpointPolicyEnforcement = nil
-	ds.OnPolicyEnforcement = nil
 	ds.OnAlwaysAllowLocalhost = nil
 	ds.OnGetCachedLabelList = nil
 	ds.OnGetPolicyRepository = nil
@@ -175,20 +171,6 @@ func (e *DaemonConsulSuite) TearDownTest(c *C) {
 func (ds *DaemonSuite) TestMinimumWorkerThreadsIsSet(c *C) {
 	c.Assert(numWorkerThreads() >= 2, Equals, true)
 	c.Assert(numWorkerThreads() >= runtime.NumCPU(), Equals, true)
-}
-
-func (ds *DaemonSuite) EnableEndpointPolicyEnforcement(e *e.Endpoint) (bool, bool) {
-	if ds.OnEnableEndpointPolicyEnforcement != nil {
-		return ds.OnEnableEndpointPolicyEnforcement(e)
-	}
-	panic("UpdateEndpointPolicyEnforcement should not have been called")
-}
-
-func (ds *DaemonSuite) PolicyEnforcement() string {
-	if ds.OnPolicyEnforcement != nil {
-		return ds.OnPolicyEnforcement()
-	}
-	panic("PolicyEnforcement should not have been called")
 }
 
 func (ds *DaemonSuite) AlwaysAllowLocalhost() bool {

--- a/daemon/endpoint_test.go
+++ b/daemon/endpoint_test.go
@@ -87,17 +87,17 @@ func (ds *DaemonSuite) TestEndpointAddNoLabels(c *C) {
 	// endpoints with the reserved:init label. If no policy rules match
 	// reserved:init, this drops all ingress and egress traffic.
 	policy.SetPolicyEnabled(option.DefaultEnforcement)
-	ingress, egress := ds.d.EnableEndpointPolicyEnforcement(ep)
+	ingress, egress := ep.ComputePolicyEnforcement(ds.d.GetPolicyRepository())
 	c.Assert(ingress, Equals, true)
 	c.Assert(egress, Equals, true)
 
 	// Check that the "always" and "never" modes are not affected.
 	policy.SetPolicyEnabled(option.AlwaysEnforce)
-	ingress, egress = ds.d.EnableEndpointPolicyEnforcement(ep)
+	ingress, egress = ep.ComputePolicyEnforcement(ds.d.GetPolicyRepository())
 	c.Assert(ingress, Equals, true)
 	c.Assert(egress, Equals, true)
 	policy.SetPolicyEnabled(option.NeverEnforce)
-	ingress, egress = ds.d.EnableEndpointPolicyEnforcement(ep)
+	ingress, egress = ep.ComputePolicyEnforcement(ds.d.GetPolicyRepository())
 	c.Assert(ingress, Equals, false)
 	c.Assert(egress, Equals, false)
 

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -108,9 +108,6 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 	ds.OnAlwaysAllowLocalhost = func() bool {
 		return false
 	}
-	ds.OnEnableEndpointPolicyEnforcement = func(e *e.Endpoint) (bool, bool) {
-		return true, true
-	}
 
 	ds.OnGetCompilationLock = func() *lock.RWMutex {
 		return ds.d.compilationMutex
@@ -126,10 +123,6 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 	}
 
 	ds.OnRemoveNetworkPolicy = func(e *e.Endpoint) {}
-
-	ds.OnPolicyEnforcement = func() string {
-		return option.DefaultEnforcement
-	}
 
 	// Since all owner's funcs are implemented we can regenerate every endpoint.
 	epsNames := []string{}

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -25,13 +25,6 @@ import (
 // Owner is the interface defines the requirements for anybody owning policies.
 type Owner interface {
 
-	// EnableEndpointPolicyEnforcement returns whether policy enforcement
-	// should be enabled for the specified endpoint.
-	EnableEndpointPolicyEnforcement(e *Endpoint) (bool, bool)
-
-	// GetPolicyEnforcementType returns the type of policy enforcement for the Owner.
-	PolicyEnforcement() string
-
 	// Must return the policy repository
 	GetPolicyRepository() *policy.Repository
 


### PR DESCRIPTION
WIP - Based on #5410 . 

Move this function out of the endpoint Owner interface and instead have it apply to a given endpoint. No functional changes intended.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5415)
<!-- Reviewable:end -->
