### PR TITLE
k8s: Make Cilium aware of well known deployments such as kube-dns and etcd-operator

### DIFF
--- a/Documentation/kubernetes/install/eks.rst
+++ b/Documentation/kubernetes/install/eks.rst
@@ -54,21 +54,12 @@ Create EKS Cluster
 
        kubectl -n kube-system set env ds aws-node AWS_VPC_K8S_CNI_EXTERNALSNAT=true
 
-#. Assign a fixed security identity to ``kube-dns`` by  adding the label ``io.cilium.fixed-identity: kube-dns``
+#. Restart kube-dns to ensure that it is being managed by Cilium.
 
    .. code:: bash
 
-       # if using kube-dns
-       kubectl patch -n kube-system deployment/kube-dns --type merge -p '{"spec":{"template":{"metadata":{"labels":{"io.cilium.fixed-identity":"kube-dns"}}}}}'
+       kubectl -n kube-system delete pod -l k8s-app=kube-dns
        
-       # if using coredns
-       kubectl patch -n kube-system deployment/coredns --type merge -p '{"spec":{"template":{"metadata":{"labels":{"io.cilium.fixed-identity":"kube-dns"}}}}}'
-
-   This step allows Cilium to bring up ``kube-dns`` networking and enforce
-   security policies before etcd is up. (Note: By default, kubernetes keeps the old ReplicaSet 
-   but those sets are not running. When the deployment is deleted all ReplicaSets will be cleaned up 
-   and they are not left in the users's cluster.)
-
 Prepare etcd operator
 =====================
 

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -996,3 +996,20 @@ resources.
 
         .. literalinclude:: ../../examples/policies/kubernetes/serviceaccount/serviceaccount-policy.json
 
+Well-known Identities
+---------------------
+
+The following is a list of well known identities which Cilium is aware of
+automatically and will hand out a security identity without requiring to
+contact any external dependencies. The purpose of this is to allow
+bootstrapping Cilium and enable network connectivity with policy enforcement in
+the cluster for essential services without depending on any dependencies.
+
+======================== ============ ============== =========== ================================================================
+Deployment               Namespace    ServiceAccount Numeric ID  Labels
+======================== ============ ============== =========== ================================================================
+etcd-operator            kube-system  default        100         ``io.cilium/app=etcd-operator``
+cilium-etcd              kube-system  default        101         ``app=etcd``, ``etcd_cluster=cilium-etcd``, ``io.cilium/app=etcd-operator``
+kube-dns                 kube-system  kube-dns       102         ``k8s-app=kube-dns``
+kube-dns (EKS)           kube-system  default        103         ``k8s-app=kube-dns``, ``eks.amazonaws.com/component=kube-dns``
+======================== ============ ============== =========== ================================================================

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -332,7 +332,6 @@ function write_cilium_cfg() {
     fi
 
     cilium_options+=" --access-log=/var/log/cilium-access.log"
-    cilium_options+=" --fixed-identity-mapping=128=kv-store --fixed-identity-mapping=129=kube-dns"
 
 cat <<EOF >> "$filename"
 sleep 2s

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -206,8 +206,8 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) {
 			}
 			// Wait for initial identities from the kvstore before
 			// doing any policy calculation for endpoints that don't have
-			// a fixed identity.
-			if !identity.IsFixed() {
+			// a fixed identity or are not well known.
+			if !identity.IsFixed() && !identity.IsWellKnown() {
 				identityPkg.WaitForInitialIdentities()
 			}
 

--- a/examples/kubernetes/addons/etcd-operator/README.md
+++ b/examples/kubernetes/addons/etcd-operator/README.md
@@ -51,18 +51,11 @@ in the Kubernetes cluster, this can be achieved by running:
 tls/deploy-certs.sh
 ```
 
-Deploy kube-dns and make sure it contains the required label
-------------------------------------------------------------
+Restart kube-dns/coredn to ensure it is managed by Cilium
+--------------------------------------------------
 
-Ensure your DNS service is running and contains the label `io.cilium.fixed-identity=kube-dns` using the following command.
-
-# if using kube-dns
 ```
-kubectl patch -n kube-system deployment/kube-dns --type merge -p '{"spec":{"template":{"metadata":{"labels":{"io.cilium.fixed-identity":"kube-dns"}}}}}'
-```
-# if using coredns
-```
-kubectl patch -n kube-system deployment/coredns --type merge -p '{"spec":{"template":{"metadata":{"labels":{"io.cilium.fixed-identity":"kube-dns"}}}}}'
+kubectl -n kube-system delete pod -l k8s-app=kube-dns
 ```
 
 Deploy Kubernetes descriptors for etcd operator as well Cilium

--- a/examples/kubernetes/addons/etcd-operator/cilium-deployment.yaml
+++ b/examples/kubernetes/addons/etcd-operator/cilium-deployment.yaml
@@ -137,8 +137,6 @@ spec:
         - "--kvstore=etcd"
         - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
         - "--disable-ipv4=$(DISABLE_IPV4)"
-        - "--fixed-identity-mapping=128=kv-store"
-        - "--fixed-identity-mapping=129=kube-dns"
         ports:
         - name: prometheus
           containerPort: 9090

--- a/examples/kubernetes/addons/etcd-operator/cilium-etcd-cluster.yaml
+++ b/examples/kubernetes/addons/etcd-operator/cilium-etcd-cluster.yaml
@@ -14,4 +14,4 @@ spec:
       operatorSecret: cilium-etcd-client-tls
   pod:
     labels:
-      "io.cilium.fixed-identity": "kv-store"
+      "io.cilium/app": "etcd-operator"

--- a/examples/kubernetes/addons/etcd-operator/deployment.yaml
+++ b/examples/kubernetes/addons/etcd-operator/deployment.yaml
@@ -8,8 +8,7 @@ spec:
   template:
     metadata:
       labels:
-        name: etcd-operator
-        io.cilium.fixed-identity: "kv-store"
+        io.cilium/app: etcd-operator
     spec:
       serviceAccountName: cilium-etcd-sa
       containers:

--- a/examples/kubernetes/addons/etcd-operator/development/cilium-development.yaml
+++ b/examples/kubernetes/addons/etcd-operator/development/cilium-development.yaml
@@ -137,8 +137,6 @@ spec:
         - "--kvstore=etcd"
         - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
         - "--disable-ipv4=$(DISABLE_IPV4)"
-        - "--fixed-identity-mapping=128=kv-store"
-        - "--fixed-identity-mapping=129=kube-dns"
         ports:
         - name: prometheus
           containerPort: 9090

--- a/pkg/identity/allocator.go
+++ b/pkg/identity/allocator.go
@@ -71,6 +71,8 @@ type IdentityAllocatorOwner interface {
 // InitIdentityAllocator creates the the identity allocator. Only the first
 // invocation of this function will have an effect.
 func InitIdentityAllocator(owner IdentityAllocatorOwner) {
+	initWellKnownIdentities()
+
 	setupOnce.Do(func() {
 		log.Info("Initializing identity allocator")
 

--- a/pkg/identity/cache.go
+++ b/pkg/identity/cache.go
@@ -57,6 +57,10 @@ func GetIdentityCache() IdentityCache {
 		}
 	})
 
+	for key, identity := range reservedIdentityCache {
+		cache[key] = identity.Labels.LabelArray()
+	}
+
 	return cache
 }
 
@@ -131,6 +135,10 @@ func LookupIdentity(lbls labels.Labels) *Identity {
 // LookupReservedIdentityByLabels looks up a reserved identity by its labels and
 // returns it if found. Returns nil if not found.
 func LookupReservedIdentityByLabels(lbls labels.Labels) *Identity {
+	if identity := wellKnown.lookupByLabels(lbls); identity != nil {
+		return identity
+	}
+
 	for _, lbl := range lbls {
 		switch {
 		// If the set of labels contain a fixed identity then and exists in

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -118,6 +118,12 @@ func (id *Identity) IsFixed() bool {
 	return LookupReservedIdentity(id.ID) != nil && IsUserReservedIdentity(id.ID)
 }
 
+// IsWellKnown returns whether the identity represents a well known identity
+// (true), or not (false).
+func (id *Identity) IsWellKnown() bool {
+	return wellKnown.lookupByNumericIdentity(id.ID) != nil
+}
+
 // NewIdentity creates a new identity
 func NewIdentity(id NumericIdentity, lbls labels.Labels) *Identity {
 	var lblArray labels.LabelArray

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -145,6 +145,15 @@ func (d dummyOwner) GetNodeSuffix() string {
 	return "foo"
 }
 
+func (ias *IdentityAllocatorSuite) TestGetIdentityCache(c *C) {
+	InitIdentityAllocator(dummyOwner{})
+	defer identityAllocator.DeleteAllKeys()
+
+	cache := GetIdentityCache()
+	_, ok := cache[ReservedCiliumKVStore]
+	c.Assert(ok, Equals, true)
+}
+
 func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 	lbls1 := labels.NewLabelsFromSortedList("id=foo;user=anna;blah=%%//!!")
 	lbls2 := labels.NewLabelsFromSortedList("id=bar;user=anna")

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -16,8 +16,11 @@ package identity
 
 import (
 	"errors"
+	"fmt"
+	"github.com/cilium/cilium/pkg/option"
 	"strconv"
 
+	api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 )
 
@@ -55,7 +58,138 @@ const (
 	// ReservedIdentityInit is the identity given to endpoints that have not
 	// received any labels yet.
 	ReservedIdentityInit
+
+	// --------------------------------------------------------------
+	// Special identities for well-known cluster components
+
+	// ReservedETCDOperator is the reserved identity used for the etcd-operator
+	// managed by Cilium.
+	ReservedETCDOperator NumericIdentity = 100
+
+	// ReservedCiliumKVStore is the reserved identity used for the kvstore
+	// managed by Cilium (etcd-operator).
+	ReservedCiliumKVStore NumericIdentity = 101
+
+	// ReservedKubeDNS is the reserved identity used for kube-dns.
+	ReservedKubeDNS NumericIdentity = 102
+
+	// ReservedEKSKubeDNS is the reserved identity used for kube-dns on EKS
+	ReservedEKSKubeDNS NumericIdentity = 103
+
+	// ReservedEKSCoreDNS is the reserved identity used for CoreDNS
+	ReservedCoreDNS NumericIdentity = 104
 )
+
+type wellKnownIdentities map[NumericIdentity]wellKnownIdentity
+
+// wellKnownIdentitity is an identity for well-known security labels for which
+// a well-known numeric identity is reserved to avoid requiring a cluster wide
+// setup. Examples of this include kube-dns and the etcd-operator.
+type wellKnownIdentity struct {
+	identity   *Identity
+	labelArray labels.LabelArray
+}
+
+func (w wellKnownIdentities) add(i NumericIdentity, lbls []string) {
+	labelMap := labels.NewLabelsFromModel(lbls)
+	identity := NewIdentity(i, labelMap)
+	w[i] = wellKnownIdentity{
+		identity:   NewIdentity(i, labelMap),
+		labelArray: labelMap.LabelArray(),
+	}
+
+	reservedIdentityCache[i] = identity
+}
+
+func (w wellKnownIdentities) lookupByLabels(lbls labels.Labels) *Identity {
+	for _, i := range w {
+		if lbls.Equals(i.identity.Labels) {
+			return i.identity
+		}
+	}
+
+	return nil
+}
+
+func (w wellKnownIdentities) lookupByNumericIdentity(identity NumericIdentity) *Identity {
+	wki, ok := w[identity]
+	if !ok {
+		return nil
+	}
+	return wki.identity
+}
+
+// initWellKnownIdentities establishes all well-known identities
+func initWellKnownIdentities() {
+	// etcd-operator labels
+	//   k8s:io.cilium.k8s.policy.serviceaccount=cilium-etcd-sa
+	//   k8s:io.kubernetes.pod.namespace=kube-system
+	//   k8s:io.cilium/app=etcd-operator
+	//   k8s:io.cilium.k8s.policy.cluster=default
+	wellKnown.add(ReservedETCDOperator, []string{
+		"k8s:io.cilium/app=etcd-operator",
+		fmt.Sprintf("k8s:%s=kube-system", api.PodNamespaceLabel),
+		fmt.Sprintf("k8s:%s=cilium-etcd-sa", api.PolicyLabelServiceAccount),
+		fmt.Sprintf("k8s:%s=%s", api.PolicyLabelCluster, option.Config.ClusterName),
+	})
+
+	// cilium-etcd labels
+	//   k8s:app=etcd
+	//   k8s:io.cilium/app=etcd-operator
+	//   k8s:etcd_cluster=cilium-etcd
+	//   k8s:io.cilium.k8s.policy.serviceaccount=default
+	//   k8s:io.kubernetes.pod.namespace=kube-system
+	//   k8s:io.cilium.k8s.policy.cluster=default
+	// these 2 labels are ignored by cilium-agent as they can change over time
+	//   container:annotation.etcd.version=3.3.9
+	//   k8s:etcd_node=cilium-etcd-6snk6vsjcm
+	wellKnown.add(ReservedCiliumKVStore, []string{
+		"k8s:app=etcd",
+		"k8s:etcd_cluster=cilium-etcd",
+		"k8s:io.cilium/app=etcd-operator",
+		fmt.Sprintf("k8s:%s=kube-system", api.PodNamespaceLabel),
+		fmt.Sprintf("k8s:%s=default", api.PolicyLabelServiceAccount),
+		fmt.Sprintf("k8s:%s=%s", api.PolicyLabelCluster, option.Config.ClusterName),
+	})
+
+	// kube-dns labels
+	//   k8s:io.cilium.k8s.policy.serviceaccount=kube-dns
+	//   k8s:io.kubernetes.pod.namespace=kube-system
+	//   k8s:k8s-app=kube-dns
+	//   k8s:io.cilium.k8s.policy.cluster=default
+	wellKnown.add(ReservedKubeDNS, []string{
+		"k8s:k8s-app=kube-dns",
+		fmt.Sprintf("k8s:%s=kube-system", api.PodNamespaceLabel),
+		fmt.Sprintf("k8s:%s=kube-dns", api.PolicyLabelServiceAccount),
+		fmt.Sprintf("k8s:%s=%s", api.PolicyLabelCluster, option.Config.ClusterName),
+	})
+
+	// kube-dns EKS labels
+	//   k8s:io.cilium.k8s.policy.serviceaccount=kube-dns
+	//   k8s:io.kubernetes.pod.namespace=kube-system
+	//   k8s:k8s-app=kube-dns
+	//   k8s:io.cilium.k8s.policy.cluster=default
+	//   k8s:eks.amazonaws.com/component=kube-dns
+	wellKnown.add(ReservedEKSKubeDNS, []string{
+		"k8s:k8s-app=kube-dns",
+		"k8s:eks.amazonaws.com/component=kube-dns",
+		fmt.Sprintf("k8s:%s=kube-system", api.PodNamespaceLabel),
+		fmt.Sprintf("k8s:%s=default", api.PolicyLabelServiceAccount),
+		fmt.Sprintf("k8s:%s=%s", api.PolicyLabelCluster, option.Config.ClusterName),
+	})
+
+	// CoreDNS labels
+	//   k8s:io.cilium.k8s.policy.serviceaccount=coredns
+	//   k8s:io.kubernetes.pod.namespace=kube-system
+	//   k8s:k8s-app=kube-dns
+	//   k8s:io.cilium.k8s.policy.cluster=default
+	wellKnown.add(ReservedCoreDNS, []string{
+		"k8s:k8s-app=kube-dns",
+		fmt.Sprintf("k8s:%s=kube-system", api.PodNamespaceLabel),
+		fmt.Sprintf("k8s:%s=coredns", api.PolicyLabelServiceAccount),
+		fmt.Sprintf("k8s:%s=%s", api.PolicyLabelCluster, option.Config.ClusterName),
+	})
+}
 
 var (
 	reservedIdentities = map[string]NumericIdentity{
@@ -70,6 +204,8 @@ var (
 		ReservedIdentityHealth: labels.IDNameHealth,
 		ReservedIdentityInit:   labels.IDNameInit,
 	}
+
+	wellKnown = wellKnownIdentities{}
 
 	// ErrNotUserIdentity is an error returned for an identity that is not user
 	// reserved.

--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -169,6 +169,8 @@ func defaultLabelPrefixCfg() *labelPrefixCfg {
 		"!annotation." + k8sConst.CiliumK8sAnnotationPrefix,          // ignore all cilium annotations
 		"!annotation." + k8sConst.CiliumIdentityAnnotationDeprecated, // ignore all cilium annotations
 		"!annotation.sidecar.istio.io",                               // ignore all istio sidecar annotation labels
+		"!annotation.etcd.version",                                   // ignore all etcd.version annotations
+		"!etcd_node",                                                 // ignore etcd_node label
 	}
 
 	for _, e := range expressions {

--- a/test/k8sT/manifests/cilium-ds-patch-auto-routing.yaml
+++ b/test/k8sT/manifests/cilium-ds-patch-auto-routing.yaml
@@ -16,8 +16,6 @@ spec:
         - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
         - "--disable-ipv4=$(DISABLE_IPV4)"
         - "--log-system-load"
-        - "--fixed-identity-mapping=128=kv-store"
-        - "--fixed-identity-mapping=129=kube-dns"
       volumes:
       - name: etcd-secrets
         secret:

--- a/test/k8sT/manifests/cilium-ds-patch-geneve.yaml
+++ b/test/k8sT/manifests/cilium-ds-patch-geneve.yaml
@@ -17,8 +17,6 @@ spec:
         - "--k8s-require-ipv4-pod-cidr"
         - "--pprof=true"
         - "--log-system-load"
-        - "--fixed-identity-mapping=128=kv-store"
-        - "--fixed-identity-mapping=129=kube-dns"
       volumes:
       - name: etcd-secrets
         secret:

--- a/test/k8sT/manifests/cilium-ds-patch.yaml
+++ b/test/k8sT/manifests/cilium-ds-patch.yaml
@@ -17,8 +17,6 @@ spec:
         - "--k8s-require-ipv4-pod-cidr"
         - "--pprof=true"
         - "--log-system-load"
-        - "--fixed-identity-mapping=128=kv-store"
-        - "--fixed-identity-mapping=129=kube-dns"
       volumes:
       - name: etcd-secrets
         secret:

--- a/test/k8sT/manifests/v1.2/cilium-ds-patch.yaml
+++ b/test/k8sT/manifests/v1.2/cilium-ds-patch.yaml
@@ -17,8 +17,6 @@ spec:
         - "--k8s-require-ipv4-pod-cidr"
         - "--pprof=true"
         - "--log-system-load"
-        - "--fixed-identity-mapping=128=kv-store"
-        - "--fixed-identity-mapping=129=kube-dns"
       volumes:
       - name: etcd-secrets
         secret:

--- a/test/provision/manifest/1.12/coredns_deployment.yaml
+++ b/test/provision/manifest/1.12/coredns_deployment.yaml
@@ -83,7 +83,6 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "CoreDNS"
-    io.cilium.fixed-identity: kube-dns
 spec:
   # replicas: not specified here:
   # 1. In order to make Addon Manager do not reconcile this replicas parameter.
@@ -96,12 +95,10 @@ spec:
   selector:
     matchLabels:
       k8s-app: kube-dns
-      io.cilium.fixed-identity: kube-dns
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        io.cilium.fixed-identity: kube-dns
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:

--- a/test/provision/manifest/coredns_deployment.yaml
+++ b/test/provision/manifest/coredns_deployment.yaml
@@ -9,7 +9,6 @@ metadata:
   generation: 1
   labels:
     k8s-app: kube-dns
-    io.cilium.fixed-identity: kube-dns
   name: coredns
   namespace: kube-system
 spec:
@@ -19,7 +18,6 @@ spec:
   selector:
     matchLabels:
       k8s-app: kube-dns
-      io.cilium.fixed-identity: kube-dns
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -30,7 +28,6 @@ spec:
       creationTimestamp: null
       labels:
         k8s-app: kube-dns
-        io.cilium.fixed-identity: kube-dns
     spec:
       containers:
       - args:

--- a/test/provision/manifest/kubedns_deployment.yaml
+++ b/test/provision/manifest/kubedns_deployment.yaml
@@ -11,7 +11,6 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "KubeDNS"
-    io.cilium.fixed-identity: kube-dns
 spec:
   selector:
     k8s-app: kube-dns
@@ -32,7 +31,6 @@ metadata:
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    io.cilium.fixed-identity: kube-dns
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -48,7 +46,6 @@ metadata:
   generation: 1
   labels:
     k8s-app: kube-dns
-    io.cilium.fixed-identity: kube-dns
   name: kube-dns
   namespace: kube-system
 spec:
@@ -56,7 +53,6 @@ spec:
   selector:
     matchLabels:
       k8s-app: kube-dns
-      io.cilium.fixed-identity: kube-dns
   strategy:
     rollingUpdate:
       maxSurge: 10%
@@ -67,7 +63,6 @@ spec:
       creationTimestamp: null
       labels:
         k8s-app: kube-dns
-        io.cilium.fixed-identity: kube-dns
     spec:
       affinity:
         nodeAffinity:


### PR DESCRIPTION
Make Cilium aware of kube-dns and the etcd-operator used for managed Kubernetes instead of requiring the user to assign fixed identities. This guarantees that existing label based kube-dns network policies continue working even in this new deployment mode. Previously, kube-dns would change its security relevant labels to `reserved:kube-dns`

Fixes: #5529

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5702)
<!-- Reviewable:end -->
