### PR TITLE
[v1.2] examples/kubernetes: fix cilium tolerations

### DIFF
--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -230,11 +230,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -298,11 +298,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -231,11 +231,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -299,11 +299,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -231,11 +231,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -299,11 +299,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.7/cilium-ds.yaml
+++ b/examples/kubernetes/1.7/cilium-ds.yaml
@@ -230,11 +230,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.7/cilium.yaml
+++ b/examples/kubernetes/1.7/cilium.yaml
@@ -298,11 +298,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -230,11 +230,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -298,11 +298,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -230,11 +230,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -298,11 +298,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -230,11 +230,13 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
+          operator: "Exists"
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: "Exists"
         - effect: NoSchedule
           key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: "Exists"
         # Mark cilium's pod as critical for rescheduling
         - key: CriticalAddonsOnly
           operator: "Exists"


### PR DESCRIPTION
[ upstream commit 1f39ded3bfa4e0165d55be46b6af1de5b7b7f265 ]

If the operator "Exists" is not specified, by default kubernetes will
compare if the value of the node toleration equals to the value
specified in kubernetes node.

Reported-by: Lennart Weller <lhw@ring0.de>
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6064)
<!-- Reviewable:end -->
