### PR TITLE
Ginkgo: avoid trigger AfterFailed two times.

### DIFF
--- a/test/ginkgo-ext/scopes.go
+++ b/test/ginkgo-ext/scopes.go
@@ -274,7 +274,7 @@ func RunAfterEach(cs *scope) {
 		body()
 	}
 	// Run the afterFailed in case that something fails on afterEach
-	if hasFailed != afterEachFailed[testName] {
+	if hasFailed == false && afterEachFailed[testName] {
 		GinkgoPrint("Something has failed on AfterEach, running AfterFailed functions")
 		afterFailedStatus[testName] = false
 		runAllAfterFail(cs, testName)


### PR DESCRIPTION
At the moment, with the changes added on commit
`15c7ef1fad2774cf20e8f8dae526ae6a40bbf37f` if a test failed on the `It`
or `JustAfterEach` functions, it'll trigger two times the AfterFailed
functions because hasFailed is always different if no issues on
AfterEach.

With this change, next AfterFailed will only trigger if the test does
not fail and if the AfterEach fails.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5784)
<!-- Reviewable:end -->
