### PR TITLE
cilium: eppolicymap unit tests

### DIFF
--- a/pkg/maps/eppolicymap/eppolicymap_test.go
+++ b/pkg/maps/eppolicymap/eppolicymap_test.go
@@ -1,0 +1,100 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build privileged_tests
+
+package eppolicymap
+
+import (
+	"net"
+	"testing"
+	"unsafe"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/maps/lxcmap"
+	"github.com/cilium/cilium/pkg/maps/policymap"
+	"github.com/cilium/cilium/pkg/option"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type EPPolicyMapTestSuite struct{}
+
+var _ = Suite(&EPPolicyMapTestSuite{})
+
+func (e *EPPolicyMapTestSuite) TestCreateEPPolicy(c *C) {
+	bpf.CheckOrMountFS("")
+	CreateEPPolicyMap()
+}
+
+func (e *EPPolicyMapTestSuite) TestWriteEndpoint(c *C) {
+	option.Config.SockopsEnable = true
+	bpf.CheckOrMountFS("")
+	keys := make([]*lxcmap.EndpointKey, 1)
+	many := make([]*lxcmap.EndpointKey, 256)
+	fd, err := bpf.CreateMap(bpf.BPF_MAP_TYPE_HASH,
+		uint32(unsafe.Sizeof(policymap.PolicyKey{})),
+		uint32(unsafe.Sizeof(policymap.PolicyEntry{})), 1024, 0, 0)
+	c.Assert(err, IsNil)
+
+	keys[0] = lxcmap.NewEndpointKey(net.ParseIP("1.2.3.4"))
+	for i := 0; i < 256; i++ {
+		ip := net.ParseIP("1.2.3." + string(i))
+		many[i] = lxcmap.NewEndpointKey(ip)
+	}
+
+	CreateEPPolicyMap()
+	err = WriteEndpoint(keys, fd)
+	c.Assert(err, Not(IsNil))
+	err = WriteEndpoint(many, fd)
+	c.Assert(err, Not(IsNil))
+}
+
+// We allow calls into WriteEndpoint with invalid fd allowing users of the
+// API to avoid doing if enabled { WriteEndpoint() } and simply passing
+// in invalid fd in if its disabled.
+func (e *EPPolicyMapTestSuite) TestWriteEndpointFails(c *C) {
+	option.Config.SockopsEnable = true
+	bpf.CheckOrMountFS("")
+	keys := make([]*lxcmap.EndpointKey, 1)
+	_, err := bpf.CreateMap(bpf.BPF_MAP_TYPE_HASH,
+		uint32(unsafe.Sizeof(policymap.PolicyKey{})),
+		uint32(unsafe.Sizeof(policymap.PolicyEntry{})), 1024, 0, 0)
+	c.Assert(err, IsNil)
+
+	keys[0] = lxcmap.NewEndpointKey(net.ParseIP("1.2.3.4"))
+	CreateEPPolicyMap()
+	err = WriteEndpoint(keys, -1)
+	c.Assert(err, Not(IsNil))
+}
+
+func (e *EPPolicyMapTestSuite) TestWriteEndpointDisabled(c *C) {
+	option.Config.SockopsEnable = false
+	bpf.CheckOrMountFS("")
+	keys := make([]*lxcmap.EndpointKey, 1)
+	fd, err := bpf.CreateMap(bpf.BPF_MAP_TYPE_HASH,
+		uint32(unsafe.Sizeof(policymap.PolicyKey{})),
+		uint32(unsafe.Sizeof(policymap.PolicyEntry{})), 1024, 0, 0)
+	c.Assert(err, IsNil)
+
+	keys[0] = lxcmap.NewEndpointKey(net.ParseIP("1.2.3.4"))
+	CreateEPPolicyMap()
+	err = WriteEndpoint(keys, fd)
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
Add a unit test for eppolicymap. This requires mounting bpffs from unit tests otherwise the tests are mostly useless. For this call directly into BPFFS code paths. It doesn't at the moment cleanup the BPFFS mount point this seems OK to me otherwise we have to do tracking to see if it exists or not before the tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6184)
<!-- Reviewable:end -->
