### PR TITLE
Jenkins: Adjust timeouts to be more precise.

### DIFF
--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
                 CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
             }
             options {
-                timeout(time: 120, unit: 'MINUTES')
+                timeout(time: 100, unit: 'MINUTES')
             }
             steps {
                 script {
@@ -120,7 +120,7 @@ pipeline {
                 CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
             }
             options {
-                timeout(time: 120, unit: 'MINUTES')
+                timeout(time: 100, unit: 'MINUTES')
             }
             steps {
                 script {

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -91,7 +91,7 @@ pipeline {
             }
 
             options {
-                timeout(time: 140, unit: 'MINUTES')
+                timeout(time: 100, unit: 'MINUTES')
             }
 
             steps {


### PR DESCRIPTION
At the moment the Kubernetes timeouts are set to more than two hours,
where the stage only takes around 1h and 8 minutes.

This PR set the limit to 1h 40m, to allow 30 minutes if any issue.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5647)
<!-- Reviewable:end -->
