### PR TITLE
pkg/logging: move pkg/debugdetection to pkg/logging

### DIFF
--- a/pkg/logging/debugdetection.go
+++ b/pkg/logging/debugdetection.go
@@ -12,19 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package debugdetection
+package logging
 
 import (
 	"io/ioutil"
 	"os"
 
-	"github.com/cilium/cilium/pkg/logging"
-
 	"github.com/sirupsen/logrus"
 	flag "github.com/spf13/pflag"
 )
-
-var log = logging.DefaultLogger
 
 func init() {
 	flags := flag.NewFlagSet("init-debug", flag.ContinueOnError)
@@ -35,6 +31,6 @@ func init() {
 	flags.Parse(os.Args)
 
 	if *debug {
-		log.SetLevel(logrus.DebugLevel)
+		DefaultLogger.SetLevel(logrus.DebugLevel)
 	}
 }

--- a/pkg/logging/logfields/helpers.go
+++ b/pkg/logging/logfields/helpers.go
@@ -16,9 +16,6 @@ package logfields
 
 import (
 	"fmt"
-
-	// Initialize logrus package with debug log level if needed
-	_ "github.com/cilium/cilium/pkg/debugdetection"
 )
 
 // Repr formats an object with the Printf %+v formatter


### PR DESCRIPTION
Since the debug detection is only used for the log package it doesn't
make sense to have them split in different packages.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5447)
<!-- Reviewable:end -->
