### PR TITLE
test: add k8s 1.13 to testing framework

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -652,6 +652,7 @@ The Kubernetes tests support the following Kubernetes versions:
 * 1.10
 * 1.11
 * 1.12
+* 1.13
 
 By default, the Vagrant VMs are provisioned with Kubernetes 1.9. To run with any other
 supported version of Kubernetes, run the test suite with the following format:

--- a/Documentation/gettingstarted/cilium_install_crio.rst
+++ b/Documentation/gettingstarted/cilium_install_crio.rst
@@ -82,6 +82,18 @@ To deploy Cilium, run:
       clusterrole.rbac.authorization.k8s.io "cilium" created
       serviceaccount "cilium" created
 
+  .. group-tab:: K8s 1.13
+
+    .. parsed-literal::
+
+      $ kubectl create -f \ |SCM_WEB|\/examples/kubernetes/1.13/cilium-crio.yaml
+      configmap "cilium-config" created
+      secret "cilium-etcd-secrets" created
+      daemonset.extensions "cilium" created
+      clusterrolebinding.rbac.authorization.k8s.io "cilium" created
+      clusterrole.rbac.authorization.k8s.io "cilium" created
+      serviceaccount "cilium" created
+
 Kubernetes is now deploying Cilium with its RBAC settings, ConfigMap
 and DaemonSet as a pod on minikube. This operation is performed in the
 background.

--- a/Documentation/gettingstarted/cilium_install_docker.rst
+++ b/Documentation/gettingstarted/cilium_install_docker.rst
@@ -81,6 +81,18 @@ To deploy Cilium, run:
       clusterrole.rbac.authorization.k8s.io "cilium" created
       serviceaccount "cilium" created
 
+  .. group-tab:: K8s 1.13
+
+    .. parsed-literal::
+
+      $ kubectl create -f \ |SCM_WEB|\/examples/kubernetes/1.13/cilium.yaml
+      configmap "cilium-config" created
+      secret "cilium-etcd-secrets" created
+      daemonset.extensions "cilium" created
+      clusterrolebinding.rbac.authorization.k8s.io "cilium" created
+      clusterrole.rbac.authorization.k8s.io "cilium" created
+      serviceaccount "cilium" created
+
 Kubernetes is now deploying Cilium with its RBAC settings, ConfigMap
 and DaemonSet as a pod on minikube. This operation is performed in the
 background.

--- a/Documentation/gettingstarted/gsg_starwars.rst
+++ b/Documentation/gettingstarted/gsg_starwars.rst
@@ -439,6 +439,13 @@ To try out the metrics exported by cilium, simply install the example prometheus
       $ kubectl create -f \ |SCM_WEB|\/examples/kubernetes/addons/prometheus/prometheus.yaml
       $ kubectl replace --force -f \ |SCM_WEB|\/examples/kubernetes/1.12/cilium.yaml
 
+  .. group-tab:: K8s 1.13
+
+    .. parsed-literal::
+
+      $ kubectl create -f \ |SCM_WEB|\/examples/kubernetes/addons/prometheus/prometheus.yaml
+      $ kubectl replace --force -f \ |SCM_WEB|\/examples/kubernetes/1.13/cilium.yaml
+
 This will create a barebones prometheus installation that you can use to
 inspect metrics from the agent, then restart cilium so it can consume the new
 prometheus configuration. Navigate to the web ui with:

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -174,6 +174,13 @@ Both files are dedicated to "\ |SCM_BRANCH|" for each Kubernetes version.
       $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.12/cilium-rbac.yaml
       $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.12/cilium-ds.yaml
 
+  .. group-tab:: K8s 1.13
+
+    .. parsed-literal::
+
+      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.13/cilium-rbac.yaml
+      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.13/cilium-ds.yaml
+
 Below we will show examples of how Cilium should be upgraded using Kubernetes
 rolling upgrade functionality in order to preserve any existing Cilium
 configuration changes (e.g., etc configuration) and minimize network
@@ -615,6 +622,11 @@ Download the ConfigMap with the changes for |SCM_BRANCH|
 
       $ wget \ |SCM_WEB|\/examples/kubernetes/1.12/cilium-cm.yaml
 
+  .. group-tab:: K8s 1.12
+
+    .. parsed-literal::
+
+      $ wget \ |SCM_WEB|\/examples/kubernetes/1.13/cilium-cm.yaml
 
 Verify its contents:
 

--- a/Documentation/kubernetes/compatibility.rst
+++ b/Documentation/kubernetes/compatibility.rst
@@ -16,11 +16,11 @@ or beta, and may only be available in specific versions of Kubernetes.
 
 All Kubernetes versions listed are compatible with Cilium:
 
-+----------------------------+---------------------------+----------------------------+
-| k8s Version                | k8s NetworkPolicy API     | CiliumNetworkPolicy        |
-+----------------------------+---------------------------+----------------------------+
-|                            |                           | ``cilium.io/v2`` has a     |
-| 1.8, 1.9, 1.10, 1.11, 1.12 | * `networking.k8s.io/v1`_ | `CustomResourceDefinition` |
-+----------------------------+---------------------------+----------------------------+
++----------------------------------+---------------------------+----------------------------+
+| k8s Version                      | k8s NetworkPolicy API     | CiliumNetworkPolicy        |
++----------------------------------+---------------------------+----------------------------+
+|                                  |                           | ``cilium.io/v2`` has a     |
+| 1.8, 1.9, 1.10, 1.11, 1.12, 1.13 | * `networking.k8s.io/v1`_ | `CustomResourceDefinition` |
++----------------------------------+---------------------------+----------------------------+
 
 .. _networking.k8s.io/v1: https://kubernetes.io/docs/api-reference/v1.8/#networkpolicy-v1-networking

