### PR TITLE
cmd: fix documentation links for cmdref

### DIFF
--- a/Documentation/cmdref/cilium.md
+++ b/Documentation/cmdref/cilium.md
@@ -18,21 +18,21 @@ CLI for interacting with the local Cilium Agent
 ```
 
 ### SEE ALSO
-* [cilium bpf](cilium_bpf.html)	 - Direct access to local BPF maps
-* [cilium cleanup](cilium_cleanup.html)	 - Reset the agent state
-* [cilium completion](cilium_completion.html)	 - Output shell completion code for bash
-* [cilium config](cilium_config.html)	 - Cilium configuration options
-* [cilium debuginfo](cilium_debuginfo.html)	 - Request available debugging information from agent
-* [cilium endpoint](cilium_endpoint.html)	 - Manage endpoints
-* [cilium identity](cilium_identity.html)	 - Manage security identities
-* [cilium kvstore](cilium_kvstore.html)	 - Direct access to the kvstore
-* [cilium map](cilium_map.html)	 - Access BPF maps
-* [cilium metrics](cilium_metrics.html)	 - Access metric status
-* [cilium monitor](cilium_monitor.html)	 - Display BPF program events
-* [cilium node](cilium_node.html)	 - Manage cluster nodes
-* [cilium policy](cilium_policy.html)	 - Manage security policies
-* [cilium prefilter](cilium_prefilter.html)	 - Manage XDP CIDR filters
-* [cilium service](cilium_service.html)	 - Manage services & loadbalancers
-* [cilium status](cilium_status.html)	 - Display status of daemon
-* [cilium version](cilium_version.html)	 - Print version information
+* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
+* [cilium cleanup](../cilium_cleanup)	 - Reset the agent state
+* [cilium completion](../cilium_completion)	 - Output shell completion code for bash
+* [cilium config](../cilium_config)	 - Cilium configuration options
+* [cilium debuginfo](../cilium_debuginfo)	 - Request available debugging information from agent
+* [cilium endpoint](../cilium_endpoint)	 - Manage endpoints
+* [cilium identity](../cilium_identity)	 - Manage security identities
+* [cilium kvstore](../cilium_kvstore)	 - Direct access to the kvstore
+* [cilium map](../cilium_map)	 - Access BPF maps
+* [cilium metrics](../cilium_metrics)	 - Access metric status
+* [cilium monitor](../cilium_monitor)	 - Display BPF program events
+* [cilium node](../cilium_node)	 - Manage cluster nodes
+* [cilium policy](../cilium_policy)	 - Manage security policies
+* [cilium prefilter](../cilium_prefilter)	 - Manage XDP CIDR filters
+* [cilium service](../cilium_service)	 - Manage services & loadbalancers
+* [cilium status](../cilium_status)	 - Display status of daemon
+* [cilium version](../cilium_version)	 - Print version information
 

--- a/Documentation/cmdref/cilium_bpf.md
+++ b/Documentation/cmdref/cilium_bpf.md
@@ -18,13 +18,13 @@ Direct access to local BPF maps
 ```
 
 ### SEE ALSO
-* [cilium](cilium.html)	 - CLI
-* [cilium bpf ct](cilium_bpf_ct.html)	 - Connection tracking tables
-* [cilium bpf endpoint](cilium_bpf_endpoint.html)	 - Local endpoint map
-* [cilium bpf ipcache](cilium_bpf_ipcache.html)	 - Manage the IPCache mappings for IP/CIDR <-> Identity
-* [cilium bpf lb](cilium_bpf_lb.html)	 - Load-balancing configuration
-* [cilium bpf metrics](cilium_bpf_metrics.html)	 - BPF datapath traffic metrics
-* [cilium bpf policy](cilium_bpf_policy.html)	 - Manage policy related BPF maps
-* [cilium bpf proxy](cilium_bpf_proxy.html)	 - Proxy configuration
-* [cilium bpf tunnel](cilium_bpf_tunnel.html)	 - Tunnel endpoint map
+* [cilium](../cilium)	 - CLI
+* [cilium bpf ct](../cilium_bpf_ct)	 - Connection tracking tables
+* [cilium bpf endpoint](../cilium_bpf_endpoint)	 - Local endpoint map
+* [cilium bpf ipcache](../cilium_bpf_ipcache)	 - Manage the IPCache mappings for IP/CIDR <-> Identity
+* [cilium bpf lb](../cilium_bpf_lb)	 - Load-balancing configuration
+* [cilium bpf metrics](../cilium_bpf_metrics)	 - BPF datapath traffic metrics
+* [cilium bpf policy](../cilium_bpf_policy)	 - Manage policy related BPF maps
+* [cilium bpf proxy](../cilium_bpf_proxy)	 - Proxy configuration
+* [cilium bpf tunnel](../cilium_bpf_tunnel)	 - Tunnel endpoint map
 

