### PR TITLE
cni: use hash to generate host-side veth name

### DIFF
--- a/pkg/endpoint/connector/add.go
+++ b/pkg/endpoint/connector/add.go
@@ -15,6 +15,7 @@
 package connector
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -37,7 +38,8 @@ const (
 
 // Endpoint2IfName returns the host interface name for the given endpointID.
 func Endpoint2IfName(endpointID string) string {
-	return hostInterfacePrefix + truncateString(endpointID, 5)
+	sum := fmt.Sprintf("%x", sha256.Sum256([]byte(endpointID)))
+	return hostInterfacePrefix + truncateString(sum, 5)
 }
 
 // Endpoint2TempIfName returns the temporary interface name for the given

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -339,7 +339,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		Addressing:  &models.AddressPair{},
 	}
 
-	veth, peer, tmpIfName, err := connector.SetupVeth(ep.ContainerID, int(conf.DeviceMTU), ep)
+	veth, peer, tmpIfName, err := connector.SetupVeth(args.IfName, int(conf.DeviceMTU), ep)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
if CNI_CONTAINERID has 1st 5 char same then cni fails
    chapman:/home/nirmoy/go/src/github.com/cilium/cilium # CNI_COMMAND=ADD CNI_CONTAINERID=1234567891 CNI_NETNS=/var/run/netns/1234567891 CNI_IFNAME=eth12 CNI_PATH=/opt/cni/bin ./plugins/cilium-cni/cilium-cni < ./plugins/cilium-cni/05-cilium-cni.conf  2>/dev/null >/dev/null
    chapman:/home/nirmoy/go/src/github.com/cilium/cilium # CNI_COMMAND=ADD CNI_CONTAINERID=1234567892 CNI_NETNS=/var/run/netns/1234567892 CNI_IFNAME=eth12 CNI_PATH=/opt/cni/bin ./plugins/cilium-cni/cilium-cni < ./plugins/cilium-cni/05-cilium-cni.conf
    {
        "code": 100,
        "msg": "unable to create veth pair: file exists"


Signed-off-by: Nirmoy Das <ndas@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5619)
<!-- Reviewable:end -->
