### PR TITLE
Framework to stop unnecessary syncing of k8s object updates

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -50,6 +50,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/service"
 	"github.com/cilium/cilium/pkg/versioncheck"
+	"github.com/cilium/cilium/pkg/versioned"
 
 	go_version "github.com/hashicorp/go-version"
 	"github.com/sirupsen/logrus"
@@ -382,7 +383,6 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 		policyController := k8sUtils.ControllerFactory(
 			k8s.Client().NetworkingV1().RESTClient(),
 			&networkingv1.NetworkPolicy{},
-			reSyncPeriod,
 			k8sUtils.ResourceEventHandlerFactory(
 				func(i interface{}) func() error {
 					return func() error {
@@ -402,7 +402,12 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 						return nil
 					}
 				},
+				func(m versioned.Map) versioned.Map {
+					return m
+				},
 				&networkingv1.NetworkPolicy{},
+				k8s.Client(),
+				reSyncPeriod,
 				metrics.EventTSK8s,
 			),
 			fields.Everything(),
@@ -416,7 +421,6 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 	svcController := k8sUtils.ControllerFactory(
 		k8s.Client().CoreV1().RESTClient(),
 		&v1.Service{},
-		reSyncPeriod,
 		k8sUtils.ResourceEventHandlerFactory(
 			func(i interface{}) func() error {
 				return func() error {
@@ -436,7 +440,12 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 					return nil
 				}
 			},
+			func(m versioned.Map) versioned.Map {
+				return m
+			},
 			&v1.Service{},
+			k8s.Client(),
+			reSyncPeriod,
 			metrics.EventTSK8s,
 		),
 		fields.Everything(),
@@ -448,7 +457,6 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 	endpointController := k8sUtils.ControllerFactory(
 		k8s.Client().CoreV1().RESTClient(),
 		&v1.Endpoints{},
-		reSyncPeriod,
 		k8sUtils.ResourceEventHandlerFactory(
 			func(i interface{}) func() error {
 				return func() error {
@@ -468,7 +476,12 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 					return nil
 				}
 			},
+			func(m versioned.Map) versioned.Map {
+				return m
+			},
 			&v1.Endpoints{},
+			k8s.Client(),
+			reSyncPeriod,
 			metrics.EventTSK8s,
 		),
 		// Don't get any events from kubernetes endpoints.
@@ -482,7 +495,6 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 		ingressController := k8sUtils.ControllerFactory(
 			k8s.Client().ExtensionsV1beta1().RESTClient(),
 			&v1beta1.Ingress{},
-			reSyncPeriod,
 			k8sUtils.ResourceEventHandlerFactory(
 				func(i interface{}) func() error {
 					return func() error {
@@ -502,7 +514,12 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 						return nil
 					}
 				},
+				func(m versioned.Map) versioned.Map {
+					return m
+				},
 				&v1beta1.Ingress{},
+				k8s.Client(),
+				reSyncPeriod,
 				metrics.EventTSK8s,
 			),
 			fields.Everything(),
@@ -542,7 +559,12 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 					return nil
 				}
 			},
+			func(m versioned.Map) versioned.Map {
+				return m
+			},
 			&cilium_v2.CiliumNetworkPolicy{},
+			ciliumNPClient,
+			reSyncPeriod,
 			metrics.EventTSK8s,
 		)
 		blockWaitGroupToSyncResources(&d.k8sResourceSyncWaitGroup, ciliumV2Controller, "CiliumNetworkPolicy")
@@ -555,7 +577,6 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 	podsController := k8sUtils.ControllerFactory(
 		k8s.Client().CoreV1().RESTClient(),
 		&v1.Pod{},
-		reSyncPeriod,
 		k8sUtils.ResourceEventHandlerFactory(
 			func(i interface{}) func() error {
 				return func() error {
@@ -575,7 +596,12 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 					return nil
 				}
 			},
+			func(m versioned.Map) versioned.Map {
+				return m
+			},
 			&v1.Pod{},
+			k8s.Client(),
+			reSyncPeriod,
 			metrics.EventTSK8s,
 		),
 		fields.Everything(),
@@ -587,7 +613,6 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 	nodesController := k8sUtils.ControllerFactory(
 		k8s.Client().CoreV1().RESTClient(),
 		&v1.Node{},
-		reSyncPeriod,
 		k8sUtils.ResourceEventHandlerFactory(
 			func(i interface{}) func() error {
 				return func() error {
@@ -607,7 +632,12 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 					return nil
 				}
 			},
+			func(m versioned.Map) versioned.Map {
+				return m
+			},
 			&v1.Node{},
+			k8s.Client(),
+			reSyncPeriod,
 			metrics.EventTSK8s,
 		),
 		fields.Everything(),
@@ -619,7 +649,6 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 	namespaceController := k8sUtils.ControllerFactory(
 		k8s.Client().CoreV1().RESTClient(),
 		&v1.Namespace{},
-		reSyncPeriod,
 		k8sUtils.ResourceEventHandlerFactory(
 			// AddFunc does not matter since the endpoint will fetch
 			// namespace labels when the endpoint is created
@@ -633,7 +662,12 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 					return nil
 				}
 			},
+			func(m versioned.Map) versioned.Map {
+				return m
+			},
 			&v1.Namespace{},
+			k8s.Client(),
+			reSyncPeriod,
 			metrics.EventTSK8s,
 		),
 		fields.Everything(),

--- a/pkg/k8s/utils/factory_test.go
+++ b/pkg/k8s/utils/factory_test.go
@@ -1,0 +1,671 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"log"
+	"reflect"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/serializer"
+	"github.com/cilium/cilium/pkg/versioned"
+
+	. "gopkg.in/check.v1"
+	"k8s.io/api/networking/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	k8sTesting "k8s.io/client-go/testing"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type FactorySuite struct{}
+
+var _ = Suite(&FactorySuite{})
+
+func init() {
+	RegisterObject(
+		&v1.NetworkPolicy{},
+		"networkpolicies",
+		copyObjToTestObject,
+		listTestObject,
+		equalTestObject,
+	)
+}
+
+func listTestObject(client interface{}) func() (versioned.Map, error) {
+	k8sClient, ok := client.(kubernetes.Interface)
+	if !ok {
+		log.Panicf("Invalid resource type %s: expecting 'kubernetes.Interface'", reflect.TypeOf(client))
+	}
+	return func() (versioned.Map, error) {
+		m := versioned.NewMap()
+		list, err := k8sClient.NetworkingV1().NetworkPolicies("").List(meta_v1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		for i := range list.Items {
+			m.Add(GetVerStructFrom(&list.Items[i]))
+		}
+		return m, nil
+	}
+}
+
+func copyObjToTestObject(obj interface{}) meta_v1.Object {
+	k8sNP, ok := obj.(*v1.NetworkPolicy)
+	if !ok {
+		return nil
+	}
+	return k8sNP.DeepCopy()
+}
+
+func equalTestObject(o1, o2 interface{}) bool {
+	np1, ok := o1.(*v1.NetworkPolicy)
+	if !ok {
+		log.Panicf("Invalid resource type %q, expecting *v1.NetworkPolicy", reflect.TypeOf(o1))
+		return false
+	}
+	np2, ok := o2.(*v1.NetworkPolicy)
+	if !ok {
+		log.Panicf("Invalid resource type %q, expecting *v1.NetworkPolicy", reflect.TypeOf(o2))
+		return false
+	}
+	// As Cilium uses all of the Spec from a NP it's not probably not worth
+	// it to create a dedicated deep equal	 function to compare both network
+	// policies.
+	return np1.Name == np2.Name &&
+		np1.Namespace == np2.Namespace &&
+		reflect.DeepEqual(np1.Spec, np2.Spec)
+}
+
+func (s *FactorySuite) Test_replaceFuncFactory(c *C) {
+	type args struct {
+		listerClient interface{}
+		resourceObj  runtime.Object
+		addFunc      func(i interface{}) func() error
+		delFunc      func(i interface{}) func() error
+		missingFunc  func(comparableMap versioned.Map) versioned.Map
+		fqueue       *serializer.FunctionQueue
+		addFuncCalls *int
+		delFuncCalls *int
+	}
+	type want struct {
+		oldMap       *versioned.ComparableMap
+		newMap       *versioned.ComparableMap
+		addFuncCalls int
+		delFuncCalls int
+	}
+	tests := []struct {
+		name      string
+		setupArgs func() args
+		setupWant func() want
+	}{
+		{
+			name: "missing NetworkPolicy from the repository. When doing a re-sync Cilium should get an AddEvent",
+			setupArgs: func() args {
+				addFuncCalls := 0
+				delFuncCalls := 0
+
+				k8sClient := &fake.Clientset{}
+				k8sClient.AddReactor("list", "networkpolicies",
+					func(action k8sTesting.Action) (bool, runtime.Object, error) {
+						la := action.(k8sTesting.ListAction)
+						c.Assert(la.GetNamespace(), Equals, "")
+						list := &v1.NetworkPolicyList{}
+						list.Items = append(list.Items, v1.NetworkPolicy{
+							ObjectMeta: meta_v1.ObjectMeta{
+								Name:            "foo",
+								Namespace:       "bar",
+								UID:             "1234",
+								ResourceVersion: "12",
+							},
+						})
+						return true, list, nil
+					})
+				addFunc := func(i interface{}) func() error {
+					obj, ok := i.(*v1.NetworkPolicy)
+					c.Assert(ok, Equals, true)
+					wanted := &v1.NetworkPolicy{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Name:            "foo",
+							Namespace:       "bar",
+							UID:             "1234",
+							ResourceVersion: "12",
+						},
+					}
+					c.Assert(obj, DeepEquals, wanted, Commentf("NetworkPolicy added should be exactly the same from kube-apiserver"))
+					addFuncCalls++
+					return func() error {
+						return nil
+					}
+				}
+				delFunc := func(i interface{}) func() error {
+					delFuncCalls++
+					return func() error {
+						return nil
+					}
+				}
+				fqueue := serializer.NewFunctionQueue(1024)
+
+				missingFunc := func(m versioned.Map) versioned.Map {
+					// returns the same received map because it's missing from
+					// the local repository
+					return m
+				}
+
+				return args{
+					listerClient: k8sClient,
+					resourceObj:  &v1.NetworkPolicy{},
+					addFunc:      addFunc,
+					delFunc:      delFunc,
+					missingFunc:  missingFunc,
+					fqueue:       fqueue,
+					addFuncCalls: &addFuncCalls,
+					delFuncCalls: &delFuncCalls,
+				}
+			},
+			setupWant: func() want {
+				newMap := versioned.NewComparableMap(nil)
+				// NewMap should contain the missing NetworkPolicy
+				newMap.Add(versioned.UUID("bar/foo/1234"), versioned.Object{
+					Data: &v1.NetworkPolicy{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Name:            "foo",
+							Namespace:       "bar",
+							UID:             "1234",
+							ResourceVersion: "12",
+						},
+					},
+					Version: versioned.Version(12),
+				})
+				return want{
+					oldMap:       versioned.NewComparableMap(equalTestObject),
+					newMap:       newMap,
+					addFuncCalls: 1,
+				}
+			},
+		},
+		{
+			name: "Cilium missed a Delete event from k8s, when doing a re-sync it should get a Delete event",
+			setupArgs: func() args {
+				addFuncCalls := 0
+				delFuncCalls := 0
+
+				k8sClient := &fake.Clientset{}
+				k8sClient.AddReactor("list", "networkpolicies",
+					func(action k8sTesting.Action) (bool, runtime.Object, error) {
+						la := action.(k8sTesting.ListAction)
+						c.Assert(la.GetNamespace(), Equals, "")
+						list := &v1.NetworkPolicyList{}
+						return true, list, nil
+					})
+				addFunc := func(i interface{}) func() error {
+					addFuncCalls++
+					return func() error {
+						return nil
+					}
+				}
+				delFunc := func(i interface{}) func() error {
+					obj, ok := i.(*v1.NetworkPolicy)
+					c.Assert(ok, Equals, true)
+					wanted := &v1.NetworkPolicy{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Name:            "foo",
+							Namespace:       "bar",
+							UID:             "1234",
+							ResourceVersion: "12",
+						},
+					}
+					c.Assert(obj, DeepEquals, wanted, Commentf("NetworkPolicy deleted should be exactly that is missing from kube-apiserver"))
+					delFuncCalls++
+					return func() error {
+						return nil
+					}
+				}
+				fqueue := serializer.NewFunctionQueue(1024)
+
+				missingFunc := func(m versioned.Map) versioned.Map {
+					// missingFunc will be called with all objects that should
+					// exist locally.
+					c.Assert(m, DeepEquals, versioned.NewMap())
+					return m
+				}
+
+				return args{
+					listerClient: k8sClient,
+					resourceObj:  &v1.NetworkPolicy{},
+					addFunc:      addFunc,
+					delFunc:      delFunc,
+					missingFunc:  missingFunc,
+					fqueue:       fqueue,
+					addFuncCalls: &addFuncCalls,
+					delFuncCalls: &delFuncCalls,
+				}
+			},
+			setupWant: func() want {
+				oldMap := versioned.NewComparableMap(nil)
+				// oldMap will contain a Network Policy that should have been deleted
+				oldMap.Add(versioned.UUID("bar/foo/1234"), versioned.Object{
+					Data: &v1.NetworkPolicy{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Name:            "foo",
+							Namespace:       "bar",
+							UID:             "1234",
+							ResourceVersion: "12",
+						},
+					},
+					Version: versioned.Version(12),
+				})
+				return want{
+					oldMap:       oldMap,
+					newMap:       versioned.NewComparableMap(equalTestObject),
+					delFuncCalls: 1,
+				}
+			},
+		},
+		{
+			name: "Cilium is already synced so a no-op should be executed for a field changed that Cilium doesn't care",
+			setupArgs: func() args {
+				addFuncCalls := 0
+				delFuncCalls := 0
+
+				k8sClient := &fake.Clientset{}
+				k8sClient.AddReactor("list", "networkpolicies",
+					func(action k8sTesting.Action) (bool, runtime.Object, error) {
+						la := action.(k8sTesting.ListAction)
+						c.Assert(la.GetNamespace(), Equals, "")
+						list := &v1.NetworkPolicyList{}
+						list.Items = append(list.Items, v1.NetworkPolicy{
+							ObjectMeta: meta_v1.ObjectMeta{
+								Name:      "foo",
+								Namespace: "bar",
+								UID:       "1234",
+								Labels: map[string]string{
+									"useless": "label",
+								},
+								ResourceVersion: "13",
+							},
+						})
+						return true, list, nil
+					})
+				addFunc := func(i interface{}) func() error {
+					addFuncCalls++
+					return func() error {
+						return nil
+					}
+				}
+				delFunc := func(i interface{}) func() error {
+					delFuncCalls++
+					return func() error {
+						return nil
+					}
+				}
+				fqueue := serializer.NewFunctionQueue(1024)
+
+				missingFunc := func(m versioned.Map) versioned.Map {
+					newMap := versioned.NewMap()
+					newMap.Add(versioned.UUID("bar/foo/1234"), versioned.Object{
+						Data: &v1.NetworkPolicy{
+							ObjectMeta: meta_v1.ObjectMeta{
+								Name:      "foo",
+								Namespace: "bar",
+								UID:       "1234",
+								Labels: map[string]string{
+									"useless": "label",
+								},
+								ResourceVersion: "13",
+							},
+						},
+						Version: versioned.Version(13),
+					})
+					// missingFunc will be called with all objects that should
+					// exist locally.
+					c.Assert(m, DeepEquals, newMap)
+					return nil
+				}
+
+				return args{
+					listerClient: k8sClient,
+					resourceObj:  &v1.NetworkPolicy{},
+					addFunc:      addFunc,
+					delFunc:      delFunc,
+					missingFunc:  missingFunc,
+					fqueue:       fqueue,
+					addFuncCalls: &addFuncCalls,
+					delFuncCalls: &delFuncCalls,
+				}
+			},
+			setupWant: func() want {
+
+				oldMap := versioned.NewComparableMap(equalTestObject)
+				oldMap.Add(versioned.UUID("bar/foo/1234"), versioned.Object{
+					Data: &v1.NetworkPolicy{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Name:            "foo",
+							Namespace:       "bar",
+							UID:             "1234",
+							ResourceVersion: "12",
+						},
+					},
+					Version: versioned.Version(12),
+				})
+
+				newMap := versioned.NewComparableMap(nil)
+				// NewMap will contain the updated network policy with the
+				// new "useless" label. As Cilium doesn't need the labels
+				// no Add/Del Funcs should be called.
+				newMap.Add(versioned.UUID("bar/foo/1234"), versioned.Object{
+					Data: &v1.NetworkPolicy{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "bar",
+							UID:       "1234",
+							Labels: map[string]string{
+								"useless": "label",
+							},
+							ResourceVersion: "13",
+						},
+					},
+					Version: versioned.Version(13),
+				})
+
+				return want{
+					oldMap: oldMap,
+					newMap: newMap,
+				}
+			},
+		},
+		{
+			name: "Cilium is not synced with kube-apiserver. When a field, that Cilium cares about, " +
+				"was modified then it needs to send an AddFunc event",
+			setupArgs: func() args {
+				addFuncCalls := 0
+				delFuncCalls := 0
+
+				k8sClient := &fake.Clientset{}
+				k8sClient.AddReactor("list", "networkpolicies",
+					func(action k8sTesting.Action) (bool, runtime.Object, error) {
+						la := action.(k8sTesting.ListAction)
+						c.Assert(la.GetNamespace(), Equals, "")
+						list := &v1.NetworkPolicyList{}
+						list.Items = append(list.Items, v1.NetworkPolicy{
+							ObjectMeta: meta_v1.ObjectMeta{
+								Name:      "foo",
+								Namespace: "bar",
+								UID:       "1234",
+								Labels: map[string]string{
+									"useless": "label",
+								},
+								ResourceVersion: "13",
+							},
+							Spec: v1.NetworkPolicySpec{
+								PodSelector: meta_v1.LabelSelector{
+									MatchLabels: map[string]string{
+										"labels": "that-matter",
+									},
+								},
+							},
+						})
+						return true, list, nil
+					})
+				addFunc := func(i interface{}) func() error {
+					obj, ok := i.(*v1.NetworkPolicy)
+					c.Assert(ok, Equals, true)
+					wanted := &v1.NetworkPolicy{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "bar",
+							UID:       "1234",
+							Labels: map[string]string{
+								"useless": "label",
+							},
+							ResourceVersion: "13",
+						},
+						Spec: v1.NetworkPolicySpec{
+							PodSelector: meta_v1.LabelSelector{
+								MatchLabels: map[string]string{
+									"labels": "that-matter",
+								},
+							},
+						},
+					}
+					c.Assert(obj, DeepEquals, wanted, Commentf("NetworkPolicy deleted should be exactly that is missing from kube-apiserver"))
+					addFuncCalls++
+					return func() error {
+						return nil
+					}
+				}
+				delFunc := func(i interface{}) func() error {
+					delFuncCalls++
+					return func() error {
+						return nil
+					}
+				}
+				fqueue := serializer.NewFunctionQueue(1024)
+
+				missingFunc := func(m versioned.Map) versioned.Map {
+					newMap := versioned.NewMap()
+					newMap.Add(versioned.UUID("bar/foo/1234"), versioned.Object{
+						Data: &v1.NetworkPolicy{
+							ObjectMeta: meta_v1.ObjectMeta{
+								Name:      "foo",
+								Namespace: "bar",
+								UID:       "1234",
+								Labels: map[string]string{
+									"useless": "label",
+								},
+								ResourceVersion: "13",
+							},
+							Spec: v1.NetworkPolicySpec{
+								PodSelector: meta_v1.LabelSelector{
+									MatchLabels: map[string]string{
+										"labels": "that-matter",
+									},
+								},
+							},
+						},
+						Version: versioned.Version(13),
+					})
+					// missingFunc will be called with all objects that should
+					// exist locally.
+					c.Assert(m, DeepEquals, newMap)
+					return nil
+				}
+
+				return args{
+					listerClient: k8sClient,
+					resourceObj:  &v1.NetworkPolicy{},
+					addFunc:      addFunc,
+					delFunc:      delFunc,
+					missingFunc:  missingFunc,
+					fqueue:       fqueue,
+					addFuncCalls: &addFuncCalls,
+					delFuncCalls: &delFuncCalls,
+				}
+			},
+			setupWant: func() want {
+
+				oldMap := versioned.NewComparableMap(equalTestObject)
+				oldMap.Add(versioned.UUID("bar/foo/1234"), versioned.Object{
+					Data: &v1.NetworkPolicy{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Name:            "foo",
+							Namespace:       "bar",
+							UID:             "1234",
+							ResourceVersion: "12",
+						},
+					},
+					Version: versioned.Version(12),
+				})
+
+				newMap := versioned.NewComparableMap(nil)
+				// NewMap will contain the updated network policy
+				newMap.Add(versioned.UUID("bar/foo/1234"), versioned.Object{
+					Data: &v1.NetworkPolicy{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "bar",
+							UID:       "1234",
+							Labels: map[string]string{
+								"useless": "label",
+							},
+							ResourceVersion: "13",
+						},
+						Spec: v1.NetworkPolicySpec{
+							PodSelector: meta_v1.LabelSelector{
+								MatchLabels: map[string]string{
+									"labels": "that-matter",
+								},
+							},
+						},
+					},
+					Version: versioned.Version(13),
+				})
+
+				return want{
+					oldMap:       oldMap,
+					newMap:       newMap,
+					addFuncCalls: 1,
+				}
+			},
+		},
+		{
+			name: "Cilium already processed an event with a newer resource version so it will discard anything from the lister",
+			setupArgs: func() args {
+				addFuncCalls := 0
+				delFuncCalls := 0
+
+				k8sClient := &fake.Clientset{}
+				k8sClient.AddReactor("list", "networkpolicies",
+					func(action k8sTesting.Action) (bool, runtime.Object, error) {
+						la := action.(k8sTesting.ListAction)
+						c.Assert(la.GetNamespace(), Equals, "")
+						list := &v1.NetworkPolicyList{}
+						list.Items = append(list.Items, v1.NetworkPolicy{
+							ObjectMeta: meta_v1.ObjectMeta{
+								Name:      "foo",
+								Namespace: "bar",
+								UID:       "1234",
+								Labels: map[string]string{
+									"useless": "label",
+								},
+								ResourceVersion: "13",
+							},
+							Spec: v1.NetworkPolicySpec{
+								PodSelector: meta_v1.LabelSelector{
+									MatchLabels: map[string]string{
+										"labels": "that-matter",
+									},
+								},
+							},
+						})
+						return true, list, nil
+					})
+				addFunc := func(i interface{}) func() error {
+					addFuncCalls++
+					return func() error {
+						return nil
+					}
+				}
+				delFunc := func(i interface{}) func() error {
+					delFuncCalls++
+					return func() error {
+						return nil
+					}
+				}
+				fqueue := serializer.NewFunctionQueue(1024)
+
+				missingFunc := func(m versioned.Map) versioned.Map {
+					wanted := versioned.NewMap()
+					wanted.Add(versioned.UUID("bar/foo/1234"), versioned.Object{
+						Data: &v1.NetworkPolicy{
+							ObjectMeta: meta_v1.ObjectMeta{
+								Name:            "foo",
+								Namespace:       "bar",
+								UID:             "1234",
+								ResourceVersion: "14",
+							},
+						},
+						Version: versioned.Version(14),
+					})
+					// missingFunc will be called with all objects that should
+					// exist locally.
+					c.Assert(m, DeepEquals, wanted)
+					return nil
+				}
+
+				return args{
+					listerClient: k8sClient,
+					resourceObj:  &v1.NetworkPolicy{},
+					addFunc:      addFunc,
+					delFunc:      delFunc,
+					missingFunc:  missingFunc,
+					fqueue:       fqueue,
+					addFuncCalls: &addFuncCalls,
+					delFuncCalls: &delFuncCalls,
+				}
+			},
+			setupWant: func() want {
+
+				oldMap := versioned.NewComparableMap(equalTestObject)
+				oldMap.Add(versioned.UUID("bar/foo/1234"), versioned.Object{
+					Data: &v1.NetworkPolicy{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Name:            "foo",
+							Namespace:       "bar",
+							UID:             "1234",
+							ResourceVersion: "14",
+						},
+					},
+					Version: versioned.Version(14),
+				})
+
+				newMap := versioned.NewComparableMap(nil)
+				// NewMap will contain the updated network policy
+				newMap.Add(versioned.UUID("bar/foo/1234"), versioned.Object{
+					Data: &v1.NetworkPolicy{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Name:            "foo",
+							Namespace:       "bar",
+							UID:             "1234",
+							ResourceVersion: "14",
+						},
+					},
+					Version: versioned.Version(14),
+				})
+
+				return want{
+					oldMap: oldMap,
+					newMap: newMap,
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		args := tt.setupArgs()
+		want := tt.setupWant()
+		replaceFunc := replaceFuncFactory(args.listerClient, args.resourceObj, args.addFunc, args.delFunc, args.missingFunc, args.fqueue)
+		newMap, err := replaceFunc(want.oldMap)
+		c.Assert(err, IsNil, Commentf("Test Name: %s", tt.name))
+		c.Assert(newMap.Map, DeepEquals, want.newMap.Map, Commentf("Test Name: %s", tt.name))
+		c.Assert(*args.addFuncCalls, Equals, want.addFuncCalls, Commentf("Test Name: %s", tt.name))
+		c.Assert(*args.delFuncCalls, Equals, want.delFuncCalls, Commentf("Test Name: %s", tt.name))
+	}
+}

