### PR TITLE
test: fix install script to allow install all k8s with binaries

### DIFF
--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -111,8 +111,8 @@ if [[ -f  "/etc/cni/net.d/100-crio-bridge.conf" ]]; then
 fi
 
 # Around the `--ignore-preflight-errors=cri` is used because
-# /var/run/dockershim.sock is not present (because base image has containerid)
-# so with that option Kubeadm fallbacks to /var/run/docker.sock
+# /var/run/dockershim.sock is not present (because base image has containerd)
+# so with that option kubeadm fallback to /var/run/docker.sock
 case $K8S_VERSION in
     "1.8")
         KUBERNETES_CNI_VERSION="0.5.1-00"
@@ -133,8 +133,8 @@ case $K8S_VERSION in
     "1.11")
         KUBERNETES_CNI_VERSION="0.6.0-00"
         K8S_FULL_VERSION="1.11.3"
-        KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
-        KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri"
+        KUBEADM_OPTIONS="--ignore-preflight-errors=cri,FileExisting-crictl"
+        KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,FileExisting-crictl"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT
         ;;
     "1.12")

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -157,7 +157,7 @@ case $K8S_VERSION in
             kubectl=${K8S_FULL_VERSION}*
         ;;
     "1.13")
-        install_k8s_using_binary "v${K8S_FULL_VERSION}" "${KUBERNETES_CNI_VERSION}"
+        install_k8s_using_binary "v${K8S_FULL_VERSION}" "v${KUBERNETES_CNI_VERSION}"
         ;;
 esac
 


### PR DESCRIPTION
This small fixes will allow us to easily switch between installing from a binary or from a package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5823)
<!-- Reviewable:end -->
