### PR TITLE
test: Use cilium-etcd-operator

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -264,15 +264,7 @@ var ciliumKubCLICommands = map[string]string{
 	"cilium kvstore get cilium --recursive": "kvstore_get.txt",
 }
 
-// etcdDeploymentFiles are the list of files used to deploy etcd operator.
-var etcdDeploymentFiles = []string{
-	"00-crd-etcd.yaml",
-	"cilium-etcd-sa.yaml",
-	"cluster-role-binding-template.yaml",
-	"cluster-role-template.yaml",
-	"deployment.yaml",
-	"cilium-etcd-cluster.yaml",
-}
+const ciliumEtcdOperator = "https://raw.githubusercontent.com/cilium/cilium-etcd-operator/v2.0.0/cilium-etcd-operator.yaml"
 
 //GetFilePath returns the absolute path of the provided filename
 func GetFilePath(filename string) string {

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -353,6 +353,7 @@ var _ = Describe("NightlyExamples", func() {
 			// clean-state the quorum is lost.
 			// ETCD operator maybe is not installed at all, so no assert here.
 			_ = kubectl.DeleteETCDOperator()
+			ExpectAllPodsTerminated(kubectl)
 
 		})
 

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -104,6 +104,8 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 
 		kubectl.DeleteETCDOperator()
 
+		ExpectAllPodsTerminated(kubectl)
+
 		// make sure we clean everything up before doing any other test
 		err := kubectl.CiliumInstall(
 			helpers.CiliumDefaultDSPatch,

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -59,14 +59,14 @@ func ExpectCEPUpdates(vm *helpers.Kubectl) {
 // ExpectETCDOperatorReady is a wrapper around helpers/WaitForNPods. It asserts
 // the error returned by that function is nil.
 func ExpectETCDOperatorReady(vm *helpers.Kubectl) {
-	// Etcd operator creates 4 nodes (1 etcd-operator + 3 etcd nodes),
+	// Etcd operator creates 5 nodes (1 cilium-etcd-operator + 1 etcd-operator + 3 etcd nodes),
 	// the new pods are added when the previous is ready,
-	// so we need to wait until 4 pods are in ready state.
+	// so we need to wait until 5 pods are in ready state.
 	// This is to avoid cases where a few pods are ready, but the
 	// new one is not created yet.
 	By("Waiting for all etcd-operator pods are ready")
 
-	err := vm.WaitforNPods(helpers.KubeSystemNamespace, "-l io.cilium/app=etcd-operator", 4, 600)
+	err := vm.WaitforNPods(helpers.KubeSystemNamespace, "-l io.cilium/app=etcd-operator", 5, 600)
 	warningMessage := ""
 	if err != nil {
 		res := vm.Exec(fmt.Sprintf(

--- a/test/kubernetes-test.sh
+++ b/test/kubernetes-test.sh
@@ -6,17 +6,8 @@ KUBERNETES_MAJOR_MINOR_VER="$(echo "${k8sVersionJson}" | jq -r '.serverVersion |
 
 k8sDescriptorsPath="./examples/kubernetes/${KUBERNETES_MAJOR_MINOR_VER}"
 k8sManifestsPath="./test/k8sT/manifests"
-etcdOperatorDir="./examples/kubernetes/addons/etcd-operator"
 
-"${etcdOperatorDir}/tls/certs/gen-cert.sh" "cluster.local"
-"${etcdOperatorDir}/tls/deploy-certs.sh"
-kubectl apply --filename="${etcdOperatorDir}/00-crd-etcd.yaml"
-kubectl apply --filename="${etcdOperatorDir}/cilium-etcd-cluster.yaml"
-kubectl apply --filename="${etcdOperatorDir}/cilium-etcd-sa.yaml"
-kubectl apply --filename="${etcdOperatorDir}/cluster-role-binding-template.yaml"
-kubectl apply --filename="${etcdOperatorDir}/cluster-role-template.yaml"
-kubectl apply --filename="${etcdOperatorDir}/deployment.yaml"
-
+kubectl apply --filename="https://raw.githubusercontent.com/cilium/cilium-etcd-operator/1.2/cilium-etcd-operator.yaml"
 kubectl apply --filename="${k8sDescriptorsPath}/cilium-sa.yaml"
 kubectl apply --filename="${k8sDescriptorsPath}/cilium-rbac.yaml"
 kubectl patch --filename="${k8sDescriptorsPath}/cilium-cm.yaml" --patch "$(cat ${k8sManifestsPath}/cilium-cm-patch.yaml)" --local -o yaml | kubectl apply -f -


### PR DESCRIPTION
The cilium-etcd-operator takes care of secret key creation and will
re-bootstrap the etcd cluster after it has scaled down to a point where the
etcd operator can't recover.

Signed-off-by: Thomas Graf <thomas@cilium.io>

Fixes https://github.com/cilium/cilium/issues/5968

Fixes https://github.com/cilium/cilium/issues/6268

Fixes #6051

Fixes #5932

Fixes #5812



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6062)
<!-- Reviewable:end -->
