### PR TITLE
travis: fix coveralls for external contributions

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -9,6 +9,6 @@ export CGO_CFLAGS="-DCI_BUILD"
 
 make unit-tests
 
-$HOME/gopath/bin/goveralls -coverprofile=coverage-all.out -service=travis-ci -repotoken ${COVERALLS_REPO_TOKEN}
+$HOME/gopath/bin/goveralls -coverprofile=coverage-all.out -service=travis-ci
 
 exit 0


### PR DESCRIPTION
Repotoken is not necessary to be set for public repositories this should
also PRs made by external contributors.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6127)
<!-- Reviewable:end -->
