### PR TITLE
v1.2-Backports-18-09-25

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -856,11 +856,6 @@ func (d *Daemon) init() error {
 			return err
 		}
 
-		// Clean all endpoint entries
-		if err := lxcmap.LXCMap.DeleteAll(); err != nil {
-			return err
-		}
-
 		// Set up the list of IPCache listeners in the daemon, to be
 		// used by syncLXCMap().
 		ipcache.IPIdentityCache.SetListeners([]ipcache.IPIdentityMappingListener{
@@ -935,6 +930,10 @@ func (d *Daemon) init() error {
 					return err
 				}
 			}
+
+			// If we are not restoring state, all endpoints can be
+			// deleted. Entries will be re-populated.
+			lxcmap.LXCMap.DeleteAll()
 		}
 	}
 
@@ -1025,7 +1024,6 @@ func createNodeConfigHeaderfile() error {
 func (d *Daemon) syncLXCMap() error {
 	// TODO: Update addresses first, in case node addressing has changed.
 	// TODO: Once these start changing on runtime, figure out the locking strategy.
-	// TODO: Delete stale host entries from the lxcmap.
 	specialIdentities := []identity.IPIdentityPair{
 		{
 			IP: node.GetInternalIPv4(),
@@ -1065,6 +1063,11 @@ func (d *Daemon) syncLXCMap() error {
 		},
 	}
 
+	existingEndpoints, err := lxcmap.DumpToMap()
+	if err != nil {
+		return err
+	}
+
 	for _, ipIDPair := range specialIdentities {
 		isHost := ipIDPair.ID == identity.ReservedIdentityHost
 		if isHost {
@@ -1076,6 +1079,9 @@ func (d *Daemon) syncLXCMap() error {
 				log.WithField(logfields.IPAddr, ipIDPair.IP).Debugf("Added local ip to endpoint map")
 			}
 		}
+
+		delete(existingEndpoints, ipIDPair.IP.String())
+
 		// Upsert will not propagate (reserved:foo->ID) mappings across the cluster,
 		// and we specifically don't want to do so.
 		ipcache.IPIdentityCache.Upsert(ipIDPair.PrefixString(), nil, ipcache.Identity{
@@ -1083,6 +1089,17 @@ func (d *Daemon) syncLXCMap() error {
 			Source: ipcache.FromAgentLocal,
 		})
 	}
+
+	for hostIP, info := range existingEndpoints {
+		if ip := net.ParseIP(hostIP); info.IsHost() && ip != nil {
+			if err := lxcmap.DeleteEntry(ip); err != nil {
+				log.WithError(err).Warn("Unable to delete obsolete host IP from BPF map")
+			} else {
+				log.Debugf("Removed outdated host ip %s from endpoint map", hostIP)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -136,6 +136,11 @@ func NewEndpointKey(ip net.IP) *EndpointKey {
 	}
 }
 
+// IsHost returns true if the EndpointInfo represents a host IP
+func (v *EndpointInfo) IsHost() bool {
+	return v.Flags&EndpointFlagHost != 0
+}
+
 // String returns the human readable representation of an EndpointInfo
 func (v *EndpointInfo) String() string {
 	if v.Flags&EndpointFlagHost != 0 {
@@ -206,4 +211,22 @@ func DeleteElement(f EndpointFrontend) []error {
 	}
 
 	return errors
+}
+
+// DumpToMap dumps the contents of the lxcmap into a map and returns it
+func DumpToMap() (map[string]*EndpointInfo, error) {
+	m := map[string]*EndpointInfo{}
+	callback := func(key bpf.MapKey, value bpf.MapValue) {
+		if info, ok := value.(*EndpointInfo); ok {
+			if endpointKey, ok := key.(*EndpointKey); ok {
+				m[endpointKey.IP.String()] = info
+			}
+		}
+	}
+
+	if err := LXCMap.DumpWithCallback(callback); err != nil {
+		return m, fmt.Errorf("unable to read BPF endpoint list: %s", err)
+	}
+
+	return m, nil
 }


### PR DESCRIPTION
Backported PR:

https://github.com/cilium/cilium/pull/5663

---

[ upstream commit 4ecf111c35f047f490f5cc8858d23c15e342541f ]

Due to deleting and repopulating the BPF endpoint map on startup. Cilium agent
restarts would introduce a race window of a couple of seconds [0] in which
local endpoints would not be reachable. This would result in packet drops or
depending on the routing path, a routing loop which eventually leads to a drop
followed by a ICMP TTL exceeded.

[0] The race window for host IPs was in the microseconds range. The race
window for endpoints depended on the number of local endpoints and etcd
latency as the endpoint would reappear as it was regenerated on restore.

Fixes: #5651

Signed-off-by: Thomas Graf <thomas@cilium.io>
Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5690)
<!-- Reviewable:end -->
