### PR TITLE
k8s: add K8s pods equalness and missing function

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	cilium_client_v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
@@ -1055,6 +1056,29 @@ func (e *Endpoint) GetLabels() []string {
 	}
 
 	return e.SecurityIdentity.Labels.GetModel()
+}
+
+// GetK8sPodLabels returns all labels that exist in the endpoint and were
+// derived from k8s pod.
+func (e *Endpoint) GetK8sPodLabels() pkgLabels.Labels {
+	e.UnconditionalRLock()
+	defer e.RUnlock()
+	allLabels := e.OpLabels.AllLabels()
+	if allLabels == nil {
+		return nil
+	}
+
+	allLabelsFromK8s := allLabels.GetFromSource(pkgLabels.LabelSourceK8s)
+
+	k8sEPPodLabels := pkgLabels.Labels{}
+	for k, v := range allLabelsFromK8s {
+		if !strings.HasPrefix(v.Key, ciliumio.PodNamespaceMetaLabels) &&
+			!strings.HasPrefix(v.Key, ciliumio.PolicyLabelServiceAccount) &&
+			!strings.HasPrefix(v.Key, ciliumio.PodNamespaceLabel) {
+			k8sEPPodLabels[k] = v
+		}
+	}
+	return k8sEPPodLabels
 }
 
 // GetLabelsSHA returns the SHA of labels

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -301,3 +301,142 @@ func (s *K8sSuite) Test_equalV1Endpoints(c *C) {
 		c.Assert(got, Equals, tt.want, Commentf("Test Name: %s", tt.name))
 	}
 }
+
+func (s *K8sSuite) Test_equalV1Pod(c *C) {
+	type args struct {
+		o1 interface{}
+		o2 interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+
+		{
+			name: "Pods with the same name",
+			args: args{
+				o1: &core_v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+					},
+				},
+				o2: &core_v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Pods with the different spec",
+			args: args{
+				o1: &core_v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+					},
+					Status: core_v1.PodStatus{
+						HostIP: "127.0.0.1",
+						PodIP:  "127.0.0.2",
+					},
+				},
+				o2: &core_v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+					},
+					Status: core_v1.PodStatus{
+						HostIP: "127.0.0.1",
+						PodIP:  "127.0.0.1",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Pods with the same spec",
+			args: args{
+				o1: &core_v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+					},
+					Status: core_v1.PodStatus{
+						HostIP: "127.0.0.1",
+						PodIP:  "127.0.0.2",
+					},
+				},
+				o2: &core_v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+					},
+					Status: core_v1.PodStatus{
+						HostIP: "127.0.0.1",
+						PodIP:  "127.0.0.2",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Pods with the same spec but different labels",
+			args: args{
+				o1: &core_v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+					Status: core_v1.PodStatus{
+						HostIP: "127.0.0.1",
+						PodIP:  "127.0.0.2",
+					},
+				},
+				o2: &core_v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+					},
+					Status: core_v1.PodStatus{
+						HostIP: "127.0.0.1",
+						PodIP:  "127.0.0.2",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Pods with the same spec and same labels",
+			args: args{
+				o1: &core_v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+					Status: core_v1.PodStatus{
+						HostIP: "127.0.0.1",
+						PodIP:  "127.0.0.2",
+					},
+				},
+				o2: &core_v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+					Status: core_v1.PodStatus{
+						HostIP: "127.0.0.1",
+						PodIP:  "127.0.0.2",
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		got := equalV1Pod(tt.args.o1, tt.args.o2)
+		c.Assert(got, Equals, tt.want, Commentf("Test Name: %s", tt.name))
+	}
+}

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -281,6 +281,17 @@ func (l Labels) Equals(other Labels) bool {
 	return true
 }
 
+// GetFromSource returns all labels that are from the given source.
+func (l Labels) GetFromSource(source string) Labels {
+	lbls := Labels{}
+	for k, v := range l {
+		if v.Source == source {
+			lbls[k] = v
+		}
+	}
+	return lbls
+}
+
 // NewLabel returns a new label from the given key, value and source. If source is empty,
 // the default value will be LabelSourceUnspec. If key starts with '$', the source
 // will be overwritten with LabelSourceReserved. If key contains ':', the value

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -16,11 +16,11 @@ package labels
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/checker"
-
 	. "gopkg.in/check.v1"
 )
 
@@ -244,4 +244,48 @@ func (s *LabelsSuite) TestLabelsCompare(c *C) {
 	c.Assert(lblsLa22.Equals(lblsLa12), Equals, false)
 	c.Assert(lblsLa22.Equals(lblsLb22), Equals, false)
 	c.Assert(lblsLb22.Equals(lblsLa22), Equals, false)
+}
+
+func TestLabels_GetFromSource(t *testing.T) {
+	type args struct {
+		source string
+	}
+	tests := []struct {
+		name string
+		l    Labels
+		args args
+		want Labels
+	}{
+		{
+			name: "should contain label with the given source",
+			l: Labels{
+				"foo":   NewLabel("foo", "bar", "my-source"),
+				"other": NewLabel("other", "bar", ""),
+			},
+			args: args{
+				source: "my-source",
+			},
+			want: Labels{
+				"foo": NewLabel("foo", "bar", "my-source"),
+			},
+		},
+		{
+			name: "should return an empty slice as there are not labels for the given source",
+			l: Labels{
+				"foo":   NewLabel("foo", "bar", "any"),
+				"other": NewLabel("other", "bar", ""),
+			},
+			args: args{
+				source: "my-source",
+			},
+			want: Labels{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.l.GetFromSource(tt.args.source); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Labels.GetFromSource() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
With this commit, Cilium will no longer send unnecessary AddFunc events
and running useless operations for pods that have non-relevant
changes.
    
Signed-off-by: André Martins <andre@cilium.io>

Read per commit basis.

```release-note
Stop triggering unnecessary ipcache setup for every Kubernetes pod watch event.
```

Depends on https://github.com/cilium/cilium/pull/5644

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5655)
<!-- Reviewable:end -->
