### PR TITLE
Block endpoints addition until all policies are processed from k8s

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -317,19 +317,27 @@ func k8sErrorHandler(e error) {
 
 // blockWaitGroupToSyncResources ensures that anything which waits on waitGroup
 // waits until all objects of the specified resource stored in Kubernetes are
-// received by informer. Fatally exits if syncing these initial objects fails.
-func blockWaitGroupToSyncResources(waitGroup *sync.WaitGroup, informer cache.Controller, resourceName string) {
+// received by the informer and processed by the given Function Queue.
+// Fatally exits if syncing these initial objects fails.
+func blockWaitGroupToSyncResources(waitGroup *sync.WaitGroup, informer cache.Controller,
+	resourceName string, queue *serializer.FunctionQueue) {
+
 	waitGroup.Add(1)
 	go func() {
-		completed := make(<-chan struct{})
 		scopedLog := log.WithField("kubernetesResource", resourceName)
 		scopedLog.Debug("waiting for cache to synchronize")
-		if ok := cache.WaitForCacheSync(completed, informer.HasSynced); !ok {
+		if ok := cache.WaitForCacheSync(wait.NeverStop, informer.HasSynced); !ok {
 			// Fatally exit it resource fails to sync
 			scopedLog.Fatalf("failed to wait for cache to sync")
 		}
-		scopedLog.Debug("cache synced")
-		waitGroup.Done()
+		// Enqueue the waitGroup.Done to signalize the that all other functions
+		// queued were serialized. This will make sure the all events received
+		// after the cached was synced were processed by the queue.
+		queue.Enqueue(func() error {
+			scopedLog.Debug("cache synced")
+			waitGroup.Done()
+			return nil
+		}, serializer.NoRetry)
 	}()
 }
 
@@ -422,7 +430,7 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 				},
 			},
 		)
-		blockWaitGroupToSyncResources(&d.k8sResourceSyncWaitGroup, policyController, "NetworkPolicy")
+		blockWaitGroupToSyncResources(&d.k8sResourceSyncWaitGroup, policyController, "NetworkPolicy", serKNPs)
 		go policyController.Run(wait.NeverStop)
 
 		d.k8sAPIGroups.addAPI(k8sAPIGroupNetworkingV1Core)
@@ -465,7 +473,7 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 			},
 		},
 	)
-	blockWaitGroupToSyncResources(&d.k8sResourceSyncWaitGroup, svcController, "Service")
+	blockWaitGroupToSyncResources(&d.k8sResourceSyncWaitGroup, svcController, "Service", serSvcs)
 	go svcController.Run(wait.NeverStop)
 	d.k8sAPIGroups.addAPI(k8sAPIGroupServiceV1Core)
 
@@ -508,7 +516,7 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 			},
 		},
 	)
-	blockWaitGroupToSyncResources(&d.k8sResourceSyncWaitGroup, endpointController, "Endpoint")
+	blockWaitGroupToSyncResources(&d.k8sResourceSyncWaitGroup, endpointController, "Endpoint", serEps)
 	go endpointController.Run(wait.NeverStop)
 	d.k8sAPIGroups.addAPI(k8sAPIGroupEndpointV1Core)
 
@@ -550,7 +558,7 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 				},
 			},
 		)
-		blockWaitGroupToSyncResources(&d.k8sResourceSyncWaitGroup, ingressController, "Ingress")
+		blockWaitGroupToSyncResources(&d.k8sResourceSyncWaitGroup, ingressController, "Ingress", serEps)
 		go ingressController.Run(wait.NeverStop)
 		d.k8sAPIGroups.addAPI(k8sAPIGroupIngressV1Beta1)
 	}
@@ -592,7 +600,7 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 				}
 			},
 		})
-		blockWaitGroupToSyncResources(&d.k8sResourceSyncWaitGroup, ciliumV2Controller, "CiliumNetworkPolicy")
+		blockWaitGroupToSyncResources(&d.k8sResourceSyncWaitGroup, ciliumV2Controller, "CiliumNetworkPolicy", serCNPs)
 	}
 
 	si.Start(wait.NeverStop)

--- a/pkg/serializer/func_queue.go
+++ b/pkg/serializer/func_queue.go
@@ -30,15 +30,15 @@ type queuedFunction struct {
 	waitFunc WaitFunc
 }
 
