### PR TITLE
test/k8sT: add common helper which ensures DNS, etcd, Cilium are deployed

### DIFF
--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -34,20 +34,7 @@ var _ = Describe("K8sChaosTest", func() {
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-
-		_ = kubectl.Apply(helpers.DNSDeployment())
-
-		// Deploy the etcd operator
-		By("Deploying etcd-operator")
-		err := kubectl.DeployETCDOperator()
-		Expect(err).To(BeNil(), "Unable to deploy etcd operator")
-
-		err = kubectl.CiliumInstall(helpers.CiliumDefaultDSPatch, helpers.CiliumConfigMapPatch)
-		Expect(err).To(BeNil(), "Cilium cannot be installed")
-
-		ExpectCiliumReady(kubectl)
-		ExpectKubeDNSReady(kubectl)
-		ExpectETCDOperatorReady(kubectl)
+		ProvisionInfraPods(kubectl)
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -31,18 +31,7 @@ var _ = Describe("K8sHealthTest", func() {
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-
-		_ = kubectl.Apply(helpers.DNSDeployment())
-
-		// Deploy the etcd operator
-		err := kubectl.DeployETCDOperator()
-		Expect(err).To(BeNil(), "Unable to deploy etcd operator")
-
-		err = kubectl.CiliumInstall(helpers.CiliumDefaultDSPatch, helpers.CiliumConfigMapPatch)
-		Expect(err).To(BeNil(), "Cilium cannot be installed")
-
-		ExpectCiliumReady(kubectl)
-		ExpectETCDOperatorReady(kubectl)
+		ProvisionInfraPods(kubectl)
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -122,21 +122,10 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 
 		BeforeAll(func() {
 			kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-
-			_ = kubectl.Apply(helpers.DNSDeployment())
-
-			// Deploy the etcd operator
-			err := kubectl.DeployETCDOperator()
-			Expect(err).To(BeNil(), "Unable to deploy etcd operator")
-
-			err = kubectl.CiliumInstall(helpers.CiliumDefaultDSPatch, helpers.CiliumConfigMapPatch)
-			Expect(err).To(BeNil(), "Cilium cannot be installed")
-			ExpectCiliumReady(kubectl)
-			ExpectKubeDNSReady(kubectl)
-			ExpectETCDOperatorReady(kubectl)
+			ProvisionInfraPods(kubectl)
 
 			kubectl.Apply(demoPath)
-			err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=kafkaTestApp", helpers.HelperTimeout)
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=kafkaTestApp", helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Kafka Pods are not ready after timeout")
 
 			err = kubectl.WaitForKubeDNSEntry("kafka-service", helpers.DefaultNamespace)

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -48,19 +48,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-
-		_ = kubectl.Apply(helpers.DNSDeployment())
-
-		// Deploy the etcd operator
-		err := kubectl.DeployETCDOperator()
-		Expect(err).To(BeNil(), "Unable to deploy etcd operator")
-
-		err = kubectl.CiliumInstall(helpers.CiliumDefaultDSPatch, helpers.CiliumConfigMapPatch)
-		Expect(err).To(BeNil(), "Cilium cannot be installed")
-
-		ExpectCiliumReady(kubectl)
-		ExpectKubeDNSReady(kubectl)
-		ExpectETCDOperatorReady(kubectl)
+		ProvisionInfraPods(kubectl)
 	})
 	deleteAll := func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
@@ -402,18 +390,7 @@ var _ = Describe("NightlyExamples", func() {
 		)
 
 		BeforeAll(func() {
-			_ = kubectl.Apply(helpers.DNSDeployment())
-
-			// Deploy the etcd operator
-			err := kubectl.DeployETCDOperator()
-			Expect(err).To(BeNil(), "Unable to deploy etcd operator")
-
-			err = kubectl.CiliumInstall(helpers.CiliumDefaultDSPatch, helpers.CiliumConfigMapPatch)
-			Expect(err).To(BeNil(), "Cilium cannot be installed")
-
-			ExpectCiliumReady(kubectl)
-			ExpectKubeDNSReady(kubectl)
-			ExpectETCDOperatorReady(kubectl)
+			ProvisionInfraPods(kubectl)
 		})
 
 		AfterAll(func() {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -53,18 +53,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-		_ = kubectl.Apply(helpers.DNSDeployment())
-
-		// Deploy the etcd operator
-		err := kubectl.DeployETCDOperator()
-		Expect(err).To(BeNil(), "Unable to deploy etcd operator")
-
-		err = kubectl.CiliumInstall(helpers.CiliumDefaultDSPatch, helpers.CiliumConfigMapPatch)
-		Expect(err).To(BeNil(), "Cilium cannot be installed")
-
-		ExpectCiliumReady(kubectl)
-		ExpectKubeDNSReady(kubectl)
-		ExpectETCDOperatorReady(kubectl)
+		ProvisionInfraPods(kubectl)
 	})
 
 	AfterEach(func() {

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -31,18 +31,7 @@ var _ = Describe("NightlyPolicies", func() {
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-		_ = kubectl.Apply(helpers.DNSDeployment())
-
-		// Deploy the etcd operator
-		err := kubectl.DeployETCDOperator()
-		Expect(err).To(BeNil(), "Unable to deploy etcd operator")
-
-		err = kubectl.CiliumInstall(helpers.CiliumDefaultDSPatch, helpers.CiliumConfigMapPatch)
-		Expect(err).To(BeNil(), "Cilium cannot be installed")
-
-		ExpectCiliumReady(kubectl)
-		ExpectKubeDNSReady(kubectl)
-		ExpectETCDOperatorReady(kubectl)
+		ProvisionInfraPods(kubectl)
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -51,19 +51,7 @@ var _ = Describe("K8sServicesTest", func() {
 		var err error
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-		_ = kubectl.Apply(helpers.DNSDeployment())
-
-		// Deploy the etcd operator
-		err = kubectl.DeployETCDOperator()
-		Expect(err).To(BeNil(), "Unable to deploy etcd operator")
-
-		err = kubectl.CiliumInstall(helpers.CiliumDefaultDSPatch, helpers.CiliumConfigMapPatch)
-		Expect(err).To(BeNil(), "Cilium cannot be installed")
-
-		ExpectCiliumReady(kubectl)
-
-		ExpectKubeDNSReady(kubectl)
-		ExpectETCDOperatorReady(kubectl)
+		ProvisionInfraPods(kubectl)
 
 		ciliumPodK8s1, err = kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
 		Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -75,19 +75,8 @@ var _ = Describe("K8sTunnelTest", func() {
 		})
 
 		It("Check VXLAN mode", func() {
-			_ = kubectl.Apply(helpers.DNSDeployment())
-
-			// Deploy the etcd operator
-			err := kubectl.DeployETCDOperator()
-			Expect(err).To(BeNil(), "Unable to deploy etcd operator")
-
-			err = kubectl.CiliumInstall(helpers.CiliumDefaultDSPatch, helpers.CiliumConfigMapPatch)
-			Expect(err).To(BeNil(), "Cilium cannot be installed")
-
-			ExpectCiliumReady(kubectl)
-			ExpectETCDOperatorReady(kubectl)
-
-			err = kubectl.WaitforPods(helpers.DefaultNamespace, "", 300)
+			ProvisionInfraPods(kubectl)
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "", 300)
 			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 
 			ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -52,19 +52,7 @@ var _ = Describe("K8sDemosTest", func() {
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-
-		_ = kubectl.Apply(helpers.DNSDeployment())
-
-		// Deploy the etcd operator
-		err := kubectl.DeployETCDOperator()
-		Expect(err).To(BeNil(), "Unable to deploy etcd operator")
-
-		err = kubectl.CiliumInstall(helpers.CiliumDefaultDSPatch, helpers.CiliumConfigMapPatch)
-		Expect(err).To(BeNil(), "Cilium cannot be installed")
-
-		ExpectCiliumReady(kubectl)
-		ExpectKubeDNSReady(kubectl)
-		ExpectETCDOperatorReady(kubectl)
+		ProvisionInfraPods(kubectl)
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -81,18 +81,7 @@ var _ = Describe("K8sIstioTest", func() {
 		}
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-
-		_ = kubectl.Apply(helpers.DNSDeployment())
-
-		err := kubectl.DeployETCDOperator()
-		Expect(err).To(BeNil(), "Unable to deploy etcd operator")
-
-		err = kubectl.CiliumInstall(helpers.CiliumDefaultDSPatch, helpers.CiliumConfigMapPatch)
-		Expect(err).To(BeNil(), "Cilium cannot be installed")
-
-		ExpectCiliumReady(kubectl)
-		ExpectETCDOperatorReady(kubectl)
-		ExpectKubeDNSReady(kubectl)
+		ProvisionInfraPods(kubectl)
 
 		By("Creating the istio-system namespace")
 		res := kubectl.NamespaceCreate(istioSystemNamespace)
@@ -105,7 +94,7 @@ var _ = Describe("K8sIstioTest", func() {
 		// Ignore one-time jobs and Prometheus. All other pods in the
 		// namespaces have an "istio" label.
 		By("Waiting for Istio pods to be ready")
-		err = kubectl.WaitforPods(istioSystemNamespace, "-l istio", 300)
+		err := kubectl.WaitforPods(istioSystemNamespace, "-l istio", 300)
 		Expect(err).To(BeNil(),
 			"Istio pods are not ready after timeout in namespace %q", istioSystemNamespace)
 

--- a/test/k8sT/microscope.go
+++ b/test/k8sT/microscope.go
@@ -28,18 +28,7 @@ var _ = Describe("K8sMicroscope", func() {
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-
-		_ = kubectl.Apply(helpers.DNSDeployment())
-
-		// Deploy the etcd operator
-		err := kubectl.DeployETCDOperator()
-		Expect(err).To(BeNil(), "Unable to deploy etcd operator")
-
-		err = kubectl.CiliumInstall(helpers.CiliumDefaultDSPatch, helpers.CiliumConfigMapPatch)
-		Expect(err).To(BeNil(), "Cilium cannot be installed")
-
-		ExpectCiliumReady(kubectl)
-		ExpectETCDOperatorReady(kubectl)
+		ProvisionInfraPods(kubectl)
 	})
 
 	AfterFailed(func() {


### PR DESCRIPTION
The K8s tests have a lot of boilerplate code related to setting up DNS,
etcd-operator, and Cilium. Factor this out into a function which can be called
from almost all K8s tests.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6042)
<!-- Reviewable:end -->
