### PR TITLE
Update envoy proxy, add llvm to Requires

### DIFF
--- a/contrib/packaging/rpm/Makefile
+++ b/contrib/packaging/rpm/Makefile
@@ -13,6 +13,7 @@ build: clean
 	echo "export VERSION=$(VERSION) RELEASE=$(RELEASE) COMMIT=$(COMMIT) SHORTCOMMIT=$(SHORTCOMMIT)" > env
 	(cd $(BASEDIR) && git bundle create $(CURDIR)/version_$(VERSION) $(BRANCH) --tags)
 	(cd $(CURDIR) && git clone $(CURDIR)/version_$(VERSION) cilium -b $(BRANCH))
+	(cd $(CURDIR)/cilium/envoy && make BINDIR=$$PWD install)
 	tar -c cilium --transform s/cilium/cilium-$(COMMIT)/ | gzip -9 &> cilium-$(SHORTCOMMIT).tar.gz
 	docker build -t cilium:cilium-bin-rpm-$(VERSION) $(CURDIR)
 	docker run --rm -v $(CURDIR)/output:/output cilium:cilium-bin-rpm-$(VERSION)

--- a/contrib/packaging/rpm/cilium.spec.envsubst
+++ b/contrib/packaging/rpm/cilium.spec.envsubst
@@ -103,7 +103,7 @@ export GOPATH=$(pwd):%{gopath}
 export GOPATH=$(pwd):$(pwd)/vendor:%{gopath}
 %endif
 
-echo "%{version}.%{release}.git%{shortcommit0}" > VERSION
+echo "%{version}.%{release}" > VERSION
 
 export PKG_BUILD=1
 
@@ -114,6 +114,8 @@ make V=1 proxylib plugins bpf cilium daemon monitor cilium-health bugtool tools
 export PKG_BUILD=1
 
 %{__make} DESTDIR=%{buildroot} BINDIR=%{_bindir} LIBDIR=%{_libdir} install
+
+cp envoy/cilium-envoy %{buildroot}%{_bindir}
 
 mkdir -p %{buildroot}%{_unitdir}
 mkdir -p %{buildroot}%{_sysconfdir}/sysconfig
@@ -142,6 +144,7 @@ chmod 644 %{buildroot}%{_sysconfdir}/sysconfig/cilium
 %{_bindir}/cilium-node-monitor
 %{_bindir}/cilium-bugtool
 %{_bindir}/cilium-health
+%{_bindir}/cilium-envoy
 %{_bindir}/cilium-map-migrate
 %{_bindir}/cilium-ring-dump
 

--- a/contrib/packaging/rpm/cilium.spec.envsubst
+++ b/contrib/packaging/rpm/cilium.spec.envsubst
@@ -51,6 +51,7 @@ Source0:       https://%{provider_prefix}/archive/%{commit0}/%{repo}-%{shortcomm
 ExclusiveArch: x86_64
 
 Requires:      git
+Requires:      llvm
 Requires:      docker-engine >= 1.12, glibc-devel(x86-32), iproute >= 4.10, clang
 %{?fc25:Requires: clang >= 3.8, clang < 3.9}
 
@@ -109,15 +110,6 @@ export PKG_BUILD=1
 make -C daemon apply-bindata
 make V=1 proxylib plugins bpf cilium daemon monitor cilium-health bugtool tools
 
-export CC="/usr/bin/gcc"
-export CXX="/usr/bin/g++"
-
-cd envoy
-make proxylib-hdrs
-
-bazel clean
-bazel build //:envoy --action_env=PATH="$PATH"
-
 %install
 export PKG_BUILD=1
 
@@ -150,7 +142,6 @@ chmod 644 %{buildroot}%{_sysconfdir}/sysconfig/cilium
 %{_bindir}/cilium-node-monitor
 %{_bindir}/cilium-bugtool
 %{_bindir}/cilium-health
-%{_bindir}/cilium-envoy
 %{_bindir}/cilium-map-migrate
 %{_bindir}/cilium-ring-dump
 


### PR DESCRIPTION
Remove deprecated envoy proxy from build
Add llvm to requirements for runtime compilation (requiring llc executable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6159)
<!-- Reviewable:end -->