--- a/Documentation/kubernetes/install/standard.rst
+++ b/Documentation/kubernetes/install/standard.rst
@@ -143,6 +143,12 @@ Configuration
 
       $ wget \ |SCM_WEB|\/examples/kubernetes/1.12/cilium.yaml
 
+  .. group-tab:: K8s 1.13
+
+    .. parsed-literal::
+
+      $ wget \ |SCM_WEB|\/examples/kubernetes/1.13/cilium.yaml
+
 Configuring etcd (Required)
 ---------------------------
 

--- a/Documentation/kubernetes/quickinstall.rst
+++ b/Documentation/kubernetes/quickinstall.rst
@@ -65,6 +65,14 @@ chapter.
       $ vim cilium.yaml
       [adjust the etcd address]
 
+  .. group-tab:: K8s 1.13
+
+    .. parsed-literal::
+
+      $ wget \ |SCM_WEB|\/examples/kubernetes/1.13/cilium.yaml
+      $ vim cilium.yaml
+      [adjust the etcd address]
+
 
 3. Deploy ``cilium`` with your local changes
 

--- a/examples/kubernetes/1.13/cilium-cm.yaml
+++ b/examples/kubernetes/1.13/cilium-cm.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+  # This etcd-config contains the etcd endpoints of your cluster. If you use
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
+  etcd-config: |-
+    ---
+    endpoints:
+      - http://127.0.0.1:31079
+    #
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
+    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
+    #
+    # In case you want client to server authentication, uncomment the following
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
+    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  disable-ipv4: "false"
+
+  # If a serious issue occurs during Cilium startup, this
+  # invasive option may be set to true to remove all persistent
+  # state. Endpoints will not be restored using knowledge from a
+  # prior Cilium run, so they may receive new IP addresses upon
+  # restart. This also triggers clean-cilium-bpf-state.
+  clean-cilium-state: "false"
+  # If you want to clean cilium BPF state, set this to true;
+  # Removes all BPF maps from the filesystem. Upon restart,
+  # endpoints are restored with the same IP addresses, however
+  # any ongoing connections may be disrupted briefly.
+  # Loadbalancing decisions will be reset, so any ongoing
+  # connections via a service may be loadbalanced to a different
+  # backend after restart.
+  clean-cilium-bpf-state: "false"
+
+  legacy-host-allows-world: "false"
+
+  # If you want cilium monitor to aggregate tracing for packets, set this level
+  # to "low", "medium", or "maximum". The higher the level, the less packets
+  # that will be seen in monitor output.
+  monitor-aggregation-level: "none"
+
+  # ct-global-max-entries-* specifies the maximum number of connections
+  # supported across all endpoints, split by protocol: tcp or other. One pair
+  # of maps uses these values for IPv4 connections, and another pair of maps
+  # use these values for IPv6 connections.
+  #
+  # If these values are modified, then during the next Cilium startup the
+  # tracking of ongoing connections may be disrupted. This may lead to brief
+  # policy drops or a change in loadbalancing decisions for a connection.
+  #
+  # For users upgrading from Cilium 1.2 or earlier, to minimize disruption
+  # during the upgrade process, comment out these options.
+  ct-global-max-entries-tcp: "524288"
+  ct-global-max-entries-other: "262144"
+
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
+  # Encapsulation mode for communication between nodes
+  # Possible values:
+  #   - disabled
+  #   - vxlan (default)
+  #   - geneve
+  tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -1,0 +1,240 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  updateStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+  selector:
+    matchLabels:
+      k8s-app: cilium
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
+      annotations:
+        # This annotation plus the CriticalAddonsOnly toleration makes
+        # cilium to be a critical pod in the cluster, which ensures cilium
+        # gets priority scheduling.
+        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: >-
+          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+    spec:
+      serviceAccountName: cilium
+      initContainers:
+        - name: clean-cilium-state
+          image: docker.io/cilium/cilium-init:2018-10-16
+          imagePullPolicy: IfNotPresent
+          command: ["/init-container.sh"]
+          securityContext:
+            capabilities:
+              add:
+                - "NET_ADMIN"
+            privileged: true
+          volumeMounts:
+            - name: cilium-run
+              mountPath: /var/run/cilium
+          env:
+            - name: "CLEAN_CILIUM_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-state
+            - name: "CLEAN_CILIUM_BPF_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-bpf-state
+      containers:
+        - image: docker.io/cilium/cilium:latest
+          imagePullPolicy: Always
+          name: cilium-agent
+          command: ["cilium-agent"]
+          args:
+            - "--debug=$(CILIUM_DEBUG)"
+            - "--kvstore=etcd"
+            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+            - "--disable-ipv4=$(DISABLE_IPV4)"
+            - "--container-runtime=crio"
+          ports:
+            - name: prometheus
+              containerPort: 9090
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - "/cni-install.sh"
+            preStop:
+              exec:
+                command:
+                  - "/cni-uninstall.sh"
+          env:
+            - name: "K8S_NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "CILIUM_DEBUG"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  key: debug
+            - name: "DISABLE_IPV4"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  key: disable-ipv4
+            # Note: this variable is a no-op if not defined, and is used in the
+            # prometheus examples.
+            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-metrics-config
+                  optional: true
+                  key: prometheus-serve-addr
+            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: legacy-host-allows-world
+            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  key: sidecar-istio-proxy-image
+                  optional: true
+            - name: "CILIUM_TUNNEL"
+              valueFrom:
+                configMapKeyRef:
+                  key: tunnel
+                  name: cilium-config
+                  optional: true
+            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
+              valueFrom:
+                configMapKeyRef:
+                  key: monitor-aggregation-level
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
+          livenessProbe:
+            exec:
+              command:
+                - cilium
+                - status
+            # The initial delay for the liveness probe is intentionally large to
+            # avoid an endless kill & restart cycle if in the event that the initial
+            # bootstrapping takes longer than expected.
+            initialDelaySeconds: 120
+            failureThreshold: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - cilium
+                - status
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: cilium-run
+              mountPath: /var/run/cilium
+            - name: cni-path
+              mountPath: /host/opt/cni/bin
+            - name: etc-cni-netd
+              mountPath: /host/etc/cni/net.d
+            - name: crio-socket
+              mountPath: /var/run/crio.sock
+              readOnly: true
+            - name: etcd-config-path
+              mountPath: /var/lib/etcd-config
+              readOnly: true
+            - name: etcd-secrets
+              mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
+              readOnly: true
+          securityContext:
+            capabilities:
+              add:
+                - "NET_ADMIN"
+            privileged: true
+      hostNetwork: true
+      volumes:
+        # To keep state between restarts / upgrades
+        - name: cilium-run
+          hostPath:
+            path: /var/run/cilium
+            type: "DirectoryOrCreate"
+        # To read labels from CRI-O containers running in the host
+        - name: crio-socket
+          hostPath:
+            path: /var/run/crio/crio.sock
+            type: "Socket"
+        # To install cilium cni plugin in the host
+        - name: cni-path
+          hostPath:
+            path: /opt/cni/bin
+            type: "DirectoryOrCreate"
+        # To install cilium cni configuration in the host
+        - name: etc-cni-netd
+          hostPath:
+            path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+          operator: "Exists"
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: "Exists"
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          operator: "Exists"
+        # Mark cilium's pod as critical for rescheduling
+        - key: CriticalAddonsOnly
+          operator: "Exists"

