### PR TITLE
Metrics: Add endpoint policy enforcement status

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -73,8 +73,8 @@ Drops/Forwards (L3/L4)
 * ``drop_count_total``: Total dropped packets, tagged by drop reason and ingress/egress direction
 * ``forward_count_total``: Total forwarded packets, tagged by ingress/egress direction
 
-Policy Imports
---------------
+Policy
+------
 
 * ``policy_count``: Number of policies currently loaded
 * ``policy_regeneration_total``: Total number of policies regenerated successfully
@@ -82,6 +82,7 @@ Policy Imports
 * ``policy_regeneration_square_seconds_total``: Total sum of squares of successful policy regeneration times
 * ``policy_max_revision``: Highest policy revision number in the agent
 * ``policy_import_errors``: Number of times a policy import has failed
+* ``policy_endpoint_enforcement_status``: Number of endpoints labeled by policy enforcement status.
 
 Policy L7 (HTTP/Kafka)
 ----------------------

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -673,7 +673,6 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 
 	context.Stats = regenerationStatistics{}
 	stats := &context.Stats
-
 	metrics.EndpointCountRegenerating.Inc()
 	stats.totalTime.Start()
 	e.Logger().WithFields(logrus.Fields{
@@ -684,6 +683,11 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 	defer func() {
 		stats.totalTime.End()
 		stats.success = retErr == nil
+
+		e.mutex.RLock()
+		stats.endpointID = e.ID
+		stats.policyStatus = e.policyStatus()
+		e.RUnlock()
 		stats.SendMetrics()
 
 		scopedLog := e.Logger().WithFields(logrus.Fields{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -92,6 +92,9 @@ var (
 	// LabelStatus the label from completed task
 	LabelStatus = "status"
 
+	//LabelPolicyEnforcement is the label used to see the enforcement status
+	LabelPolicyEnforcement = "enforcement"
+
 	// LabelScope is the label used to defined multiples scopes in the same
 	// metric. For example, one counter may measure a metric over the scope of
 	// the entire event (scope=global), or just part of an event
@@ -211,6 +214,13 @@ var (
 		Name:      "policy_import_errors",
 		Help:      "Number of times a policy import has failed",
 	})
+
+	// PolicyEndpointStatus is the number of endpoints with policy labeled by enforcement type
+	PolicyEndpointStatus = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      "policy_endpoint_enforcement_status",
+		Help:      "Number of endpoints labeled by policy enforcement status",
+	}, []string{LabelPolicyEnforcement})
 
 	// Events
 
@@ -405,6 +415,7 @@ func init() {
 	MustRegister(PolicyRegenerationTimeSquare)
 	MustRegister(PolicyRevision)
 	MustRegister(PolicyImportErrors)
+	MustRegister(PolicyEndpointStatus)
 
 	MustRegister(EventTSK8s)
 	MustRegister(EventTSContainerd)


### PR DESCRIPTION
This commits adds the new metrics to have the number of endpoints with
the policy enforcement status.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5603)
<!-- Reviewable:end -->
