### PR TITLE
Correctly collect stats in case of error in regenerateBPF

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -166,12 +166,13 @@ var (
 		[]string{"endpoint_state"},
 	)
 
-	// EndpointRegenerationTimeStats is the total time taken to regenerate endpoint
+	// EndpointRegenerationTimeStats is the total time taken to regenerate
+	// endpoints, labeled by span name and status ("success" or "failure")
 	EndpointRegenerationTimeStats = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
 		Name:      "endpoint_regeneration_time_stats_seconds",
 		Help:      "Endpoint regeneration time stats labeled by the scope",
-	}, []string{LabelScope})
+	}, []string{LabelScope, LabelStatus})
 
 	// Policy
 

--- a/pkg/spanstat/spanstat.go
+++ b/pkg/spanstat/spanstat.go
@@ -19,10 +19,11 @@ import (
 )
 
 // SpanStat measures the total duration of all time spent in between Start()
-// and Stop() calls
+// and Stop() calls.
 type SpanStat struct {
-	spanStart     time.Time
-	totalDuration time.Duration
+	spanStart       time.Time
+	successDuration time.Duration
+	failureDuration time.Duration
 }
 
 // Start starts a new span
@@ -31,19 +32,38 @@ func (s *SpanStat) Start() {
 }
 
 // End ends the current span and adds the measured duration to the total
-func (s *SpanStat) End() {
+// cumulated duration, and to the success or failure cumulated duration
+// depending on the given success flag
+func (s *SpanStat) End(success bool) {
 	if !s.spanStart.IsZero() {
-		s.totalDuration += time.Since(s.spanStart)
+		d := time.Since(s.spanStart)
+		if success {
+			s.successDuration += d
+		} else {
+			s.failureDuration += d
+		}
 	}
 	s.spanStart = time.Time{}
 }
 
-// Total returns the total duration of all spans measured
+// Total returns the total duration of all spans measured, including both
+// successes and failures
 func (s *SpanStat) Total() time.Duration {
-	return s.totalDuration
+	return s.successDuration + s.failureDuration
 }
 
-// Reset rests the duration measurement
+// SuccessTotal returns the total duration of all successful spans measured
+func (s *SpanStat) SuccessTotal() time.Duration {
+	return s.successDuration
+}
+
+// FailureTotal returns the total duration of all successful spans measured
+func (s *SpanStat) FailureTotal() time.Duration {
+	return s.failureDuration
+}
+
+// Reset rests the duration measurements
 func (s *SpanStat) Reset() {
-	s.totalDuration = 0
+	s.successDuration = 0
+	s.failureDuration = 0
 }

--- a/pkg/spanstat/spanstat_test.go
+++ b/pkg/spanstat/spanstat_test.go
@@ -34,27 +34,46 @@ func (s *SpanStatTestSuite) TestSpanStat(c *C) {
 
 	// no spans measured yet
 	c.Assert(span1.Total(), Equals, time.Duration(0))
+	c.Assert(span1.SuccessTotal(), Equals, time.Duration(0))
+	c.Assert(span1.FailureTotal(), Equals, time.Duration(0))
 
 	// End() without Start()
-	span1.End()
+	span1.End(true)
 	c.Assert(span1.Total(), Equals, time.Duration(0))
+	c.Assert(span1.SuccessTotal(), Equals, time.Duration(0))
+	c.Assert(span1.FailureTotal(), Equals, time.Duration(0))
 
 	// Start() but no end yet
 	span1.Start()
 	c.Assert(span1.Total(), Equals, time.Duration(0))
+	c.Assert(span1.SuccessTotal(), Equals, time.Duration(0))
+	c.Assert(span1.FailureTotal(), Equals, time.Duration(0))
 
 	// First span measured with End()
-	span1.End()
-	firstSpanTotal := span1.Total()
-	c.Assert(firstSpanTotal, Not(Equals), time.Duration(0))
+	span1.End(true)
+	spanTotal1 := span1.Total()
+	spanSuccessTotal1 := span1.SuccessTotal()
+	spanFailureTotal1 := span1.FailureTotal()
+	c.Assert(span1.Total(), Not(Equals), time.Duration(0))
+	c.Assert(span1.SuccessTotal(), Not(Equals), time.Duration(0))
+	c.Assert(span1.FailureTotal(), Equals, time.Duration(0))
+	c.Assert(span1.Total(), Equals, span1.SuccessTotal()+span1.FailureTotal())
 
 	// End() without a prior Start(), no change
-	span1.End()
-	c.Assert(span1.Total(), Equals, firstSpanTotal)
+	span1.End(true)
+	c.Assert(span1.Total(), Equals, spanTotal1)
+	c.Assert(span1.SuccessTotal(), Equals, spanSuccessTotal1)
+	c.Assert(span1.FailureTotal(), Equals, spanFailureTotal1)
 
 	span1.Start()
-	span1.End()
-	c.Assert(span1.Total(), Not(Equals), firstSpanTotal)
-	c.Assert(span1.Total(), Not(Equals), time.Duration(0))
+	span1.End(false)
+	c.Assert(span1.Total(), Not(Equals), spanTotal1)
+	c.Assert(span1.SuccessTotal(), Equals, spanSuccessTotal1)
+	c.Assert(span1.FailureTotal(), Not(Equals), spanFailureTotal1)
+	c.Assert(span1.Total(), Equals, span1.SuccessTotal()+span1.FailureTotal())
 
+	span1.Reset()
+	c.Assert(span1.Total(), Equals, time.Duration(0))
+	c.Assert(span1.SuccessTotal(), Equals, time.Duration(0))
+	c.Assert(span1.FailureTotal(), Equals, time.Duration(0))
 }


### PR DESCRIPTION
Cumulate separate duration totals for successful and failing spans.
Collect all span durations in case of regeneration failures.
Export the sucess and failure duration totals separately in metrics using labels.
    
When exporting metrics, skip span scopes that have not been hit (zero duration), so the count in the histograms accurately reflect the number of times each scope is hit, and the distribution is not incorrectly skewed towards zero.

Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5841)
<!-- Reviewable:end -->
