### PR TITLE
Improve label parsing

### DIFF
--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -85,10 +85,10 @@ func (p LabelPrefix) matches(l *Label) (bool, int) {
 // parseLabelPrefix returns a LabelPrefix created from the string label parameter.
 func parseLabelPrefix(label string) (*LabelPrefix, error) {
 	labelPrefix := LabelPrefix{}
-	t := strings.SplitN(label, ":", 2)
-	if len(t) > 1 {
-		labelPrefix.Source = t[0]
-		labelPrefix.Prefix = t[1]
+	i := strings.IndexByte(label, ':')
+	if i >= 0 {
+		labelPrefix.Source = label[:i]
+		labelPrefix.Prefix = label[i+1:]
 	} else {
 		labelPrefix.Prefix = label
 	}

--- a/pkg/labels/filter_test.go
+++ b/pkg/labels/filter_test.go
@@ -33,7 +33,7 @@ func (s *LabelsPrefCfgSuite) TestFilterLabels(c *C) {
 	}
 
 	dlpcfg := defaultLabelPrefixCfg()
-	d, err := parseLabelPrefix("!ignor[eE]")
+	d, err := parseLabelPrefix(":!ignor[eE]")
 	c.Assert(err, IsNil)
 	c.Assert(d, Not(IsNil))
 	dlpcfg.LabelPrefixes = append(dlpcfg.LabelPrefixes, d)

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -595,12 +595,12 @@ func parseSource(str string) (src, next string) {
 		return "", ""
 	}
 	if str[0] == '$' {
-		str = strings.Replace(str, "$", LabelSourceReserved+":", 1)
+		return LabelSourceReserved, str[1:]
 	}
 	sourceSplit := strings.SplitN(str, ":", 2)
 	if len(sourceSplit) != 2 {
 		next = sourceSplit[0]
-		if strings.HasPrefix(next, LabelSourceReserved) {
+		if strings.HasPrefix(next, LabelSourceReservedKeyPrefix) {
 			src = LabelSourceReserved
 			next = strings.TrimPrefix(next, LabelSourceReservedKeyPrefix)
 		}

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -110,11 +110,14 @@ func (s *LabelsSuite) TestParseLabel(c *C) {
 		{"1foo", NewLabel("1foo", "", LabelSourceUnspec)},
 		{":2foo", NewLabel("2foo", "", LabelSourceUnspec)},
 		{":3foo=", NewLabel("3foo", "", LabelSourceUnspec)},
+		{"reserved:=key", NewLabel("key", "", LabelSourceReserved)},
 		{"4blah=:foo=", NewLabel("foo", "", "4blah=")},
 		{"5blah::foo=", NewLabel("::foo", "", "5blah")},
 		{"6foo==", NewLabel("6foo", "=", LabelSourceUnspec)},
 		{"7foo=bar", NewLabel("7foo", "bar", LabelSourceUnspec)},
 		{"k8s:foo=bar:", NewLabel("foo", "bar:", "k8s")},
+		{"reservedz=host", NewLabel("reservedz", "host", LabelSourceUnspec)},
+		{":", NewLabel("", "", LabelSourceUnspec)},
 		{LabelSourceReservedKeyPrefix + "host", NewLabel("host", "", LabelSourceReserved)},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Fix parsing of labels like 'reservedz=foo".

Use strings.IndexByte() instead of strings.SplitN() when the delimiter is a single character and N==2. This avoids allocating string slices for the SplitN() return values, which has shown up in pprof output.

These changes make `labels.ParseLabel()` about 4x faster than before.

```release-note
Improve label parsing to be 4x faster.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5928)
<!-- Reviewable:end -->
