### PR TITLE
k8s: annotate k8s node after IP address allocation

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1229,16 +1229,6 @@ func NewDaemon() (*Daemon, *endpointRestoreState, error) {
 		node.AddAuxPrefix(ipnet)
 	}
 
-	if k8s.IsEnabled() {
-		log.Info("Annotating k8s node with CIDR ranges")
-		err := k8s.AnnotateNode(k8s.Client(), node.GetName(),
-			node.GetIPv4AllocRange(), node.GetIPv6NodeRange(),
-			nil, nil, node.GetInternalIPv4())
-		if err != nil {
-			log.WithError(err).Warning("Cannot annotate k8s node with CIDR range")
-		}
-	}
-
 	// Set up ipam conf after init() because we might be running d.conf.KVStoreIPv4Registration
 	log.Info("Initializing IPAM")
 	ipam.Init()
@@ -1278,6 +1268,17 @@ func NewDaemon() (*Daemon, *endpointRestoreState, error) {
 	if err := node.ValidatePostInit(); err != nil {
 		log.WithError(err).Fatal("postinit failed")
 	}
+
+	if k8s.IsEnabled() {
+		log.Info("Annotating k8s node with CIDR ranges")
+		err := k8s.AnnotateNode(k8s.Client(), node.GetName(),
+			node.GetIPv4AllocRange(), node.GetIPv6NodeRange(),
+			nil, nil, node.GetInternalIPv4())
+		if err != nil {
+			log.WithError(err).Warning("Cannot annotate k8s node with CIDR range")
+		}
+	}
+
 	log.Info("Addressing information:")
 	log.Infof("  Cluster-Name: %s", option.Config.ClusterName)
 	log.Infof("  Cluster-ID: %d", option.Config.ClusterID)


### PR DESCRIPTION
In a k8s environment, the node annotation is fundamental for the
etcd-operator integration. Cilium uses the node annotation to create the
bpf tunnels between the nodes until it falls back to the kvstore.

As AnnotateNode runs inside a go routine, the IP address annotation
would race when executing ipam.Init().

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5428)
<!-- Reviewable:end -->
