### PR TITLE
daemon: always dump IPAM pool information

### DIFF
--- a/daemon/ipam.go
+++ b/daemon/ipam.go
@@ -89,7 +89,7 @@ func (h *deleteIPAMIP) Handle(params ipamapi.DeleteIPAMIPParams) middleware.Resp
 	return ipamapi.NewDeleteIPAMIPOK()
 }
 
-// DumpIPAM dumps in the form of a map, and only if debug is enabled, the list of
+// DumpIPAM dumps in the form of a map, the list of
 // reserved IPv4 and IPv6 addresses.
 func (d *Daemon) DumpIPAM() *models.IPAMStatus {
 	allocv4, allocv6 := ipam.Dump()

--- a/daemon/status.go
+++ b/daemon/status.go
@@ -157,10 +157,7 @@ func (d *Daemon) getStatus() models.StatusResponse {
 		sr.Cilium = &models.Status{State: models.StatusStateOk, Msg: "OK"}
 	}
 
-	if d.DebugEnabled() {
-		sr.IPAM = d.DumpIPAM()
-	}
-
+	sr.IPAM = d.DumpIPAM()
 	sr.NodeMonitor = d.nodeMonitor.State()
 
 	sr.Cluster = d.getNodeStatus()


### PR DESCRIPTION
Previously, having debug mode enabled to dump IPAM information was required.
Drop this requirement and always dump IPAM information when users query for
`cilium status`.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #5630 

Note: I trawled through past code iterations to figure out why we were only dumping this when debug mode was enabled, but there was no explanation anywhere as to why. It could be that this is quite a costly operation (dumping IPAM does require holding the IPAM allocator mutex for reading). This isn't really a 'bug' per se, so I'm open to closing this. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5687)
<!-- Reviewable:end -->
