### PR TITLE
Add CNP and K8s NP equalness and missing func

### DIFF
--- a/daemon/k8s_watcher_test.go
+++ b/daemon/k8s_watcher_test.go
@@ -17,7 +17,16 @@ package main
 import (
 	"time"
 
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/versioned"
+
 	. "gopkg.in/check.v1"
+	"k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (ds *DaemonSuite) TestK8sErrorLogTimeout(c *C) {
@@ -39,4 +48,195 @@ func (ds *DaemonSuite) TestK8sErrorLogTimeout(c *C) {
 	// Returns true because k8sErrLogTimeout has passed
 	shouldLogTime := startTime.Add(k8sErrLogTimeout).Add(time.Nanosecond)
 	c.Assert(k8sErrorUpdateCheckUnmuteTime(errstr, shouldLogTime), Equals, true)
+}
+
+func (ds *DaemonSuite) Test_missingK8sNetworkPolicyV1(c *C) {
+	type args struct {
+		m    versioned.Map
+		repo *policy.Repository
+	}
+	tests := []struct {
+		name        string
+		setupArgs   func() args
+		setupWanted func() versioned.Map
+	}{
+		{
+			name: "both equal",
+			setupArgs: func() args {
+				p1 := policy.NewPolicyRepository()
+				return args{
+					repo: p1,
+					m:    versioned.NewMap(),
+				}
+			},
+			setupWanted: func() versioned.Map {
+				return versioned.NewMap()
+			},
+		},
+		{
+			name: "repository is missing a policy",
+			setupArgs: func() args {
+				p1 := policy.NewPolicyRepository()
+
+				m := versioned.NewMap()
+				m.Add("", versioned.Object{
+					Data: &v1.NetworkPolicy{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "bar",
+							Namespace: "foo",
+						},
+					},
+				})
+
+				return args{
+					m:    m,
+					repo: p1,
+				}
+			},
+			setupWanted: func() versioned.Map {
+				m := versioned.NewMap()
+				m.Add("", versioned.Object{
+					Data: &v1.NetworkPolicy{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "bar",
+							Namespace: "foo",
+						},
+					},
+				})
+				return m
+			},
+		},
+		{
+			name: "repository contains all policies",
+			setupArgs: func() args {
+				p1 := policy.NewPolicyRepository()
+				_, err := p1.Add(api.Rule{
+					EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("id=a")),
+					Labels: labels.LabelArray{labels.NewLabel(k8sConst.PolicyLabelName, "bar", labels.LabelSourceK8s),
+						labels.NewLabel(k8sConst.PolicyLabelNamespace, "foo", labels.LabelSourceK8s)},
+				})
+				c.Assert(err, IsNil)
+
+				m := versioned.NewMap()
+				m.Add("", versioned.Object{
+					Data: &v1.NetworkPolicy{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "bar",
+							Namespace: "foo",
+						},
+					},
+				})
+
+				return args{
+					m:    m,
+					repo: p1,
+				}
+			},
+			setupWanted: func() versioned.Map {
+				return versioned.NewMap()
+			},
+		},
+	}
+	for _, tt := range tests {
+		args := tt.setupArgs()
+		want := tt.setupWanted()
+		ds.d.policy = args.repo
+		got := ds.d.missingK8sNetworkPolicyV1(args.m)
+		c.Assert(got, DeepEquals, want, Commentf("Test name: %q", tt.name))
+	}
+}
+
+func (ds *DaemonSuite) Test_missingCNPv2(c *C) {
+	type args struct {
+		m    versioned.Map
+		repo *policy.Repository
+	}
+	tests := []struct {
+		name        string
+		setupArgs   func() args
+		setupWanted func() versioned.Map
+	}{
+		{
+			name: "both equal",
+			setupArgs: func() args {
+				p1 := policy.NewPolicyRepository()
+				return args{
+					repo: p1,
+					m:    versioned.NewMap(),
+				}
+			},
+			setupWanted: func() versioned.Map {
+				return versioned.NewMap()
+			},
+		},
+		{
+			name: "repository is missing a policy",
+			setupArgs: func() args {
+				p1 := policy.NewPolicyRepository()
+
+				m := versioned.NewMap()
+				m.Add("", versioned.Object{
+					Data: &v2.CiliumNetworkPolicy{
+						Spec: &api.Rule{
+							EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("id=a")),
+							Labels:           labels.ParseLabelArray("k8s:name=bar", "k8s:namespace=bar"),
+						},
+					},
+				})
+
+				return args{
+					m:    m,
+					repo: p1,
+				}
+			},
+			setupWanted: func() versioned.Map {
+				m := versioned.NewMap()
+				m.Add("", versioned.Object{
+					Data: &v2.CiliumNetworkPolicy{
+						Spec: &api.Rule{
+							EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("id=a")),
+							Labels:           labels.ParseLabelArray("k8s:name=bar", "k8s:namespace=bar"),
+						},
+					},
+				})
+				return m
+			},
+		},
+		{
+			name: "repository contains all policies",
+			setupArgs: func() args {
+				p1 := policy.NewPolicyRepository()
+				_, err := p1.Add(api.Rule{
+					EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("id=a")),
+					Labels:           labels.ParseLabelArray("k8s:name=bar", "k8s:namespace=bar"),
+				})
+				c.Assert(err, IsNil)
+
+				m := versioned.NewMap()
+				m.Add("", versioned.Object{
+					Data: &v2.CiliumNetworkPolicy{
+						Spec: &api.Rule{
+							EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("id=a")),
+							Labels:           labels.ParseLabelArray("k8s:name=bar", "k8s:namespace=bar"),
+						},
+					},
+				})
+
+				return args{
+					m:    m,
+					repo: p1,
+				}
+			},
+			setupWanted: func() versioned.Map {
+				return versioned.NewMap()
+			},
+		},
+	}
+	for _, tt := range tests {
+		args := tt.setupArgs()
+		want := tt.setupWanted()
+		ds.d.policy = args.repo
+		got := ds.d.missingCNPv2(args.m)
+		c.Assert(got, DeepEquals, want, Commentf("Test name: %q", tt.name))
+	}
 }

