### PR TITLE
cni: fix typo

### DIFF
--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -423,7 +423,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		allInterfacesPath := filepath.Join("/proc", "sys", "net", "ipv6", "conf", "all", "disable_ipv6")
 		err = connector.WriteSysConfig(allInterfacesPath, "0\n")
 		if err != nil {
-			logger.WithError(err).Warn("unable to disable ipv6 on all interfaces")
+			logger.WithError(err).Warn("unable to enable ipv6 on all interfaces")
 		}
 		macAddrStr, err = configureIface(ipam, args.IfName, &state)
 		return err


### PR DESCRIPTION
It was introduce in 6a6ced45192074bb6f084ae26701f7f59fea327f

Signed-off-by: Nirmoy Das <ndas@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5544)
<!-- Reviewable:end -->
