### PR TITLE
daemon: move map-related code to map.go

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -76,12 +75,10 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	policyApi "github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/proxy/logger"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/sockops"
-	"github.com/cilium/cilium/pkg/u8proto"
 	"github.com/cilium/cilium/pkg/workloads"
 
 	"github.com/go-openapi/runtime/middleware"
@@ -1369,75 +1366,6 @@ func NewDaemon() (*Daemon, *endpointRestoreState, error) {
 	fqdn.StartDNSPoller(d.dnsPoller)
 
 	return &d, restoredEndpoints, nil
-}
-
-func (d *Daemon) collectStaleMapGarbage() {
-	if option.Config.DryMode {
-		return
-	}
-	walker := func(path string, _ os.FileInfo, _ error) error {
-		return d.staleMapWalker(path)
-	}
-
-	if err := filepath.Walk(bpf.MapPrefixPath(), walker); err != nil {
-		log.WithError(err).Warn("Error while scanning for stale maps")
-	}
-}
-
-func (d *Daemon) removeStaleMap(path string) {
-	if err := os.RemoveAll(path); err != nil {
-		log.WithError(err).WithField(logfields.Path, path).Warn("Error while deleting stale map file")
-	} else {
-		log.WithField(logfields.Path, path).Info("Removed stale bpf map")
-	}
-}
-
-func (d *Daemon) removeStaleIDFromPolicyMap(id uint32) {
-	gpm, err := policymap.OpenGlobalMap(bpf.MapPath(endpoint.PolicyGlobalMapName))
-	if err == nil {
-		gpm.Delete(id, policymap.AllPorts, u8proto.All, trafficdirection.Ingress)
-		gpm.Delete(id, policymap.AllPorts, u8proto.All, trafficdirection.Egress)
-		gpm.Close()
-	}
-}
-
-func (d *Daemon) checkStaleMap(path string, filename string, id string) {
-	if tmp, err := strconv.ParseUint(id, 0, 16); err == nil {
-		if ep := endpointmanager.LookupCiliumID(uint16(tmp)); ep == nil {
-			d.removeStaleIDFromPolicyMap(uint32(tmp))
-			d.removeStaleMap(path)
-		}
-	}
-}
-
-func (d *Daemon) checkStaleGlobalMap(path string, filename string) {
-	globalCTinUse := endpointmanager.HasGlobalCT()
-
-	if !globalCTinUse && ctmap.NameIsGlobal(filename) {
-		d.removeStaleMap(path)
-	}
-}
-
-func (d *Daemon) staleMapWalker(path string) error {
-	filename := filepath.Base(path)
-
-	mapPrefix := []string{
-		policymap.MapName,
-		ctmap.MapNamePrefix,
-		endpoint.CallsMapName,
-	}
-
-	d.checkStaleGlobalMap(path, filename)
-
-	for _, m := range mapPrefix {
-		if strings.HasPrefix(filename, m) {
-			if id := strings.TrimPrefix(filename, m); id != filename {
-				d.checkStaleMap(path, filename, id)
-			}
-		}
-	}
-
-	return nil
 }
 
 // TriggerReloadWithoutCompile causes all BPF programs and maps to be reloaded,

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/datapath/maps"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/envoy"
@@ -925,7 +926,7 @@ func runDaemon() {
 		workloads.IgnoreRunningWorkloads()
 	}
 
-	d.collectStaleMapGarbage()
+	maps.CollectStaleMapGarbage()
 
 	// The workload event listener *must* be enabled *after* restored endpoints
 	// are added into the endpoint manager; otherwise, updates to important

--- a/pkg/datapath/maps/doc.go
+++ b/pkg/datapath/maps/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package maps performs various lifecycle operations related to maps in the
+// datapath.
+package maps

--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -1,0 +1,108 @@
+// Copyright 2016-2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maps
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/maps/policymap"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+	"github.com/cilium/cilium/pkg/u8proto"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "datapath-maps")
+)
+
+// CollectStaleMapGarbage cleans up stale content in the BPF maps from the
+// datapath.
+func CollectStaleMapGarbage() {
+	if option.Config.DryMode {
+		return
+	}
+	walker := func(path string, _ os.FileInfo, _ error) error {
+		return staleMapWalker(path)
+	}
+
+	if err := filepath.Walk(bpf.MapPrefixPath(), walker); err != nil {
+		log.WithError(err).Warn("Error while scanning for stale maps")
+	}
+}
+
+func removeStaleMap(path string) {
+	if err := os.RemoveAll(path); err != nil {
+		log.WithError(err).WithField(logfields.Path, path).Warn("Error while deleting stale map file")
+	} else {
+		log.WithField(logfields.Path, path).Info("Removed stale bpf map")
+	}
+}
+
+func removeStaleIDFromPolicyMap(id uint32) {
+	gpm, err := policymap.OpenGlobalMap(bpf.MapPath(endpoint.PolicyGlobalMapName))
+	if err == nil {
+		gpm.Delete(id, policymap.AllPorts, u8proto.All, trafficdirection.Ingress)
+		gpm.Delete(id, policymap.AllPorts, u8proto.All, trafficdirection.Egress)
+		gpm.Close()
+	}
+}
+
+func checkStaleMap(path string, filename string, id string) {
+	if tmp, err := strconv.ParseUint(id, 0, 16); err == nil {
+		if ep := endpointmanager.LookupCiliumID(uint16(tmp)); ep == nil {
+			removeStaleIDFromPolicyMap(uint32(tmp))
+			removeStaleMap(path)
+		}
+	}
+}
+
+func checkStaleGlobalMap(path string, filename string) {
+	globalCTinUse := endpointmanager.HasGlobalCT()
+
+	if !globalCTinUse && ctmap.NameIsGlobal(filename) {
+		removeStaleMap(path)
+	}
+}
+
+func staleMapWalker(path string) error {
+	filename := filepath.Base(path)
+
+	mapPrefix := []string{
+		policymap.MapName,
+		ctmap.MapNamePrefix,
+		endpoint.CallsMapName,
+	}
+
+	checkStaleGlobalMap(path, filename)
+
+	for _, m := range mapPrefix {
+		if strings.HasPrefix(filename, m) {
+			if id := strings.TrimPrefix(filename, m); id != filename {
+				checkStaleMap(path, filename, id)
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Navigating daemon.go is confusing; there is a lot of code in various places that
could be separated out into smaller files that more logically indicate the
function of the code contained inside of them. Move map-related code to its own
file accordingly.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5442)
<!-- Reviewable:end -->
