### PR TITLE
bpf, perf: refine barriers and tail update, fix scratch buffer

### DIFF
--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -240,7 +240,7 @@ func (m *Monitor) dumpStat() {
 	c := int64(m.monitorEvents.Cpus)
 	n := int64(m.monitorEvents.Npages)
 	p := int64(m.monitorEvents.Pagesize)
-	l, u := m.monitorEvents.Stats()
+	l, _, u := m.monitorEvents.Stats()
 	ms := models.MonitorStatus{Cpus: c, Npages: n, Pagesize: p, Lost: int64(l), Unknown: int64(u)}
 
 	mp, err := json.Marshal(ms)


### PR DESCRIPTION
- Refine paired memory barriers from user space side.
- In place tail update which allows kernel to fill new entries before we finished full run as before.
- Increase tmp buffer to avoid potential of corruptions.
- Reduce complexity overall on read side.

Fixes: #5671
Fixes: #5826

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5842)
<!-- Reviewable:end -->
