### PR TITLE
policy/api: validate EndpointSelectors at import time

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,15 +2,12 @@
 
 
 [[projects]]
-  digest = "1:2be791e7b333ff7c06f8fb3dc18a7d70580e9399dbdffd352621d067ff260b6e"
   name = "github.com/Microsoft/go-winio"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "97e4973ce50b2ff5f09635a57e2b88a037aae829"
   version = "v0.4.11"
 
 [[projects]]
-  digest = "1:cdc437f886880a489106fbd4ea9de678603b7f7fecc4e339ebdd21074ee8b88b"
   name = "github.com/Microsoft/hcsshim"
   packages = [
     ".",
@@ -24,60 +21,46 @@
     "internal/safefile",
     "internal/schema1",
     "internal/timeout",
-    "internal/wclayer",
+    "internal/wclayer"
   ]
-  pruneopts = "NUT"
   revision = "e44e499d29527b244d6858772f1b9090eeaddc4e"
   version = "v0.7.4"
 
 [[projects]]
-  digest = "1:d8ebbd207f3d3266d4423ce4860c9f3794956306ded6c7ba312ecc69cdfbf04c"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:8098cd40cd09879efbf12e33bcd51ead4a66006ac802cd563a66c4f3373b9727"
   name = "github.com/PuerkitoBio/urlesc"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
-  digest = "1:3ccf8ba7afe02fd470c4f07d6eea4d0e6875da3d129f95b925f2003ce5dd2024"
   name = "github.com/StackExchange/wmi"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "5d049714c4a64225c3c79a7cf7d02f7fb5b96338"
   version = "1.0.0"
 
 [[projects]]
-  digest = "1:b481bb1a9d7b0b76177c4111c05c39d99733e3f8886141981baba118b3a025ec"
   name = "github.com/asaskevich/govalidator"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "fdf19785fd3558d619ef81212f5edf1d6c2a5911"
 
 [[projects]]
   branch = "master"
-  digest = "1:707ebe952a8b3d00b343c01536c79c73771d100f63ec6babeaed5c79e2b8a8dd"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
-  pruneopts = "NUT"
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
-  digest = "1:080689a7cb710dc8f694005f8e5b3aab861d01e885eaf53fae54431c4635bfe6"
   name = "github.com/c9s/goprocinfo"
   packages = ["linux"]
-  pruneopts = "NUT"
   revision = "0010a05ce49fde7f50669bc7ecda7d41dd6ab824"
 
 [[projects]]
-  digest = "1:7d39d7f6f0947a8ecbce768541e6737ae71bf756d6d3ed0bd78b1c0290a59c8d"
   name = "github.com/containerd/containerd"
   packages = [
     ".",
@@ -120,49 +103,39 @@
     "remotes/docker",
     "remotes/docker/schema1",
     "rootfs",
-    "snapshots",
+    "snapshots"
   ]
-  pruneopts = "NUT"
   revision = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:c00f005eefdfa33203448db0c58f3ab0964bc4df68166e21077c6787e97e8de0"
   name = "github.com/containerd/continuity"
   packages = [
     "fs",
     "syscallx",
-    "sysx",
+    "sysx"
   ]
-  pruneopts = "NUT"
   revision = "7f53d412b9eb1cbf744c2063185d703a0ee34700"
 
 [[projects]]
-  digest = "1:be4d4d147d2bb077ba21edbcceca7582d94e58709dcf38e8fc7c753fcead5648"
   name = "github.com/containerd/cri"
   packages = ["pkg/store"]
-  pruneopts = "NUT"
   revision = "f3687c59470b76ee57c90d4b3dd92888dec58c2b"
   version = "v1.11.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:a16d601cf7295c29ccc3e7711be788bca1376e1f22e0826929f8883ed36c7c99"
   name = "github.com/containerd/fifo"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "3d5202aec260678c48179c56f40e6f38a095738c"
 
 [[projects]]
   branch = "master"
-  digest = "1:e0e54b26bdc49d5471260485d6e41819b55c63f18d5686372d8bbab2c7c43c95"
   name = "github.com/containerd/typeurl"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "a93fcdb778cd272c6e9b3028b2f42d813e785d40"
 
 [[projects]]
-  digest = "1:76dccc71c0eb5bfa2c849fc15d0e0deef0312c830af3b98761f03839dae2f78c"
   name = "github.com/containernetworking/cni"
   packages = [
     "pkg/ip",
@@ -174,13 +147,11 @@
     "pkg/utils/hwaddr",
     "pkg/version",
     "plugins/ipam/host-local/backend",
-    "plugins/ipam/host-local/backend/allocator",
+    "plugins/ipam/host-local/backend/allocator"
   ]
-  pruneopts = "NUT"
   revision = "v0.5.2"
 
 [[projects]]
-  digest = "1:f704a45f113af247cbcbe72b05f3b59927089a0cb782600e0c4261c106774cdd"
   name = "github.com/coreos/etcd"
   packages = [
     "auth/authpb",
@@ -191,48 +162,38 @@
     "etcdserver/etcdserverpb",
     "mvcc/mvccpb",
     "pkg/tlsutil",
-    "pkg/types",
+    "pkg/types"
   ]
-  pruneopts = "NUT"
   revision = "v3.3.9"
 
 [[projects]]
-  digest = "1:536efb6849eb903912acbec0183e1b34e31cc75217b44988aedde59ad249c693"
   name = "github.com/coreos/go-iptables"
   packages = ["iptables"]
-  pruneopts = "NUT"
   revision = "47f22b0dd3355c0ba570ba12b0b8a36bf214c04b"
   version = "v0.4.0"
 
 [[projects]]
-  digest = "1:73857c01e2e98400b0e01c917e1d9ca7d9644c3736037f152cd0bb89562f6add"
   name = "github.com/cpuguy83/go-md2man"
   packages = ["md2man"]
-  pruneopts = "NUT"
   revision = "a65d4d2de4d5f7c74868dfa9b202a3c8be315aaa"
   version = "v1.0.6"
 
 [[projects]]
-  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  pruneopts = "NUT"
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:3cabbabc9e0e4aa7e12b882bdc213f41cf8bd2b2ce2a7b5e0aceaf8a6a78049b"
   name = "github.com/docker/distribution"
   packages = [
     "digest",
-    "reference",
+    "reference"
   ]
-  pruneopts = "NUT"
   revision = "48294d928ced5dd9b378f7fd7c6f5da3ff3f2c89"
   version = "v2.6.2"
 
 [[projects]]
-  digest = "1:bdda594d1f922e89568b121116a27cb3114b58fbfca1d1f91aeac9de1af2c041"
   name = "github.com/docker/engine-api"
   packages = [
     "client",
@@ -249,41 +210,33 @@
     "types/strslice",
     "types/swarm",
     "types/time",
-    "types/versions",
+    "types/versions"
   ]
-  pruneopts = "NUT"
   revision = "4eca04ae18f4f93f40196a17b9aa6e11262a7269"
 
 [[projects]]
-  digest = "1:2a47f7eb1a2c30428d1ee6808cb66d4deb17e68a3e55d696f03c8068552ba5e8"
   name = "github.com/docker/go-connections"
   packages = [
     "nat",
     "sockets",
-    "tlsconfig",
+    "tlsconfig"
   ]
