### PR TITLE
test: perform downgrade for given version

### DIFF
--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -271,12 +271,12 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		err = kubectl.CiliumInstallVersion(
 			helpers.CiliumDefaultDSPatch,
 			helpers.CiliumConfigMapPatch,
-			helpers.CiliumStableVersion,
+			oldVersion,
 		)
-		ExpectWithOffset(1, err).To(BeNil(), "Cilium %q was not able to be deployed", helpers.CiliumStableVersion)
+		ExpectWithOffset(1, err).To(BeNil(), "Cilium %q was not able to be deployed", oldVersion)
 
 		err = helpers.WithTimeout(
-			waitForUpdateImage(helpers.CiliumStableVersion),
+			waitForUpdateImage(oldVersion),
 			"Cilium Pods are not updating correctly",
 			&helpers.TimeoutConfig{Timeout: timeout})
 		ExpectWithOffset(1, err).To(BeNil(), "Pods are not updating")
@@ -285,7 +285,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 			helpers.KubeSystemNamespace, "-l k8s-app=cilium", timeout)
 		ExpectWithOffset(1, err).Should(BeNil(), "Cilium is not ready after timeout")
 
-		validatedImage(helpers.CiliumStableImageVersion)
+		validatedImage(oldVersion)
 
 		validateEndpointsConnection()
 


### PR DESCRIPTION
The nightly downgrade tests have been performing the tests
against the helpers.CiliumStableImageVersion but they should
perform the downgrade for the given oldVersion image tag.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6293)
<!-- Reviewable:end -->
