### PR TITLE
endpoint: avoid deferring code which locks endpoint in regenerateBPF

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -773,7 +773,12 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext) (retErr
 		e.Unlock()
 	}()
 
-	revision, compilationExecuted, err = e.regenerateBPF(owner, origDir, tmpDir, context)
+	revision, compilationExecuted, afterFunc, err := e.regenerateBPF(owner, origDir, tmpDir, context)
+
+	if afterFunc != nil {
+		afterFunc(err)
+	}
+
 	if err != nil {
 		failDir := e.FailedDirectoryPath()
 		e.getLogger().WithFields(logrus.Fields{


### PR DESCRIPTION
If a panic occurs while this function is running and the endpoint lock is held
when the panic happens, the deferred proxy finalization / reverting code will
try to acquire the endpoint lock, resulting in the agent to hang. Now, the
function is returned to the caller of regenerateBPF to call when it returns.
This allows for a 'deferring' of the code in a sense, but the returned function
will only be called if a panic has not occurred.

More information about panic: https://blog.golang.org/defer-panic-and-recover

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6210)
<!-- Reviewable:end -->
