### PR TITLE
istio: Quit init container as soon as DNS connectivity works.

### DIFF
--- a/examples/kubernetes-istio/cilium-kube-inject.awk
+++ b/examples/kubernetes-istio/cilium-kube-inject.awk
@@ -16,9 +16,9 @@
 /initContainers:/ {
 	indent = $0 ; gsub(/[^ ].*/, "", indent)
 	print indent "- name: sleep"
-	print indent "  image: busybox"
+	print indent "  image: busybox:1.28.4"
 	print indent "  imagePullPolicy: IfNotPresent"
-	print indent "  command: ['sh', '-c', 'sleep 10']"
+	print indent "  command: ['sh', '-c', 'until nslookup kube-dns.kube-system.svc.cluster.local; do sleep 1; done']"
 }
 
 # Mount the Cilium state directory to give Cilium's Envoy filters access to the

--- a/test/k8sT/manifests/bookinfo-v1-istio.yaml
+++ b/test/k8sT/manifests/bookinfo-v1-istio.yaml
@@ -125,8 +125,8 @@ spec:
       - command:
         - sh
         - -c
-        - sleep 30
-        image: busybox
+        - "until nslookup kube-dns.kube-system.svc.cluster.local; do sleep 1; done"
+        image: busybox:1.28.4
         imagePullPolicy: IfNotPresent
         name: sleep
         resources: {}
@@ -280,8 +280,8 @@ spec:
       - command:
         - sh
         - -c
-        - sleep 30
-        image: busybox
+        - "until nslookup kube-dns.kube-system.svc.cluster.local; do sleep 1; done"
+        image: busybox:1.28.4
         imagePullPolicy: IfNotPresent
         name: sleep
         resources: {}
@@ -435,8 +435,8 @@ spec:
       - command:
         - sh
         - -c
-        - sleep 30
-        image: busybox
+        - "until nslookup kube-dns.kube-system.svc.cluster.local; do sleep 1; done"
+        image: busybox:1.28.4
         imagePullPolicy: IfNotPresent
         name: sleep
         resources: {}

--- a/test/k8sT/manifests/bookinfo-v2-istio.yaml
+++ b/test/k8sT/manifests/bookinfo-v2-istio.yaml
@@ -124,8 +124,8 @@ spec:
       - command:
         - sh
         - -c
-        - sleep 30
-        image: busybox
+        - "until nslookup kube-dns.kube-system.svc.cluster.local; do sleep 1; done"
+        image: busybox:1.28.4
         imagePullPolicy: IfNotPresent
         name: sleep
         resources: {}
@@ -262,8 +262,8 @@ spec:
       - command:
         - sh
         - -c
-        - sleep 30
-        image: busybox
+        - "until nslookup kube-dns.kube-system.svc.cluster.local; do sleep 1; done"
+        image: busybox:1.28.4
         imagePullPolicy: IfNotPresent
         name: sleep
         resources: {}

--- a/test/k8sT/manifests/istio-cilium.yaml
+++ b/test/k8sT/manifests/istio-cilium.yaml
@@ -590,9 +590,9 @@ data:
     template: |-
       initContainers:
       - name: sleep
-        image: busybox
+        image: busybox:1.28.4
         imagePullPolicy: IfNotPresent
-        command: ['sh', '-c', 'sleep 10']
+        command: ['sh', '-c', 'until nslookup kube-dns.kube-system.svc.cluster.local; do sleep 1; done']
       - name: istio-init
         image: "docker.io/istio/proxy_init:1.0.2"
         args:


### PR DESCRIPTION
Speeds up the already slow Istio container start times, as typically can skip the wait altogether.
Helps to make sure basic networking works before quitting the init container, as in the worst case the fixed 10 second wait may not be enough.

Must use busybox:1.28.4, as the latest has a regression that breaks "nslookup".

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6212)
<!-- Reviewable:end -->
