### PR TITLE
cilium: config fails without MonitorAggregationLevel specified

### DIFF
--- a/pkg/option/monitor.go
+++ b/pkg/option/monitor.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/cilium/cilium/pkg/color"
 )
 
 // MonitorAggregationLevel represents a level of aggregation for monitor events
@@ -79,10 +77,10 @@ func init() {
 
 // monitorAggregationFormat maps an aggregation level to a formatted string.
 var monitorAggregationFormat = map[OptionSetting]string{
-	MonitorAggregationLevelNone:   color.Red("None"),
-	MonitorAggregationLevelLowest: color.Green("Lowest"),
-	MonitorAggregationLevelLow:    color.Green("Low"),
-	MonitorAggregationLevelMedium: color.Green("Medium"),
+	MonitorAggregationLevelNone:   "None",
+	MonitorAggregationLevelLowest: "Lowest",
+	MonitorAggregationLevelLow:    "Low",
+	MonitorAggregationLevelMedium: "Medium",
 }
 
 // VerifyMonitorAggregationLevel validates the specified key/value for a


### PR DESCRIPTION
Running 'cilium config' without explicitely setting
MonitorAggregationLevel after previously setting it can result in
the following error,

$ cilium config PolicyEnforcement=default
Error: Unable to change agent configuration: [PATCH /config][400] patchConfigBadRequest  Invalid configuration option Invalid monitor aggregation level "\x1b[31mNone\x1b[0m

If we query the config we notice the following,

$ curl -s --unix-socket /var/run/cilium/cilium.sock http://localhost/v1/config/
{"spec":{"options":{
   [...]
   "MonitorAggregationLevel":"\u001b[31mNone\u001b
   [...]
}

Where the color values are being stored with the option incorrectly.
Really the daemon side should not be doing anything for pretty
printing output on the cilium CLI side. So revert this part from the
monitor code.

Further work can push pretty printing of the output into the cilium
CLI. After this change the user will now see all aggregation monitor
levels as green in 'cilium config'. Previously 'none' was shown in
red.

$ cilium config DropNotification=true MonitorAggregationLevel=0
$ cilium config 
Conntrack                Enabled
ConntrackAccounting      Enabled
ConntrackLocal           Disabled
Debug                    Enabled
DropNotification         Enabled
MonitorAggregationLevel  None
PolicyTracing            Disabled
TraceNotification        Enabled
k8s-configuration        
k8s-endpoint             
PolicyEnforcement        default
$ cilium config DropNotification=true

Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5627)
<!-- Reviewable:end -->
