### PR TITLE
daemon: simplify createEndpoint handle logic

### DIFF
--- a/daemon/endpoint_test.go
+++ b/daemon/endpoint_test.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	"strconv"
 	"time"
 
@@ -56,16 +57,16 @@ func getEPTemplate(c *C) *models.EndpointChangeRequest {
 
 func (ds *DaemonSuite) TestEndpointAddReservedLabel(c *C) {
 	epTemplate := getEPTemplate(c)
-	lbls := []string{"reserved:world"}
-	code, err := ds.d.createEndpoint(epTemplate, strconv.FormatInt(epTemplate.ID, 10), lbls)
+	epTemplate.Labels = []string{"reserved:world"}
+	code, err := ds.d.createEndpoint(context.TODO(), epTemplate)
 	c.Assert(err, Not(IsNil))
 	c.Assert(code, Equals, apiEndpoint.PutEndpointIDInvalidCode)
 }
 
 func (ds *DaemonSuite) TestEndpointAddInvalidLabel(c *C) {
 	epTemplate := getEPTemplate(c)
-	lbls := []string{"reserved:foo"}
-	code, err := ds.d.createEndpoint(epTemplate, strconv.FormatInt(epTemplate.ID, 10), lbls)
+	epTemplate.Labels = []string{"reserved:foo"}
+	code, err := ds.d.createEndpoint(context.TODO(), epTemplate)
 	c.Assert(err, Not(IsNil))
 	c.Assert(code, Equals, apiEndpoint.PutEndpointIDInvalidCode)
 }
@@ -73,7 +74,7 @@ func (ds *DaemonSuite) TestEndpointAddInvalidLabel(c *C) {
 func (ds *DaemonSuite) TestEndpointAddNoLabels(c *C) {
 	// Create the endpoint without any labels.
 	epTemplate := getEPTemplate(c)
-	code, err := ds.d.createEndpoint(epTemplate, strconv.FormatInt(epTemplate.ID, 10), nil)
+	code, err := ds.d.createEndpoint(context.TODO(), epTemplate)
 	c.Assert(err, IsNil)
 	c.Assert(code, Equals, apiEndpoint.PutEndpointIDCreatedCode)
 


### PR DESCRIPTION
This also moves the wait for an endpoint to be in ready state inside the
daemon.createEndpoint instead of waiting for the endpoint to be ready in
the handler.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6247)
<!-- Reviewable:end -->