--- a/examples/kubernetes/1.13/cilium-crio-transforms2sed.sed
+++ b/examples/kubernetes/1.13/cilium-crio-transforms2sed.sed
@@ -1,0 +1,4 @@
+# delete mounts
+/            - name: bpf-maps/,+1 d
+# delete volumes
+/        # To keep state between restarts \/ upgrades for bpf maps/,+4 d

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -1,0 +1,521 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+  # This etcd-config contains the etcd endpoints of your cluster. If you use
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
+  etcd-config: |-
+    ---
+    endpoints:
+      - http://127.0.0.1:31079
+    #
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
+    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
+    #
+    # In case you want client to server authentication, uncomment the following
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
+    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  disable-ipv4: "false"
+
+  # If a serious issue occurs during Cilium startup, this
+  # invasive option may be set to true to remove all persistent
+  # state. Endpoints will not be restored using knowledge from a
+  # prior Cilium run, so they may receive new IP addresses upon
+  # restart. This also triggers clean-cilium-bpf-state.
+  clean-cilium-state: "false"
+  # If you want to clean cilium BPF state, set this to true;
+  # Removes all BPF maps from the filesystem. Upon restart,
+  # endpoints are restored with the same IP addresses, however
+  # any ongoing connections may be disrupted briefly.
+  # Loadbalancing decisions will be reset, so any ongoing
+  # connections via a service may be loadbalanced to a different
+  # backend after restart.
+  clean-cilium-bpf-state: "false"
+
+  legacy-host-allows-world: "false"
+
+  # If you want cilium monitor to aggregate tracing for packets, set this level
+  # to "low", "medium", or "maximum". The higher the level, the less packets
+  # that will be seen in monitor output.
+  monitor-aggregation-level: "none"
+
+  # ct-global-max-entries-* specifies the maximum number of connections
+  # supported across all endpoints, split by protocol: tcp or other. One pair
+  # of maps uses these values for IPv4 connections, and another pair of maps
+  # use these values for IPv6 connections.
+  #
+  # If these values are modified, then during the next Cilium startup the
+  # tracking of ongoing connections may be disrupted. This may lead to brief
+  # policy drops or a change in loadbalancing decisions for a connection.
+  #
+  # For users upgrading from Cilium 1.2 or earlier, to minimize disruption
+  # during the upgrade process, comment out these options.
+  ct-global-max-entries-tcp: "524288"
+  ct-global-max-entries-other: "262144"
+
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
+  # Encapsulation mode for communication between nodes
+  # Possible values:
+  #   - disabled
+  #   - vxlan (default)
+  #   - geneve
+  tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  updateStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+  selector:
+    matchLabels:
+      k8s-app: cilium
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
+      annotations:
+        # This annotation plus the CriticalAddonsOnly toleration makes
+        # cilium to be a critical pod in the cluster, which ensures cilium
+        # gets priority scheduling.
+        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: >-
+          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+    spec:
+      serviceAccountName: cilium
+      initContainers:
+        - name: clean-cilium-state
+          image: docker.io/cilium/cilium-init:2018-10-16
+          imagePullPolicy: IfNotPresent
+          command: ["/init-container.sh"]
+          securityContext:
+            capabilities:
+              add:
+                - "NET_ADMIN"
+            privileged: true
+          volumeMounts:
+            - name: cilium-run
+              mountPath: /var/run/cilium
+          env:
+            - name: "CLEAN_CILIUM_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-state
+            - name: "CLEAN_CILIUM_BPF_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-bpf-state
+      containers:
+        - image: docker.io/cilium/cilium:latest
+          imagePullPolicy: Always
+          name: cilium-agent
+          command: ["cilium-agent"]
+          args:
+            - "--debug=$(CILIUM_DEBUG)"
+            - "--kvstore=etcd"
+            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+            - "--disable-ipv4=$(DISABLE_IPV4)"
+            - "--container-runtime=crio"
+          ports:
+            - name: prometheus
+              containerPort: 9090
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - "/cni-install.sh"
+            preStop:
+              exec:
+                command:
+                  - "/cni-uninstall.sh"
+          env:
+            - name: "K8S_NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "CILIUM_DEBUG"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  key: debug
+            - name: "DISABLE_IPV4"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  key: disable-ipv4
+            # Note: this variable is a no-op if not defined, and is used in the
+            # prometheus examples.
+            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-metrics-config
+                  optional: true
+                  key: prometheus-serve-addr
+            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: legacy-host-allows-world
+            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  key: sidecar-istio-proxy-image
+                  optional: true
+            - name: "CILIUM_TUNNEL"
+              valueFrom:
+                configMapKeyRef:
+                  key: tunnel
+                  name: cilium-config
+                  optional: true
+            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
+              valueFrom:
+                configMapKeyRef:
+                  key: monitor-aggregation-level
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
+          livenessProbe:
+            exec:
+              command:
+                - cilium
+                - status
+            # The initial delay for the liveness probe is intentionally large to
+            # avoid an endless kill & restart cycle if in the event that the initial
+            # bootstrapping takes longer than expected.
+            initialDelaySeconds: 120
+            failureThreshold: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - cilium
+                - status
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: cilium-run
+              mountPath: /var/run/cilium
+            - name: cni-path
+              mountPath: /host/opt/cni/bin
+            - name: etc-cni-netd
+              mountPath: /host/etc/cni/net.d
+            - name: crio-socket
+              mountPath: /var/run/crio.sock
+              readOnly: true
+            - name: etcd-config-path
+              mountPath: /var/lib/etcd-config
+              readOnly: true
+            - name: etcd-secrets
+              mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
+              readOnly: true
+          securityContext:
+            capabilities:
+              add:
+                - "NET_ADMIN"
+            privileged: true
+      hostNetwork: true
+      volumes:
+        # To keep state between restarts / upgrades
+        - name: cilium-run
+          hostPath:
+            path: /var/run/cilium
+            type: "DirectoryOrCreate"
+        # To read labels from CRI-O containers running in the host
+        - name: crio-socket
+          hostPath:
+            path: /var/run/crio/crio.sock
+            type: "Socket"
+        # To install cilium cni plugin in the host
+        - name: cni-path
+          hostPath:
+            path: /opt/cni/bin
+            type: "DirectoryOrCreate"
+        # To install cilium cni configuration in the host
+        - name: etc-cni-netd
+          hostPath:
+            path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+          operator: "Exists"
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: "Exists"
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          operator: "Exists"
+        # Mark cilium's pod as critical for rescheduling
+        - key: CriticalAddonsOnly
+          operator: "Exists"
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: cilium-operator
+        io.cilium/app: operator
+    spec:
+      serviceAccountName: cilium-operator
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      containers:
+      - name: cilium-operator
+        image: docker.io/cilium/operator:latest
+        imagePullPolicy: Always
+        command: ["cilium-operator"]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        env:
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+                optional: true
+          - name: CILIUM_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-name
+                name: cilium-config
+                optional: true
+          - name: CILIUM_CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-id
+                name: cilium-config
+                optional: true
+        volumeMounts:
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+      volumes:
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - componentstatuses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+  - kind: ServiceAccount
+    name: cilium
+    namespace: kube-system
+  - kind: Group
+    name: system:nodes
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium
+rules:
+  - apiGroups:
+      - "networking.k8s.io"
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - services
+      - nodes
+      - endpoints
+      - componentstatuses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+      - ciliumnetworkpolicies/status
+      - ciliumendpoints
+      - ciliumendpoints/status
+    verbs:
+      - "*"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium
+  namespace: kube-system

