### PR TITLE
daemon: Handle listen/serve errors with channels

### DIFF
--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -45,15 +45,17 @@ func (h *getMetrics) Handle(params restapi.GetMetricsParams) middleware.Responde
 	return restapi.NewGetMetricsOK().WithPayload(metrics)
 }
 
-func initMetrics() {
+func initMetrics() <-chan error {
+	var errs <-chan error
+
 	promAddr := viper.GetString("prometheus-serve-addr")
 	if promAddr == "" {
 		promAddr = viper.GetString("prometheus-serve-addr-deprecated")
 	}
 	if promAddr != "" {
 		log.Infof("Serving prometheus metrics on %s", promAddr)
-		if err := metrics.Enable(promAddr); err != nil {
-			log.WithError(err).Fatal("Error while starting metrics")
-		}
+		errs = metrics.Enable(promAddr)
 	}
+
+	return errs
 }


### PR DESCRIPTION
Metrics server was always running in goroutine without error
channel. Daemon module expected an error to be returned, which
was never happening.

After this change, both metrics server and Cilium daemon server
are running in goroutines with error channels and then errors
are handled by `select` function.

Signed-off-by: Michal Rostecki <mrostecki@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6261)
<!-- Reviewable:end -->
