### PR TITLE
lbmap: Guarantee order of backends while scaling service

### DIFF
--- a/pkg/maps/lbmap/bpfservice.go
+++ b/pkg/maps/lbmap/bpfservice.go
@@ -1,0 +1,183 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lbmap
+
+type serviceValueMap map[string]ServiceValue
+
+type bpfBackend struct {
+	id       string
+	isHole   bool
+	bpfValue ServiceValue
+}
+
+type bpfService struct {
+	// holes lists all backend indices that are currently filling in as
+	// hole
+	holes []int
+
+	frontendKey ServiceKey
+
+	// backendsByMapIndex is the 1:1 representation of service backends as
+	// written into the BPF map. As service backends are scaled up or down,
+	// duplicate entries may be required to avoid moving backends to
+	// different map index slots. This map represents this and thus may
+	// contain duplicate backend entries in different map index slots.
+	backendsByMapIndex map[int]*bpfBackend
+
+	// uniqueBackends is a map of all service backends indexed by service
+	// backend ID. A backend may be listed multiple times in
+	// backendsByMapIndex, it will only be listed once in uniqueBackends.
+	uniqueBackends serviceValueMap
+}
+
+func newBpfService(key ServiceKey) *bpfService {
+	return &bpfService{
+		frontendKey:        key,
+		backendsByMapIndex: map[int]*bpfBackend{},
+		uniqueBackends:     map[string]ServiceValue{},
+	}
+}
+
+func (b *bpfService) addBackend(backend ServiceValue) {
+	if len(b.holes) > 0 {
+		// Retrieve map index of next hole and remove it from the list
+		index := b.holes[0]
+		b.holes = b.holes[1:]
+
+		// Fill in backend in already existing hole that currently
+		// holds a duplicate
+		b.backendsByMapIndex[index].bpfValue = backend
+		b.backendsByMapIndex[index].id = backend.String()
+		b.backendsByMapIndex[index].isHole = false
+	} else {
+		// No holes, we need to allocate a new backend slot
+		nextSlot := len(b.uniqueBackends) + 1
+		b.backendsByMapIndex[nextSlot] = &bpfBackend{
+			bpfValue: backend,
+			id:       backend.String(),
+		}
+	}
+
+	b.uniqueBackends[backend.String()] = backend
+}
+
+func (b *bpfService) deleteBackend(backend ServiceValue) {
+	idToRemove := backend.String()
+	indicesToRemove := []int{}
+	duplicateCount := map[string]int{}
+
+	for index, backend := range b.backendsByMapIndex {
+		// create a slice of all backend indices that match the backend
+		// ID (ip, port, revnat id)
+		if idToRemove == backend.id {
+			indicesToRemove = append(indicesToRemove, index)
+		} else {
+			duplicateCount[backend.id]++
+		}
+	}
+
+	// select the backend with the most duplicates that is not the backend
+	var lowestCount int
+	var fillBackendID string
+	for backendID, count := range duplicateCount {
+		if lowestCount == 0 || count < lowestCount {
+			lowestCount = count
+			fillBackendID = backendID
+		}
+	}
+
+	if fillBackendID == "" {
+		// No more entries to fill in, we can remove all backend slots
+		b.holes = []int{}
+		b.backendsByMapIndex = map[int]*bpfBackend{}
+	} else {
+		fillBackend := &bpfBackend{
+			id:       fillBackendID,
+			isHole:   true,
+			bpfValue: b.uniqueBackends[fillBackendID],
+		}
+		for _, removeIndex := range indicesToRemove {
+			if !b.backendsByMapIndex[removeIndex].isHole {
+				b.holes = append(b.holes, removeIndex)
+			}
+			b.backendsByMapIndex[removeIndex] = fillBackend
+		}
+	}
+
+	delete(b.uniqueBackends, idToRemove)
+}
+
+func (b *bpfService) getBackends() []ServiceValue {
+	backends := make([]ServiceValue, len(b.backendsByMapIndex))
+	for i := 1; i <= len(b.backendsByMapIndex); i++ {
+		backends[i-1] = b.backendsByMapIndex[i].bpfValue
+	}
+	return backends
+}
+
+type lbmapCache struct {
+	entries map[string]*bpfService
+}
+
+func newLBMapCache() lbmapCache {
+	return lbmapCache{
+		entries: map[string]*bpfService{},
+	}
+}
+
+func createBackendsMap(backends []ServiceValue) serviceValueMap {
+	m := serviceValueMap{}
+	for _, b := range backends {
+		m[b.String()] = b
+	}
+	return m
+}
+
+func (l *lbmapCache) prepareUpdate(fe ServiceKey, backends []ServiceValue) *bpfService {
+	frontendID := fe.String()
+
+	bpfSvc, ok := l.entries[frontendID]
+	if !ok {
+		bpfSvc = newBpfService(fe)
+		l.entries[frontendID] = bpfSvc
+	}
+
+	newBackendsMap := createBackendsMap(backends)
+
+	// Step 1: Delete all backends that no longer exist. This will not
+	// actually remove the backends but overwrite all slave slots that
+	// point to the removed backend with the backend that has the least
+	// duplicated slots.
+	for key, b := range bpfSvc.uniqueBackends {
+		if _, ok := newBackendsMap[key]; !ok {
+			bpfSvc.deleteBackend(b)
+		}
+	}
+
+	// Step 2: Add all backends that don't exist yet. This will use up
+	// holes that have been created by deleteBackend() first before adding
+	// new slave slots.
+	for _, b := range backends {
+		if _, ok := bpfSvc.uniqueBackends[b.String()]; !ok {
+			bpfSvc.addBackend(b)
+		}
+	}
+
+	return bpfSvc
+}
+
+func (l *lbmapCache) delete(fe ServiceKey) {
+	delete(l.entries, fe.String())
+}

