### PR TITLE
contrib/scripts: add checker for missing tags in test files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,8 @@ precheck: govet ineffassign logging-subsys-field
 	$(QUIET) contrib/scripts/check-fmt.sh
 	@$(ECHO_CHECK) contrib/scripts/check-log-newlines.sh
 	$(QUIET) contrib/scripts/check-log-newlines.sh
+	@$(ECHO_CHECK) contrib/scripts/check-missing-tags-in-tests.sh
+	$(QUIET) contrib/scripts/check-missing-tags-in-tests.sh
 
 pprof-help:
 	@echo "Available pprof targets:"

--- a/contrib/scripts/check-missing-tags-in-tests.sh
+++ b/contrib/scripts/check-missing-tags-in-tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+if grep -L --include \*_test.go '// +build' . -r | grep -v vendor | grep -v test/ ; then
+  echo "Test file(s) does not contain a tag privileged_tests or !privileged_tests tags"
+  exit 1
+fi


### PR DESCRIPTION
This prevents developer mistakes by not having tags in the test files.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6120)
<!-- Reviewable:end -->
