### PR TITLE
pid: handle os interrupts in daemon_main

### DIFF
--- a/daemon/cleanup.go
+++ b/daemon/cleanup.go
@@ -1,0 +1,38 @@
+// Copyright 2018-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/cilium/cilium/pkg/pidfile"
+)
+
+func registerSigHandler() <-chan struct{} {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGQUIT, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM)
+	interrupt := make(chan struct{})
+	go func() {
+		for s := range sig {
+			log.WithField("signal", s).Info("Exiting due to signal")
+			pidfile.Clean()
+			break
+		}
+		close(interrupt)
+	}()
+	return interrupt
+}

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -115,11 +115,13 @@ func daemonMain() {
 		fmt.Println(errorString)
 		os.Exit(-1)
 	}
-
+	interruptCh := registerSigHandler()
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}
+	<-interruptCh
+	os.Exit(0)
 }
 
 func parseKernelVersion(ver string) (*go_version.Version, error) {

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -1,0 +1,33 @@
+// Copyright 2018-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cleanup
+
+import (
+	"sync"
+)
+
+// DeferTerminationCleanupFunction will execute the given function `f` when the
+// channel `ch` is closed.
+// The given waitGroup will be added with a delta +1 and once the function
+// `f` returns from its execution that same waitGroup will signalize function
+// `f` is completed.
+func DeferTerminationCleanupFunction(wg *sync.WaitGroup, ch <-chan struct{}, f func()) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-ch
+		f()
+	}()
+}

--- a/pkg/cleanup/cleanup_test.go
+++ b/pkg/cleanup/cleanup_test.go
@@ -1,0 +1,45 @@
+// Copyright 2018-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package cleanup
+
+import (
+	"sync"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type CleanupTestSuite struct{}
+
+var _ = Suite(&CleanupTestSuite{})
+
+func (cts *CleanupTestSuite) TestHandleCleanup(c *C) {
+	wg := &sync.WaitGroup{}
+	ch := make(chan struct{})
+	i := 0
+	DeferTerminationCleanupFunction(wg, ch, func() {
+		i++
+	})
+	close(ch)
+	wg.Wait()
+	c.Assert(i, Equals, 1)
+}


### PR DESCRIPTION
Instead of running an exit inside the pkg/pidfile, we should be
performing the exit through the daemon_main.go and wait for all the
subpackages to perform their cleanups once the daemon signals them.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6248)
<!-- Reviewable:end -->
