### PR TITLE
pkg/identity: allow multiple labels for the identity of reserved fixed identities

### DIFF
--- a/pkg/identity/allocator.go
+++ b/pkg/identity/allocator.go
@@ -119,6 +119,8 @@ func IdentityAllocationIsLocal(lbls labels.Labels) bool {
 // an identity for the specified set of labels already exist, the identity is
 // re-used and reference counting is performed, otherwise a new identity is
 // allocated via the kvstore.
+// If the set of labels contains a fixed-identity label, the ID of the Identity
+// returned will the value set in the fixed-identity label.
 func AllocateIdentity(lbls labels.Labels) (*Identity, bool, error) {
 	log.WithFields(logrus.Fields{
 		logfields.IdentityLabels: lbls.String(),
@@ -132,7 +134,10 @@ func AllocateIdentity(lbls labels.Labels) (*Identity, bool, error) {
 			logfields.IdentityLabels: lbls.String(),
 			"isNew":                  false,
 		}).Debug("Resolved reserved identity")
-		return reservedIdentity, false, nil
+		// Don't return the reserved identity directly, return a new identity,
+		// with the labels received by the allocate identity.
+		id := NewIdentity(reservedIdentity.ID, lbls)
+		return id, false, nil
 	}
 
 	if identityAllocator == nil {

--- a/pkg/identity/allocator_test.go
+++ b/pkg/identity/allocator_test.go
@@ -1,0 +1,82 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identity
+
+import (
+	"github.com/cilium/cilium/pkg/labels"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *IdentityTestSuite) TestAllocateIdentity(c *C) {
+	err := AddUserDefinedNumericIdentitySet(map[string]string{"129": "kube-dns"})
+	c.Assert(err, IsNil)
+	defer DelReservedNumericIdentity(NumericIdentity(129))
+
+	type args struct {
+		lbls labels.Labels
+	}
+	type want struct {
+		id    *Identity
+		isNew bool
+		err   error
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "getting only the reserved identity label should return the numeric identity of the fixed label",
+			args: args{
+				lbls: labels.NewLabelsFromSortedList("reserved:" + labels.LabelKeyFixedIdentity + "=kube-dns"),
+			},
+			want: want{
+				id: NewIdentity(
+					NumericIdentity(129),
+					labels.NewLabelsFromSortedList("reserved:"+labels.LabelKeyFixedIdentity+"=kube-dns"),
+				),
+				isNew: false,
+				err:   nil,
+			},
+		},
+		{
+			name: "getting the reserved identity label plus a user label should return the numeric identity of the fixed label",
+			args: args{
+				labels.NewLabelsFromSortedList(
+					"id.foo=bar;" +
+						"reserved:" + labels.LabelKeyFixedIdentity + "=kube-dns",
+				),
+			},
+			want: want{
+				id: NewIdentity(
+					NumericIdentity(129),
+					labels.NewLabelsFromSortedList(
+						"id.foo=bar;"+
+							"reserved:"+labels.LabelKeyFixedIdentity+"=kube-dns",
+					),
+				),
+				isNew: false,
+				err:   nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		id, isNew, err := AllocateIdentity(tt.args.lbls)
+		c.Assert(err, Equals, tt.want.err, Commentf("Test Name: %s", tt.name))
+		c.Assert(isNew, Equals, tt.want.isNew, Commentf("Test Name: %s", tt.name))
+		c.Assert(id, DeepEquals, tt.want.id, Commentf("Test Name: %s", tt.name))
+	}
+}


### PR DESCRIPTION
When a endpoint has a fixed identity label set up with other labels,
a policy couldn't be applied to any of the other labels for that
particular endpoint.

To avoid this, when allocating a new identity for a set of labels that
contains the fixed identity label the allocation should return a
Identity with all the identity labels of that particular endpoint.

Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/5529

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5548)
<!-- Reviewable:end -->
