### PR TITLE
Test: Add a background http connection during upgrade

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -102,6 +102,7 @@ const (
 	App1   = "app1"
 	App2   = "app2"
 	App3   = "app3"
+	App4   = "app4"
 	Client = "client"
 	Server = "server"
 	Host   = "host"

--- a/test/k8sT/manifests/demo_extended.yaml
+++ b/test/k8sT/manifests/demo_extended.yaml
@@ -1,0 +1,112 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: app1-account
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: app2-account
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app1-service
+spec:
+  ports:
+  - port: 80
+  selector:
+    id: app1
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        id: app1
+        zgroup: testapp
+    spec:
+      serviceAccountName: app1-account
+      containers:
+      - name: web
+        image: docker.io/cilium/demo-httpd:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: app2
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        id: app2
+        zgroup: testapp
+        appSecond: "true"
+    spec:
+      serviceAccountName: app2-account
+      containers:
+      - name: app-frontend
+        image: docker.io/cilium/demo-client:latest
+        imagePullPolicy: IfNotPresent
+        command: [ "sleep" ]
+        args:
+          - "1000h"
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: app3
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        id: app3
+        zgroup: testapp
+    spec:
+      containers:
+      - name: app-frontend
+        image: docker.io/cilium/demo-client:latest
+        imagePullPolicy: IfNotPresent
+        command: [ "sleep" ]
+        args:
+          - "1000h"
+        ports:
+        - containerPort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: app4
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        id: app4
+        zgroup: testapp
+    spec:
+      containers:
+      - name: web
+        image: docker.io/cilium/demo-httpd:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app4-service
+spec:
+  ports:
+  - port: 80
+  selector:
+    id: app4

--- a/test/k8sT/manifests/l3-l4-policy-extended.yaml
+++ b/test/k8sT/manifests/l3-l4-policy-extended.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+description: "L3-L4 policy"
+metadata:
+  name: "l3-l4-policy-app4"
+specs:
+  - endpointSelector:
+      matchLabels:
+        id: app4
+    ingress:
+    - fromEndpoints:
+      - matchLabels:
+          id: app2
+      toPorts:
+      - ports:
+        - port: "80"
+          protocol: TCP
+  - endpointSelector:
+      matchLabels:
+        id: app3
+    egress:
+    - toCIDR:
+      - 1.1.1.1/32


### PR DESCRIPTION
This commit adds a new way to check that the connection during upgrade
was made correctly and the connection is never drop in that time.

This adds a demo_extended, where a new endpoint is added `app4` and the
L3/L4 policy from app2 to app4.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5668)
<!-- Reviewable:end -->
