### PR TITLE
endpoint: remove Iteration field

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -354,11 +354,6 @@ type Endpoint struct {
 	// previous policy computation
 	prevIdentityCache *identityPkg.IdentityCache
 
-	// Iteration policy of the Endpoint
-	// TODO: update documentation; description is not clear, and needs to be
-	// more specific.
-	Iteration uint64 `json:"-"`
-
 	// RealizedL4Policy is the L4Policy in effect for the endpoint.
 	RealizedL4Policy *policy.L4Policy `json:"-"`
 
@@ -1024,8 +1019,9 @@ func (e *Endpoint) GetPolicyModel() *models.EndpointPolicyStatus {
 	sortProxyStats(proxyStats)
 
 	mdl := &models.EndpointPolicy{
-		ID:                       int64(e.SecurityIdentity.ID),
-		Build:                    int64(e.Iteration),
+		ID: int64(e.SecurityIdentity.ID),
+		// This field should be removed.
+		Build:                    int64(e.policyRevision),
 		PolicyRevision:           int64(e.policyRevision),
 		AllowedIngressIdentities: realizedIngressIdentities,
 		AllowedEgressIdentities:  realizedEgressIdentities,
@@ -1035,8 +1031,9 @@ func (e *Endpoint) GetPolicyModel() *models.EndpointPolicyStatus {
 	}
 
 	desiredMdl := &models.EndpointPolicy{
-		ID:                       int64(e.SecurityIdentity.ID),
-		Build:                    int64(e.Iteration),
+		ID: int64(e.SecurityIdentity.ID),
+		// This field should be removed.
+		Build:                    int64(e.nextPolicyRevision),
 		PolicyRevision:           int64(e.nextPolicyRevision),
 		AllowedIngressIdentities: desiredIngressIdentities,
 		AllowedEgressIdentities:  desiredEgressIdentities,

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -565,13 +565,11 @@ func (e *Endpoint) regeneratePolicy(owner Owner) (isPolicyComp bool, err error) 
 	// Skip L4 policy recomputation if possible. However, the rest of the
 	// policy computation still needs to be done for each endpoint separately.
 	l4PolicyChanged := false
-	if e.Iteration != revision {
+	if e.policyRevision != revision {
 		l4PolicyChanged, err = e.resolveL4Policy(repo)
 		if err != nil {
 			return false, err
 		}
-		// Result is valid until cache iteration advances
-		e.Iteration = revision
 	} else {
 		e.getLogger().WithField(logfields.Identity, e.SecurityIdentity.ID).Debug("Reusing cached L4 policy")
 	}


### PR DESCRIPTION
This field was leftover from the `Consumable`. It serves the same purpose as
endpoint policy revision; remove it and just use the endpoint policy revision.

Signed-off by: Ian Vernon <ian@cilium.io>

I am replacing the `Build` in `EndpointPolicyModel` with this revision. Ideally we can get rid of this, but I didn't want to mess with the API as part of this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5436)
<!-- Reviewable:end -->
