### PR TITLE
Add runtime policy test with server l7 egress

### DIFF
--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -644,6 +644,8 @@ var _ = Describe("RuntimePolicies", func() {
 		app3EndpointID, exists := endpointIDS[helpers.App3]
 		Expect(exists).To(BeTrue(), "Expected endpoint ID to exist for %s", helpers.App3)
 
+		connectivityTest(httpRequestsPublic, helpers.Host, helpers.Httpd2, true)
+
 		connectivityTest(httpRequestsPublic, helpers.App3, helpers.Httpd1, true)
 
 		// Since policy allows connectivity on /public to httpd1 from app3, we

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -329,13 +329,21 @@ var _ = Describe("RuntimePolicies", func() {
 				dst = fmt.Sprintf("[%s]", srvIP[helpers.IPv6])
 			}
 			switch test {
-			case ping, ping6:
+			case ping:
 				commandName = "ping"
-			case http, http6:
-				commandName = "curl public URL on"
+			case ping6:
+				commandName = "ping6"
+			case http:
+				commandName = "curl public IPv4 URL on"
 				command = helpers.CurlFail("http://%s:80/public", dst)
-			case httpPrivate, http6Private:
-				commandName = "curl private URL on"
+			case http6:
+				commandName = "curl public IPv6 URL on"
+				command = helpers.CurlFail("http://%s:80/public", dst)
+			case httpPrivate:
+				commandName = "curl private IPv4 URL on"
+				command = helpers.CurlFail("http://%s:80/private", dst)
+			case http6Private:
+				commandName = "curl private IPv6 URL on"
 				command = helpers.CurlFail("http://%s:80/private", dst)
 			}
 			if expectsSuccess {

--- a/test/runtime/manifests/Policies-l3-dependent-l7-egress.json
+++ b/test/runtime/manifests/Policies-l3-dependent-l7-egress.json
@@ -22,4 +22,16 @@
             {"matchLabels":{"id.httpd2":""}}
         ]
     }]
+},{
+    "endpointSelector":
+        {"matchLabels":{"id.httpd2":""}},
+    "egress": [{
+	"toEntities": ["host"],
+        "toPorts": [{
+            "ports": [{"port": "80", "protocol": "tcp"}],
+            "rules": {
+                "http": [{}]
+            }
+        }]
+    }]
 }]


### PR DESCRIPTION
Test http connectivity from host to a pod when the pod has an http egress policy on port 80.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5836)
<!-- Reviewable:end -->
