### PR TITLE
loader: Log PIDs of compiler/linker on error

### DIFF
--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -156,7 +156,10 @@ func compileAndLink(ctx context.Context, prog *progInfo, dir *directoryInfo, deb
 	}
 	if err != nil {
 		err = fmt.Errorf("Failed to compile %s: %s", prog.Output, err)
-		log.Error(err)
+		log.WithFields(logrus.Fields{
+			"compiler-pid": compileCmd.Process.Pid,
+			"linker-pid":   linkCmd.Process.Pid,
+		}).Error(err)
 		if compileOut != nil {
 			scopedLog := log.Warn
 			if debug {


### PR DESCRIPTION
When there's an error, it may be useful for debugging purposes to have
the PID of the compiler and linker processes available. Log them.

I believe that these will be the PID of the shell that executes the commands, so the actual PIDs of the related processes may be off by one or so.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5906)
<!-- Reviewable:end -->
