### PR TITLE
endpoint: Skip conntrack clean on endpoint restore

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -130,6 +130,8 @@ func (d *Daemon) restoreOldEndpoints(dir string, clean bool) (*endpointRestoreSt
 
 		ep.Unlock()
 
+		ep.SkipStateClean()
+
 		state.restored = append(state.restored, ep)
 
 		delete(existingEndpoints, ep.IPv4.String())

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2759,3 +2759,16 @@ func (e *Endpoint) scrubIPsInConntrackTable() {
 	e.scrubIPsInConntrackTableLocked()
 	e.Unlock()
 }
+
+// SkipStateClean can be called on a endpoint before its first build to skip
+// the cleaning of state such as the conntrack table. This is useful when an
+// endpoint is being restored from state and the datapath state should not be
+// claned.
+//
+// The endpoint lock must NOT be held.
+func (e *Endpoint) SkipStateClean() {
+	// Mark conntrack as already cleaned
+	e.UnconditionalLock()
+	e.ctCleaned = true
+	e.Unlock()
+}


### PR DESCRIPTION
The commit cb49db51afa introduced conntrack cleaning on the initial endpoint
build to clean eventual state from a previous endpoint build. This is correct
in principle but the commit missed to exclude endpoint builds triggered by
restored endpoints.

Fixes: cb49db51afa ("endpoint: Clear conntrack on initial endpoint build")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5882)
<!-- Reviewable:end -->
