### PR TITLE
endpoint: Skip compilation if unneeded

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -563,16 +563,20 @@ func (e *Endpoint) regenerateBPF(owner Owner, epdir string, regenContext *Regene
 		closeChan := loadinfo.LogPeriodicSystemLoad(log.WithFields(logrus.Fields{logfields.EndpointID: epID}).Debugf, time.Second)
 
 		// Compile and install BPF programs for this endpoint
-		stats.bpfCompilation.Start()
 		ctx, cancel := context.WithTimeout(context.Background(), ExecTimeout)
-		err = loader.CompileAndLoad(ctx, epInfoCache)
-		stats.bpfCompilation.End()
+		if bpfHeaderfilesChanged {
+			stats.bpfCompilation.Start()
+			err = loader.CompileAndLoad(ctx, epInfoCache)
+			stats.bpfCompilation.End()
+			e.Logger().WithError(err).
+				WithField(logfields.BPFCompilationTime, stats.bpfCompilation.Total().String()).
+				Info("Recompiled endpoint BPF program")
+		} else {
+			err = loader.ReloadDatapath(ctx, epInfoCache)
+			e.Logger().WithError(err).Info("Reloaded endpoint BPF program")
+		}
 		cancel()
 		close(closeChan)
-
-		e.Logger().WithError(err).
-			WithField(logfields.BPFCompilationTime, stats.bpfCompilation.Total().String()).
-			Info("Recompiled endpoint BPF program")
 
 		if err != nil {
 			return epInfoCache.revision, compilationExecuted, err


### PR DESCRIPTION
When the periodic IPCache garbage collector replaces the LPM map on
kernels 4.11-4.14, it sets `regenContext.ReloadDatapath` and it only requires
a datapath reload and not a complete recompilation. Skip compilation in this case.

Related: #5303

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5452)
<!-- Reviewable:end -->
