### PR TITLE
v1.0: examples/kubernetes: add node.kubernetes.io/not-ready toleration

### DIFF
--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -181,6 +181,8 @@ spec:
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -228,6 +228,8 @@ spec:
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -182,6 +182,8 @@ spec:
       priorityClassName: system-node-critical
       tolerations:
       - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -229,6 +229,8 @@ spec:
       priorityClassName: system-node-critical
       tolerations:
       - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -182,6 +182,8 @@ spec:
       priorityClassName: system-node-critical
       tolerations:
       - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -229,6 +229,8 @@ spec:
       priorityClassName: system-node-critical
       tolerations:
       - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -181,6 +181,8 @@ spec:
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -228,6 +228,8 @@ spec:
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -181,6 +181,8 @@ spec:
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -228,6 +228,8 @@ spec:
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -181,6 +181,8 @@ spec:
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -228,6 +228,8 @@ spec:
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -181,6 +181,8 @@ spec:
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized


### PR DESCRIPTION
[ upstream commit 1c3ff40396690bfbcaa66d855dae540bac862fd9 ]

Kubernetes 1.12 added node.kubernetes.io/not-ready for nodes that don't
have its runtime network ready. Since Cilium needs to be deployed on
nodes so it can setup the CNI configuration the not-ready toleration
needs to be added to the DaemonSet.

Signed-off-by: André Martins <andre@cilium.io>

```release-note
add node.kubernetes.io/not-ready toleration to Cilium DaemonSet
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5476)
<!-- Reviewable:end -->
