### PR TITLE
fqdn: split DNSPoller into RuleGen and DNSPoller

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1359,7 +1359,7 @@ func NewDaemon() (*Daemon, *endpointRestoreState, error) {
 	if err := fqdn.ConfigFromResolvConf(); err != nil {
 		return nil, nil, err
 	}
-	d.dnsPoller = fqdn.NewDNSPoller(fqdn.DNSPollerConfig{
+	d.dnsPoller = fqdn.NewDNSPoller(fqdn.Config{
 		MinTTL:         toFQDNsMinTTL,
 		LookupDNSNames: fqdn.DNSLookupDefaultResolver,
 		AddGeneratedRules: func(generatedRules []*policyApi.Rule) error {

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -1,0 +1,46 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fqdn
+
+import (
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/miekg/dns"
+)
+
+// Config is a simple configuration structure to set how pkg/fqdn subcomponents
+// behave.
+// DNSPoller relies on LookupDNSNames to control how DNS lookups are done, and
+// AddGeneratedRules to control how generated policy rules are emitted.
+type Config struct {
+	// MinTTL is the time used by the poller to cache information.
+	// When set to 0, 2*DNSPollerInterval is used.
+	MinTTL int
+
+	// Cache is where the poller stores DNS data used to generate rules.
+	// When set to nil, it uses fqdn.DefaultDNSCache, a global cache instance.
+	Cache *DNSCache
+
+	// DNSConfig includes the Resolver IPs, port, timeout and retry count. It is
+	// expected to be  generated from /etc/resolv.conf.
+	DNSConfig *dns.ClientConfig
+
+	// LookupDNSNames is a callback to run the provided DNS lookups.
+	// When set to nil, fqdn.DNSLookupDefaultResolver is used.
+	LookupDNSNames func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error)
+
+	// AddGeneratedRules is a callback  to emit generated rules.
+	// When set to nil, it is a no-op.
+	AddGeneratedRules func([]*api.Rule) error
+}

--- a/pkg/fqdn/dnspoller.go
+++ b/pkg/fqdn/dnspoller.go
@@ -15,44 +15,17 @@
 package fqdn
 
 import (
-	"net"
-	"strings"
 	"time"
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/miekg/dns"
-
-	"github.com/sirupsen/logrus"
 )
 
-// Notes
-// Hack 1: We strip ToCIDRSet rules. These are already dissallowed by our
-// validation. We do this to simplify handling our own generated rules.
-// StartPollForDNSName is called by daemon when we inject the generated rules. By
-// stripping ToCIDRSet we make the rule equivalent to what it was before. This is
-// inefficient.
-// We also rely on this in addRule, where we now keep the newest instance of a
-// rule to allow handling policy updates for rules we don't look at, but need to
-// retain while generating.
-
-const (
-	// generatedLabelNameUUID is the label key for policy rules that contain a
-	// ToFQDN section and need to be updated
-	generatedLabelNameUUID = "ToFQDN-UUID"
-
-	// DNSPollerInterval is the time between 2 complete DNS lookup runs of the
-	// DNSPoller controller
-	// Note: This cannot be less than 1*time.Second, as it is used as a default
-	// for MinTTL in fqdn.Config
-	DNSPollerInterval = 5 * time.Second
-)
-
-// uuidLabelSearchKey is an *extended* label key. This is because .Has
-// expects the source:key delimiter to be the labels.PathDelimiter
-var uuidLabelSearchKey = generateUUIDLabel().GetExtendedKey()
+// DNSPollerInterval is the time between 2 complete DNS lookup runs of the
+// DNSPoller controller
+// Note: This cannot be less than 1*time.Second, as it is used as a default
+// for MinTTL in DNSPollerConfig
+const DNSPollerInterval = 5 * time.Second
 
 // StartDNSPoller spawns a singleton DNS polling controller. The controller
 // will, periodically, run a DNS lookup for each ToFQDN target DNS name
@@ -79,166 +52,42 @@ func StartDNSPoller(poller *DNSPoller) {
 type DNSPoller struct {
 	lock.Mutex // this guards both maps and their contents
 
+	// ruleManager is the backing RuleGen that tells this poller which names to
+	// poll, and where to submit DNS updates.
+	ruleManager *RuleGen
+
 	// config is a copy from when this instance was initialized.
 	// It is read-only once set
 	config Config
-
-	// IPs maps dnsNames as strings to the most recent IPs seen for them. It is,
-	// in effect, a reflection of the realized DNS -> IP state (but acts as a
-	// source of information for the CIDR rules we generate)
-	// Note: The IP slice is sorted. on insert in updateIPsForName, and should
-	// not be reshuffled.
-	// Note: Names are turned into FQDNs when stored
-	IPs map[string][]net.IP
-
-	// sourceRule maps dnsNames to a set of rule UUIDs that depend on
-	// that dnsName. It is the desired state for DNS -> IP data, and drives IPs
-	// above, which drives CIDR rule generation.
-	// The data here is map[dnsName][rule uuid]struct{} where the inner map acts
-	// as a refcount of rules that depend on this dnsName.
-	// The UUID -> rule mapping is allRules below.
-	sourceRules map[string]map[string]struct{}
-
-	// allRules is the global source of truth for rules we are managing. It maps
-	// UUID to the rule copy.
-	allRules map[string]*api.Rule
-
-	// cache is a private copy of the pointer from config.
-	cache *DNSCache
 }
 
 // NewDNSPoller creates an initialized DNSPoller. It does not start the controller (use .Start)
-func NewDNSPoller(config Config) *DNSPoller {
+func NewDNSPoller(config Config, ruleManager *RuleGen) *DNSPoller {
 	if config.MinTTL == 0 {
 		config.MinTTL = 2 * int(DNSPollerInterval/time.Second)
-	}
-
-	if config.Cache == nil {
-		config.Cache = DefaultDNSCache
 	}
 
 	if config.LookupDNSNames == nil {
 		config.LookupDNSNames = DNSLookupDefaultResolver
 	}
 
-	if config.AddGeneratedRules == nil {
-		config.AddGeneratedRules = func(generatedRules []*api.Rule) error { return nil }
-	}
-
 	return &DNSPoller{
 		config:      config,
-		IPs:         make(map[string][]net.IP),
-		sourceRules: make(map[string]map[string]struct{}),
-		allRules:    make(map[string]*api.Rule),
-		cache:       config.Cache,
+		ruleManager: ruleManager,
 	}
 }
 
-// MarkToFQDNRules adds a tracking label to the rule, if it contains ToFQDN
-// rules. The label is used to ensure that the ToFQDN rules are replaced
-// correctly when they are regenerated with IPs. It will also include the
-// generated ToCIDRSet section for IPs that are in the cache.
-// NOTE: It edits the rules in-place
-func (poller *DNSPoller) MarkToFQDNRules(sourceRules []*api.Rule) {
-	poller.Lock()
-	defer poller.Unlock()
-
-perRule:
-	for _, sourceRule := range sourceRules {
-		// This rule has already been seen, and has a UUID label OR it has no
-		// ToFQDN rules. Do no more processing on it.
-		// Note: this label can only come from us. An external rule add or replace
-		// would lack the UUID-tagged rule and we would add a new UUID label in
-		// this function. Cleanup for existing rules with UUIDs is handled in
-		// StopPollForDNSName
-		if !hasToFQDN(sourceRule) || sourceRule.Labels.Has(uuidLabelSearchKey) {
-			continue perRule
-		}
-
-		// add a unique ID that we can use later to replace this rule.
-		uuidLabel := generateUUIDLabel()
-		sourceRule.Labels = append(sourceRule.Labels, uuidLabel)
-
-		// Inject initial IPs in this rule, best effort from the cache
-		injectToCIDRSetRules(sourceRule, poller.IPs)
-	}
-}
-
-// StartPollForDNSName sets up the polling for ToFQDN rules in each api.Rule.
-// It only adds rules with the ToFQDN-UUID label, added by MarkToFQDNRules, and
-// repeat inserts are effectively no-ops.
-func (poller *DNSPoller) StartPollForDNSName(sourceRules []*api.Rule) {
-	poller.Lock()
-	defer poller.Unlock()
-
-perRule:
-	for _, sourceRule := range sourceRules {
-		// Note: we rely on this reject to enforce calling stripToCIDRSet
-		// in MarkToFQDNRules
-		if !sourceRule.Labels.Has(uuidLabelSearchKey) {
-			continue perRule
-		}
-
-		// Make a copy to avoid breaking the input rules. Strip ToCIDRSet to avoid
-		// accumulating anything we included during MarkToFQDNRules
-		sourceRuleCopy := sourceRule.DeepCopy()
-		stripToCIDRSet(sourceRuleCopy)
-
-		uuid := getRuleUUIDLabel(sourceRuleCopy)
-		newDNSNames, alreadyExistsDNSNames := poller.addRule(uuid, sourceRuleCopy)
-		// only debug print for new names, since this function is called
-		// unconditionally, even when we insert generated rules (which aren't new)
-		if len(newDNSNames) > 0 {
-			log.WithFields(logrus.Fields{
-				"newDNSNames":           newDNSNames,
-				"alreadyExistsDNSNames": alreadyExistsDNSNames,
-				"numRules":              len(sourceRules),
-			}).Debug("Added FQDN to poll list")
-		}
-	}
-}
-
-// StopPollForDNSName runs the bookkeeping to remove each api.Rule from
-// corresponding dnsName entries in sourceRules and IPs.  When no more rules
-// rely on a specific dnsName, we remove it from the maps and stop polling for
-// it. It expects rules to still be labelled with a ToFQDN-UUID if
-// StartPollForDNSName had added the label on insertion.
-// Note: rule deletion in policy.Repository is by label, where the rules must
-// have at least the labels in the delete.  This means our ToFQDN-UUID label,
-// and later ToCIDRSet additions will also be deleted correctly, and no action
-// is needed here.
-func (poller *DNSPoller) StopPollForDNSName(sourceRules []*api.Rule) {
-	poller.Lock()
-	defer poller.Unlock()
-
-	for _, sourceRule := range sourceRules {
-		// skip unmarked rules, nothing to do
-		if !sourceRule.Labels.Has(uuidLabelSearchKey) {
-			continue
-		}
-
-		uuid := getRuleUUIDLabel(sourceRule)
-		noLongerPolledDNSNames := poller.removeRule(uuid, sourceRule)
-		log.WithFields(logrus.Fields{
-			"noLongerPolled": noLongerPolledDNSNames,
-		}).Debug("Removed FQDN from poll list")
-	}
-}
-
-// LookupUpdateDNS runs a DNS lookup for each stored DNS name, storing updates,
-// and then emits regenerated policy rules.
+// LookupUpdateDNS runs a DNS lookup for each stored DNS name, storing updates
+// into ruleManager, which may emit regenerated policy rules.
 // The general steps are:
-// 1- take a snapshot of DNS names to lookup from poller, into dnsNamesToPoll
+// 1- take a snapshot of DNS names to lookup from .ruleManager, into dnsNamesToPoll
 // 2- Do a DNS lookup for each DNS name (map key) in poller via LookupDNSNames
-// 3- Update IPs for each dnsName in poller. If the IPs have changed for the
-// name, store which rules must be updated in rulesToUpdate. This is a set and
-// is deduped
-// 4- For each rule in rulesToUpdate, generate a new policy rule with IPs
-// 5- If we have any rules to update, emit them with AddGeneratedRules
+// 3- Update IPs for each dnsName in .ruleManager. If the IPs have changed for the
+// name, it will generate and emit them.
 func (poller *DNSPoller) LookupUpdateDNS() error {
 	// Collect the DNS names that need lookups. This avoids locking
 	// poller during lookups.
-	dnsNamesToPoll := poller.GetDNSNames()
+	dnsNamesToPoll := poller.ruleManager.GetDNSNames()
 
 	// lookup the DNS names. Names with failures will not be updated (and we
 	// will use the most recent data below)
@@ -249,272 +98,5 @@ func (poller *DNSPoller) LookupUpdateDNS() error {
 			Warn("Cannot resolve FQDN. Traffic egressing to this destination may be incorrectly dropped due to stale data.")
 	}
 
-	// TODO: when poller can get the TTLs of DNS responses, pass that here
-	return poller.UpdateGenerateDNS(lookupTime, updatedDNSIPs)
-}
-
-// UpdateGenerateDNS inserts the new DNS information into the cache, and
-// regenerates rules that need to be regenerated.
-func (poller *DNSPoller) UpdateGenerateDNS(lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) error {
-	// Update IPs in poller
-	uuidsToUpdate, updatedDNSNames := poller.UpdateDNSIPs(lookupTime, updatedDNSIPs)
-	for dnsName, IPs := range updatedDNSNames {
-		log.WithFields(logrus.Fields{
-			"matchName":     dnsName,
-			"IPs":           IPs,
-			"uuidsToUpdate": uuidsToUpdate,
-		}).Debug("Updated FQDN with new IPs")
-	}
-
-	// Generate a new rule for each sourceRule that needs an update.
-	rulesToUpdate, notFoundUUIDs := poller.GetRulesByUUID(uuidsToUpdate)
-	if len(notFoundUUIDs) != 0 {
-		log.WithField("uuid", strings.Join(notFoundUUIDs, ",")).
-			Debug("Did not find all rules during update")
-	}
-	generatedRules, namesMissingIPs := poller.GenerateRulesFromSources(rulesToUpdate)
-	if len(namesMissingIPs) != 0 {
-		log.WithField(logfields.DNSName, strings.Join(namesMissingIPs, ",")).
-			Warn("Missing IPs for ToFQDN rule")
-	}
-
-	// no rules to add, do not call AddGeneratedRules below
-	if len(generatedRules) == 0 {
-		return nil
-	}
-
-	// emit the new rules
-	return poller.config.AddGeneratedRules(generatedRules)
-}
-
-// GetDNSNames returns a snapshot of the DNS names in DNSPoller
-func (poller *DNSPoller) GetDNSNames() (dnsNames []string) {
-	poller.Lock()
-	defer poller.Unlock()
-
-	for name := range poller.IPs {
-		dnsNames = append(dnsNames, name)
-	}
-
-	return dnsNames
-}
-
-// UpdateDNSIPs updates the IPs for each DNS name in updatedDNSIPs.
-// It returns:
-// affectedRules: a list of rule UUIDs that were affected by the new IPs (lookup in .allRules)
-// updatedNames: a map of DNS names to the IPs they were updated with.
-func (poller *DNSPoller) UpdateDNSIPs(lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (affectedRules []string, updatedNames map[string][]net.IP) {
-	updatedNames = make(map[string][]net.IP, len(updatedDNSIPs))
-	affectedRulesSet := make(map[string]struct{}, len(updatedDNSIPs))
-
-	poller.Lock()
-	defer poller.Unlock()
-
-perDNSName:
-	for dnsName, lookupIPs := range updatedDNSIPs {
-		updated := poller.updateIPsForName(lookupTime, dnsName, lookupIPs.IPs, lookupIPs.TTL)
-
-		// The IPs didn't change. No more to be done for this dnsName
-		if !updated {
-			continue perDNSName
-		}
-
-		// record the IPs that were different
-		updatedNames[dnsName] = lookupIPs.IPs
-
-		// accumulate the rules affected by new IPs, that we need to update with
-		// CIDR rules
-		for uuid := range poller.sourceRules[dnsName] {
-			affectedRulesSet[uuid] = struct{}{}
-		}
-	}
-
-	// Convert the set to a list
-	for uuid := range affectedRulesSet {
-		affectedRules = append(affectedRules, uuid)
-	}
-
-	return affectedRules, updatedNames
-}
-
-// GetRulesByUUID returns the sourceRule copies of inserted rules. These are
-// the source of truth when generating rules with update IPs.
-// sourceRules is the list of *api.Rule objects that were found (i.e. currently
-// in the poller and not deleted)
-// notFoundUUIDs is the set of UUIDs not found. This can occur when a delete
-// races with other operations. It is benign in the sense that if a rule UUID is
-// not found, no action is supposed to be taken on it by the poller.
-func (poller *DNSPoller) GetRulesByUUID(uuids []string) (sourceRules []*api.Rule, notFoundUUIDs []string) {
-	poller.Lock()
-	defer poller.Unlock()
-
-	for _, uuid := range uuids {
-		rule, ok := poller.allRules[uuid]
-		// This may happen if a rule was deleted during the DNS lookups
-		if !ok {
-			notFoundUUIDs = append(notFoundUUIDs, uuid)
-			continue
-		}
-
-		sourceRules = append(sourceRules, rule)
-	}
-
-	return sourceRules, notFoundUUIDs
-}
-
-// GenerateRulesFromSources creates new api.Rule instances with all ToFQDN
-// targets resolved to IPs. The IPs are in generated CIDRSet rules in the
-// ToCIDRSet section. Pre-existing rules in ToCIDRSet are preserved
-// Note: GenerateRulesFromSources will make a copy each sourceRule
-func (poller *DNSPoller) GenerateRulesFromSources(sourceRules []*api.Rule) (generatedRules []*api.Rule, namesMissingIPs []string) {
-	poller.Lock()
-	defer poller.Unlock()
-
-	var namesMissingMap = make(map[string]struct{})
-
-	for _, sourceRule := range sourceRules {
-		newRule := sourceRule.DeepCopy()
-		namesMissingIPs := injectToCIDRSetRules(newRule, poller.IPs)
-		for _, missing := range namesMissingIPs {
-			namesMissingMap[missing] = struct{}{}
-		}
-
-		generatedRules = append(generatedRules, newRule)
-	}
-
-	for missing := range namesMissingMap {
-		namesMissingIPs = append(namesMissingIPs, missing)
-	}
-	return generatedRules, namesMissingIPs
-}
-
-// addRule places an api.Rule in the source list for a DNS name.
-// uuid must be the unique identifier generated for the ToFQDN-UUID label.
-// newDNSNames and oldDNSNames indicate names that were newly added from this
-// rule, or that were seen in this rule but were already polled for.
-// If newDNSNames and oldDNSNames are both empty, the rule was not added to the
-// poll list.
-func (poller *DNSPoller) addRule(uuid string, sourceRule *api.Rule) (newDNSNames, oldDNSNames []string) {
-	// if we are updating a rule, track which old dnsNames are removed. We store
-	// possible names to stop polling for in namesToStopPolling. As we add names
-	// from the new rule below, these are cleared.
-	namesToStopPolling := make(map[string]struct{})
-	if oldRule, exists := poller.allRules[uuid]; exists {
-		for _, egressRule := range oldRule.Egress {
-			for _, ToFQDN := range egressRule.ToFQDNs {
-				matchName := dns.Fqdn(ToFQDN.MatchName)
-				namesToStopPolling[matchName] = struct{}{}
-			}
-		}
-	}
-
-	// Always add to allRules
-	poller.allRules[uuid] = sourceRule
-
-	// Add a dnsname -> rule reference
-	for _, egressRule := range sourceRule.Egress {
-		for _, ToFQDN := range egressRule.ToFQDNs {
-			dnsName := dns.Fqdn(ToFQDN.MatchName)
-
-			delete(namesToStopPolling, dnsName)
-
-			dnsNameAlreadyExists := poller.ensureExists(dnsName)
-			if dnsNameAlreadyExists {
-				oldDNSNames = append(oldDNSNames, dnsName)
-			} else {
-				newDNSNames = append(newDNSNames, dnsName)
-				// Add this egress rule as a dependent on dnsName.
-				poller.sourceRules[dnsName][uuid] = struct{}{}
-			}
-		}
-	}
-
-	// Stop polling names that were not re-added by deleting them from the IP map
-	// Remove references to the uuid that were present in the old rule but not
-	// re-added by the new one. This may result in removing the dnsName from
-	// polling, if no other rules depend on this dnsName
-	for dnsName := range namesToStopPolling {
-		if shouldStopPolling := poller.removeFromDNSName(dnsName, uuid); shouldStopPolling {
-			delete(poller.IPs, dnsName)
-		}
-	}
-
-	return newDNSNames, oldDNSNames
-}
-
-// removeRule removes an api.Rule from the source rule set for each DNS name,
-// and from the IPs if no rules depend on that DNS name. This also stops polling for that DNS name.
-// uuid must be a unique identifier for the sourceRule
-// noLongerPolled indicates that no more rules rely on this DNS target
-func (poller *DNSPoller) removeRule(uuid string, sourceRule *api.Rule) (noLongerPolled []string) {
-	// Always delete from allRules
-	delete(poller.allRules, uuid)
-
-	// Delete dnsname -> rule references
-	for _, egressRule := range sourceRule.Egress {
-		for _, ToFQDN := range egressRule.ToFQDNs {
-			dnsName := dns.Fqdn(ToFQDN.MatchName)
-
-			if shouldStopPolling := poller.removeFromDNSName(dnsName, uuid); shouldStopPolling {
-				delete(poller.IPs, dnsName) // also delete from the IP map, stopping polling
-				noLongerPolled = append(noLongerPolled, dnsName)
-			}
-		}
-	}
-
-	return noLongerPolled
-}
-
-// removeFromDNSName removes the uuid from the list attached to a dns name. It
-// will clean up poller.sourceRules if needed.
-// shouldStopPolling indicates that no more rules rely on this DNS target
-// Note: This does not touch the IP list, and does not change polling
-func (poller *DNSPoller) removeFromDNSName(dnsName, uuid string) (shouldStopPolling bool) {
-	// remove the rule from the set of rules that rely on dnsName.
-	// Note: this isn't removing dnsName from poller.sourceRules, that is just
-	// below.
-	delete(poller.sourceRules[dnsName], uuid)
-
-	// Check if any rules remain that rely on this dnsName by checking
-	// if the inner map[rule uuid]struct{} set is empty. If none do we
-	// can delete it so we no longer poll it.
-	isEmpty := len(poller.sourceRules[dnsName]) == 0
-	if isEmpty {
-		shouldStopPolling = true
-		delete(poller.sourceRules, dnsName)
-	}
-
-	return shouldStopPolling
-}
-
-// ensureExists ensures that we have allocated objects for dnsName, and creates
-// them if needed.
-func (poller *DNSPoller) ensureExists(dnsName string) (exists bool) {
-	_, exists = poller.IPs[dnsName]
-	if !exists {
-		poller.IPs[dnsName] = make([]net.IP, 0)
-		poller.sourceRules[dnsName] = make(map[string]struct{})
-	}
-
-	return exists
-}
-
-// updateIPsName will update the IPs for dnsName. It always retains a copy of
-// newIPs.
-// updated is true when the new IPs differ from the old IPs
-func (poller *DNSPoller) updateIPsForName(lookupTime time.Time, dnsName string, newIPs []net.IP, ttl int) (updated bool) {
-	oldIPs := poller.IPs[dnsName]
-
-	if poller.config.MinTTL > ttl {
-		ttl = poller.config.MinTTL
-	}
-
-	// TODO: when poller can get the TTLs of DNS responses, apply min(ttl, poller.config.MinTTL)
-	poller.cache.Update(lookupTime, dnsName, newIPs, ttl)
-	sortedNewIPs := poller.cache.Lookup(dnsName) // DNSCache returns IPs sorted
-
-	// store the new IPs, sorted (to help with the updated determination below)
-	poller.IPs[dnsName] = sortedNewIPs
-
-	return !sortedIPsAreEqual(sortedNewIPs, oldIPs)
+	return poller.ruleManager.UpdateGenerateDNS(lookupTime, updatedDNSIPs)
 }

--- a/pkg/fqdn/dnspoller.go
+++ b/pkg/fqdn/dnspoller.go
@@ -274,6 +274,13 @@ func (poller *DNSPoller) LookupUpdateDNS() error {
 			Warn("Cannot resolve FQDN. Traffic egressing to this destination may be incorrectly dropped due to stale data.")
 	}
 
+	// TODO: when poller can get the TTLs of DNS responses, pass that here
+	return poller.UpdateGenerateDNS(lookupTime, updatedDNSIPs)
+}
+
+// UpdateGenerateDNS inserts the new DNS information into the cache, and
+// regenerates rules that need to be regenerated.
+func (poller *DNSPoller) UpdateGenerateDNS(lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) error {
 	// Update IPs in poller
 	uuidsToUpdate, updatedDNSNames := poller.UpdateDNSIPs(lookupTime, updatedDNSIPs)
 	for dnsName, IPs := range updatedDNSNames {
@@ -320,7 +327,7 @@ func (poller *DNSPoller) GetDNSNames() (dnsNames []string) {
 // UpdateDNSIPs updates the IPs for each DNS name in updatedDNSIPs.
 // It returns:
 // affectedRules: a list of rule UUIDs that were affected by the new IPs (lookup in .allRules)
-// updatedNames: a map of DNS names to the IPs they were updated with. This is always a superset of updatedDNSIPs.
+// updatedNames: a map of DNS names to the IPs they were updated with.
 func (poller *DNSPoller) UpdateDNSIPs(lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (affectedRules []string, updatedNames map[string][]net.IP) {
 	updatedNames = make(map[string][]net.IP, len(updatedDNSIPs))
 	affectedRulesSet := make(map[string]struct{}, len(updatedDNSIPs))

--- a/pkg/fqdn/dnspoller_test.go
+++ b/pkg/fqdn/dnspoller_test.go
@@ -17,107 +17,13 @@
 package fqdn
 
 import (
-	"encoding/json"
-	"fmt"
-	"net"
-	"strings"
-
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/miekg/dns"
 
 	. "gopkg.in/check.v1"
 )
 
-func makeRule(key string, dnsNames ...string) *api.Rule {
-	matchNames := []string{}
-	for _, name := range dnsNames {
-		matchNames = append(matchNames,
-			fmt.Sprintf(`{"matchName": "%s"}`, dns.Fqdn(name)))
-	}
-
-	rule := `{`
-	if key != "" {
-		rule += fmt.Sprintf(`"labels": [{ "key": "%s" }],`, key)
-	}
-	rule += fmt.Sprintf(`"endpointSelector": {
-    "matchLabels": {
-      "class": "xwing"
-    }
-  },
-  "egress": [
-    {
-      "toFQDNs": [
-      %s
-      ]
-    }
-  ]
-}`, strings.Join(matchNames, ",\n"))
-	//fmt.Print(rule)
-	return mustParseRule(rule)
-}
-
-func parseRule(rule string) (parsedRule *api.Rule, err error) {
-	if err := json.Unmarshal([]byte(rule), &parsedRule); err != nil {
-		return nil, err
-	}
-
-	if err := parsedRule.Sanitize(); err != nil {
-		return nil, err
-	}
-
-	return parsedRule, nil
-}
-
-func mustParseRule(rule string) (parsedRule *api.Rule) {
-	parsedRule, err := parseRule(rule)
-	if err != nil {
-		panic(fmt.Sprintf("Error parsing FQDN test rules: %s", err))
-	}
-	return parsedRule
-}
-
-var (
-	// cilium.io dns target, no rule name => no rule labels
-	rule1 = makeRule("", "cilium.io")
-
-	// cilium.io dns target, no rule name => no rule labels
-	rule2 = makeRule("", "cilium.io")
-
-	// cilium.io, github.com dns targets
-	rule3 = makeRule("rule3", "cilium.io", "github.com")
-
-	// github.com dns target
-	rule4 = makeRule("rule4", "github.com")
-
-	ipLookups = map[string]*DNSIPRecords{
-		dns.Fqdn("cilium.io"): {
-			TTL: 60,
-			IPs: []net.IP{
-				net.ParseIP("172.217.18.174"),
-				net.ParseIP("2a00:1450:4001:811::200e")}},
-		dns.Fqdn("github.com"): {
-			TTL: 60,
-			IPs: []net.IP{
-				net.ParseIP("98.138.219.231"),
-				net.ParseIP("72.30.35.10"),
-				net.ParseIP("001:4998:c:1023::4"),
-				net.ParseIP("001:4998:58:1836::10")}},
-	}
-)
-
-// LookupDNSNames is a wrappable dummy used by the tests. It counts the number
-// of times a name is looked up in lookups, and uses ipData as a source for the
-// "response"
-func lookupDNSNames(ipData map[string]*DNSIPRecords, lookups map[string]int, dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
-	DNSIPs = make(map[string]*DNSIPRecords)
-	for _, dnsName := range dnsNames {
-		lookups[dnsName] += 1
-		DNSIPs[dnsName] = ipData[dnsName]
-	}
-	return DNSIPs, errorDNSNames
-}
-
-// TestDNSPollerRuleHandling tests these cases:
+// TestRuleGenRuleHandling tests these cases:
 // add a rule, get one poll for that name
 // add 2 rules, get one lookup for each name
 // add 2 rules with the same name, get one lookup for that name
@@ -131,20 +37,20 @@ func lookupDNSNames(ipData map[string]*DNSIPRecords, lookups map[string]int, dns
 // 3- remove rulesToDelete
 // 4- rule lookupIterationsAfterDelete DNS lookups
 // 5- call the testCase checkFunc
-func (ds *FQDNTestSuite) TestDNSPollerRuleHandling(c *C) {
+func (ds *FQDNTestSuite) TestRuleGenRuleHandling(c *C) {
 	var testCases = []struct {
 		desc                        string
 		rulesToAdd                  []*api.Rule
 		rulesToDelete               []*api.Rule
 		lookupIterationsAfterAdd    int // # of times to call LookupUpdateDNS after add but before delete
 		lookupIterationsAfterDelete int // # of times to call LookupUpdateDNS after delete
-		checkFunc                   func(lookups map[string]int, generatedRules []*api.Rule, poller *DNSPoller)
+		checkFunc                   func(lookups map[string]int, generatedRules []*api.Rule, gen *RuleGen)
 	}{
 		{
 			desc:                        "Lookup a name when added in a rule",
 			lookupIterationsAfterAdd:    1,
 			lookupIterationsAfterDelete: 0,
-			checkFunc: func(lookups map[string]int, generatedRules []*api.Rule, poller *DNSPoller) {
+			checkFunc: func(lookups map[string]int, generatedRules []*api.Rule, gen *RuleGen) {
 				c.Assert(len(lookups), Equals, 1, Commentf("More than one DNS name was looked up for a rule with 1 DNS name"))
 				for _, name := range []string{dns.Fqdn("cilium.io")} {
 					c.Assert(lookups[name], Not(Equals), 0, Commentf("No lookups for DNS name %s in rule", name))
@@ -159,7 +65,7 @@ func (ds *FQDNTestSuite) TestDNSPollerRuleHandling(c *C) {
 			desc:                        "Lookup each name once when 2 are added in a rule",
 			lookupIterationsAfterAdd:    1,
 			lookupIterationsAfterDelete: 0,
-			checkFunc: func(lookups map[string]int, generatedRules []*api.Rule, poller *DNSPoller) {
+			checkFunc: func(lookups map[string]int, generatedRules []*api.Rule, gen *RuleGen) {
 				c.Assert(len(lookups), Equals, 2, Commentf("More than two DNS names was looked up for a rule with 2 DNS name"))
 				for _, name := range []string{dns.Fqdn("cilium.io"), dns.Fqdn("github.com")} {
 					c.Assert(lookups[name], Not(Equals), 0, Commentf("No lookups for DNS name %s in rule", name))
@@ -174,7 +80,7 @@ func (ds *FQDNTestSuite) TestDNSPollerRuleHandling(c *C) {
 			desc:                        "Lookup name once when two rules refer to it",
 			lookupIterationsAfterAdd:    1,
 			lookupIterationsAfterDelete: 0,
-			checkFunc: func(lookups map[string]int, generatedRules []*api.Rule, poller *DNSPoller) {
+			checkFunc: func(lookups map[string]int, generatedRules []*api.Rule, gen *RuleGen) {
 				c.Assert(len(lookups), Equals, 1, Commentf("More than one DNS name was looked up for a rule with 1 DNS name"))
 				for _, name := range []string{dns.Fqdn("cilium.io")} {
 					c.Assert(lookups[name], Not(Equals), 0, Commentf("No lookups for DNS name %s in rule", name))
@@ -189,7 +95,7 @@ func (ds *FQDNTestSuite) TestDNSPollerRuleHandling(c *C) {
 			desc:                        "No lookups after removing all rules",
 			lookupIterationsAfterAdd:    0,
 			lookupIterationsAfterDelete: 1,
-			checkFunc: func(lookups map[string]int, generatedRules []*api.Rule, poller *DNSPoller) {
+			checkFunc: func(lookups map[string]int, generatedRules []*api.Rule, gen *RuleGen) {
 				c.Assert(len(lookups), Equals, 0, Commentf("DNS lookups occurred after removing all rules"))
 			},
 			rulesToAdd:    []*api.Rule{rule1},
@@ -200,8 +106,8 @@ func (ds *FQDNTestSuite) TestDNSPollerRuleHandling(c *C) {
 			desc:                        "One lookup for a name after removing one of two referring rules",
 			lookupIterationsAfterAdd:    0,
 			lookupIterationsAfterDelete: 1,
-			checkFunc: func(lookups map[string]int, generatedRules []*api.Rule, poller *DNSPoller) {
-				c.Assert(len(poller.GetDNSNames()), Equals, 1, Commentf("Incorrect number of DNS targets for single name with a single referring rule"))
+			checkFunc: func(lookups map[string]int, generatedRules []*api.Rule, gen *RuleGen) {
+				c.Assert(len(gen.GetDNSNames()), Equals, 1, Commentf("Incorrect number of DNS targets for single name with a single referring rule"))
 				c.Assert(len(lookups), Equals, 1, Commentf("Incorrect number of lookups for single name with a single referring rule"))
 				for _, name := range []string{dns.Fqdn("cilium.io")} {
 					c.Assert(lookups[name], Not(Equals), 0, Commentf("No lookups for DNS name %s in rule", name))
@@ -216,8 +122,8 @@ func (ds *FQDNTestSuite) TestDNSPollerRuleHandling(c *C) {
 			desc:                        "One lookup for a name after removing an unrelated rule",
 			lookupIterationsAfterAdd:    0,
 			lookupIterationsAfterDelete: 1,
-			checkFunc: func(lookups map[string]int, generatedRules []*api.Rule, poller *DNSPoller) {
-				c.Assert(len(poller.GetDNSNames()), Equals, 1, Commentf("Incorrect number of DNS targets for single name with a single referring rule"))
+			checkFunc: func(lookups map[string]int, generatedRules []*api.Rule, gen *RuleGen) {
+				c.Assert(len(gen.GetDNSNames()), Equals, 1, Commentf("Incorrect number of DNS targets for single name with a single referring rule"))
 				c.Assert(len(lookups), Equals, 1, Commentf("Incorrect number of lookups for single name with a single referring rule"))
 				for _, name := range []string{dns.Fqdn("cilium.io")} {
 					c.Assert(lookups[name], Not(Equals), 0, Commentf("No lookups for DNS name %s in rule", name))
@@ -235,19 +141,22 @@ func (ds *FQDNTestSuite) TestDNSPollerRuleHandling(c *C) {
 			lookups        = make(map[string]int)
 			generatedRules = make([]*api.Rule, 0)
 
-			poller = NewDNSPoller(Config{
+			cfg = Config{
 				MinTTL: 1,
 				Cache:  NewDNSCache(),
 
 				LookupDNSNames: func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
-					return lookupDNSNames(ipLookups, lookups, dnsNames)
+					return lookupDNSNames(ipLookups, lookups, dnsNames), nil
 				},
 
 				AddGeneratedRules: func(rules []*api.Rule) error {
 					generatedRules = append(generatedRules, rules...)
 					return nil
 				},
-			})
+			}
+
+			gen    = NewRuleGen(cfg)
+			poller = NewDNSPoller(cfg, gen)
 		)
 
 		rulesToAdd := []*api.Rule{}
@@ -265,7 +174,7 @@ func (ds *FQDNTestSuite) TestDNSPollerRuleHandling(c *C) {
 		}
 
 		// add rules and run basic checks
-		poller.MarkToFQDNRules(rulesToAdd)
+		gen.MarkToFQDNRules(rulesToAdd)
 		for i, rule := range rulesToAdd {
 			c.Assert(len(getRuleUUIDLabel(rule)), Not(Equals), 0, Commentf("Added a FQDN label to each marked rule"))
 			if i > 0 {
@@ -276,7 +185,7 @@ func (ds *FQDNTestSuite) TestDNSPollerRuleHandling(c *C) {
 			c.Assert(len(getRuleUUIDLabel(rule)), Not(Equals), 0, Commentf("Added a FQDN label to each marked rule"))
 		}
 
-		poller.StartPollForDNSName(rulesToAdd)
+		gen.StartManageDNSName(rulesToAdd)
 		for i := testCase.lookupIterationsAfterAdd; i > 0; i-- {
 			err := poller.LookupUpdateDNS()
 			c.Assert(err, IsNil, Commentf("Error running DNS lookups"))
@@ -284,280 +193,13 @@ func (ds *FQDNTestSuite) TestDNSPollerRuleHandling(c *C) {
 
 		// delete rules listed in the test case (note: we don't delete any unless
 		// they are listed)
-		poller.StopPollForDNSName(rulesToDelete)
+		gen.StopManageDNSName(rulesToDelete)
 		for i := testCase.lookupIterationsAfterDelete; i > 0; i-- {
 			err := poller.LookupUpdateDNS()
 			c.Assert(err, IsNil, Commentf("Error running DNS lookups"))
 		}
 
 		// call the testcase checkFunc, it will assert everything relevant to the test
-		testCase.checkFunc(lookups, generatedRules, poller)
+		testCase.checkFunc(lookups, generatedRules, gen)
 	}
-}
-
-// TestDNSPollerCIDRGeneration tests rule generation output:
-// add a rule, get correct IP4/6 in ToCIDRSet
-// add a rule, lookup twice, get correct IP4/6 in TOCIDRSet after change
-// add a rule w/ToCIDRSet, get correct IP4/6 and old rules
-// add a rule, get same UUID label on repeat generations
-func (ds *FQDNTestSuite) TestDNSPollerCIDRGeneration(c *C) {
-	var (
-		pollCount      = 0
-		generatedRules = make([]*api.Rule, 0)
-
-		poller = NewDNSPoller(Config{
-			MinTTL: 1,
-			Cache:  NewDNSCache(),
-
-			LookupDNSNames: func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
-				switch pollCount {
-				case 1:
-					return map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}}, nil
-				case 2:
-					return map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}}}, nil
-				}
-				return nil, nil
-			},
-
-			AddGeneratedRules: func(rules []*api.Rule) error {
-				generatedRules = append(generatedRules, rules...)
-				return nil
-			},
-		})
-	)
-
-	// add rules
-	rulesToAdd := []*api.Rule{rule1.DeepCopy()}
-	poller.MarkToFQDNRules(rulesToAdd)
-	poller.StartPollForDNSName(rulesToAdd)
-
-	// store original UUID
-	uuidOrig := getRuleUUIDLabel(rulesToAdd[0])
-	c.Assert(uuidOrig, Not(Equals), "", Commentf("UUID label not set on rule, or not recovered correctly"))
-
-	// poll DNS once, check that we only generate 1 rule (for 1 IP) and that we
-	// still have 1 ToFQDN rule, and that the IP is correct
-	generatedRules = nil
-	pollCount++
-	err := poller.LookupUpdateDNS()
-	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
-	c.Assert(len(generatedRules), Equals, 1, Commentf("Incorrect number of generated rules for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress[0].ToFQDNs), Equals, len(generatedRules[0].Egress[0].ToCIDRSet), Commentf("Generated CIDR count is not the same as ToFQDNs"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
-
-	// Check that the UUID has not changed
-	uuid1 := getRuleUUIDLabel(generatedRules[0])
-	c.Assert(uuid1, Equals, uuidOrig, Commentf("UUID label has changed on rule since original insert"))
-
-	// poll DNS once, check that we only generate 1 rule (for 2 IPs that we
-	// inserted) and that we still have 1 ToFQDN rule, and that the IP, now
-	// different, is correct
-	generatedRules = nil
-	pollCount++
-	err = poller.LookupUpdateDNS()
-	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
-	c.Assert(len(generatedRules), Equals, 1, Commentf("More than 1 generated rule for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress), Equals, 1, Commentf("More than 1 generated rule for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress[0].ToFQDNs), Equals, 1, Commentf("toFQDNs rule count changed when it should not"))
-	c.Assert(len(generatedRules[0].Egress[0].ToCIDRSet), Equals, 2, Commentf("Generated CIDR count is not the same as inserted IPs"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[1].Cidr, Equals, api.CIDR("2.2.2.2/32"), Commentf("Incorrect IP CIDR generated"))
-
-	// check that the UUID has not changed
-	uuid2 := getRuleUUIDLabel(generatedRules[0])
-	c.Assert(uuid2, Equals, uuidOrig, Commentf("UUID label has changed on rule since original insert"))
-	c.Assert(uuid2, Equals, uuid1, Commentf("UUID label has changed on rule since previous generation"))
-}
-
-// TestDNSPollerDropCIDROnReinsert tests that we correctly guard against
-// pre-existing toCIDRSet sections:
-// - when we initially insert
-// - when we re-insert a generated rule
-func (ds *FQDNTestSuite) TestDNSPollerDropCIDROnReinsert(c *C) {
-	var (
-		generatedRules = make([]*api.Rule, 0)
-
-		poller = NewDNSPoller(Config{
-			LookupDNSNames: func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
-				return map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}}, nil
-			},
-
-			AddGeneratedRules: func(rules []*api.Rule) error {
-				generatedRules = append(generatedRules, rules...)
-				return nil
-			},
-		})
-	)
-
-	// Add a fake "generated" CIDR entry, it should not come back later when generated
-	rulesToAdd := []*api.Rule{rule1.DeepCopy()}
-	poller.MarkToFQDNRules(rulesToAdd)
-	rulesToAdd[0].Egress[0].ToCIDRSet = append(rulesToAdd[0].Egress[0].ToCIDRSet, api.CIDRRule{Cidr: api.CIDR("2.2.2.2/32")})
-	poller.StartPollForDNSName(rulesToAdd)
-	err := poller.LookupUpdateDNS()
-	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
-	c.Assert(len(generatedRules), Equals, 1, Commentf("Generated an unexpected number of rules"))
-	c.Assert(len(rulesToAdd[0].Egress[0].ToCIDRSet), Equals, 1, Commentf("existing toCIDRSet section not stripped by GenerateRules"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
-}
-
-// Test that all IPs are updated when one is
-func (ds *FQDNTestSuite) TestDNSPollerMultiIPUpdate(c *C) {
-	var (
-		pollCount      = 0
-		generatedRules = make([]*api.Rule, 0)
-
-		poller = NewDNSPoller(Config{
-			MinTTL: 1,
-			Cache:  NewDNSCache(),
-
-			LookupDNSNames: func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
-				switch pollCount {
-				case 1:
-					return map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}}, nil
-				case 2:
-					return map[string]*DNSIPRecords{
-						dns.Fqdn("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
-						dns.Fqdn("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("3.3.3.3")}}}, nil
-				case 3:
-					return map[string]*DNSIPRecords{
-						dns.Fqdn("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
-						dns.Fqdn("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("4.4.4.4")}}}, nil
-				}
-				return nil, nil
-			},
-
-			AddGeneratedRules: func(rules []*api.Rule) error {
-				generatedRules = append(generatedRules, rules...)
-				return nil
-			},
-		})
-	)
-
-	// add rules
-	rulesToAdd := []*api.Rule{rule3.DeepCopy()}
-	poller.MarkToFQDNRules(rulesToAdd)
-	poller.StartPollForDNSName(rulesToAdd)
-
-	// poll DNS once, check that we only generate 1 IP for cilium.io
-	generatedRules = nil
-	pollCount++
-	err := poller.LookupUpdateDNS()
-	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
-	c.Assert(len(generatedRules), Equals, 1, Commentf("Incorrect number of generated rules for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress[0].ToCIDRSet), Equals, 1, Commentf("Generated CIDR count is not the same as ToFQDNs"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
-
-	// poll DNS once, check that we only generate 3 IPs, 2 cached from before and 1 new one for github.com
-	generatedRules = nil
-	pollCount++
-	err = poller.LookupUpdateDNS()
-	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
-	c.Assert(len(generatedRules), Equals, 1, Commentf("More than 1 generated rule for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress[0].ToCIDRSet), Equals, 3, Commentf("Generated CIDR count is not the same as ToFQDNs"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[1].Cidr, Equals, api.CIDR("2.2.2.2/32"), Commentf("Incorrect IP CIDR generated"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[2].Cidr, Equals, api.CIDR("3.3.3.3/32"), Commentf("Incorrect IP CIDR generated"))
-
-	// poll DNS once, check that we only generate 4 IPs, 2 cilium.io cached IPs, 1 cached gituhub.com IP, 1 new github.com IP
-	generatedRules = nil
-	pollCount++
-	err = poller.LookupUpdateDNS()
-	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
-	c.Assert(len(generatedRules), Equals, 1, Commentf("More than 1 generated rule for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress[0].ToCIDRSet), Equals, 4, Commentf("Generated CIDR count is not the same as ToFQDNs"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[1].Cidr, Equals, api.CIDR("2.2.2.2/32"), Commentf("Incorrect IP CIDR generated"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[2].Cidr, Equals, api.CIDR("3.3.3.3/32"), Commentf("Incorrect IP CIDR generated"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[3].Cidr, Equals, api.CIDR("4.4.4.4/32"), Commentf("Incorrect IP CIDR generated"))
-}
-
-// TestDNSPollerUpdatesOnReplace tests updates without deletion:
-// add 1 matchname, poll. re-add it. See the correct output on MarkToFQDNRules
-// add 2 matchnames with the different names, replace one, then back. See the correct output on MarkToFQDNRules
-// re-add the original rule with only 1 matchname. It is not cached because that name was deleted
-func (ds *FQDNTestSuite) TestDNSPollerUpdatesOnReplace(c *C) {
-
-	var (
-		dnsIPs = map[string]*DNSIPRecords{
-			dns.Fqdn("cilium.io"):         {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}},
-			dns.Fqdn("github.com"):        {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
-			dns.Fqdn("anotherdomain.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("3.3.3.3")}},
-		}
-
-		poller = NewDNSPoller(Config{
-			MinTTL: 1,
-			Cache:  NewDNSCache(),
-
-			LookupDNSNames: func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
-				lookups := make(map[string]int) // dummy
-				return lookupDNSNames(dnsIPs, lookups, dnsNames)
-			},
-
-			AddGeneratedRules: func(rules []*api.Rule) error {
-				return nil
-			},
-		})
-	)
-
-	// Add 1 rules and poll
-	rules := []*api.Rule{makeRule("testRule", "cilium.io")}
-	// MarkToFQDNRules adds nothing on the first try
-	poller.MarkToFQDNRules(rules)
-	c.Assert(len(rules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single ToFQDNs entry"))
-	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 0, Commentf("Generated CIDR count is 0 when no CIDRs should have been added"))
-
-	poller.StartPollForDNSName(rules)
-	poller.LookupUpdateDNS()
-
-	// Add another rule with the same FQDN. We should see IPs in-place BEFORE StartPollForDNSName.
-	// MarkToFQDNRules adds the IP from the cache
-	rules = []*api.Rule{makeRule("testRule2", "cilium.io")}
-	poller.MarkToFQDNRules(rules)
-	c.Assert(len(rules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single ToFQDNs entry"))
-	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 1, Commentf("Generated CIDR count is not the same as ToFQDNs"))
-	c.Assert(rules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
-
-	poller.StartPollForDNSName(rules)
-	poller.LookupUpdateDNS()
-
-	// Add 2 rules and poll
-	rules = []*api.Rule{makeRule("testRule3", "cilium.io", "github.com")}
-	poller.MarkToFQDNRules(rules)
-	poller.StartPollForDNSName(rules)
-	poller.LookupUpdateDNS()
-
-	// Add a 2 matchnames, only one overlaps
-	// MarkToFQDNRules should add only 1 entry
-	rules = []*api.Rule{makeRule("testRule4", "cilium.io", "anotherdomain.com")}
-	poller.MarkToFQDNRules(rules)
-	c.Assert(len(rules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single cached ToFQDNs DNS entry"))
-	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 1, Commentf("Generated CIDR count is not the same as ToFQDNs DNS entries in cache"))
-	c.Assert(rules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
-
-	poller.StartPollForDNSName(rules)
-	poller.LookupUpdateDNS()
-
-	fmt.Printf("%#v\n", poller.IPs)
-	// Add the original 2 matchnames without deleting
-	// MarkToFQDNRules should add 2 entries, as those should be in the poller cache
-	rules = []*api.Rule{makeRule("testRule5", "cilium.io", "github.com")}
-	poller.MarkToFQDNRules(rules)
-	c.Assert(len(rules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single cached ToFQDNs DNS entry"))
-	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 2, Commentf("Generated CIDR count is not the same as ToFQDNs DNS entries in cache"))
-	c.Assert(rules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect first IP CIDR generated from cache"))
-
-	poller.StartPollForDNSName(rules)
-	poller.LookupUpdateDNS()
-
-	// Add a rule with 1 old matchname
-	// MarkToFQDNRules should add one entry
-	rules = []*api.Rule{makeRule("testRule6", "anotherdomain.com")}
-	poller.MarkToFQDNRules(rules)
-	c.Assert(len(rules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single cached ToFQDNs DNS entry"))
-	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 1, Commentf("Generated CIDR count is not the same as ToFQDNs DNS entries in cache"))
 }

--- a/pkg/fqdn/dnspoller_test.go
+++ b/pkg/fqdn/dnspoller_test.go
@@ -235,7 +235,7 @@ func (ds *FQDNTestSuite) TestDNSPollerRuleHandling(c *C) {
 			lookups        = make(map[string]int)
 			generatedRules = make([]*api.Rule, 0)
 
-			poller = NewDNSPoller(DNSPollerConfig{
+			poller = NewDNSPoller(Config{
 				MinTTL: 1,
 				Cache:  NewDNSCache(),
 
@@ -305,7 +305,7 @@ func (ds *FQDNTestSuite) TestDNSPollerCIDRGeneration(c *C) {
 		pollCount      = 0
 		generatedRules = make([]*api.Rule, 0)
 
-		poller = NewDNSPoller(DNSPollerConfig{
+		poller = NewDNSPoller(Config{
 			MinTTL: 1,
 			Cache:  NewDNSCache(),
 
@@ -378,7 +378,7 @@ func (ds *FQDNTestSuite) TestDNSPollerDropCIDROnReinsert(c *C) {
 	var (
 		generatedRules = make([]*api.Rule, 0)
 
-		poller = NewDNSPoller(DNSPollerConfig{
+		poller = NewDNSPoller(Config{
 			LookupDNSNames: func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
 				return map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}}, nil
 			},
@@ -408,7 +408,7 @@ func (ds *FQDNTestSuite) TestDNSPollerMultiIPUpdate(c *C) {
 		pollCount      = 0
 		generatedRules = make([]*api.Rule, 0)
 
-		poller = NewDNSPoller(DNSPollerConfig{
+		poller = NewDNSPoller(Config{
 			MinTTL: 1,
 			Cache:  NewDNSCache(),
 
@@ -489,7 +489,7 @@ func (ds *FQDNTestSuite) TestDNSPollerUpdatesOnReplace(c *C) {
 			dns.Fqdn("anotherdomain.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("3.3.3.3")}},
 		}
 
-		poller = NewDNSPoller(DNSPollerConfig{
+		poller = NewDNSPoller(Config{
 			MinTTL: 1,
 			Cache:  NewDNSCache(),
 

--- a/pkg/fqdn/rulegen.go
+++ b/pkg/fqdn/rulegen.go
@@ -1,0 +1,463 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fqdn
+
+import (
+	"net"
+	"strings"
+	"time"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/miekg/dns"
+	"github.com/sirupsen/logrus"
+)
+
+// Notes
+// Hack 1: We strip ToCIDRSet rules. These are already dissallowed by our
+// validation. We do this to simplify handling our own generated rules.
+// StartManageDNSName is called by daemon when we inject the generated rules. By
+// stripping ToCIDRSet we make the rule equivalent to what it was before. This is
+// inefficient.
+// We also rely on this in addRule, where we now keep the newest instance of a
+// rule to allow handling policy updates for rules we don't look at, but need to
+// retain while generating.
+
+const (
+	// generatedLabelNameUUID is the label key for policy rules that contain a
+	// ToFQDN section and need to be updated
+	generatedLabelNameUUID = "ToFQDN-UUID"
+)
+
+// uuidLabelSearchKey is an *extended* label key. This is because .Has
+// expects the source:key delimiter to be the labels.PathDelimiter
+var uuidLabelSearchKey = generateUUIDLabel().GetExtendedKey()
+
+// RuleGen tracks which rules depend on which DNS names. When DNS updates are
+// given to a RuleGen it will emit generated policy rules with DNS IPs inserted
+// as toCIDR rules. These correspond to the toFQDN matchName entries and are
+// emitted via AddGeneratedRules.
+// DNS information is cached, respecting TTL.
+// Note: When DNS data expires rules are not generated again!
+type RuleGen struct {
+	lock.Mutex // this guards both maps and their contents
+
+	// config is a copy from when this instance was initialized.
+	// It is read-only once set
+	config Config // FIXME: make this fqdn.Config
+
+	// IPs maps dnsNames as strings to the most recent IPs emitted for them. It
+	// is, in effect, a reflection of the realized DNS -> IP state (but acts as a
+	// source of information for the CIDR rules we generate).
+	// Note: The IP slice is sorted on insert, in updateIPsForName, and should
+	// not be reshuffled.
+	// Note: Names are turned into FQDNs when stored
+	IPs map[string][]net.IP
+
+	// sourceRule maps dnsNames to a set of rule UUIDs that depend on
+	// that dnsName. It is the desired state for DNS -> IP data, and drives IPs
+	// above, which drives CIDR rule generation.
+	// The data here is map[dnsName][rule uuid]struct{} where the inner map acts
+	// as a refcount of rules that depend on this dnsName.
+	// The UUID -> rule mapping is allRules below.
+	sourceRules map[string]map[string]struct{}
+
+	// allRules is the global source of truth for rules we are managing. It maps
+	// UUID to the rule copy.
+	allRules map[string]*api.Rule
+
+	// cache is a private copy of the pointer from config.
+	cache *DNSCache
+}
+
+// NewRuleGen creates an initialized RuleGen.
+// When config.Cache is nil, the global fqdn.DefaultDNSCache is used.
+func NewRuleGen(config Config) *RuleGen {
+
+	if config.Cache == nil {
+		config.Cache = DefaultDNSCache
+	}
+
+	if config.AddGeneratedRules == nil {
+		config.AddGeneratedRules = func(generatedRules []*api.Rule) error { return nil }
+	}
+
+	return &RuleGen{
+		config:      config,
+		IPs:         make(map[string][]net.IP),
+		sourceRules: make(map[string]map[string]struct{}),
+		allRules:    make(map[string]*api.Rule),
+		cache:       config.Cache,
+	}
+}
+
+// MarkToFQDNRules adds a tracking label to rules that contain ToFQDN sections.
+// The label is used to ensure that the ToFQDN rules are replaced correctly
+// when they are regenerated with IPs. It will also include the generated IPs
+// (in the ToCIDRSet) section for DNS names already present in the cache.
+// NOTE: It edits the rules in-place
+func (gen *RuleGen) MarkToFQDNRules(sourceRules []*api.Rule) {
+	gen.Lock()
+	defer gen.Unlock()
+
+perRule:
+	for _, sourceRule := range sourceRules {
+		// This rule has already been seen, and has a UUID label OR it has no
+		// ToFQDN rules. Do no more processing on it.
+		// Note: this label can only come from us. An external rule add or replace
+		// would lack the UUID-tagged rule and we would add a new UUID label in
+		// this function. Cleanup for existing rules with UUIDs is handled in
+		// StopManageDNSName
+		if !hasToFQDN(sourceRule) || sourceRule.Labels.Has(uuidLabelSearchKey) {
+			continue perRule
+		}
+
+		// add a unique ID that we can use later to replace this rule.
+		uuidLabel := generateUUIDLabel()
+		sourceRule.Labels = append(sourceRule.Labels, uuidLabel)
+
+		// Inject initial IPs in this rule, best effort from the cache
+		injectToCIDRSetRules(sourceRule, gen.IPs)
+	}
+}
+
+// StartManageDNSName begins managing sourceRules that contain toFQDNs
+// sections. When the DNS data of the included matchNames changes, RuleGen will
+// emit a replacement rule that contains the IPs for each matchName.
+// It only adds rules with the ToFQDN-UUID label, added by MarkToFQDNRules, and
+// repeat inserts are effectively no-ops.
+func (gen *RuleGen) StartManageDNSName(sourceRules []*api.Rule) {
+	gen.Lock()
+	defer gen.Unlock()
+
+perRule:
+	for _, sourceRule := range sourceRules {
+		// Note: we rely on MarkToFQDNRules to insert this label.
+		if !sourceRule.Labels.Has(uuidLabelSearchKey) {
+			continue perRule
+		}
+
+		// Make a copy to avoid breaking the input rules. Strip ToCIDRSet to avoid
+		// re-including IPs we optimistically inserted in MarkToFQDNRules
+		sourceRuleCopy := sourceRule.DeepCopy()
+		stripToCIDRSet(sourceRuleCopy)
+
+		uuid := getRuleUUIDLabel(sourceRuleCopy)
+		newDNSNames, alreadyExistsDNSNames := gen.addRule(uuid, sourceRuleCopy)
+		// only debug print for new names since this function is called
+		// unconditionally, even when we insert generated rules (which aren't new)
+		if len(newDNSNames) > 0 {
+			log.WithFields(logrus.Fields{
+				"newDNSNames":           newDNSNames,
+				"alreadyExistsDNSNames": alreadyExistsDNSNames,
+				"numRules":              len(sourceRules),
+			}).Debug("Added FQDN to managed list")
+		}
+	}
+}
+
+// StopManageDNSName runs the bookkeeping to remove each api.Rule from
+// corresponding dnsName entries in sourceRules and IPs. When no more rules
+// rely on a specific dnsName, we remove it from the maps and stop returning it
+// from GetDNSNames, or emitting it when regenerating rules. Only rules
+// labelled with a ToFQDN-UUID label are processed (added by MarkToFQDNRules).
+// Note: rule deletion in policy.Repository is by label, where the rules must
+// have at least the labels in the delete. This means our ToFQDN-UUID label,
+// and later ToCIDRSet additions will also be deleted correctly, and no action
+// is needed here to remove rules we generated.
+func (gen *RuleGen) StopManageDNSName(sourceRules []*api.Rule) {
+	gen.Lock()
+	defer gen.Unlock()
+
+	for _, sourceRule := range sourceRules {
+		// skip unmarked rules, nothing to do
+		if !sourceRule.Labels.Has(uuidLabelSearchKey) {
+			continue
+		}
+
+		uuid := getRuleUUIDLabel(sourceRule)
+		noLongerManagedDNSNames := gen.removeRule(uuid, sourceRule)
+		log.WithFields(logrus.Fields{
+			"noLongerManaged": noLongerManagedDNSNames,
+		}).Debug("Removed FQDN from managed list")
+	}
+}
+
+// GetDNSNames returns a snapshot of the DNS names managed by this RuleGen
+func (gen *RuleGen) GetDNSNames() (dnsNames []string) {
+	gen.Lock()
+	defer gen.Unlock()
+
+	for name := range gen.IPs {
+		dnsNames = append(dnsNames, name)
+	}
+
+	return dnsNames
+}
+
+// UpdateGenerateDNS inserts the new DNS information into the cache. If the IPs
+// have changed for a name, store which rules must be updated in rulesToUpdate,
+// regenerate them, and emit via AddGeneratedRules.
+func (gen *RuleGen) UpdateGenerateDNS(lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) error {
+	// Update IPs in gen
+	uuidsToUpdate, updatedDNSNames := gen.UpdateDNSIPs(lookupTime, updatedDNSIPs)
+	for dnsName, IPs := range updatedDNSNames {
+		log.WithFields(logrus.Fields{
+			"matchName":     dnsName,
+			"IPs":           IPs,
+			"uuidsToUpdate": uuidsToUpdate,
+		}).Debug("Updated FQDN with new IPs")
+	}
+
+	// Generate a new rule for each sourceRule that needs an update.
+	rulesToUpdate, notFoundUUIDs := gen.GetRulesByUUID(uuidsToUpdate)
+	if len(notFoundUUIDs) != 0 {
+		log.WithField("uuid", strings.Join(notFoundUUIDs, ",")).
+			Debug("Did not find all rules during update")
+	}
+	generatedRules, namesMissingIPs := gen.GenerateRulesFromSources(rulesToUpdate)
+	if len(namesMissingIPs) != 0 {
+		log.WithField(logfields.DNSName, strings.Join(namesMissingIPs, ",")).
+			Warn("Missing IPs for ToFQDN rule")
+	}
+
+	// no new rules to add, do not call AddGeneratedRules below
+	if len(generatedRules) == 0 {
+		return nil
+	}
+
+	// emit the new rules
+	return gen.config.AddGeneratedRules(generatedRules)
+}
+
+// UpdateDNSIPs updates the IPs for each DNS name in updatedDNSIPs.
+// It returns:
+// affectedRules: a list of rule UUIDs that were affected by the new IPs (lookup in .allRules)
+// updatedNames: a map of DNS names to all the valid IPs we store for each.
+func (gen *RuleGen) UpdateDNSIPs(lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (affectedRules []string, updatedNames map[string][]net.IP) {
+	updatedNames = make(map[string][]net.IP, len(updatedDNSIPs))
+	affectedRulesSet := make(map[string]struct{}, len(updatedDNSIPs))
+
+	gen.Lock()
+	defer gen.Unlock()
+
+perDNSName:
+	for dnsName, lookupIPs := range updatedDNSIPs {
+		updated := gen.updateIPsForName(lookupTime, dnsName, lookupIPs.IPs, lookupIPs.TTL)
+
+		// The IPs didn't change. No more to be done for this dnsName
+		if !updated {
+			continue perDNSName
+		}
+
+		// record the IPs that were different
+		updatedNames[dnsName] = lookupIPs.IPs
+
+		// accumulate the rules affected by new IPs, that we need to update with
+		// CIDR rules
+		for uuid := range gen.sourceRules[dnsName] {
+			affectedRulesSet[uuid] = struct{}{}
+		}
+	}
+
+	// Convert the set to a list
+	for uuid := range affectedRulesSet {
+		affectedRules = append(affectedRules, uuid)
+	}
+
+	return affectedRules, updatedNames
+}
+
+// GetRulesByUUID returns the sourceRule copies of inserted rules. These are
+// the source of truth when generating rules with update IPs.
+// sourceRules is the list of *api.Rule objects that were found (i.e. currently
+// in the gen and not deleted)
+// notFoundUUIDs is the set of UUIDs not found. This can occur when a delete
+// races with other operations. It is benign in the sense that if a rule UUID is
+// not found, no action further action is needed.
+func (gen *RuleGen) GetRulesByUUID(uuids []string) (sourceRules []*api.Rule, notFoundUUIDs []string) {
+	gen.Lock()
+	defer gen.Unlock()
+
+	for _, uuid := range uuids {
+		rule, ok := gen.allRules[uuid]
+		// This may happen if a rule was deleted during, other processing, like the DNS lookups
+		if !ok {
+			notFoundUUIDs = append(notFoundUUIDs, uuid)
+			continue
+		}
+
+		sourceRules = append(sourceRules, rule)
+	}
+
+	return sourceRules, notFoundUUIDs
+}
+
+// GenerateRulesFromSources creates new api.Rule instances with all ToFQDN
+// targets resolved to IPs. The IPs are in generated CIDRSet rules in the
+// ToCIDRSet section. Pre-existing rules in ToCIDRSet are preserved
+// Note: GenerateRulesFromSources will make a copy of each sourceRule
+func (gen *RuleGen) GenerateRulesFromSources(sourceRules []*api.Rule) (generatedRules []*api.Rule, namesMissingIPs []string) {
+	gen.Lock()
+	defer gen.Unlock()
+
+	var namesMissingMap = make(map[string]struct{})
+
+	for _, sourceRule := range sourceRules {
+		newRule := sourceRule.DeepCopy()
+		namesMissingIPs := injectToCIDRSetRules(newRule, gen.IPs)
+		for _, missing := range namesMissingIPs {
+			namesMissingMap[missing] = struct{}{}
+		}
+
+		generatedRules = append(generatedRules, newRule)
+	}
+
+	for missing := range namesMissingMap {
+		namesMissingIPs = append(namesMissingIPs, missing)
+	}
+	return generatedRules, namesMissingIPs
+}
+
+// addRule places an api.Rule in the source list for a DNS name.
+// uuid must be the unique identifier generated for the ToFQDN-UUID label.
+// newDNSNames and oldDNSNames indicate names that were newly added from this
+// rule, or that were seen in this rule but were already managed.
+// If newDNSNames and oldDNSNames are both empty, the rule was not added to the
+// managed list.
+func (gen *RuleGen) addRule(uuid string, sourceRule *api.Rule) (newDNSNames, oldDNSNames []string) {
+	// if we are updating a rule, track which old dnsNames are removed. We store
+	// possible names to stop managing in namesToStopManaging. As we add names
+	// from the new rule below, these are cleared.
+	namesToStopManaging := make(map[string]struct{})
+	if oldRule, exists := gen.allRules[uuid]; exists {
+		for _, egressRule := range oldRule.Egress {
+			for _, ToFQDN := range egressRule.ToFQDNs {
+				matchName := dns.Fqdn(ToFQDN.MatchName)
+				namesToStopManaging[matchName] = struct{}{}
+			}
+		}
+	}
+
+	// Always add to allRules
+	gen.allRules[uuid] = sourceRule
+
+	// Add a dnsname -> rule reference
+	for _, egressRule := range sourceRule.Egress {
+		for _, ToFQDN := range egressRule.ToFQDNs {
+			dnsName := dns.Fqdn(ToFQDN.MatchName)
+
+			delete(namesToStopManaging, dnsName)
+
+			dnsNameAlreadyExists := gen.ensureExists(dnsName)
+			if dnsNameAlreadyExists {
+				oldDNSNames = append(oldDNSNames, dnsName)
+			} else {
+				newDNSNames = append(newDNSNames, dnsName)
+				// Add this egress rule as a dependent on dnsName.
+				gen.sourceRules[dnsName][uuid] = struct{}{}
+			}
+		}
+	}
+
+	// Stop managing names that were not re-added by deleting them from the IP
+	// map Remove references to the uuid that were present in the old rule but
+	// not re-added by the new one. This may result in no longer managing the
+	// dnsName, if no other rules depend on this dnsName
+	for dnsName := range namesToStopManaging {
+		if shouldStopManaging := gen.removeFromDNSName(dnsName, uuid); shouldStopManaging {
+			delete(gen.IPs, dnsName)
+		}
+	}
+
+	return newDNSNames, oldDNSNames
+}
+
+// removeRule removes an api.Rule from the source rule set for each DNS name,
+// and from the IPs if no rules depend on that DNS name.
+// uuid must be a unique identifier for the sourceRule
+// noLongerManaged indicates that no more rules rely on this DNS target
+func (gen *RuleGen) removeRule(uuid string, sourceRule *api.Rule) (noLongerManaged []string) {
+	// Always delete from allRules
+	delete(gen.allRules, uuid)
+
+	// Delete dnsname -> rule references
+	for _, egressRule := range sourceRule.Egress {
+		for _, ToFQDN := range egressRule.ToFQDNs {
+			dnsName := dns.Fqdn(ToFQDN.MatchName)
+
+			if shouldStopManaging := gen.removeFromDNSName(dnsName, uuid); shouldStopManaging {
+				delete(gen.IPs, dnsName) // also delete from the IP map, no longer managed
+				noLongerManaged = append(noLongerManaged, dnsName)
+			}
+		}
+	}
+
+	return noLongerManaged
+}
+
+// removeFromDNSName removes the uuid from the list attached to a dns name. It
+// will clean up gen.sourceRules if needed.
+// shouldStopManaging indicates that no more rules rely on this DNS target
+func (gen *RuleGen) removeFromDNSName(dnsName, uuid string) (shouldStopManaging bool) {
+	// remove the rule from the set of rules that rely on dnsName.
+	// Note: this isn't removing dnsName from gen.sourceRules, that is just
+	// below.
+	delete(gen.sourceRules[dnsName], uuid)
+
+	// Check if any rules remain that rely on this dnsName by checking
+	// if the inner map[rule uuid]struct{} set is empty. If none, we
+	// can delete it so we no longer manage it.
+	isEmpty := len(gen.sourceRules[dnsName]) == 0
+	if isEmpty {
+		shouldStopManaging = true
+		delete(gen.sourceRules, dnsName)
+	}
+
+	return shouldStopManaging
+}
+
+// ensureExists ensures that we have allocated objects for dnsName, and creates
+// them if needed.
+func (gen *RuleGen) ensureExists(dnsName string) (exists bool) {
+	_, exists = gen.IPs[dnsName]
+	if !exists {
+		gen.IPs[dnsName] = make([]net.IP, 0)
+		gen.sourceRules[dnsName] = make(map[string]struct{})
+	}
+
+	return exists
+}
+
+// updateIPsName will update the IPs for dnsName. It always retains a copy of
+// newIPs.
+// updated is true when the new IPs differ from the old IPs
+func (gen *RuleGen) updateIPsForName(lookupTime time.Time, dnsName string, newIPs []net.IP, ttl int) (updated bool) {
+	oldIPs := gen.IPs[dnsName]
+
+	if gen.config.MinTTL > ttl {
+		ttl = gen.config.MinTTL
+	}
+
+	// TODO: when gen can get the TTLs of DNS responses, apply min(ttl, gen.config.MinTTL)
+	gen.cache.Update(lookupTime, dnsName, newIPs, ttl)
+	sortedNewIPs := gen.cache.Lookup(dnsName) // DNSCache returns IPs sorted
+
+	// store the new IPs, sorted (to help with the updated determination below)
+	gen.IPs[dnsName] = sortedNewIPs
+
+	return !sortedIPsAreEqual(sortedNewIPs, oldIPs)
+}

--- a/pkg/fqdn/rulegen_test.go
+++ b/pkg/fqdn/rulegen_test.go
@@ -1,0 +1,280 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package fqdn
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/miekg/dns"
+
+	. "gopkg.in/check.v1"
+)
+
+// force a fail if something calls this function
+func lookupFail(c *C, dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
+	c.Error("Lookup function called when it should not")
+	return nil, nil
+}
+
+// TestRuleGenCIDRGeneration tests rule generation output:
+// add a rule, get correct IP4/6 in ToCIDRSet
+// add a rule, lookup twice, get correct IP4/6 in TOCIDRSet after change
+// add a rule w/ToCIDRSet, get correct IP4/6 and old rules
+// add a rule, get same UUID label on repeat generations
+func (ds *FQDNTestSuite) TestRuleGenCIDRGeneration(c *C) {
+	var (
+		generatedRules = make([]*api.Rule, 0)
+
+		gen = NewRuleGen(Config{
+			MinTTL: 1,
+			Cache:  NewDNSCache(),
+
+			LookupDNSNames: func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
+				return lookupFail(c, dnsNames)
+			},
+
+			AddGeneratedRules: func(rules []*api.Rule) error {
+				generatedRules = append(generatedRules, rules...)
+				return nil
+			},
+		})
+	)
+
+	// add rules
+	rulesToAdd := []*api.Rule{rule1.DeepCopy()}
+	gen.MarkToFQDNRules(rulesToAdd)
+	gen.StartManageDNSName(rulesToAdd)
+
+	// store original UUID
+	uuidOrig := getRuleUUIDLabel(rulesToAdd[0])
+	c.Assert(uuidOrig, Not(Equals), "", Commentf("UUID label not set on rule, or not recovered correctly"))
+
+	// poll DNS once, check that we only generate 1 rule (for 1 IP) and that we
+	// still have 1 ToFQDN rule, and that the IP is correct
+	generatedRules = nil
+	err := gen.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
+	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
+	c.Assert(len(generatedRules), Equals, 1, Commentf("Incorrect number of generated rules for testCase with single ToFQDNs entry"))
+	c.Assert(len(generatedRules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single ToFQDNs entry"))
+	c.Assert(len(generatedRules[0].Egress[0].ToFQDNs), Equals, len(generatedRules[0].Egress[0].ToCIDRSet), Commentf("Generated CIDR count is not the same as ToFQDNs"))
+	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
+
+	// Check that the UUID has not changed
+	uuid1 := getRuleUUIDLabel(generatedRules[0])
+	c.Assert(uuid1, Equals, uuidOrig, Commentf("UUID label has changed on rule since original insert"))
+
+	// poll DNS once, check that we only generate 1 rule (for 2 IPs that we
+	// inserted) and that we still have 1 ToFQDN rule, and that the IP, now
+	// different, is correct
+	generatedRules = nil
+	err = gen.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}}})
+	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
+	c.Assert(len(generatedRules), Equals, 1, Commentf("More than 1 generated rule for testCase with single ToFQDNs entry"))
+	c.Assert(len(generatedRules[0].Egress), Equals, 1, Commentf("More than 1 generated rule for testCase with single ToFQDNs entry"))
+	c.Assert(len(generatedRules[0].Egress[0].ToFQDNs), Equals, 1, Commentf("toFQDNs rule count changed when it should not"))
+	c.Assert(len(generatedRules[0].Egress[0].ToCIDRSet), Equals, 2, Commentf("Generated CIDR count is not the same as inserted IPs"))
+	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
+	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[1].Cidr, Equals, api.CIDR("2.2.2.2/32"), Commentf("Incorrect IP CIDR generated"))
+
+	// check that the UUID has not changed
+	uuid2 := getRuleUUIDLabel(generatedRules[0])
+	c.Assert(uuid2, Equals, uuidOrig, Commentf("UUID label has changed on rule since original insert"))
+	c.Assert(uuid2, Equals, uuid1, Commentf("UUID label has changed on rule since previous generation"))
+}
+
+// TestRuleGenDropCIDROnReinsert tests that we correctly guard against
+// pre-existing toCIDRSet sections:
+// - when we initially insert
+// - when we re-insert a generated rule
+func (ds *FQDNTestSuite) TestRuleGenDropCIDROnReinsert(c *C) {
+	var (
+		generatedRules = make([]*api.Rule, 0)
+
+		gen = NewRuleGen(Config{
+			LookupDNSNames: func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
+				return lookupFail(c, dnsNames)
+			},
+
+			AddGeneratedRules: func(rules []*api.Rule) error {
+				generatedRules = append(generatedRules, rules...)
+				return nil
+			},
+		})
+	)
+
+	// Add a fake "generated" CIDR entry, it should not come back later when generated
+	rulesToAdd := []*api.Rule{rule1.DeepCopy()}
+	gen.MarkToFQDNRules(rulesToAdd)
+	rulesToAdd[0].Egress[0].ToCIDRSet = append(rulesToAdd[0].Egress[0].ToCIDRSet, api.CIDRRule{Cidr: api.CIDR("2.2.2.2/32")})
+	gen.StartManageDNSName(rulesToAdd)
+	err := gen.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
+	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
+	c.Assert(len(generatedRules), Equals, 1, Commentf("Generated an unexpected number of rules"))
+	c.Assert(len(rulesToAdd[0].Egress[0].ToCIDRSet), Equals, 1, Commentf("existing toCIDRSet section not stripped by GenerateRules"))
+	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
+}
+
+// Test that all IPs are updated when one is
+func (ds *FQDNTestSuite) TestRuleGenMultiIPUpdate(c *C) {
+	var (
+		generatedRules = make([]*api.Rule, 0)
+
+		gen = NewRuleGen(Config{
+			MinTTL: 1,
+			Cache:  NewDNSCache(),
+
+			LookupDNSNames: func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
+				return lookupFail(c, dnsNames)
+			},
+
+			AddGeneratedRules: func(rules []*api.Rule) error {
+				generatedRules = append(generatedRules, rules...)
+				return nil
+			},
+		})
+	)
+
+	// add rules
+	rulesToAdd := []*api.Rule{rule3.DeepCopy()}
+	gen.MarkToFQDNRules(rulesToAdd)
+	gen.StartManageDNSName(rulesToAdd)
+
+	// poll DNS once, check that we only generate 1 IP for cilium.io
+	generatedRules = nil
+	err := gen.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
+	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
+	c.Assert(len(generatedRules), Equals, 1, Commentf("Incorrect number of generated rules for testCase with single ToFQDNs entry"))
+	c.Assert(len(generatedRules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single ToFQDNs entry"))
+	c.Assert(len(generatedRules[0].Egress[0].ToCIDRSet), Equals, 1, Commentf("Generated CIDR count is not the same as ToFQDNs"))
+	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
+
+	// poll DNS once, check that we only generate 3 IPs, 2 cached from before and 1 new one for github.com
+	generatedRules = nil
+	err = gen.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{
+		dns.Fqdn("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
+		dns.Fqdn("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("3.3.3.3")}}})
+	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
+	c.Assert(len(generatedRules), Equals, 1, Commentf("More than 1 generated rule for testCase with single ToFQDNs entry"))
+	c.Assert(len(generatedRules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single ToFQDNs entry"))
+	c.Assert(len(generatedRules[0].Egress[0].ToCIDRSet), Equals, 3, Commentf("Generated CIDR count is not the same as ToFQDNs"))
+	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
+	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[1].Cidr, Equals, api.CIDR("2.2.2.2/32"), Commentf("Incorrect IP CIDR generated"))
+	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[2].Cidr, Equals, api.CIDR("3.3.3.3/32"), Commentf("Incorrect IP CIDR generated"))
+
+	// poll DNS once, check that we only generate 4 IPs, 2 cilium.io cached IPs, 1 cached gituhub.com IP, 1 new github.com IP
+	generatedRules = nil
+	err = gen.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{
+		dns.Fqdn("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
+		dns.Fqdn("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("4.4.4.4")}}})
+	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
+	c.Assert(len(generatedRules), Equals, 1, Commentf("More than 1 generated rule for testCase with single ToFQDNs entry"))
+	c.Assert(len(generatedRules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single ToFQDNs entry"))
+	c.Assert(len(generatedRules[0].Egress[0].ToCIDRSet), Equals, 4, Commentf("Generated CIDR count is not the same as ToFQDNs"))
+	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
+	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[1].Cidr, Equals, api.CIDR("2.2.2.2/32"), Commentf("Incorrect IP CIDR generated"))
+	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[2].Cidr, Equals, api.CIDR("3.3.3.3/32"), Commentf("Incorrect IP CIDR generated"))
+	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[3].Cidr, Equals, api.CIDR("4.4.4.4/32"), Commentf("Incorrect IP CIDR generated"))
+}
+
+// TestRuleGenUpdatesOnReplace tests updates without deletion:
+// add 1 matchname, poll. re-add it. See the correct output on MarkToFQDNRules
+// add 2 matchnames with the different names, replace one, then back. See the correct output on MarkToFQDNRules
+// re-add the original rule with only 1 matchname. It is not cached because that name was deleted
+func (ds *FQDNTestSuite) TestRuleGenUpdatesOnReplace(c *C) {
+
+	var (
+		lookups = make(map[string]int)
+		dnsIPs  = map[string]*DNSIPRecords{
+			dns.Fqdn("cilium.io"):         {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}},
+			dns.Fqdn("github.com"):        {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
+			dns.Fqdn("anotherdomain.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("3.3.3.3")}},
+		}
+
+		gen = NewRuleGen(Config{
+			MinTTL: 1,
+			Cache:  NewDNSCache(),
+
+			LookupDNSNames: func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
+				return lookupFail(c, dnsNames)
+			},
+
+			AddGeneratedRules: func(rules []*api.Rule) error {
+				return nil
+			},
+		})
+	)
+
+	// Add 1 rules and poll
+	rules := []*api.Rule{makeRule("testRule", "cilium.io")}
+	// MarkToFQDNRules adds nothing on the first try
+	gen.MarkToFQDNRules(rules)
+	c.Assert(len(rules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single ToFQDNs entry"))
+	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 0, Commentf("Generated CIDR count is 0 when no CIDRs should have been added"))
+
+	gen.StartManageDNSName(rules)
+	gen.UpdateGenerateDNS(time.Now(), lookupDNSNames(dnsIPs, lookups, []string{dns.Fqdn("cilium.io")}))
+
+	// Add another rule with the same FQDN. We should see IPs in-place BEFORE StartManageDNSName.
+	// MarkToFQDNRules adds the IP from the cache
+	rules = []*api.Rule{makeRule("testRule2", "cilium.io")}
+	gen.MarkToFQDNRules(rules)
+	c.Assert(len(rules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single ToFQDNs entry"))
+	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 1, Commentf("Generated CIDR count is not the same as ToFQDNs"))
+	c.Assert(rules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
+
+	gen.StartManageDNSName(rules)
+	gen.UpdateGenerateDNS(time.Now(), lookupDNSNames(dnsIPs, lookups, []string{dns.Fqdn("cilium.io")}))
+
+	// Add 2 rules and poll
+	rules = []*api.Rule{makeRule("testRule3", "cilium.io", "github.com")}
+	gen.MarkToFQDNRules(rules)
+	gen.StartManageDNSName(rules)
+	gen.UpdateGenerateDNS(time.Now(), lookupDNSNames(dnsIPs, lookups, []string{dns.Fqdn("cilium.io"), dns.Fqdn("github.com")}))
+
+	// Add a 2 matchnames, only one overlaps
+	// MarkToFQDNRules should add only 1 entry
+	rules = []*api.Rule{makeRule("testRule4", "cilium.io", "anotherdomain.com")}
+	gen.MarkToFQDNRules(rules)
+	c.Assert(len(rules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single cached ToFQDNs DNS entry"))
+	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 1, Commentf("Generated CIDR count is not the same as ToFQDNs DNS entries in cache"))
+	c.Assert(rules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
+
+	gen.StartManageDNSName(rules)
+	gen.UpdateGenerateDNS(time.Now(), lookupDNSNames(dnsIPs, lookups, []string{dns.Fqdn("cilium.io"), dns.Fqdn("anotherdomain.com")}))
+
+	fmt.Printf("%#v\n", gen.IPs)
+	// Add the original 2 matchnames without deleting
+	// MarkToFQDNRules should add 2 entries, as those should be in the gen cache
+	rules = []*api.Rule{makeRule("testRule5", "cilium.io", "github.com")}
+	gen.MarkToFQDNRules(rules)
+	c.Assert(len(rules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single cached ToFQDNs DNS entry"))
+	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 2, Commentf("Generated CIDR count is not the same as ToFQDNs DNS entries in cache"))
+	c.Assert(rules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect first IP CIDR generated from cache"))
+
+	gen.StartManageDNSName(rules)
+	gen.UpdateGenerateDNS(time.Now(), lookupDNSNames(dnsIPs, lookups, []string{dns.Fqdn("cilium.io"), dns.Fqdn("github.com")}))
+
+	// Add a rule with 1 old matchname
+	// MarkToFQDNRules should add one entry
+	rules = []*api.Rule{makeRule("testRule6", "anotherdomain.com")}
+	gen.MarkToFQDNRules(rules)
+	c.Assert(len(rules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single cached ToFQDNs DNS entry"))
+	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 1, Commentf("Generated CIDR count is not the same as ToFQDNs DNS entries in cache"))
+}

--- a/pkg/fqdn/util_test.go
+++ b/pkg/fqdn/util_test.go
@@ -1,0 +1,116 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package fqdn
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/miekg/dns"
+)
+
+var (
+	// cilium.io dns target, no rule name => no rule labels
+	rule1 = makeRule("", "cilium.io")
+
+	// cilium.io dns target, no rule name => no rule labels
+	rule2 = makeRule("", "cilium.io")
+
+	// cilium.io, github.com dns targets
+	rule3 = makeRule("rule3", "cilium.io", "github.com")
+
+	// github.com dns target
+	rule4 = makeRule("rule4", "github.com")
+
+	ipLookups = map[string]*DNSIPRecords{
+		dns.Fqdn("cilium.io"): {
+			TTL: 60,
+			IPs: []net.IP{
+				net.ParseIP("172.217.18.174"),
+				net.ParseIP("2a00:1450:4001:811::200e")}},
+		dns.Fqdn("github.com"): {
+			TTL: 60,
+			IPs: []net.IP{
+				net.ParseIP("98.138.219.231"),
+				net.ParseIP("72.30.35.10"),
+				net.ParseIP("001:4998:c:1023::4"),
+				net.ParseIP("001:4998:58:1836::10")}},
+	}
+)
+
+func makeRule(key string, dnsNames ...string) *api.Rule {
+	matchNames := []string{}
+	for _, name := range dnsNames {
+		matchNames = append(matchNames,
+			fmt.Sprintf(`{"matchName": "%s"}`, dns.Fqdn(name)))
+	}
+
+	rule := `{`
+	if key != "" {
+		rule += fmt.Sprintf(`"labels": [{ "key": "%s" }],`, key)
+	}
+	rule += fmt.Sprintf(`"endpointSelector": {
+    "matchLabels": {
+      "class": "xwing"
+    }
+  },
+  "egress": [
+    {
+      "toFQDNs": [
+      %s
+      ]
+    }
+  ]
+}`, strings.Join(matchNames, ",\n"))
+	//fmt.Print(rule)
+	return mustParseRule(rule)
+}
+
+func parseRule(rule string) (parsedRule *api.Rule, err error) {
+	if err := json.Unmarshal([]byte(rule), &parsedRule); err != nil {
+		return nil, err
+	}
+
+	if err := parsedRule.Sanitize(); err != nil {
+		return nil, err
+	}
+
+	return parsedRule, nil
+}
+
+func mustParseRule(rule string) (parsedRule *api.Rule) {
+	parsedRule, err := parseRule(rule)
+	if err != nil {
+		panic(fmt.Sprintf("Error parsing FQDN test rules: %s", err))
+	}
+	return parsedRule
+}
+
+// LookupDNSNames is a wrappable dummy used by the tests. It counts the number
+// of times a name is looked up in lookups, and uses ipData as a source for the
+// "response"
+func lookupDNSNames(ipData map[string]*DNSIPRecords, lookups map[string]int, dnsNames []string) (DNSIPs map[string]*DNSIPRecords) {
+	DNSIPs = make(map[string]*DNSIPRecords)
+	for _, dnsName := range dnsNames {
+		lookups[dnsName] += 1
+		DNSIPs[dnsName] = ipData[dnsName]
+	}
+	return DNSIPs
+}


### PR DESCRIPTION
The DNSPoller does two things: poll DNS and generate rules when they change. Most of the code and complexity is in the generation and we will soon have sources of DNS data that aren't from a DNS poll. We might also end up with a more generic scheme to generate rules that isn't specific to the fqdn package, and this makes it clearer what component would be replaced.

There is no change in functionality but note that `DNSPoller.LookupUpdateDNS` is now split into `.LookupUpdateDNS` and `.UpdateGenerateDNS` (the first commit in this PR). This meant that some tests were changed but they now update the DNS data directly instead of doing a lookup as the poller tests still do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6030)
<!-- Reviewable:end -->
