### PR TITLE
v1.0 backports 2018-09-10

### DIFF
--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -34,14 +34,7 @@ func (d *Daemon) addSVC2BPFMap(feCilium types.L3n4AddrID, feBPF lbmap.ServiceKey
 	besBPF []lbmap.ServiceValue, addRevNAT bool) error {
 	log.WithField(logfields.ServiceName, feCilium.String()).Debug("adding service to BPF maps")
 
-	// Try to delete service before adding it and ignore errors as it might not exist.
-	err := d.svcDeleteByFrontendLocked(&feCilium.L3n4Addr)
-	if err != nil {
-		log.WithError(err).WithField(logfields.ServiceName, feCilium.L3n4Addr.String()).Debug("error deleting service before adding it")
-	}
-
-	err = lbmap.AddSVC2BPFMap(feBPF, besBPF, addRevNAT, int(feCilium.ID))
-	if err != nil {
+	if err := lbmap.UpdateService(feBPF, besBPF, addRevNAT, int(feCilium.ID)); err != nil {
 		if addRevNAT {
 			delete(d.loadBalancer.RevNATMap, feCilium.ID)
 		}

--- a/examples/kubernetes/1.10/cilium-cm.yaml
+++ b/examples/kubernetes/1.10/cilium-cm.yaml
@@ -27,4 +27,18 @@ data:
   disable-ipv4: "false"
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
+
+  # If a serious issue occurs during Cilium startup, this
+  # invasive option may be set to true to remove all persistent
+  # state. Endpoints will not be restored using knowledge from a
+  # prior Cilium run, so they may receive new IP addresses upon
+  # restart. This also triggers clean-cilium-bpf-state.
   clean-cilium-state: "false"
+  # If you want to clean cilium BPF state, set this to true;
+  # Removes all BPF maps from the filesystem. Upon restart,
+  # endpoints are restored with the same IP addresses, however
+  # any ongoing connections may be disrupted briefly.
+  # Loadbalancing decisions will be reset, so any ongoing
+  # connections via a service may be loadbalanced to a different
+  # backend after restart.
+  clean-cilium-bpf-state: "false"

--- a/examples/kubernetes/1.10/cilium-cm.yaml
+++ b/examples/kubernetes/1.10/cilium-cm.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,19 +28,3 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -34,7 +34,7 @@ spec:
       - name: clean-cilium-state
         image: docker.io/library/busybox:1.28.4
         imagePullPolicy: IfNotPresent
-        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
         securityContext:
           capabilities:
             add:
@@ -52,6 +52,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: clean-cilium-state
+            - name: "CLEAN_CILIUM_BPF_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-bpf-state
       containers:
       - image: docker.io/cilium/cilium:v1.0.5
         imagePullPolicy: IfNotPresent

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -178,6 +178,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -27,7 +27,21 @@ data:
   disable-ipv4: "false"
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
+
+  # If a serious issue occurs during Cilium startup, this
+  # invasive option may be set to true to remove all persistent
+  # state. Endpoints will not be restored using knowledge from a
+  # prior Cilium run, so they may receive new IP addresses upon
+  # restart. This also triggers clean-cilium-bpf-state.
   clean-cilium-state: "false"
+  # If you want to clean cilium BPF state, set this to true;
+  # Removes all BPF maps from the filesystem. Upon restart,
+  # endpoints are restored with the same IP addresses, however
+  # any ongoing connections may be disrupted briefly.
+  # Loadbalancing decisions will be reset, so any ongoing
+  # connections via a service may be loadbalanced to a different
+  # backend after restart.
+  clean-cilium-bpf-state: "false"
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -65,7 +79,7 @@ spec:
       - name: clean-cilium-state
         image: docker.io/library/busybox:1.28.4
         imagePullPolicy: IfNotPresent
-        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
         securityContext:
           capabilities:
             add:
@@ -83,6 +97,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: clean-cilium-state
+            - name: "CLEAN_CILIUM_BPF_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-bpf-state
       containers:
       - image: docker.io/cilium/cilium:v1.0.5
         imagePullPolicy: IfNotPresent

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,22 +28,6 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -225,6 +209,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.11/cilium-cm.yaml
+++ b/examples/kubernetes/1.11/cilium-cm.yaml
@@ -27,4 +27,18 @@ data:
   disable-ipv4: "false"
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
+
+  # If a serious issue occurs during Cilium startup, this
+  # invasive option may be set to true to remove all persistent
+  # state. Endpoints will not be restored using knowledge from a
+  # prior Cilium run, so they may receive new IP addresses upon
+  # restart. This also triggers clean-cilium-bpf-state.
   clean-cilium-state: "false"
+  # If you want to clean cilium BPF state, set this to true;
+  # Removes all BPF maps from the filesystem. Upon restart,
+  # endpoints are restored with the same IP addresses, however
+  # any ongoing connections may be disrupted briefly.
+  # Loadbalancing decisions will be reset, so any ongoing
+  # connections via a service may be loadbalanced to a different
+  # backend after restart.
+  clean-cilium-bpf-state: "false"

--- a/examples/kubernetes/1.11/cilium-cm.yaml
+++ b/examples/kubernetes/1.11/cilium-cm.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,19 +28,3 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -34,7 +34,7 @@ spec:
       - name: clean-cilium-state
         image: docker.io/library/busybox:1.28.4
         imagePullPolicy: IfNotPresent
-        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
         securityContext:
           capabilities:
             add:
@@ -52,6 +52,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: clean-cilium-state
+            - name: "CLEAN_CILIUM_BPF_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-bpf-state
       containers:
       - image: docker.io/cilium/cilium:v1.0.5
         imagePullPolicy: IfNotPresent

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -178,6 +178,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -27,7 +27,21 @@ data:
   disable-ipv4: "false"
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
+
+  # If a serious issue occurs during Cilium startup, this
+  # invasive option may be set to true to remove all persistent
+  # state. Endpoints will not be restored using knowledge from a
+  # prior Cilium run, so they may receive new IP addresses upon
+  # restart. This also triggers clean-cilium-bpf-state.
   clean-cilium-state: "false"
+  # If you want to clean cilium BPF state, set this to true;
+  # Removes all BPF maps from the filesystem. Upon restart,
+  # endpoints are restored with the same IP addresses, however
+  # any ongoing connections may be disrupted briefly.
+  # Loadbalancing decisions will be reset, so any ongoing
+  # connections via a service may be loadbalanced to a different
+  # backend after restart.
+  clean-cilium-bpf-state: "false"
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -65,7 +79,7 @@ spec:
       - name: clean-cilium-state
         image: docker.io/library/busybox:1.28.4
         imagePullPolicy: IfNotPresent
-        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
         securityContext:
           capabilities:
             add:
@@ -83,6 +97,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: clean-cilium-state
+            - name: "CLEAN_CILIUM_BPF_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-bpf-state
       containers:
       - image: docker.io/cilium/cilium:v1.0.5
         imagePullPolicy: IfNotPresent

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,22 +28,6 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -225,6 +209,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:

--- a/examples/kubernetes/1.12/cilium-cm.yaml
+++ b/examples/kubernetes/1.12/cilium-cm.yaml
@@ -27,4 +27,18 @@ data:
   disable-ipv4: "false"
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
+
+  # If a serious issue occurs during Cilium startup, this
+  # invasive option may be set to true to remove all persistent
+  # state. Endpoints will not be restored using knowledge from a
+  # prior Cilium run, so they may receive new IP addresses upon
+  # restart. This also triggers clean-cilium-bpf-state.
   clean-cilium-state: "false"
+  # If you want to clean cilium BPF state, set this to true;
+  # Removes all BPF maps from the filesystem. Upon restart,
+  # endpoints are restored with the same IP addresses, however
+  # any ongoing connections may be disrupted briefly.
+  # Loadbalancing decisions will be reset, so any ongoing
+  # connections via a service may be loadbalanced to a different
+  # backend after restart.
+  clean-cilium-bpf-state: "false"

--- a/examples/kubernetes/1.12/cilium-cm.yaml
+++ b/examples/kubernetes/1.12/cilium-cm.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,19 +28,3 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -34,7 +34,7 @@ spec:
       - name: clean-cilium-state
         image: docker.io/library/busybox:1.28.4
         imagePullPolicy: IfNotPresent
-        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
         securityContext:
           capabilities:
             add:
@@ -52,6 +52,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: clean-cilium-state
+            - name: "CLEAN_CILIUM_BPF_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-bpf-state
       containers:
       - image: docker.io/cilium/cilium:v1.0.5
         imagePullPolicy: IfNotPresent

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -178,6 +178,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -27,7 +27,21 @@ data:
   disable-ipv4: "false"
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
+
+  # If a serious issue occurs during Cilium startup, this
+  # invasive option may be set to true to remove all persistent
+  # state. Endpoints will not be restored using knowledge from a
+  # prior Cilium run, so they may receive new IP addresses upon
+  # restart. This also triggers clean-cilium-bpf-state.
   clean-cilium-state: "false"
+  # If you want to clean cilium BPF state, set this to true;
+  # Removes all BPF maps from the filesystem. Upon restart,
+  # endpoints are restored with the same IP addresses, however
+  # any ongoing connections may be disrupted briefly.
+  # Loadbalancing decisions will be reset, so any ongoing
+  # connections via a service may be loadbalanced to a different
+  # backend after restart.
+  clean-cilium-bpf-state: "false"
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -65,7 +79,7 @@ spec:
       - name: clean-cilium-state
         image: docker.io/library/busybox:1.28.4
         imagePullPolicy: IfNotPresent
-        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
         securityContext:
           capabilities:
             add:
@@ -83,6 +97,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: clean-cilium-state
+            - name: "CLEAN_CILIUM_BPF_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-bpf-state
       containers:
       - image: docker.io/cilium/cilium:v1.0.5
         imagePullPolicy: IfNotPresent

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,22 +28,6 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -225,6 +209,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:

--- a/examples/kubernetes/1.7/cilium-cm.yaml
+++ b/examples/kubernetes/1.7/cilium-cm.yaml
@@ -27,4 +27,18 @@ data:
   disable-ipv4: "false"
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
+
+  # If a serious issue occurs during Cilium startup, this
+  # invasive option may be set to true to remove all persistent
+  # state. Endpoints will not be restored using knowledge from a
+  # prior Cilium run, so they may receive new IP addresses upon
+  # restart. This also triggers clean-cilium-bpf-state.
   clean-cilium-state: "false"
+  # If you want to clean cilium BPF state, set this to true;
+  # Removes all BPF maps from the filesystem. Upon restart,
+  # endpoints are restored with the same IP addresses, however
+  # any ongoing connections may be disrupted briefly.
+  # Loadbalancing decisions will be reset, so any ongoing
+  # connections via a service may be loadbalanced to a different
+  # backend after restart.
+  clean-cilium-bpf-state: "false"

--- a/examples/kubernetes/1.7/cilium-cm.yaml
+++ b/examples/kubernetes/1.7/cilium-cm.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,19 +28,3 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -34,7 +34,7 @@ spec:
       - name: clean-cilium-state
         image: docker.io/library/busybox:1.28.4
         imagePullPolicy: IfNotPresent
-        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
         securityContext:
           capabilities:
             add:
@@ -52,6 +52,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: clean-cilium-state
+            - name: "CLEAN_CILIUM_BPF_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-bpf-state
       containers:
       - image: docker.io/cilium/cilium:v1.0.5
         imagePullPolicy: IfNotPresent

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -178,6 +178,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -27,7 +27,21 @@ data:
   disable-ipv4: "false"
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
+
+  # If a serious issue occurs during Cilium startup, this
+  # invasive option may be set to true to remove all persistent
+  # state. Endpoints will not be restored using knowledge from a
+  # prior Cilium run, so they may receive new IP addresses upon
+  # restart. This also triggers clean-cilium-bpf-state.
   clean-cilium-state: "false"
+  # If you want to clean cilium BPF state, set this to true;
+  # Removes all BPF maps from the filesystem. Upon restart,
+  # endpoints are restored with the same IP addresses, however
+  # any ongoing connections may be disrupted briefly.
+  # Loadbalancing decisions will be reset, so any ongoing
+  # connections via a service may be loadbalanced to a different
+  # backend after restart.
+  clean-cilium-bpf-state: "false"
 ---
 kind: DaemonSet
 apiVersion: extensions/v1beta1
@@ -65,7 +79,7 @@ spec:
       - name: clean-cilium-state
         image: docker.io/library/busybox:1.28.4
         imagePullPolicy: IfNotPresent
-        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
         securityContext:
           capabilities:
             add:
@@ -83,6 +97,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: clean-cilium-state
+            - name: "CLEAN_CILIUM_BPF_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-bpf-state
       containers:
       - image: docker.io/cilium/cilium:v1.0.5
         imagePullPolicy: IfNotPresent

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,22 +28,6 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
 ---
 kind: DaemonSet
 apiVersion: extensions/v1beta1
@@ -225,6 +209,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.8/cilium-cm.yaml
+++ b/examples/kubernetes/1.8/cilium-cm.yaml
@@ -27,4 +27,18 @@ data:
   disable-ipv4: "false"
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
+
+  # If a serious issue occurs during Cilium startup, this
+  # invasive option may be set to true to remove all persistent
+  # state. Endpoints will not be restored using knowledge from a
+  # prior Cilium run, so they may receive new IP addresses upon
+  # restart. This also triggers clean-cilium-bpf-state.
   clean-cilium-state: "false"
+  # If you want to clean cilium BPF state, set this to true;
+  # Removes all BPF maps from the filesystem. Upon restart,
+  # endpoints are restored with the same IP addresses, however
+  # any ongoing connections may be disrupted briefly.
+  # Loadbalancing decisions will be reset, so any ongoing
+  # connections via a service may be loadbalanced to a different
+  # backend after restart.
+  clean-cilium-bpf-state: "false"

--- a/examples/kubernetes/1.8/cilium-cm.yaml
+++ b/examples/kubernetes/1.8/cilium-cm.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,19 +28,3 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -34,7 +34,7 @@ spec:
       - name: clean-cilium-state
         image: docker.io/library/busybox:1.28.4
         imagePullPolicy: IfNotPresent
-        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
         securityContext:
           capabilities:
             add:
@@ -52,6 +52,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: clean-cilium-state
+            - name: "CLEAN_CILIUM_BPF_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-bpf-state
       containers:
       - image: docker.io/cilium/cilium:v1.0.5
         imagePullPolicy: IfNotPresent

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -178,6 +178,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,22 +28,6 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
 ---
 kind: DaemonSet
 apiVersion: apps/v1beta2
@@ -225,6 +209,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -27,7 +27,21 @@ data:
   disable-ipv4: "false"
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
+
+  # If a serious issue occurs during Cilium startup, this
+  # invasive option may be set to true to remove all persistent
+  # state. Endpoints will not be restored using knowledge from a
+  # prior Cilium run, so they may receive new IP addresses upon
+  # restart. This also triggers clean-cilium-bpf-state.
   clean-cilium-state: "false"
+  # If you want to clean cilium BPF state, set this to true;
+  # Removes all BPF maps from the filesystem. Upon restart,
+  # endpoints are restored with the same IP addresses, however
+  # any ongoing connections may be disrupted briefly.
+  # Loadbalancing decisions will be reset, so any ongoing
+  # connections via a service may be loadbalanced to a different
+  # backend after restart.
+  clean-cilium-bpf-state: "false"
 ---
 kind: DaemonSet
 apiVersion: apps/v1beta2
@@ -65,7 +79,7 @@ spec:
       - name: clean-cilium-state
         image: docker.io/library/busybox:1.28.4
         imagePullPolicy: IfNotPresent
-        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
         securityContext:
           capabilities:
             add:
@@ -83,6 +97,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: clean-cilium-state
+            - name: "CLEAN_CILIUM_BPF_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-bpf-state
       containers:
       - image: docker.io/cilium/cilium:v1.0.5
         imagePullPolicy: IfNotPresent

--- a/examples/kubernetes/1.9/cilium-cm.yaml
+++ b/examples/kubernetes/1.9/cilium-cm.yaml
@@ -27,4 +27,18 @@ data:
   disable-ipv4: "false"
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
+
+  # If a serious issue occurs during Cilium startup, this
+  # invasive option may be set to true to remove all persistent
+  # state. Endpoints will not be restored using knowledge from a
+  # prior Cilium run, so they may receive new IP addresses upon
+  # restart. This also triggers clean-cilium-bpf-state.
   clean-cilium-state: "false"
+  # If you want to clean cilium BPF state, set this to true;
+  # Removes all BPF maps from the filesystem. Upon restart,
+  # endpoints are restored with the same IP addresses, however
+  # any ongoing connections may be disrupted briefly.
+  # Loadbalancing decisions will be reset, so any ongoing
+  # connections via a service may be loadbalanced to a different
+  # backend after restart.
+  clean-cilium-bpf-state: "false"

--- a/examples/kubernetes/1.9/cilium-cm.yaml
+++ b/examples/kubernetes/1.9/cilium-cm.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,19 +28,3 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -34,7 +34,7 @@ spec:
       - name: clean-cilium-state
         image: docker.io/library/busybox:1.28.4
         imagePullPolicy: IfNotPresent
-        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
         securityContext:
           capabilities:
             add:
@@ -52,6 +52,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: clean-cilium-state
+            - name: "CLEAN_CILIUM_BPF_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-bpf-state
       containers:
       - image: docker.io/cilium/cilium:v1.0.5
         imagePullPolicy: IfNotPresent

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -178,6 +178,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -27,7 +27,21 @@ data:
   disable-ipv4: "false"
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
+
+  # If a serious issue occurs during Cilium startup, this
+  # invasive option may be set to true to remove all persistent
+  # state. Endpoints will not be restored using knowledge from a
+  # prior Cilium run, so they may receive new IP addresses upon
+  # restart. This also triggers clean-cilium-bpf-state.
   clean-cilium-state: "false"
+  # If you want to clean cilium BPF state, set this to true;
+  # Removes all BPF maps from the filesystem. Upon restart,
+  # endpoints are restored with the same IP addresses, however
+  # any ongoing connections may be disrupted briefly.
+  # Loadbalancing decisions will be reset, so any ongoing
+  # connections via a service may be loadbalanced to a different
+  # backend after restart.
+  clean-cilium-bpf-state: "false"
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -65,7 +79,7 @@ spec:
       - name: clean-cilium-state
         image: docker.io/library/busybox:1.28.4
         imagePullPolicy: IfNotPresent
-        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
         securityContext:
           capabilities:
             add:
@@ -83,6 +97,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: clean-cilium-state
+            - name: "CLEAN_CILIUM_BPF_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-bpf-state
       containers:
       - image: docker.io/cilium/cilium:v1.0.5
         imagePullPolicy: IfNotPresent

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,22 +28,6 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -225,6 +209,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/examples/kubernetes/templates/v1/cilium-cm.yaml
+++ b/examples/kubernetes/templates/v1/cilium-cm.yaml
@@ -27,4 +27,18 @@ data:
   disable-ipv4: "false"
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
+
+  # If a serious issue occurs during Cilium startup, this
+  # invasive option may be set to true to remove all persistent
+  # state. Endpoints will not be restored using knowledge from a
+  # prior Cilium run, so they may receive new IP addresses upon
+  # restart. This also triggers clean-cilium-bpf-state.
   clean-cilium-state: "false"
+  # If you want to clean cilium BPF state, set this to true;
+  # Removes all BPF maps from the filesystem. Upon restart,
+  # endpoints are restored with the same IP addresses, however
+  # any ongoing connections may be disrupted briefly.
+  # Loadbalancing decisions will be reset, so any ongoing
+  # connections via a service may be loadbalanced to a different
+  # backend after restart.
+  clean-cilium-bpf-state: "false"

--- a/examples/kubernetes/templates/v1/cilium-cm.yaml
+++ b/examples/kubernetes/templates/v1/cilium-cm.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: kube-system
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
-  # TLS please make sure you uncomment the ca-file line and add the respective
-  # certificate has a k8s secret, see explanation below in the comment labeled
-  # "ETCD-CERT"
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
     - http://127.0.0.1:31079
     #
-    # In case you want to use TLS in etcd, uncomment the following line
-    # and add the certificate as explained in the comment labeled "ETCD-CERT"
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
-    # lines and add the certificate and key in cilium-etcd-secrets below
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
     #key-file: '/var/lib/etcd-secrets/etcd-client-key'
     #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
@@ -28,19 +28,3 @@ data:
   sidecar-http-proxy: "false"
   # If you want to clean cilium state; change this value to true
   clean-cilium-state: "false"
----
-# The etcd secrets can be populated in kubernetes.
-# For more information see: https://kubernetes.io/docs/concepts/configuration/secret
-kind: Secret
-apiVersion: v1
-type: Opaque
-metadata:
-  name: cilium-etcd-secrets
-  namespace: kube-system
-data:
-  # ETCD-CERT: Each value should contain the whole certificate in base64, on a
-  # single line. You can generate the base64 with: $ base64 -w 0 ./ca.pem
-  # (the "-w 0" generates the output on a single line)
-  etcd-ca: ""
-  etcd-client-key: ""
-  etcd-client-crt: ""

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -34,7 +34,7 @@ spec:
       - name: clean-cilium-state
         image: docker.io/library/busybox:1.28.4
         imagePullPolicy: IfNotPresent
-        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
         securityContext:
           capabilities:
             add:
@@ -52,6 +52,12 @@ spec:
                 name: cilium-config
                 optional: true
                 key: clean-cilium-state
+            - name: "CLEAN_CILIUM_BPF_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-bpf-state
       containers:
       - image: docker.io/cilium/cilium:__CILIUM_VERSION__
         imagePullPolicy: IfNotPresent

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -178,6 +178,7 @@ spec:
         - name: etcd-secrets
           secret:
             secretName: cilium-etcd-secrets
+            optional: true
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule

--- a/pkg/maps/lbmap/bpfservice.go
+++ b/pkg/maps/lbmap/bpfservice.go
@@ -1,0 +1,183 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lbmap
+
+type serviceValueMap map[string]ServiceValue
+
+type bpfBackend struct {
+	id       string
+	isHole   bool
+	bpfValue ServiceValue
+}
+
+type bpfService struct {
+	// holes lists all backend indices that are currently filling in as
+	// hole
+	holes []int
+
+	frontendKey ServiceKey
+
+	// backendsByMapIndex is the 1:1 representation of service backends as
+	// written into the BPF map. As service backends are scaled up or down,
+	// duplicate entries may be required to avoid moving backends to
+	// different map index slots. This map represents this and thus may
+	// contain duplicate backend entries in different map index slots.
+	backendsByMapIndex map[int]*bpfBackend
+
+	// uniqueBackends is a map of all service backends indexed by service
+	// backend ID. A backend may be listed multiple times in
+	// backendsByMapIndex, it will only be listed once in uniqueBackends.
+	uniqueBackends serviceValueMap
+}
+
+func newBpfService(key ServiceKey) *bpfService {
+	return &bpfService{
+		frontendKey:        key,
+		backendsByMapIndex: map[int]*bpfBackend{},
+		uniqueBackends:     map[string]ServiceValue{},
+	}
+}
+
+func (b *bpfService) addBackend(backend ServiceValue) {
+	if len(b.holes) > 0 {
+		// Retrieve map index of next hole and remove it from the list
+		index := b.holes[0]
+		b.holes = b.holes[1:]
+
+		// Fill in backend in already existing hole that currently
+		// holds a duplicate
+		b.backendsByMapIndex[index].bpfValue = backend
+		b.backendsByMapIndex[index].id = backend.String()
+		b.backendsByMapIndex[index].isHole = false
+	} else {
+		// No holes, we need to allocate a new backend slot
+		nextSlot := len(b.uniqueBackends) + 1
+		b.backendsByMapIndex[nextSlot] = &bpfBackend{
+			bpfValue: backend,
+			id:       backend.String(),
+		}
+	}
+
+	b.uniqueBackends[backend.String()] = backend
+}
+
+func (b *bpfService) deleteBackend(backend ServiceValue) {
+	idToRemove := backend.String()
+	indicesToRemove := []int{}
+	duplicateCount := map[string]int{}
+
+	for index, backend := range b.backendsByMapIndex {
+		// create a slice of all backend indices that match the backend
+		// ID (ip, port, revnat id)
+		if idToRemove == backend.id {
+			indicesToRemove = append(indicesToRemove, index)
+		} else {
+			duplicateCount[backend.id]++
+		}
+	}
+
+	// select the backend with the most duplicates that is not the backend
+	var lowestCount int
+	var fillBackendID string
+	for backendID, count := range duplicateCount {
+		if lowestCount == 0 || count < lowestCount {
+			lowestCount = count
+			fillBackendID = backendID
+		}
+	}
+
+	if fillBackendID == "" {
+		// No more entries to fill in, we can remove all backend slots
+		b.holes = []int{}
+		b.backendsByMapIndex = map[int]*bpfBackend{}
+	} else {
+		fillBackend := &bpfBackend{
+			id:       fillBackendID,
+			isHole:   true,
+			bpfValue: b.uniqueBackends[fillBackendID],
+		}
+		for _, removeIndex := range indicesToRemove {
+			if !b.backendsByMapIndex[removeIndex].isHole {
+				b.holes = append(b.holes, removeIndex)
+			}
+			b.backendsByMapIndex[removeIndex] = fillBackend
+		}
+	}
+
+	delete(b.uniqueBackends, idToRemove)
+}
+
+func (b *bpfService) getBackends() []ServiceValue {
+	backends := make([]ServiceValue, len(b.backendsByMapIndex))
+	for i := 1; i <= len(b.backendsByMapIndex); i++ {
+		backends[i-1] = b.backendsByMapIndex[i].bpfValue
+	}
+	return backends
+}
+
+type lbmapCache struct {
+	entries map[string]*bpfService
+}
+
+func newLBMapCache() lbmapCache {
+	return lbmapCache{
+		entries: map[string]*bpfService{},
+	}
+}
+
+func createBackendsMap(backends []ServiceValue) serviceValueMap {
+	m := serviceValueMap{}
+	for _, b := range backends {
+		m[b.String()] = b
+	}
+	return m
+}
+
+func (l *lbmapCache) prepareUpdate(fe ServiceKey, backends []ServiceValue) *bpfService {
+	frontendID := fe.String()
+
+	bpfSvc, ok := l.entries[frontendID]
+	if !ok {
+		bpfSvc = newBpfService(fe)
+		l.entries[frontendID] = bpfSvc
+	}
+
+	newBackendsMap := createBackendsMap(backends)
+
+	// Step 1: Delete all backends that no longer exist. This will not
+	// actually remove the backends but overwrite all slave slots that
+	// point to the removed backend with the backend that has the least
+	// duplicated slots.
+	for key, b := range bpfSvc.uniqueBackends {
+		if _, ok := newBackendsMap[key]; !ok {
+			bpfSvc.deleteBackend(b)
+		}
+	}
+
+	// Step 2: Add all backends that don't exist yet. This will use up
+	// holes that have been created by deleteBackend() first before adding
+	// new slave slots.
+	for _, b := range backends {
+		if _, ok := bpfSvc.uniqueBackends[b.String()]; !ok {
+			bpfSvc.addBackend(b)
+		}
+	}
+
+	return bpfSvc
+}
+
+func (l *lbmapCache) delete(fe ServiceKey) {
+	delete(l.entries, fe.String())
+}

--- a/pkg/maps/lbmap/bpfservice_test.go
+++ b/pkg/maps/lbmap/bpfservice_test.go
@@ -1,0 +1,176 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lbmap
+
+import (
+	"net"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type LBMapTestSuite struct{}
+
+var _ = Suite(&LBMapTestSuite{})
+
+func createBackend(c *C, ip string, port, revnat uint16) ServiceValue {
+	i := net.ParseIP(ip)
+	c.Assert(i, Not(IsNil))
+	v := NewService4Value(0, i, port, revnat, 0)
+	c.Assert(v, Not(IsNil))
+	return v
+}
+
+func (b *LBMapTestSuite) TestScaleService(c *C) {
+	ip := net.ParseIP("1.1.1.1")
+	c.Assert(ip, Not(IsNil))
+	frontend := NewService4Key(ip, 80, 0)
+
+	svc := newBpfService(frontend)
+	c.Assert(svc, Not(IsNil))
+
+	b1 := createBackend(c, "2.2.2.2", 80, 1)
+	svc.addBackend(b1)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 1)
+	c.Assert(len(svc.holes), Equals, 0)
+	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b1)
+
+	b2 := createBackend(c, "3.3.3.3", 80, 1)
+	svc.addBackend(b2)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 2)
+	c.Assert(len(svc.holes), Equals, 0)
+	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b1)
+	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
+
+	svc.deleteBackend(b1)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 2)
+	c.Assert(len(svc.holes), Equals, 1)
+	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b2)
+	c.Assert(svc.backendsByMapIndex[1].isHole, Equals, true)
+	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
+
+	b3 := createBackend(c, "4.4.4.4", 80, 1)
+	svc.addBackend(b3)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 2)
+	c.Assert(len(svc.holes), Equals, 0)
+	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b3)
+	c.Assert(svc.backendsByMapIndex[1].isHole, Equals, false)
+	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
+	c.Assert(svc.backendsByMapIndex[2].isHole, Equals, false)
+
+	b4 := createBackend(c, "5.5.5.5", 80, 1)
+	svc.addBackend(b4)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 3)
+	c.Assert(len(svc.holes), Equals, 0)
+	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b3)
+	c.Assert(svc.backendsByMapIndex[1].isHole, Equals, false)
+	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
+	c.Assert(svc.backendsByMapIndex[2].isHole, Equals, false)
+	c.Assert(svc.backendsByMapIndex[3].bpfValue, Equals, b4)
+	c.Assert(svc.backendsByMapIndex[3].isHole, Equals, false)
+
+	svc.deleteBackend(b4)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 3)
+	c.Assert(len(svc.holes), Equals, 1)
+	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b3)
+	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
+	// either b2 or b3 can be used to fill in
+	c.Assert(svc.backendsByMapIndex[3].isHole && (svc.backendsByMapIndex[3].bpfValue == b3 || svc.backendsByMapIndex[3].bpfValue == b2), Equals, true)
+
+	svc.deleteBackend(b3)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 3)
+	c.Assert(len(svc.holes), Equals, 2)
+	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b2)
+	c.Assert(svc.backendsByMapIndex[1].isHole, Equals, true)
+	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
+	c.Assert(svc.backendsByMapIndex[2].isHole, Equals, false)
+	c.Assert(svc.backendsByMapIndex[3].bpfValue, Equals, b2)
+	c.Assert(svc.backendsByMapIndex[3].isHole, Equals, true)
+
+	// last backend is removed, we can finally remove all backend slots
+	svc.deleteBackend(b2)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 0)
+	c.Assert(len(svc.holes), Equals, 0)
+
+	svc.addBackend(b4)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 1)
+	c.Assert(len(svc.holes), Equals, 0)
+	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b4)
+}
+
+func (b *LBMapTestSuite) TestPrepareUpdate(c *C) {
+	cache := newLBMapCache()
+
+	ip := net.ParseIP("1.1.1.1")
+	c.Assert(ip, Not(IsNil))
+	frontend := NewService4Key(ip, 80, 0)
+
+	b1 := createBackend(c, "2.2.2.2", 80, 1)
+	b2 := createBackend(c, "3.3.3.3", 80, 1)
+	b3 := createBackend(c, "4.4.4.4", 80, 1)
+
+	bpfSvc := cache.prepareUpdate(frontend, []ServiceValue{b1, b2})
+	c.Assert(bpfSvc.backendsByMapIndex[1].bpfValue, DeepEquals, b1)
+	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, DeepEquals, b2)
+
+	backends := bpfSvc.getBackends()
+	c.Assert(len(backends), Equals, 2)
+	c.Assert(backends[0], DeepEquals, b1)
+	c.Assert(backends[1], DeepEquals, b2)
+
+	bpfSvc = cache.prepareUpdate(frontend, []ServiceValue{b1, b2, b3})
+	c.Assert(bpfSvc.backendsByMapIndex[1].bpfValue, DeepEquals, b1)
+	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, DeepEquals, b2)
+	c.Assert(bpfSvc.backendsByMapIndex[3].bpfValue, DeepEquals, b3)
+
+	backends = bpfSvc.getBackends()
+	c.Assert(len(backends), Equals, 3)
+	c.Assert(backends[0], DeepEquals, b1)
+	c.Assert(backends[1], DeepEquals, b2)
+	c.Assert(backends[2], DeepEquals, b3)
+
+	bpfSvc = cache.prepareUpdate(frontend, []ServiceValue{b2, b3})
+	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, Not(DeepEquals), b1)
+	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, DeepEquals, b2)
+	c.Assert(bpfSvc.backendsByMapIndex[3].bpfValue, DeepEquals, b3)
+
+	backends = bpfSvc.getBackends()
+	c.Assert(len(backends), Equals, 3)
+	c.Assert(backends[0], Not(DeepEquals), b1)
+	c.Assert(backends[1], DeepEquals, b2)
+	c.Assert(backends[2], DeepEquals, b3)
+
+	bpfSvc = cache.prepareUpdate(frontend, []ServiceValue{b1, b2, b3})
+	c.Assert(bpfSvc.backendsByMapIndex[1].bpfValue, DeepEquals, b1)
+	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, DeepEquals, b2)
+	c.Assert(bpfSvc.backendsByMapIndex[3].bpfValue, DeepEquals, b3)
+
+	backends = bpfSvc.getBackends()
+	c.Assert(len(backends), Equals, 3)
+	c.Assert(backends[0], DeepEquals, b1)
+	c.Assert(backends[1], DeepEquals, b2)
+	c.Assert(backends[2], DeepEquals, b3)
+
+	bpfSvc = cache.prepareUpdate(frontend, []ServiceValue{})
+	c.Assert(len(bpfSvc.backendsByMapIndex), Equals, 0)
+
+	backends = bpfSvc.getBackends()
+	c.Assert(len(backends), Equals, 0)
+}

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -118,7 +118,7 @@ func (s *RRSeqValue) String() string {
 	return fmt.Sprintf("count=%d idx=%v", s.Count, s.Idx)
 }
 
