### PR TITLE
pkg/bpf: update BPF constants and structs as of Linux kernel 4.19-rc2

### DIFF
--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -36,23 +36,27 @@ var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "bpf")
 
 const (
 	// BPF map type constants. Must match enum bpf_map_type from linux/bpf.h
-	BPF_MAP_TYPE_UNSPEC           = 0
-	BPF_MAP_TYPE_HASH             = 1
-	BPF_MAP_TYPE_ARRAY            = 2
-	BPF_MAP_TYPE_PROG_ARRAY       = 3
-	BPF_MAP_TYPE_PERF_EVENT_ARRAY = 4
-	BPF_MAP_TYPE_PERCPU_HASH      = 5
-	BPF_MAP_TYPE_PERCPU_ARRAY     = 6
-	BPF_MAP_TYPE_STACK_TRACE      = 7
-	BPF_MAP_TYPE_CGROUP_ARRAY     = 8
-	BPF_MAP_TYPE_LRU_HASH         = 9
-	BPF_MAP_TYPE_LRU_PERCPU_HASH  = 10
-	BPF_MAP_TYPE_LPM_TRIE         = 11
-	BPF_MAP_TYPE_ARRAY_OF_MAPS    = 12
-	BPF_MAP_TYPE_HASH_OF_MAPS     = 13
-	BPF_MAP_TYPE_DEVMAP           = 14
-	BPF_MAP_TYPE_SOCKMAP          = 15
-	BPF_MAP_TYPE_CPUMAP           = 16
+	BPF_MAP_TYPE_UNSPEC              = 0
+	BPF_MAP_TYPE_HASH                = 1
+	BPF_MAP_TYPE_ARRAY               = 2
+	BPF_MAP_TYPE_PROG_ARRAY          = 3
+	BPF_MAP_TYPE_PERF_EVENT_ARRAY    = 4
+	BPF_MAP_TYPE_PERCPU_HASH         = 5
+	BPF_MAP_TYPE_PERCPU_ARRAY        = 6
+	BPF_MAP_TYPE_STACK_TRACE         = 7
+	BPF_MAP_TYPE_CGROUP_ARRAY        = 8
+	BPF_MAP_TYPE_LRU_HASH            = 9
+	BPF_MAP_TYPE_LRU_PERCPU_HASH     = 10
+	BPF_MAP_TYPE_LPM_TRIE            = 11
+	BPF_MAP_TYPE_ARRAY_OF_MAPS       = 12
+	BPF_MAP_TYPE_HASH_OF_MAPS        = 13
+	BPF_MAP_TYPE_DEVMAP              = 14
+	BPF_MAP_TYPE_SOCKMAP             = 15
+	BPF_MAP_TYPE_CPUMAP              = 16
+	BPF_MAP_TYPE_XSKMAP              = 17
+	BPF_MAP_TYPE_SOCKHASH            = 18
+	BPF_MAP_TYPE_CGROUP_STORAGE      = 19
+	BPF_MAP_TYPE_REUSEPORT_SOCKARRAY = 20
 
 	// BPF syscall command constants. Must match enum bpf_cmd from linux/bpf.h
 	BPF_MAP_CREATE          = 0
@@ -73,6 +77,9 @@ const (
 	BPF_OBJ_GET_INFO_BY_FD  = 15
 	BPF_PROG_QUERY          = 16
 	BPF_RAW_TRACEPOINT_OPEN = 17
+	BPF_BTF_LOAD            = 18
+	BPF_BTF_GET_FD_BY_ID    = 19
+	BPF_TASK_FD_QUERY       = 20
 
 	// Flags for BPF_MAP_UPDATE_ELEM. Must match values from linux/bpf.h
 	BPF_ANY     = 0

--- a/pkg/bpf/prog.go
+++ b/pkg/bpf/prog.go
@@ -45,6 +45,9 @@ const (
 	ProgTypeSkMsg
 	ProgTypeRawTracepoint
 	ProgTypeCgroupSockAddr
+	ProgTypeLwtSeg6Local
+	ProgTypeLircMode2
+	ProgTypeSkReusePort
 )
 
 func (t ProgType) String() string {
@@ -85,13 +88,19 @@ func (t ProgType) String() string {
 		return "Raw tracepoint"
 	case ProgTypeCgroupSockAddr:
 		return "Cgroup sockaddr"
+	case ProgTypeLwtSeg6Local:
+		return "LWT seg6local"
+	case ProgTypeLircMode2:
+		return "LIRC"
+	case ProgTypeSkReusePort:
+		return "Socket SO_REUSEPORT"
 	}
 
 	return "Unknown"
 }
 
 // attrProg holds values from the upstream struct union for BPF_*_GET_*_ID.
-// From: https://github.com/torvalds/linux/blob/v4.16/include/uapi/linux/bpf.h#L299
+// From: https://github.com/torvalds/linux/blob/v4.19-rc2/include/uapi/linux/bpf.h#L358
 type attrProg struct {
 	progID    uint32 // union: start_id, prog_id, or map_id
 	nextID    uint32
@@ -99,7 +108,7 @@ type attrProg struct {
 }
 
 // ProgInfo holds values from the upstream struct bpf_prog_info.
-// From: https://github.com/torvalds/linux/blob/v4.16/include/uapi/linux/bpf.h#924
+// From: https://github.com/torvalds/linux/blob/v4.19-rc2/include/uapi/linux/bpf.h#L2427
 type ProgInfo struct {
 	ProgType        uint32
 	ID              uint32
@@ -116,10 +125,14 @@ type ProgInfo struct {
 	IfIndex         uint32
 	NetnsDev        uint64
 	NetnsIno        uint64
+	NrJitedKsyms    uint32
+	NrJitedFuncLens uint32
+	JitedKsyms      uint64
+	JitedFuncLens   uint64
 }
 
 // attrObjInfo holds values from the upstream struct union for BPF_OBJ_GET_INFO_BY_FD.
-// From: https://github.com/torvalds/linux/blob/v4.16/include/uapi/linux/bpf.h#L309
+// From: https://github.com/torvalds/linux/blob/v4.19-rc2/include/uapi/linux/bpf.h#L369
 type attrObjInfo struct {
 	bpfFD   uint32
 	infoLen uint32


### PR DESCRIPTION
Add newly added constants from linux/bpf.h (as of Linux kernel
4.19-rc2) to pkg/bpf. Also update layout of the ProgInfo struct
accordingly and drop the outdated github links to linux/bpf.h

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5460)
<!-- Reviewable:end -->
