### PR TITLE
k8s: stop watching for kubernetes management endpoints

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -471,7 +471,9 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 
 	_, endpointController := cache.NewInformer(
 		cache.NewListWatchFromClient(k8s.Client().CoreV1().RESTClient(),
-			"endpoints", v1.NamespaceAll, fields.Everything()),
+			"endpoints", v1.NamespaceAll,
+			// Don't get any events from kubernetes endpoints.
+			fields.ParseSelectorOrDie("metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager")),
 		&v1.Endpoints{},
 		reSyncPeriod,
 		cache.ResourceEventHandlerFuncs{


### PR DESCRIPTION
While working in k8s watcher code it was noticed Cilium was receiving a
"Endpoint" event update every second.

It was confirmed by running:
```
$ kubectl get endpoints --all-namespaces  -w
...
kube-system   kube-scheduler   <none>    5h
kube-system   kube-controller-manager   <none>    5h
kube-system   kube-scheduler   <none>    5h
kube-system   kube-controller-manager   <none>    5h
...
```

After taking a closer look, Cilium does not perform any operation with
those endpoints (kube-scheduler and kube-controller-manager) so we can
stop receiving any endpoint events from kube-apiserver by filtering
the endpoints by field selector.

As those endpoints don't contain any labels, it's not possible to filter
by not having their labels.

Unfortunately the field selector does not seem to offer better logic, for
example 'metadata.name!=foo,metadata.name!=bar,metadata.namespace=kube-system'
does not select all other endpoints running in the "default" namespace.
It is also unfortunate but the field selector for endpoints only allow
to select by "metadata.name" and "metadata.namespace".

Signed-off-by: André Martins <andre@cilium.io>

```release-note
k8s: stop watching for kubernetes management endpoints events: kube-scheduler and kube-controller-manager
```

**NOTE**: TBH I don't like this idea. If the user has any endpoint in any namespace with those names they will not be caught by the watcher.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5448)
<!-- Reviewable:end -->