-  pruneopts = "NUT"
   revision = "7395e3f8aa162843a74ed6d48e79627d9792ac55"
   version = "v0.4.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:3c7e22fc463067fcb27473d9010b9ac8c49b791357e0c7e7da6002a291129162"
   name = "github.com/docker/go-events"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "9461782956ad83b30282bf90e31fa6a70c255ba9"
 
 [[projects]]
-  digest = "1:4340101f42556a9cb2f7a360a0e95a019bfef6247d92e6c4c46f2433cf86a482"
   name = "github.com/docker/go-units"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "47565b4f722fb6ceae66b95f853feed578a4a51c"
   version = "v0.3.3"
 
 [[projects]]
-  digest = "1:87f5143b5261a8a356a0e385b608f68191a43095cc228c4bf3666d752d04fba1"
   name = "github.com/docker/libnetwork"
   packages = [
     "discoverapi",
@@ -291,102 +244,78 @@
     "drivers/remote/api",
     "ipamapi",
     "ipams/remote/api",
-    "types",
+    "types"
   ]
-  pruneopts = "NUT"
   revision = "82fb373e3eaa4e9bbb5b5ac148b0a3a71f80fca6"
 
 [[projects]]
-  digest = "1:11233cc46c89b30602ce683997dca8f4d5b9476041f38e79ac035cdc5da344ea"
   name = "github.com/evalphobia/logrus_fluent"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "v0.4.0"
 
 [[projects]]
-  digest = "1:f35faf953fdca65ab88b705da82272662c79a0f942d6764afd232c1eba8d8bdb"
   name = "github.com/fatih/color"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "533cd7fd8a85905f67a1753afb4deddc85ea174f"
 
 [[projects]]
-  digest = "1:1a1fda2eefc60b9b047b3812b26be4779352aa80cab966b77e6fe77b157a7a4b"
   name = "github.com/fluent/fluent-logger-golang"
   packages = ["fluent"]
-  pruneopts = "NUT"
   revision = "8bbc2356beaf021b04c9bd5cdc76ea5a7ccb40ec"
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:1b91ae0dc69a41d4c2ed23ea5cffb721ea63f5037ca4b81e6d6771fbb8f45129"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
 
 [[projects]]
-  digest = "1:81466b4218bf6adddac2572a30ac733a9255919bc2f470b4827a317bd4ee1756"
   name = "github.com/ghodss/yaml"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:cb4e216bd9f58866f42dc65893455b24f879b026fdaa1ecc3aafff625fdb5a66"
   name = "github.com/go-ole/go-ole"
   packages = [
     ".",
-    "oleutil",
+    "oleutil"
   ]
-  pruneopts = "NUT"
   revision = "a41e3c4b706f6ae8dfbff342b06e40fa4d2d0506"
   version = "v1.2.1"
 
 [[projects]]
-  digest = "1:a5ed113e47732685c9c0cf527b29b51364f42064e3f602b270e0c06c182b403a"
   name = "github.com/go-openapi/analysis"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "d5a75b7d751ca3f11ad5d93cfe97405f2c3f6a47"
 
 [[projects]]
-  digest = "1:9839ea727da3bb175c788768f6236e189502af3dc49facd1a4af0eb12b6a3f74"
   name = "github.com/go-openapi/errors"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "fc3f73a224499b047eda7191e5d22e1e9631e86f"
 
 [[projects]]
-  digest = "1:260f7ebefc63024c8dfe2c9f1a2935a89fa4213637a1f522f592f80c001cc441"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "3a0015ad55fa9873f41605d3e8f28cd279c32ab2"
   version = "0.16.0"
 
 [[projects]]
-  digest = "1:98abd61947ff5c7c6fcfec5473d02a4821ed3a2dd99a4fbfdb7925b0dd745546"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "3fb327e6747da3043567ee86abd02bb6376b6be2"
   version = "0.16.0"
 
 [[projects]]
-  digest = "1:9950e28fe5089a160efe645f3e465db93cf93624863b6be8b6d9fff5fff42c50"
   name = "github.com/go-openapi/loads"
   packages = [
     ".",
-    "fmts",
+    "fmts"
   ]
-  pruneopts = "NUT"
   revision = "bf98340e04734f11563fd3008e87be4c1d4ffc08"
 
 [[projects]]
-  digest = "1:32e86b550f87a82ae43329513219500eba6202df30187720487b8a86777fcf61"
   name = "github.com/go-openapi/runtime"
   packages = [
     ".",
@@ -396,70 +325,54 @@
     "middleware/denco",
     "middleware/header",
     "middleware/untyped",
-    "security",
+    "security"
   ]
-  pruneopts = "NUT"
   revision = "bf2ff8f7150788b1c7256abb0805ba0410cbbabb"
 
 [[projects]]
-  digest = "1:538322c5ec78fdd1bcff870b2c0704fc81265aebfb9e4e45031bf5d05233717d"
   name = "github.com/go-openapi/spec"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "3a0434164aa36744c7ba29b822d36894a1e5ec96"
 
 [[projects]]
-  digest = "1:92d0a87fc62ffd2c7da0e4619923dd28b563ccf2c2247cef8e271a27966f5999"
   name = "github.com/go-openapi/strfmt"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "0cb3db44c13bad3b3f567b762a66751972a310cc"
 
 [[projects]]
-  digest = "1:6e5a718679890d1ec2015824fe27c8580f02a273675a324e708fcb033592c684"
   name = "github.com/go-openapi/swag"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "96d7b9ebd181a1735a1c9ac87914f2b32fbf56c9"
 
 [[projects]]
-  digest = "1:3fb29099436d9eb621797ec58e9e54573ecbb9223927a56bac16d9f06a2b2e10"
   name = "github.com/go-openapi/validate"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "b11dbf889b64cf815a7e2667412df313f4a3f17b"
 
 [[projects]]
-  digest = "1:60e4d28196ed68e967bc01901d7ff6a9b67285d0544a79e589d2525750b6b399"
   name = "github.com/gogo/googleapis"
   packages = ["google/rpc"]
-  pruneopts = "NUT"
   revision = "08a7655d27152912db7aaf4f983275eaf8d128ef"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:1ed3ce6dc71db5472f4a1944db4430a9abe3c1e63b859b375da6e330148e94bd"
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
     "proto",
     "protoc-gen-gogo/descriptor",
     "sortkeys",
-    "types",
+    "types"
   ]
-  pruneopts = "NUT"
   revision = "v0.4-3-gc0656ed"
 
 [[projects]]
   branch = "master"
-  digest = "1:e2b86e41f3d669fc36b50d31d32d22c8ac656c75aa5ea89717ce7177e134ff2a"
   name = "github.com/golang/glog"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
-  digest = "1:a69e319c474caf18c6b5ff39aa57366ee12c72b3366506695f3e3617c75d4ba4"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -470,137 +383,107 @@
     "ptypes/empty",
     "ptypes/struct",
     "ptypes/timestamp",
-    "ptypes/wrappers",
+    "ptypes/wrappers"
   ]
-  pruneopts = "NUT"
   revision = "5831880292e721c76b58a16ecc60adc27d8e6355"
 
 [[projects]]
   branch = "master"
