### PR TITLE
endpoint: Wait for CT cleanup to complete before BPF compilation

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -695,6 +695,11 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 
 	e.Unlock()
 
+	// Wait for connection tracking cleaning to complete
+	stats.waitingForCTClean.Start()
+	<-ctCleaned
+	stats.waitingForCTClean.End(true)
+
 	e.getLogger().WithField("bpfHeaderfilesChanged", bpfHeaderfilesChanged).Debug("Preparing to compile BPF")
 
 	stats.prepareBuild.End(true)
@@ -733,11 +738,6 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 	if err != nil {
 		return 0, compilationExecuted, fmt.Errorf("Error while configuring proxy redirects: %s", err)
 	}
-
-	// Wait for connection tracking cleaning to be complete
-	stats.waitingForCTClean.Start()
-	<-ctCleaned
-	stats.waitingForCTClean.End(true)
 
 	stats.waitingForLock.Start()
 	err = e.LockAlive()


### PR DESCRIPTION
The conntrack table is cleaned when the endpoint is being built for the first time except when the endpoint was restored. This is to ensure that no obsolete connection tracking entries exist in the table which would result in incorrect datapath behavior. The cleaning is performed in the background. The cleaning must complete before the BPF program is being loaded into the kernel. As soon as the program is loaded, egress flows may start creating connection tracking entries while the CT cleanup is still cleaning and thus removing such newly created entries again.

Technically, the cleaning could continue throughout the compilation and would only need to complete before the loader loads it.

Signed-off-by: Romain Lenglet <romain@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5912)
<!-- Reviewable:end -->
