### PR TITLE
Documentation: add step to update VMs with new cilium images

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -202,6 +202,8 @@ If for some reason, running of the provisioning script fails, you should bring t
 
     $ vagrant halt
 
+.. _packer_ci:
+
 Packer-CI-Build
 ^^^^^^^^^^^^^^^
 
@@ -2156,6 +2158,12 @@ update:
 You have created a new image build with a new tag. The next steps should be to
 update the repository root's Dockerfile so that it points to the new
 ``cilium-builder`` or ``cilium-runtime`` image recently created.
+
+21. Update the versions of the images that are pulled into the CI VMs.
+
+* Open a PR against the :ref:`packer_ci` with an update to said image versions. Once your PR is merged, a new version of the VM will be ready for consumption in the CI.
+* Update the ``SERVER_VERSION``  field in ``test/Vagrantfile`` to contain the new version, which is the build number from the `Jenkins Job for the VMs <https://jenkins.cilium.io/job/Vagrant-Master-Boxes-Packer-Build/>`_. For example, build 119 from the pipeline would be the value to set for ``SERVER_VERSION``. 
+* Open a pull request with this version change in the cilium repository.
 
 
 Nightly Docker image


### PR DESCRIPTION
If we update the cilium-builder or cilium-runtime images, we should update the
CI VM to have them already downloaded to avoid having to download them for every
CI run. Document that this should be done.

Fixes: #5134

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5633)
<!-- Reviewable:end -->