-  digest = "1:7f114b78210bf5b75f307fc97cff293633c835bab1e0ea8a744a44b39c042dfe"
   name = "github.com/golang/snappy"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
   branch = "master"
-  digest = "1:05f95ffdfcf651bdb0f05b40b69e7f5663047f8da75c72d58728acb59b5cc107"
   name = "github.com/google/btree"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
 
 [[projects]]
   branch = "master"
-  digest = "1:52c5834e2bebac9030c97cc0798ac11c3aa8a39f098aeb419f142533da6cd3cc"
   name = "github.com/google/gofuzz"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
-  digest = "1:d3f6676fcd4dfe8f413321cda442bf930eccfefb709a441c999c3bb9aea6257b"
   name = "github.com/google/gopacket"
   packages = [
     ".",
-    "layers",
+    "layers"
   ]
-  pruneopts = "NUT"
   revision = "632566d585d0456397d2058bd9cb800c48e3230b"
 
 [[projects]]
-  digest = "1:8c5824301211ae803face8d4b8ff1c9ebd2d989e4dc4093d5ab483c031c905d9"
   name = "github.com/google/gops"
   packages = [
     "agent",
     "internal",
-    "signal",
+    "signal"
   ]
-  pruneopts = "NUT"
   revision = "25312cafb9a191a6d377c480a4666beec3105e4a"
 
 [[projects]]
-  digest = "1:06a7dadb7b760767341ffb6c8d377238d68a1226f2b21b5d497d2e3f6ecf6b4e"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions",
+    "extensions"
   ]
-  pruneopts = "NUT"
   revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:c01767916c59f084bb7c41a7d5877c0f3099b1595cfa066e84ec6ad6b084dd89"
   name = "github.com/gorilla/context"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:b6d06869a1fe464c3781f34f36d0d41fbd9e5452917cf9d5a18422f17fc85c2c"
   name = "github.com/gorilla/mux"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "26a6070f849969ba72b72256e9f14cf519751690"
 
 [[projects]]
   branch = "master"
-  digest = "1:7fdf3223c7372d1ced0b98bf53457c5e89d89aecbad9a77ba9fcc6e01f9e5621"
   name = "github.com/gregjones/httpcache"
   packages = [
     ".",
-    "diskcache",
+    "diskcache"
   ]
-  pruneopts = "NUT"
   revision = "9cad4c3443a7200dd6400aef47183728de563a38"
 
 [[projects]]
-  digest = "1:faa81a2b9cb109a5b035586bc74ffafabd17127c55815d91018aea27ba39ff7a"
   name = "github.com/hashicorp/consul"
   packages = ["api"]
-  pruneopts = "NUT"
   revision = "05bc9149a5204b213a61bc410b8cec21f10a23fe"
 
 [[projects]]
-  digest = "1:a5d940c38bf56f121721bfa747c66356df387cb9d5318c570c6d4170aab62862"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "e8ab9daed8d1ddd2d3c4efba338fe2eeae2e4f18"
   version = "v0.5.0"
 
 [[projects]]
-  digest = "1:1cf16b098a70d6c02899608abbb567296d11c7b830635014dfe6124a02dc1369"
   name = "github.com/hashicorp/go-immutable-radix"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "27df80928bb34bb1b0d6d0e01b9e679902e7a6b5"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:f7b3db9cb74d13f6a7cf84b3801e68585745eacaf7d40cc10ecc4734c30503d3"
   name = "github.com/hashicorp/go-version"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "03c5bf6be031b6dd45afec16b1cf94fc8938bc77"
 
 [[projects]]
-  digest = "1:b42cde0e1f3c816dd57f57f7bbcf05ca40263ad96f168714c130c611fc0856a6"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru",
+    "simplelru"
   ]
-  pruneopts = "NUT"
   revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
   version = "v0.5.0"
 
 [[projects]]
-  digest = "1:39f543569bf189e228c84a294c50aca8ea56c82b3d9df5c9b788249907d7049a"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -611,180 +494,136 @@
     "hcl/token",
     "json/parser",
     "json/scanner",
-    "json/token",
+    "json/token"
   ]
-  pruneopts = "NUT"
   revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:0dd7b7b01769f9df356dc99f9e4144bdbabf6c79041ea7c0892379c5737f3c44"
   name = "github.com/hashicorp/serf"
   packages = ["coordinate"]
-  pruneopts = "NUT"
   revision = "d6574a5bb1226678d7010325fb6c985db20ee458"
   version = "v0.8.1"
 
 [[projects]]
-  digest = "1:9a52adf44086cead3b384e5d0dbf7a1c1cce65e67552ee3383a8561c42a18cd3"
   name = "github.com/imdario/mergo"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4"
   version = "v0.3.6"
 
 [[projects]]
-  digest = "1:406338ad39ab2e37b7f4452906442a3dbf0eb3379dd1f06aafb5c07e769a5fbb"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
-  digest = "1:d3956ca35b6433618aad53cb167a3fc3ea43a0c181bdc382eaea30ce80d2b903"
   name = "github.com/jessevdk/go-flags"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "4e64e4a4e2552194cf594243e23aa9baf3b4297e"
 
 [[projects]]
-  digest = "1:8e36686e8b139f8fe240c1d5cf3a145bc675c22ff8e707857cdd3ae17b00d728"
   name = "github.com/json-iterator/go"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "1624edc4454b8682399def8740d46db5e4362ba4"
   version = "v1.1.5"
 
 [[projects]]
   branch = "master"
-  digest = "1:263f9b0a0bcbfff9d5e7d9f2aa11f53995d98214fe0fb97e429e7a5f4534a0f9"
   name = "github.com/kardianos/osext"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "ae77be60afb1dcacde03767a8c37337fad28ac14"
 
 [[projects]]
-  digest = "1:a310f6d9c2ab6d34834393dfa25ca7f07ed2738089cb43b75d16aaf5808c2024"
   name = "github.com/kevinburke/ssh_config"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "db49ba357de1f26c56dac48a5de39c65785bf24a"
 
 [[projects]]
-  digest = "1:7b21c7fc5551b46d1308b4ffa9e9e49b66c7a8b0ba88c0130474b0e7a20d859f"
   name = "github.com/kr/pretty"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "cfb55aafdaf3ec08f0db22699ab822c50091b1c4"
 
 [[projects]]
-  digest = "1:c3a7836b5904db0f8b609595b619916a6831cb35b8b714aec39f96d00c6155d8"
   name = "github.com/kr/text"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f"
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:06fc5328859ae6e2d7bf900483d4489d0f826acab879fb8bc1c8607caf95a9a9"
   name = "github.com/lyft/protoc-gen-validate"
   packages = ["validate"]
-  pruneopts = "NUT"
   revision = "d75a15c1da0f853ca31399f30c49088ca5716b04"
 
 [[projects]]
-  digest = "1:d244f8666a838fe6ad70ec8fe77f50ebc29fdc3331a2729ba5886bef8435d10d"
   name = "github.com/magiconair/properties"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c2353362d570a7bfa228149c62842019201cfb71"
   version = "v1.8.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:84a5a2b67486d5d67060ac393aa255d05d24ed5ee41daecd5635ec22657b6492"
   name = "github.com/mailru/easyjson"
   packages = [
     "buffer",
     "jlexer",
-    "jwriter",
+    "jwriter"
   ]
