### PR TITLE
policy: refactor some policy repository functions to act upon a slice of *rule instead of repository itself

### DIFF
--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -67,8 +67,8 @@ type traceState struct {
 	ruleID int
 }
 
-func (state *traceState) trace(p *Repository, ctx *SearchContext) {
-	ctx.PolicyTrace("%d/%d rules selected\n", state.selectedRules, len(p.rules))
+func (state *traceState) trace(rules ruleSlice, ctx *SearchContext) {
+	ctx.PolicyTrace("%d/%d rules selected\n", state.selectedRules, len(rules))
 	if state.constrainedRules > 0 {
 		ctx.PolicyTrace("Found unsatisfied FromRequires constraint\n")
 	} else if state.matchedRules > 0 {
@@ -286,7 +286,7 @@ func (p *Repository) ResolveL4IngressPolicy(ctx *SearchContext) (*L4PolicyMap, e
 
 	p.wildcardL3L4Rules(ctx, true, result.Ingress)
 
-	state.trace(p, ctx)
+	state.trace(p.rules, ctx)
 	return &result.Ingress, nil
 }
 
@@ -337,7 +337,7 @@ func (p *Repository) ResolveL4EgressPolicy(ctx *SearchContext) (*L4PolicyMap, er
 
 	p.wildcardL3L4Rules(ctx, false, result.Egress)
 
-	state.trace(p, ctx)
+	state.trace(p.rules, ctx)
 	return &result.Egress, nil
 }
 
@@ -356,7 +356,7 @@ func (p *Repository) ResolveCIDRPolicy(ctx *SearchContext) *CIDRPolicy {
 		state.ruleID++
 	}
 
-	state.trace(p, ctx)
+	state.trace(p.rules, ctx)
 	return result
 }
 
@@ -493,7 +493,7 @@ egressLoop:
 		}
 	}
 
