### PR TITLE
cilium-health: Fix status cmd nil pointer derefence

### DIFF
--- a/cilium-health/cmd/status.go
+++ b/cilium-health/cmd/status.go
@@ -39,6 +39,10 @@ var statusGetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		var sr *models.HealthStatusResponse
 
+		if client == nil {
+			Fatalf("Invalid combination of arguments")
+		}
+
 		if probe {
 			result, err := client.Connectivity.PutStatusProbe(nil)
 			if err != nil {


### PR DESCRIPTION
Adds a check to the command client and instead fails with
an error message if it is nil.

Example:
```
vagrant@runtime1:~$ cilium-health status  -d
Error: Invalid combination of arguments
```

Fixes #5779

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5820)
<!-- Reviewable:end -->
