### PR TITLE
protect bpf.PerfEvent.Read from infinite loop

### DIFF
--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -808,7 +808,7 @@ func (m *Map) DeleteAll() error {
 		if err2 == nil {
 			m.deleteCacheEntry(k, err)
 		} else {
-			log.WithError(err2).Warning("Unable to correlate iteration key %v with cache entry. Inconsistent cache.", nextKey)
+			log.WithError(err2).Warningf("Unable to correlate iteration key %v with cache entry. Inconsistent cache.", nextKey)
 		}
 
 		if err != nil {


### PR DESCRIPTION
Supersedes: https://github.com/cilium/cilium/pull/5827

Infinite loop in `Read` can be caused by corrupted data in perf ring
buffer.

If the timeout in `Read` loop is reached, perf event is logged for
further debugging.

Edits by @tgraf:
* Removed erroneous test
* Replace long log message with dump to `/var/run/cilium/state/ring-buffer-crash.dump`
* Ring buffer rest on timeout contributed by @borkmann 

Signed-off-by: Maciej Kwiek <maciej@covalent.io>

Fixes: #5826

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5856)
<!-- Reviewable:end -->