--- a/pkg/maps/lbmap/bpfservice_test.go
+++ b/pkg/maps/lbmap/bpfservice_test.go
@@ -1,0 +1,176 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lbmap
+
+import (
+	"net"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type LBMapTestSuite struct{}
+
+var _ = Suite(&LBMapTestSuite{})
+
+func createBackend(c *C, ip string, port, revnat uint16) ServiceValue {
+	i := net.ParseIP(ip)
+	c.Assert(i, Not(IsNil))
+	v := NewService4Value(0, i, port, revnat, 0)
+	c.Assert(v, Not(IsNil))
+	return v
+}
+
+func (b *LBMapTestSuite) TestScaleService(c *C) {
+	ip := net.ParseIP("1.1.1.1")
+	c.Assert(ip, Not(IsNil))
+	frontend := NewService4Key(ip, 80, 0)
+
+	svc := newBpfService(frontend)
+	c.Assert(svc, Not(IsNil))
+
+	b1 := createBackend(c, "2.2.2.2", 80, 1)
+	svc.addBackend(b1)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 1)
+	c.Assert(len(svc.holes), Equals, 0)
+	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b1)
+
+	b2 := createBackend(c, "3.3.3.3", 80, 1)
+	svc.addBackend(b2)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 2)
+	c.Assert(len(svc.holes), Equals, 0)
+	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b1)
+	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
+
+	svc.deleteBackend(b1)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 2)
+	c.Assert(len(svc.holes), Equals, 1)
+	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b2)
+	c.Assert(svc.backendsByMapIndex[1].isHole, Equals, true)
+	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
+
+	b3 := createBackend(c, "4.4.4.4", 80, 1)
+	svc.addBackend(b3)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 2)
+	c.Assert(len(svc.holes), Equals, 0)
+	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b3)
+	c.Assert(svc.backendsByMapIndex[1].isHole, Equals, false)
+	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
+	c.Assert(svc.backendsByMapIndex[2].isHole, Equals, false)
+
+	b4 := createBackend(c, "5.5.5.5", 80, 1)
+	svc.addBackend(b4)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 3)
+	c.Assert(len(svc.holes), Equals, 0)
+	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b3)
+	c.Assert(svc.backendsByMapIndex[1].isHole, Equals, false)
+	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
+	c.Assert(svc.backendsByMapIndex[2].isHole, Equals, false)
+	c.Assert(svc.backendsByMapIndex[3].bpfValue, Equals, b4)
+	c.Assert(svc.backendsByMapIndex[3].isHole, Equals, false)
+
+	svc.deleteBackend(b4)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 3)
+	c.Assert(len(svc.holes), Equals, 1)
+	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b3)
+	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
+	// either b2 or b3 can be used to fill in
+	c.Assert(svc.backendsByMapIndex[3].isHole && (svc.backendsByMapIndex[3].bpfValue == b3 || svc.backendsByMapIndex[3].bpfValue == b2), Equals, true)
+
+	svc.deleteBackend(b3)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 3)
+	c.Assert(len(svc.holes), Equals, 2)
+	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b2)
+	c.Assert(svc.backendsByMapIndex[1].isHole, Equals, true)
+	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
+	c.Assert(svc.backendsByMapIndex[2].isHole, Equals, false)
+	c.Assert(svc.backendsByMapIndex[3].bpfValue, Equals, b2)
+	c.Assert(svc.backendsByMapIndex[3].isHole, Equals, true)
+
+	// last backend is removed, we can finally remove all backend slots
+	svc.deleteBackend(b2)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 0)
+	c.Assert(len(svc.holes), Equals, 0)
+
+	svc.addBackend(b4)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 1)
+	c.Assert(len(svc.holes), Equals, 0)
+	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b4)
+}
+
+func (b *LBMapTestSuite) TestPrepareUpdate(c *C) {
+	cache := newLBMapCache()
+
+	ip := net.ParseIP("1.1.1.1")
+	c.Assert(ip, Not(IsNil))
+	frontend := NewService4Key(ip, 80, 0)
+
+	b1 := createBackend(c, "2.2.2.2", 80, 1)
+	b2 := createBackend(c, "3.3.3.3", 80, 1)
+	b3 := createBackend(c, "4.4.4.4", 80, 1)
+
+	bpfSvc := cache.prepareUpdate(frontend, []ServiceValue{b1, b2})
+	c.Assert(bpfSvc.backendsByMapIndex[1].bpfValue, DeepEquals, b1)
+	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, DeepEquals, b2)
+
+	backends := bpfSvc.getBackends()
+	c.Assert(len(backends), Equals, 2)
+	c.Assert(backends[0], DeepEquals, b1)
+	c.Assert(backends[1], DeepEquals, b2)
+
+	bpfSvc = cache.prepareUpdate(frontend, []ServiceValue{b1, b2, b3})
+	c.Assert(bpfSvc.backendsByMapIndex[1].bpfValue, DeepEquals, b1)
+	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, DeepEquals, b2)
+	c.Assert(bpfSvc.backendsByMapIndex[3].bpfValue, DeepEquals, b3)
+
+	backends = bpfSvc.getBackends()
+	c.Assert(len(backends), Equals, 3)
+	c.Assert(backends[0], DeepEquals, b1)
+	c.Assert(backends[1], DeepEquals, b2)
+	c.Assert(backends[2], DeepEquals, b3)
+
+	bpfSvc = cache.prepareUpdate(frontend, []ServiceValue{b2, b3})
+	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, Not(DeepEquals), b1)
+	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, DeepEquals, b2)
+	c.Assert(bpfSvc.backendsByMapIndex[3].bpfValue, DeepEquals, b3)
+
+	backends = bpfSvc.getBackends()
+	c.Assert(len(backends), Equals, 3)
+	c.Assert(backends[0], Not(DeepEquals), b1)
+	c.Assert(backends[1], DeepEquals, b2)
+	c.Assert(backends[2], DeepEquals, b3)
+
+	bpfSvc = cache.prepareUpdate(frontend, []ServiceValue{b1, b2, b3})
+	c.Assert(bpfSvc.backendsByMapIndex[1].bpfValue, DeepEquals, b1)
+	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, DeepEquals, b2)
+	c.Assert(bpfSvc.backendsByMapIndex[3].bpfValue, DeepEquals, b3)
+
+	backends = bpfSvc.getBackends()
+	c.Assert(len(backends), Equals, 3)
+	c.Assert(backends[0], DeepEquals, b1)
+	c.Assert(backends[1], DeepEquals, b2)
+	c.Assert(backends[2], DeepEquals, b3)
+
+	bpfSvc = cache.prepareUpdate(frontend, []ServiceValue{})
+	c.Assert(len(bpfSvc.backendsByMapIndex), Equals, 0)
+
+	backends = bpfSvc.getBackends()
+	c.Assert(len(backends), Equals, 0)
+}


### PR DESCRIPTION
[This commit is deliberately kept with a minimal scope to only change the package lbmap. The purpose of this is to allow backporting to 1.1 and 1.0 without massive merge conflicts that are difficult to resolve.]

This commits resolves inconsistency when updating loadbalancer BPF map entries.
The datapath relies on a consistent mapping of backend index to backend IP as
the backend index is cached in the connection tracking table.

The commit resolves the following deficits:

* The previous listing of backend services when synchronizing down was relying
on map iteration. Unfortunately, map iteration order is random which was able
to lead to unnecessary backend slot reordering.

* When scaling down the number of backends. The previous behavior would delete
the backends and shift all entries to correspond to the new backend count.
This did break consistent load-balancing mapping for existing connections
relying on the shifted backends.

Unfortunately, the datapath relies on a hole free list of backends in order to
perform cheap slave selection based on the packet hash.

The resolution is to preserve backend slots that are freeing up due to backend
deletions and fill them with duplicates of other backends. In order to keep
load balancing distribution fair, the backend with the least duplicates is
nominated to fill in.

Fixes: 42254ccbfaf ("lbmap: Support transactional updates")
Fixes: #5425

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5502)
<!-- Reviewable:end -->
