### PR TITLE
daemon: Allow releasing builder while waiting for proxy ACKs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1227,12 +1227,14 @@
   revision = "d2e6202438beef2727060aa7cabdd924d92ebfd9"
 
 [[projects]]
-  branch = "master"
-  digest = "1:39ebcc2b11457b703ae9ee2e8cca0f68df21969c6102cb3b705f76cca0ea0239"
+  digest = "1:d6b0cfc5ae30841c4b116ac589629f56f8add0955a39f11d8c0d06ca67f5b3d5"
   name = "golang.org/x/sync"
-  packages = ["errgroup"]
+  packages = [
+    "errgroup",
+    "semaphore",
+  ]
   pruneopts = "NUT"
-  revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
+  revision = "42b317875d0fa942474b76e1b46a6060d720ae6e"
 
 [[projects]]
   digest = "1:21b27f093d86b15a6cb6b63591f664dce78ad3004bee2f649bc01a0f93b37612"
@@ -1770,6 +1772,7 @@
     "golang.org/x/crypto/ssh",
     "golang.org/x/crypto/ssh/agent",
     "golang.org/x/net/context",
+    "golang.org/x/sync/semaphore",
     "golang.org/x/sys/unix",
     "google.golang.org/genproto/googleapis/rpc/status",
     "google.golang.org/grpc",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -260,6 +260,10 @@ required = [
   revision = "0744d001aa8470aaa53df28d32e5ceeb8af9bd70"
 
 [[constraint]]
+  name = "golang.org/x/sync"
+  revision = "42b317875d0fa942474b76e1b46a6060d720ae6e"
+
+[[constraint]]
   name = "golang.org/x/sys"
   revision = "14742f9018cd6651ec7364dc6ee08af0baaa1031"
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -63,7 +63,7 @@ type DaemonSuite struct {
 	OnRemoveProxyRedirect     func(e *e.Endpoint, id string, proxyWaitGroup *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc)
 	OnUpdateNetworkPolicy     func(e *e.Endpoint, policy *policy.L4Policy, labelsMap cache.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc)
 	OnRemoveNetworkPolicy     func(e *e.Endpoint)
-	OnQueueEndpointBuild      func(r *e.Request)
+	OnQueueEndpointBuild      func(epID uint64) func()
 	OnRemoveFromEndpointQueue func(epID uint64)
 	OnDebugEnabled            func() bool
 	OnGetCompilationLock      func() *lock.RWMutex
@@ -227,10 +227,9 @@ func (ds *DaemonSuite) RemoveNetworkPolicy(e *e.Endpoint) {
 	panic("RemoveNetworkPolicy should not have been called")
 }
 
-func (ds *DaemonSuite) QueueEndpointBuild(r *e.Request) {
+func (ds *DaemonSuite) QueueEndpointBuild(epID uint64) func() {
 	if ds.OnQueueEndpointBuild != nil {
-		ds.OnQueueEndpointBuild(r)
-		return
+		return ds.OnQueueEndpointBuild(epID)
 	}
 	panic("QueueEndpointBuild should not have been called")
 }

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/completion"
@@ -107,12 +108,11 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 
 	ds.OnQueueEndpointBuild = func(epID uint64) func() {
 		builders++
-		done := false
+		var once sync.Once
 		return func() {
-			if !done {
+			once.Do(func() {
 				builders--
-				done = true
-			}
+			})
 		}
 	}
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -60,7 +60,10 @@ const (
 	ExecTimeout = 300 * time.Second
 
 	// EndpointGenerationTimeout specifies timeout for proxy completion context
-	EndpointGenerationTimeout = 55 * time.Second
+	// Must be greater than `ExecTimeout` as a context with this timeout
+	// is started before using `ExecTimeout` and still used after `ExecTimeout`
+	// is already canceled.
+	EndpointGenerationTimeout = 330 * time.Second
 )
 
 // mapPath returns the path to a map for endpoint ID.

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -835,6 +835,11 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 	// The endpoint has at least L3/L4 connectivity at this point.
 	e.CloseBPFProgramChannel()
 
+	// Allow another builder to start while we wait for the proxy
+	if regenContext.DoneFunc != nil {
+		regenContext.DoneFunc()
+	}
+
 	stats.proxyWaitForAck.Start()
 	err = e.WaitForProxyCompletions(proxyWaitGroup)
 	stats.proxyWaitForAck.End(err == nil)

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -45,10 +45,10 @@ type Owner interface {
 	// L7 proxies.
 	RemoveNetworkPolicy(e *Endpoint)
 
-	// QueueEndpointBuild puts the given request in the processing queue
-	QueueEndpointBuild(*Request)
+	// QueueEndpointBuild puts the given endpoint in the processing queue
+	QueueEndpointBuild(epID uint64) func()
 
-	// RemoveFromEndpointQueue removes all requests from the working queue
+	// RemoveFromEndpointQueue removes an endpoint from the working queue
 	RemoveFromEndpointQueue(epID uint64)
 
 	// GetCompilationLock returns the mutex responsible for synchronizing compilation
@@ -57,18 +57,4 @@ type Owner interface {
 
 	// SendNotification is called to emit an agent notification
 	SendNotification(typ monitor.AgentNotification, text string) error
-}
-
-// Request is used to create the endpoint's request and send it to the endpoints
-// processor.
-type Request struct {
-	// ID request ID.
-	ID uint64
-	// MyTurn is used to know when is its turn.
-	MyTurn chan bool
-	// Done is used to tell the Processor the request as finished.
-	Done chan bool
-	// ExternalDone is used for external listeners this request as finished
-	// if returns true the build was successful, false otherwise.
-	ExternalDone chan bool
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -826,17 +826,12 @@ func (e *Endpoint) regenerate(owner Owner, context *RegenerationContext, reloadD
 // ReloadDatapath forces the datapath programs to be reloaded. It does
 // not guarantee recompilation of the programs.
 func (e *Endpoint) Regenerate(owner Owner, context *RegenerationContext, reloadDatapath bool) <-chan bool {
-	done := make(chan bool)
+	done := make(chan bool, 1)
 
 	go func() {
 		var buildSuccess bool
 		defer func() {
-			// The external listener can ignore the channel so we need to
-			// make sure we don't block
-			select {
-			case done <- buildSuccess:
-			default:
-			}
+			done <- buildSuccess
 			close(done)
 		}()
 

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -7,9 +7,8 @@
 package errgroup
 
 import (
+	"context"
 	"sync"
-
-	"golang.org/x/net/context"
 )
 
 // A Group is a collection of goroutines working on subtasks that are part of

--- a/vendor/golang.org/x/sync/semaphore/semaphore.go
+++ b/vendor/golang.org/x/sync/semaphore/semaphore.go
@@ -1,0 +1,127 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package semaphore provides a weighted semaphore implementation.
+package semaphore // import "golang.org/x/sync/semaphore"
+
+import (
+	"container/list"
+	"context"
+	"sync"
+)
+
+type waiter struct {
+	n     int64
+	ready chan<- struct{} // Closed when semaphore acquired.
+}
+
+// NewWeighted creates a new weighted semaphore with the given
+// maximum combined weight for concurrent access.
+func NewWeighted(n int64) *Weighted {
+	w := &Weighted{size: n}
+	return w
+}
+
+// Weighted provides a way to bound concurrent access to a resource.
+// The callers can request access with a given weight.
+type Weighted struct {
+	size    int64
+	cur     int64
+	mu      sync.Mutex
+	waiters list.List
+}
+
+// Acquire acquires the semaphore with a weight of n, blocking only until ctx
+// is done. On success, returns nil. On failure, returns ctx.Err() and leaves
+// the semaphore unchanged.
+//
+// If ctx is already done, Acquire may still succeed without blocking.
+func (s *Weighted) Acquire(ctx context.Context, n int64) error {
+	s.mu.Lock()
+	if s.size-s.cur >= n && s.waiters.Len() == 0 {
+		s.cur += n
+		s.mu.Unlock()
+		return nil
+	}
+
+	if n > s.size {
+		// Don't make other Acquire calls block on one that's doomed to fail.
+		s.mu.Unlock()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	ready := make(chan struct{})
+	w := waiter{n: n, ready: ready}
+	elem := s.waiters.PushBack(w)
+	s.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		err := ctx.Err()
+		s.mu.Lock()
+		select {
+		case <-ready:
+			// Acquired the semaphore after we were canceled.  Rather than trying to
+			// fix up the queue, just pretend we didn't notice the cancelation.
+			err = nil
+		default:
+			s.waiters.Remove(elem)
+		}
+		s.mu.Unlock()
+		return err
+
+	case <-ready:
+		return nil
+	}
+}
+
+// TryAcquire acquires the semaphore with a weight of n without blocking.
+// On success, returns true. On failure, returns false and leaves the semaphore unchanged.
+func (s *Weighted) TryAcquire(n int64) bool {
+	s.mu.Lock()
+	success := s.size-s.cur >= n && s.waiters.Len() == 0
+	if success {
+		s.cur += n
+	}
+	s.mu.Unlock()
+	return success
+}
+
+// Release releases the semaphore with a weight of n.
+func (s *Weighted) Release(n int64) {
+	s.mu.Lock()
+	s.cur -= n
+	if s.cur < 0 {
+		s.mu.Unlock()
+		panic("semaphore: bad release")
+	}
+	for {
+		next := s.waiters.Front()
+		if next == nil {
+			break // No more waiters blocked.
+		}
+
+		w := next.Value.(waiter)
+		if s.size-s.cur < w.n {
+			// Not enough tokens for the next waiter.  We could keep going (to try to
+			// find a waiter with a smaller request), but under load that could cause
+			// starvation for large requests; instead, we leave all remaining waiters
+			// blocked.
+			//
+			// Consider a semaphore used as a read-write lock, with N tokens, N
+			// readers, and one writer.  Each reader can Acquire(1) to obtain a read
+			// lock.  The writer can Acquire(N) to obtain a write lock, excluding all
+			// of the readers.  If we allow the readers to jump ahead in the queue,
+			// the writer will starve — there is always one token available for every
+			// reader.
+			break
+		}
+
+		s.cur += w.n
+		s.waiters.Remove(next)
+		close(w.ready)
+	}
+	s.mu.Unlock()
+}


### PR DESCRIPTION
Sidecar proxy ACKs can take a long time due to container
initialization. Allow other Endpoints to build while another Endpoint
is waiting for proxy completions.

Build queue is implemented with a semaphore to simplify the implementation. Queueing for the build new makes the calling go-routine wait when Acquiring the "build permission". A function for releasing the permission is returned if a permission is granted, nil otherwise. The permission is released after the endpoint bpf compilation and before waiting for the proxy completion so that endpoint builds are not blocked when other endpoints are waiting for proxy completions. This allows the overall build timeout to be increased so that endpoint builds need not fail because of slow container initialization.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6211)
<!-- Reviewable:end -->
