### PR TITLE
test: add new skipLogs option to CI

### DIFF
--- a/test/config/config.go
+++ b/test/config/config.go
@@ -18,11 +18,12 @@ import "flag"
 
 // CiliumTestConfigType holds all of the configurable elements of the testsuite
 type CiliumTestConfigType struct {
-	Reprovision     bool
-	HoldEnvironment bool
-	SSHConfig       string
-	ShowCommands    bool
-	TestScope       string
+	Reprovision      bool
+	HoldEnvironment  bool
+	SSHConfig        string
+	ShowCommands     bool
+	TestScope        string
+	SkipLogGathering bool
 }
 
 // CiliumTestConfig holds the global configuration of commandline flags
@@ -35,6 +36,8 @@ func (c *CiliumTestConfigType) ParseFlags() {
 		"Provision Vagrant boxes and Cilium before running test")
 	flag.BoolVar(&c.HoldEnvironment, "cilium.holdEnvironment", false,
 		"On failure, hold the environment in its current state")
+	flag.BoolVar(&c.SkipLogGathering, "cilium.skipLogs", false,
+		"skip gathering logs if a test fails")
 	flag.StringVar(&c.SSHConfig, "cilium.SSHConfig", "",
 		"Specify a custom command to fetch SSH configuration (eg: 'vagrant ssh-config')")
 	flag.BoolVar(&c.ShowCommands, "cilium.showCommands", false,

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -611,8 +611,8 @@ func (s *SSHMeta) PolicyWait(revisionNum int) *CmdRes {
 // ReportFailed gathers relevant Cilium runtime data and logs for debugging
 // purposes.
 func (s *SSHMeta) ReportFailed(commands ...string) {
-	if config.CiliumTestConfig.HoldEnvironment {
-		ginkgoext.GinkgoPrint("Skipped gathering logs (-cilium.holdEnvironment=true)\n")
+	if config.CiliumTestConfig.SkipLogGathering {
+		ginkgoext.GinkgoPrint("Skipped gathering logs (-cilium.skipLogs=true)\n")
 		return
 	}
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1291,8 +1291,8 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 // CiliumReport report the cilium pod to the log and appends the logs for the
 // given commands.
 func (kub *Kubectl) CiliumReport(namespace string, commands ...string) {
-	if config.CiliumTestConfig.HoldEnvironment {
-		ginkgoext.GinkgoPrint("Skipped gathering logs (-cilium.holdEnvironment=true)\n")
+	if config.CiliumTestConfig.SkipLogGathering {
+		ginkgoext.GinkgoPrint("Skipped gathering logs (-cilium.skipLogs=true)\n")
 		return
 	}
 	kub.CiliumCheckReport()


### PR DESCRIPTION
Before, log gathering was skipped if `-cilium.holdEnvironment=true`. Instead,
decouple log gathering from holding the environment for local debugging so that
if developers desire, they can still gather logs while keeping the local
environment preserved. This is useful in the case where the output from
`cilium monitor` wants to be introspected, as it can reveal transient behavior
in the datapath that is incorrect which is impossible to discover otherwise.

Signed-off by: Ian Vernon <ian@cilium.io>

@joestringer let me know if you are OK with this since you added the holdEnvironment functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6043)
<!-- Reviewable:end -->
