### PR TITLE
endpoint: Establish grace period when endpoint changes identity

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -15,6 +15,8 @@
 package defaults
 
 import (
+	"time"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -85,4 +87,11 @@ const (
 
 	// ToFQDNsMinTTL is the default lower bound for TTLs used with ToFQDNs rules.
 	ToFQDNsMinTTL = 365 * 86400 // 1 year in seconds
+
+	// IdentityChangeGracePeriod is the grace period that needs to pass
+	// before an endpoint that has changed its identity will start using
+	// that new identity. During the grace period, the new identity has
+	// already been allocated and other nodes in the cluster have a chance
+	// to whitelist the new upcoming identity of the endpoint.
+	IdentityChangeGracePeriod = 25 * time.Second
 )

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/defaults"
 	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -2467,6 +2468,33 @@ func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
 					WithError(err).Warn("BUG: Unable to release old endpoint identity")
 			}
 		}()
+
+		// The identity of the endpoint is changing, delay the use of
+		// the identity by a grace period to give all other cluster
+		// nodes a chance to adjust their policies first. This requires
+		// to unlock the endpoit and then lock it again.
+		//
+		// If the identity change is from init -> *, don't delay the
+		// use of the identity as we want the init duration to be as
+		// short as possible.
+		if identity.ID != oldIdentity.ID && oldIdentity.ID != identityPkg.ReservedIdentityInit {
+			e.Unlock()
+
+			elog.Debugf("Applying grace period before regeneration due to identity change")
+			time.Sleep(defaults.IdentityChangeGracePeriod)
+
+			if err := e.LockAlive(); err != nil {
+				identity.Release()
+				return err
+			}
+
+			// Since we unlocked the endpoint and re-locked, the label update may already be obsolete
+			if e.identityResolutionIsObsolete(myChangeRev) {
+				e.Unlock()
+				identity.Release()
+				return nil
+			}
+		}
 	}
 
 	elog.WithFields(logrus.Fields{logfields.Identity: identity.StringID()}).


### PR DESCRIPTION
So far, when an endpoint had changed its identity, the changed identity was
used immediately. This caused potential downtime for the service as the
time frame between the allocation of the security identity and use of it cluster-wide was potentially very short.

By establishing a grace period, other nodes in the cluster have time to get
notified about the new security identity and can whitelist the new security
identity for existing endpoints. This reduces the risk of potential downtime
when endpoints are changing security identity.

The downside of the grace period is that the use of the new identity is delayed
for some time.

For now, the grace period is 20 seconds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5771)
<!-- Reviewable:end -->
