### PR TITLE
k8s: add K8s namespace equalness and missing function

### DIFF
--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -529,16 +529,17 @@ func equalV1Node(o1, o2 interface{}) bool {
 }
 
 func equalV1Namespace(o1, o2 interface{}) bool {
-	_, ok := o1.(*v1.Namespace)
+	ns1, ok := o1.(*v1.Namespace)
 	if !ok {
 		log.Panicf("Invalid resource type %q, expecting *v1.Namespace", reflect.TypeOf(o1))
 		return false
 	}
-	_, ok = o1.(*v1.Namespace)
+	ns2, ok := o2.(*v1.Namespace)
 	if !ok {
 		log.Panicf("Invalid resource type %q, expecting *v1.Namespace", reflect.TypeOf(o2))
 		return false
 	}
-	// FIXME write dedicated deep equal function
-	return false
+	// we only care about namespace labels.
+	return ns1.Name == ns2.Name &&
+		comparator.MapStringEquals(ns1.GetLabels(), ns2.GetLabels())
 }

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -584,3 +584,144 @@ func (s *K8sSuite) Test_equalV1Node(c *C) {
 		c.Assert(got, Equals, tt.want, Commentf("Test Name: %s", tt.name))
 	}
 }
+
+func (s *K8sSuite) Test_equalV1Namespace(c *C) {
+	type args struct {
+		o1 interface{}
+		o2 interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Namespaces with the same name",
+			args: args{
+				o1: &core_v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Namespace1",
+					},
+				},
+				o2: &core_v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Namespace1",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Namespaces with the different names",
+			args: args{
+				o1: &core_v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Namespace1",
+					},
+				},
+				o2: &core_v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Namespace2",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Namespaces with the different spec should return true as we don't care about the spec",
+			args: args{
+				o1: &core_v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Namespace1",
+					},
+					Spec: core_v1.NamespaceSpec{
+						Finalizers: []core_v1.FinalizerName{
+							core_v1.FinalizerName("foo"),
+						},
+					},
+				},
+				o2: &core_v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Namespace1",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Namespaces with the same labels",
+			args: args{
+				o1: &core_v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Namespace1",
+						Labels: map[string]string{
+							"prod": "true",
+						},
+					},
+				},
+				o2: &core_v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Namespace1",
+						Labels: map[string]string{
+							"prod": "true",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Namespaces with the different labels",
+			args: args{
+				o1: &core_v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Namespace1",
+						Labels: map[string]string{
+							"prod": "true",
+						},
+					},
+				},
+				o2: &core_v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Namespace1",
+						Labels: map[string]string{
+							"prod": "false",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Namespaces with the same annotations and different specs should return true because he don't care about the spec",
+			args: args{
+				o1: &core_v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Namespace1",
+						Labels: map[string]string{
+							"prod": "false",
+						},
+					},
+					Spec: core_v1.NamespaceSpec{
+						Finalizers: []core_v1.FinalizerName{
+							core_v1.FinalizerName("foo"),
+						},
+					},
+				},
+				o2: &core_v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Namespace1",
+						Labels: map[string]string{
+							"prod": "false",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		got := equalV1Namespace(tt.args.o1, tt.args.o2)
+		c.Assert(got, Equals, tt.want, Commentf("Test Name: %s", tt.name))
+	}
+}


### PR DESCRIPTION
With this commit, Cilium will no longer send unnecessary AddFunc events
and running useless operations for namespaces that have non-relevant
changes.
    
Signed-off-by: André Martins <andre@cilium.io>

Read per commit basis.

```release-note
Stop triggering endpoints identities resolutions for every unnecessary Kubernetes namespace watch event.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5664)
<!-- Reviewable:end -->
