### PR TITLE
labels: Remove unnecessary memory allocations from k8s Labels interface

### DIFF
--- a/pkg/labels/array.go
+++ b/pkg/labels/array.go
@@ -91,8 +91,7 @@ nextLabel:
 // Implementation of the k8s.io/apimachinery/pkg/labels.Labels interface.
 func (ls LabelArray) Has(key string) bool {
 	// The key is submitted in the form of `source.key=value`
-	ck := GetCiliumKeyFrom(key)
-	keyLabel := ParseLabel(ck)
+	keyLabel := parseSelectLabel(key, '.')
 	if keyLabel.IsAnySource() {
 		for _, lsl := range ls {
 			if lsl.Key == keyLabel.Key {
@@ -101,7 +100,8 @@ func (ls LabelArray) Has(key string) bool {
 		}
 	} else {
 		for _, lsl := range ls {
-			if lsl.GetExtendedKey() == key {
+			// Note that if '=value' is part of 'key' it is ignored here
+			if lsl.Source == keyLabel.Source && lsl.Key == keyLabel.Key {
 				return true
 			}
 		}
@@ -112,8 +112,7 @@ func (ls LabelArray) Has(key string) bool {
 // Get returns the value for the provided key.
 // Implementation of the k8s.io/apimachinery/pkg/labels.Labels interface.
 func (ls LabelArray) Get(key string) string {
-	ck := GetCiliumKeyFrom(key)
-	keyLabel := ParseLabel(ck)
+	keyLabel := parseSelectLabel(key, '.')
 	if keyLabel.IsAnySource() {
 		for _, lsl := range ls {
 			if lsl.Key == keyLabel.Key {
@@ -122,7 +121,7 @@ func (ls LabelArray) Get(key string) string {
 		}
 	} else {
 		for _, lsl := range ls {
-			if lsl.GetExtendedKey() == key {
+			if lsl.Source == keyLabel.Source && lsl.Key == keyLabel.Key {
 				return lsl.Value
 			}
 		}

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -302,7 +302,7 @@ func (l Labels) GetFromSource(source string) Labels {
 // ':' will be deleted and unused.
 func NewLabel(key string, value string, source string) *Label {
 	var src string
-	src, key = parseSource(key)
+	src, key = parseSource(key, ':')
 	if source == "" {
 		if src == "" {
 			source = LabelSourceUnspec
@@ -436,7 +436,7 @@ func GetCiliumKeyFrom(extKey string) string {
 // `container:foo=bar` returns `container.foo`
 // `foo=bar` returns `any.foo=bar`
 func GetExtendedKeyFrom(str string) string {
-	src, next := parseSource(str)
+	src, next := parseSource(str, ':')
 	if src == "" {
 		src = LabelSourceAny
 	}
@@ -592,16 +592,18 @@ func (l Labels) FindReserved() Labels {
 //  src, next := parseSource("foo:bar==value")
 // Println(src) // foo
 // Println(next) // bar==value
-func parseSource(str string) (src, next string) {
+// For Cilium format 'delim' must be passed in as ':'
+// For k8s format 'delim' must be passed in as '.'
+func parseSource(str string, delim byte) (src, next string) {
 	if str == "" {
 		return "", ""
 	}
 	if str[0] == '$' {
 		return LabelSourceReserved, str[1:]
 	}
-	i := strings.IndexByte(str, ':')
+	i := strings.IndexByte(str, delim)
 	if i < 0 {
-		if strings.HasPrefix(str, LabelSourceReservedKeyPrefix) {
+		if delim != '.' && strings.HasPrefix(str, LabelSourceReservedKeyPrefix) {
 			return LabelSourceReserved, strings.TrimPrefix(str, LabelSourceReservedKeyPrefix)
 		}
 		return "", str
@@ -613,8 +615,12 @@ func parseSource(str string) (src, next string) {
 // in the form of Source:Key=Value or Source:Key if Value is empty. It also parses short
 // forms, for example: $host will be Label{Key: "host", Source: "reserved", Value: ""}.
 func ParseLabel(str string) *Label {
-	lbl := Label{}
-	src, next := parseSource(str)
+	lbl := parseLabel(str, ':')
+	return &lbl
+}
+
+func parseLabel(str string, delim byte) (lbl Label) {
+	src, next := parseSource(str, delim)
 	if src != "" {
 		lbl.Source = src
 	} else {
@@ -632,14 +638,20 @@ func ParseLabel(str string) *Label {
 			lbl.Value = next[i+1:]
 		}
 	}
-	return &lbl
+	return lbl
 }
 
 // ParseSelectLabel returns a selecting label representation of the given
 // string. Unlike ParseLabel, if source is unspecified, the source defaults to
 // LabelSourceAny
 func ParseSelectLabel(str string) *Label {
-	lbl := ParseLabel(str)
+	lbl := parseSelectLabel(str, ':')
+
+	return &lbl
+}
+
+func parseSelectLabel(str string, delim byte) Label {
+	lbl := parseLabel(str, delim)
 
 	if lbl.Source == LabelSourceUnspec {
 		lbl.Source = LabelSourceAny


### PR DESCRIPTION
LabelArray implements the k8s apimachinery Labels interface, which
contains the functions Has() and Get(). Due to the differences in key
punctuation we have so far been converting key strings between the k8s
notation and Cilium notation in both Has() and Get() functions.

Remove the unnecessary string allocations by allowing keys to be
parsed from their k8s 'dot' notation and allowing such labels to be
returned by value. Also, when comparing keys that are not "any source"
perform the comparison between Cilium Labels rather than creating a
temporary string for the comparison.

Based on a simple Rule.canReachEgress() benchmark test this reduces
memory allocations and execution time by about 40%.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5945)
<!-- Reviewable:end -->
