### PR TITLE
proxylib: Make xDS node-id configurable.

### DIFF
--- a/proxylib/proxylib.go
+++ b/proxylib/proxylib.go
@@ -204,16 +204,18 @@ func Close(connectionId uint64) {
 // Zero return value indicates an error.
 //export OpenModule
 func OpenModule(params [][2]string, debug bool) uint64 {
-	accessLogPath, xdsPath := "", ""
+	var accessLogPath, xdsPath, nodeID string
 	for i := range params {
 		key := params[i][0]
-		value := params[i][1]
+		value := strcpy(params[i][1])
 
 		switch key {
 		case "access-log-path":
 			accessLogPath = value
 		case "xds-path":
 			xdsPath = value
+		case "node-id":
+			nodeID = value
 		default:
 			return 0
 		}
@@ -226,7 +228,7 @@ func OpenModule(params [][2]string, debug bool) uint64 {
 	}
 	// Copy strings from C-memory to Go-memory so that the string remains valid
 	// also after this function returns
-	return OpenInstance(strcpy(xdsPath), npds.NewClient, strcpy(accessLogPath), accesslog.NewClient)
+	return OpenInstance(nodeID, xdsPath, npds.NewClient, accessLogPath, accesslog.NewClient)
 }
 
 //export CloseModule

--- a/proxylib/proxylib_test.go
+++ b/proxylib/proxylib_test.go
@@ -66,6 +66,16 @@ func TestOpenModule(t *testing.T) {
 	if mod4 == mod1 {
 		t.Error("OpenModule() should have returned a different module")
 	}
+
+	mod5 := OpenModule([][2]string{{"access-log-path", logServer.Path}, {"node-id", "host~127.0.0.1~libcilium~localdomain"}}, true)
+	if mod5 == 0 {
+		t.Errorf("OpenModule() with access log path %s failed", logServer.Path)
+	} else {
+		defer CloseModule(mod5)
+	}
+	if mod5 == mod1 || mod5 == mod2 || mod5 == mod3 || mod5 == mod4 {
+		t.Error("OpenModule() should have returned a different module")
+	}
 }
 
 func TestOnNewConnection(t *testing.T) {


### PR DESCRIPTION
Cilium needs to distinguish between ACKs from the NPDS clients
connecting from Envoy and proxylib. It also needs to separate between
NPDS clients connecting from the host proxy vs. sidecars. To
facilitate this the node-id used by the proxylib's NPDS client needs
to be configurable.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5704)
<!-- Reviewable:end -->
