### PR TITLE
Test long lived connections on cilium restarts

### DIFF
--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -15,6 +15,7 @@
 package k8sTest
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
@@ -41,14 +42,6 @@ var _ = Describe("K8sChaosTest", func() {
 		ExpectKubeDNSReady(kubectl)
 	})
 
-	BeforeEach(func() {
-		kubectl.Apply(demoDSPath).ExpectSuccess("DS deployment cannot be applied")
-
-		err := kubectl.WaitforPods(
-			helpers.DefaultNamespace, fmt.Sprintf("-l zgroup=testDS"), 300)
-		Expect(err).Should(BeNil(), "Pods are not ready after timeout")
-	})
-
 	AfterFailed(func() {
 		kubectl.CiliumReport(helpers.KubeSystemNamespace,
 			"cilium service list",
@@ -59,41 +52,59 @@ var _ = Describe("K8sChaosTest", func() {
 		kubectl.ValidateNoErrorsOnLogs(CurrentGinkgoTestDescription().Duration)
 	})
 
-	AfterEach(func() {
-		kubectl.Delete(demoDSPath).ExpectSuccess(
-			"%s deployment cannot be deleted", demoDSPath)
+	AfterAll(func() {
 		ExpectAllPodsTerminated(kubectl)
-
 	})
 
-	PingService := func() {
-		pods, err := kubectl.GetPodNames(helpers.DefaultNamespace, "zgroup=testDSClient")
-		Expect(err).To(BeNil(), "Cannot get pods names")
-		Expect(len(pods)).To(BeNumerically(">", 0), "No pods available to test connectivity")
+	Context("Connectivity demo application", func() {
+		BeforeEach(func() {
+			kubectl.Apply(demoDSPath).ExpectSuccess("DS deployment cannot be applied")
 
-		dsPods, err := kubectl.GetPodsIPs(helpers.DefaultNamespace, "zgroup=testDS")
-		Expect(err).To(BeNil(), "Cannot get daemonset pods IPS")
-		Expect(len(pods)).To(BeNumerically(">", 0), "No pods available to test connectivity")
+			err := kubectl.WaitforPods(
+				helpers.DefaultNamespace, fmt.Sprintf("-l zgroup=testDS"), 300)
+			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
+		})
 
-		By("Waiting for kube-dns entry for service testds-service")
-		err = kubectl.WaitForKubeDNSEntry(testDSService, helpers.DefaultNamespace)
-		ExpectWithOffset(1, err).To(BeNil(), "DNS entry is not ready after timeout")
+		AfterEach(func() {
+			kubectl.Delete(demoDSPath).ExpectSuccess(
+				"%s deployment cannot be deleted", demoDSPath)
+			ExpectAllPodsTerminated(kubectl)
 
-		By("Getting ClusterIP For testds-service")
-		host, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, "testds-service")
-		ExpectWithOffset(1, err).To(BeNil(), "unable to get ClusterIP and port for service testds-service")
+		})
 
-		for _, pod := range pods {
-			for _, ip := range dsPods {
-				By("Pinging test-ds service pod with IP %q from client pod %q", ip, pod)
-				res := kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, pod, helpers.Ping(ip))
-				log.Debugf("Pod %s ping %v", pod, ip)
-				ExpectWithOffset(1, res).To(helpers.CMDSuccess(),
-					"Cannot ping from %q to %q", pod, ip)
+		// connectivityTest  performs a few test inside:
+		// - tests connectivity of all client pods to the backend pods directly via ping
+		// - tests connectivity of all client pods to the ClusterIP of the test-ds service via curl
+		// - tests connectivity of all client pods to the DNS name for the test-ds service via curl
+		connectivityTest := func() {
+			pods, err := kubectl.GetPodNames(helpers.DefaultNamespace, "zgroup=testDSClient")
+			Expect(err).To(BeNil(), "Cannot get pods names")
+			Expect(len(pods)).To(BeNumerically(">", 0), "No pods available to test connectivity")
+
+			dsPods, err := kubectl.GetPodsIPs(helpers.DefaultNamespace, "zgroup=testDS")
+			Expect(err).To(BeNil(), "Cannot get daemonset pods IPS")
+			Expect(len(dsPods)).To(BeNumerically(">", 0), "No pods available to test connectivity")
+
+			By("Waiting for kube-dns entry for service testds-service")
+			err = kubectl.WaitForKubeDNSEntry(testDSService, helpers.DefaultNamespace)
+			ExpectWithOffset(1, err).To(BeNil(), "DNS entry is not ready after timeout")
+
+			By("Getting ClusterIP For testds-service")
+			host, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, "testds-service")
+			ExpectWithOffset(1, err).To(BeNil(), "unable to get ClusterIP and port for service testds-service")
+
+			for _, pod := range pods {
+				for _, ip := range dsPods {
+					By("Pinging testds pod with IP %q from client pod %q", ip, pod)
+					res := kubectl.ExecPodCmd(
+						helpers.DefaultNamespace, pod, helpers.Ping(ip))
+					log.Debugf("Pod %s ping %v", pod, ip)
+					ExpectWithOffset(1, res).To(helpers.CMDSuccess(),
+						"Cannot ping from %q to %q", pod, ip)
+				}
 
 				By("Curling testds-service via ClusterIP %q", host)
-				res = kubectl.ExecPodCmd(
+				res := kubectl.ExecPodCmd(
 					helpers.DefaultNamespace, pod, helpers.CurlFail("http://%s:80/", host))
 				ExpectWithOffset(1, res).To(helpers.CMDSuccess(),
 					"Cannot curl from %q to testds-service via ClusterIP", pod)
@@ -105,57 +116,151 @@ var _ = Describe("K8sChaosTest", func() {
 					"Cannot curl from %q to testds-service via DNS hostname", pod)
 			}
 		}
-	}
 
-	It("Endpoint can still connect while Cilium is not running", func() {
-		By("Waiting for deployed pods to be ready")
-		err := kubectl.WaitforPods(
-			helpers.DefaultNamespace,
-			fmt.Sprintf("-l zgroup=testDSClient"), 300)
-		Expect(err).Should(BeNil(), "Pods are not ready after timeout")
+		It("Endpoint can still connect while Cilium is not running", func() {
+			By("Waiting for deployed pods to be ready")
+			err := kubectl.WaitforPods(
+				helpers.DefaultNamespace,
+				fmt.Sprintf("-l zgroup=testDSClient"), 300)
+			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 
-		err = kubectl.CiliumEndpointWaitReady()
-		Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
+			err = kubectl.CiliumEndpointWaitReady()
+			Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 
-		By("Checking connectivity before restarting Cilium")
-		PingService()
+			By("Checking connectivity before restarting Cilium")
+			connectivityTest()
 
-		By("Deleting cilium pods")
-		res := kubectl.Exec(fmt.Sprintf("%s -n %s delete pods -l k8s-app=cilium",
-			helpers.KubectlCmd, helpers.KubeSystemNamespace))
-		res.ExpectSuccess()
+			By("Deleting cilium pods")
+			res := kubectl.Exec(fmt.Sprintf("%s -n %s delete pods -l k8s-app=cilium",
+				helpers.KubectlCmd, helpers.KubeSystemNamespace))
+			res.ExpectSuccess()
 
-		ExpectAllPodsTerminated(kubectl)
+			ExpectAllPodsTerminated(kubectl)
 
-		ExpectCiliumReady(kubectl)
-		err = kubectl.CiliumEndpointWaitReady()
-		Expect(err).To(BeNil(), "Endpoints are not ready after Cilium restarts")
+			ExpectCiliumReady(kubectl)
+			err = kubectl.CiliumEndpointWaitReady()
+			Expect(err).To(BeNil(), "Endpoints are not ready after Cilium restarts")
 
-		By("Checking connectivity after restarting Cilium")
-		PingService()
+			By("Checking connectivity after restarting Cilium")
+			connectivityTest()
 
-		By("Uninstall cilium pods")
+			By("Uninstall cilium pods")
 
-		res = kubectl.DeleteResource(
-			"ds", fmt.Sprintf("-n %s cilium", helpers.KubeSystemNamespace))
-		res.ExpectSuccess("Cilium DS cannot be deleted")
+			res = kubectl.DeleteResource(
+				"ds", fmt.Sprintf("-n %s cilium", helpers.KubeSystemNamespace))
+			res.ExpectSuccess("Cilium DS cannot be deleted")
 
-		ExpectAllPodsTerminated(kubectl)
+			ExpectAllPodsTerminated(kubectl)
 
-		By("Checking connectivity after uninstalling Cilium")
-		PingService()
+			By("Checking connectivity after uninstalling Cilium")
+			connectivityTest()
 
-		By("Install cilium pods")
+			By("Install cilium pods")
 
-		err = kubectl.CiliumInstall(helpers.CiliumDefaultDSPatch, helpers.CiliumConfigMapPatch)
-		Expect(err).To(BeNil(), "Cilium cannot be installed")
+			err = kubectl.CiliumInstall(helpers.CiliumDefaultDSPatch, helpers.CiliumConfigMapPatch)
+			Expect(err).To(BeNil(), "Cilium cannot be installed")
 
-		ExpectCiliumReady(kubectl)
+			ExpectCiliumReady(kubectl)
 
-		err = kubectl.CiliumEndpointWaitReady()
-		Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
+			err = kubectl.CiliumEndpointWaitReady()
+			Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 
-		By("Checking connectivity after reinstalling Cilium")
-		PingService()
+			By("Checking connectivity after reinstalling Cilium")
+			connectivityTest()
+		})
+	})
+
+	Context("Restart with long lived connections", func() {
+
+		var (
+			netperfManifest    = helpers.ManifestGet("netperf-deployment.yaml")
+			netperfPolicy      = helpers.ManifestGet("netperf-policy.yaml")
+			netperfServiceName = "netperf-service"
+			podsIps            map[string]string
+			netperfServiceIP   string
+			netperfClient      = "netperf-client"
+			netperfServer      = "netperf-server"
+		)
+
+		BeforeAll(func() {
+			kubectl.Apply(netperfManifest).ExpectSuccess("Netperf cannot be deployed")
+
+			err := kubectl.WaitforPods(
+				helpers.DefaultNamespace,
+				fmt.Sprintf("-l zgroup=testapp"), 300)
+			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
+
+			podsIps, err = kubectl.GetPodsIPs(helpers.DefaultNamespace, "zgroup=testapp")
+			Expect(err).To(BeNil(), "Cannot get pods ips")
+
+			netperfServiceIP, _, err = kubectl.GetServiceHostPort(helpers.DefaultNamespace, netperfServiceName)
+			Expect(err).To(BeNil(), "cannot get service netperf ip")
+		})
+
+		AfterAll(func() {
+			_ = kubectl.Delete(netperfManifest)
+		})
+
+		AfterEach(func() {
+			_ = kubectl.Delete(netperfPolicy)
+		})
+
+		restartCilium := func() {
+			ciliumFilter := "k8s-app=cilium"
+
+			By("Deleting all cilium pods")
+			res := kubectl.Exec(fmt.Sprintf(
+				"%s -n %s delete pods -l %s",
+				helpers.KubectlCmd, helpers.KubeSystemNamespace, ciliumFilter))
+			res.ExpectSuccess("Failed to delete cilium pods")
+
+			By("Waiting cilium pods to terminate")
+			ExpectAllPodsTerminated(kubectl)
+
+			By("Waiting for cilium pods to be ready")
+			err := kubectl.WaitforPods(
+				helpers.KubeSystemNamespace, fmt.Sprintf("-l %s", ciliumFilter), 300)
+			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
+		}
+
+		It("TCP connection is not dropped when cilium restarts", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			res := kubectl.ExecPodCmdContext(
+				ctx,
+				helpers.DefaultNamespace,
+				netperfClient,
+				fmt.Sprintf("netperf -l 300 -t TCP_STREAM -H %s", podsIps[netperfServer]))
+
+			restartCilium()
+
+			By("Stopping netperf client test")
+			cancel()
+			res.WaitUntilFinish()
+			res.ExpectSuccess("Failed while cilium was restarting")
+		})
+
+		It("L3/L4 policies still work while Cilium is restarted", func() {
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			res := kubectl.ExecPodCmdContext(
+				ctx,
+				helpers.DefaultNamespace,
+				netperfClient,
+				fmt.Sprintf("netperf -l 300 -t TCP_STREAM -H %s", podsIps[netperfServer]))
+
+			By("Installing the L3-L4 Policy")
+			_, err := kubectl.CiliumPolicyAction(
+				helpers.KubeSystemNamespace, netperfPolicy, helpers.KubectlApply, 300)
+			Expect(err).Should(BeNil(), "Cannot install %q policy", netperfPolicy)
+
+			restartCilium()
+
+			By("Stopping netperf client test")
+			cancel()
+			res.WaitUntilFinish()
+			res.ExpectSuccess("Failed while cilium was restarting")
+		})
 	})
 })

--- a/test/k8sT/manifests/netperf-deployment.yaml
+++ b/test/k8sT/manifests/netperf-deployment.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: netperf-server
+  labels:
+    id: netperf-server
+    zgroup: testapp
+spec:
+  containers:
+  - name: netperf
+    image: tgraf/netperf
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: netperf-client
+  labels:
+    id: netperf-client
+    zgroup: testapp
+spec:
+  containers:
+  - name: netperf
+    image: tgraf/netperf
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: netperf-service
+spec:
+  ports:
+  - port: 12865
+  selector:
+    name: netperf-server

--- a/test/k8sT/manifests/netperf-policy.yaml
+++ b/test/k8sT/manifests/netperf-policy.yaml
@@ -1,0 +1,17 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+description: "netperf-policy"
+metadata:
+  name: "netperf-policy"
+spec:
+  endpointSelector:
+    matchLabels:
+      id: netperf-server
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        id: netperf-client
+    toPorts:
+    - ports:
+      - port: "12865"
+        protocol: TCP


### PR DESCRIPTION
Two new tests to validate that no traffic is drop when Cilium restarts. 

Keep two test because are quite fast 80seconds, and it's easy to see when it fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5768)
<!-- Reviewable:end -->
