### PR TITLE
envoy: Pass nil completion if Acks are not expected.

### DIFF
--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -623,10 +623,7 @@ func (s *XDSServer) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *polic
 			}
 		}
 		var c *completion.Completion
-		if wg == nil {
-			// Passing a nil CancelFunc
-			c = completion.NewCompletion(nil, callback)
-		} else {
+		if wg != nil {
 			c = wg.AddCompletionWithCallback(callback)
 		}
 		nodeIDs := make([]string, 0, 1)


### PR DESCRIPTION
[ upstream commit 8babf8dff27bc5eeef391cd01084474e14069293 ]

Completions are cleaned up when an ack or nack for the resource type
is received. This never happens if there are no configured L7 proxies.

Prevent indefinite collection of completions in this case by passing
nil completion to Upsert().

Fixes: 99a73a2fbd ("envoy: Update revision upon acks from NPDS")
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5919)
<!-- Reviewable:end -->
