### PR TITLE
Test: Print large error message when etcd-operator is not ready.

### DIFF
--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -15,9 +15,10 @@
 package k8sTest
 
 import (
+	"fmt"
+
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
-
 	. "github.com/onsi/gomega"
 )
 
@@ -64,6 +65,14 @@ func ExpectETCDOperatorReady(vm *helpers.Kubectl) {
 	// This is to avoid cases where a few pods are ready, but the
 	// new one is not created yet.
 	By("Waiting for all etcd-operator pods are ready")
+
 	err := vm.WaitforNPods(helpers.KubeSystemNamespace, "-l io.cilium/app=etcd-operator", 4, 600)
-	Expect(err).To(BeNil(), "etcd-operator is not ready after timeout")
+	warningMessage := ""
+	if err != nil {
+		res := vm.Exec(fmt.Sprintf(
+			"%s -n %s get pods -l io.cilium/app=etcd-operator",
+			helpers.KubectlCmd, helpers.KubeSystemNamespace))
+		warningMessage = res.Output().String()
+	}
+	Expect(err).To(BeNil(), "etcd-operator is not ready after timeout, pods status:\n %s", warningMessage)
 }


### PR DESCRIPTION
Sometimes etcd-operator was not ready after timeout, but only one of 3
pods are ready. With this change the pods list for etcd will be
printed on the error message.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

Please ensure your pull request adheres to the following guidelines:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6050)
<!-- Reviewable:end -->
