### PR TITLE
RFC: sockops: fix missing /usr/include/asm symlink

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -39,6 +39,7 @@ RUN apt-get update \
 		wget \
 		zip \
 		zlib1g-dev \
+		gcc-multilib \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
cilium fails to compile bpf_sockops.o because /usr/include/asm doesn't
exist on the docker image

error:
level=error msg="Failed to compile bpf_sockops.o: exit status 1" compiler-pid=228 linker-pid=229 subsys=datapath-loader
level=warning msg="In file included from /var/lib/cilium/bpf/sockops/bpf_sockops.c:29:" subsys=datapath-loader
level=warning msg="In file included from /usr/include/sys/socket.h:33:" subsys=datapath-loader
level=warning msg="/usr/include/bits/socket.h:390:10: fatal error: 'asm/socket.h' file not found" subsys=datapath-loader
level=warning msg="#include <asm/socket.h>" subsys=datapath-loader
level=warning msg="         ^" subsys=datapath-loader
level=warning msg="1 error generated." subsys=datapath-loader
level=error msg="failed compile sockops/bpf_sockops.c: Failed to compile bpf_sockops.o: exit status 1" subsys=sockops
level=error msg="Failed to compile bpf_redir.o: exit status 1" compiler-pid=231 linker-pid=232 subsys=datapath-loader
level=warning msg="In file included from /var/lib/cilium/bpf/sockops/bpf_redir.c:29:" subsys=datapath-loader
level=warning msg="In file included from /usr/include/sys/socket.h:33:" subsys=datapath-loader
level=warning msg="/usr/include/bits/socket.h:390:10: fatal error: 'asm/socket.h' file not found" subsys=datapath-loader
level=warning msg="#include <asm/socket.h>" subsys=datapath-loader
level=warning msg="         ^" subsys=datapath-loader
level=warning msg="1 error generated." subsys=datapath-loader
level=error msg="failed compile sockops/bpf_redir.c: Failed to compile bpf_redir.o: exit status 1" subsys=sockops

Signed-off-by: Nirmoy Das <ndas@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6213)
<!-- Reviewable:end -->
