### PR TITLE
ipcache: Manage IPIdentityCache in agent

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -2024,7 +2024,7 @@ func (d *Daemon) deletePodHostIP(pod *v1.Pod) (bool, error) {
 		return true, fmt.Errorf("ipcache entry not owned by kubernetes source")
 	}
 
-	ipcache.IPIdentityCache.Delete(pod.Status.PodIP)
+	ipcache.IPIdentityCache.Delete(pod.Status.PodIP, ipcache.FromKubernetes)
 
 	return false, nil
 }
@@ -2357,7 +2357,7 @@ func (d *Daemon) deleteK8sNodeV1(k8sNode *v1.Node) error {
 		return nil
 	}
 
-	ipcache.IPIdentityCache.Delete(ip)
+	ipcache.IPIdentityCache.Delete(ip, ipcache.FromKubernetes)
 
 	ciliumIP := net.ParseIP(ip)
 	if ciliumIP == nil {

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -339,7 +339,7 @@ func (ipc *IPCache) DumpToListenerLocked(listener IPIdentityMappingListener) {
 
 // deleteLocked removes removes the provided IP-to-security-identity mapping
 // from ipc with the assumption that the IPCache's mutex is held.
-func (ipc *IPCache) deleteLocked(ip string) {
+func (ipc *IPCache) deleteLocked(ip string, src Source) {
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.IPAddr: ip,
 	})
@@ -348,6 +348,11 @@ func (ipc *IPCache) deleteLocked(ip string) {
 	if !found {
 		scopedLog.Debug("Attempt to remove non-existing IP from ipcache layer")
 		return
+	} else {
+		if !allowOverwrite(cachedIdentity.Source, src) {
+			scopedLog.Warnf("Ignoring IPCache delete with source %s for existing source  %s", src, cachedIdentity.Source)
+			return
+		}
 	}
 
 	var cidr *net.IPNet
@@ -426,10 +431,10 @@ func (ipc *IPCache) deleteLocked(ip string) {
 }
 
 // Delete removes the provided IP-to-security-identity mapping from the IPCache.
-func (ipc *IPCache) Delete(IP string) {
+func (ipc *IPCache) Delete(IP string, src Source) {
 	ipc.mutex.Lock()
 	defer ipc.mutex.Unlock()
-	ipc.deleteLocked(IP)
+	ipc.deleteLocked(IP, src)
 }
 
 // LookupByIP returns the corresponding security identity that endpoint IP maps

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -43,7 +43,7 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	c.Assert(len(IPIdentityCache.identityToIPCache), Equals, 0)
 
 	// Deletion of key that doesn't exist doesn't cause panic.
-	IPIdentityCache.Delete(endpointIP)
+	IPIdentityCache.Delete(endpointIP, FromKVStore)
 
 	IPIdentityCache.Upsert(endpointIP, nil, Identity{
 		ID:     identity,
@@ -75,7 +75,7 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 1)
 	c.Assert(len(IPIdentityCache.identityToIPCache), Equals, 1)
 
-	IPIdentityCache.Delete(endpointIP)
+	IPIdentityCache.Delete(endpointIP, FromKVStore)
 
 	// Assure deletion occurs across both mappings.
 	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 0)
@@ -107,7 +107,7 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 		c.Assert(cachedIP, Equals, endpointIP)
 	}
 
-	IPIdentityCache.Delete(endpointIP)
+	IPIdentityCache.Delete(endpointIP, FromKVStore)
 
 	// Assure deletion occurs across both mappings.
 	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 0)
@@ -134,7 +134,7 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	cachedEndpointIPs, _ := IPIdentityCache.LookupByIdentity(29)
 	c.Assert(reflect.DeepEqual(cachedEndpointIPs, expectedIPList), Equals, true)
 
-	IPIdentityCache.Delete("27.2.2.2")
+	IPIdentityCache.Delete("27.2.2.2", FromKVStore)
 
 	expectedIPList = map[string]struct{}{
 		"127.0.0.1": {},
@@ -152,7 +152,7 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	c.Assert(exists, Equals, true)
 	c.Assert(cachedIdentity.ID, Equals, identityPkg.NumericIdentity(29))
 
-	IPIdentityCache.Delete("127.0.0.1")
+	IPIdentityCache.Delete("127.0.0.1", FromKVStore)
 
 	_, exists = IPIdentityCache.LookupByIdentity(29)
 	c.Assert(exists, Equals, false)
@@ -162,7 +162,7 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 
 	// Clean up.
 	for index := range endpointIPs {
-		IPIdentityCache.Delete(endpointIPs[index])
+		IPIdentityCache.Delete(endpointIPs[index], FromKVStore)
 		_, exists = IPIdentityCache.LookupByIP(endpointIPs[index])
 		c.Assert(exists, Equals, false)
 

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -370,7 +370,7 @@ restart:
 				} else {
 					ip = ipnet.String()
 				}
-				IPIdentityCache.Delete(ip)
+				IPIdentityCache.Delete(ip, FromKVStore)
 			}
 
 		case <-iw.stop:


### PR DESCRIPTION
This PR is the height of hackery. It is also missing:
- protection around not deleting Host or Pod IPs when deleting things. This might be as simple as adding a new ipcache.Source that is between FromAgentLocal and FromKVStore in priority. This then means we cannot delete the hostIP and local endpoint IPs via CIDR policy.
- proper testing? I didn't test multi-policy one-IP cases, but I think the ref counting will take care of it (ignoring bugs in the ref counter).

We saw bogus deletes of ipcache entries. We avoid relying on the KVStore
to propagate ipcache changes that happen locally, and guard against them
by FromAgentLocal.

I put this branch in the cilium repo so that others can clone/push to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5801)
<!-- Reviewable:end -->
