### PR TITLE
allocator: Only re-create verified local keys

### DIFF
--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -722,7 +722,7 @@ func (a *Allocator) syncLocalKeys() error {
 	// disappear while we perform the sync but that is fine as worst case,
 	// a master key is created for a slave key that no longer exists. The
 	// garbage collector will remove it again.
-	ids := a.localKeys.getIDs()
+	ids := a.localKeys.getVerifiedIDs()
 
 	for id, value := range ids {
 		a.recreateMasterKey(id, value)

--- a/pkg/kvstore/allocator/localkeys.go
+++ b/pkg/kvstore/allocator/localkeys.go
@@ -135,11 +135,13 @@ func (lk *localKeys) release(key string) (lastUse bool, err error) {
 	return false, fmt.Errorf("unable to find key in local cache")
 }
 
-func (lk *localKeys) getIDs() map[ID]string {
+func (lk *localKeys) getVerifiedIDs() map[ID]string {
 	ids := map[ID]string{}
 	lk.RLock()
 	for id, localKey := range lk.ids {
-		ids[id] = localKey.key
+		if localKey.verified {
+			ids[id] = localKey.key
+		}
 	}
 	lk.RUnlock()
 

--- a/pkg/kvstore/allocator/localkeys_test.go
+++ b/pkg/kvstore/allocator/localkeys_test.go
@@ -44,8 +44,9 @@ func (s *AllocatorSuite) TestLocalKeys(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(v, Equals, val2)
 
-	ids := k.getIDs()
-	c.Assert(len(ids), Equals, 2)
+	// only one of the two keys is verified yet
+	ids := k.getVerifiedIDs()
+	c.Assert(len(ids), Equals, 1)
 
 	// allocate with different value must fail
 	_, err = k.allocate(key2, val)


### PR DESCRIPTION
The re-creation logic recreated all local keys, even keys that were not
verified yet. Unverified keys are keys that have been locally allocated but not
yet synchronized with the kvstore. Upon re-creating such keys, the later
initial creation of the key in the regular code path would no longer regard
such keys as created and unit tests would fail. This happened when the background
sync routine ran in between local allocation and kvstore synchronization.

Fixes: #5437
Fixes: 10e50bef7b6a ("allocator: Periodically re-create master keys for local allocations")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5458)
<!-- Reviewable:end -->
