### PR TITLE
Update Cilium etcd operator kubernetes descriptors

### DIFF
--- a/examples/kubernetes/addons/etcd-operator/cilium-deployment.yaml
+++ b/examples/kubernetes/addons/etcd-operator/cilium-deployment.yaml
@@ -24,10 +24,24 @@ data:
     cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
 
   # If you want to run cilium in debug mode change this value to true
-  debug: "true"
+  debug: "false"
   disable-ipv4: "false"
-  # If you want to clean cilium state; change this value to true
+
+  # If a serious issue occurs during Cilium startup, this
+  # invasive option may be set to true to remove all persistent
+  # state. Endpoints will not be restored using knowledge from a
+  # prior Cilium run, so they may receive new IP addresses upon
+  # restart. This also triggers clean-cilium-bpf-state.
   clean-cilium-state: "false"
+  # If you want to clean cilium BPF state, set this to true;
+  # Removes all BPF maps from the filesystem. Upon restart,
+  # endpoints are restored with the same IP addresses, however
+  # any ongoing connections may be disrupted briefly.
+  # Loadbalancing decisions will be reset, so any ongoing
+  # connections via a service may be loadbalanced to a different
+  # backend after restart.
+  clean-cilium-bpf-state: "false"
+
   legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
@@ -45,6 +59,13 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -56,8 +77,6 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
       maxUnavailable: 2
   selector:
     matchLabels:
@@ -81,181 +100,223 @@ spec:
     spec:
       serviceAccountName: cilium
       initContainers:
-        - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
-          imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
+      - name: clean-cilium-state
+        image: docker.io/library/busybox:1.28.4
+        imagePullPolicy: IfNotPresent
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+        securityContext:
+          capabilities:
+            add:
+            - "NET_ADMIN"
+          privileged: true
+        volumeMounts:
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+        - name: cilium-run
+          mountPath: /var/run/cilium
+        env:
+        - name: "CLEAN_CILIUM_STATE"
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              optional: true
+              key: clean-cilium-state
+        - name: "CLEAN_CILIUM_BPF_STATE"
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              optional: true
+              key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.0
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-            - "--fixed-identity-mapping=128=kv-store"
-            - "--fixed-identity-mapping=129=kube-dns"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - image: docker.io/cilium/cilium:v1.2.0
+        imagePullPolicy: IfNotPresent
+        name: cilium-agent
+        command: ["cilium-agent"]
+        args:
+        - "--debug=$(CILIUM_DEBUG)"
+        - "--kvstore=etcd"
+        - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        - "--disable-ipv4=$(DISABLE_IPV4)"
+        - "--fixed-identity-mapping=128=kv-store"
+        - "--fixed-identity-mapping=129=kube-dns"
+        ports:
+        - name: prometheus
+          containerPort: 9090
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - "/cni-install.sh"
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: docker-socket
-              mountPath: /var/run/docker.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - "/cni-uninstall.sh"
+        env:
+        - name: "K8S_NODE_NAME"
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: "CILIUM_DEBUG"
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: debug
+        - name: "DISABLE_IPV4"
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: disable-ipv4
+        # Note: this variable is a no-op if not defined, and is used in the
+        # prometheus examples.
+        - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-metrics-config
+              optional: true
+              key: prometheus-serve-addr
+        - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              optional: true
+              key: legacy-host-allows-world
+        - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: sidecar-istio-proxy-image
+              optional: true
+        - name: "CILIUM_TUNNEL"
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: "/var/lib/cilium/clustermesh/"
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          failureThreshold: 10
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+        - name: cilium-run
+          mountPath: /var/run/cilium
+        - name: cni-path
+          mountPath: /host/opt/cni/bin
+        - name: etc-cni-netd
+          mountPath: /host/etc/cni/net.d
+        - name: docker-socket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        - name: etcd-config-path
+          mountPath: /var/lib/etcd-config
+          readOnly: true
+        - name: etcd-secrets
+          mountPath: /var/lib/etcd-secrets
+          readOnly: true
+        - name: clustermesh-secrets
+          mountPath: /var/lib/cilium/clustermesh
+          readOnly: true
+        securityContext:
+          capabilities:
+            add:
+            - "NET_ADMIN"
+          privileged: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       volumes:
-        # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-        # To keep state between restarts / upgrades
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-        # To read docker events from the node
-        - name: docker-socket
-          hostPath:
-            path: /var/run/docker.sock
-        # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-        # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
-        # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-client-tls
+      # To keep state between restarts / upgrades
+      - name: cilium-run
+        hostPath:
+          path: /var/run/cilium
+          type: "DirectoryOrCreate"
+      # To keep state between restarts / upgrades
+      - name: bpf-maps
+        hostPath:
+          path: /sys/fs/bpf
+          type: "DirectoryOrCreate"
+      # To read docker events from the node
+      - name: docker-socket
+        hostPath:
+          path: /var/run/docker.sock
+          type: "Socket"
+      # To install cilium cni plugin in the host
+      - name: cni-path
+        hostPath:
+          path: /opt/cni/bin
+          type: "DirectoryOrCreate"
+      # To install cilium cni configuration in the host
+      - name: etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+          type: "DirectoryOrCreate"
+      # To read the etcd config stored in config maps
+      - name: etcd-config-path
+        configMap:
+          name: cilium-config
+          items:
+          - key: etcd-config
+            path: etcd.config
+      # To read the k8s etcd secrets in case the user might want to use TLS
+      - name: etcd-secrets
+        secret:
+          secretName: cilium-etcd-secrets
+          optional: true
+      # To read the clustermesh configuration
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+      - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+      # Mark cilium's pod as critical for rescheduling
+      - key: CriticalAddonsOnly
+        operator: "Exists"
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: cilium
@@ -264,75 +325,75 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - "*"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/examples/kubernetes/addons/etcd-operator/development/cilium-development.yaml
+++ b/examples/kubernetes/addons/etcd-operator/development/cilium-development.yaml
@@ -26,8 +26,22 @@ data:
   # If you want to run cilium in debug mode change this value to true
   debug: "true"
   disable-ipv4: "false"
