### PR TITLE
Add Cilium pre-flight check

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -17,6 +17,66 @@ It is assuming that Cilium has been deployed using standard procedures as
 described in the :ref:`k8s_concepts_deployment`. If you have installed Cilium
 using the guide :ref:`ds_deploy`, then this is automatically the case.
 
+Running a pre-flight DaemonSet
+==============================
+
+.. _pre_flight:
+
+When rolling out an upgrade with Kubernetes, Kubernetes will first terminate the
+pod followed by pulling the new image version and then finally spin up the new
+image. In order to reduce the downtime of the agent, the new image version can
+be pre-pulled. It also verifies that the new image version can be pulled and
+avoids ErrImagePull errors during the rollout.
+
+.. tabs::
+  .. group-tab:: K8s 1.8
+
+    .. parsed-literal::
+
+      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.8/cilium-pre-flight.yaml
+
+  .. group-tab:: K8s 1.9
+
+    .. parsed-literal::
+
+      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.9/cilium-pre-flight.yaml
+
+  .. group-tab:: K8s 1.10
+
+    .. parsed-literal::
+
+      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.10/cilium-pre-flight.yaml
+
+  .. group-tab:: K8s 1.11
+
+    .. parsed-literal::
+
+      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.11/cilium-pre-flight.yaml
+
+  .. group-tab:: K8s 1.12
+
+    .. parsed-literal::
+
+      $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.12/cilium-pre-flight.yaml
+
+
+After running the cilium-pre-flight.yaml, make sure the number of READY pods
+is the same number of Cilium pods running.
+
+.. code-block:: shell-session
+
+    kubectl get daemonset -n kube-system | grep cilium
+    NAME                      DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
+    cilium                    2         2         2       2            2           <none>          1h20m
+    cilium-pre-flight-check   2         2         2       2            2           <none>          7m15s
+
+Once the number of READY pods are the same, you can delete cilium-pre-flight-check
+`DaemonSet` and proceed with the upgrade.
+
+.. code-block:: shell-session
+
+      kubectl -n kube-system delete ds cilium-pre-flight-check
+
 .. _upgrade_micro:
 
 Upgrading Micro Versions

--- a/examples/kubernetes/1.10/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.10/cilium-pre-flight.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cilium-pre-flight-check
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium-pre-flight-check
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        k8s-app: cilium-pre-flight-check
+        kubernetes.io/cluster-service: "true"
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "k8s-app"
+                operator: In
+                values:
+                - cilium
+            topologyKey: "kubernetes.io/hostname"
+      initContainers:
+        - name: clean-cilium-state
+          image: docker.io/cilium/cilium-init:2018-10-16
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/echo"]
+          args:
+          - "hello"
+      containers:
+        - image: docker.io/cilium/cilium:latest
+          imagePullPolicy: Always
+          name: cilium-pre-flight-check
+          command: ["/bin/sh"]
+          args:
+          - -c
+          - touch /tmp/ready; sleep 1h
+          livenessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      restartPolicy: Always
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+        - key: CriticalAddonsOnly
+          operator: "Exists"

--- a/examples/kubernetes/1.11/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.11/cilium-pre-flight.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cilium-pre-flight-check
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium-pre-flight-check
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        k8s-app: cilium-pre-flight-check
+        kubernetes.io/cluster-service: "true"
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "k8s-app"
+                operator: In
+                values:
+                - cilium
+            topologyKey: "kubernetes.io/hostname"
+      initContainers:
+        - name: clean-cilium-state
+          image: docker.io/cilium/cilium-init:2018-10-16
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/echo"]
+          args:
+          - "hello"
+      containers:
+        - image: docker.io/cilium/cilium:latest
+          imagePullPolicy: Always
+          name: cilium-pre-flight-check
+          command: ["/bin/sh"]
+          args:
+          - -c
+          - touch /tmp/ready; sleep 1h
+          livenessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+        - key: CriticalAddonsOnly
+          operator: "Exists"

