### PR TITLE
Update Cilium image to 1.2.2 in etcd-operator guide

### DIFF
--- a/examples/kubernetes/addons/etcd-operator/cilium-deployment.yaml
+++ b/examples/kubernetes/addons/etcd-operator/cilium-deployment.yaml
@@ -294,8 +294,7 @@ spec:
       # To read the k8s etcd secrets in case the user might want to use TLS
       - name: etcd-secrets
         secret:
-          secretName: cilium-etcd-secrets
-          optional: true
+          secretName: cilium-etcd-client-tls
       # To read the clustermesh configuration
       - name: clustermesh-secrets
         secret:

--- a/examples/kubernetes/addons/etcd-operator/cilium-deployment.yaml
+++ b/examples/kubernetes/addons/etcd-operator/cilium-deployment.yaml
@@ -128,7 +128,7 @@ spec:
               optional: true
               key: clean-cilium-bpf-state
       containers:
-      - image: docker.io/cilium/cilium:v1.2.0
+      - image: docker.io/cilium/cilium:v1.2.2
         imagePullPolicy: IfNotPresent
         name: cilium-agent
         command: ["cilium-agent"]

--- a/examples/kubernetes/addons/etcd-operator/development/cilium-development.yaml
+++ b/examples/kubernetes/addons/etcd-operator/development/cilium-development.yaml
@@ -294,8 +294,7 @@ spec:
       # To read the k8s etcd secrets in case the user might want to use TLS
       - name: etcd-secrets
         secret:
-          secretName: cilium-etcd-secrets
-          optional: true
+          secretName: cilium-etcd-client-tls
       # To read the clustermesh configuration
       - name: clustermesh-secrets
         secret:


### PR DESCRIPTION
I've test it manually to check if was working. Fixes a bug in the k8s descriptor.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5574)
<!-- Reviewable:end -->