--- a/pkg/k8s/utils/utils.go
+++ b/pkg/k8s/utils/utils.go
@@ -15,6 +15,8 @@
 package utils
 
 import (
+	"github.com/cilium/cilium/pkg/versioned"
+
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -31,4 +33,20 @@ func ExtractNamespace(np metav1.Object) string {
 // GetObjNamespaceName returns the object's namespace and name.
 func GetObjNamespaceName(obj metav1.Object) string {
 	return ExtractNamespace(obj) + "/" + obj.GetName()
+}
+
+// GetObjUID returns the object's namespace and name.
+func GetObjUID(obj metav1.Object) string {
+	return GetObjNamespaceName(obj) + "/" + string(obj.GetUID())
+}
+
+// GetVerStructFrom returns a versionedObject of the given objMeta.
+func GetVerStructFrom(objMeta metav1.Object) (versioned.UUID, versioned.Object) {
+	uuid := versioned.UUID(GetObjUID(objMeta))
+	v := versioned.ParseVersion(objMeta.GetResourceVersion())
+	vs := versioned.Object{
+		Data:    objMeta,
+		Version: v,
+	}
+	return uuid, vs
 }

--- a/pkg/versioned/doc.go
+++ b/pkg/versioned/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package versioned provides a map that allows versioned objects to be stored
+// based on their version number.
+package versioned

--- a/pkg/versioned/map.go
+++ b/pkg/versioned/map.go
@@ -1,0 +1,162 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package versioned
+
+import (
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// UUID is the UUID for the object that is going to be stored in the map.
+type UUID string
+
+// Map maps a UUID to an Object.
+type Map map[UUID]Object
+
+// NewMap returns an initialized Map.
+func NewMap() Map {
+	return make(Map)
+}
+
+// Add maps the uuid to the given obj.
+func (m Map) Add(uuid UUID, obj Object) {
+	m[uuid] = obj
+}
+
+// Delete deletes the value that maps uuid in the map. Returns true or false
+// if the object existed in the map before deletion.
+func (m Map) Delete(uuid UUID) bool {
+	_, exists := m[uuid]
+	if exists {
+		delete(m, uuid)
+	}
+	return exists
+}
+
+// Get returns the object that maps to the given uuid and returns true or false
+// either the object exists or not.
+func (m Map) Get(uuid UUID) (Object, bool) {
+	o, exists := m[uuid]
+	return o, exists
+}
+
+// DeepEqualFunc should return true or false if both interfaces `o1` and `o2`
+// are considered equal.
+type DeepEqualFunc func(o1, o2 interface{}) bool
+
+// ComparableMap is a map that can store Objects that are comparable between
+// each other.
+type ComparableMap struct {
+	Map
+	DeepEquals DeepEqualFunc
+}
+
+// NewComparableMap returns an initialized map with the equalFunc set as the
+// DeepEquals of the map.
+func NewComparableMap(equalFunc DeepEqualFunc) *ComparableMap {
+	return &ComparableMap{
+		Map:        NewMap(),
+		DeepEquals: equalFunc,
+	}
+}
+
+// AddEqual maps `uuid` to `newObj` if the object to be inserted has a newer
+// Version than the one already mapped in the map. Returns false if the object
+// inserted is not mapped yet or if the object has a newer version and
+// is not deeply equal to the object already stored.
+func (m *ComparableMap) AddEqual(uuid UUID, newObj Object) bool {
+	oldObj, ok := m.Map.Get(uuid)
+	if ok {
+		// small performance optimization where we only add
+		// an object if the version is newer than the one we have.
+		if newObj.CompareVersion(oldObj) > 0 {
+			m.Map.Add(uuid, newObj)
+			return m.DeepEquals(oldObj.Data, newObj.Data)
+		}
+		return true
+	}
+	m.Map.Add(uuid, newObj)
+	return false
+}
+
+// SyncComparableMap is a thread-safe wrapper around ComparableMap.
+type SyncComparableMap struct {
+	mutex *lock.RWMutex
+	cm    *ComparableMap
+}
+
+// NewSyncComparableMap returns a thread-safe ComparableMap.
+func NewSyncComparableMap(def DeepEqualFunc) *SyncComparableMap {
+	return &SyncComparableMap{
+		mutex: &lock.RWMutex{},
+		cm:    NewComparableMap(def),
+	}
+}
+
+// Add maps the uuid to the given obj without any comparison.
+func (sm *SyncComparableMap) Add(uuid UUID, obj Object) {
+	sm.mutex.Lock()
+	sm.cm.Add(uuid, obj)
+	sm.mutex.Unlock()
+}
+
+// AddEqual maps `uuid` to `newObj` if the object to be inserted has a newer
+// Version than the one already mapped in the map. Returns false if the object
+// inserted is not mapped yet or if the object has a newer version and
+// is not deeply equal to the object already stored.
+func (sm *SyncComparableMap) AddEqual(uuid UUID, obj Object) bool {
+	sm.mutex.Lock()
+	added := sm.cm.AddEqual(uuid, obj)
+	sm.mutex.Unlock()
+	return added
+}
+
+// Delete deletes the value that maps uuid in the map. Returns true of false
+// if the object existed in the map before deletion.
+func (sm *SyncComparableMap) Delete(uuid UUID) bool {
+	sm.mutex.Lock()
+	exists := sm.cm.Delete(uuid)
+	sm.mutex.Unlock()
+	return exists
+}
+
+// Get returns the object that maps to the given uuid and returns true or false
+// either the object exists or not.
+func (sm *SyncComparableMap) Get(uuid UUID) (Object, bool) {
+	sm.mutex.RLock()
+	v, e := sm.cm.Get(uuid)
+	sm.mutex.RUnlock()
+	return v, e
+}
+
+// Replace is a thread-safe function that can be used to perform multiple
+// operations in the map atomically.
+// Parameters:
+//  * replace: if not nil, replace is called with the internal ComparableMap,
+//    the returned ComparableMap will be set as the new internal ComparableMap.
+//    If an error is returned, the replace operation won't take place.
+// In case both `iterate` and `replace` are provided, `iterate` is executed
+// first and `replace` is executed afterwards.
+func (sm *SyncComparableMap) Replace(replace func(old *ComparableMap) (*ComparableMap, error)) error {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+	if replace != nil {
+		newMap, err := replace(sm.cm)
+		if err != nil {
+			return err
+		}
+		sm.cm = newMap
+	}
+	return nil
+}

--- a/pkg/versioned/map_test.go
+++ b/pkg/versioned/map_test.go
@@ -1,0 +1,223 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package versioned
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/lock"
+
+	"gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+type VersionedSuite struct{}
+
+var _ = check.Suite(&VersionedSuite{})
+
+func (s *VersionedSuite) TestComparableMap_AddEqual(c *check.C) {
+	type fields struct {
+		m          Map
+		deepEquals DeepEqualFunc
+	}
+	type args struct {
+		uuid UUID
+		obj  Object
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "same object inserted twice should return true because the version is the same",
+			fields: fields{
+				m: Map{
+					"foo": {
+						Data:    nil,
+						Version: ParseVersion("1"),
+					},
+				},
+				deepEquals: DeepEqualFunc(func(o1, o2 interface{}) bool {
+					return true
+				}),
+			},
+			args: args{
+				uuid: "foo",
+				obj: Object{
+					Data:    nil,
+					Version: ParseVersion("1"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "new object inserted should return false",
+			fields: fields{
+				m: Map{},
+				deepEquals: DeepEqualFunc(func(o1, o2 interface{}) bool {
+					return true
+				}),
+			},
+			args: args{
+				uuid: "foo",
+				obj: Object{
+					Data:    nil,
+					Version: ParseVersion("1"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "new object with new version but deep equaled should return true",
+			fields: fields{
+				m: Map{
+					"foo": {
+						Data:    nil,
+						Version: ParseVersion("1"),
+					},
+				},
+				deepEquals: DeepEqualFunc(func(o1, o2 interface{}) bool {
+					return true
+				}),
+			},
+			args: args{
+				uuid: "foo",
+				obj: Object{
+					Data:    nil,
+					Version: ParseVersion("2"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "new object with new version but not equaled should return false",
+			fields: fields{
+				m: Map{
+					"foo": {
+						Data:    nil,
+						Version: ParseVersion("1"),
+					},
+				},
+				deepEquals: DeepEqualFunc(func(o1, o2 interface{}) bool {
+					return false
+				}),
+			},
+			args: args{
+				uuid: "foo",
+				obj: Object{
+					Data:    nil,
+					Version: ParseVersion("2"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "new object with old version should return true as it already exists in the map",
+			fields: fields{
+				m: Map{
+					"foo": {
+						Data:    nil,
+						Version: ParseVersion("2"),
+					},
+				},
+				deepEquals: DeepEqualFunc(func(o1, o2 interface{}) bool {
+					return false
+				}),
+			},
+			args: args{
+				uuid: "foo",
+				obj: Object{
+					Data:    nil,
+					Version: ParseVersion("1"),
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		m := &ComparableMap{
+			Map:        tt.fields.m,
+			DeepEquals: tt.fields.deepEquals,
+		}
+		if got := m.AddEqual(tt.args.uuid, tt.args.obj); got != tt.want {
+			c.Assert(got, check.DeepEquals, tt.want, check.Commentf("Test name: %q", tt.name))
+		}
+	}
+}
+
+func (s *VersionedSuite) TestSyncComparableMap_DoLocked(c *check.C) {
+	m := NewComparableMap(DeepEqualFunc(func(o1, o2 interface{}) bool {
+		return true
+	}))
+	m.Map = Map{
+		UUID("foo"): {
+			Data:    "bar",
+			Version: ParseVersion("1"),
+		},
+	}
+	type fields struct {
+		mutex *lock.RWMutex
+		cm    *ComparableMap
+	}
+	type args struct {
+		replace func(old *ComparableMap) (*ComparableMap, error)
+	}
+	tests := []struct {
+		name            string
+		fields          fields
+		args            args
+		wantErr         bool
+		functionsCalled []string
+	}{
+		{
+			name: "testing replace function",
+			fields: fields{
+				mutex: &lock.RWMutex{},
+				cm: NewComparableMap(DeepEqualFunc(func(o1, o2 interface{}) bool {
+					return true
+				})),
+			},
+			args: args{
+				replace: func(old *ComparableMap) (*ComparableMap, error) {
+					return m, nil
+				},
+			},
+			wantErr:         false,
+			functionsCalled: []string{"replace"},
+		},
+	}
+	for _, tt := range tests {
+		sm := &SyncComparableMap{
+			mutex: tt.fields.mutex,
+			cm:    tt.fields.cm,
+		}
+		if err := sm.Replace(tt.args.replace); (err != nil) != tt.wantErr {
+			c.Assert(err, check.DeepEquals, tt.wantErr, check.Commentf("Test name: %q", tt.name))
+		}
+		for _, v := range tt.functionsCalled {
+			switch v {
+			case "replace":
+				c.Assert(sm.cm, check.DeepEquals, m,
+					check.Commentf("%s", "replace function was not called, otherwise the maps would be the same"))
+			}
+		}
+	}
+}

--- a/pkg/versioned/versioned.go
+++ b/pkg/versioned/versioned.go
@@ -1,0 +1,46 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package versioned
+
+import (
+	"strconv"
+)
+
+// Version is the version used for each Object.
+type Version int64
+
+// ParseVersion parses the given string to Version, if the string is not
+// parsable a 0 Version is returned.
+// If the version is bigger than int64, it will return math.MaxUint64.
+func ParseVersion(s string) Version {
+	i, _ := strconv.ParseInt(s, 10, 64)
+	return Version(i)
+}
+
+// Object is used to store a particular interface at a specific version.
+type Object struct {
+	// Data is any data that can be stored in this object.
+	Data interface{}
+	// Version is the version used for the data stored.
+	Version Version
+}
+
+// CompareVersion returns:
+//  < 0 if receiver's version is older than `other` Object.
+//  0 if receiver's version is the same as the `other` version.
+//  > 0 if receiver's version is newer than `other` Object.
+func (o *Object) CompareVersion(other Object) int64 {
+	return int64(o.Version) - int64(other.Version)
+}

--- a/pkg/versioned/versioned_test.go
+++ b/pkg/versioned/versioned_test.go
@@ -1,0 +1,121 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package versioned
+
+import "testing"
+
+func TestParseVersion(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name string
+		args args
+		want Version
+	}{
+		{
+			name: "valid version",
+			args: args{
+				"123456789",
+			},
+			want: Version(123456789),
+		},
+		{
+			name: "invalid version max than uint64",
+			args: args{
+				"123456789123456789123456789123456789123456789123456789123456789",
+			},
+			want: Version(9223372036854775807),
+		},
+		{
+			name: "invalid version with letters",
+			args: args{
+				"a",
+			},
+			want: Version(0),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseVersion(tt.args.s); got != tt.want {
+				t.Errorf("ParseVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestObject_CompareVersion(t *testing.T) {
+	type fields struct {
+		Data    interface{}
+		Version Version
+	}
+	type args struct {
+		other Object
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   int64
+	}{
+		{
+			name: "same version objects",
+			fields: fields{
+				Version: Version(0),
+			},
+			args: args{
+				Object{
+					Version: Version(0),
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "receiver is newer",
+			fields: fields{
+				Version: Version(1),
+			},
+			args: args{
+				Object{
+					Version: Version(0),
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "receiver is older",
+			fields: fields{
+				Version: Version(-1),
+			},
+			args: args{
+				Object{
+					Version: Version(0),
+				},
+			},
+			want: -1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &Object{
+				Data:    tt.fields.Data,
+				Version: tt.fields.Version,
+			}
+			if got := o.CompareVersion(tt.args.other); got != tt.want {
+				t.Errorf("Object.CompareVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces a framework to prevent Cilium from receiving useless "Adds" events every N minutes.

It also fixes a bug where in the case Cilium would not receive a Delete event, the default resync from kubernetes library wouldn't be aware of this missing Delete event. The new framework is also aware of objects that no longer exist in kube api-server and should be deleted from Cilium.

In following PRs the dedicated Equalness and MissingFunc should be written for each object. Without those functions the default behavior of kubernetes watcher remains the same.

An example of the of those dedicated function implementations can be found in the last commit of https://github.com/cilium/cilium/pull/5519

Reead per commit basis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5449)
<!-- Reviewable:end -->
