### PR TITLE
ipam: fix the display of allocated ipv4 addresses

### DIFF
--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -156,7 +156,7 @@ func Dump() ([]string, []string) {
 	ralv4 := k8sAPI.RangeAllocation{}
 	if ipamConf.IPv4Allocator != nil {
 		ipamConf.IPv4Allocator.Snapshot(&ralv4)
-		origIP := big.NewInt(0).SetBytes(node.GetIPv4AllocRange().IP)
+		origIP := big.NewInt(0).SetBytes(node.GetIPv4AllocRange().IP.To4())
 		v4Bits := big.NewInt(0).SetBytes(ralv4.Data)
 		for i := 0; i < v4Bits.BitLen(); i++ {
 			if v4Bits.Bit(i) != 0 {

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -1,0 +1,45 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_test
+
+package ipam
+
+import (
+	"net"
+
+	"github.com/cilium/cilium/pkg/node"
+
+	. "gopkg.in/check.v1"
+)
+
+type AllocatorSuite struct{}
+
+var _ = Suite(&AllocatorSuite{})
+
+func (s *AllocatorSuite) TestAllocatedIPDump(c *C) {
+	node.InitDefaultPrefix("")
+	Init()
+	err := AllocateInternalIPs()
+	c.Assert(err, IsNil)
+
+	allocv4, allocv6 := Dump()
+	// Test the format of the dumped ip addresses
+	for i := 0; i < len(allocv4); i++ {
+		c.Assert(net.ParseIP(allocv4[i]), NotNil)
+	}
+	for i := 0; i < len(allocv6); i++ {
+		c.Assert(net.ParseIP(allocv6[i]), NotNil)
+	}
+}


### PR DESCRIPTION
Previously, the allocated ipv4 addresses displayed in the cilium status
command are not properly displayed. The reason is golang's net package
stores ip addresses in 16-byte format for both ipv4 and ipv6.
This patch truncates the ipv4 address to 4 bytes before using it.
This patch also added a unit test to make sure the dumped ip addresses
are valid.

Signed-off-by: Rui Gu <rui@covalent.io>

Fixes: #5796

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6134)
<!-- Reviewable:end -->
