### PR TITLE
cilium/cmd: Refactor updatePolicyKey

### DIFF
--- a/cilium/cmd/bpf_policy_add.go
+++ b/cilium/cmd/bpf_policy_add.go
@@ -27,7 +27,7 @@ var bpfPolicyAddCmd = &cobra.Command{
 	PreRun: requireEndpointID,
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf policy add")
-		updatePolicyKey(cmd, args, true)
+		updatePolicyKey(parsePolicyUpdateArgs(cmd, args), true)
 	},
 }
 

--- a/cilium/cmd/bpf_policy_delete.go
+++ b/cilium/cmd/bpf_policy_delete.go
@@ -27,7 +27,7 @@ var bpfPolicyDeleteCmd = &cobra.Command{
 	PreRun: requireEndpointID,
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf policy delete")
-		updatePolicyKey(cmd, args, false)
+		updatePolicyKey(parsePolicyUpdateArgs(cmd, args), false)
 	},
 }
 

--- a/cilium/cmd/policy_trace.go
+++ b/cilium/cmd/policy_trace.go
@@ -275,7 +275,7 @@ func getSecIDFromK8s(podName string) (string, error) {
 }
 
 // parseL4PortsSlice parses a given `slice` of strings. Each string should be in
-// the form of `<port>[/<protocol>]`, where the `<port>` in an integer and an
+// the form of `<port>[/<protocol>]`, where the `<port>` is an integer and
 // `<protocol>` is an optional layer 4 protocol `tcp` or `udp`. In case
 // `protocol` is not present, or is set to `any`, the parsed port will be set to
 // `models.PortProtocolAny`.


### PR DESCRIPTION
This commit separates the cli command handling logic from the
actual policy update logic.

 * add new type PolicyUpdateArgs to represent parsed command arguments
 * extract function parsePolicyUpdateArgs from updatePolicyKey
     to handle cli logic
 * add test for parsePolicyUpdateArgs to helper_test.go
 * update bpf_policy_add.go and bpf_policy_delete.go to use new function api
 * fix minor typo in parseL4PortsSlice function in policy_trace.go

Fixes #3396

Happy to make any suggested changes :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5590)
<!-- Reviewable:end -->
