### PR TITLE
pkg/bpf: send currentKey and not nextKey in the callback func

### DIFF
--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -584,7 +584,7 @@ func (m *Map) DumpReliablyWithCallback(cb DumpCallback, stats *DumpStats) error 
 			continue
 		}
 
-		k, v, err := m.dumpParser(nextKey, value)
+		k, v, err := m.dumpParser(currentKey, value)
 		if err != nil {
 			stats.Interrupted++
 			return err


### PR DESCRIPTION
When executing the callback function in DumpReliablyWithCallback
function, the callback should have the currentKey and not the nextKey.

This prevents the call back function to do any wrongly operations with
the wrong key for the mismatched value.

Signed-off-by: André Martins <andre@cilium.io>

A behavior I've noticed to detect this bug was the huge amount of CT entries that were being clean up. The weird part was the entries were being deleted but they were still there in the map. This causes the CT table to have this weird behavior every 1 minute, when the GC is executed).

```release-note
Stop clean up of wrong CT entries
```

Fixes https://github.com/cilium/cilium/issues/5512

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5539)
<!-- Reviewable:end -->
