### PR TITLE
cilium: fix service_cache_test literal copies

### DIFF
--- a/pkg/k8s/service_cache_test.go
+++ b/pkg/k8s/service_cache_test.go
@@ -264,7 +264,7 @@ func (s *K8sSuite) TestServiceCache(c *check.C) {
 func (s *K8sSuite) Test_missingK8sEndpointsV1(c *check.C) {
 	type args struct {
 		m        versioned.Map
-		svcCache ServiceCache
+		svcCache *ServiceCache
 	}
 	tests := []struct {
 		name        string
@@ -274,8 +274,9 @@ func (s *K8sSuite) Test_missingK8sEndpointsV1(c *check.C) {
 		{
 			name: "both equal",
 			setupArgs: func() args {
+				svcCache := NewServiceCache()
 				return args{
-					svcCache: NewServiceCache(),
+					svcCache: &svcCache,
 					m:        versioned.NewMap(),
 				}
 			},
@@ -296,9 +297,10 @@ func (s *K8sSuite) Test_missingK8sEndpointsV1(c *check.C) {
 					},
 				})
 
+				svcCache := NewServiceCache()
 				return args{
 					m:        m,
-					svcCache: NewServiceCache(),
+					svcCache: &svcCache,
 				}
 			},
 			setupWanted: func() versioned.Map {
@@ -337,7 +339,7 @@ func (s *K8sSuite) Test_missingK8sEndpointsV1(c *check.C) {
 
 				return args{
 					m:        m,
-					svcCache: svcCache,
+					svcCache: &svcCache,
 				}
 			},
 			setupWanted: func() versioned.Map {
@@ -356,7 +358,7 @@ func (s *K8sSuite) Test_missingK8sEndpointsV1(c *check.C) {
 func (s *K8sSuite) Test_missingK8sServicesV1(c *check.C) {
 	type args struct {
 		m        versioned.Map
-		svcCache ServiceCache
+		svcCache *ServiceCache
 	}
 
 	k8sSvc := &v1.Service{
@@ -384,8 +386,9 @@ func (s *K8sSuite) Test_missingK8sServicesV1(c *check.C) {
 		{
 			name: "both equal",
 			setupArgs: func() args {
+				svcCache := NewServiceCache()
 				return args{
-					svcCache: NewServiceCache(),
+					svcCache: &svcCache,
 					m:        versioned.NewMap(),
 				}
 			},
@@ -408,10 +411,10 @@ func (s *K8sSuite) Test_missingK8sServicesV1(c *check.C) {
 						},
 					},
 				})
-
+				svcCache := NewServiceCache()
 				return args{
 					m:        m,
-					svcCache: NewServiceCache(),
+					svcCache: &svcCache,
 				}
 			},
 			setupWanted: func() versioned.Map {
@@ -443,7 +446,7 @@ func (s *K8sSuite) Test_missingK8sServicesV1(c *check.C) {
 
 				return args{
 					m:        m,
-					svcCache: svcCache,
+					svcCache: &svcCache,
 				}
 			},
 			setupWanted: func() versioned.Map {
@@ -463,7 +466,7 @@ func (s *K8sSuite) Test_missingK8sIngressV1Beta1(c *check.C) {
 	hostIP := net.ParseIP("172.0.0.1")
 	type args struct {
 		m        versioned.Map
-		svcCache ServiceCache
+		svcCache *ServiceCache
 	}
 
 	k8sIngress := &v1beta1.Ingress{
@@ -487,8 +490,9 @@ func (s *K8sSuite) Test_missingK8sIngressV1Beta1(c *check.C) {
 		{
 			name: "both equal",
 			setupArgs: func() args {
+				svcCache := NewServiceCache()
 				return args{
-					svcCache: NewServiceCache(),
+					svcCache: &svcCache,
 					m:        versioned.NewMap(),
 				}
 			},
@@ -503,10 +507,10 @@ func (s *K8sSuite) Test_missingK8sIngressV1Beta1(c *check.C) {
 				m.Add("", versioned.Object{
 					Data: k8sIngress,
 				})
-
+				svcCache := NewServiceCache()
 				return args{
 					m:        m,
-					svcCache: NewServiceCache(),
+					svcCache: &svcCache,
 				}
 			},
 			setupWanted: func() versioned.Map {
@@ -530,7 +534,7 @@ func (s *K8sSuite) Test_missingK8sIngressV1Beta1(c *check.C) {
 
 				return args{
 					m:        m,
-					svcCache: svcCache,
+					svcCache: &svcCache,
 				}
 			},
 			setupWanted: func() versioned.Map {
@@ -560,7 +564,7 @@ func (s *K8sSuite) Test_missingK8sIngressV1Beta1(c *check.C) {
 				})
 				return args{
 					m:        m,
-					svcCache: svcCache,
+					svcCache: &svcCache,
 				}
 			},
 			setupWanted: func() versioned.Map {


### PR DESCRIPTION
Fix literal copies in service_cache_test caused by passing struct with
a RWMutex lock via copy. Instead pass the pointer.

Version and error from 'make' below

$ go version
go version go1.11.2 linux/amd64

$ make
can't load package: package github.com/cilium/cilium/test/bpf: C source files not allowed when not using cgo or SWIG: bpf-event-test.c unit-test.c
go tool vet api pkg test proxylib envoy plugins bpf daemon cilium-health bugtool tools operator
pkg/k8s/service_cache_test.go:340: literal copies lock value from svcCache: k8s.ServiceCache contains github.com/cilium/cilium/pkg/lock.RWMutex
pkg/k8s/service_cache_test.go:446: literal copies lock value from svcCache: k8s.ServiceCache contains github.com/cilium/cilium/pkg/lock.RWMutex
pkg/k8s/service_cache_test.go:533: literal copies lock value from svcCache: k8s.ServiceCache contains github.com/cilium/cilium/pkg/lock.RWMutex
pkg/k8s/service_cache_test.go:563: literal copies lock value from svcCache: k8s.ServiceCache contains github.com/cilium/cilium/pkg/lock.RWMutex
Makefile:212: recipe for target 'govet' failed
make: *** [govet] Error 1

Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6235)
<!-- Reviewable:end -->
