### PR TITLE
backport-v1.2-18-08-29

### DIFF
--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -121,22 +121,27 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := identity.AllocateIdentity(qaBarLbls)
 	c.Assert(err, Equals, nil)
+	defer qaBarSecLblsCtx.Release()
 
 	prodBarLbls := labels.Labels{lblBar.Key: lblBar, lblProd.Key: lblProd}
 	prodBarSecLblsCtx, _, err := identity.AllocateIdentity(prodBarLbls)
 	c.Assert(err, Equals, nil)
+	defer prodBarSecLblsCtx.Release()
 
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
 	qaFooSecLblsCtx, _, err := identity.AllocateIdentity(qaFooLbls)
 	c.Assert(err, Equals, nil)
+	defer qaFooSecLblsCtx.Release()
 
 	prodFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblProd.Key: lblProd}
 	prodFooSecLblsCtx, _, err := identity.AllocateIdentity(prodFooLbls)
 	c.Assert(err, Equals, nil)
+	defer prodFooSecLblsCtx.Release()
 
 	prodFooJoeLbls := labels.Labels{lblFoo.Key: lblFoo, lblProd.Key: lblProd, lblJoe.Key: lblJoe}
 	prodFooJoeSecLblsCtx, _, err := identity.AllocateIdentity(prodFooJoeLbls)
 	c.Assert(err, Equals, nil)
+	defer prodFooJoeSecLblsCtx.Release()
 
 	e := endpoint.NewEndpointWithState(1, endpoint.StateWaitingForIdentity)
 	e.IfName = "dummy1"
@@ -421,6 +426,7 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := identity.AllocateIdentity(qaBarLbls)
 	c.Assert(err, Equals, nil)
+	defer qaBarSecLblsCtx.Release()
 
 	// Create the endpoint and generate its policy.
 	e := endpoint.NewEndpointWithState(1, endpoint.StateWaitingForIdentity)

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -184,6 +184,10 @@ func StartXDSServer(stateDir string) *XDSServer {
 										"route": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
 											"cluster":          {Kind: &structpb.Value_StringValue{StringValue: "cluster1"}},
 											"max_grpc_timeout": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{}}}},
+											"retry_policy": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
+												"retry_on":    {Kind: &structpb.Value_StringValue{StringValue: "5xx"}},
+												"num_retries": {Kind: &structpb.Value_NumberValue{NumberValue: 3}},
+											}}}},
 										}}}},
 									}}}},
 								}}}},

