### PR TITLE
bpf: llvm 32-bit subregister doc updates

### DIFF
--- a/.authors.aux
+++ b/.authors.aux
@@ -4,5 +4,6 @@ helpful bug reports, suggestions or have otherwise provided value to the
 project:
 
 Brenden Blanco                          bblanco@plumgrid.com
+Jakub Kicinski                          jakub.kicinski@netronome.com
 Salvatore Orlando                       salv.orlando@gmail.com
 Tomás Senart                            tsenart@gmail.com

--- a/.mailmap
+++ b/.mailmap
@@ -12,3 +12,9 @@ Ashwin Paranjpe <ashwinp.work@gmail.com>
 Jerry J. Muzsik <jerrymuzsik@icloud.com>
 Zhu Yan <hackzhuyan@gmail.com>
 Junli Ou <oujunli306@gmail.com>
+Ian Vernon <ian@cilium.io> <vagrant@k8s1>
+Arvind Soni <arvind@covalent.io>
+Andrew Sy Kim <kim.andrewsy@gmail.com>
+Ifeanyi Ubah <ify1992@yahoo.com>
+Thomas Graf <thomas@cilium.io>
+Christopher Biscardi <chris@christopherbiscardi.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -7,9 +7,11 @@ Alexei Starovoitov                      alexei.starovoitov@gmail.com
 Amey Bhide                              amey@covalent.io
 Amre Shakimov                           amre@covalent.io
 André Martins                           andre@cilium.io
+Andrew Sy Kim                           kim.andrewsy@gmail.com
+Anit Gandhi                             anitgandhi@gmail.com
 Arvind Soni                             arvindsoni@gmail.com
 Ashwin Paranjpe                         ashwin@covalent.io
-ChristopherBiscardi                     chris@christopherbiscardi.com
+Christopher Biscardi                    chris@christopherbiscardi.com
 Craig Box                               craig.box@gmail.com
 Cynthia Thomas                          cynthia@covalent.io
 Daniel Borkmann                         daniel@iogearbox.net
@@ -27,11 +29,13 @@ Fred Hsu                                fredlhsu@gmail.com
 Fulvio Risso                            fulvio.risso@polito.it
 Gianluca Arbezzano                      gianarb92@gmail.com
 Ian Vernon                              ian@cilium.io
+Ifeanyi Ubah                            ify1992@yahoo.com
 Ivar Lazzaro                            ivarlazzaro@gmail.com
 Jan-Erik Rediger                        janerik@fnordig.de
 Jarno Rajahalme                         jarno@covalent.io
 Jerry J. Muzsik                         jerrymuzsik@icloud.com
 Jess Frazelle                           acidburn@microsoft.com
+Jiong Wang                              jiong.wang@netronome.com
 Joe Farrell                             joe2farrell@gmail.com
 Joe Stringer                            joe@covalent.io
 John Fastabend                          john.fastabend@gmail.com
@@ -50,7 +54,7 @@ Martin Charles                          martincharles07@gmail.com
 Matthew Gumport                         me@gum.pt
 Matt Layher                             mdlayher@gmail.com
 Michael Schubert                        michael@kinvolk.io
-Michal Rostecki                         mrostecki@suse.com
+Michal Rostecki                         mrostecki@suse.de
 Michi Mutsuzaki                         michi@covalent.io
 Nathan Taylor                           ntaylor1781@gmail.com
 Nirmoy Das                              ndas@suse.de
@@ -62,11 +66,13 @@ Ray Bejjani                             ray@covalent.io
 Romain Lenglet                          romain@covalent.io
 Ross Guarino                            rssguar@gmail.com
 Russell Bryant                          russell@russellbryant.net
+Scott Albertson                         ascottalbertson@gmail.com
 Sergey Generalov                        sergey@genbit.ru
 Shantanu Deshpande                      shantanud106@gmail.com
 Simon Pasquier                          spasquier@mirantis.com
 Steven Ceuppens                         steven.ceuppens@icloud.com
 Strukov Anton                           anstrukov@luxoft.com
+Taeung Song                             treeze.taeung@gmail.com
 Tasdik Rahman                           prodicus@outlook.com
 Thomas Bachman                          tbachman@yahoo.com
 Thomas Graf                             thomas@cilium.io
@@ -74,11 +80,13 @@ Tobias Klauser                          tklauser@distanz.ch
 Tony Lambiris                           tony@criticalstack.com
 Trevor Roberts Jr                       Trevor.Roberts.Jr@gmail.com
 Zhu Yan                                 hackzhuyan@gmail.com
+Zinin D.A                               admin@kami-no.ru
 
 The following additional people are mentioned in commit logs as having provided
 helpful bug reports, suggestions or have otherwise provided value to the
 project:
 
 Brenden Blanco                          bblanco@plumgrid.com
+Jakub Kicinski                          jakub.kicinski@netronome.com
 Salvatore Orlando                       salv.orlando@gmail.com
 Tomás Senart                            tsenart@gmail.com

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -2,6 +2,7 @@
 admin
 Alemayhu
 allocators
+alu
 ami
 analytics
 api
@@ -298,6 +299,8 @@ lwt
 macOS
 Majkowski
 Marek
+mattr
+mc
 Meetup
 Menlo
 Mesos
@@ -436,6 +439,7 @@ subcommands
 subdirectories
 subnet
 subnets
+subregister
 subregisters
 Suchakra
 superset


### PR DESCRIPTION
Passing on a doc patch I got from Jiong for 32-bit subregisters in LLVM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5562)
<!-- Reviewable:end -->
