### PR TITLE
Add BPF build and load dependencies to builder image

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -25,11 +25,16 @@ RUN apt-get update \
 		apt-utils \
 		binutils \
 		ca-certificates \
+		clang \
 		coreutils \
 		curl \
 		gcc \
 		git \
+		iproute2 \
+		libc6-dev \
+		libc6-dev-i386 \
 		libelf-dev \
+		llvm \
 		m4 \
 		make \
 		pkg-config \

--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,7 @@ clean-ginkgo-tests:
 TEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyAddress=consul:8500 -X github.com/cilium/cilium/pkg/kvstore.etcdDummyAddress=http://etcd:4002"
 
 # invoked from ginkgo compose file after starting kvstore backends
-tests-ginkgo-real:
-	$(QUIET)$(foreach pkg,$(TESTPKGS),\
-		$(GO) test $(TEST_LDFLAGS) $(pkg) $(GOTEST_BASE) || exit 1;)
+tests-privileged:
 	$(QUIET)$(foreach pkg,$(TESTPKGS),\
 		$(GO) test $(TEST_LDFLAGS) $(pkg) $(GOTEST_PRIV_OPTS) || exit 1;)
 	@rmdir ./daemon/1 ./daemon/1_backup 2> /dev/null || true
@@ -88,9 +86,6 @@ unit-tests: start-kvstores
 	$(QUIET) echo "mode: count" > coverage.out
 	$(QUIET)$(foreach pkg,$(TESTPKGS),\
 		$(GO) test $(pkg) $(GOTEST_BASE) $(GOTEST_COVER_OPTS) || exit 1; \
-		tail -n +2 coverage.out >> coverage-all-tmp.out;)
-	$(QUIET)$(foreach pkg,$(TESTPKGS),\
-		sudo -E $(GO) test $(pkg) $(GOTEST_PRIV_OPTS) $(GOTEST_COVER_OPTS) || exit 1; \
 		tail -n +2 coverage.out >> coverage-all-tmp.out;)
 	# Remove generated code from coverage
 	$(QUIET) grep -Ev '(^github.com/cilium/cilium/api/v1)|(generated.deepcopy.go)|(^github.com/cilium/cilium/pkg/k8s/client/)' \

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ GOTEST_BASE = -test.v -check.vv -timeout 360s
 GOTEST_PRIV_OPTS = $(GOTEST_BASE) -tags=privileged_tests
 GOTEST_COVER_OPTS = -coverprofile=coverage.out -covermode=count -coverpkg $(COVERPKG)
 
+JOB_BASE_NAME ?= cilium_test
+
 UTC_DATE=$(shell date -u "+%Y-%m-%d")
 
 SKIP_DOCS ?= false
@@ -32,19 +34,19 @@ $(SUBDIRS): force
 	@ $(MAKE) -C $@ all
 
 jenkins-precheck:
-	docker-compose -f test/docker-compose.yml -p $$JOB_BASE_NAME-$$BUILD_NUMBER run --rm precheck
+	docker-compose -f test/docker-compose.yml -p $(JOB_BASE_NAME)-$$BUILD_NUMBER run --rm precheck
 
 # invoked from ginkgo Jenkinsfile
 tests-ginkgo: force
 	# Make the bindata to run the unittest
 	$(MAKE) -C daemon go-bindata
-	docker-compose -f test/docker-compose.yml -p $$JOB_BASE_NAME-$$BUILD_NUMBER run --rm test
+	docker-compose -f test/docker-compose.yml -p $(JOB_BASE_NAME)-$$BUILD_NUMBER run --rm test
 	# Remove the networks
-	docker-compose -f test/docker-compose.yml -p $$JOB_BASE_NAME-$$BUILD_NUMBER down
+	docker-compose -f test/docker-compose.yml -p $(JOB_BASE_NAME)-$$BUILD_NUMBER down
 
 clean-ginkgo-tests:
-	docker-compose -f test/docker-compose.yml -p $$JOB_BASE_NAME-$$BUILD_NUMBER down
-	docker-compose -f test/docker-compose.yml -p $$JOB_BASE_NAME-$$BUILD_NUMBER rm
+	docker-compose -f test/docker-compose.yml -p $(JOB_BASE_NAME)-$$BUILD_NUMBER down
+	docker-compose -f test/docker-compose.yml -p $(JOB_BASE_NAME)-$$BUILD_NUMBER rm
 
 TEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyAddress=consul:8500 -X github.com/cilium/cilium/pkg/kvstore.etcdDummyAddress=http://etcd:4002"
 

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -53,6 +53,26 @@ pipeline {
                }
             }
         }
+        // We run privileged tests in Jenkins to work around privilege
+        // limitations in the Travis environment that prevents running tests.
+        stage('PrivilegedUnitTesting') {
+            options {
+                timeout(time: 20, unit: 'MINUTES')
+            }
+
+            environment {
+                GOPATH="${WORKSPACE}"
+                TESTDIR="${WORKSPACE}/${PROJ_PATH}/"
+            }
+            steps {
+                sh "cd ${TESTDIR}; make tests-ginkgo"
+            }
+            post {
+                always {
+                    sh "cd ${TESTDIR}; make clean-ginkgo-tests || true"
+                }
+            }
+        }
         stage('Boot VMs'){
             options {
                 timeout(time: 30, unit: 'MINUTES')

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     depends_on:
       - consul
       - etcd
-    command: "bash -c 'cd /go/src/github.com/cilium/cilium/; make tests-ginkgo-real'"
+    command: "bash -c 'cd /go/src/github.com/cilium/cilium/; make tests-privileged'"
   precheck:
     extends:
       service: base_image

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     command: "etcd -name etcd0 -advertise-client-urls http://0.0.0.0:4002 -listen-client-urls http://0.0.0.0:4002 -initial-cluster-token etcd-cluster-1 -initial-cluster-state new"
     privileged: true
   base_image:
-    image: "quay.io/cilium/cilium-builder:2018-11-01"
+    image: "quay.io/cilium/cilium-builder:2018-11-05"
     volumes:
       - "./../:/go/src/github.com/cilium/cilium/"
     privileged: true


### PR DESCRIPTION
This PR adds dependencies for building and loading BPF programs into the builder image, which can then be used by `test/docker-compose.yml` to run unit tests successfully, including the upcoming tests in https://github.com/cilium/cilium/pull/6117 .

The image is here:

https://quay.io/repository/cilium/cilium-builder/build/aac43e23-c4fe-4cb1-9ac0-5ddb8a51bbf4

This PR also updates the Makefile target for running unit tests from ginkgo, so that someone can just manually run the target locally for testing purposes.

This PR also reintroduces the Jenkins job for running privileged unit tests (related: #6165), as Travis is not appropriate for running such tests. Travis will run unprivileged tests and Jenkins will run privileged tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6180)
<!-- Reviewable:end -->
