### PR TITLE
add additional logs for CNP rules

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1777,6 +1777,8 @@ func cnpNodeStatusController(ciliumV2Store cache.Store, cnp *cilium_v2.CiliumNet
 				Warn("Error parsing new CiliumNetworkPolicy rule")
 		}
 
+		logger.WithField("cnpFromStore", serverRuleCpy.String()).Debug("copy of CNP retrieved from store which is being updated with status")
+
 		// Update the status of whether the rule is enforced on this node.
 		// If we are unable to parse the CNP retrieved from the store,
 		// or if endpoints did not reach the desired policy revision

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -165,7 +165,7 @@ type AddOptions struct {
 // pods which are selected. Eventual changes in policy rules are propagated to
 // all locally managed endpoints.
 func (d *Daemon) PolicyAdd(rules policyAPI.Rules, opts *AddOptions) (uint64, error) {
-	log.WithField(logfields.CiliumNetworkPolicy, logfields.Repr(rules)).Debug("Policy Add Request")
+	log.WithField(logfields.CiliumNetworkPolicy, rules.String()).Info("Policy Add Request")
 
 	// These must be marked before actually adding them to the repository since a
 	// copy may be made and we won't be able to add the ToFQDN tracking labels

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -119,6 +119,20 @@ func (t *Timestamp) DeepCopyInto(out *Timestamp) {
 	*out = *t
 }
 
+func (r *CiliumNetworkPolicy) String() string {
+	result := ""
+	result += fmt.Sprintf("TypeMeta: %s, ", r.TypeMeta.String())
+	result += fmt.Sprintf("ObjectMeta: %s, ", r.ObjectMeta.String())
+	if r.Spec != nil {
+		result += fmt.Sprintf("Spec: %v", *(r.Spec))
+	}
+	if r.Specs != nil {
+		result += fmt.Sprintf("Specs: %s", r.Specs)
+	}
+	result += fmt.Sprintf("Status: %v", r.Status)
+	return result
+}
+
 // GetPolicyStatus returns the CiliumNetworkPolicyNodeStatus corresponding to
 // nodeName in the provided CiliumNetworkPolicy. If Nodes within the rule's
 // Status is nil, returns an empty CiliumNetworkPolicyNodeStatus.

--- a/pkg/policy/api/rules.go
+++ b/pkg/policy/api/rules.go
@@ -14,9 +14,44 @@
 
 package api
 
+import "fmt"
+
 // Rules is a collection of api.Rule.
 //
 // All rules must be evaluated in order to come to a conclusion. While
 // it is sufficient to have a single fromEndpoints rule match, none of
 // the fromRequires may be violated at the same time.
 type Rules []*Rule
+
+func (r Rules) String() string {
+
+	if len(r) == 0 {
+		return ""
+	}
+
+	if len(r) == 1 {
+		if r[0] != nil {
+			return fmt.Sprintf("%v", *r[0])
+		}
+		return "<nil>"
+	}
+
+	rulesString := ""
+
+	if r[0] != nil {
+		rulesString = fmt.Sprintf("[%v", *r[0])
+	} else {
+		rulesString = "[<nil>"
+	}
+	for i := 1; i < len(r); i++ {
+		if r[i] == nil {
+			rulesString += ", <nil>"
+		} else {
+			rulesString += fmt.Sprintf(", %v", *r[i])
+		}
+	}
+
+	rulesString += "]"
+
+	return rulesString
+}


### PR DESCRIPTION
Currently, we do not log anywhere the actual content of the rules we receive from Kubernetes. This means that if policy was to say, get transformed before we added it into the policy repository or when we pushed the Status of the CNP to K8s, we would not be able to tell that said things were happening. Add `String` functions for `CiliumNetworkPolicy` and for `api.Rules` to get visibility into what the content of the rules being added is. 

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #5728 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5733)
<!-- Reviewable:end -->
