### PR TITLE
Test: Enable a custom tmp folder for etcd certs.

### DIFF
--- a/examples/kubernetes/addons/etcd-operator/tls/deploy-certs.sh
+++ b/examples/kubernetes/addons/etcd-operator/tls/deploy-certs.sh
@@ -2,7 +2,13 @@
 
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-cd "${dir}/certs"
+CERT_TMP_DIR=${1:-"${dir}/certs"}
+
+if [ -z "${1}" ]; then
+    echo "DEBUG: Using provided folder ${CERT_TMP_DIR}"
+fi
+
+cd "${CERT_TMP_DIR}"
 
 # member.peerSecret
 kubectl create secret generic -n kube-system cilium-etcd-peer-tls --from-file=peer-ca.crt --from-file=peer.crt --from-file=peer.key


### PR DESCRIPTION
Due Jenkins is executing actions in parallel, the etcd certs can't be in
the same folder and need to be in a temporal folder to avoid collusions
between parallel jobs.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

Fixes: #5932

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6049)
<!-- Reviewable:end -->