--- a/examples/kubernetes/1.13/cilium-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-ds.yaml
@@ -1,0 +1,260 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  updateStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+  selector:
+    matchLabels:
+      k8s-app: cilium
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
+      annotations:
+        # This annotation plus the CriticalAddonsOnly toleration makes
+        # cilium to be a critical pod in the cluster, which ensures cilium
+        # gets priority scheduling.
+        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: >-
+          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+    spec:
+      serviceAccountName: cilium
+      initContainers:
+        - name: clean-cilium-state
+          image: docker.io/cilium/cilium-init:2018-10-16
+          imagePullPolicy: IfNotPresent
+          command: ["/init-container.sh"]
+          securityContext:
+            capabilities:
+              add:
+                - "NET_ADMIN"
+            privileged: true
+          volumeMounts:
+            - name: bpf-maps
+              mountPath: /sys/fs/bpf
+            - name: cilium-run
+              mountPath: /var/run/cilium
+          env:
+            - name: "CLEAN_CILIUM_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-state
+            - name: "CLEAN_CILIUM_BPF_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-bpf-state
+      containers:
+        - image: docker.io/cilium/cilium:latest
+          imagePullPolicy: Always
+          name: cilium-agent
+          command: ["cilium-agent"]
+          args:
+            - "--debug=$(CILIUM_DEBUG)"
+            - "--kvstore=etcd"
+            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+            - "--disable-ipv4=$(DISABLE_IPV4)"
+          ports:
+            - name: prometheus
+              containerPort: 9090
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - "/cni-install.sh"
+            preStop:
+              exec:
+                command:
+                  - "/cni-uninstall.sh"
+          env:
+            - name: "K8S_NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "CILIUM_DEBUG"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  key: debug
+            - name: "DISABLE_IPV4"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  key: disable-ipv4
+            # Note: this variable is a no-op if not defined, and is used in the
+            # prometheus examples.
+            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-metrics-config
+                  optional: true
+                  key: prometheus-serve-addr
+            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: legacy-host-allows-world
+            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  key: sidecar-istio-proxy-image
+                  optional: true
+            - name: "CILIUM_TUNNEL"
+              valueFrom:
+                configMapKeyRef:
+                  key: tunnel
+                  name: cilium-config
+                  optional: true
+            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
+              valueFrom:
+                configMapKeyRef:
+                  key: monitor-aggregation-level
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_GLOBAL_CT_MAX_TCP
+              valueFrom:
+                configMapKeyRef:
+                  key: ct-global-max-entries-tcp
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_GLOBAL_CT_MAX_ANY
+              valueFrom:
+                configMapKeyRef:
+                  key: ct-global-max-entries-other
+                  name: cilium-config
+                  optional: true
+          livenessProbe:
+            exec:
+              command:
+                - cilium
+                - status
+            # The initial delay for the liveness probe is intentionally large to
+            # avoid an endless kill & restart cycle if in the event that the initial
+            # bootstrapping takes longer than expected.
+            initialDelaySeconds: 120
+            failureThreshold: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - cilium
+                - status
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: bpf-maps
+              mountPath: /sys/fs/bpf
+            - name: cilium-run
+              mountPath: /var/run/cilium
+            - name: cni-path
+              mountPath: /host/opt/cni/bin
+            - name: etc-cni-netd
+              mountPath: /host/etc/cni/net.d
+            - name: docker-socket
+              mountPath: /var/run/docker.sock
+              readOnly: true
+            - name: etcd-config-path
+              mountPath: /var/lib/etcd-config
+              readOnly: true
+            - name: etcd-secrets
+              mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
+              readOnly: true
+          securityContext:
+            capabilities:
+              add:
+                - "NET_ADMIN"
+            privileged: true
+      hostNetwork: true
+      volumes:
+        # To keep state between restarts / upgrades
+        - name: cilium-run
+          hostPath:
+            path: /var/run/cilium
+            type: "DirectoryOrCreate"
+        # To keep state between restarts / upgrades for bpf maps
+        - name: bpf-maps
+          hostPath:
+            path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
+        # To read docker events from the node
+        - name: docker-socket
+          hostPath:
+            path: /var/run/docker.sock
+            type: "Socket"
+        # To install cilium cni plugin in the host
+        - name: cni-path
+          hostPath:
+            path: /opt/cni/bin
+            type: "DirectoryOrCreate"
+        # To install cilium cni configuration in the host
+        - name: etc-cni-netd
+          hostPath:
+            path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+          operator: "Exists"
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: "Exists"
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          operator: "Exists"
+        # Mark cilium's pod as critical for rescheduling
+        - key: CriticalAddonsOnly
+          operator: "Exists"

