### PR TITLE
doc: add openSUSE as supported distro

### DIFF
--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -793,6 +793,16 @@ The following applies to Ubuntu 17.04 or later:
       clang gcc-multilib llvm libncurses5-dev git pkg-config libmnl bison flex \
       graphviz
 
+openSUSE Tumbleweed
+```````````````````
+
+The following applies to openSUSE Tumbleweed and openSUSE Leap 15.0 or later:
+
+::
+
+   $ sudo  zypper install -y git gcc ncurses-devel libelf-devel bc libopenssl-devel \
+   libcap-devel clang llvm graphviz bison flex glibc-devel-static
+
 Compiling the Kernel
 ````````````````````
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -374,6 +374,7 @@ ons
 onwards
 oolchain
 opcodes
+openSUSE
 orchestrator
 org
 osx

--- a/README.rst
+++ b/README.rst
@@ -183,7 +183,7 @@ kernel version 4.8.0 or newer (the latest current stable Linux kernel is
 4.14.x).
 
 Many Linux distributions including CoreOS, Debian, Docker's LinuxKit, Fedora,
-and Ubuntu already ship kernel versions >= 4.8.x. You can check your Linux
+openSUSE and Ubuntu already ship kernel versions >= 4.8.x. You can check your Linux
 kernel version by running ``uname -a``. If you are not yet running a recent
 enough kernel, check the Documentation of your Linux distribution on how to run
 Linux kernel 4.9.x or later.


### PR DESCRIPTION
SUSE supports cilium and bpf in  Leap 15/Tumbleweed

Signed-off-by: Nirmoy Das <ndas@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6288)
<!-- Reviewable:end -->
