### PR TITLE
endpoint: signal when BPF program is compiled for the first time

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -732,6 +732,9 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 			Debug("BPF header file unchanged, skipping BPF compilation and installation")
 	}
 
+	// Signal that BPF program has been generated.
+	e.CloseBPFProgramChannel()
+
 	stats.proxyWaitForAck.Start()
 	err = e.WaitForProxyCompletions(proxyWaitGroup)
 	stats.proxyWaitForAck.End(err == nil)

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -732,7 +732,16 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 			Debug("BPF header file unchanged, skipping BPF compilation and installation")
 	}
 
+	// Hook the endpoint into the endpoint table and expose it
+	stats.mapSync.Start()
+	err = lxcmap.WriteEndpoint(epInfoCache)
+	stats.mapSync.End(err == nil)
+	if err != nil {
+		return 0, compilationExecuted, fmt.Errorf("Exposing new BPF failed: %s", err)
+	}
+
 	// Signal that BPF program has been generated.
+	// The endpoint has at least L3/L4 connectivity at this point.
 	e.CloseBPFProgramChannel()
 
 	stats.proxyWaitForAck.Start()
@@ -763,17 +772,10 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 	// policy map with the new proxy ports.
 	stats.mapSync.Start()
 	err = e.syncPolicyMap()
+	stats.mapSync.End(err == nil)
 	if err != nil {
-		stats.mapSync.End(false)
 		return 0, compilationExecuted, fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
 	}
-
-	// The last operation hooks the endpoint into the endpoint table and exposes it
-	err = lxcmap.WriteEndpoint(epInfoCache)
-	if err != nil {
-		log.WithField(logfields.EndpointID, e.ID).WithError(err).Error("Exposing new bpf failed")
-	}
-	stats.mapSync.End(true)
 
 	return epInfoCache.revision, compilationExecuted, err
 }


### PR DESCRIPTION
The Istio CI test has been unstable because of behavior in some pods where, if DNS fails to resolve, before the BPF program for the pod is installed, even after the pod has a BPF program installed, it will not be able to connect to the DNS server to resolve DNS again until the pod restarts.

Prior to this change, if Cilium is running in tandem with Istio, we returned before the BPF program was installed for the endpoint to avoid deadlock when configuring Envoy. To ensure that this sort of behavior in pods does not occur again, return from endpoint creation if the endpoint has been determined to be Istio-injected, and has a BPF program installed.

This PR adds a channel which is closed once the initial BPF compilation has occurred for an endpoint. The state of this channel is used to determine if a BPF program has been compiled for the endpoint.
    
Fixes: #5859
    
Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5869)
<!-- Reviewable:end -->
