### PR TITLE
ClusterMesh service discovery

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1019,6 +1019,7 @@ func NewDaemon() (*Daemon, *endpointRestoreState, error) {
 				Name:            "clustermesh",
 				ConfigDirectory: path,
 				NodeKeyCreator:  nodeStore.KeyCreator,
+				ServiceMerger:   &d.k8sSvcCache,
 			})
 			if err != nil {
 				log.WithError(err).Fatal("Unable to initialize ClusterMesh")

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -108,8 +108,6 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	kvstore.DeletePrefix(common.OperationalPath)
 	kvstore.DeletePrefix(kvstore.BaseKeyPrefix)
 
-	cache.InitIdentityAllocator(d)
-
 	ds.OnTracingEnabled = nil
 	ds.OnAlwaysAllowLocalhost = nil
 	ds.OnGetCachedLabelList = nil
@@ -140,6 +138,10 @@ func (ds *DaemonSuite) TearDownTest(c *C) {
 
 	// Restore the policy enforcement mode.
 	policy.SetPolicyEnabled(ds.oldPolicyEnabled)
+
+	// Release the identity allocator reference created by NewDaemon. This
+	// is done manually here as we have no Close() function daemon
+	cache.Close()
 }
 
 type DaemonEtcdSuite struct {

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -15,26 +15,33 @@
 package annotation
 
 const (
+	// Prefix is the common prefix for all annotations
+	Prefix = "io.cilium"
+
 	// Name is an optional annotation to the NetworkPolicy
 	// resource which specifies the name of the policy node to which all
 	// rules should be applied to.
-	Name = "io.cilium.name"
+	Name = Prefix + ".name"
 
 	// V4CIDRName is the annotation name used to store the IPv4
 	// pod CIDR in the node's annotations.
-	V4CIDRName = "io.cilium.network.ipv4-pod-cidr"
+	V4CIDRName = Prefix + ".network.ipv4-pod-cidr"
 	// V6CIDRName is the annotation name used to store the IPv6
 	// pod CIDR in the node's annotations.
-	V6CIDRName = "io.cilium.network.ipv6-pod-cidr"
+	V6CIDRName = Prefix + ".network.ipv6-pod-cidr"
 
 	// V4HealthName is the annotation name used to store the IPv4
 	// address of the cilium-health endpoint in the node's annotations.
-	V4HealthName = "io.cilium.network.ipv4-health-ip"
+	V4HealthName = Prefix + ".network.ipv4-health-ip"
 	// V6HealthName is the annotation name used to store the IPv6
 	// address of the cilium-health endpoint in the node's annotations.
-	V6HealthName = "io.cilium.network.ipv6-health-ip"
+	V6HealthName = Prefix + ".network.ipv6-health-ip"
 
 	// CiliumHostIP is the annotation name used to store the IPv4 address
 	// of the cilium host interface in the node's annotations.
-	CiliumHostIP = "io.cilium.network.ipv4-cilium-host"
+	CiliumHostIP = Prefix + ".network.ipv4-cilium-host"
+
+	// GlobalService if set to true, marks a service to become a global
+	// service
+	GlobalService = Prefix + "/global-service"
 )

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -44,4 +44,11 @@ const (
 	// GlobalService if set to true, marks a service to become a global
 	// service
 	GlobalService = Prefix + "/global-service"
+
+	// SharedService if set to false, prevents a service from being shared,
+	// the default is true if GlobalService is set, otherwise false,
+	// Setting the annotation SharedService to false while setting
+	// GlobalService to true allows to expose remote endpoints without
+	// sharing local endpoints.
+	SharedService = Prefix + "shared-service"
 )

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
+	nodeStore "github.com/cilium/cilium/pkg/node/store"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -44,7 +45,20 @@ type Configuration struct {
 	// nodes are being discovered in remote clusters
 	NodeKeyCreator store.KeyCreator
 
-	observer store.Observer
+	// ServiceMerger is the interface responsible to merge service and
+	// endpoints into an existing cache
+	ServiceMerger ServiceMerger
+
+	nodeObserver store.Observer
+}
+
+// NodeObserver returns the node store observer of the configuration
+func (c *Configuration) NodeObserver() store.Observer {
+	if c.nodeObserver != nil {
+		return c.nodeObserver
+	}
+
+	return &nodeStore.NodeObserver{}
 }
 
 // ClusterMesh is a cache of multiple remote clusters
@@ -56,15 +70,20 @@ type ClusterMesh struct {
 	clusters      map[string]*remoteCluster
 	controllers   *controller.Manager
 	configWatcher *configDirectoryWatcher
+
+	// globalServices is a list of all global services. The datastructure
+	// is protected by its own mutex inside of the structure.
+	globalServices *globalServiceCache
 }
 
 // NewClusterMesh creates a new remote cluster cache based on the
 // provided configuration
 func NewClusterMesh(c Configuration) (*ClusterMesh, error) {
 	cm := &ClusterMesh{
-		conf:        c,
-		clusters:    map[string]*remoteCluster{},
-		controllers: controller.NewManager(),
+		conf:           c,
+		clusters:       map[string]*remoteCluster{},
+		controllers:    controller.NewManager(),
+		globalServices: newGlobalServiceCache(),
 	}
 
 	w, err := createConfigDirectoryWatcher(c.ConfigDirectory, cm)
@@ -140,6 +159,8 @@ func (cm *ClusterMesh) remove(name string) {
 	if cluster, ok := cm.clusters[name]; ok {
 		cluster.onRemove()
 		delete(cm.clusters, name)
+
+		cm.globalServices.onClusterDelete(name)
 	}
 	cm.mutex.Unlock()
 

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -128,7 +128,7 @@ func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 		Name:            "test2",
 		ConfigDirectory: dir,
 		NodeKeyCreator:  testNodeCreator,
-		observer:        &testObserver{},
+		nodeObserver:    &testObserver{},
 	})
 	c.Assert(err, IsNil)
 	c.Assert(cm, Not(IsNil))

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -108,6 +108,7 @@ func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 	logging.DefaultLogger.SetLevel(logrus.DebugLevel)
 
 	cache.InitIdentityAllocator(&identityAllocatorOwnerMock{})
+	defer cache.Close()
 
 	dir, err := ioutil.TempDir("", "multicluster")
 	c.Assert(err, IsNil)

--- a/pkg/clustermesh/config_test.go
+++ b/pkg/clustermesh/config_test.go
@@ -55,6 +55,9 @@ func expectNotExist(c *C, cm *ClusterMesh, name string) {
 
 func (s *ClusterMeshTestSuite) TestWatchConfigDirectory(c *C) {
 	skipKvstoreConnection = true
+	defer func() {
+		skipKvstoreConnection = false
+	}()
 
 	dir, err := ioutil.TempDir("", "multicluster")
 	c.Assert(err, IsNil)

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
 	nodeStore "github.com/cilium/cilium/pkg/node/store"
+	"github.com/cilium/cilium/pkg/service"
 
 	"github.com/sirupsen/logrus"
 )
@@ -63,6 +64,10 @@ type remoteCluster struct {
 
 	// store is the shared store representing all nodes in the remote cluster
 	remoteNodes *store.SharedStore
+
+	// remoteServices is the shared store representing services in remote
+	// clusters
+	remoteServices *store.SharedStore
 
 	// ipCacheWatcher is the watcher that notifies about IP<->identity
 	// changes in the remote cluster
@@ -111,19 +116,32 @@ func (rc *remoteCluster) restartRemoteConnection() {
 					return err
 				}
 
-				observer := rc.mesh.conf.observer
-				if observer == nil {
-					observer = &nodeStore.NodeObserver{}
-				}
-
 				remoteNodes, err := store.JoinSharedStore(store.Configuration{
 					Prefix:                  path.Join(nodeStore.NodeStorePrefix, rc.name),
 					KeyCreator:              rc.mesh.conf.NodeKeyCreator,
 					SynchronizationInterval: time.Minute,
 					Backend:                 backend,
-					Observer:                observer,
+					Observer:                rc.mesh.conf.NodeObserver(),
 				})
 				if err != nil {
+					backend.Close()
+					return err
+				}
+
+				remoteServices, err := store.JoinSharedStore(store.Configuration{
+					Prefix: path.Join(service.ServiceStorePrefix, rc.name),
+					KeyCreator: func() store.Key {
+						svc := service.ClusterService{}
+						return &svc
+					},
+					SynchronizationInterval: time.Minute,
+					Backend:                 backend,
+					Observer: &remoteServiceObserver{
+						remoteCluster: rc,
+					},
+				})
+				if err != nil {
+					remoteNodes.Close()
 					backend.Close()
 					return err
 				}
@@ -135,6 +153,7 @@ func (rc *remoteCluster) restartRemoteConnection() {
 
 				rc.mutex.Lock()
 				rc.remoteNodes = remoteNodes
+				rc.remoteServices = remoteServices
 				rc.backend = backend
 				rc.ipCacheWatcher = ipCacheWatcher
 				rc.remoteIdentityCache = remoteIdentityCache
@@ -153,11 +172,14 @@ func (rc *remoteCluster) restartRemoteConnection() {
 				if rc.remoteNodes != nil {
 					rc.remoteNodes.Close()
 				}
-				if rc.backend != nil {
-					rc.backend.Close()
-				}
 				if rc.remoteIdentityCache != nil {
 					rc.remoteIdentityCache.Close()
+				}
+				if rc.remoteServices != nil {
+					rc.remoteServices.Close()
+				}
+				if rc.backend != nil {
+					rc.backend.Close()
 				}
 				rc.mutex.Unlock()
 

--- a/pkg/clustermesh/services.go
+++ b/pkg/clustermesh/services.go
@@ -1,0 +1,127 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clustermesh
+
+import (
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/service"
+)
+
+// ServiceMerger is the interface to be implemented by the owner of local
+// services. The functions have to merge service updates and deletions with
+// local services to provide a shared view.
+type ServiceMerger interface {
+	MergeExternalServiceUpdate(service *service.ClusterService)
+	MergeExternalServiceDelete(service *service.ClusterService)
+}
+
+type globalService struct {
+	clusterServices map[string]*service.ClusterService
+}
+
+func newGlobalService() *globalService {
+	return &globalService{
+		clusterServices: map[string]*service.ClusterService{},
+	}
+}
+
+type globalServiceCache struct {
+	mutex  lock.RWMutex
+	byName map[string]*globalService
+}
+
+func newGlobalServiceCache() *globalServiceCache {
+	return &globalServiceCache{
+		byName: map[string]*globalService{},
+	}
+}
+
+func (c *globalServiceCache) onUpdate(svc *service.ClusterService) {
+	c.mutex.Lock()
+
+	// Validate that the global service is known
+	globalSvc, ok := c.byName[svc.NamespaceServiceName()]
+	if !ok {
+		globalSvc = newGlobalService()
+		c.byName[svc.NamespaceServiceName()] = globalSvc
+	}
+
+	globalSvc.clusterServices[svc.Cluster] = svc
+	c.mutex.Unlock()
+}
+
+// must be called with c.mutex held
+func (c *globalServiceCache) delete(globalService *globalService, clusterName, serviceName string) {
+	if _, ok := globalService.clusterServices[clusterName]; !ok {
+		return
+	}
+
+	delete(globalService.clusterServices, clusterName)
+
+	// After the last cluster service is removed, remove the
+	// global service
+	if len(globalService.clusterServices) == 0 {
+		delete(c.byName, serviceName)
+	}
+}
+
+func (c *globalServiceCache) onDelete(svc *service.ClusterService) {
+	c.mutex.Lock()
+	if globalService, ok := c.byName[svc.NamespaceServiceName()]; ok {
+		c.delete(globalService, svc.NamespaceServiceName(), svc.Cluster)
+	}
+	c.mutex.Unlock()
+}
+
+func (c *globalServiceCache) onClusterDelete(clusterName string) {
+	c.mutex.Lock()
+	for serviceName, globalService := range c.byName {
+		c.delete(globalService, serviceName, clusterName)
+	}
+	c.mutex.Unlock()
+}
+
+type remoteServiceObserver struct {
+	remoteCluster *remoteCluster
+}
+
+// OnUpdate is called when a service in a remote cluster is updated
+func (r *remoteServiceObserver) OnUpdate(key store.Key) {
+	if svc, ok := key.(*service.ClusterService); ok {
+		mesh := r.remoteCluster.mesh
+		mesh.globalServices.onUpdate(svc)
+
+		if merger := mesh.conf.ServiceMerger; merger != nil {
+			merger.MergeExternalServiceUpdate(svc)
+		}
+	} else {
+		log.Warningf("Received unexpected remote service update object %+v", key)
+	}
+}
+
+// OnDelete is called when a service in a remote cluster is deleted
+func (r *remoteServiceObserver) OnDelete(key store.Key) {
+	if svc, ok := key.(*service.ClusterService); ok {
+		mesh := r.remoteCluster.mesh
+		mesh.globalServices.onDelete(svc)
+
+		if merger := mesh.conf.ServiceMerger; merger != nil {
+			merger.MergeExternalServiceDelete(svc)
+		}
+	} else {
+		log.Warningf("Received unexpected remote service delete object %+v", key)
+	}
+}

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -1,0 +1,261 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package clustermesh
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"time"
+
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/testutils"
+
+	"github.com/sirupsen/logrus"
+	. "gopkg.in/check.v1"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var etcdConfig = []byte(fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddress()))
+
+func (s *ClusterMeshServicesTestSuite) prepareServiceUpdate(clusterSuffix, backendIP, portName, port string) (string, []byte) {
+	return "cilium/state/services/v1/" + s.randomName + clusterSuffix + "/default/foo",
+		[]byte(`{"cluster":"` + s.randomName + clusterSuffix + `","namespace":"default","name":"foo","frontends":{"172.20.0.177":{"port":{"protocol":"TCP","port":80}}},"backends":{"` + backendIP + `":{"` + portName + `":{"protocol":"TCP","port":` + port + `}}},"labels":{},"selector":{"name":"foo"}}`)
+
+}
+
+type ClusterMeshServicesTestSuite struct {
+	svcCache   k8s.ServiceCache
+	testDir    string
+	mesh       *ClusterMesh
+	randomName string
+}
+
+var (
+	_ = Suite(&ClusterMeshServicesTestSuite{})
+)
+
+func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
+	kvstore.SetupDummy("etcd")
+
+	s.randomName = testutils.RandomRune()
+
+	kvstore.DeletePrefix("cilium/state/services/v1/" + s.randomName)
+	s.svcCache = k8s.NewServiceCache()
+	logging.DefaultLogger.SetLevel(logrus.DebugLevel)
+	cache.InitIdentityAllocator(&identityAllocatorOwnerMock{})
+	dir, err := ioutil.TempDir("", "multicluster")
+	s.testDir = dir
+	c.Assert(err, IsNil)
+
+	config1 := path.Join(dir, s.randomName+"1")
+	err = ioutil.WriteFile(config1, etcdConfig, 0644)
+	c.Assert(err, IsNil)
+
+	config2 := path.Join(dir, s.randomName+"2")
+	err = ioutil.WriteFile(config2, etcdConfig, 0644)
+	c.Assert(err, IsNil)
+
+	cm, err := NewClusterMesh(Configuration{
+		Name:            "test2",
+		ConfigDirectory: dir,
+		NodeKeyCreator:  testNodeCreator,
+		nodeObserver:    &testObserver{},
+		ServiceMerger:   &s.svcCache,
+	})
+	c.Assert(err, IsNil)
+	c.Assert(cm, Not(IsNil))
+
+	s.mesh = cm
+
+	// wait for both clusters to appear in the list of cm clusters
+	c.Assert(testutils.WaitUntil(func() bool {
+		return cm.NumReadyClusters() == 2
+	}, 10*time.Second), IsNil)
+}
+
+func (s *ClusterMeshServicesTestSuite) TearDownTest(c *C) {
+	if s.mesh != nil {
+		s.mesh.Close()
+	}
+
+	cache.Close()
+
+	os.RemoveAll(s.testDir)
+	kvstore.DeletePrefix("cilium/state/services/v1/" + s.randomName)
+	kvstore.Close()
+}
+
+func (s *ClusterMeshServicesTestSuite) expectEvent(c *C, action k8s.CacheAction, id k8s.ServiceID, fn func(event k8s.ServiceEvent) bool) {
+	c.Assert(testutils.WaitUntil(func() bool {
+		var event k8s.ServiceEvent
+		select {
+		case event = <-s.svcCache.Events:
+		case <-time.After(time.Second * 10):
+			c.Errorf("Timeout while waiting for event to be received")
+			return false
+		}
+
+		c.Assert(event.Action, Equals, action)
+		c.Assert(event.ID, Equals, id)
+
+		if fn != nil {
+			return fn(event)
+		}
+
+		return true
+	}, 2*time.Second), IsNil)
+}
+
+func (s *ClusterMeshServicesTestSuite) TestClusterMeshServicesGlobal(c *C) {
+	kvstore.Set(s.prepareServiceUpdate("1", "10.0.185.196", "http", "80"))
+	kvstore.Set(s.prepareServiceUpdate("2", "20.0.185.196", "http2", "90"))
+
+	k8sSvc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"io.cilium/global-service": "true",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: "127.0.0.1",
+			Type:      v1.ServiceTypeClusterIP,
+		},
+	}
+
+	svcID := s.svcCache.UpdateService(k8sSvc)
+
+	s.expectEvent(c, k8s.UpdateService, svcID, func(event k8s.ServiceEvent) bool {
+		return event.Endpoints.Backends["10.0.185.196"] != nil &&
+			event.Endpoints.Backends["20.0.185.196"] != nil
+	})
+
+	k8sEndpoints := &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Subsets: []v1.EndpointSubset{
+			{
+				Addresses: []v1.EndpointAddress{{IP: "30.0.185.196"}},
+				Ports: []v1.EndpointPort{
+					{
+						Name:     "http",
+						Port:     100,
+						Protocol: v1.ProtocolTCP,
+					},
+				},
+			},
+		},
+	}
+
+	s.svcCache.UpdateEndpoints(k8sEndpoints)
+	s.expectEvent(c, k8s.UpdateService, svcID, func(event k8s.ServiceEvent) bool {
+		return event.Endpoints.Backends["30.0.185.196"] != nil
+	})
+
+	s.svcCache.DeleteEndpoints(k8sEndpoints)
+	s.expectEvent(c, k8s.UpdateService, svcID, func(event k8s.ServiceEvent) bool {
+		return event.Endpoints.Backends["30.0.185.196"] == nil
+	})
+
+	kvstore.DeletePrefix("cilium/state/services/v1/" + s.randomName + "1")
+	s.expectEvent(c, k8s.UpdateService, svcID, nil)
+
+	kvstore.DeletePrefix("cilium/state/services/v1/" + s.randomName + "2")
+	s.expectEvent(c, k8s.DeleteService, svcID, nil)
+}
+
+func (s *ClusterMeshServicesTestSuite) TestClusterMeshServicesUpdate(c *C) {
+	kvstore.Set(s.prepareServiceUpdate("1", "10.0.185.196", "http", "80"))
+	kvstore.Set(s.prepareServiceUpdate("2", "20.0.185.196", "http2", "90"))
+
+	k8sSvc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"io.cilium/global-service": "true",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: "127.0.0.1",
+			Type:      v1.ServiceTypeClusterIP,
+		},
+	}
+
+	svcID := s.svcCache.UpdateService(k8sSvc)
+
+	s.expectEvent(c, k8s.UpdateService, svcID, func(event k8s.ServiceEvent) bool {
+		return event.Endpoints.Backends["10.0.185.196"]["http"].Equals(
+			loadbalancer.NewL4Addr(loadbalancer.TCP, 80)) &&
+			event.Endpoints.Backends["20.0.185.196"]["http2"].Equals(
+				loadbalancer.NewL4Addr(loadbalancer.TCP, 90))
+	})
+
+	kvstore.Set(s.prepareServiceUpdate("1", "80.0.185.196", "http", "8080"))
+	s.expectEvent(c, k8s.UpdateService, svcID, func(event k8s.ServiceEvent) bool {
+		return event.Endpoints.Backends["80.0.185.196"] != nil &&
+			event.Endpoints.Backends["20.0.185.196"] != nil
+	})
+
+	kvstore.Set(s.prepareServiceUpdate("2", "90.0.185.196", "http", "8080"))
+	s.expectEvent(c, k8s.UpdateService, svcID, func(event k8s.ServiceEvent) bool {
+		return event.Endpoints.Backends["80.0.185.196"] != nil &&
+			event.Endpoints.Backends["90.0.185.196"] != nil
+	})
+
+	kvstore.DeletePrefix("cilium/state/services/v1/" + s.randomName + "1")
+	s.expectEvent(c, k8s.UpdateService, svcID, nil)
+
+	kvstore.DeletePrefix("cilium/state/services/v1/" + s.randomName + "2")
+	s.expectEvent(c, k8s.DeleteService, svcID, nil)
+}
+
+func (s *ClusterMeshServicesTestSuite) TestClusterMeshServicesNonGlobal(c *C) {
+	kvstore.Set(s.prepareServiceUpdate("1", "10.0.185.196", "http", "80"))
+	kvstore.Set(s.prepareServiceUpdate("2", "20.0.185.196", "http2", "90"))
+
+	k8sSvc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+			// shared annotation is NOT set
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: "127.0.0.1",
+			Type:      v1.ServiceTypeClusterIP,
+		},
+	}
+
+	s.svcCache.UpdateService(k8sSvc)
+
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case event := <-s.svcCache.Events:
+		c.Errorf("Unexpected service event received: %+v", event)
+	default:
+	}
+}

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -111,6 +111,7 @@ func (d dummyOwner) GetNodeSuffix() string {
 
 func (ias *IdentityAllocatorSuite) TestGetIdentityCache(c *C) {
 	InitIdentityAllocator(dummyOwner{})
+	defer Close()
 	defer IdentityAllocator.DeleteAllKeys()
 
 	cache := GetIdentityCache()
@@ -124,6 +125,7 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 	lbls3 := labels.NewLabelsFromSortedList("id=bar;user=susan")
 
 	InitIdentityAllocator(dummyOwner{})
+	defer Close()
 	defer IdentityAllocator.DeleteAllKeys()
 
 	id1a, isNew, err := AllocateIdentity(lbls1)

--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -42,6 +42,10 @@ type Endpoints struct {
 // String returns the string representation of an endpoints resource, with
 // backends and ports sorted.
 func (e *Endpoints) String() string {
+	if e == nil {
+		return ""
+	}
+
 	backends := []string{}
 	for ip, ports := range e.Backends {
 		for _, port := range ports {
@@ -133,4 +137,17 @@ func ParseEndpoints(ep *v1.Endpoints) (ServiceID, *Endpoints) {
 	}
 
 	return ParseEndpointsID(ep), endpoints
+}
+
+// externalEndpoints is the collection of external endpoints in all remote
+// clusters. The map key is the name of the remote cluster.
+type externalEndpoints struct {
+	endpoints map[string]*Endpoints
+}
+
+// newExternalEndpoints returns a new ExternalEndpoints
+func newExternalEndpoints() externalEndpoints {
+	return externalEndpoints{
+		endpoints: map[string]*Endpoints{},
+	}
 }

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -37,6 +37,14 @@ func getAnnotationIncludeExternal(svc *v1.Service) bool {
 	return false
 }
 
+func getAnnotationShared(svc *v1.Service) bool {
+	if value, ok := svc.ObjectMeta.Annotations[annotation.SharedService]; ok {
+		return strings.ToLower(value) == "true"
+	}
+
+	return getAnnotationIncludeExternal(svc)
+}
+
 // ParseServiceID parses a Kubernetes service and returns the ServiceID
 func ParseServiceID(svc *v1.Service) ServiceID {
 	return ServiceID{
@@ -81,6 +89,7 @@ func ParseService(svc *v1.Service) (ServiceID, *Service) {
 	}
 	svcInfo := NewService(clusterIP, headless, svc.Labels, svc.Spec.Selector)
 	svcInfo.IncludeExternal = getAnnotationIncludeExternal(svc)
+	svcInfo.Shared = getAnnotationShared(svc)
 
 	// FIXME: Add support for
 	//  - NodePort
@@ -114,6 +123,9 @@ type Service struct {
 	// IncludeExternal is true when external endpoints from other clusters
 	// should be included
 	IncludeExternal bool
+
+	// Shared is true when the service should be exposed/shared to other clusters
+	Shared bool
 
 	Ports    map[loadbalancer.FEPortName]*loadbalancer.FEPort
 	Labels   map[string]string

--- a/pkg/k8s/service_cache_test.go
+++ b/pkg/k8s/service_cache_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/service"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/versioned"
@@ -152,6 +153,10 @@ func (s *K8sSuite) TestServiceCache(c *check.C) {
 		return true
 	}, 2*time.Second), check.IsNil)
 
+	endpoints, ready := svcCache.correlateEndpoints(svcID)
+	c.Assert(ready, check.Equals, true)
+	c.Assert(endpoints.String(), check.Equals, "2.2.2.2:8080/TCP")
+
 	// Updating the service without chaning it should not result in an event
 	svcCache.UpdateService(k8sSvc)
 	time.Sleep(100 * time.Millisecond)
@@ -188,6 +193,10 @@ func (s *K8sSuite) TestServiceCache(c *check.C) {
 		return true
 	}, 2*time.Second), check.IsNil)
 
+	endpoints, serviceReady := svcCache.correlateEndpoints(svcID)
+	c.Assert(serviceReady, check.Equals, false)
+	c.Assert(endpoints.String(), check.Equals, "")
+
 	// Reinserting the endpoints should re-match with the still existing service
 	svcCache.UpdateEndpoints(k8sEndpoints)
 	c.Assert(testutils.WaitUntil(func() bool {
@@ -196,6 +205,10 @@ func (s *K8sSuite) TestServiceCache(c *check.C) {
 		c.Assert(event.ID, check.Equals, svcID)
 		return true
 	}, 2*time.Second), check.IsNil)
+
+	endpoints, serviceReady = svcCache.correlateEndpoints(svcID)
+	c.Assert(serviceReady, check.Equals, true)
+	c.Assert(endpoints.String(), check.Equals, "2.2.2.2:8080/TCP")
 
 	// Deleting the service will result in a service delete event
 	svcCache.DeleteService(k8sSvc)
@@ -589,4 +602,255 @@ func (s *K8sSuite) TestCacheActionString(c *check.C) {
 	c.Assert(DeleteService.String(), check.Equals, "service-deleted")
 	c.Assert(UpdateIngress.String(), check.Equals, "ingress-updated")
 	c.Assert(DeleteIngress.String(), check.Equals, "ingress-deleted")
+}
+
+func (s *K8sSuite) TestServiceMerging(c *check.C) {
+	svcCache := NewServiceCache()
+
+	k8sSvc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+			Annotations: map[string]string{
+				"io.cilium/global-service": "true",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: "127.0.0.1",
+			Type:      v1.ServiceTypeClusterIP,
+		},
+	}
+
+	svcID := svcCache.UpdateService(k8sSvc)
+
+	k8sEndpoints := &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+		},
+		Subsets: []v1.EndpointSubset{
+			{
+				Addresses: []v1.EndpointAddress{{IP: "2.2.2.2"}},
+				Ports: []v1.EndpointPort{
+					{
+						Name:     "http-test-svc",
+						Port:     8080,
+						Protocol: v1.ProtocolTCP,
+					},
+				},
+			},
+		},
+	}
+
+	svcCache.UpdateEndpoints(k8sEndpoints)
+
+	// The service should be ready as both service and endpoints have been
+	// imported
+	c.Assert(testutils.WaitUntil(func() bool {
+		event := <-svcCache.Events
+		c.Assert(event.Action, check.Equals, UpdateService)
+		c.Assert(event.ID, check.Equals, svcID)
+		return true
+	}, 2*time.Second), check.IsNil)
+
+	// Merging a service update with own cluster name must not result in update
+	svcCache.MergeExternalServiceUpdate(&service.ClusterService{
+		Cluster:   option.Config.ClusterName,
+		Namespace: "bar",
+		Name:      "foo",
+		Frontends: map[string]service.PortConfiguration{
+			"1.1.1.1": {},
+		},
+		Backends: map[string]service.PortConfiguration{
+			"3.3.3.3": map[string]*loadbalancer.L4Addr{
+				"port": {Protocol: loadbalancer.TCP, Port: 80},
+			},
+		},
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	select {
+	case <-svcCache.Events:
+		c.Error("Unexpected service event received")
+	default:
+	}
+
+	svcCache.MergeExternalServiceUpdate(&service.ClusterService{
+		Cluster:   "cluster1",
+		Namespace: "bar",
+		Name:      "foo",
+		Frontends: map[string]service.PortConfiguration{
+			"1.1.1.1": {},
+		},
+		Backends: map[string]service.PortConfiguration{
+			"3.3.3.3": map[string]*loadbalancer.L4Addr{
+				"port": {Protocol: loadbalancer.TCP, Port: 80},
+			},
+		},
+	})
+
+	// Adding remote endpoints will trigger a service update
+	c.Assert(testutils.WaitUntil(func() bool {
+		event := <-svcCache.Events
+		c.Assert(event.Action, check.Equals, UpdateService)
+		c.Assert(event.ID, check.Equals, svcID)
+
+		c.Assert(event.Endpoints.Backends["2.2.2.2"], checker.DeepEquals, service.PortConfiguration{
+			"http-test-svc": {Protocol: loadbalancer.TCP, Port: 8080},
+		})
+
+		c.Assert(event.Endpoints.Backends["3.3.3.3"], checker.DeepEquals, service.PortConfiguration{
+			"port": {Protocol: loadbalancer.TCP, Port: 80},
+		})
+
+		return true
+	}, 2*time.Second), check.IsNil)
+
+	// Merging a service for another name should not trigger any updates
+	svcCache.MergeExternalServiceUpdate(&service.ClusterService{
+		Cluster:   "cluster",
+		Namespace: "bar",
+		Name:      "foo2",
+		Frontends: map[string]service.PortConfiguration{
+			"1.1.1.1": {},
+		},
+		Backends: map[string]service.PortConfiguration{
+			"3.3.3.3": map[string]*loadbalancer.L4Addr{
+				"port": {Protocol: loadbalancer.TCP, Port: 80},
+			},
+		},
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	select {
+	case <-svcCache.Events:
+		c.Error("Unexpected service event received")
+	default:
+	}
+
+	// Adding the service later must trigger an update
+	svcID2 := svcCache.UpdateService(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo2",
+			Namespace: "bar",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+			Annotations: map[string]string{
+				"io.cilium/global-service": "true",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: "127.0.0.2",
+			Selector: map[string]string{
+				"foo": "bar",
+			},
+			Type: v1.ServiceTypeClusterIP,
+		},
+	})
+
+	c.Assert(testutils.WaitUntil(func() bool {
+		event := <-svcCache.Events
+		c.Assert(event.Action, check.Equals, UpdateService)
+		c.Assert(event.ID, check.Equals, svcID2)
+		return true
+	}, 2*time.Second), check.IsNil)
+
+	cluster2svc := &service.ClusterService{
+		Cluster:   "cluster2",
+		Namespace: "bar",
+		Name:      "foo",
+		Frontends: map[string]service.PortConfiguration{
+			"1.1.1.1": {},
+		},
+		Backends: map[string]service.PortConfiguration{
+			"4.4.4.4": map[string]*loadbalancer.L4Addr{
+				"port": {Protocol: loadbalancer.TCP, Port: 80},
+			},
+		},
+	}
+
+	// Adding another cluster to the first service will triger an event
+	svcCache.MergeExternalServiceUpdate(cluster2svc)
+	c.Assert(testutils.WaitUntil(func() bool {
+		event := <-svcCache.Events
+		c.Assert(event.Action, check.Equals, UpdateService)
+
+		c.Assert(event.Endpoints.Backends["4.4.4.4"], checker.DeepEquals, service.PortConfiguration{
+			"port": {Protocol: loadbalancer.TCP, Port: 80},
+		})
+
+		return true
+	}, 2*time.Second), check.IsNil)
+
+	svcCache.MergeExternalServiceDelete(cluster2svc)
+	c.Assert(testutils.WaitUntil(func() bool {
+		event := <-svcCache.Events
+		c.Assert(event.Action, check.Equals, UpdateService)
+		c.Assert(event.Endpoints.Backends["4.4.4.4"], check.IsNil)
+		return true
+	}, 2*time.Second), check.IsNil)
+
+	// Deletion of the service frontend will trigger the delete notification
+	svcCache.DeleteService(k8sSvc)
+	c.Assert(testutils.WaitUntil(func() bool {
+		event := <-svcCache.Events
+		c.Assert(event.Action, check.Equals, DeleteService)
+		c.Assert(event.ID, check.Equals, svcID)
+		return true
+	}, 2*time.Second), check.IsNil)
+
+	// When readding the service, the remote endpoints of cluster1 must still be present
+	svcCache.UpdateService(k8sSvc)
+	c.Assert(testutils.WaitUntil(func() bool {
+		event := <-svcCache.Events
+		c.Assert(event.Action, check.Equals, UpdateService)
+		c.Assert(event.ID, check.Equals, svcID)
+		c.Assert(event.Endpoints.Backends["3.3.3.3"], checker.DeepEquals, service.PortConfiguration{
+			"port": {Protocol: loadbalancer.TCP, Port: 80},
+		})
+		return true
+	}, 2*time.Second), check.IsNil)
+}
+
+func (s *K8sSuite) TestNonSharedServie(c *check.C) {
+	svcCache := NewServiceCache()
+
+	k8sSvc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+			Annotations: map[string]string{
+				"io.cilium/global-service": "false",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: "127.0.0.1",
+			Type:      v1.ServiceTypeClusterIP,
+		},
+	}
+
+	svcCache.UpdateService(k8sSvc)
+
+	svcCache.MergeExternalServiceUpdate(&service.ClusterService{
+		Cluster:   "cluster1",
+		Namespace: "bar",
+		Name:      "foo",
+		Backends: map[string]service.PortConfiguration{
+			"3.3.3.3": map[string]*loadbalancer.L4Addr{
+				"port": {Protocol: loadbalancer.TCP, Port: 80},
+			},
+		},
+	})
+
+	// The service is unshared, it should not trigger an update
+	time.Sleep(100 * time.Millisecond)
+
+	select {
+	case <-svcCache.Events:
+		c.Error("Unexpected service event received")
+	default:
+	}
 }

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -29,6 +29,28 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func (s *K8sSuite) TestGetAnnotationIncludeExternal(c *check.C) {
+	svc := &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: "foo",
+	}}
+	c.Assert(getAnnotationIncludeExternal(svc), check.Equals, false)
+
+	svc = &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{"io.cilium/global-service": "True"},
+	}}
+	c.Assert(getAnnotationIncludeExternal(svc), check.Equals, true)
+
+	svc = &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{"io.cilium/global-service": "false"},
+	}}
+	c.Assert(getAnnotationIncludeExternal(svc), check.Equals, false)
+
+	svc = &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{"io.cilium/global-service": ""},
+	}}
+	c.Assert(getAnnotationIncludeExternal(svc), check.Equals, false)
+}
+
 func (s *K8sSuite) TestParseServiceID(c *check.C) {
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/service/store.go
+++ b/pkg/service/store.go
@@ -81,7 +81,12 @@ type ClusterService struct {
 }
 
 func (s *ClusterService) String() string {
-	return s.Cluster + "/" + s.Namespace + ":" + s.Name
+	return s.Cluster + "/" + s.Namespace + "/" + s.Name
+}
+
+// NamespaceServiceName returns the namespace and service name
+func (s *ClusterService) NamespaceServiceName() string {
+	return s.Namespace + "/" + s.Name
 }
 
 // GetKeyName returns the kvstore key to be used for the global service

--- a/pkg/service/store_test.go
+++ b/pkg/service/store_test.go
@@ -33,7 +33,7 @@ func (s *ServiceGenericSuite) TestClusterService(c *check.C) {
 	c.Assert(svc.Name, check.Equals, "foo")
 	c.Assert(svc.Namespace, check.Equals, "bar")
 
-	c.Assert(svc.String(), check.Equals, "default/bar:foo")
+	c.Assert(svc.String(), check.Equals, "default/bar/foo")
 
 	b, err := svc.Marshal()
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
This makes use of the already introduced cilium operator to synchronize
Kubernetes services into the kvstore and maintains a shared store to
synchronize remote services of all connected cluster into individual agents.

Upon presence of the annotation io.cilium/global-service=true, a Kubernetes
service will be completed with remote endpoints which match the namespace and
service name.

The ClusterIP of the remote services is ignored. The selector is only
implemented in the local cluster and the already expanded list of endpoints
(backend IPs and ports) is synchronized. The selector and labels are
synchronized into the kvstore for troubleshooting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6229)
<!-- Reviewable:end -->
