### PR TITLE
Upgrade downgrade test clean up

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -212,7 +212,7 @@ const (
 )
 
 // NightlyStableUpgradesFrom the cilium images to update from in Nightly test.
-var NightlyStableUpgradesFrom = []string{"v1.0"}
+var NightlyStableUpgradesFrom = []string{"v1.0", "v1.1"}
 
 var (
 	CiliumV1_0 = versioncheck.MustCompile(">=v1.0,<v1.1")

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -212,7 +212,7 @@ const (
 )
 
 // NightlyStableUpgradesFrom the cilium images to update from in Nightly test.
-var NightlyStableUpgradesFrom = []string{"docker.io/cilium/cilium:v1.0"}
+var NightlyStableUpgradesFrom = []string{"v1.0"}
 
 var (
 	CiliumV1_0 = versioncheck.MustCompile(">=v1.0,<v1.1")


### PR DESCRIPTION
Hi, 

Nightly is failing in the downgrade+Upgrade test because the changes that has been made in the last days. This PR has two commits: 

- One fix some asserts failures that are not correct and mark the test as skipped. 
- Fix the issues on Upgrade from v1.0, if cannot be installed will skip the test. This commit has a dependency on #5507 PR. 

This should fix the Nigthly builds from 320-327. 

Regards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5508)
<!-- Reviewable:end -->
