### PR TITLE
envoy: Use separate clusters for egress and ingress redirects.

### DIFF
--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -140,8 +140,8 @@ func StartEnvoy(adminPort uint32, stateDir, logPath string, baseID uint64) *Envo
 	nodeId := "host~127.0.0.1~no-id~localdomain"
 
 	// Create static configuration
-	createBootstrap(bootstrapPath, nodeId, "cluster1", "version1",
-		xdsPath, "cluster1", adminPort)
+	createBootstrap(bootstrapPath, nodeId, ingressClusterName, "version1",
+		xdsPath, egressClusterName, ingressClusterName, adminPort)
 
 	log.Debugf("Envoy: Starting: %v", *e)
 

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -58,6 +58,11 @@ var (
 	}
 )
 
+const (
+	egressClusterName  = "egress-cluster"
+	ingressClusterName = "ingress-cluster"
+)
+
 // XDSServer provides a high-lever interface to manage resources published
 // using the xDS gRPC API.
 type XDSServer struct {
@@ -182,7 +187,7 @@ func StartXDSServer(stateDir string) *XDSServer {
 											"prefix": {&structpb.Value_StringValue{StringValue: "/"}},
 										}}}},
 										"route": {&structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
-											"cluster": {&structpb.Value_StringValue{StringValue: "cluster1"}},
+											"cluster": {&structpb.Value_StringValue{StringValue: "cluster-set-separately-below"}},
 										}}}},
 									}}}},
 								}}}},
@@ -227,6 +232,11 @@ func (s *XDSServer) AddListener(name string, endpointPolicyName string, port uin
 
 	s.mutex.Unlock()
 
+	clusterName := egressClusterName
+	if isIngress {
+		clusterName = ingressClusterName
+	}
+
 	// Fill in the listener-specific parts.
 	listenerConf := proto.Clone(s.listenerProto).(*envoy_api_v2.Listener)
 	listenerConf.Name = name
@@ -236,6 +246,7 @@ func (s *XDSServer) AddListener(name string, endpointPolicyName string, port uin
 	}
 
 	listenerConf.FilterChains[0].Filters[1].Config.Fields["http_filters"].GetListValue().Values[0].GetStructValue().Fields["config"].GetStructValue().Fields["policy_name"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: endpointPolicyName}}
+	listenerConf.FilterChains[0].Filters[1].Config.Fields["route_config"].GetStructValue().Fields["virtual_hosts"].GetListValue().Values[0].GetStructValue().Fields["routes"].GetListValue().Values[0].GetStructValue().Fields["route"].GetStructValue().Fields["cluster"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: clusterName}}
 
 	s.listenerMutator.Upsert(ListenerTypeURL, name, listenerConf, []string{"127.0.0.1"}, wg.AddCompletion())
 }
@@ -320,13 +331,21 @@ func getHTTPRule(h *api.PortRuleHTTP) (headers []*envoy_api_v2_route.HeaderMatch
 	return
 }
 
-func createBootstrap(filePath string, name, cluster, version string, xdsSock, envoyClusterName string, adminPort uint32) {
+func createBootstrap(filePath string, name, cluster, version string, xdsSock, egressClusterName, ingressClusterName string, adminPort uint32) {
 	bs := &envoy_config_bootstrap_v2.Bootstrap{
 		Node: &envoy_api_v2_core.Node{Id: name, Cluster: cluster, Metadata: nil, Locality: nil, BuildVersion: version},
 		StaticResources: &envoy_config_bootstrap_v2.Bootstrap_StaticResources{
 			Clusters: []*envoy_api_v2.Cluster{
 				{
-					Name:              envoyClusterName,
+					Name:              egressClusterName,
+					Type:              envoy_api_v2.Cluster_ORIGINAL_DST,
+					ConnectTimeout:    &duration.Duration{Seconds: 1, Nanos: 0},
+					CleanupInterval:   &duration.Duration{Seconds: 1, Nanos: 500000000},
+					LbPolicy:          envoy_api_v2.Cluster_ORIGINAL_DST_LB,
+					ProtocolSelection: envoy_api_v2.Cluster_USE_DOWNSTREAM_PROTOCOL,
+				},
+				{
+					Name:              ingressClusterName,
 					Type:              envoy_api_v2.Cluster_ORIGINAL_DST,
 					ConnectTimeout:    &duration.Duration{Seconds: 1, Nanos: 0},
 					CleanupInterval:   &duration.Duration{Seconds: 1, Nanos: 500000000},


### PR DESCRIPTION
[ upstream commit 8bd65a6bfd44b9949362999073c363273133623a ]

Currently it is possible that an ingress proxy accidentally reuses a
connection opened by an egress proxy, since in both cases the
connections share the same (original) destination address and the same
source security ID. Fix this by using separate clusters for ingress
and egress redirects, as each cluster has its own connection pool.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5799)
<!-- Reviewable:end -->
