### PR TITLE
Support service update in BPF maps

### DIFF
--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -35,14 +35,7 @@ func (d *Daemon) addSVC2BPFMap(feCilium loadbalancer.L3n4AddrID, feBPF lbmap.Ser
 	besBPF []lbmap.ServiceValue, addRevNAT bool) error {
 	log.WithField(logfields.ServiceName, feCilium.String()).Debug("adding service to BPF maps")
 
-	// Try to delete service before adding it and ignore errors as it might not exist.
-	err := d.svcDeleteByFrontendLocked(&feCilium.L3n4Addr)
-	if err != nil {
-		log.WithError(err).WithField(logfields.ServiceName, feCilium.L3n4Addr.String()).Debug("error deleting service before adding it")
-	}
-
-	err = lbmap.AddSVC2BPFMap(feBPF, besBPF, addRevNAT, int(feCilium.ID))
-	if err != nil {
+	if err := lbmap.UpdateService(feBPF, besBPF, addRevNAT, int(feCilium.ID)); err != nil {
 		if addRevNAT {
 			delete(d.loadBalancer.RevNATMap, feCilium.ID)
 		}


### PR DESCRIPTION
The existing servive update logic deleted and re-added a service every time a
service had to be updated. This commit adds update logic to the load balancer
map and uses it when adding and updating services.

Related: #5425

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5469)
<!-- Reviewable:end -->
