### PR TITLE
test: deploy etcd-operator deployment last

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -258,11 +258,11 @@ var ciliumKubCLICommands = map[string]string{
 // etcdDeploymentFiles are the list of files used to deploy etcd operator.
 var etcdDeploymentFiles = []string{
 	"00-crd-etcd.yaml",
-	"cilium-etcd-cluster.yaml",
 	"cilium-etcd-sa.yaml",
 	"cluster-role-binding-template.yaml",
 	"cluster-role-template.yaml",
 	"deployment.yaml",
+	"cilium-etcd-cluster.yaml",
 }
 
 //GetFilePath returns the absolute path of the provided filename


### PR DESCRIPTION
It seems when we create the CRD kube-apiserver doesn't create it
immediately causing the creating of the CR to fail. To avoid this we
deploy the CR after deploying all etcd-operator related kubernetes
descriptors.

Signed-off-by: André Martins <andre@cilium.io>

It will help fix issues like https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-K8s/1045/testReport/junit/k8s-1/9/K8sHealthTest_checks_cilium_health_status_between_nodes/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5854)
<!-- Reviewable:end -->
