### PR TITLE
Test: Add a new global JustBeforeEach function to validate internet connectivity

### DIFF
--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -2,7 +2,7 @@
 
 pipeline {
     agent {
-        label 'baremetal'
+        label 'eloy'
     }
 
     environment {

--- a/test/provision/dns.sh
+++ b/test/provision/dns.sh
@@ -10,5 +10,5 @@ echo "updating /etc/resolv.conf"
 
 cat <<EOF > /etc/resolv.conf
 nameserver 8.8.8.8
-nameserver 8.8.4.4
+nameserver 1.1.1.1
 EOF

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -252,9 +252,20 @@ var _ = JustBeforeEach(func() {
 	if node == nil {
 		return
 	}
+
+	debugCallback := func() string {
+		result := node.Exec("mtr --report --report-cycles 10 8.8.8.8 -z -n").CombineOutput().String()
+		result += "\n---------------------------\n1.1.1.1\n"
+		result += node.Exec("mtr --report --report-cycles 10 1.1.1.1 -z -n").CombineOutput().String()
+		return result
+	}
+
 	By("Preflight test to validate internet access")
-	node.Exec(helpers.CurlFail("-4 https://google.com")).ExpectSuccess(
-		"Node cannot connect to Google in a pre-flight test")
+
+	res := node.Exec(helpers.CurlFail("-4 https://www.google.es"))
+	res.ExpectSuccess(
+		"Node cannot connect to Google in a pre-flight test: MTR output %v",
+		debugCallback())
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
Add a new JustBeforeEach function that curl from host to google to
validate that internet connectivity is in there.

Fixes #5853

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5860)
<!-- Reviewable:end -->
