### PR TITLE
test: Set kube-system namespace in patch files

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -800,8 +800,8 @@ func (kub *Kubectl) ciliumInstall(dsPatchName, cmPatchName string, getK8sDescrip
 		}
 
 		res = kub.Exec(fmt.Sprintf(
-			`%s patch --filename='%s' --patch "$(cat '%s')" --local -o yaml | kubectl apply -n %s -f -`,
-			KubectlCmd, original, patch, KubeSystemNamespace))
+			`%s patch --filename='%s' --patch "$(cat '%s')" --local -o yaml | kubectl apply -f -`,
+			KubectlCmd, original, patch))
 		if !res.WasSuccessful() {
 			debugYaml(original, patch)
 			return res.GetErr("Cilium manifest patch instalation failed")

--- a/test/k8sT/manifests/1.10/v1.0/cilium-ds-patch.yaml
+++ b/test/k8sT/manifests/1.10/v1.0/cilium-ds-patch.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 spec:
   template:
     spec:

--- a/test/k8sT/manifests/1.10/v1.1/cilium-ds-patch.yaml
+++ b/test/k8sT/manifests/1.10/v1.1/cilium-ds-patch.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 spec:
   template:
     spec:

--- a/test/k8sT/manifests/1.10/v1.2/cilium-ds-patch.yaml
+++ b/test/k8sT/manifests/1.10/v1.2/cilium-ds-patch.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 spec:
   template:
     spec:

--- a/test/k8sT/manifests/1.11/v1.0/cilium-ds-patch.yaml
+++ b/test/k8sT/manifests/1.11/v1.0/cilium-ds-patch.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 spec:
   template:
     spec:

--- a/test/k8sT/manifests/1.11/v1.1/cilium-ds-patch.yaml
+++ b/test/k8sT/manifests/1.11/v1.1/cilium-ds-patch.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 spec:
   template:
     spec:

--- a/test/k8sT/manifests/1.11/v1.2/cilium-ds-patch.yaml
+++ b/test/k8sT/manifests/1.11/v1.2/cilium-ds-patch.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 spec:
   template:
     spec:

--- a/test/k8sT/manifests/1.12/v1.0/cilium-ds-patch.yaml
+++ b/test/k8sT/manifests/1.12/v1.0/cilium-ds-patch.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 spec:
   template:
     spec:

--- a/test/k8sT/manifests/1.12/v1.1/cilium-ds-patch.yaml
+++ b/test/k8sT/manifests/1.12/v1.1/cilium-ds-patch.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 spec:
   template:
     spec:

--- a/test/k8sT/manifests/1.12/v1.2/cilium-ds-patch.yaml
+++ b/test/k8sT/manifests/1.12/v1.2/cilium-ds-patch.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 spec:
   template:
     spec:

--- a/test/k8sT/manifests/1.8/v1.0/cilium-ds-patch.yaml
+++ b/test/k8sT/manifests/1.8/v1.0/cilium-ds-patch.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 spec:
   template:
     spec:

--- a/test/k8sT/manifests/1.8/v1.1/cilium-ds-patch.yaml
+++ b/test/k8sT/manifests/1.8/v1.1/cilium-ds-patch.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 spec:
   template:
     spec:

--- a/test/k8sT/manifests/1.8/v1.2/cilium-ds-patch.yaml
+++ b/test/k8sT/manifests/1.8/v1.2/cilium-ds-patch.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 spec:
   template:
     spec:

--- a/test/k8sT/manifests/1.9/v1.0/cilium-ds-patch.yaml
+++ b/test/k8sT/manifests/1.9/v1.0/cilium-ds-patch.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 spec:
   template:
     spec:

--- a/test/k8sT/manifests/1.9/v1.1/cilium-ds-patch.yaml
+++ b/test/k8sT/manifests/1.9/v1.1/cilium-ds-patch.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 spec:
   template:
     spec:

--- a/test/k8sT/manifests/1.9/v1.2/cilium-ds-patch.yaml
+++ b/test/k8sT/manifests/1.9/v1.2/cilium-ds-patch.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 spec:
   template:
     spec:

--- a/test/k8sT/manifests/cilium-cm-patch-clean-cilium-state.yaml
+++ b/test/k8sT/manifests/cilium-cm-patch-clean-cilium-state.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 data:
   etcd-config: |-
     ---

--- a/test/k8sT/manifests/cilium-cm-patch.yaml
+++ b/test/k8sT/manifests/cilium-cm-patch.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 data:
   etcd-config: |-
     ---

--- a/test/k8sT/manifests/cilium-ds-patch-auto-routing.yaml
+++ b/test/k8sT/manifests/cilium-ds-patch-auto-routing.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 spec:
   template:
     spec:

--- a/test/k8sT/manifests/cilium-ds-patch-geneve.yaml
+++ b/test/k8sT/manifests/cilium-ds-patch-geneve.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 spec:
   template:
     spec:

--- a/test/k8sT/manifests/cilium-ds-patch.yaml
+++ b/test/k8sT/manifests/cilium-ds-patch.yaml
@@ -1,4 +1,6 @@
 ---
+metadata:
+  namespace: kube-system
 spec:
   template:
     spec:


### PR DESCRIPTION
In case the k8s descriptor failed to be installed in the kube-apiserver, the `debugYaml` would print the yaml that was attempted to be installed. Unfortunately, `debugYaml` would not print the exact same descriptor that was being installed in kubernetes as it will lack the namespace set by the `kubectl apply`. To avoid this issue, the namespace is set in each kubernetes descriptor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5711)
<!-- Reviewable:end -->
