### PR TITLE
daemon: move CNP store error to debug level

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1764,7 +1764,7 @@ func cnpNodeStatusController(ciliumV2Store cache.Store, cnp *cilium_v2.CiliumNet
 
 		serverRule, fromStoreErr := getUpdatedCNPFromStore(ciliumV2Store, cnp)
 		if fromStoreErr != nil {
-			logger.WithError(fromStoreErr).Error("error getting updated CNP from store")
+			logger.WithError(fromStoreErr).Debug("error getting updated CNP from store")
 			return fromStoreErr
 		}
 


### PR DESCRIPTION
This is not an error condition. It should be moved to a debug as several
attempts are made to retrieve and update the CNP status and a warning is already
printed when the update doesn't succeed in the configurable number of attempts.

Fixes: #5824

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5829)
<!-- Reviewable:end -->