-	egressState.trace(p, egressCtx)
+	egressState.trace(p.rules, egressCtx)
 
 	return egressDecision
 }

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -504,11 +504,15 @@ func (p *Repository) AllowsEgressLabelAccess(egressCtx *SearchContext) api.Decis
 // policy.
 // The policy repository mutex must be held.
 func (p *Repository) CanReachEgressRLocked(egressCtx *SearchContext) api.Decision {
+	return p.rules.canReachEgressRLocked(egressCtx)
+}
+
+func (rules ruleSlice) canReachEgressRLocked(egressCtx *SearchContext) api.Decision {
 	egressDecision := api.Undecided
 	egressState := traceState{}
 
 egressLoop:
-	for i, r := range p.rules {
+	for i, r := range rules {
 		egressState.ruleID = i
 		switch r.canReachEgress(egressCtx, &egressState) {
 		// The rule contained a constraint which was not met, this
@@ -525,7 +529,7 @@ egressLoop:
 		}
 	}
 
-	egressState.trace(p.rules, egressCtx)
+	egressState.trace(rules, egressCtx)
 
 	return egressDecision
 }

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -26,12 +26,16 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// ruleSlice is a wrapper around a slice of *rule, which allows for functions
+// to be written with []*rule as a receiver.
+type ruleSlice []*rule
+
 // Repository is a list of policy rules which in combination form the security
 // policy. A policy repository can be
 type Repository struct {
 	// Mutex protects the whole policy tree
 	Mutex lock.RWMutex
-	rules []*rule
+	rules ruleSlice
 
 	// revision is the revision of the policy repository. It will be
 	// incremented whenever the policy repository is changed.

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -169,11 +169,9 @@ func wildcardL3L4Rule(proto api.L4Proto, port int, endpoints api.EndpointSelecto
 	}
 }
 
-// wildcardL3L4Rules updates each ingress L7 rule to allow at L7 all traffic that
-// is allowed at L3-only or L3/L4.
-func (p *Repository) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Policy L4PolicyMap) {
+func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Policy L4PolicyMap) {
 	// Duplicate L3-only rules into wildcard L7 rules.
-	for _, r := range p.rules {
+	for _, r := range rules {
 		if ingress {
 			if !r.EndpointSelector.Matches(ctx.To) {
 				continue
@@ -236,6 +234,12 @@ func (p *Repository) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Polic
 			}
 		}
 	}
+}
+
+// wildcardL3L4Rules updates each ingress L7 rule to allow at L7 all traffic that
+// is allowed at L3-only or L3/L4.
+func (p *Repository) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Policy L4PolicyMap) {
+	p.rules.wildcardL3L4Rules(ctx, ingress, l4Policy)
 }
 
 // ResolveL4IngressPolicy resolves the L4 ingress policy for a set of endpoints

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -374,17 +374,21 @@ func (rules ruleSlice) resolveL4EgressPolicy(ctx *SearchContext) (*L4Policy, err
 // where the EndpointSelector matches `ctx.To`. `ctx.From` takes no effect and
 // is ignored in the search.
 func (p *Repository) ResolveCIDRPolicy(ctx *SearchContext) *CIDRPolicy {
+	return p.rules.resolveCIDRPolicy(ctx)
+}
+
+func (rules ruleSlice) resolveCIDRPolicy(ctx *SearchContext) *CIDRPolicy {
 	result := NewCIDRPolicy()
 
 	ctx.PolicyTrace("Resolving L3 (CIDR) policy for %+v\n", ctx.To)
 
 	state := traceState{}
-	for _, r := range p.rules {
+	for _, r := range rules {
 		r.resolveCIDRPolicy(ctx, &state, result)
 		state.ruleID++
 	}
 
-	state.trace(p.rules, ctx)
+	state.trace(rules, ctx)
 	return result
 }
 

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -256,19 +256,15 @@ func (p *Repository) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Polic
 // TODO: Coalesce l7 rules?
 func (p *Repository) ResolveL4IngressPolicy(ctx *SearchContext) (*L4PolicyMap, error) {
 
-	result, err := p.rules.resolveL4IngressPolicy(ctx)
+	result, err := p.rules.resolveL4IngressPolicy(ctx, p.revision)
 	if err != nil {
 		return nil, err
-	}
-
-	if result != nil {
-		result.Revision = p.GetRevision()
 	}
 
 	return &result.Ingress, nil
 }
 
-func (rules ruleSlice) resolveL4IngressPolicy(ctx *SearchContext) (*L4Policy, error) {
+func (rules ruleSlice) resolveL4IngressPolicy(ctx *SearchContext, revision uint64) (*L4Policy, error) {
 	result := NewL4Policy()
 
 	ctx.PolicyTrace("\n")
@@ -303,6 +299,7 @@ func (rules ruleSlice) resolveL4IngressPolicy(ctx *SearchContext) (*L4Policy, er
 	}
 
 	rules.wildcardL3L4Rules(ctx, true, result.Ingress)
+	result.Revision = revision
 
 	state.trace(rules, ctx)
 	return result, nil
@@ -315,20 +312,16 @@ func (rules ruleSlice) resolveL4IngressPolicy(ctx *SearchContext) (*L4Policy, er
 // are merged together. If rules contains overlapping port definitions, the first
 // rule found in the repository takes precedence.
 func (p *Repository) ResolveL4EgressPolicy(ctx *SearchContext) (*L4PolicyMap, error) {
-	result, err := p.rules.resolveL4EgressPolicy(ctx)
+	result, err := p.rules.resolveL4EgressPolicy(ctx, p.revision)
 
 	if err != nil {
 		return nil, err
 	}
 
-	if result != nil {
-		result.Revision = p.GetRevision()
-	}
-
 	return &result.Egress, nil
 }
 
-func (rules ruleSlice) resolveL4EgressPolicy(ctx *SearchContext) (*L4Policy, error) {
+func (rules ruleSlice) resolveL4EgressPolicy(ctx *SearchContext, revision uint64) (*L4Policy, error) {
 	result := NewL4Policy()
 
 	ctx.PolicyTrace("\n")
@@ -364,6 +357,7 @@ func (rules ruleSlice) resolveL4EgressPolicy(ctx *SearchContext) (*L4Policy, err
 	}
 
 	rules.wildcardL3L4Rules(ctx, false, result.Egress)
+	result.Revision = revision
 
 	state.trace(rules, ctx)
 	return result, nil

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -1,0 +1,246 @@
+// Copyright 2016-2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"strconv"
+
+	"github.com/cilium/cilium/pkg/policy/api"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ruleSlice is a wrapper around a slice of *rule, which allows for functions
+// to be written with []*rule as a receiver.
+type ruleSlice []*rule
+
+func (rules ruleSlice) canReachIngressRLocked(ctx *SearchContext) api.Decision {
+	decision := api.Undecided
+	state := traceState{}
+
+loop:
+	for i, r := range rules {
+		state.ruleID = i
+		switch r.canReachIngress(ctx, &state) {
+		// The rule contained a constraint which was not met, this
+		// connection is not allowed
+		case api.Denied:
+			decision = api.Denied
+			break loop
+
+			// The rule allowed the connection but a later rule may impose
+			// additional constraints, so we store the decision but allow
+			// it to be overwritten by an additional requirement
+		case api.Allowed:
+			decision = api.Allowed
+		}
+	}
+
+	state.trace(rules, ctx)
+
+	return decision
+}
+
+func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Policy L4PolicyMap) {
+	// Duplicate L3-only rules into wildcard L7 rules.
+	for _, r := range rules {
+		if ingress {
+			if !r.EndpointSelector.Matches(ctx.To) {
+				continue
+			}
+			for _, rule := range r.Ingress {
+				// Non-label-based rule. Ignore.
+				if !rule.IsLabelBased() {
+					continue
+				}
+
+				fromEndpoints := rule.GetSourceEndpointSelectors()
+				ruleLabels := r.Rule.Labels.DeepCopy()
+
+				// L3-only rule.
+				if len(rule.ToPorts) == 0 {
+					wildcardL3L4Rule(api.ProtoTCP, 0, fromEndpoints, ruleLabels, l4Policy)
+					wildcardL3L4Rule(api.ProtoUDP, 0, fromEndpoints, ruleLabels, l4Policy)
+				} else {
+					for _, toPort := range rule.ToPorts {
+						// L3/L4-only rule
+						if toPort.Rules.IsEmpty() {
+							for _, p := range toPort.Ports {
+								// Already validated via PortRule.Validate().
+								port, _ := strconv.ParseUint(p.Port, 0, 16)
+								wildcardL3L4Rule(p.Protocol, int(port), fromEndpoints, ruleLabels, l4Policy)
+							}
+						}
+					}
+				}
+			}
+		} else {
+			if !r.EndpointSelector.Matches(ctx.From) {
+				continue
+			}
+			for _, rule := range r.Egress {
+				// Non-label-based rule. Ignore.
+				if !rule.IsLabelBased() {
+					continue
+				}
+
+				toEndpoints := rule.GetDestinationEndpointSelectors()
+				ruleLabels := r.Rule.Labels.DeepCopy()
+
+				// L3-only rule.
+				if len(rule.ToPorts) == 0 {
+					wildcardL3L4Rule(api.ProtoTCP, 0, toEndpoints, ruleLabels, l4Policy)
+					wildcardL3L4Rule(api.ProtoUDP, 0, toEndpoints, ruleLabels, l4Policy)
+				} else {
+					for _, toPort := range rule.ToPorts {
+						// L3/L4-only rule
+						if toPort.Rules.IsEmpty() {
+							for _, p := range toPort.Ports {
+								// Already validated via PortRule.Validate().
+								port, _ := strconv.ParseUint(p.Port, 0, 16)
+								wildcardL3L4Rule(p.Protocol, int(port), toEndpoints, ruleLabels, l4Policy)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func (rules ruleSlice) resolveL4IngressPolicy(ctx *SearchContext, revision uint64) (*L4Policy, error) {
+	result := NewL4Policy()
+
+	ctx.PolicyTrace("\n")
+	ctx.PolicyTrace("Resolving ingress port policy for %+v\n", ctx.To)
+
+	state := traceState{}
+	var requirements []v1.LabelSelectorRequirement
+
+	// Iterate over all FromRequires which select ctx.To. These requirements
+	// will be appended to each EndpointSelector's MatchExpressions in
+	// each FromEndpoints for all ingress rules. This ensures that FromRequires
+	// is taken into account when evaluating policy at L4.
+	for _, r := range rules {
+		for _, ingressRule := range r.Ingress {
+			if r.EndpointSelector.Matches(ctx.To) {
+				for _, requirement := range ingressRule.FromRequires {
+					requirements = append(requirements, requirement.ConvertToLabelSelectorRequirementSlice()...)
+				}
+			}
+		}
+	}
+
+	for _, r := range rules {
+		found, err := r.resolveL4IngressPolicy(ctx, &state, result, requirements)
+		if err != nil {
+			return nil, err
+		}
+		state.ruleID++
+		if found != nil {
+			state.matchedRules++
+		}
+	}
+
+	rules.wildcardL3L4Rules(ctx, true, result.Ingress)
+	result.Revision = revision
+
+	state.trace(rules, ctx)
+	return result, nil
+}
+
+func (rules ruleSlice) resolveL4EgressPolicy(ctx *SearchContext, revision uint64) (*L4Policy, error) {
+	result := NewL4Policy()
+
+	ctx.PolicyTrace("\n")
+	ctx.PolicyTrace("Resolving egress port policy for %+v\n", ctx.To)
+
+	var requirements []v1.LabelSelectorRequirement
+
+	// Iterate over all ToRequires which select ctx.To. These requirements will
+	// be appended to each EndpointSelector's MatchExpressions in each
+	// ToEndpoints for all ingress rules. This ensures that ToRequires is
+	// taken into account when evaluating policy at L4.
+	for _, r := range rules {
+		for _, egressRule := range r.Egress {
+			if r.EndpointSelector.Matches(ctx.From) {
+				for _, requirement := range egressRule.ToRequires {
+					requirements = append(requirements, requirement.ConvertToLabelSelectorRequirementSlice()...)
+				}
+			}
+		}
+	}
+
+	state := traceState{}
+	for i, r := range rules {
+		state.ruleID = i
+		found, err := r.resolveL4EgressPolicy(ctx, &state, result, requirements)
+		if err != nil {
+			return nil, err
+		}
+		state.ruleID++
+		if found != nil {
+			state.matchedRules++
+		}
+	}
+
+	rules.wildcardL3L4Rules(ctx, false, result.Egress)
+	result.Revision = revision
+
+	state.trace(rules, ctx)
+	return result, nil
+}
+
+func (rules ruleSlice) resolveCIDRPolicy(ctx *SearchContext) *CIDRPolicy {
+	result := NewCIDRPolicy()
+
+	ctx.PolicyTrace("Resolving L3 (CIDR) policy for %+v\n", ctx.To)
+
+	state := traceState{}
+	for _, r := range rules {
+		r.resolveCIDRPolicy(ctx, &state, result)
+		state.ruleID++
+	}
+
+	state.trace(rules, ctx)
+	return result
+}
+
+func (rules ruleSlice) canReachEgressRLocked(egressCtx *SearchContext) api.Decision {
+	egressDecision := api.Undecided
+	egressState := traceState{}
+
+egressLoop:
+	for i, r := range rules {
+		egressState.ruleID = i
+		switch r.canReachEgress(egressCtx, &egressState) {
+		// The rule contained a constraint which was not met, this
+		// connection is not allowed
+		case api.Denied:
+			egressDecision = api.Denied
+			break egressLoop
+
+			// The rule allowed the connection but a later rule may impose
+			// additional constraints, so we store the decision but allow
+			// it to be overwritten by an additional requirement
+		case api.Allowed:
+			egressDecision = api.Allowed
+		}
+	}
+
+	egressState.trace(rules, egressCtx)
+
+	return egressDecision
+}


### PR DESCRIPTION
Add a new type to `pkg/policy` called `ruleSlice`, which is wrapper type for `[]*rule`.  This is part of an iterative process to improve policy calculation in Cilium. By making these functions act upon a `ruleSlice`, the functions that apply to the whole policy repository can simply act upon its `rules`; no existing functionality is broken. 

The motivation behind this is so in the future, when policy is computed, we can compute which rules select a given set of labels only once instead of doing it multiple times per policy calculation against that set of labels at each protocol layer (L3, L4, L7, etc). The translation of these rules into the data structures that are utilized within endpoint (`CIDRPolicy`, `L4Policy`) will then be done only against the set of rules that select the endpoint, instead of the against the entire repository. This improves performance because performing the `Match` operation against an endpoint selector is quite costly. 

No functional change is intended by this PR. 

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6265)
<!-- Reviewable:end -->
