### PR TITLE
KVStore: refactor and add metrics.

### DIFF
--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -305,24 +305,28 @@ func (c *consulClient) Status() (string, error) {
 }
 
 func (c *consulClient) DeletePrefix(path string) error {
+	increaseMetric(path, metricDelete, "DeletePrefix")
 	_, err := c.Client.KV().DeleteTree(path, nil)
 	return err
 }
 
 // Set sets value of key
 func (c *consulClient) Set(key string, value []byte) error {
+	increaseMetric(key, metricSet, "Set")
 	_, err := c.KV().Put(&consulAPI.KVPair{Key: key, Value: value}, nil)
 	return err
 }
 
 // Delete deletes a key
 func (c *consulClient) Delete(key string) error {
+	increaseMetric(key, metricDelete, "Delete")
 	_, err := c.KV().Delete(key, nil)
 	return err
 }
 
 // Get returns value of key
 func (c *consulClient) Get(key string) ([]byte, error) {
+	increaseMetric(key, metricRead, "Get")
 	pair, _, err := c.KV().Get(key, nil)
 	if err != nil {
 		return nil, err
@@ -335,6 +339,7 @@ func (c *consulClient) Get(key string) ([]byte, error) {
 
 // GetPrefix returns the first key which matches the prefix
 func (c *consulClient) GetPrefix(prefix string) ([]byte, error) {
+	increaseMetric(prefix, metricRead, "GetPrefix")
 	pairs, _, err := c.KV().List(prefix, nil)
 	if err != nil {
 		return nil, err
@@ -349,6 +354,7 @@ func (c *consulClient) GetPrefix(prefix string) ([]byte, error) {
 
 // Update creates or updates a key with the value
 func (c *consulClient) Update(key string, value []byte, lease bool) error {
+	increaseMetric(key, metricSet, "Update")
 	k := &consulAPI.KVPair{Key: key, Value: value}
 
 	if lease {
@@ -361,6 +367,7 @@ func (c *consulClient) Update(key string, value []byte, lease bool) error {
 
 // CreateOnly creates a key with the value and will fail if the key already exists
 func (c *consulClient) CreateOnly(key string, value []byte, lease bool) error {
+	increaseMetric(key, metricSet, "CreateOnly")
 	k := &consulAPI.KVPair{
 		Key:         key,
 		Value:       value,
@@ -389,6 +396,8 @@ func (c *consulClient) CreateIfExists(condKey, key string, value []byte, lease b
 	// manipulated
 	//
 	// Lock the conditional key to serialize all CreateIfExists() calls
+
+	increaseMetric(key, metricSet, "CreateIfExists")
 	l, err := LockPath(condKey)
 	if err != nil {
 		return fmt.Errorf("unable to lock condKey for CreateIfExists: %s", err)
@@ -414,6 +423,7 @@ func (c *consulClient) CreateIfExists(condKey, key string, value []byte, lease b
 
 // ListPrefix returns a map of matching keys
 func (c *consulClient) ListPrefix(prefix string) (KeyValuePairs, error) {
+	increaseMetric(prefix, metricRead, "ListPrefix")
 	pairs, _, err := c.KV().List(prefix, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -360,6 +360,7 @@ func (e *etcdClient) LockPath(path string) (kvLocker, error) {
 }
 
 func (e *etcdClient) DeletePrefix(path string) error {
+	increaseMetric(path, metricDelete, "DeletePrefix")
 	_, err := e.client.Delete(ctx.Background(), path, client.WithPrefix())
 	return err
 }
@@ -555,6 +556,7 @@ func (e *etcdClient) Status() (string, error) {
 
 // Get returns value of key
 func (e *etcdClient) Get(key string) ([]byte, error) {
+	increaseMetric(key, metricRead, "Get")
 	getR, err := e.client.Get(ctx.Background(), key)
 	if err != nil {
 		return nil, err
@@ -568,6 +570,7 @@ func (e *etcdClient) Get(key string) ([]byte, error) {
 
 // GetPrefix returns the first key which matches the prefix
 func (e *etcdClient) GetPrefix(prefix string) ([]byte, error) {
+	increaseMetric(prefix, metricRead, "GetPrefix")
 	getR, err := e.client.Get(ctx.Background(), prefix, client.WithPrefix())
 	if err != nil {
 		return nil, err
@@ -581,12 +584,14 @@ func (e *etcdClient) GetPrefix(prefix string) ([]byte, error) {
 
 // Set sets value of key
 func (e *etcdClient) Set(key string, value []byte) error {
+	increaseMetric(key, metricSet, "Set")
 	_, err := e.client.Put(ctx.Background(), key, string(value))
 	return err
 }
 
 // Delete deletes a key
 func (e *etcdClient) Delete(key string) error {
+	increaseMetric(key, metricDelete, "Delete")
 	_, err := e.client.Delete(ctx.Background(), key)
 	return err
 }
@@ -603,6 +608,7 @@ func (e *etcdClient) createOpPut(key string, value []byte, lease bool) *client.O
 
 // Update creates or updates a key
 func (e *etcdClient) Update(key string, value []byte, lease bool) error {
+	increaseMetric(key, metricSet, "Update")
 	<-e.firstSession
 	if lease {
 		_, err := e.client.Put(ctx.Background(), key, string(value), client.WithLease(e.GetLeaseID()))
@@ -615,6 +621,7 @@ func (e *etcdClient) Update(key string, value []byte, lease bool) error {
 
 // CreateOnly creates a key with the value and will fail if the key already exists
 func (e *etcdClient) CreateOnly(key string, value []byte, lease bool) error {
+	increaseMetric(key, metricSet, "CreateOnly")
 	req := e.createOpPut(key, value, lease)
 	cond := client.Compare(client.Version(key), "=", 0)
 	txnresp, err := e.client.Txn(ctx.TODO()).If(cond).Then(*req).Commit()
@@ -631,6 +638,7 @@ func (e *etcdClient) CreateOnly(key string, value []byte, lease bool) error {
 
 // CreateIfExists creates a key with the value only if key condKey exists
 func (e *etcdClient) CreateIfExists(condKey, key string, value []byte, lease bool) error {
+	increaseMetric(key, metricSet, "CreateIfExists")
 	req := e.createOpPut(key, value, lease)
 	cond := client.Compare(client.Version(condKey), "!=", 0)
 	txnresp, err := e.client.Txn(ctx.TODO()).If(cond).Then(*req).Commit()
@@ -666,6 +674,7 @@ func (e *etcdClient) CreateIfExists(condKey, key string, value []byte, lease boo
 
 // ListPrefix returns a map of matching keys
 func (e *etcdClient) ListPrefix(prefix string) (KeyValuePairs, error) {
+	increaseMetric(prefix, metricRead, "ListPrefix")
 	getR, err := e.client.Get(ctx.Background(), prefix, client.WithPrefix())
 	if err != nil {
 		return nil, err

--- a/pkg/kvstore/kvstore_test.go
+++ b/pkg/kvstore/kvstore_test.go
@@ -35,3 +35,17 @@ func (s *independentSuite) TestGetLockPath(c *C) {
 	const path = "foo/path"
 	c.Assert(getLockPath(path), Equals, path+".lock")
 }
+
+func (s *independentSuite) TestValidateScopesFromKey(c *C) {
+	mockData := map[string]string{
+		"cilium/state/identities/v1/id": "identities/v1",
+		"cilium/state/identities/v1/value/Y29udGFpbmVyOmlkPWFwcDE7Y29udGFpbmVyOmlkLnNlcnZpY2UxPTs=": "identities/v1",
+		"cilium/state/ip/v1/default/10.15.189.183":                                                  "ip/v1",
+		"cilium/state/ip/v1/default/f00d::a0f:0:0:6f2e":                                             "ip/v1",
+		"cilium/state/nodes/v1/default/runtime":                                                     "nodes/v1",
+	}
+
+	for key, val := range mockData {
+		c.Assert(getScopeFromKey(key), Equals, val)
+	}
+}

--- a/pkg/kvstore/metrics.go
+++ b/pkg/kvstore/metrics.go
@@ -1,0 +1,45 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvstore
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cilium/cilium/pkg/metrics"
+)
+
+const (
+	metricDelete = "delete"
+	metricRead   = "read"
+	metricSet    = "set"
+)
+
+func getScopeFromKey(key string) string {
+	s := strings.SplitN(key, "/", 5)
+	if len(s) != 5 {
+		if len(key) >= 12 {
+			return key[:12]
+		}
+		return key
+	}
+	return fmt.Sprintf("%s/%s", s[2], s[3])
+}
+
+func increaseMetric(key, kind, action string) {
+	namespace := getScopeFromKey(key)
+	metrics.KVStoreOperationsTotal.WithLabelValues(
+		namespace, kind, action).Inc()
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -117,6 +117,9 @@ var (
 	// started by cilium (Envoy, monitor, etc..)
 	LabelSubsystem = "subsystem"
 
+	// LabelKind is the kind a label
+	LabelKind = "kind"
+
 	// Endpoint
 
 	// EndpointCount is a function used to collect this metric.
@@ -427,6 +430,15 @@ var (
 		Name:      "ipam_events_total",
 		Help:      "Number of IPAM events received labeled by action and datapath family type",
 	}, []string{LabelAction, LabelDatapathFamily})
+
+	// KVstore events
+
+	// KVStoreOperationsTotal is the  number of interactions with the Key-Value
+	// Store, labeled by subsystem, kind of action and action
+	KVStoreOperationsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "kvstore_operations_total",
+		Help: "Number of interactions with the Key-Value Store, labeled by subsystem, kind of action and action",
+	}, []string{LabelScope, LabelKind, LabelAction})
 )
 
 func init() {
@@ -484,6 +496,8 @@ func init() {
 	MustRegister(KubernetesEvent)
 
 	MustRegister(IpamEvent)
+
+	MustRegister(KVStoreOperationsTotal)
 }
 
 // MustRegister adds the collector to the registry, exposing this metric to


### PR DESCRIPTION
This only adds a new functionality based on metrics, but the refactor the
kvstore is a bit large.

With this change `kvstore.go` now does not export any method, all the methods
are now under `ExtendedKVStore` that wraps a namespace, that enables to know
who is using the kvstore to send metrics.

Now all `BackendOperations` methods that interact with the kvstore need to have
a namespace argument, to send the metrics. The main reason to add the namespaces is
because that methods are public, so can be used by any other package. (As
example, kvstore/store/)

New metrics are the following:

```
kvstore_operations_total                            kind="read" scope="allocator" action="GetCapabilities"   1.000000
kvstore_operations_total                            action="ListPrefix" kind="read" scope="allocator"        3.000000
kvstore_operations_total                            kind="update" scope="ipcache" action="Update"            12.000000
kvstore_operations_total                            kind="update" scope="shared-store" action="Update"       28.000000
```

The reason of the labels:

- Scope, that it's the namespace, to know what package uses the kvstore.
- Kind: There are a few kind (delete, read, set) that defines what action was
  made in the kvstore integrations.
- action: This is a low level information. is not too big (12 actions) and it's
  mainly to debug in cases that the kvstore is heavily used.

The idea for the metric is:

- Have a dashboard with the kind of operation
- Have a debug dashboard that display how many interactions per scope.

This commit is related to #5382

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5920)
<!-- Reviewable:end -->
