### PR TITLE
test: bump k8s versions to 1.8.14, 1.9.11 and 1.10.9

### DIFF
--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -120,13 +120,13 @@ case $K8S_VERSION in
         ;;
     "1.9")
         KUBERNETES_CNI_VERSION="0.6.0"
-        K8S_FULL_VERSION="1.9.10"
+        K8S_FULL_VERSION="1.9.11"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
         ;;
     "1.10")
         KUBERNETES_CNI_VERSION="0.6.0"
-        K8S_FULL_VERSION="1.10.7"
+        K8S_FULL_VERSION="1.10.9"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
         ;;


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5949)
<!-- Reviewable:end -->
