### PR TITLE
Fix `go vet` errors and `gofmt` issue

### DIFF
--- a/cilium/cmd/metrics_list.go
+++ b/cilium/cmd/metrics_list.go
@@ -17,7 +17,7 @@ var MetricsListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		res, err := client.Metrics.GetMetrics(nil)
 		if err != nil {
-			Fatalf("Cannot get metrics list", err)
+			Fatalf("Cannot get metrics list: %s", err)
 		}
 
 		if command.OutputJSON() {

--- a/contrib/scripts/check-fmt.sh
+++ b/contrib/scripts/check-fmt.sh
@@ -4,6 +4,7 @@ set -e
 diff="$(find . ! \( -path './contrib' -prune \) \
         ! \( -path './vendor' -prune \) \
         ! \( -path './.git' -prune \) \
+        ! \( -path '*.validate.go' -prune \) \
         ! -samefile ./daemon/bindata.go \
         -type f -name '*.go' -print0 \
                 | xargs -0 gofmt -d -l -s )"

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -688,7 +688,7 @@ func initEnv(cmd *cobra.Command) {
 
 	monitorAggregationLevel, err := option.ParseMonitorAggregationLevel(viper.GetString(option.MonitorAggregationName))
 	if err != nil {
-		log.WithError(err).Fatal("Failed to parse %s: %s",
+		log.WithError(err).Fatalf("Failed to parse %s: %s",
 			option.MonitorAggregationName, err)
 	}
 	option.Config.Opts.SetValidated(option.MonitorAggregation, monitorAggregationLevel)
@@ -696,7 +696,7 @@ func initEnv(cmd *cobra.Command) {
 	policy.SetPolicyEnabled(strings.ToLower(viper.GetString("enable-policy")))
 
 	if err := identity.AddUserDefinedNumericIdentitySet(fixedIdentity); err != nil {
-		log.Fatal("Invalid fixed identities provided: %s", err)
+		log.Fatalf("Invalid fixed identities provided: %s", err)
 	}
 
 	if err := kvstore.Setup(kvStore, kvStoreOpts); err != nil {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2633,7 +2633,7 @@ func (e *Endpoint) syncPolicyMap() error {
 			// converted to network byte-order.
 			err := e.PolicyMap.DeleteKey(keyHostOrder)
 			if err != nil {
-				e.Logger().WithError(err).Errorf("Failed to delete PolicyMap key %s", entry.Key)
+				e.Logger().WithError(err).Errorf("Failed to delete PolicyMap key %s", entry.Key.String())
 				errors = append(errors, err)
 			} else {
 				// Operation was successful, remove from realized state.
@@ -2646,7 +2646,7 @@ func (e *Endpoint) syncPolicyMap() error {
 		if oldEntry, ok := e.realizedMapState[keyToAdd]; !ok || oldEntry != entry {
 			err := e.PolicyMap.AllowKey(keyToAdd, entry.ProxyPort)
 			if err != nil {
-				e.Logger().WithError(err).Errorf("Failed to add PolicyMap key %s %d", keyToAdd, entry.ProxyPort)
+				e.Logger().WithError(err).Errorf("Failed to add PolicyMap key %s %d", keyToAdd.String(), entry.ProxyPort)
 				errors = append(errors, err)
 			} else {
 				// Operation was successful, add to realized state.


### PR DESCRIPTION
This PR fixes the following `make` errors:

```
pkg/endpoint/endpoint.go:2636: arg entry.Key for printf verb %s of wrong type: github.com/cilium/cilium/pkg/maps/policymap.PolicyKey
pkg/endpoint/endpoint.go:2649: arg keyToAdd for printf verb %s of wrong type: github.com/cilium/cilium/pkg/maps/policymap.PolicyKey
cilium/cmd/metrics_list.go:20: no formatting directive in Fatalf call
daemon/main.go:691: possible formatting directive in Fatal call
daemon/main.go:699: possible formatting directive in Fatal call
```

```
contrib/scripts/check-fmt.sh
Unformatted Go source code:
./pkg/envoy/cilium/accesslog.pb.validate.gocontrib/scripts/check-fmt.sh
diff -u ./pkg/envoy/cilium/accesslog.pb.validate.go.orig ./pkg/envoy/cilium/accesslog.pb.validate.go
--- ./pkg/envoy/cilium/accesslog.pb.validate.go.orig	2018-09-03 17:38:04.685610606 +0200
+++ ./pkg/envoy/cilium/accesslog.pb.validate.go	2018-09-03 17:38:04.685610606 +0200
@@ -100,7 +100,9 @@
 	for idx, item := range m.GetHeaders() {
 		_, _ = idx, item
 
-		if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+		if v, ok := interface{}(item).(interface {
+			Validate() error
+		}); ok {
 			if err := v.Validate(); err != nil {
 				return HttpLogEntryValidationError{
 					Field:  fmt.Sprintf("Headers[%v]", idx),
[...]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5466)
<!-- Reviewable:end -->
