### PR TITLE
.gitignore: Ignore temporary LLVM files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # LLVM IR files
 *.ll
+*.ll-*
 
 # Folders
 _obj


### PR DESCRIPTION
Now that we build docker images without cleaning, we must exclude also
temporary files generated by a parallel build. This helps avoid errors
like this:

error checking context: 'file ('/home/vagrant/go/src/github.com/cilium/cilium/bpf/bpf_netdev.ll-8d2f3a79')
not found or excluded by .dockerignore'.

Manually checked that no file in the git repo matches with the new ignored pattern '*.ll-*'

Fixes: #6132 
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6160)
<!-- Reviewable:end -->