-type functionQueue struct {
+type FunctionQueue struct {
 	queue  chan queuedFunction
 	stopCh chan struct{}
 }
 
-// NewFunctionQueue returns a functionQueue that will be used to execute
+// NewFunctionQueue returns a FunctionQueue that will be used to execute
 // functions in the same order they are enqueued.
-func NewFunctionQueue(queueSize uint) *functionQueue {
-	fq := &functionQueue{
+func NewFunctionQueue(queueSize uint) *FunctionQueue {
+	fq := &FunctionQueue{
 		queue:  make(chan queuedFunction, queueSize),
 		stopCh: make(chan struct{}),
 	}
@@ -46,9 +46,9 @@ func NewFunctionQueue(queueSize uint) *functionQueue {
 	return fq
 }
 
-// run starts the functionQueue internal worker. It will be stopped once
+// run starts the FunctionQueue internal worker. It will be stopped once
 // `stopCh` is closed or receives a value.
-func (fq *functionQueue) run() {
+func (fq *FunctionQueue) run() {
 	for {
 		select {
 		case <-fq.stopCh:
@@ -77,7 +77,7 @@ func (fq *functionQueue) run() {
 // Stop stops the function queue from processing the functions on the queue.
 // If there are functions in the queue waiting for them to be processed, they
 // won't be executed.
-func (fq *functionQueue) Stop() {
+func (fq *FunctionQueue) Stop() {
 	close(fq.stopCh)
 }
 
@@ -89,6 +89,6 @@ func (fq *functionQueue) Stop() {
 // return value of `waitFunc`, `f` will be executed again or not.
 // The return value of `f` will not be logged and it's up to the caller to log
 // it properly.
-func (fq *functionQueue) Enqueue(f func() error, waitFunc WaitFunc) {
+func (fq *FunctionQueue) Enqueue(f func() error, waitFunc WaitFunc) {
 	fq.queue <- queuedFunction{f: f, waitFunc: waitFunc}
 }


### PR DESCRIPTION
For a large number of policies it is possible Cilium signalizes that caches
were synced with Kubernetes although they might not have been processed
and pushed down the local policy repository.

With the following diff is easy to replicate the bug:

```golang
diff --git a/daemon/k8s_watcher.go b/daemon/k8s_watcher.go
index da3fcba1e..3e6ddef6c 100644
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -571,10 +571,13 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
                                metrics.EventTSK8s.SetToCurrentTime()
                                if cnp := copyObjToV2CNP(obj); cnp != nil {
                                        serCNPs.Enqueue(func() error {
+                                               time.Sleep(5 * time.Second)
+                                               log.Debugf("adding cilium network policy after sleeping")
                                                d.addCiliumNetworkPolicyV2(cnpStore, cnp)
                                                return nil
                                        }, serializer.NoRetry)
                                }
+                               log.Debugf("adding cilium network policy in AddFunc")
                        },
                        UpdateFunc: func(oldObj, newObj interface{}) {
                                metrics.EventTSK8s.SetToCurrentTime()
```
would give the following logs:

```
msg="cache synced" kubernetesResource=NetworkPolicy subsys=daemon
msg="cache synced" kubernetesResource=Service subsys=daemon
msg="cache synced" kubernetesResource=Endpoint subsys=daemon
msg="adding cilium network policy in AddFunc" subsys=daemon
msg="cache synced" kubernetesResource=CiliumNetworkPolicy subsys=daemon
msg="adding cilium network policy after sleeping" subsys=daemon
```

With this commit we make sure all policies are received and processed by
Cilium before signalizing the cache was synced with Kubernetes.

As we can see in the following logs, the policies were processed and
added to the policy repository before signalizing that caches were
synced.

```
msg="adding cilium network policy in AddFunc" subsys=daemon
msg="cache synced" kubernetesResource=NetworkPolicy subsys=daemon
msg="cache synced" kubernetesResource=Service subsys=daemon
msg="cache synced" kubernetesResource=Endpoint subsys=daemon
msg="adding cilium network policy after sleeping" subsys=daemon
msg="cache synced" kubernetesResource=CiliumNetworkPolicy subsys=daemon
```

Fixes: d440059 ("daemon: block until initial policy list")
Signed-off-by: André Martins <andre@cilium.io>

Fixes: https://github.com/cilium/cilium/issues/5038

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5486)
<!-- Reviewable:end -->
