### PR TITLE
v1.1: k8s: add /status to RBAC for backport compatability

### DIFF
--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -307,7 +307,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.10/cilium-rbac.yaml
+++ b/examples/kubernetes/1.10/cilium-rbac.yaml
@@ -73,6 +73,8 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -306,7 +306,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -308,7 +308,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.11/cilium-rbac.yaml
+++ b/examples/kubernetes/1.11/cilium-rbac.yaml
@@ -73,6 +73,8 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -307,7 +307,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -308,7 +308,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.12/cilium-rbac.yaml
+++ b/examples/kubernetes/1.12/cilium-rbac.yaml
@@ -73,6 +73,8 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -307,7 +307,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.7/cilium-crio.yaml
+++ b/examples/kubernetes/1.7/cilium-crio.yaml
@@ -307,7 +307,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.7/cilium-rbac.yaml
+++ b/examples/kubernetes/1.7/cilium-rbac.yaml
@@ -73,6 +73,8 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -306,7 +306,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -307,7 +307,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.8/cilium-rbac.yaml
+++ b/examples/kubernetes/1.8/cilium-rbac.yaml
@@ -73,6 +73,8 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -306,7 +306,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -307,7 +307,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/1.9/cilium-rbac.yaml
+++ b/examples/kubernetes/1.9/cilium-rbac.yaml
@@ -73,6 +73,8 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -306,7 +306,9 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"
 ---

--- a/examples/kubernetes/templates/v1/cilium-rbac.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-rbac.yaml.sed
@@ -73,6 +73,8 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/status
   verbs:
   - "*"


### PR DESCRIPTION
In Cilium 1.2, a k8s functionality was added called "CRD Subresources".
Cilium enables this functionality by updating its CRD definition in
Kubenetes API-Server and with it, the CRD version.
This functionality, allows Cilium to only update the Cilium Network
Policy (CNP) and Cilium Endpoint (CEP) Status in the `/status` API
endpoint without sending the full object to Kubernetes API-Server.

On a downgrade from 1.2 to 1.1, where the user also downgrades the RBAC
rules, Cilium will send the full object to Kubernetes whenever wants to
update the status of the CNP or the CEP. As the user downgraded the
RBAC definition, Cilium will no longer have permissions to write any
status for any Cilium object. As the CRD definition was updated into
Kubernetes API-Server in 1.2, Cilium 1.1 will not perform any changes of
that CRD definition as its version is lower the one installed in
kube-apiserver.

To fix this issue, it is easier to backport the RBAC rules for 1.1 which
allows Cilium to continue to have write permissions in `/status`.

This downgrade issue will only happen in Kubernetes >= 1.11 which was
when the "CRD Subresources" where enabled by default in Kubernetes
API-Server.

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Backported some RBAC definitions from Cilium 1.2 to allow a seamless downgrade for k8s >= 1.11
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5462)
<!-- Reviewable:end -->
