### PR TITLE
[v1.2] CRI-O: Don't mount bpf path since k8s >= 1.11

### DIFF
--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -187,7 +187,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -255,7 +255,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -192,7 +192,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -260,7 +260,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -187,7 +187,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -42,8 +42,6 @@ spec:
                 - "NET_ADMIN"
             privileged: true
           volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
             - name: cilium-run
               mountPath: /var/run/cilium
           env:
@@ -156,8 +154,6 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
           volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
             - name: cilium-run
               mountPath: /var/run/cilium
             - name: cni-path
@@ -187,10 +183,6 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
         # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:

--- a/examples/kubernetes/1.11/cilium-crio-transforms2sed.sed
+++ b/examples/kubernetes/1.11/cilium-crio-transforms2sed.sed
@@ -1,0 +1,4 @@
+# delete mounts
+/            - name: bpf-maps/,+1 d
+# delete volumes
+/        # To keep state between restarts \/ upgrades for bpf maps/,+3 d

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -255,7 +255,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -110,8 +110,6 @@ spec:
                 - "NET_ADMIN"
             privileged: true
           volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
             - name: cilium-run
               mountPath: /var/run/cilium
           env:
@@ -224,8 +222,6 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
           volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
             - name: cilium-run
               mountPath: /var/run/cilium
             - name: cni-path
@@ -255,10 +251,6 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
         # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -192,7 +192,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -260,7 +260,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -187,7 +187,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -42,8 +42,6 @@ spec:
                 - "NET_ADMIN"
             privileged: true
           volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
             - name: cilium-run
               mountPath: /var/run/cilium
           env:
@@ -156,8 +154,6 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
           volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
             - name: cilium-run
               mountPath: /var/run/cilium
             - name: cni-path
@@ -187,10 +183,6 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
         # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:

--- a/examples/kubernetes/1.12/cilium-crio-transforms2sed.sed
+++ b/examples/kubernetes/1.12/cilium-crio-transforms2sed.sed
@@ -1,0 +1,4 @@
+# delete mounts
+/            - name: bpf-maps/,+1 d
+# delete volumes
+/        # To keep state between restarts \/ upgrades for bpf maps/,+3 d

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -255,7 +255,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -110,8 +110,6 @@ spec:
                 - "NET_ADMIN"
             privileged: true
           volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
             - name: cilium-run
               mountPath: /var/run/cilium
           env:
@@ -224,8 +222,6 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
           volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
             - name: cilium-run
               mountPath: /var/run/cilium
             - name: cni-path
@@ -255,10 +251,6 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
         # To read labels from CRI-O containers running in the host
         - name: crio-socket
           hostPath:

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -192,7 +192,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -260,7 +260,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.7/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-crio-ds.yaml
@@ -187,7 +187,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.7/cilium-crio.yaml
+++ b/examples/kubernetes/1.7/cilium-crio.yaml
@@ -255,7 +255,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -192,7 +192,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -260,7 +260,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -187,7 +187,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -255,7 +255,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -192,7 +192,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -260,7 +260,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -187,7 +187,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -255,7 +255,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -192,7 +192,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -260,7 +260,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/Makefile
+++ b/examples/kubernetes/Makefile
@@ -22,7 +22,15 @@ $(1)/$(patsubst templates/v1/%,%,$(patsubst %.yaml.sed,%.yaml,$(2))):
 	@$(ECHO_GEN)$$@
 	@echo "$(CILIUM_VERSION)" | egrep -Eq '(v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-.+)?)|(latest)' || \
 	(echo "\"$(CILIUM_VERSION)\" is not a valid version. Must match regexp '(v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-.+)?)|(latest)'. Please fix VERSION file" && false)
+ifneq ("$(wildcard $(1)/cilium-crio-transforms2sed.sed)","")
+ifneq ("$(findstring cilium-crio,$(2))","")
+	-$(QUIET)sed -f $(1)/transforms2sed.sed -f $(1)/cilium-crio-transforms2sed.sed -e s+__CILIUM_VERSION__+$$(CILIUM_VERSION)+ <$$< >$$@
+else
 	-$(QUIET)sed -f $(1)/transforms2sed.sed -e s+__CILIUM_VERSION__+$$(CILIUM_VERSION)+ <$$< >$$@
+endif
+else
+	-$(QUIET)sed -f $(1)/transforms2sed.sed -e s+__CILIUM_VERSION__+$$(CILIUM_VERSION)+ <$$< >$$@
+endif
 endef
 
 SOURCES = $(wildcard templates/v1/*.yaml*)

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -187,7 +187,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -192,7 +192,7 @@ spec:
         - name: cilium-run
           hostPath:
             path: /var/run/cilium
-        # To keep state between restarts / upgrades
+        # To keep state between restarts / upgrades for bpf maps
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf


### PR DESCRIPTION
It seems since cri-o 1.11 the `/sys/fs/bpf` is already mounted into the
container. To avoid Cilium from failing its initialization setup, as it
checks if bpf is correctly mounted, the crio kubernetes descriptors
won't have the volume mounted for `/sys/fs/bpf` as it is automatically
done by runc.

Upstream PR https://github.com/cilium/cilium/pull/5623

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5625)
<!-- Reviewable:end -->
