### PR TITLE
Metrics: Add Controllers metrics

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -84,6 +84,14 @@ Events external to Cilium
 * ``event_ts``: Last timestamp when we received an event. Further labeled by
   source: ``api``, ``containerd``, ``k8s``.
 
+Controllers
+-----------
+
+* ``controllers_runs_total``: Number of times that a controller process was run
+  labeled by completion status
+* ``controllers_runs_duration_seconds``: Duration in seconds of the controller
+  process labeled by completion status
+
 Cilium as a Kubernetes pod
 ==========================
 The Cilium Prometheus reference configuration configures jobs that automatically

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -330,6 +330,20 @@ var (
 		Name:      "errors_warnings_total",
 		Help:      "Number of total errors in cilium-agent instances",
 	}, []string{"level", "subsystem"})
+
+	// ControllerRuns is the number of times that a controller process runs.
+	ControllerRuns = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "controllers_runs_total",
+		Help:      "Number of times that a controller process was run labeled by completion status",
+	}, []string{LabelStatus})
+
+	// ControllerRunsDuration the duration of the controller process in seconds
+	ControllerRunsDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: Namespace,
+		Name:      "controllers_runs_duration_seconds",
+		Help:      "Duration in seconds of the controller process labeled by completion status",
+	}, []string{LabelStatus})
 )
 
 func init() {
@@ -373,6 +387,9 @@ func init() {
 	MustRegister(ConntrackGCDuration)
 
 	MustRegister(ErrorsWarnings)
+
+	MustRegister(ControllerRuns)
+	MustRegister(ControllerRunsDuration)
 }
 
 // MustRegister adds the collector to the registry, exposing this metric to


### PR DESCRIPTION
Added two new metrics related to controllers:

- controllers_runs_total which provide the number of runs labeled by
success or not.
- controllers_runs_duration_seconds which provide the number of seconds
that a controller took labeled by the status.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5434)
<!-- Reviewable:end -->
