### PR TITLE
Introduce cilium operator to manage per cluster tasks

### DIFF
--- a/Documentation/kvstore.rst
+++ b/Documentation/kvstore.rst
@@ -28,17 +28,31 @@ following information available to other agents:
 - Health checking IP addresses
 - Allocation range of endpoints on the node
 
-===================================================== ====================
-Key                                                   Value
-===================================================== ====================
-``cilium/state/nodes/v1/<cluster name>/<node name>``  node.Node_
-===================================================== ====================
+============================================================ ====================
+Key                                                          Value
+============================================================ ====================
+``cilium/state/nodes/v1/<cluster>/<node>``                   node.Node_
+============================================================ ====================
 
 .. _node.Node: https://godoc.org/github.com/cilium/cilium/pkg/node#Node
 
 All node keys are attached to a lease owned by the agent of the respective
 node.
 
+
+Services
+--------
+
+All Kubernetes services are mirrored into the kvstore by the Cilium operator. This is
+required to implement multi cluster service discovery.
+
+============================================================= ====================
+Key                                                           Value
+============================================================= ====================
+``cilium/state/services/v1/<cluster>/<namespace>/<service>``  service.ClusterService_
+============================================================= ====================
+
+.. _service.ClusterService: https://godoc.org/github.com/cilium/cilium/pkg/service#ClusterService
 
 Leases
 ======

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include Makefile.defs
 include daemon/bpf.sha
 
-SUBDIRS = proxylib envoy plugins bpf daemon cilium-health bugtool tools
+SUBDIRS = proxylib envoy plugins bpf daemon cilium-health bugtool tools operator
 GOFILES ?= $(subst _$(ROOT_DIR)/,,$(shell $(GO) list ./... | grep -v -e /vendor/ -e /contrib/))
 TESTPKGS ?= $(subst _$(ROOT_DIR)/,,$(shell $(GO) list ./... | grep -v -e /api/v1 -e /vendor/ -e /contrib/ -e test))
 GOLANGVERSION = $(shell $(GO) version 2>/dev/null | grep -Eo '(go[0-9].[0-9])')

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -329,6 +329,119 @@ spec:
         - key: CriticalAddonsOnly
           operator: "Exists"
 ---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: cilium-operator
+        io.cilium/app: operator
+    spec:
+      serviceAccountName: cilium-operator
+      restartPolicy: Always
+      containers:
+      - name: cilium-operator
+        image: docker.io/cilium/operator:latest
+        imagePullPolicy: Always
+        command: ["cilium-operator"]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        env:
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+                optional: true
+          - name: CILIUM_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-name
+                name: cilium-config
+                optional: true
+          - name: CILIUM_CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-id
+                name: cilium-config
+                optional: true
+        volumeMounts:
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+      volumes:
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - componentstatuses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/examples/kubernetes/1.10/cilium-operator.yaml
+++ b/examples/kubernetes/1.10/cilium-operator.yaml
@@ -1,0 +1,113 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: cilium-operator
+        io.cilium/app: operator
+    spec:
+      serviceAccountName: cilium-operator
+      restartPolicy: Always
+      containers:
+      - name: cilium-operator
+        image: docker.io/cilium/operator:latest
+        imagePullPolicy: Always
+        command: ["cilium-operator"]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        env:
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+                optional: true
+          - name: CILIUM_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-name
+                name: cilium-config
+                optional: true
+          - name: CILIUM_CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-id
+                name: cilium-config
+                optional: true
+        volumeMounts:
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+      volumes:
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - componentstatuses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -340,6 +340,119 @@ spec:
         - key: CriticalAddonsOnly
           operator: "Exists"
 ---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: cilium-operator
+        io.cilium/app: operator
+    spec:
+      serviceAccountName: cilium-operator
+      restartPolicy: Always
+      containers:
+      - name: cilium-operator
+        image: docker.io/cilium/operator:latest
+        imagePullPolicy: Always
+        command: ["cilium-operator"]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        env:
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+                optional: true
+          - name: CILIUM_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-name
+                name: cilium-config
+                optional: true
+          - name: CILIUM_CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-id
+                name: cilium-config
+                optional: true
+        volumeMounts:
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+      volumes:
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - componentstatuses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -321,6 +321,120 @@ spec:
         - key: CriticalAddonsOnly
           operator: "Exists"
 ---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: cilium-operator
