### PR TITLE
Jenkins: Do the VM cleanup in sequential mode

### DIFF
--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -53,18 +53,12 @@ pipeline {
             }
 
             steps {
-                parallel(
-                    "checkout": {
-                        sh 'env'
-                        Status("PENDING", "${env.JOB_NAME}")
-                        sh 'rm -rf src; mkdir -p src/github.com/cilium'
-                        sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
-                        checkout scm
-                    },
-                    "cleanup": {
-                        sh '/usr/local/bin/cleanup || true'
-                    }
-                )
+                sh 'env'
+                Status("PENDING", "${env.JOB_NAME}")
+                sh 'rm -rf src; mkdir -p src/github.com/cilium'
+                sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
+                checkout scm
+                sh '/usr/local/bin/cleanup || true'
             }
         }
         stage('Boot VMs'){

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -25,20 +25,14 @@ pipeline {
             }
 
             steps {
-                parallel(
-                    "checkout": {
-                        BuildIfLabel('area/k8s', 'Cilium-PR-Kubernetes-Upstream')
-                        BuildIfLabel('area/k8s', 'Cilium-PR-Ginkgo-Tests-K8s')
-                        BuildIfLabel('area/documentation', 'Cilium-PR-Doc-Tests')
-                        sh 'env'
-                        sh 'rm -rf src; mkdir -p src/github.com/cilium'
-                        sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
-                        checkout scm
-                    },
-                    "cleanup": {
-                        sh '/usr/local/bin/cleanup || true'
-                    },
-                )
+                BuildIfLabel('area/k8s', 'Cilium-PR-Kubernetes-Upstream')
+                BuildIfLabel('area/k8s', 'Cilium-PR-Ginkgo-Tests-K8s')
+                BuildIfLabel('area/documentation', 'Cilium-PR-Doc-Tests')
+                sh 'env'
+                sh 'rm -rf src; mkdir -p src/github.com/cilium'
+                sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
+                checkout scm
+                sh '/usr/local/bin/cleanup || true'
             }
         }
         stage('Precheck') {

--- a/kubernetes-upstream.Jenkinsfile
+++ b/kubernetes-upstream.Jenkinsfile
@@ -48,18 +48,12 @@ pipeline {
     stages {
         stage('Checkout') {
             steps {
-                parallel(
-                    "checkout": {
-                        sh 'env'
-                        Status("PENDING", "${env.JOB_NAME}")
-                        sh 'rm -rf src; mkdir -p src/github.com/cilium'
-                        sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
-                        checkout scm
-                    },
-                    "cleanup": {
-                        sh '/usr/local/bin/cleanup || true'
-                    }
-                )
+                sh 'env'
+                Status("PENDING", "${env.JOB_NAME}")
+                sh 'rm -rf src; mkdir -p src/github.com/cilium'
+                sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
+                checkout scm
+                sh '/usr/local/bin/cleanup || true'
             }
         }
         stage('Boot VMs'){


### PR DESCRIPTION
From the day that we setup the parallel in checkout [0] we started to seen
the following error:

```
Using context: Cilium-Ginkgo-Tests
an exception which occurred:
	in field com.cloudbees.groovy.cps.impl.BlockScopeEnv.locals
	in object com.cloudbees.groovy.cps.impl.BlockScopeEnv@195b5c5
	in field com.cloudbees.groovy.cps.impl.CallEnv.caller
	in object com.cloudbees.groovy.cps.impl.FunctionCallEnv@2dc285bc
	in field com.cloudbees.groovy.cps.impl.ProxyEnv.parent
```

The parallel shouldn't be related at all, but cleanup takes <2secs, so
add it on the sequential mode to validate that it's not a parallel
issue and be able to debug all the workflow in a simple way.

[0] Commit fbf3fa21615dcf4b5b5e9078ac5e8ec4c84e7da5#diff-fb0829c8c95bc1e5695b0cb02699d295

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5570)
<!-- Reviewable:end -->
