### PR TITLE
Test: Refactor CmdRes.GetErr function

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -259,7 +259,7 @@ func (res *CmdRes) Unmarshal(data interface{}) error {
 
 // GetDebugMessage returns executed command and its output
 func (res *CmdRes) GetDebugMessage() string {
-	return fmt.Sprintf("cmd: %s\n%s", res.GetCmd(), res.CombineOutput())
+	return fmt.Sprintf("cmd: %s\n%s", res.GetCmd(), res.OutputPrettyPrint())
 }
 
 // WaitUntilMatch waits until the given substring is present in the `CmdRes.stdout`
@@ -294,7 +294,7 @@ func (res *CmdRes) GetErr(context string) error {
 	if res.WasSuccessful() {
 		return nil
 	}
-	return fmt.Errorf("command context:%s, output: %s", context, res.GetDebugMessage())
+	return &cmdError{fmt.Sprintf("%s output: %s", context, res.GetDebugMessage())}
 }
 
 // BeSuccesfulMatcher a new Ginkgo matcher for CmdRes struct
@@ -330,4 +330,17 @@ func (matcher *BeSuccesfulMatcher) NegatedFailureMessage(actual interface{}) (me
 // CMDSuccess return a new Matcher that expects a CmdRes is a successful run command.
 func CMDSuccess() types.GomegaMatcher {
 	return &BeSuccesfulMatcher{}
+}
+
+// cmdError is a implementation of error with String method to improve the debugging.
+type cmdError struct {
+	s string
+}
+
+func (e *cmdError) Error() string {
+	return e.s
+}
+
+func (e *cmdError) String() string {
+	return e.s
 }


### PR DESCRIPTION
This commit change the way that the error messages are reported when is
returned as error. In each fail the stdout, stderr returns all the
string scaped and it was difficult to copy and paste the commands.

With this change a new cmdError is in place, that implements a String
and the information in the error will be human readable.

Also, this commit add some new error messages on `ciliumInstall` to be
able to debug it easily and use the standar variables like KubectlCmd

Examples:

Invalid output:

```
/home/jenkins/workspace/Cilium-Master-Nightly-Tests-All/src/github.com/cilium/cilium/test/ginkgo-ext/scopes.go:376
Cilium docker.io/cilium/cilium:v1.0 was not able to be deployed
Expected
    <*errors.errorString | 0xc420330ad0>: {
        s: "cmd: kubectl apply --filename='https://raw.githubusercontent.com/cilium/cilium/docker.io/cilium/cilium:v1.0/examples/kubernetes/1.11/cilium-sa.yaml' --dry-run\nerror: unable to read URL \"https://raw.githubusercontent.com/cilium/cilium/docker.io/cilium/cilium:v1.0/examples/kubernetes/1.11/cilium-sa.yaml\", server reported 404 Not Found, status code=404\n",
    }
to be nil
/home/jenkins/workspace/Cilium-Master-Nightly-Tests-All/src/github.com/cilium/cilium/test/k8sT/Nightly.go:432
```

New Ouput:

Example1:
```
    Cilium docker.io/cilium/cilium:v1.0 was not able to be deployed
    Expected
        <*helpers.cmdError | 0xc42057a8c0>: Cilium manifest validation fails output: cmd: kubectl apply --filename='https://raw.githubusercontent.com/cilium/cilium/docker.io/cilium/cilium:v1.0/examples/kubernetes/1.11/cilium-sa.yaml' --dry-run
    Exitcode: 1
    Stdout:

    Stderr:
         error: unable to read URL "https://raw.githubusercontent.com/cilium/cilium/docker.io/cilium/cilium:v1.0/examples/kubernetes/1.11/cilium-sa.yaml", server reported 404 Not Found, status code=404

    to be nil
```

Example 2:

```
  Cilium cannot be installed
  Expected
      <*helpers.cmdError | 0xc420500cb0>: Cilium manifest patch instalation failed output: cmd: kubectl patch --filename='/home/vagrant/go/src/github.com/cilium/cilium/examples/kubernetes/1.11/cilium-cm.yaml' --patch "$(cat '/home/vagrant/go/src/github.com/cilium/cilium/test/k8sT/manifests/cilium-cm-patch.yaml')" --local -o yaml | kubectl apply -f - *******
  error: Unexpected args: [apt-key.gpg certs cilium-cm.yaml cilium-cm.yaml_bk go server.conf]
  See 'kubectl apply -h' for help and examples.

  to be nil
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5511)
<!-- Reviewable:end -->
