### PR TITLE
envoy: Use separate clusters for egress and ingress redirects.

### DIFF
--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -168,8 +168,8 @@ func StartEnvoy(stateDir, logPath string, baseID uint64) *Envoy {
 	nodeId := "host~127.0.0.1~no-id~localdomain"
 
 	// Create static configuration
-	createBootstrap(bootstrapPath, nodeId, "cluster1", "version1",
-		xdsPath, "cluster1", adminPath)
+	createBootstrap(bootstrapPath, nodeId, ingressClusterName, "version1",
+		xdsPath, egressClusterName, ingressClusterName, adminPath)
 
 	log.Debugf("Envoy: Starting: %v", *e)
 


### PR DESCRIPTION
Currently it is possible that an ingress proxy accidentally reuses a
connection opened by an egress proxy, since in both cases the
connections share the same (original) destination address and the same
source security ID. Fix this by using separate clusters for ingress
and egress redirects, as each cluster has its own connection pool.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5763)
<!-- Reviewable:end -->
