### PR TITLE
pkg/k8s: make output of Endpoints.String() deterministic

### DIFF
--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -17,6 +17,7 @@ package k8s
 import (
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 
 	"github.com/cilium/cilium/pkg/comparator"
@@ -36,7 +37,8 @@ type Endpoints struct {
 	Ports      map[loadbalancer.FEPortName]*loadbalancer.L4Addr
 }
 
-// String returns the string representation of an endpoints resource
+// String returns the string representation of an endpoints resource, with
+// backends and ports sorted.
 func (e *Endpoints) String() string {
 	if e == nil {
 		return "nil"
@@ -55,6 +57,9 @@ func (e *Endpoints) String() string {
 		ports[i] = string(p)
 		i++
 	}
+
+	sort.Strings(backends)
+	sort.Strings(ports)
 
 	return fmt.Sprintf("backends:%v/ports:%v", strings.Join(backends, ","), strings.Join(ports, ","))
 }

--- a/pkg/k8s/endpoints_test.go
+++ b/pkg/k8s/endpoints_test.go
@@ -433,18 +433,21 @@ func (s *K8sSuite) TestEndpointsString(c *check.C) {
 			{
 				Addresses: []v1.EndpointAddress{
 					{
+						IP: "172.0.0.2",
+					},
+					{
 						IP: "172.0.0.1",
 					},
 				},
 				Ports: []v1.EndpointPort{
 					{
-						Name:     "http-test-svc",
-						Port:     8080,
+						Name:     "http-test-svc-2",
+						Port:     8081,
 						Protocol: v1.ProtocolTCP,
 					},
 					{
-						Name:     "http-test-svc-2",
-						Port:     8081,
+						Name:     "http-test-svc",
+						Port:     8080,
 						Protocol: v1.ProtocolTCP,
 					},
 				},
@@ -453,5 +456,5 @@ func (s *K8sSuite) TestEndpointsString(c *check.C) {
 	}
 
 	_, ep := ParseEndpoints(endpoints)
-	c.Assert(ep.String(), check.Equals, "backends:172.0.0.1/ports:http-test-svc,http-test-svc-2")
+	c.Assert(ep.String(), check.Equals, "backends:172.0.0.1,172.0.0.2/ports:http-test-svc,http-test-svc-2")
 }


### PR DESCRIPTION
Endpoints.String() ranges over maps to produce this output. Since ranging over
golang maps is nondeterministic, sort the backends and ports before creating the
string representation of the Endpoints so the output is deterministic. If this
is not done, unit tests will intermittently fail.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6182)
<!-- Reviewable:end -->