--- a/pkg/identity/allocator.go
+++ b/pkg/identity/allocator.go
@@ -87,6 +87,7 @@ func InitIdentityAllocator(owner IdentityAllocatorOwner) {
 			allocator.WithMax(maxID), allocator.WithMin(minID),
 			allocator.WithSuffix(owner.GetNodeSuffix()),
 			allocator.WithEvents(events),
+			allocator.WithMasterKeyProtection(),
 			allocator.WithPrefixMask(allocator.ID(option.Config.ClusterID<<option.ClusterIDShift)))
 		if err != nil {
 			log.WithError(err).Fatal("Unable to initialize identity allocator")

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -681,19 +681,30 @@ func (a *Allocator) runGC() error {
 
 		lock, err := a.lockPath(key)
 		if err != nil {
+			log.WithError(err).WithField(fieldKey, key).Warning("allocator garbage collector was unable to lock key")
 			continue
 		}
 
 		// fetch list of all /value/<key> keys
-		uses, err := kvstore.ListPrefix(path.Join(a.valuePrefix, string(v)))
+		valueKeyPrefix := path.Join(a.valuePrefix, string(v))
+		uses, err := kvstore.ListPrefix(valueKeyPrefix)
 		if err != nil {
+			log.WithError(err).WithField(fieldPrefix, valueKeyPrefix).Warning("allocator garbage collector was unable to list keys")
 			lock.Unlock()
 			continue
 		}
 
 		// if ID has no user, delete it
 		if len(uses) == 0 {
-			kvstore.Delete(key)
+			scopedLog := log.WithFields(logrus.Fields{
+				fieldKey: key,
+				fieldID:  path.Base(key),
+			})
+			if err := kvstore.Delete(key); err != nil {
+				scopedLog.WithError(err).Warning("Unable to delete unused allocator master key")
+			} else {
+				scopedLog.Info("Deleted unused allocator master key")
+			}
 		}
 
 		lock.Unlock()
@@ -707,7 +718,7 @@ func (a *Allocator) startGC() {
 		for {
 			if err := a.runGC(); err != nil {
 				log.WithError(err).WithFields(logrus.Fields{fieldPrefix: a.idPrefix}).
-					Debug("Unable to run garbage collector")
+					Warning("Unable to run allocator garbage collector")
 			}
 
 			select {

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -54,6 +54,10 @@ const (
 	// attempted to be expired from the kvstore
 	gcInterval = time.Duration(10) * time.Minute
 
+	// localKeySyncInterval is the interval in which local keys are being
+	// synced to the kvstore in case master keys get lost
+	localKeySyncInterval = 1 * time.Minute
+
 	// NoID is a special ID that represents "no ID available"
 	NoID ID = 0
 )
@@ -203,6 +207,10 @@ type Allocator struct {
 	// initialListDone is a channel that is closed when the initial
 	// synchronization has completed
 	initialListDone waitChan
+
+	// enableMasterKeyProtection if true, causes master keys that are still in
+	// local use to be automatically re-created
+	enableMasterKeyProtection bool
 }
 
 func locklessCapability() bool {
@@ -316,6 +324,12 @@ func WithMax(id ID) AllocatorOption {
 // min..max.
 func WithPrefixMask(mask ID) AllocatorOption {
 	return func(a *Allocator) { a.prefixMask = mask }
+}
+
+// WithMasterKeyProtection will watch for delete events on master keys and
+// re-created them if local usage suggests that the key is still in use
+func WithMasterKeyProtection() AllocatorOption {
+	return func(a *Allocator) { a.enableMasterKeyProtection = true }
 }
 
 // Delete deletes an allocator and stops the garbage collector
@@ -713,6 +727,34 @@ func (a *Allocator) runGC() error {
 	return nil
 }
 
+func (a *Allocator) recreateMasterKey(id ID, value string) {
+	keyPath := path.Join(a.idPrefix, id.String())
+
+	// Use of CreateOnly() ensures that any existing potentially
+	// conflicting key is never overwritten.
+	if err := kvstore.CreateOnly(keyPath, []byte(value), false); err == nil {
+		log.WithField(fieldKey, keyPath).Warning("Re-created missing master key")
+	}
+}
+
+// syncLocalKeys checks the kvstore and verifies that a master key exists for
+// all locally used allocations. This will restore master keys if deleted for
+// some reason.
+func (a *Allocator) syncLocalKeys() error {
+	// Create a local copy of all local allocations to not require to hold
+	// any locks while performing kvstore operations. Local use can
+	// disappear while we perform the sync but that is fine as worst case,
+	// a master key is created for a slave key that no longer exists. The
+	// garbage collector will remove it again.
+	ids := a.localKeys.getIDs()
+
+	for id, value := range ids {
+		a.recreateMasterKey(id, value)
+	}
+
+	return nil
+}
+
 func (a *Allocator) startGC() {
 	go func(a *Allocator) {
 		for {
@@ -729,6 +771,23 @@ func (a *Allocator) startGC() {
 			case <-time.After(gcInterval):
 			}
 
+		}
+	}(a)
+
+	go func(a *Allocator) {
+		for {
+			if err := a.syncLocalKeys(); err != nil {
+				log.WithError(err).WithFields(logrus.Fields{fieldPrefix: a.idPrefix}).
+					Warning("Unable to run local key sync routine")
+			}
+
+			select {
+			case <-a.stopGC:
+				log.WithFields(logrus.Fields{fieldPrefix: a.idPrefix}).
+					Debug("Stopped master key sync routine")
+				return
+			case <-time.After(localKeySyncInterval):
+			}
 		}
 	}(a)
 }

--- a/pkg/kvstore/allocator/cache.go
+++ b/pkg/kvstore/allocator/cache.go
@@ -195,6 +195,13 @@ func (c *cache) start(a *Allocator) waitChan {
 					case kvstore.EventTypeDelete:
 						kvstore.Trace("Removing id from cache", nil, debugFields.Data)
 
+						if a.enableMasterKeyProtection {
+							if value := a.localKeys.lookupID(id); value != "" {
+								a.recreateMasterKey(id, value)
+								break
+							}
+						}
+
 						if k, ok := c.nextCache[id]; ok && k != nil {
 							delete(c.nextKeyCache, k.GetKey())
 						}

--- a/pkg/kvstore/allocator/localkeys.go
+++ b/pkg/kvstore/allocator/localkeys.go
@@ -134,3 +134,14 @@ func (lk *localKeys) release(key string) (lastUse bool, err error) {
 
 	return false, fmt.Errorf("unable to find key in local cache")
 }
+
+func (lk *localKeys) getIDs() map[ID]string {
+	ids := map[ID]string{}
+	lk.RLock()
+	for id, localKey := range lk.ids {
+		ids[id] = localKey.key
+	}
+	lk.RUnlock()
+
+	return ids
+}

--- a/pkg/kvstore/allocator/localkeys_test.go
+++ b/pkg/kvstore/allocator/localkeys_test.go
@@ -44,6 +44,9 @@ func (s *AllocatorSuite) TestLocalKeys(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(v, Equals, val2)
 
+	ids := k.getIDs()
+	c.Assert(len(ids), Equals, 2)
+
 	// allocate with different value must fail
 	_, err = k.allocate(key2, val)
 	c.Assert(err, Not(IsNil))


### PR DESCRIPTION
* PR: 5400 -- Automatically re-create master keys for local allocations (@tgraf) -- https://github.com/cilium/cilium/pull/5400

 * PR: 5403 -- envoy: Set route reply policy to retry on "5xx" (@jrajahalme) -- https://github.com/cilium/cilium/pull/5403

 * PR: 5413 -- policy: Fix policy unit tests in context of new identity garbage coll… (@tgraf) -- https://github.com/cilium/cilium/pull/5413

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5427)
<!-- Reviewable:end -->
