### PR TITLE
Jenkins cleanup old vms on builds

### DIFF
--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -53,11 +53,18 @@ pipeline {
             }
 
             steps {
-                sh 'env'
-                Status("PENDING", "${env.JOB_NAME}")
-                sh 'rm -rf src; mkdir -p src/github.com/cilium'
-                sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
-                checkout scm
+                parallel(
+                    "checkout": {
+                        sh 'env'
+                        Status("PENDING", "${env.JOB_NAME}")
+                        sh 'rm -rf src; mkdir -p src/github.com/cilium'
+                        sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
+                        checkout scm
+                    },
+                    "cleanup": {
+                        sh '/usr/local/bin/cleanup || true'
+                    }
+                )
             }
         }
         stage('Boot VMs'){

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -25,13 +25,20 @@ pipeline {
             }
 
             steps {
-                BuildIfLabel('area/k8s', 'Cilium-PR-Kubernetes-Upstream')
-                BuildIfLabel('area/k8s', 'Cilium-PR-Ginkgo-Tests-K8s')
-                BuildIfLabel('area/documentation', 'Cilium-PR-Doc-Tests')
-                sh 'env'
-                sh 'rm -rf src; mkdir -p src/github.com/cilium'
-                sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
-                checkout scm
+                parallel(
+                    "checkout": {
+                        BuildIfLabel('area/k8s', 'Cilium-PR-Kubernetes-Upstream')
+                        BuildIfLabel('area/k8s', 'Cilium-PR-Ginkgo-Tests-K8s')
+                        BuildIfLabel('area/documentation', 'Cilium-PR-Doc-Tests')
+                        sh 'env'
+                        sh 'rm -rf src; mkdir -p src/github.com/cilium'
+                        sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
+                        checkout scm
+                    },
+                    "cleanup": {
+                        sh '/usr/local/bin/cleanup || true'
+                    },
+                )
             }
         }
         stage('Precheck') {

--- a/kubernetes-upstream.Jenkinsfile
+++ b/kubernetes-upstream.Jenkinsfile
@@ -48,11 +48,18 @@ pipeline {
     stages {
         stage('Checkout') {
             steps {
-                Status("PENDING", "$JOB_BASE_NAME")
-                sh 'env'
-                sh 'rm -rf src; mkdir -p src/github.com/cilium'
-                sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
-                checkout scm
+                parallel(
+                    "checkout": {
+                        sh 'env'
+                        Status("PENDING", "${env.JOB_NAME}")
+                        sh 'rm -rf src; mkdir -p src/github.com/cilium'
+                        sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
+                        checkout scm
+                    },
+                    "cleanup": {
+                        sh '/usr/local/bin/cleanup || true'
+                    }
+                )
             }
         }
         stage('Boot VMs'){

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure("2") do |config|
             vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
             vb.cpus = $CPU
             vb.memory= $MEMORY
-            vb.linked_clone = false
+            vb.linked_clone = true
         end
 
         server.vm.box =  "#{$SERVER_BOX}"
@@ -53,7 +53,7 @@ Vagrant.configure("2") do |config|
                 vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
                 vb.cpus = $CPU
                 vb.memory= $MEMORY
-                vb.linked_clone = false
+                vb.linked_clone = true
             end
 
             server.vm.box =  "#{$SERVER_BOX}"


### PR DESCRIPTION
Two commits here:

- One executes the cleanup script when start, the idea is to clean old Vms and docker-images. 
- Other one enables vagrant linked clones to make deploy faster as before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5553)
<!-- Reviewable:end -->
