### PR TITLE
Document safe downgrade from 1.2 or later to 1.0

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -52,7 +52,7 @@ Datapath
 * ``datapath_conntrack_gc_entries``: The number of alive and deleted conntrack
   entries at the end of a garbage collector run labeled by datapath family.
 * ``datapath_conntrack_gc_duration_seconds``: Duration in seconds of the garbage
-  collector process labeled by datapath and completation status.
+  collector process labeled by datapath and completion status.
 
 Drops/Forwards (L3/L4)
 ----------------------

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -389,9 +389,21 @@ Downgrading to Cilium 1.0.x from Cilium 1.1.y
    * **IPv6 CIDR matching:** Technically supported since 1.0.2, officially supported
      since 1.1.0. (`PR 4004 <https://github.com/cilium/cilium/pull/4004>`_)
 
-#. Follow the instructions in the section :ref:`upgrade_minor` to perform the
+   Any rules that are not compatible with 1.0.x must be removed before
    downgrade.
 
+#. Add or update the option ``clean-cilium-bpf-state`` to the `ConfigMap` and
+   set to ``true``. This will cause BPF maps to be removed during the
+   downgrade, which avoids bugs such as `Issue 5070
+   <https://github.com/cilium/cilium/issues/5070>`_. As a side effect, any
+   loadbalancing decisions for active connections will be disrupted during
+   downgrade. For more information on changing `ConfigMap` options, see
+   :ref:`upgrade_configmap`.
+
+#. Follow the instructions in the section :ref:`upgrade_minor` to perform the
+   downgrade to the latest micro release of the 1.0 series.
+
+#. Set the ``clean-cilium-bpf-state`` `ConfigMap` option back to ``false``.
 
 .. _upgrade_advanced:
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -79,6 +79,7 @@ conf
 config
 ConfigMap
 configMapKeyRef
+conntrack
 containerd
 contributing
 CoreOS


### PR DESCRIPTION
**Do not merge before #5503, #5504**

If these instructions are followed to downgrade to the latest micro
release of Cilium 1.0 (after PR #5504 is merged and the user uses the DS
YAMLs that are changed as part of that backport), then the downgrade
should be fairly safe.

The actual changes for safety are in #5503, which needs to be
backported.

*Note to the backporter: The "fix build" commit will likely cause conflicts and should not be necessary for backport. Please test via `test-docs-please` in backport PR to confirm.*

Fixes: #5454

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5513)
<!-- Reviewable:end -->