-  pruneopts = "NUT"
   revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
 
 [[projects]]
-  digest = "1:08c231ec84231a7e23d67e4b58f975e1423695a32467a362ee55a803f9de8061"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
   version = "v0.0.9"
 
 [[projects]]
-  digest = "1:bffa444ca07c69c599ae5876bc18b25bfd5fa85b297ca10a25594d284a7e9c5d"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c"
   version = "v0.0.4"
 
 [[projects]]
-  digest = "1:4c8622179c0c2527c7ad7ebee8def63f8866c8aeaae369ed5516d87b752c37d0"
   name = "github.com/mattn/go-shellwords"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "9858af9cca4c73576f0b8c6609a396eb0878023c"
 
 [[projects]]
-  digest = "1:5985ef4caf91ece5d54817c11ea25f182697534f8ae6521eadcd628c142ac4b6"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
-  pruneopts = "NUT"
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:ce8be734bbd95f29dc049610c998be4994eb3ea2c87ac8cb1b9425d39f18ddf4"
   name = "github.com/miekg/dns"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "f4db2ca6edc3af0ee51bf332099cc480bcf3ef9d"
   version = "v1.0.10"
 
 [[projects]]
-  digest = "1:e34decedbcec12332c5836d16a6838f864e0b43c5b4f9aa9d9a85101015f87c2"
   name = "github.com/mitchellh/hashstructure"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "2bca23e0e452137f789efbc8610126fd8b94f73b"
 
 [[projects]]
-  digest = "1:5fe20cfe4ef484c237cec9f947b2a6fa90bad4b8610fd014f0e4211e13d82d5d"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "fa473d140ef3c6adf42d6b391fe76707f1f243c8"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:2f42fa12d6911c7b7659738758631bec870b7e9b4c6be5444f963cdcfccc191f"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
   version = "1.0.3"
 
 [[projects]]
-  digest = "1:c6aca19413b13dc59c220ad7430329e2ec454cc310bc6d8de2c7e2b93c18a0f6"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
 
 [[projects]]
-  digest = "1:3dc39744bbac155b21a79c6b8e250d6985bbab77b71c073a4477071e59fe5e61"
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -804,13 +643,11 @@
     "reporters/stenographer",
     "reporters/stenographer/support/go-colorable",
     "reporters/stenographer/support/go-isatty",
-    "types",
+    "types"
   ]
-  pruneopts = "NUT"
   revision = "ba8e856bb854d6771a72ddf6497a42dad3a0c971"
 
 [[projects]]
-  digest = "1:2714e6fd12597d802d18dd2f864a8d82311145eeb2c8f5dcb3f6fa8aca1004f6"
   name = "github.com/onsi/gomega"
   packages = [
     ".",
@@ -824,201 +661,155 @@
     "matchers/support/goraph/edge",
     "matchers/support/goraph/node",
     "matchers/support/goraph/util",
-    "types",
+    "types"
   ]
-  pruneopts = "NUT"
   revision = "283ed655c6b8238afecd5bea6434bc9b03129f2f"
 
 [[projects]]
-  digest = "1:421eddadca0860f5c4e6ba2890b0cca3e4c2c5515dd9cbcc6f51eb033cd89e30"
   name = "github.com/op/go-logging"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "0882c9abce533ab4afbab5677fcef7434dd36d5a"
 
 [[projects]]
-  digest = "1:e0cc8395ea893c898ff5eb0850f4d9851c1f57c78c232304a026379a47a552d0"
   name = "github.com/opencontainers/go-digest"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
   version = "v1.0.0-rc1"
 
 [[projects]]
-  digest = "1:70711188c19c53147099d106169d6a81941ed5c2658651432de564a7d60fd288"
   name = "github.com/opencontainers/image-spec"
   packages = [
     "identity",
     "specs-go",
-    "specs-go/v1",
+    "specs-go/v1"
   ]
-  pruneopts = "NUT"
   revision = "d60099175f88c47cd379c4738d158884749ed235"
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:918dbd46ad099418ce9760291bb156ebf23d441aad4cb682dd9bf09e2d3c0c7b"
   name = "github.com/opencontainers/runc"
   packages = ["libcontainer/user"]
-  pruneopts = "NUT"
   revision = "baf6536d6259209c3edfa2b22237af82942d3dfa"
   version = "v0.1.1"
 
 [[projects]]
-  digest = "1:57234a321bf1f8f98a8a9a5122a2404cc60d0800516f4ab7a7b2375e4b2d19ea"
   name = "github.com/opencontainers/runtime-spec"
   packages = ["specs-go"]
-  pruneopts = "NUT"
   revision = "4e3b9264a330d094b0386c3703c5f379119711e8"
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:f7844587d310fe1f876ee17d32ac04b9b8d49f4c023c04c19bb6c0b0680463c7"
   name = "github.com/optiopay/kafka"
   packages = [
     ".",
-    "proto",
+    "proto"
   ]
-  pruneopts = "NUT"
   revision = "01ce283b732b96914f62b1ff1bf5d8b90f7db86c"
   source = "https://github.com/cilium/kafka"
 
 [[projects]]
-  digest = "1:a8ebc818b2e43e2fa7f052e5e7848aa2b288810a949fb5a65f283b2942c00501"
   name = "github.com/pborman/uuid"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "14801136da1260ea57627a3af55873f59f9ee1ea"
 
 [[projects]]
-  digest = "1:cf254277d898b713195cc6b4a3fac8bf738b9f1121625df27843b52b267eec6c"
   name = "github.com/pelletier/go-buffruneio"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c37440a7cf42ac63b919c752ca73a85067e05992"
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:51ea800cff51752ff68e12e04106f5887b4daec6f9356721238c28019f0b42db"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c01d1270ff3e442a8a57cddc1c92dc1138598194"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:3bf17a6e6eaa6ad24152148a631d18662f7212e21637c2699bff3369b7f00fa2"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
-  pruneopts = "NUT"
   revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
 
 [[projects]]
-  digest = "1:6c6d91dc326ed6778783cff869c49fb2f61303cdd2ebbcf90abe53505793f3b6"
   name = "github.com/peterbourgon/diskv"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:ef6f545f048a0e64f3ec7a0709149e6c01af28f99b4b1e518e9f9db5e8036579"
   name = "github.com/petermattis/goid"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "b0b1615b78e5ee59739545bb38426383b2cda4c9"
 
 [[projects]]
-  digest = "1:44c66ad69563dbe3f8e76d7d6cad21a03626e53f1875b5ab163ded419e01ca7a"
   name = "github.com/philhofer/fwd"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "bb6d471dc95d4fe11e432687f8b70ff496cf3136"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"
   name = "github.com/pkg/errors"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
-  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  pruneopts = "NUT"
   revision = "v1.0.0"
 
 [[projects]]
-  digest = "1:167888737cd5a7d9cac6422e1216be91a687d5c6c752dfb88ba6879d179159e7"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
-    "prometheus/promhttp",
+    "prometheus/promhttp"
   ]
