### PR TITLE
k8s: ignore service updates if they are the same

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -910,6 +910,12 @@ func (d *Daemon) addK8sServiceV1(svc *v1.Service) {
 	d.loadBalancer.K8sMU.Lock()
 	defer d.loadBalancer.K8sMU.Unlock()
 
+	if oldSI, ok := d.loadBalancer.K8sServices[svcns]; ok {
+		if oldSI.Equals(newSI) {
+			return
+		}
+	}
+
 	d.loadBalancer.K8sServices[svcns] = newSI
 
 	d.syncLB(&svcns, nil, nil)


### PR DESCRIPTION
To prevent doing useless operations at the BPF LB map, if a k8s service
received is the same as the one stored in golang map, the update should
be ignored as Cilium has the necessary state already in memory.

Related: #5425 

Signed-off-by: André Martins <andre@cilium.io>

This is just a PR made to be backportable for 1.2. A proper fix will be introduced in 1.3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5475)
<!-- Reviewable:end -->
