### PR TITLE
Fix Kubernetes endpoints subsets behavior

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -957,7 +957,6 @@ func (d *Daemon) addK8sSVCs(svcID k8s.ServiceID, svc *k8s.Service, endpoints *k8
 			continue
 		}
 
-		k8sBEPort := endpoints.Ports[fePortName]
 		uniqPorts[fePort.Port] = false
 
 		if fePort.ID == 0 {
@@ -981,14 +980,12 @@ func (d *Daemon) addK8sSVCs(svcID k8s.ServiceID, svc *k8s.Service, endpoints *k8
 		}
 
 		besValues := []loadbalancer.LBBackEnd{}
-
-		if k8sBEPort != nil {
-			for epIP := range endpoints.BackendIPs {
-				bePort := loadbalancer.LBBackEnd{
-					L3n4Addr: loadbalancer.L3n4Addr{IP: net.ParseIP(epIP), L4Addr: *k8sBEPort},
+		for ip, portConfiguration := range endpoints.Backends {
+			if backendPort := portConfiguration[string(fePortName)]; backendPort != nil {
+				besValues = append(besValues, loadbalancer.LBBackEnd{
+					L3n4Addr: loadbalancer.L3n4Addr{IP: net.ParseIP(ip), L4Addr: *backendPort},
 					Weight:   0,
-				}
-				besValues = append(besValues, bePort)
+				})
 			}
 		}
 

--- a/pkg/k8s/endpoints_test.go
+++ b/pkg/k8s/endpoints_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/service"
 
 	"gopkg.in/check.v1"
 	"k8s.io/api/core/v1"
@@ -44,26 +45,24 @@ func TestEndpoints_DeepEqual(t *testing.T) {
 			name: "both equal",
 			fields: fields{
 				svcEP: &Endpoints{
-					BackendIPs: map[string]bool{
-						"172.20.0.1": true,
-					},
-					Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
-						loadbalancer.FEPortName("foo"): {
-							Protocol: loadbalancer.NONE,
-							Port:     1,
+					Backends: map[string]service.PortConfiguration{
+						"172.20.0.1": map[string]*loadbalancer.L4Addr{
+							"foo": {
+								Protocol: loadbalancer.NONE,
+								Port:     1,
+							},
 						},
 					},
 				},
 			},
 			args: args{
 				o: &Endpoints{
-					BackendIPs: map[string]bool{
-						"172.20.0.1": true,
-					},
-					Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
-						loadbalancer.FEPortName("foo"): {
-							Protocol: loadbalancer.NONE,
-							Port:     1,
+					Backends: map[string]service.PortConfiguration{
+						"172.20.0.1": map[string]*loadbalancer.L4Addr{
+							"foo": {
+								Protocol: loadbalancer.NONE,
+								Port:     1,
+							},
 						},
 					},
 				},
@@ -74,26 +73,24 @@ func TestEndpoints_DeepEqual(t *testing.T) {
 			name: "different BE IPs",
 			fields: fields{
 				svcEP: &Endpoints{
-					BackendIPs: map[string]bool{
-						"172.20.0.1": true,
-					},
-					Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
-						loadbalancer.FEPortName("foo"): {
-							Protocol: loadbalancer.NONE,
-							Port:     1,
+					Backends: map[string]service.PortConfiguration{
+						"172.20.0.1": map[string]*loadbalancer.L4Addr{
+							"foo": {
+								Protocol: loadbalancer.NONE,
+								Port:     1,
+							},
 						},
 					},
 				},
 			},
 			args: args{
 				o: &Endpoints{
-					BackendIPs: map[string]bool{
-						"172.20.0.2": true,
-					},
-					Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
-						loadbalancer.FEPortName("foo"): {
-							Protocol: loadbalancer.NONE,
-							Port:     1,
+					Backends: map[string]service.PortConfiguration{
+						"172.20.0.2": map[string]*loadbalancer.L4Addr{
+							"foo": {
+								Protocol: loadbalancer.NONE,
+								Port:     1,
+							},
 						},
 					},
 				},
@@ -104,26 +101,24 @@ func TestEndpoints_DeepEqual(t *testing.T) {
 			name: "ports different name",
 			fields: fields{
 				svcEP: &Endpoints{
-					BackendIPs: map[string]bool{
-						"172.20.0.1": true,
-					},
-					Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
-						loadbalancer.FEPortName("foo"): {
-							Protocol: loadbalancer.NONE,
-							Port:     1,
+					Backends: map[string]service.PortConfiguration{
+						"172.20.0.1": map[string]*loadbalancer.L4Addr{
+							"foo": {
+								Protocol: loadbalancer.NONE,
+								Port:     1,
+							},
 						},
 					},
 				},
 			},
 			args: args{
 				o: &Endpoints{
-					BackendIPs: map[string]bool{
-						"172.20.0.1": true,
-					},
-					Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
-						loadbalancer.FEPortName("foz"): {
-							Protocol: loadbalancer.NONE,
-							Port:     1,
+					Backends: map[string]service.PortConfiguration{
+						"172.20.0.1": map[string]*loadbalancer.L4Addr{
+							"foz": {
+								Protocol: loadbalancer.NONE,
+								Port:     1,
+							},
 						},
 					},
 				},
@@ -134,26 +129,24 @@ func TestEndpoints_DeepEqual(t *testing.T) {
 			name: "ports different content",
 			fields: fields{
 				svcEP: &Endpoints{
-					BackendIPs: map[string]bool{
-						"172.20.0.1": true,
-					},
-					Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
-						loadbalancer.FEPortName("foo"): {
-							Protocol: loadbalancer.NONE,
-							Port:     1,
+					Backends: map[string]service.PortConfiguration{
+						"172.20.0.1": map[string]*loadbalancer.L4Addr{
+							"foo": {
+								Protocol: loadbalancer.NONE,
+								Port:     1,
+							},
 						},
 					},
 				},
 			},
 			args: args{
 				o: &Endpoints{
-					BackendIPs: map[string]bool{
-						"172.20.0.1": true,
-					},
-					Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
-						loadbalancer.FEPortName("foo"): {
-							Protocol: loadbalancer.NONE,
-							Port:     2,
+					Backends: map[string]service.PortConfiguration{
+						"172.20.0.1": map[string]*loadbalancer.L4Addr{
+							"foo": {
+								Protocol: loadbalancer.NONE,
+								Port:     2,
+							},
 						},
 					},
 				},
@@ -164,24 +157,28 @@ func TestEndpoints_DeepEqual(t *testing.T) {
 			name: "ports different one is bigger",
 			fields: fields{
 				svcEP: &Endpoints{
-					Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
-						loadbalancer.FEPortName("foo"): {
-							Protocol: loadbalancer.NONE,
-							Port:     1,
+					Backends: map[string]service.PortConfiguration{
+						"172.20.0.1": map[string]*loadbalancer.L4Addr{
+							"foo": {
+								Protocol: loadbalancer.NONE,
+								Port:     1,
+							},
 						},
 					},
 				},
 			},
 			args: args{
 				o: &Endpoints{
-					Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
-						loadbalancer.FEPortName("foo"): {
-							Protocol: loadbalancer.NONE,
-							Port:     1,
-						},
-						loadbalancer.FEPortName("baz"): {
-							Protocol: loadbalancer.NONE,
-							Port:     2,
+					Backends: map[string]service.PortConfiguration{
+						"172.20.0.1": map[string]*loadbalancer.L4Addr{
+							"foo": {
+								Protocol: loadbalancer.NONE,
+								Port:     1,
+							},
+							"baz": {
+								Protocol: loadbalancer.NONE,
+								Port:     2,
+							},
 						},
 					},
 				},
@@ -193,10 +190,12 @@ func TestEndpoints_DeepEqual(t *testing.T) {
 			fields: fields{},
 			args: args{
 				o: &Endpoints{
-					Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
-						loadbalancer.FEPortName("foo"): {
-							Protocol: loadbalancer.NONE,
-							Port:     1,
+					Backends: map[string]service.PortConfiguration{
+						"172.20.0.1": map[string]*loadbalancer.L4Addr{
+							"foo": {
+								Protocol: loadbalancer.NONE,
+								Port:     1,
+							},
 						},
 					},
 				},
@@ -240,7 +239,7 @@ func (s *K8sSuite) Test_parseK8sEPv1(c *check.C) {
 				}
 			},
 			setupWanted: func() *Endpoints {
-				return NewEndpoints()
+				return newEndpoints()
 			},
 		},
 		{
@@ -272,9 +271,10 @@ func (s *K8sSuite) Test_parseK8sEPv1(c *check.C) {
 				}
 			},
 			setupWanted: func() *Endpoints {
-				svcEP := NewEndpoints()
-				svcEP.Ports["http-test-svc"] = loadbalancer.NewL4Addr(loadbalancer.TCP, 8080)
-				svcEP.BackendIPs["172.0.0.1"] = true
+				svcEP := newEndpoints()
+				svcEP.Backends["172.0.0.1"] = service.PortConfiguration{
+					"http-test-svc": loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+				}
 				return svcEP
 			},
 		},
@@ -312,10 +312,11 @@ func (s *K8sSuite) Test_parseK8sEPv1(c *check.C) {
 				}
 			},
 			setupWanted: func() *Endpoints {
-				svcEP := NewEndpoints()
-				svcEP.Ports["http-test-svc"] = loadbalancer.NewL4Addr(loadbalancer.TCP, 8080)
-				svcEP.Ports["http-test-svc-2"] = loadbalancer.NewL4Addr(loadbalancer.TCP, 8081)
-				svcEP.BackendIPs["172.0.0.1"] = true
+				svcEP := newEndpoints()
+				svcEP.Backends["172.0.0.1"] = service.PortConfiguration{
+					"http-test-svc":   loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+					"http-test-svc-2": loadbalancer.NewL4Addr(loadbalancer.TCP, 8081),
+				}
 				return svcEP
 			},
 		},
@@ -356,11 +357,15 @@ func (s *K8sSuite) Test_parseK8sEPv1(c *check.C) {
 				}
 			},
 			setupWanted: func() *Endpoints {
-				svcEP := NewEndpoints()
-				svcEP.Ports["http-test-svc"] = loadbalancer.NewL4Addr(loadbalancer.TCP, 8080)
-				svcEP.Ports["http-test-svc-2"] = loadbalancer.NewL4Addr(loadbalancer.TCP, 8081)
-				svcEP.BackendIPs["172.0.0.1"] = true
-				svcEP.BackendIPs["172.0.0.2"] = true
+				svcEP := newEndpoints()
+				svcEP.Backends["172.0.0.1"] = service.PortConfiguration{
+					"http-test-svc":   loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+					"http-test-svc-2": loadbalancer.NewL4Addr(loadbalancer.TCP, 8081),
+				}
+				svcEP.Backends["172.0.0.2"] = service.PortConfiguration{
+					"http-test-svc":   loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+					"http-test-svc-2": loadbalancer.NewL4Addr(loadbalancer.TCP, 8081),
+				}
 				return svcEP
 			},
 		},
@@ -406,11 +411,15 @@ func (s *K8sSuite) Test_parseK8sEPv1(c *check.C) {
 				}
 			},
 			setupWanted: func() *Endpoints {
-				svcEP := NewEndpoints()
-				svcEP.Ports["http-test-svc"] = loadbalancer.NewL4Addr(loadbalancer.TCP, 8080)
-				svcEP.Ports["http-test-svc-2"] = loadbalancer.NewL4Addr(loadbalancer.TCP, 8081)
-				svcEP.BackendIPs["172.0.0.1"] = true
-				svcEP.BackendIPs["172.0.0.2"] = true
+				svcEP := newEndpoints()
+				svcEP.Backends["172.0.0.1"] = service.PortConfiguration{
+					"http-test-svc":   loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+					"http-test-svc-2": loadbalancer.NewL4Addr(loadbalancer.TCP, 8081),
+				}
+				svcEP.Backends["172.0.0.2"] = service.PortConfiguration{
+					"http-test-svc":   loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
+					"http-test-svc-2": loadbalancer.NewL4Addr(loadbalancer.TCP, 8081),
+				}
 				return svcEP
 			},
 		},
@@ -456,5 +465,5 @@ func (s *K8sSuite) TestEndpointsString(c *check.C) {
 	}
 
 	_, ep := ParseEndpoints(endpoints)
-	c.Assert(ep.String(), check.Equals, "backends:172.0.0.1,172.0.0.2/ports:http-test-svc,http-test-svc-2")
+	c.Assert(ep.String(), check.Equals, "172.0.0.1:8080/TCP,172.0.0.1:8081/TCP,172.0.0.2:8080/TCP,172.0.0.2:8081/TCP")
 }

--- a/pkg/k8s/rule_translate.go
+++ b/pkg/k8s/rule_translate.go
@@ -133,7 +133,7 @@ func generateToCidrFromEndpoint(
 
 	// This will generate one-address CIDRs consisting of endpoint backend ip
 	mask := net.CIDRMask(128, 128)
-	for ip := range endpoint.BackendIPs {
+	for ip := range endpoint.Backends {
 		epIP := net.ParseIP(ip)
 		if epIP == nil {
 			return fmt.Errorf("Unable to parse ip: %s", ip)
@@ -177,7 +177,7 @@ func deleteToCidrFromEndpoint(
 	newToCIDR := make([]api.CIDRRule, 0, len(egress.ToCIDRSet))
 	deleted := make([]api.CIDRRule, 0, len(egress.ToCIDRSet))
 
-	for ip := range endpoint.BackendIPs {
+	for ip := range endpoint.Backends {
 		epIP := net.ParseIP(ip)
 		if epIP == nil {
 			return fmt.Errorf("Unable to parse ip: %s", ip)

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/service"
 
 	. "gopkg.in/check.v1"
 )
@@ -37,13 +38,12 @@ func (s *K8sSuite) TestTranslatorDirect(c *C) {
 	epIP := "10.1.1.1"
 
 	endpointInfo := Endpoints{
-		BackendIPs: map[string]bool{
-			epIP: true,
-		},
-		Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
-			"port": {
-				Protocol: loadbalancer.TCP,
-				Port:     80,
+		Backends: map[string]service.PortConfiguration{
+			epIP: map[string]*loadbalancer.L4Addr{
+				"port": {
+					Protocol: loadbalancer.TCP,
+					Port:     80,
+				},
 			},
 		},
 	}
@@ -101,13 +101,12 @@ func (s *K8sSuite) TestServiceMatches(c *C) {
 
 	epIP := "10.1.1.1"
 	endpointInfo := Endpoints{
-		BackendIPs: map[string]bool{
-			epIP: true,
-		},
-		Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
-			"port": {
-				Protocol: loadbalancer.TCP,
-				Port:     80,
+		Backends: map[string]service.PortConfiguration{
+			epIP: map[string]*loadbalancer.L4Addr{
+				"port": {
+					Protocol: loadbalancer.TCP,
+					Port:     80,
+				},
 			},
 		},
 	}
@@ -139,13 +138,12 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 	epIP := "10.1.1.1"
 
 	endpointInfo := Endpoints{
-		BackendIPs: map[string]bool{
-			epIP: true,
-		},
-		Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
-			"port": {
-				Protocol: loadbalancer.TCP,
-				Port:     80,
+		Backends: map[string]service.PortConfiguration{
+			epIP: map[string]*loadbalancer.L4Addr{
+				"port": {
+					Protocol: loadbalancer.TCP,
+					Port:     80,
+				},
 			},
 		},
 	}
@@ -196,13 +194,12 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 	epIP := "10.1.1.1"
 
 	endpointInfo := Endpoints{
-		BackendIPs: map[string]bool{
-			epIP: true,
-		},
-		Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
-			"port": {
-				Protocol: loadbalancer.TCP,
-				Port:     80,
+		Backends: map[string]service.PortConfiguration{
+			epIP: map[string]*loadbalancer.L4Addr{
+				"port": {
+					Protocol: loadbalancer.TCP,
+					Port:     80,
+				},
 			},
 		},
 	}
@@ -237,13 +234,12 @@ func (s *K8sSuite) TestPreprocessRules(c *C) {
 	cache := NewServiceCache()
 
 	endpointInfo := Endpoints{
-		BackendIPs: map[string]bool{
-			epIP: true,
-		},
-		Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
-			"port": {
-				Protocol: loadbalancer.TCP,
-				Port:     80,
+		Backends: map[string]service.PortConfiguration{
+			epIP: map[string]*loadbalancer.L4Addr{
+				"port": {
+					Protocol: loadbalancer.TCP,
+					Port:     80,
+				},
 			},
 		},
 	}
@@ -295,13 +291,12 @@ func (s *K8sSuite) TestDontDeleteUserRules(c *C) {
 	epIP := "10.1.1.1"
 
 	endpointInfo := Endpoints{
-		BackendIPs: map[string]bool{
-			epIP: true,
-		},
-		Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
-			"port": {
-				Protocol: loadbalancer.TCP,
-				Port:     80,
+		Backends: map[string]service.PortConfiguration{
+			epIP: map[string]*loadbalancer.L4Addr{
+				"port": {
+					Protocol: loadbalancer.TCP,
+					Port:     80,
+				},
 			},
 		},
 	}

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -70,18 +70,8 @@ type ServiceEvent struct {
 	// Service is the service structure
 	Service *Service
 
-	// K8sService is the corresponding Kubernetes service resource that
-	// triggered the action or nil if the action was not triggered by a
-	// Kubernetes service update
-	K8sService *v1.Service
-
 	// Endpoints is the endpoints structured correlated with the service
 	Endpoints *Endpoints
-
-	// K8sEndpoints is the corresponding Kubernetes endpoints resource that
-	// triggered the action or nil if the action was not triggered by a
-	// Kubernetes endpoints update
-	K8sEndpoints *v1.Endpoints
 }
 
 // ServiceCache is a list of services and ingresses correlated with the
@@ -131,11 +121,10 @@ func (s *ServiceCache) UpdateService(k8sSvc *v1.Service) ServiceID {
 	endpoints, ok := s.endpoints[svcID]
 	if ok {
 		s.Events <- ServiceEvent{
-			Action:     UpdateService,
-			ID:         svcID,
-			Service:    newService,
-			K8sService: k8sSvc,
-			Endpoints:  endpoints,
+			Action:    UpdateService,
+			ID:        svcID,
+			Service:   newService,
+			Endpoints: endpoints,
 		}
 	}
 
@@ -155,11 +144,10 @@ func (s *ServiceCache) DeleteService(k8sSvc *v1.Service) {
 
 	if serviceOK && endpointsOK {
 		s.Events <- ServiceEvent{
-			Action:     DeleteService,
-			ID:         svcID,
-			Service:    oldService,
-			K8sService: k8sSvc,
-			Endpoints:  endpoints,
+			Action:    DeleteService,
+			ID:        svcID,
+			Service:   oldService,
+			Endpoints: endpoints,
 		}
 	}
 }
@@ -212,11 +200,10 @@ func (s *ServiceCache) UpdateEndpoints(k8sEndpoints *v1.Endpoints) (ServiceID, *
 	service, ok := s.services[svcID]
 	if ok {
 		s.Events <- ServiceEvent{
-			Action:       UpdateService,
-			ID:           svcID,
-			Service:      service,
-			Endpoints:    newEndpoints,
-			K8sEndpoints: k8sEndpoints,
+			Action:    UpdateService,
+			ID:        svcID,
+			Service:   service,
+			Endpoints: newEndpoints,
 		}
 	}
 

--- a/pkg/k8s/service_cache_test.go
+++ b/pkg/k8s/service_cache_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/service"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/versioned"
 
@@ -37,13 +38,12 @@ func (s *K8sSuite) TestGetUniqueServiceFrontends(c *check.C) {
 	svcID2 := ServiceID{Name: "svc2", Namespace: "default"}
 
 	endpoints := Endpoints{
-		BackendIPs: map[string]bool{
-			"3.3.3.3": true,
-		},
-		Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
-			"port": {
-				Protocol: loadbalancer.TCP,
-				Port:     80,
+		Backends: map[string]service.PortConfiguration{
+			"3.3.3.3": map[string]*loadbalancer.L4Addr{
+				"port": {
+					Protocol: loadbalancer.TCP,
+					Port:     80,
+				},
 			},
 		},
 	}

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -491,15 +491,17 @@ func (s *K8sSuite) TestNewClusterService(c *check.C) {
 
 	clusterService := NewClusterService(id, svc, endpoints)
 	c.Assert(clusterService, check.DeepEquals, service.ClusterService{
-		Name:          "foo",
-		Namespace:     "bar",
-		Labels:        map[string]string{"foo": "bar"},
-		Selector:      map[string]string{"foo": "bar"},
-		FrontendIP:    "127.0.0.1",
-		FrontendPorts: map[string]loadbalancer.L4Addr{},
-		BackendIPs:    []string{"2.2.2.2"},
-		BackendPorts: map[string]loadbalancer.L4Addr{
-			"http-test-svc": {Protocol: loadbalancer.TCP, Port: 8080},
+		Name:      "foo",
+		Namespace: "bar",
+		Labels:    map[string]string{"foo": "bar"},
+		Selector:  map[string]string{"foo": "bar"},
+		Frontends: map[string]service.PortConfiguration{
+			"127.0.0.1": {},
+		},
+		Backends: map[string]service.PortConfiguration{
+			"2.2.2.2": {
+				"http-test-svc": {Protocol: loadbalancer.TCP, Port: 8080},
+			},
 		},
 	})
 }

--- a/pkg/service/store_test.go
+++ b/pkg/service/store_test.go
@@ -17,6 +17,8 @@
 package service
 
 import (
+	"github.com/cilium/cilium/pkg/loadbalancer"
+
 	"gopkg.in/check.v1"
 )
 
@@ -42,4 +44,66 @@ func (s *ServiceGenericSuite) TestClusterService(c *check.C) {
 	c.Assert(svc, check.DeepEquals, unmarshal)
 
 	c.Assert(svc.GetKeyName(), check.Equals, "default/bar/foo")
+}
+
+func (s *ServiceGenericSuite) TestPortConfigurationDeepEqual(c *check.C) {
+	tests := []struct {
+		a    PortConfiguration
+		b    PortConfiguration
+		want bool
+	}{
+
+		{
+			a: PortConfiguration{
+				"foo": {Protocol: loadbalancer.NONE, Port: 1},
+			},
+			b: PortConfiguration{
+				"foo": {Protocol: loadbalancer.NONE, Port: 1},
+			},
+			want: true,
+		},
+		{
+			a: PortConfiguration{
+				"foo": {Protocol: loadbalancer.NONE, Port: 1},
+			},
+			b: PortConfiguration{
+				"foz": {Protocol: loadbalancer.NONE, Port: 1},
+			},
+			want: false,
+		},
+		{
+			a: PortConfiguration{
+				"foo": {Protocol: loadbalancer.NONE, Port: 1},
+			},
+			b: PortConfiguration{
+				"foo": {Protocol: loadbalancer.NONE, Port: 2},
+			},
+			want: false,
+		},
+		{
+			a: PortConfiguration{
+				"foo": {Protocol: loadbalancer.NONE, Port: 1},
+			},
+			b: PortConfiguration{
+				"foo": {Protocol: loadbalancer.NONE, Port: 1},
+				"baz": {Protocol: loadbalancer.NONE, Port: 2},
+			},
+			want: false,
+		},
+		{
+			a: PortConfiguration{},
+			b: PortConfiguration{
+				"foo": {Protocol: loadbalancer.NONE, Port: 1},
+			},
+			want: false,
+		},
+		{
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		if got := tt.a.DeepEquals(tt.b); got != tt.want {
+			c.Errorf("PortConfiguration.DeepEqual() = %v, want %v", got, tt.want)
+		}
+	}
 }


### PR DESCRIPTION
The Kubernetes Endpoints resource is split into a list of subsets, each consists of a list of addresses and a list of ports. So far, all subsets have been merged together, creating the cross product over addresses and ports of all subsets. This is incorrect. Each subset must have its cross product created before being merged together to a list of backends.

This is a dependency for clustermesh service discovery

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6225)
<!-- Reviewable:end -->
