### PR TITLE
examples: fix L7 example policies for k8s 1.11 case sensitivity issue

### DIFF
--- a/examples/policies/getting-started/cilium_dkr_demo_l7-policy-230817.json
+++ b/examples/policies/getting-started/cilium_dkr_demo_l7-policy-230817.json
@@ -8,7 +8,7 @@
         "toPorts": [{
             "ports": [{"port": "80", "protocol": "TCP"}],
             "rules": {
-                "HTTP": [{
+                "http": [{
                     "method": "GET",
                     "path": "/public"
                 }]

--- a/examples/policies/getting-started/cilium_dkr_demo_l7-policy-230817.yaml
+++ b/examples/policies/getting-started/cilium_dkr_demo_l7-policy-230817.yaml
@@ -15,6 +15,6 @@ spec:
       - port: '80'
         protocol: TCP
       rules:
-        HTTP:
+        http:
         - method: GET
           path: "/public"

--- a/examples/policies/getting-started/l7-policy.json
+++ b/examples/policies/getting-started/l7-policy.json
@@ -8,7 +8,7 @@
         "toPorts": [{
             "ports": [{"port": "8181", "protocol": "TCP"}],
             "rules": {
-                "HTTP": [{
+                "http": [{
                     "method": "GET",
                     "path": "/public"
                 }]

--- a/examples/policies/getting-started/l7-policy.yaml
+++ b/examples/policies/getting-started/l7-policy.yaml
@@ -15,6 +15,6 @@ spec:
       - port: '8181'
         protocol: TCP
       rules:
-        HTTP:
+        http:
         - method: GET
           path: "/public"

--- a/examples/policies/kubernetes/serviceaccount/serviceaccount-policy.json
+++ b/examples/policies/kubernetes/serviceaccount/serviceaccount-policy.json
@@ -10,7 +10,7 @@
                 {"port": "80", "protocol": "TCP"}
             ],
             "rules": {
-                "HTTP": [
+                "http": [
                     {
                         "method": "GET",
                         "path": "/public$"

--- a/examples/policies/kubernetes/serviceaccount/serviceaccount-policy.yaml
+++ b/examples/policies/kubernetes/serviceaccount/serviceaccount-policy.yaml
@@ -15,6 +15,6 @@ spec:
       - port: '80'
         protocol: TCP
       rules:
-        HTTP:
+        http:
         - method: GET
           path: "/public$"

--- a/examples/policies/l7/http/http.json
+++ b/examples/policies/l7/http/http.json
@@ -7,7 +7,7 @@
                 {"port": "80", "protocol": "TCP"}
             ],
             "rules": {
-                "HTTP": [
+                "http": [
                     {
                         "method": "GET",
                         "path": "/path1$"

--- a/examples/policies/l7/http/http.yaml
+++ b/examples/policies/l7/http/http.yaml
@@ -12,7 +12,7 @@ spec:
       - port: '80'
         protocol: TCP
       rules:
-        HTTP:
+        http:
         - method: GET
           path: "/path1$"
         - method: PUT

--- a/examples/policies/l7/http/l7_multi.json
+++ b/examples/policies/l7/http/l7_multi.json
@@ -10,7 +10,7 @@
         {"port": "80", "protocol": "TCP"}
       ],
       "rules": {
-        "HTTP": [
+        "http": [
           {
             "method": "GET",
             "path": "/public"
@@ -28,7 +28,7 @@
         { "port": "80", "protocol": "TCP"}
       ],
       "rules": {
-        "HTTP": [
+        "http": [
           {
             "method": "POST",
             "host": "^external-service.org$"

--- a/examples/policies/l7/http/simple/l7.json
+++ b/examples/policies/l7/http/simple/l7.json
@@ -10,7 +10,7 @@
         {"port": "80", "protocol": "TCP"}
       ],
       "rules": {
-        "HTTP": [
+        "http": [
           {
             "method": "GET",
             "path": "/public"


### PR DESCRIPTION
**Summary of changes**:

Kubernetes 1.11 started enforcing case sensitivity for certain sections of manifests (https://kubernetes.io/docs/setup/release/notes/#urgent-upgrade-notes). This caused some of the existing CiliumNetworkPolicies HTTP example policies to fail when applied via `kubectl`; while the policy object would be created, it wasn't enforced properly.

This PR fixes those example manifests, which will also be reflected in the docs.

Fixes: #5419

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5422)
<!-- Reviewable:end -->