--- a/examples/kubernetes/1.13/cilium-operator.yaml
+++ b/examples/kubernetes/1.13/cilium-operator.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: cilium-operator
+        io.cilium/app: operator
+    spec:
+      serviceAccountName: cilium-operator
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      containers:
+      - name: cilium-operator
+        image: docker.io/cilium/operator:latest
+        imagePullPolicy: Always
+        command: ["cilium-operator"]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        env:
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+                optional: true
+          - name: CILIUM_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-name
+                name: cilium-config
+                optional: true
+          - name: CILIUM_CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-id
+                name: cilium-config
+                optional: true
+        volumeMounts:
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+      volumes:
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - componentstatuses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system

--- a/examples/kubernetes/1.13/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.13/cilium-pre-flight.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cilium-pre-flight-check
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium-pre-flight-check
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        k8s-app: cilium-pre-flight-check
+        kubernetes.io/cluster-service: "true"
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "k8s-app"
+                operator: In
+                values:
+                - cilium
+            topologyKey: "kubernetes.io/hostname"
+      initContainers:
+        - name: clean-cilium-state
+          image: docker.io/cilium/cilium-init:2018-10-16
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/echo"]
+          args:
+          - "hello"
+      containers:
+        - image: docker.io/cilium/cilium:latest
+          imagePullPolicy: Always
+          name: cilium-pre-flight-check
+          command: ["/bin/sh"]
+          args:
+          - -c
+          - touch /tmp/ready; sleep 1h
+          livenessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+        - key: CriticalAddonsOnly
+          operator: "Exists"

--- a/examples/kubernetes/1.13/cilium-rbac.yaml
+++ b/examples/kubernetes/1.13/cilium-rbac.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+  - kind: ServiceAccount
+    name: cilium
+    namespace: kube-system
+  - kind: Group
+    name: system:nodes
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium
+rules:
+  - apiGroups:
+      - "networking.k8s.io"
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - services
+      - nodes
+      - endpoints
+      - componentstatuses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+      - ciliumnetworkpolicies/status
+      - ciliumendpoints
+      - ciliumendpoints/status
+    verbs:
+      - "*"

