### PR TITLE
Test/Demos: Make assert more robust.

### DIFF
--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -113,7 +113,7 @@ var _ = Describe("K8sDemosTest", func() {
 		By("Getting xwing pod names")
 		xwingPods, err := kubectl.GetPodNames(helpers.DefaultNamespace, allianceLabel)
 		Expect(err).Should(BeNil())
-		Expect(xwingPods[0]).ShouldNot(Equal(""), "unable to get xwing pod names")
+		Expect(xwingPods).ShouldNot(BeEmpty(), "Unable to get xwing pod names")
 
 		// Test only needs to access one of the pods.
 		xwingPod := xwingPods[0]


### PR DESCRIPTION
Seen in 1.0 branch and issue #5531 that xwingPods array  had 0 len,
and the assert will not work, pod is different than a empty string.

With this commit the assert will check that the array does not have 0
len and it'll be not a test flake

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5575)
<!-- Reviewable:end -->
