### PR TITLE
endpoint: Unlock endpoint to prevent deadlocks.

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2298,6 +2298,7 @@ func (e *Endpoint) ModifyIdentityLabels(owner Owner, addLabels, delLabels pkgLab
 
 	switch e.GetStateLocked() {
 	case StateDisconnected, StateDisconnecting:
+		e.Unlock()
 		return nil
 	}
 


### PR DESCRIPTION
Endpoint was inadvertently left locked by ModifyIdentityLabels() if
the endpoint is already disconnected or disconnecting when
ModifyIdentityLabels() acquired the endpoint lock. Unlock also in this
case.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6145)
<!-- Reviewable:end -->
