### PR TITLE
Policy: Import kubernetes UID into the policy.

### DIFF
--- a/daemon/k8s_watcher_test.go
+++ b/daemon/k8s_watcher_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/cache"
 )
@@ -163,6 +164,8 @@ func (ds *DaemonSuite) Test_missingK8sNetworkPolicyV1(c *C) {
 }
 
 func (ds *DaemonSuite) Test_missingCNPv2(c *C) {
+	uuid := types.UID("11bba160-ddca-11e8-b697-0800273b04ff")
+
 	type args struct {
 		m    versioned.Map
 		repo *policy.Repository
@@ -224,7 +227,8 @@ func (ds *DaemonSuite) Test_missingCNPv2(c *C) {
 				p1 := policy.NewPolicyRepository()
 				_, err := p1.Add(api.Rule{
 					EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("id=a")),
-					Labels: utils.GetPolicyLabels("foo", "bar",
+					Labels: utils.GetPolicyLabels(
+						"foo", "bar", uuid,
 						utils.ResourceTypeCiliumNetworkPolicy),
 				})
 				c.Assert(err, IsNil)
@@ -235,6 +239,7 @@ func (ds *DaemonSuite) Test_missingCNPv2(c *C) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "bar",
 							Namespace: "foo",
+							UID:       uuid,
 						},
 						Spec: &api.Rule{
 							EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("id=a")),
@@ -1569,6 +1574,8 @@ func (ds *DaemonSuite) Test_missingK8sIngressV1Beta1(c *C) {
 
 func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 	// ciliumV2Store cache.Store, oldRules api.Rules, cnp *cilium_v2.CiliumNetworkPolicy
+
+	uuid := types.UID("11bba160-ddca-11e8-b697-0800273b04ff")
 	type args struct {
 		ciliumV2Store cache.Store
 		cnp           *v2.CiliumNetworkPolicy
@@ -1592,6 +1599,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "db",
 							Namespace: "production",
+							UID:       uuid,
 						},
 						Spec: &api.Rule{
 							EndpointSelector: api.EndpointSelector{
@@ -1620,7 +1628,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 						},
 						Ingress:     nil,
 						Egress:      nil,
-						Labels:      utils.GetPolicyLabels("production", "db", utils.ResourceTypeCiliumNetworkPolicy),
+						Labels:      utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy),
 						Description: "",
 					},
 				})
@@ -1634,7 +1642,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 			name: "have a rule with user labels and update it without user labels, all other rules should be deleted",
 			setupArgs: func() args {
 				r := policy.NewPolicyRepository()
-				lbls := utils.GetPolicyLabels("production", "db", utils.ResourceTypeCiliumNetworkPolicy)
+				lbls := utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy)
 				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...)
 				r.AddList(api.Rules{
 					{
@@ -1658,6 +1666,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "db",
 							Namespace: "production",
+							UID:       uuid,
 						},
 						Spec: &api.Rule{
 							EndpointSelector: api.EndpointSelector{
@@ -1686,7 +1695,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 						},
 						Ingress:     nil,
 						Egress:      nil,
-						Labels:      utils.GetPolicyLabels("production", "db", utils.ResourceTypeCiliumNetworkPolicy),
+						Labels:      utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy),
 						Description: "",
 					},
 				})
@@ -1712,7 +1721,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 						},
 						Ingress:     nil,
 						Egress:      nil,
-						Labels:      utils.GetPolicyLabels("production", "db", utils.ResourceTypeCiliumNetworkPolicy),
+						Labels:      utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy),
 						Description: "",
 					},
 				})
@@ -1722,6 +1731,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "db",
 							Namespace: "production",
+							UID:       uuid,
 						},
 						Spec: &api.Rule{
 							EndpointSelector: api.EndpointSelector{
@@ -1739,7 +1749,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 			},
 			setupWanted: func() wanted {
 				r := policy.NewPolicyRepository()
-				lbls := utils.GetPolicyLabels("production", "db", utils.ResourceTypeCiliumNetworkPolicy)
+				lbls := utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy)
 				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...)
 				r.AddList(api.Rules{
 					{
@@ -1792,7 +1802,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 							},
 						},
 						Egress:      nil,
-						Labels:      utils.GetPolicyLabels("production", "db", utils.ResourceTypeCiliumNetworkPolicy),
+						Labels:      utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy),
 						Description: "",
 					},
 				})
@@ -1802,6 +1812,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "db",
 							Namespace: "production",
+							UID:       uuid,
 						},
 					},
 					repo: r,

--- a/pkg/k8s/apis/cilium.io/const.go
+++ b/pkg/k8s/apis/cilium.io/const.go
@@ -19,6 +19,10 @@ const (
 	// k8s policy name.
 	PolicyLabelName = "io.cilium.k8s.policy.name"
 
+	// PolicyLabelUID is the uid of the policy label which refers to the
+	// k8s policy UID.
+	PolicyLabelUID = "io.cilium.k8s.policy.uid"
+
 	// PolicyLabelNamespace is the policy's namespace set in k8s.
 	PolicyLabelNamespace = "io.cilium.k8s.policy.namespace"
 

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -179,6 +179,7 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 
 	namespace := k8sUtils.ExtractNamespace(&r.ObjectMeta)
 	name := r.ObjectMeta.Name
+	uid := r.ObjectMeta.UID
 
 	retRules := api.Rules{}
 
@@ -187,7 +188,7 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 			return nil, fmt.Errorf("Invalid CiliumNetworkPolicy spec: %s", err)
 
 		}
