### PR TITLE
fqdn: Strip ToCIDRSet on poll start

### DIFF
--- a/pkg/fqdn/dnspoller.go
+++ b/pkg/fqdn/dnspoller.go
@@ -179,8 +179,10 @@ perRule:
 			continue perRule
 		}
 
-		// make a copy to avoid breaking the input rules in any way
+		// Make a copy to avoid breaking the input rules. Strip ToCIDRSet to avoid
+		// accumulating anything we included during MarkToFQDNRules
 		sourceRuleCopy := sourceRule.DeepCopy()
+		stripToCIDRSet(sourceRuleCopy)
 
 		uuid := getUUIDFromRuleLabels(sourceRule)
 		newDNSNames, alreadyExistsDNSNames := poller.addRule(uuid, sourceRuleCopy)


### PR DESCRIPTION
When CIDRs are added to a rule by MarkToFQDNRules and then the rule is
inserted via StartPollForDNSName the resulting generated rule may
contain an additional copy of the IPs. This is now accounted for
correctly.

Fixes b147ac07799d2930e380cf9268093e69027604e6

```release-note/bug
Correct toFQDNs rules erroneously including some IPs twice in generated rules.
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5453)
<!-- Reviewable:end -->
