### PR TITLE
proxy: Remove port binding check on redirect creation

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -119,16 +119,6 @@ var (
 	portRandomizerMutex lock.Mutex
 )
 
-func isPortBindable(port uint16) bool {
-	socket, err := listenSocket(fmt.Sprintf(":%d", port), 0)
-	if err != nil {
-		log.WithError(err).Infof("Skipping port %d already in use", port)
-		return false
-	}
-	socket.Close()
-	return true
-}
-
 func (p *Proxy) allocatePort() (uint16, error) {
 	portRandomizerMutex.Lock()
 	defer portRandomizerMutex.Unlock()
@@ -137,9 +127,7 @@ func (p *Proxy) allocatePort() (uint16, error) {
 		resPort := uint16(r) + p.rangeMin
 
 		if _, ok := p.allocatedPorts[resPort]; !ok {
-			if isPortBindable(resPort) {
-				return resPort, nil
-			}
+			return resPort, nil
 		}
 
 	}


### PR DESCRIPTION
On redirect creation, we were checking that the allocated port
could be bound, by opening and closing a listen socket on that
port.
However, Linux gives no guarantees about the delay after closing
when the port can be bound again (by Envoy, in this case). Due to
recent performance improvements, the delay between the test and the
creation of the listener in Envoy was shortened, which increased
the probability of Envoy not being able to bind the port for a new
listener.
Remove this check altogether.

Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5495)
<!-- Reviewable:end -->
