### PR TITLE
examples: set Cilium image version to v1.2.3

### DIFF
--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -54,7 +54,7 @@ spec:
                   optional: true
                   key: clean-cilium-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -122,7 +122,7 @@ spec:
                   optional: true
                   key: clean-cilium-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -60,7 +60,7 @@ spec:
                   optional: true
                   key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -128,7 +128,7 @@ spec:
                   optional: true
                   key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -54,7 +54,7 @@ spec:
                   optional: true
                   key: clean-cilium-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -122,7 +122,7 @@ spec:
                   optional: true
                   key: clean-cilium-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -60,7 +60,7 @@ spec:
                   optional: true
                   key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -128,7 +128,7 @@ spec:
                   optional: true
                   key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -54,7 +54,7 @@ spec:
                   optional: true
                   key: clean-cilium-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -122,7 +122,7 @@ spec:
                   optional: true
                   key: clean-cilium-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -60,7 +60,7 @@ spec:
                   optional: true
                   key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -128,7 +128,7 @@ spec:
                   optional: true
                   key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.7/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-crio-ds.yaml
@@ -54,7 +54,7 @@ spec:
                   optional: true
                   key: clean-cilium-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.7/cilium-crio.yaml
+++ b/examples/kubernetes/1.7/cilium-crio.yaml
@@ -122,7 +122,7 @@ spec:
                   optional: true
                   key: clean-cilium-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -60,7 +60,7 @@ spec:
                   optional: true
                   key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -128,7 +128,7 @@ spec:
                   optional: true
                   key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -54,7 +54,7 @@ spec:
                   optional: true
                   key: clean-cilium-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -122,7 +122,7 @@ spec:
                   optional: true
                   key: clean-cilium-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -60,7 +60,7 @@ spec:
                   optional: true
                   key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -128,7 +128,7 @@ spec:
                   optional: true
                   key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -54,7 +54,7 @@ spec:
                   optional: true
                   key: clean-cilium-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -122,7 +122,7 @@ spec:
                   optional: true
                   key: clean-cilium-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -60,7 +60,7 @@ spec:
                   optional: true
                   key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -128,7 +128,7 @@ spec:
                   optional: true
                   key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:v1.2.4
+        - image: docker.io/cilium/cilium:v1.2.3
           imagePullPolicy: IfNotPresent
           name: cilium-agent
           command: ["cilium-agent"]


### PR DESCRIPTION
When using the 1.2 branch of documentation, ReadTheDocs will use HEAD of
1.2. To prepare for v1.2.4, the version of Cilium used in the images was
bumped. This resulted in the documentation having the Kubernetes YAMLs
list v1.2.4 as the version to use for Cilium. This version had not been
yet, so change it back to v1.2.3 accordingly.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #5722

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5781)
<!-- Reviewable:end -->
