### PR TITLE
loader: Cancel compiler context if linker fails

### DIFF
--- a/pkg/command/exec/exec.go
+++ b/pkg/command/exec/exec.go
@@ -95,6 +95,14 @@ func WithTimeout(timeout time.Duration, prog string, args ...string) *Cmd {
 	return cmd
 }
 
+// WithCancel creates a Cmd with a context that can be cancelled by calling the
+// resulting Cancel() function.
+func WithCancel(ctx context.Context, prog string, args ...string) (*Cmd, context.CancelFunc) {
+	newCtx, cancel := context.WithCancel(ctx)
+	cmd := CommandContext(newCtx, prog, args...)
+	return cmd, cancel
+}
+
 // WithFilters modifies the specified command to filter any output lines from
 // logs if they contain any of the substrings specified as arguments to this
 // function.


### PR DESCRIPTION
Create a new context for the compiler that can be cancelled, then when
the linker fails, cancel the compiler. Otherwise, if the linker
successfully completes, then read all of stderr from the compiler and
its error.

The previous behaviour was believed to cause deadlock as the compiler process would never exit if the linker exited, so the `ReadAll()` would block potentially forever.

Related: #5748

This only affects master (v1.3)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5838)
<!-- Reviewable:end -->
