### PR TITLE
doc: Typo fixes

### DIFF
--- a/Documentation/concepts.rst
+++ b/Documentation/concepts.rst
@@ -176,7 +176,7 @@ guaranteed:
   containers which are already running will not lose any connectivity, and they
   will keep running with the policy loaded before Cilium stopped unexpectedly.
 
-* When running Cilium on a different way, just make sure the bpf fs is mounted
+* When running Cilium in a different way, just make sure the bpf fs is mounted
   :ref:`admin_mount_bpffs`.
 
 ***********
@@ -192,10 +192,10 @@ Labels
 
 Labels are a generic, flexible and highly scalable way of addressing a large
 set of resources as they allow for arbitrary grouping and creation of sets.
-Whenever something needs to be described, addressed or selected this is done
+Whenever something needs to be described, addressed or selected, it is done
 based on labels:
 
-- `Endpoints` are assigned labels as derived from container runtime, the
+- `Endpoints` are assigned labels as derived from the container runtime,
   orchestration system, or other sources.
 - `Network policies` select pairs of `endpoints` which are allowed to
   communicate based on labels. The policies themselves are identified by labels
@@ -262,7 +262,7 @@ an endpoint.
 
 Allocating individual IP addresses enables the use of the entire Layer 4 port
 range by each endpoint. This essentially allows multiple application containers
-running on the same cluster node to all bind to well known ports such ``80``
+running on the same cluster node to all bind to well known ports such as ``80``
 without causing any conflicts.
 
 The default behavior of Cilium is to assign both an IPv6 and IPv4 address to
@@ -337,7 +337,7 @@ An identity is identified by `labels` and is given a cluster wide unique
 identifier. The endpoint is assigned the identity which matches the endpoint's
 `security relevant labels`, i.e. all endpoints which share the same set of
 `security relevant labels` will share the same identity. This concept allows to
-scale policy enforcement to massive number of endpoints as many individual
+scale policy enforcement to a massive number of endpoints as many individual
 endpoints will typically share the same set of security `labels` as applications
 are scaled.
 
@@ -742,7 +742,7 @@ well.  However, ``B`` is not automatically allowed to initiate connections to
 ``A``. If that outcome is desired, then both directions must be explicitly
 allowed.
 
-Security policies are may be enforced at *ingress* or *egress*. For *ingress*,
+Security policies may be enforced at *ingress* or *egress*. For *ingress*,
 this means that each cluster node verifies all incoming packets and determines
 whether the packet is allowed to be transmitted to the intended endpoint.
 Correspondingly, for *egress* each cluster node verifies outgoing packets and

--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -176,7 +176,7 @@ automatically using `VirtualBox Shared Folders <https://www.virtualbox.org/manua
 You can also use NFS to access your Cilium tree from the VM by
 setting the environment variable ``NFS`` (mentioned above) before running the
 startup script (``export NFS=1``). Note that your host firewall must have a variety
-of port open. The Vagrantfile will inform you of the configuration of these addresses
+of ports open. The Vagrantfile will inform you of the configuration of these addresses
 and ports to enable NFS.
 
 .. note::
@@ -1043,7 +1043,7 @@ requirements have been met:
        Make sure to include a blank line in between commit title and commit
        description.
 
-#. If any of of the commits fixes a particular commit already in the tree, that
+#. If any of the commits fixes a particular commit already in the tree, that
    commit is referenced in the commit message of the bugfix. This ensures that
    whoever performs a backport will pull in all required fixes:
 

--- a/Documentation/gettingstarted/docker.rst
+++ b/Documentation/gettingstarted/docker.rst
@@ -158,8 +158,8 @@ to be reachable on port 80, but no other ports.  This is a simple policy that
 filters only on IP address (network layer 3) and TCP port (network layer 4), so
 it is often referred to as an L3/L4 network security policy.
 
-Cilium performs stateful ''connection tracking'', meaning that if policy allows
-the *app2* to contact *app1*, it will automatically allow return
+Cilium performs stateful ''connection tracking'', meaning that if a policy allows
+*app2* to contact *app1*, it will automatically allow return
 packets that are part of *app1* replying to *app2* within the context
 of the same TCP/UDP connection.
 
@@ -230,7 +230,7 @@ For example, consider a scenario where *app1* has two API calls:
  * GET /private
 
 Continuing with the example from above, if *app2* requires access only to
-the GET /public API call, the L3/L4 policy along has no visibility into the
+the GET /public API call, the L3/L4 policy alone has no visibility into the
 HTTP requests, and therefore would allow any HTTP request from *app2*
 (since all HTTP is over port 80).
 

--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ tooling to provide:
 
 - Event monitoring with metadata: When a packet is dropped, the tool doesn't
   just report the source and destination IP of the packet, the tool provides
-  the full label information of both the sender and receiving among a lot of
+  the full label information of both the sender and receiver among a lot of
   other information.
 
 - Policy decision tracing: Why is a packet being dropped or a request rejected.


### PR DESCRIPTION
Fixes minor typos in the documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5567)
<!-- Reviewable:end -->
