### PR TITLE
ci: Fix date normalization in jenkins-failures.sh

### DIFF
--- a/contrib/scripts/jenkins-failures.sh
+++ b/contrib/scripts/jenkins-failures.sh
@@ -5,10 +5,10 @@
 # To clean the list of Jenkins builds, build description needs to be updated with a comment.
 
 # allow users to specify SINCE as seconds since epoch
-YESTERDAY=$(date -d -1day +%s)
+YESTERDAY=$(date -d -1day)
 SINCE=${SINCE:-$YESTERDAY}
 # ensure SINCE is the correct length
-SINCE=$(date -d @$SINCE +%s%N  | cut -b1-13)
+SINCE=$(date -d "$SINCE" +%s%N  | cut -b1-13)
 
 TAB="   "
 BOLD=$(tput bold)


### PR DESCRIPTION
We suggest that the user select a time via SINCE=`date -d -3days` but
that wasn't parsed correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5470)
<!-- Reviewable:end -->
