### PR TITLE
Test: Fix kubetcl patch installation issue.

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -800,8 +800,8 @@ func (kub *Kubectl) ciliumInstall(dsPatchName, cmPatchName string, getK8sDescrip
 		}
 
 		res = kub.Exec(fmt.Sprintf(
-			`%s patch --filename='%s' --patch "$(cat '%s')" --local -o yaml | kubectl apply -f -`,
-			KubectlCmd, original, patch))
+			`%s patch --filename='%s' --patch "$(cat '%s')" --local -o yaml | kubectl apply -n %s -f -`,
+			KubectlCmd, original, patch, KubeSystemNamespace))
 		if !res.WasSuccessful() {
 			debugYaml(original, patch)
 			return res.GetErr("Cilium manifest patch instalation failed")


### PR DESCRIPTION
When debugging the issue on update to Kubernetes 1.12 PR #5484 I found
that cilium does not started because the config-map and the daemon set
was installed on default namespace instead of `kube-system`

Issue:

```
vagrant@k8s1:~$ kubectl version
Client Version: version.Info{Major:"1", Minor:"12+", GitVersion:"v1.12.0-rc.2", GitCommit:"5a80e28431c7469d677c5b17277266d1da4e5c8d", GitTreeState:"clean", BuildDate:"2018-09-21T22:03:03Z", GoVersion:"go1.10.4", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"12+", GitVersion:"v1.12.0-rc.2", GitCommit:"5a80e28431c7469d677c5b17277266d1da4e5c8d", GitTreeState:"clean", BuildDate:"2018-09-21T21:52:36Z", GoVersion:"go1.10.4", Compiler:"gc", Platform:"linux/amd64"}
vagrant@k8s1:~$
vagrant@k8s1:~$ kubectl patch --filename='/home/vagrant/go/src/github.com/cilium/cilium/examples/kubernetes/1.12/cilium-ds.yaml' --patch "$(cat '/home/vagrant/go/src/github.com/cilium/cilium/test/k8sT/manifests/cilium-ds-patch.yaml')" --local -o yaml | head -n 10
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: cilium
spec:
  selector:
    matchLabels:
      k8s-app: cilium
      kubernetes.io/cluster-service: "true"
  template:
vagrant@k8s1:~$
```

This patch make sure that the Cilium daemon set and the config map is
installed on `kube-system` namespace.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5701)
<!-- Reviewable:end -->
