### PR TITLE
docs: remove width from cilium arch image

### DIFF
--- a/Documentation/concepts.rst
+++ b/Documentation/concepts.rst
@@ -21,7 +21,6 @@ Component Overview
 ******************
 
 .. image:: images/cilium-arch.png
-    :width: 600px
     :align: center
 
 A deployment of Cilium consists of the following components running on each


### PR DESCRIPTION
This allows a browser to properly scale the image.

Signed-off-by: Martynas Pumputis <martynas@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6231)
<!-- Reviewable:end -->
