### PR TITLE
set reloadDatapath flag as a function parameter

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1080,10 +1080,9 @@ func (d *Daemon) TriggerReloadWithoutCompile(reason string) (*sync.WaitGroup, er
 		return nil, fmt.Errorf("Unable to recompile base programs from %s: %s", reason, err)
 	}
 	regenContext := &endpoint.RegenerationContext{
-		Reason:         reason,
-		ReloadDatapath: true,
+		Reason: reason,
 	}
-	return endpointmanager.RegenerateAllEndpoints(d, regenContext), nil
+	return endpointmanager.RegenerateAllEndpoints(d, regenContext, true), nil
 }
 
 func changedOption(key string, value option.OptionSetting, data interface{}) {

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -53,7 +53,7 @@ func (d *Daemon) TriggerPolicyUpdates(force bool, reason string) *sync.WaitGroup
 		log.Debugf("Full policy recalculation triggered")
 	}
 	regenContext := endpoint.NewRegenerationContext(reason)
-	return endpointmanager.RegenerateAllEndpoints(d, regenContext)
+	return endpointmanager.RegenerateAllEndpoints(d, regenContext, false)
 }
 
 type getPolicyResolve struct {

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -168,7 +168,7 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 	ready := e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
 	e.Unlock()
 	c.Assert(ready, Equals, true)
-	buildSuccess := <-e.Regenerate(ds.d, regenContext)
+	buildSuccess := <-e.Regenerate(ds.d, regenContext, false)
 	c.Assert(buildSuccess, Equals, true)
 	c.Assert(e.Allows(qaBarSecLblsCtx.ID), Equals, false)
 	c.Assert(e.Allows(prodBarSecLblsCtx.ID), Equals, false)
@@ -186,7 +186,7 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 	ready = e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
 	e.Unlock()
 	c.Assert(ready, Equals, true)
-	buildSuccess = <-e.Regenerate(ds.d, regenContext)
+	buildSuccess = <-e.Regenerate(ds.d, regenContext, false)
 	c.Assert(buildSuccess, Equals, true)
 	c.Assert(e.Allows(0), Equals, false)
 	c.Assert(e.Allows(qaBarSecLblsCtx.ID), Equals, false)
@@ -462,7 +462,7 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 	ready := e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
 	e.Unlock()
 	c.Assert(ready, Equals, true)
-	buildSuccess := <-e.Regenerate(ds.d, regenContext)
+	buildSuccess := <-e.Regenerate(ds.d, regenContext, false)
 	c.Assert(buildSuccess, Equals, true)
 
 	// Check that the policy has been updated in the xDS cache for the L7

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -279,7 +279,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) {
 			}
 			regenContext := endpoint.NewRegenerationContext(
 				"syncing state to host")