--- a/Documentation/cmdref/cilium_bpf_ct.md
+++ b/Documentation/cmdref/cilium_bpf_ct.md
@@ -18,7 +18,7 @@ Connection tracking tables
 ```
 
 ### SEE ALSO
-* [cilium bpf](cilium_bpf.html)	 - Direct access to local BPF maps
-* [cilium bpf ct flush](cilium_bpf_ct_flush.html)	 - Flush all connection tracking entries
-* [cilium bpf ct list](cilium_bpf_ct_list.html)	 - List connection tracking entries
+* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
+* [cilium bpf ct flush](../cilium_bpf_ct_flush)	 - Flush all connection tracking entries
+* [cilium bpf ct list](../cilium_bpf_ct_list)	 - List connection tracking entries
 

--- a/Documentation/cmdref/cilium_bpf_ct_flush.md
+++ b/Documentation/cmdref/cilium_bpf_ct_flush.md
@@ -22,5 +22,5 @@ cilium bpf ct flush ( <endpoint identifier> | global )
 ```
 
 ### SEE ALSO
-* [cilium bpf ct](cilium_bpf_ct.html)	 - Connection tracking tables
+* [cilium bpf ct](../cilium_bpf_ct)	 - Connection tracking tables
 

--- a/Documentation/cmdref/cilium_bpf_ct_list.md
+++ b/Documentation/cmdref/cilium_bpf_ct_list.md
@@ -28,5 +28,5 @@ cilium bpf ct list ( <endpoint identifier> | global )
 ```
 
 ### SEE ALSO
-* [cilium bpf ct](cilium_bpf_ct.html)	 - Connection tracking tables
+* [cilium bpf ct](../cilium_bpf_ct)	 - Connection tracking tables
 

--- a/Documentation/cmdref/cilium_bpf_endpoint.md
+++ b/Documentation/cmdref/cilium_bpf_endpoint.md
@@ -18,7 +18,7 @@ Local endpoint map
 ```
 
 ### SEE ALSO
-* [cilium bpf](cilium_bpf.html)	 - Direct access to local BPF maps
-* [cilium bpf endpoint delete](cilium_bpf_endpoint_delete.html)	 - Delete local endpoint entries
-* [cilium bpf endpoint list](cilium_bpf_endpoint_list.html)	 - List local endpoint entries
+* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
+* [cilium bpf endpoint delete](../cilium_bpf_endpoint_delete)	 - Delete local endpoint entries
+* [cilium bpf endpoint list](../cilium_bpf_endpoint_list)	 - List local endpoint entries
 

--- a/Documentation/cmdref/cilium_bpf_endpoint_delete.md
+++ b/Documentation/cmdref/cilium_bpf_endpoint_delete.md
@@ -22,5 +22,5 @@ cilium bpf endpoint delete
 ```
 
 ### SEE ALSO
-* [cilium bpf endpoint](cilium_bpf_endpoint.html)	 - Local endpoint map
+* [cilium bpf endpoint](../cilium_bpf_endpoint)	 - Local endpoint map
 

--- a/Documentation/cmdref/cilium_bpf_endpoint_list.md
+++ b/Documentation/cmdref/cilium_bpf_endpoint_list.md
@@ -28,5 +28,5 @@ cilium bpf endpoint list
 ```
 
 ### SEE ALSO
-* [cilium bpf endpoint](cilium_bpf_endpoint.html)	 - Local endpoint map
+* [cilium bpf endpoint](../cilium_bpf_endpoint)	 - Local endpoint map
 

--- a/Documentation/cmdref/cilium_bpf_ipcache.md
+++ b/Documentation/cmdref/cilium_bpf_ipcache.md
@@ -18,7 +18,7 @@ Manage the IPCache mappings for IP/CIDR <-> Identity
 ```
 
 ### SEE ALSO
-* [cilium bpf](cilium_bpf.html)	 - Direct access to local BPF maps
-* [cilium bpf ipcache get](cilium_bpf_ipcache_get.html)	 - Retrieve identity for an ip
-* [cilium bpf ipcache list](cilium_bpf_ipcache_list.html)	 - List endpoint IPs (local and remote) and their corresponding security identities
+* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
+* [cilium bpf ipcache get](../cilium_bpf_ipcache_get)	 - Retrieve identity for an ip
+* [cilium bpf ipcache list](../cilium_bpf_ipcache_list)	 - List endpoint IPs (local and remote) and their corresponding security identities
 

--- a/Documentation/cmdref/cilium_bpf_ipcache_get.md
+++ b/Documentation/cmdref/cilium_bpf_ipcache_get.md
@@ -22,5 +22,5 @@ cilium bpf ipcache get
 ```
 
 ### SEE ALSO
-* [cilium bpf ipcache](cilium_bpf_ipcache.html)	 - Manage the IPCache mappings for IP/CIDR <-> Identity
+* [cilium bpf ipcache](../cilium_bpf_ipcache)	 - Manage the IPCache mappings for IP/CIDR <-> Identity
 

--- a/Documentation/cmdref/cilium_bpf_ipcache_list.md
+++ b/Documentation/cmdref/cilium_bpf_ipcache_list.md
@@ -34,5 +34,5 @@ cilium bpf ipcache list
 ```
 
 ### SEE ALSO
-* [cilium bpf ipcache](cilium_bpf_ipcache.html)	 - Manage the IPCache mappings for IP/CIDR <-> Identity
+* [cilium bpf ipcache](../cilium_bpf_ipcache)	 - Manage the IPCache mappings for IP/CIDR <-> Identity
 

--- a/Documentation/cmdref/cilium_bpf_lb.md
+++ b/Documentation/cmdref/cilium_bpf_lb.md
@@ -18,6 +18,6 @@ Load-balancing configuration
 ```
 
 ### SEE ALSO
