### PR TITLE
proxylib: Simplify Parser interface and document it.

### DIFF
--- a/envoy/cilium_proxylib.cc
+++ b/envoy/cilium_proxylib.cc
@@ -209,11 +209,14 @@ FilterResult GoFilter::Instance::OnIO(bool reply, Buffer::Instance& data, bool e
 
     int64_t total_length = 0;
     GoSlice<uint8_t> buffer_slices[num_slices];
+    uint64_t non_empty_slices = 0;
     for (uint64_t i = 0; i < num_slices; i++) {
-      buffer_slices[i] = GoSlice<uint8_t>(reinterpret_cast<uint8_t*>(raw_slices[i].mem_), raw_slices[i].len_);
-      total_length += raw_slices[i].len_;
+      if (raw_slices[i].len_ > 0) {
+	buffer_slices[non_empty_slices++] = GoSlice<uint8_t>(reinterpret_cast<uint8_t*>(raw_slices[i].mem_), raw_slices[i].len_);
+	total_length += raw_slices[i].len_;
+      }
     }
-    GoDataSlices input_slices(buffer_slices, num_slices);
+    GoDataSlices input_slices(buffer_slices, non_empty_slices);
 
     ENVOY_CONN_LOG(trace, "Cilium Network::OnIO: Calling go module, data starting at {}, {} bytes", conn_, raw_slices[0].mem_, total_length);
     res = (*parent_.go_on_data_)(connection_id_, reply, end_stream, &input_slices, &ops);

--- a/proxylib/cassandra/cassandraparser.go
+++ b/proxylib/cassandra/cassandraparser.go
@@ -168,11 +168,10 @@ func (pf *CassandraParserFactory) Create(connection *Connection) Parser {
 	return &p
 }
 
-func (p *CassandraParser) OnData(reply, endStream bool, dataArray [][]byte, offset int) (OpType, int) {
+func (p *CassandraParser) OnData(reply, endStream bool, dataArray [][]byte) (OpType, int) {
 
 	// inefficient, but simple for now
-	data := bytes.Join(dataArray, []byte(""))[offset:]
-	log.Debugf("OnData offset  = %d", offset)
+	data := bytes.Join(dataArray, []byte{})
 
 	if len(data) < cassHdrLen {
 		// Partial header received, ask for more

--- a/proxylib/input_test.go
+++ b/proxylib/input_test.go
@@ -33,37 +33,32 @@ type LibSuite struct{}
 var _ = Suite(&LibSuite{})
 
 func (l *LibSuite) TestAdvanceInput(c *C) {
-	data := &[][]byte{[]byte("ABCD"), []byte("1234567890"), []byte("abcdefghij")}
-	unit := 0
-	offset := 0
-	var bytes int
+	input := [][]byte{[]byte("ABCD"), []byte("1234567890"), []byte("abcdefghij")}
 
-	c.Assert((*data)[unit][offset], Equals, byte('A'))
+	c.Assert(input[0][0], Equals, byte('A'))
+	c.Assert(len(input), Equals, 3) // Three slices in input
 
 	// Advance to one byte before the end of the first slice
-	bytes, unit, offset = advanceInput(3, unit, offset, data)
-	c.Assert(bytes, Equals, 0)  // Had as many bytes as requested
-	c.Assert(unit, Equals, 0)   // Still in the first slice
-	c.Assert(offset, Equals, 3) // At the offset 3 within the first unit
-	c.Assert((*data)[unit][offset], Equals, byte('D'))
+	input = advanceInput(input, 3)
+	c.Assert(len(input), Equals, 3)    // Still in the first slice
+	c.Assert(len(input[0]), Equals, 1) // One byte left in the first slice
+	c.Assert(input[0][0], Equals, byte('D'))
 
 	// Advance to the beginning of the next slice
-	bytes, unit, offset = advanceInput(1, unit, offset, data)
-	c.Assert(bytes, Equals, 0)  // Had as many bytes as requested
-	c.Assert(unit, Equals, 1)   // Moved to the next slice
-	c.Assert(offset, Equals, 0) // In the begining of the 2nd slice
-	c.Assert((*data)[unit][offset], Equals, byte('1'))
+	input = advanceInput(input, 1)
+	c.Assert(len(input), Equals, 2) // Moved to the next slice
+	c.Assert(input[0][0], Equals, byte('1'))
 
 	// Advance 11 bytes, crossing to the next slice
-	bytes, unit, offset = advanceInput(11, unit, offset, data)
-	c.Assert(bytes, Equals, 0)  // Had as many bytes as requested
-	c.Assert(unit, Equals, 2)   // Moved to the 3rd slice
-	c.Assert(offset, Equals, 1) // One past the beginning
-	c.Assert((*data)[unit][offset], Equals, byte('b'))
+	input = advanceInput(input, 11)
+	c.Assert(len(input), Equals, 1) // Moved to the 3rd slice
+	c.Assert(input[0][0], Equals, byte('b'))
 
 	// Try to advance 11 bytes when only 9 remmain
-	bytes, unit, offset = advanceInput(11, unit, offset, data)
-	c.Assert(bytes, Equals, 2) // 2 bytes remaining
-	c.Assert(unit, Equals, 3)  // All data exhausted
-	c.Assert(offset, Equals, 0)
+	input = advanceInput(input, 11)
+	c.Assert(len(input), Equals, 0) // All data exhausted
+
+	// Try advance on an empty slice
+	input = advanceInput(input, 1)
+	c.Assert(len(input), Equals, 0)
 }

--- a/proxylib/memcached/binary/parser.go
+++ b/proxylib/memcached/binary/parser.go
@@ -157,9 +157,7 @@ var _ proxylib.Parser = &BinaryMemcacheParser{}
 const headerSize = 24
 
 // OnData parses binary memcached data
-func (p *BinaryMemcacheParser) OnData(reply, endStream bool, dataBuffers [][]byte, offset int) (proxylib.OpType, int) {
-	log.Debugf("OnData with offset %d", offset)
-
+func (p *BinaryMemcacheParser) OnData(reply, endStream bool, dataBuffers [][]byte) (proxylib.OpType, int) {
 	if reply {
 		if p.injectFromQueue() {
 			return proxylib.INJECT, len(DeniedMsgBase)
@@ -170,7 +168,7 @@ func (p *BinaryMemcacheParser) OnData(reply, endStream bool, dataBuffers [][]byt
 	}
 
 	//TODO don't copy data from buffers
-	data := (bytes.Join(dataBuffers, []byte{}))[offset:]
+	data := bytes.Join(dataBuffers, []byte{})
 	log.Debugf("Data length: %d", len(data))
 
 	if headerSize > len(data) {

--- a/proxylib/proxylib/parserfactory.go
+++ b/proxylib/proxylib/parserfactory.go
@@ -20,7 +20,40 @@ import (
 
 // A parser instance is used for each connection. OnData will be called from a single thread only.
 type Parser interface {
-	OnData(reply, endStream bool, data [][]byte, offset int) (OpType, int)
+	// OnData() is called when input is available on the underlying connection. The Parser
+	// instance is only ever used for processing data of a single connection, which allows
+	// the parser instance to keep connection specific state. All OnData() calls for a
+	// single connection (both directions) are made from a single thread, so that
+	// no locking is needed for the parser instance if no other goroutines need to access
+	// the parser instance. (Note that any L7 policy protocol rule parsing happens in
+	// other goroutine so any such parsing should not access parser instances directly.)
+	//
+	// OnData() parameters are as follows:
+	// 'reply' is 'false' for original direction of the connection, 'true' otherwise.
+	// 'endStream' is true if there is no more data after 'data' in this direction.
+	// 'data' is the available data in the current direction. The datapath buffers
+	//        partial frames as instructed by the operations returned by the parser
+	//        so that the 'data' always starts on a frame boundary. That is, whenever
+	//        the parser returns `MORE` indicating it needs more input, the bytes
+	//        not 'PASS'ed or 'DROP'ped are retained in a datapath buffer and those
+	//        same bytes are passed to the parser again when more input is available.
+	//        'data' may be an empty slice, but the slices contained are never empty.
+	//
+	// OnData() returns an operation and the number of bytes ('N') the operation applies.
+	// The possible values for 'op' are:
+	// 'MORE' -   Data currently in 'data' is to be retained by the datapath and passed
+	//            again to OnData() after 'N' bytes more data is available.
+	// 'PASS' -   Allow 'N' bytes.
+	// 'DROP' -   Drop 'N' bytes and call OnData() again for the remaining data.
+	// 'INJECT' - Insert 'N' bytes of data placed into the inject buffer in to the
+	//            data stream in this direction.
+	// 'NOP' -    Do nothing, to be used when it is known if no more input
+	//            is to be expected.
+	// 'ERROR' -  Protocol parsing failed and the connection should be closed.
+	//
+	// OnData() is called again after 'PASS', 'DROP', and 'INJECT' with the remaining
+	// data even if none remains.
+	OnData(reply, endStream bool, data [][]byte) (op OpType, N int)
 }
 
 type ParserFactory interface {

--- a/proxylib/proxylib_test.go
+++ b/proxylib/proxylib_test.go
@@ -194,9 +194,9 @@ func (p *PanicParserFactory) Create(connection *proxylib.Connection) proxylib.Pa
 //
 // Parses individual lines and verifies them against the policy
 //
-func (p *PanicParser) OnData(reply, endStream bool, data [][]byte, offset int) (proxylib.OpType, int) {
+func (p *PanicParser) OnData(reply, endStream bool, data [][]byte) (proxylib.OpType, int) {
 	if !reply {
-		panic(fmt.Errorf("PanicParser OnData(reply=%t, endStream=%t, data=%v, offset=%d) panicing...", reply, endStream, data, offset))
+		panic(fmt.Errorf("PanicParser OnData(reply=%t, endStream=%t, data=%v) panicing...", reply, endStream, data))
 	}
 	return proxylib.NOP, 0
 }

--- a/proxylib/testparsers/blockparser.go
+++ b/proxylib/testparsers/blockparser.go
@@ -48,9 +48,10 @@ func (p *BlockParserFactory) Create(connection *Connection) Parser {
 	return &BlockParser{connection: connection}
 }
 
-func getBlock(data [][]byte, offset int) ([]byte, int, int, error) {
+func getBlock(data [][]byte) ([]byte, int, int, error) {
 	var block bytes.Buffer
 
+	offset := 0
 	block_len := 0
 	have_length := false
 	missing := 0
@@ -105,8 +106,8 @@ func getBlock(data [][]byte, offset int) ([]byte, int, int, error) {
 // "INJECT" the block is injected in reverse direction
 // "INSERT" the block is injected in current direction
 //
-func (p *BlockParser) OnData(reply, endStream bool, data [][]byte, offset int) (OpType, int) {
-	block, block_len, missing, err := getBlock(data, offset)
+func (p *BlockParser) OnData(reply, endStream bool, data [][]byte) (OpType, int) {
+	block, block_len, missing, err := getBlock(data)
 	if err != nil {
 		log.WithError(err).Warnf("BlockParser: Invalid frame length")
 		return ERROR, int(ERROR_INVALID_FRAME_LENGTH)

--- a/proxylib/testparsers/headerparser.go
+++ b/proxylib/testparsers/headerparser.go
@@ -119,8 +119,8 @@ func (p *HeaderParserFactory) Create(connection *Connection) Parser {
 //
 // Parses individual lines and verifies them against the policy
 //
-func (p *HeaderParser) OnData(reply, endStream bool, data [][]byte, offset int) (OpType, int) {
-	line, ok := getLine(data, offset)
+func (p *HeaderParser) OnData(reply, endStream bool, data [][]byte) (OpType, int) {
+	line, ok := getLine(data)
 	line_len := len(line)
 
 	if !reply {

--- a/proxylib/testparsers/lineparser.go
+++ b/proxylib/testparsers/lineparser.go
@@ -45,18 +45,17 @@ func (p *LineParserFactory) Create(connection *Connection) Parser {
 	return &LineParser{connection: connection}
 }
 
-func getLine(data [][]byte, offset int) ([]byte, bool) {
+func getLine(data [][]byte) ([]byte, bool) {
 	var line bytes.Buffer
 	for i, s := range data {
-		index := bytes.IndexByte(s[offset:], '\n')
+		index := bytes.IndexByte(s, '\n')
 		if index < 0 {
-			line.Write(s[offset:])
+			line.Write(s)
 		} else {
-			log.Infof("getLine: unit: %d offset: %d length: %d index: %d", i, offset, len(s), index)
-			line.Write(s[offset : offset+index+1])
+			log.Infof("getLine: unit: %d length: %d index: %d", i, len(s), index)
+			line.Write(s[:index+1])
 			return line.Bytes(), true
 		}
-		offset = 0
 	}
 	return line.Bytes(), false
 }
@@ -68,8 +67,8 @@ func getLine(data [][]byte, offset int) ([]byte, bool) {
 // "INJECT" the line is injected in reverse direction
 // "INSERT" the line is injected in current direction
 //
-func (p *LineParser) OnData(reply, endStream bool, data [][]byte, offset int) (OpType, int) {
-	line, ok := getLine(data, offset)
+func (p *LineParser) OnData(reply, endStream bool, data [][]byte) (OpType, int) {
+	line, ok := getLine(data)
 	line_len := len(line)
 
 	if p.inserted {

--- a/proxylib/testparsers/passer.go
+++ b/proxylib/testparsers/passer.go
@@ -42,11 +42,10 @@ func (p *PasserParserFactory) Create(connection *Connection) Parser {
 //
 // This simply passes all data in either direction.
 //
-func (p *PasserParser) OnData(reply, endStream bool, data [][]byte, offset int) (OpType, int) {
+func (p *PasserParser) OnData(reply, endStream bool, data [][]byte) (OpType, int) {
 	n_bytes := 0
 	for _, s := range data {
-		n_bytes += len(s) - offset
-		offset = 0
+		n_bytes += len(s)
 	}
 	if n_bytes == 0 {
 		return NOP, 0


### PR DESCRIPTION
In hindsight the Parser interface is more complex than it needs to
be. Modify the OnData() function to pass in resliced data instead of
using an explicit offset into the data.

Document the Parser interface.

Make the Envoy proxylib caller bypass empty slices so that we never
get empty byte slices as input. The overall data may still be empty,
but now it is guaranteed that the slice of byte slices is empty in
that case.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5730)
<!-- Reviewable:end -->
