### PR TITLE
Documentation: describe default allow localhost ingress

### DIFF
--- a/Documentation/kubernetes/concepts.rst
+++ b/Documentation/kubernetes/concepts.rst
@@ -65,3 +65,12 @@ Running ``kubectl get pods`` will show you that Kubernetes started a new set of
         kube-dns-268032401-j0vml      3/3       Running       0          9s
         kube-dns-268032401-t57r2      3/3       Terminating   0          57m
 
+
+Default Ingress Allow from Local Host
+=====================================
+
+Kubernetes has functionality to indicate to users the current health of their
+applications via `Liveness Probes and Readiness Probes <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/>`_.
+In order for ``kubelet`` to run these health checks for each pod, by default,
+Cilium will always allow all ingress traffic from the local host to each pod. 
+ 


### PR DESCRIPTION
Add documentation to the Kubernetes section describing why Cilium always allows
traffic from the local host when running with Kubernetes.

Fixes: #5160

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5637)
<!-- Reviewable:end -->
