### PR TITLE
cni: use right network NS while removing link

### DIFF
--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -478,7 +478,11 @@ func cmdDel(args *skel.CmdArgs) error {
 		log.WithError(err).Warn("Deletion of endpoint failed")
 	}
 
-	return ns.WithNetNSPath(args.Netns, func(netNs ns.NetNS) error {
-		return removeIfFromNSIfExists(netNs, args.IfName)
-	})
+	netNs, err := ns.GetNS(args.Netns)
+	if err != nil {
+		return fmt.Errorf("failed to open netns %q: %s", args.Netns, err)
+	}
+	defer netNs.Close()
+
+	return removeIfFromNSIfExists(netNs, args.IfName)
 }


### PR DESCRIPTION
WithNetNSPath(removeIfFromNSIfExists) == removeIfFromNSIfExists(hostNS,
..). removeIfFromNSIfExists runs in expected network namespace but
it gets hostNS as a argument

Signed-off-by: Nirmoy Das <ndas@suse.de>
https://github.com/cilium/cilium/blob/c1f2f3fbe871b3a8b2dbd2b85ff9d1cd4389cfa4/vendor/github.com/containernetworking/cni/pkg/ns/ns.go#L145
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5557)
<!-- Reviewable:end -->
