### PR TITLE
Make documentation build properly fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG V
 # Please do not add any dependency updates before the 'make install' here,
 # as that will mess with caching for incremental builds!
 #
-RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V DESTDIR=/tmp/install clean-container build install
+RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V SKIP_DOCS=true DESTDIR=/tmp/install clean-container build install
 
 #
 # Cilium runtime install.

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -44,18 +44,25 @@ cmdref:
 	@$(ECHO_GEN)cmdref/cilium-health
 	$(QUIET) ${HEALTHDIR}/cilium-health --cmdref $(CMDREFDIR)
 
-spellcheck: check-requirements
-	@$(ECHO_CHECK) documentation spelling...
-	$(QUIET)$(SPHINXBUILD) -b spelling -d "$(BUILDDIR)/doctrees" "$(SOURCEDIR)" "$(BUILDDIR)/spelling" $(SPHINXOPTS)
+# Touch "$@.ok" if the docs build succeeds. Fail if there are errors
+# or output other than those including the following phrases:
+# "tabs assets" - These are always printed by the spelling check.
+# "misspelled words" - These will be explicitly checked below.
+# Finally, fail out if we can't remove the file that marks success.
+check-build: check-requirements
+	@$(ECHO_CHECK) documentation build...
+	$(QUIET)! ($(SPHINXBUILD) -b spelling -d "$(BUILDDIR)/doctrees" "$(SOURCEDIR)" "$(BUILDDIR)/spelling" -q -E $(SPHINXOPTS) 2>&1 && touch $@.ok) \
+		| grep -v -e "tabs assets" -e "misspelled words"
 	@if [ "$$(wc -l < "$(BUILDDIR)/spelling/output.txt")" -ne "0" ]; then \
 		echo "Please fix the following spelling mistakes:"; \
 		sed 's/^/* Documentation\//' $(BUILDDIR)/spelling/output.txt; \
 		echo "If the words are not misspelled, add them to Documentation/$(SPELLING_LIST)."; \
 		exit 1; \
 	fi
+	@rm $@.ok 2>/dev/null
 
 # To use checklinks with `make render-docs`,
-# edit the line `%: Makefile check-requirements spellcheck checklinks`
+# edit the line `%: Makefile check-requirements check-build checklinks`
 checklinks:
 	$(QUIET)$(SPHINXBUILD) -b linkcheck -d "$(BUILDDIR)/doctrees" "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 
@@ -63,6 +70,6 @@ checklinks:
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile check-requirements spellcheck
+%: Makefile check-requirements check-build
 	@$(ECHO_GEN)_build/$@
 	$(QUIET)$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -4,7 +4,7 @@ include ../Makefile.quiet
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = $(QUIET) sphinx-build
+SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = Cilium
 SOURCEDIR     = .
 BUILDDIR      = _build
@@ -46,7 +46,7 @@ cmdref:
 
 spellcheck: check-requirements
 	@$(ECHO_CHECK) documentation spelling...
-	$(SPHINXBUILD) -b spelling -d "$(BUILDDIR)/doctrees" "$(SOURCEDIR)" "$(BUILDDIR)/spelling" $(SPHINXOPTS)
+	$(QUIET)$(SPHINXBUILD) -b spelling -d "$(BUILDDIR)/doctrees" "$(SOURCEDIR)" "$(BUILDDIR)/spelling" $(SPHINXOPTS)
 	@if [ "$$(wc -l < "$(BUILDDIR)/spelling/output.txt")" -ne "0" ]; then \
 		echo "Please fix the following spelling mistakes:"; \
 		sed 's/^/* Documentation\//' $(BUILDDIR)/spelling/output.txt; \
@@ -57,7 +57,7 @@ spellcheck: check-requirements
 # To use checklinks with `make render-docs`,
 # edit the line `%: Makefile check-requirements spellcheck checklinks`
 checklinks:
-	$(SPHINXBUILD) -b linkcheck -d "$(BUILDDIR)/doctrees" "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+	$(QUIET)$(SPHINXBUILD) -b linkcheck -d "$(BUILDDIR)/doctrees" "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 
 .PHONY: help Makefile ../Makefile.quiet check-requirements cmdref
 
