### PR TITLE
Fix deletion of CiliumNetworkPolicy

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	informer "github.com/cilium/cilium/pkg/k8s/client/informers/externalversions"
@@ -1631,17 +1632,10 @@ func (d *Daemon) deleteCiliumNetworkPolicyV2(cnp *cilium_v2.CiliumNetworkPolicy)
 		log.Debugf("Unable to remove controller %s: %s", ctrlName, err)
 	}
 
-	rules, err := cnp.Parse()
-	if err == nil {
-		if len(rules) > 0 {
-			// On a CNP, the transformed rule is stored in the local repository
-			// with a set of labels. On a CNP with multiple rules all rules are
-			// stored in the local repository with the same set of labels.
-			// Therefore the deletion on the local repository can be done with
-			// the set of labels of the first rule.
-			_, err = d.PolicyDelete(rules[0].Labels)
-		}
-	}
+	labels := utils.GetPolicyLabels(cnp.ObjectMeta.Namespace, cnp.ObjectMeta.Name,
+		utils.ResourceTypeCiliumNetworkPolicy)
+
+	_, err = d.PolicyDelete(labels)
 	if err == nil {
 		scopedLog.Info("Deleted CiliumNetworkPolicy")
 	} else {

--- a/pkg/k8s/apis/cilium.io/const.go
+++ b/pkg/k8s/apis/cilium.io/const.go
@@ -18,8 +18,13 @@ const (
 	// PolicyLabelName is the name of the policy label which refers to the
 	// k8s policy name.
 	PolicyLabelName = "io.cilium.k8s.policy.name"
+
 	// PolicyLabelNamespace is the policy's namespace set in k8s.
 	PolicyLabelNamespace = "io.cilium.k8s.policy.namespace"
+
+	// PolicyLabelDerivedFrom is the resource type which was used to
+	// derived the policy rule
+	PolicyLabelDerivedFrom = "io.cilium.k8s.policy.derived-from"
 
 	// PolicyLabelServiceAccount is the name of the label associated with
 	// an endpoint to represent the Kubernetes ServiceAccount name

--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -39,6 +39,8 @@ const (
 	// podInitLbl is the label used in a label selector to match on
 	// initializing pods.
 	podInitLbl = labels.LabelSourceReservedKeyPrefix + labels.IDNameInit
+
+	resourceTypeCiliumNetworkPolicy = "CiliumNetworkPolicy"
 )
 
 var (
@@ -47,10 +49,11 @@ var (
 )
 
 // GetPolicyLabels returns a LabelArray for the given namespace and name.
-func GetPolicyLabels(ns, name string) labels.LabelArray {
+func GetPolicyLabels(ns, name, derivedFrom string) labels.LabelArray {
 	return []*labels.Label{
 		labels.NewLabel(k8sConst.PolicyLabelName, name, labels.LabelSourceK8s),
 		labels.NewLabel(k8sConst.PolicyLabelNamespace, ns, labels.LabelSourceK8s),
+		labels.NewLabel(k8sConst.PolicyLabelDerivedFrom, derivedFrom, labels.LabelSourceK8s),
 	}
 }
 
@@ -214,7 +217,7 @@ func ParseToCiliumRule(namespace, name string, r *api.Rule) *api.Rule {
 	parseToCiliumIngressRule(namespace, r, retRule)
 	parseToCiliumEgressRule(namespace, r, retRule)
 
-	policyLbls := GetPolicyLabels(namespace, name)
+	policyLbls := GetPolicyLabels(namespace, name, resourceTypeCiliumNetworkPolicy)
 	if retRule.Labels == nil {
 		retRule.Labels = make(labels.LabelArray, 0, len(policyLbls)+len(r.Labels))
 	}

--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -40,7 +40,9 @@ const (
 	// initializing pods.
 	podInitLbl = labels.LabelSourceReservedKeyPrefix + labels.IDNameInit
 
-	resourceTypeCiliumNetworkPolicy = "CiliumNetworkPolicy"
+	// ResourceTypeCiliumNetworkPolicy is the resource type used for the
+	// PolicyLabelDerivedFrom label
+	ResourceTypeCiliumNetworkPolicy = "CiliumNetworkPolicy"
 )
 
 var (
@@ -217,7 +219,7 @@ func ParseToCiliumRule(namespace, name string, r *api.Rule) *api.Rule {
 	parseToCiliumIngressRule(namespace, r, retRule)
 	parseToCiliumEgressRule(namespace, r, retRule)
 
-	policyLbls := GetPolicyLabels(namespace, name, resourceTypeCiliumNetworkPolicy)
+	policyLbls := GetPolicyLabels(namespace, name, ResourceTypeCiliumNetworkPolicy)
 	if retRule.Labels == nil {
 		retRule.Labels = make(labels.LabelArray, 0, len(policyLbls)+len(r.Labels))
 	}

--- a/pkg/k8s/apis/cilium.io/utils/utils_test.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils_test.go
@@ -90,6 +90,11 @@ func Test_ParseToCiliumRule(t *testing.T) {
 						Value:  "default",
 						Source: labels.LabelSourceK8s,
 					},
+					{
+						Key:    "io.cilium.k8s.policy.derived-from",
+						Value:  "CiliumNetworkPolicy",
+						Source: labels.LabelSourceK8s,
+					},
 				},
 			},
 		},
@@ -126,6 +131,11 @@ func Test_ParseToCiliumRule(t *testing.T) {
 					{
 						Key:    "io.cilium.k8s.policy.namespace",
 						Value:  "default",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.derived-from",
+						Value:  "CiliumNetworkPolicy",
 						Source: labels.LabelSourceK8s,
 					},
 				},
@@ -166,6 +176,11 @@ func Test_ParseToCiliumRule(t *testing.T) {
 					{
 						Key:    "io.cilium.k8s.policy.namespace",
 						Value:  "default",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.derived-from",
+						Value:  "CiliumNetworkPolicy",
 						Source: labels.LabelSourceK8s,
 					},
 				},
@@ -227,6 +242,11 @@ func Test_ParseToCiliumRule(t *testing.T) {
 					{
 						Key:    "io.cilium.k8s.policy.namespace",
 						Value:  "default",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.derived-from",
+						Value:  "CiliumNetworkPolicy",
 						Source: labels.LabelSourceK8s,
 					},
 				},

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -145,7 +145,7 @@ var (
 				ToCIDRSet: []api.CIDRRule{{Cidr: api.CIDR("10.0.0.0/8"), ExceptCIDRs: []api.CIDR{"10.96.0.0/12"}}},
 			},
 		},
-		Labels: k8sUtils.GetPolicyLabels("default", "rule1"),
+		Labels: k8sUtils.GetPolicyLabels("default", "rule1", "CiliumNetworkPolicy"),
 	}
 
 	rawRule = []byte(`{

--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -29,6 +29,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	resourceTypeNetworkPolicy = "NetworkPolicy"
+)
+
 var (
 	allowAllNamespacesRequirement = v1.LabelSelectorRequirement{
 		Key:      k8sConst.PodNamespaceLabel,
@@ -55,7 +59,7 @@ func GetPolicyLabelsv1(np *networkingv1.NetworkPolicy) labels.LabelArray {
 
 	ns := k8sUtils.ExtractNamespace(&np.ObjectMeta)
 
-	return k8sCiliumUtils.GetPolicyLabels(ns, policyName)
+	return k8sCiliumUtils.GetPolicyLabels(ns, policyName, resourceTypeNetworkPolicy)
 }
 
 func parseNetworkPolicyPeer(namespace string, peer *networkingv1.NetworkPolicyPeer) *api.EndpointSelector {

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -174,6 +174,7 @@ func (s *K8sSuite) TestParseNetworkPolicyIngress(c *C) {
 				labels.ParseLabelArray(
 					"k8s:"+k8sConst.PolicyLabelName,
 					"k8s:"+k8sConst.PolicyLabelNamespace+"=default",
+					"k8s:"+k8sConst.PolicyLabelDerivedFrom+"="+resourceTypeNetworkPolicy,
 				),
 			},
 		},
@@ -262,6 +263,7 @@ func (s *K8sSuite) TestParseNetworkPolicyNoSelectors(c *C) {
 			Labels: labels.ParseLabelArray(
 				"k8s:"+k8sConst.PolicyLabelName+"=ingress-cidr-test",
 				"k8s:"+k8sConst.PolicyLabelNamespace+"=myns",
+				"k8s:"+k8sConst.PolicyLabelDerivedFrom+"="+resourceTypeNetworkPolicy,
 			),
 		},
 	}
@@ -350,6 +352,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEgress(c *C) {
 				labels.ParseLabelArray(
 					"k8s:"+k8sConst.PolicyLabelName,
 					"k8s:"+k8sConst.PolicyLabelNamespace+"=default",
+					"k8s:"+k8sConst.PolicyLabelDerivedFrom+"="+resourceTypeNetworkPolicy,
 				),
 			},
 		},


### PR DESCRIPTION
This PR addresses two issues:
 * The unique identification of CNP and NP was achieved with a combination of namespace and name of the policy. This is not unique enough across CNP and NP as both resource types can hold resources with identical names.
 * The deletion of CNP required the original rules to be embedded in order to extract the labels. This is not required and may have caused CNPs to not be properly deleted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5556)
<!-- Reviewable:end -->
