### PR TITLE
v1.2: bump timeout on K8s upstream tests to 40 minutes

### DIFF
--- a/kubernetes-upstream.Jenkinsfile
+++ b/kubernetes-upstream.Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
         }
         stage('Boot VMs'){
             options {
-                timeout(time: 30, unit: 'MINUTES')
+                timeout(time: 40, unit: 'MINUTES')
             }
 
             steps {


### PR DESCRIPTION
Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5914)
<!-- Reviewable:end -->
