### PR TITLE
Test: Avoid linked clone in Vagrant

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure("2") do |config|
             vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
             vb.cpus = $CPU
             vb.memory= $MEMORY
-            vb.linked_clone = true
+            vb.linked_clone = false
         end
 
         server.vm.box =  "#{$SERVER_BOX}"
@@ -53,7 +53,7 @@ Vagrant.configure("2") do |config|
                 vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
                 vb.cpus = $CPU
                 vb.memory= $MEMORY
-                vb.linked_clone = true
+                vb.linked_clone = false
             end
 
             server.vm.box =  "#{$SERVER_BOX}"


### PR DESCRIPTION
Linked clone was enabled to make the import of VM faster, but on
delete/prunes the images was not deleted at all.

With this change the size used by the images will be much lower.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5546)
<!-- Reviewable:end -->
