### PR TITLE
Add unit tests for pkg/datapath/loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,8 @@ TEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyAddres
 
 # invoked from ginkgo compose file after starting kvstore backends
 tests-privileged:
+	# cilium-map-migrate is a dependency of some unit tests.
+	$(MAKE) -C bpf cilium-map-migrate
 	$(QUIET)$(foreach pkg,$(TESTPKGS),\
 		$(GO) test $(TEST_LDFLAGS) $(pkg) $(GOTEST_PRIV_OPTS) || exit 1;)
 	@rmdir ./daemon/1 ./daemon/1_backup 2> /dev/null || true

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -54,6 +54,8 @@ type directoryInfo struct {
 	Library string
 	// Runtime contains headers for compilation
 	Runtime string
+	// State contains node, lxc, and features headers for templatization
+	State string
 	// Output is the directory where the files will be stored
 	Output string
 }
@@ -187,7 +189,7 @@ func progCFlags(prog *progInfo, dir *directoryInfo) []string {
 
 	return []string{
 		fmt.Sprintf("-I%s", path.Join(dir.Runtime, "globals")),
-		fmt.Sprintf("-I%s", dir.Output),
+		fmt.Sprintf("-I%s", dir.State),
 		fmt.Sprintf("-I%s", path.Join(dir.Library, "include")),
 		"-c", path.Join(dir.Library, prog.Source),
 		"-o", output,

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -74,6 +74,10 @@ var (
 	endpointObjDebug = fmt.Sprintf("%s.dbg.o", endpointPrefix)
 	endpointAsm      = fmt.Sprintf("%s.%s", endpointPrefix, outputAssembly)
 
+	// testIncludes allows the unit tests to inject additional include
+	// paths into the compile command at test time. It is usually nil.
+	testIncludes string
+
 	debugProgs = []*progInfo{
 		{
 			Source:     endpointProg,
@@ -188,6 +192,7 @@ func progCFlags(prog *progInfo, dir *directoryInfo) []string {
 	}
 
 	return []string{
+		testIncludes,
 		fmt.Sprintf("-I%s", path.Join(dir.Runtime, "globals")),
 		fmt.Sprintf("-I%s", dir.State),
 		fmt.Sprintf("-I%s", path.Join(dir.Library, "include")),

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -116,6 +116,7 @@ func CompileAndLoad(ctx context.Context, ep endpoint) error {
 	dirs := directoryInfo{
 		Library: option.Config.BpfDir,
 		Runtime: option.Config.StateDir,
+		State:   ep.StateDir(),
 		Output:  ep.StateDir(),
 	}
 	return compileAndLoad(ctx, ep, &dirs)
@@ -125,6 +126,7 @@ func ReloadDatapath(ctx context.Context, ep endpoint) error {
 	dirs := directoryInfo{
 		Library: option.Config.BpfDir,
 		Runtime: option.Config.StateDir,
+		State:   ep.StateDir(),
 		Output:  ep.StateDir(),
 	}
 	return reloadDatapath(ctx, ep, &dirs)

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !privileged_tests
+// +build privileged_tests
 
 package loader
 

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -50,7 +50,9 @@ func Test(t *testing.T) {
 // cleanups and pass the exit code of the test run to the caller which can run
 // os.Exit() with the result.
 func runTests(m *testing.M) (int, error) {
-	tmpDir, err := ioutil.TempDir("", "cilium_")
+	testIncludes = "-I/usr/include/x86_64-linux-gnu/"
+
+	tmpDir, err := ioutil.TempDir("/tmp/", "cilium_")
 	if err != nil {
 		return 1, fmt.Errorf("Failed to create temporary directory: %s", err)
 	}

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -63,7 +63,9 @@ func replaceDatapath(ctx context.Context, ifName string, objPath string, progSec
 	// FIXME: Replace cilium-map-migrate with Golang map migration
 	cmd := exec.CommandContext(ctx, "cilium-map-migrate", "-s", objPath)
 	cmd.Env = bpf.Environment()
-	_, err = cmd.CombinedOutput(log, true)
+	if _, err = cmd.CombinedOutput(log, true); err != nil {
+		return err
+	}
 	defer func() {
 		var retCode string
 		if err == nil {

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     depends_on:
       - consul
       - etcd
-    command: "bash -c 'cd /go/src/github.com/cilium/cilium/; make tests-privileged'"
+    command: "bash -c 'cd /go/src/github.com/cilium/cilium/; export PATH=$$PATH:$$PWD/bpf; make tests-privileged'"
   precheck:
     extends:
       service: base_image


### PR DESCRIPTION
Based upon ~~https://github.com/cilium/cilium/pull/6180~~ .

```
$ sudo -E make tests-privileged TESTPKGS=github.com/cilium/cilium/pkg/datapath/loader
can't load package: package github.com/cilium/cilium/test/bpf: C source files not allowed when not using cgo or SWIG: bpf-event-test.c unit-test.c
Starting key-value store containers...                                              
cilium-etcd-test-container                                                      
c82049bf4918b79499a1d11acbcc24a01099743c2d823b52255b18b17e857928                   
cilium-consul-test-container                                                
aa9893473cfc45ed563a3c94a274955a3c71dca63a53a6d5ba18f08cef7e0dd0          
  CHECK contrib/scripts/bindata.sh                                                 
?       github.com/cilium/cilium/pkg/datapath/loader    [no test files]
=== RUN   Test                               
START: loader_test.go:123: LoaderTestSuite.TestCompileAndLoad                   
PASS: loader_test.go:123: LoaderTestSuite.TestCompileAndLoad    1.609s         
                                                                                
START: loader_test.go:149: LoaderTestSuite.TestCompileFailure               
level=error msg="Command execution failed" cmd="[llc -march=bpf -mcpu=probe -filetype=obj -o /tmp/cilium_814020965/bpf_lxc.o]" error="signal: killed" subsys=datapath-loader
level=error msg="Failed to compile bpf_lxc.o: signal: killed" compiler-pid=14494 linker-pid=14496 subsys=datapath-loader
level=warning msg="JoinEP: Failed to compile" debug=false error="Failed to compile bpf_lxc.o: signal: killed" params="&{Source:bpf_lxc.c Output:bpf_lxc.o OutputType:obj}" subsys=datapath-loader
PASS: loader_test.go:149: LoaderTestSuite.TestCompileFailure    0.103s
                                                                                  
START: loader_test.go:132: LoaderTestSuite.TestReload            
PASS: loader_test.go:132: LoaderTestSuite.TestReload    3.637s
                                                                                
OK: 3 passed                                    
--- PASS: Test (5.35s)                             
PASS                                                                   
coverage: 75.8% of statements                                                      
ok      github.com/cilium/cilium/pkg/datapath/loader    5.403s  coverage: 75.8% of statements
cilium-etcd-test-container                                                
cilium-consul-test-container
```

Most of the remaining coverage is error cases which are hard to properly test.

The test `TestCompileFailure` is expected to fail, hence why there are error logs but the test is marked as passed in the above example output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6117)
<!-- Reviewable:end -->
