### PR TITLE
endpoint: add wrapper around directory deletion

### DIFF
--- a/pkg/endpoint/directory.go
+++ b/pkg/endpoint/directory.go
@@ -135,3 +135,10 @@ func (e *Endpoint) removeDirectory(path string) error {
 	e.getLogger().WithField("directory", path).Debug("removing directory")
 	return os.RemoveAll(path)
 }
+
+func (e *Endpoint) removeDirectories() {
+	e.removeDirectory(e.DirectoryPath())
+	e.removeDirectory(e.FailedDirectoryPath())
+	e.removeDirectory(e.NextDirectoryPath())
+	e.removeDirectory(e.backupDirectoryPath())
+}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1842,13 +1842,6 @@ func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup
 	return errors
 }
 
-func (e *Endpoint) removeDirectories() {
-	e.removeDirectory(e.DirectoryPath())
-	e.removeDirectory(e.FailedDirectoryPath())
-	e.removeDirectory(e.NextDirectoryPath())
-	e.removeDirectory(e.backupDirectoryPath())
-}
-
 // RegenerateWait should only be called when endpoint's state has successfully
 // been changed to "waiting-to-regenerate"
 func (e *Endpoint) RegenerateWait(owner Owner, reason string) error {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1843,10 +1843,10 @@ func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup
 }
 
 func (e *Endpoint) removeDirectories() {
-	os.RemoveAll(e.DirectoryPath())
-	os.RemoveAll(e.FailedDirectoryPath())
-	os.RemoveAll(e.NextDirectoryPath())
-	os.RemoveAll(e.backupDirectoryPath())
+	e.removeDirectory(e.DirectoryPath())
+	e.removeDirectory(e.FailedDirectoryPath())
+	e.removeDirectory(e.NextDirectoryPath())
+	e.removeDirectory(e.backupDirectoryPath())
 }
 
 // RegenerateWait should only be called when endpoint's state has successfully

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -744,7 +744,7 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 
 	// Remove an eventual existing temporary directory that has been left
 	// over to make sure we can start the build from scratch
-	if err := os.RemoveAll(tmpDir); err != nil && !os.IsNotExist(err) {
+	if err := e.removeDirectory(tmpDir); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("unable to remove old temporary directory: %s", err)
 	}
 
@@ -769,7 +769,7 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 		// build. If the build was successful, the temporary directory will
 		// have been moved to a new permanent location. If the build failed,
 		// the temporary directory will still exist and we will reomve it.
-		os.RemoveAll(tmpDir)
+		e.removeDirectory(tmpDir)
 
 		// Set to Ready, but only if no other changes are pending.
 		// State will remain as waiting-to-regenerate if further
@@ -787,7 +787,7 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 		}).Warn("generating BPF for endpoint failed, keeping stale directory.")
 
 		// Remove an eventual existing previous failure directory
-		os.RemoveAll(failDir)
+		e.removeDirectory(failDir)
 		os.Rename(tmpDir, failDir)
 		return err
 	}


### PR DESCRIPTION
Add a wrapper around `os.RemoveAll` which logs that the directory passed to `os.RemoveAll` is being deleted using the endpoint's logger at Debug level.
    
Signed-off by: Ian Vernon <ian@cilium.io>

The motivation behind this PR was because of this comment ( 
https://github.com/cilium/cilium/issues/5683#issuecomment-426038179 ) which hypothesized that #5684 might be a cause of #5683 . Either way, it is useful to have visibility into when we are changing state for endpoints by providing more context when debugging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5776)
<!-- Reviewable:end -->
