### PR TITLE
Refactor CTMap details into CTMap implementation

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
@@ -497,29 +496,8 @@ func (d *Daemon) deleteEndpointQuiet(ep *endpoint.Endpoint, releaseIP bool) []er
 			errors = append(errors, errs...)
 		}
 
-		// Remove policy BPF map
-		if err := os.RemoveAll(ep.PolicyMapPathLocked()); err != nil {
-			errors = append(errors, fmt.Errorf("unable to remove policy map file %s: %s", ep.PolicyMapPathLocked(), err))
-		}
-
-		// Remove calls BPF map
-		if err := os.RemoveAll(ep.CallsMapPathLocked()); err != nil {
-			errors = append(errors, fmt.Errorf("unable to remove calls map file %s: %s", ep.CallsMapPathLocked(), err))
-		}
-
-		// Remove IPv6 connection tracking map
-		if err := os.RemoveAll(ep.Ct6MapPathLocked()); err != nil {
-			errors = append(errors, fmt.Errorf("unable to remove IPv6 CT map %s: %s", ep.Ct6MapPathLocked(), err))
-		}
-
-		// Remove IPv4 connection tracking map
-		if err := os.RemoveAll(ep.Ct4MapPathLocked()); err != nil {
-			errors = append(errors, fmt.Errorf("unable to remove IPv4 CT map %s: %s", ep.Ct4MapPathLocked(), err))
-		}
-
-		// Remove handle_policy() tail call entry for EP
-		if err := ep.RemoveFromGlobalPolicyMap(); err != nil {
-			errors = append(errors, fmt.Errorf("unable to remove endpoint from global policy map: %s", err))
+		if errs := ep.DeleteMapsLocked(); errs != nil {
+			errors = append(errors, errs...)
 		}
 	}
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -26,7 +26,6 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
-	"strconv"
 	"time"
 
 	"github.com/cilium/cilium/common"
@@ -169,13 +168,9 @@ func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 	fmt.Fprintf(fw, "#define POLICY_MAP %s\n", path.Base(e.PolicyMapPathLocked()))
 	fmt.Fprintf(fw, "#define CALLS_MAP %s\n", path.Base(e.CallsMapPathLocked()))
 	if e.Options.IsEnabled(option.ConntrackLocal) {
-		fmt.Fprintf(fw, "#define CT_MAP_SIZE %s\n", strconv.Itoa(ctmap.MapNumEntriesLocal))
-		fmt.Fprintf(fw, "#define CT_MAP6 %s\n", ctmap.MapName6+strconv.Itoa(int(e.ID)))
-		fmt.Fprintf(fw, "#define CT_MAP4 %s\n", ctmap.MapName4+strconv.Itoa(int(e.ID)))
+		ctmap.WriteBPFMacros(fw, e)
 	} else {
-		fmt.Fprintf(fw, "#define CT_MAP_SIZE %s\n", strconv.Itoa(ctmap.MapNumEntriesGlobal))
-		fmt.Fprintf(fw, "#define CT_MAP6 %s\n", ctmap.MapName6Global)
-		fmt.Fprintf(fw, "#define CT_MAP4 %s\n", ctmap.MapName4Global)
+		ctmap.WriteBPFMacros(fw, nil)
 	}
 
 	// Always enable L4 and L3 load balancer for now

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -167,7 +167,7 @@ func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 	}
 	fmt.Fprintf(fw, "#define POLICY_MAP %s\n", path.Base(e.PolicyMapPathLocked()))
 	fmt.Fprintf(fw, "#define CALLS_MAP %s\n", path.Base(e.CallsMapPathLocked()))
-	if e.Options.IsEnabled(option.ConntrackLocal) {
+	if e.ConntrackLocalLocked() {
 		ctmap.WriteBPFMacros(fw, e)
 	} else {
 		ctmap.WriteBPFMacros(fw, nil)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1538,24 +1538,6 @@ func (e *Endpoint) CallsMapPathLocked() string {
 	return CallsMapPath(int(e.ID))
 }
 
-// Ct6MapPath returns the path to IPv6 connection tracking map of endpoint.
-func Ct6MapPath(id int) string {
-	return bpf.MapPath(ctmap.MapName6 + strconv.Itoa(id))
-}
-
-func (e *Endpoint) Ct6MapPathLocked() string {
-	return Ct6MapPath(int(e.ID))
-}
-
-// Ct4MapPath returns the path to IPv4 connection tracking map of endpoint.
-func Ct4MapPath(id int) string {
-	return bpf.MapPath(ctmap.MapName4 + strconv.Itoa(id))
-}
-
-func (e *Endpoint) Ct4MapPathLocked() string {
-	return Ct4MapPath(int(e.ID))
-}
-
 func (e *Endpoint) LogStatus(typ StatusType, code StatusCode, msg string) {
 	e.UnconditionalLock()
 	defer e.Unlock()

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1326,7 +1326,14 @@ func (e *Endpoint) ConntrackLocal() bool {
 	e.UnconditionalRLock()
 	defer e.RUnlock()
 
-	if e.SecurityIdentity == nil || !e.Options.IsEnabled(option.ConntrackLocal) {
+	return e.ConntrackLocalLocked()
+}
+
+// ConntrackLocalLocked is the same as ConntrackLocal, but assumes that the
+// endpoint is already locked for reading.
+func (e *Endpoint) ConntrackLocalLocked() bool {
+	if e.SecurityIdentity == nil || e.Options == nil ||
+		!e.Options.IsEnabled(option.ConntrackLocal) {
 		return false
 	}
 
@@ -2697,7 +2704,7 @@ func (e *Endpoint) IsDisconnecting() bool {
 func (e *Endpoint) doGarbageCollectConntrack(isIPv6 bool, filter *ctmap.GCFilter) {
 	var file, mapType string
 
-	if e.Options != nil && e.Options.IsEnabled(option.ConntrackLocal) {
+	if e.ConntrackLocalLocked() {
 		mapType, file = ctmap.GetMapTypeAndPath(e, isIPv6)
 	} else {
 		mapType, file = ctmap.GetMapTypeAndPath(nil, isIPv6)

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -24,7 +24,6 @@ import (
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
-	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -196,18 +195,7 @@ func (m *Map) DumpEntries() (string, error) {
 			return
 		}
 		value := v.(*CtEntry)
-		buffer.WriteString(
-			fmt.Sprintf(" expires=%d rx_packets=%d rx_bytes=%d tx_packets=%d tx_bytes=%d flags=%x revnat=%d src_sec_id=%d\n",
-				value.Lifetime,
-				value.RxPackets,
-				value.RxBytes,
-				value.TxPackets,
-				value.TxBytes,
-				value.Flags,
-				byteorder.NetworkToHost(value.RevNAT),
-				value.SourceSecurityID,
-			),
-		)
+		buffer.WriteString(value.String())
 	}
 	// DumpWithCallback() must be called before buffer.String().
 	err := m.DumpWithCallback(cb)


### PR DESCRIPTION
Based on ~~#5480~~.

This PR simplifies the callers of the CTMap listing and garbage collection functions to remove duplicated code paths which reimplement common functionality.

Take note particularly for the patch "ctmap: Simplify garbage collection" which changes the ctmap garbage collection functions to be called with a single filter that contains all IPv4/IPv6 addresses to be saved, rather than individually handling IPv4/IPv6 CT maps.

There's also a couple of misc patches here that just refactor code to live in more appropriate places or de-duplicate implementations of, eg, string-formatting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5488)
<!-- Reviewable:end -->
