### PR TITLE
Tune microscope readiness probe in ci

### DIFF
--- a/test/k8sT/manifests/microscope.yaml
+++ b/test/k8sT/manifests/microscope.yaml
@@ -81,4 +81,5 @@ spec:
         - --timeout-monitors
         - "2"
       initialDelaySeconds: 0
-      periodSeconds: 3
+      periodSeconds: 5
+      timeoutSeconds: 3


### PR DESCRIPTION
fixes #5667

seems like microscope readiness probe sometimes timed out after 1 second (default readiness probe timeout), but before readiness probe stopped. (timeout set to 2 seconds in readiness probe command). This change increases the timeout to 3 seconds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6020)
<!-- Reviewable:end -->
