### PR TITLE
pkg/{identity,ipcache}: check for nil identity in slice of identities

### DIFF
--- a/pkg/identity/allocator.go
+++ b/pkg/identity/allocator.go
@@ -176,6 +176,9 @@ func (id *Identity) Release() error {
 func ReleaseSlice(identities []*Identity) error {
 	var err error
 	for _, id := range identities {
+		if id == nil {
+			continue
+		}
 		if err2 := id.Release(); err2 != nil {
 			log.WithError(err2).WithFields(logrus.Fields{
 				logfields.Identity: id,

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -246,6 +246,9 @@ func upsertIPNetsToKVStore(prefixes []*net.IPNet, identities []*identity.Identit
 	}
 	for i, prefix := range prefixes {
 		id := identities[i]
+		if id == nil {
+			continue
+		}
 		err = upsertIPNetToKVStore(prefix, id)
 		if err != nil {
 			for j := 0; j < i; j++ {


### PR DESCRIPTION
As the slice of identities can contain identities that were not
previously allocated, set as nil, we need to check if they are nil
while iterating over the slice of identities to be released or
inserted into the kvstore.

Fixes: 6494f0e01364 ("identity: Guarantee 1:1 prefix <-> identity slices")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5851)
<!-- Reviewable:end -->
