### PR TITLE
Documentation: add minimum firewall rules, examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ envoy/Dockerfile.builder
 envoy/external
 
 test/bpf/_results
+
+# generated from make targets
+*.ok

--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -155,7 +155,7 @@ Firewall Rules
 
 If you are running Cilium in an environment that requires firewall rules to enable connectivity, you will have to add the following rules to ensure Cilium works properly.
 
-At a minimum, all nodes running Cilium in a given cluster must be able to ping each other so ``cilium-health`` can report and monitor connectivity among nodes. This requires ICMP Type 0/8, Code 0 open among all nodes. TCP 4240 must also be open among all nodes for ``cilium-health`` monitoring.
+It is recommended but optional that all nodes running Cilium in a given cluster must be able to ping each other so ``cilium-health`` can report and monitor connectivity among nodes. This requires ICMP Type 0/8, Code 0 open among all nodes. TCP 4240 should also be open among all nodes for ``cilium-health`` monitoring. Note that it is also an option to only use one of these two methods to enable health monitoring. If the firewall does not permit either of these methods, Cilium will still operate fine but will not be able to provide health information.
 
 If you are using VXLAN overlay network mode, Cilium uses Linux's default VXLAN port 8472 over UDP, unless Linux has been configured otherwise. In this case, UDP 8472 must be open among all nodes to enable VXLAN overlay mode. The same applies to Geneve overlay network mode, except the port is UDP 6081.
 

--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -151,7 +151,7 @@ https://www.kernel.org/pub/linux/utils/net/iproute2/ for documentation on how
 to install iproute2.
 
 Firewall Rules
-========
+==============
 
 If you are running Cilium in an environment that requires firewall rules to enable connectivity, you will have to add the following rules to ensure Cilium works properly.
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -145,6 +145,7 @@ eu
 eXpress
 extensibility
 Facebook
+fallback
 Fastabend
 filename
 filesystem
@@ -355,6 +356,7 @@ pem
 Pepelnjak
 perf
 Pfaff
+playbook
 pluggable
 plugin
 Plugin
@@ -486,6 +488,7 @@ ui
 Uncomment
 underrepresents
 uninline
+Uninstalling
 unix
 Unix
 unmanaged

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -308,7 +308,7 @@ When running in :ref:`arch_overlay` mode:
 
    * verify that the node IP listed in ``cilium bpf tunnel list`` can reach each
      other.
-   * verify that the firewall on each node allows UDP port 4789.
+   * verify that the firewall on each node allows UDP port 8472.
 
 When running in :ref:`arch_direct_routing` mode:
 


### PR DESCRIPTION
Based on multiple discussions on Slack, a gap in the documentation was observed around firewall rules needed to run Cilium in an environment that has limited network connectivity. This change fixes that by adding a codified set of minimum network firewall rules that have been tested succesfully by checking `cilium status` and `cilium-health status` outputs.

Signed-off-by: Anit Gandhi <anitgandhi@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5660)
<!-- Reviewable:end -->
