### PR TITLE
Ginkgo Test: Add benchmark class of tests and an initial netperf test

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -916,6 +916,15 @@ func (s *SSHMeta) SetUpCiliumWithOptions(template string) error {
 	return nil
 }
 
+func (s *SSHMeta) SetUpCiliumWithSockops() error {
+	var config = `
++PATH=/usr/lib/llvm-3.8/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
++CILIUM_OPTS=--sockops-enable --kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug --pprof=true --log-system-load --tofqdns-enable-poller=true
++INITSYSTEM=SYSTEMD`
+
+	return s.SetUpCiliumWithOptions(config)
+}
+
 // WaitUntilReady waits until the output of `cilium status` returns with code
 // zero. Returns an error if the output of `cilium status` returns a nonzero
 // return code after the specified timeout duration has elapsed.

--- a/test/runtime/benchmark.go
+++ b/test/runtime/benchmark.go
@@ -1,0 +1,287 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package RuntimeTest
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cilium/cilium/pkg/logging"
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
+
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+func superNetperfRRIPv4(s *helpers.SSHMeta, client string, server string, num int) *helpers.CmdRes {
+	var res *helpers.CmdRes
+
+	serverNet, _ := s.ContainerInspectNet(server)
+	serverIpv4 := serverNet[helpers.IPv4]
+	By("super_netperf to %s from %s (should succeed)", server, client)
+	cmd := fmt.Sprintf("super_netperf %d -t TCP_RR -H %s", num, serverIpv4)
+	res = s.ContainerExec(client, cmd)
+	res.ExpectSuccess("failed: %s", cmd)
+	return res
+}
+
+// SuperNetperfRR launches 'num' parallel netperf TCP_RR
+// (request/response) tests from client to server.
+func superNetperfRR(s *helpers.SSHMeta, client string, server string, num int) *helpers.CmdRes {
+	return superNetperfRRIPv4(s, client, server, num)
+}
+
+func superNetperfStreamIPv4(s *helpers.SSHMeta, client string, server string, num int) *helpers.CmdRes {
+	var res *helpers.CmdRes
+
+	serverNet, _ := s.ContainerInspectNet(server)
+	serverIpv4 := serverNet[helpers.IPv4]
+	By("super_netperf to %s from %s (should succeed)", server, client)
+	cmd := fmt.Sprintf("super_netperf %d -f g -t TCP_STREAM -H %s", num, serverIpv4)
+	res = s.ContainerExec(client, cmd)
+	res.ExpectSuccess("failed: %s", cmd)
+	return res
+}
+
+// SuperNetperfStream launches 'num' parallel netperf TCP_STREAM
+// tests from client to server.
+func superNetperfStream(s *helpers.SSHMeta, client string, server string, num int) *helpers.CmdRes {
+	return superNetperfStreamIPv4(s, client, server, num)
+}
+
+var _ = Describe("BenchmarkNetperfPerformance", func() {
+	var (
+		vm          *helpers.SSHMeta
+		monitorStop = func() error { return nil }
+
+		log    = logging.DefaultLogger
+		logger = logrus.NewEntry(log)
+
+		PerfLogFile   = "l4bench_perf.log"
+		PerfLogWriter bytes.Buffer
+	)
+
+	BeforeAll(func() {
+		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+		ExpectCiliumReady(vm)
+	})
+
+	JustBeforeEach(func() {
+		monitorStop = vm.MonitorStart()
+	})
+
+	JustAfterEach(func() {
+		vm.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		Expect(monitorStop()).To(BeNil(), "cannot stop monitor command")
+	})
+
+	AfterFailed(func() {
+		vm.ReportFailed(
+			"cilium service list",
+			"cilium policy get")
+	})
+
+	AfterEach(func() {
+		LogPerm := os.FileMode(0666)
+		testPath, err := helpers.CreateReportDirectory()
+		Expect(err).Should(BeNil(), "cannot create log file")
+		helpers.WriteOrAppendToFile(filepath.Join(testPath, PerfLogFile), PerfLogWriter.Bytes(), LogPerm)
+		PerfLogWriter.Reset()
+	}, 500)
+
+	createContainers := func() {
+		By("create Client container")
+		vm.ContainerCreate(helpers.Client, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
+		By("create Server containers")
+		vm.ContainerCreate(helpers.Server, helpers.NetperfImage, helpers.CiliumDockerNetwork, "-l id.server")
+		vm.PolicyDelAll()
+		Expect( vm.WaitEndpointsReady() ).To(BeNil(), "Endpoints are not ready")
+	}
+
+	removeContainers := func(containerName string) {
+		By("removing container %s", containerName)
+		res := vm.ContainerRm(containerName)
+		Expect(res.WasSuccessful()).Should(BeTrue(), "Container removal failed")
+	}
+
+	deleteContainers := func() {
+		removeContainers(helpers.Client)
+		removeContainers(helpers.Server)
+	}
+
+	superNetperfRRLog := func(client string, server string, num int) {
+		res := superNetperfRR(vm, client, server, num)
+		fmt.Fprintf(&PerfLogWriter, "%s,", strings.TrimSuffix(res.GetStdOut(), "\n"))
+	}
+
+	superNetperfStreamLog := func(client string, server string, num int) {
+		res := superNetperfStream(vm, client, server, num)
+		fmt.Fprintf(&PerfLogWriter, "%s,", strings.TrimSuffix(res.GetStdOut(), "\n"))
+	}
+
+	Context("Benchmark Netperf Tests", func() {
+		BeforeAll(func() {
+			createContainers()
+		})
+
+		AfterAll(func() {
+			deleteContainers()
+		})
+
+		It("Test L4 Netperf TCP_RR Performance lo:1", func() {
+			superNetperfRRLog(helpers.Server, helpers.Server, 1)
+		}, 300)
+
+		It("Test L4 Netperf TCP_RR Performance lo:10", func() {
+			superNetperfRRLog(helpers.Server, helpers.Server, 10)
+		}, 300)
+
+		It("Test L4 Netperf Performance lo:100", func() {
+			superNetperfRRLog(helpers.Server, helpers.Server, 100)
+		}, 300)
+
+		It("Test L4 Netperf TCP_RR Performance lo:1000", func() {
+			superNetperfRRLog(helpers.Server, helpers.Server, 1000)
+		}, 300)
+
+		It("Test L4 Netperf TCP_RR Performance inter-container:1", func() {
+			superNetperfRRLog(helpers.Client, helpers.Server, 1)
+		}, 300)
+
+		It("Test L4 Netperf TCP_RR Performance inter-container:10", func() {
+			superNetperfRRLog(helpers.Client, helpers.Server, 10)
+		}, 300)
+
+		It("Test L4 Netperf TCP_RR Performance inter-container:100", func() {
+			superNetperfRRLog(helpers.Client, helpers.Server, 100)
+		}, 300)
+
+		It("Test L4 Netperf TCP_RR Performance inter-container:1000", func() {
+			superNetperfRRLog(helpers.Client, helpers.Server, 1000)
+		}, 300)
+
+		It("Test L4 Netperf TCP_STREAM Performance lo:1", func() {
+			superNetperfStreamLog(helpers.Server, helpers.Server, 1)
+		}, 300)
+
+		It("Test L4 Netperf TCP_STREAM Performance lo:10", func() {
+			superNetperfStreamLog(helpers.Server, helpers.Server, 10)
+		}, 300)
+
+		It("Test L4 Netperf TCP_STREAM Performance lo:100", func() {
+			superNetperfStreamLog(helpers.Server, helpers.Server, 100)
+		}, 300)
+
+		It("Test L4 Netperf TCP_STREAM Performance lo:1000", func() {
+			superNetperfStreamLog(helpers.Server, helpers.Server, 1000)
+		}, 300)
+
+		It("Test L4 Netperf TCP_STREAM Performance lo:1", func() {
+			superNetperfStreamLog(helpers.Client, helpers.Server, 1)
+		}, 300)
+
+		It("Test L4 Netperf TCP_STREAM Performance lo:10", func() {
+			superNetperfStreamLog(helpers.Client, helpers.Server, 10)
+		}, 300)
+
+		It("Test L4 Netperf TCP_STREAM Performance lo:100", func() {
+			superNetperfStreamLog(helpers.Client, helpers.Server, 100)
+		}, 300)
+
+		It("Test L4 Netperf TCP_STREAM Performance lo:1000", func() {
+			superNetperfStreamLog(helpers.Client, helpers.Server, 1000)
+		}, 300)
+	})
+
+	Context("Benchmark Netperf Tests Sockops-Enabled", func() {
+		BeforeAll(func() {
+			vm.SetUpCiliumWithSockops()
+			ExpectCiliumReady(vm)
+			createContainers()
+		})
+
+		AfterAll(func() {
+			deleteContainers()
+		})
+
+		It("Test L4 Netperf TCP_RR Performance Sockops lo:1", func() {
+			superNetperfRRLog(helpers.Server, helpers.Server, 1)
+		}, 300)
+
+		It("Test L4 Netperf TCP_RR Performance Sockops lo:10", func() {
+			superNetperfRRLog(helpers.Server, helpers.Server, 10)
+		}, 300)
+
+		It("Test L4 Netperf TCP_RR Performance Sockops lo:100", func() {
+			superNetperfRRLog(helpers.Server, helpers.Server, 100)
+		}, 300)
+
+		It("Test L4 Netperf TCP_RR Performance Sockops lo:1000", func() {
+			superNetperfRRLog(helpers.Server, helpers.Server, 1000)
+		}, 300)
+
+		It("Test L4 Netperf TCP_RR Performance Sockops inter-container:1", func() {
+			superNetperfRRLog(helpers.Client, helpers.Server, 1)
+		}, 300)
+
+		It("Test L4 Netperf TCP_RR Performance Sockops inter-container:10", func() {
+			superNetperfRRLog(helpers.Client, helpers.Server, 10)
+		}, 300)
+
+		It("Test L4 Netperf TCP_RR Performance Sockops inter-container:100", func() {
+			superNetperfRRLog(helpers.Client, helpers.Server, 100)
+		}, 300)
+
+		It("Test L4 Netperf TCP_RR Performance Sockops inter-container:1000", func() {
+			superNetperfRRLog(helpers.Client, helpers.Server, 1000)
+		}, 300)
+
+		It("Test L4 Netperf TCP_STREAM Performance Sockops lo:1", func() {
+			superNetperfStreamLog(helpers.Server, helpers.Server, 1)
+		}, 300)
+
+		It("Test L4 Netperf TCP_STREAM Performance Sockops lo:10", func() {
+			superNetperfStreamLog(helpers.Server, helpers.Server, 10)
+		}, 300)
+
+		It("Test L4 Netperf TCP_STREAM Performance Sockops lo:100", func() {
+			superNetperfStreamLog(helpers.Server, helpers.Server, 100)
+		}, 300)
+
+		It("Test L4 Netperf TCP_STREAM Performance Sockops lo:1000", func() {
+			superNetperfStreamLog(helpers.Server, helpers.Server, 1000)
+		}, 300)
+
+		It("Test L4 Netperf TCP_STREAM Performance Sockops lo:1", func() {
+			superNetperfStreamLog(helpers.Client, helpers.Server, 1)
+		}, 300)
+
+		It("Test L4 Netperf TCP_STREAM Performance Sockops lo:10", func() {
+			superNetperfStreamLog(helpers.Client, helpers.Server, 10)
+		}, 300)
+
+		It("Test L4 Netperf TCP_STREAM Performance Sockops lo:100", func() {
+			superNetperfStreamLog(helpers.Client, helpers.Server, 100)
+		}, 300)
+
+		It("Test L4 Netperf TCP_STREAM Performance Sockops lo:1000", func() {
+			superNetperfStreamLog(helpers.Client, helpers.Server, 1000)
+		}, 300)
+	})
+})


### PR DESCRIPTION
This adds a super_netperf test that reports metrics in a l4bench_perf.log file for an increasing number of instances. We do two test configures initially (a) netperf over loopback and (b) netperf from endpoint to endpoint. The test is run twice first without sockmap enabled and then again with it enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6193)
<!-- Reviewable:end -->
