### PR TITLE
move prefilter code to pkg/datapath

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/counter"
 	bpfIPCache "github.com/cilium/cilium/pkg/datapath/ipcache"
+	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -112,7 +113,7 @@ type Daemon struct {
 	l7Proxy           *proxy.Proxy
 	loadBalancer      *loadbalancer.LoadBalancer
 	policy            *policy.Repository
-	preFilter         *policy.PreFilter
+	preFilter         *prefilter.PreFilter
 	// Only used for CRI-O since it does not support events.
 	workloadsEventsCh chan<- *workloads.EventMessage
 
@@ -708,13 +709,13 @@ func (d *Daemon) compileBase() error {
 
 	scopedLog := log.WithField(logfields.XDPDevice, option.Config.DevicePreFilter)
 	if option.Config.DevicePreFilter != "undefined" {
-		if err := policy.ProbePreFilter(option.Config.DevicePreFilter, option.Config.ModePreFilter); err != nil {
+		if err := prefilter.ProbePreFilter(option.Config.DevicePreFilter, option.Config.ModePreFilter); err != nil {
 			scopedLog.WithError(err).Warn("Turning off prefilter")
 			option.Config.DevicePreFilter = "undefined"
 		}
 	}
 	if option.Config.DevicePreFilter != "undefined" {
-		if d.preFilter, ret = policy.NewPreFilter(); ret != nil {
+		if d.preFilter, ret = prefilter.NewPreFilter(); ret != nil {
 			scopedLog.WithError(ret).Warn("Unable to init prefilter")
 			return ret
 		}

--- a/pkg/datapath/prefilter/doc.go
+++ b/pkg/datapath/prefilter/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package prefilter provides a means of configuring XDP pre-filters for
+// DDoS-mitigation.
+package prefilter

--- a/pkg/datapath/prefilter/prefilter.go
+++ b/pkg/datapath/prefilter/prefilter.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package policy
+package prefilter
 
 import (
 	"fmt"


### PR DESCRIPTION
This code was in `pkg/policy` but is used for configuring the datapath
directly, and does not tie into the policy repository. Refactor it into
`pkg/datapath` accordingly.

Fixes: #5865

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5894)
<!-- Reviewable:end -->