--- a/examples/kubernetes/1.12/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.12/cilium-pre-flight.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cilium-pre-flight-check
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium-pre-flight-check
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        k8s-app: cilium-pre-flight-check
+        kubernetes.io/cluster-service: "true"
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "k8s-app"
+                operator: In
+                values:
+                - cilium
+            topologyKey: "kubernetes.io/hostname"
+      initContainers:
+        - name: clean-cilium-state
+          image: docker.io/cilium/cilium-init:2018-10-16
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/echo"]
+          args:
+          - "hello"
+      containers:
+        - image: docker.io/cilium/cilium:latest
+          imagePullPolicy: Always
+          name: cilium-pre-flight-check
+          command: ["/bin/sh"]
+          args:
+          - -c
+          - touch /tmp/ready; sleep 1h
+          livenessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+        - key: CriticalAddonsOnly
+          operator: "Exists"

--- a/examples/kubernetes/1.8/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.8/cilium-pre-flight.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  name: cilium-pre-flight-check
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium-pre-flight-check
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        k8s-app: cilium-pre-flight-check
+        kubernetes.io/cluster-service: "true"
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "k8s-app"
+                operator: In
+                values:
+                - cilium
+            topologyKey: "kubernetes.io/hostname"
+      initContainers:
+        - name: clean-cilium-state
+          image: docker.io/cilium/cilium-init:2018-10-16
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/echo"]
+          args:
+          - "hello"
+      containers:
+        - image: docker.io/cilium/cilium:latest
+          imagePullPolicy: Always
+          name: cilium-pre-flight-check
+          command: ["/bin/sh"]
+          args:
+          - -c
+          - touch /tmp/ready; sleep 1h
+          livenessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      restartPolicy: Always
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+        - key: CriticalAddonsOnly
+          operator: "Exists"

--- a/examples/kubernetes/1.9/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.9/cilium-pre-flight.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cilium-pre-flight-check
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium-pre-flight-check
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        k8s-app: cilium-pre-flight-check
+        kubernetes.io/cluster-service: "true"
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "k8s-app"
+                operator: In
+                values:
+                - cilium
+            topologyKey: "kubernetes.io/hostname"
+      initContainers:
+        - name: clean-cilium-state
+          image: docker.io/cilium/cilium-init:2018-10-16
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/echo"]
+          args:
+          - "hello"
+      containers:
+        - image: docker.io/cilium/cilium:latest
+          imagePullPolicy: Always
+          name: cilium-pre-flight-check
+          command: ["/bin/sh"]
+          args:
+          - -c
+          - touch /tmp/ready; sleep 1h
+          livenessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      restartPolicy: Always
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+        - key: CriticalAddonsOnly
+          operator: "Exists"

--- a/examples/kubernetes/Makefile
+++ b/examples/kubernetes/Makefile
@@ -6,64 +6,66 @@ endif
 
 K8S_VERSIONS = 1.8 1.9 1.10 1.11 1.12
 