-* [cilium bpf](cilium_bpf.html)	 - Direct access to local BPF maps
-* [cilium bpf lb list](cilium_bpf_lb_list.html)	 - List load-balancing configuration
+* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
+* [cilium bpf lb list](../cilium_bpf_lb_list)	 - List load-balancing configuration
 

--- a/Documentation/cmdref/cilium_bpf_lb_list.md
+++ b/Documentation/cmdref/cilium_bpf_lb_list.md
@@ -29,5 +29,5 @@ cilium bpf lb list
 ```
 
 ### SEE ALSO
-* [cilium bpf lb](cilium_bpf_lb.html)	 - Load-balancing configuration
+* [cilium bpf lb](../cilium_bpf_lb)	 - Load-balancing configuration
 

--- a/Documentation/cmdref/cilium_bpf_metrics.md
+++ b/Documentation/cmdref/cilium_bpf_metrics.md
@@ -18,6 +18,6 @@ BPF datapath traffic metrics
 ```
 
 ### SEE ALSO
-* [cilium bpf](cilium_bpf.html)	 - Direct access to local BPF maps
-* [cilium bpf metrics list](cilium_bpf_metrics_list.html)	 - List BPF datapath traffic metrics
+* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
+* [cilium bpf metrics list](../cilium_bpf_metrics_list)	 - List BPF datapath traffic metrics
 

--- a/Documentation/cmdref/cilium_bpf_metrics_list.md
+++ b/Documentation/cmdref/cilium_bpf_metrics_list.md
@@ -28,5 +28,5 @@ cilium bpf metrics list
 ```
 
 ### SEE ALSO
-* [cilium bpf metrics](cilium_bpf_metrics.html)	 - BPF datapath traffic metrics
+* [cilium bpf metrics](../cilium_bpf_metrics)	 - BPF datapath traffic metrics
 

--- a/Documentation/cmdref/cilium_bpf_policy.md
+++ b/Documentation/cmdref/cilium_bpf_policy.md
@@ -18,8 +18,8 @@ Manage policy related BPF maps
 ```
 
 ### SEE ALSO
-* [cilium bpf](cilium_bpf.html)	 - Direct access to local BPF maps
-* [cilium bpf policy add](cilium_bpf_policy_add.html)	 - Add/update policy entry
-* [cilium bpf policy delete](cilium_bpf_policy_delete.html)	 - Delete a policy entry
-* [cilium bpf policy get](cilium_bpf_policy_get.html)	 - List contents of a policy BPF map
+* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
+* [cilium bpf policy add](../cilium_bpf_policy_add)	 - Add/update policy entry
+* [cilium bpf policy delete](../cilium_bpf_policy_delete)	 - Delete a policy entry
+* [cilium bpf policy get](../cilium_bpf_policy_get)	 - List contents of a policy BPF map
 

--- a/Documentation/cmdref/cilium_bpf_policy_add.md
+++ b/Documentation/cmdref/cilium_bpf_policy_add.md
@@ -22,5 +22,5 @@ cilium bpf policy add <endpoint id> <traffic-direction> <identity> [port/proto]
 ```
 
 ### SEE ALSO
-* [cilium bpf policy](cilium_bpf_policy.html)	 - Manage policy related BPF maps
+* [cilium bpf policy](../cilium_bpf_policy)	 - Manage policy related BPF maps
 

--- a/Documentation/cmdref/cilium_bpf_policy_delete.md
+++ b/Documentation/cmdref/cilium_bpf_policy_delete.md
@@ -22,5 +22,5 @@ cilium bpf policy delete <endpoint id> <identity> [port/proto]
 ```
 
 ### SEE ALSO
-* [cilium bpf policy](cilium_bpf_policy.html)	 - Manage policy related BPF maps
+* [cilium bpf policy](../cilium_bpf_policy)	 - Manage policy related BPF maps
 

--- a/Documentation/cmdref/cilium_bpf_policy_get.md
+++ b/Documentation/cmdref/cilium_bpf_policy_get.md
@@ -30,5 +30,5 @@ cilium bpf policy get
 ```
 
 ### SEE ALSO
-* [cilium bpf policy](cilium_bpf_policy.html)	 - Manage policy related BPF maps
+* [cilium bpf policy](../cilium_bpf_policy)	 - Manage policy related BPF maps
 

--- a/Documentation/cmdref/cilium_bpf_proxy.md
+++ b/Documentation/cmdref/cilium_bpf_proxy.md
@@ -18,7 +18,7 @@ Proxy configuration
 ```
 
 ### SEE ALSO
-* [cilium bpf](cilium_bpf.html)	 - Direct access to local BPF maps
-* [cilium bpf proxy flush](cilium_bpf_proxy_flush.html)	 - Flush all proxy entries
-* [cilium bpf proxy list](cilium_bpf_proxy_list.html)	 - List proxy configuration
+* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
+* [cilium bpf proxy flush](../cilium_bpf_proxy_flush)	 - Flush all proxy entries
+* [cilium bpf proxy list](../cilium_bpf_proxy_list)	 - List proxy configuration
 

