### PR TITLE
k8s: add K8s nodes equalness and missing function

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -622,9 +622,7 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 					return nil
 				}
 			},
-			func(m versioned.Map) versioned.Map {
-				return m
-			},
+			d.missingK8sNodeV1,
 			&v1.Node{},
 			k8s.Client(),
 			reSyncPeriod,
@@ -2173,4 +2171,45 @@ func (d *Daemon) deleteK8sNodeV1(k8sNode *v1.Node) {
 		logger.Warning("Unable to parse Cilium IP")
 		return
 	}
+}
+
+// missingK8sNodeV1 checks if all nodes from the possible missing nodes have
+// their CiliumHostIP missing from the ipcache or if the CiliumHostIP is
+// associated with the right node.
+func (d *Daemon) missingK8sNodeV1(m versioned.Map) versioned.Map {
+	missing := versioned.NewMap()
+	nodes := node.GetNodes()
+	for k, v := range m {
+		n := v.Data.(*v1.Node)
+		ciliumHostIPStr := n.GetAnnotations()[annotation.CiliumHostIP]
+		if ciliumHostIPStr == "" {
+			continue
+		}
+		_, exists := ipcache.IPIdentityCache.LookupByIP(ciliumHostIPStr)
+		// The node is considered missing if the Cilium HostIP of that
+		// node doesn't exist in the identity cache.
+		if !exists {
+			missing.Add(k, v)
+			continue
+		}
+
+		ciliumHostIP := net.ParseIP(ciliumHostIPStr)
+		if ciliumHostIP == nil {
+			continue
+		}
+
+		// Or if the CiliumHostIP is the right one for this node.
+		nodeIdentity := node.Identity{Name: n.GetName(), Cluster: option.Config.ClusterName}
+		var found bool
+		for _, v := range nodes[nodeIdentity].IPAddresses {
+			if v.IP.Equal(ciliumHostIP) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			missing.Add(k, v)
+		}
+	}
+	return missing
 }

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -15,6 +15,7 @@
 package k8s
 
 import (
+	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/comparator"
 	"net"
 	"reflect"
@@ -511,18 +512,20 @@ func equalV1Pod(o1, o2 interface{}) bool {
 }
 
 func equalV1Node(o1, o2 interface{}) bool {
-	_, ok := o1.(*v1.Node)
+	node1, ok := o1.(*v1.Node)
 	if !ok {
 		log.Panicf("Invalid resource type %q, expecting *v1.Node", reflect.TypeOf(o1))
 		return false
 	}
-	_, ok = o1.(*v1.Node)
+	node2, ok := o2.(*v1.Node)
 	if !ok {
 		log.Panicf("Invalid resource type %q, expecting *v1.Node", reflect.TypeOf(o2))
 		return false
 	}
-	// FIXME write dedicated deep equal function
-	return false
+	// The only information we care about the node is it's annotations, in
+	// particularly the CiliumHostIP annotation.
+	return node1.GetObjectMeta().GetName() == node2.GetObjectMeta().GetName() &&
+		node1.GetAnnotations()[annotation.CiliumHostIP] == node2.GetAnnotations()[annotation.CiliumHostIP]
 }
 
 func equalV1Namespace(o1, o2 interface{}) bool {

--- a/pkg/node/manager.go
+++ b/pkg/node/manager.go
@@ -322,6 +322,13 @@ func GetNodes() map[Identity]Node {
 	return nodes
 }
 
+// DeleteAllNodes deletes all nodes from the node maanger.
+func DeleteAllNodes() {
+	clusterConf.RLock()
+	defer clusterConf.RUnlock()
+	clusterConf.nodes = map[Identity]*Node{}
+}
+
 // updateIPRoute updates the IP routing entry for the given node n via the
 // network interface that as ownAddr.
 func updateIPRoute(oldNode, n *Node, ownAddr net.IP) {


### PR DESCRIPTION
With this commit, Cilium will no longer send unnecessary AddFunc events
and running useless operations for nodes that have non-relevant
changes.
    
Signed-off-by: André Martins <andre@cilium.io>

Read per commit basis.

```release-note
Stop triggering unnecessary ipcache setup for every Kubernetes node watch event.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5659)
<!-- Reviewable:end -->