-  pruneopts = "NUT"
   revision = "v0.9.0-pre1"
 
 [[projects]]
   branch = "master"
-  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
-  pruneopts = "NUT"
   revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
 
 [[projects]]
   branch = "master"
-  digest = "1:fad5a35eea6a1a33d6c8f949fbc146f24275ca809ece854248187683f52cc30b"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model",
+    "model"
   ]
-  pruneopts = "NUT"
   revision = "c7de2306084e37d54b8be01f3541a8464345e9a5"
 
 [[projects]]
   branch = "master"
-  digest = "1:26a2f5e891cc4d2321f18a0caa84c8e788663c17bed6a487f3cbe2c4295292d0"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
     "nfs",
-    "xfs",
+    "xfs"
   ]
-  pruneopts = "NUT"
   revision = "418d78d0b9a7b7de3a6bbc8a23def624cc977bb2"
 
 [[projects]]
-  digest = "1:ed79e22e8070bbe689f17994cc754cf54686be4e357b8280fe77a7400134adac"
   name = "github.com/russross/blackfriday"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "6d1ef893fcb01b4f50cb6e57ed7df3e2e627b6b2"
 
 [[projects]]
-  digest = "1:b4172dc5c988d904d5806acc6a010d9c988b547b06ce068b3a48d9ccb965c361"
   name = "github.com/sasha-s/go-deadlock"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "master"
 
 [[projects]]
-  digest = "1:cfde76df2f6c17783765b016cdddf6eb5727de3c644b5ef94611f3c3baf2f8c0"
   name = "github.com/servak/go-fastping"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "5718d12e20a0705da242a29ded0482dabae84363"
 
 [[projects]]
-  digest = "1:6e6acd8902e66defe020233670b70c268e37865521e2bf6910e59e05202336b2"
   name = "github.com/shirou/gopsutil"
   packages = [
     "cpu",
@@ -1027,123 +818,95 @@
     "load",
     "mem",
     "net",
-    "process",
+    "process"
   ]
-  pruneopts = "NUT"
   revision = "v2.18.07"
 
 [[projects]]
   branch = "master"
-  digest = "1:869e13958e05ca96407cecebea71a60310256aba8f70244d05a06ce09e3f60ba"
   name = "github.com/shirou/w32"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "bb4de0191aa41b5507caa14b0650cdbddcd9280b"
 
 [[projects]]
-  digest = "1:81aa9c5acf59350f3255a67a1dae67ad27c81fee74d103e4b47cfa0d495e9a81"
   name = "github.com/sirupsen/logrus"
   packages = [
     ".",
-    "hooks/syslog",
+    "hooks/syslog"
   ]
-  pruneopts = "NUT"
   revision = "v1.0.3"
 
 [[projects]]
-  digest = "1:330e9062b308ac597e28485699c02223bd052437a6eed32a173c9227dcb9d95a"
   name = "github.com/spf13/afero"
   packages = [
     ".",
-    "mem",
+    "mem"
   ]
-  pruneopts = "NUT"
   revision = "d40851caa0d747393da1ffb28f7f9d8b4eeffebd"
   version = "v1.1.2"
 
 [[projects]]
-  digest = "1:3fa7947ca83b98ae553590d993886e845a4bff19b7b007e869c6e0dd3b9da9cd"
   name = "github.com/spf13/cast"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "8965335b8c7107321228e3e3702cab9832751bac"
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:db6f8df63cc6b64be8e6a1df637690e2963b632a82c1ccda7cf21c0cd2fca176"
   name = "github.com/spf13/cobra"
   packages = [
     ".",
-    "doc",
+    "doc"
   ]
-  pruneopts = "NUT"
   revision = "92ea23a837e66f46ac9e7d04fa826602b7b0a42d"
 
 [[projects]]
-  digest = "1:f29f83301ed096daed24a90f4af591b7560cb14b9cc3e1827abbf04db7269ab5"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "4a4406e478ca629068e7768fc33f3f044173c0a6"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:ed545897e7363038a3e467e8b24c12e7f540f6a114c08a7dca7746a3fe291358"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "9ff6c6923cfffbcd502984b8e0c80539a94968b7"
 
 [[projects]]
-  digest = "1:60a9c0de0c7ebddf40461261b6f8f767c61b27cf2b6b31c1735459563df83ff9"
   name = "github.com/spf13/viper"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "7538d73b4eb9511d85a9f1dfef202eeb8ac260f4"
 
 [[projects]]
   branch = "master"
-  digest = "1:e14e467ed00ab98665623c5060fa17e3d7079be560ffc33cabafd05d35894f05"
   name = "github.com/syndtr/gocapability"
   packages = ["capability"]
-  pruneopts = "NUT"
   revision = "d98352740cb2c55f81556b63d4a1ec64c5a319c2"
 
 [[projects]]
-  digest = "1:eaa6698f44de8f2977e93c9b946e60a8af75f565058658aad2df8032b55c84e5"
   name = "github.com/tinylib/msgp"
   packages = ["msgp"]
-  pruneopts = "NUT"
   revision = "b2b6a672cf1e5b90748f79b8b81fc8c5cf0571a1"
   version = "1.0.2"
 
 [[projects]]
-  digest = "1:49fe0137c9f8623cb88500da6ee2a5c59469e1ead2d95a4225a6c5936f5d0b75"
   name = "github.com/tylerb/graceful"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "d37e108c89765a8e307f15b8fb2ecd10575da6bb"
 
 [[projects]]
-  digest = "1:936ab0fd3f16edc83131e626594a4f4e75426e5adeb7adbe57ed203db4c1b950"
   name = "github.com/vishvananda/netlink"
   packages = [
     ".",
-    "nl",
+    "nl"
   ]
-  pruneopts = "NUT"
   revision = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:2a1bbe57bb2602803e0f142d88453b0d9fec89e496aaa2cd8807bcae2e05a4a7"
   name = "github.com/vishvananda/netns"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "13995c7128ccc8e51e9a6bd2b551020a27180abd"
 
 [[projects]]
-  digest = "1:0dea92322600b83d86e3ad7c10770e03a92d6aae9bd0b7e8620e38653f030769"
   name = "golang.org/x/crypto"
   packages = [
     "curve25519",
@@ -1153,13 +916,11 @@
     "poly1305",
     "ssh",
     "ssh/agent",
-    "ssh/terminal",
+    "ssh/terminal"
   ]
-  pruneopts = "NUT"
   revision = "5ba7f63082460102a45837dbd1827e10f9479ac0"
 
 [[projects]]
-  digest = "1:36d7c2490cae958afcd40b50f7840339409576240f410ecccdd3487d547f14d0"
   name = "golang.org/x/net"
   packages = [
     "bpf",
@@ -1179,42 +940,34 @@
     "ipv6",
     "lex/httplex",
     "proxy",
-    "trace",
+    "trace"
   ]
-  pruneopts = "NUT"
   revision = "0744d001aa8470aaa53df28d32e5ceeb8af9bd70"
 
 [[projects]]
   branch = "master"
-  digest = "1:db0ef10bef8ec68d343f7371d5d6006c1086b5882654e10e7cc9335bfb551b8d"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
-    "internal",
+    "internal"
   ]