--- a/Documentation/cmdref/cilium_bpf_proxy_flush.md
+++ b/Documentation/cmdref/cilium_bpf_proxy_flush.md
@@ -22,5 +22,5 @@ cilium bpf proxy flush
 ```
 
 ### SEE ALSO
-* [cilium bpf proxy](cilium_bpf_proxy.html)	 - Proxy configuration
+* [cilium bpf proxy](../cilium_bpf_proxy)	 - Proxy configuration
 

--- a/Documentation/cmdref/cilium_bpf_proxy_list.md
+++ b/Documentation/cmdref/cilium_bpf_proxy_list.md
@@ -28,5 +28,5 @@ cilium bpf proxy list
 ```
 
 ### SEE ALSO
-* [cilium bpf proxy](cilium_bpf_proxy.html)	 - Proxy configuration
+* [cilium bpf proxy](../cilium_bpf_proxy)	 - Proxy configuration
 

--- a/Documentation/cmdref/cilium_bpf_tunnel.md
+++ b/Documentation/cmdref/cilium_bpf_tunnel.md
@@ -18,6 +18,6 @@ Tunnel endpoint map
 ```
 
 ### SEE ALSO
-* [cilium bpf](cilium_bpf.html)	 - Direct access to local BPF maps
-* [cilium bpf tunnel list](cilium_bpf_tunnel_list.html)	 - List tunnel endpoint entries
+* [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
+* [cilium bpf tunnel list](../cilium_bpf_tunnel_list)	 - List tunnel endpoint entries
 

--- a/Documentation/cmdref/cilium_bpf_tunnel_list.md
+++ b/Documentation/cmdref/cilium_bpf_tunnel_list.md
@@ -28,5 +28,5 @@ cilium bpf tunnel list
 ```
 
 ### SEE ALSO
-* [cilium bpf tunnel](cilium_bpf_tunnel.html)	 - Tunnel endpoint map
+* [cilium bpf tunnel](../cilium_bpf_tunnel)	 - Tunnel endpoint map
 

--- a/Documentation/cmdref/cilium_cleanup.md
+++ b/Documentation/cmdref/cilium_cleanup.md
@@ -28,5 +28,5 @@ cilium cleanup
 ```
 
 ### SEE ALSO
-* [cilium](cilium.html)	 - CLI
+* [cilium](../cilium)	 - CLI
 

--- a/Documentation/cmdref/cilium_completion.md
+++ b/Documentation/cmdref/cilium_completion.md
@@ -47,5 +47,5 @@ cilium completion [bash]
 ```
 
 ### SEE ALSO
-* [cilium](cilium.html)	 - CLI
+* [cilium](../cilium)	 - CLI
 

--- a/Documentation/cmdref/cilium_config.md
+++ b/Documentation/cmdref/cilium_config.md
@@ -30,5 +30,5 @@ cilium config [<option>=(enable|disable) ...]
 ```
 
 ### SEE ALSO
-* [cilium](cilium.html)	 - CLI
+* [cilium](../cilium)	 - CLI
 

--- a/Documentation/cmdref/cilium_debuginfo.md
+++ b/Documentation/cmdref/cilium_debuginfo.md
@@ -30,5 +30,5 @@ cilium debuginfo
 ```
 
 ### SEE ALSO
-* [cilium](cilium.html)	 - CLI
+* [cilium](../cilium)	 - CLI
 

--- a/Documentation/cmdref/cilium_endpoint.md
+++ b/Documentation/cmdref/cilium_endpoint.md
@@ -18,13 +18,13 @@ Manage endpoints
 ```
 
 ### SEE ALSO
-* [cilium](cilium.html)	 - CLI
-* [cilium endpoint config](cilium_endpoint_config.html)	 - View & modify endpoint configuration
-* [cilium endpoint disconnect](cilium_endpoint_disconnect.html)	 - Disconnect an endpoint from the network
-* [cilium endpoint get](cilium_endpoint_get.html)	 - Display endpoint information
-* [cilium endpoint health](cilium_endpoint_health.html)	 - View endpoint health
-* [cilium endpoint labels](cilium_endpoint_labels.html)	 - Manage label configuration of endpoint
-* [cilium endpoint list](cilium_endpoint_list.html)	 - List all endpoints
-* [cilium endpoint log](cilium_endpoint_log.html)	 - View endpoint status log
-* [cilium endpoint regenerate](cilium_endpoint_regenerate.html)	 - Force regeneration of endpoint program
+* [cilium](../cilium)	 - CLI
+* [cilium endpoint config](../cilium_endpoint_config)	 - View & modify endpoint configuration
+* [cilium endpoint disconnect](../cilium_endpoint_disconnect)	 - Disconnect an endpoint from the network
+* [cilium endpoint get](../cilium_endpoint_get)	 - Display endpoint information
+* [cilium endpoint health](../cilium_endpoint_health)	 - View endpoint health
+* [cilium endpoint labels](../cilium_endpoint_labels)	 - Manage label configuration of endpoint
+* [cilium endpoint list](../cilium_endpoint_list)	 - List all endpoints
+* [cilium endpoint log](../cilium_endpoint_log)	 - View endpoint status log
+* [cilium endpoint regenerate](../cilium_endpoint_regenerate)	 - Force regeneration of endpoint program
 

--- a/Documentation/cmdref/cilium_endpoint_config.md
+++ b/Documentation/cmdref/cilium_endpoint_config.md
@@ -35,5 +35,5 @@ endpoint config 5421 DropNotification=false TraceNotification=false
 ```
 
 ### SEE ALSO