+        io.cilium/app: operator
+    spec:
+      serviceAccountName: cilium-operator
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      containers:
+      - name: cilium-operator
+        image: docker.io/cilium/operator:latest
+        imagePullPolicy: Always
+        command: ["cilium-operator"]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        env:
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+                optional: true
+          - name: CILIUM_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-name
+                name: cilium-config
+                optional: true
+          - name: CILIUM_CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-id
+                name: cilium-config
+                optional: true
+        volumeMounts:
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+      volumes:
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - componentstatuses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/examples/kubernetes/1.11/cilium-operator.yaml
+++ b/examples/kubernetes/1.11/cilium-operator.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: cilium-operator
+        io.cilium/app: operator
+    spec:
+      serviceAccountName: cilium-operator
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      containers:
+      - name: cilium-operator
+        image: docker.io/cilium/operator:latest
+        imagePullPolicy: Always
+        command: ["cilium-operator"]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        env:
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+                optional: true
+          - name: CILIUM_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-name
+                name: cilium-config
+                optional: true
+          - name: CILIUM_CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-id
+                name: cilium-config
+                optional: true
+        volumeMounts:
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+      volumes:
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - componentstatuses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -341,6 +341,120 @@ spec:
         - key: CriticalAddonsOnly
           operator: "Exists"
 ---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: cilium-operator
+        io.cilium/app: operator
+    spec:
+      serviceAccountName: cilium-operator
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      containers:
+      - name: cilium-operator
+        image: docker.io/cilium/operator:latest
+        imagePullPolicy: Always
+        command: ["cilium-operator"]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        env:
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+                optional: true
+          - name: CILIUM_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-name
+                name: cilium-config
+                optional: true
+          - name: CILIUM_CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-id
+                name: cilium-config
+                optional: true
+        volumeMounts:
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+      volumes:
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - componentstatuses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -321,6 +321,120 @@ spec:
         - key: CriticalAddonsOnly
           operator: "Exists"
 ---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: cilium-operator
+        io.cilium/app: operator
+    spec:
+      serviceAccountName: cilium-operator
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      containers:
+      - name: cilium-operator
+        image: docker.io/cilium/operator:latest
+        imagePullPolicy: Always
+        command: ["cilium-operator"]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        env:
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+                optional: true
+          - name: CILIUM_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-name
+                name: cilium-config
+                optional: true
+          - name: CILIUM_CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-id
+                name: cilium-config
+                optional: true
+        volumeMounts:
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+      volumes:
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - componentstatuses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/examples/kubernetes/1.12/cilium-operator.yaml
+++ b/examples/kubernetes/1.12/cilium-operator.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: cilium-operator
+        io.cilium/app: operator
+    spec:
+      serviceAccountName: cilium-operator
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      containers:
+      - name: cilium-operator
+        image: docker.io/cilium/operator:latest
+        imagePullPolicy: Always
+        command: ["cilium-operator"]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        env:
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+                optional: true
+          - name: CILIUM_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-name
+                name: cilium-config
+                optional: true
+          - name: CILIUM_CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-id
+                name: cilium-config
+                optional: true
+        volumeMounts:
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+      volumes:
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - componentstatuses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -341,6 +341,120 @@ spec:
         - key: CriticalAddonsOnly
           operator: "Exists"
 ---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: cilium-operator
+        io.cilium/app: operator
+    spec:
+      serviceAccountName: cilium-operator
+      restartPolicy: Always
+      priorityClassName: system-node-critical
+      containers:
+      - name: cilium-operator
+        image: docker.io/cilium/operator:latest
+        imagePullPolicy: Always
+        command: ["cilium-operator"]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        env:
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+                optional: true
+          - name: CILIUM_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-name
+                name: cilium-config
+                optional: true
+          - name: CILIUM_CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-id
+                name: cilium-config
+                optional: true
+        volumeMounts:
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+      volumes:
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - componentstatuses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -329,6 +329,119 @@ spec:
         - key: CriticalAddonsOnly
           operator: "Exists"
 ---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: cilium-operator
