### PR TITLE
Test: Bump upgrade test from 1.2 to master

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -173,7 +173,7 @@ const (
 	KubectlPolicyNameLabel      = k8sConst.PolicyLabelName
 	KubectlPolicyNameSpaceLabel = k8sConst.PolicyLabelNamespace
 
-	CiliumStableVersion      = "v1.1"
+	CiliumStableVersion      = "v1.2"
 	CiliumStableImageVersion = "docker.io/cilium/cilium:" + CiliumStableVersion
 	CiliumDeveloperImage     = "k8s1:5000/cilium/cilium-dev:latest"
 


### PR DESCRIPTION
Updating the image upgrade from 1.2 instead of 1.1 to validate the
upgrade from 1.2 to 1.3

Nightly changes happens on PR: 5508
Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5510)
<!-- Reviewable:end -->
