### PR TITLE
sort-of TTL based toFQDNs policy

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -79,6 +79,7 @@ cilium-agent
       --single-cluster-route                        Use a single cluster route instead of per node routes
       --socket-path string                          Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
       --state-dir string                            Directory path to store runtime state (default "/var/run/cilium")
+      --tofqdns-min-ttl int                         The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 31536000)
       --trace-payloadlen int                        Length of payload to capture when tracing (default 128)
   -t, --tunnel string                               Tunnel mode {vxlan, geneve, disabled} (default "vxlan")
       --version                                     Print version information

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1327,6 +1327,7 @@ func NewDaemon() (*Daemon, *endpointRestoreState, error) {
 
 	d.startStatusCollector()
 	d.dnsPoller = fqdn.NewDNSPoller(fqdn.DNSPollerConfig{
+		MinTTL:         toFQDNsMinTTL,
 		LookupDNSNames: fqdn.DNSLookupDefaultResolver,
 		AddGeneratedRules: func(generatedRules []*policyApi.Rule) error {
 			// Insert the new rules into the policy repository. We need them to

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -120,6 +120,7 @@ var (
 	v6Prefix              string
 	v6ServicePrefix       string
 	validLabels           []string
+	toFQDNsMinTTL         int
 )
 
 var (
@@ -487,6 +488,9 @@ func init() {
 	flags.StringVar(&cmdRefDir,
 		"cmdref", "", "Path to cmdref output directory")
 	flags.MarkHidden("cmdref")
+
+	flags.IntVar(&toFQDNsMinTTL,
+		"tofqdns-min-ttl", defaults.ToFQDNsMinTTL, "The minimum time, in seconds, to use DNS data for toFQDNs policies.")
 
 	viper.BindPFlags(flags)
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -82,4 +82,7 @@ const (
 
 	// DefaultMapPrefix is the default prefix for all BPF maps.
 	DefaultMapPrefix = "tc/globals"
+
+	// ToFQDNsMinTTL is the default lower bound for TTLs used with ToFQDNs rules.
+	ToFQDNsMinTTL = 365 * 86400 // 1 year in seconds
 )

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -1,0 +1,212 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fqdn
+
+import (
+	"bytes"
+	"net"
+	"sort"
+	"time"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// DefaultDNSCache is a global, shared, DNS cache. It is the default cache used
+// by DNSPoller instances, unless initialized to use another.
+// Note: The DNSCache type returns all DNS information, regardless of source.
+var DefaultDNSCache = NewDNSCache()
+
+// cacheEntry objects hold data passed in via DNSCache.Update, nominally
+// equating to a DNS lookup. They are internal to DNSCache and should not be
+// returned.
+// cacheEntry objects are immutable once created.
+type cacheEntry struct {
+	// Name is a DNS name, it my be not fully qualified (e.g. myservice.namespace)
+	Name string
+
+	// LookupTime is when the data begins being valid
+	LookupTime time.Time
+
+	// ExpirationTime is a calcutated time when the DNS data stops being valid.
+	// It is simply LookupTime + TTL
+	ExpirationTime time.Time
+
+	// TTL represents the number of seconds past LookupTime that this data is
+	// valid.
+	TTL int
+
+	// IPs are the IPs associated with Name for this cacheEntry.
+	IPs []net.IP
+}
+
+// isExpiredBy returns true if entry is no longer valid at pointInTime
+func (entry *cacheEntry) isExpiredBy(pointInTime time.Time) bool {
+	return pointInTime.After(entry.ExpirationTime)
+}
+
+// ipEntries maps a unique IP to the cacheEntry that provides it in .IPs.
+// Multiple IPs may point to the same cacheEntry, or they may all be different.
+// Crucially, an IP may be present in a cacheEntry but the IP in ipEntries
+// points to another cacheEntry. This is because the second cacheEntry has a
+// later expiration for this specific IP, and may not include the other IPs
+// provided by the first entry.
+// The DNS name in the entries is not checked, but is assumed to be the same
+// for all entries.
+// Note: They are guarded by the DNSCache mutex.
+type ipEntries map[string]*cacheEntry
+
+// getIPs returns a sorted list of non-expired unique IPs.
+// This needs a read-lock
+func (s ipEntries) getIPs(now time.Time) []net.IP {
+	ips := make([]net.IP, 0, len(s)) // worst case size
+	for ip, entry := range s {
+		if entry != nil && !entry.isExpiredBy(now) {
+			ips = append(ips, net.ParseIP(ip))
+		}
+	}
+
+	return keepUniqueIPs(ips) // sorts IPs
+}
+
+// DNSCache manages DNS data that will expire after a certain TTL. Information
+// is tracked per-IP address, retaining the latest-expiring DNS data for each
+// address.
+// For most real-world DNS data, the entry per name remains small because newer
+// lookups replace older ones. Large TTLs may cause entries to grow if many
+// unique IPs are returned in separate lookups.
+// Redundant or expired entries are removed on insert.
+// Lookups check for expired entries.
+type DNSCache struct {
+	lock.RWMutex
+
+	// forward DNS lookups name -> IPEntries
+	// IPEntries maps IP -> entry that provides it. An entry may provide multiple IPs.
+	forward map[string]ipEntries
+}
+
+// NewDNSCache returns an initialized DNSCache
+func NewDNSCache() *DNSCache {
+	c := &DNSCache{
+		forward: make(map[string]ipEntries),
+	}
+
+	return c
+}
+
+// Update inserts a new entry into the cache.
+// After insertion cache entries for name are expired and redundant entries
+// evicted. This is O(number of new IPs) for eviction, and O(number of IPs for
+// name) for expiration.
+// lookupTime is the time the DNS information began being valid. It should be
+// in the past.
+// name is used as is and may be an unqualified name (e.g. myservice.namespace).
+// ips may be an IPv4 or IPv6 IP. Duplicates will be removed.
+// ttl is the DNS TTL for ips and is a seconds value.
+func (c *DNSCache) Update(lookupTime time.Time, name string, ips []net.IP, ttl int) {
+	entry := &cacheEntry{
+		Name:           name,
+		LookupTime:     lookupTime,
+		ExpirationTime: lookupTime.Add(time.Duration(ttl) * time.Second),
+		TTL:            ttl,
+		IPs:            ips,
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	entries, exists := c.forward[name]
+	if !exists {
+		entries = make(map[string]*cacheEntry)
+		c.forward[name] = entries
+	}
+	c.updateWithEntryIPs(entries, entry)
+	// When lookupTime is much earlier than time.Now(), we may not expire all
+	// entries that should be expired, leaving more work for .Lookup.
+	c.removeExpired(entries, time.Now())
+}
+
+// Lookup returns a set of unique IPs that are currently unexpired for name, if
+// any exist. An empty list indicates no valid records exist. The IPs are
+// returned sorted.
+func (c *DNSCache) Lookup(name string) (ips []net.IP) {
+	c.RLock()
+	defer c.RUnlock()
+
+	return c.lookupByTime(time.Now(), name)
+}
+
+// lookupByTime takes a timestamp for expiration comparisions, and is only
+// intended for testing.
+func (c *DNSCache) lookupByTime(now time.Time, name string) (ips []net.IP) {
+	entries, found := c.forward[name]
+	if !found {
+		return nil
+	}
+
+	return entries.getIPs(now)
+}
+
+// updateWithEntry adds a mapping for every IP found in `entry` to `ipEntries`
+// (which maps IP -> cacheEntry). It will replace existing IP->old mappings in
+// `entries` if the current entry expires sooner (or has already expired).
+// This needs a write lock
+func (c *DNSCache) updateWithEntryIPs(entries ipEntries, entry *cacheEntry) {
+	for _, ip := range entry.IPs {
+		ipStr := ip.String()
+		old, exists := entries[ipStr]
+		if old == nil || !exists || old.isExpiredBy(entry.ExpirationTime) {
+			entries[ipStr] = entry
+		}
+	}
+}
+
+// removeExpired removes expired (or nil) cacheEntry pointers from entries, an
+// ipEntries for a specific name.
+// This needs a write lock
+func (c *DNSCache) removeExpired(entries ipEntries, now time.Time) {
+	for ip, entry := range entries {
+		if entry == nil || entry.isExpiredBy(now) {
+			delete(entries, ip)
+		}
+	}
+}
+
+// keepUniqueIPs transforms the provided multiset of IPs into a single set,
+// lexicographically sorted via a byte-wise comparison of the IP slices (i.e.
+// IPv4 addresses show up before IPv6).
+// The slice is manipulated in-place destructively.
+//
+// 1- Sort the slice by comparing the IPs as bytes
+// 2- For every unseen unique IP in the sorted slice, move it to the start of
+// the return slice.
+// Note that the slice is always large enough and, because it is sorted, we
+// will not overwrite a valid element with another. To overwrite an element i
+// with j, i must have come before j AND we decided it was a duplicate of the
+// element at i-1.
+func keepUniqueIPs(ips []net.IP) []net.IP {
+	sort.Slice(ips, func(i, j int) bool {
+		return bytes.Compare(ips[i], ips[j]) == -1
+	})
+
+	returnIPs := ips[:0] // len==0 but cap==cap(ips)
+	for readIdx, ip := range ips {
+		if len(returnIPs) == 0 ||
+			bytes.Compare(returnIPs[len(returnIPs)-1], ips[readIdx]) != 0 {
+			returnIPs = append(returnIPs, ip)
+		}
+	}
+
+	return returnIPs
+}

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -1,0 +1,253 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fqdn
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"sort"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+type DNSCacheTestSuite struct{}
+
+var _ = Suite(&DNSCacheTestSuite{})
+
+func sortByName(entries []*cacheEntry) {
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name < entries[j].Name
+	})
+}
+
+// TestKeepUniqueIPs tests that KeepUniqueIPs returns a slice with only the unique IPs
+func (ds *DNSCacheTestSuite) TestKeepUniqueIPs(c *C) {
+	// test nil/empty handling
+	ips := keepUniqueIPs(nil)
+	c.Assert(len(ips), Equals, 0, Commentf("Non-empty slice returned with empty input"))
+
+	// test all duplicate
+	ips = keepUniqueIPs([]net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("1.1.1.1"), net.ParseIP("1.1.1.1")})
+	c.Assert(len(ips), Equals, 1, Commentf("Too many IPs returned for only 1 unique"))
+	c.Assert(ips[0].String(), Equals, "1.1.1.1", Commentf("Incorrect unique IP returned"))
+
+	// test all unique
+	ipSource := []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2"), net.ParseIP("3.3.3.3")}
+	ips = keepUniqueIPs(ipSource)
+	c.Assert(len(ips), Equals, 3, Commentf("Too few IPs returned for only 3 uniques"))
+	for i := range ipSource {
+		c.Assert(ips[i].String(), Equals, ipSource[i].String(), Commentf("Incorrect unique IP returned"))
+	}
+
+	// test mixed
+	ipSource = []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2"), net.ParseIP("3.3.3.3"), net.ParseIP("2.2.2.2")}
+	ips = keepUniqueIPs(ipSource)
+	c.Assert(len(ips), Equals, 3, Commentf("Too few IPs returned for only 3 uniques"))
+	for i := range ipSource[:3] {
+		c.Assert(ips[i].String(), Equals, ipSource[i].String(), Commentf("Incorrect unique IP returned"))
+	}
+}
+
+// TestUpdateLookup tests that we can insert DNS data and retrieve it. We
+// iterate through time, ensuring that data is expired as appropriate. We also
+// insert redundant DNS entries that should not change the output.
+func (ds *DNSCacheTestSuite) TestUpdateLookup(c *C) {
+	name := "test.com"
+	now := time.Now()
+	cache := NewDNSCache()
+	endTimeSeconds := 4
+
+	// Add 1 new entry "per second", and one with a redundant IP (with ttl/2).
+	// The IP reflects the second in which it will expire, and should show up for
+	// all now+ttl that is less than it.
+	for i := 1; i <= endTimeSeconds; i++ {
+		ttl := i
+		cache.Update(now,
+			name,
+			[]net.IP{net.ParseIP(fmt.Sprintf("1.1.1.%d", i)), net.ParseIP(fmt.Sprintf("2.2.2.%d", i))},
+			ttl)
+
+		cache.Update(now,
+			name,
+			[]net.IP{net.ParseIP(fmt.Sprintf("1.1.1.%d", i))},
+			ttl/2)
+	}
+
+	// lookup our entries
+	//  - no redundant entries (the 1.1.1.x is not repeated)
+	//  - with each step of secondsPastNow, fewer entries are returned
+	for secondsPastNow := 1; secondsPastNow <= endTimeSeconds; secondsPastNow++ {
+		ips := cache.lookupByTime(now.Add(time.Duration(secondsPastNow)*time.Second), name)
+		c.Assert(len(ips), Equals, 2*(endTimeSeconds-secondsPastNow+1), Commentf("Incorrect number of IPs returned"))
+
+		// Check that we returned each 1.1.1.x entry where x={1..endTimeSeconds}
+		// These are sorted, and are in the first half of the array
+		// Similarly, check the 2.2.2.x entries in the second half of the array
+		j := secondsPastNow
+		halfIndex := endTimeSeconds - secondsPastNow + 1
+		for _, ip := range ips[:halfIndex] {
+			c.Assert(ip.String(), Equals, fmt.Sprintf("1.1.1.%d", j), Commentf("Incorrect IP returned (j=%d, secondsPastNow=%d)", j, secondsPastNow))
+			j++
+		}
+		j = secondsPastNow
+		for _, ip := range ips[halfIndex:] {
+			c.Assert(ip.String(), Equals, fmt.Sprintf("2.2.2.%d", j), Commentf("Incorrect IP returned (j=%d, secondsPastNow=%d)", j, secondsPastNow))
+			j++
+		}
+
+	}
+}
+
+/* Benchmarks
+ * These are here to help gauge the relative costs of operations in DNSCache.
+ * Note: some are on arrays `size` elements, so the benchmark "op time" is too
+ * large.
+ */
+
+var (
+	now         = time.Now()
+	size        = 1000 // size of array to operate on
+	entriesOrig = makeEntries(now, 1+size/3, 1+size/3, 1+size/3)
+	ipsOrig     = func() []net.IP {
+		ips := make([]net.IP, 0, size)
+		for i := 0; i < size; i++ {
+			ips = append(ips, net.IPv4(byte(i>>24), byte(i>>16), byte(i>>8), byte(i>>0)))
+		}
+		return ips
+	}()
+)
+
+func makeEntries(now time.Time, live, redundant, expired int) (entries []*cacheEntry) {
+	liveTTL := 120
+	redundantTTL := 60
+
+	for ; live > 0; live-- {
+		ip := net.IPv4(byte(live>>24), byte(live>>16), byte(live>>8), byte(live>>0))
+
+		entries = append(entries, &cacheEntry{
+			Name:           fmt.Sprintf("live-%s", ip.String()),
+			LookupTime:     now,
+			ExpirationTime: now.Add(time.Duration(liveTTL) * time.Second),
+			TTL:            liveTTL,
+			IPs:            []net.IP{ip}})
+
+		if redundant > 0 {
+			redundant--
+			entries = append(entries, &cacheEntry{
+				Name:           fmt.Sprintf("redundant-%s", ip.String()),
+				LookupTime:     now,
+				ExpirationTime: now.Add(time.Duration(redundantTTL) * time.Second),
+				TTL:            redundantTTL,
+				IPs:            []net.IP{ip}})
+		}
+
+		if expired > 0 {
+			expired--
+			entries = append(entries, &cacheEntry{
+				Name:           fmt.Sprintf("expired-%s", ip.String()),
+				LookupTime:     now.Add(-time.Duration(liveTTL) * time.Second),
+				ExpirationTime: now.Add(-time.Second),
+				TTL:            liveTTL,
+				IPs:            []net.IP{ip}})
+		}
+	}
+
+	rand.Shuffle(len(entries), func(i, j int) {
+		entries[i], entries[j] = entries[j], entries[i]
+	})
+
+	return entries
+}
+
+// Note: each "op" works on size things
+func (ds *DNSCacheTestSuite) BenchmarkGetIPs(c *C) {
+	c.StopTimer()
+	now := time.Now()
+	cache := NewDNSCache()
+	cache.Update(now, "test.com", []net.IP{net.ParseIP("1.2.3.4")}, 60)
+	entries := cache.forward["test.com"]
+	for _, entry := range entriesOrig {
+		cache.updateWithEntryIPs(entries, entry)
+	}
+	c.StartTimer()
+
+	for i := 0; i < c.N; i++ {
+		entries.getIPs(now)
+	}
+}
+
+// Note: each "op" works on size things
+func (ds *DNSCacheTestSuite) BenchmarkUpdateIPs(c *C) {
+	for i := 0; i < c.N; i++ {
+		c.StopTimer()
+		now := time.Now()
+		cache := NewDNSCache()
+		cache.Update(now, "test.com", []net.IP{net.ParseIP("1.2.3.4")}, 60)
+		entries := cache.forward["test.com"]
+		c.StartTimer()
+
+		for _, entry := range entriesOrig {
+			cache.updateWithEntryIPs(entries, entry)
+			cache.removeExpired(entries, now)
+		}
+	}
+}
+
+// Note: each "op" works on size things
+func (ds *DNSCacheTestSuite) BenchmarkKeepUniqueIPs(c *C) {
+	ips := make([]net.IP, 0, len(ipsOrig))
+
+	copy(ips, ipsOrig)
+	for i := 0; i < c.N; i++ {
+		c.StopTimer()
+		rand.Shuffle(len(ips), func(i, j int) {
+			ips[i], ips[j] = ips[j], ips[i]
+		})
+		c.StartTimer()
+
+		keepUniqueIPs(ips)
+	}
+}
+
+func (ds *DNSCacheTestSuite) BenchmarkIPString(c *C) {
+	for i := 0; i < c.N; i++ {
+		_ = net.IPv4(byte(i>>24), byte(i>>16), byte(i>>8), byte(i>>0)).String()
+	}
+}
+
+func (ds *DNSCacheTestSuite) BenchmarkParseIPSimple(c *C) {
+	ip := ipsOrig[0].String()
+	for i := 0; i < c.N; i++ {
+		_ = net.ParseIP(ip)
+	}
+}
+
+// Note: each "op" works on size things
+func (ds *DNSCacheTestSuite) BenchmarkParseIP(c *C) {
+	c.StopTimer()
+	ips := make([]string, 0, len(ipsOrig))
+	for _, ip := range ipsOrig {
+		ips = append(ips, ip.String())
+	}
+	c.StartTimer()
+
+	for i := 0; i < c.N; i++ {
+		for _, ipStr := range ips {
+			_ = net.ParseIP(ipStr)
+		}
+	}
+}

--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -142,3 +142,23 @@ func hasToFQDN(rule *api.Rule) bool {
 
 	return false
 }
+
+// sortedIPsAreEqual compares two lists of sorted IPs. If any differ it returns
+// false.
+func sortedIPsAreEqual(a, b []net.IP) bool {
+	// the IP set is definitely different if the lengths are different
+	if len(a) != len(b) {
+		return false
+	}
+
+	// lengths are equal, so each member in one set must be in the other
+	// Note: we sorted fullNewIPs above, and sorted oldIPs when they were
+	// inserted in this function, previously.
+	// If any IPs at the same index differ, updated = true.
+	for i := range a {
+		if !a[i].Equal(b[i]) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
_This PR is most easily reviewed commit-by-commit. Most of the diffs are tests_

This PR mostly fixes the intent behind  https://github.com/cilium/cilium/issues/5310 but not in the most elegant way. I have further work but this PR is good enough to commit. Some of the code here is in place to better support future work (e.g. reverse DNS lookups) or multiple sources of DNS information (poller, monitor, DNS proxy, or arbitrary user inputs).

The daemon now takes a `--tofqdns-min-ttl` option. It is currently badly renamed, and is used as-is by DNSPoller as the TTL in the cache. Once we have DNS lookup TTLs, this will behave as a minimum. The goal is to allow handling various use-cases:
1. All IPs seen for a DNS name should be allowed, forever.
2. IPs for a DNS name seen in the past x seconds should be considered valid, but expired after that
3. IPs backed by unexpired DNS lookups should each expire following their TTL

(1) is now the default daemon behaviour (forever is 1 year).
(2) will need a `--tofqdns-max-ttl` but I didn't introduce it now since it can't be used
The current code would enforce (2) & (3) but the golang DNS lookups hide their TTL. Once that data is present the cache will correctly expire DNS.

The cache tracks DNS data by-IP, grouped by DNS name. This effectively means that lookups are: name -> set of IPs, but then we check for TTL expiry. The "set of IPs" maintains a map of IP -> DNS cache entry but ensure that the cache entry is the one that expires the furthest into the future for that IP. This means that in most normal DNS use-cases, even with a very high TTL, the number of entries will remain small. This is especially likely since DNS responses often include more than one IP.

```release-note
IPs generated by toFQDNs rules can have a TTL period.
```

**How to test (optional)**:
If you add a toFQDNs policy for a domain that changes IPs periodically (google.com, for example) you can notice that the IPs included in `cilium policy get` now accumulate valid IPs over time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5457)
<!-- Reviewable:end -->
