### PR TITLE
cmd: refactor CLI for `cilium debuginfo`

### DIFF
--- a/Documentation/cmdref/cilium_debuginfo.md
+++ b/Documentation/cmdref/cilium_debuginfo.md
@@ -16,9 +16,9 @@ cilium debuginfo
 ### Options
 
 ```
-  -f, --file string        Redirect output to file
-      --file-per-command   Generate a single file per command
-      --html-file string   Convert default output to HTML file
+  -f, --file                 Redirect output to file(s)
+      --file-per-command     Generate a single file per command
+      --output stringSlice   markdown| html| json| jsonpath='{}'
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium_debuginfo.md
+++ b/Documentation/cmdref/cilium_debuginfo.md
@@ -16,9 +16,10 @@ cilium debuginfo
 ### Options
 
 ```
-  -f, --file                 Redirect output to file(s)
-      --file-per-command     Generate a single file per command
-      --output stringSlice   markdown| html| json| jsonpath='{}'
+  -f, --file                      Redirect output to file(s)
+      --file-per-command          Generate a single file per command
+      --output stringSlice        markdown| html| json| jsonpath='{}'
+      --output-directory string   directory for files (if specified will use directory in which this command was ran)
 ```
 
 ### Options inherited from parent commands

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -213,7 +213,7 @@ func copyCiliumInfoCommands(cmdDir string, k8sPods []string) []string {
 	// Most of the output should come via debuginfo but also adding
 	// these ones for skimming purposes
 	ciliumCommands := []string{
-		"cilium debuginfo",
+		fmt.Sprintf("cilium debuginfo --output=markdown,json -f --output-directory=%s", cmdDir),
 		"cilium metrics list",
 		"cilium config",
 		"cilium bpf tunnel list",

--- a/cilium/cmd/debuginfo.go
+++ b/cilium/cmd/debuginfo.go
@@ -50,7 +50,7 @@ const (
 )
 
 var (
-	// Can't tall it jsonOutput because another var in this package uses that.
+	// Can't call it jsonOutput because another var in this package uses that.
 	jsonOutputDebuginfo = "json"
 	markdownOutput      = "markdown"
 	htmlOutput          = "html"

--- a/pkg/command/output.go
+++ b/pkg/command/output.go
@@ -60,44 +60,44 @@ func PrintOutputWithType(data interface{}, outputType string) error {
 	return fmt.Errorf("Couldn't found output printer")
 }
 
-// DumpJSONToString dumps the contents of data into a string. If jsonpath
+// DumpJSONToSlice dumps the contents of data into a byte slice. If jsonpath
 // is non-empty, will attempt to do jsonpath filtering using said string.
-// Returns the string representation of the JSON in data, or an error if
-// any JSON marshaling, parsing operations fail.
-func DumpJSONToString(data interface{}, jsonPath string) (string, error) {
+// Returns byte array containing the JSON in data, or an error if any JSON
+// marshaling, parsing operations fail.
+func DumpJSONToSlice(data interface{}, jsonPath string) ([]byte, error) {
 	if len(jsonPath) == 0 {
 		result, err := json.MarshalIndent(data, "", "  ")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Couldn't marshal to json: '%s'\n", err)
-			return "", err
+			return nil, err
 		}
 		fmt.Println(string(result))
-		return "", nil
+		return nil, nil
 	}
 
 	parser := jsonpath.New("").AllowMissingKeys(true)
 	if err := parser.Parse(jsonPath); err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't parse jsonpath expression: '%s'\n", err)
-		return "", err
+		return nil, err
 	}
 
 	buf := new(bytes.Buffer)
 	if err := parser.Execute(buf, data); err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't parse jsonpath expression: '%s'\n", err)
-		return "", err
+		return nil, err
 
 	}
-	return buf.String(), nil
+	return buf.Bytes(), nil
 }
 
 // dumpJSON dump the data variable to the stdout as json.
 // If somethings fail, it'll return an error
 // If jsonPath is passed, it'll run the json query over data var.
 func dumpJSON(data interface{}, jsonPath string) error {
-	strOut, err := DumpJSONToString(data, jsonPath)
+	jsonBytes, err := DumpJSONToSlice(data, jsonPath)
 	if err != nil {
 		return err
 	}
-	fmt.Println(strOut)
+	fmt.Println(string(jsonBytes[:]))
 	return nil
 }


### PR DESCRIPTION
When debugging cilium installations across a large cluster of nodes, it is quite difficult to figure out certain information, i.e. which endpoints are running on which nodes, what their state is, etc., because the information is not in a machine-readable format which can be consumed by tooling. Consequently, it behooves us to have machine-readable output for `cilium debuginfo`. This commit refactors the `cilium debuginfo` CLI to have four arguments:

* `--file` : redirect output of command to a file
* `--file-per-command` : create a file for each separate field within the returned DebugInfo API model. Not supported when json or jsonpath output is specified.
* `--output`: a list of supported output types. All can be supplied at once, and the same DebugInfo model retrieved via the API will be formatted for all provided output formats. This avoids making multiple calls to the API, which would result in different contents for each file.  If --file is specified in conduit with this field, each output format will have its own individual file created.
* `--output-directory`: where the files created from running `cilium debuginfo` are stored if the command is ran with the `-f` option.

These new changes are consumed by `cilium bugtool`, which now saves the output in both Markdown and JSON formats for readability by humans and external tooling. 

Note: I tried to make the implementation as clean as possible, but found it a bit difficult to cleanly handle all the different permutations of CLI flags. Happy for suggestions on how to make this cleaner / more readable.

<details>
 <summary>Example JSON output</summary>

```
$ sudo cilium debuginfo --output=json
{
  "cilium-memory-map": "00400000-038d2000 r-xp 00000000 fd:00 279868                             /usr/bin/cilium-agent\n03ad1000-03ad2000 r--p 034d1000 fd:00 279868                             /usr/bin/cilium-agent\n03ad2000-03b79000 rw-p 034d2000 fd:00 279868                             /usr/bin/cilium-agent\n03b79000-040f2000 rw-p 00000000 00:00 0                                  [heap]\nc000000000-c000012000 rw-p 00000000 00:00 0 \nc41fdc6000-c424740000 rw-p 00000000 00:00 0 \n7fffc0000000-7fffc0021000 rw-p 00000000 00:00 0 \n7fffc0021000-7fffc4000000 ---p 00000000 00:00 0 \n7fffc4000000-7fffc4021000 rw-p 00000000 00:00 0 \n7fffc4021000-7fffc8000000 ---p 00000000 00:00 0 \n7fffc8000000-7fffc8021000 rw-p 00000000 00:00 0 \n7fffc8021000-7fffcc000000 ---p 00000000 00:00 0 \n7fffcc000000-7fffcc021000 rw-p 00000000 00:00 0 \n7fffcc021000-7fffd0000000 ---p 00000000 00:00 0 \n7fffd0000000-7fffd0021000 rw-p 00000000 00:00 0 \n7fffd0021000-7fffd4000000 ---p 00000000 00:00 0 \n7fffd4000000-7fffd4021000 rw-p 00000000 00:00 0 \n7fffd4021000-7fffd8000000 ---p 00000000 00:00 0 \n7fffd8000000-7fffd8021000 rw-p 00000000 00:00 0 \n7fffd8021000-7fffdc000000 ---p 00000000 00:00 0 \n7fffdc7f9000-7fffdc7fa000 ---p 00000000 00:00 0 \n7fffdc7fa000-7fffdcffa000 rw-p 00000000 00:00 0 \n7fffdcffa000-7fffdcffb000 ---p 00000000 00:00 0 \n7fffdcffb000-7fffdd7fb000 rw-p 00000000 00:00 0 \n7fffdd7fb000-7fffdd7fc000 ---p 00000000 00:00 0 \n7fffdd7fc000-7fffddffc000 rw-p 00000000 00:00 0 \n7fffddffc000-7fffddffd000 ---p 00000000 00:00 0 \n7fffddffd000-7fffde7fd000 rw-p 00000000 00:00 0 \n7fffde7fd000-7fffde7fe000 ---p 00000000 00:00 0 \n7fffde7fe000-7fffdeffe000 rw-p 00000000 00:00 0 \n7fffdeffe000-7fffdefff000 ---p 00000000 00:00 0 \n7fffdefff000-7fffdf7ff000 rw-p 00000000 00:00 0 \n7fffdf7ff000-7fffdf800000 ---p 00000000 00:00 0 \n7fffdf800000-7fffe0000000 rw-p 00000000 00:00 0 \n7fffe0000000-7fffe0021000 rw-p 00000000 00:00 0 \n7fffe0021000-7fffe4000000 ---p 00000000 00:00 0 \n7fffe4000000-7fffe4021000 rw-p 00000000 00:00 0 \n7fffe4021000-7fffe8000000 ---p 00000000 00:00 0 \n7fffe8000000-7fffe8021000 rw-p 00000000 00:00 0 \n7fffe8021000-7fffec000000 ---p 00000000 00:00 0 \n7fffec000000-7fffec021000 rw-p 00000000 00:00 0 \n7fffec021000-7ffff0000000 ---p 00000000 00:00 0 \n7ffff0000000-7ffff0021000 rw-p 00000000 00:00 0 \n7ffff0021000-7ffff4000000 ---p 00000000 00:00 0 \n7ffff43da000-7ffff441a000 rw-p 00000000 00:00 0 \n7ffff441a000-7ffff441b000 ---p 00000000 00:00 0 \n7ffff441b000-7ffff4c1b000 rw-p 00000000 00:00 0 \n7ffff4c1b000-7ffff4c26000 r-xp 00000000 fd:00 523757                     /lib/x86_64-linux-gnu/libnss_files-2.27.so\n7ffff4c26000-7ffff4e25000 ---p 0000b000 fd:00 523757                     /lib/x86_64-linux-gnu/libnss_files-2.27.so\n7ffff4e25000-7ffff4e26000 r--p 0000a000 fd:00 523757                     /lib/x86_64-linux-gnu/libnss_files-2.27.so\n7ffff4e26000-7ffff4e27000 rw-p 0000b000 fd:00 523757                     /lib/x86_64-linux-gnu/libnss_files-2.27.so\n7ffff4e27000-7ffff4e2d000 rw-p 00000000 00:00 0 \n7ffff4e2d000-7ffff4e44000 r-xp 00000000 fd:00 523751                     /lib/x86_64-linux-gnu/libnsl-2.27.so\n7ffff4e44000-7ffff5043000 ---p 00017000 fd:00 523751                     /lib/x86_64-linux-gnu/libnsl-2.27.so\n7ffff5043000-7ffff5044000 r--p 00016000 fd:00 523751                     /lib/x86_64-linux-gnu/libnsl-2.27.so\n7ffff5044000-7ffff5045000 rw-p 00017000 fd:00 523751                     /lib/x86_64-linux-gnu/libnsl-2.27.so\n7ffff5045000-7ffff5047000 rw-p 00000000 00:00 0 \n7ffff5047000-7ffff5052000 r-xp 00000000 fd:00 523761                     /lib/x86_64-linux-gnu/libnss_nis-2.27.so\n7ffff5052000-7ffff5251000 ---p 0000b000 fd:00 523761                     /lib/x86_64-linux-gnu/libnss_nis-2.27.so\n7ffff5251000-7ffff5252000 r--p 0000a000 fd:00 523761                     /lib/x86_64-linux-gnu/libnss_nis-2.27.so\n7ffff5252000-7ffff5253000 rw-p 0000b000 fd:00 523761                     /lib/x86_64-linux-gnu/libnss_nis-2.27.so\n7ffff5253000-7ffff525b000 r-xp 00000000 fd:00 523753                     /lib/x86_64-linux-gnu/libnss_compat-2.27.so\n7ffff525b000-7ffff545b000 ---p 00008000 fd:00 523753                     /lib/x86_64-linux-gnu/libnss_compat-2.27.so\n7ffff545b000-7ffff545c000 r--p 00008000 fd:00 523753                     /lib/x86_64-linux-gnu/libnss_compat-2.27.so\n7ffff545c000-7ffff545d000 rw-p 00009000 fd:00 523753                     /lib/x86_64-linux-gnu/libnss_compat-2.27.so\n7ffff545d000-7ffff55bd000 rw-p 00000000 00:00 0 \n7ffff55bd000-7ffff55be000 ---p 00000000 00:00 0 \n7ffff55be000-7ffff5dbe000 rw-p 00000000 00:00 0 \n7ffff5dbe000-7ffff5dbf000 ---p 00000000 00:00 0 \n7ffff5dbf000-7ffff65bf000 rw-p 00000000 00:00 0 \n7ffff65bf000-7ffff65c0000 ---p 00000000 00:00 0 \n7ffff65c0000-7ffff6dc0000 rw-p 00000000 00:00 0 \n7ffff6dc0000-7ffff6dc1000 ---p 00000000 00:00 0 \n7ffff6dc1000-7ffff75c1000 rw-p 00000000 00:00 0 \n7ffff75c1000-7ffff77a8000 r-xp 00000000 fd:00 523690                     /lib/x86_64-linux-gnu/libc-2.27.so\n7ffff77a8000-7ffff79a8000 ---p 001e7000 fd:00 523690                     /lib/x86_64-linux-gnu/libc-2.27.so\n7ffff79a8000-7ffff79ac000 r--p 001e7000 fd:00 523690                     /lib/x86_64-linux-gnu/libc-2.27.so\n7ffff79ac000-7ffff79ae000 rw-p 001eb000 fd:00 523690                     /lib/x86_64-linux-gnu/libc-2.27.so\n7ffff79ae000-7ffff79b2000 rw-p 00000000 00:00 0 \n7ffff79b2000-7ffff79b5000 r-xp 00000000 fd:00 523707                     /lib/x86_64-linux-gnu/libdl-2.27.so\n7ffff79b5000-7ffff7bb4000 ---p 00003000 fd:00 523707                     /lib/x86_64-linux-gnu/libdl-2.27.so\n7ffff7bb4000-7ffff7bb5000 r--p 00002000 fd:00 523707                     /lib/x86_64-linux-gnu/libdl-2.27.so\n7ffff7bb5000-7ffff7bb6000 rw-p 00003000 fd:00 523707                     /lib/x86_64-linux-gnu/libdl-2.27.so\n7ffff7bb6000-7ffff7bd0000 r-xp 00000000 fd:00 523777                     /lib/x86_64-linux-gnu/libpthread-2.27.so\n7ffff7bd0000-7ffff7dcf000 ---p 0001a000 fd:00 523777                     /lib/x86_64-linux-gnu/libpthread-2.27.so\n7ffff7dcf000-7ffff7dd0000 r--p 00019000 fd:00 523777                     /lib/x86_64-linux-gnu/libpthread-2.27.so\n7ffff7dd0000-7ffff7dd1000 rw-p 0001a000 fd:00 523777                     /lib/x86_64-linux-gnu/libpthread-2.27.so\n7ffff7dd1000-7ffff7dd5000 rw-p 00000000 00:00 0 \n7ffff7dd5000-7ffff7dfc000 r-xp 00000000 fd:00 523666                     /lib/x86_64-linux-gnu/ld-2.27.so\n7ffff7e03000-7ffff7fee000 rw-p 00000000 00:00 0 \n7ffff7ff8000-7ffff7ffa000 r--p 00000000 00:00 0                          [vvar]\n7ffff7ffa000-7ffff7ffc000 r-xp 00000000 00:00 0                          [vdso]\n7ffff7ffc000-7ffff7ffd000 r--p 00027000 fd:00 523666                     /lib/x86_64-linux-gnu/ld-2.27.so\n7ffff7ffd000-7ffff7ffe000 rw-p 00028000 fd:00 523666                     /lib/x86_64-linux-gnu/ld-2.27.so\n7ffff7ffe000-7ffff7fff000 rw-p 00000000 00:00 0 \n7ffffffde000-7ffffffff000 rw-p 00000000 00:00 0                          [stack]\nffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]\n",
  "cilium-status": {
    "cilium": {
      "msg": "OK",
      "state": "Ok"
    },
    "cluster": {
      "ciliumHealth": {
        "state": "Ok"
      },
      "nodes": [
        {
          "health-endpoint-address": {
            "ipv4": {
              "enabled": true,
              "ip": "10.0.233.169"
            },
            "ipv6": {
              "ip": "f00d::a00:0:0:a03a"
            }
          },
          "name": "k8s1",
          "primary-address": {
            "ipv4": {
              "address-type": "InternalIP",
              "alloc-range": "10.0.0.0/16",
              "enabled": true,
              "ip": "192.168.34.11"
            },
            "ipv6": {
              "alloc-range": "f00d::a00:0:0:0/112",
              "ip": "\u003cnil\u003e"
            }
          },
          "secondary-addresses": []
        }
      ],
      "self": "k8s1"
    },
    "container-runtime": {
      "msg": "docker daemon: OK",
      "state": "Ok"
    },
    "controllers": [
      {
        "configuration": {
          "error-retry": true,
          "interval": "5m0s"
        },
        "name": "sync-IPv4-identity-mapping (41018)",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:28:42.741Z",
          "success-count": 1
        },
        "uuid": "fbfa21e0-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true,
          "interval": "5m0s"
        },
        "name": "k8s-sync-endpoints",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:28:42.495Z",
          "success-count": 1
        },
        "uuid": "fbde8d76-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true,
          "interval": "5m0s"
        },
        "name": "k8s-sync-nodes",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:28:42.494Z",
          "success-count": 1
        },
        "uuid": "fbde92b4-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true,
          "interval": "1m0s"
        },
        "name": "sync-policymap-41018",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:28:44.151Z",
          "success-count": 1
        },
        "uuid": "fce0289f-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true,
          "interval": "5s"
        },
        "name": "metricsmap-bpf-prom-sync",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:29:05.810Z",
          "success-count": 6
        },
        "uuid": "fadbd5c1-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true,
          "interval": "5m0s"
        },
        "name": "k8s-sync-networkpolicies",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:28:42.470Z",
          "success-count": 1
        },
        "uuid": "fbde8a30-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true,
          "interval": "5m0s"
        },
        "name": "k8s-sync-pods",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:28:42.495Z",
          "success-count": 1
        },
        "uuid": "fbde91c3-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true,
          "interval": "30s"
        },
        "name": "cilium-health-ep",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:28:43.707Z",
          "success-count": 1
        },
        "uuid": "fbf2d579-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true
        },
        "name": "propagating local node change to kv-store",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:28:42.602Z",
          "success-count": 1
        },
        "uuid": "fbf39183-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true,
          "interval": "5s"
        },
        "name": "lxcmap-bpf-host-sync",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:29:05.809Z",
          "success-count": 6
        },
        "uuid": "fadbd4fc-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true,
          "interval": "5m0s"
        },
        "name": "k8s-sync-ciliumnetworkpolicies",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:28:42.495Z",
          "success-count": 1
        },
        "uuid": "fbde8f34-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true,
          "interval": "1m0s"
        },
        "name": "sync-to-k8s-ciliumendpoint-gc (k8s1)",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:28:42.471Z",
          "success-count": 1
        },
        "uuid": "fbdfe863-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true,
          "interval": "5s"
        },
        "name": "dns-poller",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:29:05.809Z",
          "success-count": 6
        },
        "uuid": "fadc0133-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true,
          "interval": "10ms"
        },
        "name": "kvstore-etcd-session-renew",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "0001-01-01T00:00:00.000Z"
        },
        "uuid": "f98a1b66-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true
        },
        "name": "sync-lb-maps-with-k8s-services",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:28:42.572Z",
          "success-count": 1
        },
        "uuid": "fbef26a3-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true,
          "interval": "1m0s"
        },
        "name": "sync-identity-to-k8s-pod (41018)",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:28:42.644Z",
          "success-count": 1
        },
        "uuid": "fbfa20ee-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true,
          "interval": "1m0s"
        },
        "name": "kvstore-sync-store-cilium/state/nodes/v1",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:28:38.771Z",
          "success-count": 1
        },
        "uuid": "f9a4b7f2-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true,
          "interval": "5m0s"
        },
        "name": "k8s-sync-services",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:28:42.495Z",
          "success-count": 1
        },
        "uuid": "fbde8c5c-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true,
          "interval": "5m0s"
        },
        "name": "resolve-identity-41018",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:28:42.644Z",
          "success-count": 1
        },
        "uuid": "fbfa24a6-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true,
          "interval": "5m0s"
        },
        "name": "ipcache-bpf-garbage-collection",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:28:40.772Z",
          "success-count": 1
        },
        "uuid": "fadc5cc9-cb27-11e8-8fb4-0800279075f3"
      },
      {
        "configuration": {
          "error-retry": true,
          "interval": "5m0s"
        },
        "name": "sync-IPv6-identity-mapping (41018)",
        "status": {
          "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
          "last-success-timestamp": "2018-10-08T18:28:42.742Z",
          "success-count": 1
        },
        "uuid": "fbfa225a-cb27-11e8-8fb4-0800279075f3"
      }
    ],
    "ipam": {
      "ipv4": [
        "10.0.0.1",
        "10.0.2.0",
        "10.0.2.1",
        "10.0.2.2",
        "10.0.2.3",
        "10.0.2.4",
        "10.0.2.5",
        "10.0.2.6",
        "10.0.2.7",
        "10.0.2.8",
        "10.0.2.9",
        "10.0.2.10",
        "10.0.2.11",
        "10.0.2.12",
        "10.0.2.13",
        "10.0.2.14",
        "10.0.2.15",
        "10.0.2.16",
        "10.0.2.17",
        "10.0.2.18",
        "10.0.2.19",
        "10.0.2.20",
        "10.0.2.21",
        "10.0.2.22",
        "10.0.2.23",
        "10.0.2.24",
        "10.0.2.25",
        "10.0.2.26",
        "10.0.2.27",
        "10.0.2.28",
        "10.0.2.29",
        "10.0.2.30",
        "10.0.2.31",
        "10.0.2.32",
        "10.0.2.33",
        "10.0.2.34",
        "10.0.2.35",
        "10.0.2.36",
        "10.0.2.37",
        "10.0.2.38",
        "10.0.2.39",
        "10.0.2.40",
        "10.0.2.41",
        "10.0.2.42",
        "10.0.2.43",
        "10.0.2.44",
        "10.0.2.45",
        "10.0.2.46",
        "10.0.2.47",
        "10.0.2.48",
        "10.0.2.49",
        "10.0.2.50",
        "10.0.2.51",
        "10.0.2.52",
        "10.0.2.53",
        "10.0.2.54",
        "10.0.2.55",
        "10.0.2.56",
        "10.0.2.57",
        "10.0.2.58",
        "10.0.2.59",
        "10.0.2.60",
        "10.0.2.61",
        "10.0.2.62",
        "10.0.2.63",
        "10.0.2.64",
        "10.0.2.65",
        "10.0.2.66",
        "10.0.2.67",
        "10.0.2.68",
        "10.0.2.69",
        "10.0.2.70",
        "10.0.2.71",
        "10.0.2.72",
        "10.0.2.73",
        "10.0.2.74",
        "10.0.2.75",
        "10.0.2.76",
        "10.0.2.77",
        "10.0.2.78",
        "10.0.2.79",
        "10.0.2.80",
        "10.0.2.81",
        "10.0.2.82",
        "10.0.2.83",
        "10.0.2.84",
        "10.0.2.85",
        "10.0.2.86",
        "10.0.2.87",
        "10.0.2.88",
        "10.0.2.89",
        "10.0.2.90",
        "10.0.2.91",
        "10.0.2.92",
        "10.0.2.93",
        "10.0.2.94",
        "10.0.2.95",
        "10.0.2.96",
        "10.0.2.97",
        "10.0.2.98",
        "10.0.2.99",
        "10.0.2.100",
        "10.0.2.101",
        "10.0.2.102",
        "10.0.2.103",
        "10.0.2.104",
        "10.0.2.105",
        "10.0.2.106",
        "10.0.2.107",
        "10.0.2.108",
        "10.0.2.109",
        "10.0.2.110",
        "10.0.2.111",
        "10.0.2.112",
        "10.0.2.113",
        "10.0.2.114",
        "10.0.2.115",
        "10.0.2.116",
        "10.0.2.117",
        "10.0.2.118",
        "10.0.2.119",
        "10.0.2.120",
        "10.0.2.121",
        "10.0.2.122",
        "10.0.2.123",
        "10.0.2.124",
        "10.0.2.125",
        "10.0.2.126",
        "10.0.2.127",
        "10.0.2.128",
        "10.0.2.129",
        "10.0.2.130",
        "10.0.2.131",
        "10.0.2.132",
        "10.0.2.133",
        "10.0.2.134",
        "10.0.2.135",
        "10.0.2.136",
        "10.0.2.137",
        "10.0.2.138",
        "10.0.2.139",
        "10.0.2.140",
        "10.0.2.141",
        "10.0.2.142",
        "10.0.2.143",
        "10.0.2.144",
        "10.0.2.145",
        "10.0.2.146",
        "10.0.2.147",
        "10.0.2.148",
        "10.0.2.149",
        "10.0.2.150",
        "10.0.2.151",
        "10.0.2.152",
        "10.0.2.153",
        "10.0.2.154",
        "10.0.2.155",
        "10.0.2.156",
        "10.0.2.157",
        "10.0.2.158",
        "10.0.2.159",
        "10.0.2.160",
        "10.0.2.161",
        "10.0.2.162",
        "10.0.2.163",
        "10.0.2.164",
        "10.0.2.165",
        "10.0.2.166",
        "10.0.2.167",
        "10.0.2.168",
        "10.0.2.169",
        "10.0.2.170",
        "10.0.2.171",
        "10.0.2.172",
        "10.0.2.173",
        "10.0.2.174",
        "10.0.2.175",
        "10.0.2.176",
        "10.0.2.177",
        "10.0.2.178",
        "10.0.2.179",
        "10.0.2.180",
        "10.0.2.181",
        "10.0.2.182",
        "10.0.2.183",
        "10.0.2.184",
        "10.0.2.185",
        "10.0.2.186",
        "10.0.2.187",
        "10.0.2.188",
        "10.0.2.189",
        "10.0.2.190",
        "10.0.2.191",
        "10.0.2.192",
        "10.0.2.193",
        "10.0.2.194",
        "10.0.2.195",
        "10.0.2.196",
        "10.0.2.197",
        "10.0.2.198",
        "10.0.2.199",
        "10.0.2.200",
        "10.0.2.201",
        "10.0.2.202",
        "10.0.2.203",
        "10.0.2.204",
        "10.0.2.205",
        "10.0.2.206",
        "10.0.2.207",
        "10.0.2.208",
        "10.0.2.209",
        "10.0.2.210",
        "10.0.2.211",
        "10.0.2.212",
        "10.0.2.213",
        "10.0.2.214",
        "10.0.2.215",
        "10.0.2.216",
        "10.0.2.217",
        "10.0.2.218",
        "10.0.2.219",
        "10.0.2.220",
        "10.0.2.221",
        "10.0.2.222",
        "10.0.2.223",
        "10.0.2.224",
        "10.0.2.225",
        "10.0.2.226",
        "10.0.2.227",
        "10.0.2.228",
        "10.0.2.229",
        "10.0.2.230",
        "10.0.2.231",
        "10.0.2.232",
        "10.0.2.233",
        "10.0.2.234",
        "10.0.2.235",
        "10.0.2.236",
        "10.0.2.237",
        "10.0.2.238",
        "10.0.2.239",
        "10.0.2.240",
        "10.0.2.241",
        "10.0.2.242",
        "10.0.2.243",
        "10.0.2.244",
        "10.0.2.245",
        "10.0.2.246",
        "10.0.2.247",
        "10.0.2.248",
        "10.0.2.249",
        "10.0.2.250",
        "10.0.2.251",
        "10.0.2.252",
        "10.0.2.253",
        "10.0.2.254",
        "10.0.2.255",
        "10.0.6.150",
        "10.0.233.169"
      ],
      "ipv6": [
        "f00d::a00:0:0:1",
        "f00d::a00:0:0:a03a"
      ]
    },
    "kubernetes": {
      "k8s-api-versions": [
        "core/v1::Node",
        "core/v1::Namespace",
        "CustomResourceDefinition",
        "cilium/v2::CiliumNetworkPolicy",
        "networking.k8s.io/v1::NetworkPolicy",
        "core/v1::Service",
        "core/v1::Endpoint",
        "core/v1::Pods"
      ],
      "msg": "1.12 (v1.12.0) [linux/amd64]",
      "state": "Ok"
    },
    "kvstore": {
      "msg": "etcd: 1/1 connected: https://192.168.33.11:2379 - 3.2.24 (Leader)",
      "state": "Ok"
    },
    "proxy": {
      "ip": "10.0.0.1",
      "port-range": "10000-20000"
    }
  },
  "cilium-version": "1.2.90 fb85d017c 2018-10-05T14:02:41-07:00 go version go1.10.3 linux/amd64",
  "endpoint-list": [
    {
      "id": 41018,
      "spec": {
        "label-configuration": {
          "user": []
        },
        "options": {
          "Conntrack": "Enabled",
          "ConntrackAccounting": "Enabled",
          "ConntrackLocal": "Disabled",
          "Debug": "Enabled",
          "DebugLB": "Disabled",
          "DropNotification": "Enabled",
          "MonitorAggregationLevel": "None",
          "NAT46": "Disabled",
          "TraceNotification": "Enabled"
        }
      },
      "status": {
        "controllers": [
          {
            "configuration": {
              "error-retry": true,
              "interval": "5m0s"
            },
            "name": "resolve-identity-41018",
            "status": {
              "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
              "last-success-timestamp": "2018-10-08T18:28:42.644Z",
              "success-count": 1
            },
            "uuid": "fbfa24a6-cb27-11e8-8fb4-0800279075f3"
          },
          {
            "configuration": {
              "error-retry": true,
              "interval": "5m0s"
            },
            "name": "sync-IPv4-identity-mapping (41018)",
            "status": {
              "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
              "last-success-timestamp": "2018-10-08T18:28:42.741Z",
              "success-count": 1
            },
            "uuid": "fbfa21e0-cb27-11e8-8fb4-0800279075f3"
          },
          {
            "configuration": {
              "error-retry": true,
              "interval": "5m0s"
            },
            "name": "sync-IPv6-identity-mapping (41018)",
            "status": {
              "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
              "last-success-timestamp": "2018-10-08T18:28:42.742Z",
              "success-count": 1
            },
            "uuid": "fbfa225a-cb27-11e8-8fb4-0800279075f3"
          },
          {
            "configuration": {
              "error-retry": true,
              "interval": "1m0s"
            },
            "name": "sync-identity-to-k8s-pod (41018)",
            "status": {
              "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
              "last-success-timestamp": "2018-10-08T18:28:42.644Z",
              "success-count": 1
            },
            "uuid": "fbfa20ee-cb27-11e8-8fb4-0800279075f3"
          },
          {
            "configuration": {
              "error-retry": true,
              "interval": "1m0s"
            },
            "name": "sync-policymap-41018",
            "status": {
              "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
              "last-success-timestamp": "2018-10-08T18:28:44.151Z",
              "success-count": 1
            },
            "uuid": "fce0289f-cb27-11e8-8fb4-0800279075f3"
          }
        ],
        "external-identifiers": {
          "container-id": "cilium-local:41018",
          "container-name": "cilium-health",
          "pod-name": "/"
        },
        "health": {
          "bpf": "OK",
          "connected": true,
          "overallHealth": "OK",
          "policy": "OK"
        },
        "identity": {
          "id": 4,
          "labels": [
            "reserved:health"
          ],
          "labelsSHA256": "9f122da90704e5177f344e0582800e43b05842f9f6b1812cf4690aade0915275"
        },
        "labels": {
          "derived": [],
          "disabled": [],
          "realized": {
            "user": []
          },
          "security-relevant": [
            "reserved:health"
          ]
        },
        "log": [
          {
            "code": "OK",
            "message": "Successfully regenerated endpoint program (Reason: updated security labels)",
            "state": "ready",
            "timestamp": "2018-10-08T18:28:44Z"
          }
        ],
        "networking": {
          "addressing": [
            {
              "ipv4": "10.0.233.169",
              "ipv6": "f00d::a00:0:0:a03a"
            }
          ],
          "host-mac": "8e:eb:f1:09:84:9f",
          "interface-index": 36,
          "interface-name": "cilium_health",
          "mac": "d6:fc:85:61:3c:fa"
        },
        "policy": {
          "proxy-statistics": [],
          "realized": {
            "allowed-egress-identities": [
              5,
              1,
              128,
              2,
              129,
              4
            ],
            "allowed-ingress-identities": [
              5,
              4,
              128,
              129,
              1,
              2
            ],
            "build": 2,
            "cidr-policy": {
              "egress": [],
              "ingress": []
            },
            "id": 4,
            "l4": {
              "egress": [],
              "ingress": []
            },
            "policy-enabled": "none",
            "policy-revision": 2
          },
          "spec": {
            "allowed-egress-identities": [
              128,
              2,
              129,
              1,
              4,
              5
            ],
            "allowed-ingress-identities": [
              1,
              2,
              128,
              4,
              5,
              129
            ],
            "build": 2,
            "cidr-policy": {
              "egress": [],
              "ingress": []
            },
            "id": 4,
            "l4": {
              "egress": [],
              "ingress": []
            },
            "policy-enabled": "none",
            "policy-revision": 2
          }
        },
        "realized": {
          "label-configuration": {
            "user": []
          },
          "options": {
            "Conntrack": "Enabled",
            "ConntrackAccounting": "Enabled",
            "ConntrackLocal": "Disabled",
            "Debug": "Enabled",
            "DebugLB": "Disabled",
            "DropNotification": "Enabled",
            "MonitorAggregationLevel": "None",
            "NAT46": "Disabled",
            "TraceNotification": "Enabled"
          }
        },
        "state": "ready"
      }
    }
  ],
  "environment-variables": [
    "allow-localhost:always",
    "version:false",
    "conntrack-garbage-collector-interval:60",
    "sidecar-http-proxy:false",
    "log-system-load:false",
    "tunnel:vxlan",
    "bpf-root:",
    "kvstore-opt:map[etcd.config:/var/lib/cilium/etcd-config.yml]",
    "device:undefined",
    "http-403-msg:",
    "agent-labels:",
    "bpf-ct-global-tcp-max:1000000",
    "docker:unix:///var/run/docker.sock",
    "nat46-range:0:0:0:0:0:FFFF::/96",
    "tofqdns-min-ttl:31536000",
    "masquerade:true",
    "prometheus-serve-addr-deprecated:",
    "access-labels:",
    "cluster-name:default",
    "prefilter-device:undefined",
    "prefilter-mode:xdpdrv",
    "k8s-legacy-host-allows-world:",
    "bpf-ct-global-any-max:262144",
    "auto-ipv6-node-routes:true",
    "container-runtime:docker",
    "kvstore:etcd",
    "log-driver:",
    "pprof:false",
    "trace-payloadlen:128",
    "lib-dir:/var/lib/cilium",
    "clustermesh-config:",
    "keep-config:false",
    "keep-bpf-templates:false",
    "disable-conntrack:false",
    "ipv4-node:auto",
    "disable-k8s-services:false",
    "bpf-compile-debug:false",
    "fixed-identity-mapping:map[128:kv-store 129:kube-dns]",
    "cmdref:",
    "mtu:1500",
    "ipv6-range:auto",
    "enable-policy:default",
    "sidecar-istio-proxy-image:cilium/istio_proxy",
    "monitor-aggregation:None",
    "logstash-probe-timer:10",
    "log-opt:map[]",
    "ipv6-node:auto",
    "ipv6-service-range:auto",
    "single-cluster-route:false",
    "k8s-require-ipv6-pod-cidr:false",
    "ipv4-service-range:auto",
    "lb:",
    "ipv4-cluster-cidr-mask-size:8",
    "ipv4-range:auto",
    "labels:",
    "envoy-log:",
    "prometheus-serve-addr:",
    "enable-tracing:false",
    "disable-ipv4:false",
    "container-runtime-endpoint:map[unix:///var/run/docker.sock:]",
    "ipv6-cluster-alloc-cidr:f00d::/64",
    "socket-path:/var/run/cilium/cilium.sock",
    "k8s-api-server:",
    "k8s-kubeconfig-path:/var/lib/cilium/cilium.kubeconfig",
    "access-log:/var/log/cilium-access.log",
    "prepend-iptables-chains:true",
    "disable-envoy-version-check:false",
    "label-prefix-file:",
    "restore:true",
    "state-dir:/var/run/cilium",
    "config:",
    "k8s-require-ipv4-pod-cidr:false",
    "logstash-agent:127.0.0.1:8080",
    "logstash:false",
    "cluster-id:0",
    "debug:true",
    "debug-verbose:"
  ],
  "kernel-version": "4.9.17",
  "policy": {
    "policy": "[]",
    "revision": 2
  },
  "service-list": [
    {
      "spec": {
        "backend-addresses": [
          {
            "ip": "192.168.33.11",
            "port": 6443
          }
        ],
        "frontend-address": {
          "ip": "172.20.0.1",
          "port": 443,
          "protocol": "TCP"
        },
        "id": 1
      },
      "status": {
        "realized": {
          "backend-addresses": [
            {
              "ip": "192.168.33.11",
              "port": 6443
            }
          ],
          "frontend-address": {
            "ip": "172.20.0.1",
            "port": 443,
            "protocol": "TCP"
          },
          "id": 1
        }
      }
    }
  ]
}
```

</details>


Signed-off by: Ian Vernon <ian@cilium.io>

Partially-fixes: #5594

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5831)
<!-- Reviewable:end -->
