### PR TITLE
Makefiles: Fix up GO references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ before_install: ./.travis/prepare.sh
 
 before_script:
   - export PATH=/usr/local/clang/bin:$PATH
-  - export GO_NOQUIET=/home/travis/.gimme/versions/go1.11.1.linux.amd64/bin/go
+  - export GO=/home/travis/.gimme/versions/go1.11.1.linux.amd64/bin/go
 
 script: ./.travis/build.sh

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ unit-tests: start-kvstores
 	$(QUIET)$(foreach pkg,$(TESTPKGS),\
 		sudo $(GO) test $(pkg) $(GOTEST_PRIV_OPTS) $(GOTEST_COVER_OPTS) || exit 1; \
 		tail -n +2 coverage.out >> coverage-all.out;)
-	$(GO) tool cover -html=coverage-all.out -o=coverage-all.html
+	$(QUIET)$(GO) tool cover -html=coverage-all.out -o=coverage-all.html
 	$(QUIET) rm coverage.out
 	@rmdir ./daemon/1 ./daemon/1_backup 2> /dev/null || true
 	$(DOCKER) rm -f "cilium-etcd-test-container"
@@ -212,11 +212,11 @@ release:
 	git archive --format tar $(BRANCH) | gzip > ../cilium_$(VERSION).orig.tar.gz
 
 gofmt:
-	for pkg in $(GOFILES); do $(GO) fmt $$pkg; done
+	$(QUIET)for pkg in $(GOFILES); do $(GO) fmt $$pkg; done
 
 govet:
 	@$(ECHO_CHECK) vetting all GOFILES...
-	$(GO) tool vet api pkg test $(SUBDIRS)
+	$(QUIET)$(GO) tool vet api pkg test $(SUBDIRS)
 
 ineffassign:
 	@$(ECHO_CHECK) ineffassign
@@ -243,20 +243,20 @@ pprof-help:
 	@echo "  pprof-mutex"
 
 pprof-heap:
-	$(GO) tool pprof http://localhost:6060/debug/pprof/heap
+	$(QUIET)$(GO) tool pprof http://localhost:6060/debug/pprof/heap
 
 pprof-profile:
-	$(GO) tool pprof http://localhost:6060/debug/pprof/profile
+	$(QUIET)$(GO) tool pprof http://localhost:6060/debug/pprof/profile
 
 
 pprof-block:
-	$(GO) tool pprof http://localhost:6060/debug/pprof/block
+	$(QUIET)$(GO) tool pprof http://localhost:6060/debug/pprof/block
 
 pprof-trace-5s:
 	curl http://localhost:6060/debug/pprof/trace?seconds=5
 
 pprof-mutex:
-	$(GO) tool pprof http://localhost:6060/debug/pprof/mutex
+	$(QUIET)$(GO) tool pprof http://localhost:6060/debug/pprof/mutex
 
 update-authors:
 	@echo "Updating AUTHORS file..."

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -7,11 +7,9 @@ LIBDIR?=$(PREFIX)/lib
 RUNDIR?=/var/run
 CONFDIR?=/etc
 
-# GO_NOQUIET should not have any Makefile directives.
-ifeq ($(GO_NOQUIET),)
-	GO_NOQUIET = go
+ifeq ($(GO),)
+	GO = go
 endif
-GO = $(QUIET)$(GO_NOQUIET)
 INSTALL = $(QUIET)install
 
 VERSION = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/VERSION)

--- a/bugtool/Makefile
+++ b/bugtool/Makefile
@@ -18,14 +18,14 @@ TARGET=cilium-bugtool
 SOURCES := $(shell find ../common . -name '*.go')
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
-	$(GO) build $(GOBUILD) -o $(TARGET)
+	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)
 
 all: $(TARGET)
 
 clean:
 	@$(ECHO_CLEAN) $(notdir $(shell pwd))
 	-$(QUIET)rm -f .cilium-bugtool.config $(TARGET)
-	$(GO) clean
+	$(QUIET)$(GO) clean
 
 install:
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)

--- a/cilium-health/Makefile
+++ b/cilium-health/Makefile
@@ -4,14 +4,14 @@ TARGET=cilium-health
 SOURCES := $(shell find ../api/v1/health ../pkg/health cmd . \( -name '*.go' ! -name '*_test.go' \))
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
-	$(GO) build $(GOBUILD) -o $(TARGET)
+	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)
 
 all: $(TARGET)
 
 clean:
 	@$(ECHO_CLEAN) $(notdir $(shell pwd))
 	-$(QUIET)rm -f $(TARGET)
-	$(GO) clean
+	$(QUIET)$(GO) clean
 
 install:
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)

--- a/cilium/Makefile
+++ b/cilium/Makefile
@@ -5,14 +5,14 @@ TARGET=cilium
 SOURCES := $(shell find ../api ../daemon ../common ../pkg cmd . \( -name '*.go' ! -name '*_test.go' \))
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
-	$(GO) build $(GOBUILD) -o $(TARGET)
+	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)
 
 all: $(TARGET)
 
 clean:
 	@$(ECHO_CLEAN) $(notdir $(shell pwd))
 	-$(QUIET)rm -f $(TARGET)
-	$(GO) clean
+	$(QUIET)$(GO) clean
 
 install:
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -11,7 +11,7 @@ TARGET=cilium-agent
 SOURCES := $(shell find ../api ../common ../daemon ../pkg ../monitor . \( -name '*.go'  ! -name '*_test.go' \))
 $(TARGET): $(SOURCES) check-bindata
 	@$(ECHO_GO)
