### PR TITLE
endpoint: Do not hold manager and endpoint lock during RunK8sCiliumEndpointSync()

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -156,9 +156,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) {
 		// upon returning that endpoints are exposed to other subsystems via
 		// endpointmanager.
 
-		ep.UnconditionalRLock()
 		endpointmanager.Insert(ep)
-		ep.RUnlock()
 
 		go func(ep *endpoint.Endpoint, epRegenerated chan<- bool) {
 			if err := ep.RLockAlive(); err != nil {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -540,9 +540,6 @@ func (e *Endpoint) WaitForProxyCompletions(proxyWaitGroup *completion.WaitGroup)
 // RunK8sCiliumEndpointSync starts a controller that syncronizes the endpoint
 // to the corresponding k8s CiliumEndpoint CRD
 // CiliumEndpoint objects have the same name as the pod they represent
-//
-// Endpoint.Mutex must be RLocked. This is guaranteed via
-// endpointmanager.Insert() but is really not ideal.
 func (e *Endpoint) RunK8sCiliumEndpointSync() {
 	var (
 		endpointID     = e.ID
@@ -576,7 +573,7 @@ func (e *Endpoint) RunK8sCiliumEndpointSync() {
 
 	// The health endpoint doesn't really exist in k8s and updates to it caused
 	// arbitrary errors. Disable the controller for these endpoints.
-	if isHealthEP := e.hasLabelsRLocked(pkgLabels.LabelHealth); isHealthEP {
+	if isHealthEP := e.HasLabels(pkgLabels.LabelHealth); isHealthEP {
 		scopedLog.Debug("Not starting unnecessary CEP controller for cilium-health endpoint")
 		return
 	}


### PR DESCRIPTION
RunK8sCiliumEndpointSync() interacts with the apiserver. This is a potentially
blocking operation. Do not hold any locks while doing so.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5456)
<!-- Reviewable:end -->
