### PR TITLE
endpoint: Don't scrub local ct map on leave

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1807,7 +1807,9 @@ func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup
 	e.controllers.RemoveAll()
 	e.cleanPolicySignals()
 
-	e.scrubIPsInConntrackTableLocked()
+	if !e.ConntrackLocalLocked() {
+		e.scrubIPsInConntrackTableLocked()
+	}
 
 	e.SetStateLocked(StateDisconnected, "Endpoint removed")
 


### PR DESCRIPTION
The local ct map will be deleted soon after, so don't bother spending
the CPU cycles to dump and delete entries from the table.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5676)
<!-- Reviewable:end -->