+        io.cilium/app: operator
+    spec:
+      serviceAccountName: cilium-operator
+      restartPolicy: Always
+      containers:
+      - name: cilium-operator
+        image: docker.io/cilium/operator:latest
+        imagePullPolicy: Always
+        command: ["cilium-operator"]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        env:
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+                optional: true
+          - name: CILIUM_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-name
+                name: cilium-config
+                optional: true
+          - name: CILIUM_CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-id
+                name: cilium-config
+                optional: true
+        volumeMounts:
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+      volumes:
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - componentstatuses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:

--- a/examples/kubernetes/1.8/cilium-operator.yaml
+++ b/examples/kubernetes/1.8/cilium-operator.yaml
@@ -1,0 +1,113 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: cilium-operator
+        io.cilium/app: operator
+    spec:
+      serviceAccountName: cilium-operator
+      restartPolicy: Always
+      containers:
+      - name: cilium-operator
+        image: docker.io/cilium/operator:latest
+        imagePullPolicy: Always
+        command: ["cilium-operator"]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        env:
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+                optional: true
+          - name: CILIUM_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-name
+                name: cilium-config
+                optional: true
+          - name: CILIUM_CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-id
+                name: cilium-config
+                optional: true
+        volumeMounts:
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+      volumes:
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - componentstatuses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -340,6 +340,119 @@ spec:
         - key: CriticalAddonsOnly
           operator: "Exists"
 ---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: cilium-operator
+        io.cilium/app: operator
+    spec:
+      serviceAccountName: cilium-operator
+      restartPolicy: Always
+      containers:
+      - name: cilium-operator
+        image: docker.io/cilium/operator:latest
+        imagePullPolicy: Always
+        command: ["cilium-operator"]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        env:
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+                optional: true
+          - name: CILIUM_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-name
+                name: cilium-config
+                optional: true
+          - name: CILIUM_CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-id
+                name: cilium-config
+                optional: true
+        volumeMounts:
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+      volumes:
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - componentstatuses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -329,6 +329,119 @@ spec:
         - key: CriticalAddonsOnly
           operator: "Exists"
 ---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: cilium-operator
+        io.cilium/app: operator
+    spec:
+      serviceAccountName: cilium-operator
+      restartPolicy: Always
+      containers:
+      - name: cilium-operator
+        image: docker.io/cilium/operator:latest
+        imagePullPolicy: Always
+        command: ["cilium-operator"]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        env:
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+                optional: true
+          - name: CILIUM_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-name
+                name: cilium-config
+                optional: true
+          - name: CILIUM_CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-id
+                name: cilium-config
+                optional: true
+        volumeMounts:
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+      volumes:
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - componentstatuses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/examples/kubernetes/1.9/cilium-operator.yaml
+++ b/examples/kubernetes/1.9/cilium-operator.yaml
@@ -1,0 +1,113 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: cilium-operator
+        io.cilium/app: operator
+    spec:
+      serviceAccountName: cilium-operator
+      restartPolicy: Always
+      containers:
+      - name: cilium-operator
+        image: docker.io/cilium/operator:latest
+        imagePullPolicy: Always
+        command: ["cilium-operator"]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        env:
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+                optional: true
+          - name: CILIUM_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-name
+                name: cilium-config
+                optional: true
+          - name: CILIUM_CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-id
+                name: cilium-config
+                optional: true
+        volumeMounts:
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+      volumes:
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - componentstatuses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -340,6 +340,119 @@ spec:
         - key: CriticalAddonsOnly
           operator: "Exists"
 ---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: cilium-operator
+        io.cilium/app: operator
+    spec:
+      serviceAccountName: cilium-operator
+      restartPolicy: Always
+      containers:
+      - name: cilium-operator
+        image: docker.io/cilium/operator:latest
+        imagePullPolicy: Always
+        command: ["cilium-operator"]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        env:
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+                optional: true
+          - name: CILIUM_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-name
+                name: cilium-config
+                optional: true
+          - name: CILIUM_CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-id
+                name: cilium-config
+                optional: true
+        volumeMounts:
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+      volumes:
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - componentstatuses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/examples/kubernetes/Makefile
+++ b/examples/kubernetes/Makefile
@@ -67,6 +67,7 @@ transform: cilium-rbac.yaml.sed \
     cilium-ds.yaml.sed \
     cilium-pre-flight.yaml.sed \
     cilium-rbac.yaml.sed \
