### PR TITLE
loadbalancer: Remove error handling on port name

### DIFF
--- a/cilium/cmd/service_update.go
+++ b/cilium/cmd/service_update.go
@@ -123,11 +123,7 @@ func updateService(cmd *cobra.Command, args []string) {
 			Fatalf("Cannot parse backend address \"%s\": %s", backend, err)
 		}
 
-		be, err := loadbalancer.NewLBBackEnd(loadbalancer.TCP, beAddr.IP, uint16(beAddr.Port), uint16(weight))
-		if err != nil {
-			Fatalf("Unable to create a new L3n4Addr for backend %s: %s", backend, err)
-		}
-
+		be := loadbalancer.NewLBBackEnd(loadbalancer.TCP, beAddr.IP, uint16(beAddr.Port), uint16(weight))
 		if be.IsIPv6() && faIP.To4() != nil {
 			Fatalf("Address mismatch between frontend and backend %s", backend)
 		}

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -807,11 +807,7 @@ func parseSvcV1(svc *v1.Service) *loadbalancer.K8sServiceInfo {
 	// FIXME: Add support for
 	//  - NodePort
 	for _, port := range svc.Spec.Ports {
-		p, err := loadbalancer.NewFEPort(loadbalancer.L4Type(port.Protocol), uint16(port.Port))
-		if err != nil {
-			scopedLog.WithError(err).WithField("port", port).Error("Unable to add service port")
-			continue
-		}
+		p := loadbalancer.NewFEPort(loadbalancer.L4Type(port.Protocol), uint16(port.Port))
 		if _, ok := newSI.Ports[loadbalancer.FEPortName(port.Name)]; !ok {
 			newSI.Ports[loadbalancer.FEPortName(port.Name)] = p
 		}
@@ -903,12 +899,6 @@ func (d *Daemon) missingK8sServiceV1(m versioned.Map) versioned.Map {
 }
 
 func parseK8sEPv1(ep *v1.Endpoints) *loadbalancer.K8sServiceEndpoint {
-	scopedLog := log.WithFields(logrus.Fields{
-		logfields.K8sEndpointName: ep.ObjectMeta.Name,
-		logfields.K8sNamespace:    ep.ObjectMeta.Namespace,
-		logfields.K8sAPIVersion:   ep.TypeMeta.APIVersion,
-	})
-
 	newSvcEP := loadbalancer.NewK8sServiceEndpoint()
 
 	for _, sub := range ep.Subsets {
@@ -916,11 +906,7 @@ func parseK8sEPv1(ep *v1.Endpoints) *loadbalancer.K8sServiceEndpoint {
 			newSvcEP.BEIPs[addr.IP] = true
 		}
 		for _, port := range sub.Ports {
-			lbPort, err := loadbalancer.NewL4Addr(loadbalancer.L4Type(port.Protocol), uint16(port.Port))
-			if err != nil {
-				scopedLog.WithError(err).Error("Error while creating a new LB Port")
-				continue
-			}
+			lbPort := loadbalancer.NewL4Addr(loadbalancer.L4Type(port.Protocol), uint16(port.Port))
 			newSvcEP.Ports[loadbalancer.FEPortName(port.Name)] = lbPort
 		}
 	}
@@ -1170,12 +1156,7 @@ func (d *Daemon) delK8sSVCs(svc loadbalancer.K8sServiceNamespace, svcInfo *loadb
 			}
 		}
 
-		fe, err := loadbalancer.NewL3n4Addr(svcPort.Protocol, svcInfo.FEIP, svcPort.Port)
-		if err != nil {
-			scopedLog.WithError(err).Error("Error while creating a New L3n4AddrID. Ignoring service")
-			continue
-		}
-
+		fe := loadbalancer.NewL3n4Addr(svcPort.Protocol, svcInfo.FEIP, svcPort.Port)
 		if err := d.svcDeleteByFrontend(fe); err != nil {
 			scopedLog.WithError(err).WithField(logfields.Object, logfields.Repr(fe)).
 				Warn("Error deleting service by frontend")
@@ -1226,16 +1207,7 @@ func (d *Daemon) addK8sSVCs(svc loadbalancer.K8sServiceNamespace, svcInfo *loadb
 		uniqPorts[fePort.Port] = false
 
 		if fePort.ID == 0 {
-			feAddr, err := loadbalancer.NewL3n4Addr(fePort.Protocol, svcInfo.FEIP, fePort.Port)
-			if err != nil {
-				scopedLog.WithError(err).WithFields(logrus.Fields{
-					logfields.ServiceID: fePortName,
-					logfields.IPAddr:    svcInfo.FEIP,
-					logfields.Port:      fePort.Port,
-					logfields.Protocol:  fePort.Protocol,
-				}).Error("Error while creating a new L3n4Addr. Ignoring service...")
-				continue
-			}
+			feAddr := loadbalancer.NewL3n4Addr(fePort.Protocol, svcInfo.FEIP, fePort.Port)
 			feAddrID, err := service.AcquireID(*feAddr, 0)
 			if err != nil {
 				scopedLog.WithError(err).WithFields(logrus.Fields{
@@ -1266,14 +1238,7 @@ func (d *Daemon) addK8sSVCs(svc loadbalancer.K8sServiceNamespace, svcInfo *loadb
 			}
 		}
 
-		fe, err := loadbalancer.NewL3n4AddrID(fePort.Protocol, svcInfo.FEIP, fePort.Port, fePort.ID)
-		if err != nil {
-			scopedLog.WithError(err).WithFields(logrus.Fields{
-				logfields.IPAddr: svcInfo.FEIP,
-				logfields.Port:   svcInfo.Ports,
-			}).Error("Error while creating a New L3n4AddrID. Ignoring service...")
-			continue
-		}
+		fe := loadbalancer.NewL3n4AddrID(fePort.Protocol, svcInfo.FEIP, fePort.Port, fePort.ID)
 		if _, err := d.svcAdd(*fe, besValues, true); err != nil {
 			scopedLog.WithError(err).Error("Error while inserting service in LB map")
 		}
@@ -1361,11 +1326,7 @@ func parsingV1beta1(ing *v1beta1.Ingress, host net.IP) (*loadbalancer.K8sService
 	if ingressPort == 0 {
 		return nil, fmt.Errorf("invalid port number")
 	}
-	fePort, err := loadbalancer.NewFEPort(loadbalancer.TCP, uint16(ingressPort))
-	if err != nil {
-		return nil, err
-	}
-
+	fePort := loadbalancer.NewFEPort(loadbalancer.TCP, uint16(ingressPort))
 	ingressSvcInfo := loadbalancer.NewK8sServiceInfo(host, false, nil, nil)
 	portName := loadbalancer.FEPortName(ing.Spec.Backend.ServiceName + "/" + ing.Spec.Backend.ServicePort.String())
 	ingressSvcInfo.Ports[portName] = fePort
@@ -1458,11 +1419,7 @@ func (d *Daemon) updateIngressV1beta1(oldIngress, newIngress *v1beta1.Ingress) e
 			if ingressIP == nil {
 				continue
 			}
-			feAddr, err := loadbalancer.NewL3n4Addr(loadbalancer.TCP, ingressIP, uint16(port))
-			if err != nil {
-				scopedLog.WithError(err).Error("Error while creating a new L3n4Addr. Ignoring ingress...")
-				continue
-			}
+			feAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, ingressIP, uint16(port))
 			feAddrID, err := service.AcquireID(*feAddr, 0)
 			if err != nil {
 				scopedLog.WithError(err).Error("Error while getting a new service ID. Ignoring ingress...")
@@ -1518,11 +1475,7 @@ func (d *Daemon) deleteIngressV1beta1(ingress *v1beta1.Ingress) error {
 			if ingressIP == nil {
 				continue
 			}
-			feAddr, err := loadbalancer.NewL3n4Addr(loadbalancer.TCP, ingressIP, uint16(port))
-			if err != nil {
-				scopedLog.WithError(err).Error("Error while creating a new L3n4Addr. Ignoring ingress...")
-				continue
-			}
+			feAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, ingressIP, uint16(port))
 			// This is the only way that we can get the service's ID
 			// without accessing the KVStore.
 			svc := d.svcGetBySHA256Sum(feAddr.SHA256Sum())

--- a/daemon/k8s_watcher_test.go
+++ b/daemon/k8s_watcher_test.go
@@ -315,9 +315,7 @@ func (ds *DaemonSuite) Test_parseK8sEPv1(c *C) {
 			},
 			setupWanted: func() *loadbalancer.K8sServiceEndpoint {
 				svcEP := loadbalancer.NewK8sServiceEndpoint()
-				p, err := loadbalancer.NewL4Addr(loadbalancer.TCP, 8080)
-				c.Assert(err, IsNil)
-				svcEP.Ports["http-test-svc"] = p
+				svcEP.Ports["http-test-svc"] = loadbalancer.NewL4Addr(loadbalancer.TCP, 8080)
 				svcEP.BEIPs["172.0.0.1"] = true
 				return svcEP
 			},
@@ -357,12 +355,8 @@ func (ds *DaemonSuite) Test_parseK8sEPv1(c *C) {
 			},
 			setupWanted: func() *loadbalancer.K8sServiceEndpoint {
 				svcEP := loadbalancer.NewK8sServiceEndpoint()
-				p, err := loadbalancer.NewL4Addr(loadbalancer.TCP, 8080)
-				c.Assert(err, IsNil)
-				svcEP.Ports["http-test-svc"] = p
-				p, err = loadbalancer.NewL4Addr(loadbalancer.TCP, 8081)
-				c.Assert(err, IsNil)
-				svcEP.Ports["http-test-svc-2"] = p
+				svcEP.Ports["http-test-svc"] = loadbalancer.NewL4Addr(loadbalancer.TCP, 8080)
+				svcEP.Ports["http-test-svc-2"] = loadbalancer.NewL4Addr(loadbalancer.TCP, 8081)
 				svcEP.BEIPs["172.0.0.1"] = true
 				return svcEP
 			},
@@ -405,12 +399,8 @@ func (ds *DaemonSuite) Test_parseK8sEPv1(c *C) {
 			},
 			setupWanted: func() *loadbalancer.K8sServiceEndpoint {
 				svcEP := loadbalancer.NewK8sServiceEndpoint()
-				p, err := loadbalancer.NewL4Addr(loadbalancer.TCP, 8080)
-				c.Assert(err, IsNil)
-				svcEP.Ports["http-test-svc"] = p
-				p, err = loadbalancer.NewL4Addr(loadbalancer.TCP, 8081)
-				c.Assert(err, IsNil)
-				svcEP.Ports["http-test-svc-2"] = p
+				svcEP.Ports["http-test-svc"] = loadbalancer.NewL4Addr(loadbalancer.TCP, 8080)
+				svcEP.Ports["http-test-svc-2"] = loadbalancer.NewL4Addr(loadbalancer.TCP, 8081)
 				svcEP.BEIPs["172.0.0.1"] = true
 				svcEP.BEIPs["172.0.0.2"] = true
 				return svcEP
@@ -459,63 +449,8 @@ func (ds *DaemonSuite) Test_parseK8sEPv1(c *C) {
 			},
 			setupWanted: func() *loadbalancer.K8sServiceEndpoint {
 				svcEP := loadbalancer.NewK8sServiceEndpoint()
-				p, err := loadbalancer.NewL4Addr(loadbalancer.TCP, 8080)
-				c.Assert(err, IsNil)
-				svcEP.Ports["http-test-svc"] = p
-				p, err = loadbalancer.NewL4Addr(loadbalancer.TCP, 8081)
-				c.Assert(err, IsNil)
-				svcEP.Ports["http-test-svc-2"] = p
-				svcEP.BEIPs["172.0.0.1"] = true
-				svcEP.BEIPs["172.0.0.2"] = true
-				return svcEP
-			},
-		},
-		{
-			name: "endpoint with 2 addresses, 1 address not ready, 1 good port and 1 port with unknown protocol",
-			setupArgs: func() args {
-				return args{
-					eps: &core_v1.Endpoints{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "foo",
-							Namespace: "bar",
-						},
-						Subsets: []core_v1.EndpointSubset{
-							{
-								NotReadyAddresses: []core_v1.EndpointAddress{
-									{
-										IP: "172.0.0.3",
-									},
-								},
-								Addresses: []core_v1.EndpointAddress{
-									{
-										IP: "172.0.0.1",
-									},
-									{
-										IP: "172.0.0.2",
-									},
-								},
-								Ports: []core_v1.EndpointPort{
-									{
-										Name:     "http-test-svc",
-										Port:     8080,
-										Protocol: core_v1.ProtocolTCP,
-									},
-									{
-										Name:     "http-test-svc-2",
-										Port:     8081,
-										Protocol: core_v1.Protocol("foo"),
-									},
-								},
-							},
-						},
-					},
-				}
-			},
-			setupWanted: func() *loadbalancer.K8sServiceEndpoint {
-				svcEP := loadbalancer.NewK8sServiceEndpoint()
-				p, err := loadbalancer.NewL4Addr(loadbalancer.TCP, 8080)
-				c.Assert(err, IsNil)
-				svcEP.Ports["http-test-svc"] = p
+				svcEP.Ports["http-test-svc"] = loadbalancer.NewL4Addr(loadbalancer.TCP, 8080)
+				svcEP.Ports["http-test-svc-2"] = loadbalancer.NewL4Addr(loadbalancer.TCP, 8081)
 				svcEP.BEIPs["172.0.0.1"] = true
 				svcEP.BEIPs["172.0.0.2"] = true
 				return svcEP

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -304,14 +304,9 @@ type L4Addr struct {
 	Port     uint16
 }
 
-// NewL4Addr creates a new L4Addr. Returns an error if protocol is not recognized.
-func NewL4Addr(protocol L4Type, number uint16) (*L4Addr, error) {
-	switch protocol {
-	case TCP, UDP, NONE:
-	default:
-		return nil, fmt.Errorf("unknown protocol type %s", protocol)
-	}
-	return &L4Addr{Protocol: protocol, Port: number}, nil
+// NewL4Addr creates a new L4Addr.
+func NewL4Addr(protocol L4Type, number uint16) *L4Addr {
+	return &L4Addr{Protocol: protocol, Port: number}
 }
 
 // Equals returns true if both L4Addr are considered equal.
@@ -340,9 +335,9 @@ type FEPort struct {
 }
 
 // NewFEPort creates a new FEPort with the ID set to 0.
-func NewFEPort(protocol L4Type, portNumber uint16) (*FEPort, error) {
-	lbport, err := NewL4Addr(protocol, portNumber)
-	return &FEPort{L4Addr: lbport}, err
+func NewFEPort(protocol L4Type, portNumber uint16) *FEPort {
+	lbport := NewL4Addr(protocol, portNumber)
+	return &FEPort{L4Addr: lbport}
 }
 
 // EqualsIgnoreID returns true if both L4Addr are considered equal without
@@ -375,16 +370,13 @@ type L3n4Addr struct {
 }
 
 // NewL3n4Addr creates a new L3n4Addr.
-func NewL3n4Addr(protocol L4Type, ip net.IP, portNumber uint16) (*L3n4Addr, error) {
-	lbport, err := NewL4Addr(protocol, portNumber)
-	if err != nil {
-		return nil, err
-	}
+func NewL3n4Addr(protocol L4Type, ip net.IP, portNumber uint16) *L3n4Addr {
+	lbport := NewL4Addr(protocol, portNumber)
 
 	addr := L3n4Addr{IP: ip, L4Addr: *lbport}
 	log.WithField(logfields.IPAddr, addr).Debug("created new L3n4Addr")
 
-	return &addr, nil
+	return &addr
 }
 
 func NewL3n4AddrFromModel(base *models.FrontendAddress) (*L3n4Addr, error) {
@@ -401,11 +393,7 @@ func NewL3n4AddrFromModel(base *models.FrontendAddress) (*L3n4Addr, error) {
 		return nil, err
 	}
 
-	l4addr, err := NewL4Addr(proto, base.Port)
-	if err != nil {
-		return nil, err
-	}
-
+	l4addr := NewL4Addr(proto, base.Port)
 	ip := net.ParseIP(base.IP)
 	if ip == nil {
 		return nil, fmt.Errorf("Invalid IP address \"%s\"", base.IP)
@@ -414,19 +402,15 @@ func NewL3n4AddrFromModel(base *models.FrontendAddress) (*L3n4Addr, error) {
 	return &L3n4Addr{IP: ip, L4Addr: *l4addr}, nil
 }
 
-func NewLBBackEnd(protocol L4Type, ip net.IP, portNumber uint16, weight uint16) (*LBBackEnd, error) {
-	lbport, err := NewL4Addr(protocol, portNumber)
-	if err != nil {
-		return nil, err
-	}
-
+func NewLBBackEnd(protocol L4Type, ip net.IP, portNumber uint16, weight uint16) *LBBackEnd {
+	lbport := NewL4Addr(protocol, portNumber)
 	lbbe := LBBackEnd{
 		L3n4Addr: L3n4Addr{IP: ip, L4Addr: *lbport},
 		Weight:   weight,
 	}
 	log.WithField("backend", lbbe).Debug("created new LBBackend")
 
-	return &lbbe, nil
+	return &lbbe
 }
 
 func NewLBBackEndFromBackendModel(base *models.BackendAddress) (*LBBackEnd, error) {
@@ -435,11 +419,7 @@ func NewLBBackEndFromBackendModel(base *models.BackendAddress) (*LBBackEnd, erro
 	}
 
 	// FIXME: Should this be NONE ?
-	l4addr, err := NewL4Addr(NONE, base.Port)
-	if err != nil {
-		return nil, err
-	}
-
+	l4addr := NewL4Addr(NONE, base.Port)
 	ip := net.ParseIP(*base.IP)
 	if ip == nil {
 		return nil, fmt.Errorf("Invalid IP address \"%s\"", *base.IP)
@@ -457,11 +437,7 @@ func NewL3n4AddrFromBackendModel(base *models.BackendAddress) (*L3n4Addr, error)
 	}
 
 	// FIXME: Should this be NONE ?
-	l4addr, err := NewL4Addr(NONE, base.Port)
-	if err != nil {
-		return nil, err
-	}
-
+	l4addr := NewL4Addr(NONE, base.Port)
 	ip := net.ParseIP(*base.IP)
 	if ip == nil {
 		return nil, fmt.Errorf("Invalid IP address \"%s\"", *base.IP)
@@ -555,12 +531,9 @@ type L3n4AddrID struct {
 }
 
 // NewL3n4AddrID creates a new L3n4AddrID.
-func NewL3n4AddrID(protocol L4Type, ip net.IP, portNumber uint16, id ServiceID) (*L3n4AddrID, error) {
-	l3n4Addr, err := NewL3n4Addr(protocol, ip, portNumber)
-	if err != nil {
-		return nil, err
-	}
-	return &L3n4AddrID{L3n4Addr: *l3n4Addr, ID: id}, nil
+func NewL3n4AddrID(protocol L4Type, ip net.IP, portNumber uint16, id ServiceID) *L3n4AddrID {
+	l3n4Addr := NewL3n4Addr(protocol, ip, portNumber)
+	return &L3n4AddrID{L3n4Addr: *l3n4Addr, ID: id}
 }
 
 // DeepCopy returns a DeepCopy of the given L3n4AddrID.

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -481,7 +481,7 @@ func L3n4Addr2RevNatKeynValue(svcID loadbalancer.ServiceID, feL3n4Addr loadbalan
 }
 
 // serviceKey2L3n4Addr converts the given svcKey to a L3n4Addr.
-func serviceKey2L3n4Addr(svcKey ServiceKey) (*loadbalancer.L3n4Addr, error) {
+func serviceKey2L3n4Addr(svcKey ServiceKey) *loadbalancer.L3n4Addr {
 	log.WithField(logfields.ServiceID, svcKey).Debug("creating L3n4Addr for ServiceKey")
 	var (
 		feIP   net.IP
@@ -501,7 +501,7 @@ func serviceKey2L3n4Addr(svcKey ServiceKey) (*loadbalancer.L3n4Addr, error) {
 
 // serviceKeynValue2FEnBE converts the given svcKey and svcValue to a frontend in the
 // form of L3n4AddrID and backend in the form of L3n4Addr.
-func serviceKeynValue2FEnBE(svcKey ServiceKey, svcValue ServiceValue) (*loadbalancer.L3n4AddrID, *loadbalancer.LBBackEnd, error) {
+func serviceKeynValue2FEnBE(svcKey ServiceKey, svcValue ServiceValue) (*loadbalancer.L3n4AddrID, *loadbalancer.LBBackEnd) {
 	var (
 		beIP     net.IP
 		svcID    loadbalancer.ServiceID
@@ -528,59 +528,49 @@ func serviceKeynValue2FEnBE(svcKey ServiceKey, svcValue ServiceValue) (*loadbala
 		beWeight = svc4Val.Weight
 	}
 
-	feL3n4Addr, err := serviceKey2L3n4Addr(svcKey)
-	if err != nil {
-		return nil, nil, fmt.Errorf("unable to create a new frontend for service key %s: %s", svcKey, err)
-	}
+	feL3n4Addr := serviceKey2L3n4Addr(svcKey)
 
-	beLBBackEnd, err := loadbalancer.NewLBBackEnd(loadbalancer.TCP, beIP, bePort, beWeight)
-	if err != nil {
-		return nil, nil, fmt.Errorf("unable to create a new backend for %s:%d: %s", beIP, bePort, err)
-	}
+	beLBBackEnd := loadbalancer.NewLBBackEnd(loadbalancer.TCP, beIP, bePort, beWeight)
 
 	feL3n4AddrID := &loadbalancer.L3n4AddrID{
 		L3n4Addr: *feL3n4Addr,
 		ID:       svcID,
 	}
 
-	return feL3n4AddrID, beLBBackEnd, nil
+	return feL3n4AddrID, beLBBackEnd
 }
 
 // RevNat6Value2L3n4Addr converts the given RevNat6Value to a L3n4Addr.
-func revNat6Value2L3n4Addr(revNATV *RevNat6Value) (*loadbalancer.L3n4Addr, error) {
+func revNat6Value2L3n4Addr(revNATV *RevNat6Value) *loadbalancer.L3n4Addr {
 	return loadbalancer.NewL3n4Addr(loadbalancer.TCP, revNATV.Address.IP(), revNATV.Port)
 }
 
 // revNat4Value2L3n4Addr converts the given RevNat4Value to a L3n4Addr.
-func revNat4Value2L3n4Addr(revNATV *RevNat4Value) (*loadbalancer.L3n4Addr, error) {
+func revNat4Value2L3n4Addr(revNATV *RevNat4Value) *loadbalancer.L3n4Addr {
 	return loadbalancer.NewL3n4Addr(loadbalancer.TCP, revNATV.Address.IP(), revNATV.Port)
 }
 
 // revNatValue2L3n4AddrID converts the given RevNatKey and RevNatValue to a L3n4AddrID.
-func revNatValue2L3n4AddrID(revNATKey RevNatKey, revNATValue RevNatValue) (*loadbalancer.L3n4AddrID, error) {
+func revNatValue2L3n4AddrID(revNATKey RevNatKey, revNATValue RevNatValue) *loadbalancer.L3n4AddrID {
 	var (
 		svcID loadbalancer.ServiceID
 		be    *loadbalancer.L3n4Addr
-		err   error
 	)
 	if revNATKey.IsIPv6() {
 		revNat6Key := revNATKey.(*RevNat6Key)
 		svcID = loadbalancer.ServiceID(revNat6Key.Key)
 
 		revNat6Value := revNATValue.(*RevNat6Value)
-		be, err = revNat6Value2L3n4Addr(revNat6Value)
+		be = revNat6Value2L3n4Addr(revNat6Value)
 	} else {
 		revNat4Key := revNATKey.(*RevNat4Key)
 		svcID = loadbalancer.ServiceID(revNat4Key.Key)
 
 		revNat4Value := revNATValue.(*RevNat4Value)
-		be, err = revNat4Value2L3n4Addr(revNat4Value)
-	}
-	if err != nil {
-		return nil, err
+		be = revNat4Value2L3n4Addr(revNat4Value)
 	}
 
-	return &loadbalancer.L3n4AddrID{L3n4Addr: *be, ID: svcID}, nil
+	return &loadbalancer.L3n4AddrID{L3n4Addr: *be, ID: svcID}
 }
 
 // DeleteRevNATBPF deletes the revNAT entry from its corresponding BPF map
@@ -622,12 +612,7 @@ func DumpServiceMapsToUserspace(includeMasterBackend, skipIPv4 bool) (loadbalanc
 		})
 
 		scopedLog.Debug("parsing service mapping")
-		fe, be, err := serviceKeynValue2FEnBE(svcKey, svcValue)
-		if err != nil {
-			scopedLog.WithError(err).Error("error converting service key to userspace representation")
-			errors = append(errors, err)
-			return
-		}
+		fe, be := serviceKeynValue2FEnBE(svcKey, svcValue)
 
 		svc := newSVCMap.AddFEnBE(fe, be, svcKey.GetBackend())
 		newSVCList = append(newSVCList, svc)
@@ -669,12 +654,7 @@ func DumpRevNATMapsToUserspace(skipIPv4 bool) (loadbalancer.RevNATMap, []error) 
 		})
 
 		scopedLog.Debug("parsing BPF revNAT mapping")
-		fe, err := revNatValue2L3n4AddrID(revNatK, revNatV)
-		if err != nil {
-			scopedLog.WithError(err).Error("error converting revNAT key to userspace representation")
-			errors = append(errors, err)
-			return
-		}
+		fe := revNatValue2L3n4AddrID(revNatK, revNatV)
 		newRevNATMap[fe.ID] = fe.L3n4Addr
 	}
 


### PR DESCRIPTION
For the REST API, the L4 type is already validated at the API entry and an
error code is returned. For Kubernetes, the is no way to handle feedback. The
datapath does not even respect the protocol field yet so it will implement
whatever port extraction it understands. Hence all the error handling adds
unneeded complexity and can be removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6083)
<!-- Reviewable:end -->
