### PR TITLE
Make policy modifications based on the CNP identifiable labels

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1716,7 +1716,14 @@ func (d *Daemon) addCiliumNetworkPolicyV2(ciliumV2Store cache.Store, cnp *cilium
 		policyImportErr = k8s.PreprocessRules(rules, d.loadBalancer.K8sEndpoints, d.loadBalancer.K8sServices)
 		d.loadBalancer.K8sMU.Unlock()
 		if policyImportErr == nil {
-			rev, policyImportErr = d.PolicyAdd(rules, &AddOptions{Replace: true})
+			// Replace all rules with the same name, namespace and
+			// resourceTypeCiliumNetworkPolicy
+			rev, policyImportErr = d.PolicyAdd(rules, &AddOptions{
+				ReplaceWithLabels: utils.GetPolicyLabels(
+					cnp.ObjectMeta.Namespace,
+					cnp.ObjectMeta.Name,
+					utils.ResourceTypeCiliumNetworkPolicy),
+			})
 		}
 	}
 


### PR DESCRIPTION
**Summary of changes**:

    When doing a policy update of an existing CNP, where that new CNP
    does not contain a single valid rule defined in its spec, the old CNP
    rules would be kept running creating a unsynced state against the policy
    installed in kubernetes

steps to reproduce:

install:
```
apiVersion: "cilium.io/v2"
kind: CiliumNetworkPolicy
metadata:
  name: "guestbook-web"
  annotations:
    "foo": "bar"
specs:
- endpointSelector:
    matchLabels:
      k8s-app.guestbook: web-3
  ingress:
  - fromEndpoints:
    - matchLabels:
        "reserved.world": ""
    toPorts:
    - ports:
      - port: "80"
        protocol: TCP
```

apply:
```
apiVersion: "cilium.io/v2"
kind: CiliumNetworkPolicy
metadata:
  name: "guestbook-web"
  annotations:
    "foo": "bar"
specs:
- endpointSelector:
    matchLabels:
      k8s-app.guestbook: web-2
  ingress:
  - fromEndpoints:
    - matchLabels:
        "reserved.world": ""
    toPorts:
    - ports:
      - port: "80"
        protocol: TCP
  labels:
  - key: foo
    value: "baz"
```

and verify that the rule `web-3` still exists in `cilium policy get`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5732)
<!-- Reviewable:end -->
