### PR TITLE
Add MaxControllerInterval for testing purposes

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -448,6 +448,10 @@ func init() {
 		"nat46-range", defaults.DefaultNAT46Prefix, "IPv6 prefix to map IPv4 addresses to")
 	flags.BoolVar(&masquerade,
 		"masquerade", true, "Masquerade packets from endpoints leaving the host")
+	flags.IntVar(&option.Config.MaxControllerInterval, option.MaxCtrlIntervalName, 0,
+		"Maximum interval (in seconds) between controller runs. Zero is no limit.")
+	viper.BindEnv(option.MaxCtrlIntervalName, option.MaxCtrlIntervalNameEnv)
+	flags.MarkHidden(option.MaxCtrlIntervalName)
 	flags.String(option.MonitorAggregationName, "None",
 		"Level of monitor aggregation for traces from the datapath")
 	viper.BindEnv(option.MonitorAggregationName, "CILIUM_MONITOR_AGGREGATION_LEVEL")
@@ -651,6 +655,11 @@ func initEnv(cmd *cobra.Command) {
 		if err := RestoreExecPermissions(option.Config.LibDir, `.*\.sh`); err != nil {
 			scopedLog.WithError(err).Fatal("Unable to restore agent assets")
 		}
+	}
+	if maxCtrlInterval := viper.GetInt(option.MaxCtrlIntervalName); maxCtrlInterval >= 0 {
+		option.Config.MaxControllerInterval = maxCtrlInterval
+	} else {
+		scopedLog.Fatalf("Invalid %s value %d", option.MaxCtrlIntervalName, maxCtrlInterval)
 	}
 
 	checkMinRequirements()

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -77,7 +77,7 @@ func (m *Manager) UpdateController(name string, params ControllerParams) *Contro
 
 		ctrl.getLogger().Debug("Updating existing controller")
 		ctrl.mutex.Lock()
-		ctrl.params = params
+		ctrl.updateParamsLocked(params)
 		ctrl.mutex.Unlock()
 
 		// Notify the goroutine of the params update.
@@ -90,12 +90,12 @@ func (m *Manager) UpdateController(name string, params ControllerParams) *Contro
 	} else {
 		ctrl = &Controller{
 			name:       name,
-			params:     params,
 			uuid:       uuid.NewUUID().String(),
 			stop:       make(chan struct{}, 0),
 			update:     make(chan struct{}, 1),
 			terminated: make(chan struct{}, 0),
 		}
+		ctrl.updateParamsLocked(params)
 		ctrl.getLogger().Debug("Starting new controller")
 
 		m.controllers[ctrl.name] = ctrl

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -140,6 +140,11 @@ const (
 	// DisableCiliumEndpointCRDName is the name of the option to disable
 	// use of the CEP CRD
 	DisableCiliumEndpointCRDName = "disable-endpoint-crd"
+
+	// MaxCtrlIntervalName and MaxCtrlIntervalNameEnv allow configuration
+	// of MaxControllerInterval.
+	MaxCtrlIntervalName    = "max-controller-interval"
+	MaxCtrlIntervalNameEnv = "CILIUM_MAX_CONTROLLER_INTERVAL"
 )
 
 // Available option for daemonConfig.Tunnel
@@ -261,6 +266,10 @@ type daemonConfig struct {
 
 	// DisableCiliumEndpointCRD disables the use of CiliumEndpoint CRD
 	DisableCiliumEndpointCRD bool
+
+	// MaxControllerInterval is the maximum value for a controller's
+	// RunInterval. Zero means unlimited.
+	MaxControllerInterval int
 }
 
 var (


### PR DESCRIPTION
Add a new MaxControllerInterval option which can be configured to bound
the interval between controller runs to within a limited range. This can
be set to a low value to assist in observing issues that are related to
regular controller runs.

This option is not intended for end-user usage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5896)
<!-- Reviewable:end -->