-	$(GO) build $(GOBUILD) -o $(TARGET)
+	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)
 
 GO_BINDATA := $(QUIET) go-bindata -prefix ../ -mode 0640 -modtime 1450269211 \
 	-ignore Makefile -ignore bpf_features.h -ignore lxc_config.h \
@@ -24,7 +24,7 @@ all: $(TARGET)
 clean:
 	@$(ECHO_CLEAN) $(notdir $(shell pwd))
 	$(QUIET)rm -f $(TARGET)
-	$(GO) clean
+	$(QUIET)$(GO) clean
 
 ifeq ("$(PKG_BUILD)","")
 

--- a/monitor/Makefile
+++ b/monitor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2017 Authors of Cilium
+# Copyright 2017-2018 Authors of Cilium
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,14 +18,14 @@ TARGET=cilium-node-monitor
 SOURCES := $(shell find ../monitor ../common ../pkg ../api . \( -name '*.go' ! -name '*_test.go' \))
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
-	$(GO) build $(GOBUILD) -o $(TARGET)
+	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)
 
 all: $(TARGET)
 
 clean:
 	@$(ECHO_CLEAN) $(notdir $(shell pwd))
 	$(QUIET)rm -f $(TARGET)
-	$(GO) clean
+	$(QUIET)$(GO) clean
 
 install:
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)

--- a/plugins/cilium-cni/Makefile
+++ b/plugins/cilium-cni/Makefile
@@ -6,7 +6,7 @@ TARGET=cilium-cni
 
 clean:
 	@$(ECHO_CLEAN) $(notdir $(shell pwd))
-	$(GO) clean
+	$(QUIET)$(GO) clean
 	-$(QUIET)rm -f $(TARGET)
 
 SOURCES := $(shell find ../../api/v1/models ../../common ../../pkg/client ../../pkg/endpoint . -name '*.go')
@@ -14,7 +14,7 @@ SOURCES := $(shell find ../../api/v1/models ../../common ../../pkg/client ../../
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
 	# Compile without cgo to allow use of cilium-cni on non-glibc platforms - see GH-5055
-	$(QUIET)CGO_ENABLED=0 $(GO_NOQUIET) build $(GOBUILD) -o $(TARGET) ./cilium-cni.go
+	$(QUIET)CGO_ENABLED=0 $(GO) build $(GOBUILD) -o $(TARGET) ./cilium-cni.go
 
 install:
 	$(INSTALL) -m 0755 -d $(DESTDIR)/etc/cni/net.d

--- a/plugins/cilium-docker/Makefile
+++ b/plugins/cilium-docker/Makefile
@@ -8,14 +8,14 @@ SOURCES := $(shell find ../../api/v1 ../../common ../../pkg/client ../../pkg/end
 
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
-	$(GO) build $(GOBUILD) -o $(TARGET)
+	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)
 
 run:
 	./cilium-docker -d
 
 clean:
 	@$(ECHO_CLEAN) $(notdir $(shell pwd))
-	$(GO) clean
+	$(QUIET)$(GO) clean
 	-$(QUIET) rm -f $(TARGET)
 
 install:

--- a/proxylib/Makefile
+++ b/proxylib/Makefile
@@ -5,14 +5,14 @@ TARGET=libcilium.so
 DEPS := $(shell find ../pkg accesslog npds test . \( -name '*.go' ! -name '*_test.go' \))
 $(TARGET): $(DEPS)
 	@$(ECHO_GO)
-	$(GO) build $(GOBUILD) -o $@ -buildmode=c-shared
+	$(QUIET)$(GO) build $(GOBUILD) -o $@ -buildmode=c-shared
 
 all: $(TARGET)
 
 clean:
 	@$(ECHO_CLEAN) $(notdir $(shell pwd))
 	-$(QUIET)rm -f $(TARGET)
-	$(GO) clean
+	$(QUIET)$(GO) clean
 
 install:
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(LIBDIR)

--- a/test/bpf/Makefile
+++ b/test/bpf/Makefile
@@ -14,7 +14,7 @@ all: $(TARGETS)
 
 perf-event-test: perf-event-test.go
 	@$(ECHO_GO)
-	$(GO) build $(GOBUILD) -o $@ $<
+	$(QUIET)$(GO) build $(GOBUILD) -o $@ $<
 
 bpf-event-test.o: bpf-event-test.c
 	@$(ECHO_CC)

--- a/tools/ring-dump/Makefile
+++ b/tools/ring-dump/Makefile
@@ -4,14 +4,14 @@ TARGET=cilium-ring-dump
 SOURCES := $(shell find ../../pkg/bpf cmd . \( -name '*.go' ! -name '*_test.go' \))
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
-	$(GO) build $(GOBUILD) -o $(TARGET)
+	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)
 
 all: $(TARGET)
 
 clean:
 	@$(ECHO_CLEAN) $(notdir $(shell pwd))
 	-$(QUIET)rm -f $(TARGET)
-	$(GO) clean
+	$(QUIET)$(GO) clean
 
 install:
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)


### PR DESCRIPTION
Previously, GO was defined to include the quiet make directive '@' if
V=0 is specified on the commandline. However, this caused confusion
because it forced GO to only be used directly from Makefile statements
rather than inside nested shell statements (which are commonly used in
Makefiles across the codebase).

Standardize GO to mean only the binary and update all references across
the tree to provide $(QUIET) beforehand directly if they are guaranteed
to be Makefile statements.

This fixes the breakage of quiet builds in #6094.

Fixes: 8d31b882bcd1 ("travis: change target to run unit-tests")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6129)
<!-- Reviewable:end -->
