### PR TITLE
Decouple endpoint ID from addressing

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -25,11 +25,9 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/datapath/route"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/connector"
-	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	healthPkg "github.com/cilium/cilium/pkg/health/client"
 	"github.com/cilium/cilium/pkg/health/defaults"
@@ -195,10 +193,7 @@ func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressin
 	cmd := launcher.Launcher{}
 
 	// Prepare the endpoint change request
-	id := int64(addressing.CiliumIPv6(ip6).EndpointID())
 	info := &models.EndpointChangeRequest{
-		ID:            id,
-		ContainerID:   endpointid.NewCiliumID(id),
 		ContainerName: ciliumHealth,
 		State:         models.EndpointStateWaitingForIdentity,
 		Addressing: &models.AddressPair{

--- a/cilium/cmd/endpoint_config.go
+++ b/cilium/cmd/endpoint_config.go
@@ -57,7 +57,7 @@ func listEndpointOptions() {
 }
 
 func configEndpoint(cmd *cobra.Command, args []string) {
-	_, id, _ := endpointid.ValidateID(args[0])
+	_, id, _ := endpointid.Parse(args[0])
 	cfg, err := client.EndpointConfigGet(id)
 	if err != nil {
 		Fatalf("Cannot get configuration of endpoint %s: %s\n", id, err)

--- a/cilium/cmd/endpoint_labels.go
+++ b/cilium/cmd/endpoint_labels.go
@@ -39,7 +39,7 @@ var endpointLabelsCmd = &cobra.Command{
 	Short:  "Manage label configuration of endpoint",
 	PreRun: requireEndpointID,
 	Run: func(cmd *cobra.Command, args []string) {
-		_, id, _ := endpointid.ValidateID(args[0])
+		_, id, _ := endpointid.Parse(args[0])
 		addLabels := labels.NewLabelsFromModel(toAdd).GetModel()
 
 		deleteLabels := labels.NewLabelsFromModel(toDelete).GetModel()

--- a/cilium/cmd/helpers.go
+++ b/cilium/cmd/helpers.go
@@ -60,7 +60,7 @@ func requireEndpointID(cmd *cobra.Command, args []string) {
 	}
 
 	if id := identity.GetReservedID(args[0]); id == identity.IdentityUnknown {
-		_, _, err := endpointid.ValidateID(args[0])
+		_, _, err := endpointid.Parse(args[0])
 
 		if err != nil {
 			Fatalf("Cannot parse endpoint id \"%s\": %s", args[0], err)

--- a/cilium/cmd/policy_trace.go
+++ b/cilium/cmd/policy_trace.go
@@ -235,7 +235,7 @@ func parseLabels(slice []string) ([]string, error) {
 
 func getSecIDFromK8s(podName string) (string, error) {
 	fmtdPodName := endpointid.NewID(endpointid.PodNamePrefix, podName)
-	_, _, err := endpointid.ValidateID(fmtdPodName)
+	_, _, err := endpointid.Parse(fmtdPodName)
 	if err != nil {
 		Fatalf("Cannot parse pod name \"%s\": %s", fmtdPodName, err)
 	}

--- a/common/addressing/ip.go
+++ b/common/addressing/ip.go
@@ -33,6 +33,7 @@ type CiliumIP interface {
 	String() string
 	IsIPv6() bool
 	GetFamilyString() string
+	IsSet() bool
 }
 
 type CiliumIPv6 []byte
@@ -64,6 +65,11 @@ func DeriveCiliumIPv6(src net.IP) CiliumIPv6 {
 	ip := make(CiliumIPv6, 16)
 	copy(ip, src.To16())
 	return ip
+}
+
+// IsSet returns true if the IP is set
+func (ip CiliumIPv6) IsSet() bool {
+	return ip.String() != ""
 }
 
 func (ip CiliumIPv6) IsIPv6() bool {
@@ -191,6 +197,11 @@ func DeriveCiliumIPv4(src net.IP) CiliumIPv4 {
 	ip := make(CiliumIPv4, 4)
 	copy(ip, src.To4())
 	return ip
+}
+
+// IsSet returns true if the IP is set
+func (ip CiliumIPv4) IsSet() bool {
+	return ip.String() != ""
 }
 
 func (ip CiliumIPv4) IsIPv6() bool {

--- a/common/addressing/ip.go
+++ b/common/addressing/ip.go
@@ -18,15 +18,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"reflect"
-
-	"github.com/cilium/cilium/pkg/byteorder"
 )
 
 type CiliumIP interface {
-	NodeID() uint32
-	State() uint16
-	EndpointID() uint16
 	IPNet(ones int) *net.IPNet
 	EndpointPrefix() *net.IPNet
 	IP() net.IP
@@ -74,59 +68,6 @@ func (ip CiliumIPv6) IsSet() bool {
 
 func (ip CiliumIPv6) IsIPv6() bool {
 	return true
-}
-
-// NodeID returns the node ID portion of the address or 0.
-func (ip CiliumIPv6) NodeID() uint32 {
-	return byteorder.HostToNetworkSlice(ip[8:12], reflect.Uint32).(uint32)
-}
-
-func (ip CiliumIPv6) State() uint16 {
-	return byteorder.HostToNetworkSlice(ip[12:14], reflect.Uint16).(uint16)
-}
-
-func (ip CiliumIPv6) SetState(state uint16) {
-	byteorder.HostToNetworkPut(ip[12:14], state)
-}
-
-// EndpointID returns the container ID portion of the address or 0.
-func (ip CiliumIPv6) EndpointID() uint16 {
-	return byteorder.HostToNetworkSlice(ip[14:], reflect.Uint16).(uint16)
-}
-
-// ValidContainerIP returns true if IP is a valid IP for a container.
-// To be valid must obey to the following rules:
-// - Node ID, bits from 64 to 96, must be different than 0
-// - State, bits from 96 to 112, must be 0
-// - Endpoint ID, bits from 112 to 128, must be different than 0
-func (ip CiliumIPv6) ValidContainerIP() bool {
-	return ip.NodeID() != 0 && ip.State() == 0 && ip.EndpointID() != 0
-}
-
-// ValidNodeIP returns true if IP is a valid IP of a node.
-// - Node ID, bits from 64 to 96, must be different than 0
-// - State, bits from 96 to 112, must be 0
-// - Endpoint ID, bits from 112 to 128, must be 0
-func (ip *CiliumIPv6) ValidNodeIP() bool {
-	return ip.NodeID() != 0 && ip.State() == 0 && ip.EndpointID() == 0
-}
-
-// NodeIP returns the node's IP based on an endpoint IP of the local node.
-func (ip CiliumIPv6) NodeIP() net.IP {
-	nodeAddr := make(net.IP, len(ip))
-	copy(nodeAddr, ip)
-	nodeAddr[14] = 0
-	nodeAddr[15] = 0
-	return nodeAddr
-}
-
-// HostIP returns the host address from the node ID.
-func (ip CiliumIPv6) HostIP() net.IP {
-	nodeAddr := make(net.IP, len(ip))
-	copy(nodeAddr, ip)
-	nodeAddr[14] = 0xff
-	nodeAddr[15] = 0xff
-	return nodeAddr
 }
 
 func (ip CiliumIPv6) IPNet(ones int) *net.IPNet {
@@ -208,16 +149,6 @@ func (ip CiliumIPv4) IsIPv6() bool {
 	return false
 }
 
-func (ip CiliumIPv4) NodeID() uint32 {
-	data := make([]byte, 4)
-	copy(data, ip[0:2])
-	return byteorder.HostToNetworkSlice(data, reflect.Uint32).(uint32)
-}
-
-func (ip CiliumIPv4) EndpointID() uint16 {
-	return byteorder.HostToNetworkSlice(ip[2:], reflect.Uint16).(uint16)
-}
-
 func (ip CiliumIPv4) IPNet(ones int) *net.IPNet {
 	return &net.IPNet{
 		IP:   net.IP(ip),
@@ -231,11 +162,6 @@ func (ip CiliumIPv4) EndpointPrefix() *net.IPNet {
 
 func (ip CiliumIPv4) IP() net.IP {
 	return net.IP(ip)
-}
-
-func (ip CiliumIPv4) State() uint16 {
-	// IPv4 addresses can't carry state
-	return 0
 }
 
 func (ip CiliumIPv4) String() string {
@@ -267,29 +193,6 @@ func (ip *CiliumIPv4) UnmarshalJSON(b []byte) error {
 
 	*ip = c
 	return nil
-}
-
-// ValidContainerIP returns true if the IPv4 address is a valid IP for a container.
-// To be valid must obey to the following rules:
-// - Node ID, bits from 0 to 16, must be different than 0
-// - Endpoint ID, bits from 16 to 32, must be different than 0
-func (ip CiliumIPv4) ValidContainerIP() bool {
-	return ip.NodeID() != 0 && ip.EndpointID() != 0
-}
-
-// ValidNodeIP returns true if the IPv4 address is a valid IP of a node.
-func (ip CiliumIPv4) ValidNodeIP() bool {
-	// Unlike IPv6, a node address looks the same as a container address
-	return ip.ValidContainerIP()
-}
-
-// NodeIP returns the node's IP based on an endpoint IP of the local node.
-func (ip CiliumIPv4) NodeIP() net.IP {
-	nodeIP := make(net.IP, len(ip))
-	copy(nodeIP, ip)
-	nodeIP[3] = 1
-
-	return nodeIP
 }
 
 // GetFamilyString returns the address family of ip as a string.

--- a/common/addressing/ip_test.go
+++ b/common/addressing/ip_test.go
@@ -17,10 +17,7 @@
 package addressing
 
 import (
-	"net"
 	"testing"
-
-	"github.com/cilium/cilium/pkg/checker"
 
 	. "gopkg.in/check.v1"
 )
@@ -37,59 +34,29 @@ var _ = Suite(&AddressingSuite{})
 func (s *AddressingSuite) TestCiliumIPv6(c *C) {
 	ip, err := NewCiliumIPv6("b007::")
 	c.Assert(err, IsNil)
-	c.Assert(ip.ValidContainerIP(), Equals, false)
-	c.Assert(ip.ValidNodeIP(), Equals, false)
-	c.Assert(ip.EndpointID(), Equals, uint16(0))
-	c.Assert(ip.NodeID(), Equals, uint32(0))
-	c.Assert(ip.NodeIP(), checker.DeepEquals, net.ParseIP("b007::"))
-	c.Assert(ip.HostIP(), checker.DeepEquals, net.ParseIP("b007::ffff"))
 	ip2, _ := NewCiliumIPv6("")
 	c.Assert(ip2.IsSet(), Equals, false)
 	// Lacking a better Equals method, checking if the stringified IP is consistent
 	c.Assert(ip.String() == ip2.String(), Equals, false)
-	marsh, _ := ip.MarshalJSON()
-	ip2.UnmarshalJSON(marsh)
-	c.Assert(ip.String() == ip2.String(), Equals, true)
 
 	ip, err = NewCiliumIPv6("b007::aaaa:bbbb:0:0")
 	c.Assert(err, IsNil)
-	c.Assert(ip.ValidContainerIP(), Equals, false)
-	c.Assert(ip.ValidNodeIP(), Equals, true)
-	c.Assert(ip.EndpointID(), Equals, uint16(0))
-	c.Assert(ip.NodeID(), Equals, uint32(0xaaaabbbb))
 	c.Assert(ip.String(), Equals, "b007::aaaa:bbbb:0:0")
-	c.Assert(ip.NodeIP(), checker.DeepEquals, net.ParseIP("b007::aaaa:bbbb:0:0"))
 	c.Assert(ip.IsSet(), Equals, true)
 }
 
 func (s *AddressingSuite) TestCiliumIPv4(c *C) {
 	ip, err := NewCiliumIPv4("10.1.0.0")
 	c.Assert(err, IsNil)
-	c.Assert(ip.EndpointID(), Equals, uint16(0))
-	c.Assert(ip.NodeID(), Equals, uint32(0xa010000))
-	c.Assert(ip.ValidContainerIP(), Equals, false)
-	c.Assert(ip.ValidNodeIP(), Equals, false)
-	c.Assert(ip.NodeIP().String(), Equals, "10.1.0.1")
 	c.Assert(ip.IsSet(), Equals, true)
 
 	ip2, _ := NewCiliumIPv4("")
 	c.Assert(ip2.IsSet(), Equals, false)
 	// Lacking a better Equals method, checking if the stringified IP is consistent
 	c.Assert(ip.String() == ip2.String(), Equals, false)
-	marsh, _ := ip.MarshalJSON()
-	ip2.UnmarshalJSON(marsh)
-	c.Assert(ip.String() == ip2.String(), Equals, true)
 
 	ip, err = NewCiliumIPv4("b007::")
 	c.Assert(err, Not(Equals), nil)
-}
-
-func (s *AddressingSuite) TestCiliumIPv6NodeIP(c *C) {
-	ip, err := NewCiliumIPv6("b007::aaaa:bbbb:0:1")
-	c.Assert(err, IsNil)
-	c.Assert(ip.ValidContainerIP(), Equals, true)
-	c.Assert(ip.ValidNodeIP(), Equals, false)
-	c.Assert(ip.NodeIP(), checker.DeepEquals, net.ParseIP("b007::aaaa:bbbb:0:0"))
 }
 
 func (s *AddressingSuite) TestCiliumIPv6Negative(c *C) {
@@ -97,25 +64,10 @@ func (s *AddressingSuite) TestCiliumIPv6Negative(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(ip, IsNil)
 	c.Assert(ip.String(), Equals, "")
-	marsh, _ := ip.MarshalJSON()
-	// Unmarshal nil IP
-	c.Assert(ip.UnmarshalJSON(marsh), IsNil)
-	// Unmarshal IP of invalid length
-	c.Assert(ip.UnmarshalJSON([]byte{0x01}), NotNil)
-	// Unmarshal IPv4
-	c.Assert(ip.UnmarshalJSON(
-		[]byte{'1', '0', '.', '1', '.', '0', '.', '0'}), NotNil)
 
 	ip, err = NewCiliumIPv6("192.168.0.1")
 	c.Assert(err, NotNil)
 	c.Assert(ip, IsNil)
-}
-
-func (s *AddressingSuite) TestCiliumIPv6State(c *C) {
-	ip, _ := NewCiliumIPv6("b007::")
-	c.Assert(ip.State(), Equals, uint16(0x0))
-	ip.SetState(uint16(0xAABB))
-	c.Assert(ip.State(), Equals, uint16(0xAABB))
 }
 
 func (s *AddressingSuite) TestCiliumIPv4Negative(c *C) {
@@ -123,11 +75,4 @@ func (s *AddressingSuite) TestCiliumIPv4Negative(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(ip, IsNil)
 	c.Assert(ip.String(), Equals, "")
-	marsh, _ := ip.MarshalJSON()
-	// Unmarshal nil IP
-	c.Assert(ip.UnmarshalJSON(marsh), IsNil)
-	// Unmarshal IP of invalid length
-	c.Assert(ip.UnmarshalJSON([]byte{0x01}), NotNil)
-	// Unmarshal IPv6
-	c.Assert(ip.UnmarshalJSON([]byte{'f', 'a', 'c', 'e', ':', ':'}), NotNil)
 }

--- a/common/addressing/ip_test.go
+++ b/common/addressing/ip_test.go
@@ -44,6 +44,7 @@ func (s *AddressingSuite) TestCiliumIPv6(c *C) {
 	c.Assert(ip.NodeIP(), checker.DeepEquals, net.ParseIP("b007::"))
 	c.Assert(ip.HostIP(), checker.DeepEquals, net.ParseIP("b007::ffff"))
 	ip2, _ := NewCiliumIPv6("")
+	c.Assert(ip2.IsSet(), Equals, false)
 	// Lacking a better Equals method, checking if the stringified IP is consistent
 	c.Assert(ip.String() == ip2.String(), Equals, false)
 	marsh, _ := ip.MarshalJSON()
@@ -58,6 +59,7 @@ func (s *AddressingSuite) TestCiliumIPv6(c *C) {
 	c.Assert(ip.NodeID(), Equals, uint32(0xaaaabbbb))
 	c.Assert(ip.String(), Equals, "b007::aaaa:bbbb:0:0")
 	c.Assert(ip.NodeIP(), checker.DeepEquals, net.ParseIP("b007::aaaa:bbbb:0:0"))
+	c.Assert(ip.IsSet(), Equals, true)
 }
 
 func (s *AddressingSuite) TestCiliumIPv4(c *C) {
@@ -68,7 +70,10 @@ func (s *AddressingSuite) TestCiliumIPv4(c *C) {
 	c.Assert(ip.ValidContainerIP(), Equals, false)
 	c.Assert(ip.ValidNodeIP(), Equals, false)
 	c.Assert(ip.NodeIP().String(), Equals, "10.1.0.1")
+	c.Assert(ip.IsSet(), Equals, true)
+
 	ip2, _ := NewCiliumIPv4("")
+	c.Assert(ip2.IsSet(), Equals, false)
 	// Lacking a better Equals method, checking if the stringified IP is consistent
 	c.Assert(ip.String() == ip2.String(), Equals, false)
 	marsh, _ := ip.MarshalJSON()

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -144,7 +144,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 
 	ep.SetDefaultOpts(option.Config.Opts)
 
-	checkIDs := []string{ep.ID}
+	checkIDs := []string{}
 
 	if ep.IPv4.IsSet() {
 		checkIDs = append(checkIDs, endpointid.NewID(endpointid.IPv4Prefix, ep.IPv4.String()))
@@ -269,20 +269,9 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder 
 	epTemplate := params.Endpoint
 
 	logger := log.WithFields(logrus.Fields{
-		logfields.EndpointID:  epTemplate.ID,
 		logfields.ContainerID: epTemplate.ContainerID,
 		logfields.EventUUID:   uuid.NewUUID(),
 	})
-
-	if n, err := endpointid.ParseCiliumID(params.ID); err != nil {
-		return api.Error(PutEndpointIDInvalidCode, err)
-	} else if n != epTemplate.ID {
-		return api.New(PutEndpointIDInvalidCode,
-			"ID parameter does not match ID in endpoint parameter")
-	} else if epTemplate.ID == 0 {
-		return api.New(PutEndpointIDInvalidCode,
-			"endpoint ID cannot be 0")
-	}
 
 	code, err := h.d.createEndpoint(params.HTTPRequest.Context(), epTemplate)
 	if err != nil {

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -144,10 +144,25 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 
 	ep.SetDefaultOpts(option.Config.Opts)
 
-	oldEp := endpointmanager.LookupCiliumID(ep.ID)
-	if oldEp != nil {
-		return PutEndpointIDExistsCode, fmt.Errorf("endpoint ID %d exists", ep.ID)
+	checkIDs := []string{ep.ID}
+
+	if ep.IPv4.IsSet() {
+		checkIDs = append(checkIDs, endpointid.NewID(endpointid.IPv4Prefix, ep.IPv4.String()))
 	}
+
+	if ep.IPv6.IsSet() {
+		checkIDs = append(checkIDs, endpointid.NewID(endpointid.IPv6Prefix, ep.IPv6.String()))
+	}
+
+	for _, id := range checkIDs {
+		oldEp, err2 := endpointmanager.Lookup(id)
+		if err2 != nil {
+			return PutEndpointIDInvalidCode, err2
+		} else if oldEp != nil {
+			return PutEndpointIDExistsCode, fmt.Errorf("Endpoint ID %s already exists", id)
+		}
+	}
+
 	if err = endpoint.APICanModify(ep); err != nil {
 		return PutEndpointIDInvalidCode, err
 	}

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -19,13 +19,11 @@ import (
 	"time"
 
 	health "github.com/cilium/cilium/cilium-health/launch"
-	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/k8s"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pidfile"
@@ -88,11 +86,9 @@ func (d *Daemon) cleanupHealthEndpoint() {
 	// Delete the process
 	health.KillEndpoint()
 	// Clean up agent resources
-	ip6 := node.GetIPv6HealthIP()
-	id := addressing.CiliumIPv6(ip6).EndpointID()
-	ep := endpointmanager.LookupCiliumID(id)
+	ep := endpointmanager.LookupIPv4(node.GetIPv4HealthIP().String())
 	if ep == nil {
-		log.WithField(logfields.EndpointID, id).Debug("Didn't find existing cilium-health endpoint to delete")
+		log.Debug("Didn't find existing cilium-health endpoint to delete")
 	} else {
 		log.Debug("Removing existing cilium-health endpoint")
 		errs := d.deleteEndpointQuiet(ep, false)

--- a/daemon/k8s_watcher_test.go
+++ b/daemon/k8s_watcher_test.go
@@ -291,7 +291,9 @@ func (ds *DaemonSuite) Test_missingK8sPodV1(c *C) {
 			name: "ipcache is missing a pod",
 			setupArgs: func() args {
 				endpointmanager.RemoveAll()
-				endpointmanager.Insert(endpointCreator(123, identity.NumericIdentity(1000)))
+				if err := endpointmanager.Insert(endpointCreator(123, identity.NumericIdentity(1000))); err != nil {
+					panic(err)
+				}
 				m := versioned.NewMap()
 				m.Add("", versioned.Object{
 					Data: &core_v1.Pod{
@@ -330,7 +332,9 @@ func (ds *DaemonSuite) Test_missingK8sPodV1(c *C) {
 			name: "ipcache contains the pod but endpointmanager doesn't contain any endpoint that manages the pod. Should be no-op",
 			setupArgs: func() args {
 				endpointmanager.RemoveAll()
-				endpointmanager.Insert(endpointCreator(123, identity.NumericIdentity(1000)))
+				if err := endpointmanager.Insert(endpointCreator(123, identity.NumericIdentity(1000))); err != nil {
+					panic(err)
+				}
 				cache := ipcache.NewIPCache()
 				cache.Upsert("127.0.0.1", net.ParseIP("127.0.0.2"), ipcache.Identity{
 					ID:     identity.ReservedIdentityInit,
@@ -366,7 +370,9 @@ func (ds *DaemonSuite) Test_missingK8sPodV1(c *C) {
 				ep := endpointCreator(123, identity.NumericIdentity(1000))
 				ep.SetK8sPodName("foo")
 				ep.SetK8sNamespace("bar")
-				endpointmanager.Insert(ep)
+				if err := endpointmanager.Insert(ep); err != nil {
+					panic(err)
+				}
 				cache := ipcache.NewIPCache()
 				cache.Upsert("127.0.0.1", net.ParseIP("127.0.0.2"), ipcache.Identity{
 					ID:     identity.ReservedIdentityInit,
@@ -422,7 +428,9 @@ func (ds *DaemonSuite) Test_missingK8sPodV1(c *C) {
 				ep.OpLabels.OrchestrationIdentity = labels.Map2Labels(map[string]string{"foo": "bar"}, labels.LabelSourceK8s)
 				ep.SetK8sPodName("foo")
 				ep.SetK8sNamespace("bar")
-				endpointmanager.Insert(ep)
+				if err := endpointmanager.Insert(ep); err != nil {
+					panic(err)
+				}
 				cache := ipcache.NewIPCache()
 				cache.Upsert("127.0.0.1", net.ParseIP("127.0.0.2"), ipcache.Identity{
 					ID:     identity.ReservedIdentityInit,
@@ -462,7 +470,9 @@ func (ds *DaemonSuite) Test_missingK8sPodV1(c *C) {
 				ep.OpLabels.OrchestrationIdentity = labels.Map2Labels(map[string]string{"foo": "bar"}, labels.LabelSourceK8s)
 				ep.SetK8sPodName("foo")
 				ep.SetK8sNamespace("bar")
-				endpointmanager.Insert(ep)
+				if err := endpointmanager.Insert(ep); err != nil {
+					panic(err)
+				}
 				cache := ipcache.NewIPCache()
 				cache.Upsert("127.0.0.1", net.ParseIP("127.0.0.2"), ipcache.Identity{
 					ID:     identity.ReservedIdentityInit,
@@ -713,6 +723,7 @@ func (ds *DaemonSuite) Test_missingK8sNamespaceV1(c *C) {
 	type args struct {
 		m versioned.Map
 	}
+
 	tests := []struct {
 		name        string
 		setupArgs   func() args
@@ -732,8 +743,11 @@ func (ds *DaemonSuite) Test_missingK8sNamespaceV1(c *C) {
 		{
 			name: "endpointmanager doesn't contain any endpoint that is part of that namespace. Should be no-op",
 			setupArgs: func() args {
+				endpointmanager.RemoveAll()
 				ep := endpointCreator(123, identity.NumericIdentity(1000))
-				endpointmanager.Insert(ep)
+				if err := endpointmanager.Insert(ep); err != nil {
+					panic(err)
+				}
 				m := versioned.NewMap()
 				m.Add("", versioned.Object{
 					Data: &core_v1.Namespace{
@@ -754,9 +768,12 @@ func (ds *DaemonSuite) Test_missingK8sNamespaceV1(c *C) {
 		{
 			name: "endpointmanager contains the endpoint that is part of that namespace but ep doesn't have all labels",
 			setupArgs: func() args {
-				ep := endpointCreator(123, identity.NumericIdentity(1000))
+				endpointmanager.RemoveAll()
+				ep := endpointCreator(124, identity.NumericIdentity(1000))
 				ep.SetK8sNamespace("foo")
-				endpointmanager.Insert(ep)
+				if err := endpointmanager.Insert(ep); err != nil {
+					panic(err)
+				}
 				m := versioned.NewMap()
 				m.Add("", versioned.Object{
 					Data: &core_v1.Namespace{
@@ -791,12 +808,15 @@ func (ds *DaemonSuite) Test_missingK8sNamespaceV1(c *C) {
 		{
 			name: "endpointmanager contains the endpoint that is part of that namespace and have all labels",
 			setupArgs: func() args {
-				ep := endpointCreator(123, identity.NumericIdentity(1000))
+				endpointmanager.RemoveAll()
+				ep := endpointCreator(125, identity.NumericIdentity(1000))
 				ep.OpLabels.OrchestrationIdentity = labels.Map2Labels(
 					map[string]string{policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "id.foo"): "bar"},
 					labels.LabelSourceK8s)
 				ep.SetK8sNamespace("foo")
-				endpointmanager.Insert(ep)
+				if err := endpointmanager.Insert(ep); err != nil {
+					panic(err)
+				}
 				m := versioned.NewMap()
 				m.Add("", versioned.Object{
 					Data: &core_v1.Namespace{

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2061,7 +2061,19 @@ func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
 
 	e.SetIdentity(identity)
 
-	readyToRegenerate := e.SetStateLocked(StateWaitingToRegenerate, "Triggering regeneration due to new identity")
+	readyToRegenerate := false
+
+	// Regeneration is olny triggered once the endpoint ID has been
+	// assigned. This ensures that on the initial creation, the endpoint is
+	// not generated until the endpoint ID has been assigned. If the
+	// identity is resolved before the endpoint ID is assigned, the
+	// regeneration is deferred into endpointmanager.AddEndpoint(). If the
+	// identity is not allocated yet when endpointmanager.AddEndpoint() is
+	// called, the controller calling identityLabelsChanged() will trigger
+	// the regeneration as soon as the identity is known.
+	if e.ID != 0 {
+		readyToRegenerate = e.SetStateLocked(StateWaitingToRegenerate, "Triggering regeneration due to new identity")
+	}
 
 	// Unconditionally force policy recomputation after a new identity has been
 	// assigned.

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -17,7 +17,6 @@
 package endpoint
 
 import (
-	"bytes"
 	"context"
 	"reflect"
 	"testing"
@@ -45,18 +44,6 @@ func Test(t *testing.T) { TestingT(t) }
 type EndpointSuite struct{}
 
 var _ = Suite(&EndpointSuite{})
-
-func (s *EndpointSuite) TestEndpointID(c *C) {
-	e := Endpoint{
-		ID:     IPv6Addr.EndpointID(),
-		IPv6:   IPv6Addr,
-		IPv4:   IPv4Addr,
-		Status: NewEndpointStatus(),
-	}
-	c.Assert(e.ID, Equals, uint16(4370)) //"0x1112"
-	c.Assert(bytes.Compare(e.IPv6, IPv6Addr) == 0, Equals, true)
-	c.Assert(bytes.Compare(e.IPv4, IPv4Addr) == 0, Equals, true)
-}
 
 func (s *EndpointSuite) TestOrderEndpointAsc(c *C) {
 	eps := []*models.Endpoint{
@@ -178,7 +165,7 @@ func (s *EndpointSuite) TestEndpointStatus(c *C) {
 
 func (s *EndpointSuite) TestEndpointUpdateLabels(c *C) {
 	e := Endpoint{
-		ID:       IPv6Addr.EndpointID(),
+		ID:       100,
 		IPv6:     IPv6Addr,
 		IPv4:     IPv4Addr,
 		Status:   NewEndpointStatus(),
@@ -211,7 +198,7 @@ func (s *EndpointSuite) TestEndpointUpdateLabels(c *C) {
 
 func (s *EndpointSuite) TestEndpointState(c *C) {
 	e := Endpoint{
-		ID:     IPv6Addr.EndpointID(),
+		ID:     100,
 		IPv6:   IPv6Addr,
 		IPv4:   IPv4Addr,
 		Status: NewEndpointStatus(),

--- a/pkg/endpoint/id/allocator.go
+++ b/pkg/endpoint/id/allocator.go
@@ -1,0 +1,69 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package id
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/idpool"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+const (
+	minID = idpool.ID(1)
+	maxID = idpool.ID(^uint16(0))
+)
+
+var (
+	pool = idpool.NewIDPool(minID, maxID)
+	log  = logging.DefaultLogger.WithField(logfields.LogSubsys, "endpoint")
+)
+
+// ReallocatePool starts over with a new pool.
+func ReallocatePool() {
+	pool = idpool.NewIDPool(minID, maxID)
+}
+
+// Allocate returns a new random ID from the pool
+func Allocate() uint16 {
+	id := pool.AllocateID()
+
+	// Out of endpoint IDs
+	if id == idpool.NoID {
+		return uint16(0)
+	}
+
+	return uint16(id)
+}
+
+// Reuse grabs a specific endpoint ID for reuse. This can be used when
+// restoring endpoints.
+func Reuse(id uint16) error {
+	if !pool.Remove(idpool.ID(id)) {
+		return fmt.Errorf("endpoint ID %d is already in use", id)
+	}
+
+	return nil
+}
+
+// Release releases an endpoint ID that was previously allocated or reused
+func Release(id uint16) error {
+	if !pool.Insert(idpool.ID(id)) {
+		return fmt.Errorf("Unable to release endpoint ID %d", id)
+	}
+
+	return nil
+}

--- a/pkg/endpoint/id/allocator_test.go
+++ b/pkg/endpoint/id/allocator_test.go
@@ -1,0 +1,103 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// +build !privileged_tests
+
+package id
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+func (s *IDSuite) TestAllocation(c *C) {
+	ReallocatePool()
+
+	idsReturned := map[uint16]struct{}{}
+
+	for i := minID; i <= maxID; i++ {
+		id := Allocate()
+		c.Assert(id, Not(Equals), uint16(0))
+
+		// check if same ID is returned more than once
+		_, ok := idsReturned[id]
+		c.Assert(ok, Equals, false)
+
+		idsReturned[id] = struct{}{}
+	}
+
+	// We should be out of allocations
+	c.Assert(Allocate(), Equals, uint16(0))
+}
+
+func (s *IDSuite) TestReuse(c *C) {
+	ReallocatePool()
+
+	idsReturned := map[uint16]struct{}{}
+
+	c.Assert(Reuse(uint16(2)), IsNil)
+	idsReturned[uint16(2)] = struct{}{}
+
+	c.Assert(Reuse(uint16(8)), IsNil)
+	idsReturned[uint16(8)] = struct{}{}
+
+	for i := minID; i <= maxID-2; i++ {
+		id := Allocate()
+		c.Assert(id, Not(Equals), uint16(0))
+
+		// check if same ID is returned more than once
+		_, ok := idsReturned[id]
+		c.Assert(ok, Equals, false)
+
+		idsReturned[id] = struct{}{}
+	}
+
+	// We should be out of allocations
+	c.Assert(Allocate(), Equals, uint16(0))
+
+	// 2nd reuse should fail
+	c.Assert(Reuse(uint16(2)), Not(IsNil))
+
+	// reuse of allocated id should fail
+	c.Assert(Reuse(uint16(3)), Not(IsNil))
+
+	// relese 5
+	c.Assert(Release(uint16(5)), IsNil)
+	delete(idsReturned, uint16(5))
+
+	// relese 6
+	c.Assert(Release(uint16(6)), IsNil)
+	delete(idsReturned, uint16(6))
+
+	// reuse 5 after release
+	c.Assert(Reuse(uint16(5)), IsNil)
+	idsReturned[uint16(5)] = struct{}{}
+
+	// allocate only avaiable id 6
+	c.Assert(Allocate(), Equals, uint16(6))
+}
+
+func (s *IDSuite) TestRelease(c *C) {
+	ReallocatePool()
+
+	for i := minID; i <= maxID; i++ {
+		c.Assert(Reuse(uint16(i)), IsNil)
+	}
+
+	// must be out of IDs
+	c.Assert(Allocate(), Equals, uint16(0))
+
+	for i := minID; i <= maxID; i++ {
+		c.Assert(Release(uint16(i)), IsNil)
+	}
+}

--- a/pkg/endpoint/id/id.go
+++ b/pkg/endpoint/id/id.go
@@ -16,6 +16,7 @@ package id
 
 import (
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 )
@@ -74,6 +75,15 @@ func NewCiliumID(id int64) string {
 // NewID returns a new endpoint identifier
 func NewID(prefix PrefixType, id string) string {
 	return string(prefix) + ":" + id
+}
+
+// NewIPPrefixID returns an identifier based on the IP address specified
+func NewIPPrefixID(ip net.IP) string {
+	if ip.To4() != nil {
+		return NewID(IPv4Prefix, ip.String())
+	}
+
+	return NewID(IPv6Prefix, ip.String())
 }
 
 // splitID splits ID into prefix and id. No validation is performed on prefix.

--- a/pkg/endpoint/id/id.go
+++ b/pkg/endpoint/id/id.go
@@ -61,6 +61,9 @@ const (
 	// IPv4Prefix is used to address an endpoint via the endpoint's IPv4
 	// address.
 	IPv4Prefix PrefixType = "ipv4"
+
+	// IPv6Prefix is the prefix used to refer to an endpoint via IPv6 address
+	IPv6Prefix PrefixType = "ipv6"
 )
 
 // NewCiliumID returns a new endpoint identifier of type CiliumLocalIdPrefix
@@ -101,7 +104,7 @@ func ParseCiliumID(id string) (int64, error) {
 func Parse(id string) (PrefixType, string, error) {
 	prefix, id := splitID(id)
 	switch prefix {
-	case CiliumLocalIdPrefix, CiliumGlobalIdPrefix, ContainerIdPrefix, DockerEndpointPrefix, ContainerNamePrefix, PodNamePrefix, IPv4Prefix:
+	case CiliumLocalIdPrefix, CiliumGlobalIdPrefix, ContainerIdPrefix, DockerEndpointPrefix, ContainerNamePrefix, PodNamePrefix, IPv4Prefix, IPv6Prefix:
 		return prefix, id, nil
 	}
 

--- a/pkg/endpoint/id/id_test.go
+++ b/pkg/endpoint/id/id_test.go
@@ -17,6 +17,8 @@
 package id
 
 import (
+	"net"
+	"strings"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -210,4 +212,9 @@ func (s *IDSuite) TestParse(c *C) {
 			c.Assert(err, IsNil)
 		}
 	}
+}
+
+func (s *IDSuite) TestNewIPPrefix(c *C) {
+	c.Assert(strings.HasPrefix(NewIPPrefixID(net.ParseIP("1.1.1.1")), string(IPv4Prefix)), Equals, true)
+	c.Assert(strings.HasPrefix(NewIPPrefixID(net.ParseIP("f00d::1")), string(IPv6Prefix)), Equals, true)
 }

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -122,6 +122,9 @@ func Lookup(id string) (*endpoint.Endpoint, error) {
 	case endpointid.IPv4Prefix:
 		return lookupIPv4(eid), nil
 
+	case endpointid.IPv6Prefix:
+		return lookupIPv4(eid), nil
+
 	default:
 		return nil, ErrInvalidPrefix{InvalidPrefix: prefix.String()}
 	}
@@ -183,8 +186,12 @@ func Remove(ep *endpoint.Endpoint) {
 		delete(endpointsAux, endpointid.NewID(endpointid.DockerEndpointPrefix, ep.DockerEndpointID))
 	}
 
-	if ep.IPv4.String() != "" {
+	if ep.IPv4.IsSet() {
 		delete(endpointsAux, endpointid.NewID(endpointid.IPv4Prefix, ep.IPv4.String()))
+	}
+
+	if ep.IPv6.IsSet() {
+		delete(endpointsAux, endpointid.NewID(endpointid.IPv6Prefix, ep.IPv6.String()))
 	}
 
 	if ep.ContainerName != "" {
@@ -240,6 +247,13 @@ func lookupIPv4(ipv4 string) *endpoint.Endpoint {
 	return nil
 }
 
+func lookupIPv6(ipv6 string) *endpoint.Endpoint {
+	if ep, ok := endpointsAux[endpointid.NewID(endpointid.IPv6Prefix, ipv6)]; ok {
+		return ep
+	}
+	return nil
+}
+
 func lookupContainerID(id string) *endpoint.Endpoint {
 	if ep, ok := endpointsAux[endpointid.NewID(endpointid.ContainerIdPrefix, id)]; ok {
 		return ep
@@ -258,8 +272,12 @@ func updateReferences(ep *endpoint.Endpoint) {
 		endpointsAux[endpointid.NewID(endpointid.DockerEndpointPrefix, ep.DockerEndpointID)] = ep
 	}
 
-	if ep.IPv4.String() != "" {
+	if ep.IPv4.IsSet() {
 		endpointsAux[endpointid.NewID(endpointid.IPv4Prefix, ep.IPv4.String())] = ep
+	}
+
+	if ep.IPv6.IsSet() {
+		endpointsAux[endpointid.NewID(endpointid.IPv6Prefix, ep.IPv6.String())] = ep
 	}
 
 	if ep.ContainerName != "" {

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -91,7 +91,7 @@ func Lookup(id string) (*endpoint.Endpoint, error) {
 	mutex.RLock()
 	defer mutex.RUnlock()
 
-	prefix, eid, err := endpointid.ParsePrefix(id)
+	prefix, eid, err := endpointid.Parse(id)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/workloads/cri.go
+++ b/pkg/workloads/cri.go
@@ -182,14 +182,20 @@ func (c *criClient) processEvents(events chan EventMessage) {
 	}
 }
 
-func (c *criClient) getCiliumEndpointID(pod *criRuntime.PodSandboxStatus) uint16 {
+func (c *criClient) getEndpointByPodIP(pod *criRuntime.PodSandboxStatus) *endpoint.Endpoint {
 	scopedLog := log.WithField(logfields.ContainerID, shortContainerID(pod.GetId()))
+
 	if ciliumIP := c.getCiliumIP(pod); ciliumIP != nil {
-		return ciliumIP.EndpointID()
+		id := endpointid.NewIPPrefixID(ciliumIP.IP())
+		if ep, err := endpointmanager.Lookup(id); err != nil {
+			log.WithError(err).Warning("Unable to lookup endpoint by IP prefix")
+		} else if ep != nil {
+			return ep
+		}
 	}
 
 	scopedLog.Debug("IP address assigned by Cilium could not be derived from pod")
-	return 0
+	return nil
 }
 
 func (c *criClient) getCiliumIP(pod *criRuntime.PodSandboxStatus) addressing.CiliumIP {
@@ -237,12 +243,13 @@ func (c *criClient) handleCreateWorkload(id string, retry bool) {
 
 		ep := endpointmanager.LookupContainerID(id)
 		if ep == nil {
-			// Container ID is not yet known; try and find endpoint via
-			// the IP address assigned.
-			ciliumID = c.getCiliumEndpointID(pod)
-			if ciliumID != 0 {
-				ep = endpointmanager.LookupCiliumID(ciliumID)
-			}
+			// Container ID is not yet known; try and find endpoint
+			// via one of the IP addresses assigned.
+			ep = c.getEndpointByPodIP(pod)
+		}
+
+		if ep != nil {
+			ciliumID = ep.ID
 		}
 
 		retryLog.WithFields(logrus.Fields{

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -403,7 +403,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 		if err != nil {
 			return err
 		}
-		ep.ID = int64(state.IP6.EndpointID())
 		res.IPs = append(res.IPs, ipConfig)
 		res.Routes = append(res.Routes, routes...)
 	} else {
@@ -442,13 +441,11 @@ func cmdAdd(args *skel.CmdArgs) error {
 	ep.SyncBuildEndpoint = true
 	if err = c.EndpointCreate(ep); err != nil {
 		logger.WithError(err).WithFields(logrus.Fields{
-			logfields.EndpointID:  ep.ID,
 			logfields.ContainerID: ep.ContainerID}).Warn("Unable to create endpoint")
 		return fmt.Errorf("Unable to create endpoint: %s", err)
 	}
 
 	logger.WithFields(logrus.Fields{
-		logfields.EndpointID:  ep.ID,
 		logfields.ContainerID: ep.ContainerID}).Debug("Endpoint successfully created")
 	return cniTypes.PrintResult(res, cniVer)
 }

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cilium/cilium/api/v1/client/endpoint"
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/client"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	"github.com/cilium/cilium/pkg/datapath/route"
@@ -306,20 +305,12 @@ func (driver *driver) createEndpoint(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ip6, err := addressing.NewCiliumIPv6(create.Interface.AddressIPv6)
-	if err != nil {
-		sendError(w, fmt.Sprintf("Unable to parse IPv6 address: %s", err),
-			http.StatusBadRequest)
-		return
-	}
-
 	endpoint := &models.EndpointChangeRequest{
-		ID:               int64(ip6.EndpointID()),
 		State:            models.EndpointStateWaitingForIdentity,
 		DockerEndpointID: create.EndpointID,
 		DockerNetworkID:  create.NetworkID,
 		Addressing: &models.AddressPair{
-			IPV6: ip6.String(),
+			IPV6: create.Interface.AddressIPv6,
 			IPV4: create.Interface.Address,
 		},
 	}


### PR DESCRIPTION
This decouples the endpoint ID from the addressing model and requires plugins such as the CNI plugin to no longer be aware of the endpoint ID at all. Endpoints can be referred to by either container ID or ip addressing information. This allows use of 3rd party IPAM plugins and enables disablement of IPv6.

Depends on: #6079 

*API Consequences:*
* The endpoint ID parameters in PUT /endpoint/{id} becomes meaningless and will be allocated instead
* Clients that blindly assume that the endpoint ID is valid after the API will break. No such clients are known.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6080)
<!-- Reviewable:end -->
