### PR TITLE
pkg/fqdn: make any operation in the sourceRuleCopy

### DIFF
--- a/pkg/fqdn/dnspoller.go
+++ b/pkg/fqdn/dnspoller.go
@@ -209,7 +209,7 @@ perRule:
 		sourceRuleCopy := sourceRule.DeepCopy()
 		stripToCIDRSet(sourceRuleCopy)
 
-		uuid := getRuleUUIDLabel(sourceRule)
+		uuid := getRuleUUIDLabel(sourceRuleCopy)
 		newDNSNames, alreadyExistsDNSNames := poller.addRule(uuid, sourceRuleCopy)
 		// only debug print for new names, since this function is called
 		// unconditionally, even when we insert generated rules (which aren't new)


### PR DESCRIPTION
This will avoid problems that might happen in the future where the
function getRuleUUIDLabel can be changed and modify the rule without we
realizing it.

Fixes: 92243feb5df4 ("policy: Support ToFQDN rules via DNS poller")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6034)
<!-- Reviewable:end -->
