### PR TITLE
Wait for CNP status controller to terminate

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1869,7 +1869,7 @@ func (d *Daemon) deleteCiliumNetworkPolicyV2(cnp *cilium_v2.CiliumNetworkPolicy)
 
 	importMetadataCache.delete(cnp)
 	ctrlName := cnp.GetControllerName()
-	err := k8sCM.RemoveController(ctrlName)
+	err := k8sCM.RemoveControllerAndWait(ctrlName)
 	if err != nil {
 		log.Debugf("Unable to remove controller %s: %s", ctrlName, err)
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -138,6 +138,9 @@ type Controller struct {
 	uuid              string
 	stop              chan struct{}
 	update            chan struct{}
+
+	// terminated is closed after the controller has been terminated
+	terminated chan struct{}
 }
 
 // GetSuccessCount returns the number of successful controller runs
@@ -271,6 +274,8 @@ shutdown:
 		c.getLogger().WithField(fieldConsecutiveErrors, errorRetries).
 			WithError(err).Warn("Error on Controller stop")
 	}
+
+	close(c.terminated)
 }
 
 func (c *Controller) stopController() {


### PR DESCRIPTION
This ensures that no old CNP status controller can continue running before a new CNP with an identical name can be added again. This fixes a bug where a CNP controller from a previous CNP with a conflicting name can continue update the status  incorrectly if a CNP is deleted and re-added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5754)
<!-- Reviewable:end -->
