### PR TITLE
Test: Use AfterSuite to clean the VMs at the end.

### DIFF
--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -237,14 +237,14 @@ var _ = BeforeAll(func() {
 	return
 })
 
-var _ = AfterAll(func() {
+var _ = AfterSuite(func() {
 	if !helpers.IsRunningOnJenkins() {
-		log.Infof("AfterSuite: not running on Jenkins; leaving VMs running for debugging")
+		GinkgoPrint("AfterSuite: not running on Jenkins; leaving VMs running for debugging")
 		return
 	}
 	// Errors are not checked here because it should fail on BeforeAll
 	scope, _ := helpers.GetScope()
-	log.Infof("cleaning up VMs started for %s tests", scope)
+	GinkgoPrint("cleaning up VMs started for %s tests", scope)
 	switch scope {
 	case helpers.Runtime:
 		helpers.DestroyVM(helpers.Runtime)


### PR DESCRIPTION
AfterAll was not trigger when the filter of the focus was in the
`Describe`, with this change the AfterSuite will always happens when the
test suite finished.

Fix #5648 

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5675)
<!-- Reviewable:end -->
