### PR TITLE
Generic BuildQueue

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -39,6 +39,14 @@ Endpoint
 * ``endpoint_regeneration_time_stats_seconds``: Endpoint regeneration time stats labeled by scope.
 * ``endpoint_state``: Count of all endpoints, tagged by different endpoint states
 
+Build Queue
+-----------
+
+* ``buildqueue_entries``: Number of queued, waiting, and running builds.
+  * ``state=running``: Number of builds currently in progress
+  * ``state=blocked``: Number of builds selected for building, waiting for build conditions to be met.
+  * ``state=waiting``: Number of builds in the queue, waiting to be selected.
+
 Datapath
 --------
 

--- a/pkg/buildqueue/buildqueue.go
+++ b/pkg/buildqueue/buildqueue.go
@@ -1,0 +1,595 @@
+// Copyright 2016-2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildqueue
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/metrics"
+)
+
+const (
+	// minWorkerThreads is the minimum number of worker threads to use
+	// regardless of the number of cores available in the system
+	minWorkerThreads = 2
+
+	// buildQueueSize is the maximum number of builds that can be queued
+	// before Enqueue() starts blocking
+	buildQueueSize = 4096
+)
+
+// buildStatusMap contains the build status of all queued builders
+type buildStatusMap map[string]*buildStatus
+
+// buildGroup is a logical grouping of builds
+type buildGroup struct {
+	// running is the number of builds running of this group
+	running int
+
+	// waiting is the number of builds currently blocked in
+	// waitForBuildCondition(), waiting for their build condition to be
+	// met.
+	waiting int
+
+	// condition is the condition that must be met throughout the build.
+	// The condition function is called with q.mutex held.
+	condition func(q *BuildQueue) bool
+}
+
+// waitForBuildCondition is called by a build which has been dequeued and
+// assigned to a worker and will block until the build condition associated
+// with the builder is being met, e.g. the exclusive build condition will block
+// until all currently running regular builds have completed.
+func (b *buildGroup) waitForBuildCondition(q *BuildQueue) {
+	metric := metrics.BuildQueueEntries.With(map[string]string{
+		metrics.LabelBuildQueueName: q.name,
+		metrics.LabelBuildState:     metrics.BuildStateBlocked,
+	})
+
+	q.mutex.Lock()
+	b.waiting++
+	metric.Inc()
+	for !b.condition(q) {
+		q.waitingBuilders.Wait()
+	}
+
+	metric.Dec()
+	b.waiting--
+	b.running++
+	q.mutex.Unlock()
+}
+
+// finish signals that a build of this buildGroup has completed
+func (b *buildGroup) finish(q *BuildQueue, buildStatus *buildStatus) {
+	q.mutex.Lock()
+	b.running--
+	buildStatus.currentBuild = nil
+	q.mutex.Unlock()
+
+	q.waitingBuilders.Broadcast()
+}
+
+// BuildQueue is a queueing system for builds
+type BuildQueue struct {
+	// name is the name of the build queue
+	name string
+
+	// mutex protects access to the buildStatus map and for the
+	// waitingBuilders sync.Condition in waitForBuildCondition()
+	mutex lock.Mutex
+
+	// buildStatus contains the status of all builders indexed by UUID
+	buildStatus buildStatusMap
+
+	// workerBuildQueue is a buffered channel that contains all scheduled
+	// builds
+	workerBuildQueue chan Builder
+
+	// stopWorker is used to stop worker threads and exclusive builders
+	// when the build queue is shutdown. Workers will run until this
+	// channel is closed.
+	stopWorker chan struct{}
+
+	// regularBuilds accounts for running regular builds
+	regularBuilds buildGroup
+
+	// exclusiveBuilds accounts for running exclusive builds
+	exclusiveBuilds buildGroup
+
+	// waitingBuilders is used to wake up builders waiting for their
+	// condition to be met
+	waitingBuilders *sync.Cond
+}
+
+// NewBuildQueue returns a new build queue
+func NewBuildQueue(name string) *BuildQueue {
+	q := &BuildQueue{
+		name:             name,
+		buildStatus:      buildStatusMap{},
+		workerBuildQueue: make(chan Builder, buildQueueSize),
+		stopWorker:       make(chan struct{}, 0),
+		regularBuilds: buildGroup{
+			condition: func(q *BuildQueue) bool {
+				return q.exclusiveBuilds.waiting == 0 && q.exclusiveBuilds.running == 0
+			},
+		},
+		exclusiveBuilds: buildGroup{
+			condition: func(q *BuildQueue) bool {
+				return q.exclusiveBuilds.running == 0 && q.regularBuilds.running == 0
+			},
+		},
+	}
+
+	q.waitingBuilders = sync.NewCond(&q.mutex)
+
+	nWorkers := numWorkerThreads()
+	for w := 0; w < nWorkers; w++ {
+		go q.runWorker()
+	}
+
+	return q
+}
+
+// Stop stops the build queue and terminates all workers
+func (q *BuildQueue) Stop() {
+	close(q.stopWorker)
+
+	waitForCleanup := sync.WaitGroup{}
+
+	q.mutex.Lock()
+	for _, status := range q.buildStatus {
+		waitForCleanup.Add(1)
+		go func(b Builder) {
+			q.Drain(b)
+			waitForCleanup.Done()
+		}(status.builder)
+	}
+	q.mutex.Unlock()
+
+	waitForCleanup.Wait()
+}
+
+// numWorkerThreads returns the number of worker threads to use. This does not
+// apply to exclusive builds.
+func numWorkerThreads() int {
+	ncpu := runtime.NumCPU()
+
+	if ncpu < minWorkerThreads {
+		return minWorkerThreads
+	}
+	return ncpu
+}
+
+// Buildable is an object that is buildable
+type Buildable interface {
+	// GetUUID must return a unique UUID of the object
+	GetUUID() string
+}
+
+// Builder is an object that can build itself. A builder must also be Buildable
+type Builder interface {
+	Buildable
+
+	// BuildQueued is called every time a builder is enqueued
+	BuildQueued()
+
+	// BuildsDequeued is called when a scheduled builder has been dequeued
+	// for building or has been cancelled. The nbuilds accounts for the
+	// number of builders folded together while the builder was queued.
+	BuildsDequeued(nbuilds int, cancelled bool)
+
+	// Build must build the Buildable. When a builder was cancelled,
+	// Build() will not be called. When a builder is folded into an
+	// existing builder, Build() is only called on the first builder.
+	Build() error
+}
+
+// BuildNotification is a channel to receive the status of a build. The channel
+// will receive true if the build was successful. The channel is buffered and
+// is guaranteed to only be written to exactly once and is then immediately
+// closed. It is up to the caller of Enqueue() to decide whether to read on the
+// channel or not.
+type BuildNotification <-chan bool
+
+func newBuildNotification() chan bool {
+	return make(chan bool, 1)
+}
+
+// build is what is returned by Enqueue() to provide information about the
+// build
+type build struct {
+	builder Builder
+
+	// uuid is the UUID of the Buildable
+	uuid string
+
+	// notificationChannels is a list of a channels that should be notified
+	// about the completion of the build
+	notificationChannels []chan bool
+}
+
+// createAndAddNotificationChannel creates and adds a build notification
+// channel. This function may only be called while the build is not yet in
+// progress.
+func (b *build) createAndAddNotificationChannel() BuildNotification {
+	notify := newBuildNotification()
+	b.notificationChannels = append(b.notificationChannels, notify)
+	return notify
+}
+
+// reportStatus reports the status of a build to all notification channels.
+// This function may only be called if the build is the currentBuild. It may
+// never be called while the build is still assigned to nextBuild.
+func (b *build) reportStatus(q *BuildQueue, success bool) {
+	for _, notify := range b.notificationChannels {
+		notify <- success
+		close(notify)
+	}
+}
+
+// cancel cancels a scheduled and not yet running build. q.mutex must be held.
+func (b *build) cancelScheduled(q *BuildQueue) int {
+	numBuilds := b.numFolded()
+
+	metrics.BuildQueueEntries.With(map[string]string{
+		metrics.LabelBuildQueueName: q.name,
+		metrics.LabelBuildState:     metrics.BuildStateWaiting,
+	}).Sub(float64(numBuilds))
+
+	b.reportStatus(q, false)
+
+	return numBuilds
+}
+
+// numFolded returns the number of enqueued builders that have been folded into
+// this build.
+func (b *build) numFolded() int {
+	// For each builder folded, the BuildNotification returned via
+	// Enqueue() was added to the notoficiationChannels slice of the
+	// primary build so we can use the length of the slice to determine the
+	// number of folded builds.
+	return len(b.notificationChannels)
+}
+
+func newBuild(b Builder, uuid string) *build {
+	return &build{
+		builder:              b,
+		uuid:                 uuid,
+		notificationChannels: []chan bool{},
+	}
+}
+
+// buildStatus is the current status of a build
+type buildStatus struct {
+	builder Builder
+
+	// curentBuild is the building information of any running build
+	currentBuild *build
+
+	// nextBuild is the building information of the next build for this
+	// UUID
+	nextBuild *build
+}
+
+func (q *BuildQueue) enqueueBuild(b Builder) (BuildNotification, bool) {
+	q.mutex.Lock()
+	build, enqueued := q.serializeBuild(b)
+	notify := build.createAndAddNotificationChannel()
+	builder := build.builder
+	q.mutex.Unlock()
+
+	metrics.BuildQueueEntries.With(map[string]string{
+		metrics.LabelBuildQueueName: q.name,
+		metrics.LabelBuildState:     metrics.BuildStateWaiting,
+	}).Inc()
+
+	// Call BuildQueued() on the builder, if the builder was folded, this
+	// will not be the builder that was just enqueued.
+	builder.BuildQueued()
+
+	return notify, enqueued
+}
+
+// serializeBuild verifies whether the UUID of the Builder/Buildable is
+// currently being built or already queued. If already queued but not yet being
+// built, the build is folded into the already queued build by return the
+// already queued build. If the UUID of the builder is currently being built, a
+// new build is created and attached to nextBuild to schedule the build for
+// queueing via needToBuildAgain().
+//
+// Returns true if the UUID was entirely unknown to the build queue. This
+// indicates that the builder must be enqueued either via the workerBuildQueue
+// or by spawning a go routine.
+func (q *BuildQueue) serializeBuild(b Builder) (*build, bool) {
+	uuid := b.GetUUID()
+	build := newBuild(b, uuid)
+
+	if buildStatus, ok := q.buildStatus[uuid]; ok {
+		// If the builder is currently being built, prepare the next
+		// build and store it in the nextBuild field. When the current
+		// build finishes, the next build will automatically be added
+		// to the workerBuildQueue
+		if buildStatus.currentBuild != nil && buildStatus.nextBuild == nil {
+			buildStatus.nextBuild = build
+			return build, false
+		}
+
+		// The builder is already in the queue but not being built, the
+		// build request will be fulfilled when the queued build is
+		// executed. The caller can be notified to skip the build.
+		return buildStatus.nextBuild, false
+	}
+
+	q.buildStatus[uuid] = &buildStatus{
+		builder:   b,
+		nextBuild: build,
+	}
+
+	return build, true
+}
+
+// Enqueue schedules Builder for building. A channel is returned to provide the
+// ability to wait for the build to complete and check for success or failure.
+//
+// A regular build fullfils the following build guarantees:
+// * The same Buildable, i.e. the same UUID, will not be built in parallel on
+//   multiple workers.
+// * The order in which regular builds are enqueued is maintained in the build
+//   order across different Buildables. If the same Buildable is enqueued
+//   multiple times, the buils are automatically folded together until the
+//   build is executed. This means in practise that a specific Buildable can only
+//   be in the build queue once.
+// * In the presence of preemptive, exclusive builds, regular builds get a fair
+//   chance to run but preemptive builds always preempt any queued, not yet
+//   running regular build.
+func (q *BuildQueue) Enqueue(b Builder) BuildNotification {
+	notify, notInQueue := q.enqueueBuild(b)
+	if notInQueue {
+		// This should be non-blocking unless there is contention beyond
+		// queueBuildSize in which case this will block until a slot in the
+		// queue becomes available.
+		q.workerBuildQueue <- b
+	}
+
+	return notify
+}
+
+// Remove removes the builder from the queue.
+func (q *BuildQueue) Remove(b Buildable) {
+	uuid := b.GetUUID()
+	q.mutex.Lock()
+	if status, ok := q.buildStatus[uuid]; ok {
+		// Only remove the builder UUID from the buildStatus if no
+		// build is currently running. If a build is running, the
+		// buildStatus continue to be in place until the build has
+		// completed.
+		if status.currentBuild == nil {
+			delete(q.buildStatus, uuid)
+		}
+
+		if status.nextBuild != nil {
+			num := status.nextBuild.cancelScheduled(q)
+			defer status.builder.BuildsDequeued(num, true)
+		}
+	}
+	q.mutex.Unlock()
+}
+
+// Drain will drain the queue from any running or scheduled builds of a
+// Buildable. If a build is running, the function will block for the build to
+// complete. It is the responsibility of the caller that the Buildable does not
+// get re-scheduled during the draining. Returns true if waiting was required.
+func (q *BuildQueue) Drain(b Buildable) bool {
+	uuid := b.GetUUID()
+	waited := false
+
+	q.mutex.Lock()
+	status, ok := q.buildStatus[uuid]
+	if ok {
+		if status.nextBuild != nil {
+			num := status.nextBuild.cancelScheduled(q)
+			status.nextBuild = nil
+			defer status.builder.BuildsDequeued(num, true)
+		}
+
+		for status.currentBuild != nil {
+			waited = true
+			q.waitingBuilders.Wait()
+		}
+
+		delete(q.buildStatus, uuid)
+	}
+
+	q.mutex.Unlock()
+	return waited
+}
+
+func (q *BuildQueue) build(b Builder) error {
+	metric := metrics.BuildQueueEntries.With(map[string]string{
+		metrics.LabelBuildQueueName: q.name,
+		metrics.LabelBuildState:     metrics.BuildStateRunning,
+	})
+
+	metric.Inc()
+	err := b.Build()
+	metric.Dec()
+
+	return err
+}
+
+func (q *BuildQueue) runExclusiveBuild(b Builder) {
+	uuid := b.GetUUID()
+
+	for {
+		currentBuild, buildStatus := q.nominateBuild(uuid)
+		if currentBuild == nil {
+			return
+		}
+
+		q.exclusiveBuilds.waitForBuildCondition(q)
+		err := q.build(b)
+		q.exclusiveBuilds.finish(q, buildStatus)
+
+		currentBuild.reportStatus(q, err == nil)
+
+		if !q.needToBuildAgain(uuid) {
+			return
+		}
+
+		select {
+		case <-q.stopWorker:
+			return
+		default:
+		}
+	}
+}
+
+// PreemptExclusive enqueues a build at the front of the queue and provides
+// exclusive build access. All other builds enqueued via Enqueue()
+// PreemptExclusive() have to finish before the exclusive build is executed.
+// The exclusive build will then be the only build executed until it finishes.
+//
+// If an exclusive build for the same UUID is already enqueued but not yet
+// running, the build will be folded into the already scheduled build but both
+// notification channels will be notified.
+func (q *BuildQueue) PreemptExclusive(b Builder) BuildNotification {
+	notify, notInQueue := q.enqueueBuild(b)
+	if notInQueue {
+		go q.runExclusiveBuild(b)
+	}
+
+	return notify
+}
+
+// nominateBuild is called when a build has made it to the front of the build
+// queue or the build is a preemptive build. nominateBuild will pull the
+// build information from the buildStatus.nextBuild and nominate the build as
+// buildStatus.currentBuild. nominateBuild() returns the build or nil if the
+// build has since been cancelled.
+func (q *BuildQueue) nominateBuild(uuid string) (*build, *buildStatus) {
+	q.mutex.Lock()
+
+	buildStatus, ok := q.buildStatus[uuid]
+	if !ok || buildStatus.nextBuild == nil {
+		// The builder has been removed since the build was
+		// scheduled. Cancel the build.
+		q.mutex.Unlock()
+		return nil, nil
+	}
+
+	// Safety measure: q.serializeBuild() already ensures that the same
+	// builder can only be queued once in the go channel. Double check here
+	// that the builder is not running in another worker, if so, wait for
+	// it to be done.
+	for buildStatus.currentBuild != nil {
+		q.waitingBuilders.Wait()
+	}
+
+	// Mark the scheduled build as building
+	currentBuild := buildStatus.nextBuild
+	buildStatus.currentBuild = currentBuild
+	buildStatus.nextBuild = nil
+	q.mutex.Unlock()
+
+	num := currentBuild.numFolded()
+	metrics.BuildQueueEntries.With(map[string]string{
+		metrics.LabelBuildQueueName: q.name,
+		metrics.LabelBuildState:     metrics.BuildStateWaiting,
+	}).Sub(float64(num))
+
+	buildStatus.builder.BuildsDequeued(num, false)
+
+	return currentBuild, buildStatus
+}
+
+func (q *BuildQueue) needToBuildAgain(uuid string) bool {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	buildStatus, ok := q.buildStatus[uuid]
+	var nextBuild *build
+	if ok {
+		nextBuild = buildStatus.nextBuild
+
+		// If no next build is scheduled, the builder can be
+		// removed from the build status entirely
+		if nextBuild == nil {
+			delete(q.buildStatus, uuid)
+		}
+	}
+
+	return nextBuild != nil
+}
+
+func (q *BuildQueue) runWorker() {
+	for b := range q.workerBuildQueue {
+		uuid := b.GetUUID()
+
+		currentBuild, buildStatus := q.nominateBuild(uuid)
+		if currentBuild == nil {
+			return
+		}
+
+		q.regularBuilds.waitForBuildCondition(q)
+		err := q.build(b)
+		q.regularBuilds.finish(q, buildStatus)
+
+		currentBuild.reportStatus(q, err == nil)
+
+		// If another build for the same builder is scheduled, queue it
+		if q.needToBuildAgain(uuid) {
+			q.workerBuildQueue <- b
+		}
+
+		select {
+		case <-q.stopWorker:
+			return
+		default:
+		}
+	}
+}
+
+// checkBuildGuarantees reports errors when build conditions are currently not
+// being respected. This function is used for unit testing.
+func (q *BuildQueue) checkBuildGuarantees() error {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	buildCount := map[string]int{}
+
+	for _, status := range q.buildStatus {
+		if build := status.currentBuild; build != nil {
+			buildCount[build.uuid]++
+		}
+	}
+
+	switch {
+	case q.exclusiveBuilds.running > 1:
+		return fmt.Errorf("More than one exclusive build is running")
+	case q.exclusiveBuilds.running > 0 && q.regularBuilds.running > 0:
+		return fmt.Errorf("Exclusive build is running in parallel with regular build")
+	default:
+		for uuid, count := range buildCount {
+			if count > 1 {
+				return fmt.Errorf("UUID %s is being built in parallel", uuid)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/buildqueue/buildqueue_test.go
+++ b/pkg/buildqueue/buildqueue_test.go
@@ -1,0 +1,433 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildqueue
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/testutils"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+// BuildQueueTestSuite tests the build queue
+//
+// The tests are split into two main strategies to provide best coverage:
+//
+// 1) DETERMINISTIC: Tests that are as guided as possible to verify
+//    correctness by putting the build queue through individual stages, e.g.
+//    queue a regular build, queue exclusive, ensure regular does not interrupt
+//    exclusive, ...
+//
+//      TestBuildQueue(c *C)
+//      TestBuildStatus(c *C)
+//      TestDrain(c *C)
+//      TestExclusiveBuild(c *C)
+//
+// 2) BRUTE FORCE: This test enqueues a lot of parallel builds with semi random
+//    build times while constantly checking for build guarantees. This test
+//    will run differently in each run. The goal is to catch build guarantee
+//    failures by means of brute force
+//
+//      TestBuildGuarantees(c *C)
+//
+type BuildQueueTestSuite struct{}
+
+var _ = Suite(&BuildQueueTestSuite{})
+
+type testBuilder struct {
+	mutex         lock.Mutex
+	uuid          string
+	nbuilds       int
+	building      bool
+	finishBuild   chan error
+	queued        int
+	checkParallel *BuildQueue
+	completeAfter time.Duration
+}
+
+func newTestBuilder(uuid string) *testBuilder {
+	test := &testBuilder{
+		uuid:        uuid,
+		finishBuild: make(chan error, 1),
+	}
+
+	return test
+}
+
+func (t *testBuilder) GetUUID() string {
+	return t.uuid
+}
+
+func (t *testBuilder) BuildQueued() {
+	t.mutex.Lock()
+	t.queued++
+	fmt.Printf("%s: queued build, %d now queued\n", t.uuid, t.queued)
+	t.mutex.Unlock()
+}
+
+func (t *testBuilder) BuildsDequeued(nbuilds int, cancelled bool) {
+	t.mutex.Lock()
+	t.queued -= nbuilds
+	fmt.Printf("%s: dequeued %d builds cancelled=%t, %d now queued\n", t.uuid, nbuilds, cancelled, t.queued)
+	t.mutex.Unlock()
+}
+
+func (t *testBuilder) Build() error {
+	var err error
+
+	t.mutex.Lock()
+	fmt.Printf("%s: starting build...\n", t.uuid)
+	t.building = true
+	t.mutex.Unlock()
+
+	if t.checkParallel != nil {
+		err := t.checkParallel.checkBuildGuarantees()
+		if err != nil {
+			msg := fmt.Sprintf("Build guarantee violated: %s", err)
+			panic(msg)
+		}
+	}
+
+	if t.completeAfter != 0 {
+		time.Sleep(t.completeAfter)
+		fmt.Printf("%s: build finished after %s\n", t.uuid, t.completeAfter)
+		err = nil
+	} else {
+		err = <-t.finishBuild
+		fmt.Printf("%s: build finished success=%t\n", t.uuid, err == nil)
+	}
+
+	t.mutex.Lock()
+	t.building = false
+	t.nbuilds++
+	t.mutex.Unlock()
+
+	return err
+}
+
+func (t *testBuilder) getNumQueuedBuilds() int {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	return t.queued
+}
+
+func (t *testBuilder) getNumBuilds() int {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	return t.nbuilds
+}
+
+func (t *testBuilder) isBuilding() bool {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	return t.building
+}
+
+func (t *testBuilder) makeBuildReturn(err error) {
+	t.finishBuild <- err
+}
+
+func (s *BuildQueueTestSuite) TestBuildQueue(c *C) {
+	bq := NewBuildQueue("test")
+	c.Assert(bq, Not(IsNil))
+	defer bq.Stop()
+
+	// create & enqueue builder1
+	builder1 := newTestBuilder("builder1")
+	c.Assert(builder1.getNumBuilds(), Equals, 0)
+	bq.Enqueue(builder1)
+
+	// create & enqueue builder2
+	builder2 := newTestBuilder("builder2")
+	c.Assert(builder2.getNumBuilds(), Equals, 0)
+	bq.Enqueue(builder2)
+
+	// Wait for builder1 to start building
+	c.Assert(testutils.WaitUntil(func() bool {
+		return builder1.isBuilding()
+	}, 2*time.Second), IsNil)
+
+	// Since builder1 started, no build should be queued
+	c.Assert(builder1.getNumQueuedBuilds(), Equals, 0)
+
+	// Wait for builder2 to start building
+	c.Assert(testutils.WaitUntil(func() bool {
+		return builder2.isBuilding()
+	}, 2*time.Second), IsNil)
+
+	// Since builder2 started, no build should be queued
+	c.Assert(builder2.getNumQueuedBuilds(), Equals, 0)
+
+	// Enqueue a 2nd build of builder1
+	bq.Enqueue(builder1)
+	c.Assert(builder1.getNumQueuedBuilds(), Equals, 1)
+
+	// Let the first build of builder1 complete
+	builder1.makeBuildReturn(nil)
+
+	// Wait for first build of builder1 to complete
+	c.Assert(testutils.WaitUntil(func() bool {
+		return builder1.getNumBuilds() == 1
+	}, 2*time.Second), IsNil)
+
+	// Wait for the 2nd build of builder1 to start
+	c.Assert(testutils.WaitUntil(func() bool {
+		return builder1.isBuilding()
+	}, 2*time.Second), IsNil)
+
+	// The 2nd build should have started and thus no build should be queued
+	c.Assert(builder1.getNumQueuedBuilds(), Equals, 0)
+
+	// Check that the 2nd build of builder1 did not complete. Give it 100 millisecond
+	c.Assert(testutils.WaitUntil(func() bool {
+		return builder1.getNumBuilds() == 2
+	}, 100*time.Millisecond), Not(IsNil))
+
+	// Let the build 2 of builder1 complete
+	builder1.makeBuildReturn(nil)
+	c.Assert(builder1.getNumQueuedBuilds(), Equals, 0)
+
+	// Build 2 of builder1 should complete
+	c.Assert(testutils.WaitUntil(func() bool {
+		return builder1.getNumBuilds() == 2
+	}, 2*time.Second), IsNil)
+	c.Assert(builder1.getNumQueuedBuilds(), Equals, 0)
+
+	// Let the first build of builder 2 complete
+	builder2.makeBuildReturn(nil)
+
+	// Out of the two builds of builder 2, only one should have been
+	// performed
+	c.Assert(testutils.WaitUntil(func() bool {
+		return builder2.getNumBuilds() == 1
+	}, 2*time.Second), IsNil)
+}
+
+func (s *BuildQueueTestSuite) TestBuildStatus(c *C) {
+	bq := NewBuildQueue("test")
+	c.Assert(bq, Not(IsNil))
+	defer bq.Stop()
+
+	// create builder1
+	builder1 := newTestBuilder("builder1")
+
+	// enqueue builder1
+	buildStatus := bq.Enqueue(builder1)
+
+	// Let the build fail with a failure
+	builder1.makeBuildReturn(fmt.Errorf("build error"))
+
+	buildSuccessful := <-buildStatus
+	c.Assert(buildSuccessful, Equals, false)
+	c.Assert(builder1.getNumBuilds(), Equals, 1)
+
+	// enqueue builder1
+	buildStatus = bq.Enqueue(builder1)
+
+	// Let the build succeed
+	builder1.makeBuildReturn(nil)
+
+	buildSuccessful = <-buildStatus
+	c.Assert(builder1.getNumBuilds(), Equals, 2)
+	c.Assert(buildSuccessful, Equals, true)
+}
+
+func (s *BuildQueueTestSuite) TestDrain(c *C) {
+	bq := NewBuildQueue("test")
+	c.Assert(bq, Not(IsNil))
+	defer bq.Stop()
+
+	builder1 := newTestBuilder("builder1")
+	bq.Enqueue(builder1)
+
+	// Wait for builder1 to start building
+	c.Assert(testutils.WaitUntil(func() bool {
+		return builder1.isBuilding()
+	}, 2*time.Second), IsNil)
+
+	bq.Enqueue(builder1)
+	bq.Enqueue(builder1)
+	bq.Enqueue(builder1)
+	bq.Enqueue(builder1)
+
+	// Drain in the background and wait
+	drainDone := make(chan bool, 1)
+	go func() {
+		drainDone <- bq.Drain(builder1)
+		close(drainDone)
+	}()
+
+	// Drain in the background and wait
+	drainDone2 := make(chan bool, 1)
+	go func() {
+		drainDone2 <- bq.Drain(builder1)
+		close(drainDone2)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	builder1.makeBuildReturn(nil)
+
+	select {
+	case hasWaited := <-drainDone:
+		c.Assert(hasWaited, Equals, true)
+		// 2nd drain must have waited as well
+		c.Assert(<-drainDone2, Equals, true)
+	case <-time.After(2 * time.Second):
+		c.Fatalf("timeout while waiting for build to drain")
+	}
+
+	c.Assert(builder1.getNumQueuedBuilds(), Equals, 0)
+}
+
+func (s *BuildQueueTestSuite) TestExclusiveBuild(c *C) {
+	bq := NewBuildQueue("test")
+	c.Assert(bq, Not(IsNil))
+	defer bq.Stop()
+
+	// Enqueue builder1
+	builder1 := newTestBuilder("builder1")
+	bq.Enqueue(builder1)
+
+	// Wait for builder1 to start building
+	c.Assert(testutils.WaitUntil(func() bool {
+		return builder1.isBuilding()
+	}, 2*time.Second), IsNil)
+
+	// Enqueue a follow-up build of builder1. The build will not start yet
+	// as the first build of builder1 is still ongoing. It will be queued.
+	bq.Enqueue(builder1)
+	c.Assert(builder1.getNumQueuedBuilds(), Equals, 1)
+
+	// Enqueue builder2
+	builder2 := newTestBuilder("builder2")
+	bq.Enqueue(builder2)
+
+	// Wait for builder2 to start building. The build will start
+	// immediately as we have at least 2 workers and builder2 is using a
+	// different UUID as builder1.
+	c.Assert(testutils.WaitUntil(func() bool {
+		return builder2.isBuilding()
+	}, 2*time.Second), IsNil)
+
+	// Enqueue a follow-up build of builder2. The build will be queued as
+	// the builder2 build is still ongoing.
+	bq.Enqueue(builder2)
+	c.Assert(builder2.getNumQueuedBuilds(), Equals, 1)
+
+	// Create exclusive builder
+	exclusive := newTestBuilder("exclusive")
+
+	// Enqueue a preempt build. The build will be queued as regular builds
+	// are still ongoing and exclusive builds require exclusive access to
+	// the buildqueue.
+	bq.PreemptExclusive(exclusive)
+	c.Assert(exclusive.getNumQueuedBuilds(), Equals, 1)
+
+	// Make sure exclusive build does not start. We assume that the build
+	// would start within 100 milliseconds.
+	c.Assert(testutils.WaitUntil(func() bool {
+		return exclusive.isBuilding()
+	}, 100*time.Millisecond), Not(IsNil))
+
+	// Let the initial builds of builder1 and builder2 succeed.
+	builder1.makeBuildReturn(nil)
+	builder2.makeBuildReturn(nil)
+
+	// The exclusive build will have preempted the build queue and will be
+	// built next.
+	c.Assert(testutils.WaitUntil(func() bool {
+		return exclusive.isBuilding()
+	}, 2*time.Second), IsNil)
+	c.Assert(exclusive.getNumQueuedBuilds(), Equals, 0)
+
+	// Make sure builder1 and builder2 did not start in parallel to the
+	// exclusive build.
+	c.Assert(testutils.WaitUntil(func() bool {
+		return builder1.isBuilding() || builder2.isBuilding()
+	}, 100*time.Millisecond), Not(IsNil))
+
+	// Let the first exclusive build finish.
+	exclusive.makeBuildReturn(nil)
+
+	// Wait for builder1 and builder2 to start
+	c.Assert(testutils.WaitUntil(func() bool {
+		return builder1.isBuilding() && builder2.isBuilding()
+	}, 2*time.Second), IsNil)
+
+	builder1.makeBuildReturn(nil)
+	builder2.makeBuildReturn(nil)
+
+	// exclusive build must have completed and no builds must be scheduled
+	c.Assert(exclusive.getNumQueuedBuilds(), Equals, 0)
+}
+
+func (s *BuildQueueTestSuite) TestBuildGuarantees(c *C) {
+	bq := NewBuildQueue("test")
+	c.Assert(bq, Not(IsNil))
+	defer bq.Stop()
+
+	allBuilds := sync.WaitGroup{}
+
+	builders := map[int]*testBuilder{}
+
+	for i := 0; i < 256; i++ {
+		builder := newTestBuilder(fmt.Sprintf("builder%d", i))
+		builder.checkParallel = bq
+		builder.completeAfter = time.Millisecond * time.Duration(10+i%32)
+		builders[i] = builder
+
+		if i%4 == 0 {
+			go func(builder *testBuilder) {
+				allBuilds.Add(1)
+				c := bq.PreemptExclusive(builder)
+				go func() {
+					<-c
+					allBuilds.Done()
+				}()
+			}(builder)
+		} else {
+			go func(builder *testBuilder) {
+				for n := 0; n < 8; n++ {
+					allBuilds.Add(1)
+					c := bq.Enqueue(builder)
+					time.Sleep(5 * time.Millisecond)
+					go func() {
+						<-c
+						allBuilds.Done()
+					}()
+				}
+			}(builder)
+		}
+	}
+
+	allBuilds.Wait()
+
+	for _, builder := range builders {
+		c.Assert(builder.queued, Equals, 0)
+	}
+}

--- a/pkg/buildqueue/doc.go
+++ b/pkg/buildqueue/doc.go
@@ -1,0 +1,28 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package buildqueue provides a basic build queue for objects identified by
+// UUID. An object is buildable if it implements GetUUID(). An object can build
+// itself if it implements the Builder interface.
+//
+// Objects with identical UUID will never be built in parallel. The build queue
+// will maintain a set of worker threads which will build objects in parallel.
+//
+// When an object is already queued to be built not being being built yet, any
+// further build request will be ignored.
+//
+// When an object is being actively built and a new build request is enqueued,
+// the build request will deferred. It will be scheduled into the build queue
+// when the currently ongoing build of that same object has completed.
+package buildqueue

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -33,6 +33,21 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	// BuildStateWaiting is the value of LabelBuildState to describe
+	// the number of entries waiting in the build queue
+	BuildStateWaiting = "waiting"
+
+	// BuildStateBlocked is the value of LabelBuildState to describe
+	// the number of entries scheduled for building but blocked due to
+	// build conditions
+	BuildStateBlocked = "blocked"
+
+	// BuildStateRunning is the value of LabelBuildState to describe
+	// the number of builds currently running
+	BuildStateRunning = "running"
+)
+
 var (
 	registry = prometheus.NewPedanticRegistry()
 
@@ -85,6 +100,12 @@ var (
 
 	// LabelProtocolL7 is the label used when working with layer 7 protocols.
 	LabelProtocolL7 = "protocol_l7"
+
+	// LabelBuildState is the state a build queue entry is in
+	LabelBuildState = "state"
+
+	// LabelBuildQueueName is the name of the build queue
+	LabelBuildQueueName = "name"
 
 	// Endpoint
 
@@ -344,6 +365,14 @@ var (
 		Name:      "controllers_runs_duration_seconds",
 		Help:      "Duration in seconds of the controller process labeled by completion status",
 	}, []string{LabelStatus})
+
+	// BuildQueueEntries is the number of queued, waiting and running
+	// builds in the build queue
+	BuildQueueEntries = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      "buildqueue_entries",
+		Help:      "The number of queued, waiting and running builds in the build queue",
+	}, []string{LabelBuildState, LabelBuildQueueName})
 )
 
 func init() {
@@ -390,6 +419,8 @@ func init() {
 
 	MustRegister(ControllerRuns)
 	MustRegister(ControllerRunsDuration)
+
+	MustRegister(BuildQueueEntries)
 }
 
 // MustRegister adds the collector to the registry, exposing this metric to


### PR DESCRIPTION
This introduces a basic build queue for objects identified by UUID. An object
is buildabe if it implements GetUUID(). An object can build itself if it
implements a Build() method.

Objects with identical UUID will never be built in parallel. The build queue
will maintain a set of worker threads which will build objects in parallel.

When an object is already queued to be built not being being built yet, any
further build request will be ignored.

When an object is being actively built and a new build request is enqueued, the
build request will deferred. It wil be scheduled into the build queue when the
currently ongoing build of that same object has completed.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5446)
<!-- Reviewable:end -->
