### PR TITLE
cilium: spelling, sha is an acronym replace with SHA

### DIFF
--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -2617,7 +2617,7 @@ bpftool can provide some high-level metadata specific to the program:
           xlated 11144B  jited 7721B  memlock 12288B  map_ids 18,20,8,5,6,14
 
 The program of ID 406 is of type ``sched_cls`` (``BPF_PROG_TYPE_SCHED_CLS``),
-has a ``tag`` of ``e0362f5bd9163a0a`` (sha sum over the instruction sequence),
+has a ``tag`` of ``e0362f5bd9163a0a`` (SHA sum over the instruction sequence),
 it was loaded by root ``uid 0`` on ``Apr 09/16:24``. The BPF instruction
 sequence is ``11,144 bytes`` long and the JITed image ``7,721 bytes``. The
 program itself (excluding maps) consumes ``12,288 bytes`` that are accounted /


### PR DESCRIPTION
When running 'make html' in Documentation my version of this command
`sphinx-build -b spelling ...' through an error on sha. Presumably,
I have different dictionary then standard builds (this is a bare
metal build on my dev box). But, really sha is an acronym so lets
capitalize and this has the nice side benefit of getting docs to
build for me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6151)
<!-- Reviewable:end -->