--- a/examples/kubernetes/1.13/cilium-sa.yaml
+++ b/examples/kubernetes/1.13/cilium-sa.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium
+  namespace: kube-system

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -1,0 +1,541 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+  # This etcd-config contains the etcd endpoints of your cluster. If you use
+  # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
+  etcd-config: |-
+    ---
+    endpoints:
+      - http://127.0.0.1:31079
+    #
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
+    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
+    #
+    # In case you want client to server authentication, uncomment the following
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
+    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "false"
+  disable-ipv4: "false"
+
+  # If a serious issue occurs during Cilium startup, this
+  # invasive option may be set to true to remove all persistent
+  # state. Endpoints will not be restored using knowledge from a
+  # prior Cilium run, so they may receive new IP addresses upon
+  # restart. This also triggers clean-cilium-bpf-state.
+  clean-cilium-state: "false"
+  # If you want to clean cilium BPF state, set this to true;
+  # Removes all BPF maps from the filesystem. Upon restart,
+  # endpoints are restored with the same IP addresses, however
+  # any ongoing connections may be disrupted briefly.
+  # Loadbalancing decisions will be reset, so any ongoing
+  # connections via a service may be loadbalanced to a different
+  # backend after restart.
+  clean-cilium-bpf-state: "false"
+
+  legacy-host-allows-world: "false"
+
+  # If you want cilium monitor to aggregate tracing for packets, set this level
+  # to "low", "medium", or "maximum". The higher the level, the less packets
+  # that will be seen in monitor output.
+  monitor-aggregation-level: "none"
+
+  # ct-global-max-entries-* specifies the maximum number of connections
+  # supported across all endpoints, split by protocol: tcp or other. One pair
+  # of maps uses these values for IPv4 connections, and another pair of maps
+  # use these values for IPv6 connections.
+  #
+  # If these values are modified, then during the next Cilium startup the
+  # tracking of ongoing connections may be disrupted. This may lead to brief
+  # policy drops or a change in loadbalancing decisions for a connection.
+  #
+  # For users upgrading from Cilium 1.2 or earlier, to minimize disruption
+  # during the upgrade process, comment out these options.
+  ct-global-max-entries-tcp: "524288"
+  ct-global-max-entries-other: "262144"
+
+  # Regular expression matching compatible Istio sidecar istio-proxy
+  # container image names
+  sidecar-istio-proxy-image: "cilium/istio_proxy"
+
+  # Encapsulation mode for communication between nodes
+  # Possible values:
+  #   - disabled
+  #   - vxlan (default)
+  #   - geneve
+  tunnel: "vxlan"
+
+  # Name of the cluster. Only relevant when building a mesh of clusters.
+  cluster-name: default
+
+  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
+  #cluster-id: 1
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  updateStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+  selector:
+    matchLabels:
+      k8s-app: cilium
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
+      annotations:
+        # This annotation plus the CriticalAddonsOnly toleration makes
+        # cilium to be a critical pod in the cluster, which ensures cilium
+        # gets priority scheduling.
+        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: >-
+          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+    spec:
+      serviceAccountName: cilium
+      initContainers:
+        - name: clean-cilium-state
+          image: docker.io/cilium/cilium-init:2018-10-16
+          imagePullPolicy: IfNotPresent
+          command: ["/init-container.sh"]
+          securityContext:
+            capabilities:
+              add:
+                - "NET_ADMIN"
+            privileged: true
+          volumeMounts:
+            - name: bpf-maps
+              mountPath: /sys/fs/bpf
+            - name: cilium-run
+              mountPath: /var/run/cilium
+          env:
+            - name: "CLEAN_CILIUM_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-state
+            - name: "CLEAN_CILIUM_BPF_STATE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: clean-cilium-bpf-state
+      containers:
+        - image: docker.io/cilium/cilium:latest
+          imagePullPolicy: Always
+          name: cilium-agent
+          command: ["cilium-agent"]
+          args:
+            - "--debug=$(CILIUM_DEBUG)"
+            - "--kvstore=etcd"
+            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+            - "--disable-ipv4=$(DISABLE_IPV4)"
+          ports:
+            - name: prometheus
+              containerPort: 9090
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - "/cni-install.sh"
+            preStop:
+              exec:
+                command:
+                  - "/cni-uninstall.sh"
+          env:
+            - name: "K8S_NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "CILIUM_DEBUG"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  key: debug
+            - name: "DISABLE_IPV4"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  key: disable-ipv4
+            # Note: this variable is a no-op if not defined, and is used in the
+            # prometheus examples.
+            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-metrics-config
+                  optional: true
+                  key: prometheus-serve-addr
+            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  optional: true
+                  key: legacy-host-allows-world
+            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
+              valueFrom:
+                configMapKeyRef:
+                  name: cilium-config
+                  key: sidecar-istio-proxy-image
+                  optional: true
+            - name: "CILIUM_TUNNEL"
+              valueFrom:
+                configMapKeyRef:
+                  key: tunnel
+                  name: cilium-config
+                  optional: true
+            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
+              valueFrom:
+                configMapKeyRef:
+                  key: monitor-aggregation-level
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTERMESH_CONFIG
+              value: "/var/lib/cilium/clustermesh/"
+            - name: CILIUM_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-name
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: cluster-id
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_GLOBAL_CT_MAX_TCP
+              valueFrom:
+                configMapKeyRef:
+                  key: ct-global-max-entries-tcp
+                  name: cilium-config
+                  optional: true
+            - name: CILIUM_GLOBAL_CT_MAX_ANY
+              valueFrom:
+                configMapKeyRef:
+                  key: ct-global-max-entries-other
+                  name: cilium-config
+                  optional: true
+          livenessProbe:
+            exec:
+              command:
+                - cilium
+                - status
+            # The initial delay for the liveness probe is intentionally large to
+            # avoid an endless kill & restart cycle if in the event that the initial
+            # bootstrapping takes longer than expected.
+            initialDelaySeconds: 120
+            failureThreshold: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - cilium
+                - status
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: bpf-maps
+              mountPath: /sys/fs/bpf
+            - name: cilium-run
+              mountPath: /var/run/cilium
+            - name: cni-path
+              mountPath: /host/opt/cni/bin
+            - name: etc-cni-netd
+              mountPath: /host/etc/cni/net.d
+            - name: docker-socket
+              mountPath: /var/run/docker.sock
+              readOnly: true
+            - name: etcd-config-path
+              mountPath: /var/lib/etcd-config
+              readOnly: true
+            - name: etcd-secrets
+              mountPath: /var/lib/etcd-secrets
+              readOnly: true
+            - name: clustermesh-secrets
+              mountPath: /var/lib/cilium/clustermesh
+              readOnly: true
+          securityContext:
+            capabilities:
+              add:
+                - "NET_ADMIN"
+            privileged: true
+      hostNetwork: true
+      volumes:
+        # To keep state between restarts / upgrades
+        - name: cilium-run
+          hostPath:
+            path: /var/run/cilium
+            type: "DirectoryOrCreate"
+        # To keep state between restarts / upgrades for bpf maps
+        - name: bpf-maps
+          hostPath:
+            path: /sys/fs/bpf
+            type: "DirectoryOrCreate"
+        # To read docker events from the node
+        - name: docker-socket
+          hostPath:
+            path: /var/run/docker.sock
+            type: "Socket"
+        # To install cilium cni plugin in the host
+        - name: cni-path
+          hostPath:
+            path: /opt/cni/bin
+            type: "DirectoryOrCreate"
+        # To install cilium cni configuration in the host
+        - name: etc-cni-netd
+          hostPath:
+            path: /etc/cni/net.d
+            type: "DirectoryOrCreate"
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+        # To read the clustermesh configuration
+        - name: clustermesh-secrets
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cilium-clustermesh
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+          operator: "Exists"
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: "Exists"
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          operator: "Exists"
+        # Mark cilium's pod as critical for rescheduling
+        - key: CriticalAddonsOnly
+          operator: "Exists"
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: cilium-operator
+        io.cilium/app: operator
+    spec:
+      serviceAccountName: cilium-operator
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      containers:
+      - name: cilium-operator
+        image: docker.io/cilium/operator:latest
+        imagePullPolicy: Always
+        command: ["cilium-operator"]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        env:
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+                optional: true
+          - name: CILIUM_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-name
+                name: cilium-config
+                optional: true
+          - name: CILIUM_CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-id
+                name: cilium-config
+                optional: true
+        volumeMounts:
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+      volumes:
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - componentstatuses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+  - kind: ServiceAccount
+    name: cilium
+    namespace: kube-system
+  - kind: Group
+    name: system:nodes
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium
+rules:
+  - apiGroups:
+      - "networking.k8s.io"
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - services
+      - nodes
+      - endpoints
+      - componentstatuses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+      - ciliumnetworkpolicies/status
+      - ciliumendpoints
+      - ciliumendpoints/status
+    verbs:
+      - "*"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium
+  namespace: kube-system

