### PR TITLE
Test: WaitForPods fail if pods are schedulled to be deleted.

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -517,25 +517,16 @@ func (kub *Kubectl) NamespaceDelete(name string) *CmdRes {
 // the aforementioned desired state within timeout seconds. Returns false and
 // an error if the command failed or the timeout was exceeded.
 func (kub *Kubectl) WaitforPods(namespace string, filter string, timeout int64) error {
+	data, err := kub.GetPods(namespace, filter).Filter("{.items[*].metadata.deletionTimestamp}")
+	if err != nil {
+		return fmt.Errorf("Cannot get pods with filter '%s': %s", filter, err)
+	}
+	if data.String() != "" {
+		return fmt.Errorf(
+			"There are some pods with filter %s that are marked to be deleted", filter)
+	}
 
 	body := func() bool {
-		data, err := kub.GetPods(namespace, filter).Filter("{.items[*].metadata.deletionTimestamp}")
-		if err != nil {
-			kub.logger.WithFields(logrus.Fields{
-				"namespace": namespace,
-				"filter":    filter,
-				"data":      data,
-			}).Info("Cannot get pods with filter '%s': %s")
-			return false
-		}
-		if data.String() != "" {
-			kub.logger.WithFields(logrus.Fields{
-				"namespace": namespace,
-				"filter":    filter,
-				"data":      data,
-			}).Info("There are some pods with filter %s that are marked to be deleted")
-			return false
-		}
 
 		var jsonPath = "{.items[*].status.containerStatuses[*].ready}"
 		data, err = kub.GetPods(namespace, filter).Filter(jsonPath)

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -114,6 +114,8 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 			"cilium-cm-patch-clean-cilium-state.yaml",
 		)
 		ExpectWithOffset(1, err).To(BeNil(), "Cilium %q was not able to be deployed", newVersion)
+
+		ExpectAllPodsTerminated(kubectl)
 		ExpectCiliumReady(kubectl)
 
 		_ = kubectl.DeleteResource(


### PR DESCRIPTION
To make sure that the pods are deleted, is important to fail on the first
time, and not hide the issue in a wait condition and do not see why a
test does not wait until pods are deleted.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5509)
<!-- Reviewable:end -->