-# make_concat creates a concatenated YAML file specific for a K8s version.
-# $(1) is the K8s version. $(2) is the concatenated file.
-define make_concat
-all: $(1)/$(2)
-$(1)/$(2):
-	@$(ECHO_GEN)$$@
-	-$(QUIET)for f in $$^ ; do cat "$$$${f}"; done >$$@
-endef
-
-# make_yaml creates a YAML specific for a K8s version.
-# $(1) is the K8s version. $(2) is the source file.
-define make_yaml
-$(1)/$(patsubst templates/v1/%,%,$(patsubst %.yaml.sed,%.yaml,$(2))):
-	@$(ECHO_GEN)$$@
-	@echo "$(CILIUM_VERSION)" | egrep -Eq '(v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-.+)?)|(latest)' || \
-	(echo "\"$(CILIUM_VERSION)\" is not a valid version. Must match regexp '(v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-.+)?)|(latest)'. Please fix VERSION file" && false)
-ifneq ("$(wildcard $(1)/cilium-crio-transforms2sed.sed)","")
-ifneq ("$(findstring cilium-crio,$(2))","")
-	-$(QUIET)sed -f $(1)/transforms2sed.sed -f $(1)/cilium-crio-transforms2sed.sed -e s+__CILIUM_VERSION__+$$(CILIUM_VERSION)+ <$$< >$$@
-else
-	-$(QUIET)sed -f $(1)/transforms2sed.sed -e s+__CILIUM_VERSION__+$$(CILIUM_VERSION)+ <$$< >$$@
-endif
-else
-	-$(QUIET)sed -f $(1)/transforms2sed.sed -e s+__CILIUM_VERSION__+$$(CILIUM_VERSION)+ <$$< >$$@
-endif
-endef
-
 SOURCES = $(wildcard templates/v1/*.yaml*)
-YAMLS = $(patsubst templates/v1/%,%,$(patsubst %.yaml.sed,%.yaml,$(SOURCES)))
-NON_DAEMONSET_YAMLS = $(filter-out %-ds.yaml,$(YAMLS))
-DAEMONSET_YAMLS = $(filter %-ds.yaml,$(YAMLS))
-CONCAT_FILES = $(patsubst %-ds.yaml,%.yaml,$(DAEMONSET_YAMLS))
+FILENAME_SOURCES = $(patsubst templates/v1/%,%,$(patsubst %.yaml.sed,%.yaml,$(SOURCES)))
+CILIUM_CRIO_SOURCES = $(sort $(filter-out cilium-ds.yaml,$(FILENAME_SOURCES)))
+CILIUM_DOCKER_SOURCES = $(sort $(filter-out cilium-crio-ds.yaml,$(FILENAME_SOURCES)))
 
-# Add the concatenated files as a dependency of all.
-# Build the concatenated files.
-$(foreach K8S_VERSION,$(K8S_VERSIONS), \
-	$(foreach CONCAT_FILE,$(CONCAT_FILES), \
-		$(eval $(call make_concat,$(K8S_VERSION),$(CONCAT_FILE)))))
+all: transform cilium.yaml cilium-crio.yaml
 
-# Add all YAML files as dependencies of concatenated files.
-$(foreach K8S_VERSION,$(K8S_VERSIONS), \
-	$(foreach CONCAT_FILE,$(CONCAT_FILES), \
-		$(eval $(K8S_VERSION)/$(CONCAT_FILE): $(sort    $(patsubst %,$(K8S_VERSION)/%,$(NON_DAEMONSET_YAMLS)) \
-														$(K8S_VERSION)/$(patsubst %.yaml,%-ds.yaml,$(CONCAT_FILE)))) \
-	))
+%.sed:
+	for k8s_version in $(K8S_VERSIONS); do \
+	    (mkdir -p $$k8s_version && \
+	    cd $$k8s_version && \
+	    sed -f transforms2sed.sed ../templates/v1/$@ | \
+	    sed s+__CILIUM_VERSION__+$(CILIUM_VERSION)+g > "$*"); \
+	done
 
-# Add dependencies for individual YAML files.
-$(foreach K8S_VERSION,$(K8S_VERSIONS), \
-	$(foreach SOURCE,$(SOURCES), \
-		$(eval $(K8S_VERSION)/$(patsubst templates/v1/%,%,$(patsubst %.yaml.sed,%.yaml,$(SOURCE))): $(SOURCE) $(K8S_VERSION)/transforms2sed.sed)))
+cilium-crio-ds.yaml.sed:
+	for k8s_version in $(K8S_VERSIONS); do \
+	    (mkdir -p $$k8s_version && \
+	    cd $$k8s_version && \
+	    if [ -f cilium-crio-transforms2sed.sed ]; then \
+	        sed -f transforms2sed.sed ../templates/v1/$@ | \
+	        sed -f cilium-crio-transforms2sed.sed | \
+	        sed s+__CILIUM_VERSION__+$(CILIUM_VERSION)+g > "cilium-crio-ds.yaml"; \
+	    else \
+	        sed -f transforms2sed.sed ../templates/v1/$@ | \
+	        sed s+__CILIUM_VERSION__+$(CILIUM_VERSION)+g > "cilium-crio-ds.yaml"; \
+	    fi); \
+	done
 
-# Build the individual YAML files.
-$(foreach K8S_VERSION,$(K8S_VERSIONS), \
-	$(foreach SOURCE,$(SOURCES), \
-		$(eval $(call make_yaml,$(K8S_VERSION),$(SOURCE)))))
+%.yaml:
+	for k8s_version in $(K8S_VERSIONS); do \
+	    (mkdir -p $$k8s_version && \
+	    cd $$k8s_version && \
+	    cp ../templates/v1/$@ $@); \
+	done
+
+cilium.yaml:
+	for k8s_version in $(K8S_VERSIONS); do \
+        (cd $$k8s_version && \
+            rm -f ./$@ && \
+            for f in $(CILIUM_DOCKER_SOURCES); do (cat "$${f}") >> $@; done); \
+	done
+
+cilium-crio.yaml:
+	for k8s_version in $(K8S_VERSIONS); do \
+        (cd $$k8s_version && \
+            rm -f ./$@ && \
+            for f in $(CILIUM_CRIO_SOURCES); do (cat "$${f}") >> $@; done); \
+	done
 
 clean:
-	@$(ECHO_CLEAN) $(notdir $(shell pwd))
-	-$(QUIET)for k8s_version in $(K8S_VERSIONS); do  rm -f ./$$k8s_version/*.yaml; done
+	for k8s_version in $(K8S_VERSIONS); do \
+        rm ./$$k8s_version/*.yaml; \
+	done
 
-.PHONY: all clean
+transform: cilium-rbac.yaml.sed \
+    cilium-cm.yaml \
+    cilium-crio-ds.yaml.sed \
+    cilium-ds.yaml.sed \
+    cilium-rbac.yaml.sed \
+    cilium-sa.yaml
+
+.PHONY: transform cilium.yaml

--- a/examples/kubernetes/Makefile
+++ b/examples/kubernetes/Makefile
@@ -8,8 +8,8 @@ K8S_VERSIONS = 1.8 1.9 1.10 1.11 1.12
 
 SOURCES = $(wildcard templates/v1/*.yaml*)
 FILENAME_SOURCES = $(patsubst templates/v1/%,%,$(patsubst %.yaml.sed,%.yaml,$(SOURCES)))
-CILIUM_CRIO_SOURCES = $(sort $(filter-out cilium-ds.yaml,$(FILENAME_SOURCES)))
-CILIUM_DOCKER_SOURCES = $(sort $(filter-out cilium-crio-ds.yaml,$(FILENAME_SOURCES)))
+CILIUM_CRIO_SOURCES = $(sort $(filter-out cilium-pre-flight.yaml cilium-ds.yaml,$(FILENAME_SOURCES)))
+CILIUM_DOCKER_SOURCES = $(sort $(filter-out cilium-pre-flight.yaml cilium-crio-ds.yaml,$(FILENAME_SOURCES)))
 
 all: transform cilium.yaml cilium-crio.yaml
 
@@ -65,6 +65,7 @@ transform: cilium-rbac.yaml.sed \
     cilium-cm.yaml \
     cilium-crio-ds.yaml.sed \
     cilium-ds.yaml.sed \
+    cilium-pre-flight.yaml.sed \
     cilium-rbac.yaml.sed \
     cilium-sa.yaml
 

--- a/examples/kubernetes/templates/v1/cilium-pre-flight.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-pre-flight.yaml.sed
@@ -1,0 +1,67 @@
+---
+apiVersion: __DS_API_VERSION__
+kind: DaemonSet
+metadata:
+  name: cilium-pre-flight-check
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium-pre-flight-check
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      labels:
+        k8s-app: cilium-pre-flight-check
+        kubernetes.io/cluster-service: "true"
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "k8s-app"
+                operator: In
+                values:
+                - cilium
+            topologyKey: "kubernetes.io/hostname"
+      initContainers:
+        - name: clean-cilium-state
+          image: docker.io/cilium/cilium-init:2018-10-16
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/echo"]
+          args:
+          - "hello"
+      containers:
+        - image: docker.io/cilium/cilium:__CILIUM_VERSION__
+          imagePullPolicy: Always
+          name: cilium-pre-flight-check
+          command: ["/bin/sh"]
+          args:
+          - -c
+          - touch /tmp/ready; sleep 1h
+          livenessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      restartPolicy: Always
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+        - key: CriticalAddonsOnly
+          operator: "Exists"

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -226,6 +226,12 @@ var (
 // CiliumDefaultDSPatch is the default Cilium DaemonSet patch to be used in all tests.
 const CiliumDefaultDSPatch = "cilium-ds-patch.yaml"
 
+// CiliumDefaultPreFlightPatch is the default Cilium Pre-flight DaemonSet patch to be used in all tests.
+const CiliumDefaultPreFlightPatch = "cilium-pre-flight-patch.yaml"
+
+// CiliumDefaultPreFlight is the default Cilium Pre-flight DaemonSet descriptor to be used in all tests.
+const CiliumDefaultPreFlight = "cilium-pre-flight.yaml"
+
 // CiliumConfigMapPatch is the default Cilium ConfigMap patch to be used in all tests.
 const CiliumConfigMapPatch = "cilium-cm-patch.yaml"
 

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -238,6 +238,15 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 			}
 		}
 
+		By("Install Cilium pre-flight check DaemonSet")
+		err = kubectl.CiliumPreFlightInstall(helpers.CiliumDefaultPreFlightPatch)
+		ExpectWithOffset(1, err).To(BeNil(), "Cilium pre-flight %q was not able to be deployed", newVersion)
+		ExpectCiliumPreFlightInstallReady(kubectl)
+
+		// Once they are installed we can remove it
+		By("Removing Cilium pre-flight check DaemonSet")
+		kubectl.Delete(helpers.GetK8sDescriptor(helpers.CiliumDefaultPreFlight))
+
 		err = kubectl.CiliumInstall(helpers.CiliumDefaultDSPatch, helpers.CiliumConfigMapPatch)
 		ExpectWithOffset(1, err).To(BeNil(), "Cilium %q was not able to be deployed", newVersion)
 

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -77,6 +77,22 @@ func ExpectETCDOperatorReady(vm *helpers.Kubectl) {
 	Expect(err).To(BeNil(), "etcd-operator is not ready after timeout, pods status:\n %s", warningMessage)
 }
 
+// ExpectCiliumPreFlightInstallReady is a wrapper around helpers/WaitForNPods.
+// It asserts the error returned by that function is nil.
+func ExpectCiliumPreFlightInstallReady(vm *helpers.Kubectl) {
+	By("Waiting for all cilium pre-flight pods to be ready")
+
+	err := vm.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium-pre-flight-check", 600)
+	warningMessage := ""
+	if err != nil {
+		res := vm.Exec(fmt.Sprintf(
+			"%s -n %s get pods -l k8s-app=cilium-pre-flight-check",
+			helpers.KubectlCmd, helpers.KubeSystemNamespace))
+		warningMessage = res.Output().String()
+	}
+	Expect(err).To(BeNil(), "cilium pre-flight check is not ready after timeout, pods status:\n %s", warningMessage)
+}
+
 // ProvisionInfraPods deploys DNS, etcd-operator, and cilium into the kubernetes
 // cluster of which vm is a member.
 func ProvisionInfraPods(vm *helpers.Kubectl) {

--- a/test/k8sT/manifests/cilium-pre-flight-patch.yaml
+++ b/test/k8sT/manifests/cilium-pre-flight-patch.yaml
@@ -1,0 +1,10 @@
+---
+metadata:
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - image: k8s1:5000/cilium/cilium-dev:latest
+        imagePullPolicy: IfNotPresent
+        name: cilium-pre-flight-check


### PR DESCRIPTION
This will allow users to pre-download the Cilium image for the versions they will try to upgrade.

```release-note
Add optional DaemonSet for pre-flight checks before performing upgrades
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6067)
<!-- Reviewable:end -->
