### PR TITLE
allocator: Re-create slave keys to recover from identity loss

### DIFF
--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -139,7 +139,8 @@ func (s *AllocatorSuite) BenchmarkAllocate(c *C) {
 }
 
 func testAllocator(c *C, maxID ID, allocatorName string, suffix string) {
-	allocator, err := NewAllocator(allocatorName, TestType(""), WithMax(maxID), WithSuffix(suffix))
+	allocator, err := NewAllocator(allocatorName, TestType(""), WithMax(maxID),
+		WithSuffix(suffix), WithoutGC())
 	c.Assert(err, IsNil)
 	c.Assert(allocator, Not(IsNil))
 
@@ -181,7 +182,8 @@ func testAllocator(c *C, maxID ID, allocatorName string, suffix string) {
 	}
 
 	// Create a 2nd allocator, refill it
-	allocator2, err := NewAllocator(allocatorName, TestType(""), WithMax(maxID), WithSuffix("b"))
+	allocator2, err := NewAllocator(allocatorName, TestType(""), WithMax(maxID),
+		WithSuffix("b"), WithoutGC())
 	c.Assert(err, IsNil)
 	c.Assert(allocator2, Not(IsNil))
 
@@ -223,6 +225,11 @@ func testAllocator(c *C, maxID ID, allocatorName string, suffix string) {
 	// release final reference of all IDs
 	for i := ID(1); i <= maxID; i++ {
 		allocator.Release(TestType(fmt.Sprintf("key%04d", i)))
+	}
+
+	for i := ID(1); i <= maxID; i++ {
+		key := TestType(fmt.Sprintf("key%04d", i))
+		c.Assert(allocator.localKeys.keys[key.GetKey()], IsNil)
 	}
 
 	// running the GC should evict all entries

--- a/pkg/kvstore/allocator/cache.go
+++ b/pkg/kvstore/allocator/cache.go
@@ -200,7 +200,7 @@ func (c *cache) start(a *Allocator) waitChan {
 
 						if a.enableMasterKeyProtection {
 							if value := a.localKeys.lookupID(id); value != "" {
-								a.recreateMasterKey(id, value)
+								a.recreateMasterKey(id, value, true)
 								break
 							}
 						}


### PR DESCRIPTION
This PR improves ressiliency when slave keys disappear from an allocator prefix by re-creating slave keys automatically and resolving a small race window.

## Tested manually:
1. Deletion of master key:
```
Oct 16 18:23:31 k8s1 cilium-agent[9312]: level=warning msg="Re-created potentially missing master key" error="<nil>" key=cilium/state/identities/v1/id/55133 subsys=allocator
Oct 16 18:23:31 k8s1 cilium-agent[9312]: level=warning msg="Re-created potentially missing slave key" error="create was unsuccessful" key="cilium/state/identities/v1/value/k8s:io.cilium.k8s.policy.cluster=default;k8s:io.cilium.k8s.policy.serviceaccount=cilium-etcd-operator;k8s:io.kubernetes.pod.namespace=kube-system;k8s:name=cilium-etcd-operator;/192.168.34.11" subsys=allocator
```

2. Deletion of slave key:
```
Oct 16 18:25:43 k8s1 cilium-agent[9312]: level=warning msg="Re-created potentially missing slave key" error="<nil>" key="cilium/state/identities/v1/value/k8s:io.cilium.k8s.policy.cluster=default;k8s:io.cilium.k8s.policy.serviceaccount=cilium-etcd-operator;k8s:io.kubernetes.pod.namespace=kube-system;k8s:name=cilium-etcd-operator;/192.168.34.11" subsys=allocator
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5908)
<!-- Reviewable:end -->
