### PR TITLE
policy: move PolicyMapState into policy package

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -312,7 +312,7 @@ func (e *Endpoint) addNewRedirectsFromMap(owner Owner, m policy.L4PolicyMap, des
 	var finalizeList revert.FinalizeList
 	var revertStack revert.RevertStack
 	var updatedStats []*models.ProxyStatistics
-	insertedDesiredMapState := make(map[policymap.PolicyKey]struct{})
+	insertedDesiredMapState := make(map[policy.Key]struct{})
 	updatedDesiredMapState := make(policy.MapState)
 
 	for _, l4 := range m {
@@ -1064,8 +1064,16 @@ func (e *Endpoint) syncPolicyMap() error {
 		// Convert key to host-byte order for lookup in the desiredMapState.
 		keyHostOrder := entry.Key.ToHost()
 
+		// Convert from policymap.Key to policy.Key
+		policyMapKeyToPolicyKey := policy.Key{
+			Identity:         keyHostOrder.Identity,
+			DestPort:         keyHostOrder.DestPort,
+			Nexthdr:          keyHostOrder.Nexthdr,
+			TrafficDirection: keyHostOrder.TrafficDirection,
+		}
+
 		// If key that is in policy map is not in desired state, just remove it.
-		if _, ok := e.desiredMapState[keyHostOrder]; !ok {
+		if _, ok := e.desiredMapState[policyMapKeyToPolicyKey]; !ok {
 			// Can pass key with host byte-order fields, as it will get
 			// converted to network byte-order.
 			err := e.PolicyMap.DeleteKey(keyHostOrder)
@@ -1074,16 +1082,25 @@ func (e *Endpoint) syncPolicyMap() error {
 				errors = append(errors, err)
 			} else {
 				// Operation was successful, remove from realized state.
-				delete(e.realizedMapState, keyHostOrder)
+				delete(e.realizedMapState, policyMapKeyToPolicyKey)
 			}
 		}
 	}
 
 	for keyToAdd, entry := range e.desiredMapState {
 		if oldEntry, ok := e.realizedMapState[keyToAdd]; !ok || oldEntry != entry {
-			err := e.PolicyMap.AllowKey(keyToAdd, entry.ProxyPort)
+
+			// Convert from policy.Key to policymap.Key
+			policyKeyToPolicyMapKey := policymap.PolicyKey{
+				Identity:         keyToAdd.Identity,
+				DestPort:         keyToAdd.DestPort,
+				Nexthdr:          keyToAdd.Nexthdr,
+				TrafficDirection: keyToAdd.TrafficDirection,
+			}
+
+			err := e.PolicyMap.AllowKey(policyKeyToPolicyMapKey, entry.ProxyPort)
 			if err != nil {
-				e.getLogger().WithError(err).Errorf("Failed to add PolicyMap key %s %d", keyToAdd.String(), entry.ProxyPort)
+				e.getLogger().WithError(err).Errorf("Failed to add PolicyMap key %s %d", policyKeyToPolicyMapKey.String(), entry.ProxyPort)
 				errors = append(errors, err)
 			} else {
 				// Operation was successful, add to realized state.

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -313,7 +313,7 @@ func (e *Endpoint) addNewRedirectsFromMap(owner Owner, m policy.L4PolicyMap, des
 	var revertStack revert.RevertStack
 	var updatedStats []*models.ProxyStatistics
 	insertedDesiredMapState := make(map[policymap.PolicyKey]struct{})
-	updatedDesiredMapState := make(PolicyMapState)
+	updatedDesiredMapState := make(policy.MapState)
 
 	for _, l4 := range m {
 		if l4.IsRedirect() {
@@ -372,7 +372,7 @@ func (e *Endpoint) addNewRedirectsFromMap(owner Owner, m policy.L4PolicyMap, des
 					insertedDesiredMapState[keyFromFilter] = struct{}{}
 				}
 
-				e.desiredMapState[keyFromFilter] = PolicyMapStateEntry{ProxyPort: redirectPort}
+				e.desiredMapState[keyFromFilter] = policy.MapStateEntry{ProxyPort: redirectPort}
 			}
 
 		}
@@ -602,7 +602,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 
 		// Also reset the in-memory state of the realized state as the
 		// BPF map content is guaranteed to be empty right now.
-		e.realizedMapState = make(PolicyMapState)
+		e.realizedMapState = make(policy.MapState)
 	}
 
 	if e.bpfConfigMap == nil {
@@ -1008,18 +1008,6 @@ func (e *Endpoint) GetBPFValue() (*lxcmap.EndpointInfo, error) {
 	return info, nil
 }
 
-// PolicyMapState is a state of a policy map.
-type PolicyMapState map[policymap.PolicyKey]PolicyMapStateEntry
-
-// PolicyMapStateEntry is the configuration associated with a PolicyKey in a
-// PolicyMapState. This is a minimized version of policymap.PolicyEntry.
-type PolicyMapStateEntry struct {
-	// The proxy port, in host byte order.
-	// If 0 (default), there is no proxy redirection for the corresponding
-	// PolicyKey.
-	ProxyPort uint16
-}
-
 // syncPolicyMap attempts to synchronize the PolicyMap for this endpoint to
 // contain the set of PolicyKeys represented by the endpoint's desiredMapState.
 // It checks the current contents of the endpoint's PolicyMap and deletes any
@@ -1032,11 +1020,11 @@ type PolicyMapStateEntry struct {
 func (e *Endpoint) syncPolicyMap() error {
 
 	if e.realizedMapState == nil {
-		e.realizedMapState = make(PolicyMapState)
+		e.realizedMapState = make(policy.MapState)
 	}
 
 	if e.desiredMapState == nil {
-		e.desiredMapState = make(PolicyMapState)
+		e.desiredMapState = make(policy.MapState)
 	}
 
 	if e.PolicyMap == nil {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -266,7 +266,7 @@ type Endpoint struct {
 	// inserted (realized) in the endpoint's BPF PolicyMap to a proxy port.
 	// Proxy port 0 indicates no proxy redirection.
 	// All fields within the PolicyKey and the proxy port must be in host byte-order.
-	realizedMapState PolicyMapState
+	realizedMapState policy.MapState
 
 	// desiredMapState maps each PolicyKeys which should be synched
 	// with, but may not yet be synched with, the endpoint's BPF PolicyMap, to
@@ -274,7 +274,7 @@ type Endpoint struct {
 	// This map is updated upon regeneration of policy for an endpoint.
 	// Proxy port 0 indicates no proxy redirection.
 	// All fields within the PolicyKey and the proxy port must be in host byte-order.
-	desiredMapState PolicyMapState
+	desiredMapState policy.MapState
 
 	// BPFConfigMap provides access to the endpoint's BPF configuration.
 	bpfConfigMap *bpfconfig.EndpointConfigMap

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -262,10 +262,10 @@ type Endpoint struct {
 	// You must hold Endpoint.Mutex to read or write it.
 	realizedRedirects map[string]uint16
 
-	// realizedMapState maps each PolicyKey which is presently
+	// realizedMapState maps each Key which is presently
 	// inserted (realized) in the endpoint's BPF PolicyMap to a proxy port.
 	// Proxy port 0 indicates no proxy redirection.
-	// All fields within the PolicyKey and the proxy port must be in host byte-order.
+	// All fields within the Key and the proxy port must be in host byte-order.
 	realizedMapState policy.MapState
 
 	// desiredMapState maps each PolicyKeys which should be synched
@@ -273,7 +273,7 @@ type Endpoint struct {
 	// a proxy port.
 	// This map is updated upon regeneration of policy for an endpoint.
 	// Proxy port 0 indicates no proxy redirection.
-	// All fields within the PolicyKey and the proxy port must be in host byte-order.
+	// All fields within the Key and the proxy port must be in host byte-order.
 	desiredMapState policy.MapState
 
 	// BPFConfigMap provides access to the endpoint's BPF configuration.
@@ -653,7 +653,7 @@ func (e *Endpoint) GetPolicyModel() *models.EndpointPolicyStatus {
 
 	for policyMapKey := range e.realizedMapState {
 		if policyMapKey.DestPort != 0 {
-			// If the port is non-zero, then the PolicyKey no longer only applies
+			// If the port is non-zero, then the Key no longer only applies
 			// at L3. AllowedIngressIdentities and AllowedEgressIdentities
 			// contain sets of which identities (i.e., label-based L3 only)
 			// are allowed, so anything which contains L4-related policy should
@@ -675,7 +675,7 @@ func (e *Endpoint) GetPolicyModel() *models.EndpointPolicyStatus {
 
 	for policyMapKey := range e.desiredMapState {
 		if policyMapKey.DestPort != 0 {
-			// If the port is non-zero, then the PolicyKey no longer only applies
+			// If the port is non-zero, then the Key no longer only applies
 			// at L3. AllowedIngressIdentities and AllowedEgressIdentities
 			// contain sets of which identities (i.e., label-based L3 only)
 			// are allowed, so anything which contains L4-related policy should
@@ -995,7 +995,7 @@ func (e *Endpoint) Allows(id identityPkg.NumericIdentity) bool {
 	e.UnconditionalRLock()
 	defer e.RUnlock()
 
-	keyToLookup := policymap.PolicyKey{
+	keyToLookup := policy.Key{
 		Identity:         uint32(id),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -144,9 +144,9 @@ func (e *Endpoint) lookupRedirectPort(l4Filter *policy.L4Filter) uint16 {
 	return e.realizedRedirects[proxyID]
 }
 
-func (e *Endpoint) computeDesiredL4PolicyMapEntries(keysToAdd PolicyMapState) {
+func (e *Endpoint) computeDesiredL4PolicyMapEntries(keysToAdd policy.MapState) {
 	if keysToAdd == nil {
-		keysToAdd = PolicyMapState{}
+		keysToAdd = policy.MapState{}
 	}
 
 	if e.DesiredL4Policy == nil {
@@ -169,7 +169,7 @@ func (e *Endpoint) computeDesiredL4PolicyMapEntries(keysToAdd PolicyMapState) {
 					continue
 				}
 			}
-			keysToAdd[keyFromFilter] = PolicyMapStateEntry{ProxyPort: proxyPort}
+			keysToAdd[keyFromFilter] = policy.MapStateEntry{ProxyPort: proxyPort}
 		}
 	}
 
@@ -189,7 +189,7 @@ func (e *Endpoint) computeDesiredL4PolicyMapEntries(keysToAdd PolicyMapState) {
 					continue
 				}
 			}
-			keysToAdd[keyFromFilter] = PolicyMapStateEntry{ProxyPort: proxyPort}
+			keysToAdd[keyFromFilter] = policy.MapStateEntry{ProxyPort: proxyPort}
 		}
 	}
 	return
@@ -255,7 +255,7 @@ func (e *Endpoint) resolveL4Policy(repo *policy.Repository) (policyChanged bool,
 }
 
 func (e *Endpoint) computeDesiredPolicyMapState(repo *policy.Repository) {
-	desiredPolicyKeys := make(PolicyMapState)
+	desiredPolicyKeys := make(policy.MapState)
 	e.computeDesiredL4PolicyMapEntries(desiredPolicyKeys)
 	e.determineAllowLocalhost(desiredPolicyKeys)
 	e.determineAllowFromWorld(desiredPolicyKeys)
@@ -267,14 +267,14 @@ func (e *Endpoint) computeDesiredPolicyMapState(repo *policy.Repository) {
 // communicate with the localhost. It inserts the PolicyKey corresponding to
 // the localhost in the desiredPolicyKeys if the endpoint is allowed to
 // communicate with the localhost.
-func (e *Endpoint) determineAllowLocalhost(desiredPolicyKeys PolicyMapState) {
+func (e *Endpoint) determineAllowLocalhost(desiredPolicyKeys policy.MapState) {
 
 	if desiredPolicyKeys == nil {
-		desiredPolicyKeys = PolicyMapState{}
+		desiredPolicyKeys = policy.MapState{}
 	}
 
 	if option.Config.AlwaysAllowLocalhost() || (e.DesiredL4Policy != nil && e.DesiredL4Policy.HasRedirect()) {
-		desiredPolicyKeys[localHostKey] = PolicyMapStateEntry{}
+		desiredPolicyKeys[localHostKey] = policy.MapStateEntry{}
 	}
 }
 
@@ -286,22 +286,22 @@ func (e *Endpoint) determineAllowLocalhost(desiredPolicyKeys PolicyMapState) {
 // This must be run after determineAllowLocalhost().
 //
 // For more information, see https://cilium.link/host-vs-world
-func (e *Endpoint) determineAllowFromWorld(desiredPolicyKeys PolicyMapState) {
+func (e *Endpoint) determineAllowFromWorld(desiredPolicyKeys policy.MapState) {
 
 	if desiredPolicyKeys == nil {
-		desiredPolicyKeys = PolicyMapState{}
+		desiredPolicyKeys = policy.MapState{}
 	}
 
 	_, localHostAllowed := desiredPolicyKeys[localHostKey]
 	if option.Config.HostAllowsWorld && localHostAllowed {
-		desiredPolicyKeys[worldKey] = PolicyMapStateEntry{}
+		desiredPolicyKeys[worldKey] = policy.MapStateEntry{}
 	}
 }
 
-func (e *Endpoint) computeDesiredL3PolicyMapEntries(repo *policy.Repository, desiredPolicyKeys PolicyMapState) {
+func (e *Endpoint) computeDesiredL3PolicyMapEntries(repo *policy.Repository, desiredPolicyKeys policy.MapState) {
 
 	if desiredPolicyKeys == nil {
-		desiredPolicyKeys = PolicyMapState{}
+		desiredPolicyKeys = policy.MapState{}
 	}
 
 	ingressCtx := policy.SearchContext{
@@ -349,7 +349,7 @@ func (e *Endpoint) computeDesiredL3PolicyMapEntries(repo *policy.Repository, des
 				Identity:         identity.Uint32(),
 				TrafficDirection: trafficdirection.Ingress.Uint8(),
 			}
-			desiredPolicyKeys[keyToAdd] = PolicyMapStateEntry{}
+			desiredPolicyKeys[keyToAdd] = policy.MapStateEntry{}
 		}
 
 		var egressAccess api.Decision
@@ -368,7 +368,7 @@ func (e *Endpoint) computeDesiredL3PolicyMapEntries(repo *policy.Repository, des
 				Identity:         identity.Uint32(),
 				TrafficDirection: trafficdirection.Egress.Uint8(),
 			}
-			desiredPolicyKeys[keyToAdd] = PolicyMapStateEntry{}
+			desiredPolicyKeys[keyToAdd] = policy.MapStateEntry{}
 		}
 	}
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -257,45 +257,10 @@ func (e *Endpoint) resolveL4Policy(repo *policy.Repository) (policyChanged bool,
 func (e *Endpoint) computeDesiredPolicyMapState(repo *policy.Repository) {
 	desiredPolicyKeys := make(policy.MapState)
 	e.computeDesiredL4PolicyMapEntries(desiredPolicyKeys)
-	e.determineAllowLocalhost(desiredPolicyKeys)
-	e.determineAllowFromWorld(desiredPolicyKeys)
+	desiredPolicyKeys.DetermineAllowLocalhost(e.DesiredL4Policy)
+	desiredPolicyKeys.DetermineAllowFromWorld()
 	e.computeDesiredL3PolicyMapEntries(repo, desiredPolicyKeys)
 	e.desiredMapState = desiredPolicyKeys
-}
-
-// determineAllowLocalhost determines whether endpoint should be allowed to
-// communicate with the localhost. It inserts the PolicyKey corresponding to
-// the localhost in the desiredPolicyKeys if the endpoint is allowed to
-// communicate with the localhost.
-func (e *Endpoint) determineAllowLocalhost(desiredPolicyKeys policy.MapState) {
-
-	if desiredPolicyKeys == nil {
-		desiredPolicyKeys = policy.MapState{}
-	}
-
-	if option.Config.AlwaysAllowLocalhost() || (e.DesiredL4Policy != nil && e.DesiredL4Policy.HasRedirect()) {
-		desiredPolicyKeys[localHostKey] = policy.MapStateEntry{}
-	}
-}
-
-// determineAllowFromWorld determines whether world should be allowed to
-// communicate with the endpoint, based on legacy Cilium 1.0 behaviour. It
-// inserts the PolicyKey corresponding to the world in the desiredPolicyKeys
-// if the legacy mode is enabled.
-//
-// This must be run after determineAllowLocalhost().
-//
-// For more information, see https://cilium.link/host-vs-world
-func (e *Endpoint) determineAllowFromWorld(desiredPolicyKeys policy.MapState) {
-
-	if desiredPolicyKeys == nil {
-		desiredPolicyKeys = policy.MapState{}
-	}
-
-	_, localHostAllowed := desiredPolicyKeys[localHostKey]
-	if option.Config.HostAllowsWorld && localHostAllowed {
-		desiredPolicyKeys[worldKey] = policy.MapStateEntry{}
-	}
 }
 
 func (e *Endpoint) computeDesiredL3PolicyMapEntries(repo *policy.Repository, desiredPolicyKeys policy.MapState) {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -111,15 +111,15 @@ func getSecurityIdentities(labelsMap cache.IdentityCache, selector *api.Endpoint
 // convertL4FilterToPolicyMapKeys converts filter into a list of PolicyKeys
 // that apply to this endpoint.
 // Must be called with endpoint.Mutex locked.
-func (e *Endpoint) convertL4FilterToPolicyMapKeys(filter *policy.L4Filter, direction trafficdirection.TrafficDirection) []policymap.PolicyKey {
-	keysToAdd := []policymap.PolicyKey{}
+func (e *Endpoint) convertL4FilterToPolicyMapKeys(filter *policy.L4Filter, direction trafficdirection.TrafficDirection) []policy.Key {
+	keysToAdd := []policy.Key{}
 	port := uint16(filter.Port)
 	proto := uint8(filter.U8Proto)
 
 	for _, sel := range filter.Endpoints {
 		for _, id := range getSecurityIdentities(*e.prevIdentityCache, &sel) {
 			srcID := id.Uint32()
-			keyToAdd := policymap.PolicyKey{
+			keyToAdd := policy.Key{
 				Identity: srcID,
 				// NOTE: Port is in host byte-order!
 				DestPort:         port,
@@ -310,7 +310,7 @@ func (e *Endpoint) computeDesiredL3PolicyMapEntries(repo *policy.Repository, des
 			ingressAccess = api.Allowed
 		}
 		if ingressAccess == api.Allowed {
-			keyToAdd := policymap.PolicyKey{
+			keyToAdd := policy.Key{
 				Identity:         identity.Uint32(),
 				TrafficDirection: trafficdirection.Ingress.Uint8(),
 			}
@@ -329,7 +329,7 @@ func (e *Endpoint) computeDesiredL3PolicyMapEntries(repo *policy.Repository, des
 			egressAccess = api.Allowed
 		}
 		if egressAccess == api.Allowed {
-			keyToAdd := policymap.PolicyKey{
+			keyToAdd := policy.Key{
 				Identity:         identity.Uint32(),
 				TrafficDirection: trafficdirection.Egress.Uint8(),
 			}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -1,0 +1,29 @@
+// Copyright 2016-2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import "github.com/cilium/cilium/pkg/maps/policymap"
+
+// MapState is a state of a policy map.
+type MapState map[policymap.PolicyKey]MapStateEntry
+
+// MapStateEntry is the configuration associated with a PolicyKey in a
+// MapState. This is a minimized version of policymap.PolicyEntry.
+type MapStateEntry struct {
+	// The proxy port, in host byte order.
+	// If 0 (default), there is no proxy redirection for the corresponding
+	// PolicyKey.
+	ProxyPort uint16
+}


### PR DESCRIPTION
This is part of a broader effort to move most of the policy computation logic into the policy package itself, and out of endpoint. The idea is that in the future, we will have a single 'policy' object, which will be a field within `Endpoint`. The endpoint will consume this type, but will not be involved in its creation - that will be the responsibility of the policy package. This will make unit-testing policy generation easier, and will hide implementation details away from the endpoint package.

I don't like putting something related closely to the datapath implementation within the policy package, but in order to unify everything in one 'Policy' object for an endpoint, I think this is a necessary step to do so. Eventually, translation to `PolicyMapState` can be done via some translation into a datapath representation of the generated policy.

No functional changes are intended here.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6275)
<!-- Reviewable:end -->
