### PR TITLE
Test: Re-Enable kafka

### DIFF
--- a/test/k8sT/manifests/kafka-sw-app.yaml
+++ b/test/k8sT/manifests/kafka-sw-app.yaml
@@ -12,21 +12,15 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: docker.io/wurstmeister/kafka:1.1.0
+        image: docker.io/spotify/kafkaproxy
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9092
         env:
-        - name: KAFKA_ADVERTISED_HOST_NAME
+        - name: ADVERTISED_HOST
           value: kafka-service
-        - name: KAFKA_ZOOKEEPER_CONNECT
-          value: zook:2181
-        - name: KAFKA_BROKER_ID
-          value: "1"
-        - name: KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS
-          value: "60000"
-        - name: KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS
-          value: "60000"
+        - name: ADVERTISED_PORT
+          value: "9092"
         livenessProbe:
           tcpSocket:
             port: 9092
@@ -36,42 +30,8 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 9092
-          initialDelaySeconds: 5
+          initialDelaySeconds: 30
           periodSeconds: 5
----
-apiVersion: extensions/v1beta1
-kind: Deployment
-metadata:
-  name: zookeeper
-spec:
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        app: zook
-        zgroup: kafkaTestApp
-    spec:
-      containers:
-      - name: zookeeper
-        image: docker.io/digitalwonderland/zookeeper:latest
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 2181
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: zook
-  labels:
-    app: zook
-spec:
-  ports:
-  - port: 2181
-    name: zookeeper-port
-    targetPort: 2181
-    protocol: TCP
-  selector:
-    app: zook
 ---
 apiVersion: v1
 kind: Service

--- a/test/k8sT/manifests/kafka-sw-security-policy.yaml
+++ b/test/k8sT/manifests/kafka-sw-security-policy.yaml
@@ -21,17 +21,6 @@ specs:
     egress:
     - toEndpoints:
       - matchLabels:
-          app: zook
-      toPorts:
-      - ports:
-        - port: "2181"
-          protocol: TCP
-  - endpointSelector:
-      matchLabels:
-        app: kafka
-    egress:
-    - toEndpoints:
-      - matchLabels:
           k8s-app: kube-dns
   - endpointSelector:
       matchLabels:


### PR DESCRIPTION
- Use a `spotify/kafkaproxy` image instead of old one.
- Remove invalid egress rule to zook

Fix #5309

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5467)
<!-- Reviewable:end -->
