### PR TITLE
Test: stop background monitor command.

### DIFF
--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -135,12 +135,10 @@ var _ = Describe("RuntimeMonitorTest", func() {
 				defer cancel()
 				res := vm.ExecContext(ctx, fmt.Sprintf("cilium monitor --type %s -v", k))
 
-				areEndpointsReady := vm.WaitEndpointsReady()
-				Expect(areEndpointsReady).Should(BeTrue())
-
 				vm.ContainerExec(helpers.App1, helpers.Ping(helpers.Httpd1))
 				vm.ContainerExec(helpers.App3, helpers.Ping(helpers.Httpd1))
 
+				cancel()
 				Expect(res.WaitUntilMatch(v)).To(BeNil(),
 					"%q is not in the output after timeout", v)
 				Expect(res.CountLines()).Should(BeNumerically(">", 3))


### PR DESCRIPTION
Always call cancel in a for loop to not leak the monitor command in
background.

Fix #6022

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6026)
<!-- Reviewable:end -->
