### PR TITLE
Simplify Makefile for unit testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ DOCKER=$(QUIET)docker
 SWAGGER_VERSION = 0.12.0
 SWAGGER = $(DOCKER) run --rm -v $(CURDIR):$(CURDIR) -w $(CURDIR) -e GOPATH=$(GOPATH) --entrypoint swagger quay.io/goswagger/swagger:$(SWAGGER_VERSION)
 
-GOTEST_OPTS = -test.v -check.vv -timeout 360s -coverprofile=coverage.out -covermode=count -coverpkg ./...
+COVERPKG ?= ./...
+GOTEST_OPTS = -test.v -check.vv -timeout 360s -coverprofile=coverage.out -covermode=count -coverpkg $(COVERPKG)
 GOTEST_PRIV_OPTS = $(GOTEST_OPTS) -tags=privileged_tests
 
 UTC_DATE=$(shell date -u "+%Y-%m-%d")

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ include Makefile.defs
 include daemon/bpf.sha
 
 SUBDIRS = proxylib envoy plugins bpf cilium daemon monitor cilium-health bugtool tools
-GOFILES ?= $(subst _$(ROOT_DIR)/,,$(shell go list ./... | grep -v /vendor/ | grep -v /contrib/ | grep -v envoy/envoy))
-TESTPKGS ?= $(subst _$(ROOT_DIR)/,,$(shell go list ./... | grep -v /vendor/ | grep -v /contrib/ | grep -v envoy/envoy | grep -v test))
+GOFILES ?= $(subst _$(ROOT_DIR)/,,$(shell go list ./... | grep -v -e /vendor/ -e /contrib/ -e envoy/envoy))
+TESTPKGS ?= $(subst _$(ROOT_DIR)/,,$(shell go list ./... | grep -v -e /vendor/ -e /contrib/ -e envoy/envoy -e test))
 GOLANGVERSION = $(shell go version 2>/dev/null | grep -Eo '(go[0-9].[0-9])')
 GOLANG_SRCFILES=$(shell for pkg in $(subst github.com/cilium/cilium/,,$(GOFILES)); do find $$pkg -name *.go -print; done | grep -v vendor)
 BPF_FILES ?= $(shell git ls-files ../bpf/ | tr "\n" ' ')

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ include daemon/bpf.sha
 
 SUBDIRS = proxylib envoy plugins bpf cilium daemon monitor cilium-health bugtool tools
 GOFILES ?= $(subst _$(ROOT_DIR)/,,$(shell go list ./... | grep -v -e /vendor/ -e /contrib/ -e envoy/envoy))
-TESTPKGS ?= $(subst _$(ROOT_DIR)/,,$(shell go list ./... | grep -v -e /vendor/ -e /contrib/ -e envoy/envoy -e test))
+TESTPKGS ?= $(subst _$(ROOT_DIR)/,,$(shell go list ./... | grep -v -e /api/v1 -e /vendor/ -e /contrib/ -e envoy/envoy -e test))
 GOLANGVERSION = $(shell go version 2>/dev/null | grep -Eo '(go[0-9].[0-9])')
 GOLANG_SRCFILES=$(shell for pkg in $(subst github.com/cilium/cilium/,,$(GOFILES)); do find $$pkg -name *.go -print; done | grep -v vendor)
 BPF_FILES ?= $(shell git ls-files ../bpf/ | tr "\n" ' ')


### PR DESCRIPTION
Streamline some of the Makefile for unit testing, by for example sharing variables for configuration opts for `go test`, reducing the number of unique `grep` calls, avoiding looking for tests under `api/v1`, and parameterize the coverpkg option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6119)
<!-- Reviewable:end -->
