### PR TITLE
bpf: fix empty map check condition

### DIFF
--- a/cilium/cmd/map_get.go
+++ b/cilium/cmd/map_get.go
@@ -33,7 +33,7 @@ var mapGetCmd = &cobra.Command{
 	Short:   "Display BPF map information",
 	Example: "cilium map get cilium_ipcache",
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) < 0 {
+		if len(args) == 0 {
 			Fatalf("map name must be specified")
 		}
 


### PR DESCRIPTION
without the fix:

linux-436c:/sys/fs/bpf/tc/globals # cilium map get
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/cilium/cilium/cilium/cmd.glob..func33(0x22a8b20, 0x2852118, 0x0, 0x0)
	/home/nirmoy/go/src/github.com/cilium/cilium/cilium/cmd/map_get.go:42 +0x2d2
github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).execute(0x22a8b20, 0x2852118, 0x0, 0x0, 0x22a8b20, 0x2852118)
	/home/nirmoy/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:648 +0x234
github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x22ac040, 0x22abe20, 0xc421635f20, 0x1)
	/home/nirmoy/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:735 +0x2d4
github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).Execute(0x22ac040, 0xc4200ac058, 0x0)
	/home/nirmoy/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:693 +0x2b
github.com/cilium/cilium/cilium/cmd.Execute()
	/home/nirmoy/go/src/github.com/cilium/cilium/cilium/cmd/root.go:46 +0x2d
main.main()
	/home/nirmoy/go/src/github.com/cilium/cilium/cilium/main.go:20 +0x20

Signed-off-by: Nirmoy Das <ndas@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6164)
<!-- Reviewable:end -->