-    cilium-sa.yaml
+    cilium-sa.yaml \
+    cilium-operator.yaml.sed
 
 .PHONY: transform cilium.yaml

--- a/examples/kubernetes/templates/v1/cilium-operator.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-operator.yaml.sed
@@ -1,0 +1,113 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: cilium-operator
+        io.cilium/app: operator
+    spec:
+      serviceAccountName: cilium-operator
+      restartPolicy: Always
+      containers:
+      - name: cilium-operator
+        image: docker.io/cilium/operator:__CILIUM_VERSION__
+        imagePullPolicy: Always
+        command: ["cilium-operator"]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        env:
+          - name: "POD_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: "K8S_NODE_NAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: "CILIUM_DEBUG"
+            valueFrom:
+              configMapKeyRef:
+                name: cilium-config
+                key: debug
+                optional: true
+          - name: CILIUM_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-name
+                name: cilium-config
+                optional: true
+          - name: CILIUM_CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                key: cluster-id
+                name: cilium-config
+                optional: true
+        volumeMounts:
+          - name: etcd-config-path
+            mountPath: /var/lib/etcd-config
+            readOnly: true
+          - name: etcd-secrets
+            mountPath: /var/lib/etcd-secrets
+            readOnly: true
+      volumes:
+        # To read the etcd config stored in config maps
+        - name: etcd-config-path
+          configMap:
+            name: cilium-config
+            items:
+              - key: etcd-config
+                path: etcd.config
+        # To read the k8s etcd secrets in case the user might want to use TLS
+        - name: etcd-secrets
+          secret:
+            secretName: cilium-etcd-secrets
+            optional: true
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - componentstatuses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system

--- a/operator/.gitignore
+++ b/operator/.gitignore
@@ -1,0 +1,1 @@
+cilium-operator

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang as builder
+LABEL maintainer="maintainer@cilium.io"
+WORKDIR /go/src/github.com/cilium/cilium
+COPY . ./
+ARG LOCKDEBUG
+ARG V
+RUN make -C operator LOCKDEBUG=$LOCKDEBUG V=$V
+
+FROM ubuntu:18.04
+LABEL maintainer="maintainer@cilium.io"
+WORKDIR /root
+RUN groupadd -f cilium
+COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator /usr/bin/cilium-operator
+CMD ["/usr/bin/cilium-operator"]

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -1,0 +1,17 @@
+# GOBUILD relies on the order of makefile list to get VERSION file
+include ../Makefile.defs
+
+TARGET=cilium-operator
+SOURCES := $(shell find ../pkg . \( -name '*.go'  ! -name '*_test.go' \))
+$(TARGET): $(SOURCES)
+	@$(ECHO_GO)
+	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)
+
+all: $(TARGET)
+
+clean:
+	@$(ECHO_CLEAN) $(notdir $(shell pwd))
+	$(QUIET)rm -f $(TARGET)
+	$(GO) clean
+
+install:

