### PR TITLE
v1.0-backport-18-09-26

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -945,7 +945,9 @@ func (d *Daemon) syncLXCMap() error {
 	for hostIP, info := range existingEndpoints {
 		if ip := net.ParseIP(hostIP); info.IsHost() && ip != nil {
 			if err := lxcmap.DeleteEntry(ip); err != nil {
-				log.WithError(err).Warn("Unable to delete obsolete host IP from BPF map")
+				log.WithError(err).WithFields(logrus.Fields{
+					logfields.IPAddr: hostIP,
+				}).Warn("Unable to delete obsolete host IP from BPF map")
 			} else {
 				log.Debugf("Removed outdated host ip %s from endpoint map", hostIP)
 			}

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -146,6 +146,11 @@ func NewEndpointKey(ip net.IP) *EndpointKey {
 	}
 }
 
+// IsHost returns true if the EndpointInfo represents a host IP
+func (v *EndpointInfo) IsHost() bool {
+	return v.Flags&EndpointFlagHost != 0
+}
+
 // String returns the human readable representation of an EndpointInfo
 func (v *EndpointInfo) String() string {
 	if v.Flags&EndpointFlagHost != 0 {
@@ -226,4 +231,22 @@ func DeleteElement(f EndpointFrontend) []error {
 	}
 
 	return errors
+}
+
+// DumpToMap dumps the contents of the lxcmap into a map and returns it
+func DumpToMap() (map[string]*EndpointInfo, error) {
+	m := map[string]*EndpointInfo{}
+	callback := func(key bpf.MapKey, value bpf.MapValue) {
+		if info, ok := value.(*EndpointInfo); ok {
+			if endpointKey, ok := key.(*EndpointKey); ok {
+				m[endpointKey.IP.String()] = info
+			}
+		}
+	}
+
+	if err := LXCMap.DumpWithCallback(callback); err != nil {
+		return m, fmt.Errorf("unable to read BPF endpoint list: %s", err)
+	}
+
+	return m, nil
 }


### PR DESCRIPTION
Backports

#5663 (note on backport: resolved conflicts by hand)
https://github.com/cilium/cilium/pull/5708

---
[ upstream commit 4ecf111c35f047f490f5cc8858d23c15e342541f ]

Due to deleting and repopulating the BPF endpoint map on startup. Cilium agent
restarts would introduce a race window of a couple of seconds [0] in which
local endpoints would not be reachable. This would result in packet drops or
depending on the routing path, a routing loop which eventually leads to a drop
followed by a ICMP TTL exceeded.

[0] The race window for host IPs was in the microseconds range. The race
window for endpoints depended on the number of local endpoints and etcd
latency as the endpoint would reappear as it was regenerated on restore.

Fixes: #5651

Signed-off-by: Thomas Graf <thomas@cilium.io>
Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5706)
<!-- Reviewable:end -->
