### PR TITLE
defaults: Remove DefaultLogLevel

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -704,7 +704,6 @@ func initEnv(cmd *cobra.Command) {
 	// BPF filesystem is mapped into the slave namespace.
 	bpf.CheckOrMountFS(bpfRoot)
 
-	logging.DefaultLogLevel = defaults.DefaultLogLevel
 	option.Config.Opts.SetBool(option.Debug, viper.GetBool("debug"))
 
 	option.Config.Opts.SetBool(option.DropNotify, true)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -16,8 +16,6 @@ package defaults
 
 import (
 	"time"
-
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -63,10 +61,6 @@ const (
 
 	// PidFilePath is the path to the pid file for the agent.
 	PidFilePath = RuntimePath + "/cilium.pid"
-
-	// DefaultLogLevel is the alternative we provide to Debug
-	// We set this in pkg/logging.
-	DefaultLogLevel = logrus.InfoLevel
 
 	// EventsPipe is the name of the named pipe for agent <=> monitor events
 	EventsPipe = "events.sock"


### PR DESCRIPTION
The value was not used correctly as logging.SetupLogging() was invoked before the
default was written into the loggging package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6069)
<!-- Reviewable:end -->