-  # If you want to clean cilium state; change this value to true
+
+  # If a serious issue occurs during Cilium startup, this
+  # invasive option may be set to true to remove all persistent
+  # state. Endpoints will not be restored using knowledge from a
+  # prior Cilium run, so they may receive new IP addresses upon
+  # restart. This also triggers clean-cilium-bpf-state.
   clean-cilium-state: "false"
+  # If you want to clean cilium BPF state, set this to true;
+  # Removes all BPF maps from the filesystem. Upon restart,
+  # endpoints are restored with the same IP addresses, however
+  # any ongoing connections may be disrupted briefly.
+  # Loadbalancing decisions will be reset, so any ongoing
+  # connections via a service may be loadbalanced to a different
+  # backend after restart.
+  clean-cilium-bpf-state: "false"
+
   legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
@@ -45,6 +59,13 @@ data:
   #   - vxlan (default)
   #   - geneve
   tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -56,8 +77,6 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
       maxUnavailable: 2
   selector:
     matchLabels:
@@ -81,181 +100,223 @@ spec:
     spec:
       serviceAccountName: cilium
       initContainers:
-        - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
-          imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
+      - name: clean-cilium-state
+        image: docker.io/library/busybox:1.28.4
+        imagePullPolicy: IfNotPresent
+        command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+        securityContext:
+          capabilities:
+            add:
+            - "NET_ADMIN"
+          privileged: true
+        volumeMounts:
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+        - name: cilium-run
+          mountPath: /var/run/cilium
+        env:
+        - name: "CLEAN_CILIUM_STATE"
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              optional: true
+              key: clean-cilium-state
+        - name: "CLEAN_CILIUM_BPF_STATE"
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              optional: true
+              key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.0
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-            - "--fixed-identity-mapping=128=kv-store"
-            - "--fixed-identity-mapping=129=kube-dns"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        name: cilium-agent
+        command: ["cilium-agent"]
+        args:
+        - "--debug=$(CILIUM_DEBUG)"
+        - "--kvstore=etcd"
+        - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        - "--disable-ipv4=$(DISABLE_IPV4)"
+        - "--fixed-identity-mapping=128=kv-store"
+        - "--fixed-identity-mapping=129=kube-dns"
+        ports:
+        - name: prometheus
+          containerPort: 9090
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - "/cni-install.sh"
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: docker-socket
-              mountPath: /var/run/docker.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - "/cni-uninstall.sh"
+        env:
+        - name: "K8S_NODE_NAME"
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: "CILIUM_DEBUG"
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: debug
+        - name: "DISABLE_IPV4"
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: disable-ipv4
+        # Note: this variable is a no-op if not defined, and is used in the
+        # prometheus examples.
+        - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-metrics-config
+              optional: true
+              key: prometheus-serve-addr
+        - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              optional: true
+              key: legacy-host-allows-world
+        - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: sidecar-istio-proxy-image
+              optional: true
+        - name: "CILIUM_TUNNEL"
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: "/var/lib/cilium/clustermesh/"
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          failureThreshold: 10
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+        - name: cilium-run
+          mountPath: /var/run/cilium
+        - name: cni-path
+          mountPath: /host/opt/cni/bin
+        - name: etc-cni-netd
+          mountPath: /host/etc/cni/net.d
+        - name: docker-socket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+        - name: etcd-config-path
+          mountPath: /var/lib/etcd-config
+          readOnly: true
+        - name: etcd-secrets
+          mountPath: /var/lib/etcd-secrets
+          readOnly: true
+        - name: clustermesh-secrets
+          mountPath: /var/lib/cilium/clustermesh
+          readOnly: true
+        securityContext:
+          capabilities:
+            add:
+            - "NET_ADMIN"
+          privileged: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       volumes:
-        # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-        # To keep state between restarts / upgrades
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-        # To read docker events from the node
-        - name: docker-socket
-          hostPath:
-            path: /var/run/docker.sock
-        # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-        # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
-        # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-client-tls
+      # To keep state between restarts / upgrades
+      - name: cilium-run
+        hostPath:
+          path: /var/run/cilium
+          type: "DirectoryOrCreate"
+      # To keep state between restarts / upgrades
+      - name: bpf-maps
+        hostPath:
+          path: /sys/fs/bpf
+          type: "DirectoryOrCreate"
+      # To read docker events from the node
+      - name: docker-socket
+        hostPath:
+          path: /var/run/docker.sock
+          type: "Socket"
+      # To install cilium cni plugin in the host
+      - name: cni-path
+        hostPath:
+          path: /opt/cni/bin
+          type: "DirectoryOrCreate"
+      # To install cilium cni configuration in the host
+      - name: etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+          type: "DirectoryOrCreate"
+      # To read the etcd config stored in config maps
+      - name: etcd-config-path
+        configMap:
+          name: cilium-config
+          items:
+          - key: etcd-config
+            path: etcd.config
+      # To read the k8s etcd secrets in case the user might want to use TLS
+      - name: etcd-secrets
+        secret:
+          secretName: cilium-etcd-secrets
+          optional: true
+      # To read the clustermesh configuration
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+      - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+      # Mark cilium's pod as critical for rescheduling
+      - key: CriticalAddonsOnly
+        operator: "Exists"
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: cilium
@@ -264,75 +325,75 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - "*"
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Read per commit

@tgraf should we backport this to 1.2? (at least the debug flag and the image pull policy commit)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5550)
<!-- Reviewable:end -->
