### PR TITLE
Refactor IPv4/IPv6 ctmap dump code into shared library function

### DIFF
--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -541,8 +541,8 @@ func (m *Map) DumpReliablyWithCallback(cb DumpCallback, stats *DumpStats) error 
 
 		prevKeyValid = false
 	)
-	stats.Start()
-	defer stats.Finish()
+	stats.start()
+	defer stats.finish()
 
 	if err := m.Open(); err != nil {
 		return err

--- a/pkg/bpf/stats.go
+++ b/pkg/bpf/stats.go
@@ -54,21 +54,17 @@ type DumpStats struct {
 // NewDumpStats returns a new stats structure for collecting dump statistics.
 func NewDumpStats(m *Map) *DumpStats {
 	return &DumpStats{
-		Lookup:     1,
 		MaxEntries: m.MapInfo.MaxEntries,
 	}
 }
 
-// Start starts the dump.
-//
-// For convenience, it returns a pointer to itself.
-func (d *DumpStats) Start() *DumpStats {
+// start starts the dump.
+func (d *DumpStats) start() {
 	d.Started = time.Now()
-	return d
 }
 
-// Finish finishes the dump.
-func (d *DumpStats) Finish() {
+// finish finishes the dump.
+func (d *DumpStats) finish() {
 	d.Finished = time.Now()
 }
 

--- a/pkg/bpf/stats.go
+++ b/pkg/bpf/stats.go
@@ -1,0 +1,78 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf
+
+import (
+	"time"
+)
+
+// DumpStats tracks statistics over the dump of a map.
+type DumpStats struct {
+	// Started is the timestamp when the gc run was started.
+	Started time.Time
+
+	// Finished is the timestamp when the gc run completed.
+	Finished time.Time
+
+	// Lookup is the number of key lookups performed.
+	Lookup uint32
+
+	// LookupFailed is the number of key lookups that failed.
+	LookupFailed uint32
+
+	// PrevKeyUnavailable is the number of times the previous key was not
+	// available.
+	PrevKeyUnavailable uint32
+
+	// KeyFallback is the number of times the current key became invalid
+	// while traversing and we had to fall back to the previous key.
+	KeyFallback uint32
+
+	// MaxEntries is the maximum number of entries in the gc table.
+	MaxEntries uint32
+
+	// Interrupted is the number of times the gc run was interrupted and
+	// had to start from scratch.
+	Interrupted uint32
+
+	// Completed is true when the gc run has been completed.
+	Completed bool
+}
+
+// NewDumpStats returns a new stats structure for collecting dump statistics.
+func NewDumpStats(m *Map) *DumpStats {
+	return &DumpStats{
+		Lookup:     1,
+		MaxEntries: m.MapInfo.MaxEntries,
+	}
+}
+
+// Start starts the dump.
+//
+// For convenience, it returns a pointer to itself.
+func (d *DumpStats) Start() *DumpStats {
+	d.Started = time.Now()
+	return d
+}
+
+// Finish finishes the dump.
+func (d *DumpStats) Finish() {
+	d.Finished = time.Now()
+}
+
+// Duration returns the duration of the dump.
+func (d *DumpStats) Duration() time.Duration {
+	return d.Finished.Sub(d.Started)
+}

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -250,11 +250,11 @@ func doGC6(m *bpf.Map, filter *GCFilter) gcStats {
 	err := m.GetNextKey(&prevKey, &currentKey)
 	if err != nil {
 		// Map is empty, nothing to clean up.
-		stats.completed = true
+		stats.Completed = true
 		return stats
 	}
 
-	for stats.count = 1; stats.count <= m.MapInfo.MaxEntries; stats.count++ {
+	for stats.Lookup = 1; stats.Lookup <= stats.MaxEntries; stats.Lookup++ {
 		// currentKey was returned by GetNextKey() so we know it existed in the map, but it may have been
 		// deleted by a concurrent map operation. If currentKey is no longer in the map, nextKey will be
 		// the first key in the map again. Use the nextKey only if we still find currentKey in the Lookup()
@@ -262,7 +262,7 @@ func doGC6(m *bpf.Map, filter *GCFilter) gcStats {
 		nextKeyValid := m.GetNextKey(&currentKey, &nextKey)
 		entryMap, err := m.Lookup(&currentKey)
 		if err != nil {
-			stats.lookupFailed++
+			stats.LookupFailed++
 
 			// Restarting from a invalid key starts the iteration again from the beginning.
 			// If we have a previously found key, try to restart from there instead
@@ -271,12 +271,12 @@ func doGC6(m *bpf.Map, filter *GCFilter) gcStats {
 				// Restart from a given previous key only once, otherwise if the prevKey is
 				// concurrently deleted we might loop forever trying to look it up.
 				prevKeyValid = false
-				stats.keyFallback++
+				stats.KeyFallback++
 			} else {
 				// Depending on exactly when currentKey was deleted from the map, nextKey may be the actual
 				// keyelement after the deleted one, or the first element in the map.
 				currentKey = nextKey
-				stats.interrupted++
+				stats.Interrupted++
 			}
 			continue
 		}
@@ -302,7 +302,7 @@ func doGC6(m *bpf.Map, filter *GCFilter) gcStats {
 		}
 
 		if nextKeyValid != nil {
-			stats.completed = true
+			stats.Completed = true
 			break
 		}
 		// remember the last found key
@@ -328,11 +328,11 @@ func doGC4(m *bpf.Map, filter *GCFilter) gcStats {
 	err := m.GetNextKey(&prevKey, &currentKey)
 	if err != nil {
 		// Map is empty, nothing to clean up.
-		stats.completed = true
+		stats.Completed = true
 		return stats
 	}
 
-	for stats.count = 1; stats.count <= m.MapInfo.MaxEntries; stats.count++ {
+	for stats.Lookup = 1; stats.Lookup <= stats.MaxEntries; stats.Lookup++ {
 		// currentKey was returned by GetNextKey() so we know it existed in the map, but it may have been
 		// deleted by a concurrent map operation. If currentKey is no longer in the map, nextKey will be
 		// the first key in the map again. Use the nextKey only if we still find currentKey in the Lookup()
@@ -340,7 +340,7 @@ func doGC4(m *bpf.Map, filter *GCFilter) gcStats {
 		nextKeyValid := m.GetNextKey(&currentKey, &nextKey)
 		entryMap, err := m.Lookup(&currentKey)
 		if err != nil {
-			stats.lookupFailed++
+			stats.LookupFailed++
 
 			// Restarting from a invalid key starts the iteration again from the beginning.
 			// If we have a previously found key, try to restart from there instead
@@ -349,12 +349,12 @@ func doGC4(m *bpf.Map, filter *GCFilter) gcStats {
 				// Restart from a given previous key only once, otherwise if the prevKey is
 				// concurrently deleted we might loop forever trying to look it up.
 				prevKeyValid = false
-				stats.keyFallback++
+				stats.KeyFallback++
 			} else {
 				// Depending on exactly when currentKey was deleted from the map, nextKey may be the actual
 				// keyelement after the deleted one, or the first element in the map.
 				currentKey = nextKey
-				stats.interrupted++
+				stats.Interrupted++
 			}
 			continue
 		}
@@ -380,7 +380,7 @@ func doGC4(m *bpf.Map, filter *GCFilter) gcStats {
 		}
 
 		if nextKeyValid != nil {
-			stats.completed = true
+			stats.Completed = true
 			break
 		}
 		// remember the last found key


### PR DESCRIPTION
This will be rebased against ~~#5480~~ ~~#5488~~ after it is merged.

Refactor the IPv4/IPv6 CT dump code so that more code can be shared between the implementations. This should reduce problems such as the one found in #5313.

This is a step on the path towards using standard Map types for all maps so that upgrades can be handled consistently via `Map.Open()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5450)
<!-- Reviewable:end -->
