### PR TITLE
proxylib: Fix `go vet` errors

### DIFF
--- a/proxylib/testparsers/blockparser.go
+++ b/proxylib/testparsers/blockparser.go
@@ -131,11 +131,11 @@ func (p *BlockParser) OnData(reply, endStream bool, data [][]byte, offset int) (
 	log.Infof("BlockParser: missing: %d", missing)
 
 	if bytes.Contains(block, []byte("PASS")) {
-		p.connection.Log(cilium.EntryType_Request, &cilium.LogEntry_Http{&cilium.HttpLogEntry{Status: 200}})
+		p.connection.Log(cilium.EntryType_Request, &cilium.LogEntry_Http{Http: &cilium.HttpLogEntry{Status: 200}})
 		return PASS, block_len
 	}
 	if bytes.Contains(block, []byte("DROP")) {
-		p.connection.Log(cilium.EntryType_Denied, &cilium.LogEntry_Http{&cilium.HttpLogEntry{Status: 201}})
+		p.connection.Log(cilium.EntryType_Denied, &cilium.LogEntry_Http{Http: &cilium.HttpLogEntry{Status: 201}})
 		return DROP, block_len
 	}
 

--- a/proxylib/testparsers/headerparser.go
+++ b/proxylib/testparsers/headerparser.go
@@ -143,7 +143,7 @@ func (p *HeaderParser) OnData(reply, endStream bool, data [][]byte, offset int) 
 	if reply || p.connection.Matches(line) {
 		p.connection.Log(cilium.EntryType_Request,
 			&cilium.LogEntry_GenericL7{
-				&cilium.L7LogEntry{
+				GenericL7: &cilium.L7LogEntry{
 					Proto: parserName,
 					Fields: map[string]string{
 						"status": "PASS",
@@ -158,7 +158,7 @@ func (p *HeaderParser) OnData(reply, endStream bool, data [][]byte, offset int) 
 	// Drop the line in the current direction
 	p.connection.Log(cilium.EntryType_Denied,
 		&cilium.LogEntry_GenericL7{
-			&cilium.L7LogEntry{
+			GenericL7: &cilium.L7LogEntry{
 				Proto: parserName,
 				Fields: map[string]string{
 					"status": "DROP",


### PR DESCRIPTION
```
proxylib/testparsers/blockparser.go:134: github.com/cilium/cilium/pkg/envoy/cilium.LogEntry_Http composite literal uses unkeyed fields
proxylib/testparsers/blockparser.go:138: github.com/cilium/cilium/pkg/envoy/cilium.LogEntry_Http composite literal uses unkeyed fields
proxylib/testparsers/headerparser.go:145: github.com/cilium/cilium/pkg/envoy/cilium.LogEntry_GenericL7 composite literal uses unkeyed fields
proxylib/testparsers/headerparser.go:160: github.com/cilium/cilium/pkg/envoy/cilium.LogEntry_GenericL7 composite literal uses unkeyed fields
```

Signed-off-by: Michal Rostecki <mrostecki@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5643)
<!-- Reviewable:end -->
