### PR TITLE
Test: Fix Nightly timeouts

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -711,8 +711,8 @@ func (kub *Kubectl) WaitForKubeDNSEntry(serviceName, serviceNamespace string) er
 
 // WaitCleanAllTerminatingPods waits until all nodes that are in `Terminating`
 // state are deleted correctly in the platform. In case of excedding the
-// default timeout it returns an error
-func (kub *Kubectl) WaitCleanAllTerminatingPods() error {
+// given timeout (in seconds) it returns an error
+func (kub *Kubectl) WaitCleanAllTerminatingPods(timeout int64) error {
 	body := func() bool {
 		res := kub.Exec(fmt.Sprintf(
 			"%s get pods --all-namespaces -o jsonpath='{.items[*].metadata.deletionTimestamp}'",
@@ -737,7 +737,7 @@ func (kub *Kubectl) WaitCleanAllTerminatingPods() error {
 	err := WithTimeout(
 		body,
 		"Pods are still not deleted after a timeout",
-		&TimeoutConfig{Timeout: HelperTimeout})
+		&TimeoutConfig{Timeout: timeout})
 	return err
 }
 

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -80,7 +80,7 @@ var _ = Describe("K8sPolicyTest", func() {
 	})
 
 	AfterAll(func() {
-		_ = kubectl.WaitCleanAllTerminatingPods()
+		ExpectAllPodsTerminated(kubectl)
 	})
 
 	JustBeforeEach(func() {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -233,7 +233,7 @@ var _ = Describe("K8sServicesTest", func() {
 			_ = kubectl.Delete(servicePath)
 			_ = kubectl.Delete(podPath)
 
-			kubectl.WaitCleanAllTerminatingPods()
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		validateEgress := func() {

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -43,7 +43,7 @@ func ExpectCiliumReady(vm *helpers.Kubectl) {
 // ExpectAllPodsTerminated is a wrapper around helpers/WaitCleanAllTerminatingPods.
 // It asserts that the error returned by that function is nil.
 func ExpectAllPodsTerminated(vm *helpers.Kubectl) {
-	err := vm.WaitCleanAllTerminatingPods()
+	err := vm.WaitCleanAllTerminatingPods(helpers.HelperTimeout)
 	ExpectWithOffset(1, err).To(BeNil(), "terminating containers are not deleted after timeout")
 }
 


### PR DESCRIPTION
At the moment, nightly is failing because pods are deleted after a while
and pods are always deleting so it fails on the `afterEach` waiting to
pods to terminate.

With this change the `WaitCleanAllTerminatingPods` function receives a
duration variable that can be used on the AfterAll to wait more time, so
we only wait once.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5807)
<!-- Reviewable:end -->
