### PR TITLE
factor out code from pkg/endpoint, cilium-health which depends on pkg/k8s 

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1278,7 +1278,7 @@ func NewDaemon() (*Daemon, *endpointRestoreState, error) {
 
 	if k8s.IsEnabled() {
 		log.Info("Annotating k8s node with CIDR ranges")
-		err := k8s.AnnotateNode(k8s.Client(), node.GetName(),
+		err := k8s.Client().AnnotateNode(node.GetName(),
 			node.GetIPv4AllocRange(), node.GetIPv6NodeRange(),
 			nil, nil, node.GetInternalIPv4())
 		if err != nil {

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/flowdebug"
@@ -863,6 +864,8 @@ func runDaemon() {
 		viper.GetInt("conntrack-garbage-collector-interval"),
 		restoredEndpoints.restored)
 
+	endpointmanager.EndpointSynchronizer = &k8s.EndpointSynchronizer{}
+
 	if enableLogstash {
 		log.Info("Enabling Logstash")
 		go EnableLogstash(logstashAddr, int(logstashProbeTimer))
@@ -971,6 +974,11 @@ func runDaemon() {
 		// running inside a new PID namespace which means that existing
 		// PIDfiles are referring to PIDs that may be reused. Clean up.
 		pidfile.Remove(filepath.Join(option.Config.StateDir, health.PidfilePath))
+
+		// Inject K8s dependency into packages which need to annotate K8s resources.
+		endpoint.EpAnnotator = k8s.Client()
+		health.NodeEpAnnotator = k8s.Client()
+
 	}
 	controller.NewManager().UpdateController("cilium-health-ep",
 		controller.ControllerParams{

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -136,10 +136,12 @@ func NewPutEndpointIDHandler(d *Daemon) PutEndpointIDHandler {
 // request that was specified. Returns an HTTP code response code and an
 // error msg (or nil on success).
 func (d *Daemon) createEndpoint(epTemplate *models.EndpointChangeRequest, id string, lbls []string) (int, error) {
+
 	ep, err := endpoint.NewEndpointFromChangeModel(epTemplate)
 	if err != nil {
 		return PutEndpointIDInvalidCode, err
 	}
+
 	ep.SetDefaultOpts(option.Config.Opts)
 
 	oldEp, err2 := endpointmanager.Lookup(id)

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/controller"
-	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -695,7 +694,7 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 	go namespaceController.Run(wait.NeverStop)
 	d.k8sAPIGroups.addAPI(k8sAPIGroupNamespaceV1Core)
 
-	endpoint.RunK8sCiliumEndpointSyncGC()
+	k8s.CiliumEndpointSyncGC()
 
 	return nil
 }

--- a/pkg/endpoint/annotator.go
+++ b/pkg/endpoint/annotator.go
@@ -1,0 +1,32 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+var (
+	// EpAnnotator is a shared annotator amongst all endpoints. It is used to
+	// annotate resources in orchestration systems with information about
+	// their corresponding endpoints.
+	EpAnnotator Annotator
+)
+
+// Annotator is an interface which annotates a pod. Its primary use is to
+// remove pulling in Kubernetes dependencies into packages which need to
+// update K8s objects with annotations.
+type Annotator interface {
+	// AnnotatePod annotates the pod k8sPodName in namespace k8sNamespace with
+	// the annotation annotationKey=annotationValue. Returns an error if
+	// annotating failed.
+	AnnotatePod(k8sNamespace, k8sPodName, annotationKey, annotationValue string) error
+}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -18,16 +18,13 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"os"
-	"reflect"
 	"runtime"
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 	"unsafe"
 
@@ -39,11 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
-	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
-	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
-	cilium_client_v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
 	pkgLabels "github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -54,18 +47,11 @@ import (
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/monitor/notifications"
-	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/u8proto"
-	"github.com/cilium/cilium/pkg/versioncheck"
-
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
-
 	"github.com/sirupsen/logrus"
 )
 
@@ -75,165 +61,7 @@ const (
 
 var (
 	EndpointMutableOptionLibrary = option.GetEndpointMutableOptionLibrary()
-
-	// ciliumEPControllerLimit is the range of k8s versions with which we are
-	// willing to run the EndpointCRD controllers
-	ciliumEPControllerLimit = versioncheck.MustCompile("> 1.6")
-
-	// ciliumEndpointSyncControllerK8sClient is a k8s client shared by the
-	// RunK8sCiliumEndpointSync and RunK8sCiliumEndpointSyncGC. They obtain the
-	// controller via getCiliumClient and the sync.Once is used to avoid race.
-	ciliumEndpointSyncControllerOnce      sync.Once
-	ciliumEndpointSyncControllerK8sClient clientset.Interface
-
-	// ciliumUpdateStatusVerConstr is the minimal version supported for
-	// to perform a CRD UpdateStatus.
-	ciliumUpdateStatusVerConstr = versioncheck.MustCompile(">= 1.11.0")
 )
-
-// getCiliumClient builds and returns a k8s auto-generated client for cilium
-// objects
-func getCiliumClient() (ciliumClient cilium_client_v2.CiliumV2Interface, err error) {
-	// This allows us to reuse the k8s client
-	ciliumEndpointSyncControllerOnce.Do(func() {
-		var (
-			restConfig *rest.Config
-			k8sClient  *clientset.Clientset
-		)
-
-		restConfig, err = k8s.CreateConfig()
-		if err != nil {
-			return
-		}
-
-		k8sClient, err = clientset.NewForConfig(restConfig)
-		if err != nil {
-			return
-		}
-
-		ciliumEndpointSyncControllerK8sClient = k8sClient
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	// This guards against the situation where another invocation of this
-	// function (in another thread or previous in time) might have returned an
-	// error and not initialized ciliumEndpointSyncControllerK8sClient
-	if ciliumEndpointSyncControllerK8sClient == nil {
-		return nil, errors.New("No initialised k8s Cilium CRD client")
-	}
-
-	return ciliumEndpointSyncControllerK8sClient.CiliumV2(), nil
-}
-
-// RunK8sCiliumEndpointSyncGC starts the node-singleton sweeper for
-// CiliumEndpoint objects where the managing node is no longer running. These
-// objects are created by the sync-to-k8s-ciliumendpoint controller on each
-// Endpoint.
-// The general steps are:
-//   - get list of nodes
-//   - only run with probability 1/nodes
-//   - get list of CEPs
-//   - for each CEP
-//       delete CEP if the corresponding pod does not exist
-// CiliumEndpoint objects have the same name as the pod they represent
-func RunK8sCiliumEndpointSyncGC() {
-	var (
-		controllerName = fmt.Sprintf("sync-to-k8s-ciliumendpoint-gc (%v)", node.GetName())
-		scopedLog      = log.WithField("controller", controllerName)
-		firstRun       = true
-	)
-
-	if option.Config.DisableCiliumEndpointCRD {
-		scopedLog.WithField("name", controllerName).Warn("Not running controller. CEP CRD synchronization is disabled")
-		return
-	}
-
-	// this is a sanity check
-	if !k8s.IsEnabled() {
-		scopedLog.WithField("name", controllerName).Warn("Not running controller because k8s is disabled")
-		return
-	}
-	sv, err := k8s.GetServerVersion()
-	if err != nil {
-		scopedLog.WithError(err).Error("unable to retrieve kubernetes serverversion")
-		return
-	}
-	if !ciliumEPControllerLimit.Check(sv) {
-		scopedLog.WithFields(logrus.Fields{
-			"expected": sv,
-			"found":    ciliumEPControllerLimit,
-		}).Warn("cannot run with this k8s version")
-		return
-	}
-
-	ciliumClient, err := getCiliumClient()
-	if err != nil {
-		scopedLog.WithError(err).Error("Not starting controller because unable to get cilium k8s client")
-		return
-	}
-	k8sClient := k8s.Client()
-
-	// this dummy manager is needed only to add this controller to the global list
-	controller.NewManager().UpdateController(controllerName,
-		controller.ControllerParams{
-			RunInterval: 30 * time.Minute,
-			DoFunc: func() error {
-				// Don't run immediately
-				if firstRun {
-					firstRun = false
-					return nil
-				}
-
-				// Only run if we are the "lowest" node in our cluster, when sorted by
-				// names. This means only one node will ever run GCs in a given
-				// cluster.
-				thisNode := node.GetLocalNode().Identity()
-				thisNodeStr := thisNode.String()
-				for id := range node.GetNodes() {
-					if idStr := id.String(); id.Cluster == thisNode.Cluster && idStr < thisNodeStr {
-						scopedLog.WithField(logfields.Node, idStr).Debug("Skipping GC because another node is a better candidate")
-						return nil
-					}
-				}
-
-				clusterPodSet := map[string]bool{}
-				clusterPods, err := k8sClient.CoreV1().Pods("").List(meta_v1.ListOptions{})
-				if err != nil {
-					return err
-				}
-				for _, pod := range clusterPods.Items {
-					podFullName := pod.Name + ":" + pod.Namespace
-					clusterPodSet[podFullName] = true
-				}
-
-				// "" is all-namespaces
-				ceps, err := ciliumClient.CiliumEndpoints(meta_v1.NamespaceAll).List(meta_v1.ListOptions{})
-				if err != nil {
-					scopedLog.WithError(err).Debug("Cannot list CEPs")
-					return err
-				}
-				for _, cep := range ceps.Items {
-					cepFullName := cep.Name + ":" + cep.Namespace
-					if _, found := clusterPodSet[cepFullName]; !found {
-						// delete
-						scopedLog = scopedLog.WithFields(logrus.Fields{
-							logfields.EndpointID: cep.Status.ID,
-							logfields.K8sPodName: cepFullName,
-						})
-						scopedLog.Debug("Orphaned CiliumEndpoint is being garbage collected")
-						if err := ciliumClient.CiliumEndpoints(cep.Namespace).Delete(cep.Name, &meta_v1.DeleteOptions{}); err != nil {
-							scopedLog.WithError(err).Debug("Unable to delete CEP")
-							return err
-						}
-					}
-				}
-				return nil
-			},
-		})
-}
 
 const (
 	// StateCreating is used to set the endpoint is being created.
@@ -486,6 +314,12 @@ type Endpoint struct {
 	DeprecatedOpts deprecatedOptions `json:"Opts"`
 }
 
+// UpdateController updates the controller with the specified name with the
+// provided list of parameters in endpoint's list of controllers.
+func (e *Endpoint) UpdateController(name string, params controller.ControllerParams) *controller.Controller {
+	return e.controllers.UpdateController(name, params)
+}
+
 // CloseBPFProgramChannel closes the channel that signals whether the endpoint
 // has had its BPF program compiled. If the channel is already closed, this is
 // a no-op.
@@ -571,163 +405,6 @@ func (e *Endpoint) WaitForProxyCompletions(proxyWaitGroup *completion.WaitGroup)
 	e.getLogger().Debug("Wait time for proxy updates: ", time.Since(start))
 
 	return nil
-}
-
-// RunK8sCiliumEndpointSync starts a controller that syncronizes the endpoint
-// to the corresponding k8s CiliumEndpoint CRD
-// CiliumEndpoint objects have the same name as the pod they represent
-func (e *Endpoint) RunK8sCiliumEndpointSync() {
-	var (
-		endpointID     = e.ID
-		controllerName = fmt.Sprintf("sync-to-k8s-ciliumendpoint (%v)", endpointID)
-		scopedLog      = e.getLogger().WithField("controller", controllerName)
-		err            error
-	)
-
-	if option.Config.DisableCiliumEndpointCRD {
-		scopedLog.Warn("Not running controller. CEP CRD synchronization is disabled")
-		return
-	}
-
-	if !k8s.IsEnabled() {
-		scopedLog.Debug("Not starting controller because k8s is disabled")
-		return
-	}
-	k8sServerVer, err := k8s.GetServerVersion()
-	if err != nil {
-		scopedLog.WithError(err).Error("unable to retrieve kubernetes serverversion")
-		return
-	}
-	if !ciliumEPControllerLimit.Check(k8sServerVer) {
-		scopedLog.WithFields(logrus.Fields{
-			"expected": k8sServerVer,
-			"found":    ciliumEPControllerLimit,
-		}).Warn("cannot run with this k8s version")
-		return
-	}
-
-	ciliumClient, err := getCiliumClient()
-	if err != nil {
-		scopedLog.WithError(err).Error("Not starting controller because unable to get cilium k8s client")
-		return
-	}
-
-	// The health endpoint doesn't really exist in k8s and updates to it caused
-	// arbitrary errors. Disable the controller for these endpoints.
-	if isHealthEP := e.HasLabels(pkgLabels.LabelHealth); isHealthEP {
-		scopedLog.Debug("Not starting unnecessary CEP controller for cilium-health endpoint")
-		return
-	}
-
-	var (
-		lastMdl  *models.Endpoint
-		firstRun = true
-	)
-
-	// NOTE: The controller functions do NOT hold the endpoint locks
-	e.controllers.UpdateController(controllerName,
-		controller.ControllerParams{
-			RunInterval: 10 * time.Second,
-			DoFunc: func() (err error) {
-				// Update logger as scopeLog might not have the podName when it
-				// was created.
-				scopedLog = e.getLogger().WithField("controller", controllerName)
-
-				podName := e.GetK8sPodName()
-				if podName == "" {
-					scopedLog.Debug("Skipping CiliumEndpoint update because it has no k8s pod name")
-					return nil
-				}
-
-				namespace := e.GetK8sNamespace()
-				if namespace == "" {
-					scopedLog.Debug("Skipping CiliumEndpoint update because it has no k8s namespace")
-					return nil
-				}
-
-				mdl := e.GetModel()
-				if reflect.DeepEqual(mdl, lastMdl) {
-					scopedLog.Debug("Skipping CiliumEndpoint update because it has not changed")
-					return nil
-				}
-				k8sMdl := (*cilium_v2.CiliumEndpointDetail)(mdl)
-
-				cep, err := ciliumClient.CiliumEndpoints(namespace).Get(podName, meta_v1.GetOptions{})
-				switch {
-				// The CEP doesn't exist. We will fall through to the create code below
-				case err != nil && k8serrors.IsNotFound(err):
-					break
-
-				// Delete the CEP on the first ever run. We will fall through to the create code below
-				case firstRun:
-					firstRun = false
-					scopedLog.Debug("Deleting CEP on first run")
-					err := ciliumClient.CiliumEndpoints(namespace).Delete(podName, &meta_v1.DeleteOptions{})
-					if err != nil {
-						scopedLog.WithError(err).Warn("Error deleting CEP")
-						return err
-					}
-
-				// Delete an invalid CEP. We will fall through to the create code below
-				case err != nil && k8serrors.IsInvalid(err):
-					scopedLog.WithError(err).Warn("Invalid CEP during update")
-					err := ciliumClient.CiliumEndpoints(namespace).Delete(podName, &meta_v1.DeleteOptions{})
-					if err != nil {
-						scopedLog.WithError(err).Warn("Error deleting invalid CEP during update")
-						return err
-					}
-
-				// A real error
-				case err != nil && !k8serrors.IsNotFound(err):
-					scopedLog.WithError(err).Error("Cannot get CEP for update")
-					return err
-
-				// do an update
-				case err == nil:
-					// Update the copy of the cep
-					k8sMdl.DeepCopyInto(&cep.Status)
-					var err2 error
-					switch {
-					case ciliumUpdateStatusVerConstr.Check(k8sServerVer):
-						_, err2 = ciliumClient.CiliumEndpoints(namespace).UpdateStatus(cep)
-					default:
-						_, err2 = ciliumClient.CiliumEndpoints(namespace).Update(cep)
-					}
-					if err2 != nil {
-						scopedLog.WithError(err2).Error("Cannot update CEP")
-						return err2
-					}
-
-					lastMdl = mdl
-					return nil
-				}
-
-				// The CEP was not found, this is the first creation of the endpoint
-				cep = &cilium_v2.CiliumEndpoint{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Name: podName,
-					},
-					Status: *k8sMdl,
-				}
-
-				_, err = ciliumClient.CiliumEndpoints(namespace).Create(cep)
-				if err != nil {
-					scopedLog.WithError(err).Error("Cannot create CEP")
-					return err
-				}
-
-				return nil
-			},
-			StopFunc: func() error {
-				podName := e.GetK8sPodName()
-				namespace := e.GetK8sNamespace()
-				if err := ciliumClient.CiliumEndpoints(namespace).Delete(podName, &meta_v1.DeleteOptions{}); err != nil {
-					scopedLog.WithError(err).Error("Unable to delete CEP")
-					return err
-				}
-				return nil
-			},
-		})
 }
 
 // NewEndpointWithState creates a new endpoint useful for testing purposes

--- a/pkg/k8s/annotate.go
+++ b/pkg/k8s/annotate.go
@@ -16,12 +16,18 @@ package k8s
 
 import (
 	"fmt"
+	"net"
+	"time"
 
+	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/uuid"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 // PodEndpoint is the interface that the endpoint representing a pod has to implement
@@ -63,5 +69,89 @@ func AnnotatePod(e PodEndpoint, annotationKey, annotationValue string) error {
 	}
 
 	scopedLog.Debugf("Successfully annotated pod with %s=%s", annotationKey, annotationValue)
+	return nil
+}
+
+func updateNodeAnnotation(c kubernetes.Interface, node *v1.Node, v4CIDR, v6CIDR *net.IPNet, v4HealthIP, v6HealthIP, v4CiliumHostIP net.IP) (*v1.Node, error) {
+	if node.Annotations == nil {
+		node.Annotations = map[string]string{}
+	}
+
+	if v4CIDR != nil {
+		node.Annotations[annotation.V4CIDRName] = v4CIDR.String()
+	}
+	if v6CIDR != nil {
+		node.Annotations[annotation.V6CIDRName] = v6CIDR.String()
+	}
+
+	if v4HealthIP != nil {
+		node.Annotations[annotation.V4HealthName] = v4HealthIP.String()
+	}
+	if v6HealthIP != nil {
+		node.Annotations[annotation.V6HealthName] = v6HealthIP.String()
+	}
+
+	if v4CiliumHostIP != nil {
+		node.Annotations[annotation.CiliumHostIP] = v4CiliumHostIP.String()
+	}
+
+	node, err := c.CoreV1().Nodes().Update(node)
+	if err != nil {
+		return nil, err
+	}
+
+	if node == nil {
+		return nil, ErrNilNode
+	}
+
+	return node, nil
+}
+
+// AnnotateNode writes v4 and v6 CIDRs and health IPs in the given k8s node name.
+// In case of failure while updating the node, this function while spawn a go
+// routine to retry the node update indefinitely.
+func AnnotateNode(c kubernetes.Interface, nodeName string, v4CIDR, v6CIDR *net.IPNet, v4HealthIP, v6HealthIP, v4CiliumHostIP net.IP) error {
+	scopedLog := log.WithFields(logrus.Fields{
+		logfields.NodeName:       nodeName,
+		logfields.V4Prefix:       v4CIDR,
+		logfields.V6Prefix:       v6CIDR,
+		logfields.V4HealthIP:     v4HealthIP,
+		logfields.V6HealthIP:     v6HealthIP,
+		logfields.V4CiliumHostIP: v4CiliumHostIP,
+	})
+	scopedLog.Debug("Updating node annotations with node CIDRs")
+
+	go func(c kubernetes.Interface, nodeName string, v4CIDR, v6CIDR *net.IPNet, v4HealthIP, v6HealthIP, v4CiliumHostIP net.IP) {
+		var node *v1.Node
+		var err error
+
+		for n := 1; n <= maxUpdateRetries; n++ {
+			node, err = GetNode(c, nodeName)
+			switch {
+			case err == nil:
+				_, err = updateNodeAnnotation(c, node, v4CIDR, v6CIDR, v4HealthIP, v6HealthIP, v4CiliumHostIP)
+			case errors.IsNotFound(err):
+				err = ErrNilNode
+			}
+
+			switch {
+			case err == nil:
+				return
+			case errors.IsConflict(err):
+				scopedLog.WithFields(logrus.Fields{
+					fieldRetry:    n,
+					fieldMaxRetry: maxUpdateRetries,
+				}).WithError(err).Debugf("Unable to update node resource with annotation")
+			default:
+				scopedLog.WithFields(logrus.Fields{
+					fieldRetry:    n,
+					fieldMaxRetry: maxUpdateRetries,
+				}).WithError(err).Warn("Unable to update node resource with annotation")
+			}
+
+			time.Sleep(time.Duration(n) * time.Second)
+		}
+	}(c, nodeName, v4CIDR, v6CIDR, v4HealthIP, v6HealthIP, v4CiliumHostIP)
+
 	return nil
 }

--- a/pkg/k8s/cep.go
+++ b/pkg/k8s/cep.go
@@ -1,0 +1,363 @@
+// Copyright 2016-2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/endpoint"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
+	cilium_client_v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
+	pkgLabels "github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/versioncheck"
+
+	"github.com/sirupsen/logrus"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+// EndpointSynchronizer currently is an empty type, which wraps around syncing
+// of CiliumEndpoint resources.
+// TODO - see whether folding the global variables below into this function
+// is cleaner.
+type EndpointSynchronizer struct{}
+
+var (
+	// ciliumEPControllerLimit is the range of k8s versions with which we are
+	// willing to run the EndpointCRD controllers
+	ciliumEPControllerLimit = versioncheck.MustCompile("> 1.6")
+
+	// ciliumEndpointSyncControllerK8sClient is a k8s client shared by the
+	// RunK8sCiliumEndpointSync and CiliumEndpointSyncGC. They obtain the
+	// controller via getCiliumClient and the sync.Once is used to avoid race.
+	ciliumEndpointSyncControllerOnce      sync.Once
+	ciliumEndpointSyncControllerK8sClient clientset.Interface
+
+	// ciliumUpdateStatusVerConstr is the minimal version supported for
+	// to perform a CRD UpdateStatus.
+	ciliumUpdateStatusVerConstr = versioncheck.MustCompile(">= 1.11.0")
+)
+
+// getCiliumClient builds and returns a k8s auto-generated client for cilium
+// objects
+func getCiliumClient() (ciliumClient cilium_client_v2.CiliumV2Interface, err error) {
+	// This allows us to reuse the k8s client
+	ciliumEndpointSyncControllerOnce.Do(func() {
+		var (
+			restConfig *rest.Config
+			k8sClient  *clientset.Clientset
+		)
+
+		restConfig, err = CreateConfig()
+		if err != nil {
+			return
+		}
+
+		k8sClient, err = clientset.NewForConfig(restConfig)
+		if err != nil {
+			return
+		}
+
+		ciliumEndpointSyncControllerK8sClient = k8sClient
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	// This guards against the situation where another invocation of this
+	// function (in another thread or previous in time) might have returned an
+	// error and not initialized ciliumEndpointSyncControllerK8sClient
+	if ciliumEndpointSyncControllerK8sClient == nil {
+		return nil, errors.New("No initialised k8s Cilium CRD client")
+	}
+
+	return ciliumEndpointSyncControllerK8sClient.CiliumV2(), nil
+}
+
+// CiliumEndpointSyncGC starts the node-singleton sweeper for
+// CiliumEndpoint objects where the managing node is no longer running. These
+// objects are created by the sync-to-k8s-ciliumendpoint controller on each
+// Endpoint.
+// The general steps are:
+//   - get list of nodes
+//   - only run with probability 1/nodes
+//   - get list of CEPs
+//   - for each CEP
+//       delete CEP if the corresponding pod does not exist
+// CiliumEndpoint objects have the same name as the pod they represent
+func CiliumEndpointSyncGC() {
+	var (
+		controllerName = fmt.Sprintf("sync-to-k8s-ciliumendpoint-gc (%v)", node.GetName())
+		scopedLog      = log.WithField("controller", controllerName)
+		firstRun       = true
+	)
+
+	if option.Config.DisableCiliumEndpointCRD {
+		scopedLog.WithField("name", controllerName).Warn("Not running controller. CEP CRD synchronization is disabled")
+		return
+	}
+
+	// this is a sanity check
+	if !IsEnabled() {
+		scopedLog.WithField("name", controllerName).Warn("Not running controller because k8s is disabled")
+		return
+	}
+	sv, err := GetServerVersion()
+	if err != nil {
+		scopedLog.WithError(err).Error("unable to retrieve kubernetes serverversion")
+		return
+	}
+	if !ciliumEPControllerLimit.Check(sv) {
+		scopedLog.WithFields(logrus.Fields{
+			"expected": sv,
+			"found":    ciliumEPControllerLimit,
+		}).Warn("cannot run with this k8s version")
+		return
+	}
+
+	ciliumClient, err := getCiliumClient()
+	if err != nil {
+		scopedLog.WithError(err).Error("Not starting controller because unable to get cilium k8s client")
+		return
+	}
+	k8sClient := Client()
+
+	// this dummy manager is needed only to add this controller to the global list
+	controller.NewManager().UpdateController(controllerName,
+		controller.ControllerParams{
+			RunInterval: 30 * time.Minute,
+			DoFunc: func() error {
+				// Don't run immediately
+				if firstRun {
+					firstRun = false
+					return nil
+				}
+
+				// Only run if we are the "lowest" node in our cluster, when sorted by
+				// names. This means only one node will ever run GCs in a given
+				// cluster.
+				thisNode := node.GetLocalNode().Identity()
+				thisNodeStr := thisNode.String()
+				for id := range node.GetNodes() {
+					if idStr := id.String(); id.Cluster == thisNode.Cluster && idStr < thisNodeStr {
+						scopedLog.WithField(logfields.Node, idStr).Debug("Skipping GC because another node is a better candidate")
+						return nil
+					}
+				}
+
+				clusterPodSet := map[string]bool{}
+				clusterPods, err := k8sClient.CoreV1().Pods("").List(meta_v1.ListOptions{})
+				if err != nil {
+					return err
+				}
+				for _, pod := range clusterPods.Items {
+					podFullName := pod.Name + ":" + pod.Namespace
+					clusterPodSet[podFullName] = true
+				}
+
+				// "" is all-namespaces
+				ceps, err := ciliumClient.CiliumEndpoints(meta_v1.NamespaceAll).List(meta_v1.ListOptions{})
+				if err != nil {
+					scopedLog.WithError(err).Debug("Cannot list CEPs")
+					return err
+				}
+				for _, cep := range ceps.Items {
+					cepFullName := cep.Name + ":" + cep.Namespace
+					if _, found := clusterPodSet[cepFullName]; !found {
+						// delete
+						scopedLog = scopedLog.WithFields(logrus.Fields{
+							logfields.EndpointID: cep.Status.ID,
+							logfields.K8sPodName: cepFullName,
+						})
+						scopedLog.Debug("Orphaned CiliumEndpoint is being garbage collected")
+						if err := ciliumClient.CiliumEndpoints(cep.Namespace).Delete(cep.Name, &meta_v1.DeleteOptions{}); err != nil {
+							scopedLog.WithError(err).Debug("Unable to delete CEP")
+							return err
+						}
+					}
+				}
+				return nil
+			},
+		})
+}
+
+// RunK8sCiliumEndpointSync starts a controller that synchronizes the endpoint
+// to the corresponding k8s CiliumEndpoint CRD
+// CiliumEndpoint objects have the same name as the pod they represent
+func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoint) {
+	var (
+		endpointID     = e.ID
+		controllerName = fmt.Sprintf("sync-to-k8s-ciliumendpoint (%v)", endpointID)
+		scopedLog      = e.Logger(subsysK8s).WithField("controller", controllerName)
+		err            error
+	)
+
+	if option.Config.DisableCiliumEndpointCRD {
+		scopedLog.Warn("Not running controller. CEP CRD synchronization is disabled")
+		return
+	}
+
+	if !IsEnabled() {
+		scopedLog.Debug("Not starting controller because k8s is disabled")
+		return
+	}
+	k8sServerVer, err := GetServerVersion()
+	if err != nil {
+		scopedLog.WithError(err).Error("unable to retrieve kubernetes serverversion")
+		return
+	}
+	if !ciliumEPControllerLimit.Check(k8sServerVer) {
+		scopedLog.WithFields(logrus.Fields{
+			"expected": k8sServerVer,
+			"found":    ciliumEPControllerLimit,
+		}).Warn("cannot run with this k8s version")
+		return
+	}
+
+	ciliumClient, err := getCiliumClient()
+	if err != nil {
+		scopedLog.WithError(err).Error("Not starting controller because unable to get cilium k8s client")
+		return
+	}
+
+	// The health endpoint doesn't really exist in k8s and updates to it caused
+	// arbitrary errors. Disable the controller for these endpoints.
+	if isHealthEP := e.HasLabels(pkgLabels.LabelHealth); isHealthEP {
+		scopedLog.Debug("Not starting unnecessary CEP controller for cilium-health endpoint")
+		return
+	}
+
+	var (
+		lastMdl  *models.Endpoint
+		firstRun = true
+	)
+
+	// NOTE: The controller functions do NOT hold the endpoint locks
+	e.UpdateController(controllerName,
+		controller.ControllerParams{
+			RunInterval: 10 * time.Second,
+			DoFunc: func() (err error) {
+				// Update logger as scopeLog might not have the podName when it
+				// was created.
+				scopedLog = e.Logger(subsysK8s).WithField("controller", controllerName)
+
+				podName := e.GetK8sPodName()
+				if podName == "" {
+					scopedLog.Debug("Skipping CiliumEndpoint update because it has no k8s pod name")
+					return nil
+				}
+
+				namespace := e.GetK8sNamespace()
+				if namespace == "" {
+					scopedLog.Debug("Skipping CiliumEndpoint update because it has no k8s namespace")
+					return nil
+				}
+
+				mdl := e.GetModel()
+				if reflect.DeepEqual(mdl, lastMdl) {
+					scopedLog.Debug("Skipping CiliumEndpoint update because it has not changed")
+					return nil
+				}
+				k8sMdl := (*cilium_v2.CiliumEndpointDetail)(mdl)
+
+				cep, err := ciliumClient.CiliumEndpoints(namespace).Get(podName, meta_v1.GetOptions{})
+				switch {
+				// The CEP doesn't exist. We will fall through to the create code below
+				case err != nil && k8serrors.IsNotFound(err):
+					break
+
+				// Delete the CEP on the first ever run. We will fall through to the create code below
+				case firstRun:
+					firstRun = false
+					scopedLog.Debug("Deleting CEP on first run")
+					err := ciliumClient.CiliumEndpoints(namespace).Delete(podName, &meta_v1.DeleteOptions{})
+					if err != nil {
+						scopedLog.WithError(err).Warn("Error deleting CEP")
+						return err
+					}
+
+				// Delete an invalid CEP. We will fall through to the create code below
+				case err != nil && k8serrors.IsInvalid(err):
+					scopedLog.WithError(err).Warn("Invalid CEP during update")
+					err := ciliumClient.CiliumEndpoints(namespace).Delete(podName, &meta_v1.DeleteOptions{})
+					if err != nil {
+						scopedLog.WithError(err).Warn("Error deleting invalid CEP during update")
+						return err
+					}
+
+				// A real error
+				case err != nil && !k8serrors.IsNotFound(err):
+					scopedLog.WithError(err).Error("Cannot get CEP for update")
+					return err
+
+				// do an update
+				case err == nil:
+					// Update the copy of the cep
+					k8sMdl.DeepCopyInto(&cep.Status)
+					var err2 error
+					switch {
+					case ciliumUpdateStatusVerConstr.Check(k8sServerVer):
+						_, err2 = ciliumClient.CiliumEndpoints(namespace).UpdateStatus(cep)
+					default:
+						_, err2 = ciliumClient.CiliumEndpoints(namespace).Update(cep)
+					}
+					if err2 != nil {
+						scopedLog.WithError(err2).Error("Cannot update CEP")
+						return err2
+					}
+
+					lastMdl = mdl
+					return nil
+				}
+
+				// The CEP was not found, this is the first creation of the endpoint
+				cep = &cilium_v2.CiliumEndpoint{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name: podName,
+					},
+					Status: *k8sMdl,
+				}
+
+				_, err = ciliumClient.CiliumEndpoints(namespace).Create(cep)
+				if err != nil {
+					scopedLog.WithError(err).Error("Cannot create CEP")
+					return err
+				}
+
+				return nil
+			},
+			StopFunc: func() error {
+				podName := e.GetK8sPodName()
+				namespace := e.GetK8sNamespace()
+				if err := ciliumClient.CiliumEndpoints(namespace).Delete(podName, &meta_v1.DeleteOptions{}); err != nil {
+					scopedLog.WithError(err).Error("Unable to delete CEP")
+					return err
+				}
+				return nil
+			},
+		})
+}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -35,9 +35,8 @@ var (
 	// ErrNilNode is returned when the Kubernetes API server has returned a nil node
 	ErrNilNode = goerrors.New("API server returned nil node")
 
-	// client is the object through which interactions with Kubernetes are
-	// performed.
-	client kubernetes.Interface
+	// k8sCli is the default client.
+	k8sCli = &K8sClient{}
 )
 
 // CreateConfig creates a rest.Config for a given endpoint using a kubeconfig file.
@@ -134,9 +133,9 @@ func isConnReady(c *kubernetes.Clientset) error {
 	return err
 }
 
-// Client returns the default Kubernetes client
-func Client() kubernetes.Interface {
-	return client
+// Client returns the default Kubernetes client.
+func Client() *K8sClient {
+	return k8sCli
 }
 
 func createDefaultClient() error {
@@ -145,12 +144,12 @@ func createDefaultClient() error {
 		return fmt.Errorf("unable to create k8s client rest configuration: %s", err)
 	}
 
-	k8sClient, err := CreateClient(restConfig)
+	createdK8sClient, err := CreateClient(restConfig)
 	if err != nil {
 		return fmt.Errorf("unable to create k8s client: %s", err)
 	}
 
-	client = k8sClient
+	k8sCli.Interface = createdK8sClient
 
 	return nil
 }

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -18,17 +18,12 @@ package k8s
 import (
 	goerrors "errors"
 	"fmt"
-	"net"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
 	go_version "github.com/hashicorp/go-version"
-	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -137,90 +132,6 @@ func GetServerVersion() (ver *go_version.Version, err error) {
 func isConnReady(c *kubernetes.Clientset) error {
 	_, err := c.CoreV1().ComponentStatuses().Get("controller-manager", metav1.GetOptions{})
 	return err
-}
-
-func updateNodeAnnotation(c kubernetes.Interface, node *v1.Node, v4CIDR, v6CIDR *net.IPNet, v4HealthIP, v6HealthIP, v4CiliumHostIP net.IP) (*v1.Node, error) {
-	if node.Annotations == nil {
-		node.Annotations = map[string]string{}
-	}
-
-	if v4CIDR != nil {
-		node.Annotations[annotation.V4CIDRName] = v4CIDR.String()
-	}
-	if v6CIDR != nil {
-		node.Annotations[annotation.V6CIDRName] = v6CIDR.String()
-	}
-
-	if v4HealthIP != nil {
-		node.Annotations[annotation.V4HealthName] = v4HealthIP.String()
-	}
-	if v6HealthIP != nil {
-		node.Annotations[annotation.V6HealthName] = v6HealthIP.String()
-	}
-
-	if v4CiliumHostIP != nil {
-		node.Annotations[annotation.CiliumHostIP] = v4CiliumHostIP.String()
-	}
-
-	node, err := c.CoreV1().Nodes().Update(node)
-	if err != nil {
-		return nil, err
-	}
-
-	if node == nil {
-		return nil, ErrNilNode
-	}
-
-	return node, nil
-}
-
-// AnnotateNode writes v4 and v6 CIDRs and health IPs in the given k8s node name.
-// In case of failure while updating the node, this function while spawn a go
-// routine to retry the node update indefinitely.
-func AnnotateNode(c kubernetes.Interface, nodeName string, v4CIDR, v6CIDR *net.IPNet, v4HealthIP, v6HealthIP, v4CiliumHostIP net.IP) error {
-	scopedLog := log.WithFields(logrus.Fields{
-		logfields.NodeName:       nodeName,
-		logfields.V4Prefix:       v4CIDR,
-		logfields.V6Prefix:       v6CIDR,
-		logfields.V4HealthIP:     v4HealthIP,
-		logfields.V6HealthIP:     v6HealthIP,
-		logfields.V4CiliumHostIP: v4CiliumHostIP,
-	})
-	scopedLog.Debug("Updating node annotations with node CIDRs")
-
-	go func(c kubernetes.Interface, nodeName string, v4CIDR, v6CIDR *net.IPNet, v4HealthIP, v6HealthIP, v4CiliumHostIP net.IP) {
-		var node *v1.Node
-		var err error
-
-		for n := 1; n <= maxUpdateRetries; n++ {
-			node, err = GetNode(c, nodeName)
-			switch {
-			case err == nil:
-				_, err = updateNodeAnnotation(c, node, v4CIDR, v6CIDR, v4HealthIP, v6HealthIP, v4CiliumHostIP)
-			case errors.IsNotFound(err):
-				err = ErrNilNode
-			}
-
-			switch {
-			case err == nil:
-				return
-			case errors.IsConflict(err):
-				scopedLog.WithFields(logrus.Fields{
-					fieldRetry:    n,
-					fieldMaxRetry: maxUpdateRetries,
-				}).WithError(err).Debugf("Unable to update node resource with annotation")
-			default:
-				scopedLog.WithFields(logrus.Fields{
-					fieldRetry:    n,
-					fieldMaxRetry: maxUpdateRetries,
-				}).WithError(err).Warn("Unable to update node resource with annotation")
-			}
-
-			time.Sleep(time.Duration(n) * time.Second)
-		}
-	}(c, nodeName, v4CIDR, v6CIDR, v4HealthIP, v6HealthIP, v4CiliumHostIP)
-
-	return nil
 }
 
 // Client returns the default Kubernetes client


### PR DESCRIPTION
This PR does some code reorganizing to inject the Kubernetes dependency into the endpoint package and the cilium-health package at runtime. 

I had to change `endpoint.getLogger()` to be exported to allow for this, as well as expose the capability of updating a controller for an endpoint by external packages. I haven't done dependency injection before this, so I am open to alternative proposals in how to remove these dependencies.

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #6101

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6126)
<!-- Reviewable:end -->