### PR TITLE
test: remove more containers in AfterAll for RuntimeChaos

### DIFF
--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -47,6 +47,7 @@ var _ = Describe("RuntimeChaos", func() {
 	AfterAll(func() {
 		vm.ContainerRm(helpers.Client)
 		vm.ContainerRm(helpers.Server)
+		vm.SampleContainersActions(helpers.Delete, helpers.CiliumDockerNetwork)
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
A newly added test created containers which were not cleaned in up
`AfterAll`, which polluted the CI environment, causing failures
in subsequent tests.

Fixes: c493267d47 ("Test: Add restart test in Cilium with L4 policy to validate no traffic drops.")
Fixes: #5773 

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5775)
<!-- Reviewable:end -->
