### PR TITLE
Metrics: Add subprocess metrics

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -105,6 +105,13 @@ Controllers
 * ``controllers_runs_duration_seconds``: Duration in seconds of the controller
   process labeled by completion status
 
+
+SubProcess
+----------
+
+* ``subprocess_start_total``: Number of times that Cilium has started a
+  subprocess, labeled by subsystem
+
 Cilium as a Kubernetes pod
 ==========================
 The Cilium Prometheus reference configuration configures jobs that automatically

--- a/monitor/launch/launcher.go
+++ b/monitor/launch/launcher.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "monitor-launcher")
@@ -101,6 +102,7 @@ func (nm *NodeMonitor) run(sockPath, bpfRoot string) error {
 	if err := nm.Launcher.Run(); err != nil {
 		return err
 	}
+	metrics.SubprocessStart.WithLabelValues(targetName).Inc()
 
 	r := bufio.NewReader(nm.GetStdout())
 	for nm.GetProcess() != nil {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -110,6 +110,10 @@ var (
 	// LabelAction is the label used to defined what kind of action was performed in a metric
 	LabelAction = "action"
 
+	// LabelSubsystem is the label used to refer to any of the child process
+	// started by cilium (Envoy, monitor, etc..)
+	LabelSubsystem = "subsystem"
+
 	// Endpoint
 
 	// EndpointCount is a function used to collect this metric.
@@ -385,6 +389,14 @@ var (
 		Name:      "buildqueue_entries",
 		Help:      "The number of queued, waiting and running builds in the build queue",
 	}, []string{LabelBuildState, LabelBuildQueueName})
+
+	// SubprocessStart is the number of times that Cilium has started a
+	// subprocess, labeled by Subsystem
+	SubprocessStart = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "subprocess_start_total",
+		Help:      "Number of times that Cilium has started a subprocess, labeled by subsystem",
+	}, []string{LabelSubsystem})
 )
 
 func init() {
@@ -435,6 +447,8 @@ func init() {
 	MustRegister(ControllerRunsDuration)
 
 	MustRegister(BuildQueueEntries)
+
+	MustRegister(SubprocessStart)
 }
 
 // MustRegister adds the collector to the registry, exposing this metric to


### PR DESCRIPTION
When cilium starts it creates a few new process in background that are
used for multiple things.

With this change, all this subroutines (envoy, health, monitor) will
trigger a new metric when starts. The idea behind is to know if a
process is restarting a lot.

Sample data:

```
->cilium metrics list | grep subro
cilium_subroutine_start_total                       scope="cilium-envoy"                                    1.000000
cilium_subroutine_start_total                       scope="cilium-health"                                   1.000000
cilium_subroutine_start_total                       scope="cilium-node-monitor"                             1.000000
->
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5673)
<!-- Reviewable:end -->
