### PR TITLE
[V1.3]: pkg/endpoint: fix global k8sServerVer variable assignment

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -61,7 +61,6 @@ import (
 	"github.com/cilium/cilium/pkg/u8proto"
 	"github.com/cilium/cilium/pkg/versioncheck"
 
-	go_version "github.com/hashicorp/go-version"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
@@ -89,8 +88,6 @@ var (
 	// ciliumUpdateStatusVerConstr is the minimal version supported for
 	// to perform a CRD UpdateStatus.
 	ciliumUpdateStatusVerConstr = versioncheck.MustCompile(">= 1.11.0")
-
-	k8sServerVer *go_version.Version
 )
 
 // getCiliumClient builds and returns a k8s auto-generated client for cilium
@@ -554,7 +551,7 @@ func (e *Endpoint) RunK8sCiliumEndpointSync() {
 		scopedLog.Debug("Not starting controller because k8s is disabled")
 		return
 	}
-	k8sServerVer, err = k8s.GetServerVersion()
+	k8sServerVer, err := k8s.GetServerVersion()
 	if err != nil {
 		scopedLog.WithError(err).Error("unable to retrieve kubernetes serverversion")
 		return


### PR DESCRIPTION
[ upstream commit 86c88ab1f12cc6285399a4798e4b66d5b26e6fe9 ]

As the variable is being globally assigned for all endpoints, if one
endpoints re-sets it to nil it can cause a nil pointer exception during
a controller execution causing the cilium-agent to crash.

Fixes: a8a81b32a771 ("pkg/endpoint: add UpdateStatus functionality for CEP")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Check for k8s server version for each endpoint
```

Original PR: https://github.com/cilium/cilium/pull/5926

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5935)
<!-- Reviewable:end -->
