### PR TITLE
endpoint: store more contextual information about datapath regenerations while regenerating endpoints

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1070,6 +1070,7 @@ func (d *Daemon) TriggerReloadWithoutCompile(reason string) (*sync.WaitGroup, er
 	if err := d.compileBase(); err != nil {
 		return nil, fmt.Errorf("Unable to recompile base programs from %s: %s", reason, err)
 	}
+
 	regenRequest := &endpoint.ExternalRegenerationMetadata{
 		Reason:         reason,
 		ReloadDatapath: true,

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1070,10 +1070,11 @@ func (d *Daemon) TriggerReloadWithoutCompile(reason string) (*sync.WaitGroup, er
 	if err := d.compileBase(); err != nil {
 		return nil, fmt.Errorf("Unable to recompile base programs from %s: %s", reason, err)
 	}
-	regenContext := &endpoint.RegenerationContext{
-		Reason: reason,
+	regenRequest := &endpoint.ExternalRegenerationMetadata{
+		Reason:         reason,
+		ReloadDatapath: true,
 	}
-	return endpointmanager.RegenerateAllEndpoints(d, regenContext, true), nil
+	return endpointmanager.RegenerateAllEndpoints(d, regenRequest), nil
 }
 
 func changedOption(key string, value option.OptionSetting, data interface{}) {

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -52,8 +52,8 @@ func (d *Daemon) TriggerPolicyUpdates(force bool, reason string) *sync.WaitGroup
 	} else {
 		log.Debugf("Full policy recalculation triggered")
 	}
-	regenContext := endpoint.NewRegenerationContext(reason)
-	return endpointmanager.RegenerateAllEndpoints(d, regenContext, false)
+	regenerationMetadata := &endpoint.ExternalRegenerationMetadata{Reason: reason}
+	return endpointmanager.RegenerateAllEndpoints(d, regenerationMetadata)
 }
 
 type getPolicyResolve struct {

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -44,7 +44,9 @@ var (
 	ProdIPv6Addr, _ = addressing.NewCiliumIPv6("cafe:cafe:cafe:cafe:aaaa:aaaa:1111:1112")
 	ProdIPv4Addr, _ = addressing.NewCiliumIPv4("10.11.12.14")
 
-	regenContext = endpoint.NewRegenerationContext("test")
+	regenerationMetadata = &endpoint.ExternalRegenerationMetadata{
+		Reason: "test",
+	}
 )
 
 // getXDSNetworkPolicies returns the representation of the xDS network policies
@@ -168,7 +170,7 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 	ready := e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
 	e.Unlock()
 	c.Assert(ready, Equals, true)
-	buildSuccess := <-e.Regenerate(ds.d, regenContext, false)
+	buildSuccess := <-e.Regenerate(ds.d, regenerationMetadata)
 	c.Assert(buildSuccess, Equals, true)
 	c.Assert(e.Allows(qaBarSecLblsCtx.ID), Equals, false)
 	c.Assert(e.Allows(prodBarSecLblsCtx.ID), Equals, false)
@@ -186,7 +188,7 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 	ready = e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
 	e.Unlock()
 	c.Assert(ready, Equals, true)
-	buildSuccess = <-e.Regenerate(ds.d, regenContext, false)
+	buildSuccess = <-e.Regenerate(ds.d, regenerationMetadata)
 	c.Assert(buildSuccess, Equals, true)
 	c.Assert(e.Allows(0), Equals, false)
 	c.Assert(e.Allows(qaBarSecLblsCtx.ID), Equals, false)
@@ -462,7 +464,7 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 	ready := e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
 	e.Unlock()
 	c.Assert(ready, Equals, true)
-	buildSuccess := <-e.Regenerate(ds.d, regenContext, false)
+	buildSuccess := <-e.Regenerate(ds.d, regenerationMetadata)
 	c.Assert(buildSuccess, Equals, true)
 
 	// Check that the policy has been updated in the xDS cache for the L7

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -277,9 +277,10 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) {
 				epRegenerated <- false
 				return
 			}
-			regenContext := endpoint.NewRegenerationContext(
-				"syncing state to host")
-			if buildSuccess := <-ep.Regenerate(d, regenContext, false); !buildSuccess {
+			regenerationMetadata := &endpoint.ExternalRegenerationMetadata{
+				Reason: "syncing state to host",
+			}
+			if buildSuccess := <-ep.Regenerate(d, regenerationMetadata); !buildSuccess {
 				scopedLog.Warn("Failed while regenerating endpoint")
 				epRegenerated <- false
 				return

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -151,7 +151,7 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 		ready := ep.SetStateLocked(e.StateWaitingToRegenerate, "test")
 		ep.Unlock()
 		if ready {
-			<-ep.Regenerate(ds, regenContext, false)
+			<-ep.Regenerate(ds, regenerationMetadata)
 		}
 
 		switch ep.ID {
@@ -174,7 +174,7 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 				ready := ep.SetStateLocked(e.StateWaitingToRegenerate, "test")
 				ep.Unlock()
 				if ready {
-					<-ep.Regenerate(ds, regenContext, false)
+					<-ep.Regenerate(ds, regenerationMetadata)
 				}
 				epsNames = append(epsNames, ep.DirectoryPath())
 			}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -517,7 +517,7 @@ func (e *Endpoint) removeOldRedirects(owner Owner, desiredRedirects map[string]b
 // Must be called with endpoint.Mutex not held and endpoint.BuildMutex held.
 // Returns the policy revision number when the regeneration has called, a
 // boolean if the BPF compilation was executed and an error in case of an error.
-func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenContext *regenerationContext) (revnum uint64, compiled bool, reterr error) {
+func (e *Endpoint) regenerateBPF(owner Owner, regenContext *regenerationContext) (revnum uint64, compiled bool, reterr error) {
 	var (
 		err                 error
 		compilationExecuted bool
@@ -539,6 +539,9 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 
 	datapathRegenCtxt := regenContext.datapathRegenerationContext
 	datapathRegenCtxt.prepareForDatapathRegeneration()
+
+	currentDir := datapathRegenCtxt.currentDir
+	nextDir := datapathRegenCtxt.nextDir
 
 	epID := e.StringID()
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -624,25 +624,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 	// Also keep track of the regeneration finalization code that can't be
 	// reverted, and execute it in case of regeneration success.
 	defer func() {
-		if reterr == nil {
-			// Always execute the finalization code, even if the endpoint is
-			// terminating, in order to properly release resources.
-			e.UnconditionalLock()
-			e.getLogger().Debug("Finalizing successful endpoint regeneration")
-			datapathRegenCtxt.finalizeList.Finalize()
-			e.Unlock()
-		} else {
-			if err := e.LockAlive(); err != nil {
-				e.getLogger().WithError(err).Debug("Skipping unnecessary restoring endpoint state")
-				return
-			}
-			e.getLogger().Error("Restoring endpoint state after BPF regeneration failed")
-			if err := datapathRegenCtxt.revertStack.Revert(); err != nil {
-				e.getLogger().WithError(err).Error("Restoring endpoint state failed")
-			}
-			e.getLogger().Error("Finished restoring endpoint state after BPF regeneration failed")
-			e.Unlock()
-		}
+		e.finalizeProxyState(regenContext, reterr)
 	}()
 
 	// Only generate & populate policy map if a security identity is set up for
@@ -862,6 +844,29 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 	}
 
 	return datapathRegenCtxt.epInfoCache.revision, compilationExecuted, err
+}
+
+func (e *Endpoint) finalizeProxyState(regenContext *regenerationContext, err error) {
+	datapathRegenCtx := regenContext.datapathRegenerationContext
+	if err == nil {
+		// Always execute the finalization code, even if the endpoint is
+		// terminating, in order to properly release resources.
+		e.UnconditionalLock()
+		e.getLogger().Debug("Finalizing successful endpoint regeneration")
+		datapathRegenCtx.finalizeList.Finalize()
+		e.Unlock()
+	} else {
+		if err := e.LockAlive(); err != nil {
+			e.getLogger().WithError(err).Debug("Skipping unnecessary restoring endpoint state")
+			return
+		}
+		e.getLogger().Error("Restoring endpoint state after BPF regeneration failed")
+		if err := datapathRegenCtx.revertStack.Revert(); err != nil {
+			e.getLogger().WithError(err).Error("Restoring endpoint state failed")
+		}
+		e.getLogger().Error("Finished restoring endpoint state after BPF regeneration failed")
+		e.Unlock()
+	}
 }
 
 // DeleteMapsLocked releases references to all BPF maps associated with this

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -524,6 +524,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 		compilationExecuted bool
 	)
 
+	datapathRegenCtxt := regenContext.datapathRegenerationContext
 	stats := &regenContext.Stats
 	stats.waitingForLock.Start()
 
@@ -787,7 +788,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 	e.getLogger().WithField("bpfHeaderfilesChanged", bpfHeaderfilesChanged).Debug("Preparing to compile BPF")
 
 	stats.prepareBuild.End(true)
-	if bpfHeaderfilesChanged || regenContext.ReloadDatapath {
+	if bpfHeaderfilesChanged || datapathRegenCtxt.reloadDatapath {
 		closeChan := loadinfo.LogPeriodicSystemLoad(log.WithFields(logrus.Fields{logfields.EndpointID: epID}).Debugf, time.Second)
 
 		// Compile and install BPF programs for this endpoint

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -756,15 +756,13 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 			Debugf("BPF header file hashed (was: %q)", e.bpfHeaderfileHash)
 	}
 
-	// Cache endpoint information
-	// TODO (ianvernon): why do we need to do this?
-	var epInfoCache *epInfoCache
+	// Cache endpoint information so that we can release the endpoint lock.
 	if datapathRegenCtxt.bpfHeaderfilesChanged {
-		epInfoCache = e.createEpInfoCache(nextDir)
+		datapathRegenCtxt.epInfoCache = e.createEpInfoCache(nextDir)
 	} else {
-		epInfoCache = e.createEpInfoCache(currentDir)
+		datapathRegenCtxt.epInfoCache = e.createEpInfoCache(currentDir)
 	}
-	if epInfoCache == nil {
+	if datapathRegenCtxt.epInfoCache == nil {
 		stats.prepareBuild.End(false)
 		e.Unlock()
 		err = fmt.Errorf("Unable to cache endpoint information")
@@ -793,20 +791,20 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 		// Compile and install BPF programs for this endpoint
 		if datapathRegenCtxt.bpfHeaderfilesChanged {
 			stats.bpfCompilation.Start()
-			err = loader.CompileAndLoad(completionCtx, epInfoCache)
+			err = loader.CompileAndLoad(completionCtx, datapathRegenCtxt.epInfoCache)
 			stats.bpfCompilation.End(err == nil)
 			e.getLogger().WithError(err).
 				WithField(logfields.BPFCompilationTime, stats.bpfCompilation.Total().String()).
 				Info("Recompiled endpoint BPF program")
 			compilationExecuted = true
 		} else {
-			err = loader.ReloadDatapath(completionCtx, epInfoCache)
+			err = loader.ReloadDatapath(completionCtx, datapathRegenCtxt.epInfoCache)
 			e.getLogger().WithError(err).Info("Reloaded endpoint BPF program")
 		}
 		close(closeChan)
 
 		if err != nil {
-			return epInfoCache.revision, compilationExecuted, err
+			return datapathRegenCtxt.epInfoCache.revision, compilationExecuted, err
 		}
 		e.bpfHeaderfileHash = datapathRegenCtxt.bpfHeaderfilesHash
 	} else {
@@ -816,8 +814,8 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 
 	// Hook the endpoint into the endpoint and endpoint to policy tables then expose it
 	stats.mapSync.Start()
-	epErr := eppolicymap.WriteEndpoint(epInfoCache.keys, e.PolicyMap.Fd)
-	err = lxcmap.WriteEndpoint(epInfoCache)
+	epErr := eppolicymap.WriteEndpoint(datapathRegenCtxt.epInfoCache.keys, e.PolicyMap.Fd)
+	err = lxcmap.WriteEndpoint(datapathRegenCtxt.epInfoCache)
 	stats.mapSync.End(err == nil)
 	if epErr != nil {
 		e.logStatusLocked(BPF, Warning, fmt.Sprintf("Unable to sync EpToPolicy Map continue with Sockmap support: %s", err))
@@ -868,7 +866,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 		return 0, compilationExecuted, fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
 	}
 
-	return epInfoCache.revision, compilationExecuted, err
+	return datapathRegenCtxt.epInfoCache.revision, compilationExecuted, err
 }
 
 // DeleteMapsLocked releases references to all BPF maps associated with this

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -623,15 +623,13 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 	// reverted in case of failure.
 	// Also keep track of the regeneration finalization code that can't be
 	// reverted, and execute it in case of regeneration success.
-	var finalizeList revert.FinalizeList
-	var revertStack revert.RevertStack
 	defer func() {
 		if reterr == nil {
 			// Always execute the finalization code, even if the endpoint is
 			// terminating, in order to properly release resources.
 			e.UnconditionalLock()
 			e.getLogger().Debug("Finalizing successful endpoint regeneration")
-			finalizeList.Finalize()
+			datapathRegenCtxt.finalizeList.Finalize()
 			e.Unlock()
 		} else {
 			if err := e.LockAlive(); err != nil {
@@ -639,7 +637,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 				return
 			}
 			e.getLogger().Error("Restoring endpoint state after BPF regeneration failed")
-			if err := revertStack.Revert(); err != nil {
+			if err := datapathRegenCtxt.revertStack.Revert(); err != nil {
 				e.getLogger().WithError(err).Error("Restoring endpoint state failed")
 			}
 			e.getLogger().Error("Finished restoring endpoint state after BPF regeneration failed")
@@ -703,7 +701,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 			return 0, compilationExecuted, err
 		}
 
-		revertStack.Push(networkPolicyRevertFunc)
+		datapathRegenCtxt.revertStack.Push(networkPolicyRevertFunc)
 	}
 
 	stats.proxyConfiguration.Start()
@@ -719,15 +717,15 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 			e.Unlock()
 			return 0, compilationExecuted, err
 		}
-		finalizeList.Append(finalizeFunc)
-		revertStack.Push(revertFunc)
+		datapathRegenCtxt.finalizeList.Append(finalizeFunc)
+		datapathRegenCtxt.revertStack.Push(revertFunc)
 	}
 	// At this point, traffic is no longer redirected to the proxy for
 	// now-obsolete redirects, since we synced the updated policy map above.
 	// It's now safe to remove the redirects from the proxy's configuration.
 	finalizeFunc, revertFunc = e.removeOldRedirects(owner, desiredRedirects, datapathRegenCtxt.proxyWaitGroup)
-	finalizeList.Append(finalizeFunc)
-	revertStack.Push(revertFunc)
+	datapathRegenCtxt.finalizeList.Append(finalizeFunc)
+	datapathRegenCtxt.revertStack.Push(revertFunc)
 	stats.proxyConfiguration.End(true)
 
 	stats.prepareBuild.Start()

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -544,7 +544,10 @@ func (e *Endpoint) regenerateBPF(owner Owner, regenContext *regenerationContext)
 	// Also keep track of the regeneration finalization code that can't be
 	// reverted, and execute it in case of regeneration success.
 	defer func() {
-		e.finalizeProxyState(regenContext, reterr)
+		// Ignore finalizing of proxy state in dry mode.
+		if option.Config.DryMode {
+			e.finalizeProxyState(regenContext, reterr)
+		}
 	}()
 
 	if err != nil {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -526,99 +526,221 @@ func (e *Endpoint) regenerateBPF(owner Owner, regenContext *regenerationContext)
 	stats := &regenContext.Stats
 	stats.waitingForLock.Start()
 
+	datapathRegenCtxt := regenContext.datapathRegenerationContext
+
 	// Make sure that owner is not compiling base programs while we are
 	// regenerating an endpoint.
 	owner.GetCompilationLock().RLock()
+	stats.waitingForLock.End(true)
 	defer owner.GetCompilationLock().RUnlock()
-
-	err = e.LockAlive()
-	stats.waitingForLock.End(err == nil)
-	if err != nil {
-		return 0, compilationExecuted, err
-	}
-
-	datapathRegenCtxt := regenContext.datapathRegenerationContext
-	datapathRegenCtxt.prepareForDatapathRegeneration()
-
-	currentDir := datapathRegenCtxt.currentDir
-	nextDir := datapathRegenCtxt.nextDir
-
-	// In the first ever regeneration of the endpoint, the conntrack table
-	// is cleaned from the new endpoint IPs as it is guaranteed that any
-	// pre-existing connections using that IP are now invalid.
-	if !e.ctCleaned {
-		go func() {
-			ipv4 := !option.Config.IPv4Disabled
-			created := ctmap.Exists(nil, ipv4, true)
-			if e.ConntrackLocal() {
-				created = ctmap.Exists(e, ipv4, true)
-			}
-			if created {
-				e.scrubIPsInConntrackTable()
-			}
-			close(datapathRegenCtxt.ctCleaned)
-		}()
-	} else {
-		close(datapathRegenCtxt.ctCleaned)
-	}
-
-	// If dry mode is enabled, no further changes to BPF maps are performed
-	if option.Config.DryMode {
-		defer e.Unlock()
-
-		// Compute policy for this endpoint.
-		if err = e.regeneratePolicy(owner); err != nil {
-			return 0, compilationExecuted, fmt.Errorf("Unable to regenerate policy: %s", err)
-		}
-
-		_ = e.updateAndOverrideEndpointOptions(nil)
-
-		// Dry mode needs Network Policy Updates, but the proxy wait group must
-		// not be initialized, as there is no proxy ACKing the changes.
-		if err, _ = e.updateNetworkPolicy(owner, nil); err != nil {
-			return 0, compilationExecuted, err
-		}
-
-		if err = e.writeHeaderfile(nextDir, owner); err != nil {
-			return 0, compilationExecuted, fmt.Errorf("Unable to write header file: %s", err)
-		}
-
-		log.WithField(logfields.EndpointID, e.ID).Debug("Skipping bpf updates due to dry mode")
-		return e.nextPolicyRevision, compilationExecuted, nil
-	}
-
-	if e.PolicyMap == nil {
-		e.PolicyMap, _, err = policymap.OpenMap(e.PolicyMapPathLocked())
-		if err != nil {
-			e.Unlock()
-			return 0, compilationExecuted, err
-		}
-		// Clean up map contents
-		e.getLogger().Debug("flushing old PolicyMap")
-		err = e.PolicyMap.Flush()
-		if err != nil {
-			e.Unlock()
-			return 0, compilationExecuted, err
-		}
-
-		// Also reset the in-memory state of the realized state as the
-		// BPF map content is guaranteed to be empty right now.
-		e.realizedMapState = make(PolicyMapState)
-	}
-
-	if e.bpfConfigMap == nil {
-		e.bpfConfigMap, _, err = bpfconfig.OpenMapWithName(e.BPFConfigMapPath(), e.BPFConfigMapName())
-		if err != nil {
-			e.Unlock()
-			return 0, compilationExecuted, err
-		}
-		// Also reset the in-memory state of the realized state as the
-		// BPF map content is guaranteed to be empty right now.
-		e.realizedBPFConfig = &bpfconfig.EndpointConfig{}
-	}
 
 	datapathRegenCtxt.prepareForProxyUpdates()
 	defer datapathRegenCtxt.completionCancel()
+
+	err = func() error {
+
+		stats.waitingForLock.Start()
+		err = e.LockAlive()
+		stats.waitingForLock.End(err == nil)
+		if err != nil {
+			return err
+		}
+
+		defer e.Unlock()
+
+		datapathRegenCtxt.prepareForDatapathRegeneration()
+
+		currentDir := datapathRegenCtxt.currentDir
+		nextDir := datapathRegenCtxt.nextDir
+
+		// In the first ever regeneration of the endpoint, the conntrack table
+		// is cleaned from the new endpoint IPs as it is guaranteed that any
+		// pre-existing connections using that IP are now invalid.
+		if !e.ctCleaned {
+			go func() {
+				ipv4 := !option.Config.IPv4Disabled
+				created := ctmap.Exists(nil, ipv4, true)
+				if e.ConntrackLocal() {
+					created = ctmap.Exists(e, ipv4, true)
+				}
+				if created {
+					e.scrubIPsInConntrackTable()
+				}
+				close(datapathRegenCtxt.ctCleaned)
+			}()
+		} else {
+			close(datapathRegenCtxt.ctCleaned)
+		}
+
+		// If dry mode is enabled, no further changes to BPF maps are performed
+		if option.Config.DryMode {
+
+			// Compute policy for this endpoint.
+			if err = e.regeneratePolicy(owner); err != nil {
+				return fmt.Errorf("Unable to regenerate policy: %s", err)
+			}
+
+			_ = e.updateAndOverrideEndpointOptions(nil)
+
+			// Dry mode needs Network Policy Updates, but the proxy wait group must
+			// not be initialized, as there is no proxy ACKing the changes.
+			if err, _ = e.updateNetworkPolicy(owner, nil); err != nil {
+				return err
+			}
+
+			if err = e.writeHeaderfile(nextDir, owner); err != nil {
+				return fmt.Errorf("Unable to write header file: %s", err)
+			}
+
+			log.WithField(logfields.EndpointID, e.ID).Debug("Skipping bpf updates due to dry mode")
+			return nil
+		}
+
+		if e.PolicyMap == nil {
+			e.PolicyMap, _, err = policymap.OpenMap(e.PolicyMapPathLocked())
+			if err != nil {
+				return err
+			}
+			// Clean up map contents
+			e.getLogger().Debug("flushing old PolicyMap")
+			err = e.PolicyMap.Flush()
+			if err != nil {
+				return err
+			}
+
+			// Also reset the in-memory state of the realized state as the
+			// BPF map content is guaranteed to be empty right now.
+			e.realizedMapState = make(PolicyMapState)
+		}
+
+		if e.bpfConfigMap == nil {
+			e.bpfConfigMap, _, err = bpfconfig.OpenMapWithName(e.BPFConfigMapPath(), e.BPFConfigMapName())
+			if err != nil {
+				return err
+			}
+			// Also reset the in-memory state of the realized state as the
+			// BPF map content is guaranteed to be empty right now.
+			e.realizedBPFConfig = &bpfconfig.EndpointConfig{}
+		}
+
+		// Only generate & populate policy map if a security identity is set up for
+		// this endpoint.
+		if e.SecurityIdentity != nil {
+			stats.policyCalculation.Start()
+			err = e.regeneratePolicy(owner)
+			stats.policyCalculation.End(err == nil)
+			if err != nil {
+				return fmt.Errorf("unable to regenerate policy for '%s': %s", e.PolicyMap.String(), err)
+			}
+
+			_ = e.updateAndOverrideEndpointOptions(nil)
+
+			// realizedBPFConfig may be updated at any point after we figure out
+			// whether ingress/egress policy is enabled.
+			e.desiredBPFConfig = bpfconfig.GetConfig(e)
+
+			// Synchronously try to update PolicyMap for this endpoint. If any
+			// part of updating the PolicyMap fails, bail out and do not generate
+			// BPF. Unfortunately, this means that the map will be in an inconsistent
+			// state with the current program (if it exists) for this endpoint.
+			// GH-3897 would fix this by creating a new map to do an atomic swap
+			// with the old one.
+			stats.mapSync.Start()
+			err := e.syncPolicyMap()
+			stats.mapSync.End(err == nil)
+			if err != nil {
+				return fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
+			}
+
+			// Synchronously update the BPF ConfigMap for this endpoint.
+			// This is unlikely to fail, but will have the same
+			// inconsistency issues as above if there is a failure. Long
+			// term the solution to this is to templatize this map in the
+			// ELF file, but there's no solution to this just yet.
+			if err = e.bpfConfigMap.Update(e.desiredBPFConfig); err != nil {
+				e.getLogger().WithError(err).Error("unable to update BPF config map")
+				return err
+			}
+
+			datapathRegenCtxt.revertStack.Push(func() error {
+				return e.bpfConfigMap.Update(e.realizedBPFConfig)
+			})
+
+			// Configure the new network policy with the proxies.
+			stats.proxyPolicyCalculation.Start()
+			var networkPolicyRevertFunc revert.RevertFunc
+			err, networkPolicyRevertFunc = e.updateNetworkPolicy(owner, datapathRegenCtxt.proxyWaitGroup)
+			stats.proxyPolicyCalculation.End(err == nil)
+			if err != nil {
+				return err
+			}
+
+			datapathRegenCtxt.revertStack.Push(networkPolicyRevertFunc)
+		}
+
+		stats.proxyConfiguration.Start()
+		var finalizeFunc revert.FinalizeFunc
+		var revertFunc revert.RevertFunc
+		// Walk the L4Policy to add new redirects and update the desired policy map
+		// state to set the newly allocated proxy ports.
+		var desiredRedirects map[string]bool
+		if e.DesiredL4Policy != nil {
+			desiredRedirects, err, finalizeFunc, revertFunc = e.addNewRedirects(owner, e.DesiredL4Policy, datapathRegenCtxt.proxyWaitGroup)
+			if err != nil {
+				stats.proxyConfiguration.End(false)
+				return err
+			}
+			datapathRegenCtxt.finalizeList.Append(finalizeFunc)
+			datapathRegenCtxt.revertStack.Push(revertFunc)
+		}
+		// At this point, traffic is no longer redirected to the proxy for
+		// now-obsolete redirects, since we synced the updated policy map above.
+		// It's now safe to remove the redirects from the proxy's configuration.
+		finalizeFunc, revertFunc = e.removeOldRedirects(owner, desiredRedirects, datapathRegenCtxt.proxyWaitGroup)
+		datapathRegenCtxt.finalizeList.Append(finalizeFunc)
+		datapathRegenCtxt.revertStack.Push(revertFunc)
+		stats.proxyConfiguration.End(true)
+
+		stats.prepareBuild.Start()
+
+		// Generate header file specific to this endpoint for use in compiling
+		// BPF programs for this endpoint.
+		if err = e.writeHeaderfile(nextDir, owner); err != nil {
+			stats.prepareBuild.End(false)
+			return fmt.Errorf("unable to write header file: %s", err)
+		}
+
+		// Avoid BPF program compilation and installation if the headerfile for the endpoint
+		// or the node have not changed.
+		datapathRegenCtxt.bpfHeaderfilesHash, err = hashEndpointHeaderfiles(nextDir)
+		if err != nil {
+			e.getLogger().WithError(err).Warn("Unable to hash header file")
+			datapathRegenCtxt.bpfHeaderfilesHash = ""
+			datapathRegenCtxt.bpfHeaderfilesChanged = true
+		} else {
+			datapathRegenCtxt.bpfHeaderfilesChanged = (datapathRegenCtxt.bpfHeaderfilesHash != e.bpfHeaderfileHash)
+			e.getLogger().WithField(logfields.BPFHeaderfileHash, datapathRegenCtxt.bpfHeaderfilesHash).
+				Debugf("BPF header file hashed (was: %q)", e.bpfHeaderfileHash)
+		}
+
+		// Cache endpoint information so that we can release the endpoint lock.
+		if datapathRegenCtxt.bpfHeaderfilesChanged {
+			datapathRegenCtxt.epInfoCache = e.createEpInfoCache(nextDir)
+		} else {
+			datapathRegenCtxt.epInfoCache = e.createEpInfoCache(currentDir)
+		}
+		if datapathRegenCtxt.epInfoCache == nil {
+			stats.prepareBuild.End(false)
+			return fmt.Errorf("Unable to cache endpoint information")
+		}
+
+		// TODO: In Cilium v1.4 or later cycle, remove this.
+		os.RemoveAll(e.IPv6EgressMapPathLocked())
+		os.RemoveAll(e.IPv4EgressMapPathLocked())
+		os.RemoveAll(e.IPv6IngressMapPathLocked())
+		os.RemoveAll(e.IPv4IngressMapPathLocked())
+		return nil
+	}()
 
 	// Keep track of the side-effects of the regeneration that need to be
 	// reverted in case of failure.
@@ -628,132 +750,14 @@ func (e *Endpoint) regenerateBPF(owner Owner, regenContext *regenerationContext)
 		e.finalizeProxyState(regenContext, reterr)
 	}()
 
-	// Only generate & populate policy map if a security identity is set up for
-	// this endpoint.
-	if e.SecurityIdentity != nil {
-		stats.policyCalculation.Start()
-		err = e.regeneratePolicy(owner)
-		stats.policyCalculation.End(err == nil)
-		if err != nil {
-			e.Unlock()
-			return 0, compilationExecuted, fmt.Errorf("unable to regenerate policy for '%s': %s", e.PolicyMap.String(), err)
-		}
-
-		_ = e.updateAndOverrideEndpointOptions(nil)
-
-		// realizedBPFConfig may be updated at any point after we figure out
-		// whether ingress/egress policy is enabled.
-		e.desiredBPFConfig = bpfconfig.GetConfig(e)
-
-		// Synchronously try to update PolicyMap for this endpoint. If any
-		// part of updating the PolicyMap fails, bail out and do not generate
-		// BPF. Unfortunately, this means that the map will be in an inconsistent
-		// state with the current program (if it exists) for this endpoint.
-		// GH-3897 would fix this by creating a new map to do an atomic swap
-		// with the old one.
-		stats.mapSync.Start()
-		err := e.syncPolicyMap()
-		stats.mapSync.End(err == nil)
-		if err != nil {
-			e.Unlock()
-			return 0, compilationExecuted, fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
-		}
-
-		// Synchronously update the BPF ConfigMap for this endpoint.
-		// This is unlikely to fail, but will have the same
-		// inconsistency issues as above if there is a failure. Long
-		// term the solution to this is to templatize this map in the
-		// ELF file, but there's no solution to this just yet.
-		if err = e.bpfConfigMap.Update(e.desiredBPFConfig); err != nil {
-			e.getLogger().WithError(err).Error("unable to update BPF config map")
-			e.Unlock()
-			return 0, compilationExecuted, err
-		}
-
-		datapathRegenCtxt.revertStack.Push(func() error {
-			return e.bpfConfigMap.Update(e.realizedBPFConfig)
-		})
-
-		// Configure the new network policy with the proxies.
-		stats.proxyPolicyCalculation.Start()
-		var networkPolicyRevertFunc revert.RevertFunc
-		err, networkPolicyRevertFunc = e.updateNetworkPolicy(owner, datapathRegenCtxt.proxyWaitGroup)
-		stats.proxyPolicyCalculation.End(err == nil)
-		if err != nil {
-			e.Unlock()
-			return 0, compilationExecuted, err
-		}
-
-		datapathRegenCtxt.revertStack.Push(networkPolicyRevertFunc)
-	}
-
-	stats.proxyConfiguration.Start()
-	var finalizeFunc revert.FinalizeFunc
-	var revertFunc revert.RevertFunc
-	// Walk the L4Policy to add new redirects and update the desired policy map
-	// state to set the newly allocated proxy ports.
-	var desiredRedirects map[string]bool
-	if e.DesiredL4Policy != nil {
-		desiredRedirects, err, finalizeFunc, revertFunc = e.addNewRedirects(owner, e.DesiredL4Policy, datapathRegenCtxt.proxyWaitGroup)
-		if err != nil {
-			stats.proxyConfiguration.End(false)
-			e.Unlock()
-			return 0, compilationExecuted, err
-		}
-		datapathRegenCtxt.finalizeList.Append(finalizeFunc)
-		datapathRegenCtxt.revertStack.Push(revertFunc)
-	}
-	// At this point, traffic is no longer redirected to the proxy for
-	// now-obsolete redirects, since we synced the updated policy map above.
-	// It's now safe to remove the redirects from the proxy's configuration.
-	finalizeFunc, revertFunc = e.removeOldRedirects(owner, desiredRedirects, datapathRegenCtxt.proxyWaitGroup)
-	datapathRegenCtxt.finalizeList.Append(finalizeFunc)
-	datapathRegenCtxt.revertStack.Push(revertFunc)
-	stats.proxyConfiguration.End(true)
-
-	stats.prepareBuild.Start()
-
-	// Generate header file specific to this endpoint for use in compiling
-	// BPF programs for this endpoint.
-	if err = e.writeHeaderfile(nextDir, owner); err != nil {
-		stats.prepareBuild.End(false)
-		e.Unlock()
-		return 0, compilationExecuted, fmt.Errorf("unable to write header file: %s", err)
-	}
-
-	// Avoid BPF program compilation and installation if the headerfile for the endpoint
-	// or the node have not changed.
-	datapathRegenCtxt.bpfHeaderfilesHash, err = hashEndpointHeaderfiles(nextDir)
 	if err != nil {
-		e.getLogger().WithError(err).Warn("Unable to hash header file")
-		datapathRegenCtxt.bpfHeaderfilesHash = ""
-		datapathRegenCtxt.bpfHeaderfilesChanged = true
-	} else {
-		datapathRegenCtxt.bpfHeaderfilesChanged = (datapathRegenCtxt.bpfHeaderfilesHash != e.bpfHeaderfileHash)
-		e.getLogger().WithField(logfields.BPFHeaderfileHash, datapathRegenCtxt.bpfHeaderfilesHash).
-			Debugf("BPF header file hashed (was: %q)", e.bpfHeaderfileHash)
-	}
-
-	// Cache endpoint information so that we can release the endpoint lock.
-	if datapathRegenCtxt.bpfHeaderfilesChanged {
-		datapathRegenCtxt.epInfoCache = e.createEpInfoCache(nextDir)
-	} else {
-		datapathRegenCtxt.epInfoCache = e.createEpInfoCache(currentDir)
-	}
-	if datapathRegenCtxt.epInfoCache == nil {
-		stats.prepareBuild.End(false)
-		e.Unlock()
-		err = fmt.Errorf("Unable to cache endpoint information")
 		return 0, compilationExecuted, err
 	}
 
-	// TODO: In Cilium v1.4 or later cycle, remove this.
-	os.RemoveAll(e.IPv6EgressMapPathLocked())
-	os.RemoveAll(e.IPv4EgressMapPathLocked())
-	os.RemoveAll(e.IPv6IngressMapPathLocked())
-	os.RemoveAll(e.IPv4IngressMapPathLocked())
-
-	e.Unlock()
+	// No need to compile BPF in dry mode.
+	if option.Config.DryMode {
+		return e.nextPolicyRevision, false, nil
+	}
 
 	// Wait for connection tracking cleaning to complete
 	stats.waitingForCTClean.Start()
@@ -858,6 +862,13 @@ func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (compilati
 	}
 
 	return compilationExecuted, nil
+}
+
+// runPreCompilationSteps runs all of the regeneration steps that are necessary
+// right before compiling the BPF for the given endpoint.
+// The endpoint mutex must not be held.
+func (e *Endpoint) runPreCompilationSteps(owner Owner, regenContext *regenerationContext) error {
+	return nil
 }
 
 func (e *Endpoint) finalizeProxyState(regenContext *regenerationContext, err error) {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -525,6 +525,8 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 	)
 
 	datapathRegenCtxt := regenContext.datapathRegenerationContext
+	datapathRegenCtxt.prepareForDatapathRegeneration()
+
 	stats := &regenContext.Stats
 	stats.waitingForLock.Start()
 
@@ -532,8 +534,6 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 	// regenerating an endpoint.
 	owner.GetCompilationLock().RLock()
 	defer owner.GetCompilationLock().RUnlock()
-
-	ctCleaned := make(chan struct{})
 
 	err = e.LockAlive()
 	stats.waitingForLock.End(err == nil)
@@ -556,10 +556,10 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 			if created {
 				e.scrubIPsInConntrackTable()
 			}
-			close(ctCleaned)
+			close(datapathRegenCtxt.ctCleaned)
 		}()
 	} else {
-		close(ctCleaned)
+		close(datapathRegenCtxt.ctCleaned)
 	}
 
 	// If dry mode is enabled, no further changes to BPF maps are performed
@@ -782,7 +782,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 
 	// Wait for connection tracking cleaning to complete
 	stats.waitingForCTClean.Start()
-	<-ctCleaned
+	<-datapathRegenCtxt.ctCleaned
 	stats.waitingForCTClean.End(true)
 
 	e.getLogger().WithField("bpfHeaderfilesChanged", bpfHeaderfilesChanged).Debug("Preparing to compile BPF")

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -745,14 +745,14 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 
 	// Avoid BPF program compilation and installation if the headerfile for the endpoint
 	// or the node have not changed.
-	bpfHeaderfilesHash, err := hashEndpointHeaderfiles(nextDir)
+	datapathRegenCtxt.bpfHeaderfilesHash, err = hashEndpointHeaderfiles(nextDir)
 	if err != nil {
 		e.getLogger().WithError(err).Warn("Unable to hash header file")
-		bpfHeaderfilesHash = ""
+		datapathRegenCtxt.bpfHeaderfilesHash = ""
 		datapathRegenCtxt.bpfHeaderfilesChanged = true
 	} else {
-		datapathRegenCtxt.bpfHeaderfilesChanged = (bpfHeaderfilesHash != e.bpfHeaderfileHash)
-		e.getLogger().WithField(logfields.BPFHeaderfileHash, bpfHeaderfilesHash).
+		datapathRegenCtxt.bpfHeaderfilesChanged = (datapathRegenCtxt.bpfHeaderfilesHash != e.bpfHeaderfileHash)
+		e.getLogger().WithField(logfields.BPFHeaderfileHash, datapathRegenCtxt.bpfHeaderfilesHash).
 			Debugf("BPF header file hashed (was: %q)", e.bpfHeaderfileHash)
 	}
 
@@ -808,9 +808,9 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 		if err != nil {
 			return epInfoCache.revision, compilationExecuted, err
 		}
-		e.bpfHeaderfileHash = bpfHeaderfilesHash
+		e.bpfHeaderfileHash = datapathRegenCtxt.bpfHeaderfilesHash
 	} else {
-		e.getLogger().WithField(logfields.BPFHeaderfileHash, bpfHeaderfilesHash).
+		e.getLogger().WithField(logfields.BPFHeaderfileHash, datapathRegenCtxt.bpfHeaderfilesHash).
 			Debug("BPF header file unchanged, skipping BPF compilation and installation")
 	}
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -680,7 +680,6 @@ func (e *Endpoint) runPreCompilationSteps(owner Owner, regenContext *regeneratio
 
 	defer e.Unlock()
 
-	datapathRegenCtxt.prepareForDatapathRegeneration()
 	currentDir := datapathRegenCtxt.currentDir
 	nextDir := datapathRegenCtxt.nextDir
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -537,210 +537,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, regenContext *regenerationContext)
 	datapathRegenCtxt.prepareForProxyUpdates()
 	defer datapathRegenCtxt.completionCancel()
 
-	err = func() error {
-
-		stats.waitingForLock.Start()
-		err = e.LockAlive()
-		stats.waitingForLock.End(err == nil)
-		if err != nil {
-			return err
-		}
-
-		defer e.Unlock()
-
-		datapathRegenCtxt.prepareForDatapathRegeneration()
-
-		currentDir := datapathRegenCtxt.currentDir
-		nextDir := datapathRegenCtxt.nextDir
-
-		// In the first ever regeneration of the endpoint, the conntrack table
-		// is cleaned from the new endpoint IPs as it is guaranteed that any
-		// pre-existing connections using that IP are now invalid.
-		if !e.ctCleaned {
-			go func() {
-				ipv4 := !option.Config.IPv4Disabled
-				created := ctmap.Exists(nil, ipv4, true)
-				if e.ConntrackLocal() {
-					created = ctmap.Exists(e, ipv4, true)
-				}
-				if created {
-					e.scrubIPsInConntrackTable()
-				}
-				close(datapathRegenCtxt.ctCleaned)
-			}()
-		} else {
-			close(datapathRegenCtxt.ctCleaned)
-		}
-
-		// If dry mode is enabled, no further changes to BPF maps are performed
-		if option.Config.DryMode {
-
-			// Compute policy for this endpoint.
-			if err = e.regeneratePolicy(owner); err != nil {
-				return fmt.Errorf("Unable to regenerate policy: %s", err)
-			}
-
-			_ = e.updateAndOverrideEndpointOptions(nil)
-
-			// Dry mode needs Network Policy Updates, but the proxy wait group must
-			// not be initialized, as there is no proxy ACKing the changes.
-			if err, _ = e.updateNetworkPolicy(owner, nil); err != nil {
-				return err
-			}
-
-			if err = e.writeHeaderfile(nextDir, owner); err != nil {
-				return fmt.Errorf("Unable to write header file: %s", err)
-			}
-
-			log.WithField(logfields.EndpointID, e.ID).Debug("Skipping bpf updates due to dry mode")
-			return nil
-		}
-
-		if e.PolicyMap == nil {
-			e.PolicyMap, _, err = policymap.OpenMap(e.PolicyMapPathLocked())
-			if err != nil {
-				return err
-			}
-			// Clean up map contents
-			e.getLogger().Debug("flushing old PolicyMap")
-			err = e.PolicyMap.Flush()
-			if err != nil {
-				return err
-			}
-
-			// Also reset the in-memory state of the realized state as the
-			// BPF map content is guaranteed to be empty right now.
-			e.realizedMapState = make(PolicyMapState)
-		}
-
-		if e.bpfConfigMap == nil {
-			e.bpfConfigMap, _, err = bpfconfig.OpenMapWithName(e.BPFConfigMapPath(), e.BPFConfigMapName())
-			if err != nil {
-				return err
-			}
-			// Also reset the in-memory state of the realized state as the
-			// BPF map content is guaranteed to be empty right now.
-			e.realizedBPFConfig = &bpfconfig.EndpointConfig{}
-		}
-
-		// Only generate & populate policy map if a security identity is set up for
-		// this endpoint.
-		if e.SecurityIdentity != nil {
-			stats.policyCalculation.Start()
-			err = e.regeneratePolicy(owner)
-			stats.policyCalculation.End(err == nil)
-			if err != nil {
-				return fmt.Errorf("unable to regenerate policy for '%s': %s", e.PolicyMap.String(), err)
-			}
-
-			_ = e.updateAndOverrideEndpointOptions(nil)
-
-			// realizedBPFConfig may be updated at any point after we figure out
-			// whether ingress/egress policy is enabled.
-			e.desiredBPFConfig = bpfconfig.GetConfig(e)
-
-			// Synchronously try to update PolicyMap for this endpoint. If any
-			// part of updating the PolicyMap fails, bail out and do not generate
-			// BPF. Unfortunately, this means that the map will be in an inconsistent
-			// state with the current program (if it exists) for this endpoint.
-			// GH-3897 would fix this by creating a new map to do an atomic swap
-			// with the old one.
-			stats.mapSync.Start()
-			err := e.syncPolicyMap()
-			stats.mapSync.End(err == nil)
-			if err != nil {
-				return fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
-			}
-
-			// Synchronously update the BPF ConfigMap for this endpoint.
-			// This is unlikely to fail, but will have the same
-			// inconsistency issues as above if there is a failure. Long
-			// term the solution to this is to templatize this map in the
-			// ELF file, but there's no solution to this just yet.
-			if err = e.bpfConfigMap.Update(e.desiredBPFConfig); err != nil {
-				e.getLogger().WithError(err).Error("unable to update BPF config map")
-				return err
-			}
-
-			datapathRegenCtxt.revertStack.Push(func() error {
-				return e.bpfConfigMap.Update(e.realizedBPFConfig)
-			})
-
-			// Configure the new network policy with the proxies.
-			stats.proxyPolicyCalculation.Start()
-			var networkPolicyRevertFunc revert.RevertFunc
-			err, networkPolicyRevertFunc = e.updateNetworkPolicy(owner, datapathRegenCtxt.proxyWaitGroup)
-			stats.proxyPolicyCalculation.End(err == nil)
-			if err != nil {
-				return err
-			}
-
-			datapathRegenCtxt.revertStack.Push(networkPolicyRevertFunc)
-		}
-
-		stats.proxyConfiguration.Start()
-		var finalizeFunc revert.FinalizeFunc
-		var revertFunc revert.RevertFunc
-		// Walk the L4Policy to add new redirects and update the desired policy map
-		// state to set the newly allocated proxy ports.
-		var desiredRedirects map[string]bool
-		if e.DesiredL4Policy != nil {
-			desiredRedirects, err, finalizeFunc, revertFunc = e.addNewRedirects(owner, e.DesiredL4Policy, datapathRegenCtxt.proxyWaitGroup)
-			if err != nil {
-				stats.proxyConfiguration.End(false)
-				return err
-			}
-			datapathRegenCtxt.finalizeList.Append(finalizeFunc)
-			datapathRegenCtxt.revertStack.Push(revertFunc)
-		}
-		// At this point, traffic is no longer redirected to the proxy for
-		// now-obsolete redirects, since we synced the updated policy map above.
-		// It's now safe to remove the redirects from the proxy's configuration.
-		finalizeFunc, revertFunc = e.removeOldRedirects(owner, desiredRedirects, datapathRegenCtxt.proxyWaitGroup)
-		datapathRegenCtxt.finalizeList.Append(finalizeFunc)
-		datapathRegenCtxt.revertStack.Push(revertFunc)
-		stats.proxyConfiguration.End(true)
-
-		stats.prepareBuild.Start()
-
-		// Generate header file specific to this endpoint for use in compiling
-		// BPF programs for this endpoint.
-		if err = e.writeHeaderfile(nextDir, owner); err != nil {
-			stats.prepareBuild.End(false)
-			return fmt.Errorf("unable to write header file: %s", err)
-		}
-
-		// Avoid BPF program compilation and installation if the headerfile for the endpoint
-		// or the node have not changed.
-		datapathRegenCtxt.bpfHeaderfilesHash, err = hashEndpointHeaderfiles(nextDir)
-		if err != nil {
-			e.getLogger().WithError(err).Warn("Unable to hash header file")
-			datapathRegenCtxt.bpfHeaderfilesHash = ""
-			datapathRegenCtxt.bpfHeaderfilesChanged = true
-		} else {
-			datapathRegenCtxt.bpfHeaderfilesChanged = (datapathRegenCtxt.bpfHeaderfilesHash != e.bpfHeaderfileHash)
-			e.getLogger().WithField(logfields.BPFHeaderfileHash, datapathRegenCtxt.bpfHeaderfilesHash).
-				Debugf("BPF header file hashed (was: %q)", e.bpfHeaderfileHash)
-		}
-
-		// Cache endpoint information so that we can release the endpoint lock.
-		if datapathRegenCtxt.bpfHeaderfilesChanged {
-			datapathRegenCtxt.epInfoCache = e.createEpInfoCache(nextDir)
-		} else {
-			datapathRegenCtxt.epInfoCache = e.createEpInfoCache(currentDir)
-		}
-		if datapathRegenCtxt.epInfoCache == nil {
-			stats.prepareBuild.End(false)
-			return fmt.Errorf("Unable to cache endpoint information")
-		}
-
-		// TODO: In Cilium v1.4 or later cycle, remove this.
-		os.RemoveAll(e.IPv6EgressMapPathLocked())
-		os.RemoveAll(e.IPv4EgressMapPathLocked())
-		os.RemoveAll(e.IPv6IngressMapPathLocked())
-		os.RemoveAll(e.IPv4IngressMapPathLocked())
-		return nil
-	}()
+	err = e.runPreCompilationSteps(owner, regenContext)
 
 	// Keep track of the side-effects of the regeneration that need to be
 	// reverted in case of failure.
@@ -867,7 +664,212 @@ func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (compilati
 // runPreCompilationSteps runs all of the regeneration steps that are necessary
 // right before compiling the BPF for the given endpoint.
 // The endpoint mutex must not be held.
-func (e *Endpoint) runPreCompilationSteps(owner Owner, regenContext *regenerationContext) error {
+func (e *Endpoint) runPreCompilationSteps(owner Owner, regenContext *regenerationContext) (preCompilationError error) {
+	stats := &regenContext.Stats
+	datapathRegenCtxt := regenContext.datapathRegenerationContext
+
+	stats.waitingForLock.Start()
+	err := e.LockAlive()
+	stats.waitingForLock.End(err == nil)
+	if err != nil {
+		return err
+	}
+
+	defer e.Unlock()
+
+	datapathRegenCtxt.prepareForDatapathRegeneration()
+	currentDir := datapathRegenCtxt.currentDir
+	nextDir := datapathRegenCtxt.nextDir
+
+	// In the first ever regeneration of the endpoint, the conntrack table
+	// is cleaned from the new endpoint IPs as it is guaranteed that any
+	// pre-existing connections using that IP are now invalid.
+	if !e.ctCleaned {
+		go func() {
+			ipv4 := !option.Config.IPv4Disabled
+			created := ctmap.Exists(nil, ipv4, true)
+			if e.ConntrackLocal() {
+				created = ctmap.Exists(e, ipv4, true)
+			}
+			if created {
+				e.scrubIPsInConntrackTable()
+			}
+			close(datapathRegenCtxt.ctCleaned)
+		}()
+	} else {
+		close(datapathRegenCtxt.ctCleaned)
+	}
+
+	// If dry mode is enabled, no further changes to BPF maps are performed
+	if option.Config.DryMode {
+
+		// Compute policy for this endpoint.
+		if err = e.regeneratePolicy(owner); err != nil {
+			return fmt.Errorf("Unable to regenerate policy: %s", err)
+		}
+
+		_ = e.updateAndOverrideEndpointOptions(nil)
+
+		// Dry mode needs Network Policy Updates, but the proxy wait group must
+		// not be initialized, as there is no proxy ACKing the changes.
+		if err, _ = e.updateNetworkPolicy(owner, nil); err != nil {
+			return err
+		}
+
+		if err = e.writeHeaderfile(nextDir, owner); err != nil {
+			return fmt.Errorf("Unable to write header file: %s", err)
+		}
+
+		log.WithField(logfields.EndpointID, e.ID).Debug("Skipping bpf updates due to dry mode")
+		return nil
+	}
+
+	if e.PolicyMap == nil {
+		e.PolicyMap, _, err = policymap.OpenMap(e.PolicyMapPathLocked())
+		if err != nil {
+			return err
+		}
+		// Clean up map contents
+		e.getLogger().Debug("flushing old PolicyMap")
+		err = e.PolicyMap.Flush()
+		if err != nil {
+			return err
+		}
+
+		// Also reset the in-memory state of the realized state as the
+		// BPF map content is guaranteed to be empty right now.
+		e.realizedMapState = make(PolicyMapState)
+	}
+
+	if e.bpfConfigMap == nil {
+		e.bpfConfigMap, _, err = bpfconfig.OpenMapWithName(e.BPFConfigMapPath(), e.BPFConfigMapName())
+		if err != nil {
+			return err
+		}
+		// Also reset the in-memory state of the realized state as the
+		// BPF map content is guaranteed to be empty right now.
+		e.realizedBPFConfig = &bpfconfig.EndpointConfig{}
+	}
+
+	// Only generate & populate policy map if a security identity is set up for
+	// this endpoint.
+	if e.SecurityIdentity != nil {
+		stats.policyCalculation.Start()
+		err = e.regeneratePolicy(owner)
+		stats.policyCalculation.End(err == nil)
+		if err != nil {
+			return fmt.Errorf("unable to regenerate policy for '%s': %s", e.PolicyMap.String(), err)
+		}
+
+		_ = e.updateAndOverrideEndpointOptions(nil)
+
+		// realizedBPFConfig may be updated at any point after we figure out
+		// whether ingress/egress policy is enabled.
+		e.desiredBPFConfig = bpfconfig.GetConfig(e)
+
+		// Synchronously try to update PolicyMap for this endpoint. If any
+		// part of updating the PolicyMap fails, bail out and do not generate
+		// BPF. Unfortunately, this means that the map will be in an inconsistent
+		// state with the current program (if it exists) for this endpoint.
+		// GH-3897 would fix this by creating a new map to do an atomic swap
+		// with the old one.
+		stats.mapSync.Start()
+		err := e.syncPolicyMap()
+		stats.mapSync.End(err == nil)
+		if err != nil {
+			return fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
+		}
+
+		// Synchronously update the BPF ConfigMap for this endpoint.
+		// This is unlikely to fail, but will have the same
+		// inconsistency issues as above if there is a failure. Long
+		// term the solution to this is to templatize this map in the
+		// ELF file, but there's no solution to this just yet.
+		if err = e.bpfConfigMap.Update(e.desiredBPFConfig); err != nil {
+			e.getLogger().WithError(err).Error("unable to update BPF config map")
+			return err
+		}
+
+		datapathRegenCtxt.revertStack.Push(func() error {
+			return e.bpfConfigMap.Update(e.realizedBPFConfig)
+		})
+
+		// Configure the new network policy with the proxies.
+		stats.proxyPolicyCalculation.Start()
+		var networkPolicyRevertFunc revert.RevertFunc
+		err, networkPolicyRevertFunc = e.updateNetworkPolicy(owner, datapathRegenCtxt.proxyWaitGroup)
+		stats.proxyPolicyCalculation.End(err == nil)
+		if err != nil {
+			return err
+		}
+
+		datapathRegenCtxt.revertStack.Push(networkPolicyRevertFunc)
+	}
+
+	stats.proxyConfiguration.Start()
+	var finalizeFunc revert.FinalizeFunc
+	var revertFunc revert.RevertFunc
+	// Walk the L4Policy to add new redirects and update the desired policy map
+	// state to set the newly allocated proxy ports.
+	var desiredRedirects map[string]bool
+	if e.DesiredL4Policy != nil {
+		desiredRedirects, err, finalizeFunc, revertFunc = e.addNewRedirects(owner, e.DesiredL4Policy, datapathRegenCtxt.proxyWaitGroup)
+		if err != nil {
+			stats.proxyConfiguration.End(false)
+			return err
+		}
+		datapathRegenCtxt.finalizeList.Append(finalizeFunc)
+		datapathRegenCtxt.revertStack.Push(revertFunc)
+	}
+
+	// At this point, traffic is no longer redirected to the proxy for
+	// now-obsolete redirects, since we synced the updated policy map above.
+	// It's now safe to remove the redirects from the proxy's configuration.
+	finalizeFunc, revertFunc = e.removeOldRedirects(owner, desiredRedirects, datapathRegenCtxt.proxyWaitGroup)
+	datapathRegenCtxt.finalizeList.Append(finalizeFunc)
+	datapathRegenCtxt.revertStack.Push(revertFunc)
+	stats.proxyConfiguration.End(true)
+
+	stats.prepareBuild.Start()
+	defer func() {
+		stats.prepareBuild.End(preCompilationError == nil)
+	}()
+
+	// Generate header file specific to this endpoint for use in compiling
+	// BPF programs for this endpoint.
+	if err = e.writeHeaderfile(nextDir, owner); err != nil {
+		return fmt.Errorf("unable to write header file: %s", err)
+	}
+
+	// Avoid BPF program compilation and installation if the headerfile for the endpoint
+	// or the node have not changed.
+	datapathRegenCtxt.bpfHeaderfilesHash, err = hashEndpointHeaderfiles(nextDir)
+	if err != nil {
+		e.getLogger().WithError(err).Warn("Unable to hash header file")
+		datapathRegenCtxt.bpfHeaderfilesHash = ""
+		datapathRegenCtxt.bpfHeaderfilesChanged = true
+	} else {
+		datapathRegenCtxt.bpfHeaderfilesChanged = (datapathRegenCtxt.bpfHeaderfilesHash != e.bpfHeaderfileHash)
+		e.getLogger().WithField(logfields.BPFHeaderfileHash, datapathRegenCtxt.bpfHeaderfilesHash).
+			Debugf("BPF header file hashed (was: %q)", e.bpfHeaderfileHash)
+	}
+
+	// Cache endpoint information so that we can release the endpoint lock.
+	if datapathRegenCtxt.bpfHeaderfilesChanged {
+		datapathRegenCtxt.epInfoCache = e.createEpInfoCache(nextDir)
+	} else {
+		datapathRegenCtxt.epInfoCache = e.createEpInfoCache(currentDir)
+	}
+	if datapathRegenCtxt.epInfoCache == nil {
+		return fmt.Errorf("Unable to cache endpoint information")
+	}
+
+	// TODO: In Cilium v1.4 or later cycle, remove this.
+	os.RemoveAll(e.IPv6EgressMapPathLocked())
+	os.RemoveAll(e.IPv4EgressMapPathLocked())
+	os.RemoveAll(e.IPv6IngressMapPathLocked())
+	os.RemoveAll(e.IPv4IngressMapPathLocked())
+
 	return nil
 }
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -524,9 +524,6 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 		compilationExecuted bool
 	)
 
-	datapathRegenCtxt := regenContext.datapathRegenerationContext
-	datapathRegenCtxt.prepareForDatapathRegeneration()
-
 	stats := &regenContext.Stats
 	stats.waitingForLock.Start()
 
@@ -540,6 +537,9 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 	if err != nil {
 		return 0, compilationExecuted, err
 	}
+
+	datapathRegenCtxt := regenContext.datapathRegenerationContext
+	datapathRegenCtxt.prepareForDatapathRegeneration()
 
 	epID := e.StringID()
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -518,7 +518,7 @@ func (e *Endpoint) removeOldRedirects(owner Owner, desiredRedirects map[string]b
 // Must be called with endpoint.Mutex not held and endpoint.BuildMutex held.
 // Returns the policy revision number when the regeneration has called, a
 // boolean if the BPF compilation was executed and an error in case of an error.
-func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenContext *RegenerationContext, reloadDatapath bool) (revnum uint64, compiled bool, reterr error) {
+func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenContext *regenerationContext) (revnum uint64, compiled bool, reterr error) {
 	var (
 		err                 error
 		compilationExecuted bool
@@ -787,7 +787,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 	e.getLogger().WithField("bpfHeaderfilesChanged", bpfHeaderfilesChanged).Debug("Preparing to compile BPF")
 
 	stats.prepareBuild.End(true)
-	if bpfHeaderfilesChanged || reloadDatapath {
+	if bpfHeaderfilesChanged || regenContext.ReloadDatapath {
 		closeChan := loadinfo.LogPeriodicSystemLoad(log.WithFields(logrus.Fields{logfields.EndpointID: epID}).Debugf, time.Second)
 
 		// Compile and install BPF programs for this endpoint

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -543,8 +543,6 @@ func (e *Endpoint) regenerateBPF(owner Owner, regenContext *regenerationContext)
 	currentDir := datapathRegenCtxt.currentDir
 	nextDir := datapathRegenCtxt.nextDir
 
-	epID := e.StringID()
-
 	// In the first ever regeneration of the endpoint, the conntrack table
 	// is cleaned from the new endpoint IPs as it is guaranteed that any
 	// pre-existing connections using that IP are now invalid.
@@ -672,7 +670,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, regenContext *regenerationContext)
 			return 0, compilationExecuted, err
 		}
 
-		revertStack.Push(func() error {
+		datapathRegenCtxt.revertStack.Push(func() error {
 			return e.bpfConfigMap.Update(e.realizedBPFConfig)
 		})
 
@@ -762,34 +760,11 @@ func (e *Endpoint) regenerateBPF(owner Owner, regenContext *regenerationContext)
 	<-datapathRegenCtxt.ctCleaned
 	stats.waitingForCTClean.End(true)
 
-	e.getLogger().WithField("bpfHeaderfilesChanged", datapathRegenCtxt.bpfHeaderfilesChanged).Debug("Preparing to compile BPF")
-
 	stats.prepareBuild.End(true)
-	if datapathRegenCtxt.bpfHeaderfilesChanged || datapathRegenCtxt.reloadDatapath {
-		closeChan := loadinfo.LogPeriodicSystemLoad(log.WithFields(logrus.Fields{logfields.EndpointID: epID}).Debugf, time.Second)
 
-		// Compile and install BPF programs for this endpoint
-		if datapathRegenCtxt.bpfHeaderfilesChanged {
-			stats.bpfCompilation.Start()
-			err = loader.CompileAndLoad(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache)
-			stats.bpfCompilation.End(err == nil)
-			e.getLogger().WithError(err).
-				WithField(logfields.BPFCompilationTime, stats.bpfCompilation.Total().String()).
-				Info("Recompiled endpoint BPF program")
-			compilationExecuted = true
-		} else {
-			err = loader.ReloadDatapath(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache)
-			e.getLogger().WithError(err).Info("Reloaded endpoint BPF program")
-		}
-		close(closeChan)
-
-		if err != nil {
-			return datapathRegenCtxt.epInfoCache.revision, compilationExecuted, err
-		}
-		e.bpfHeaderfileHash = datapathRegenCtxt.bpfHeaderfilesHash
-	} else {
-		e.getLogger().WithField(logfields.BPFHeaderfileHash, datapathRegenCtxt.bpfHeaderfilesHash).
-			Debug("BPF header file unchanged, skipping BPF compilation and installation")
+	compilationExecuted, err = e.realizeBPFState(regenContext)
+	if err != nil {
+		return datapathRegenCtxt.epInfoCache.revision, compilationExecuted, err
 	}
 
 	// Hook the endpoint into the endpoint and endpoint to policy tables then expose it
@@ -847,6 +822,42 @@ func (e *Endpoint) regenerateBPF(owner Owner, regenContext *regenerationContext)
 	}
 
 	return datapathRegenCtxt.epInfoCache.revision, compilationExecuted, err
+}
+
+func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (compilationExecuted bool, err error) {
+	stats := &regenContext.Stats
+	datapathRegenCtxt := regenContext.datapathRegenerationContext
+
+	e.getLogger().WithField("bpfHeaderfilesChanged", datapathRegenCtxt.bpfHeaderfilesChanged).Debug("Preparing to compile BPF")
+
+	if datapathRegenCtxt.bpfHeaderfilesChanged || datapathRegenCtxt.reloadDatapath {
+		closeChan := loadinfo.LogPeriodicSystemLoad(log.WithFields(logrus.Fields{logfields.EndpointID: e.StringID()}).Debugf, time.Second)
+
+		// Compile and install BPF programs for this endpoint
+		if datapathRegenCtxt.bpfHeaderfilesChanged {
+			stats.bpfCompilation.Start()
+			err = loader.CompileAndLoad(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache)
+			stats.bpfCompilation.End(err == nil)
+			e.getLogger().WithError(err).
+				WithField(logfields.BPFCompilationTime, stats.bpfCompilation.Total().String()).
+				Info("Recompiled endpoint BPF program")
+			compilationExecuted = true
+		} else {
+			err = loader.ReloadDatapath(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache)
+			e.getLogger().WithError(err).Info("Reloaded endpoint BPF program")
+		}
+		close(closeChan)
+
+		if err != nil {
+			return compilationExecuted, err
+		}
+		e.bpfHeaderfileHash = datapathRegenCtxt.bpfHeaderfilesHash
+	} else {
+		e.getLogger().WithField(logfields.BPFHeaderfileHash, datapathRegenCtxt.bpfHeaderfilesHash).
+			Debug("BPF header file unchanged, skipping BPF compilation and installation")
+	}
+
+	return compilationExecuted, nil
 }
 
 func (e *Endpoint) finalizeProxyState(regenContext *regenerationContext, err error) {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1316,7 +1316,7 @@ func (e *Endpoint) Update(owner Owner, cfg *models.EndpointConfigurationSpec) er
 				stateTransitionSucceeded := e.SetStateLocked(StateWaitingToRegenerate, reason)
 				if stateTransitionSucceeded {
 					e.Unlock()
-					e.Regenerate(owner, NewRegenerationContext(reason), false)
+					e.Regenerate(owner, &ExternalRegenerationMetadata{Reason: reason})
 					return nil
 				}
 				e.Unlock()
@@ -1440,7 +1440,7 @@ func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup
 // RegenerateWait should only be called when endpoint's state has successfully
 // been changed to "waiting-to-regenerate"
 func (e *Endpoint) RegenerateWait(owner Owner, reason string) error {
-	if !<-e.Regenerate(owner, NewRegenerationContext(reason), false) {
+	if !<-e.Regenerate(owner, &ExternalRegenerationMetadata{Reason: reason}) {
 		return fmt.Errorf("error while regenerating endpoint."+
 			" For more info run: 'cilium endpoint get %d'", e.ID)
 	}
@@ -2070,7 +2070,7 @@ func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
 	e.Unlock()
 
 	if readyToRegenerate {
-		e.Regenerate(owner, NewRegenerationContext("updated security labels"), false)
+		e.Regenerate(owner, &ExternalRegenerationMetadata{Reason: "updated security labels"})
 	}
 
 	return nil

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -703,11 +703,13 @@ func (e *Endpoint) regenerate(owner Owner, context *regenerationContext) (retErr
 
 	stats.prepareBuild.Start()
 	origDir := filepath.Join(option.Config.StateDir, e.StringID())
+	context.datapathRegenerationContext.currentDir = origDir
 
 	// This is the temporary directory to store the generated headers,
 	// the original existing directory is not overwritten until the
 	// entire generation process has succeeded.
 	tmpDir := e.NextDirectoryPath()
+	context.datapathRegenerationContext.nextDir = tmpDir
 
 	// Remove an eventual existing temporary directory that has been left
 	// over to make sure we can start the build from scratch
@@ -748,7 +750,7 @@ func (e *Endpoint) regenerate(owner Owner, context *regenerationContext) (retErr
 		e.Unlock()
 	}()
 
-	revision, compilationExecuted, err = e.regenerateBPF(owner, origDir, tmpDir, context)
+	revision, compilationExecuted, err = e.regenerateBPF(owner, context)
 	if err != nil {
 		failDir := e.FailedDirectoryPath()
 		e.getLogger().WithFields(logrus.Fields{

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -62,25 +62,6 @@ var (
 	}
 )
 
-// regenerationContext provides context to regenerate() calls to determine
-// the caller, and which specific aspects to regeneration are necessary to
-// update the datapath to implement the new behavior.
-type regenerationContext struct {
-	// Reason provides context to source for the regeneration, which is
-	// used to generate useful log messages.
-	Reason string
-
-	ReloadDatapath bool
-
-	// Stats are collected during the endpoint regeneration and provided
-	// back to the caller
-	Stats regenerationStatistics
-
-	// DoneFunc must be called when the most resource intensive portion of
-	// the regeneration is done
-	DoneFunc func()
-}
-
 // ProxyID returns a unique string to identify a proxy mapping.
 func (e *Endpoint) ProxyID(l4 *policy.L4Filter) string {
 	return policy.ProxyID(e.ID, l4.Ingress, string(l4.Protocol), uint16(l4.Port))

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -62,13 +62,15 @@ var (
 	}
 )
 
-// RegenerationContext provides context to regenerate() calls to determine
+// regenerationContext provides context to regenerate() calls to determine
 // the caller, and which specific aspects to regeneration are necessary to
 // update the datapath to implement the new behavior.
-type RegenerationContext struct {
+type regenerationContext struct {
 	// Reason provides context to source for the regeneration, which is
 	// used to generate useful log messages.
 	Reason string
+
+	ReloadDatapath bool
 
 	// Stats are collected during the endpoint regeneration and provided
 	// back to the caller
@@ -77,14 +79,6 @@ type RegenerationContext struct {
 	// DoneFunc must be called when the most resource intensive portion of
 	// the regeneration is done
 	DoneFunc func()
-}
-
-// NewRegenerationContext returns a new context for regeneration that does not
-// force any recalculation, rebuild or reload of policy.
-func NewRegenerationContext(reason string) *RegenerationContext {
-	return &RegenerationContext{
-		Reason: reason,
-	}
 }
 
 // ProxyID returns a unique string to identify a proxy mapping.
@@ -652,7 +646,7 @@ func (e *Endpoint) ComputePolicyEnforcement(repo *policy.Repository) (ingress bo
 }
 
 // Called with e.Mutex UNlocked
-func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext, reloadDatapath bool) (retErr error) {
+func (e *Endpoint) regenerate(owner Owner, context *regenerationContext) (retErr error) {
 	var revision uint64
 	var compilationExecuted bool
 	var err error
@@ -773,7 +767,7 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext, reloadD
 		e.Unlock()
 	}()
 
-	revision, compilationExecuted, err = e.regenerateBPF(owner, origDir, tmpDir, context, reloadDatapath)
+	revision, compilationExecuted, err = e.regenerateBPF(owner, origDir, tmpDir, context)
 	if err != nil {
 		failDir := e.FailedDirectoryPath()
 		e.getLogger().WithFields(logrus.Fields{
@@ -823,13 +817,14 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext, reloadD
 // Regenerate forces the regeneration of endpoint programs & policy
 // Should only be called with e.state == StateWaitingToRegenerate or with
 // e.state == StateWaitingForIdentity
-// ReloadDatapath forces the datapath programs to be reloaded. It does
-// not guarantee recompilation of the programs.
-func (e *Endpoint) Regenerate(owner Owner, context *RegenerationContext, reloadDatapath bool) <-chan bool {
+func (e *Endpoint) Regenerate(owner Owner, regenMetadata *ExternalRegenerationMetadata) <-chan bool {
 	done := make(chan bool, 1)
 
 	go func() {
 		var buildSuccess bool
+
+		regenContext := regenMetadata.toRegenerationContext()
+
 		defer func() {
 			done <- buildSuccess
 			close(done)
@@ -850,8 +845,8 @@ func (e *Endpoint) Regenerate(owner Owner, context *RegenerationContext, reloadD
 		if doneFunc != nil {
 			scopedLog.Debug("Dequeued endpoint from build queue")
 
-			context.DoneFunc = doneFunc
-			err := e.regenerate(owner, context, reloadDatapath)
+			regenContext.DoneFunc = doneFunc
+			err := e.regenerate(owner, regenContext)
 			doneFunc() // in case not called already
 
 			repr, reprerr := monitor.EndpointRegenRepr(e, err)

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -80,3 +80,7 @@ type datapathRegenerationContext struct {
 	finalizeList   revert.FinalizeList
 	revertStack    revert.RevertStack
 }
+
+func (ctx *datapathRegenerationContext) prepareForDatapathRegeneration() {
+	ctx.ctCleaned = make(chan struct{})
+}

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -23,8 +23,10 @@ import (
 
 func (e *ExternalRegenerationMetadata) toRegenerationContext() *regenerationContext {
 	return &regenerationContext{
-		Reason:         e.Reason,
-		ReloadDatapath: e.ReloadDatapath,
+		Reason: e.Reason,
+		datapathRegenerationContext: &datapathRegenerationContext{
+			reloadDatapath: e.ReloadDatapath,
+		},
 	}
 }
 
@@ -47,10 +49,6 @@ type regenerationContext struct {
 	// Reason provides context to source for the regeneration, which is
 	// used to generate useful log messages.
 	Reason string
-
-	// ReloadDatapath forces the datapath programs to be reloaded. It does
-	// not guarantee recompilation of the programs.
-	ReloadDatapath bool
 
 	// Stats are collected during the endpoint regeneration and provided
 	// back to the caller
@@ -75,7 +73,10 @@ type datapathRegenerationContext struct {
 	completionCancel      context.CancelFunc
 	currentDir            string
 	nextDir               string
-	reloadDatapath        bool
-	finalizeList          revert.FinalizeList
-	revertStack           revert.RevertStack
+
+	// reloadDatapath forces the datapath programs to be reloaded. It does
+	// not guarantee recompilation of the programs.
+	reloadDatapath bool
+	finalizeList   revert.FinalizeList
+	revertStack    revert.RevertStack
 }

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -26,6 +26,7 @@ func (e *ExternalRegenerationMetadata) toRegenerationContext() *regenerationCont
 		Reason: e.Reason,
 		datapathRegenerationContext: &datapathRegenerationContext{
 			reloadDatapath: e.ReloadDatapath,
+			ctCleaned:      make(chan struct{}),
 		},
 	}
 }
@@ -79,10 +80,6 @@ type datapathRegenerationContext struct {
 	reloadDatapath bool
 	finalizeList   revert.FinalizeList
 	revertStack    revert.RevertStack
-}
-
-func (ctx *datapathRegenerationContext) prepareForDatapathRegeneration() {
-	ctx.ctCleaned = make(chan struct{})
 }
 
 func (ctx *datapathRegenerationContext) prepareForProxyUpdates() {

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -1,0 +1,34 @@
+// Copyright 2016-2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+// ExternalRegenerationMetadata contains any information about a regeneration that
+// the endpoint subsystem should be made aware of for a given endpoint.
+type ExternalRegenerationMetadata struct {
+	// Reason provides context to source for the regeneration, which is
+	// used to generate useful log messages.
+	Reason string
+
+	// ReloadDatapath forces the datapath programs to be reloaded. It does
+	// not guarantee recompilation of the programs.
+	ReloadDatapath bool
+}
+
+func (e *ExternalRegenerationMetadata) toRegenerationContext() *regenerationContext {
+	return &regenerationContext{
+		Reason:         e.Reason,
+		ReloadDatapath: e.ReloadDatapath,
+	}
+}

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -14,6 +14,13 @@
 
 package endpoint
 
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/revert"
+)
+
 func (e *ExternalRegenerationMetadata) toRegenerationContext() *regenerationContext {
 	return &regenerationContext{
 		Reason:         e.Reason,
@@ -52,4 +59,23 @@ type regenerationContext struct {
 	// DoneFunc must be called when the most resource intensive portion of
 	// the regeneration is done
 	DoneFunc func()
+
+	datapathRegenerationContext *datapathRegenerationContext
+}
+
+// datapathRegenerationContext contains information related to regenerating the
+// datapath (BPF, proxy, etc.).
+type datapathRegenerationContext struct {
+	bpfHeaderfilesHash    string
+	epInfoCache           *epInfoCache
+	bpfHeaderfilesChanged bool
+	proxyWaitGroup        *completion.WaitGroup
+	ctCleaned             chan struct{}
+	completionCtx         context.Context
+	completionCancel      context.CancelFunc
+	currentDir            string
+	nextDir               string
+	reloadDatapath        bool
+	finalizeList          revert.FinalizeList
+	revertStack           revert.RevertStack
 }

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -84,3 +84,11 @@ type datapathRegenerationContext struct {
 func (ctx *datapathRegenerationContext) prepareForDatapathRegeneration() {
 	ctx.ctCleaned = make(chan struct{})
 }
+
+func (ctx *datapathRegenerationContext) prepareForProxyUpdates() {
+	// Set up a context to wait for proxy completions.
+	completionCtx, completionCancel := context.WithTimeout(context.Background(), EndpointGenerationTimeout)
+	ctx.proxyWaitGroup = completion.NewWaitGroup(completionCtx)
+	ctx.completionCtx = completionCtx
+	ctx.completionCancel = completionCancel
+}

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -14,6 +14,13 @@
 
 package endpoint
 
+func (e *ExternalRegenerationMetadata) toRegenerationContext() *regenerationContext {
+	return &regenerationContext{
+		Reason:         e.Reason,
+		ReloadDatapath: e.ReloadDatapath,
+	}
+}
+
 // ExternalRegenerationMetadata contains any information about a regeneration that
 // the endpoint subsystem should be made aware of for a given endpoint.
 type ExternalRegenerationMetadata struct {
@@ -26,9 +33,23 @@ type ExternalRegenerationMetadata struct {
 	ReloadDatapath bool
 }
 
-func (e *ExternalRegenerationMetadata) toRegenerationContext() *regenerationContext {
-	return &regenerationContext{
-		Reason:         e.Reason,
-		ReloadDatapath: e.ReloadDatapath,
-	}
+// RegenerationContext provides context to regenerate() calls to determine
+// the caller, and which specific aspects to regeneration are necessary to
+// update the datapath to implement the new behavior.
+type regenerationContext struct {
+	// Reason provides context to source for the regeneration, which is
+	// used to generate useful log messages.
+	Reason string
+
+	// ReloadDatapath forces the datapath programs to be reloaded. It does
+	// not guarantee recompilation of the programs.
+	ReloadDatapath bool
+
+	// Stats are collected during the endpoint regeneration and provided
+	// back to the caller
+	Stats regenerationStatistics
+
+	// DoneFunc must be called when the most resource intensive portion of
+	// the regeneration is done
+	DoneFunc func()
 }

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -274,30 +274,26 @@ func updateReferences(ep *endpoint.Endpoint) {
 // RegenerateAllEndpoints calls a SetStateLocked for each endpoint and
 // regenerates if state transaction is valid. During this process, the endpoint
 // list is locked and cannot be modified.
-// The endpoint.RegenerationContext will be cloned to send a new context to
-// each endpoint to avoid issue on endpoint regenerations statistics.
 // Returns a waiting group that can be used to know when all the endpoints are
 // regenerated.
-func RegenerateAllEndpoints(owner endpoint.Owner, regenContext *endpoint.RegenerationContext, reloadDatapath bool) *sync.WaitGroup {
+func RegenerateAllEndpoints(owner endpoint.Owner, regenMetadata *endpoint.ExternalRegenerationMetadata) *sync.WaitGroup {
 	var wg sync.WaitGroup
 
 	eps := GetEndpoints()
 	wg.Add(len(eps))
 
-	log.Infof("regenerating all endpoints due to %s", regenContext.Reason)
+	log.Infof("regenerating all endpoints due to %s", regenMetadata.Reason)
 	for _, ep := range eps {
 		go func(ep *endpoint.Endpoint, wg *sync.WaitGroup) {
 			if err := ep.LockAlive(); err != nil {
-				log.WithError(err).Warnf("Endpoint disappeared while queued to be regenerated: %s", regenContext.Reason)
+				log.WithError(err).Warnf("Endpoint disappeared while queued to be regenerated: %s", regenMetadata.Reason)
 				ep.LogStatus(endpoint.Policy, endpoint.Failure, "Error while handling policy updates for endpoint: "+err.Error())
 			} else {
-				regen := ep.SetStateLocked(endpoint.StateWaitingToRegenerate, fmt.Sprintf("Triggering endpoint regeneration due to %s", regenContext.Reason))
+				regen := ep.SetStateLocked(endpoint.StateWaitingToRegenerate, fmt.Sprintf("Triggering endpoint regeneration due to %s", regenMetadata.Reason))
 				ep.Unlock()
 				if regen {
 					// Regenerate logs status according to the build success/failure
-					// Create a new regenContext to not overwrite the spanStats
-					// values on the endpoint regeneration.
-					<-ep.Regenerate(owner, endpoint.NewRegenerationContext(regenContext.Reason), reloadDatapath)
+					<-ep.Regenerate(owner, regenMetadata)
 				}
 			}
 			wg.Done()


### PR DESCRIPTION
This is a revival / update of #5616. 

It makes `regenerationContext` private to the endpoint package, and ensures that a given `regenerationContext` is created in a single goroutine for a given endpoint so as to not have multiple threads accidentally modifying the same structure concurrently. 

Information that is related to the state of the datapath for a regeneration is stored in a new member of `regenerationContext`, called `datapathRegenerationContext`. I'm open to changing the name of these types if desired. Storing information in this type allows for `regenerateBPF` to be split up into separate functions, which consume this type. It also ensures that these functions can defer the unlocking of the endpoint if needed in case there is a panic that arises. This reduces the risk of deadlock, as there are other functions in `regenerateBPF` which are deferred and lock the endpoint structure, which would deadlock the agent if a panic occurred while `regenerateBPF` was holding the endpoint lock.

This change makes `regenerateBPF` easier to divide up into logical, more readable chunks. It also ensures that state related to regeneration is stored in a type, which we can remove / add members from if so desired, while maintaining the same function signatures. 

I also believe that grouping more of the information related to plumbing the datapath into a single type will help us figure out how we can hide `pkg/bpf` from the endpoint package in the future. 

I tried to make this as easy to review as possible by having a lot of small, easy to digest commits.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6191)
<!-- Reviewable:end -->
