### PR TITLE
endpoint/id: improve SplitID function performance by 6x

### DIFF
--- a/pkg/endpoint/id/id.go
+++ b/pkg/endpoint/id/id.go
@@ -26,15 +26,15 @@ func (s PrefixType) String() string { return string(s) }
 
 const (
 	CiliumLocalIdPrefix  PrefixType = "cilium-local"
-	CiliumGlobalIdPrefix            = "cilium-global"
-	ContainerIdPrefix               = "container-id"
-	DockerEndpointPrefix            = "docker-endpoint"
-	ContainerNamePrefix             = "container-name"
-	PodNamePrefix                   = "pod-name"
+	CiliumGlobalIdPrefix PrefixType = "cilium-global"
+	ContainerIdPrefix    PrefixType = "container-id"
+	DockerEndpointPrefix PrefixType = "docker-endpoint"
+	ContainerNamePrefix  PrefixType = "container-name"
+	PodNamePrefix        PrefixType = "pod-name"
 
 	// IPv4Prefix is the prefix used in Cilium IDs when the identifier is
 	// the IPv4 address of the endpoint
-	IPv4Prefix = "ipv4"
+	IPv4Prefix PrefixType = "ipv4"
 )
 
 func NewCiliumID(id int64) string {
@@ -47,12 +47,8 @@ func NewID(prefix PrefixType, id string) string {
 
 // SplitID splits ID into prefix and id. No validation is performed on prefix.
 func SplitID(id string) (PrefixType, string) {
-	if s := strings.Split(id, ":"); len(s) == 2 {
-		return PrefixType(s[0]), s[1]
-	} else if len(s) == 3 {
-		// PodNamePrefix case, e.g. "pod-name:default:foobar" where the prefix is
-		// pod-name, the pod namespace is default, and the pod-name is foobar.
-		return PrefixType(s[0]), strings.Join([]string{s[1], s[2]}, ":")
+	if idx := strings.Index(id, ":"); idx > -1 {
+		return PrefixType(id[:idx]), id[idx+1:]
 	}
 	// default prefix
 	return CiliumLocalIdPrefix, id

--- a/pkg/endpoint/id/id_test.go
+++ b/pkg/endpoint/id/id_test.go
@@ -1,0 +1,186 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package id
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type IDSuite struct{}
+
+var _ = Suite(&IDSuite{})
+
+func (s *IDSuite) TestSplitID(c *C) {
+	type args struct {
+		id string
+	}
+	type want struct {
+		prefixType      PrefixType
+		prefixTypeCheck Checker
+		id              string
+		idCheck         Checker
+	}
+	tests := []struct {
+		name        string
+		setupArgs   func() args
+		setupWant   func() want
+		preTestRun  func()
+		postTestRun func()
+	}{
+		{
+			name: "ID without a prefix",
+			preTestRun: func() {
+			},
+			setupArgs: func() args {
+				return args{
+					"123456",
+				}
+			},
+			setupWant: func() want {
+				return want{
+					prefixType:      CiliumLocalIdPrefix,
+					prefixTypeCheck: Equals,
+					id:              "123456",
+					idCheck:         Equals,
+				}
+			},
+			postTestRun: func() {
+			},
+		},
+		{
+			name: "ID CiliumLocalIdPrefix prefix",
+			preTestRun: func() {
+			},
+			setupArgs: func() args {
+				return args{
+					string(CiliumLocalIdPrefix) + ":123456",
+				}
+			},
+			setupWant: func() want {
+				return want{
+					prefixType:      CiliumLocalIdPrefix,
+					prefixTypeCheck: Equals,
+					id:              "123456",
+					idCheck:         Equals,
+				}
+			},
+			postTestRun: func() {
+			},
+		},
+		{
+			name: "ID with PodNamePrefix prefix",
+			preTestRun: func() {
+			},
+			setupArgs: func() args {
+				return args{
+					string(PodNamePrefix) + ":default:foobar",
+				}
+			},
+			setupWant: func() want {
+				return want{
+					prefixType:      PodNamePrefix,
+					prefixTypeCheck: Equals,
+					id:              "default:foobar",
+					idCheck:         Equals,
+				}
+			},
+			postTestRun: func() {
+			},
+		},
+		{
+			name: "ID with ':'",
+			preTestRun: func() {
+			},
+			setupArgs: func() args {
+				return args{
+					":",
+				}
+			},
+			setupWant: func() want {
+				return want{
+					prefixType:      "",
+					prefixTypeCheck: Equals,
+					id:              "",
+					idCheck:         Equals,
+				}
+			},
+			postTestRun: func() {
+			},
+		},
+		{
+			name: "Empty ID",
+			preTestRun: func() {
+			},
+			setupArgs: func() args {
+				return args{
+					"",
+				}
+			},
+			setupWant: func() want {
+				return want{
+					prefixType:      CiliumLocalIdPrefix,
+					prefixTypeCheck: Equals,
+					id:              "",
+					idCheck:         Equals,
+				}
+			},
+			postTestRun: func() {
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt.preTestRun()
+		args := tt.setupArgs()
+		want := tt.setupWant()
+		prefixType, id := SplitID(args.id)
+		c.Assert(prefixType, want.prefixTypeCheck, want.prefixType, Commentf("Test Name: %s", tt.name))
+		c.Assert(id, want.idCheck, want.id, Commentf("Test Name: %s", tt.name))
+		tt.postTestRun()
+	}
+}
+
+func BenchmarkSplitID(b *testing.B) {
+	tests := []struct {
+		str        string
+		prefixType PrefixType
+		id         string
+	}{
+		{"123456", CiliumLocalIdPrefix, "123456"},
+		{string(CiliumLocalIdPrefix + ":123456"), CiliumLocalIdPrefix, "123456"},
+		{string(PodNamePrefix + ":default:foobar"), PodNamePrefix, "default:foobar"},
+	}
+	count := 0
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, test := range tests {
+			pt, str := SplitID(test.str)
+			if pt == test.prefixType && str == test.id {
+				count++
+			}
+		}
+	}
+	b.StopTimer()
+	if count != len(tests)*b.N {
+		b.Errorf("SplitID didn't produce correct results")
+	}
+	b.ReportAllocs()
+}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -904,7 +904,7 @@ func (e *Endpoint) runIdentityToK8sPodSync() {
 // / <global ID Prefix>:<cluster name>:<node name>:<endpoint ID> as a string.
 func (e *Endpoint) FormatGlobalEndpointID() string {
 	n := node.GetLocalNode()
-	metadata := []string{endpointid.CiliumGlobalIdPrefix, ipcache.AddressSpace, n.Name, strconv.Itoa(int(e.ID))}
+	metadata := []string{endpointid.CiliumGlobalIdPrefix.String(), ipcache.AddressSpace, n.Name, strconv.Itoa(int(e.ID))}
 	return strings.Join(metadata, ":")
 }
 


### PR DESCRIPTION
Add unit tests for SplitID, make BenchmarkFunction for that function and
rewrote function to have a better performance.

Before changes:

```
goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/endpoint/id
BenchmarkSplitID-8   	 3000000	       370 ns/op	     112 B/op	       4 allocs/op
PASS
```

After changes:
```
goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/endpoint/id
BenchmarkSplitID-8   	20000000	        57.6 ns/op	       0 B/op	       0 allocs/op
PASS
```

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6152)
<!-- Reviewable:end -->
