### PR TITLE
proxylib: Recover from datapath panics, accesslog them as drops

### DIFF
--- a/proxylib/proxylib/connection.go
+++ b/proxylib/proxylib/connection.go
@@ -53,9 +53,10 @@ type Connection struct {
 	PolicyName string    // Identifies which policy instance applies to this connection
 	Port       uint32    // (original) destination port number in numeric format
 
-	Parser   Parser    // Parser instance used on this connection
-	OrigBuf  InjectBuf // Buffer for injected frames in original direction
-	ReplyBuf InjectBuf // Buffer for injected frames in reply direction
+	ParserName string    // Name of the parser
+	Parser     Parser    // Parser instance used on this connection
+	OrigBuf    InjectBuf // Buffer for injected frames in original direction
+	ReplyBuf   InjectBuf // Buffer for injected frames in reply direction
 }
 
 func (connection *Connection) Matches(l7 interface{}) bool {

--- a/proxylib/testhelpers.go
+++ b/proxylib/testhelpers.go
@@ -45,7 +45,7 @@ func checkConnectionCount(t *testing.T, expConns int) {
 	}
 }
 
-func checkConnections(t *testing.T, expected, res Result, expConns int) {
+func checkConnections(t *testing.T, res, expected Result, expConns int) {
 	t.Helper()
 	if res != expected {
 		t.Errorf("OnNewConnection(): Invalid result, have %s, expected %s", res.String(), expected.String())
@@ -135,7 +135,7 @@ func CheckOnData(t *testing.T, connectionId uint64, reply, endStream bool, data 
 		t.Errorf("OnData(): Connection %d not found!", connectionId)
 	}
 
-	ops := make([]C.FilterOp, 0, len(expOps)*2)
+	ops := make([]C.FilterOp, 0, 1+len(expOps)*2)
 
 	res := Result(OnData(connectionId, reply, endStream, data, &ops))
 


### PR DESCRIPTION
So far parser panics have crashed the whole proxy, which leads to
cilium restarting the proxy. Diagnozing the misbehavior has so far
required debug-verbose logging on the flow level, This has made
diagnozing parser bugs unreasonably hard. Besides, flow-level debug
logging is very verbose and not practical in long-run testing
environments.

This commit adds a deferred recover to the proxylib OnData method
which accesslogs revocered panics as drops with the error detail in
"status" field, which is also shown in the cilium monitor, making any
panics easily visible without requiring detailed logging levels. The
OnData() return code is also changed to parser error, which cases the
datapath to close the TCP connection.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5685)
<!-- Reviewable:end -->