--- a/operator/k8s_service_sync.go
+++ b/operator/k8s_service_sync.go
@@ -1,0 +1,158 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"time"
+
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/service"
+	"github.com/cilium/cilium/pkg/versioned"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	k8sSvcCache   = k8s.NewServiceCache()
+	servicesStore *store.SharedStore
+)
+
+func k8sServiceHandler() {
+	for {
+		event, ok := <-k8sSvcCache.Events
+		if !ok {
+			return
+		}
+
+		svc := k8s.NewClusterService(event.ID, event.Service, event.Endpoints)
+		svc.Cluster = option.Config.ClusterName
+
+		log.WithFields(logrus.Fields{
+			logfields.K8sSvcName:   event.ID.Name,
+			logfields.K8sNamespace: event.ID.Namespace,
+			"action":               event.Action.String(),
+			"service":              event.Service.String(),
+			"endpoints":            event.Endpoints.String(),
+		}).Info("Kubernetes service definition changed")
+
+		switch event.Action {
+		case k8s.UpdateService, k8s.UpdateIngress:
+			servicesStore.UpdateLocalKeySync(&svc)
+
+		case k8s.DeleteService, k8s.DeleteIngress:
+			servicesStore.DeleteLocalKey(&svc)
+		}
+	}
+}
+
+func startSynchronizingServices() {
+	log.Info("Starting to synchronize Kubernetes services to kvstore")
+
+	store, err := store.JoinSharedStore(store.Configuration{
+		Prefix: service.ServiceStorePrefix,
+		KeyCreator: func() store.Key {
+			return &service.ClusterService{}
+		},
+		SynchronizationInterval: 5 * time.Minute,
+	})
+
+	if err != nil {
+		log.WithError(err).Fatal("Unable to join kvstore store to announce services")
+	}
+
+	servicesStore = store
+
+	// Watch for v1.Service changes and push changes into ServiceCache
+	svcController := utils.ControllerFactory(
+		k8s.Client().CoreV1().RESTClient(),
+		&v1.Service{},
+		utils.ResourceEventHandlerFactory(
+			func(new interface{}) func() error {
+				return func() error {
+					k8sSvcCache.UpdateService(new.(*v1.Service))
+					return nil
+				}
+			},
+			func(old interface{}) func() error {
+				return func() error {
+					k8sSvcCache.DeleteService(old.(*v1.Service))
+					return nil
+				}
+			},
+			func(old, new interface{}) func() error {
+				return func() error {
+					k8sSvcCache.UpdateService(new.(*v1.Service))
+					return nil
+				}
+			},
+			func(m versioned.Map) versioned.Map {
+				return m
+			},
+			&v1.Service{},
+			k8s.Client(),
+			0,
+			nil,
+		),
+		fields.Everything(),
+	)
+
+	go svcController.Run(wait.NeverStop)
+
+	// Watch for v1.Endpoints changes and push changes into ServiceCache
+	endpointController := utils.ControllerFactory(
+		k8s.Client().CoreV1().RESTClient(),
+		&v1.Endpoints{},
+		utils.ResourceEventHandlerFactory(
+			func(new interface{}) func() error {
+				return func() error {
+					k8sSvcCache.UpdateEndpoints(new.(*v1.Endpoints))
+					return nil
+				}
+			},
+			func(old interface{}) func() error {
+				return func() error {
+					k8sSvcCache.DeleteEndpoints(old.(*v1.Endpoints))
+					return nil
+				}
+			},
+			func(old, new interface{}) func() error {
+				return func() error {
+					k8sSvcCache.UpdateEndpoints(new.(*v1.Endpoints))
+					return nil
+				}
+			},
+			func(m versioned.Map) versioned.Map {
+				return m
+			},
+			&v1.Endpoints{},
+			k8s.Client(),
+			0,
+			nil,
+		),
+		// Don't get any events from kubernetes endpoints.
+		fields.ParseSelectorOrDie("metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager"),
+	)
+
+	go endpointController.Run(wait.NeverStop)
+	go k8sServiceHandler()
+}

