### PR TITLE
bugtool: add new options for prepending archive-prefix, enabling Markdown formatting

### DIFF
--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -37,9 +37,11 @@ cilium-bugtool [OPTIONS]
 
 ```
       --archive                 Create archive when false skips deletion of the output directory (default true)
+      --archive-prefix string   String to prefix to name of archive if created (e.g., with cilium pod-name)
   -o, --archiveType string      Archive type: tar | gz (default "tar")
       --config string           Configuration to decide what should be run (default "./.cilium-bugtool.config")
       --dry-run                 Create configuration file of all commands that would have been executed
+      --enable-markdown         Dump output of commands in markdown format
       --exec-timeout duration   The default timeout for any cmd execution in seconds (default 30s)
   -H, --host string             URI to server-side API
       --k8s-label string        Kubernetes label for Cilium pod (default "k8s-app=cilium")


### PR DESCRIPTION
Add two new options for cilium-bugtool:

* `--archive-prefix`: optional string which can be added as a prefix to the
created-archive and the directory containing the bugtool output within the
archive. This is helpful when a large number of bugtool archives are gathered
within a cluster. Before, when this was done, and the archives were
decompressed, there was no identifying information about to which Cilium pod the
resulting directory created from unarchiving the bugtool archive belonged.

Example:

```
$ sudo cilium-bugtool --archive-prefix foobar
Deleted empty directory /tmp/foobar-cilium-bugtool-20181005-214006.925+0000-UTC-097029198/cmd
Deleted empty directory /tmp/foobar-cilium-bugtool-20181005-214006.925+0000-UTC-097029198/conf

ARCHIVE at /tmp/foobar-cilium-bugtool-20181005-214006.925+0000-UTC-097029198.tar
...

$ tar xvf /tmp/foobar-cilium-bugtool-20181005-214006.925+0000-UTC-097029198.tar
foobar-cilium-bugtool-20181005-214006.925+0000-UTC-097029198
...
```

* `--enable-markdown`: before, all output from the bugtool was written in
Markdown format. Now, this behavior is opt-in; the output of the commands
that are ran by the bugtool is, by default, dumped to file without any
surrounding Markdown formatting.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #5830

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5832)
<!-- Reviewable:end -->
