### PR TITLE
Jenkinsfile: do not run unit tests

### DIFF
--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -53,24 +53,6 @@ pipeline {
                }
             }
         }
-        stage('UnitTesting') {
-            options {
-                timeout(time: 20, unit: 'MINUTES')
-            }
-
-            environment {
-                GOPATH="${WORKSPACE}"
-                TESTDIR="${WORKSPACE}/${PROJ_PATH}/"
-            }
-            steps {
-                sh "cd ${TESTDIR}; make tests-ginkgo"
-            }
-            post {
-                always {
-                    sh "cd ${TESTDIR}; make clean-ginkgo-tests || true"
-                }
-            }
-        }
         stage('Boot VMs'){
             options {
                 timeout(time: 30, unit: 'MINUTES')


### PR DESCRIPTION
Now that we use Travis CI to run the unit tests in parallel when changes
are pushed in a PR, we don't need to run them in the Jenkins tests as well.
This will reduce the build time per PR by about 4 minutes.

Fixes: #6165

Signed-off by: Ian Vernon <ian@cilium.io>

Since the proposal in #6165 is low-hanging fruit, I created the PR for it. We can close this if #6165 is rejected by other Cilium team members.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6166)
<!-- Reviewable:end -->
