### PR TITLE
k8s: CEP GC runs in steps

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -597,7 +597,7 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 
 	si.Start(wait.NeverStop)
 
-	_, podsController := k8sUtils.ControllerFactory(
+	podsStore, podsController := k8sUtils.ControllerFactory(
 		k8s.Client().CoreV1().RESTClient(),
 		&v1.Pod{},
 		k8sUtils.ResourceEventHandlerFactory(
@@ -700,7 +700,7 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 	go namespaceController.Run(wait.NeverStop)
 	d.k8sAPIGroups.addAPI(k8sAPIGroupNamespaceV1Core)
 
-	k8s.CiliumEndpointSyncGC()
+	k8s.CiliumEndpointSyncGC(podsStore)
 
 	return nil
 }

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -396,7 +396,7 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 
 	switch {
 	case networkPolicyV1VerConstr.Check(k8sServerVer):
-		policyController := k8sUtils.ControllerFactory(
+		_, policyController := k8sUtils.ControllerFactory(
 			k8s.Client().NetworkingV1().RESTClient(),
 			&networkingv1.NetworkPolicy{},
 			k8sUtils.ResourceEventHandlerFactory(
@@ -437,7 +437,7 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 		d.k8sAPIGroups.addAPI(k8sAPIGroupNetworkingV1Core)
 	}
 
-	svcController := k8sUtils.ControllerFactory(
+	_, svcController := k8sUtils.ControllerFactory(
 		k8s.Client().CoreV1().RESTClient(),
 		&v1.Service{},
 		k8sUtils.ResourceEventHandlerFactory(
@@ -474,7 +474,7 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 	go svcController.Run(wait.NeverStop)
 	d.k8sAPIGroups.addAPI(k8sAPIGroupServiceV1Core)
 
-	endpointController := k8sUtils.ControllerFactory(
+	_, endpointController := k8sUtils.ControllerFactory(
 		k8s.Client().CoreV1().RESTClient(),
 		&v1.Endpoints{},
 		k8sUtils.ResourceEventHandlerFactory(
@@ -513,7 +513,7 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 	d.k8sAPIGroups.addAPI(k8sAPIGroupEndpointV1Core)
 
 	if option.Config.IsLBEnabled() {
-		ingressController := k8sUtils.ControllerFactory(
+		_, ingressController := k8sUtils.ControllerFactory(
 			k8s.Client().ExtensionsV1beta1().RESTClient(),
 			&v1beta1.Ingress{},
 			k8sUtils.ResourceEventHandlerFactory(
@@ -597,7 +597,7 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 
 	si.Start(wait.NeverStop)
 
-	podsController := k8sUtils.ControllerFactory(
+	_, podsController := k8sUtils.ControllerFactory(
 		k8s.Client().CoreV1().RESTClient(),
 		&v1.Pod{},
 		k8sUtils.ResourceEventHandlerFactory(
@@ -634,7 +634,7 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 	go podsController.Run(wait.NeverStop)
 	d.k8sAPIGroups.addAPI(k8sAPIGroupPodV1Core)
 
-	nodesController := k8sUtils.ControllerFactory(
+	_, nodesController := k8sUtils.ControllerFactory(
 		k8s.Client().CoreV1().RESTClient(),
 		&v1.Node{},
 		k8sUtils.ResourceEventHandlerFactory(
@@ -671,7 +671,7 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 	go nodesController.Run(wait.NeverStop)
 	d.k8sAPIGroups.addAPI(k8sAPIGroupNodeV1Core)
 
-	namespaceController := k8sUtils.ControllerFactory(
+	_, namespaceController := k8sUtils.ControllerFactory(
 		k8s.Client().CoreV1().RESTClient(),
 		&v1.Namespace{},
 		k8sUtils.ResourceEventHandlerFactory(

--- a/operator/k8s_service_sync.go
+++ b/operator/k8s_service_sync.go
@@ -83,7 +83,7 @@ func startSynchronizingServices() {
 	servicesStore = store
 
 	// Watch for v1.Service changes and push changes into ServiceCache
-	svcController := utils.ControllerFactory(
+	_, svcController := utils.ControllerFactory(
 		k8s.Client().CoreV1().RESTClient(),
 		&v1.Service{},
 		utils.ResourceEventHandlerFactory(
@@ -119,7 +119,7 @@ func startSynchronizingServices() {
 	go svcController.Run(wait.NeverStop)
 
 	// Watch for v1.Endpoints changes and push changes into ServiceCache
-	endpointController := utils.ControllerFactory(
+	_, endpointController := utils.ControllerFactory(
 		k8s.Client().CoreV1().RESTClient(),
 		&v1.Endpoints{},
 		utils.ResourceEventHandlerFactory(

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -53,6 +53,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/u8proto"
+
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/k8s/cep.go
+++ b/pkg/k8s/cep.go
@@ -38,7 +38,14 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	k8sToolsCache "k8s.io/client-go/tools/cache"
 )
+
+// CiliumEndpointGCInterval is the interval between attempts of the CEP GC
+// controller.
+// Note that only one node per cluster should run this, and most iterations
+// will simply return.
+const CiliumEndpointGCInterval = 30 * time.Minute
 
 // EndpointSynchronizer currently is an empty type, which wraps around syncing
 // of CiliumEndpoint resources.
@@ -110,7 +117,7 @@ func getCiliumClient() (ciliumClient cilium_client_v2.CiliumV2Interface, err err
 //   - for each CEP
 //       delete CEP if the corresponding pod does not exist
 // CiliumEndpoint objects have the same name as the pod they represent
-func CiliumEndpointSyncGC() {
+func CiliumEndpointSyncGC(podStore k8sToolsCache.Store) {
 	var (
 		controllerName = fmt.Sprintf("sync-to-k8s-ciliumendpoint-gc (%v)", node.GetName())
 		scopedLog      = log.WithField("controller", controllerName)
@@ -122,7 +129,7 @@ func CiliumEndpointSyncGC() {
 		return
 	}
 
-	// this is a sanity check
+	// this is a sanity check in case we are called with k8s not there
 	if !IsEnabled() {
 		scopedLog.WithField("name", controllerName).Warn("Not running controller because k8s is disabled")
 		return
@@ -145,12 +152,11 @@ func CiliumEndpointSyncGC() {
 		scopedLog.WithError(err).Error("Not starting controller because unable to get cilium k8s client")
 		return
 	}
-	k8sClient := Client()
 
 	// this dummy manager is needed only to add this controller to the global list
 	controller.NewManager().UpdateController(controllerName,
 		controller.ControllerParams{
-			RunInterval: 30 * time.Minute,
+			RunInterval: CiliumEndpointGCInterval,
 			DoFunc: func() error {
 				// Don't run immediately
 				if firstRun {
@@ -170,36 +176,62 @@ func CiliumEndpointSyncGC() {
 					}
 				}
 
-				clusterPodSet := map[string]bool{}
-				clusterPods, err := k8sClient.CoreV1().Pods("").List(meta_v1.ListOptions{})
-				if err != nil {
-					return err
-				}
-				for _, pod := range clusterPods.Items {
-					podFullName := pod.Name + ":" + pod.Namespace
-					clusterPodSet[podFullName] = true
-				}
+				var (
+					listOpts = meta_v1.ListOptions{Limit: 10}
+					loopStop = time.Now().Add(CiliumEndpointGCInterval)
+				)
 
-				// "" is all-namespaces
-				ceps, err := ciliumClient.CiliumEndpoints(meta_v1.NamespaceAll).List(meta_v1.ListOptions{})
-				if err != nil {
-					scopedLog.WithError(err).Debug("Cannot list CEPs")
-					return err
-				}
-				for _, cep := range ceps.Items {
-					cepFullName := cep.Name + ":" + cep.Namespace
-					if _, found := clusterPodSet[cepFullName]; !found {
-						// delete
-						scopedLog = scopedLog.WithFields(logrus.Fields{
-							logfields.EndpointID: cep.Status.ID,
-							logfields.K8sPodName: cepFullName,
-						})
-						scopedLog.Debug("Orphaned CiliumEndpoint is being garbage collected")
-						if err := ciliumClient.CiliumEndpoints(cep.Namespace).Delete(cep.Name, &meta_v1.DeleteOptions{}); err != nil {
-							scopedLog.WithError(err).Debug("Unable to delete CEP")
+			perCEPFetch:
+				for time.Now().Before(loopStop) { // Guard against no-break bugs
+					time.Sleep(time.Second) // Throttle lookups in case of a busy loop
+
+					ceps, err := ciliumClient.CiliumEndpoints(meta_v1.NamespaceAll).List(listOpts)
+					switch {
+					case err != nil && k8serrors.IsResourceExpired(err) && ceps.Continue != "":
+						// This combination means we saw a 410 ResourceExpired error but we
+						// can iterate on the now-current snapshot. We need to refetch,
+						// however.
+						// See https://github.com/kubernetes/apimachinery/blob/master/pkg/apis/meta/v1/types.go#L350-L381
+						// or the docs for k8s.io/apimachinery/pkg/apis/meta/v1.ListOptions
+						// vendored into this repo.
+						listOpts.Continue = ceps.Continue
+						continue perCEPFetch
+
+					case err != nil:
+						scopedLog.WithError(err).Debug("Cannot list CEPs")
+						return err
+					}
+
+					// setup listOpts for the next iteration
+					listOpts.Continue = ceps.Continue
+
+					// For each CEP we fetched, check if we know about it
+					for _, cep := range ceps.Items {
+						cepFullName := cep.Namespace + "/" + cep.Name
+						_, exists, err := podStore.GetByKey(cepFullName)
+						if err != nil {
 							return err
 						}
+
+						if !exists {
+							// delete
+							scopedLog = scopedLog.WithFields(logrus.Fields{
+								logfields.EndpointID: cep.Status.ID,
+								logfields.K8sPodName: cepFullName,
+							})
+							scopedLog.Debug("Orphaned CiliumEndpoint is being garbage collected")
+							PropagationPolicy := meta_v1.DeletePropagationBackground // because these are const strings but the API wants pointers
+							if err := ciliumClient.CiliumEndpoints(cep.Namespace).Delete(cep.Name, &meta_v1.DeleteOptions{PropagationPolicy: &PropagationPolicy}); err != nil {
+								scopedLog.WithError(err).Debug("Unable to delete orphaned CEP")
+								return err
+							}
+						}
 					}
+					if ceps.Continue != "" {
+						// there is more data, continue
+						continue perCEPFetch
+					}
+					break perCEPFetch // break out as a safe default to avoid spammy loops
 				}
 				return nil
 			},

--- a/pkg/k8s/utils/factory.go
+++ b/pkg/k8s/utils/factory.go
@@ -178,13 +178,13 @@ func ControllerFactory(
 	resourceObj runtime.Object,
 	rehf ResourceEventHandler,
 	selector fields.Selector,
-) cache.Controller {
+) (cache.Store, cache.Controller) {
 
 	if selector == nil {
 		selector = fields.Everything()
 	}
 
-	_, c := cache.NewInformer(
+	s, c := cache.NewInformer(
 		cache.NewListWatchFromClient(
 			k8sGetter,
 			resourceNameOf(resourceObj),
@@ -196,7 +196,7 @@ func ControllerFactory(
 		rehf,
 	)
 
-	return c
+	return s, c
 }
 
 // ResourceEventHandlerFactory returns a ResourceEventHandlerSyncer,


### PR DESCRIPTION
On large clusters the CEP GC would fetch the entire list of CEPs. These
can grow to significant sizes (100kB in one instance) and this causes
extreme degradation in kube-apiserver. We now iterate 10 CEPs at a
time, thus lowering the load we put on the cluster.

I also return the cache.Store object from our k8s helper factories. No functionality has changed there.

I began by trying to watch for CEPs in the controller but the code became a little complex. This was partly because only the node that should do GC needs to watch for CEPs, but that meant creating a non-shared informer (shared informers cannot stop once they begin watching for a specific type). In the end, limiting the list to a small number seemed like a reasonable compromise, especially since the GC isn't a critical operation here.

Relates to: https://github.com/cilium/cilium/issues/5913

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6029)
<!-- Reviewable:end -->
