### PR TITLE
docs: fix CVE-2018-18074

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -12,7 +12,7 @@ MarkupSafe==1.0
 Pygments==2.2.0
 pytz==2017.2
 PyYAML==3.12
-requests==2.18.3
+requests==2.20.0
 six==1.10.0
 snowballstemmer==1.2.1
 Sphinx==1.6.3


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

As this is related with docs I'm not entirely sure how read the docs is affected but it doesn't hurt backport this up to 1.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6109)
<!-- Reviewable:end -->
