### PR TITLE
endpoint: Fix spanstat corruption on RegenerateAllEndpoints()

### DIFF
--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -266,6 +266,8 @@ func updateReferences(ep *endpoint.Endpoint) {
 // RegenerateAllEndpoints calls a SetStateLocked for each endpoint and
 // regenerates if state transaction is valid. During this process, the endpoint
 // list is locked and cannot be modified.
+// The endpoint.RegenerationContext will be cloned to send a new context to
+// each endpoint to avoid issue on endpoint regenerations statistics.
 // Returns a waiting group that can be used to know when all the endpoints are
 // regenerated.
 func RegenerateAllEndpoints(owner endpoint.Owner, regenContext *endpoint.RegenerationContext) *sync.WaitGroup {
@@ -285,7 +287,9 @@ func RegenerateAllEndpoints(owner endpoint.Owner, regenContext *endpoint.Regener
 				ep.Unlock()
 				if regen {
 					// Regenerate logs status according to the build success/failure
-					<-ep.Regenerate(owner, regenContext)
+					// Create a new regenContext to not overwrite the spanStats
+					// values on the endpoint regeneration.
+					<-ep.Regenerate(owner, endpoint.NewRegenerationContext(regenContext.Reason))
 				}
 			}
 			wg.Done()


### PR DESCRIPTION
On endpointmanager we call to endpoint.Regenerate with the same
regenerationContext, that means that all the spanStats are updated to a
new ones instead of the correct values.

With this change, all endpoint.RegenerationContext are different per
each endpoint and the metrics will be correct.

Fix #6021
Related to commit: 1d46a782704644ec88e001d402b87f8b91156b5c

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6025)
<!-- Reviewable:end -->
