### PR TITLE
daemon: debuginfo: Read file directly instead of using cat

### DIFF
--- a/daemon/debuginfo.go
+++ b/daemon/debuginfo.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2018 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
-	"os/exec"
 
 	"github.com/cilium/cilium/api/v1/models"
 	restapi "github.com/cilium/cilium/api/v1/server/restapi/daemon"
@@ -75,7 +75,7 @@ func (h *getDebugInfo) Handle(params restapi.GetDebuginfoParams) middleware.Resp
 }
 
 func memoryMap(pid int) string {
-	m, err := exec.Command("cat", fmt.Sprintf("/proc/%d/maps", pid)).CombinedOutput()
+	m, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/maps", pid))
 	if err != nil {
 		return ""
 	}

--- a/daemon/debuginfo_test.go
+++ b/daemon/debuginfo_test.go
@@ -1,0 +1,29 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package main
+
+import (
+	"os"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *DaemonSuite) TestMemoryMap(c *C) {
+	pid := os.Getpid()
+	m := memoryMap(pid)
+	c.Assert(m, Not(Equals), "")
+}


### PR DESCRIPTION
Signed-off-by: Michal Rostecki <mrostecki@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6199)
<!-- Reviewable:end -->
