### PR TITLE
daemon: factor out iptables code into pkg/iptables

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -31,4 +31,5 @@ func populateConfig() {
 	option.Config.BPFCompilationDebug = viper.GetBool(option.BPFCompileDebugName)
 	option.Config.EnvoyLogPath = viper.GetString("envoy-log")
 	option.Config.SockopsEnable = viper.GetBool(option.SockopsEnableName)
+	option.Config.PrependIptablesChains = viper.GetBool(option.PrependIptablesChainsName)
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"fmt"
 	"net"
@@ -42,6 +41,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/counter"
 	bpfIPCache "github.com/cilium/cilium/pkg/datapath/ipcache"
+	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
@@ -82,16 +82,12 @@ import (
 	"github.com/cilium/cilium/pkg/workloads"
 
 	"github.com/go-openapi/runtime/middleware"
-	"github.com/mattn/go-shellwords"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/vishvananda/netlink"
 )
 
 const (
-	// ExecTimeout is the execution timeout to use in init.sh executions
-	ExecTimeout = 300 * time.Second
-
 	// AutoCIDR indicates that a CIDR should be allocated
 	AutoCIDR = "auto"
 )
@@ -386,314 +382,6 @@ func (d *Daemon) setHostAddresses() error {
 	return nil
 }
 
-func runProg(prog string, args []string, quiet bool) error {
-	_, err := exec.WithTimeout(ExecTimeout, prog, args...).CombinedOutput(log, !quiet)
-	return err
-}
-
-const (
-	ciliumOutputChain     = "CILIUM_OUTPUT"
-	ciliumPostNatChain    = "CILIUM_POST"
-	ciliumPostMangleChain = "CILIUM_POST_mangle"
-	ciliumForwardChain    = "CILIUM_FORWARD"
-	feederDescription     = "cilium-feeder:"
-)
-
-type customChain struct {
-	name       string
-	table      string
-	hook       string
-	feederArgs []string
-}
-
-func getFeedRule(name, args string) []string {
-	ruleTail := []string{"-m", "comment", "--comment", feederDescription + " " + name, "-j", name}
-	if args == "" {
-		return ruleTail
-	}
-	argsList, err := shellwords.Parse(args)
-	if err != nil {
-		log.WithError(err).WithField(logfields.Object, args).Fatal("Unable to parse rule into argument slice")
-	}
-	return append(argsList, ruleTail...)
-}
-
-func (c *customChain) add() error {
-	return runProg("iptables", []string{"-t", c.table, "-N", c.name}, false)
-}
-
-func reverseRule(rule string) ([]string, error) {
-	if strings.HasPrefix(rule, "-A") {
-		// From: -A POSTROUTING -m comment [...]
-		// To:   -D POSTROUTING -m comment [...]
-		return shellwords.Parse(strings.Replace(rule, "-A", "-D", 1))
-	}
-
-	if strings.HasPrefix(rule, "-I") {
-		// From: -I POSTROUTING -m comment [...]
-		// To:   -D POSTROUTING -m comment [...]
-		return shellwords.Parse(strings.Replace(rule, "-I", "-D", 1))
-	}
-
-	return []string{}, nil
-}
-
-func removeCiliumRules(table string) {
-	prog := "iptables"
-	args := []string{"-t", table, "-S"}
-
-	out, err := exec.WithTimeout(ExecTimeout, prog, args...).CombinedOutput(log, true)
-	if err != nil {
-		return
-	}
-
-	scanner := bufio.NewScanner(bytes.NewReader(out))
-	for scanner.Scan() {
-		rule := scanner.Text()
-		log.WithField(logfields.Object, logfields.Repr(rule)).Debug("Considering removing iptables rule")
-
-		if strings.Contains(strings.ToLower(rule), "cilium") {
-			reversedRule, err := reverseRule(rule)
-			if err != nil {
-				log.WithError(err).WithField(logfields.Object, rule).Warn("Unable to parse iptables rule into slice. Leaving rule behind.")
-				continue
-			}
-
-			if len(reversedRule) > 0 {
-				deleteRule := append([]string{"-t", table}, reversedRule...)
-				log.WithField(logfields.Object, logfields.Repr(deleteRule)).Debug("Removing iptables rule")
-				err = runProg("iptables", deleteRule, true)
-				if err != nil {
-					log.WithError(err).WithField(logfields.Object, rule).Warn("Unable to delete Cilium iptables rule")
-				}
-			}
-		}
-	}
-}
-
-func (c *customChain) remove() {
-	runProg("iptables", []string{
-		"-t", c.table,
-		"-F", c.name}, true)
-
-	runProg("iptables", []string{
-		"-t", c.table,
-		"-X", c.name}, true)
-}
-
-func (c *customChain) installFeeder() error {
-	installMode := "-A"
-	if viper.GetBool(option.PrependIptablesChainsName) {
-		installMode = "-I"
-	}
-
-	for _, feedArgs := range c.feederArgs {
-		err := runProg("iptables", append([]string{"-t", c.table, installMode, c.hook}, getFeedRule(c.name, feedArgs)...), true)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// ciliumChains is the list of custom iptables chain used by Cilium. Custom
-// chains are used to allow for simple replacements of all rules.
-//
-// WARNING: If you change or remove any of the feeder rules you have to ensure
-// that the old feeder rules is also removed on agent start, otherwise,
-// flushing and removing the custom chains will fail.
-var ciliumChains = []customChain{
-	{
-		name:       ciliumOutputChain,
-		table:      "filter",
-		hook:       "OUTPUT",
-		feederArgs: []string{""},
-	},
-	{
-		name:       ciliumPostNatChain,
-		table:      "nat",
-		hook:       "POSTROUTING",
-		feederArgs: []string{""},
-	},
-	{
-		name:       ciliumPostMangleChain,
-		table:      "mangle",
-		hook:       "POSTROUTING",
-		feederArgs: []string{""},
-	},
-	{
-		name:       ciliumForwardChain,
-		table:      "filter",
-		hook:       "FORWARD",
-		feederArgs: []string{""},
-	},
-}
-
-func (d *Daemon) removeIptablesRules() {
-	tables := []string{"nat", "mangle", "raw", "filter"}
-	for _, t := range tables {
-		removeCiliumRules(t)
-	}
-
-	for _, c := range ciliumChains {
-		c.remove()
-	}
-}
-
-func (d *Daemon) installIptablesRules() error {
-	for _, c := range ciliumChains {
-		if err := c.add(); err != nil {
-			return fmt.Errorf("cannot add custom chain %s: %s", c.name, err)
-		}
-	}
-
-	// Clear the Kubernetes masquerading mark bit to skip source PAT
-	// performed by kube-proxy for all packets destined for Cilium. Cilium
-	// installs a dedicated rule which does the source PAT to the right
-	// source IP.
-	clearMasqBit := fmt.Sprintf("%#08x/%#08x", 0, proxy.MagicMarkK8sMasq)
-	if err := runProg("iptables", []string{
-		"-t", "mangle",
-		"-A", ciliumPostMangleChain,
-		"-o", "cilium_host",
-		"-m", "comment", "--comment", "cilium: clear masq bit for pkts to cilium_host",
-		"-j", "MARK", "--set-xmark", clearMasqBit}, false); err != nil {
-		return err
-	}
-
-	// kube-proxy does not change the default policy of the FORWARD chain
-	// which means that while packets to services are properly DNAT'ed,
-	// they are later dropped in the FORWARD chain. The issue has been
-	// resolved in #52569 and will be fixed in k8s >= 1.8. The following is
-	// a workaround for earlier Kubernetes versions.
-	//
-	// Accept all packets in FORWARD chain that are going to cilium_host.
-	// It is safe to ignore the destination IP here as the pre-requisite
-	// for a packet being routed to cilium_host is that a route exists
-	// which is only installed for known node IP CIDR ranges.
-	if err := runProg("iptables", []string{
-		"-A", ciliumForwardChain,
-		"-o", "cilium_host",
-		"-m", "comment", "--comment", "cilium: any->cluster on cilium_host forward accept",
-		"-j", "ACCEPT"}, false); err != nil {
-		return err
-	}
-
-	// Accept all packets in the FORWARD chain that are coming from the
-	// cilium_host interface with a source IP in the local node allocation
-	// range.
-	if err := runProg("iptables", []string{
-		"-A", ciliumForwardChain,
-		"-s", node.GetIPv4AllocRange().String(),
-		"-m", "comment", "--comment", "cilium: cluster->any forward accept",
-		"-j", "ACCEPT"}, false); err != nil {
-		return err
-	}
-
-	// Mark all packets sourced from processes running on the host with a
-	// special marker so that we can differentiate traffic sourced locally
-	// vs. traffic from the outside world that was masqueraded to appear
-	// like it's from the host.
-	//
-	// Originally we set this mark only for traffic destined to the
-	// cilium_host device, to ensure that any traffic directly reaching
-	// to a Cilium-managed IP could be classified as from the host.
-	//
-	// However, there's another case where a local process attempts to
-	// reach a service IP which is backed by a Cilium-managed pod. The
-	// service implementation is outside of Cilium's control, for example,
-	// handled by kube-proxy. We can tag even this traffic with a magic
-	// mark, then when the service implementation proxies it back into
-	// Cilium the BPF will see this mark and understand that the packet
-	// originated from the host.
-	matchFromProxy := fmt.Sprintf("%#08x/%#08x", proxy.MagicMarkIsProxy, proxy.MagicMarkProxyMask)
-	markAsFromHost := fmt.Sprintf("%#08x/%#08x", proxy.MagicMarkHost, proxy.MagicMarkHostMask)
-	if err := runProg("iptables", []string{
-		"-t", "filter",
-		"-A", ciliumOutputChain,
-		"-m", "mark", "!", "--mark", matchFromProxy, // Don't match proxy traffic
-		"-m", "comment", "--comment", "cilium: host->any mark as from host",
-		"-j", "MARK", "--set-xmark", markAsFromHost}, false); err != nil {
-		return err
-	}
-
-	if masquerade {
-		ingressSnatSrcAddrExclusion := node.GetHostMasqueradeIPv4().String()
-		if option.Config.Tunnel == option.TunnelDisabled {
-			ingressSnatSrcAddrExclusion = node.GetIPv4ClusterRange().String()
-		}
-
-		// Masquerade all traffic from the host into the cilium_host
-		// interface if the source is not the internal IP
-		//
-		// The following conditions must be met:
-		// * Must be targeted for the cilium_host interface
-		// * Must be targeted to an IP that is not local
-		// * Tunnel mode:
-		//   * May not already be originating from the masquerade IP
-		// * Non-tunnel mode:
-		//   * May not orignate from any IP inside of the cluster range
-		if err := runProg("iptables", []string{
-			"-t", "nat",
-			"-A", ciliumPostNatChain,
-			"!", "-s", ingressSnatSrcAddrExclusion,
-			"!", "-d", node.GetIPv4AllocRange().String(),
-			"-o", "cilium_host",
-			"-m", "comment", "--comment", "cilium host->cluster masquerade",
-			"-j", "SNAT", "--to-source", node.GetHostMasqueradeIPv4().String()}, false); err != nil {
-			return err
-		}
-
-		// Masquerade all traffic from a local endpoint that is routed
-		// back to an endpoint on the same node. This happens if a
-		// local endpoint talks to a Kubernetes NodePort or HostPort.
-		if err := runProg("iptables", []string{
-			"-t", "nat",
-			"-A", ciliumPostNatChain,
-			"-s", node.GetIPv4AllocRange().String(),
-			"-o", "cilium_host",
-			"-m", "comment", "--comment", "cilium hostport loopback masquerade",
-			"-j", "SNAT", "--to-source", node.GetHostMasqueradeIPv4().String()}, false); err != nil {
-			return err
-		}
-
-		egressSnatDstAddrExclusion := node.GetIPv4AllocRange().String()
-		if option.Config.Tunnel == option.TunnelDisabled {
-			egressSnatDstAddrExclusion = node.GetIPv4ClusterRange().String()
-		}
-
-		// Masquerade all egress traffic leaving the node
-		//
-		// The following conditions must be met:
-		// * May not leave on a cilium_ interface, this excludes all
-		//   tunnel traffic
-		// * Must originate from an IP in the local allocation range
-		// * Tunnel mode:
-		//   * May not be targeted to an IP in the local allocation
-		//     range
-		// * Non-tunnel mode:
-		//   * May not be targeted to an IP in the cluster range
-		if err := runProg("iptables", []string{
-			"-t", "nat",
-			"-A", "CILIUM_POST",
-			"-s", node.GetIPv4AllocRange().String(),
-			"!", "-d", egressSnatDstAddrExclusion,
-			"!", "-o", "cilium_+",
-			"-m", "comment", "--comment", "cilium masquerade non-cluster",
-			"-j", "MASQUERADE"}, false); err != nil {
-			return err
-		}
-	}
-
-	for _, c := range ciliumChains {
-		if err := c.installFeeder(); err != nil {
-			return fmt.Errorf("cannot install feeder rule %s: %s", c.feederArgs, err)
-		}
-	}
-
-	return nil
-}
-
 // GetCompilationLock returns the mutex responsible for synchronizing compilation
 // of BPF programs.
 func (d *Daemon) GetCompilationLock() *lock.RWMutex {
@@ -778,7 +466,7 @@ func (d *Daemon) compileBase() error {
 	}
 
 	prog := filepath.Join(option.Config.BpfDir, "init.sh")
-	ctx, cancel := context.WithTimeout(context.Background(), ExecTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.ExecTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, prog, args...)
 	cmd.Env = bpf.Environment()
@@ -791,8 +479,8 @@ func (d *Daemon) compileBase() error {
 
 	if !option.Config.IPv4Disabled {
 		// Always remove masquerade rule and then re-add it if required
-		d.removeIptablesRules()
-		if err := d.installIptablesRules(); err != nil {
+		iptables.RemoveRules()
+		if err := iptables.InstallRules(); err != nil {
 			return err
 		}
 	}

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/datapath/maps"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
@@ -454,7 +455,7 @@ func init() {
 	flags.Bool(option.LogSystemLoadConfigName, false, "Enable periodic logging of system load")
 	flags.StringVar(&nat46prefix,
 		"nat46-range", defaults.DefaultNAT46Prefix, "IPv6 prefix to map IPv4 addresses to")
-	flags.BoolVar(&masquerade,
+	flags.BoolVar(&iptables.Masquerade,
 		"masquerade", true, "Masquerade packets from endpoints leaving the host")
 	flags.IntVar(&option.Config.MaxControllerInterval, option.MaxCtrlIntervalName, 0,
 		"Maximum interval (in seconds) between controller runs. Zero is no limit.")

--- a/pkg/datapath/iptables/doc.go
+++ b/pkg/datapath/iptables/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package iptables manages iptables-related configuration for Cilium.
+package iptables

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1,0 +1,348 @@
+// Copyright 2016-2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iptables
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/cilium/cilium/pkg/command/exec"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/proxy"
+
+	"github.com/mattn/go-shellwords"
+)
+
+const (
+	ciliumOutputChain     = "CILIUM_OUTPUT"
+	ciliumPostNatChain    = "CILIUM_POST"
+	ciliumPostMangleChain = "CILIUM_POST_mangle"
+	ciliumForwardChain    = "CILIUM_FORWARD"
+	feederDescription     = "cilium-feeder:"
+)
+
+type customChain struct {
+	name       string
+	table      string
+	hook       string
+	feederArgs []string
+}
+
+var (
+	// Masquerade specifies whether or not to masquerade packets from endpoints
+	// leaving the host.
+	Masquerade bool
+)
+
+func runProg(prog string, args []string, quiet bool) error {
+	_, err := exec.WithTimeout(defaults.ExecTimeout, prog, args...).CombinedOutput(log, !quiet)
+	return err
+}
+
+func getFeedRule(name, args string) []string {
+	ruleTail := []string{"-m", "comment", "--comment", feederDescription + " " + name, "-j", name}
+	if args == "" {
+		return ruleTail
+	}
+	argsList, err := shellwords.Parse(args)
+	if err != nil {
+		log.WithError(err).WithField(logfields.Object, args).Fatal("Unable to parse rule into argument slice")
+	}
+	return append(argsList, ruleTail...)
+}
+
+func (c *customChain) add() error {
+	return runProg("iptables", []string{"-t", c.table, "-N", c.name}, false)
+}
+
+func reverseRule(rule string) ([]string, error) {
+	if strings.HasPrefix(rule, "-A") {
+		// From: -A POSTROUTING -m comment [...]
+		// To:   -D POSTROUTING -m comment [...]
+		return shellwords.Parse(strings.Replace(rule, "-A", "-D", 1))
+	}
+
+	if strings.HasPrefix(rule, "-I") {
+		// From: -I POSTROUTING -m comment [...]
+		// To:   -D POSTROUTING -m comment [...]
+		return shellwords.Parse(strings.Replace(rule, "-I", "-D", 1))
+	}
+
+	return []string{}, nil
+}
+
+func removeCiliumRules(table string) {
+	prog := "iptables"
+	args := []string{"-t", table, "-S"}
+
+	out, err := exec.WithTimeout(defaults.ExecTimeout, prog, args...).CombinedOutput(log, true)
+	if err != nil {
+		return
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for scanner.Scan() {
+		rule := scanner.Text()
+		log.WithField(logfields.Object, logfields.Repr(rule)).Debug("Considering removing iptables rule")
+
+		if strings.Contains(strings.ToLower(rule), "cilium") {
+			reversedRule, err := reverseRule(rule)
+			if err != nil {
+				log.WithError(err).WithField(logfields.Object, rule).Warn("Unable to parse iptables rule into slice. Leaving rule behind.")
+				continue
+			}
+
+			if len(reversedRule) > 0 {
+				deleteRule := append([]string{"-t", table}, reversedRule...)
+				log.WithField(logfields.Object, logfields.Repr(deleteRule)).Debug("Removing iptables rule")
+				err = runProg("iptables", deleteRule, true)
+				if err != nil {
+					log.WithError(err).WithField(logfields.Object, rule).Warn("Unable to delete Cilium iptables rule")
+				}
+			}
+		}
+	}
+}
+
+func (c *customChain) remove() {
+	runProg("iptables", []string{
+		"-t", c.table,
+		"-F", c.name}, true)
+
+	runProg("iptables", []string{
+		"-t", c.table,
+		"-X", c.name}, true)
+}
+
+func (c *customChain) installFeeder() error {
+	installMode := "-A"
+	if option.Config.PrependIptablesChains {
+		installMode = "-I"
+	}
+
+	for _, feedArgs := range c.feederArgs {
+		err := runProg("iptables", append([]string{"-t", c.table, installMode, c.hook}, getFeedRule(c.name, feedArgs)...), true)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ciliumChains is the list of custom iptables chain used by Cilium. Custom
+// chains are used to allow for simple replacements of all rules.
+//
+// WARNING: If you change or remove any of the feeder rules you have to ensure
+// that the old feeder rules is also removed on agent start, otherwise,
+// flushing and removing the custom chains will fail.
+var ciliumChains = []customChain{
+	{
+		name:       ciliumOutputChain,
+		table:      "filter",
+		hook:       "OUTPUT",
+		feederArgs: []string{""},
+	},
+	{
+		name:       ciliumPostNatChain,
+		table:      "nat",
+		hook:       "POSTROUTING",
+		feederArgs: []string{""},
+	},
+	{
+		name:       ciliumPostMangleChain,
+		table:      "mangle",
+		hook:       "POSTROUTING",
+		feederArgs: []string{""},
+	},
+	{
+		name:       ciliumForwardChain,
+		table:      "filter",
+		hook:       "FORWARD",
+		feederArgs: []string{""},
+	},
+}
+
+// RemoveRules removes iptables rules installed by Cilium.
+func RemoveRules() {
+	tables := []string{"nat", "mangle", "raw", "filter"}
+	for _, t := range tables {
+		removeCiliumRules(t)
+	}
+
+	for _, c := range ciliumChains {
+		c.remove()
+	}
+}
+
+// InstallRules installs iptables rules for Cilium in specific use-cases
+// (most specifically, interaction with kube-proxy).
+func InstallRules() error {
+	for _, c := range ciliumChains {
+		if err := c.add(); err != nil {
+			return fmt.Errorf("cannot add custom chain %s: %s", c.name, err)
+		}
+	}
+
+	// Clear the Kubernetes masquerading mark bit to skip source PAT
+	// performed by kube-proxy for all packets destined for Cilium. Cilium
+	// installs a dedicated rule which does the source PAT to the right
+	// source IP.
+	clearMasqBit := fmt.Sprintf("%#08x/%#08x", 0, proxy.MagicMarkK8sMasq)
+	if err := runProg("iptables", []string{
+		"-t", "mangle",
+		"-A", ciliumPostMangleChain,
+		"-o", "cilium_host",
+		"-m", "comment", "--comment", "cilium: clear masq bit for pkts to cilium_host",
+		"-j", "MARK", "--set-xmark", clearMasqBit}, false); err != nil {
+		return err
+	}
+
+	// kube-proxy does not change the default policy of the FORWARD chain
+	// which means that while packets to services are properly DNAT'ed,
+	// they are later dropped in the FORWARD chain. The issue has been
+	// resolved in #52569 and will be fixed in k8s >= 1.8. The following is
+	// a workaround for earlier Kubernetes versions.
+	//
+	// Accept all packets in FORWARD chain that are going to cilium_host.
+	// It is safe to ignore the destination IP here as the pre-requisite
+	// for a packet being routed to cilium_host is that a route exists
+	// which is only installed for known node IP CIDR ranges.
+	if err := runProg("iptables", []string{
+		"-A", ciliumForwardChain,
+		"-o", "cilium_host",
+		"-m", "comment", "--comment", "cilium: any->cluster on cilium_host forward accept",
+		"-j", "ACCEPT"}, false); err != nil {
+		return err
+	}
+
+	// Accept all packets in the FORWARD chain that are coming from the
+	// cilium_host interface with a source IP in the local node allocation
+	// range.
+	if err := runProg("iptables", []string{
+		"-A", ciliumForwardChain,
+		"-s", node.GetIPv4AllocRange().String(),
+		"-m", "comment", "--comment", "cilium: cluster->any forward accept",
+		"-j", "ACCEPT"}, false); err != nil {
+		return err
+	}
+
+	// Mark all packets sourced from processes running on the host with a
+	// special marker so that we can differentiate traffic sourced locally
+	// vs. traffic from the outside world that was masqueraded to appear
+	// like it's from the host.
+	//
+	// Originally we set this mark only for traffic destined to the
+	// cilium_host device, to ensure that any traffic directly reaching
+	// to a Cilium-managed IP could be classified as from the host.
+	//
+	// However, there's another case where a local process attempts to
+	// reach a service IP which is backed by a Cilium-managed pod. The
+	// service implementation is outside of Cilium's control, for example,
+	// handled by kube-proxy. We can tag even this traffic with a magic
+	// mark, then when the service implementation proxies it back into
+	// Cilium the BPF will see this mark and understand that the packet
+	// originated from the host.
+	matchFromProxy := fmt.Sprintf("%#08x/%#08x", proxy.MagicMarkIsProxy, proxy.MagicMarkProxyMask)
+	markAsFromHost := fmt.Sprintf("%#08x/%#08x", proxy.MagicMarkHost, proxy.MagicMarkHostMask)
+	if err := runProg("iptables", []string{
+		"-t", "filter",
+		"-A", ciliumOutputChain,
+		"-m", "mark", "!", "--mark", matchFromProxy, // Don't match proxy traffic
+		"-m", "comment", "--comment", "cilium: host->any mark as from host",
+		"-j", "MARK", "--set-xmark", markAsFromHost}, false); err != nil {
+		return err
+	}
+
+	if Masquerade {
+		ingressSnatSrcAddrExclusion := node.GetHostMasqueradeIPv4().String()
+		if option.Config.Tunnel == option.TunnelDisabled {
+			ingressSnatSrcAddrExclusion = node.GetIPv4ClusterRange().String()
+		}
+
+		// Masquerade all traffic from the host into the cilium_host
+		// interface if the source is not the internal IP
+		//
+		// The following conditions must be met:
+		// * Must be targeted for the cilium_host interface
+		// * Must be targeted to an IP that is not local
+		// * Tunnel mode:
+		//   * May not already be originating from the masquerade IP
+		// * Non-tunnel mode:
+		//   * May not orignate from any IP inside of the cluster range
+		if err := runProg("iptables", []string{
+			"-t", "nat",
+			"-A", ciliumPostNatChain,
+			"!", "-s", ingressSnatSrcAddrExclusion,
+			"!", "-d", node.GetIPv4AllocRange().String(),
+			"-o", "cilium_host",
+			"-m", "comment", "--comment", "cilium host->cluster masquerade",
+			"-j", "SNAT", "--to-source", node.GetHostMasqueradeIPv4().String()}, false); err != nil {
+			return err
+		}
+
+		// Masquerade all traffic from a local endpoint that is routed
+		// back to an endpoint on the same node. This happens if a
+		// local endpoint talks to a Kubernetes NodePort or HostPort.
+		if err := runProg("iptables", []string{
+			"-t", "nat",
+			"-A", ciliumPostNatChain,
+			"-s", node.GetIPv4AllocRange().String(),
+			"-o", "cilium_host",
+			"-m", "comment", "--comment", "cilium hostport loopback masquerade",
+			"-j", "SNAT", "--to-source", node.GetHostMasqueradeIPv4().String()}, false); err != nil {
+			return err
+		}
+
+		egressSnatDstAddrExclusion := node.GetIPv4AllocRange().String()
+		if option.Config.Tunnel == option.TunnelDisabled {
+			egressSnatDstAddrExclusion = node.GetIPv4ClusterRange().String()
+		}
+
+		// Masquerade all egress traffic leaving the node
+		//
+		// The following conditions must be met:
+		// * May not leave on a cilium_ interface, this excludes all
+		//   tunnel traffic
+		// * Must originate from an IP in the local allocation range
+		// * Tunnel mode:
+		//   * May not be targeted to an IP in the local allocation
+		//     range
+		// * Non-tunnel mode:
+		//   * May not be targeted to an IP in the cluster range
+		if err := runProg("iptables", []string{
+			"-t", "nat",
+			"-A", "CILIUM_POST",
+			"-s", node.GetIPv4AllocRange().String(),
+			"!", "-d", egressSnatDstAddrExclusion,
+			"!", "-o", "cilium_+",
+			"-m", "comment", "--comment", "cilium masquerade non-cluster",
+			"-j", "MASQUERADE"}, false); err != nil {
+			return err
+		}
+	}
+
+	for _, c := range ciliumChains {
+		if err := c.installFeeder(); err != nil {
+			return fmt.Errorf("cannot install feeder rule %s: %s", c.feederArgs, err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/datapath/iptables/log.go
+++ b/pkg/datapath/iptables/log.go
@@ -1,0 +1,24 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iptables
+
+import (
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "iptables")
+)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -94,4 +94,7 @@ const (
 	// already been allocated and other nodes in the cluster have a chance
 	// to whitelist the new upcoming identity of the endpoint.
 	IdentityChangeGracePeriod = 25 * time.Second
+
+	// ExecTimeout is a timeout for executing commands.
+	ExecTimeout = 300 * time.Second
 )

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -290,6 +290,10 @@ type daemonConfig struct {
 
 	// EnableSockOps specifies whether to enable sockops (socket lookup).
 	SockopsEnable bool
+
+	// PrependIptablesChains is the name of the option to enable prepending
+	// iptables chains instead of appending
+	PrependIptablesChains bool
 }
 
 var (


### PR DESCRIPTION
Navigating daemon.go is confusing; there is a lot of code in various places that
could be separated out into smaller files that more logically indicate the
function of the code contained inside of them. Move iptables related code to its
own file accordingly.

Signed-off by: Ian Vernon <ian@cilium.io>

No functional changes are intended in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5440)
<!-- Reviewable:end -->