-			if buildSuccess := <-ep.Regenerate(d, regenContext); !buildSuccess {
+			if buildSuccess := <-ep.Regenerate(d, regenContext, false); !buildSuccess {
 				scopedLog.Warn("Failed while regenerating endpoint")
 				epRegenerated <- false
 				return

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -139,7 +139,7 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 		ready := ep.SetStateLocked(e.StateWaitingToRegenerate, "test")
 		ep.Unlock()
 		if ready {
-			<-ep.Regenerate(ds, regenContext)
+			<-ep.Regenerate(ds, regenContext, false)
 		}
 
 		switch ep.ID {
@@ -162,7 +162,7 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 				ready := ep.SetStateLocked(e.StateWaitingToRegenerate, "test")
 				ep.Unlock()
 				if ready {
-					<-ep.Regenerate(ds, regenContext)
+					<-ep.Regenerate(ds, regenContext, false)
 				}
 				epsNames = append(epsNames, ep.DirectoryPath())
 			}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -504,10 +504,12 @@ func (e *Endpoint) removeOldRedirects(owner Owner, desiredRedirects map[string]b
 
 // regenerateBPF rewrites all headers and updates all BPF maps to reflect the
 // specified endpoint.
+// ReloadDatapath forces the datapath programs to be reloaded. It does
+// not guarantee recompilation of the programs.
 // Must be called with endpoint.Mutex not held and endpoint.BuildMutex held.
 // Returns the policy revision number when the regeneration has called, a
 // boolean if the BPF compilation was executed and an error in case of an error.
-func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenContext *RegenerationContext) (revnum uint64, compiled bool, reterr error) {
+func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenContext *RegenerationContext, reloadDatapath bool) (revnum uint64, compiled bool, reterr error) {
 	var (
 		err                 error
 		compilationExecuted bool
@@ -746,7 +748,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 	e.getLogger().WithField("bpfHeaderfilesChanged", bpfHeaderfilesChanged).Debug("Preparing to compile BPF")
 
 	stats.prepareBuild.End(true)
-	if bpfHeaderfilesChanged || regenContext.ReloadDatapath {
+	if bpfHeaderfilesChanged || reloadDatapath {
 		closeChan := loadinfo.LogPeriodicSystemLoad(log.WithFields(logrus.Fields{logfields.EndpointID: epID}).Debugf, time.Second)
 
 		// Compile and install BPF programs for this endpoint

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1306,7 +1306,7 @@ func (e *Endpoint) Update(owner Owner, cfg *models.EndpointConfigurationSpec) er
 				stateTransitionSucceeded := e.SetStateLocked(StateWaitingToRegenerate, reason)
 				if stateTransitionSucceeded {
 					e.Unlock()
-					e.Regenerate(owner, NewRegenerationContext(reason))
+					e.Regenerate(owner, NewRegenerationContext(reason), false)
 					return nil
 				}
 				e.Unlock()
@@ -1430,7 +1430,7 @@ func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup
 // RegenerateWait should only be called when endpoint's state has successfully
 // been changed to "waiting-to-regenerate"
 func (e *Endpoint) RegenerateWait(owner Owner, reason string) error {
-	if !<-e.Regenerate(owner, NewRegenerationContext(reason)) {
+	if !<-e.Regenerate(owner, NewRegenerationContext(reason), false) {
 		return fmt.Errorf("error while regenerating endpoint."+
 			" For more info run: 'cilium endpoint get %d'", e.ID)
 	}
@@ -2060,7 +2060,7 @@ func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
 	e.Unlock()
 
 	if readyToRegenerate {
-		e.Regenerate(owner, NewRegenerationContext("updated security labels"))
+		e.Regenerate(owner, NewRegenerationContext("updated security labels"), false)
 	}
 
 	return nil

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -278,7 +278,7 @@ func updateReferences(ep *endpoint.Endpoint) {
 // each endpoint to avoid issue on endpoint regenerations statistics.
 // Returns a waiting group that can be used to know when all the endpoints are
 // regenerated.
-func RegenerateAllEndpoints(owner endpoint.Owner, regenContext *endpoint.RegenerationContext) *sync.WaitGroup {
+func RegenerateAllEndpoints(owner endpoint.Owner, regenContext *endpoint.RegenerationContext, reloadDatapath bool) *sync.WaitGroup {
 	var wg sync.WaitGroup
 
 	eps := GetEndpoints()
@@ -297,7 +297,7 @@ func RegenerateAllEndpoints(owner endpoint.Owner, regenContext *endpoint.Regener
 					// Regenerate logs status according to the build success/failure
 					// Create a new regenContext to not overwrite the spanStats
 					// values on the endpoint regeneration.
-					<-ep.Regenerate(owner, endpoint.NewRegenerationContext(regenContext.Reason))
+					<-ep.Regenerate(owner, endpoint.NewRegenerationContext(regenContext.Reason), reloadDatapath)
 				}
 			}
 			wg.Done()


### PR DESCRIPTION
To avoid overwritting of the RegenerationContext, as it should only be
used for statistics, we should make use of a function parameters to pass
around flags that performs a datapath reload.

Fixes: dbb5ae196089 ("Endpoint: set a new context per endpoint regeneration")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6250)
<!-- Reviewable:end -->
