### PR TITLE
Test: Chaos restart wait endpoints to be ready

### DIFF
--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -229,6 +229,9 @@ var _ = Describe("K8sChaosTest", func() {
 			err := kubectl.WaitforPods(
 				helpers.KubeSystemNamespace, fmt.Sprintf("-l %s", ciliumFilter), 300)
 			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
+
+			err = kubectl.CiliumEndpointWaitReady()
+			Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 		}
 
 		It("TCP connection is not dropped when cilium restarts", func() {


### PR DESCRIPTION
At the moment we only test that the endpoints are connecting in
background until next Cilium is ready, with this change we also wait
until all endpoints are ready, so we validate that the regeneration
happens.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

Highly related to this failure: 
https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/4456/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5946)
<!-- Reviewable:end -->
