### PR TITLE
cmd: add --all option to `cilium bpf policy get`

### DIFF
--- a/Documentation/cmdref/cilium_bpf_policy_get.md
+++ b/Documentation/cmdref/cilium_bpf_policy_get.md
@@ -16,6 +16,7 @@ cilium bpf policy get
 ### Options
 
 ```
+      --all             Dump all policy maps
   -n, --numeric         Do not resolve IDs
   -o, --output string   json| jsonpath='{}'
 ```

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -220,6 +220,7 @@ func copyCiliumInfoCommands(cmdDir string, k8sPods []string) []string {
 		"cilium bpf ct list global",
 		"cilium bpf proxy list",
 		"cilium bpf ipcache list",
+		"cilium bpf policy get --all",
 		"cilium map list --verbose",
 		"cilium status --verbose",
 		"cilium identity list",


### PR DESCRIPTION
Sometimes, the Cilium API cannot respond in time to requests due to high load. This is not optimal because these situations can require introspection into the state of policy maps for endpoints. Add a way of dumping all policy map state from the BPF file system so that even if the cilium API is not being served, all policy map state can be dumped from the BPF filesystem in a human-readable format. Also consume this in the bugtool.
    
Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5925)
<!-- Reviewable:end -->
