### PR TITLE
examples/kubernetes: fix cilium tolerations

### DIFF
--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -236,11 +236,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -318,11 +318,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -247,11 +247,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -329,11 +329,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -228,11 +228,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -310,11 +310,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -248,11 +248,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -330,11 +330,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -228,11 +228,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -310,11 +310,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -248,11 +248,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -330,11 +330,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -236,11 +236,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -318,11 +318,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -247,11 +247,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -329,11 +329,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -236,11 +236,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -318,11 +318,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -247,11 +247,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -329,11 +329,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -236,11 +236,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -247,11 +247,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"


### PR DESCRIPTION
If the operator "Exists" is not specified, by default kubernetes will
compare if the value of the node toleration equals to the value
specified in kubernetes node.

Reported-by: Lennart Weller <lhw@ring0.de>
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6063)
<!-- Reviewable:end -->
