### PR TITLE
Wait for all etcd pods before performing upgrade test

### DIFF
--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -47,6 +47,7 @@ var _ = Describe("K8sChaosTest", func() {
 
 		ExpectCiliumReady(kubectl)
 		ExpectKubeDNSReady(kubectl)
+		ExpectETCDOperatorReady(kubectl)
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -42,6 +42,7 @@ var _ = Describe("K8sHealthTest", func() {
 		Expect(err).To(BeNil(), "Cilium cannot be installed")
 
 		ExpectCiliumReady(kubectl)
+		ExpectETCDOperatorReady(kubectl)
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -133,6 +133,7 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 			Expect(err).To(BeNil(), "Cilium cannot be installed")
 			ExpectCiliumReady(kubectl)
 			ExpectKubeDNSReady(kubectl)
+			ExpectETCDOperatorReady(kubectl)
 
 			kubectl.Apply(demoPath)
 			err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=kafkaTestApp", helpers.HelperTimeout)

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -60,6 +60,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 
 		ExpectCiliumReady(kubectl)
 		ExpectKubeDNSReady(kubectl)
+		ExpectETCDOperatorReady(kubectl)
 	})
 	deleteAll := func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
@@ -412,6 +413,7 @@ var _ = Describe("NightlyExamples", func() {
 
 			ExpectCiliumReady(kubectl)
 			ExpectKubeDNSReady(kubectl)
+			ExpectETCDOperatorReady(kubectl)
 		})
 
 		AfterAll(func() {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -64,6 +64,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 		ExpectCiliumReady(kubectl)
 		ExpectKubeDNSReady(kubectl)
+		ExpectETCDOperatorReady(kubectl)
 	})
 
 	AfterEach(func() {

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -42,6 +42,7 @@ var _ = Describe("NightlyPolicies", func() {
 
 		ExpectCiliumReady(kubectl)
 		ExpectKubeDNSReady(kubectl)
+		ExpectETCDOperatorReady(kubectl)
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -63,6 +63,7 @@ var _ = Describe("K8sServicesTest", func() {
 		ExpectCiliumReady(kubectl)
 
 		ExpectKubeDNSReady(kubectl)
+		ExpectETCDOperatorReady(kubectl)
 
 		ciliumPodK8s1, err = kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
 		Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -134,6 +134,7 @@ var _ = Describe("K8sTunnelTest", func() {
 			Expect(err).To(BeNil(), "Cilium cannot be installed")
 
 			ExpectCiliumReady(kubectl)
+			ExpectETCDOperatorReady(kubectl)
 
 			err = kubectl.WaitforPods(helpers.DefaultNamespace, "", 300)
 			Expect(err).Should(BeNil(), "Pods are not ready after timeout")

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -150,9 +150,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		By("Cilium %q is installed and running", oldVersion)
 		ExpectCiliumReady(kubectl)
 
-		By("Waiting etcd-operator is ready")
-		err = kubectl.WaitforPods(helpers.KubeSystemNamespace, "-l io.cilium/app=etcd-operator", 600)
-		Expect(err).To(BeNil(), "etcd-operator is not ready after timeout on cilium %s", oldVersion)
+		ExpectETCDOperatorReady(kubectl)
 
 		By("Installing Microscope")
 		microscopeErr, microscopeCancel := kubectl.MicroscopeStart()

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -64,6 +64,7 @@ var _ = Describe("K8sDemosTest", func() {
 
 		ExpectCiliumReady(kubectl)
 		ExpectKubeDNSReady(kubectl)
+		ExpectETCDOperatorReady(kubectl)
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -82,10 +82,16 @@ var _ = Describe("K8sIstioTest", func() {
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
-		err := kubectl.CiliumInstall(helpers.CiliumDefaultDSPatch, helpers.CiliumConfigMapPatch)
+		_ = kubectl.Apply(helpers.DNSDeployment())
+
+		err := kubectl.DeployETCDOperator()
+		Expect(err).To(BeNil(), "Unable to deploy etcd operator")
+
+		err = kubectl.CiliumInstall(helpers.CiliumDefaultDSPatch, helpers.CiliumConfigMapPatch)
 		Expect(err).To(BeNil(), "Cilium cannot be installed")
 
 		ExpectCiliumReady(kubectl)
+		ExpectETCDOperatorReady(kubectl)
 		ExpectKubeDNSReady(kubectl)
 
 		By("Creating the istio-system namespace")

--- a/test/k8sT/microscope.go
+++ b/test/k8sT/microscope.go
@@ -39,6 +39,7 @@ var _ = Describe("K8sMicroscope", func() {
 		Expect(err).To(BeNil(), "Cilium cannot be installed")
 
 		ExpectCiliumReady(kubectl)
+		ExpectETCDOperatorReady(kubectl)
 	})
 
 	AfterFailed(func() {


### PR DESCRIPTION
As etcd-operator only creates one etcd pod at a time we need to check if N pods are in ready state before continuing with the upgrade test.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5922)
<!-- Reviewable:end -->
