### PR TITLE
Metrics: Add Kubernetes events metrics

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -106,12 +106,18 @@ Controllers
 * ``controllers_runs_duration_seconds``: Duration in seconds of the controller
   process labeled by completion status
 
-
 SubProcess
 ----------
 
 * ``subprocess_start_total``: Number of times that Cilium has started a
   subprocess, labeled by subsystem
+
+Kubernetes
+-----------
+
+* ``kubernetes_events_total``: Number of Kubernetes events received labeled by
+  scope, action and the execution result
+
 
 Cilium as a Kubernetes pod
 ==========================

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -400,13 +400,22 @@ var (
 		Help:      "The number of queued, waiting and running builds in the build queue",
 	}, []string{LabelBuildState, LabelBuildQueueName})
 
-	// SubprocessStart is the number of times that Cilium has started a
 	// subprocess, labeled by Subsystem
 	SubprocessStart = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "subprocess_start_total",
 		Help:      "Number of times that Cilium has started a subprocess, labeled by subsystem",
 	}, []string{LabelSubsystem})
+
+	// Kubernetes Events
+
+	// KubernetesEvent is the number of Kubernetes events received labeled by
+	// scope, action and execution result
+	KubernetesEvent = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "kubernetes_events_total",
+		Help:      "Number of Kubernetes events received labeled by scope, action and execution result",
+	}, []string{LabelScope, LabelAction, LabelStatus})
 )
 
 func init() {
@@ -460,6 +469,8 @@ func init() {
 	MustRegister(BuildQueueEntries)
 
 	MustRegister(SubprocessStart)
+
+	MustRegister(KubernetesEvent)
 }
 
 // MustRegister adds the collector to the registry, exposing this metric to


### PR DESCRIPTION
Cilium has a watcher that read some events from Kubernetes to be able to
setup correctly the services, policies, pods, endpoints, etc..

This commit adds the support to show the number of Kubernetes events
received that are used by cilium, labelled by the result and the action
that it performs (delete, update, create)

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

Disclaimer: 
1) This pr change a lot of k8s_watcher functions return, the main logic is the same, I think that I did not change anything related to that. I also keep  the `return nil` in all the `ResourceEventHandlerFactory` I can change if you want to return err, but I'm not sure if is desired. 
2) The CNP apply will create two events each time, first the create event and after that an update event with the node status.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5621)
<!-- Reviewable:end -->