-* [cilium endpoint](cilium_endpoint.html)	 - Manage endpoints
+* [cilium endpoint](../cilium_endpoint)	 - Manage endpoints
 

--- a/Documentation/cmdref/cilium_endpoint_disconnect.md
+++ b/Documentation/cmdref/cilium_endpoint_disconnect.md
@@ -22,5 +22,5 @@ cilium endpoint disconnect <endpoint-id>
 ```
 
 ### SEE ALSO
-* [cilium endpoint](cilium_endpoint.html)	 - Manage endpoints
+* [cilium endpoint](../cilium_endpoint)	 - Manage endpoints
 

--- a/Documentation/cmdref/cilium_endpoint_get.md
+++ b/Documentation/cmdref/cilium_endpoint_get.md
@@ -35,5 +35,5 @@ cilium endpoint get 4598, cilium endpoint get pod-name:default:foobar, cilium en
 ```
 
 ### SEE ALSO
-* [cilium endpoint](cilium_endpoint.html)	 - Manage endpoints
+* [cilium endpoint](../cilium_endpoint)	 - Manage endpoints
 

--- a/Documentation/cmdref/cilium_endpoint_health.md
+++ b/Documentation/cmdref/cilium_endpoint_health.md
@@ -34,5 +34,5 @@ cilium endpoint health 5421
 ```
 
 ### SEE ALSO
-* [cilium endpoint](cilium_endpoint.html)	 - Manage endpoints
+* [cilium endpoint](../cilium_endpoint)	 - Manage endpoints
 

--- a/Documentation/cmdref/cilium_endpoint_labels.md
+++ b/Documentation/cmdref/cilium_endpoint_labels.md
@@ -29,5 +29,5 @@ cilium endpoint labels
 ```
 
 ### SEE ALSO
-* [cilium endpoint](cilium_endpoint.html)	 - Manage endpoints
+* [cilium endpoint](../cilium_endpoint)	 - Manage endpoints
 

--- a/Documentation/cmdref/cilium_endpoint_list.md
+++ b/Documentation/cmdref/cilium_endpoint_list.md
@@ -29,5 +29,5 @@ cilium endpoint list
 ```
 
 ### SEE ALSO
-* [cilium endpoint](cilium_endpoint.html)	 - Manage endpoints
+* [cilium endpoint](../cilium_endpoint)	 - Manage endpoints
 

--- a/Documentation/cmdref/cilium_endpoint_log.md
+++ b/Documentation/cmdref/cilium_endpoint_log.md
@@ -34,5 +34,5 @@ cilium endpoint log 5421
 ```
 
 ### SEE ALSO
-* [cilium endpoint](cilium_endpoint.html)	 - Manage endpoints
+* [cilium endpoint](../cilium_endpoint)	 - Manage endpoints
 

--- a/Documentation/cmdref/cilium_endpoint_regenerate.md
+++ b/Documentation/cmdref/cilium_endpoint_regenerate.md
@@ -22,5 +22,5 @@ cilium endpoint regenerate <endpoint-id>
 ```
 
 ### SEE ALSO
-* [cilium endpoint](cilium_endpoint.html)	 - Manage endpoints
+* [cilium endpoint](../cilium_endpoint)	 - Manage endpoints
 

--- a/Documentation/cmdref/cilium_identity.md
+++ b/Documentation/cmdref/cilium_identity.md
@@ -18,7 +18,7 @@ Manage security identities
 ```
 
 ### SEE ALSO
-* [cilium](cilium.html)	 - CLI
-* [cilium identity get](cilium_identity_get.html)	 - Retrieve information about an identity
-* [cilium identity list](cilium_identity_list.html)	 - List identities
+* [cilium](../cilium)	 - CLI
+* [cilium identity get](../cilium_identity_get)	 - Retrieve information about an identity
+* [cilium identity list](../cilium_identity_list)	 - List identities
 

--- a/Documentation/cmdref/cilium_identity_get.md
+++ b/Documentation/cmdref/cilium_identity_get.md
@@ -29,5 +29,5 @@ cilium identity get
 ```
 
 ### SEE ALSO
-* [cilium identity](cilium_identity.html)	 - Manage security identities
+* [cilium identity](../cilium_identity)	 - Manage security identities
 

--- a/Documentation/cmdref/cilium_identity_list.md
+++ b/Documentation/cmdref/cilium_identity_list.md
@@ -28,5 +28,5 @@ cilium identity list [LABELS]
 ```
 
 ### SEE ALSO
