### PR TITLE
Report stale status

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -857,6 +857,13 @@
   version = "1.0.1"
 
 [[projects]]
+  digest = "1:048215a208d3f928e14cad3906c2aad4dc8412a81780f9a5260eaf7998c92df6"
+  name = "github.com/mohae/deepcopy"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "c48cc78d482608239f6c4c92a4abd87eb8761c90"
+
+[[projects]]
   digest = "1:3dc39744bbac155b21a79c6b8e250d6985bbab77b71c073a4477071e59fe5e61"
   name = "github.com/onsi/ginkgo"
   packages = [
@@ -1783,6 +1790,7 @@
     "github.com/kr/pretty",
     "github.com/mattn/go-shellwords",
     "github.com/miekg/dns",
+    "github.com/mohae/deepcopy",
     "github.com/onsi/ginkgo",
     "github.com/onsi/ginkgo/config",
     "github.com/onsi/ginkgo/types",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -272,6 +272,13 @@ required = [
   # on-revision = ""
 
 [[constraint]]
+  name = "github.com/mohae/deepcopy"
+  revision = "c48cc78d482608239f6c4c92a4abd87eb8761c90"
+
+  # main-usage = "daemon"
+  # on-revision = "last available commit and there is not stable releases"
+
+[[constraint]]
   name = "github.com/onsi/ginkgo"
   revision = "ba8e856bb854d6771a72ddf6497a42dad3a0c971"
 

--- a/api/v1/models/status_response.go
+++ b/api/v1/models/status_response.go
@@ -43,6 +43,9 @@ type StatusResponse struct {
 
 	// Status of proxy
 	Proxy *ProxyStatus `json:"proxy,omitempty"`
+
+	// List of stale information in the status
+	Stale map[string]strfmt.DateTime `json:"stale,omitempty"`
 }
 
 /* polymorph StatusResponse cilium false */
@@ -62,6 +65,8 @@ type StatusResponse struct {
 /* polymorph StatusResponse nodeMonitor false */
 
 /* polymorph StatusResponse proxy false */
+
+/* polymorph StatusResponse stale false */
 
 // Validate validates this status response
 func (m *StatusResponse) Validate(formats strfmt.Registry) error {

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1252,6 +1252,13 @@ definitions:
       proxy:
         description: Status of proxy
         "$ref": "#/definitions/ProxyStatus"
+      stale:
+        description: List of stale information in the status
+        type: object
+        additionalProperties:
+          description: Timestamp when the probe was started
+          type: string
+          format: date-time
 
   Status:
     description: Status of an individual component

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2338,6 +2338,15 @@ func init() {
         "proxy": {
           "description": "Status of proxy",
           "$ref": "#/definitions/ProxyStatus"
+        },
+        "stale": {
+          "description": "List of stale information in the status",
+          "type": "object",
+          "additionalProperties": {
+            "description": "Timestamp when the probe was started",
+            "type": "string",
+            "format": "date-time"
+          }
         }
       }
     },

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -80,6 +80,7 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/logger"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/sockops"
+	"github.com/cilium/cilium/pkg/status"
 	"github.com/cilium/cilium/pkg/workloads"
 
 	"github.com/go-openapi/runtime/middleware"
@@ -118,9 +119,9 @@ type Daemon struct {
 	// Only used for CRI-O since it does not support events.
 	workloadsEventsCh chan<- *workloads.EventMessage
 
-	statusCollectMutex      lock.RWMutex
-	statusResponse          models.StatusResponse
-	statusResponseTimestamp time.Time
+	statusCollectMutex lock.RWMutex
+	statusResponse     models.StatusResponse
+	statusCollector    *status.Collector
 
 	uniqueIDMU lock.Mutex
 	uniqueID   map[uint64]context.CancelFunc

--- a/daemon/status.go
+++ b/daemon/status.go
@@ -345,11 +345,7 @@ func (d *Daemon) startStatusCollector() {
 		},
 	}
 
-	d.statusCollector = status.NewCollector(probes, status.Config{
-		Interval:         5 * time.Second,
-		WarningThreshold: 15 * time.Second,
-		FailureThreshold: time.Minute,
-	})
+	d.statusCollector = status.NewCollector(probes, status.Config{})
 
 	return
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -205,6 +205,21 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, allAddresses, 
 		fmt.Fprintf(w, "Cilium:\t%s\t%s\n", sr.Cilium.State, sr.Cilium.Msg)
 	}
 
+	if sr.Stale != nil {
+		sortedProbes := make([]string, 0, len(sr.Stale))
+		for probe := range sr.Stale {
+			sortedProbes = append(sortedProbes, probe)
+		}
+		sort.Strings(sortedProbes)
+
+		stalesStr := make([]string, 0, len(sr.Stale))
+		for _, probe := range sortedProbes {
+			stalesStr = append(stalesStr, fmt.Sprintf("%q since %s", probe, sr.Stale[probe]))
+		}
+
+		fmt.Fprintf(w, "Stale status:\t%s\n", strings.Join(stalesStr, ", "))
+	}
+
 	if nm := sr.NodeMonitor; nm != nil {
 		fmt.Fprintf(w, "NodeMonitor:\tListening for events on %d CPUs with %dx%d of shared memory\n",
 			nm.Cpus, nm.Npages, nm.Pagesize)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -97,4 +97,15 @@ const (
 
 	// ExecTimeout is a timeout for executing commands.
 	ExecTimeout = 300 * time.Second
+
+	// StatusCollectorInterval is the interval between a probe invocations
+	StatusCollectorInterval = 5 * time.Second
+
+	// StatusCollectorWarningThreshold is the duration after which a probe
+	// is declared as stale
+	StatusCollectorWarningThreshold = 15 * time.Second
+
+	// StatusCollectorFailureThreshold is the duration after which a probe
+	// is considered failed
+	StatusCollectorFailureThreshold = 1 * time.Minute
 )

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -19,16 +19,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 const (
-	defaultInterval         = 5 * time.Second
-	defaultFailureThreshold = time.Minute
-	defaultWarningThreshold = 20 * time.Second
-	subsystem               = "status"
+	subsystem = "status"
 )
 
 var (
@@ -87,15 +85,15 @@ func NewCollector(probes []Probe, config Config) *Collector {
 	}
 
 	if c.config.Interval == time.Duration(0) {
-		c.config.Interval = defaultInterval
+		c.config.Interval = defaults.StatusCollectorInterval
 	}
 
 	if c.config.FailureThreshold == time.Duration(0) {
-		c.config.FailureThreshold = defaultFailureThreshold
+		c.config.FailureThreshold = defaults.StatusCollectorFailureThreshold
 	}
 
 	if c.config.WarningThreshold == time.Duration(0) {
-		c.config.WarningThreshold = defaultWarningThreshold
+		c.config.WarningThreshold = defaults.StatusCollectorWarningThreshold
 	}
 
 	for i := range probes {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -1,0 +1,237 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+const (
+	defaultInterval         = 5 * time.Second
+	defaultFailureThreshold = time.Minute
+	defaultWarningThreshold = 20 * time.Second
+	subsystem               = "status"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, subsystem)
+)
+
+// Status is passed to a probe when its state changes
+type Status struct {
+	// Data is non-nil when the probe has completed successfully. Data is
+	// set to the value returned by Probe()
+	Data interface{}
+
+	// Err is non-nil if either the probe file or the Failure or Warning
+	// threshold has been reached
+	Err error
+
+	// StaleWarning is true once the WarningThreshold has been reached
+	StaleWarning bool
+}
+
+// Probe is run by the collector at a particular interval between invocations
+type Probe struct {
+	Name string
+
+	Probe func(ctx context.Context) (interface{}, error)
+
+	// OnStatusUpdate is called whenever the status of the probe changes
+	OnStatusUpdate func(status Status)
+}
+
+// Collector concurrently runs probes used to check status of various subsystems
+type Collector struct {
+	lock.RWMutex   // protects staleProbes and probeStartTime
+	config         Config
+	stop           chan struct{}
+	staleProbes    map[string]struct{}
+	probeStartTime map[string]time.Time
+}
+
+// Config is the collector configuration
+type Config struct {
+	WarningThreshold time.Duration
+	FailureThreshold time.Duration
+	Interval         time.Duration
+}
+
+// NewCollector creates a collector and starts the given probes.
+//
+// Each probe runs in a separate goroutine.
+func NewCollector(probes []Probe, config Config) *Collector {
+	c := &Collector{
+		config:         config,
+		stop:           make(chan struct{}, 0),
+		staleProbes:    make(map[string]struct{}),
+		probeStartTime: make(map[string]time.Time),
+	}
+
+	if c.config.Interval == time.Duration(0) {
+		c.config.Interval = defaultInterval
+	}
+
+	if c.config.FailureThreshold == time.Duration(0) {
+		c.config.FailureThreshold = defaultFailureThreshold
+	}
+
+	if c.config.WarningThreshold == time.Duration(0) {
+		c.config.WarningThreshold = defaultWarningThreshold
+	}
+
+	for i := range probes {
+		c.spawnProbe(&probes[i])
+	}
+
+	return c
+}
+
+// Close exits all probes and shuts down the collector
+// TODO(brb): call it when daemon exits (after GH#6248).
+func (c *Collector) Close() {
+	close(c.stop)
+}
+
+// GetStaleProbes returns a map of stale probes which key is a probe name and
+// value is a time when the last instance of the probe has been started.
+func (c *Collector) GetStaleProbes() map[string]time.Time {
+	c.RLock()
+	defer c.RUnlock()
+
+	probes := make(map[string]time.Time)
+
+	for p := range c.staleProbes {
+		probes[p] = c.probeStartTime[p]
+	}
+
+	return probes
+}
+
+// spawnProbe starts a goroutine which invokes the probe at the particular interval.
+func (c *Collector) spawnProbe(p *Probe) {
+	go func() {
+		for {
+			c.runProbe(p)
+
+			select {
+			case <-c.stop:
+				// collector is closed, stop looping
+				return
+			case <-time.After(c.config.Interval):
+				// keep looping
+			}
+		}
+	}()
+}
+
+// runProbe runs the given probe, and returns either after the probe has returned
+// or after the collector has been closed.
+func (c *Collector) runProbe(p *Probe) {
+	var (
+		statusData       interface{}
+		err              error
+		warningThreshold = time.After(c.config.WarningThreshold)
+		hardTimeout      = false
+		probeReturned    = make(chan struct{}, 1)
+		ctx, cancel      = context.WithTimeout(context.Background(), c.config.FailureThreshold)
+		ctxTimeout       = make(chan struct{}, 1)
+	)
+
+	c.Lock()
+	c.probeStartTime[p.Name] = time.Now()
+	c.Unlock()
+
+	go func() {
+		statusData, err = p.Probe(ctx)
+		close(probeReturned)
+	}()
+
+	go func() {
+		// Once ctx.Done() has been closed, we notify the polling loop by
+		// sending to the ctxTimeout channel. We cannot just close the channel,
+		// because otherwise the loop will always enter the "<-ctxTimeout" case.
+		<-ctx.Done()
+		ctxTimeout <- struct{}{}
+	}()
+
+	// This is a loop so that, when we hit a FailureThreshold, we still do
+	// not return until the probe returns. This is to ensure the same probe
+	// does not run again while it is blocked.
+	for {
+		select {
+		case <-c.stop:
+			// Collector was closed. The probe will complete in the background
+			// and won't be restarted again.
+			cancel()
+			return
+
+		case <-warningThreshold:
+			// Publish warning and continue waiting for probe
+			staleErr := fmt.Errorf("No response from %s probe within %v seconds",
+				p.Name, c.config.WarningThreshold.Seconds())
+			c.updateProbeStatus(p, nil, true, staleErr)
+
+		case <-probeReturned:
+			// The probe completed and we can return from runProbe
+			switch {
+			case hardTimeout:
+				// FailureThreshold was already reached. Keep the failure error
+				// message
+			case err != nil:
+				c.updateProbeStatus(p, nil, false, err)
+			default:
+				c.updateProbeStatus(p, statusData, false, nil)
+			}
+
+			cancel()
+			return
+
+		case <-ctxTimeout:
+			// We have timed out. Report a status and mark that we timed out so we
+			// do not emit status later.
+			staleErr := fmt.Errorf("No response from %s probe within %v seconds",
+				p.Name, c.config.FailureThreshold.Seconds())
+			c.updateProbeStatus(p, nil, true, staleErr)
+			hardTimeout = true
+		}
+	}
+}
+
+func (c *Collector) updateProbeStatus(p *Probe, data interface{}, staleWarning bool, err error) {
+	// Update stale status of the probe
+	c.Lock()
+	startTime := c.probeStartTime[p.Name]
+	if staleWarning {
+		c.staleProbes[p.Name] = struct{}{}
+	} else {
+		delete(c.staleProbes, p.Name)
+	}
+	c.Unlock()
+
+	if staleWarning {
+		log.WithField(logfields.StartTime, startTime).
+			Warn(fmt.Sprintf("Timeout while waiting for %q probe", p.Name))
+	}
+
+	// Notify the probe about status update
+	p.OnStatusUpdate(Status{Err: err, Data: data, StaleWarning: staleWarning})
+}

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -72,7 +72,7 @@ func (s *StatusTestSuite) TestCollectorStaleWarning(c *C) {
 	c.Assert(testutils.WaitUntil(func() bool {
 		return atomic.LoadUint64(&ok) >= 2
 	}, 1*time.Second), IsNil)
-	c.Assert(len(collector.GetStaleProbes()), Equals, 1)
+	c.Assert(collector.GetStaleProbes(), HasLen, 1)
 }
 
 func (s *StatusTestSuite) TestCollectorFailureTimeout(c *C) {
@@ -103,7 +103,7 @@ func (s *StatusTestSuite) TestCollectorFailureTimeout(c *C) {
 	c.Assert(testutils.WaitUntil(func() bool {
 		return atomic.LoadUint64(&ok) >= 1
 	}, 1*time.Second), IsNil)
-	c.Assert(len(collector.GetStaleProbes()), Equals, 1)
+	c.Assert(collector.GetStaleProbes(), HasLen, 1)
 }
 
 func (s *StatusTestSuite) TestCollectorSuccess(c *C) {
@@ -138,7 +138,7 @@ func (s *StatusTestSuite) TestCollectorSuccess(c *C) {
 	c.Assert(testutils.WaitUntil(func() bool {
 		return atomic.LoadUint64(&ok) >= 3 && atomic.LoadUint64(&errors) >= 3
 	}, 1*time.Second), IsNil)
-	c.Assert(len(collector.GetStaleProbes()), Equals, 0)
+	c.Assert(collector.GetStaleProbes(), HasLen, 0)
 }
 
 func (s *StatusTestSuite) TestCollectorSuccessAfterTimeout(c *C) {
@@ -170,5 +170,5 @@ func (s *StatusTestSuite) TestCollectorSuccessAfterTimeout(c *C) {
 	c.Assert(testutils.WaitUntil(func() bool {
 		return atomic.LoadUint64(&timeout) == 2 && atomic.LoadUint64(&ok) > 0
 	}, 1*time.Second), IsNil)
-	c.Assert(len(collector.GetStaleProbes()), Equals, 0)
+	c.Assert(collector.GetStaleProbes(), HasLen, 0)
 }

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -1,0 +1,174 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package status
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cilium/cilium/pkg/testutils"
+
+	. "gopkg.in/check.v1"
+)
+
+type StatusTestSuite struct {
+	config Config
+}
+
+var _ = Suite(&StatusTestSuite{})
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+func (s *StatusTestSuite) SetUpTest(c *C) {
+	s.config = Config{
+		Interval:         10 * time.Millisecond,
+		WarningThreshold: 20 * time.Millisecond,
+		FailureThreshold: 80 * time.Millisecond,
+	}
+}
+
+func (s *StatusTestSuite) TestCollectorStaleWarning(c *C) {
+	var ok uint64
+
+	p := []Probe{
+		{
+			Probe: func(ctx context.Context) (interface{}, error) {
+				time.Sleep(s.config.WarningThreshold * 2)
+				return nil, nil
+			},
+			OnStatusUpdate: func(status Status) {
+				if status.StaleWarning && status.Data == nil && status.Err != nil {
+					atomic.AddUint64(&ok, 1)
+
+				}
+			},
+		},
+	}
+
+	collector := NewCollector(p, s.config)
+	defer collector.Close()
+
+	// wait for the warning timeout to be reached twice
+	c.Assert(testutils.WaitUntil(func() bool {
+		return atomic.LoadUint64(&ok) >= 2
+	}, 1*time.Second), IsNil)
+	c.Assert(len(collector.GetStaleProbes()), Equals, 1)
+}
+
+func (s *StatusTestSuite) TestCollectorFailureTimeout(c *C) {
+	var ok uint64
+
+	p := []Probe{
+		{
+			Probe: func(ctx context.Context) (interface{}, error) {
+				time.Sleep(s.config.FailureThreshold * 2)
+				return nil, nil
+			},
+			OnStatusUpdate: func(status Status) {
+				if status.StaleWarning && status.Data == nil && status.Err != nil {
+					if strings.Contains(status.Err.Error(),
+						fmt.Sprintf("within %v seconds", s.config.FailureThreshold.Seconds())) {
+
+						atomic.AddUint64(&ok, 1)
+					}
+				}
+			},
+		},
+	}
+
+	collector := NewCollector(p, s.config)
+	defer collector.Close()
+
+	// wait for the failure timeout to kick in
+	c.Assert(testutils.WaitUntil(func() bool {
+		return atomic.LoadUint64(&ok) >= 1
+	}, 1*time.Second), IsNil)
+	c.Assert(len(collector.GetStaleProbes()), Equals, 1)
+}
+
+func (s *StatusTestSuite) TestCollectorSuccess(c *C) {
+	var ok, errors uint64
+	err := fmt.Errorf("error")
+
+	p := []Probe{
+		{
+			Probe: func(ctx context.Context) (interface{}, error) {
+				if atomic.LoadUint64(&ok) > 3 {
+					return nil, err
+				}
+				return "testData", nil
+			},
+			OnStatusUpdate: func(status Status) {
+				if status.Err == err {
+					atomic.AddUint64(&errors, 1)
+				}
+				if !status.StaleWarning && status.Data != nil && status.Err == nil {
+					if s, isString := status.Data.(string); isString && s == "testData" {
+						atomic.AddUint64(&ok, 1)
+					}
+				}
+			},
+		},
+	}
+
+	collector := NewCollector(p, s.config)
+	defer collector.Close()
+
+	// wait for the probe to succeed 3 times and to return the error 3 times
+	c.Assert(testutils.WaitUntil(func() bool {
+		return atomic.LoadUint64(&ok) >= 3 && atomic.LoadUint64(&errors) >= 3
+	}, 1*time.Second), IsNil)
+	c.Assert(len(collector.GetStaleProbes()), Equals, 0)
+}
+
+func (s *StatusTestSuite) TestCollectorSuccessAfterTimeout(c *C) {
+	var ok, timeout uint64
+
+	p := []Probe{
+		{
+			Probe: func(ctx context.Context) (interface{}, error) {
+				if atomic.LoadUint64(&timeout) == 0 {
+					time.Sleep(2 * s.config.FailureThreshold)
+				}
+				return nil, nil
+			},
+			OnStatusUpdate: func(status Status) {
+				if status.StaleWarning {
+					atomic.AddUint64(&timeout, 1)
+				} else {
+					atomic.AddUint64(&ok, 1)
+				}
+
+			},
+		},
+	}
+
+	collector := NewCollector(p, s.config)
+	defer collector.Close()
+
+	// wait for the probe to timeout (warning and failure) and then to succeed
+	c.Assert(testutils.WaitUntil(func() bool {
+		return atomic.LoadUint64(&timeout) == 2 && atomic.LoadUint64(&ok) > 0
+	}, 1*time.Second), IsNil)
+	c.Assert(len(collector.GetStaleProbes()), Equals, 0)
+}

--- a/vendor/github.com/mohae/deepcopy/LICENSE
+++ b/vendor/github.com/mohae/deepcopy/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Joel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/mohae/deepcopy/deepcopy.go
+++ b/vendor/github.com/mohae/deepcopy/deepcopy.go
@@ -1,0 +1,125 @@
+// deepcopy makes deep copies of things. A standard copy will copy the
+// pointers: deep copy copies the values pointed to.  Unexported field
+// values are not copied.
+//
+// Copyright (c)2014-2016, Joel Scoble (github.com/mohae), all rights reserved.
+// License: MIT, for more details check the included LICENSE file.
+package deepcopy
+
+import (
+	"reflect"
+	"time"
+)
+
+// Interface for delegating copy process to type
+type Interface interface {
+	DeepCopy() interface{}
+}
+
+// Iface is an alias to Copy; this exists for backwards compatibility reasons.
+func Iface(iface interface{}) interface{} {
+	return Copy(iface)
+}
+
+// Copy creates a deep copy of whatever is passed to it and returns the copy
+// in an interface{}.  The returned value will need to be asserted to the
+// correct type.
+func Copy(src interface{}) interface{} {
+	if src == nil {
+		return nil
+	}
+
+	// Make the interface a reflect.Value
+	original := reflect.ValueOf(src)
+
+	// Make a copy of the same type as the original.
+	cpy := reflect.New(original.Type()).Elem()
+
+	// Recursively copy the original.
+	copyRecursive(original, cpy)
+
+	// Return the copy as an interface.
+	return cpy.Interface()
+}
+
+// copyRecursive does the actual copying of the interface. It currently has
+// limited support for what it can handle. Add as needed.
+func copyRecursive(original, cpy reflect.Value) {
+	// check for implement deepcopy.Interface
+	if original.CanInterface() {
+		if copier, ok := original.Interface().(Interface); ok {
+			cpy.Set(reflect.ValueOf(copier.DeepCopy()))
+			return
+		}
+	}
+
+	// handle according to original's Kind
+	switch original.Kind() {
+	case reflect.Ptr:
+		// Get the actual value being pointed to.
+		originalValue := original.Elem()
+
+		// if  it isn't valid, return.
+		if !originalValue.IsValid() {
+			return
+		}
+		cpy.Set(reflect.New(originalValue.Type()))
+		copyRecursive(originalValue, cpy.Elem())
+
+	case reflect.Interface:
+		// If this is a nil, don't do anything
+		if original.IsNil() {
+			return
+		}
+		// Get the value for the interface, not the pointer.
+		originalValue := original.Elem()
+
+		// Get the value by calling Elem().
+		copyValue := reflect.New(originalValue.Type()).Elem()
+		copyRecursive(originalValue, copyValue)
+		cpy.Set(copyValue)
+
+	case reflect.Struct:
+		t, ok := original.Interface().(time.Time)
+		if ok {
+			cpy.Set(reflect.ValueOf(t))
+			return
+		}
+		// Go through each field of the struct and copy it.
+		for i := 0; i < original.NumField(); i++ {
+			// The Type's StructField for a given field is checked to see if StructField.PkgPath
+			// is set to determine if the field is exported or not because CanSet() returns false
+			// for settable fields.  I'm not sure why.  -mohae
+			if original.Type().Field(i).PkgPath != "" {
+				continue
+			}
+			copyRecursive(original.Field(i), cpy.Field(i))
+		}
+
+	case reflect.Slice:
+		if original.IsNil() {
+			return
+		}
+		// Make a new slice and copy each element.
+		cpy.Set(reflect.MakeSlice(original.Type(), original.Len(), original.Cap()))
+		for i := 0; i < original.Len(); i++ {
+			copyRecursive(original.Index(i), cpy.Index(i))
+		}
+
+	case reflect.Map:
+		if original.IsNil() {
+			return
+		}
+		cpy.Set(reflect.MakeMap(original.Type()))
+		for _, key := range original.MapKeys() {
+			originalValue := original.MapIndex(key)
+			copyValue := reflect.New(originalValue.Type()).Elem()
+			copyRecursive(originalValue, copyValue)
+			copyKey := Copy(key.Interface())
+			cpy.SetMapIndex(reflect.ValueOf(copyKey), copyValue)
+		}
+
+	default:
+		cpy.Set(original)
+	}
+}


### PR DESCRIPTION
This PR:

- Introduces `pkg/status` which adds a mechanism for running status probes concurrently. 
- Moves status retrieval of each `daemon` subsystem into separates probe, so a deadlocking/stale status update can be reported.

Example of a stale report:
```bash
    $ cilium status
    KVStore:                Failure   Err: No response from kvstore probe within 15 seconds
    ContainerRuntime:       Ok        docker daemon: OK
    Kubernetes:             Failure   No response from kubernetes probe within 15 seconds
    Kubernetes APIs:        [""]
    Cilium:                 Warning   Stale status data
    Stale status:           "kubernetes" since 2018-11-21T11:11:45.164Z, "kvstore" since 2018-11-21T11:09:43.133Z
    NodeMonitor:            Disabled
    Cilium health daemon:   Ok
    IPv4 address pool:      260/65535 allocated
    IPv6 address pool:      3/65535 allocated
    Proxy Status:           OK, ip 10.0.0.1, port-range 10000-20000
```

Notes:
- I considered adding a smoke test, but in the end I didn't write such, as w/o adding some flags to `daemon` the test would be relatively complex and flaky.
- There is a `FIXME` for adding the locks status. It's going to be done in a separate PR, as this PR already became fairly big.
- We should probably change the order when making the final decision for `Cilium` status, as IMO any failure in `KvStore`/`ContainerRuntime`/`Kubernetes` is more important than the staleness reporting. It can be done in a separate PR.
- `cilium debuginfo` won't wait for all probes to return, so some status fields might be missing.
- Currently no probe is using `context.Context`, so the param is redundant and can be removed. However, it would be a good idea to start using it.

Joint work with @tgraf and @raybejjani.

Fixes: #5674

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6271)
<!-- Reviewable:end -->
