### PR TITLE
Test: Run AfterFailed if AfterEach Failed.

### DIFF
--- a/test/ginkgo-ext/scopes.go
+++ b/test/ginkgo-ext/scopes.go
@@ -269,8 +269,15 @@ func RunAfterEach(cs *scope) {
 	runAllAfterFail(cs, testName)
 	afterFailedStatus[testName] = true
 
+	hasFailed := afterEachFailed[testName] || ginkgo.CurrentGinkgoTestDescription().Failed
 	for _, body := range cs.afterEach {
 		body()
+	}
+	// Run the afterFailed in case that something fails on afterEach
+	if hasFailed != afterEachFailed[testName] {
+		GinkgoPrint("Something has failed on AfterEach, running AfterFailed functions")
+		afterFailedStatus[testName] = false
+		runAllAfterFail(cs, testName)
 	}
 
 	// Only run afterAll when all the counters are 0 and all afterEach are executed


### PR DESCRIPTION
If the test did not fail before, and it fails on the AfterEach it'll
trigger the AfterFailed for that function to get all the data.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5710)
<!-- Reviewable:end -->
