### PR TITLE
Jenkinsfile: reduce timeout to 75 minutes

### DIFF
--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
             }
 
             options {
-                timeout(time: 100, unit: 'MINUTES')
+                timeout(time: 75, unit: 'MINUTES')
             }
 
             steps {


### PR DESCRIPTION
The tests take at maximum an hour right now, so reduce the timeout from 100 minutes
to 75 minutes.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6196)
<!-- Reviewable:end -->