--- a/operator/main.go
+++ b/operator/main.go
@@ -1,0 +1,136 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/version"
+
+	gops "github.com/google/gops/agent"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "cilium-operator")
+
+	rootCmd = &cobra.Command{
+		Use:   "cilium-operator",
+		Short: "Run the cilium-operator",
+		Run: func(cmd *cobra.Command, args []string) {
+			runOperator(cmd)
+		},
+	}
+
+	k8sAPIServer      string
+	k8sKubeConfigPath string
+	kvStore           string
+	kvStoreOpts       = make(map[string]string)
+	shutdownSignal    = make(chan bool, 1)
+)
+
+func main() {
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-signals
+		shutdownSignal <- true
+	}()
+
+	// Open socket for using gops to get stacktraces of the agent.
+	if err := gops.Listen(gops.Options{}); err != nil {
+		errorString := fmt.Sprintf("unable to start gops: %s", err)
+		fmt.Println(errorString)
+		os.Exit(-1)
+	}
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+
+	flags := rootCmd.Flags()
+	flags.Bool("version", false, "Print version information")
+	flags.Int(option.ClusterIDName, 0, "Unique identifier of the cluster")
+	viper.BindEnv(option.ClusterIDName, option.ClusterIDEnv)
+	flags.String(option.ClusterName, defaults.ClusterName, "Name of the cluster")
+	viper.BindEnv(option.ClusterName, option.ClusterNameEnv)
+	flags.BoolP("debug", "D", false, "Enable debugging mode")
+	flags.StringVar(&k8sAPIServer, "k8s-api-server", "", "Kubernetes api address server (for https use --k8s-kubeconfig-path instead)")
+	flags.StringVar(&k8sKubeConfigPath, "k8s-kubeconfig-path", "", "Absolute path of the kubernetes kubeconfig file")
+	flags.StringVar(&kvStore, "kvstore", "", "Key-value store type")
+	flags.Var(option.NewNamedMapOptions("kvstore-opts", &kvStoreOpts, nil), "kvstore-opt", "Key-value store options")
+
+	viper.BindPFlags(flags)
+}
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if viper.GetBool("version") {
+		fmt.Printf("Cilium %s\n", version.Version)
+		os.Exit(0)
+	}
+
+	option.Config.ClusterName = viper.GetString(option.ClusterName)
+	option.Config.ClusterID = viper.GetInt(option.ClusterIDName)
+
+	viper.SetEnvPrefix("cilium")
+	viper.SetConfigName("cilium-operator")
+}
+
+func runOperator(cmd *cobra.Command) {
+	logging.SetupLogging([]string{}, map[string]string{}, "cilium-operator", viper.GetBool("debug"))
+
+	log.Infof("Cilium Operator %s", version.Version)
+
+	if err := kvstore.Setup(kvStore, kvStoreOpts); err != nil {
+		log.WithError(err).WithFields(logrus.Fields{
+			"kvstore": kvStore,
+			"address": kvStoreOpts[fmt.Sprintf("%s.address", kvStore)],
+		}).Fatal("Unable to setup kvstore")
+	}
+
+	k8s.Configure(k8sAPIServer, k8sKubeConfigPath)
+	if err := k8s.Init(); err != nil {
+		log.WithError(err).Fatal("Unable to connect to Kubernetes apiserver")
+	}
+
+	for {
+		select {
+		case <-shutdownSignal:
+			// graceful exit
+			log.Info("Received termination signal. Shutting down")
+			return
+		case <-time.After(time.Second):
+		}
+	}
+}

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -43,6 +43,8 @@ type Configuration struct {
 	// NodeKeyCreator is the function used to create node instances as
 	// nodes are being discovered in remote clusters
 	NodeKeyCreator store.KeyCreator
+
+	observer store.Observer
 }
 
 // ClusterMesh is a cache of multiple remote clusters

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -111,11 +111,17 @@ func (rc *remoteCluster) restartRemoteConnection() {
 					return err
 				}
 
+				observer := rc.mesh.conf.observer
+				if observer == nil {
+					observer = &nodeStore.NodeObserver{}
+				}
+
 				remoteNodes, err := store.JoinSharedStore(store.Configuration{
 					Prefix:                  path.Join(nodeStore.NodeStorePrefix, rc.name),
 					KeyCreator:              rc.mesh.conf.NodeKeyCreator,
 					SynchronizationInterval: time.Minute,
 					Backend:                 backend,
+					Observer:                observer,
 				})
 				if err != nil {
 					backend.Close()

--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -37,6 +37,22 @@ var (
 	}
 )
 