@@ -65,4 +65,4 @@ checklinks:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile check-requirements spellcheck
 	@$(ECHO_GEN)_build/$@
-	$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	$(QUIET)$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/Makefile
+++ b/Makefile
@@ -293,8 +293,11 @@ install-manpages:
 	cp man/* /usr/local/share/man/man1/
 	mandb
 
+# Strip "tabs assets" errors from the dummy target, but fail on target failure.
 check-docs:
-	-$(QUIET) $(MAKE) -C Documentation/ dummy SPHINXOPTS="$(SPHINXOPTS)" 2>&1 | grep -v "tabs assets"
+	$(QUIET)($(MAKE) -C Documentation/ dummy SPHINXOPTS="$(SPHINXOPTS)" 2>&1 && touch $@.ok) \
+		| grep -v "tabs assets"
+	@rm $@.ok 2>/dev/null
 
 postcheck: build
 	@$(ECHO_CHECK) contrib/scripts/check-cmdref.sh

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ GOTEST_OPTS = -test.v -check.vv
 
 UTC_DATE=$(shell date -u "+%Y-%m-%d")
 
+SKIP_DOCS ?= false
+
 all: precheck build postcheck
 	@echo "Build finished."
 
@@ -291,12 +293,15 @@ install-manpages:
 	cp man/* /usr/local/share/man/man1/
 	mandb
 
+check-docs:
+	-$(QUIET) $(MAKE) -C Documentation/ dummy SPHINXOPTS="$(SPHINXOPTS)" 2>&1 | grep -v "tabs assets"
+
 postcheck: build
 	@$(ECHO_CHECK) contrib/scripts/check-cmdref.sh
 	$(QUIET) MAKE=$(MAKE) contrib/scripts/check-cmdref.sh
 	@$(ECHO_CHECK) contrib/scripts/lock-check.sh
 	$(QUIET) contrib/scripts/lock-check.sh
-	-$(QUIET) $(MAKE) -C Documentation/ dummy SPHINXOPTS="$(SPHINXOPTS)" 2>&1 | grep -v "tabs assets"
+	@$(SKIP_DOCS) || $(MAKE) check-docs
 
 .PHONY: force generate-api generate-health-api
 force :;

--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ postcheck: build
 	$(QUIET) MAKE=$(MAKE) contrib/scripts/check-cmdref.sh
 	@$(ECHO_CHECK) contrib/scripts/lock-check.sh
 	$(QUIET) contrib/scripts/lock-check.sh
-	-$(QUIET) $(MAKE) -C Documentation/ dummy SPHINXOPTS="-q" 2>&1 | grep -v "tabs assets"
+	-$(QUIET) $(MAKE) -C Documentation/ dummy SPHINXOPTS="$(SPHINXOPTS)" 2>&1 | grep -v "tabs assets"
 
 .PHONY: force generate-api generate-health-api
 force :;

--- a/Makefile.quiet
+++ b/Makefile.quiet
@@ -7,6 +7,7 @@ ifeq ($(V),0)
 	ECHO_BAZEL=echo "  BAZEL $(notdir $(shell pwd))/$(notdir $(shell dirname $(ENVOY_BIN)))/$@"
 	ECHO_GINKGO=echo "  GINKG $(notdir $(shell pwd))"
 	ECHO_CLEAN=echo "  CLEAN"
+	SPHINXOPTS+="-q"
 else
 	# The whitespace at below EOLs is required for verbose case!
 	ECHO_CC=: 

--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -29,7 +29,7 @@ then
     fi
 else
     echo "compiling cilium..."
-    sudo -u vagrant -H -E make LOCKDEBUG=1
+    sudo -u vagrant -H -E make LOCKDEBUG=1 SKIP_DOCS=true
     echo "installing cilium..."
     make install
     mkdir -p /etc/sysconfig/


### PR DESCRIPTION
Ensure that when there are legitimate warnings from sphinx or its spelling module that these cause the build to fail. This should force developers to fix such issues prior to merging code that breaks the docs.

A new optional "SKIP_DOCS" env variable allows the docs checks to be skipped in some environments (eg, when the docs output will never be used, like in the standard docker images). Should be used like:

```
$ make SKIP_DOCS=true
```

See the individual commits for more detail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5591)
<!-- Reviewable:end -->
