### PR TITLE
lxcmap: Don't format 0 seclabel

### DIFF
--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -142,12 +142,11 @@ func (v *EndpointInfo) String() string {
 		return fmt.Sprintf("(localhost)")
 	}
 
-	return fmt.Sprintf("id=%-5d ifindex=%-3d mac=%s nodemac=%s seclabel=%#-4x",
+	return fmt.Sprintf("id=%-5d ifindex=%-3d mac=%s nodemac=%s",
 		v.LxcID,
 		v.IfIndex,
 		v.MAC,
 		v.NodeMAC,
-		0,
 	)
 }
 


### PR DESCRIPTION
The field in the EndpointInfo that used to hold the seclabel is no
longer used for this purpose, and it's misleading to print
"seclabel=0x0" for every lxcmap entry. Drop the bit about seclabel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5595)
<!-- Reviewable:end -->
