### PR TITLE
pkg/datapath/ipcache: stop leaking FD

### DIFF
--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -226,6 +226,10 @@ func (l *BPFListener) garbageCollect() error {
 		}
 		pendingListener := newListener(pendingMap, l.datapath)
 		ipcache.IPIdentityCache.DumpToListenerLocked(pendingListener)
+		err := pendingMap.Close()
+		if err != nil {
+			log.WithError(err).WithField("map-name", pendingMapName).Warning("unable to close map")
+		}
 
 		// Move the maps around on the filesystem so that BPF reload
 		// will pick up the new paths without requiring recompilation.


### PR DESCRIPTION
Once we create the pendingMap we don't close it and leads to FD leakage.

Fixes: 442e22e61a3c ("datapath/ipcache: GC maps when delete is unsupported")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6024)
<!-- Reviewable:end -->