-* [cilium identity](cilium_identity.html)	 - Manage security identities
+* [cilium identity](../cilium_identity)	 - Manage security identities
 

--- a/Documentation/cmdref/cilium_kvstore.md
+++ b/Documentation/cmdref/cilium_kvstore.md
@@ -25,8 +25,8 @@ Direct access to the kvstore
 ```
 
 ### SEE ALSO
-* [cilium](cilium.html)	 - CLI
-* [cilium kvstore delete](cilium_kvstore_delete.html)	 - Delete a key
-* [cilium kvstore get](cilium_kvstore_get.html)	 - Retrieve a key
-* [cilium kvstore set](cilium_kvstore_set.html)	 - Set a key and value
+* [cilium](../cilium)	 - CLI
+* [cilium kvstore delete](../cilium_kvstore_delete)	 - Delete a key
+* [cilium kvstore get](../cilium_kvstore_get)	 - Retrieve a key
+* [cilium kvstore set](../cilium_kvstore_set)	 - Set a key and value
 

--- a/Documentation/cmdref/cilium_kvstore_delete.md
+++ b/Documentation/cmdref/cilium_kvstore_delete.md
@@ -36,5 +36,5 @@ cilium kvstore delete --recursive foo
 ```
 
 ### SEE ALSO
-* [cilium kvstore](cilium_kvstore.html)	 - Direct access to the kvstore
+* [cilium kvstore](../cilium_kvstore)	 - Direct access to the kvstore
 

--- a/Documentation/cmdref/cilium_kvstore_get.md
+++ b/Documentation/cmdref/cilium_kvstore_get.md
@@ -37,5 +37,5 @@ cilium kvstore get --recursive foo
 ```
 
 ### SEE ALSO
-* [cilium kvstore](cilium_kvstore.html)	 - Direct access to the kvstore
+* [cilium kvstore](../cilium_kvstore)	 - Direct access to the kvstore
 

--- a/Documentation/cmdref/cilium_kvstore_set.md
+++ b/Documentation/cmdref/cilium_kvstore_set.md
@@ -37,5 +37,5 @@ cilium kvstore set foo=bar
 ```
 
 ### SEE ALSO
-* [cilium kvstore](cilium_kvstore.html)	 - Direct access to the kvstore
+* [cilium kvstore](../cilium_kvstore)	 - Direct access to the kvstore
 

--- a/Documentation/cmdref/cilium_map.md
+++ b/Documentation/cmdref/cilium_map.md
@@ -18,7 +18,7 @@ Access BPF maps
 ```
 
 ### SEE ALSO
-* [cilium](cilium.html)	 - CLI
-* [cilium map get](cilium_map_get.html)	 - Display BPF map information
-* [cilium map list](cilium_map_list.html)	 - List all open BPF maps
+* [cilium](../cilium)	 - CLI
+* [cilium map get](../cilium_map_get)	 - Display BPF map information
+* [cilium map list](../cilium_map_list)	 - List all open BPF maps
 

--- a/Documentation/cmdref/cilium_map_get.md
+++ b/Documentation/cmdref/cilium_map_get.md
@@ -34,5 +34,5 @@ cilium map get cilium_ipcache
 ```
 
 ### SEE ALSO
-* [cilium map](cilium_map.html)	 - Access BPF maps
+* [cilium map](../cilium_map)	 - Access BPF maps
 

--- a/Documentation/cmdref/cilium_map_list.md
+++ b/Documentation/cmdref/cilium_map_list.md
@@ -35,5 +35,5 @@ cilium map list
 ```
 
 ### SEE ALSO
-* [cilium map](cilium_map.html)	 - Access BPF maps
+* [cilium map](../cilium_map)	 - Access BPF maps
 

--- a/Documentation/cmdref/cilium_metrics.md
+++ b/Documentation/cmdref/cilium_metrics.md
@@ -18,6 +18,6 @@ Access metric status
 ```
 
 ### SEE ALSO
-* [cilium](cilium.html)	 - CLI
-* [cilium metrics list](cilium_metrics_list.html)	 - List all metrics
+* [cilium](../cilium)	 - CLI
+* [cilium metrics list](../cilium_metrics_list)	 - List all metrics
 

--- a/Documentation/cmdref/cilium_metrics_list.md
+++ b/Documentation/cmdref/cilium_metrics_list.md
@@ -28,5 +28,5 @@ cilium metrics list
 ```
 
 ### SEE ALSO
-* [cilium metrics](cilium_metrics.html)	 - Access metric status
+* [cilium metrics](../cilium_metrics)	 - Access metric status
 

--- a/Documentation/cmdref/cilium_monitor.md
+++ b/Documentation/cmdref/cilium_monitor.md
@@ -38,5 +38,5 @@ cilium monitor
 ```
 
 ### SEE ALSO
-* [cilium](cilium.html)	 - CLI
+* [cilium](../cilium)	 - CLI
 

