### PR TITLE
k8s: add K8s endpoints equalness and missing function

### DIFF
--- a/pkg/comparator/comparator.go
+++ b/pkg/comparator/comparator.go
@@ -60,3 +60,21 @@ func MapStringEquals(m1, m2 map[string]string) bool {
 	}
 	return true
 }
+
+// MapBoolEquals returns true if both maps are equal.
+func MapBoolEquals(m1, m2 map[string]bool) bool {
+	switch {
+	case m1 == nil && m2 == nil:
+		return true
+	case m1 == nil && m2 != nil,
+		m1 != nil && m2 == nil,
+		len(m1) != len(m2):
+		return false
+	}
+	for k1, v1 := range m1 {
+		if v2, ok := m2[k1]; !ok || v2 != v1 {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/comparator/comparator_test.go
+++ b/pkg/comparator/comparator_test.go
@@ -29,7 +29,7 @@ type ComparatorSuite struct{}
 
 var _ = Suite(&ComparatorSuite{})
 
-func (s *ComparatorSuite) TestEquals(c *C) {
+func (s *ComparatorSuite) TestMapStringEquals(c *C) {
 	tests := []struct {
 		m1   map[string]string
 		m2   map[string]string
@@ -87,5 +87,66 @@ func (s *ComparatorSuite) TestEquals(c *C) {
 	}
 	for _, tt := range tests {
 		c.Assert(MapStringEquals(tt.m1, tt.m2), Equals, tt.want)
+	}
+}
+
+func (s *ComparatorSuite) TestMapBoolEquals(c *C) {
+	tests := []struct {
+		m1   map[string]bool
+		m2   map[string]bool
+		want bool
+	}{
+		{
+			m1:   nil,
+			m2:   nil,
+			want: true,
+		},
+		{
+			m1: map[string]bool{
+				"foo": true,
+			},
+			m2: map[string]bool{
+				"foo": true,
+			},
+			want: true,
+		},
+		{
+			m1:   map[string]bool{},
+			m2:   map[string]bool{},
+			want: true,
+		},
+		{
+			m1: map[string]bool{
+				"fo": true,
+			},
+			m2: map[string]bool{
+				"foo": true,
+			},
+			want: false,
+		},
+		{
+			m1: nil,
+			m2: map[string]bool{
+				"foo": true,
+			},
+			want: false,
+		},
+		{
+			m1: map[string]bool{
+				"foo": true,
+			},
+			m2:   nil,
+			want: false,
+		},
+		{
+			m1: map[string]bool{
+				"foo": true,
+			},
+			m2:   nil,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		c.Assert(MapBoolEquals(tt.m1, tt.m2), Equals, tt.want)
 	}
 }

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -419,18 +419,21 @@ func equalV1Services(o1, o2 interface{}) bool {
 }
 
 func equalV1Endpoints(o1, o2 interface{}) bool {
-	_, ok := o1.(*v1.Endpoints)
+	ep1, ok := o1.(*v1.Endpoints)
 	if !ok {
 		log.Panicf("Invalid resource type %q, expecting *v1.Endpoints", reflect.TypeOf(o1))
 		return false
 	}
-	_, ok = o1.(*v1.Endpoints)
+	ep2, ok := o2.(*v1.Endpoints)
 	if !ok {
 		log.Panicf("Invalid resource type %q, expecting *v1.Endpoints", reflect.TypeOf(o2))
 		return false
 	}
-	// FIXME write dedicated deep equal function
-	return false
+	// We only care about the Name, Namespace and Subsets of a particular
+	// endpoint.
+	return ep1.Name == ep2.Name &&
+		ep1.Namespace == ep2.Namespace &&
+		reflect.DeepEqual(ep1.Subsets, ep2.Subsets)
 }
 
 func equalV1beta1Ingress(o1, o2 interface{}) bool {

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 
 	. "gopkg.in/check.v1"
+	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -165,6 +166,138 @@ func (s *K8sSuite) Test_equalV2CNP(c *C) {
 	}
 	for _, tt := range tests {
 		got := equalV2CNP(tt.args.o1, tt.args.o2)
+		c.Assert(got, Equals, tt.want, Commentf("Test Name: %s", tt.name))
+	}
+}
+
+func (s *K8sSuite) Test_equalV1Endpoints(c *C) {
+	type args struct {
+		o1 *core_v1.Endpoints
+		o2 *core_v1.Endpoints
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "EPs with the same name",
+			args: args{
+				o1: &core_v1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+				},
+				o2: &core_v1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "EPs with the different spec",
+			args: args{
+				o1: &core_v1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+					Subsets: []core_v1.EndpointSubset{
+						{
+							Addresses: []core_v1.EndpointAddress{
+								{
+									IP: "172.0.0.1",
+								},
+							},
+						},
+					},
+				},
+				o2: &core_v1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "EPs with the same spec",
+			args: args{
+				o1: &core_v1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+					Subsets: []core_v1.EndpointSubset{
+						{
+							Addresses: []core_v1.EndpointAddress{
+								{
+									IP: "172.0.0.1",
+								},
+							},
+						},
+					},
+				},
+				o2: &core_v1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+					Subsets: []core_v1.EndpointSubset{
+						{
+							Addresses: []core_v1.EndpointAddress{
+								{
+									IP: "172.0.0.1",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "EPs with the same spec (multiple IPs)",
+			args: args{
+				o1: &core_v1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+					Subsets: []core_v1.EndpointSubset{
+						{
+							Addresses: []core_v1.EndpointAddress{
+								{
+									IP: "172.0.0.1",
+								},
+								{
+									IP: "172.0.0.2",
+								},
+							},
+						},
+					},
+				},
+				o2: &core_v1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+					},
+					Subsets: []core_v1.EndpointSubset{
+						{
+							Addresses: []core_v1.EndpointAddress{
+								{
+									IP: "172.0.0.1",
+								},
+								{
+									IP: "172.0.0.2",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		got := equalV1Endpoints(tt.args.o1, tt.args.o2)
 		c.Assert(got, Equals, tt.want, Commentf("Test Name: %s", tt.name))
 	}
 }

--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -525,3 +525,195 @@ func TestK8sServiceInfo_Equals(t *testing.T) {
 		})
 	}
 }
+
+func TestK8sServiceEndpoint_DeepEqual(t *testing.T) {
+	type fields struct {
+		svcEP *K8sServiceEndpoint
+	}
+	type args struct {
+		o *K8sServiceEndpoint
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+
+		{
+			name: "both equal",
+			fields: fields{
+				svcEP: &K8sServiceEndpoint{
+					BEIPs: map[string]bool{
+						"172.20.0.1": true,
+					},
+					Ports: map[FEPortName]*L4Addr{
+						FEPortName("foo"): {
+							Protocol: NONE,
+							Port:     1,
+						},
+					},
+				},
+			},
+			args: args{
+				o: &K8sServiceEndpoint{
+					BEIPs: map[string]bool{
+						"172.20.0.1": true,
+					},
+					Ports: map[FEPortName]*L4Addr{
+						FEPortName("foo"): {
+							Protocol: NONE,
+							Port:     1,
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "different BE IPs",
+			fields: fields{
+				svcEP: &K8sServiceEndpoint{
+					BEIPs: map[string]bool{
+						"172.20.0.1": true,
+					},
+					Ports: map[FEPortName]*L4Addr{
+						FEPortName("foo"): {
+							Protocol: NONE,
+							Port:     1,
+						},
+					},
+				},
+			},
+			args: args{
+				o: &K8sServiceEndpoint{
+					BEIPs: map[string]bool{
+						"172.20.0.2": true,
+					},
+					Ports: map[FEPortName]*L4Addr{
+						FEPortName("foo"): {
+							Protocol: NONE,
+							Port:     1,
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "ports different name",
+			fields: fields{
+				svcEP: &K8sServiceEndpoint{
+					BEIPs: map[string]bool{
+						"172.20.0.1": true,
+					},
+					Ports: map[FEPortName]*L4Addr{
+						FEPortName("foo"): {
+							Protocol: NONE,
+							Port:     1,
+						},
+					},
+				},
+			},
+			args: args{
+				o: &K8sServiceEndpoint{
+					BEIPs: map[string]bool{
+						"172.20.0.1": true,
+					},
+					Ports: map[FEPortName]*L4Addr{
+						FEPortName("foz"): {
+							Protocol: NONE,
+							Port:     1,
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "ports different content",
+			fields: fields{
+				svcEP: &K8sServiceEndpoint{
+					BEIPs: map[string]bool{
+						"172.20.0.1": true,
+					},
+					Ports: map[FEPortName]*L4Addr{
+						FEPortName("foo"): {
+							Protocol: NONE,
+							Port:     1,
+						},
+					},
+				},
+			},
+			args: args{
+				o: &K8sServiceEndpoint{
+					BEIPs: map[string]bool{
+						"172.20.0.1": true,
+					},
+					Ports: map[FEPortName]*L4Addr{
+						FEPortName("foo"): {
+							Protocol: NONE,
+							Port:     2,
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "ports different one is bigger",
+			fields: fields{
+				svcEP: &K8sServiceEndpoint{
+					Ports: map[FEPortName]*L4Addr{
+						FEPortName("foo"): {
+							Protocol: NONE,
+							Port:     1,
+						},
+					},
+				},
+			},
+			args: args{
+				o: &K8sServiceEndpoint{
+					Ports: map[FEPortName]*L4Addr{
+						FEPortName("foo"): {
+							Protocol: NONE,
+							Port:     1,
+						},
+						FEPortName("baz"): {
+							Protocol: NONE,
+							Port:     2,
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name:   "ports different one is nil",
+			fields: fields{},
+			args: args{
+				o: &K8sServiceEndpoint{
+					Ports: map[FEPortName]*L4Addr{
+						FEPortName("foo"): {
+							Protocol: NONE,
+							Port:     1,
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "both nil",
+			args: args{},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.fields.svcEP.DeepEqual(tt.args.o); got != tt.want {
+				t.Errorf("K8sServiceEndpoint.DeepEqual() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Read per commit basis.

```release-note
Stop triggering unnecessary loadbalancer setups for every Kubernetes endpoint watch event.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5642)
<!-- Reviewable:end -->
