### PR TITLE
pkg/option: remove dependency on viper

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -1,0 +1,30 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/spf13/viper"
+)
+
+func populateConfig() {
+	option.Config.Tunnel = viper.GetString(option.TunnelName)
+	option.Config.ClusterName = viper.GetString(option.ClusterName)
+	option.Config.ClusterID = viper.GetInt(option.ClusterIDName)
+	option.Config.ClusterMeshConfig = viper.GetString(option.ClusterMeshConfigName)
+	option.Config.CTMapEntriesGlobalTCP = viper.GetInt(option.CTMapEntriesGlobalTCPName)
+	option.Config.CTMapEntriesGlobalAny = viper.GetInt(option.CTMapEntriesGlobalAnyName)
+	option.Config.UseSingleClusterRoute = viper.GetBool(option.SingleClusterRouteName)
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1104,7 +1104,10 @@ func createPrefixLengthCounter() *counter.PrefixLengthCounter {
 
 // NewDaemon creates and returns a new Daemon with the parameters set in c.
 func NewDaemon() (*Daemon, *endpointRestoreState, error) {
-	// Validate the daemon specific global options
+	// Prepopulate option.Config with options from CLI.
+	populateConfig()
+
+	// Validate the daemon-specific global options.
 	if err := option.Config.Validate(); err != nil {
 		return nil, nil, fmt.Errorf("invalid daemon configuration: %s", err)
 	}


### PR DESCRIPTION
This reduces the number of dependencies imported into the package by 23. No
functional change is intended.

Signed-off by: Ian Vernon <ian@cilium.io>

Further PRs will remove the dependency on viper, as it pulls in a hefty number of dependencies wherever it is invoked.

Related-to: #6101

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6111)
<!-- Reviewable:end -->
