### PR TITLE
proxy: Check whether a port is already open before allocating

### DIFF
--- a/pkg/proxy/netstat.go
+++ b/pkg/proxy/netstat.go
@@ -1,0 +1,75 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"strconv"
+)
+
+var (
+	// procNetTCPFiles is the constant list of /proc/net files to read to get
+	// the same information about open TCP connections as output by netstat.
+	procNetTCPFiles = []string{
+		"/proc/net/tcp",
+		"/proc/net/tcp6",
+	}
+
+	// procNetUDPFiles is the constant list of /proc/net files to read to get
+	// the same information about open UDP connections as output by netstat.
+	procNetUDPFiles = []string{
+		"/proc/net/udp",
+		"/proc/net/udp6",
+	}
+
+	// procNetFileRegexp matches the first two columns of /proc/net/{tcp,udp}*
+	// files and submatches on the local port number.
+	procNetFileRegexp = regexp.MustCompile("^ *[[:digit:]]*: *[[:xdigit:]]*:([[:xdigit:]]*) ")
+)
+
+// readOpenLocalPorts returns the set of L4 ports currently open locally.
+// procNetFiles should be procNetTCPFiles or procNetUDPFiles.
+func readOpenLocalPorts(procNetFiles []string) (map[uint16]struct{}, error) {
+	openLocalPorts := make(map[uint16]struct{}, 128)
+
+	for _, file := range procNetFiles {
+		b, err := ioutil.ReadFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("cannot read proc file %s: %s", file, err)
+		}
+
+		lines := bytes.Split(b, []byte("\n"))
+
+		// Extract the local port number from the "local_address" column.
+		// The header line won't match and will be ignored.
+		for _, line := range lines {
+			groups := procNetFileRegexp.FindSubmatch(line)
+			if len(groups) != 2 { // no match
+				continue
+			}
+			// The port number is in hexadecimal.
+			localPort, err := strconv.ParseUint(string(groups[1]), 16, 16)
+			if err != nil {
+				return nil, fmt.Errorf("invalid local port number in %s: %s", file, err)
+			}
+			openLocalPorts[uint16(localPort)] = struct{}{}
+		}
+	}
+
+	return openLocalPorts, nil
+}


### PR DESCRIPTION
#5495 removed a check that was performed before allocating any TCP
port to a new proxy redirect, which tried opening and closing
the port. That check was triggering errors in Envoy when it tried
to open the allocated port too soon after the check closed the
port. 

However, removing that check exposed Envoy to legitimate port
conflicts with other processes opening ports in the same port
rannge.

Re-add a check before port allocation, implemented by listing the
currently open ports (like netstat) instead of opening and closing
the ports.

Fixes: #5532
Fixes: #5495
Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5552)
<!-- Reviewable:end -->
