### PR TITLE
v1.0: test/k8sT: deploy xwing YAML

### DIFF
--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -125,6 +125,10 @@ var _ = Describe(demoTestName, func() {
 		_, err = kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", empireLabel), 300)
 		Expect(err).Should(BeNil(), "Empire pods are not ready after timeout")
 
+		By("Applying xwing deployment")
+		res = kubectl.Apply(xwingYAMLLink)
+		res.ExpectSuccess("unable to apply %s: %s", xwingYAMLLink, res.CombineOutput())
+
 		By("Getting xwing pod names")
 		xwingPods, err := kubectl.GetPodNames(helpers.DefaultNamespace, allianceLabel)
 		Expect(err).Should(BeNil())


### PR DESCRIPTION
The xwing YAML was never deployed in the Star Wars Demo test, which caused the
test to fail because it expected the pods to be deployed.

Signed-off by: Ian Vernon <ian@cilium.io>

While we are going to EOL v1.0 of Cilium soon, If for whatever reason we need to merge something back to v1.0, it'd be nice to know that its CI tests pass; without this change, the CI tests will fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5905)
<!-- Reviewable:end -->
