### PR TITLE
V1.2: Add toleration on not-ready

### DIFF
--- a/test/k8sT/manifests/cilium_ds.template
+++ b/test/k8sT/manifests/cilium_ds.template
@@ -296,6 +296,10 @@
             "tolerations": [
               {
                 "effect": "NoSchedule",
+                "key": "node.kubernetes.io/not-ready"
+              },
+              {
+                "effect": "NoSchedule",
                 "key": "node-role.kubernetes.io/master"
               },
               {


### PR DESCRIPTION
Commit 923491437e61c01a78dd9abedef9535906074dae added a new toleration.
That commit cannot be backported due 1.2 branch uses kubecfg instead of
kubectl patch.

Fix #5924

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5936)
<!-- Reviewable:end -->
