### PR TITLE
k8s: Add --disable-endpoint-crd to disable use of the CEP CRD

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -35,6 +35,7 @@ cilium-agent
       --debug-verbose stringSlice                   List of enabled verbose debug groups
   -d, --device string                               Device facing cluster/external network for direct L3 (non-overlay mode) (default "undefined")
       --disable-conntrack                           Disable connection tracking
+      --disable-endpoint-crd                        Disable use of CiliumEndpoint CRD
       --disable-ipv4                                Disable IPv4 mode
       --disable-k8s-services                        Disable east-west K8s load balancing by cilium
   -e, --docker string                               Path to docker runtime socket (DEPRECATED: use container-runtime-endpoint instead) (default "unix:///var/run/docker.sock")

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -378,6 +378,8 @@ func init() {
 		"disable-conntrack", false, "Disable connection tracking")
 	flags.BoolVar(&option.Config.IPv4Disabled,
 		"disable-ipv4", false, "Disable IPv4 mode")
+	flags.BoolVar(&option.Config.DisableCiliumEndpointCRD,
+		option.DisableCiliumEndpointCRDName, false, "Disable use of CiliumEndpoint CRD")
 	flags.Bool("disable-k8s-services",
 		false, "Disable east-west K8s load balancing by cilium")
 	flags.StringVarP(&dockerEndpoint,

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -147,6 +147,11 @@ func RunK8sCiliumEndpointSyncGC() {
 		runThrottler = rand.New(rand.NewSource(time.Now().UnixNano()))
 	)
 
+	if option.Config.DisableCiliumEndpointCRD {
+		scopedLog.WithField("name", controllerName).Warn("Not running controller. CEP CRD synchronization is disabled")
+		return
+	}
+
 	// this is a sanity check
 	if !k8s.IsEnabled() {
 		scopedLog.WithField("name", controllerName).Warn("Not running controller because k8s is disabled")
@@ -546,6 +551,11 @@ func (e *Endpoint) RunK8sCiliumEndpointSync() {
 		scopedLog      = e.getLogger().WithField("controller", controllerName)
 		err            error
 	)
+
+	if option.Config.DisableCiliumEndpointCRD {
+		scopedLog.Warn("Not running controller. CEP CRD synchronization is disabled")
+		return
+	}
 
 	if !k8s.IsEnabled() {
 		scopedLog.Debug("Not starting controller because k8s is disabled")

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -136,6 +136,10 @@ const (
 	// PrependIptablesChainsNameEnv is the name of the environment variable
 	// of the PrependIptablesChainsName option
 	PrependIptablesChainsNameEnv = "CILIUM_PREPEND_IPTABLES_CHAIN"
+
+	// DisableCiliumEndpointCRDName is the name of the option to disable
+	// use of the CEP CRD
+	DisableCiliumEndpointCRDName = "disable-endpoint-crd"
 )
 
 // Available option for daemonConfig.Tunnel
@@ -254,6 +258,9 @@ type daemonConfig struct {
 	// CTMapEntriesGlobalAny is the maximum number of conntrack entries
 	// allowed in each non-TCP CT table for IPv4/IPv6.
 	CTMapEntriesGlobalAny int
+
+	// DisableCiliumEndpointCRD disables the use of CiliumEndpoint CRD
+	DisableCiliumEndpointCRD bool
 }
 
 var (


### PR DESCRIPTION
[ upstream commit 324ee3887b1de9c17c656b912a514cb5d67d71af ]

Synchronization of the CEP CRD can have a large performance impact. Provide an
option to disable the feature if the CRD is not required.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5942)
<!-- Reviewable:end -->