--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -219,14 +219,17 @@ func ParseToCiliumRule(namespace, name string, r *api.Rule) *api.Rule {
 	parseToCiliumIngressRule(namespace, r, retRule)
 	parseToCiliumEgressRule(namespace, r, retRule)
 
-	policyLbls := GetPolicyLabels(namespace, name, ResourceTypeCiliumNetworkPolicy)
-	if retRule.Labels == nil {
-		retRule.Labels = make(labels.LabelArray, 0, len(policyLbls)+len(r.Labels))
-	}
-	retRule.Labels = append(retRule.Labels, policyLbls...)
-	retRule.Labels = append(retRule.Labels, r.Labels...)
+	retRule.Labels = ParseToCiliumLabels(namespace, name, r.Labels)
 
 	retRule.Description = r.Description
 
 	return retRule
+}
+
+// ParseToCiliumLabels returns all ruleLbls appended with a specific label that
+// represents the given namespace and name along with a label that specifies
+// these labels were derived from a CiliumNetworkPolicy.
+func ParseToCiliumLabels(namespace, name string, ruleLbs labels.LabelArray) labels.LabelArray {
+	policyLbls := GetPolicyLabels(namespace, name, ResourceTypeCiliumNetworkPolicy)
+	return append(policyLbls, ruleLbs...)
 }

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -385,18 +385,22 @@ func listV1Namespace(client interface{}) func() (versioned.Map, error) {
 }
 
 func equalV1NetworkPolicy(o1, o2 interface{}) bool {
-	_, ok := o1.(*networkingv1.NetworkPolicy)
+	np1, ok := o1.(*networkingv1.NetworkPolicy)
 	if !ok {
 		log.Panicf("Invalid resource type %q, expecting *networkingv1.NetworkPolicy", reflect.TypeOf(o1))
 		return false
 	}
-	_, ok = o1.(*networkingv1.NetworkPolicy)
+	np2, ok := o2.(*networkingv1.NetworkPolicy)
 	if !ok {
 		log.Panicf("Invalid resource type %q, expecting *networkingv1.NetworkPolicy", reflect.TypeOf(o2))
 		return false
 	}
-	// FIXME write dedicated deep equal function
-	return false
+	// As Cilium uses all of the Spec from a NP it's not probably not worth
+	// it to create a dedicated deep equal	 function to compare both network
+	// policies.
+	return np1.Name == np2.Name &&
+		np1.Namespace == np2.Namespace &&
+		reflect.DeepEqual(np1.Spec, np2.Spec)
 }
 
 func equalV1Services(o1, o2 interface{}) bool {
@@ -445,18 +449,20 @@ func equalV1beta1Ingress(o1, o2 interface{}) bool {
 }
 
 func equalV2CNP(o1, o2 interface{}) bool {
-	_, ok := o1.(*cilium_v2.CiliumNetworkPolicy)
+	cnp1, ok := o1.(*cilium_v2.CiliumNetworkPolicy)
 	if !ok {
 		log.Panicf("Invalid resource type %q, expecting *cilium_v2.CiliumNetworkPolicy", reflect.TypeOf(o1))
 		return false
 	}
-	_, ok = o1.(*cilium_v2.CiliumNetworkPolicy)
+	cnp2, ok := o2.(*cilium_v2.CiliumNetworkPolicy)
 	if !ok {
 		log.Panicf("Invalid resource type %q, expecting *cilium_v2.CiliumNetworkPolicy", reflect.TypeOf(o2))
 		return false
 	}
-	// FIXME write dedicated deep equal function
-	return false
+	return cnp1.Name == cnp2.Name &&
+		cnp1.Namespace == cnp2.Namespace &&
+		reflect.DeepEqual(cnp1.Spec, cnp2.Spec) &&
+		reflect.DeepEqual(cnp1.Specs, cnp2.Specs)
 }
 
 func equalV1Pod(o1, o2 interface{}) bool {

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -1,0 +1,170 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/api"
+
+	. "gopkg.in/check.v1"
+	"k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (s *K8sSuite) Test_missingK8sNetworkPolicyV1(c *C) {
+	type args struct {
+		o1 *v1.NetworkPolicy
+		o2 *v1.NetworkPolicy
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "KNP with the same name",
+			args: args{
+				o1: &v1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+				},
+				o2: &v1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "KNP with the different spec",
+			args: args{
+				o1: &v1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+					Spec: v1.NetworkPolicySpec{
+						PodSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+				o2: &v1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "KNP with the same spec",
+			args: args{
+				o1: &v1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+					Spec: v1.NetworkPolicySpec{},
+				},
+				o2: &v1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+					Spec: v1.NetworkPolicySpec{},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		got := equalV1NetworkPolicy(tt.args.o1, tt.args.o2)
+		c.Assert(got, Equals, tt.want, Commentf("Test Name: %s", tt.name))
+	}
+}
+
+func (s *K8sSuite) Test_equalV2CNP(c *C) {
+	type args struct {
+		o1 *v2.CiliumNetworkPolicy
+		o2 *v2.CiliumNetworkPolicy
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "CNP with the same name",
+			args: args{
+				o1: &v2.CiliumNetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+				},
+				o2: &v2.CiliumNetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "CNP with the different spec",
+			args: args{
+				o1: &v2.CiliumNetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+					Spec: &api.Rule{
+						EndpointSelector: api.NewESFromLabels(labels.NewLabel("foo", "bar", "k8s")),
+					},
+				},
+				o2: &v2.CiliumNetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+					Spec: nil,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "CNP with the same spec",
+			args: args{
+				o1: &v2.CiliumNetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+					Spec: &api.Rule{},
+				},
+				o2: &v2.CiliumNetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+					Spec: &api.Rule{},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		got := equalV2CNP(tt.args.o1, tt.args.o2)
+		c.Assert(got, Equals, tt.want, Commentf("Test Name: %s", tt.name))
+	}
+}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -504,6 +504,24 @@ func (p *Repository) SearchRLocked(labels labels.LabelArray) api.Rules {
 	return result
 }
 
+// ContainsAllRLocked returns true if repository contains all the labels in
+// needed. If needed contains no labels, ContainsAllRLocked() will always return
+// true.
+func (p *Repository) ContainsAllRLocked(needed labels.LabelArrayList) bool {
+nextLabel:
+	for _, neededLabel := range needed {
+		for _, l := range p.rules {
+			if len(l.Labels) > 0 && neededLabel.Contains(l.Labels) {
+				continue nextLabel
+			}
+		}
+
+		return false
+	}
+
+	return true
+}
+
 // Add inserts a rule into the policy repository
 // This is just a helper function for unit testing.
 // TODO: this should be in a test_helpers.go file or something similar


### PR DESCRIPTION
Read per commit basis.

```release-note
Stop triggering unnecessary policy regenerations for every Kubernetes watch event.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5519)
<!-- Reviewable:end -->
