### PR TITLE
daemon: do not return error if v1.Node does not have CiliumHostIP annotation

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -2166,6 +2166,13 @@ func (d *Daemon) updateK8sNodeTunneling(k8sNodeOld, k8sNodeNew *v1.Node) error {
 		}
 
 		ciliumIPStr := k8sNode.GetAnnotations()[annotation.CiliumHostIP]
+		if ciliumIPStr == "" {
+			// Don't return an error here, as the node may not have been
+			// annotated yet by the Cilium agent on it. If the node is annotated
+			// later, we will receive an event via the K8s watcher.
+			log.Infof("not updating ipcache entry for node %s because it does not have the CiliumHostIP annotation yet", k8sNode.Name)
+			return "", nil, nil
+		}
 		ciliumIP := net.ParseIP(ciliumIPStr)
 		if ciliumIP == nil {
 			return "", nil, fmt.Errorf("no/invalid Cilium-Host IP for host %s: %s", hostIP, ciliumIPStr)


### PR DESCRIPTION
Previously, when we received an event from the Kubernetes watcher code for a
v1.Node event, we logged the following if the node did not have the CiliumHostIP
annotation:

```
no/invalid Cilium-Host IP for host
```

This confused users, as it implied that there was something wrong in Cilium.
However, this just means that the v1.Node has not been annotated yet by the
Cilium agent which is on said node. When the node is updated, we will receive
the event from Kubernetes and will be able to plumb the Cilium host IP
accordingly. If the annotation for CiliumHostIP is not present, just log at
info level insetad of at warning level, and do not return an error.

Fixes: #4989

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5703)
<!-- Reviewable:end -->
