### PR TITLE
endpoint: remove revision check around L4 policy calculation

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -561,16 +561,13 @@ func (e *Endpoint) regeneratePolicy(owner Owner) error {
 	// disabled for ingress and / or egress.
 	e.ingressPolicyEnabled, e.egressPolicyEnabled = e.ComputePolicyEnforcement(repo)
 
-	// Skip L4 policy recomputation if possible. However, the rest of the
-	// policy computation still needs to be done for each endpoint separately.
-	l4PolicyChanged := false
-	if e.policyRevision != revision {
-		l4PolicyChanged, err = e.resolveL4Policy(repo)
-		if err != nil {
-			return err
-		}
-	} else {
-		e.Logger().WithField(logfields.Identity, e.SecurityIdentity.ID).Debug("Reusing cached L4 policy")
+	l4PolicyChanged, err := e.resolveL4Policy(repo)
+	if err != nil {
+		return err
+	}
+
+	if l4PolicyChanged {
+		e.Logger().WithField(logfields.Identity, e.SecurityIdentity.ID).Debug("L4 policy changed")
 	}
 
 	// Calculate L3 (CIDR) policy.


### PR DESCRIPTION
Endpoint policy regeneration logic would check if the policy repository revision
changed from the endpoint's prior policy calculation to determine if the
endpoint's L4 policy should be calculated. However, endpoint L4 policy should be
calculated for a variety of other reasons, including endpoint identity change.
Thus, short-circuiting endpoint L4 policy regeneration only based of the
difference of the endpoint's policy revision and the policy repository's
revision is incorrect and could lead to cases where L4 policy for an endpoint is
not calculated.

Signed-off by: Ian Vernon <ian@cilium.io>

```release-note
Always recalculate endpoint L4 policy when regeneratePolicy is called
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5515)
<!-- Reviewable:end -->