-  pruneopts = "NUT"
   revision = "d2e6202438beef2727060aa7cabdd924d92ebfd9"
 
 [[projects]]
   branch = "master"
-  digest = "1:39ebcc2b11457b703ae9ee2e8cca0f68df21969c6102cb3b705f76cca0ea0239"
   name = "golang.org/x/sync"
   packages = ["errgroup"]
-  pruneopts = "NUT"
   revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
 
 [[projects]]
-  digest = "1:21b27f093d86b15a6cb6b63591f664dce78ad3004bee2f649bc01a0f93b37612"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows",
+    "windows"
   ]
-  pruneopts = "NUT"
   revision = "14742f9018cd6651ec7364dc6ee08af0baaa1031"
 
 [[projects]]
-  digest = "1:2c4e3b27329379d7b5f889038b48086140ea60708fb92e4b19d6a775926ea30b"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -1243,34 +996,28 @@
     "unicode/cldr",
     "unicode/norm",
     "unicode/rangetable",
-    "width",
+    "width"
   ]
-  pruneopts = "NUT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
   name = "golang.org/x/time"
   packages = ["rate"]
-  pruneopts = "NUT"
   revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
   branch = "master"
-  digest = "1:45751dc3302c90ea55913674261b2d74286b05cdd8e3ae9606e02e4e77f4353f"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
     "imports",
-    "internal/fastwalk",
+    "internal/fastwalk"
   ]
-  pruneopts = "NUT"
   revision = "e93be7f42f9fcac2c537bcd78bab08e6e63ed5bf"
 
 [[projects]]
-  digest = "1:36354a269794d9cb4cebae233f65a966e818f763088370c8524726853a31c96f"
   name = "google.golang.org/appengine"
   packages = [
     "internal",
@@ -1279,24 +1026,20 @@
     "internal/log",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch",
+    "urlfetch"
   ]
-  pruneopts = "NUT"
   revision = "ae0ab99deb4dc413a2b4bd6c8bdd0eb67f1e4d06"
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:0efcfe82e59b828eb6f4115bba88ff45c0898c38e823fbe7f450bdffed9e739b"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api/annotations",
-    "googleapis/rpc/status",
+    "googleapis/rpc/status"
   ]
-  pruneopts = "NUT"
   revision = "595979c8a7bf586b2d293fb42246bf91a0b893d9"
 
 [[projects]]
-  digest = "1:66625ff0927350922744c0d5d25d488774948c9bcf464cab48f70fb20ca5326d"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -1324,51 +1067,39 @@
     "stats",
     "status",
     "tap",
-    "transport",
+    "transport"
   ]
-  pruneopts = "NUT"
   revision = "v1.11.3"
 
 [[projects]]
-  digest = "1:31dc2608eeec187b17712a05f92b263e04f8e02b06c672002203ddcde7b70ea3"
   name = "gopkg.in/check.v1"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "4f90aeace3a26ad7021961c297b22c42160c7b25"
 
 [[projects]]
-  digest = "1:1b91ae0dc69a41d4c2ed23ea5cffb721ea63f5037ca4b81e6d6771fbb8f45129"
   name = "gopkg.in/fsnotify.v1"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "v1.4.7"
   source = "gopkg.in/fsnotify/fsnotify.v1"
 
 [[projects]]
-  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:80c34337e8a734e190f2d1b716cae774cca74db98315166f92074434e9af0227"
   name = "gopkg.in/natefinch/lumberjack.v2"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "v2.1"
 
 [[projects]]
-  digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [[projects]]
-  digest = "1:44eacde418468b319a1454ba01b453fc99828d573cbdb20367e0950e77720684"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -1401,13 +1132,11 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1",
+    "storage/v1beta1"
   ]
-  pruneopts = "NUT"
   revision = "kubernetes-1.12.0-rc.2"
 
 [[projects]]
-  digest = "1:6863750b53ac3e57c4ea2b068c6c07d3b42a6dc965f64c5fdd56ae2ab768deb5"
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
@@ -1415,13 +1144,11 @@
     "pkg/client/clientset/clientset",
     "pkg/client/clientset/clientset/scheme",
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
-    "pkg/features",
+    "pkg/features"
   ]
-  pruneopts = "NUT"
   revision = "kubernetes-1.12.0-rc.2"
 
 [[projects]]
-  digest = "1:3e353d8babd8117333e032d7f61229ef379f59302575eb87fea15052178e97c2"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -1430,6 +1157,7 @@
     "pkg/apis/meta/internalversion",
     "pkg/apis/meta/v1",
     "pkg/apis/meta/v1/unstructured",
+    "pkg/apis/meta/v1/validation",
     "pkg/apis/meta/v1beta1",
     "pkg/conversion",
     "pkg/conversion/queryparams",
@@ -1465,24 +1193,20 @@
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/json",
-    "third_party/forked/golang/reflect",
+    "third_party/forked/golang/reflect"
   ]
-  pruneopts = "NUT"
   revision = "kubernetes-1.12.0-rc.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:0453df4e78d4b7678729cdf747169c341e57039a570b0a0b0c19198c57b6ebef"
   name = "k8s.io/apiserver"
   packages = [
     "pkg/features",
-    "pkg/util/feature",
+    "pkg/util/feature"
   ]
-  pruneopts = "NUT"
   revision = "f3682c1ab73d7ea1bd6fc22d81a44e345afb672d"
 
 [[projects]]
-  digest = "1:5deb813e0d4015d070759336fada0f723a5fdf1936635b6fb20c8165695901dd"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1578,13 +1302,11 @@
     "util/homedir",
     "util/integer",
     "util/jsonpath",
-    "util/retry",
+    "util/retry"
   ]
-  pruneopts = "NUT"
   revision = "kubernetes-1.12.0-rc.2"
 
 [[projects]]
-  digest = "1:4e2addcdbe0330f43800c1fcb905fc7a21b86415dfcca619e5c606c87257af1b"
   name = "k8s.io/code-generator"
   packages = [
     "cmd/client-gen",
@@ -1595,14 +1317,12 @@
     "cmd/client-gen/generators/util",
     "cmd/client-gen/path",
     "cmd/client-gen/types",
-    "pkg/util",
+    "pkg/util"
   ]
-  pruneopts = "T"
   revision = "kubernetes-1.12.0-rc.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:5249c83f0fb9e277b2d28c19eca814feac7ef05dc762e4deaf0a2e4b1a7c5df3"
   name = "k8s.io/gengo"
   packages = [
     "args",
@@ -1612,21 +1332,17 @@
     "generator",
     "namer",
     "parser",
-    "types",
+    "types"
   ]
-  pruneopts = "NUT"
   revision = "4242d8e6c5dba56827bb7bcf14ad11cda38f3991"
 
 [[projects]]
   branch = "master"
-  digest = "1:a2c842a1e0aed96fd732b535514556323a6f5edfded3b63e5e0ab1bce188aa54"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/util/proto"]
-  pruneopts = "NUT"
   revision = "e3762e86a74c878ffed47484592986685639c2cd"
 
 [[projects]]
