### PR TITLE
labels: Remove unnecessary memory allocations from k8s Labels interface

### DIFF
--- a/pkg/labels/array.go
+++ b/pkg/labels/array.go
@@ -91,8 +91,7 @@ nextLabel:
 // Implementation of the k8s.io/apimachinery/pkg/labels.Labels interface.
 func (ls LabelArray) Has(key string) bool {
 	// The key is submitted in the form of `source.key=value`
-	ck := GetCiliumKeyFrom(key)
-	keyLabel := ParseLabel(ck)
+	keyLabel := parseSelectLabel(key, '.')
 	if keyLabel.IsAnySource() {
 		for _, lsl := range ls {
 			if lsl.Key == keyLabel.Key {
@@ -101,7 +100,8 @@ func (ls LabelArray) Has(key string) bool {
 		}
 	} else {
 		for _, lsl := range ls {
-			if lsl.GetExtendedKey() == key {
+			// Note that if '=value' is part of 'key' it is ignored here
+			if lsl.Source == keyLabel.Source && lsl.Key == keyLabel.Key {
 				return true
 			}
 		}
@@ -112,8 +112,7 @@ func (ls LabelArray) Has(key string) bool {
 // Get returns the value for the provided key.
 // Implementation of the k8s.io/apimachinery/pkg/labels.Labels interface.
 func (ls LabelArray) Get(key string) string {
-	ck := GetCiliumKeyFrom(key)
-	keyLabel := ParseLabel(ck)
+	keyLabel := parseSelectLabel(key, '.')
 	if keyLabel.IsAnySource() {
 		for _, lsl := range ls {
 			if lsl.Key == keyLabel.Key {
@@ -122,7 +121,7 @@ func (ls LabelArray) Get(key string) string {
 		}
 	} else {
 		for _, lsl := range ls {
-			if lsl.GetExtendedKey() == key {
+			if lsl.Source == keyLabel.Source && lsl.Key == keyLabel.Key {
 				return lsl.Value
 			}
 		}


### PR DESCRIPTION
LabelArray implements the k8s apimachinery Labels interface, which
contains the functions Has() and Get(). Due to the differences in key
punctuation we have so far been converting key strings between the k8s
notation and Cilium notation in both Has() and Get() functions.

Remove the unnecessary string allocations by allowing keys to be
parsed from their k8s 'dot' notation and allowing such labels to be
returned by value. Also, when comparing keys that are not "any source"
perform the comparison between Cilium Labels rather than creating a
temporary string for the comparison.

Based on a simple Rule.canReachEgress() benchmark test this reduces
memory allocations and execution time by about 40%.

Signed-off-by: Jarno Rajahalme jarno@covalent.io

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/5967)
<!-- Reviewable:end -->