-		cr := k8sCiliumUtils.ParseToCiliumRule(namespace, name, r.Spec)
+		cr := k8sCiliumUtils.ParseToCiliumRule(namespace, name, uid, r.Spec)
 		retRules = append(retRules, cr)
 	}
 	if r.Specs != nil {
@@ -196,7 +197,7 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 				return nil, fmt.Errorf("Invalid CiliumNetworkPolicy specs: %s", err)
 
 			}
-			cr := k8sCiliumUtils.ParseToCiliumRule(namespace, name, rule)
+			cr := k8sCiliumUtils.ParseToCiliumRule(namespace, name, uid, rule)
 			retRules = append(retRules, cr)
 		}
 	}
@@ -214,7 +215,8 @@ func (r *CiliumNetworkPolicy) GetControllerName() string {
 func (r *CiliumNetworkPolicy) GetIdentityLabels() labels.LabelArray {
 	namespace := k8sUtils.ExtractNamespace(&r.ObjectMeta)
 	name := r.ObjectMeta.Name
-	return k8sCiliumUtils.GetPolicyLabels(namespace, name,
+	uid := r.ObjectMeta.UID
+	return k8sCiliumUtils.GetPolicyLabels(namespace, name, uid,
 		k8sCiliumUtils.ResourceTypeCiliumNetworkPolicy)
 }
 

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -29,6 +29,7 @@ import (
 
 	. "gopkg.in/check.v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -111,7 +112,7 @@ var (
 		},
 		Labels: labels.LabelArray{{Key: "uuid", Value: "98678-9868976-78687678887678", Source: ""}},
 	}
-
+	uuidRule         = types.UID("98678-9868976-78687678887678")
 	expectedSpecRule = api.Rule{
 		Ingress: []api.IngressRule{
 			{
@@ -147,7 +148,7 @@ var (
 				ToCIDRSet: []api.CIDRRule{{Cidr: api.CIDR("10.0.0.0/8"), ExceptCIDRs: []api.CIDR{"10.96.0.0/12"}}},
 			},
 		},
-		Labels: k8sUtils.GetPolicyLabels("default", "rule1", "CiliumNetworkPolicy"),
+		Labels: k8sUtils.GetPolicyLabels("default", "rule1", uuidRule, "CiliumNetworkPolicy"),
 	}
 
 	rawRule = []byte(`{
@@ -244,13 +245,15 @@ var (
 
 	ciliumRule = append(append([]byte(`{
     "metadata": {
-        "name": "rule1"
+        "name": "rule1",
+		"uid": "`+uuidRule+`"
     },
     "spec": `), rawRule...), []byte(`
 }`)...)
 	ciliumRuleList = append(append(append(append([]byte(`{
     "metadata": {
-        "name": "rule1"
+        "name": "rule1",
+		"uid": "`+uuidRule+`"
     },
     "specs": [`), rawRule...), []byte(`, `)...), rawRule...), []byte(`]
 }`)...)
@@ -273,6 +276,7 @@ func (s *CiliumV2Suite) TestParseSpec(c *C) {
 	expectedPolicyRule := &CiliumNetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "rule1",
+			UID:  uuidRule,
 		},
 		Spec: &apiRule,
 	}
@@ -282,6 +286,7 @@ func (s *CiliumV2Suite) TestParseSpec(c *C) {
 	expectedPolicyRuleWithLabel := &CiliumNetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "rule1",
+			UID:  uuidRule,
 		},
 		Spec: &apiRuleWithLabels,
 	}
@@ -334,6 +339,7 @@ func (s *CiliumV2Suite) TestParseRules(c *C) {
 	expectedPolicyRuleList := &CiliumNetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "rule1",
+			UID:  uuidRule,
 		},
 		Specs: api.Rules{&apiRule, &apiRule},
 	}
@@ -343,6 +349,7 @@ func (s *CiliumV2Suite) TestParseRules(c *C) {
 	expectedPolicyRuleListWithLabel := &CiliumNetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "rule1",
+			UID:  uuidRule,
 		},
 		Specs: api.Rules{&apiRuleWithLabels, &apiRuleWithLabels},
 	}

--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -50,6 +50,7 @@ func GetPolicyLabelsv1(np *networkingv1.NetworkPolicy) labels.LabelArray {
 	}
 
 	policyName := np.Annotations[annotation.Name]
+	policyUID := np.UID
 
 	if policyName == "" {
 		policyName = np.Name
@@ -57,7 +58,7 @@ func GetPolicyLabelsv1(np *networkingv1.NetworkPolicy) labels.LabelArray {
 
 	ns := k8sUtils.ExtractNamespace(&np.ObjectMeta)
 
-	return k8sCiliumUtils.GetPolicyLabels(ns, policyName, resourceTypeNetworkPolicy)
+	return k8sCiliumUtils.GetPolicyLabels(ns, policyName, policyUID, resourceTypeNetworkPolicy)
 }
 
 func parseNetworkPolicyPeer(namespace string, peer *networkingv1.NetworkPolicyPeer) *api.EndpointSelector {


### PR DESCRIPTION
Kubernetes creates a new UID per each policy, with this change the UID
is saved in the policy labels and can be used for referencing policies
for future work.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6138)
<!-- Reviewable:end -->
