### PR TITLE
Fix issue where datapath object files disappear from the filesystem

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -564,6 +564,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 			e.getLogger().WithError(err).
 				WithField(logfields.BPFCompilationTime, stats.bpfCompilation.Total().String()).
 				Info("Recompiled endpoint BPF program")
+			compilationExecuted = true
 		} else {
 			err = loader.ReloadDatapath(ctx, epInfoCache)
 			e.getLogger().WithError(err).Info("Reloaded endpoint BPF program")
@@ -574,7 +575,6 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 		if err != nil {
 			return epInfoCache.revision, compilationExecuted, err
 		}
-		compilationExecuted = true
 		e.bpfHeaderfileHash = bpfHeaderfilesHash
 	} else {
 		e.getLogger().WithField(logfields.BPFHeaderfileHash, bpfHeaderfilesHash).


### PR DESCRIPTION
When performing a simple reload of the datapath logic, don't set
`compilationExecuted`, as that setting is used to govern whether the
endpoint state directories get swapped from the `xxx_next` directory to
the `xxx` directory. Since `ReloadDatapath()` doesn't populate the object
file in the `xxx_next` directory, this leads to a situation where no
pre-compiled datapath object file is available, and if another
subsequent `ReloadDatapath()` occurs after this, it fails and puts the
endpoint into the `not-ready` state.

This only affects master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5689)
<!-- Reviewable:end -->
