### PR TITLE
cilium: ginkgo errors running on bare metal server with bash

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -733,7 +733,7 @@ func (s *SSHMeta) DumpCiliumCommandOutput() {
 	// No need to create file for bugtool because it creates an archive of files
 	// for us.
 	res := s.ExecWithSudo(
-		fmt.Sprintf("%s -t %s", CiliumBugtool, filepath.Join(BasePath, testPath)),
+		fmt.Sprintf(`%s -t " %s "`, CiliumBugtool, filepath.Join(BasePath, testPath)),
 		ExecOptions{SkipLog: true})
 	if !res.WasSuccessful() {
 		s.logger.Errorf("Error running bugtool: %s", res.CombineOutput())


### PR DESCRIPTION
Running on my Ubuntu server (with bash) resulted in a handful of
errors related to file strings being pushed into cilium debug
tool.

$ cilium-bugtool -t ..._(IP)_...
bash: syntax error near unexpected token `('

To fix this wrap these in quotes,

$ cilium-bugtool -t "..._(IP)_..."

Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5628)
<!-- Reviewable:end -->
