### PR TITLE
k8s: use CNP labels identity in all policy operations

### DIFF
--- a/daemon/k8s_watcher_test.go
+++ b/daemon/k8s_watcher_test.go
@@ -222,13 +222,18 @@ func (ds *DaemonSuite) Test_missingCNPv2(c *C) {
 				p1 := policy.NewPolicyRepository()
 				_, err := p1.Add(api.Rule{
 					EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("id=a")),
-					Labels:           labels.ParseLabelArray("k8s:name=bar", "k8s:namespace=bar"),
+					Labels: utils.GetPolicyLabels("foo", "bar",
+						utils.ResourceTypeCiliumNetworkPolicy),
 				})
 				c.Assert(err, IsNil)
 
 				m := versioned.NewMap()
 				m.Add("", versioned.Object{
 					Data: &v2.CiliumNetworkPolicy{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "bar",
+							Namespace: "foo",
+						},
 						Spec: &api.Rule{
 							EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("id=a")),
 							Labels:           labels.ParseLabelArray("k8s:name=bar", "k8s:namespace=bar"),

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -210,22 +210,12 @@ func (r *CiliumNetworkPolicy) GetControllerName() string {
 	return fmt.Sprintf("%s (v2 %s)", k8sConst.CtrlPrefixPolicyStatus, name)
 }
 
-// GetRuleLabels returns all rule labels in the CiliumNetworkPolicy.
-func (r *CiliumNetworkPolicy) GetRuleLabels() labels.LabelArrayList {
+// GetIdentityLabels returns all rule labels in the CiliumNetworkPolicy.
+func (r *CiliumNetworkPolicy) GetIdentityLabels() labels.LabelArray {
 	namespace := k8sUtils.ExtractNamespace(&r.ObjectMeta)
 	name := r.ObjectMeta.Name
-
-	var retRules labels.LabelArrayList
-
-	if r.Spec != nil {
-		retRules = append(retRules, k8sCiliumUtils.ParseToCiliumLabels(namespace, name, r.Spec.Labels))
-	}
-	if r.Specs != nil {
-		for _, rule := range r.Specs {
-			retRules = append(retRules, k8sCiliumUtils.ParseToCiliumLabels(namespace, name, rule.Labels))
-		}
-	}
-	return retRules
+	return k8sCiliumUtils.GetPolicyLabels(namespace, name,
+		k8sCiliumUtils.ResourceTypeCiliumNetworkPolicy)
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
When PR https://github.com/cilium/cilium/pull/5732 was merged, the missingCNPv2 was not changed to make usage of the same labels that are used in all CNP operations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5816)
<!-- Reviewable:end -->
