### PR TITLE
endpoint: remove forcePolicyCompute field

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -410,11 +410,6 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 
 	reason := ""
 	if changed {
-		// Force policy regeneration as endpoint's configuration was changed.
-		// Other endpoints need not be regenerated as no labels were changed.
-		// Note that we still need to (eventually) regenerate the endpoint for
-		// the changes to take effect.
-		ep.ForcePolicyCompute()
 
 		// Transition to waiting-to-regenerate if ready.
 		if ep.GetStateLocked() == endpoint.StateReady {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -419,11 +419,6 @@ type Endpoint struct {
 	// updated to and that will become effective with the next regenerate
 	nextPolicyRevision uint64
 
-	// forcePolicyCompute full endpoint policy recomputation
-	// Set when endpoint options have been changed. Cleared right before releasing the
-	// endpoint mutex after policy recalculation.
-	forcePolicyCompute bool
-
 	// BuildMutex synchronizes builds of individual endpoints and locks out
 	// deletion during builds
 	//
@@ -1318,11 +1313,6 @@ func (e *Endpoint) applyOptsLocked(opts option.OptionMap) bool {
 		e.UpdateLogger(nil)
 	}
 	return changed
-}
-
-// ForcePolicyCompute marks the endpoint for forced bpf regeneration.
-func (e *Endpoint) ForcePolicyCompute() {
-	e.forcePolicyCompute = true
 }
 
 func (e *Endpoint) SetDefaultOpts(opts *option.IntOptions) {
@@ -2498,10 +2488,6 @@ func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
 	e.SetIdentity(identity)
 
 	readyToRegenerate := e.SetStateLocked(StateWaitingToRegenerate, "Triggering regeneration due to new identity")
-
-	// Unconditionally force policy recomputation after a new identity has been
-	// assigned.
-	e.ForcePolicyCompute()
 
 	e.Unlock()
 


### PR DESCRIPTION
Ideally, only policy revision and whether any global label / identity state should
indicate that we need to regenerate policy for a given endpoint. Maintaining extra
state in the endpoint should be avoided.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #5424 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5433)
<!-- Reviewable:end -->