--- a/examples/kubernetes/1.13/transforms2sed.sed
+++ b/examples/kubernetes/1.13/transforms2sed.sed
@@ -1,0 +1,3 @@
+s+__DS_API_VERSION__+apps/v1+g
+s+__RBAC_API_VERSION__+rbac.authorization.k8s.io/v1+g
+s+restartPolicy: Always+restartPolicy: Always\n      priorityClassName: system-node-critical+g

--- a/examples/kubernetes/Makefile
+++ b/examples/kubernetes/Makefile
@@ -4,7 +4,7 @@ ifeq ($(CILIUM_VERSION),)
     CILIUM_VERSION = "v$(shell cat ../../VERSION)"
 endif
 
-K8S_VERSIONS = 1.8 1.9 1.10 1.11 1.12
+K8S_VERSIONS = 1.8 1.9 1.10 1.11 1.12 1.13
 
 SOURCES = $(wildcard templates/v1/*.yaml*)
 FILENAME_SOURCES = $(patsubst templates/v1/%,%,$(patsubst %.yaml.sed,%.yaml,$(SOURCES)))

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
                 sh 'cd ${TESTDIR}; K8S_VERSION=1.9 vagrant up --no-provision'
             }
         }
-        stage('BDD-Test-k8s-1.8-and-1.9') {
+        stage('BDD-Test-k8s-1.9-and-1.10') {
             environment {
                 CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
             }
@@ -80,11 +80,11 @@ pipeline {
             steps {
                 script {
                     parallel(
-                        "K8s-1.8":{
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.8 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST}'
-                        },
                         "K8s-1.9":{
                             sh 'cd ${TESTDIR}; K8S_VERSION=1.9 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST}'
+                        },
+                        "K8s-1.10":{
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST}'
                         },
                         failFast: "${FAILFAST}".toBoolean()
                     )
@@ -111,11 +111,11 @@ pipeline {
             }
 
             steps {
-                sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant up --no-provision'
                 sh 'cd ${TESTDIR}; K8S_VERSION=1.11 vagrant up --no-provision'
+                sh 'cd ${TESTDIR}; K8S_VERSION=1.13 vagrant up --no-provision'
             }
         }
-        stage('BDD-Test-k8s-1.10-and-1.11') {
+        stage('BDD-Test-k8s-1.11-and-1.13') {
             environment {
                 CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
             }
@@ -125,11 +125,11 @@ pipeline {
             steps {
                 script {
                     parallel(
-                        "K8s-1.10":{
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST}'
-                        },
                         "K8s-1.11":{
                             sh 'cd ${TESTDIR}; K8S_VERSION=1.11 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST}'
+                        },
+                        "K8s-1.13":{
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.13 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST}'
                         },
                         failFast: "${FAILFAST}".toBoolean()
                     )
@@ -147,10 +147,10 @@ pipeline {
     }
     post {
         always {
-            sh "cd ${TESTDIR}; K8S_VERSION=1.8 vagrant destroy -f || true"
             sh "cd ${TESTDIR}; K8S_VERSION=1.9 vagrant destroy -f || true"
             sh "cd ${TESTDIR}; K8S_VERSION=1.10 vagrant destroy -f || true"
             sh "cd ${TESTDIR}; K8S_VERSION=1.11 vagrant destroy -f || true"
+            sh "cd ${TESTDIR}; K8S_VERSION=1.13 vagrant destroy -f || true"
             sh "cd ${TESTDIR}; ./post_build_agent.sh || true"
             cleanWs()
         }

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -220,7 +220,8 @@ var (
 	CiliumV1_0 = versioncheck.MustCompile(">=v1.0,<v1.1")
 	CiliumV1_1 = versioncheck.MustCompile(">=v1.1,<v1.2")
 	CiliumV1_2 = versioncheck.MustCompile(">=v1.2,<v1.3")
-	CiliumV1_3 = versioncheck.MustCompile(">=v1.2,<v1.4")
+	CiliumV1_3 = versioncheck.MustCompile(">=v1.2.90,<v1.4")
+	CiliumV1_4 = versioncheck.MustCompile(">=v1.3.90,<v1.5")
 )
 
 // CiliumDefaultDSPatch is the default Cilium DaemonSet patch to be used in all tests.

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -310,7 +310,7 @@ func DNSDeployment() string {
 	var DNSEngine = "kubedns"
 	k8sVersion := GetCurrentK8SEnv()
 	switch k8sVersion {
-	case "1.11", "1.12":
+	case "1.11", "1.12", "1.13":
 		DNSEngine = "coredns"
 	}
 	fullPath := filepath.Join("provision", "manifest", k8sVersion, DNSEngine+"_deployment.yaml")

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -349,6 +349,8 @@ func getK8sSupportedConstraints(ciliumVersion string) (go_version.Constraints, e
 		return versioncheck.MustCompile(">= 1.8, <1.13"), nil
 	case CiliumV1_3.Check(cst):
 		return versioncheck.MustCompile(">= 1.8, <1.13"), nil
+	case CiliumV1_4.Check(cst):
+		return versioncheck.MustCompile(">= 1.8, <1.14"), nil
 	default:
 		return nil, fmt.Errorf("unrecognized version '%s'", ciliumVersion)
 	}

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -178,7 +178,7 @@ case $K8S_VERSION in
         KUBERNETES_CNI_VERSION="0.6.0"
         K8S_FULL_VERSION="1.13.0-beta.2"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
-        KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri"
+        KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT
         KUBEADM_CONFIG="${KUBEADM_CONFIG_ALPHA3}"
         ;;

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -103,6 +103,33 @@ nodeRegistration:
 EOF
 )
 
+KUBEADM_CONFIG_ALPHA3=$(cat <<-EOF
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: InitConfiguration
+api:
+  advertiseAddress: {{ .KUBEADM_ADDR }}
+  bindPort: 6443
+bootstrapTokens:
+- groups:
+  - system:bootstrappers:kubeadm:default-node-token
+  token: {{ .TOKEN }}
+  ttl: 24h0m0s
+  usages:
+  - signing
+  - authentication
+nodeRegistration:
+  criSocket: "{{ .KUBEADM_CRI_SOCKET }}"
+---
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: ClusterConfiguration
+kubernetesVersion: "v{{ .K8S_FULL_VERSION }}"
+networking:
+  dnsDomain: cluster.local
+  podSubnet: "{{ .KUBEADM_POD_NETWORK }}/{{ .KUBEADM_POD_CIDR}}"
+  serviceSubnet: "{{ .KUBEADM_SVC_CIDR }}"
+EOF
+)
+
 # CRIO bridge disabled.
 if [[ -f  "/etc/cni/net.d/100-crio-bridge.conf" ]]; then
     echo "Disabling crio CNI bridge"
@@ -146,6 +173,14 @@ case $K8S_VERSION in
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT
         KUBEADM_CONFIG="${KUBEADM_CONFIG_ALPHA2}"
+        ;;
+    "1.13")
+        KUBERNETES_CNI_VERSION="0.6.0"
+        K8S_FULL_VERSION="1.13.0-beta.2"
+        KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
+        KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri"
+        sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT
+        KUBEADM_CONFIG="${KUBEADM_CONFIG_ALPHA3}"
         ;;
 esac
 


### PR DESCRIPTION
As we are always testing against k8s 1.8 can remove it from
ginkgo-kubernetes-all.Jenkinsfile

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5959)
<!-- Reviewable:end -->
