### PR TITLE
Bugtool: Fix format in dump files.

### DIFF
--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -397,7 +397,7 @@ func writeCmdToFile(cmdDir, prompt string, k8sPods []string) {
 		// Already contains Markdown, print as is.
 		fmt.Fprint(f, output)
 	} else if len(output) > 0 {
-		fmt.Fprintf(f, fmt.Sprintf("# %s\n\n```\n%s\n```\n", prompt, output))
+		fmt.Fprint(f, fmt.Sprintf("# %s\n\n```\n%s\n```\n", prompt, output))
 	} else {
 		// Empty file
 		os.Remove(f.Name())


### PR DESCRIPTION
Nowadays each time that a % is present in the command output, the print
will be invalid and can't be read easily.

Example invalid output:

```
PID USER      PR  NI    VIRT    RES    SHR S  %!C(MISSING)PU %!M(MISSING)EM     TIME+ COMMAND
```

With this change the output will be the original one:

```
  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5465)
<!-- Reviewable:end -->