+// NodeObserver implements the store.Observer interface and delegates update
+// and deletion events to the node object itself.
+type NodeObserver struct{}
+
+func (o *NodeObserver) OnUpdate(k store.Key) {
+	if n, ok := k.(*node.Node); ok {
+		n.OnUpdate()
+	}
+}
+
+func (o *NodeObserver) OnDelete(k store.Key) {
+	if n, ok := k.(*node.Node); ok {
+		n.OnDelete()
+	}
+}
+
 // NodeRegistrar is a wrapper around store.SharedStore.
 type NodeRegistrar struct {
 	*store.SharedStore
@@ -50,6 +66,7 @@ func (nr *NodeRegistrar) RegisterNode(n *node.Node) error {
 		Prefix:                  NodeStorePrefix,
 		KeyCreator:              KeyCreator,
 		SynchronizationInterval: time.Minute,
+		Observer:                &NodeObserver{},
 	})
 
 	if err != nil {

--- a/pkg/service/store.go
+++ b/pkg/service/store.go
@@ -1,0 +1,99 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"encoding/json"
+	"path"
+
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+)
+
+var (
+	// ServiceStorePrefix is the kvstore prefix of the shared store
+	//
+	// WARNING - STABLE API: Changing the structure or values of this will
+	// break backwards compatibility
+	ServiceStorePrefix = path.Join(kvstore.BaseKeyPrefix, "state", "services", "v1")
+)
+
+// ClusterService is the definition of a service in a cluster
+//
+// WARNING - STABLE API: Any change to this structure must be done in a
+// backwards compatible way.
+type ClusterService struct {
+	// Cluster is the cluster name the service is configured in
+	Cluster string `json:"cluster"`
+
+	// Namespace is the cluster namespace the service is configured in
+	Namespace string `json:"namespace"`
+
+	// Name is the name of the service. It must be unique within the
+	// namespace of the cluster
+	Name string `json:"name"`
+
+	// FrontendIP is the frontend/service IP of the service
+	FrontendIP string `json:"frontendIP"`
+
+	// FrontendPorts is the list of portsgg
+	FrontendPorts map[string]loadbalancer.L4Addr `json:"frontendPorts"`
+
+	// BackendIPs is the list of IPs backing the service in the cluster
+	BackendIPs []string `json:"backendIPs"`
+
+	// BackendPorts is the list of ports for each backend IP. The name has
+	// to map to the FrontendPorts
+	BackendPorts map[string]loadbalancer.L4Addr `json:"backendPorts"`
+
+	// Labels are the labels of the service
+	Labels map[string]string `json:"labels"`
+
+	// Selector is the label selector used to select backends
+	Selector map[string]string `json:"selector"`
+}
+
+func (s *ClusterService) String() string {
+	return s.Cluster + "/" + s.Namespace + ":" + s.Name
+}
+
+// GetKeyName returns the kvstore key to be used for the global service
+func (s *ClusterService) GetKeyName() string {
+	// WARNING - STABLE API: Changing the structure of the key may break
+	// backwards compatibility
+	return path.Join(s.Cluster, s.Namespace, s.Name)
+}
+
+// Marshal returns the global service object as JSON byte slice
+func (s *ClusterService) Marshal() ([]byte, error) {
+	return json.Marshal(s)
+}
+
+// Unmarshal parses the JSON byte slice and updates the global service receiver
+func (s *ClusterService) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, s)
+}
+
+// NewClusterService returns a new cluster service definition
+func NewClusterService(name, namespace string) ClusterService {
+	return ClusterService{
+		Name:          name,
+		Namespace:     namespace,
+		FrontendPorts: map[string]loadbalancer.L4Addr{},
+		BackendPorts:  map[string]loadbalancer.L4Addr{},
+		Labels:        map[string]string{},
+		Selector:      map[string]string{},
+	}
+}

--- a/pkg/service/store_test.go
+++ b/pkg/service/store_test.go
@@ -1,0 +1,45 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package service
+
+import (
+	"gopkg.in/check.v1"
+)
+
+type ServiceGenericSuite struct{}
+
+var _ = check.Suite(&ServiceGenericSuite{})
+
+func (s *ServiceGenericSuite) TestClusterService(c *check.C) {
+	svc := NewClusterService("foo", "bar")
+	svc.Cluster = "default"
+
+	c.Assert(svc.Name, check.Equals, "foo")
+	c.Assert(svc.Namespace, check.Equals, "bar")
+
+	c.Assert(svc.String(), check.Equals, "default/bar:foo")
+
+	b, err := svc.Marshal()
+	c.Assert(err, check.IsNil)
+
+	unmarshal := ClusterService{}
+	err = unmarshal.Unmarshal(b)
+	c.Assert(err, check.IsNil)
+	c.Assert(svc, check.DeepEquals, unmarshal)
+
+	c.Assert(svc.GetKeyName(), check.Equals, "default/bar/foo")
+}


### PR DESCRIPTION
This introduces an operator that will run with a single replica per cluster. The purpose of the operator is to:
 * Perform janitorial tasks on the kvstore
 * Synchronize k8s state to the kvstore as required for clustermesh operation
 * Help with upgrade preparations
 * Monitor the etcd cluster
 * Translate CNPs as required

This PR establishes the skeleton and adds the required services and endpoints synchronization to prepare service discovery in a clustermesh environment.

For now, the operator lives in the main repository and versioning is directly tied to the Cilium version. It is debatable to move the operator into a separate repository but it will require a versioning strategy and a compatibility matrix with enforcement.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6171)
<!-- Reviewable:end -->
