### PR TITLE
Test: Fail if a lock took more than 10 seconds.

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -660,6 +661,15 @@ func (s *SSHMeta) ValidateNoErrorsOnLogs(duration time.Duration) {
 		if strings.Contains(logs, message) {
 			fmt.Fprintf(CheckLogs, "⚠️  Found a %q in logs\n", message)
 			ginkgoext.Fail(fmt.Sprintf("Found a %q in Cilium Logs", message))
+		}
+	}
+
+	for _, re := range checkLogsMessagesRegexp {
+		regExp := regexp.MustCompile(re)
+		val := regExp.FindString(logs)
+		if val != "" {
+			fmt.Fprintf(CheckLogs, "⚠️  Regular expression %q found in logs\n", re)
+			ginkgoext.Fail(fmt.Sprintf("Regular expression %q found in logs\n", re))
 		}
 	}
 

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -226,6 +226,11 @@ const CiliumDefaultDSPatch = "cilium-ds-patch.yaml"
 // CiliumConfigMapPatch is the default Cilium ConfigMap patch to be used in all tests.
 const CiliumConfigMapPatch = "cilium-cm-patch.yaml"
 
+// goroutineLockRegexp is a regexp that check that a gouroutine is not bigger than 10 seconds.
+// @TODO move this regexp to `[1-9]([0-9]{1,})?\.[0-9]*` to detect more than a second.
+var goroutineLockRegexp = fmt.Sprintf(`"%s.*" goroutine=".*" seconds=([0-9]{2,}\.[0-9]*)`, selfishThresholdMsg)
+
+var checkLogsMessagesRegexp = []string{goroutineLockRegexp}
 var checkLogsMessages = []string{panicMessage, deadLockHeader, segmentationFault, NACKreceived, RunInitFailed}
 var countLogsMessages = []string{contextDeadlineExceeded, ErrorLogs, WarningLogs, APIPanicked, selfishThresholdMsg}
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -1340,6 +1341,16 @@ func (kub *Kubectl) ValidateNoErrorsOnLogs(duration time.Duration) {
 			ginkgoext.Fail(fmt.Sprintf("Found a %q in Cilium Logs", message))
 		}
 	}
+
+	for _, re := range checkLogsMessagesRegexp {
+		regExp := regexp.MustCompile(re)
+		val := regExp.FindString(logs)
+		if val != "" {
+			fmt.Fprintf(CheckLogs, "⚠️  Regular expression %q found in logs\n", re)
+			ginkgoext.Fail(fmt.Sprintf("Regular expression %q found in logs\n", re))
+		}
+	}
+
 	// Count part
 	for _, message := range countLogsMessages {
 		var prefix = ""


### PR DESCRIPTION
Deadlock detection has a lot of improvements in the last release, at the
moment we only count the number of locks that took more than 0.1 second,
but we don't fail if any lock take more than X.

This PR add a initial checker to check that the lock does not take more
than 10 seconds (related with issue #5532) and in the future we can fail
when it took more than a second.

At the moment, in Nightly the number is a bit high:

```
⚠️  Number of "Goroutine took lock for more than" in logs: 269
```

The reason to have 10 seconds and not 1 seconds is to start to fail
gradually and make the improvements step by step.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5534)
<!-- Reviewable:end -->
