### PR TITLE
k8s: Simpler CEP GC should-run logic

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
 	"net"
 	"os"
 	"reflect"
@@ -142,9 +141,7 @@ func RunK8sCiliumEndpointSyncGC() {
 	var (
 		controllerName = fmt.Sprintf("sync-to-k8s-ciliumendpoint-gc (%v)", node.GetName())
 		scopedLog      = log.WithField("controller", controllerName)
-
-		// random source to throttle how often this controller runs cluster-wide
-		runThrottler = rand.New(rand.NewSource(time.Now().UnixNano()))
+		firstRun       = true
 	)
 
 	// this is a sanity check
@@ -177,13 +174,22 @@ func RunK8sCiliumEndpointSyncGC() {
 		controller.ControllerParams{
 			RunInterval: 1 * time.Minute,
 			DoFunc: func() error {
-				// Don't run if there are no other known nodes
-				// Only run with a probability of 1/(number of nodes in cluster). This
-				// is because this controller runs on every node on the same interval
-				// but only one is neede to run.
-				nodes := node.GetNodes()
-				if len(nodes) <= 1 || runThrottler.Int63n(int64(len(nodes))) != 0 {
+				// Don't run immediately
+				if firstRun {
+					firstRun = false
 					return nil
+				}
+
+				// Only run if we are the "lowest" node in our cluster, when sorted by
+				// names. This means only one node will ever run GCs in a given
+				// cluster.
+				thisNode := node.GetLocalNode().Identity()
+				thisNodeStr := thisNode.String()
+				for id := range node.GetNodes() {
+					if idStr := id.String(); id.Cluster == thisNode.Cluster && idStr < thisNodeStr {
+						scopedLog.WithField(logfields.Node, idStr).Debug("Skipping GC because another node is a better candidate")
+						return nil
+					}
 				}
 
 				clusterPodSet := map[string]bool{}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -172,7 +172,7 @@ func RunK8sCiliumEndpointSyncGC() {
 	// this dummy manager is needed only to add this controller to the global list
 	controller.NewManager().UpdateController(controllerName,
 		controller.ControllerParams{
-			RunInterval: 1 * time.Minute,
+			RunInterval: 30 * time.Minute,
 			DoFunc: func() error {
 				// Don't run immediately
 				if firstRun {


### PR DESCRIPTION
CEPs of one node need to be garbage collected by other nodes since the
original is not present to delete its endpoints. We previously selected
which remaining node to run probabilistically but this is hard to reason
about. The selection is now based on node names, where the lowest in
sorted order is selected per cluster. This assumes that the node list on
each node is the same most of the time.
This change also skips executing the GC on the first ever run, as that
occurs on agent startup and may spam GC runs needlessly. The GC now also
runs when there is only a single node.

Additionally, the interval is now 30 minutes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5937)
<!-- Reviewable:end -->
