### PR TITLE
fqdn: Make Rule UUIDs random instead of depending on the labels.

### DIFF
--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -211,6 +211,7 @@ func (d *Daemon) PolicyAdd(rules policyAPI.Rules, opts *AddOptions) (uint64, err
 			for _, r := range rules {
 				tmp := d.policy.SearchRLocked(r.Labels)
 				if len(tmp) > 0 {
+					d.dnsPoller.StopPollForDNSName(tmp)
 					d.policy.DeleteByLabelsLocked(r.Labels)
 				}
 			}
@@ -218,6 +219,7 @@ func (d *Daemon) PolicyAdd(rules policyAPI.Rules, opts *AddOptions) (uint64, err
 		if len(opts.ReplaceWithLabels) > 0 {
 			tmp := d.policy.SearchRLocked(opts.ReplaceWithLabels)
 			if len(tmp) > 0 {
+				d.dnsPoller.StopPollForDNSName(tmp)
 				d.policy.DeleteByLabelsLocked(opts.ReplaceWithLabels)
 			}
 		}


### PR DESCRIPTION
Rules may not have any labels and many rules may share the same
labels. Therefore a rule can't be uniquely identified by it's labels.

Generate a random rule UUID for each rule with "toFQDNs" so that we
can identify the same rule when needed for an update.

Unit tests are updated to not assume a stable UUID for a given set of
labels. Tests are also modified to make sure each rule has a unique
UUID regardless of it's labels, and that UUID is generated also if the
rule has no labels.

Fixes: #5890
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5897)
<!-- Reviewable:end -->
