### PR TITLE
kvstore: fix etcd option checking

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -121,6 +121,11 @@ func (e *etcdModule) newClient() (BackendOperations, error) {
 				EtcdOptionConfig, addrOption)
 		}
 
+		if endpointsOpt.value == "" && configPathOpt.value == "" {
+			return nil, fmt.Errorf("invalid etcd configuration, %s or %s must be specified",
+				EtcdOptionConfig, addrOption)
+		}
+
 		e.config = &client.Config{}
 
 		if endpointsSet {


### PR DESCRIPTION
opts is already initialized, so lookup will return true
always. Add a condition for empty string which truely
reflects if the kvstore opts was setup properly in commandline.

Signed-off-by: Nirmoy Das <ndas@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6262)
<!-- Reviewable:end -->
