### PR TITLE
test/bpf: Set pipefail to fail verification checks

### DIFF
--- a/test/bpf/check-complexity.sh
+++ b/test/bpf/check-complexity.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -eo pipefail
 
 TESTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 BPFDIR="$TESTDIR/../../bpf/"


### PR DESCRIPTION
Previously, if the verifier-test.sh script failed then the
check-complexity.sh script would not fail, even though an error
occurred. This was misleading, fix it by setting pipefail on the whole
script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5585)
<!-- Reviewable:end -->
