### PR TITLE
Refactor ctmap logic into pkg/maps/ctmap

### DIFF
--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -273,6 +273,15 @@ func (m *Map) GetFd() int {
 	return m.fd
 }
 
+// Path returns the path to this map on the filesystem.
+func (m *Map) Path() (string, error) {
+	if err := m.setPathIfUnset(); err != nil {
+		return "", err
+	}
+
+	return m.path, nil
+}
+
 // DeepEquals compares the current map against another map to see that the
 // attributes of the two maps are the same.
 func (m *Map) DeepEquals(other *Map) bool {

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"math"
 	"net"
-	"time"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -27,8 +26,6 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
-
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -277,115 +274,6 @@ func dumpToSlice(m *bpf.Map, mapType string) ([]CtEntryDump, error) {
 		}
 	}
 	return entries, nil
-}
-
-type gcStats struct {
-	// started is the timestamp when the gc run was started
-	started time.Time
-
-	// finishedis the timestamp when the gc run completed
-	finished time.Time
-
-	// lookup is the number of key lookups performed
-	lookup uint32
-
-	// lookupFailed is the number of key lookups that failed
-	lookupFailed uint32
-
-	// prevKeyUnavailable is the number of times the previous key was not
-	// available
-	prevKeyUnavailable uint32
-
-	// deleted is the number of keys deleted
-	deleted uint32
-
-	// keyFallback is the number of times the current key became invalid
-	// while traversing and we had to fall back to the previous key
-	keyFallback uint32
-
-	// count is number of lookups performed on the map
-	count uint32
-
-	// maxEntries is the maximum number of entries in the gc table
-	maxEntries uint32
-
-	// family is the address family
-	family gcFamily
-
-	// completed is true when the gc run has been completed
-	completed bool
-
-	// interrupted is the number of times the gc run was interrupted and
-	// had to start from scratch
-	interrupted uint32
-
-	// aliveEntries is the number of scanned entries that are still alive
-	aliveEntries uint32
-}
-
-type gcFamily int
-
-const (
-	gcFamilyIPv4 = iota
-	gcFamilyIPv6
-)
-
-func (g gcFamily) String() string {
-	switch g {
-	case gcFamilyIPv4:
-		return "ipv4"
-	case gcFamilyIPv6:
-		return "ipv6"
-	default:
-		return "unknown"
-	}
-}
-
-func statStartGc(m *bpf.Map, family gcFamily) gcStats {
-	return gcStats{
-		started:    time.Now(),
-		count:      1,
-		maxEntries: m.MapInfo.MaxEntries,
-		family:     family,
-	}
-}
-
-func (s *gcStats) finish() {
-	s.finished = time.Now()
-	duration := s.finished.Sub(s.started)
-	family := s.family.String()
-	switch s.family {
-	case gcFamilyIPv6:
-		metrics.DatapathErrors.With(labelIPv6CTDumpInterrupts).Add(float64(s.interrupted))
-	case gcFamilyIPv4:
-		metrics.DatapathErrors.With(labelIPv4CTDumpInterrupts).Add(float64(s.interrupted))
-	}
-
-	var status string
-	if s.completed {
-		status = "completed"
-		metrics.ConntrackGCSize.WithLabelValues(family, metricsAlive).Set(float64(s.aliveEntries))
-		metrics.ConntrackGCSize.WithLabelValues(family, metricsDeleted).Set(float64(s.deleted))
-	} else {
-		status = "uncompleted"
-		log.WithField("interrupted", s.interrupted).Warningf(
-			"Garbage collection on IPv6 CT map failed to finish")
-	}
-
-	metrics.ConntrackGCRuns.WithLabelValues(family, status).Inc()
-	metrics.ConntrackGCDuration.WithLabelValues(family, status).Observe(duration.Seconds())
-	metrics.ConntrackGCKeyFallbacks.WithLabelValues(family).Add(float64(s.keyFallback))
-
-	log.WithFields(logrus.Fields{
-		logfields.StartTime: s.started,
-		logfields.Duration:  duration,
-		"numDeleted":        s.deleted,
-		"numLookups":        s.count,
-		"numLookupsFailed":  s.lookupFailed,
-		"numKeyFallbacks":   s.keyFallback,
-		"completed":         s.completed,
-		"maxEntries":        s.maxEntries,
-	}).Infof("%s Conntrack garbage collection statistics", s.family)
 }
 
 // doGC6 iterates through a CTv6 map and drops entries based on the given

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -171,14 +171,14 @@ func ToString(m *bpf.Map, mapName string) (string, error) {
 		value := entry.Value
 		buffer.WriteString(
 			fmt.Sprintf(" expires=%d rx_packets=%d rx_bytes=%d tx_packets=%d tx_bytes=%d flags=%x revnat=%d src_sec_id=%d\n",
-				value.lifetime,
-				value.rx_packets,
-				value.rx_bytes,
-				value.tx_packets,
-				value.tx_bytes,
-				value.flags,
-				byteorder.NetworkToHost(value.revnat),
-				value.src_sec_id,
+				value.Lifetime,
+				value.RxPackets,
+				value.RxBytes,
+				value.TxPackets,
+				value.TxBytes,
+				value.Flags,
+				byteorder.NetworkToHost(value.RevNAT),
+				value.SourceSecurityID,
 			),
 		)
 
@@ -283,11 +283,11 @@ func doGC6(m *bpf.Map, filter *GCFilter) gcStats {
 
 		entry := entryMap.(*CtEntry)
 
-		// In CT entries, the source address of the conntrack entry (`saddr`) is
+		// In CT entries, the source address of the conntrack entry (`SourceAddr`) is
 		// the destination of the packet received, therefore it's the packet's
 		// destination IP
-		action := filter.doFiltering(currentKey.daddr.IP(), currentKey.saddr.IP(), currentKey.sport,
-			uint8(currentKey.nexthdr), currentKey.flags, entry)
+		action := filter.doFiltering(currentKey.DestAddr.IP(), currentKey.SourceAddr.IP(), currentKey.SourcePort,
+			uint8(currentKey.NextHeader), currentKey.Flags, entry)
 
 		switch action {
 		case deleteEntry:
@@ -361,11 +361,11 @@ func doGC4(m *bpf.Map, filter *GCFilter) gcStats {
 
 		entry := entryMap.(*CtEntry)
 
-		// In CT entries, the source address of the conntrack entry (`saddr`) is
+		// In CT entries, the source address of the conntrack entry (`SourceAddr`) is
 		// the destination of the packet received, therefore it's the packet's
 		// destination IP
-		action := filter.doFiltering(currentKey.daddr.IP(), currentKey.saddr.IP(), currentKey.sport,
-			uint8(currentKey.nexthdr), currentKey.flags, entry)
+		action := filter.doFiltering(currentKey.DestAddr.IP(), currentKey.SourceAddr.IP(), currentKey.SourcePort,
+			uint8(currentKey.NextHeader), currentKey.Flags, entry)
 
 		switch action {
 		case deleteEntry:
@@ -394,7 +394,7 @@ func doGC4(m *bpf.Map, filter *GCFilter) gcStats {
 }
 
 func (f *GCFilter) doFiltering(srcIP net.IP, dstIP net.IP, dstPort uint16, nextHdr, flags uint8, entry *CtEntry) (action int) {
-	if f.RemoveExpired && entry.lifetime < f.Time {
+	if f.RemoveExpired && entry.Lifetime < f.Time {
 		return deleteEntry
 	}
 

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -134,45 +134,6 @@ type CtKey interface {
 	Dump(buffer *bytes.Buffer) bool
 }
 
-// CtEntry represents an entry in the connection tracking table.
-type CtEntry struct {
-	rx_packets uint64
-	rx_bytes   uint64
-	tx_packets uint64
-	tx_bytes   uint64
-	lifetime   uint32
-	flags      uint16
-	// revnat is in network byte order
-	revnat         uint16
-	tx_flags_seen  uint8
-	rx_flags_seen  uint8
-	src_sec_id     uint32
-	last_tx_report uint32
-	last_rx_report uint32
-}
-
-// GetValuePtr returns the unsafe.Pointer for s.
-func (c *CtEntry) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(c) }
-
-// String returns the readable format
-func (c *CtEntry) String() string {
-	return fmt.Sprintf("expires=%d rx_packets=%d rx_bytes=%d tx_packets=%d tx_bytes=%d flags=%x revnat=%d src_sec_id=%d\n",
-		c.lifetime,
-		c.rx_packets,
-		c.rx_bytes,
-		c.tx_packets,
-		c.tx_bytes,
-		c.flags,
-		byteorder.NetworkToHost(c.revnat),
-		c.src_sec_id)
-}
-
-// CtEntryDump represents the key and value contained in the conntrack map.
-type CtEntryDump struct {
-	Key   CtKey
-	Value CtEntry
-}
-
 // GCFilter contains the necessary fields to filter the CT maps.
 // Filtering by endpoint requires both EndpointID to be > 0 and
 // EndpointIP to be not nil.

--- a/pkg/maps/ctmap/entry.go
+++ b/pkg/maps/ctmap/entry.go
@@ -23,19 +23,19 @@ import (
 
 // CtEntry represents an entry in the connection tracking table.
 type CtEntry struct {
-	rx_packets uint64
-	rx_bytes   uint64
-	tx_packets uint64
-	tx_bytes   uint64
-	lifetime   uint32
-	flags      uint16
-	// revnat is in network byte order
-	revnat         uint16
-	tx_flags_seen  uint8
-	rx_flags_seen  uint8
-	src_sec_id     uint32
-	last_tx_report uint32
-	last_rx_report uint32
+	RxPackets uint64
+	RxBytes   uint64
+	TxPackets uint64
+	TxBytes   uint64
+	Lifetime  uint32
+	Flags     uint16
+	// RevNAT is in network byte order
+	RevNAT           uint16
+	TxFlagsSeen      uint8
+	RxFlagsSeen      uint8
+	SourceSecurityID uint32
+	LastTxReport     uint32
+	LastRxReport     uint32
 }
 
 // GetValuePtr returns the unsafe.Pointer for s.
@@ -43,15 +43,15 @@ func (c *CtEntry) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(c) }
 
 // String returns the readable format
 func (c *CtEntry) String() string {
-	return fmt.Sprintf("expires=%d rx_packets=%d rx_bytes=%d tx_packets=%d tx_bytes=%d flags=%x revnat=%d src_sec_id=%d\n",
-		c.lifetime,
-		c.rx_packets,
-		c.rx_bytes,
-		c.tx_packets,
-		c.tx_bytes,
-		c.flags,
-		byteorder.NetworkToHost(c.revnat),
-		c.src_sec_id)
+	return fmt.Sprintf("expires=%d RxPackets=%d RxBytes=%d TxPackets=%d TxBytes=%d Flags=%x RevNAT=%d SourceSecurityID=%d\n",
+		c.Lifetime,
+		c.RxPackets,
+		c.RxBytes,
+		c.TxPackets,
+		c.TxBytes,
+		c.Flags,
+		byteorder.NetworkToHost(c.RevNAT),
+		c.SourceSecurityID)
 }
 
 // CtEntryDump represents the key and value contained in the conntrack map.

--- a/pkg/maps/ctmap/entry.go
+++ b/pkg/maps/ctmap/entry.go
@@ -1,0 +1,61 @@
+// Copyright 2016-2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctmap
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/cilium/cilium/pkg/byteorder"
+)
+
+// CtEntry represents an entry in the connection tracking table.
+type CtEntry struct {
+	rx_packets uint64
+	rx_bytes   uint64
+	tx_packets uint64
+	tx_bytes   uint64
+	lifetime   uint32
+	flags      uint16
+	// revnat is in network byte order
+	revnat         uint16
+	tx_flags_seen  uint8
+	rx_flags_seen  uint8
+	src_sec_id     uint32
+	last_tx_report uint32
+	last_rx_report uint32
+}
+
+// GetValuePtr returns the unsafe.Pointer for s.
+func (c *CtEntry) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(c) }
+
+// String returns the readable format
+func (c *CtEntry) String() string {
+	return fmt.Sprintf("expires=%d rx_packets=%d rx_bytes=%d tx_packets=%d tx_bytes=%d flags=%x revnat=%d src_sec_id=%d\n",
+		c.lifetime,
+		c.rx_packets,
+		c.rx_bytes,
+		c.tx_packets,
+		c.tx_bytes,
+		c.flags,
+		byteorder.NetworkToHost(c.revnat),
+		c.src_sec_id)
+}
+
+// CtEntryDump represents the key and value contained in the conntrack map.
+type CtEntryDump struct {
+	Key   CtKey
+	Value CtEntry
+}

--- a/pkg/maps/ctmap/ipv4.go
+++ b/pkg/maps/ctmap/ipv4.go
@@ -94,36 +94,7 @@ func (k CtKey4) Dump(buffer *bytes.Buffer) bool {
 //CtKey4Global represents the key for IPv4 entries in the global BPF conntrack
 // map.
 type CtKey4Global struct {
-	daddr types.IPv4
-	saddr types.IPv4
-	// sport is in network byte order
-	sport uint16
-	// dport is in network byte order
-	dport   uint16
-	nexthdr u8proto.U8proto
-	flags   uint8
-}
-
-// GetKeyPtr returns the unsafe.Pointer for k.
-func (k *CtKey4Global) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
-
-//NewValue creates a new bpf.MapValue.
-func (k *CtKey4Global) NewValue() bpf.MapValue { return &CtEntry{} }
-
-// ToNetwork converts CtKey4Global ports to network byte order.
-func (k *CtKey4Global) ToNetwork() CtKey {
-	n := *k
-	n.sport = byteorder.HostToNetwork(n.sport).(uint16)
-	n.dport = byteorder.HostToNetwork(n.dport).(uint16)
-	return &n
-}
-
-// ToHost converts CtKey4Global ports to host byte order.
-func (k *CtKey4Global) ToHost() CtKey {
-	n := *k
-	n.sport = byteorder.NetworkToHost(n.sport).(uint16)
-	n.dport = byteorder.NetworkToHost(n.dport).(uint16)
-	return &n
+	CtKey4
 }
 
 func (k *CtKey4Global) String() string {

--- a/pkg/maps/ctmap/ipv4.go
+++ b/pkg/maps/ctmap/ipv4.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,12 +27,12 @@ import (
 
 //CtKey4 represents the key for IPv4 entries in the local BPF conntrack map.
 type CtKey4 struct {
-	daddr   types.IPv4
-	saddr   types.IPv4
-	sport   uint16
-	dport   uint16
-	nexthdr u8proto.U8proto
-	flags   uint8
+	DestAddr   types.IPv4
+	SourceAddr types.IPv4
+	SourcePort uint16
+	DestPort   uint16
+	NextHeader u8proto.U8proto
+	Flags      uint8
 }
 
 // GetKeyPtr returns the unsafe.Pointer for k.
@@ -44,47 +44,47 @@ func (k *CtKey4) NewValue() bpf.MapValue { return &CtEntry{} }
 // ToNetwork converts CtKey4 ports to network byte order.
 func (k *CtKey4) ToNetwork() CtKey {
 	n := *k
-	n.sport = byteorder.HostToNetwork(n.sport).(uint16)
-	n.dport = byteorder.HostToNetwork(n.dport).(uint16)
+	n.SourcePort = byteorder.HostToNetwork(n.SourcePort).(uint16)
+	n.DestPort = byteorder.HostToNetwork(n.DestPort).(uint16)
 	return &n
 }
 
 // ToHost converts CtKey4 ports to host byte order.
 func (k *CtKey4) ToHost() CtKey {
 	n := *k
-	n.sport = byteorder.NetworkToHost(n.sport).(uint16)
-	n.dport = byteorder.NetworkToHost(n.dport).(uint16)
+	n.SourcePort = byteorder.NetworkToHost(n.SourcePort).(uint16)
+	n.DestPort = byteorder.NetworkToHost(n.DestPort).(uint16)
 	return &n
 }
 
 func (k *CtKey4) String() string {
-	return fmt.Sprintf("%s:%d, %d, %d, %d", k.daddr, k.sport, k.dport, k.nexthdr, k.flags)
+	return fmt.Sprintf("%s:%d, %d, %d, %d", k.DestAddr, k.SourcePort, k.DestPort, k.NextHeader, k.Flags)
 }
 
 // Dump writes the contents of key to buffer and returns true if the value for
 // next header in the key is nonzero.
 func (k CtKey4) Dump(buffer *bytes.Buffer) bool {
-	if k.nexthdr == 0 {
+	if k.NextHeader == 0 {
 		return false
 	}
 
-	if k.flags&TUPLE_F_IN != 0 {
+	if k.Flags&TUPLE_F_IN != 0 {
 		buffer.WriteString(fmt.Sprintf("%s IN %s %d:%d ",
-			k.nexthdr.String(),
-			k.daddr.IP().String(),
-			k.sport, k.dport),
+			k.NextHeader.String(),
+			k.DestAddr.IP().String(),
+			k.SourcePort, k.DestPort),
 		)
 
 	} else {
 		buffer.WriteString(fmt.Sprintf("%s OUT %s %d:%d ",
-			k.nexthdr.String(),
-			k.daddr.IP().String(),
-			k.dport,
-			k.sport),
+			k.NextHeader.String(),
+			k.DestAddr.IP().String(),
+			k.DestPort,
+			k.SourcePort),
 		)
 	}
 
-	if k.flags&TUPLE_F_RELATED != 0 {
+	if k.Flags&TUPLE_F_RELATED != 0 {
 		buffer.WriteString("related ")
 	}
 
@@ -98,32 +98,32 @@ type CtKey4Global struct {
 }
 
 func (k *CtKey4Global) String() string {
-	return fmt.Sprintf("%s:%d --> %s:%d, %d, %d", k.saddr, k.sport, k.daddr, k.dport, k.nexthdr, k.flags)
+	return fmt.Sprintf("%s:%d --> %s:%d, %d, %d", k.SourceAddr, k.SourcePort, k.DestAddr, k.DestPort, k.NextHeader, k.Flags)
 }
 
 // Dump writes the contents of key to buffer and returns true if the value for
 // next header in the key is nonzero.
 func (k CtKey4Global) Dump(buffer *bytes.Buffer) bool {
-	if k.nexthdr == 0 {
+	if k.NextHeader == 0 {
 		return false
 	}
 
-	if k.flags&TUPLE_F_IN != 0 {
+	if k.Flags&TUPLE_F_IN != 0 {
 		buffer.WriteString(fmt.Sprintf("%s IN %s:%d -> %s:%d ",
-			k.nexthdr.String(),
-			k.saddr.IP().String(), k.sport,
-			k.daddr.IP().String(), k.dport),
+			k.NextHeader.String(),
+			k.SourceAddr.IP().String(), k.SourcePort,
+			k.DestAddr.IP().String(), k.DestPort),
 		)
 
 	} else {
 		buffer.WriteString(fmt.Sprintf("%s OUT %s:%d -> %s:%d ",
-			k.nexthdr.String(),
-			k.saddr.IP().String(), k.sport,
-			k.daddr.IP().String(), k.dport),
+			k.NextHeader.String(),
+			k.SourceAddr.IP().String(), k.SourcePort,
+			k.DestAddr.IP().String(), k.DestPort),
 		)
 	}
 
-	if k.flags&TUPLE_F_RELATED != 0 {
+	if k.Flags&TUPLE_F_RELATED != 0 {
 		buffer.WriteString("related ")
 	}
 

--- a/pkg/maps/ctmap/ipv6.go
+++ b/pkg/maps/ctmap/ipv6.go
@@ -93,34 +93,7 @@ func (k CtKey6) Dump(buffer *bytes.Buffer) bool {
 
 //CtKey6Global represents the key for IPv6 entries in the global BPF conntrack map.
 type CtKey6Global struct {
-	daddr   types.IPv6
-	saddr   types.IPv6
-	sport   uint16
-	dport   uint16
-	nexthdr u8proto.U8proto
-	flags   uint8
-}
-
-// GetKeyPtr returns the unsafe.Pointer for k.
-func (k *CtKey6Global) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
-
-//NewValue creates a new bpf.MapValue.
-func (k *CtKey6Global) NewValue() bpf.MapValue { return &CtEntry{} }
-
-// ToNetwork converts CtKey6Global ports to network byte order.
-func (k *CtKey6Global) ToNetwork() CtKey {
-	n := *k
-	n.sport = byteorder.HostToNetwork(n.sport).(uint16)
-	n.dport = byteorder.HostToNetwork(n.dport).(uint16)
-	return &n
-}
-
-// ToHost converts CtKey6Global ports to host byte order.
-func (k *CtKey6Global) ToHost() CtKey {
-	n := *k
-	n.sport = byteorder.NetworkToHost(n.sport).(uint16)
-	n.dport = byteorder.NetworkToHost(n.dport).(uint16)
-	return &n
+	CtKey6
 }
 
 func (k *CtKey6Global) String() string {

--- a/pkg/maps/ctmap/ipv6.go
+++ b/pkg/maps/ctmap/ipv6.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,12 +27,12 @@ import (
 
 //CtKey6 represents the key for IPv6 entries in the local BPF conntrack map.
 type CtKey6 struct {
-	daddr   types.IPv6
-	saddr   types.IPv6
-	sport   uint16
-	dport   uint16
-	nexthdr u8proto.U8proto
-	flags   uint8
+	DestAddr   types.IPv6
+	SourceAddr types.IPv6
+	SourcePort uint16
+	DestPort   uint16
+	NextHeader u8proto.U8proto
+	Flags      uint8
 }
 
 // GetKeyPtr returns the unsafe.Pointer for k.
@@ -44,47 +44,47 @@ func (k *CtKey6) NewValue() bpf.MapValue { return &CtEntry{} }
 // ToNetwork converts CtKey6 ports to network byte order.
 func (k *CtKey6) ToNetwork() CtKey {
 	n := *k
-	n.sport = byteorder.HostToNetwork(n.sport).(uint16)
-	n.dport = byteorder.HostToNetwork(n.dport).(uint16)
+	n.SourcePort = byteorder.HostToNetwork(n.SourcePort).(uint16)
+	n.DestPort = byteorder.HostToNetwork(n.DestPort).(uint16)
 	return &n
 }
 
 // ToHost converts CtKey6 ports to network byte order.
 func (k *CtKey6) ToHost() CtKey {
 	n := *k
-	n.sport = byteorder.NetworkToHost(n.sport).(uint16)
-	n.dport = byteorder.NetworkToHost(n.dport).(uint16)
+	n.SourcePort = byteorder.NetworkToHost(n.SourcePort).(uint16)
+	n.DestPort = byteorder.NetworkToHost(n.DestPort).(uint16)
 	return &n
 }
 
 func (k *CtKey6) String() string {
-	return fmt.Sprintf("[%s]:%d, %d, %d, %d", k.daddr, k.sport, k.dport, k.nexthdr, k.flags)
+	return fmt.Sprintf("[%s]:%d, %d, %d, %d", k.DestAddr, k.SourcePort, k.DestPort, k.NextHeader, k.Flags)
 }
 
 // Dump writes the contents of key to buffer and returns true if the value for
 // next header in the key is nonzero.
 func (k CtKey6) Dump(buffer *bytes.Buffer) bool {
-	if k.nexthdr == 0 {
+	if k.NextHeader == 0 {
 		return false
 	}
 
-	if k.flags&TUPLE_F_IN != 0 {
+	if k.Flags&TUPLE_F_IN != 0 {
 		buffer.WriteString(fmt.Sprintf("%s IN %s %d:%d ",
-			k.nexthdr.String(),
-			k.daddr.IP().String(),
-			k.sport, k.dport),
+			k.NextHeader.String(),
+			k.DestAddr.IP().String(),
+			k.SourcePort, k.DestPort),
 		)
 
 	} else {
 		buffer.WriteString(fmt.Sprintf("%s OUT %s %d:%d ",
-			k.nexthdr.String(),
-			k.daddr.IP().String(),
-			k.dport,
-			k.sport),
+			k.NextHeader.String(),
+			k.DestAddr.IP().String(),
+			k.DestPort,
+			k.SourcePort),
 		)
 	}
 
-	if k.flags&TUPLE_F_RELATED != 0 {
+	if k.Flags&TUPLE_F_RELATED != 0 {
 		buffer.WriteString("related ")
 	}
 
@@ -97,32 +97,32 @@ type CtKey6Global struct {
 }
 
 func (k *CtKey6Global) String() string {
-	return fmt.Sprintf("[%s]:%d --> [%s]:%d, %d, %d", k.saddr, k.sport, k.daddr, k.dport, k.nexthdr, k.flags)
+	return fmt.Sprintf("[%s]:%d --> [%s]:%d, %d, %d", k.SourceAddr, k.SourcePort, k.DestAddr, k.DestPort, k.NextHeader, k.Flags)
 }
 
 // Dump writes the contents of key to buffer and returns true if the value for
 // next header in the key is nonzero.
 func (k CtKey6Global) Dump(buffer *bytes.Buffer) bool {
-	if k.nexthdr == 0 {
+	if k.NextHeader == 0 {
 		return false
 	}
 
-	if k.flags&TUPLE_F_IN != 0 {
+	if k.Flags&TUPLE_F_IN != 0 {
 		buffer.WriteString(fmt.Sprintf("%s IN [%s]:%d -> [%s]:%d ",
-			k.nexthdr.String(),
-			k.saddr.IP().String(), k.sport,
-			k.daddr.IP().String(), k.dport),
+			k.NextHeader.String(),
+			k.SourceAddr.IP().String(), k.SourcePort,
+			k.DestAddr.IP().String(), k.DestPort),
 		)
 
 	} else {
 		buffer.WriteString(fmt.Sprintf("%s OUT [%s]:%d -> [%s]:%d ",
-			k.nexthdr.String(),
-			k.saddr.IP().String(), k.sport,
-			k.daddr.IP().String(), k.dport),
+			k.NextHeader.String(),
+			k.SourceAddr.IP().String(), k.SourcePort,
+			k.DestAddr.IP().String(), k.DestPort),
 		)
 	}
 
-	if k.flags&TUPLE_F_RELATED != 0 {
+	if k.Flags&TUPLE_F_RELATED != 0 {
 		buffer.WriteString("related ")
 	}
 

--- a/pkg/maps/ctmap/metrics.go
+++ b/pkg/maps/ctmap/metrics.go
@@ -1,0 +1,134 @@
+// Copyright 2016-2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctmap
+
+import (
+	"time"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
+
+	"github.com/sirupsen/logrus"
+)
+
+type gcStats struct {
+	// started is the timestamp when the gc run was started
+	started time.Time
+
+	// finishedis the timestamp when the gc run completed
+	finished time.Time
+
+	// lookup is the number of key lookups performed
+	lookup uint32
+
+	// lookupFailed is the number of key lookups that failed
+	lookupFailed uint32
+
+	// prevKeyUnavailable is the number of times the previous key was not
+	// available
+	prevKeyUnavailable uint32
+
+	// deleted is the number of keys deleted
+	deleted uint32
+
+	// keyFallback is the number of times the current key became invalid
+	// while traversing and we had to fall back to the previous key
+	keyFallback uint32
+
+	// count is number of lookups performed on the map
+	count uint32
+
+	// maxEntries is the maximum number of entries in the gc table
+	maxEntries uint32
+
+	// family is the address family
+	family gcFamily
+
+	// completed is true when the gc run has been completed
+	completed bool
+
+	// interrupted is the number of times the gc run was interrupted and
+	// had to start from scratch
+	interrupted uint32
+
+	// aliveEntries is the number of scanned entries that are still alive
+	aliveEntries uint32
+}
+
+type gcFamily int
+
+const (
+	gcFamilyIPv4 = iota
+	gcFamilyIPv6
+)
+
+func (g gcFamily) String() string {
+	switch g {
+	case gcFamilyIPv4:
+		return "ipv4"
+	case gcFamilyIPv6:
+		return "ipv6"
+	default:
+		return "unknown"
+	}
+}
+
+func statStartGc(m *bpf.Map, family gcFamily) gcStats {
+	return gcStats{
+		started:    time.Now(),
+		count:      1,
+		maxEntries: m.MapInfo.MaxEntries,
+		family:     family,
+	}
+}
+
+func (s *gcStats) finish() {
+	s.finished = time.Now()
+	duration := s.finished.Sub(s.started)
+	family := s.family.String()
+	switch s.family {
+	case gcFamilyIPv6:
+		metrics.DatapathErrors.With(labelIPv6CTDumpInterrupts).Add(float64(s.interrupted))
+	case gcFamilyIPv4:
+		metrics.DatapathErrors.With(labelIPv4CTDumpInterrupts).Add(float64(s.interrupted))
+	}
+
+	var status string
+	if s.completed {
+		status = "completed"
+		metrics.ConntrackGCSize.WithLabelValues(family, metricsAlive).Set(float64(s.aliveEntries))
+		metrics.ConntrackGCSize.WithLabelValues(family, metricsDeleted).Set(float64(s.deleted))
+	} else {
+		status = "uncompleted"
+		log.WithField("interrupted", s.interrupted).Warningf(
+			"Garbage collection on IPv6 CT map failed to finish")
+	}
+
+	metrics.ConntrackGCRuns.WithLabelValues(family, status).Inc()
+	metrics.ConntrackGCDuration.WithLabelValues(family, status).Observe(duration.Seconds())
+	metrics.ConntrackGCKeyFallbacks.WithLabelValues(family).Add(float64(s.keyFallback))
+
+	log.WithFields(logrus.Fields{
+		logfields.StartTime: s.started,
+		logfields.Duration:  duration,
+		"numDeleted":        s.deleted,
+		"numLookups":        s.count,
+		"numLookupsFailed":  s.lookupFailed,
+		"numKeyFallbacks":   s.keyFallback,
+		"completed":         s.completed,
+		"maxEntries":        s.maxEntries,
+	}).Infof("%s Conntrack garbage collection statistics", s.family)
+}


### PR DESCRIPTION
Several bugs have been triggered in recent months due to the way that the CT package required users of the package to deal with internal implementation details of the package. For examples, see #5230, #5313, #5070

Furthermore, upcoming proposed changes to split the CT map into UDP and TCP maps are difficult to do without introducing significant boilerplate.

This PR attempts to address some of the technical debt associated with the CT map by converting it over to use the standard `bpf.Map` type from `pkg/bpf/`. This should streamline future changes.

Related: #5450

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5480)
<!-- Reviewable:end -->
