### PR TITLE
remove directory functions from Owner interface

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -198,7 +198,7 @@ func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressin
 	healthArgs := fmt.Sprintf("-d --admin=unix --passive --pidfile %s", pidfile)
 	args := []string{info.ContainerName, info.InterfaceName, vethPeerName,
 		ip6.String(), ip4.String(), "cilium-health", healthArgs}
-	prog := filepath.Join(owner.GetBpfDir(), "spawn_netns.sh")
+	prog := filepath.Join(option.Config.BpfDir, "spawn_netns.sh")
 
 	cmd := exec.CommandContext(context.Background(), prog, args...)
 	if err := logFromCommand(cmd, info.ContainerName); err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -267,10 +267,6 @@ func (d *Daemon) StartEndpointBuilders(nRoutines int) {
 	}
 }
 
-func (d *Daemon) GetBpfDir() string {
-	return option.Config.BpfDir
-}
-
 // GetPolicyRepository returns the policy repository of the daemon
 func (d *Daemon) GetPolicyRepository() *policy.Repository {
 	return d.policy

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -267,11 +267,6 @@ func (d *Daemon) StartEndpointBuilders(nRoutines int) {
 	}
 }
 
-// GetStateDir returns the path to the state directory
-func (d *Daemon) GetStateDir() string {
-	return option.Config.StateDir
-}
-
 func (d *Daemon) GetBpfDir() string {
 	return option.Config.BpfDir
 }

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -62,7 +62,6 @@ type DaemonSuite struct {
 	OnRemoveProxyRedirect             func(e *e.Endpoint, id string, proxyWaitGroup *completion.WaitGroup) error
 	OnUpdateNetworkPolicy             func(e *e.Endpoint, policy *policy.L4Policy, labelsMap identity.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool, proxyWaitGroup *completion.WaitGroup) error
 	OnRemoveNetworkPolicy             func(e *e.Endpoint)
-	OnGetStateDir                     func() string
 	OnGetBpfDir                       func() string
 	OnQueueEndpointBuild              func(r *e.Request)
 	OnRemoveFromEndpointQueue         func(epID uint64)
@@ -122,7 +121,6 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	ds.OnRemoveProxyRedirect = nil
 	ds.OnUpdateNetworkPolicy = nil
 	ds.OnRemoveNetworkPolicy = nil
-	ds.OnGetStateDir = nil
 	ds.OnGetBpfDir = nil
 	ds.OnQueueEndpointBuild = nil
 	ds.OnRemoveFromEndpointQueue = nil
@@ -252,13 +250,6 @@ func (ds *DaemonSuite) RemoveNetworkPolicy(e *e.Endpoint) {
 		ds.OnRemoveNetworkPolicy(e)
 	}
 	panic("RemoveNetworkPolicy should not have been called")
-}
-
-func (ds *DaemonSuite) GetStateDir() string {
-	if ds.OnGetStateDir != nil {
-		return ds.OnGetStateDir()
-	}
-	panic("GetStateDir should not have been called")
 }
 
 func (ds *DaemonSuite) GetBpfDir() string {

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -62,7 +62,6 @@ type DaemonSuite struct {
 	OnRemoveProxyRedirect             func(e *e.Endpoint, id string, proxyWaitGroup *completion.WaitGroup) error
 	OnUpdateNetworkPolicy             func(e *e.Endpoint, policy *policy.L4Policy, labelsMap identity.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool, proxyWaitGroup *completion.WaitGroup) error
 	OnRemoveNetworkPolicy             func(e *e.Endpoint)
-	OnGetBpfDir                       func() string
 	OnQueueEndpointBuild              func(r *e.Request)
 	OnRemoveFromEndpointQueue         func(epID uint64)
 	OnDebugEnabled                    func() bool
@@ -121,7 +120,6 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	ds.OnRemoveProxyRedirect = nil
 	ds.OnUpdateNetworkPolicy = nil
 	ds.OnRemoveNetworkPolicy = nil
-	ds.OnGetBpfDir = nil
 	ds.OnQueueEndpointBuild = nil
 	ds.OnRemoveFromEndpointQueue = nil
 	ds.OnDebugEnabled = nil
@@ -250,13 +248,6 @@ func (ds *DaemonSuite) RemoveNetworkPolicy(e *e.Endpoint) {
 		ds.OnRemoveNetworkPolicy(e)
 	}
 	panic("RemoveNetworkPolicy should not have been called")
-}
-
-func (ds *DaemonSuite) GetBpfDir() string {
-	if ds.OnGetBpfDir != nil {
-		return ds.OnGetBpfDir()
-	}
-	panic("GetBpfDir should not have been called")
 }
 
 func (ds *DaemonSuite) QueueEndpointBuild(r *e.Request) {

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -93,9 +93,6 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 
 	ds.d.compilationMutex = new(lock.RWMutex)
 
-	ds.OnGetStateDir = func() string {
-		return baseDir
-	}
 	ds.OnQueueEndpointBuild = func(r *e.Request) {
 		go func(*e.Request) {
 			r.MyTurn <- true
@@ -186,6 +183,12 @@ func (ds *DaemonSuite) TestReadEPsFromDirNames(c *C) {
 	tmpDir, err := ioutil.TempDir("", "cilium-tests")
 	defer func() {
 		os.RemoveAll(tmpDir)
+	}()
+
+	oldStateDir := option.Config.StateDir
+	option.Config.StateDir = tmpDir
+	defer func() {
+		option.Config.StateDir = oldStateDir
 	}()
 	c.Assert(err, IsNil)
 	epsNames, err := ds.generateEPs(tmpDir, epsWanted, epsMap)

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -642,7 +642,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 	e.Unlock()
 
 	e.getLogger().WithField("bpfHeaderfilesChanged", bpfHeaderfilesChanged).Debug("Preparing to compile BPF")
-	libdir := owner.GetBpfDir()
+	libdir := option.Config.BpfDir
 	rundir := option.Config.StateDir
 	debug := strconv.FormatBool(viper.GetBool(option.BPFCompileDebugName))
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -643,7 +643,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 
 	e.getLogger().WithField("bpfHeaderfilesChanged", bpfHeaderfilesChanged).Debug("Preparing to compile BPF")
 	libdir := owner.GetBpfDir()
-	rundir := owner.GetStateDir()
+	rundir := option.Config.StateDir
 	debug := strconv.FormatBool(viper.GetBool(option.BPFCompileDebugName))
 
 	stats.prepareBuild.End()

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -53,9 +53,6 @@ type Owner interface {
 	// L7 proxies.
 	RemoveNetworkPolicy(e *Endpoint)
 
-	// GetStateDir must return path to the state directory
-	GetStateDir() string
-
 	// Must return path to BPF template files directory
 	GetBpfDir() string
 

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -53,9 +53,6 @@ type Owner interface {
 	// L7 proxies.
 	RemoveNetworkPolicy(e *Endpoint)
 
-	// Must return path to BPF template files directory
-	GetBpfDir() string
-
 	// QueueEndpointBuild puts the given request in the processing queue
 	QueueEndpointBuild(*Request)
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -738,7 +738,7 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 	e.Unlock()
 
 	stats.prepareBuild.Start()
-	origDir := filepath.Join(owner.GetStateDir(), e.StringID())
+	origDir := filepath.Join(option.Config.StateDir, e.StringID())
 
 	// This is the temporary directory to store the generated headers,
 	// the original existing directory is not overwritten until the


### PR DESCRIPTION
These functions are accessible via `pkg/option`, so there is no need to wrap them behind the Owner interface. 

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5418)
<!-- Reviewable:end -->
