### PR TITLE
k8s: add K8s services equalness and missing function

### DIFF
--- a/daemon/k8s_watcher_test.go
+++ b/daemon/k8s_watcher_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"net"
 	"time"
 
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -611,6 +612,127 @@ func (ds *DaemonSuite) Test_missingK8sEndpointsV1(c *C) {
 		want := tt.setupWanted()
 		ds.d.loadBalancer = args.lb
 		got := ds.d.missingK8sEndpointsV1(args.m)
+		c.Assert(got, DeepEquals, want, Commentf("Test name: %q", tt.name))
+	}
+}
+
+func (ds *DaemonSuite) Test_missingK8sServicesV1(c *C) {
+	type args struct {
+		m  versioned.Map
+		lb *loadbalancer.LoadBalancer
+	}
+	tests := []struct {
+		name        string
+		setupArgs   func() args
+		setupWanted func() versioned.Map
+	}{
+		{
+			name: "both equal",
+			setupArgs: func() args {
+				lb := loadbalancer.NewLoadBalancer()
+				return args{
+					lb: lb,
+					m:  versioned.NewMap(),
+				}
+			},
+			setupWanted: func() versioned.Map {
+				return versioned.NewMap()
+			},
+		},
+		{
+			name: "loadbalancer is missing a service",
+			setupArgs: func() args {
+				lb := loadbalancer.NewLoadBalancer()
+
+				m := versioned.NewMap()
+				m.Add("", versioned.Object{
+					Data: &core_v1.Service{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "bar",
+						},
+						Spec: core_v1.ServiceSpec{
+							Type: core_v1.ServiceTypeClusterIP,
+						},
+					},
+				})
+
+				return args{
+					m:  m,
+					lb: lb,
+				}
+			},
+			setupWanted: func() versioned.Map {
+				m := versioned.NewMap()
+				m.Add("", versioned.Object{
+					Data: &core_v1.Service{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "bar",
+						},
+						Spec: core_v1.ServiceSpec{
+							Type: core_v1.ServiceTypeClusterIP,
+						},
+					},
+				})
+				return m
+			},
+		},
+		{
+			name: "loadbalancer contains all services",
+			setupArgs: func() args {
+				lb := loadbalancer.NewLoadBalancer()
+				lb.K8sMU.Lock()
+				svcNS := loadbalancer.K8sServiceNamespace{
+					ServiceName: "foo",
+					Namespace:   "bar",
+				}
+				lb.K8sServices[svcNS] = loadbalancer.NewK8sServiceInfo(
+					net.ParseIP("127.0.0.1"),
+					false,
+					map[string]string{
+						"foo": "bar",
+					},
+					map[string]string{
+						"foo": "bar",
+					})
+				lb.K8sMU.Unlock()
+
+				m := versioned.NewMap()
+				m.Add("", versioned.Object{
+					Data: &core_v1.Service{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "bar",
+							Labels: map[string]string{
+								"foo": "bar",
+							},
+						},
+						Spec: core_v1.ServiceSpec{
+							ClusterIP: "127.0.0.1",
+							Selector: map[string]string{
+								"foo": "bar",
+							},
+							Type: core_v1.ServiceTypeClusterIP,
+						},
+					},
+				})
+
+				return args{
+					m:  m,
+					lb: lb,
+				}
+			},
+			setupWanted: func() versioned.Map {
+				return versioned.NewMap()
+			},
+		},
+	}
+	for _, tt := range tests {
+		args := tt.setupArgs()
+		want := tt.setupWanted()
+		ds.d.loadBalancer = args.lb
+		got := ds.d.missingK8sServiceV1(args.m)
 		c.Assert(got, DeepEquals, want, Commentf("Test name: %q", tt.name))
 	}
 }


### PR DESCRIPTION
With this commit, Cilium will no longer send unnecessary AddFunc events
and running useless operations for services that have non-relevant
changes.

Signed-off-by: André Martins <andre@cilium.io>

Read per commit basis.

```release-note
Stop triggering unnecessary loadbalancer setups for every Kubernetes service watch event.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5644)
<!-- Reviewable:end -->
