### PR TITLE
spanstat: Ignore End() without Start()

### DIFF
--- a/pkg/spanstat/spanstat.go
+++ b/pkg/spanstat/spanstat.go
@@ -32,7 +32,10 @@ func (s *SpanStat) Start() {
 
 // End ends the current span and adds the measured duration to the total
 func (s *SpanStat) End() {
-	s.totalDuration += time.Since(s.spanStart)
+	if !s.spanStart.IsZero() {
+		s.totalDuration += time.Since(s.spanStart)
+	}
+	s.spanStart = time.Time{}
 }
 
 // Total returns the total duration of all spans measured

--- a/pkg/spanstat/spanstat_test.go
+++ b/pkg/spanstat/spanstat_test.go
@@ -1,0 +1,60 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanstat
+
+import (
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type SpanStatTestSuite struct{}
+
+var _ = Suite(&SpanStatTestSuite{})
+
+func (s *SpanStatTestSuite) TestSpanStat(c *C) {
+	span1 := SpanStat{}
+
+	// no spans measured yet
+	c.Assert(span1.Total(), Equals, time.Duration(0))
+
+	// End() without Start()
+	span1.End()
+	c.Assert(span1.Total(), Equals, time.Duration(0))
+
+	// Start() but no end yet
+	span1.Start()
+	c.Assert(span1.Total(), Equals, time.Duration(0))
+
+	// First span measured with End()
+	span1.End()
+	firstSpanTotal := span1.Total()
+	c.Assert(firstSpanTotal, Not(Equals), time.Duration(0))
+
+	// End() without a prior Start(), no change
+	span1.End()
+	c.Assert(span1.Total(), Equals, firstSpanTotal)
+
+	span1.Start()
+	span1.End()
+	c.Assert(span1.Total(), Not(Equals), firstSpanTotal)
+	c.Assert(span1.Total(), Not(Equals), time.Duration(0))
+
+}


### PR DESCRIPTION
Factored out the pure fix of #5478

Handle the developer mistake of End() without Start()

Fixes: 89cbe1f56a9 ("endpoint: Rework regeneration logging with detailed duration times")

No backport needed as this bug is only present in master

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5493)
<!-- Reviewable:end -->