-  digest = "1:6847551e9d5685dd8b7d32706cb1a00bcfaaf2d6bbfb3daecbe2b9b0880214cc"
   name = "k8s.io/kubernetes"
   packages = [
     "pkg/apis/core",
@@ -1636,153 +1352,13 @@
     "pkg/kubelet/types",
     "pkg/kubelet/util",
     "pkg/registry/core/service/allocator",
-    "pkg/registry/core/service/ipallocator",
+    "pkg/registry/core/service/ipallocator"
   ]
-  pruneopts = "NUT"
   revision = "v1.12.0-rc.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/asaskevich/govalidator",
-    "github.com/c9s/goprocinfo/linux",
-    "github.com/containerd/containerd",
-    "github.com/containerd/containerd/api/events",
-    "github.com/containerd/containerd/events",
-    "github.com/containerd/containerd/namespaces",
-    "github.com/containerd/cri/pkg/store",
-    "github.com/containerd/typeurl",
-    "github.com/containernetworking/cni/pkg/ns",
-    "github.com/containernetworking/cni/pkg/skel",
-    "github.com/containernetworking/cni/pkg/types",
-    "github.com/containernetworking/cni/pkg/types/current",
-    "github.com/containernetworking/cni/pkg/version",
-    "github.com/containernetworking/cni/plugins/ipam/host-local/backend/allocator",
-    "github.com/coreos/etcd/clientv3",
-    "github.com/coreos/etcd/clientv3/concurrency",
-    "github.com/coreos/etcd/clientv3/yaml",
-    "github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes",
-    "github.com/docker/engine-api/client",
-    "github.com/docker/engine-api/types",
-    "github.com/docker/engine-api/types/events",
-    "github.com/docker/engine-api/types/network",
-    "github.com/docker/libnetwork/drivers/remote/api",
-    "github.com/docker/libnetwork/ipams/remote/api",
-    "github.com/docker/libnetwork/types",
-    "github.com/evalphobia/logrus_fluent",
-    "github.com/fatih/color",
-    "github.com/go-openapi/errors",
-    "github.com/go-openapi/loads",
-    "github.com/go-openapi/runtime",
-    "github.com/go-openapi/runtime/client",
-    "github.com/go-openapi/runtime/flagext",
-    "github.com/go-openapi/runtime/middleware",
-    "github.com/go-openapi/runtime/security",
-    "github.com/go-openapi/spec",
-    "github.com/go-openapi/strfmt",
-    "github.com/go-openapi/swag",
-    "github.com/go-openapi/validate",
-    "github.com/gogo/protobuf/gogoproto",
-    "github.com/gogo/protobuf/sortkeys",
-    "github.com/golang/protobuf/proto",
-    "github.com/golang/protobuf/ptypes",
-    "github.com/golang/protobuf/ptypes/any",
-    "github.com/golang/protobuf/ptypes/duration",
-    "github.com/golang/protobuf/ptypes/empty",
-    "github.com/golang/protobuf/ptypes/struct",
-    "github.com/golang/protobuf/ptypes/timestamp",
-    "github.com/golang/protobuf/ptypes/wrappers",
-    "github.com/google/gopacket",
-    "github.com/google/gopacket/layers",
-    "github.com/google/gops/agent",
-    "github.com/gorilla/mux",
-    "github.com/hashicorp/consul/api",
-    "github.com/hashicorp/go-immutable-radix",
-    "github.com/hashicorp/go-version",
-    "github.com/jessevdk/go-flags",
-    "github.com/kevinburke/ssh_config",
-    "github.com/kr/pretty",
-    "github.com/lyft/protoc-gen-validate/validate",
-    "github.com/mattn/go-shellwords",
-    "github.com/miekg/dns",
-    "github.com/mitchellh/hashstructure",
-    "github.com/onsi/ginkgo",
-    "github.com/onsi/ginkgo/config",
-    "github.com/onsi/ginkgo/types",
-    "github.com/onsi/gomega",
-    "github.com/onsi/gomega/format",
-    "github.com/onsi/gomega/types",
-    "github.com/op/go-logging",
-    "github.com/optiopay/kafka",
-    "github.com/optiopay/kafka/proto",
-    "github.com/pborman/uuid",
-    "github.com/pmezard/go-difflib/difflib",
-    "github.com/prometheus/client_golang/prometheus",
-    "github.com/prometheus/client_golang/prometheus/promhttp",
-    "github.com/prometheus/client_model/go",
-    "github.com/russross/blackfriday",
-    "github.com/sasha-s/go-deadlock",
-    "github.com/servak/go-fastping",
-    "github.com/shirou/gopsutil/load",
-    "github.com/shirou/gopsutil/mem",
-    "github.com/shirou/gopsutil/process",
-    "github.com/sirupsen/logrus",
-    "github.com/sirupsen/logrus/hooks/syslog",
-    "github.com/spf13/cobra",
-    "github.com/spf13/cobra/doc",
-    "github.com/spf13/pflag",
-    "github.com/spf13/viper",
-    "github.com/tylerb/graceful",
-    "github.com/vishvananda/netlink",
-    "golang.org/x/crypto/ssh",
-    "golang.org/x/crypto/ssh/agent",
-    "golang.org/x/net/context",
-    "golang.org/x/sys/unix",
-    "google.golang.org/genproto/googleapis/api/annotations",
-    "google.golang.org/genproto/googleapis/rpc/status",
-    "google.golang.org/grpc",
-    "google.golang.org/grpc/reflection",
-    "gopkg.in/check.v1",
-    "gopkg.in/fsnotify.v1",
-    "gopkg.in/natefinch/lumberjack.v2",
-    "k8s.io/api/core/v1",
-    "k8s.io/api/extensions/v1beta1",
-    "k8s.io/api/networking/v1",
-    "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
-    "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
-    "k8s.io/apimachinery/pkg/api/errors",
-    "k8s.io/apimachinery/pkg/apis/meta/v1",
-    "k8s.io/apimachinery/pkg/fields",
-    "k8s.io/apimachinery/pkg/labels",
-    "k8s.io/apimachinery/pkg/runtime",
-    "k8s.io/apimachinery/pkg/runtime/schema",
-    "k8s.io/apimachinery/pkg/runtime/serializer",
-    "k8s.io/apimachinery/pkg/selection",
-    "k8s.io/apimachinery/pkg/types",
-    "k8s.io/apimachinery/pkg/util/intstr",
-    "k8s.io/apimachinery/pkg/util/runtime",
-    "k8s.io/apimachinery/pkg/util/wait",
-    "k8s.io/apimachinery/pkg/watch",
-    "k8s.io/client-go/discovery",
-    "k8s.io/client-go/discovery/fake",
-    "k8s.io/client-go/kubernetes",
-    "k8s.io/client-go/kubernetes/fake",
-    "k8s.io/client-go/kubernetes/scheme",
-    "k8s.io/client-go/rest",
-    "k8s.io/client-go/testing",
-    "k8s.io/client-go/tools/cache",
-    "k8s.io/client-go/tools/clientcmd",
-    "k8s.io/client-go/util/flowcontrol",
-    "k8s.io/client-go/util/jsonpath",
-    "k8s.io/code-generator/cmd/client-gen",
-    "k8s.io/gengo/examples/deepcopy-gen/generators",
-    "k8s.io/gengo/examples/defaulter-gen/generators",
-    "k8s.io/kubernetes/pkg/apis/core",
-    "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2",
-    "k8s.io/kubernetes/pkg/kubelet/types",
-    "k8s.io/kubernetes/pkg/kubelet/util",
-    "k8s.io/kubernetes/pkg/registry/core/service/ipallocator",
-  ]
+  inputs-digest = "c2e6063c6d64c14bd3fddde9e4017092b47c991eed655153d626518de804a102"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -49,6 +49,10 @@ func (r Rule) Sanitize() error {
 		return fmt.Errorf("rule cannot have nil EndpointSelector")
 	}
 
