### PR TITLE
endpoint: Verify whether the endpoint still exists after BPF compilation

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -775,14 +775,6 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 		return err
 	}
 
-	// Depending upon result of BPF regeneration (compilation executed),
-	// shift endpoint directories to match said BPF regeneration
-	// results.
-	err = e.synchronizeDirectories(origDir, compilationExecuted)
-	if err != nil {
-		return fmt.Errorf("error synchronizing endpoint BPF program directories: %s", err)
-	}
-
 	// Update desired policy for endpoint because policy has now been realized
 	// in the datapath. PolicyMap state is not updated here, because that is
 	// performed in endpoint.syncPolicyMap().
@@ -791,6 +783,15 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 		return err
 	}
 	stats.waitingForLock.End()
+
+	// Depending upon result of BPF regeneration (compilation executed),
+	// shift endpoint directories to match said BPF regeneration
+	// results.
+	err = e.synchronizeDirectories(origDir, compilationExecuted)
+	if err != nil {
+		e.Unlock()
+		return fmt.Errorf("error synchronizing endpoint BPF program directories: %s", err)
+	}
 
 	// Keep PolicyMap for this endpoint in sync with desired / realized state.
 	if !option.Config.DryMode {


### PR DESCRIPTION
The following error was observed in logs:

```
error synchronizing endpoint BPF program directories: unable to rename current endpoint directory: rename /var/run/cilium/state/11085 /var/run/cilium/state/11085_stale: no such file or directory
```

The likely cause is that the endpoint has been removed while BPF compilation
was occuring.  Insteading of blindly assuming that the endpoint generation
directory still exists, check its liveness beforehands

Fixes: #5586

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5525)
<!-- Reviewable:end -->
