### PR TITLE
Clean up health EP pidfile on startup in k8s mode

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -56,8 +56,8 @@ var (
 	// vethPeerName is the endpoint-side link device name for cilium-health.
 	vethPeerName = "cilium"
 
-	// healthPidfile
-	healthPidfile = "health-endpoint.pid"
+	// PidfilePath
+	PidfilePath = "health-endpoint.pid"
 
 	// client is used to ping the cilium-health endpoint as a health check.
 	client *healthPkg.Client
@@ -147,7 +147,7 @@ func PingEndpoint() error {
 // * The health endpoint crashed during the current run of the Cilium agent
 //   and needs to be cleaned up before it is restarted.
 func KillEndpoint() {
-	path := filepath.Join(option.Config.StateDir, healthPidfile)
+	path := filepath.Join(option.Config.StateDir, PidfilePath)
 	if err := pidfile.Kill(path); err != nil {
 		scopedLog := log.WithField(logfields.Path, path).WithError(err)
 		scopedLog.Info("Failed to kill previous cilium-health instance")
@@ -199,7 +199,7 @@ func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressin
 		return fmt.Errorf("Error while creating veth: %s", err)
 	}
 
-	pidfile := filepath.Join(option.Config.StateDir, healthPidfile)
+	pidfile := filepath.Join(option.Config.StateDir, PidfilePath)
 	healthArgs := fmt.Sprintf("-d --admin=unix --passive --pidfile %s", pidfile)
 	args := []string{info.ContainerName, info.InterfaceName, vethPeerName,
 		ip6.String(), ip4.String(), ciliumHealth, healthArgs}

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -939,6 +939,12 @@ func runDaemon() {
 
 	// Launch another cilium-health as an endpoint, managed by cilium.
 	log.Info("Launching Cilium health endpoint")
+	if k8s.IsEnabled() {
+		// When Cilium starts up in k8s mode, it is guaranteed to be
+		// running inside a new PID namespace which means that existing
+		// PIDfiles are referring to PIDs that may be reused. Clean up.
+		pidfile.Remove(filepath.Join(option.Config.StateDir, health.PidfilePath))
+	}
 	controller.NewManager().UpdateController("cilium-health-ep",
 		controller.ControllerParams{
 			DoFunc: func() error {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -302,4 +302,10 @@ const (
 
 	// Debug is a boolean value for whether debug is set or not.
 	Debug = "debug"
+
+	// PID is an integer value for the process identifier of a process.
+	PID = "pid"
+
+	// PIDFile is a string value for the path to a file containing a PID.
+	PIDFile = "pidfile"
 )

--- a/pkg/pidfile/pidfile.go
+++ b/pkg/pidfile/pidfile.go
@@ -31,6 +31,17 @@ import (
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "pidfile")
 
+// Remove deletes the pidfile at the specified path. This does not clean up
+// the corresponding process, so should only be used when it is known that the
+// PID contained in the file at the specified path is no longer running.
+func Remove(path string) {
+	scopedLog := log.WithField(logfields.PIDFile, path)
+	scopedLog.Debug("Removing pidfile")
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		scopedLog.WithError(err).Warning("Failed to remove pidfile")
+	}
+}
+
 // Write the pid of the process to the specified path, and attach a cleanup
 // handler to the exit of the program so it's removed afterwards.
 func Write(path string) error {
@@ -46,7 +57,7 @@ func Write(path string) error {
 	go func() {
 		for s := range sig {
 			log.WithField("signal", s).Info("Exiting due to signal")
-			os.Remove(path)
+			Remove(path)
 			os.Exit(0)
 		}
 	}()
@@ -73,8 +84,8 @@ func kill(buf []byte, pidfile string) error {
 	// It could return "os: process already finished", so just log it at
 	// a low level and ignore the error.
 	log.WithFields(logrus.Fields{
-		"pid":     pid,
-		"pidfile": pidfile,
+		logfields.PID:     pid,
+		logfields.PIDFile: pidfile,
 	}).Info("Killing old process")
 	if err := oldProc.Kill(); err != nil {
 		log.WithError(err).Debug("Ignoring process kill failure")


### PR DESCRIPTION
When in kubernetes mode, every time Cilium starts, there is a new PID
namespace. As such, any pidfiles that remain on the filesystem on
startup are pointing to PIDs which may be reused in the new PID
namespace, so it's not safe to trust their contents.

In particular, for the health endpoint, we make use of a PIDfile to
allow the Cilium agent to find and kill a health endpoint if it becomes
unresponsive. However, we should never try to kill the health endpoint
based on a PID from a previous PID namespace.

Therefore, delete the pidfile for the health endpoint when starting up,
just before the health endpoint is launched. This will avoid the logic
for killing the previous health endpoint (which has been known to
unintentionally terminate processes other than health endpoints).

Related: #5748 
Related: #5837
Fixes: #5907

---

Background: The solution in #5837 didn't always work because if Cilium crashes, then kubernetes will just restart the Cilium container without re-running the init container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5909)
<!-- Reviewable:end -->
