### PR TITLE
endpoint: remove policyCalculated field from endpoint

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -489,7 +489,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 		defer e.Unlock()
 
 		// Compute policy for this endpoint.
-		if _, err = e.regeneratePolicy(owner); err != nil {
+		if err = e.regeneratePolicy(owner); err != nil {
 			return 0, compilationExecuted, fmt.Errorf("Unable to regenerate policy: %s", err)
 		}
 
@@ -551,7 +551,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 	// this endpoint.
 	if e.SecurityIdentity != nil {
 		stats.policyCalculation.Start()
-		_, err = e.regeneratePolicy(owner)
+		err = e.regeneratePolicy(owner)
 		if err != nil {
 			e.Unlock()
 			return 0, compilationExecuted, fmt.Errorf("unable to regenerate policy for '%s': %s", e.PolicyMap.String(), err)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -382,10 +382,6 @@ type Endpoint struct {
 	// state is the state the endpoint is in. See SetStateLocked()
 	state string
 
-	// policyCalculated is true as soon as the policy has been calculated
-	// for the first time.
-	policyCalculated bool
-
 	// bpfHeaderfileHash is the hash of the last BPF headerfile that has been
 	// compiled and installed.
 	bpfHeaderfileHash string


### PR DESCRIPTION
This field no longer serves much of a purpose, for the following reason:

* `updateNetworkPolicy` is always called after endpoint policy has been
regenerated.
* we calculate policy only in `regenerateBPF`, so we are guaranteed to recompile
the endpoint program if necessary.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5426)
<!-- Reviewable:end -->