-func UpdateService(key ServiceKey, value ServiceValue) error {
+func updateService(key ServiceKey, value ServiceValue) error {
 	log.WithFields(logrus.Fields{
 		"frontend": key,
 		"backend":  value,
@@ -139,7 +139,7 @@ func DeleteService(key ServiceKey) error {
 	if err != nil {
 		return err
 	}
-	return LookupAndDeleteServiceWeights(key)
+	return lookupAndDeleteServiceWeights(key)
 }
 
 func LookupService(key ServiceKey) (ServiceValue, error) {
@@ -159,8 +159,8 @@ func LookupService(key ServiceKey) (ServiceValue, error) {
 	return svc.ToNetwork(), nil
 }
 
-// UpdateServiceWeights updates cilium_lb6_rr_seq or cilium_lb4_rr_seq bpf maps.
-func UpdateServiceWeights(key ServiceKey, value *RRSeqValue) error {
+// updateServiceWeights updates cilium_lb6_rr_seq or cilium_lb4_rr_seq bpf maps.
+func updateServiceWeights(key ServiceKey, value *RRSeqValue) error {
 	if _, err := key.RRMap().OpenOrCreate(); err != nil {
 		return err
 	}
@@ -168,8 +168,8 @@ func UpdateServiceWeights(key ServiceKey, value *RRSeqValue) error {
 	return key.RRMap().Update(key.ToNetwork(), value)
 }
 
-// LookupAndDeleteServiceWeights deletes entry from cilium_lb6_rr_seq or cilium_lb4_rr_seq
-func LookupAndDeleteServiceWeights(key ServiceKey) error {
+// lookupAndDeleteServiceWeights deletes entry from cilium_lb6_rr_seq or cilium_lb4_rr_seq
+func lookupAndDeleteServiceWeights(key ServiceKey) error {
 	_, err := key.RRMap().Lookup(key.ToNetwork())
 	if err != nil {
 		// Ignore if entry is not found.
@@ -220,24 +220,6 @@ func UpdateRevNat(key RevNatKey, value RevNatValue) error {
 func DeleteRevNat(key RevNatKey) error {
 	log.WithField(logfields.BPFMapKey, key).Debug("deleting RevNatKey")
 	return key.Map().Delete(key.ToNetwork())
-}
-
-func LookupRevNat(key RevNatKey) (RevNatValue, error) {
-	var revnat RevNatValue
-	log.WithField(logfields.BPFMapKey, key).Debug("lookup RevNatKey")
-
-	val, err := key.Map().Lookup(key.ToNetwork())
-	if err != nil {
-		return nil, err
-	}
-
-	if key.IsIPv6() {
-		revnat = val.(*RevNat6Value)
-	} else {
-		revnat = val.(*RevNat4Value)
-	}
-
-	return revnat.ToNetwork(), nil
 }
 
 // gcd computes the gcd of two numbers.
@@ -300,8 +282,8 @@ func generateWrrSeq(weights []uint16) (*RRSeqValue, error) {
 	return &svcRRSeq, nil
 }
 
-// UpdateWrrSeq updates bpf map with the generated wrr sequence.
-func UpdateWrrSeq(fe ServiceKey, weights []uint16) error {
+// updateWrrSeq updates bpf map with the generated wrr sequence.
+func updateWrrSeq(fe ServiceKey, weights []uint16) error {
 	sum := uint16(0)
 	for _, v := range weights {
 		sum += v
@@ -313,7 +295,7 @@ func UpdateWrrSeq(fe ServiceKey, weights []uint16) error {
 	if err != nil {
 		return fmt.Errorf("unable to generate weighted round robin seq for %s with value %+v: %s", fe.String(), weights, err)
 	}
-	return UpdateServiceWeights(fe, svcRRSeq)
+	return updateServiceWeights(fe, svcRRSeq)
 }
 
 // AddSVC2BPFMap adds the given bpf service to the bpf maps.
@@ -330,7 +312,7 @@ func AddSVC2BPFMap(fe ServiceKey, besValues []ServiceValue, addRevNAT bool, revN
 		if be.GetWeight() != 0 {
 			nNonZeroWeights++
 		}
-		if err = UpdateService(fe, be); err != nil {
+		if err = updateService(fe, be); err != nil {
 			return fmt.Errorf("unable to update service %+v with the value %+v: %s", fe, be, err)
 		}
 		nSvcs++
@@ -357,12 +339,12 @@ func AddSVC2BPFMap(fe ServiceKey, besValues []ServiceValue, addRevNAT bool, revN
 	zeroValue.SetCount(nSvcs - 1)
 	zeroValue.SetWeight(uint16(nNonZeroWeights))
 
-	err = UpdateService(fe, zeroValue)
+	err = updateService(fe, zeroValue)
 	if err != nil {
 		return fmt.Errorf("unable to update service %+v with the value %+v: %s", fe, zeroValue, err)
 	}
 
-	err = UpdateWrrSeq(fe, weights)
+	err = updateWrrSeq(fe, weights)
 	if err != nil {
 		return fmt.Errorf("unable to update service weights for %s with value %+v: %s", fe.String(), weights, err)
 	}
@@ -370,9 +352,9 @@ func AddSVC2BPFMap(fe ServiceKey, besValues []ServiceValue, addRevNAT bool, revN
 	return nil
 }
 
-// L3n4Addr2ServiceKey converts the given l3n4Addr to a ServiceKey with the slave ID
+// l3n4Addr2ServiceKey converts the given l3n4Addr to a ServiceKey with the slave ID
 // set to 0.
-func L3n4Addr2ServiceKey(l3n4Addr types.L3n4AddrID) ServiceKey {
+func l3n4Addr2ServiceKey(l3n4Addr types.L3n4AddrID) ServiceKey {
 	log.WithField(logfields.L3n4AddrID, l3n4Addr).Debug("converting L3n4Addr to ServiceKey")
 	if l3n4Addr.IsIPv6() {
 		return NewService6Key(l3n4Addr.IP, l3n4Addr.Port, 0)
@@ -386,7 +368,7 @@ func LBSVC2ServiceKeynValue(svc types.LBSVC) (ServiceKey, []ServiceValue, error)
 		"lbFrontend": svc.FE.String(),
 		"lbBackend":  svc.BES,
 	}).Debug("converting Cilium load-balancer service (frontend -> backend(s)) into BPF service")
-	fe := L3n4Addr2ServiceKey(svc.FE)
+	fe := l3n4Addr2ServiceKey(svc.FE)
 
 	// Create a list of ServiceValues so we know everything is safe to put in the lb
 	// map
@@ -423,8 +405,8 @@ func L3n4Addr2RevNatKeynValue(svcID types.ServiceID, feL3n4Addr types.L3n4Addr) 
 	return NewRevNat4Key(uint16(svcID)), NewRevNat4Value(feL3n4Addr.IP, feL3n4Addr.Port)
 }
 
-// ServiceKey2L3n4Addr converts the given svcKey to a L3n4Addr.
-func ServiceKey2L3n4Addr(svcKey ServiceKey) (*types.L3n4Addr, error) {
+// serviceKey2L3n4Addr converts the given svcKey to a L3n4Addr.
+func serviceKey2L3n4Addr(svcKey ServiceKey) (*types.L3n4Addr, error) {
 	log.WithField(logfields.ServiceID, svcKey).Debug("creating L3n4Addr for ServiceKey")
 	var (
 		feIP   net.IP
@@ -471,7 +453,7 @@ func ServiceKeynValue2FEnBE(svcKey ServiceKey, svcValue ServiceValue) (*types.L3
 		beWeight = svc4Val.Weight
 	}
 
-	feL3n4Addr, err := ServiceKey2L3n4Addr(svcKey)
+	feL3n4Addr, err := serviceKey2L3n4Addr(svcKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create a new frontend for service key %s: %s", svcKey, err)
 	}
@@ -489,13 +471,13 @@ func ServiceKeynValue2FEnBE(svcKey ServiceKey, svcValue ServiceValue) (*types.L3
 	return feL3n4AddrID, beLBBackEnd, nil
 }
 
-// RevNat6Value2L3n4Addr converts the given RevNat6Value to a L3n4Addr.
-func RevNat6Value2L3n4Addr(revNATV *RevNat6Value) (*types.L3n4Addr, error) {
+// revNat6Value2L3n4Addr converts the given RevNat6Value to a L3n4Addr.
+func revNat6Value2L3n4Addr(revNATV *RevNat6Value) (*types.L3n4Addr, error) {
 	return types.NewL3n4Addr(types.TCP, revNATV.Address.IP(), revNATV.Port)
 }
 
-// RevNat4Value2L3n4Addr converts the given RevNat4Value to a L3n4Addr.
-func RevNat4Value2L3n4Addr(revNATV *RevNat4Value) (*types.L3n4Addr, error) {
+// revNat4Value2L3n4Addr converts the given RevNat4Value to a L3n4Addr.
+func revNat4Value2L3n4Addr(revNATV *RevNat4Value) (*types.L3n4Addr, error) {
 	return types.NewL3n4Addr(types.TCP, revNATV.Address.IP(), revNATV.Port)
 }
 
@@ -511,40 +493,17 @@ func RevNatValue2L3n4AddrID(revNATKey RevNatKey, revNATValue RevNatValue) (*type
 		svcID = types.ServiceID(revNat6Key.Key)
 
 		revNat6Value := revNATValue.(*RevNat6Value)
-		be, err = RevNat6Value2L3n4Addr(revNat6Value)
+		be, err = revNat6Value2L3n4Addr(revNat6Value)
 	} else {
 		revNat4Key := revNATKey.(*RevNat4Key)
 		svcID = types.ServiceID(revNat4Key.Key)
 
 		revNat4Value := revNATValue.(*RevNat4Value)
-		be, err = RevNat4Value2L3n4Addr(revNat4Value)
+		be, err = revNat4Value2L3n4Addr(revNat4Value)
 	}
 	if err != nil {
 		return nil, err
 	}
 
 	return &types.L3n4AddrID{L3n4Addr: *be, ID: svcID}, nil
-}
-
-// ServiceValue2LBBackEnd converts the svcValue to a LBBackEnd. The svcKey is necessary to
-// determine which IP version svcValue is.
-func ServiceValue2LBBackEnd(svcKey ServiceKey, svcValue ServiceValue) (*types.LBBackEnd, error) {
-	var (
-		feIP     net.IP
-		fePort   uint16
-		feWeight uint16
-	)
-	if svcKey.IsIPv6() {
-		svc6Value := svcValue.(*Service6Value)
-		feIP = svc6Value.Address.IP()
-		fePort = svc6Value.Port
-		feWeight = svc6Value.Weight
-	} else {
-		svc4Value := svcValue.(*Service4Value)
-		feIP = svc4Value.Address.IP()
-		fePort = svc4Value.Port
-		feWeight = svc4Value.Weight
-	}
-
-	return types.NewLBBackEnd(types.TCP, feIP, fePort, feWeight)
 }

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -21,13 +21,20 @@ import (
 
 	"github.com/cilium/cilium/common/types"
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
 	"github.com/sirupsen/logrus"
 )
 
-var log = logging.DefaultLogger
+var (
+	log = logging.DefaultLogger
+
+	// mutex protects access to the BPF map to guarantee atomicity if a
+	// transaction must be split across multiple map access operations.
+	mutex lock.RWMutex
+)
 
 const (
 	// Maximum number of entries in each hashtable
@@ -135,6 +142,9 @@ func updateService(key ServiceKey, value ServiceValue) error {
 
 // DeleteService deletes a service from the lbmap. key should be the master (i.e., with backend set to zero).
 func DeleteService(key ServiceKey) error {
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	err := key.Map().Delete(key.ToNetwork())
 	if err != nil {
 		return err
@@ -202,11 +212,12 @@ type RevNatValue interface {
 	ToNetwork() RevNatValue
 }
 
-func UpdateRevNat(key RevNatKey, value RevNatValue) error {
+func updateRevNatLocked(key RevNatKey, value RevNatValue) error {
 	log.WithFields(logrus.Fields{
 		logfields.BPFMapKey:   key,
 		logfields.BPFMapValue: value,
 	}).Debug("adding revNat to lbmap")
+
 	if key.GetKey() == 0 {
 		return fmt.Errorf("invalid RevNat ID (0)")
 	}
@@ -217,9 +228,24 @@ func UpdateRevNat(key RevNatKey, value RevNatValue) error {
 	return key.Map().Update(key.ToNetwork(), value.ToNetwork())
 }
 
-func DeleteRevNat(key RevNatKey) error {
+func UpdateRevNat(key RevNatKey, value RevNatValue) error {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	return updateRevNatLocked(key, value)
+}
+
+func deleteRevNatLocked(key RevNatKey) error {
 	log.WithField(logfields.BPFMapKey, key).Debug("deleting RevNatKey")
+
 	return key.Map().Delete(key.ToNetwork())
+}
+
+func DeleteRevNat(key RevNatKey) error {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	return deleteRevNatLocked(key)
 }
 
 // gcd computes the gcd of two numbers.
@@ -306,6 +332,9 @@ func AddSVC2BPFMap(fe ServiceKey, besValues []ServiceValue, addRevNAT bool, revN
 	nSvcs := 1
 	nNonZeroWeights := 0
 
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	for _, be := range besValues {
 		fe.SetBackend(nSvcs)
 		weights = append(weights, be.GetWeight())
@@ -324,12 +353,12 @@ func AddSVC2BPFMap(fe ServiceKey, besValues []ServiceValue, addRevNAT bool, revN
 		revNATKey := zeroValue.RevNatKey()
 		revNATValue := fe.RevNatValue()
 
-		if err := UpdateRevNat(revNATKey, revNATValue); err != nil {
+		if err := updateRevNatLocked(revNATKey, revNATValue); err != nil {
 			return fmt.Errorf("unable to update reverse NAT %+v with value %+v, %s", revNATKey, revNATValue, err)
 		}
 		defer func() {
 			if err != nil {
-				DeleteRevNat(revNATKey)
+				deleteRevNatLocked(revNATKey)
 			}
 		}()
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -123,16 +123,6 @@ var (
 	portRandomizerMutex lock.Mutex
 )
 
-func isPortBindable(port uint16) bool {
-	socket, err := listenSocket(fmt.Sprintf(":%d", port), 0)
-	if err != nil {
-		log.WithError(err).Infof("Skipping port %d already in use", port)
-		return false
-	}
-	socket.Close()
-	return true
-}
-
 func (p *Proxy) allocatePort() (uint16, error) {
 	portRandomizerMutex.Lock()
 	defer portRandomizerMutex.Unlock()
@@ -141,9 +131,7 @@ func (p *Proxy) allocatePort() (uint16, error) {
 		resPort := uint16(r) + p.rangeMin
 
 		if _, ok := p.allocatedPorts[resPort]; !ok {
-			if isPortBindable(resPort) {
-				return resPort, nil
-			}
+			return resPort, nil
 		}
 
 	}

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -27,6 +27,7 @@ import (
 )
 
 var (
+	demoTestName         = "K8sDemosTest"
 	starWarsDemoLinkRoot = "https://raw.githubusercontent.com/cilium/star-wars-demo/v1.0"
 )
 
@@ -36,7 +37,7 @@ func getStarWarsResourceLink(file string) string {
 	return fmt.Sprintf("%s/%s", starWarsDemoLinkRoot, file)
 }
 
-var _ = Describe("K8sDemosTest", func() {
+var _ = Describe(demoTestName, func() {
 
 	var (
 		demoPath   string
@@ -51,6 +52,7 @@ var _ = Describe("K8sDemosTest", func() {
 	)
 
 	initialize := func() {
+		logger = log.WithFields(logrus.Fields{"testName": demoTestName})
 		logger.Info("Starting")
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 


### PR DESCRIPTION
Backports:
* #4520 (Partial)
* #5469 (Not a clean backport; @tgraf please review)
* #5495
* #5502
* #5503 (in lieu of #5118, #5197, #5230)

I also rolled in a fix for the missed-k8s tests that were broken by a previous bad backport.

A subsequent PR for the latest/stable docs will document how to make use of #5503 for downgrade.

This should also related fix Nightly build failures from 320 to 327.

Related: #5454

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5504)
<!-- Reviewable:end -->
