### PR TITLE
endpoint: Reload using existing compiled prog path

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -765,7 +765,7 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 		e.Unlock()
 	}()
 
-	revision, compilationExecuted, err = e.regenerateBPF(owner, tmpDir, context)
+	revision, compilationExecuted, err = e.regenerateBPF(owner, origDir, tmpDir, context)
 	if err != nil {
 		failDir := e.FailedDirectoryPath()
 		e.Logger().WithFields(logrus.Fields{


### PR DESCRIPTION
We observed that the wrong path was being used for reloading BPF
programs without compilation: ReloadDatapath() was attempting to load
from the new "xxxxx_next" directory rather than the existing state path.

Fixes: 2ab447f3f9de ("endpoint: Skip compilation if unneeded")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5662)
<!-- Reviewable:end -->
