### PR TITLE
[Backport 1.1]Test: Fix issues with kubernetes test on old branchs.

### DIFF
--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -50,6 +50,7 @@ var _ = Describe("K8sDemosTest", func() {
 	)
 
 	BeforeAll(func() {
+		logger = log.WithFields(logrus.Fields{"testName": "K8sDemosTest"})
 		logger.Info("Starting")
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 


### PR DESCRIPTION
**This PR is a fix on 1.1 branch that fixes issue #5531**

In commit `6ca4ac682c2800bd4d5bb7d221a302ef7b0532b8` logger was not
initialized and test panic on start, with this change test does  not
longer panic.

Fix #5531

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5573)
<!-- Reviewable:end -->
