### PR TITLE
proxylib: Allow missing rules in addition to empty rules.

### DIFF
--- a/proxylib/cassandra/cassandraparser.go
+++ b/proxylib/cassandra/cassandraparser.go
@@ -97,11 +97,11 @@ func (rule *CassandraRule) Matches(data interface{}) bool {
 // CassandraRuleParser parses protobuf L7 rules to enforcement objects
 // May panic
 func CassandraRuleParser(rule *cilium.PortNetworkPolicyRule) []L7NetworkPolicyRule {
+	var rules []L7NetworkPolicyRule
 	l7Rules := rule.GetL7Rules()
 	if l7Rules == nil {
-		ParseError("Can't get L7 rules.", rule)
+		return rules
 	}
-	var rules []L7NetworkPolicyRule
 	for _, l7Rule := range l7Rules.GetL7Rules() {
 		var cr CassandraRule
 		for k, v := range l7Rule.Rule {

--- a/proxylib/memcached/parser.go
+++ b/proxylib/memcached/parser.go
@@ -112,11 +112,11 @@ func (rule *Rule) matchOpcode(code byte) bool {
 // L7RuleParser parses protobuf L7 rules to and array of Rule
 // May panic
 func L7RuleParser(rule *cilium.PortNetworkPolicyRule) []proxylib.L7NetworkPolicyRule {
+	var rules []proxylib.L7NetworkPolicyRule
 	l7Rules := rule.GetL7Rules()
 	if l7Rules == nil {
-		proxylib.ParseError("Can't get L7 rules", rule)
+		return rules
 	}
-	var rules []proxylib.L7NetworkPolicyRule
 	for _, l7Rule := range l7Rules.GetL7Rules() {
 		var br Rule
 		var commandFound = false

--- a/proxylib/proxylib_test.go
+++ b/proxylib/proxylib_test.go
@@ -537,3 +537,97 @@ func TestSimplePolicy(t *testing.T) {
 
 	CheckClose(t, 1, buf, 1)
 }
+
+func TestAllowAllPolicy(t *testing.T) {
+	logServer := test.StartAccessLogServer("access_log.sock", 10)
+	defer logServer.Close()
+
+	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, true)
+	if mod == 0 {
+		t.Errorf("OpenModule() with access log path %s failed", logServer.Path)
+	} else {
+		defer CloseModule(mod)
+	}
+
+	insertPolicyText(t, mod, "1", []string{`
+		name: "FooBar"
+		policy: 2
+		ingress_per_port_policies: <
+		  port: 80
+		  rules: <
+		    l7_proto: "test.headerparser"
+		    l7_rules: <
+		      l7_rules: <>
+		    >
+		  >
+		>
+		`})
+
+	// Using headertester parser
+	buf := CheckOnNewConnection(t, mod, "test.headerparser", 1, true, 1, 2, "1.1.1.1:34567", "2.2.2.2:80", "FooBar",
+		80, proxylib.OK, 1)
+
+	// Original direction data, drops with remaining data
+	line1, line2, line3, line4 := "Beginning----\n", "foo\n", "----End\n", "\n"
+	data := line1 + line2 + line3 + line4
+	CheckOnData(t, 1, false, false, &[][]byte{[]byte(data)}, []ExpFilterOp{
+		{proxylib.PASS, len(line1)},
+		{proxylib.PASS, len(line2)},
+		{proxylib.PASS, len(line3)},
+		{proxylib.PASS, len(line4)},
+	}, proxylib.OK, "")
+
+	expPasses, expDrops := 4, 0
+	checkAccessLogs(t, logServer, expPasses, expDrops)
+
+	CheckClose(t, 1, buf, 1)
+}
+
+func TestAllowEmptyPolicy(t *testing.T) {
+	logServer := test.StartAccessLogServer("access_log.sock", 10)
+	defer logServer.Close()
+
+	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, true)
+	if mod == 0 {
+		t.Errorf("OpenModule() with access log path %s failed", logServer.Path)
+	} else {
+		defer CloseModule(mod)
+	}
+
+	insertPolicyText(t, mod, "1", []string{`
+		name: "FooBar"
+		policy: 2
+		ingress_per_port_policies: <
+		  port: 80
+		  rules: <
+		    l7_proto: "test.headerparser"
+		  >
+		>
+		`})
+
+	// Using headertester parser, policy name matches the policy
+	buf := CheckOnNewConnection(t, mod, "test.headerparser", 1, true, 1, 2, "1.1.1.1:34567", "2.2.2.2:80", "FooBar",
+		80, proxylib.OK, 1)
+
+	// Original direction data, drops with remaining data
+	line1, line2, line3, line4 := "Beginning----\n", "foo\n", "----End\n", "\n"
+	CheckOnData(t, 1, false, false, &[][]byte{[]byte(line1), []byte(line2), []byte(line3), []byte(line4)}, []ExpFilterOp{
+		{proxylib.PASS, len(line1)},
+		{proxylib.PASS, len(line2)},
+		{proxylib.PASS, len(line3)},
+		{proxylib.PASS, len(line4)},
+	}, proxylib.OK, "")
+
+	// Connection using a different policy name still drops
+	CheckOnNewConnection(t, mod, "test.headerparser", 2, true, 1, 2, "1.1.1.1:34567", "2.2.2.2:80", "FooBar2",
+		80, proxylib.OK, 2)
+	CheckOnData(t, 2, false, false, &[][]byte{[]byte(line1)}, []ExpFilterOp{
+		{proxylib.DROP, len(line1)},
+	}, proxylib.OK, "Line dropped: "+line1)
+
+	expPasses, expDrops := 4, 1
+	checkAccessLogs(t, logServer, expPasses, expDrops)
+
+	CheckClose(t, 2, buf, 2)
+	CheckClose(t, 1, buf, 1)
+}

--- a/proxylib/testparsers/headerparser.go
+++ b/proxylib/testparsers/headerparser.go
@@ -68,11 +68,11 @@ func (rule *HeaderRule) Matches(data interface{}) bool {
 
 // L7HeaderRuleParser parses protobuf L7 rules to and array of HeaderRules
 func L7HeaderRuleParser(rule *cilium.PortNetworkPolicyRule) []L7NetworkPolicyRule {
+	var rules []L7NetworkPolicyRule
 	l7Rules := rule.GetL7Rules()
 	if l7Rules == nil {
-		ParseError("Can't get L7 rules.", rule)
+		return rules
 	}
-	var rules []L7NetworkPolicyRule
 	for _, l7Rule := range l7Rules.GetL7Rules() {
 		var hr HeaderRule
 		for k, v := range l7Rule.Rule {


### PR DESCRIPTION
Allow missing `l7_rules` in the protobuf when `l7_proto` is specified. No rules allows
all frames that the parser can parse.

Signed-of-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5915)
<!-- Reviewable:end -->
