### PR TITLE
envoy: Unix domain socket for Envoy admin interface

### DIFF
--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -74,7 +74,7 @@ type admin struct {
 }
 
 func (a *admin) transact(query string) error {
-	resp, err := http.Get(a.adminURL + query)
+	resp, err := http.Post(a.adminURL+query, "", nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/envoy/envoy_test.go
+++ b/pkg/envoy/envoy_test.go
@@ -86,7 +86,7 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 	StartAccessLogServer(stateLogDir, xdsServer, &dummyEndpointInfoRegistry{})
 
 	// launch debug variant of the Envoy proxy
-	envoyProxy := StartEnvoy(9942, stateLogDir, filepath.Join(stateLogDir, "cilium-envoy.log"), 42)
+	envoyProxy := StartEnvoy(stateLogDir, filepath.Join(stateLogDir, "cilium-envoy.log"), 42)
 	c.Assert(envoyProxy, NotNil)
 	log.Debug("started Envoy")
 

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -329,7 +329,7 @@ func getHTTPRule(h *api.PortRuleHTTP) (headers []*envoy_api_v2_route.HeaderMatch
 	return
 }
 
-func createBootstrap(filePath string, name, cluster, version string, xdsSock, envoyClusterName string, adminPort uint32) {
+func createBootstrap(filePath string, name, cluster, version string, xdsSock, envoyClusterName string, adminPath string) {
 	bs := &envoy_config_bootstrap_v2.Bootstrap{
 		Node: &envoy_api_v2_core.Node{Id: name, Cluster: cluster, Metadata: nil, Locality: nil, BuildVersion: version},
 		StaticResources: &envoy_config_bootstrap_v2.Bootstrap_StaticResources{
@@ -378,12 +378,8 @@ func createBootstrap(filePath string, name, cluster, version string, xdsSock, en
 		Admin: &envoy_config_bootstrap_v2.Admin{
 			AccessLogPath: "/dev/null",
 			Address: &envoy_api_v2_core.Address{
-				Address: &envoy_api_v2_core.Address_SocketAddress{
-					SocketAddress: &envoy_api_v2_core.SocketAddress{
-						Protocol:      envoy_api_v2_core.SocketAddress_TCP,
-						Address:       "127.0.0.1",
-						PortSpecifier: &envoy_api_v2_core.SocketAddress_PortValue{PortValue: adminPort},
-					},
+				Address: &envoy_api_v2_core.Address_Pipe{
+					Pipe: &envoy_api_v2_core.Pipe{Path: adminPath},
 				},
 			},
 		},

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -40,7 +40,7 @@ var envoyOnce sync.Once
 func createEnvoyRedirect(r *Redirect, stateDir string, xdsServer *envoy.XDSServer, wg *completion.WaitGroup) (RedirectImplementation, error) {
 	envoyOnce.Do(func() {
 		// Start Envoy on first invocation
-		envoyProxy = envoy.StartEnvoy(9901, stateDir, viper.GetString("envoy-log"), 0)
+		envoyProxy = envoy.StartEnvoy(stateDir, viper.GetString("envoy-log"), 0)
 	})
 
 	if envoyProxy != nil {


### PR DESCRIPTION
Configure Envoy to use a Unix domain socket for the admin interface.

Upstream Envoy has changed to not allow GET method on the admin interface for
requests that mutate Envoy state. Use POST instead so that we can
successfully change the log level at runtime and make Envoy quit when
Cilium is terminated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5482)
<!-- Reviewable:end -->
