### PR TITLE
policy: add RulesSelect field to SearchContext

### DIFF
--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -68,6 +68,11 @@ type SearchContext struct {
 	From    labels.LabelArray
 	To      labels.LabelArray
 	DPorts  []*models.Port
+	// RulesSelect specifies whether or not to check whether a rule which is
+	// being analyzed using this SearchContext matches either From or To.
+	// This is used to avoid using EndpointSelector.Matches() if possible,
+	// since it is costly in terms of performance.
+	RulesSelect bool
 }
 
 func (s *SearchContext) String() string {

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -295,9 +295,11 @@ func mergeCIDR(ctx *SearchContext, dir string, ipRules []api.CIDR, ruleLabels la
 // added to result, a nil CIDRPolicy is returned.
 func (r *rule) resolveCIDRPolicy(ctx *SearchContext, state *traceState, result *CIDRPolicy) *CIDRPolicy {
 	// Don't select rule if it doesn't apply to the given context.
-	if !r.EndpointSelector.Matches(ctx.To) {
-		state.unSelectRule(ctx, ctx.To, r)
-		return nil
+	if !ctx.RulesSelect {
+		if !r.EndpointSelector.Matches(ctx.To) {
+			state.unSelectRule(ctx, ctx.To, r)
+			return nil
+		}
 	}
 
 	state.selectRule(ctx, r)
@@ -351,9 +353,11 @@ func (r *rule) resolveCIDRPolicy(ctx *SearchContext, state *traceState, result *
 // contained within r.
 func (r *rule) canReachIngress(ctx *SearchContext, state *traceState) api.Decision {
 
-	if !r.EndpointSelector.Matches(ctx.To) {
-		state.unSelectRule(ctx, ctx.To, r)
-		return api.Undecided
+	if !ctx.RulesSelect {
+		if !r.EndpointSelector.Matches(ctx.To) {
+			state.unSelectRule(ctx, ctx.To, r)
+			return api.Undecided
+		}
 	}
 
 	state.selectRule(ctx, r)
@@ -398,9 +402,11 @@ func (r *rule) canReachIngress(ctx *SearchContext, state *traceState) api.Decisi
 // contained within r.
 func (r *rule) canReachEgress(ctx *SearchContext, state *traceState) api.Decision {
 
-	if !r.EndpointSelector.Matches(ctx.From) {
-		state.unSelectRule(ctx, ctx.From, r)
-		return api.Undecided
+	if !ctx.RulesSelect {
+		if !r.EndpointSelector.Matches(ctx.From) {
+			state.unSelectRule(ctx, ctx.From, r)
+			return api.Undecided
+		}
 	}
 
 	state.selectRule(ctx, r)

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -57,8 +57,10 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 	// Duplicate L3-only rules into wildcard L7 rules.
 	for _, r := range rules {
 		if ingress {
-			if !r.EndpointSelector.Matches(ctx.To) {
-				continue
+			if !ctx.RulesSelect {
+				if !r.EndpointSelector.Matches(ctx.To) {
+					continue
+				}
 			}
 			for _, rule := range r.Ingress {
 				// Non-label-based rule. Ignore.
@@ -87,8 +89,10 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 				}
 			}
 		} else {
-			if !r.EndpointSelector.Matches(ctx.From) {
-				continue
+			if !ctx.RulesSelect {
+				if !r.EndpointSelector.Matches(ctx.From) {
+					continue
+				}
 			}
 			for _, rule := range r.Egress {
 				// Non-label-based rule. Ignore.


### PR DESCRIPTION
RulesSelect specifies whether or not to check whether a rule which is
being analyzed against its SearchContext has already been determined to select
the labels in the `To` or `From` fields within the SearchContext. This is used
to avoid using `EndpointSelector.Matches()` while analyzing rules if possible,
since said function is costly in terms of performance. Currently, this flag
is always false, so no functional change is intended here. In the future, the
list of rules that will be analyzed when generating policy for an endpoint will
only be the list of rules that select the endpoint.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6274)
<!-- Reviewable:end -->
