### PR TITLE
exec: Increase timeout of TestWithTimeout unit test

### DIFF
--- a/pkg/command/exec/exec_test.go
+++ b/pkg/command/exec/exec_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	timeout = 1 * time.Millisecond
+	timeout = 250 * time.Millisecond
 )
 
 // Hook up gocheck into the "go test" runner.


### PR DESCRIPTION
Increase the timeout from 1 millisecond to 250 milliseconds to
ensure that `sleep inf` process will be succesfully spawned and
able to be killed.

1 millisecond timeout was sometimes too short to spawn the process
in Travis CI.

Fixes #6162

Signed-off-by: Michal Rostecki <mrostecki@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6259)
<!-- Reviewable:end -->
