### PR TITLE
pkg/{endpoint,metrics,spanstat}: add time.Since wrapper to deal with negative durations

### DIFF
--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -108,6 +108,9 @@ const (
 	// StartTime is the start time of an event
 	StartTime = "startTime"
 
+	// EndTime is the end time of an event
+	EndTime = "endTime"
+
 	// Duration is the duration of a measured operation
 	Duration = "duration"
 
@@ -187,6 +190,9 @@ const (
 	// Note: pkg/proxy/accesslog points to this variable so be careful when
 	// changing the value
 	Path = "file-path"
+
+	// Line is a line number within a file
+	Line = "line"
 
 	// Object is used when "%+v" printing Go objects for debug or error handling.
 	// It is often paired with logfields.Repr to render the object.

--- a/pkg/safetime/doc.go
+++ b/pkg/safetime/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package safetime contains a wrapper function for time.Since to deal with
+// negative durations.
+package safetime

--- a/pkg/safetime/safetime.go
+++ b/pkg/safetime/safetime.go
@@ -1,0 +1,53 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package safetime
+
+import (
+	"runtime"
+	"time"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// TimeSinceSafe returns the duration since t. If the duration is negative,
+// returns false to indicate the fact.
+//
+// Used to workaround a malfunctioning monotonic clock.
+func TimeSinceSafe(t time.Time, logger *log.Entry) (time.Duration, bool) {
+	n := time.Now()
+	d := n.Sub(t)
+
+	if d < 0 {
+		logger = logger.WithFields(log.Fields{
+			logfields.StartTime: t,
+			logfields.EndTime:   n,
+			logfields.Duration:  d,
+		})
+		_, file, line, ok := runtime.Caller(1)
+		if ok {
+			logger = logger.WithFields(log.Fields{
+				logfields.Path: file,
+				logfields.Line: line,
+			})
+		}
+		logger.Warn("BUG: negative duration")
+
+		return time.Duration(0), false
+	}
+
+	return d, true
+}

--- a/pkg/safetime/safetime_test.go
+++ b/pkg/safetime/safetime_test.go
@@ -1,0 +1,68 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package safetime
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type SafetimeSuite struct {
+	out    *bytes.Buffer // stores log output
+	logger *log.Entry
+}
+
+var _ = Suite(&SafetimeSuite{})
+
+func (s *SafetimeSuite) SetUpTest(c *C) {
+	s.out = &bytes.Buffer{}
+	logger := log.New()
+	logger.Out = s.out
+	s.logger = log.NewEntry(logger)
+}
+
+func (s *SafetimeSuite) TestNegativeDuration(c *C) {
+	future := time.Now().Add(time.Second)
+	d, ok := TimeSinceSafe(future, s.logger)
+
+	c.Assert(ok, Equals, false)
+	c.Assert(d, Equals, time.Duration(0))
+	fmt.Println(s.out.String())
+	c.Assert(strings.Contains(s.out.String(), "BUG: negative duration"), Equals, true)
+}
+
+func (s *SafetimeSuite) TestNonNegativeDuration(c *C) {
+	// To prevent the test case from being flaky on machines with invalid
+	// CLOCK_MONOTONIC:
+	past := time.Now().Add(-10 * time.Second)
+	d, ok := TimeSinceSafe(past, s.logger)
+
+	c.Assert(ok, Equals, true)
+	c.Assert(d > time.Duration(0), Equals, true)
+	c.Assert(len(s.out.String()) == 0, Equals, true)
+}

--- a/pkg/spanstat/spanstat.go
+++ b/pkg/spanstat/spanstat.go
@@ -15,11 +15,11 @@
 package spanstat
 
 import (
-	"runtime/debug"
 	"time"
 
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/safetime"
 )
 
 var (
@@ -45,16 +45,11 @@ func (s *SpanStat) Start() {
 // depending on the given success flag
 func (s *SpanStat) End(success bool) {
 	if !s.spanStart.IsZero() {
-		d := time.Since(s.spanStart)
-		if d >= time.Duration(0) {
-			if success {
-				s.successDuration += d
-			} else {
-				s.failureDuration += d
-			}
+		d, _ := safetime.TimeSinceSafe(s.spanStart, log)
+		if success {
+			s.successDuration += d
 		} else {
-			log.WithField("duration", d).Warn("Duration is negative on End")
-			debug.PrintStack()
+			s.failureDuration += d
 		}
 	}
 	s.spanStart = time.Time{}


### PR DESCRIPTION
We've observed that on a EC2 burstable instance `CLOCK_MONOTONIC` might go backwards which makes `time.Since` to return a negative duration. The negative duration passed to some Prometheus metrics methods (e.g. `Counter.Add`) will make the runtime to panic.

This PR:

- Introduces the `safetime.TimeSinceSafe` wrapper for `time.Since`. The wrapper is guaranteed to return a non-negative duration. If a duration is negative, the wrapper will log a warning and return `time.Duration(0)` and `ok = false` to indicate the fact.
- Replaces `time.Since` with the wrapper in the place in which the returned duration is passed to Prometheus metrics which cannot tolerate a negative value.
- Refactors `spanstat.End` to use the wrapper.
  
Fixes: #6222

Signed-off-by: Martynas Pumputis <martynas@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6257)
<!-- Reviewable:end -->
