### PR TITLE
debugging tooling: run `cilium bpf policy get` in debuginfo and bugtool with `-n` option

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -222,7 +222,7 @@ func copyCiliumInfoCommands(cmdDir string, k8sPods []string) []string {
 		"cilium bpf ct list global",
 		"cilium bpf proxy list",
 		"cilium bpf ipcache list",
-		"cilium bpf policy get --all",
+		"cilium bpf policy get --all --numeric",
 		"cilium map list --verbose",
 		"cilium status --verbose",
 		"cilium identity list",

--- a/cilium/cmd/debuginfo.go
+++ b/cilium/cmd/debuginfo.go
@@ -164,7 +164,7 @@ func addCiliumEndpointList(w *tabwriter.Writer, p *models.DebugInfo) {
 
 	for _, ep := range p.EndpointList {
 		epID := strconv.FormatInt(ep.ID, 10)
-		printList(w, "BPF Policy Get "+epID, "bpf", "policy", "get", epID)
+		printList(w, "BPF Policy Get "+epID, "bpf", "policy", "get", epID, "-n")
 		printList(w, "BPF CT List "+epID, "bpf", "ct", "list", epID)
 		printList(w, "Endpoint Get "+epID, "endpoint", "get", epID)
 		printList(w, "Endpoint Health "+epID, "endpoint", "health", epID)


### PR DESCRIPTION
debuginfo: get numeric identities in policymap output

This makes searching the PolicyMap for a given identity much easier than having to map labels to numeric identity. The numeric identities can be compared to the output of \`cilium identity list\` if needed.

bugtool: get all identities in policy maps by numeric identity

The non-numeric output is hard to parse, and the numeric output is much more concise.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6045)
<!-- Reviewable:end -->
