### PR TITLE
state: Fix TestReadEPsFromDirNames unit test

### DIFF
--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -175,9 +175,12 @@ func (ds *DaemonSuite) TestReadEPsFromDirNames(c *C) {
 		os.RemoveAll(tmpDir)
 	}()
 
+	os.Chdir(tmpDir)
+
 	oldStateDir := option.Config.StateDir
 	option.Config.StateDir = tmpDir
 	defer func() {
+		os.Chdir(oldStateDir)
 		option.Config.StateDir = oldStateDir
 	}()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
The unit test started failing in the development vagrant box:
```
state_test.go:187:
    c.Assert(len(eps), Equals, len(epsWanted))
... obtained int = 0
... expected int = 4
```

The offending error was:
```
level=warning msg="Regeneration of endpoint failed" bpfCompilation=0s buildDuration=1.133726ms containerID= datapathPolicyRevision=0 desiredPolicyRevision=1 endpointID=259 error="error synchronizing endpoint BPF program directories: unable to rename current endpoint directory: rename /tmp/cilium-tests682674000/259 259_stale: permission denied" ipv4= ipv6= k8sPodName=/ mapSync=0s policyCalculation=0s prepareBuild="348.77µs" proxyConfiguration=0s proxyPolicyCalculation=0s proxyWaitForAck=0s reason=test subsys=endpoint waitingForCTClean=0s waitingForLock="4.134µs"
```

The cause of this was that although state_test.go would create a temporary
state directory. It would fail to os.Chdir() which caused directory operations
to be performed in the real state directory which would then fail because of
permissions.

Fixes: #5716

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5720)
<!-- Reviewable:end -->
