### PR TITLE
[FQDN] Delete lookups after last rule was deleted

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -181,3 +181,20 @@ func (s *DNSProxyTestSuite) TestCheckAllowedMixedCaseRule(c *C) {
 
 	c.Assert(result, Equals, true, Commentf("Mixed case dns request should be allowed based on mixed case rule"))
 }
+
+func (s *DNSProxyTestSuite) TestCheckAllowedTwiceRemovedOnce(c *C) {
+	s.proxy.AddAllowed("cilium.io.", "endpoint1")
+	s.proxy.AddAllowed("cilium.io.", "endpoint1")
+
+	result := s.proxy.CheckAllowed("cilium.io.", "endpoint1")
+	c.Assert(result, Equals, true, Commentf("Should allow requests matching duplicate rules"))
+
+	s.proxy.RemoveAllowed("cilium.io.", "endpoint1")
+	result = s.proxy.CheckAllowed("cilium.io.", "endpoint1")
+
+	c.Assert(result, Equals, true, Commentf("Should allow requests matching duplicate rules from which one was deleted"))
+
+	s.proxy.RemoveAllowed("cilium.io.", "endpoint1")
+	result = s.proxy.CheckAllowed("cilium.io.", "endpoint1")
+	c.Assert(result, Equals, false, Commentf("Should not allow requests matching duplicate rules from which both were deleted"))
+}

--- a/pkg/fqdn/regexpmap/regexp_map.go
+++ b/pkg/fqdn/regexpmap/regexp_map.go
@@ -20,8 +20,9 @@ import (
 )
 
 // lookupValueSet is a utility type. It is intended as a set of strings
-// inserted into a RegexpMap
-type lookupValueSet map[string]struct{}
+// inserted into a RegexpMap. Lookups are mapped to number of times
+// they were added to map.
+type lookupValueSet map[string]int
 
 // RegexpMap is a map-like type that allows lookups to match regexp keys. These
 // keys are managed internally as strings, and are uniqued by this
@@ -64,7 +65,7 @@ func (m *RegexpMap) Add(reStr string, lookupValue string) error {
 	}
 
 	// add the lookupValue to the set for reStr
-	m.lookups[reStr][lookupValue] = struct{}{}
+	m.lookups[reStr][lookupValue]++
 
 	return nil
 }
@@ -114,7 +115,12 @@ func (m *RegexpMap) Remove(reStr, lookupValue string) (deleted bool) {
 		return false
 	}
 
-	delete(m.lookups[reStr], lookupValue)
+	if m.lookups[reStr][lookupValue] > 0 {
+		m.lookups[reStr][lookupValue]--
+	}
+	if m.lookups[reStr][lookupValue] == 0 {
+		delete(m.lookups[reStr], lookupValue)
+	}
 	if len(m.lookups[reStr]) > 0 {
 		// there are still references to this lookup so we do not clean it up below
 		return false

--- a/pkg/fqdn/regexpmap/regexp_map_test.go
+++ b/pkg/fqdn/regexpmap/regexp_map_test.go
@@ -84,6 +84,26 @@ func (ds *RegexpMapTestSuite) TestKeepUniqueStrings(c *C) {
 	}
 }
 
+func (ds *RegexpMapTestSuite) TestRefCount(c *C) {
+	m := NewRegexpMap()
+	domain := "foo.bar.com."
+	endpoint := "ID1"
+
+	m.Add(domain, endpoint)
+	m.Add(domain, endpoint)
+
+	c.Assert(m.lookups[domain][endpoint], Equals, 2)
+
+	m.Remove(domain, endpoint)
+
+	c.Assert(m.lookups[domain][endpoint], Equals, 1)
+
+	m.Remove(domain, endpoint)
+	_, found := m.lookups[domain]
+
+	c.Assert(found, Equals, false)
+}
+
 //  reSize is the number of distinct subpatterns/regexes to benchmark with
 var reSize = 100
 


### PR DESCRIPTION
If there are two toFQDN rules for the same endpoint with the same
pattern, after deleting first one all lookups would be deleted from
RegexpMap. This change adds counter to RegexpMap lookup mapping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6300)
<!-- Reviewable:end -->