--- a/Documentation/cmdref/cilium_node.md
+++ b/Documentation/cmdref/cilium_node.md
@@ -18,6 +18,6 @@ Manage cluster nodes
 ```
 
 ### SEE ALSO
-* [cilium](cilium.html)	 - CLI
-* [cilium node list](cilium_node_list.html)	 - List nodes
+* [cilium](../cilium)	 - CLI
+* [cilium node list](../cilium_node_list)	 - List nodes
 

--- a/Documentation/cmdref/cilium_node_list.md
+++ b/Documentation/cmdref/cilium_node_list.md
@@ -28,5 +28,5 @@ cilium node list
 ```
 
 ### SEE ALSO
-* [cilium node](cilium_node.html)	 - Manage cluster nodes
+* [cilium node](../cilium_node)	 - Manage cluster nodes
 

--- a/Documentation/cmdref/cilium_policy.md
+++ b/Documentation/cmdref/cilium_policy.md
@@ -18,11 +18,11 @@ Manage security policies
 ```
 
 ### SEE ALSO
-* [cilium](cilium.html)	 - CLI
-* [cilium policy delete](cilium_policy_delete.html)	 - Delete policy rules
-* [cilium policy get](cilium_policy_get.html)	 - Display policy node information
-* [cilium policy import](cilium_policy_import.html)	 - Import security policy in JSON format
-* [cilium policy trace](cilium_policy_trace.html)	 - Trace a policy decision
-* [cilium policy validate](cilium_policy_validate.html)	 - Validate a policy
-* [cilium policy wait](cilium_policy_wait.html)	 - Wait for all endpoints to have updated to a given policy revision
+* [cilium](../cilium)	 - CLI
+* [cilium policy delete](../cilium_policy_delete)	 - Delete policy rules
+* [cilium policy get](../cilium_policy_get)	 - Display policy node information
+* [cilium policy import](../cilium_policy_import)	 - Import security policy in JSON format
+* [cilium policy trace](../cilium_policy_trace)	 - Trace a policy decision
+* [cilium policy validate](../cilium_policy_validate)	 - Validate a policy
+* [cilium policy wait](../cilium_policy_wait)	 - Wait for all endpoints to have updated to a given policy revision
 

--- a/Documentation/cmdref/cilium_policy_delete.md
+++ b/Documentation/cmdref/cilium_policy_delete.md
@@ -29,5 +29,5 @@ cilium policy delete [<labels>]
 ```
 
 ### SEE ALSO
-* [cilium policy](cilium_policy.html)	 - Manage security policies
+* [cilium policy](../cilium_policy)	 - Manage security policies
 

--- a/Documentation/cmdref/cilium_policy_get.md
+++ b/Documentation/cmdref/cilium_policy_get.md
@@ -28,5 +28,5 @@ cilium policy get [<labels>]
 ```
 
 ### SEE ALSO
-* [cilium policy](cilium_policy.html)	 - Manage security policies
+* [cilium policy](../cilium_policy)	 - Manage security policies
 

--- a/Documentation/cmdref/cilium_policy_import.md
+++ b/Documentation/cmdref/cilium_policy_import.md
@@ -36,5 +36,5 @@ cilium policy import <path>
 ```
 
 ### SEE ALSO
-* [cilium policy](cilium_policy.html)	 - Manage security policies
+* [cilium policy](../cilium_policy)	 - Manage security policies
 

