### PR TITLE
monitor: Fix logging statements

### DIFF
--- a/monitor/listener1_0.go
+++ b/monitor/listener1_0.go
@@ -46,7 +46,7 @@ func (ml *listenerv1_0) Enqueue(pl *payload.Payload) {
 	select {
 	case ml.queue <- pl:
 	default:
-		log.Debugf("Per listener queue is full, dropping message")
+		log.Debug("Per listener queue is full, dropping message")
 	}
 }
 
@@ -68,7 +68,7 @@ func (ml *listenerv1_0) drainQueue() {
 		if _, err := ml.conn.Write(buf); err != nil {
 			switch {
 			case listener.IsDisconnected(err):
-				log.Info("Listener disconnected")
+				log.Debug("Listener disconnected")
 				return
 
 			default:

--- a/monitor/listener1_2.go
+++ b/monitor/listener1_2.go
@@ -47,7 +47,7 @@ func (ml *listenerv1_2) Enqueue(pl *payload.Payload) {
 	select {
 	case ml.queue <- pl:
 	default:
-		log.Debugf("Per listener queue is full, dropping message")
+		log.Debug("Per listener queue is full, dropping message")
 	}
 }
 
@@ -64,7 +64,7 @@ func (ml *listenerv1_2) drainQueue() {
 		if err := pl.EncodeBinary(enc); err != nil {
 			switch {
 			case listener.IsDisconnected(err):
-				log.Info("Listener disconnected")
+				log.Debug("Listener disconnected")
 				return
 
 			default:

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -63,7 +63,7 @@ func init() {
 
 func execute() {
 	if err := rootCmd.Execute(); err != nil {
-		log.WithError(err)
+		log.WithError(err).Error("Monitor failed")
 		os.Exit(-1)
 	}
 }

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -152,7 +152,7 @@ func (m *Monitor) registerNewListener(parentCtx context.Context, conn net.Conn, 
 	log.WithFields(logrus.Fields{
 		"count.listener": len(m.listeners),
 		"version":        version,
-	}).Info("New listener connected.")
+	}).Debug("New listener connected")
 }
 
 // removeListener deletes the MonitorListener from the list, closes its queue, and
@@ -165,7 +165,7 @@ func (m *Monitor) removeListener(ml listener.MonitorListener) {
 	log.WithFields(logrus.Fields{
 		"count.listener": len(m.listeners),
 		"version":        ml.Version(),
-	}).Info("Removed listener")
+	}).Debug("Removed listener")
 
 	// If this was the final listener, shutdown the perf reader and unmap our
 	// ring buffer readers. This tells the kernel to not emit this data.
@@ -245,7 +245,7 @@ func (m *Monitor) dumpStat() {
 
 	mp, err := json.Marshal(ms)
 	if err != nil {
-		log.WithError(err).Error("error marshalling JSON")
+		log.WithError(err).Error("Error marshalling JSON")
 		return
 	}
 	fmt.Println(string(mp))
@@ -266,7 +266,7 @@ func (m *Monitor) connectionHandler1_0(parentCtx context.Context, server net.Lis
 			return
 
 		case err != nil:
-			log.WithError(err).Warn("error accepting connection")
+			log.WithError(err).Warn("Error accepting connection")
 			continue
 		}
 
@@ -289,7 +289,7 @@ func (m *Monitor) connectionHandler1_2(parentCtx context.Context, server net.Lis
 			return
 
 		case err != nil:
-			log.WithError(err).Warn("error accepting connection")
+			log.WithError(err).Warn("Error accepting connection")
 			continue
 		}
 


### PR DESCRIPTION
Change verbose logging statements from info to debug.
Fix minor issues: Debug vs. Debugf, etc.

Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5589)
<!-- Reviewable:end -->
