### PR TITLE
Documentation: add more notes on running unit tests with prerequisites

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -323,6 +323,8 @@ Cilium uses the standard `go test <https://golang.org/pkg/testing/>`__ framework
 in combination with `gocheck <http://labix.org/gocheck>`__ for richer testing
 functionality.
 
+.. _unit_testing_prerequisites:
+
 Prerequisites
 ^^^^^^^^^^^^^
 
@@ -369,6 +371,14 @@ If you need more verbose output, you can pass in the ``-check.v`` and
 
     $ cd pkg/kvstore
     $ go test -check.v -check.vv
+
+If the unit tests have some prerequisites like :ref:`unit_testing_prerequisites`,
+you can use the following command to automatically set up the prerequisites,
+run the unit tests and tear down the prerequisites:
+
+::
+
+    $ make unit-tests TESTPKGS=github.com/cilium/cilium/pkg/kvstore
 
 Running individual tests
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Add some extra clarifications to running unit tests with prerequisites.
A good thing using the make command is it also handles removing
the kv-store server container.

Signed-off-by: Rui Gu <rui@covalent.io>

Fixes: #6139

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6141)
<!-- Reviewable:end -->
