### PR TITLE
Test: Added tcpdump containers on test and dump output when it fails.

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -181,6 +181,8 @@ const (
 
 	MonitorLogFileName = "monitor.log"
 	microscopeManifest = "microscope.yaml"
+	TcpdumpManifest    = "tcpdump.yaml"
+	Tcpdump            = "tcpdump"
 
 	// CiliumTestLog is the filename where the cilium logs that happens during
 	// the test are saved.

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -33,7 +33,9 @@ var _ = Describe("K8sServicesTest", func() {
 		kubectl          *helpers.Kubectl
 		serviceName      = "app1-service"
 		microscopeErr    error
-		microscopeCancel                    = func() error { return nil }
+		microscopeCancel = func() error { return nil }
+		tcpdumpErr       error
+		tcpdumpCancel                       = func() error { return nil }
 		backgroundCancel context.CancelFunc = func() { return }
 		backgroundError  error
 		ciliumPodK8s1    string
@@ -68,11 +70,14 @@ var _ = Describe("K8sServicesTest", func() {
 		Expect(microscopeErr).To(BeNil(), "Microscope cannot be started")
 		backgroundCancel, backgroundError = kubectl.BackgroundReport("uptime")
 		Expect(backgroundError).To(BeNil(), "Cannot start background report process")
+		tcpdumpErr, tcpdumpCancel = kubectl.TcpdumpStart()
+		Expect(tcpdumpErr).To(BeNil(), "tcpdump cannot be started")
 	})
 
 	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 		Expect(microscopeCancel()).To(BeNil(), "cannot stop microscope")
+		Expect(tcpdumpCancel()).To(BeNil(), "cannot stop tcpdump")
 		backgroundCancel()
 	})
 

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -29,6 +29,9 @@ var _ = Describe("K8sUpdates", func() {
 		kubectl *helpers.Kubectl
 
 		cleanupCallback = func() { return }
+
+		tcpdumpCancel = func() error { return nil }
+		tcpdumpErr    error
 	)
 
 	BeforeAll(func() {
@@ -61,6 +64,12 @@ var _ = Describe("K8sUpdates", func() {
 
 	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		Expect(tcpdumpCancel()).To(BeNil(), "cannot stop tcpdump")
+	})
+
+	JustBeforeEach(func() {
+		tcpdumpErr, tcpdumpCancel = kubectl.TcpdumpStart()
+		Expect(tcpdumpErr).To(BeNil(), "tcpdump cannot be started")
 	})
 
 	AfterEach(func() {

--- a/test/k8sT/manifests/tcpdump.yaml
+++ b/test/k8sT/manifests/tcpdump.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  name: tcpdump
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: tcpdump
+  template:
+    metadata:
+      labels:
+        k8s-app: tcpdump
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: >-
+          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+    spec:
+      containers:
+        - image: docker.io/corfr/tcpdump:latest
+          imagePullPolicy: IfNotPresent
+          name: tcpdump
+          command: ["sleep"]
+          args:
+            - "1000h"
+          securityContext:
+            capabilities:
+              add:
+                - "NET_ADMIN"
+            privileged: true
+            allowPrivilegeEscalation: true
+      hostNetwork: true
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+        - key: CriticalAddonsOnly
+          operator: "Exists"

--- a/test/k8sT/manifests/tcpdump.yaml
+++ b/test/k8sT/manifests/tcpdump.yaml
@@ -32,6 +32,9 @@ spec:
                 - "NET_ADMIN"
             privileged: true
             allowPrivilegeEscalation: true
+          volumeMounts:
+            - mountPath: /test
+              name: test-volume
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-node-critical
@@ -45,3 +48,8 @@ spec:
           value: "true"
         - key: CriticalAddonsOnly
           operator: "Exists"
+      volumes:
+        - name: test-volume
+          hostPath:
+            path: /home/vagrant/go/src/github.com/cilium/cilium/test/
+            type: Directory

--- a/test/k8sT/manifests/tcpdump.yaml
+++ b/test/k8sT/manifests/tcpdump.yaml
@@ -32,9 +32,6 @@ spec:
                 - "NET_ADMIN"
             privileged: true
             allowPrivilegeEscalation: true
-          volumeMounts:
-            - mountPath: /test
-              name: test-volume
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-node-critical
@@ -48,8 +45,3 @@ spec:
           value: "true"
         - key: CriticalAddonsOnly
           operator: "Exists"
-      volumes:
-        - name: test-volume
-          hostPath:
-            path: /home/vagrant/go/src/github.com/cilium/cilium/test/
-            type: Directory

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -235,6 +235,7 @@ var _ = BeforeAll(func() {
 		}
 		kubectl := helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		kubectl.Apply(helpers.GetFilePath("../examples/kubernetes/addons/prometheus/prometheus.yaml"))
+		kubectl.Apply(helpers.ManifestGet(helpers.TcpdumpManifest))
 
 		// deploy Cilium etcd operator
 		kubectl.DeployETCDOperator()
@@ -315,5 +316,15 @@ var _ = AfterEach(func() {
 			return
 		}
 		_ = os.Remove(filepath.Join(testPath, helpers.MonitorLogFileName))
+
+		// Removed all tcpdump files if test did not fail to not store it on
+		// Jenkins.
+		tcpdumpFiles, err := filepath.Glob(fmt.Sprintf("%s/%s-*.pcap", testPath, helpers.Tcpdump))
+		if err != nil {
+			return
+		}
+		for _, file := range tcpdumpFiles {
+			_ = os.Remove(file)
+		}
 	}
 })


### PR DESCRIPTION
This commit try to get visibility when the cilium restarts on Kubernetes
test. Tcpdump containers will be in the backend running on host
networking fetching all the traffic and will be dump in logs if a test
failed.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5843)
<!-- Reviewable:end -->
