### PR TITLE
daemon: fix potential nil pointer dereference

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -67,7 +67,7 @@ func (d *Daemon) restoreOldEndpoints(dir string, clean bool) (*endpointRestoreSt
 
 	existingEndpoints, err := lxcmap.DumpToMap()
 	if err != nil {
-		return nil, err
+		return state, err
 	}
 
 	dirFiles, err := ioutil.ReadDir(dir)


### PR DESCRIPTION
During 1.1 backports, I was hitting the following golang panic
in the CI:

  [...]
  09:42:59 PANIC: daemon_test.go:158: DaemonEtcdSuite.SetUpTest
  09:42:59
  09:42:59 ... Panic: runtime error: invalid memory address or nil pointer dereference (PC=0xF3B38A)
  09:42:59
  09:42:59 /usr/local/go/src/runtime/panic.go:502
  09:42:59   in gopanic
  09:42:59 /usr/local/go/src/runtime/panic.go:63
  09:42:59   in panicmem
  09:42:59 /usr/local/go/src/runtime/signal_unix.go:388
  09:42:59   in sigpanic
  09:42:59 state.go:155
  09:42:59   in Daemon.regenerateRestoredEndpoints
  09:42:59 daemon.go:1291
  09:42:59   in NewDaemon
  09:42:59 daemon_test.go:105
  09:42:59   in DaemonSuite.SetUpTest
  09:42:59 daemon_test.go:160
  09:42:59   in DaemonEtcdSuite.SetUpTest
  09:42:59 /usr/local/go/src/reflect/value.go:308
  09:42:59   in Value.Call
  09:42:59 /usr/local/go/src/runtime/asm_amd64.s:2361
  09:42:59   in goexit

Turns out there's one spot in restoreOldEndpoints() which can
return a nil state on error instead of an empty old one as in
other error cases. While the issue was reproducing every single
run before, I wasn't able to trigger the panic after the fix.

Fixes: #5695
Spotted-by: André Martins <andre@cilium.io>
Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5737)
<!-- Reviewable:end -->
