### PR TITLE
api: Use pkg/api in api server.go autogen

### DIFF
--- a/api/v1/server.gotmpl
+++ b/api/v1/server.gotmpl
@@ -287,7 +287,7 @@ func (s *Server) Serve() (err error) {
 		configureServer(domainSocket, "unix", string(s.SocketPath))
 
 		if os.Getuid() == 0 {
-		    err := apisocket.SetDefaultPermissions(string(s.SocketPath))
+		    err := api.SetDefaultPermissions(string(s.SocketPath))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
We committed the generated code but not the base template used to
generate api/v1/server/server.go

Fixes 036982fa8ce403edf90ae98c6a494085b441e46d

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5468)
<!-- Reviewable:end -->