--- a/Documentation/cmdref/cilium_policy_trace.md
+++ b/Documentation/cmdref/cilium_policy_trace.md
@@ -44,5 +44,5 @@ cilium policy trace ( -s <label context> | --src-identity <security identity> | 
 ```
 
 ### SEE ALSO
-* [cilium policy](cilium_policy.html)	 - Manage security policies
+* [cilium policy](../cilium_policy)	 - Manage security policies
 

--- a/Documentation/cmdref/cilium_policy_validate.md
+++ b/Documentation/cmdref/cilium_policy_validate.md
@@ -28,5 +28,5 @@ cilium policy validate <path>
 ```
 
 ### SEE ALSO
-* [cilium policy](cilium_policy.html)	 - Manage security policies
+* [cilium policy](../cilium_policy)	 - Manage security policies
 

--- a/Documentation/cmdref/cilium_policy_wait.md
+++ b/Documentation/cmdref/cilium_policy_wait.md
@@ -30,5 +30,5 @@ cilium policy wait <revision>
 ```
 
 ### SEE ALSO
-* [cilium policy](cilium_policy.html)	 - Manage security policies
+* [cilium policy](../cilium_policy)	 - Manage security policies
 

--- a/Documentation/cmdref/cilium_prefilter.md
+++ b/Documentation/cmdref/cilium_prefilter.md
@@ -18,8 +18,8 @@ Manage XDP CIDR filters
 ```
 
 ### SEE ALSO
-* [cilium](cilium.html)	 - CLI
-* [cilium prefilter delete](cilium_prefilter_delete.html)	 - Delete CIDR filters
-* [cilium prefilter list](cilium_prefilter_list.html)	 - List CIDR filters
-* [cilium prefilter update](cilium_prefilter_update.html)	 - Update CIDR filters
+* [cilium](../cilium)	 - CLI
+* [cilium prefilter delete](../cilium_prefilter_delete)	 - Delete CIDR filters
+* [cilium prefilter list](../cilium_prefilter_list)	 - List CIDR filters
+* [cilium prefilter update](../cilium_prefilter_update)	 - Update CIDR filters
 

--- a/Documentation/cmdref/cilium_prefilter_delete.md
+++ b/Documentation/cmdref/cilium_prefilter_delete.md
@@ -29,5 +29,5 @@ cilium prefilter delete
 ```
 
 ### SEE ALSO
-* [cilium prefilter](cilium_prefilter.html)	 - Manage XDP CIDR filters
+* [cilium prefilter](../cilium_prefilter)	 - Manage XDP CIDR filters
 

--- a/Documentation/cmdref/cilium_prefilter_list.md
+++ b/Documentation/cmdref/cilium_prefilter_list.md
@@ -28,5 +28,5 @@ cilium prefilter list
 ```
 
 ### SEE ALSO
-* [cilium prefilter](cilium_prefilter.html)	 - Manage XDP CIDR filters
+* [cilium prefilter](../cilium_prefilter)	 - Manage XDP CIDR filters
 

--- a/Documentation/cmdref/cilium_prefilter_update.md
+++ b/Documentation/cmdref/cilium_prefilter_update.md
@@ -29,5 +29,5 @@ cilium prefilter update
 ```
 
 ### SEE ALSO
-* [cilium prefilter](cilium_prefilter.html)	 - Manage XDP CIDR filters
+* [cilium prefilter](../cilium_prefilter)	 - Manage XDP CIDR filters
 

--- a/Documentation/cmdref/cilium_service.md
+++ b/Documentation/cmdref/cilium_service.md
@@ -18,9 +18,9 @@ Manage services & loadbalancers
 ```
 
 ### SEE ALSO
-* [cilium](cilium.html)	 - CLI
-* [cilium service delete](cilium_service_delete.html)	 - Delete a service
-* [cilium service get](cilium_service_get.html)	 - Display service information
-* [cilium service list](cilium_service_list.html)	 - List services
-* [cilium service update](cilium_service_update.html)	 - Update a service
+* [cilium](../cilium)	 - CLI
+* [cilium service delete](../cilium_service_delete)	 - Delete a service
+* [cilium service get](../cilium_service_get)	 - Display service information
+* [cilium service list](../cilium_service_list)	 - List services
+* [cilium service update](../cilium_service_update)	 - Update a service
 

--- a/Documentation/cmdref/cilium_service_delete.md
+++ b/Documentation/cmdref/cilium_service_delete.md
@@ -28,5 +28,5 @@ cilium service delete { <service id> | --all }
 ```
 
 ### SEE ALSO
-* [cilium service](cilium_service.html)	 - Manage services & loadbalancers
+* [cilium service](../cilium_service)	 - Manage services & loadbalancers
 

--- a/Documentation/cmdref/cilium_service_get.md
+++ b/Documentation/cmdref/cilium_service_get.md
@@ -28,5 +28,5 @@ cilium service get <service id>
 ```
 
 ### SEE ALSO
-* [cilium service](cilium_service.html)	 - Manage services & loadbalancers
+* [cilium service](../cilium_service)	 - Manage services & loadbalancers
 

--- a/Documentation/cmdref/cilium_service_list.md
+++ b/Documentation/cmdref/cilium_service_list.md
@@ -28,5 +28,5 @@ cilium service list
 ```
 
 ### SEE ALSO
-* [cilium service](cilium_service.html)	 - Manage services & loadbalancers
+* [cilium service](../cilium_service)	 - Manage services & loadbalancers
 

--- a/Documentation/cmdref/cilium_service_update.md
+++ b/Documentation/cmdref/cilium_service_update.md
@@ -31,5 +31,5 @@ cilium service update
 ```
 
 ### SEE ALSO
-* [cilium service](cilium_service.html)	 - Manage services & loadbalancers
+* [cilium service](../cilium_service)	 - Manage services & loadbalancers
 

--- a/Documentation/cmdref/cilium_status.md
+++ b/Documentation/cmdref/cilium_status.md
@@ -35,5 +35,5 @@ cilium status
 ```
 
 ### SEE ALSO
-* [cilium](cilium.html)	 - CLI
+* [cilium](../cilium)	 - CLI
 

--- a/Documentation/cmdref/cilium_version.md
+++ b/Documentation/cmdref/cilium_version.md
@@ -28,5 +28,5 @@ cilium version
 ```
 
 ### SEE ALSO
-* [cilium](cilium.html)	 - CLI
+* [cilium](../cilium)	 - CLI
 

--- a/cilium/cmd/cmdref.go
+++ b/cilium/cmd/cmdref.go
@@ -40,11 +40,12 @@ func genCmdRef() {
 		log.Fatal(err)
 	}
 }
+
 func linkHandler(s string) string {
 	// The generated files have a 'See also' section but the URL's are
 	// hardcoded to use Markdown but we only want / have them in HTML
 	// later.
-	return strings.Replace(s, ".md", ".html", 1)
+	return "../" + strings.Replace(s, ".md", "", 1)
 }
 
 func filePrepend(s string) string {


### PR DESCRIPTION
The cmdref points the "SEE ALSO" links to non existing files, this
commit will point the "SEE ALSO" links to the right location.

Reported-by: Strukov Anton <savamech@gmail.com>
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6150)
<!-- Reviewable:end -->
