### PR TITLE
Guarantee service ID and backend ordering across restarts

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -772,6 +772,15 @@ func initEnv(cmd *cobra.Command) {
 		}
 	}
 
+	// Read the service IDs of existing services from the BPF map and
+	// reserve them. This must be done *before* connecting to the
+	// Kubernetes apiserver and serving the API to ensure service IDs are
+	// not changing across restarts or that a new service could accidentally
+	// use an existing service ID.
+	if option.Config.RestoreState {
+		restoreServiceIDs()
+	}
+
 	k8s.Configure(k8sAPIServer, k8sKubeConfigPath)
 
 	// workaround for to use the values of the deprecated dockerEndpoint

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -159,6 +159,9 @@ const (
 	// ServiceID is the orchestration unique ID of a service
 	ServiceID = "serviceID"
 
+	// ServiceIP is the IP of the service
+	ServiceIP = "serviceIP"
+
 	// CiliumNetworkPolicy is a cilium specific NetworkPolicy
 	CiliumNetworkPolicy = "ciliumNetworkPolicy"
 

--- a/pkg/maps/lbmap/bpfservice_test.go
+++ b/pkg/maps/lbmap/bpfservice_test.go
@@ -174,3 +174,33 @@ func (b *LBMapTestSuite) TestPrepareUpdate(c *C) {
 	backends = bpfSvc.getBackends()
 	c.Assert(len(backends), Equals, 0)
 }
+
+func (b *LBMapTestSuite) TestGetBackends(c *C) {
+	b1 := NewService4Value(1, net.ParseIP("2.2.2.2"), 80, 1, 0)
+	b2 := NewService4Value(2, net.ParseIP("1.1.1.1"), 80, 1, 0)
+
+	svc := bpfService{}
+	c.Assert(len(svc.getBackends()), Equals, 0)
+
+	svc = bpfService{
+		backendsByMapIndex: map[int]*bpfBackend{
+			1: {id: "1", isHole: true, bpfValue: b1},
+		},
+	}
+
+	backends := svc.getBackends()
+	c.Assert(len(backends), Equals, 1)
+	c.Assert(backends[0], DeepEquals, b1)
+
+	svc = bpfService{
+		backendsByMapIndex: map[int]*bpfBackend{
+			1: {id: "1", isHole: true, bpfValue: b1},
+			2: {id: "2", isHole: false, bpfValue: b2},
+		},
+	}
+
+	backends = svc.getBackends()
+	c.Assert(len(backends), Equals, 2)
+	c.Assert(backends[0], DeepEquals, b1)
+	c.Assert(backends[1], DeepEquals, b2)
+}

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -696,3 +696,9 @@ func DumpRevNATMapsToUserspace(skipIPv4 bool) (loadbalancer.RevNATMap, []error) 
 	return newRevNATMap, errors
 
 }
+
+// RestoreService restores a single service in the cache. This is required to
+// guarantee consistent backend ordering
+func RestoreService(svc loadbalancer.LBSVC) error {
+	return cache.restoreService(svc)
+}


### PR DESCRIPTION
This PR is deliberately kept simple and non-intrusive to allow for easy backporting.

Both the service ID and the ordering of the service backends were inconsistent across restarts which had the potential to disrupt connections across when the agent was restarted.

Fixes: #5744

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6074)
<!-- Reviewable:end -->
