### PR TITLE
make: Don't use git in check-ineffassign.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,8 +219,8 @@ govet:
 	$(GO) tool vet api pkg $(SUBDIRS)
 
 ineffassign:
-	@$(ECHO_CHECK) contrib/scripts/check-ineffassign.sh
-	$(QUIET) contrib/scripts/check-ineffassign.sh
+	@$(ECHO_CHECK) ineffassign
+	$(QUIET) ineffassign .
 
 precheck: govet ineffassign
 	@$(ECHO_CHECK) contrib/scripts/check-fmt.sh

--- a/contrib/scripts/check-ineffassign.sh
+++ b/contrib/scripts/check-ineffassign.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -eu
-
-TOPDIR=$(git rev-parse --show-toplevel)
-
-ineffassign $TOPDIR


### PR DESCRIPTION
The buildsystem of Cilium should be able to run outside of git
repository (i.e. on sources from tarball).

Signed-off-by: Michal Rostecki <mrostecki@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5485)
<!-- Reviewable:end -->