+	if err := r.EndpointSelector.sanitize(); err != nil {
+		return err
+	}
+
 	for i := range r.Ingress {
 		if err := r.Ingress[i].sanitize(); err != nil {
 			return err
@@ -77,6 +81,7 @@ func (i *IngressRule) sanitize() error {
 		"FromCIDRSet":   false,
 		"FromEntities":  true,
 	}
+
 	for m1 := range l3Members {
 		for m2 := range l3Members {
 			if m2 != m1 && l3Members[m1] > 0 && l3Members[m2] > 0 {
@@ -87,6 +92,18 @@ func (i *IngressRule) sanitize() error {
 	for member := range l3Members {
 		if l3Members[member] > 0 && len(i.ToPorts) > 0 && !l3DependentL4Support[member] {
 			return fmt.Errorf("Combining %s and ToPorts is not supported yet", member)
+		}
+	}
+
+	for _, es := range i.FromEndpoints {
+		if err := es.sanitize(); err != nil {
+			return err
+		}
+	}
+
+	for _, es := range i.FromRequires {
+		if err := es.sanitize(); err != nil {
+			return err
 		}
 	}
 
@@ -156,6 +173,18 @@ func (e *EgressRule) sanitize() error {
 	for member := range l3Members {
 		if l3Members[member] > 0 && len(e.ToPorts) > 0 && !l3DependentL4Support[member] {
 			return fmt.Errorf("Combining %s and ToPorts is not supported yet", member)
+		}
+	}
+
+	for _, es := range e.ToEndpoints {
+		if err := es.sanitize(); err != nil {
+			return err
+		}
+	}
+
+	for _, es := range e.ToRequires {
+		if err := es.sanitize(); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/cilium/cilium/pkg/labels"
@@ -23,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/mitchellh/hashstructure"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	k8sLbls "k8s.io/apimachinery/pkg/labels"
 )
 
@@ -324,6 +326,15 @@ func (n *EndpointSelector) ConvertToLabelSelectorRequirementSlice() []metav1.Lab
 		requirements = append(requirements, requirementFromMatchLabels)
 	}
 	return requirements
+}
+
+// sanitize returns an error if the EndpointSelector's LabelSelector is invalid.
+func (n *EndpointSelector) sanitize() error {
+	errList := validation.ValidateLabelSelector(n.LabelSelector, nil)
+	if len(errList) > 0 {
+		return fmt.Errorf("invalid label selector: %s", errList.ToAggregate().Error())
+	}
+	return nil
 }
 
 // EndpointSelectorSlice is a slice of EndpointSelectors that can be sorted.

--- a/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func ValidateLabelSelector(ps *metav1.LabelSelector, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if ps == nil {
+		return allErrs
+	}
+	allErrs = append(allErrs, ValidateLabels(ps.MatchLabels, fldPath.Child("matchLabels"))...)
+	for i, expr := range ps.MatchExpressions {
+		allErrs = append(allErrs, ValidateLabelSelectorRequirement(expr, fldPath.Child("matchExpressions").Index(i))...)
+	}
+	return allErrs
+}
+
+func ValidateLabelSelectorRequirement(sr metav1.LabelSelectorRequirement, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	switch sr.Operator {
+	case metav1.LabelSelectorOpIn, metav1.LabelSelectorOpNotIn:
+		if len(sr.Values) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("values"), "must be specified when `operator` is 'In' or 'NotIn'"))
+		}
+	case metav1.LabelSelectorOpExists, metav1.LabelSelectorOpDoesNotExist:
+		if len(sr.Values) > 0 {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("values"), "may not be specified when `operator` is 'Exists' or 'DoesNotExist'"))
+		}
+	default:
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("operator"), sr.Operator, "not a valid selector operator"))
+	}
+	allErrs = append(allErrs, ValidateLabelName(sr.Key, fldPath.Child("key"))...)
+	return allErrs
+}
+
+// ValidateLabelName validates that the label name is correctly defined.
+func ValidateLabelName(labelName string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for _, msg := range validation.IsQualifiedName(labelName) {
+		allErrs = append(allErrs, field.Invalid(fldPath, labelName, msg))
+	}
+	return allErrs
+}
+
+// ValidateLabels validates that a set of labels are correctly defined.
+func ValidateLabels(labels map[string]string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for k, v := range labels {
+		allErrs = append(allErrs, ValidateLabelName(k, fldPath)...)
+		for _, msg := range validation.IsValidLabelValue(v) {
+			allErrs = append(allErrs, field.Invalid(fldPath, v, msg))
+		}
+	}
+	return allErrs
+}
+
+func ValidateDeleteOptions(options *metav1.DeleteOptions) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if options.OrphanDependents != nil && options.PropagationPolicy != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("propagationPolicy"), options.PropagationPolicy, "orphanDependents and deletionPropagation cannot be both set"))
+	}
+	if options.PropagationPolicy != nil &&
+		*options.PropagationPolicy != metav1.DeletePropagationForeground &&
+		*options.PropagationPolicy != metav1.DeletePropagationBackground &&
+		*options.PropagationPolicy != metav1.DeletePropagationOrphan {
+		allErrs = append(allErrs, field.NotSupported(field.NewPath("propagationPolicy"), options.PropagationPolicy, []string{string(metav1.DeletePropagationForeground), string(metav1.DeletePropagationBackground), string(metav1.DeletePropagationOrphan), "nil"}))
+	}
+	allErrs = append(allErrs, validateDryRun(field.NewPath("dryRun"), options.DryRun)...)
+	return allErrs
+}
+
+func ValidateCreateOptions(options *metav1.CreateOptions) field.ErrorList {
+	return validateDryRun(field.NewPath("dryRun"), options.DryRun)
+}
+
+func ValidateUpdateOptions(options *metav1.UpdateOptions) field.ErrorList {
+	return validateDryRun(field.NewPath("dryRun"), options.DryRun)
+}
+
+var allowedDryRunValues = sets.NewString(metav1.DryRunAll)
+
+func validateDryRun(fldPath *field.Path, dryRun []string) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if !allowedDryRunValues.HasAll(dryRun...) {
+		allErrs = append(allErrs, field.NotSupported(fldPath, dryRun, allowedDryRunValues.List()))
+	}
+	return allErrs
+}
+
+const UninitializedStatusUpdateErrorMsg string = `must not update status when the object is uninitialized`


### PR DESCRIPTION
Before, EndpointSelectors were not validated before being imported into
the policy repository. This meant that users could provide malformed
policy and not be aware that they were doing so, and that Cilium would
accept the policy. Now, as part of the sanitization of rules, validate
the EndpointSelectors in all parts of the rule.

Fixes: #5336

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5709)
<!-- Reviewable:end -->
