### PR TITLE
Daemon: Do not clean policy maps on startup

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -773,11 +773,6 @@ func (d *Daemon) init() error {
 	}
 
 	if !option.Config.DryMode {
-		// Validate existing map paths before attempting BPF compile.
-		if err = d.validateExistingMaps(); err != nil {
-			log.WithError(err).Error("Error while validating maps")
-			return err
-		}
 
 		if err := d.compileBase(); err != nil {
 			return err
@@ -1300,14 +1295,6 @@ func NewDaemon() (*Daemon, *endpointRestoreState, error) {
 	return &d, restoredEndpoints, nil
 }
 
-func (d *Daemon) validateExistingMaps() error {
-	walker := func(path string, _ os.FileInfo, _ error) error {
-		return mapValidateWalker(path)
-	}
-
-	return filepath.Walk(bpf.MapPrefixPath(), walker)
-}
-
 func (d *Daemon) collectStaleMapGarbage() {
 	if option.Config.DryMode {
 		return
@@ -1373,31 +1360,6 @@ func (d *Daemon) staleMapWalker(path string) error {
 		if strings.HasPrefix(filename, m) {
 			if id := strings.TrimPrefix(filename, m); id != filename {
 				d.checkStaleMap(path, filename, id)
-			}
-		}
-	}
-
-	return nil
-}
-
-func mapValidateWalker(path string) error {
-	prefixToValidator := map[string]bpf.MapValidator{
-		policymap.MapName: policymap.Validate,
-	}
-
-	filename := filepath.Base(path)
-	for m, validate := range prefixToValidator {
-		if strings.HasPrefix(filename, m) {
-			valid, err := validate(path)
-			switch {
-			case err != nil:
-				return err
-			case !valid:
-				log.WithField(logfields.Path, filename).Info("Outdated non-persistent BPF map found, removing...")
-
-				if err := os.Remove(path); err != nil {
-					return err
-				}
 			}
 		}
 	}

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -291,26 +291,6 @@ func (pm *PolicyMap) Close() error {
 	return err
 }
 
-// Validate checks the map pinned to the specified path to ensure that the map
-// attributes such as type, key length, value length are the same as for the
-// current version of Cilium.
-func Validate(path string) (bool, error) {
-	dummy := bpf.NewMap(path, bpf.BPF_MAP_TYPE_HASH,
-		int(unsafe.Sizeof(PolicyKey{})),
-		int(unsafe.Sizeof(PolicyEntry{})), MaxEntries, 0, nil)
-
-	existing, err := bpf.OpenMap(path)
-	if err != nil {
-		return true, err
-	}
-
-	if existing != nil {
-		return existing.MetadataDiff(dummy), nil
-	}
-
-	return true, nil
-}
-
 func OpenMap(path string) (*PolicyMap, bool, error) {
 	fd, isNewMap, err := bpf.OpenOrCreateMap(
 		path,


### PR DESCRIPTION
On startup the filepath is not set, and the map is not open (it does not
have an fd) there will be a diff and map will always be deleted.

Fix #5142

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5559)
<!-- Reviewable:end -->
