### PR TITLE
Metrics: Add proxy redirects statistics

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -73,6 +73,7 @@ Policy Imports
 Policy L7 (HTTP/Kafka)
 ----------------------
 
+* ``proxy_redirects``: Number of redirects installed for endpoints, labeled by protocol
 * ``policy_l7_parse_errors_total``: Number of total L7 parse errors
 * ``policy_l7_forwarded_total``: Number of total L7 forwarded requests/responses
 * ``policy_l7_denied_total``: Number of total L7 denied requests/responses due to policy

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -80,6 +80,9 @@ var (
 	// (scope=slow_path)
 	LabelScope = "scope"
 
+	// LabelProtocolL7 is the label used when working with layer 7 protocols.
+	LabelProtocolL7 = "protocol_l7"
+
 	// Endpoint
 
 	// EndpointCount is a function used to collect this metric.
@@ -214,6 +217,13 @@ var (
 
 	// L7 statistics
 
+	// ProxyRedirects is the number of redirects labelled by protocol
+	ProxyRedirects = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      "proxy_redirects",
+		Help:      "Number of redirects installed for endpoints, labeled by protocol",
+	}, []string{LabelProtocolL7})
+
 	// ProxyParseErrors is a count of failed parse errors on proxy
 	ProxyParseErrors = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: Namespace,
@@ -342,6 +352,7 @@ func init() {
 	MustRegister(EventTSContainerd)
 	MustRegister(EventTSAPI)
 
+	MustRegister(ProxyRedirects)
 	MustRegister(ProxyParseErrors)
 	MustRegister(ProxyForwarded)
 	MustRegister(ProxyDenied)


### PR DESCRIPTION
Add number of proxy redirects by application protocol.

Example:
```
vagrant@runtime:~$ cilium metrics list | grep proxy_re
cilium_proxy_redirects_total                        protocol="http"                                         1.000000
cilium_proxy_redirects_total                        protocol="kafka"                                        1.000000
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5463)
<!-- Reviewable:end -->
