### PR TITLE
agent: Initialize local identity allocator before clustermesh

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1289,6 +1289,10 @@ func NewDaemon() (*Daemon, *endpointRestoreState, error) {
 		log.WithError(err).Fatal("Unable to initialize local node")
 	}
 
+	// This needs to be done after the node addressing has been configured
+	// as the node address is required as sufix
+	identity.InitIdentityAllocator(&d)
+
 	if path := option.Config.ClusterMeshConfig; path != "" {
 		if option.Config.ClusterID == 0 {
 			log.Info("Cluster-ID is not specified, skipping ClusterMesh initialization")
@@ -1306,10 +1310,6 @@ func NewDaemon() (*Daemon, *endpointRestoreState, error) {
 			d.clustermesh = clustermesh
 		}
 	}
-
-	// This needs to be done after the node addressing has been configured
-	// as the node address is required as sufix
-	identity.InitIdentityAllocator(&d)
 
 	if err = d.init(); err != nil {
 		log.WithError(err).Error("Error while initializing daemon")


### PR DESCRIPTION
The clustermesh layer depends on the local identity allocator. This inproper
ordering was causing the following panic depending on go routine scheduling:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1609906]

goroutine 140 [running]:
github.com/cilium/cilium/pkg/kvstore/allocator.(*Allocator).WatchRemoteKVStore(0x0, 0x2a09d00, 0xc421689900, 0xc4202f5f40, 0x1a, 0x1eb50dc)
        /go/src/github.com/cilium/cilium/pkg/kvstore/allocator/allocator.go:735 +0x216
github.com/cilium/cilium/pkg/identity.WatchRemoteIdentities(0x2a09d00, 0xc421689900, 0xc421b8fce0)
        /go/src/github.com/cilium/cilium/pkg/identity/allocator.go:191 +0x59
github.com/cilium/cilium/pkg/clustermesh.(*remoteCluster).restartRemoteConnection.func1(0xbed975cd9052d39c, 0x4d692b26)
        /go/src/github.com/cilium/cilium/pkg/clustermesh/remote_cluster.go:128 +0x2ea
github.com/cilium/cilium/pkg/controller.(*Controller).runController(0xc4215f7d40)
        /go/src/github.com/cilium/cilium/pkg/controller/controller.go:183 +0x488
created by github.com/cilium/cilium/pkg/controller.(*Manager).UpdateController
        /go/src/github.com/cilium/cilium/pkg/controller/manager.go:107 +0x59c
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5459)
<!-- Reviewable:end -->
