### PR TITLE
Jenkinsfile: increase memory for kubernetes upstream tests

### DIFF
--- a/kubernetes-upstream.Jenkinsfile
+++ b/kubernetes-upstream.Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
     environment {
         PROJ_PATH = "src/github.com/cilium/cilium"
         TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
-        MEMORY = "4096"
+        MEMORY = "5120"
         K8S_VERSION="1.12"
         SERVER_BOX = "cilium/ubuntu"
     }


### PR DESCRIPTION
We can't build kubernetes e2e tests because the lack of memory
available.
Increasing the memory by 1GB should help building e2e tests.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6114)
<!-- Reviewable:end -->
