### PR TITLE
cni: Synchroneous pod label retrieval on CNI add

### DIFF
--- a/Documentation/concepts.rst
+++ b/Documentation/concepts.rst
@@ -396,6 +396,10 @@ identities are prefixed with the string ``reserved:``.
 |                     | some of the metadata required to derive the       |
 |                     | security identity is still missing. This is       |
 |                     | typically the case in the bootstrapping phase.    |
+|                     |                                                   |
+|                     | The init identity is only allocated if the labels |
+|                     | of the endpoint are not known at creation time.   |
+|                     | This can be the case for the Docker plugin.       |
 +---------------------+---------------------------------------------------+
 | reserved:unmanaged  | An endpoint that is not managed by Cilium, e.g.   |
 |                     | a Kubernetes pod that was launched before Cilium  |

--- a/api/v1/models/endpoint_change_request.go
+++ b/api/v1/models/endpoint_change_request.go
@@ -45,6 +45,12 @@ type EndpointChangeRequest struct {
 	// Name of network device
 	InterfaceName string `json:"interface-name,omitempty"`
 
+	// Kubernetes namespace name
+	K8sNamespace string `json:"k8s-namespace,omitempty"`
+
+	// Kubernetes pod name
+	K8sPodName string `json:"k8s-pod-name,omitempty"`
+
 	// Labels describing the identity
 	Labels Labels `json:"labels"`
 
@@ -80,6 +86,10 @@ type EndpointChangeRequest struct {
 /* polymorph EndpointChangeRequest interface-index false */
 
 /* polymorph EndpointChangeRequest interface-name false */
+
+/* polymorph EndpointChangeRequest k8s-namespace false */
+
+/* polymorph EndpointChangeRequest k8s-pod-name false */
 
 /* polymorph EndpointChangeRequest labels false */
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -825,6 +825,12 @@ definitions:
         type: string
       addressing:
         "$ref": "#/definitions/AddressPair"
+      k8s-pod-name:
+        description: Kubernetes pod name
+        type: string
+      k8s-namespace:
+        description: Kubernetes namespace name
+        type: string
       policy-enabled:
         description: Whether policy enforcement is enabled or not
         type: boolean

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1420,6 +1420,14 @@ func init() {
           "description": "Name of network device",
           "type": "string"
         },
+        "k8s-namespace": {
+          "description": "Kubernetes namespace name",
+          "type": "string"
+        },
+        "k8s-pod-name": {
+          "description": "Kubernetes pod name",
+          "type": "string"
+        },
         "labels": {
           "description": "Labels describing the identity",
           "$ref": "#/definitions/Labels"

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -470,7 +470,7 @@ func init() {
 	flags.Bool("sidecar-http-proxy", false, "Disable host HTTP proxy, assuming proxies in sidecar containers")
 	flags.MarkHidden("sidecar-http-proxy")
 	viper.BindEnv("sidecar-http-proxy", "CILIUM_SIDECAR_HTTP_PROXY")
-	flags.String("sidecar-istio-proxy-image", workloads.DefaultSidecarIstioProxyImageRegexp,
+	flags.String("sidecar-istio-proxy-image", k8s.DefaultSidecarIstioProxyImageRegexp,
 		"Regular expression matching compatible Istio sidecar istio-proxy container image names")
 	viper.BindEnv("sidecar-istio-proxy-image", "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE")
 	flags.Bool(option.SingleClusterRouteName, false,
@@ -803,7 +803,7 @@ func initEnv(cmd *cobra.Command) {
 		log.Warn(`"sidecar-http-proxy" flag is deprecated and has no effect`)
 	}
 
-	workloads.SidecarIstioProxyImageRegexp, err = regexp.Compile(viper.GetString("sidecar-istio-proxy-image"))
+	k8s.SidecarIstioProxyImageRegexp, err = regexp.Compile(viper.GetString("sidecar-istio-proxy-image"))
 	if err != nil {
 		log.WithError(err).Fatal("Invalid sidecar-istio-proxy-image regular expression")
 		return

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -430,12 +430,15 @@ func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, 
 		DockerNetworkID:  base.DockerNetworkID,
 		DockerEndpointID: base.DockerEndpointID,
 		IfName:           base.InterfaceName,
+		k8sPodName:       base.K8sPodName,
+		k8sNamespace:     base.K8sNamespace,
 		IfIndex:          int(base.InterfaceIndex),
 		OpLabels:         pkgLabels.NewOpLabels(),
 		state:            "",
 		Status:           NewEndpointStatus(),
 		hasBPFProgram:    make(chan struct{}, 0),
 	}
+
 	ep.UpdateLogger(nil)
 
 	ep.SetStateLocked(string(base.State), "Endpoint creation")

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -1,0 +1,143 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"regexp"
+
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// AnnotationIstioSidecarStatus is the annotation added by Istio into a pod
+	// when it is injected with a sidecar proxy.
+	// Since Istio 0.5.0, the value of this annotation is a serialized JSON object
+	// with the following structure ("imagePullSecrets" was added in Istio 0.8.0):
+	//
+	//     {
+	//         "version": "0213afe1274259d2f23feb4820ad2f8eb8609b84a5538e5f51f711545b6bde88",
+	//         "initContainers": ["sleep", "istio-init"],
+	//         "containers": ["istio-proxy"],
+	//         "volumes": ["cilium-unix-sock-dir", "istio-envoy", "istio-certs"],
+	//         "imagePullSecrets": null
+	//     }
+	AnnotationIstioSidecarStatus = "sidecar.istio.io/status"
+
+	// DefaultSidecarIstioProxyImageRegexp is the default regexp compiled into
+	// SidecarIstioProxyImageRegexp.
+	DefaultSidecarIstioProxyImageRegexp = "cilium/istio_proxy"
+)
+
+var (
+	// SidecarIstioProxyImageRegexp is the regular expression matching
+	// compatible Istio sidecar istio-proxy container image names.
+	// This is set by the "sidecar-istio-proxy-image" configuration flag.
+	SidecarIstioProxyImageRegexp = regexp.MustCompile(DefaultSidecarIstioProxyImageRegexp)
+)
+
+// isInjectedWithIstioSidecarProxy returns whether the given pod has been
+// injected by Istio with a sidecar proxy that is compatible with Cilium.
+func isInjectedWithIstioSidecarProxy(scopedLog *logrus.Entry, pod *corev1.Pod) bool {
+	istioStatusString, ok := pod.GetAnnotations()[AnnotationIstioSidecarStatus]
+	if !ok {
+		// Istio's injection annotation was not found.
+		scopedLog.Debugf("No %s annotation", AnnotationIstioSidecarStatus)
+		return false
+	}
+
+	scopedLog.Debugf("Found %s annotation with value: %s",
+		AnnotationIstioSidecarStatus, istioStatusString)
+
+	// Check that there's an "istio-proxy" container that uses an image
+	// compatible with Cilium.
+	for _, container := range pod.Spec.Containers {
+		if container.Name != "istio-proxy" {
+			continue
+		}
+		scopedLog.Debug("Found istio-proxy container in pod")
+
+		if !SidecarIstioProxyImageRegexp.MatchString(container.Image) {
+			continue
+		}
+		scopedLog.Debugf("istio-proxy container runs Cilium-compatible image: %s", container.Image)
+
+		for _, mount := range container.VolumeMounts {
+			if mount.MountPath != "/var/run/cilium" {
+				continue
+			}
+			scopedLog.Debug("istio-proxy container has volume mounted into /var/run/cilium")
+
+			return true
+		}
+	}
+
+	scopedLog.Debug("No Cilium-compatible istio-proxy container found")
+	return false
+}
+
+// GetPodLabels returns the labels of a pod
+func GetPodLabels(namespace, podName string) (map[string]string, error) {
+	scopedLog := log.WithFields(logrus.Fields{
+		logfields.K8sNamespace: namespace,
+		logfields.K8sPodName:   podName,
+	})
+	scopedLog.Debug("Connecting to k8s apiserver to retrieve labels for pod")
+
+	result, err := Client().CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// Also get all labels from the namespace where the pod is running
+	k8sNs, err := Client().CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	k8sLabels := result.GetLabels()
+	if k8sLabels == nil {
+		k8sLabels = map[string]string{}
+	}
+	for k, v := range k8sNs.GetLabels() {
+		k8sLabels[policy.JoinPath(k8sConst.PodNamespaceMetaLabels, k)] = v
+	}
+	k8sLabels[k8sConst.PodNamespaceLabel] = namespace
+
+	if result.Spec.ServiceAccountName != "" {
+		k8sLabels[k8sConst.PolicyLabelServiceAccount] = result.Spec.ServiceAccountName
+	} else {
+		delete(k8sLabels, k8sConst.PolicyLabelServiceAccount)
+	}
+
+	// If the pod has been injected with an Istio sidecar proxy compatible with
+	// Cilium, add a label to notify that.
+	// If the pod already contains that label to explicitly enable or disable
+	// the sidecar proxy mode, keep it as is.
+	if _, ok := k8sLabels[k8sConst.PolicyLabelIstioSidecarProxy]; !ok &&
+		isInjectedWithIstioSidecarProxy(scopedLog, result) {
+		k8sLabels[k8sConst.PolicyLabelIstioSidecarProxy] = "true"
+	}
+
+	k8sLabels[k8sConst.PolicyLabelCluster] = option.Config.ClusterName
+
+	return k8sLabels, nil
+}

--- a/pkg/workloads/kubernetes.go
+++ b/pkg/workloads/kubernetes.go
@@ -15,45 +15,9 @@
 package workloads
 
 import (
-	"regexp"
-
 	"github.com/cilium/cilium/pkg/k8s"
-	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
-	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/policy"
 
-	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sDockerLbls "k8s.io/kubernetes/pkg/kubelet/types"
-)
-
-const (
-	// AnnotationIstioSidecarStatus is the annotation added by Istio into a pod
-	// when it is injected with a sidecar proxy.
-	// Since Istio 0.5.0, the value of this annotation is a serialized JSON object
-	// with the following structure ("imagePullSecrets" was added in Istio 0.8.0):
-	//
-	//     {
-	//         "version": "0213afe1274259d2f23feb4820ad2f8eb8609b84a5538e5f51f711545b6bde88",
-	//         "initContainers": ["sleep", "istio-init"],
-	//         "containers": ["istio-proxy"],
-	//         "volumes": ["cilium-unix-sock-dir", "istio-envoy", "istio-certs"],
-	//         "imagePullSecrets": null
-	//     }
-	AnnotationIstioSidecarStatus = "sidecar.istio.io/status"
-
-	// DefaultSidecarIstioProxyImageRegexp is the default regexp compiled into
-	// SidecarIstioProxyImageRegexp.
-	DefaultSidecarIstioProxyImageRegexp = "cilium/istio_proxy"
-)
-
-var (
-	// SidecarIstioProxyImageRegexp is the regular expression matching
-	// compatible Istio sidecar istio-proxy container image names.
-	// This is set by the "sidecar-istio-proxy-image" configuration flag.
-	SidecarIstioProxyImageRegexp = regexp.MustCompile(DefaultSidecarIstioProxyImageRegexp)
 )
 
 // fetchK8sLabels returns the kubernetes labels from the given container labels
@@ -69,89 +33,5 @@ func fetchK8sLabels(containerID string, containerLbls map[string]string) (map[st
 	if ns == "" {
 		ns = "default"
 	}
-	log.WithFields(logrus.Fields{
-		logfields.K8sNamespace: ns,
-		logfields.K8sPodName:   podName,
-	}).Debug("Connecting to k8s to retrieve labels for pod in ns")
-
-	result, err := k8s.Client().CoreV1().Pods(ns).Get(podName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	// Also get all labels from the namespace where the pod is running
-	k8sNs, err := k8s.Client().CoreV1().Namespaces().Get(ns, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	k8sLabels := result.GetLabels()
-	if k8sLabels == nil {
-		k8sLabels = map[string]string{}
-	}
-	for k, v := range k8sNs.GetLabels() {
-		k8sLabels[policy.JoinPath(k8sConst.PodNamespaceMetaLabels, k)] = v
-	}
-	k8sLabels[k8sConst.PodNamespaceLabel] = ns
-
-	if result.Spec.ServiceAccountName != "" {
-		k8sLabels[k8sConst.PolicyLabelServiceAccount] = result.Spec.ServiceAccountName
-	} else {
-		delete(k8sLabels, k8sConst.PolicyLabelServiceAccount)
-	}
-
-	// If the pod has been injected with an Istio sidecar proxy compatible with
-	// Cilium, add a label to notify that.
-	// If the pod already contains that label to explicitly enable or disable
-	// the sidecar proxy mode, keep it as is.
-	if _, ok := k8sLabels[k8sConst.PolicyLabelIstioSidecarProxy]; !ok &&
-		isInjectedWithIstioSidecarProxy(containerID, result) {
-		k8sLabels[k8sConst.PolicyLabelIstioSidecarProxy] = "true"
-	}
-
-	k8sLabels[k8sConst.PolicyLabelCluster] = option.Config.ClusterName
-
-	return k8sLabels, nil
-}
-
-// isInjectedWithIstioSidecarProxy returns whether the given pod has been
-// injected by Istio with a sidecar proxy that is compatible with Cilium.
-func isInjectedWithIstioSidecarProxy(containerID string, pod *corev1.Pod) bool {
-	scopedLog := log.WithField(logfields.ContainerID, shortContainerID(containerID))
-
-	istioStatusString, ok := pod.GetAnnotations()[AnnotationIstioSidecarStatus]
-	if !ok {
-		// Istio's injection annotation was not found.
-		scopedLog.Debugf("No %s annotation", AnnotationIstioSidecarStatus)
-		return false
-	}
-
-	scopedLog.Debugf("Found %s annotation with value: %s",
-		AnnotationIstioSidecarStatus, istioStatusString)
-
-	// Check that there's an "istio-proxy" container that uses an image
-	// compatible with Cilium.
-	for _, container := range pod.Spec.Containers {
-		if container.Name != "istio-proxy" {
-			continue
-		}
-		scopedLog.Debug("Found istio-proxy container in pod")
-
-		if !SidecarIstioProxyImageRegexp.MatchString(container.Image) {
-			continue
-		}
-		scopedLog.Debugf("istio-proxy container runs Cilium-compatible image: %s", container.Image)
-
-		for _, mount := range container.VolumeMounts {
-			if mount.MountPath != "/var/run/cilium" {
-				continue
-			}
-			scopedLog.Debug("istio-proxy container has volume mounted into /var/run/cilium")
-
-			return true
-		}
-	}
-
-	scopedLog.Debug("No Cilium-compatible istio-proxy container found")
-	return false
+	return k8s.GetPodLabels(ns, podName)
 }


### PR DESCRIPTION
Move away from asynchronous networking plumbing for CNI. This mode has been introduced to optimize the pod scheduling delay but it is causing some troubles when people perform benchmarks or rely on immediate DNS resolution success.

Leverage the CNI_ARGS to retrieve the pod name and namespace and issue a call
to the apiserver to retrieve the pod labels. This allows to retrieve the pod
labels and allocate the identity synchronously on the endpoint creation API
call.

This makes the CNI endpoint creation code divert from the CMM plugin. The CMM
plugin continues to rely on the workloads API to retrieve the metadata.

## Consequences

* The init identity will be skipped when an endpoint is managed by CNI
* An additional identity change can occur if any of the additional container labels are security relevant.

## Possible follow-ups
* This work allows potentially disabling workload association altogether when running in CNI only mode

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6299)
<!-- Reviewable:end -->
