### PR TITLE
remove dependency on viper from all pkg directories

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -28,4 +28,5 @@ func populateConfig() {
 	option.Config.CTMapEntriesGlobalAny = viper.GetInt(option.CTMapEntriesGlobalAnyName)
 	option.Config.UseSingleClusterRoute = viper.GetBool(option.SingleClusterRouteName)
 	option.Config.HTTP403Message = viper.GetString("http-403-msg")
+	option.Config.BPFCompilationDebug = viper.GetBool(option.BPFCompileDebugName)
 }

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -29,4 +29,5 @@ func populateConfig() {
 	option.Config.UseSingleClusterRoute = viper.GetBool(option.SingleClusterRouteName)
 	option.Config.HTTP403Message = viper.GetString("http-403-msg")
 	option.Config.BPFCompilationDebug = viper.GetBool(option.BPFCompileDebugName)
+	option.Config.EnvoyLogPath = viper.GetString("envoy-log")
 }

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -30,4 +30,5 @@ func populateConfig() {
 	option.Config.HTTP403Message = viper.GetString("http-403-msg")
 	option.Config.BPFCompilationDebug = viper.GetBool(option.BPFCompileDebugName)
 	option.Config.EnvoyLogPath = viper.GetString("envoy-log")
+	option.Config.SockopsEnable = viper.GetBool(option.SockopsEnableName)
 }

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -27,4 +27,5 @@ func populateConfig() {
 	option.Config.CTMapEntriesGlobalTCP = viper.GetInt(option.CTMapEntriesGlobalTCPName)
 	option.Config.CTMapEntriesGlobalAny = viper.GetInt(option.CTMapEntriesGlobalAnyName)
 	option.Config.UseSingleClusterRoute = viper.GetBool(option.SingleClusterRouteName)
+	option.Config.HTTP403Message = viper.GetString("http-403-msg")
 }

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -97,7 +96,7 @@ func reloadDatapath(ctx context.Context, ep endpoint, dirs *directoryInfo) error
 }
 
 func compileAndLoad(ctx context.Context, ep endpoint, dirs *directoryInfo) error {
-	debug := viper.GetBool(option.BPFCompileDebugName)
+	debug := option.Config.BPFCompilationDebug
 	if err := compileDatapath(ctx, ep, dirs, debug); err != nil {
 		return err
 	}
@@ -133,7 +132,7 @@ func ReloadDatapath(ctx context.Context, ep endpoint) error {
 
 // Compile compiles a BPF program generating an object file.
 func Compile(ctx context.Context, src string, out string) error {
-	debug := viper.GetBool(option.BPFCompileDebugName)
+	debug := option.Config.BPFCompilationDebug
 	prog := progInfo{
 		Source:     src,
 		Output:     out,

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/proxy/logger"
@@ -44,7 +45,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/golang/protobuf/ptypes/struct"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -115,7 +115,7 @@ func getXDSPath(stateDir string) string {
 func StartXDSServer(stateDir string) *XDSServer {
 	xdsPath := getXDSPath(stateDir)
 	accessLogPath := getAccessLogPath(stateDir)
-	denied403body := viper.GetString("http-403-msg")
+	denied403body := option.Config.HTTP403Message
 
 	os.Remove(xdsPath)
 	socketListener, err := net.ListenUnix("unix", &net.UnixAddr{Name: xdsPath, Net: "unix"})

--- a/pkg/maps/eppolicymap/eppolicymap.go
+++ b/pkg/maps/eppolicymap/eppolicymap.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
-	"github.com/spf13/viper"
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "map-ep-policy")
@@ -106,7 +105,7 @@ func newEndpointKey(ip net.IP) *endpointKey {
 // handled in the usual way via Map lock. If sockops is disabled this will be
 // a nop.
 func WriteEndpoint(keys []*lxcmap.EndpointKey, fd int) error {
-	if viper.GetBool(option.SockopsEnableName) == false {
+	if option.Config.SockopsEnable == false {
 		return nil
 	}
 

--- a/pkg/node/manager.go
+++ b/pkg/node/manager.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"github.com/vishvananda/netlink"
 )
 
@@ -151,7 +150,7 @@ func (cc *clusterConfiguation) replaceHostRoutes() {
 	// allows to share a CIDR with legacy endpoints outside of the cluster
 	// but requires individual routes to be installed which creates an
 	// overhead with many nodes.
-	if !viper.GetBool(option.SingleClusterRouteName) {
+	if !option.Config.UseSingleClusterRoute {
 		for _, n := range cc.nodes {
 			// Insert node routes in the form of:
 			//   Node-CIDR via GetRouterIP() dev cilium_host

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -283,6 +283,10 @@ type daemonConfig struct {
 	// BPFCompilationDebug specifies whether to compile BPF programs compilation
 	// debugging enabled.
 	BPFCompilationDebug bool
+
+	// EnvoyLogPath specifies where to store the Envoy proxy logs when Envoy
+	// runs in the same container as Cilium.
+	EnvoyLogPath string
 }
 
 var (

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -275,6 +275,10 @@ type daemonConfig struct {
 	// UseSingleClusterRoute specifies whether to use a single cluster route
 	// instead of per-node routes.
 	UseSingleClusterRoute bool
+
+	// HTTP403Message is the error message to return when a HTTP 403 is returned
+	// by the proxy, if L7 policy is configured.
+	HTTP403Message string
 }
 
 var (

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -287,6 +287,9 @@ type daemonConfig struct {
 	// EnvoyLogPath specifies where to store the Envoy proxy logs when Envoy
 	// runs in the same container as Cilium.
 	EnvoyLogPath string
+
+	// EnableSockOps specifies whether to enable sockops (socket lookup).
+	SockopsEnable bool
 }
 
 var (

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -279,6 +279,10 @@ type daemonConfig struct {
 	// HTTP403Message is the error message to return when a HTTP 403 is returned
 	// by the proxy, if L7 policy is configured.
 	HTTP403Message string
+
+	// BPFCompilationDebug specifies whether to compile BPF programs compilation
+	// debugging enabled.
+	BPFCompilationDebug bool
 }
 
 var (

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -16,13 +16,12 @@ package proxy
 
 import (
 	"fmt"
-	"github.com/cilium/cilium/pkg/revert"
 	"sync"
 
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/envoy"
-
-	"github.com/spf13/viper"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/revert"
 )
 
 // the global Envoy instance
@@ -41,7 +40,7 @@ var envoyOnce sync.Once
 func createEnvoyRedirect(r *Redirect, stateDir string, xdsServer *envoy.XDSServer, wg *completion.WaitGroup) (RedirectImplementation, error) {
 	envoyOnce.Do(func() {
 		// Start Envoy on first invocation
-		envoyProxy = envoy.StartEnvoy(stateDir, viper.GetString("envoy-log"), 0)
+		envoyProxy = envoy.StartEnvoy(stateDir, option.Config.EnvoyLogPath, 0)
 	})
 
 	if envoyProxy != nil {


### PR DESCRIPTION
Factor out various uses of `viper.GetX` into population of configuration at daemon startup, and use `option.Config` to access this configuration instead.

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #6101 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6179)
<!-- Reviewable:end -->
