### PR TITLE
lxcmap: Fix invalid dumping of IPv4 entries

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1032,7 +1032,9 @@ func (d *Daemon) syncLXCMap() error {
 	for hostIP, info := range existingEndpoints {
 		if ip := net.ParseIP(hostIP); info.IsHost() && ip != nil {
 			if err := lxcmap.DeleteEntry(ip); err != nil {
-				log.WithError(err).Warn("Unable to delete obsolete host IP from BPF map")
+				log.WithError(err).WithFields(logrus.Fields{
+					logfields.IPAddr: hostIP,
+				}).Warn("Unable to delete obsolete host IP from BPF map")
 			} else {
 				log.Debugf("Removed outdated host ip %s from endpoint map", hostIP)
 			}

--- a/pkg/bpf/endpoint_test.go
+++ b/pkg/bpf/endpoint_test.go
@@ -1,0 +1,48 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf
+
+import (
+	"net"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+type BPFTestSuite struct{}
+
+var _ = Suite(&BPFTestSuite{})
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+func (s *BPFTestSuite) TestEndpointKeyToString(c *C) {
+	tests := []struct {
+		ip string
+	}{
+		{"0.0.0.0"},
+		{"192.0.2.3"},
+		{"::"},
+		{"fdff::ff"},
+	}
+
+	for _, tt := range tests {
+		ip := net.ParseIP(tt.ip)
+		k := NewEndpointKey(ip)
+		c.Assert(k.ToIP().String(), Equals, tt.ip)
+	}
+}

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -218,7 +218,7 @@ func DumpToMap() (map[string]*EndpointInfo, error) {
 	callback := func(key bpf.MapKey, value bpf.MapValue) {
 		if info, ok := value.(*EndpointInfo); ok {
 			if endpointKey, ok := key.(*EndpointKey); ok {
-				m[endpointKey.IP.String()] = info
+				m[endpointKey.ToIP().String()] = info
 			}
 		}
 	}


### PR DESCRIPTION
    This would previously format IPv4 addresses in the IPv6 form, which
    would lead to the following errors:
    
      msg="Unable to delete obsolete host IP from BPF map" error="Unable to
      delete element from map cilium_lxc: no such file or directory"
    
    Fix this by using the appropriate function to convert the address into
    the right form.

Also, add a couple of basic logging/test case improvements.
    
Fixes: #5678
    

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5708)
<!-- Reviewable:end -->
