### PR TITLE
daemon: Lower default tofqdns-min-ttl to 1 hour

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -83,7 +83,7 @@ cilium-agent
       --single-cluster-route                        Use a single cluster route instead of per node routes
       --socket-path string                          Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
       --state-dir string                            Directory path to store runtime state (default "/var/run/cilium")
-      --tofqdns-min-ttl int                         The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 31536000)
+      --tofqdns-min-ttl int                         The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600)
       --trace-payloadlen int                        Length of payload to capture when tracing (default 128)
   -t, --tunnel string                               Tunnel mode {vxlan, geneve, disabled} (default "vxlan")
       --version                                     Print version information

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -86,7 +86,7 @@ const (
 	DefaultMapPrefix = "tc/globals"
 
 	// ToFQDNsMinTTL is the default lower bound for TTLs used with ToFQDNs rules.
-	ToFQDNsMinTTL = 365 * 86400 // 1 year in seconds
+	ToFQDNsMinTTL = 3600 // 1 hour in seconds
 
 	// IdentityChangeGracePeriod is the grace period that needs to pass
 	// before an endpoint that has changed its identity will start using


### PR DESCRIPTION
The previous 1 year (i.e. forever) TTL tended to hold too many IPs in
the cache and, for each IP, a separate CIDR identity. DNS Names with
large response sets (like AWS S3) tended to balloon this count.
The new 1 hour TTL should cover many common usage scenarios but allow a
smaller set of working identities. An IP must not be returned to the DNS
poller for more than 1 hour before it is removed. This means that small
response sets that repeat the same IP remain live and correct. Behaviour
on policy delete is unchanged, and if an IP no longer has any DNS names
it will release all related CIDRs and their identities.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5958)
<!-- Reviewable:end -->
