### PR TITLE
Misc logging fixes for v1.3

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -913,7 +913,7 @@ func runDaemon() {
 	log.Info("Building health endpoint")
 	health4, health6, err := ipam.AllocateNext("")
 	if err != nil {
-		log.WithError(err).Fatal("Error while allocating cilium-health IP")
+		log.WithError(err).Fatal("IPAM allocation failed. For more detail, see https://cilium.link/ipam-range-full")
 	}
 
 	err = node.SetIPv4HealthIP(health4)

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -26,7 +26,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-// TODO: Rebase against https://github.com/cilium/cilium/pull/5286.
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "datapath-loader")
 
 const (

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -46,7 +46,7 @@ func (ep *testEP) InterfaceName() string {
 	return "cilium_test"
 }
 
-func (ep *testEP) Logger() *logrus.Entry {
+func (ep *testEP) Logger(subsystem string) *logrus.Entry {
 	return log
 }
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -328,7 +328,7 @@ func (e *Endpoint) removeOldRedirects(owner Owner, desiredRedirects map[string]b
 			continue
 		}
 		if err := owner.RemoveProxyRedirect(e, id, proxyWaitGroup); err != nil {
-			e.Logger().WithError(err).WithField(logfields.L4PolicyID, id).Warn("Error while removing proxy redirect")
+			e.getLogger().WithError(err).WithField(logfields.L4PolicyID, id).Warn("Error while removing proxy redirect")
 		} else {
 			delete(e.realizedRedirects, id)
 
@@ -426,7 +426,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 			return 0, compilationExecuted, err
 		}
 		// Clean up map contents
-		e.Logger().Debug("flushing old PolicyMap")
+		e.getLogger().Debug("flushing old PolicyMap")
 		err = e.PolicyMap.Flush()
 		if err != nil {
 			e.Unlock()
@@ -511,12 +511,12 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 	bpfHeaderfilesHash, err := hashEndpointHeaderfiles(nextDir)
 	var bpfHeaderfilesChanged bool
 	if err != nil {
-		e.Logger().WithError(err).Warn("Unable to hash header file")
+		e.getLogger().WithError(err).Warn("Unable to hash header file")
 		bpfHeaderfilesHash = ""
 		bpfHeaderfilesChanged = true
 	} else {
 		bpfHeaderfilesChanged = (bpfHeaderfilesHash != e.bpfHeaderfileHash)
-		e.Logger().WithField(logfields.BPFHeaderfileHash, bpfHeaderfilesHash).
+		e.getLogger().WithField(logfields.BPFHeaderfileHash, bpfHeaderfilesHash).
 			Debugf("BPF header file hashed (was: %q)", e.bpfHeaderfileHash)
 	}
 
@@ -542,7 +542,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 
 	e.Unlock()
 
-	e.Logger().WithField("bpfHeaderfilesChanged", bpfHeaderfilesChanged).Debug("Preparing to compile BPF")
+	e.getLogger().WithField("bpfHeaderfilesChanged", bpfHeaderfilesChanged).Debug("Preparing to compile BPF")
 
 	stats.prepareBuild.End()
 	if bpfHeaderfilesChanged || regenContext.ReloadDatapath {
@@ -554,12 +554,12 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 			stats.bpfCompilation.Start()
 			err = loader.CompileAndLoad(ctx, epInfoCache)
 			stats.bpfCompilation.End()
-			e.Logger().WithError(err).
+			e.getLogger().WithError(err).
 				WithField(logfields.BPFCompilationTime, stats.bpfCompilation.Total().String()).
 				Info("Recompiled endpoint BPF program")
 		} else {
 			err = loader.ReloadDatapath(ctx, epInfoCache)
-			e.Logger().WithError(err).Info("Reloaded endpoint BPF program")
+			e.getLogger().WithError(err).Info("Reloaded endpoint BPF program")
 		}
 		cancel()
 		close(closeChan)
@@ -570,7 +570,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 		compilationExecuted = true
 		e.bpfHeaderfileHash = bpfHeaderfilesHash
 	} else {
-		e.Logger().WithField(logfields.BPFHeaderfileHash, bpfHeaderfilesHash).
+		e.getLogger().WithField(logfields.BPFHeaderfileHash, bpfHeaderfilesHash).
 			Debug("BPF header file unchanged, skipping BPF compilation and installation")
 	}
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -387,7 +387,14 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 	// pre-existing connections using that IP are now invalid.
 	if !e.ctCleaned {
 		go func() {
-			e.scrubIPsInConntrackTable()
+			ipv4 := !option.Config.IPv4Disabled
+			created := ctmap.Exists(nil, ipv4, true)
+			if e.ConntrackLocal() {
+				created = ctmap.Exists(e, ipv4, true)
+			}
+			if created {
+				e.scrubIPsInConntrackTable()
+			}
 			close(ctCleaned)
 		}()
 	} else {

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -73,8 +73,8 @@ func (ep *epInfoCache) StringID() string {
 }
 
 // Logger returns the logger for the endpoint that is being cached.
-func (ep *epInfoCache) Logger() *logrus.Entry {
-	return ep.endpoint.Logger()
+func (ep *epInfoCache) Logger(subsystem string) *logrus.Entry {
+	return ep.endpoint.Logger(subsystem)
 }
 
 // StateDir returns the directory for the endpoint's (next) state.

--- a/pkg/endpoint/directory.go
+++ b/pkg/endpoint/directory.go
@@ -48,7 +48,7 @@ func (e *Endpoint) NextDirectoryPath() string {
 // or if any updates to directories for the endpoint's directories fails.
 // Must be called with endpoint.Mutex held.
 func (e *Endpoint) synchronizeDirectories(origDir string, compilationExecuted bool) error {
-	scopedLog := e.Logger()
+	scopedLog := e.getLogger()
 
 	tmpDir := e.NextDirectoryPath()
 	// If generation failed, keep the directory around. If it ever succeeds

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -528,12 +528,12 @@ func (e *Endpoint) WaitForProxyCompletions(proxyWaitGroup *completion.WaitGroup)
 
 	start := time.Now()
 
-	e.Logger().Debug("Waiting for proxy updates to complete...")
+	e.getLogger().Debug("Waiting for proxy updates to complete...")
 	err = proxyWaitGroup.Wait()
 	if err != nil {
 		return fmt.Errorf("proxy state changes failed: %s", err)
 	}
-	e.Logger().Debug("Wait time for proxy updates: ", time.Since(start))
+	e.getLogger().Debug("Wait time for proxy updates: ", time.Since(start))
 
 	return nil
 }
@@ -545,7 +545,7 @@ func (e *Endpoint) RunK8sCiliumEndpointSync() {
 	var (
 		endpointID     = e.ID
 		controllerName = fmt.Sprintf("sync-to-k8s-ciliumendpoint (%v)", endpointID)
-		scopedLog      = e.Logger().WithField("controller", controllerName)
+		scopedLog      = e.getLogger().WithField("controller", controllerName)
 		err            error
 	)
 
@@ -591,7 +591,7 @@ func (e *Endpoint) RunK8sCiliumEndpointSync() {
 			DoFunc: func() (err error) {
 				// Update logger as scopeLog might not have the podName when it
 				// was created.
-				scopedLog = e.Logger().WithField("controller", controllerName)
+				scopedLog = e.getLogger().WithField("controller", controllerName)
 
 				podName := e.GetK8sPodName()
 				if podName == "" {
@@ -1601,7 +1601,7 @@ func (e *Endpoint) logStatusLocked(typ StatusType, code StatusCode, msg string) 
 		Timestamp: time.Now().UTC(),
 	}
 	e.Status.addStatusLog(sts)
-	e.Logger().WithFields(logrus.Fields{
+	e.getLogger().WithFields(logrus.Fields{
 		"code":                   sts.Status.Code,
 		"type":                   sts.Status.Type,
 		logfields.EndpointState:  sts.Status.State,
@@ -1645,7 +1645,7 @@ func (e *Endpoint) Update(owner Owner, cfg *models.EndpointConfigurationSpec) er
 		return err
 	}
 
-	e.Logger().WithField("configuration-options", cfg).Debug("updating endpoint configuration options")
+	e.getLogger().WithField("configuration-options", cfg).Debug("updating endpoint configuration options")
 
 	// CurrentStatus will be not OK when we have an uncleared error in BPF,
 	// policy or Other. We should keep trying to regenerate in the hopes of
@@ -1664,7 +1664,7 @@ func (e *Endpoint) Update(owner Owner, cfg *models.EndpointConfigurationSpec) er
 	}
 
 	if needToRegenerateBPF {
-		e.Logger().Debug("need to regenerate endpoint; checking state before" +
+		e.getLogger().Debug("need to regenerate endpoint; checking state before" +
 			" attempting to regenerate")
 
 		// TODO / FIXME: GH-3281: need ways to queue up regenerations per-endpoint.
@@ -1697,7 +1697,7 @@ func (e *Endpoint) Update(owner Owner, cfg *models.EndpointConfigurationSpec) er
 				}
 				e.Unlock()
 			case <-timeout:
-				e.Logger().Warningf("timed out waiting for endpoint state to change")
+				e.getLogger().Warningf("timed out waiting for endpoint state to change")
 				return UpdateStateChangeError{fmt.Sprintf("unable to regenerate endpoint program because state transition to %s was unsuccessful; check `cilium endpoint log %d` for more information", StateWaitingToRegenerate, e.ID)}
 			}
 		}
@@ -1748,7 +1748,7 @@ func (e *Endpoint) replaceInformationLabels(l pkgLabels.Labels) {
 	}
 	e.OpLabels.OrchestrationInfo.MarkAllForDeletion()
 
-	scopedLog := e.Logger()
+	scopedLog := e.getLogger()
 
 	for _, v := range l {
 		if e.OpLabels.OrchestrationInfo.UpsertLabel(v) {
@@ -1774,7 +1774,7 @@ func (e *Endpoint) replaceIdentityLabels(l pkgLabels.Labels) int {
 	e.OpLabels.OrchestrationIdentity.MarkAllForDeletion()
 	e.OpLabels.Disabled.MarkAllForDeletion()
 
-	scopedLog := e.Logger()
+	scopedLog := e.getLogger()
 
 	for k, v := range l {
 		// A disabled identity label stays disabled without value updates
@@ -1838,7 +1838,7 @@ func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup
 	e.SetStateLocked(StateDisconnected, "Endpoint removed")
 
 	endpointPolicyStatus.Remove(e.ID)
-	e.Logger().Info("Removed endpoint")
+	e.getLogger().Info("Removed endpoint")
 
 	return errors
 }
@@ -2069,7 +2069,7 @@ func (e *Endpoint) SetStateLocked(toState, reason string) bool {
 	}
 	if toState != fromState {
 		_, fileName, fileLine, _ := runtime.Caller(1)
-		e.Logger().WithFields(logrus.Fields{
+		e.getLogger().WithFields(logrus.Fields{
 			logfields.EndpointState + ".from": fromState,
 			logfields.EndpointState + ".to":   toState,
 			"file": fileName,
@@ -2393,12 +2393,12 @@ func (e *Endpoint) runLabelsResolver(owner Owner, myChangeRev int) {
 		// If a labels update and an endpoint delete API request arrive
 		// in quick succession, this could occur; in that case, there's
 		// no point updating the controller.
-		e.Logger().WithError(err).Info("Cannot run labels resolver")
+		e.getLogger().WithError(err).Info("Cannot run labels resolver")
 		return
 	}
 	newLabels := e.OpLabels.IdentityLabels()
 	e.RUnlock()
-	scopedLog := e.Logger().WithField(logfields.IdentityLabels, newLabels)
+	scopedLog := e.getLogger().WithField(logfields.IdentityLabels, newLabels)
 
 	// If we are certain we can resolve the identity without accessing the KV
 	// store, do it first synchronously right now. This can reduce the number
@@ -2427,7 +2427,7 @@ func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
 		return err
 	}
 	newLabels := e.OpLabels.IdentityLabels()
-	elog := e.Logger().WithFields(logrus.Fields{
+	elog := e.getLogger().WithFields(logrus.Fields{
 		logfields.EndpointID:     e.ID,
 		logfields.IdentityLabels: newLabels,
 	})
@@ -2589,7 +2589,7 @@ func (e *Endpoint) IPs() []net.IP {
 // InsertEvent is called when the endpoint is inserted into the endpoint
 // manager.
 func (e *Endpoint) InsertEvent() {
-	e.Logger().Info("New endpoint")
+	e.getLogger().Info("New endpoint")
 }
 
 // syncPolicyMap attempts to synchronize the PolicyMap for this endpoint to
@@ -2620,14 +2620,14 @@ func (e *Endpoint) syncPolicyMap() error {
 	// If map is unable to be dumped, attempt to close map and open it again.
 	// See GH-4229.
 	if err != nil {
-		e.Logger().WithError(err).Error("unable to dump PolicyMap when trying to sync desired and realized PolicyMap state")
+		e.getLogger().WithError(err).Error("unable to dump PolicyMap when trying to sync desired and realized PolicyMap state")
 
 		// Close to avoid leaking of file descriptors, but still continue in case
 		// Close() does not succeed, because otherwise the map will never be
 		// opened again unless the agent is restarted.
 		err := e.PolicyMap.Close()
 		if err != nil {
-			e.Logger().WithError(err).Error("unable to close PolicyMap which was not able to be dumped")
+			e.getLogger().WithError(err).Error("unable to close PolicyMap which was not able to be dumped")
 		}
 
 		e.PolicyMap, _, err = policymap.OpenMap(e.PolicyMapPathLocked())
@@ -2654,7 +2654,7 @@ func (e *Endpoint) syncPolicyMap() error {
 			// converted to network byte-order.
 			err := e.PolicyMap.DeleteKey(keyHostOrder)
 			if err != nil {
-				e.Logger().WithError(err).Errorf("Failed to delete PolicyMap key %s", entry.Key.String())
+				e.getLogger().WithError(err).Errorf("Failed to delete PolicyMap key %s", entry.Key.String())
 				errors = append(errors, err)
 			} else {
 				// Operation was successful, remove from realized state.
@@ -2667,7 +2667,7 @@ func (e *Endpoint) syncPolicyMap() error {
 		if oldEntry, ok := e.realizedMapState[keyToAdd]; !ok || oldEntry != entry {
 			err := e.PolicyMap.AllowKey(keyToAdd, entry.ProxyPort)
 			if err != nil {
-				e.Logger().WithError(err).Errorf("Failed to add PolicyMap key %s %d", keyToAdd.String(), entry.ProxyPort)
+				e.getLogger().WithError(err).Errorf("Failed to add PolicyMap key %s %d", keyToAdd.String(), entry.ProxyPort)
 				errors = append(errors, err)
 			} else {
 				// Operation was successful, add to realized state.

--- a/pkg/endpoint/lock.go
+++ b/pkg/endpoint/lock.go
@@ -62,5 +62,5 @@ func (e *Endpoint) UnconditionalRLock() {
 
 // LogDisconnectedMutexAction gets the logger and logs given error with context
 func (e *Endpoint) LogDisconnectedMutexAction(err error, context string) {
-	e.Logger().WithError(err).Error(context)
+	e.getLogger().WithError(err).Error(context)
 }

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -30,11 +30,17 @@ var (
 	log       = logging.DefaultLogger.WithField(logfields.LogSubsys, Subsystem)
 )
 
-// Logger returns a logrus object with EndpointID, ContainerID and the Endpoint
+// getLogger returns a logrus object with EndpointID, ContainerID and the Endpoint
 // revision fields.
-func (e *Endpoint) Logger() *logrus.Entry {
+func (e *Endpoint) getLogger() *logrus.Entry {
 	v := atomic.LoadPointer(&e.logger)
 	return (*logrus.Entry)(v)
+}
+
+// Logger returns a logrus object with EndpointID, ContainerID and the Endpoint
+// revision fields. The caller must specify their subsystem.
+func (e *Endpoint) Logger(subsystem string) *logrus.Entry {
+	return e.getLogger().WithField(logfields.LogSubsys, subsystem)
 }
 
 // UpdateLogger creates a logger instance specific to this endpoint. It will

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -25,7 +25,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "endpoint")
+var (
+	Subsystem = "endpoint"
+	log       = logging.DefaultLogger.WithField(logfields.LogSubsys, Subsystem)
+)
 
 // Logger returns a logrus object with EndpointID, ContainerID and the Endpoint
 // revision fields.
@@ -76,6 +79,7 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 	// When adding new fields, make sure they are abstracted by a setter
 	// and update the logger when the value is set.
 	l := baseLogger.WithFields(logrus.Fields{
+		logfields.LogSubsys:              Subsystem,
 		logfields.EndpointID:             e.ID,
 		logfields.ContainerID:            e.getShortContainerID(),
 		logfields.DatapathPolicyRevision: e.policyRevision,

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -336,11 +336,11 @@ func (e *Endpoint) computeDesiredL3PolicyMapEntries(repo *policy.Repository, des
 	egressPolicyEnabled := e.egressPolicyEnabled
 
 	if !ingressPolicyEnabled {
-		e.Logger().Debug("ingress policy is disabled, which equates to allow-all; allowing all identities")
+		e.getLogger().Debug("ingress policy is disabled, which equates to allow-all; allowing all identities")
 	}
 
 	if !egressPolicyEnabled {
-		e.Logger().Debug("egress policy is disabled, which equates to allow-all; allowing all identities")
+		e.getLogger().Debug("egress policy is disabled, which equates to allow-all; allowing all identities")
 	}
 
 	// Only L3 (label-based) policy apply.
@@ -407,7 +407,7 @@ func (e *Endpoint) regenerateL3Policy(repo *policy.Repository) (bool, error) {
 
 	if valid {
 		if reflect.DeepEqual(e.L3Policy, newL3policy) {
-			e.Logger().Debug("No change in CIDR policy")
+			e.getLogger().Debug("No change in CIDR policy")
 			return false, nil
 		}
 		e.L3Policy = newL3policy
@@ -441,7 +441,7 @@ func (e *Endpoint) updateNetworkPolicy(owner Owner, proxyWaitGroup *completion.W
 	deniedIngressIdentities := make(map[identityPkg.NumericIdentity]bool)
 	for srcID, srcLabels := range *e.prevIdentityCache {
 		ctx.From = srcLabels
-		e.Logger().WithFields(logrus.Fields{
+		e.getLogger().WithFields(logrus.Fields{
 			logfields.PolicyID: srcID,
 			"ctx":              ctx,
 		}).Debug("Evaluating context for source PolicyID")
@@ -460,7 +460,7 @@ func (e *Endpoint) updateNetworkPolicy(owner Owner, proxyWaitGroup *completion.W
 	deniedEgressIdentities := make(map[identityPkg.NumericIdentity]bool)
 	for dstID, dstLabels := range *e.prevIdentityCache {
 		ctx.To = dstLabels
-		e.Logger().WithFields(logrus.Fields{
+		e.getLogger().WithFields(logrus.Fields{
 			logfields.PolicyID: dstID,
 			"ctx":              ctx,
 		}).Debug("Evaluating context for destination PolicyID")
@@ -508,11 +508,11 @@ func (e *Endpoint) regeneratePolicy(owner Owner) error {
 
 	// No point in calculating policy if endpoint does not have an identity yet.
 	if e.SecurityIdentity == nil {
-		e.Logger().Warn("Endpoint lacks identity, skipping policy calculation")
+		e.getLogger().Warn("Endpoint lacks identity, skipping policy calculation")
 		return nil
 	}
 
-	e.Logger().Debug("Starting policy recalculation...")
+	e.getLogger().Debug("Starting policy recalculation...")
 
 	// Collect label arrays before policy computation, as this can fail.
 	// GH-1128 should allow optimizing this away, but currently we can't
@@ -520,7 +520,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner) error {
 	// through it each time.
 	labelsMap, err := getLabelsMap()
 	if err != nil {
-		e.Logger().WithError(err).Debug("Received error while evaluating policy")
+		e.getLogger().WithError(err).Debug("Received error while evaluating policy")
 		return err
 	}
 
@@ -542,7 +542,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner) error {
 	if !e.forcePolicyCompute && e.nextPolicyRevision >= revision &&
 		labelsMap == e.prevIdentityCache {
 
-		e.Logger().WithFields(logrus.Fields{
+		e.getLogger().WithFields(logrus.Fields{
 			"policyRevision.next": e.nextPolicyRevision,
 			"policyRevision.repo": revision,
 			"policyChanged":       e.nextPolicyRevision > e.policyRevision,
@@ -567,7 +567,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner) error {
 	}
 
 	if l4PolicyChanged {
-		e.Logger().WithField(logfields.Identity, e.SecurityIdentity.ID).Debug("L4 policy changed")
+		e.getLogger().WithField(logfields.Identity, e.SecurityIdentity.ID).Debug("L4 policy changed")
 	}
 
 	// Calculate L3 (CIDR) policy.
@@ -576,7 +576,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner) error {
 		return err
 	}
 	if l3PolicyChanged {
-		e.Logger().Debug("regeneration of L3 (CIDR) policy caused policy change")
+		e.getLogger().Debug("regeneration of L3 (CIDR) policy caused policy change")
 	}
 
 	// no failures after this point
@@ -586,7 +586,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner) error {
 	if e.forcePolicyCompute {
 		forceRegeneration = true     // Options were changed by the caller.
 		e.forcePolicyCompute = false // Policies just computed
-		e.Logger().Debug("Forced policy recalculation")
+		e.getLogger().Debug("Forced policy recalculation")
 	}
 
 	// Set the revision of this endpoint to the current revision of the policy
@@ -598,7 +598,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner) error {
 	// the regeneration of the endpoint to complete.
 	policyChanged := l3PolicyChanged || l4PolicyChanged
 
-	e.Logger().WithFields(logrus.Fields{
+	e.getLogger().WithFields(logrus.Fields{
 		"policyChanged":                  policyChanged,
 		"forcedRegeneration":             forceRegeneration,
 		logfields.PolicyRegenerationTime: time.Since(regenerateStart).String(),
@@ -675,7 +675,7 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 	stats := &context.Stats
 	metrics.EndpointCountRegenerating.Inc()
 	stats.totalTime.Start()
-	e.Logger().WithFields(logrus.Fields{
+	e.getLogger().WithFields(logrus.Fields{
 		logfields.StartTime: time.Now(),
 		logfields.Reason:    context.Reason,
 	}).Info("Regenerating endpoint")
@@ -690,7 +690,7 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 		e.RUnlock()
 		stats.SendMetrics()
 
-		scopedLog := e.Logger().WithFields(logrus.Fields{
+		scopedLog := e.getLogger().WithFields(logrus.Fields{
 			"waitingForLock":         stats.waitingForLock.Total(),
 			"waitingForCTClean":      stats.waitingForCTClean.Total(),
 			"policyCalculation":      stats.policyCalculation.Total(),
@@ -730,7 +730,7 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 	// GH-5350: Remove this special case to require checking for StateWaitingForIdentity
 	if e.GetStateLocked() != StateWaitingForIdentity &&
 		!e.BuilderSetStateLocked(StateRegenerating, "Regenerating endpoint: "+context.Reason) {
-		e.Logger().WithField(logfields.EndpointState, e.state).Debug("Skipping build due to invalid state")
+		e.getLogger().WithField(logfields.EndpointState, e.state).Debug("Skipping build due to invalid state")
 		e.Unlock()
 
 		return fmt.Errorf("Skipping build due to invalid state: %s", e.state)
@@ -772,7 +772,7 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 	revision, compilationExecuted, err = e.regenerateBPF(owner, origDir, tmpDir, context)
 	if err != nil {
 		failDir := e.FailedDirectoryPath()
-		e.Logger().WithFields(logrus.Fields{
+		e.getLogger().WithFields(logrus.Fields{
 			logfields.Path: failDir,
 		}).Warn("generating BPF for endpoint failed, keeping stale directory.")
 		os.Rename(tmpDir, failDir)
@@ -833,7 +833,7 @@ func (e *Endpoint) Regenerate(owner Owner, context *RegenerationContext) <-chan 
 			return
 		}
 		e.RUnlock()
-		scopedLog := e.Logger()
+		scopedLog := e.getLogger()
 
 		// We should only queue the request after we use all the endpoint's
 		// lock/unlock. Otherwise this can get a deadlock if the endpoint is
@@ -999,7 +999,7 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity) {
 	e.runIPIdentitySync(e.IPv4)
 	e.runIPIdentitySync(e.IPv6)
 
-	e.Logger().WithFields(logrus.Fields{
+	e.getLogger().WithFields(logrus.Fields{
 		logfields.Identity:       identity.StringID(),
 		logfields.OldIdentity:    oldIdentity,
 		logfields.IdentityLabels: identity.Labels.String(),

--- a/pkg/proxy/kafka.go
+++ b/pkg/proxy/kafka.go
@@ -419,7 +419,9 @@ func (k *kafkaRedirect) handleRequestConnection(pair *connectionPair) {
 		time.Sleep(proxyConnectionCloseTimeout + time.Second)
 
 		if err := k.redirect.removeProxyMapEntryOnClose(pair.Rx.conn); err != nil {
-			log.WithError(err).Warning("Unable to remove proxymap entry after closing connection")
+			log.WithError(err).WithFields(logrus.Fields{
+				"from": pair.Rx,
+			}).Warning("Unable to remove proxymap entry after closing connection")
 		}
 	}
 }


### PR DESCRIPTION
Quieten and improve some warning/error messages. For more details, see individual commit logs.

The final commit, `endpoint: Only scrub CT when map already exists` is a little more than a logging change but the focus is the same. That commit may need a bit more attention.

Fixes: #5516 
Fixes: #5677
Fixes: #5679

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5680)
<!-- Reviewable:end -->
