### PR TITLE
Create init container for Cilium

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,9 @@ docker-image: clean GIT_VERSION envoy/SOURCE_VERSION
 	$(QUIET)echo "Push like this when ready:"
 	$(QUIET)echo "docker push cilium/cilium:$(DOCKER_IMAGE_TAG)"
 
+docker-image-init:
+	$(QUIET)cd contrib/packaging/docker && docker build -t "cilium/cilium-init:$(UTC_DATE)" -f Dockerfile.init .
+
 docker-image-runtime:
 	cd contrib/packaging/docker && docker build -t "cilium/cilium-runtime:$(UTC_DATE)" -f Dockerfile.runtime .
 

--- a/contrib/packaging/docker/Dockerfile.init
+++ b/contrib/packaging/docker/Dockerfile.init
@@ -1,0 +1,10 @@
+#
+# Cilium init container.
+#
+# cilium-init is used in kubernetes environments to run miscellaneous
+# logic for cleaning up containers in between pod restarts.
+#
+FROM docker.io/library/busybox:1.28.4
+LABEL maintainer="maintainer@cilium.io"
+COPY init-container.sh /init-container.sh
+CMD ["/init-container.sh"]

--- a/contrib/packaging/docker/init-container.sh
+++ b/contrib/packaging/docker/init-container.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-echo "Removing old cilium and cilium-health pidfiles..."
-rm /var/run/cilium/cilium.pid \
-   /var/run/cilium/state/health-endpoint.pid
 if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then
     echo "Removing Cilium state..."
     rm -rf /var/run/cilium/state;

--- a/contrib/packaging/docker/init-container.sh
+++ b/contrib/packaging/docker/init-container.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+echo "Removing old cilium and cilium-health pidfiles..."
+rm /var/run/cilium/cilium.pid \
+   /var/run/cilium/state/health-endpoint.pid
+if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then
+    echo "Removing Cilium state..."
+    rm -rf /var/run/cilium/state;
+fi;
+if [ "${CLEAN_CILIUM_STATE}" = "true" ] \
+   || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then
+    echo "Removing BPF state..."
+    rm -rf /sys/fs/bpf/tc/globals/cilium_* \
+           /var/run/cilium/bpffs/tc/globals/cilium_*;
+fi

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -33,9 +33,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -115,7 +115,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -115,9 +115,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -33,9 +33,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -115,7 +115,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -115,9 +115,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -33,9 +33,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -115,7 +115,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -115,9 +115,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -33,9 +33,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -115,7 +115,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -115,9 +115,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -33,9 +33,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -115,7 +115,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -115,9 +115,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -33,9 +33,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -115,7 +115,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -115,9 +115,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -33,9 +33,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -115,7 +115,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -115,9 +115,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -33,9 +33,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -115,7 +115,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -115,9 +115,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -33,9 +33,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -115,7 +115,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -115,9 +115,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -33,9 +33,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -115,7 +115,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -115,9 +115,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -33,9 +33,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-10
+          image: docker.io/cilium/cilium-init:2018-10-16
           imagePullPolicy: IfNotPresent
           command: ["/init-container.sh"]
           securityContext:

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -33,9 +33,9 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: docker.io/cilium/cilium-init:2018-10-10
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'rm /var/run/cilium/cilium.pid; rm /var/run/cilium/state/health-endpoint.pid; if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; fi; if [ "${CLEAN_CILIUM_STATE}" = "true" ] || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then rm -rf /sys/fs/bpf/tc/globals/cilium_* /var/run/cilium/bpffs/tc/globals/cilium_*; fi']
+          command: ["/init-container.sh"]
           securityContext:
             capabilities:
               add:


### PR DESCRIPTION
Refactor the init container logic into a shell script and create a new container for it.

I've pushed an initial tag version for the container based upon the latest master logic, and manually tested this by deploying in a minikube.

Fixes: #5839

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5857)
<!-- Reviewable:end -->
