### PR TITLE
Add k8s test for nodeport with proxy

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -44,7 +44,7 @@ var _ = Describe("K8sServicesTest", func() {
 	applyPolicy := func(path string) {
 		By(fmt.Sprintf("Applying policy %s", path))
 		_, err := kubectl.CiliumPolicyAction(helpers.KubeSystemNamespace, path, helpers.KubectlApply, helpers.HelperTimeout)
-		Expect(err).Should(BeNil(), fmt.Sprintf("Error creating resource %s: %s", path, err))
+		ExpectWithOffset(1, err).Should(BeNil(), fmt.Sprintf("Error creating resource %s: %s", path, err))
 	}
 
 	BeforeAll(func() {

--- a/test/k8sT/manifests/l7-policy-demo.yaml
+++ b/test/k8sT/manifests/l7-policy-demo.yaml
@@ -1,0 +1,17 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+description: "L7 policy for allowing all traffic via proxy in demo DS"
+metadata:
+  name: "l7-policy-demo"
+spec:
+  endpointSelector:
+    matchLabels:
+      zgroup: testDS
+  ingress:
+  - toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+      rules:
+        http:
+        - {}


### PR DESCRIPTION
Add a test for nodeport that also configures traffic to flow through the proxy.

Related: #6264

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6266)
<!-- Reviewable:end -->
