### PR TITLE
k8s: Avoid TriggerPolicyUpdates when no ToServices rules are loaded

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -975,12 +975,13 @@ func (d *Daemon) addK8sEndpointV1(ep *v1.Endpoints) error {
 		// select said service.
 		if !cacheOK || (cacheOK && serviceImportMeta.ruleTranslationError != nil) {
 			translator := k8s.NewK8sTranslator(svcns, *newSvcEP, false, svc.Labels, bpfIPCache.IPCache)
-			err := d.policy.TranslateRules(translator)
+			result, err := d.policy.TranslateRules(translator)
 			endpointMetadataCache.upsert(ep, err)
 			if err != nil {
 				log.Errorf("Unable to repopulate egress policies from ToService rules: %v", err)
 				return err
-			} else {
+			} else if result.NumToServicesRules > 0 {
+				// Only trigger policy updates if ToServices rules are in effect
 				scopedLog.Info("Kubernetes service endpoint added")
 				d.TriggerPolicyUpdates(true, "Kubernetes service endpoint added")
 			}
@@ -1037,10 +1038,11 @@ func (d *Daemon) deleteK8sEndpointV1(ep *v1.Endpoints) error {
 		svc, ok := d.loadBalancer.K8sServices[svcns]
 		if ok && svc.IsExternal() {
 			translator := k8s.NewK8sTranslator(svcns, *endpoint, true, svc.Labels, bpfIPCache.IPCache)
-			err := d.policy.TranslateRules(translator)
+			result, err := d.policy.TranslateRules(translator)
 			if err != nil {
 				log.Errorf("Unable to depopulate egress policies from ToService rules: %v", err)
-			} else {
+			} else if result.NumToServicesRules > 0 {
+				// Only trigger policy updates if ToServices rules are in effect
 				d.TriggerPolicyUpdates(true, "Kubernetes service endpoint deleted")
 			}
 		}

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -68,8 +68,9 @@ func (s *K8sSuite) TestTranslatorDirect(c *C) {
 	_, err := repo.Add(rule1)
 	c.Assert(err, IsNil)
 
-	err = repo.TranslateRules(translator)
+	result, err := repo.TranslateRules(translator)
 	c.Assert(err, IsNil)
+	c.Assert(result.NumToServicesRules, Equals, 1)
 
 	rule := repo.SearchRLocked(tag1)[0].Egress[0]
 
@@ -77,7 +78,8 @@ func (s *K8sSuite) TestTranslatorDirect(c *C) {
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
 
 	translator = NewK8sTranslator(serviceInfo, endpointInfo, true, map[string]string{}, nil)
-	err = repo.TranslateRules(translator)
+	result, err = repo.TranslateRules(translator)
+	c.Assert(result.NumToServicesRules, Equals, 1)
 
 	rule = repo.SearchRLocked(tag1)[0].Egress[0]
 
@@ -167,8 +169,9 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 	_, err := repo.Add(rule1)
 	c.Assert(err, IsNil)
 
-	err = repo.TranslateRules(translator)
+	result, err := repo.TranslateRules(translator)
 	c.Assert(err, IsNil)
+	c.Assert(result.NumToServicesRules, Equals, 1)
 
 	rule := repo.SearchRLocked(tag1)[0].Egress[0]
 
@@ -176,12 +179,13 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
 
 	translator = NewK8sTranslator(serviceInfo, endpointInfo, true, svcLabels, nil)
-	err = repo.TranslateRules(translator)
+	result, err = repo.TranslateRules(translator)
 
 	rule = repo.SearchRLocked(tag1)[0].Egress[0]
 
 	c.Assert(err, IsNil)
 	c.Assert(len(rule.ToCIDRSet), Equals, 0)
+	c.Assert(result.NumToServicesRules, Equals, 1)
 }
 
 func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -97,5 +97,5 @@ func (s *SearchContext) CallDepth() string {
 
 // Translator is an interface for altering policy rules
 type Translator interface {
-	Translate(*api.Rule) error
+	Translate(*api.Rule, *TranslationResult) error
 }

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -663,17 +663,26 @@ func (p *Repository) Empty() bool {
 	return p.NumRules() == 0
 }
 
+// TranslationResult contains the results of the rule translation
+type TranslationResult struct {
+	// NumToServicesRules is the number of ToServices rules processed while
+	// translating the rules
+	NumToServicesRules int
+}
+
 // TranslateRules traverses rules and applies provided translator to rules
-func (p *Repository) TranslateRules(translator Translator) error {
+func (p *Repository) TranslateRules(translator Translator) (*TranslationResult, error) {
 	p.Mutex.Lock()
 	defer p.Mutex.Unlock()
 
+	result := &TranslationResult{}
+
 	for ruleIndex := range p.rules {
-		if err := translator.Translate(&p.rules[ruleIndex].Rule); err != nil {
-			return err
+		if err := translator.Translate(&p.rules[ruleIndex].Rule, result); err != nil {
+			return nil, err
 		}
 	}
-	return nil
+	return result, nil
 }
 
 // BumpRevision allows forcing policy regeneration


### PR DESCRIPTION
The call to regenerate policy for all endpoints due to an Endpoints change on
an external service is only required when the policy repository contains
ToServices rules. This can avoid a lot of unnecessary calls to
TriggerPolicyUpdates().

Fixes: #5871

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5875)
<!-- Reviewable:end -->
