### PR TITLE
refactor trafficdirection into its own package

### DIFF
--- a/cilium/cmd/bpf_metrics_list.go
+++ b/cilium/cmd/bpf_metrics_list.go
@@ -25,8 +25,8 @@ import (
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/maps/metricsmap"
-	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/monitor"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 
 	"github.com/spf13/cobra"
 )
@@ -98,7 +98,7 @@ func listMetrics(bpfMetricsList map[string][]string) {
 		}
 
 		if keyIsValid && valueIsValid {
-			rows = append(rows, [numColumns]string{monitor.DropReason(reasonCode), policymap.TrafficDirection(trafficDirectionCode).String(), packets, bytes})
+			rows = append(rows, [numColumns]string{monitor.DropReason(reasonCode), trafficdirection.TrafficDirection(trafficDirectionCode).String(), packets, bytes})
 		} else {
 			// Fall back to best effort printing.
 			for i, v := range value {

--- a/cilium/cmd/bpf_policy_get.go
+++ b/cilium/cmd/bpf_policy_get.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/maps/policymap"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
 
 	"github.com/spf13/cobra"
@@ -157,7 +158,7 @@ func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 	}
 	for _, stat := range statsMap {
 		id := identity.NumericIdentity(stat.Key.Identity)
-		trafficDirection := policymap.TrafficDirection(stat.Key.TrafficDirection)
+		trafficDirection := trafficdirection.TrafficDirection(stat.Key.TrafficDirection)
 		trafficDirectionString := trafficDirection.String()
 		port := models.PortProtocolANY
 		if stat.Key.DestPort != 0 {

--- a/cilium/cmd/helpers.go
+++ b/cilium/cmd/helpers.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
 
 	"github.com/spf13/cobra"
@@ -203,7 +204,7 @@ type PolicyUpdateArgs struct {
 
 	// trafficDirection represents the traffic direction provided
 	// as an argument e.g. `ingress`
-	trafficDirection policymap.TrafficDirection
+	trafficDirection trafficdirection.TrafficDirection
 
 	// label represents the identity of the label provided as argument.
 	label uint32
@@ -219,16 +220,16 @@ type PolicyUpdateArgs struct {
 // parseTrafficString converts the provided string to its corresponding
 // TrafficDirection. If the string does not correspond to a valid TrafficDirection
 // type, returns Invalid and a corresponding error.
-func parseTrafficString(td string) (policymap.TrafficDirection, error) {
+func parseTrafficString(td string) (trafficdirection.TrafficDirection, error) {
 	lowered := strings.ToLower(td)
 
 	switch lowered {
 	case "ingress":
-		return policymap.Ingress, nil
+		return trafficdirection.Ingress, nil
 	case "egress":
-		return policymap.Egress, nil
+		return trafficdirection.Egress, nil
 	default:
-		return policymap.Invalid, fmt.Errorf("invalid direction %q provided", td)
+		return trafficdirection.Invalid, fmt.Errorf("invalid direction %q provided", td)
 	}
 
 }

--- a/cilium/cmd/helpers_test.go
+++ b/cilium/cmd/helpers_test.go
@@ -2,13 +2,14 @@ package cmd
 
 import (
 	"bytes"
+
 	"sort"
 	"strconv"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/maps/policymap"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
 
 	. "gopkg.in/check.v1"
@@ -57,18 +58,18 @@ func (s *CMDHelpersSuite) TestParseTrafficString(c *C) {
 
 	for _, validCase := range validIngressCases {
 		ingressDir, err := parseTrafficString(validCase)
-		c.Assert(ingressDir, Equals, policymap.Ingress)
+		c.Assert(ingressDir, Equals, trafficdirection.Ingress)
 		c.Assert(err, IsNil)
 	}
 
 	for _, validCase := range validEgressCases {
 		egressDir, err := parseTrafficString(validCase)
-		c.Assert(egressDir, Equals, policymap.Egress)
+		c.Assert(egressDir, Equals, trafficdirection.Egress)
 		c.Assert(err, IsNil)
 	}
 
 	invalid, err := parseTrafficString(invalidStr)
-	c.Assert(invalid, Equals, policymap.Invalid)
+	c.Assert(invalid, Equals, trafficdirection.Invalid)
 	c.Assert(err, Not(IsNil))
 
 }
@@ -89,7 +90,7 @@ func (s *CMDHelpersSuite) TestParsePolicyUpdateArgsHelper(c *C) {
 		args             []string
 		invalid          bool
 		endpointID       string
-		trafficDirection policymap.TrafficDirection
+		trafficDirection trafficdirection.TrafficDirection
 		peerLbl          uint32
 		port             uint16
 		protos           []uint8
@@ -98,7 +99,7 @@ func (s *CMDHelpersSuite) TestParsePolicyUpdateArgsHelper(c *C) {
 			args:             []string{labels.IDNameHost, "ingress", "12345"},
 			invalid:          false,
 			endpointID:       "reserved_" + strconv.Itoa(int(identity.ReservedIdentityHost)),
-			trafficDirection: policymap.Ingress,
+			trafficDirection: trafficdirection.Ingress,
 			peerLbl:          12345,
 			port:             0,
 			protos:           []uint8{0},
@@ -107,7 +108,7 @@ func (s *CMDHelpersSuite) TestParsePolicyUpdateArgsHelper(c *C) {
 			args:             []string{"123", "egress", "12345", "1/tcp"},
 			invalid:          false,
 			endpointID:       "123",
-			trafficDirection: policymap.Egress,
+			trafficDirection: trafficdirection.Egress,
 			peerLbl:          12345,
 			port:             1,
 			protos:           []uint8{uint8(u8proto.TCP)},
@@ -116,7 +117,7 @@ func (s *CMDHelpersSuite) TestParsePolicyUpdateArgsHelper(c *C) {
 			args:             []string{"123", "ingress", "12345", "1"},
 			invalid:          false,
 			endpointID:       "123",
-			trafficDirection: policymap.Ingress,
+			trafficDirection: trafficdirection.Ingress,
 			peerLbl:          12345,
 			port:             1,
 			protos:           allProtos,

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -72,6 +72,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	policyApi "github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/proxy/logger"
 	"github.com/cilium/cilium/pkg/revert"
@@ -1370,8 +1371,8 @@ func (d *Daemon) removeStaleMap(path string) {
 func (d *Daemon) removeStaleIDFromPolicyMap(id uint32) {
 	gpm, err := policymap.OpenGlobalMap(bpf.MapPath(endpoint.PolicyGlobalMapName))
 	if err == nil {
-		gpm.Delete(id, policymap.AllPorts, u8proto.All, policymap.Ingress)
-		gpm.Delete(id, policymap.AllPorts, u8proto.All, policymap.Egress)
+		gpm.Delete(id, policymap.AllPorts, u8proto.All, trafficdirection.Ingress)
+		gpm.Delete(id, policymap.AllPorts, u8proto.All, trafficdirection.Egress)
 		gpm.Close()
 	}
 }

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/version"
 
@@ -306,11 +307,11 @@ func (e *Endpoint) addNewRedirectsFromMap(owner Owner, m policy.L4PolicyMap, des
 			}
 
 			// Set the proxy port in the policy map.
-			var direction policymap.TrafficDirection
+			var direction trafficdirection.TrafficDirection
 			if l4.Ingress {
-				direction = policymap.Ingress
+				direction = trafficdirection.Ingress
 			} else {
-				direction = policymap.Egress
+				direction = trafficdirection.Egress
 			}
 			keysFromFilter := e.convertL4FilterToPolicyMapKeys(&l4, direction)
 			for _, keyFromFilter := range keysFromFilter {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/u8proto"
 	"github.com/cilium/cilium/pkg/versioncheck"
@@ -996,13 +997,13 @@ func (e *Endpoint) GetPolicyModel() *models.EndpointPolicyStatus {
 			// not be added to these sets.
 			continue
 		}
-		switch policymap.TrafficDirection(policyMapKey.TrafficDirection) {
-		case policymap.Ingress:
+		switch trafficdirection.TrafficDirection(policyMapKey.TrafficDirection) {
+		case trafficdirection.Ingress:
 			realizedIngressIdentities = append(realizedIngressIdentities, int64(policyMapKey.Identity))
-		case policymap.Egress:
+		case trafficdirection.Egress:
 			realizedEgressIdentities = append(realizedEgressIdentities, int64(policyMapKey.Identity))
 		default:
-			log.WithField(logfields.TrafficDirection, policymap.TrafficDirection(policyMapKey.TrafficDirection)).Error("Unexpected traffic direction present in realized PolicyMap state for endpoint")
+			log.WithField(logfields.TrafficDirection, trafficdirection.TrafficDirection(policyMapKey.TrafficDirection)).Error("Unexpected traffic direction present in realized PolicyMap state for endpoint")
 		}
 	}
 
@@ -1018,13 +1019,13 @@ func (e *Endpoint) GetPolicyModel() *models.EndpointPolicyStatus {
 			// not be added to these sets.
 			continue
 		}
-		switch policymap.TrafficDirection(policyMapKey.TrafficDirection) {
-		case policymap.Ingress:
+		switch trafficdirection.TrafficDirection(policyMapKey.TrafficDirection) {
+		case trafficdirection.Ingress:
 			desiredIngressIdentities = append(desiredIngressIdentities, int64(policyMapKey.Identity))
-		case policymap.Egress:
+		case trafficdirection.Egress:
 			desiredEgressIdentities = append(desiredEgressIdentities, int64(policyMapKey.Identity))
 		default:
-			log.WithField(logfields.TrafficDirection, policymap.TrafficDirection(policyMapKey.TrafficDirection)).Error("Unexpected traffic direction present in desired PolicyMap state for endpoint")
+			log.WithField(logfields.TrafficDirection, trafficdirection.TrafficDirection(policyMapKey.TrafficDirection)).Error("Unexpected traffic direction present in desired PolicyMap state for endpoint")
 		}
 	}
 
@@ -1333,7 +1334,7 @@ func (e *Endpoint) Allows(id identityPkg.NumericIdentity) bool {
 
 	keyToLookup := policymap.PolicyKey{
 		Identity:         uint32(id),
-		TrafficDirection: policymap.Ingress.Uint8(),
+		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	}
 
 	_, ok := e.desiredMapState[keyToLookup]
@@ -1519,8 +1520,8 @@ func (e *Endpoint) RemoveFromGlobalPolicyMap() error {
 	if err == nil {
 		// We need to remove ourselves from global map, so that
 		// resources (prog/map reference counts) can be released.
-		gpm.Delete(uint32(e.ID), policymap.AllPorts, u8proto.All, policymap.Ingress)
-		gpm.Delete(uint32(e.ID), policymap.AllPorts, u8proto.All, policymap.Egress)
+		gpm.Delete(uint32(e.ID), policymap.AllPorts, u8proto.All, trafficdirection.Ingress)
+		gpm.Delete(uint32(e.ID), policymap.AllPorts, u8proto.All, trafficdirection.Egress)
 		gpm.Close()
 	}
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/revert"
 
 	"github.com/sirupsen/logrus"
@@ -50,13 +51,13 @@ var (
 	// localHostKey represents an ingress L3 allow from the local host.
 	localHostKey = policymap.PolicyKey{
 		Identity:         identityPkg.ReservedIdentityHost.Uint32(),
-		TrafficDirection: policymap.Ingress.Uint8(),
+		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	}
 
 	// worldKey represents an ingress L3 allow from the world.
 	worldKey = policymap.PolicyKey{
 		Identity:         identityPkg.ReservedIdentityWorld.Uint32(),
-		TrafficDirection: policymap.Ingress.Uint8(),
+		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	}
 )
 
@@ -108,7 +109,7 @@ func getSecurityIdentities(labelsMap identityPkg.IdentityCache, selector *api.En
 // convertL4FilterToPolicyMapKeys converts filter into a list of PolicyKeys
 // that apply to this endpoint.
 // Must be called with endpoint.Mutex locked.
-func (e *Endpoint) convertL4FilterToPolicyMapKeys(filter *policy.L4Filter, direction policymap.TrafficDirection) []policymap.PolicyKey {
+func (e *Endpoint) convertL4FilterToPolicyMapKeys(filter *policy.L4Filter, direction trafficdirection.TrafficDirection) []policymap.PolicyKey {
 	keysToAdd := []policymap.PolicyKey{}
 	port := uint16(filter.Port)
 	proto := uint8(filter.U8Proto)
@@ -151,7 +152,7 @@ func (e *Endpoint) computeDesiredL4PolicyMapEntries(keysToAdd PolicyMapState) {
 	}
 
 	for _, filter := range e.DesiredL4Policy.Ingress {
-		keysFromFilter := e.convertL4FilterToPolicyMapKeys(&filter, policymap.Ingress)
+		keysFromFilter := e.convertL4FilterToPolicyMapKeys(&filter, trafficdirection.Ingress)
 		for _, keyFromFilter := range keysFromFilter {
 			var proxyPort uint16
 			// Preserve the already-allocated proxy ports for redirects that
@@ -171,7 +172,7 @@ func (e *Endpoint) computeDesiredL4PolicyMapEntries(keysToAdd PolicyMapState) {
 	}
 
 	for _, filter := range e.DesiredL4Policy.Egress {
-		keysFromFilter := e.convertL4FilterToPolicyMapKeys(&filter, policymap.Egress)
+		keysFromFilter := e.convertL4FilterToPolicyMapKeys(&filter, trafficdirection.Egress)
 		for _, keyFromFilter := range keysFromFilter {
 			var proxyPort uint16
 			// Preserve the already-allocated proxy ports for redirects that
@@ -344,7 +345,7 @@ func (e *Endpoint) computeDesiredL3PolicyMapEntries(repo *policy.Repository, des
 		if ingressAccess == api.Allowed {
 			keyToAdd := policymap.PolicyKey{
 				Identity:         identity.Uint32(),
-				TrafficDirection: policymap.Ingress.Uint8(),
+				TrafficDirection: trafficdirection.Ingress.Uint8(),
 			}
 			desiredPolicyKeys[keyToAdd] = PolicyMapStateEntry{}
 		}
@@ -363,7 +364,7 @@ func (e *Endpoint) computeDesiredL3PolicyMapEntries(repo *policy.Repository, des
 		if egressAccess == api.Allowed {
 			keyToAdd := policymap.PolicyKey{
 				Identity:         identity.Uint32(),
-				TrafficDirection: policymap.Egress.Uint8(),
+				TrafficDirection: trafficdirection.Egress.Uint8(),
 			}
 			desiredPolicyKeys[keyToAdd] = PolicyMapStateEntry{}
 		}

--- a/pkg/maps/policymap/policymap_test.go
+++ b/pkg/maps/policymap/policymap_test.go
@@ -15,6 +15,8 @@
 package policymap
 
 import (
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -47,7 +49,7 @@ func (pm *PolicyMapTestSuite) TestPolicyEntriesDump_Less(c *C) {
 						Identity:         uint32(0),
 						DestPort:         0,
 						Nexthdr:          0,
-						TrafficDirection: uint8(Ingress),
+						TrafficDirection: uint8(trafficdirection.Ingress),
 					},
 				},
 			},
@@ -65,7 +67,7 @@ func (pm *PolicyMapTestSuite) TestPolicyEntriesDump_Less(c *C) {
 						Identity:         uint32(0),
 						DestPort:         0,
 						Nexthdr:          0,
-						TrafficDirection: uint8(Ingress),
+						TrafficDirection: uint8(trafficdirection.Ingress),
 					},
 				},
 				{
@@ -73,7 +75,7 @@ func (pm *PolicyMapTestSuite) TestPolicyEntriesDump_Less(c *C) {
 						Identity:         uint32(1),
 						DestPort:         0,
 						Nexthdr:          0,
-						TrafficDirection: uint8(Ingress),
+						TrafficDirection: uint8(trafficdirection.Ingress),
 					},
 				},
 			},
@@ -91,7 +93,7 @@ func (pm *PolicyMapTestSuite) TestPolicyEntriesDump_Less(c *C) {
 						Identity:         uint32(0),
 						DestPort:         0,
 						Nexthdr:          0,
-						TrafficDirection: uint8(Ingress),
+						TrafficDirection: uint8(trafficdirection.Ingress),
 					},
 				},
 				{
@@ -99,7 +101,7 @@ func (pm *PolicyMapTestSuite) TestPolicyEntriesDump_Less(c *C) {
 						Identity:         uint32(1),
 						DestPort:         0,
 						Nexthdr:          0,
-						TrafficDirection: uint8(Egress),
+						TrafficDirection: uint8(trafficdirection.Egress),
 					},
 				},
 			},
@@ -117,7 +119,7 @@ func (pm *PolicyMapTestSuite) TestPolicyEntriesDump_Less(c *C) {
 						Identity:         uint32(1),
 						DestPort:         0,
 						Nexthdr:          0,
-						TrafficDirection: uint8(Egress),
+						TrafficDirection: uint8(trafficdirection.Egress),
 					},
 				},
 				{
@@ -125,7 +127,7 @@ func (pm *PolicyMapTestSuite) TestPolicyEntriesDump_Less(c *C) {
 						Identity:         uint32(0),
 						DestPort:         0,
 						Nexthdr:          0,
-						TrafficDirection: uint8(Egress),
+						TrafficDirection: uint8(trafficdirection.Egress),
 					},
 				},
 			},

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -142,7 +142,7 @@ func mergeL4IngressPort(ctx *SearchContext, endpoints []api.EndpointSelector, en
 
 func mergeL4Ingress(ctx *SearchContext, rule api.IngressRule, ruleLabels labels.LabelArray, resMap L4PolicyMap) (int, error) {
 	if len(rule.ToPorts) == 0 {
-		ctx.PolicyTrace("    No L4 %s rules\n", policymap.Ingress)
+		ctx.PolicyTrace("    No L4 %s rules\n", trafficdirection.Ingress)
 		return 0, nil
 	}
 
@@ -172,7 +172,7 @@ func mergeL4Ingress(ctx *SearchContext, rule api.IngressRule, ruleLabels labels.
 	}
 
 	for _, r := range rule.ToPorts {
-		ctx.PolicyTrace("    Allows %s port %v from endpoints %v\n", policymap.Ingress, r.Ports, fromEndpoints)
+		ctx.PolicyTrace("    Allows %s port %v from endpoints %v\n", trafficdirection.Ingress, r.Ports, fromEndpoints)
 		if r.Rules != nil && r.Rules.L7Proto != "" {
 			ctx.PolicyTrace("      l7proto: \"%s\"\n", r.Rules.L7Proto)
 		}
@@ -441,7 +441,7 @@ func (r *rule) canReachEgress(ctx *SearchContext, state *traceState) api.Decisio
 
 func mergeL4Egress(ctx *SearchContext, rule api.EgressRule, ruleLabels labels.LabelArray, resMap L4PolicyMap) (int, error) {
 	if len(rule.ToPorts) == 0 {
-		ctx.PolicyTrace("    No L4 %s rules\n", policymap.Egress)
+		ctx.PolicyTrace("    No L4 %s rules\n", trafficdirection.Egress)
 		return 0, nil
 	}
 
@@ -449,7 +449,7 @@ func mergeL4Egress(ctx *SearchContext, rule api.EgressRule, ruleLabels labels.La
 	found := 0
 
 	for _, r := range rule.ToPorts {
-		ctx.PolicyTrace("    Allows %s port %v to endpoints %v\n", policymap.Egress, r.Ports, toEndpoints)
+		ctx.PolicyTrace("    Allows %s port %v to endpoints %v\n", trafficdirection.Egress, r.Ports, toEndpoints)
 		if r.Rules != nil && r.Rules.L7Proto != "" {
 			ctx.PolicyTrace("      l7proto: \"%s\"\n", r.Rules.L7Proto)
 		}

--- a/pkg/policy/trafficdirection/doc.go
+++ b/pkg/policy/trafficdirection/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package trafficdirection specifies the directionality of policy in a
+// numeric representation.
+package trafficdirection

--- a/pkg/policy/trafficdirection/trafficdirection.go
+++ b/pkg/policy/trafficdirection/trafficdirection.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package policymap
+package trafficdirection
 
 // TrafficDirection specifies the directionality of policy (ingress or egress).
 type TrafficDirection uint8


### PR DESCRIPTION
This removes the dependency of pkg/policy on any BPF-related code.

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #6101

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6097)
<!-- Reviewable:end -->
