### PR TITLE
cilium: test: fix check-logging-subsys-fields.sh script errrors

### DIFF
--- a/contrib/scripts/check-logging-subsys-field.sh
+++ b/contrib/scripts/check-logging-subsys-field.sh
@@ -17,9 +17,9 @@
 set -eu
 
 if grep -IPRns '(?!.*LogSubsys)log[ ]*= logging\.DefaultLogger.*' \
-        --exclude-dir=test/ \
-        --exclude-dir=pkg/debugdetection/ \
-        --exclude-dir=vendor/ \
+        --exclude-dir=test \
+        --exclude-dir=pkg/debugdetection \
+        --exclude-dir=vendor \
         --include=*.go .; then
     echo "Logging entry instances have to contain the LogSubsys field. Example of"
     echo "properly configured entry instance:"


### PR DESCRIPTION
cilium: check-looging-subsys-field.sh remove trailing '/'

Resolve log fields errors. My environment has an issue with the script
check-logging-subsys-fields where excluding ./test dir fails due to
trailing '/'. Remove '/' slashes to resolve the error below.

contrib/scripts/check-logging-subsys-field.sh
 ./test/k8sT/log.go:22:var log = logging.DefaultLogger
 ./test/runtime/log.go:22:var log = logging.DefaultLogger
 ./test/helpers/cilium.go:36:var log = logging.DefaultLogger
 ./test/test_suite_test.go:42:   log             = logging.DefaultLogger
 Logging entry instances have to contain the LogSubsys field. Example of
 properly configured entry instance:

         import (
                "github.com/cilium/cilium/pkg/logging"
                "github.com/cilium/cilium/pkg/logging/logfields"
         )

         var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "my-subsystem")

make: *** [logging-subsys-field] Error 1

Fixes: 629151d "make: Check LogSubsys field in logging entry instances"
Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5612)
<!-- Reviewable:end -->
