### PR TITLE
test: add timeout function for checking if policy is deleted

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -641,10 +641,13 @@ var _ = Describe("K8sPolicyTest", func() {
 			// the policy and we want to make sure that it's deleted
 			kubectl.Delete(helpers.ManifestGet(redisPolicy))
 
-			Expect(kubectl.CiliumIsPolicyLoaded(ciliumPod, getPolicyCmd(webPolicyName))).To(
-				BeFalse(), "WebPolicy is not deleted")
-			Expect(kubectl.CiliumIsPolicyLoaded(ciliumPod, getPolicyCmd(redisPolicyName))).To(
-				BeFalse(), "RedisPolicyName is not deleted")
+			err := kubectl.WaitPolicyDeleted(ciliumPod, getPolicyCmd(webPolicyName))
+			Expect(err).To(
+				BeNil(), "WebPolicy is not deleted")
+
+			err = kubectl.WaitPolicyDeleted(ciliumPod, getPolicyCmd(redisPolicyName))
+			Expect(err).To(
+				BeNil(), "RedisPolicy is not deleted")
 
 			ExpectAllPodsTerminated(kubectl)
 		})


### PR DESCRIPTION
78a1a4a2a131aa1c285d35a0ecae706034b1d461 changed behavior within Cilium such
that when a policy is deleted, the policy is not deleted until the CNP
controller has completed. The CI assumed that calls to `cilium policy delete`
would return after the policy rule is deleted, and some tests started to fail
because the policy was not deleted yet. Add a function which waits for policy
rules to be deleted from Cilium until some timeout is reached to get the tests
passing again.

Fixes: #5758

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5761)
<!-- Reviewable:end -->
