### PR TITLE
proxylib fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ bazel-*
 envoy/istio-envoy
 envoy/Dockerfile.istio_proxy
 envoy/Dockerfile.istio_proxy_debug
+envoy/proxylib
 
 test/tmp.yaml
 test/*_service_manifest.json

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -936,8 +936,9 @@ var (
 	}
 
 	PortRuleL7 = apiextensionsv1beta1.JSONSchemaProps{
-		Description: "PortRuleL7 is a map of {key,value} pairs which must be present in the " +
-			"request. If omitted or empty, all requests are allowed. " +
+		Description: "PortRuleL7 is a map of {key,value} pairs which is passed to the " +
+			"parser referenced in l7proto. It is up to the parser to define what to " +
+			"do with the map data. If omitted or empty, all requests are allowed. " +
 			"Both keys and values must be strings.",
 		//
 		// AdditionalProperties is supported by k8s 1.11 and later only

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -270,9 +270,6 @@ func (pr *L7Rules) sanitize() error {
 		return fmt.Errorf("'l7' may only be specified when a 'l7proto' is also specified")
 	}
 	if pr.L7Proto != "" {
-		if pr.L7 == nil {
-			return fmt.Errorf("'l7' must be specified when 'l7proto' is specified")
-		}
 		nTypes++
 		for i := range pr.L7 {
 			if err := pr.L7[i].Sanitize(); err != nil {

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -286,12 +286,8 @@ func (s *PolicyAPITestSuite) TestL7Rules(c *C) {
 					Rules: &L7Rules{
 						L7Proto: "test.lineparser",
 						L7: []PortRuleL7{
-							map[string]string{
-								"method": "PUT",
-								"path":   "/"},
-							map[string]string{
-								"method": "GET",
-								"path":   "/"},
+							{"method": "PUT", "path": "/"},
+							{"method": "GET", "path": "/"},
 						},
 					},
 				}},
@@ -300,6 +296,28 @@ func (s *PolicyAPITestSuite) TestL7Rules(c *C) {
 	}
 
 	err := validL7Rule.Sanitize()
+	c.Assert(err, IsNil)
+
+	validL7Rule2 := Rule{
+		EndpointSelector: WildcardEndpointSelector,
+		Ingress: []IngressRule{
+			{
+				FromEndpoints: []EndpointSelector{WildcardEndpointSelector},
+				ToPorts: []PortRule{{
+					Ports: []PortProtocol{
+						{Port: "80", Protocol: ProtoTCP},
+						{Port: "81", Protocol: ProtoTCP},
+					},
+					Rules: &L7Rules{
+						L7Proto: "test.lineparser",
+						// No L7 rules
+					},
+				}},
+			},
+		},
+	}
+
+	err = validL7Rule2.Sanitize()
 	c.Assert(err, IsNil)
 
 	invalidL7Rule := Rule{

--- a/pkg/policy/api/utils_test.go
+++ b/pkg/policy/api/utils_test.go
@@ -65,6 +65,31 @@ func (s *PolicyAPITestSuite) TestKafkaEqual(c *C) {
 	c.Assert(rule3.Exists(rules), Equals, false)
 }
 
+func (s *PolicyAPITestSuite) TestL7Equal(c *C) {
+	rule1 := PortRuleL7{"Path": "/foo$", "Method": "GET"}
+	rule2 := PortRuleL7{"Path": "/bar$", "Method": "GET"}
+	rule3 := PortRuleL7{"Path": "/foo$", "Method": "GET", "extra": ""}
+
+	c.Assert(rule1.Equal(rule1), Equals, true)
+	c.Assert(rule2.Equal(rule2), Equals, true)
+	c.Assert(rule3.Equal(rule3), Equals, true)
+	c.Assert(rule1.Equal(rule2), Equals, false)
+	c.Assert(rule2.Equal(rule1), Equals, false)
+	c.Assert(rule1.Equal(rule3), Equals, false)
+	c.Assert(rule3.Equal(rule1), Equals, false)
+	c.Assert(rule2.Equal(rule3), Equals, false)
+	c.Assert(rule3.Equal(rule2), Equals, false)
+
+	rules := L7Rules{
+		L7Proto: "testing",
+		L7:      []PortRuleL7{rule1, rule2},
+	}
+
+	c.Assert(rule1.Exists(rules), Equals, true)
+	c.Assert(rule2.Exists(rules), Equals, true)
+	c.Assert(rule3.Exists(rules), Equals, false)
+}
+
 func (s *PolicyAPITestSuite) TestValidateL4Proto(c *C) {
 	c.Assert(L4Proto("TCP").Validate(), IsNil)
 	c.Assert(L4Proto("UDP").Validate(), IsNil)

--- a/proxylib/input_test.go
+++ b/proxylib/input_test.go
@@ -1,0 +1,69 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/logging"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	logging.ToggleDebugLogs(true)
+	TestingT(t)
+}
+
+type LibSuite struct{}
+
+var _ = Suite(&LibSuite{})
+
+func (l *LibSuite) TestAdvanceInput(c *C) {
+	data := &[][]byte{[]byte("ABCD"), []byte("1234567890"), []byte("abcdefghij")}
+	unit := 0
+	offset := 0
+	var bytes int
+
+	c.Assert((*data)[unit][offset], Equals, byte('A'))
+
+	// Advance to one byte before the end of the first slice
+	bytes, unit, offset = advanceInput(3, unit, offset, data)
+	c.Assert(bytes, Equals, 0)  // Had as many bytes as requested
+	c.Assert(unit, Equals, 0)   // Still in the first slice
+	c.Assert(offset, Equals, 3) // At the offset 3 within the first unit
+	c.Assert((*data)[unit][offset], Equals, byte('D'))
+
+	// Advance to the beginning of the next slice
+	bytes, unit, offset = advanceInput(1, unit, offset, data)
+	c.Assert(bytes, Equals, 0)  // Had as many bytes as requested
+	c.Assert(unit, Equals, 1)   // Moved to the next slice
+	c.Assert(offset, Equals, 0) // In the begining of the 2nd slice
+	c.Assert((*data)[unit][offset], Equals, byte('1'))
+
+	// Advance 11 bytes, crossing to the next slice
+	bytes, unit, offset = advanceInput(11, unit, offset, data)
+	c.Assert(bytes, Equals, 0)  // Had as many bytes as requested
+	c.Assert(unit, Equals, 2)   // Moved to the 3rd slice
+	c.Assert(offset, Equals, 1) // One past the beginning
+	c.Assert((*data)[unit][offset], Equals, byte('b'))
+
+	// Try to advance 11 bytes when only 9 remmain
+	bytes, unit, offset = advanceInput(11, unit, offset, data)
+	c.Assert(bytes, Equals, 2) // 2 bytes remaining
+	c.Assert(unit, Equals, 3)  // All data exhausted
+	c.Assert(offset, Equals, 0)
+}

--- a/proxylib/libcilium.h
+++ b/proxylib/libcilium.h
@@ -70,6 +70,10 @@ extern "C" {
 #endif
 
 
+// OnNewConnection is used to register a new connection of protocol 'proto'.
+// Note that the 'origBuf' and replyBuf' type '*[]byte' corresponds to 'InjectBuf' type, but due to
+// cgo export restrictions we can't use the go type in the prototype.
+
 extern FilterResult OnNewConnection(GoUint64 p0, GoString p1, GoUint64 p2, GoUint8 p3, GoUint32 p4, GoUint32 p5, GoString p6, GoString p7, GoString p8, GoSlice* p9, GoSlice* p10);
 
 // Each connection is assumed to be called from a single thread, so accessing connection metadata

--- a/proxylib/npds/client.go
+++ b/proxylib/npds/client.go
@@ -179,7 +179,7 @@ func (c *Client) Run(connected func()) (err error) {
 		// Receive next policy configuration. This will block until the
 		// server has a new version to send, which may take a long time.
 		resp, err := stream.Recv()
-		if err == io.EOF {
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
 			log.Debugf("NPDS: Client %s stream on %s closed.", c.nodeId, c.path)
 			break
 		}

--- a/proxylib/npds/client_test.go
+++ b/proxylib/npds/client_test.go
@@ -37,9 +37,9 @@ func Test(t *testing.T) {
 	check.TestingT(t)
 }
 
-type ServerSuite struct{}
+type ClientSuite struct{}
 
-var _ = check.Suite(&ServerSuite{})
+var _ = check.Suite(&ClientSuite{})
 
 const (
 	TestTimeout      = 10 * time.Second
@@ -69,7 +69,7 @@ func (u *updater) PolicyUpdate(resp *envoy_api_v2.DiscoveryResponse) error {
 	return nil
 }
 
-func (s *ServerSuite) TestRequestAllResources(c *check.C) {
+func (s *ClientSuite) TestRequestAllResources(c *check.C) {
 	var updater *updater
 	xdsPath := filepath.Join(test.Tmpdir, "xds.sock")
 	client1 := NewClient(xdsPath, "sidecar~127.0.0.1~v0.default~default.svc.cluster.local", updater)

--- a/proxylib/npds/client_test.go
+++ b/proxylib/npds/client_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/envoy/cilium"
 	envoy_api_v2 "github.com/cilium/cilium/pkg/envoy/envoy/api/v2"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/proxylib/test"
 
 	log "github.com/sirupsen/logrus"
@@ -32,7 +33,7 @@ import (
 
 // Hook up gocheck into the "go test" runner.
 func Test(t *testing.T) {
-	// logging.ToggleDebugLogs(true)
+	logging.ToggleDebugLogs(true)
 	check.TestingT(t)
 }
 

--- a/proxylib/proxylib.go
+++ b/proxylib/proxylib.go
@@ -100,6 +100,23 @@ func OnNewConnection(instanceId uint64, proto string, connectionId uint64, ingre
 	return C.FILTER_OK
 }
 
+// Skip bytes in input, or exhaust the input.
+// If input is exhausted 'bytes' will return the number of bytes remaining beyond the input
+func advanceInput(bytes, unit, offset int, data *[][]byte) (int, int, int) {
+	for bytes > 0 && unit < len(*data) {
+		rem := len((*data)[unit]) - offset // this much data left in unit
+		if bytes < rem {                   // more than 'bytes' bytes in unit
+			offset += bytes
+			bytes = 0
+		} else { // go to the beginning of the next unit
+			bytes -= rem
+			unit++
+			offset = 0
+		}
+	}
+	return bytes, unit, offset
+}
+
 // Each connection is assumed to be called from a single thread, so accessing connection metadata
 // does not need protection.
 //
@@ -153,18 +170,7 @@ func OnData(connectionId uint64, reply, endStream bool, data *[][]byte, filterOp
 		}
 
 		if op == PASS || op == DROP {
-			// Skip bytes in input, or exhaust the input.
-			for bytes > 0 && unit < len(*data) {
-				rem := len((*data)[unit]) - offset // this much data left in unit
-				if bytes < rem {                   // more than 'bytes' bytes in unit
-					offset += bytes
-					bytes = 0
-				} else { // go to the beginning of the next unit
-					bytes -= rem
-					unit++
-					offset = 0
-				}
-			}
+			_, unit, offset = advanceInput(bytes, unit, offset, data)
 			// Loop back to parser even if have no more data to allow the parser to
 			// inject frames at the end of the input.
 		}

--- a/proxylib/proxylib.go
+++ b/proxylib/proxylib.go
@@ -50,6 +50,9 @@ func strcpy(str string) string {
 	return string(([]byte(str))[0:])
 }
 
+// OnNewConnection is used to register a new connection of protocol 'proto'.
+// Note that the 'origBuf' and replyBuf' type '*[]byte' corresponds to 'InjectBuf' type, but due to
+// cgo export restrictions we can't use the go type in the prototype.
 //export OnNewConnection
 func OnNewConnection(instanceId uint64, proto string, connectionId uint64, ingress bool, srcId, dstId uint32, srcAddr, dstAddr, policyName string, origBuf, replyBuf *[]byte) C.FilterResult {
 	instance := FindInstance(instanceId)
@@ -81,8 +84,8 @@ func OnNewConnection(instanceId uint64, proto string, connectionId uint64, ingre
 		DstAddr:    strcpy(dstAddr),
 		Port:       uint32(dstPort),
 		PolicyName: strcpy(policyName),
-		Orig:       Direction{InjectBuf: origBuf},
-		Reply:      Direction{InjectBuf: replyBuf},
+		OrigBuf:    origBuf,
+		ReplyBuf:   replyBuf,
 	}
 	connection.Parser = parserFactory.Create(connection)
 	if connection.Parser == nil {

--- a/proxylib/proxylib_test.go
+++ b/proxylib/proxylib_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	//	"path/filepath"
 	"testing"
 	"time"
 

--- a/proxylib/testhelpers.go
+++ b/proxylib/testhelpers.go
@@ -76,7 +76,7 @@ func CheckClose(t *testing.T, connectionId uint64, replyBufAddr *byte, n int) {
 	mutex.Unlock()
 	if !ok {
 		t.Errorf("OnData(): Connection %d not found!", connectionId)
-	} else if replyBufAddr != nil && len(*connection.Reply.InjectBuf) > 0 && replyBufAddr != &(*connection.Reply.InjectBuf)[0] {
+	} else if replyBufAddr != nil && len(*connection.ReplyBuf) > 0 && replyBufAddr != &(*connection.ReplyBuf)[0] {
 		t.Error("OnData(): Reply injection buffer reallocated while it must not be!")
 	}
 
@@ -103,7 +103,7 @@ func checkOps(ops []C.FilterOp, exp []ExpFilterOp) bool {
 	return true
 }
 
-func checkBuf(t *testing.T, buf *[]byte, expected string) {
+func checkBuf(t *testing.T, buf InjectBuf, expected string) {
 	t.Helper()
 	if len(*buf) < len(expected) {
 		t.Log("Inject buffer too small, data truncated")
@@ -142,7 +142,7 @@ func CheckOnData(t *testing.T, connectionId uint64, reply, endStream bool, data 
 	checkOnData(t, res, expResult, ops, expOps)
 
 	if ok {
-		replyBuf := connection.Reply.InjectBuf
+		replyBuf := connection.ReplyBuf
 		checkBuf(t, replyBuf, expReplyBuf)
 		*replyBuf = (*replyBuf)[:0] // make empty again
 	}


### PR DESCRIPTION
Address the remaining review comments on #5174

Allowing an L7 proto to be specified without rules turned out to be more complicated than maybe expected.

Also found out that L7 rule merging was done for ingress only, refactored the code to remove duplication between ingress/egress.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5635)
<!-- Reviewable:end -->
