### PR TITLE
make: Clean go cache before running go vet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,7 @@ gofmt:
 
 govet:
 	@$(ECHO_CHECK) vetting all GOFILES...
+	$(GO) clean -cache github.com/cilium/cilium/...
 	$(GO) tool vet api pkg $(SUBDIRS)
 
 ineffassign:

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -260,7 +260,7 @@ const (
 )
 
 // compile time interface check
-var _ notifications.RegenNotificationInfo = &Endpoint{}
+var _ notifications.RegenNotificationInfo = &Endpoint{mutex: &lock.RWMutex{}}
 
 // PolicyMapState is a state of a policy map.
 type PolicyMapState map[policymap.PolicyKey]PolicyMapStateEntry
@@ -292,7 +292,7 @@ type Endpoint struct {
 
 	// mutex protects write operations to this endpoint structure except
 	// for the logger field which has its own mutex
-	mutex lock.RWMutex
+	mutex *lock.RWMutex
 
 	// ContainerName is the name given to the endpoint by the container runtime
 	ContainerName string
@@ -697,6 +697,7 @@ func NewEndpointWithState(ID uint16, state string) *Endpoint {
 		Options: option.NewIntOptions(&EndpointMutableOptionLibrary),
 		Status:  NewEndpointStatus(),
 		state:   state,
+		mutex:   &lock.RWMutex{},
 	}
 	ep.UpdateLogger(nil)
 	return ep
@@ -724,6 +725,7 @@ func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, 
 		},
 		state:  "",
 		Status: NewEndpointStatus(),
+		mutex:  &lock.RWMutex{},
 	}
 	ep.UpdateLogger(nil)
 


### PR DESCRIPTION
Sometimes `go vet` checks become unrelialable when old Cilium's
code is cached. To ensure that `go vet` will always check fresh
code, cache should be cleaned.

Fixes #5670

Signed-off-by: Michal Rostecki <mrostecki@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5736)
<!-- Reviewable:end -->
