### PR TITLE
route, node: create stub files for Darwin builds

### DIFF
--- a/pkg/datapath/route/route.go
+++ b/pkg/datapath/route/route.go
@@ -1,0 +1,59 @@
+// Copyright 2016-2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package route
+
+import (
+	"net"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/sirupsen/logrus"
+
+	"github.com/vishvananda/netlink"
+)
+
+type Route struct {
+	Prefix  net.IPNet
+	Nexthop *net.IP
+	Local   net.IP
+	Device  string
+	MTU     int
+	Scope   netlink.Scope
+}
+
+func (r *Route) getLogger() *logrus.Entry {
+	return log.WithFields(logrus.Fields{
+		"prefix":            r.Prefix,
+		"nexthop":           r.Nexthop,
+		"local":             r.Local,
+		logfields.Interface: r.Device,
+	})
+}
+
+// ByMask is used to sort an array of routes by mask, narrow first.
+type ByMask []Route
+
+func (a ByMask) Len() int {
+	return len(a)
+}
+
+func (a ByMask) Less(i, j int) bool {
+	lenA, _ := a[i].Prefix.Mask.Size()
+	lenB, _ := a[j].Prefix.Mask.Size()
+	return lenA > lenB
+}
+
+func (a ByMask) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}

--- a/pkg/datapath/route/route_darwin.go
+++ b/pkg/datapath/route/route_darwin.go
@@ -1,0 +1,88 @@
+// Copyright 2016-2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// +build darwin
+
+package route
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+)
+
+type Route struct {
+	Prefix  net.IPNet
+	Nexthop *net.IP
+	Local   net.IP
+	Device  string
+	MTU     int
+	Scope   netlink.Scope
+}
+
+func (r *Route) getLogger() *logrus.Entry {
+	return log.WithFields(logrus.Fields{
+		"prefix":            r.Prefix,
+		"nexthop":           r.Nexthop,
+		"local":             r.Local,
+		logfields.Interface: r.Device,
+	})
+}
+
+// ToIPCommand converts the route into a full "ip route ..." command
+func (r *Route) ToIPCommand(dev string) []string {
+	res := []string{"ip"}
+	if r.Prefix.IP.To4() == nil {
+		res = append(res, "-6")
+	}
+	res = append(res, "route", "add", r.Prefix.String())
+	if r.Nexthop != nil {
+		res = append(res, "via", r.Nexthop.String())
+	}
+	if r.MTU != 0 {
+		res = append(res, "mtu", fmt.Sprintf("%d", r.MTU))
+	}
+	res = append(res, "dev", dev)
+	return res
+}
+
+// ByMask is used to sort an array of routes by mask, narrow first.
+type ByMask []Route
+
+func (a ByMask) Len() int {
+	return len(a)
+}
+
+func (a ByMask) Less(i, j int) bool {
+	lenA, _ := a[i].Prefix.Mask.Size()
+	lenB, _ := a[j].Prefix.Mask.Size()
+	return lenA > lenB
+}
+
+func (a ByMask) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+// ReplaceRoute adds or replaces the specified route if necessary
+func ReplaceRoute(route Route) error {
+	return nil
+}
+
+// DeleteRoute removes a route
+func DeleteRoute(route Route) error {
+	return nil
+}

--- a/pkg/datapath/route/route_darwin.go
+++ b/pkg/datapath/route/route_darwin.go
@@ -18,30 +18,7 @@ package route
 
 import (
 	"fmt"
-	"net"
-
-	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/sirupsen/logrus"
-	"github.com/vishvananda/netlink"
 )
-
-type Route struct {
-	Prefix  net.IPNet
-	Nexthop *net.IP
-	Local   net.IP
-	Device  string
-	MTU     int
-	Scope   netlink.Scope
-}
-
-func (r *Route) getLogger() *logrus.Entry {
-	return log.WithFields(logrus.Fields{
-		"prefix":            r.Prefix,
-		"nexthop":           r.Nexthop,
-		"local":             r.Local,
-		logfields.Interface: r.Device,
-	})
-}
 
 // ToIPCommand converts the route into a full "ip route ..." command
 func (r *Route) ToIPCommand(dev string) []string {
@@ -60,29 +37,13 @@ func (r *Route) ToIPCommand(dev string) []string {
 	return res
 }
 
-// ByMask is used to sort an array of routes by mask, narrow first.
-type ByMask []Route
-
-func (a ByMask) Len() int {
-	return len(a)
-}
-
-func (a ByMask) Less(i, j int) bool {
-	lenA, _ := a[i].Prefix.Mask.Size()
-	lenB, _ := a[j].Prefix.Mask.Size()
-	return lenA > lenB
-}
-
-func (a ByMask) Swap(i, j int) {
-	a[i], a[j] = a[j], a[i]
-}
-
-// ReplaceRoute adds or replaces the specified route if necessary
+// ReplaceRoute adds or replaces the specified route if necessary. Does nothing
+// for Darwin-based builds.
 func ReplaceRoute(route Route) error {
 	return nil
 }
 
-// DeleteRoute removes a route
+// DeleteRoute removes a route. Does nothing for Darwin-based builds.
 func DeleteRoute(route Route) error {
 	return nil
 }

--- a/pkg/datapath/route/route_linux.go
+++ b/pkg/datapath/route/route_linux.go
@@ -23,27 +23,8 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mtu"
 
-	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
-
-type Route struct {
-	Prefix  net.IPNet
-	Nexthop *net.IP
-	Local   net.IP
-	Device  string
-	MTU     int
-	Scope   netlink.Scope
-}
-
-func (r *Route) getLogger() *logrus.Entry {
-	return log.WithFields(logrus.Fields{
-		"prefix":            r.Prefix,
-		"nexthop":           r.Nexthop,
-		"local":             r.Local,
-		logfields.Interface: r.Device,
-	})
-}
 
 // getNetlinkRoute returns the route configuration as netlink.Route
 func (r *Route) getNetlinkRoute() netlink.Route {
@@ -92,23 +73,6 @@ func (r *Route) ToIPCommand(dev string) []string {
 	}
 	res = append(res, "dev", dev)
 	return res
-}
-
-// ByMask is used to sort an array of routes by mask, narrow first.
-type ByMask []Route
-
-func (a ByMask) Len() int {
-	return len(a)
-}
-
-func (a ByMask) Less(i, j int) bool {
-	lenA, _ := a[i].Prefix.Mask.Size()
-	lenB, _ := a[j].Prefix.Mask.Size()
-	return lenA > lenB
-}
-
-func (a ByMask) Swap(i, j int) {
-	a[i], a[j] = a[j], a[i]
 }
 
 func ipFamily(ip net.IP) int {

--- a/pkg/datapath/route/route_linux.go
+++ b/pkg/datapath/route/route_linux.go
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// +build !darwin
 
 package route
 

--- a/pkg/datapath/route/route_linux.go
+++ b/pkg/datapath/route/route_linux.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// +build !darwin
+// +build linux
 
 package route
 

--- a/pkg/node/manager.go
+++ b/pkg/node/manager.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
-	"github.com/vishvananda/netlink"
 )
 
 // RouteType represents the route type to be configured when adding the node
@@ -407,25 +406,6 @@ func deleteIPRoute(node *Node) {
 			"device":           node.dev,
 		}).Warn("Cannot delete route")
 	}
-}
-
-// firstLinkWithv6 returns the first network interface that contains the given
-// IPv6 address.
-func firstLinkWithv6(ip net.IP) (netlink.Link, error) {
-	links, err := netlink.LinkList()
-	if err != nil {
-		return nil, err
-	}
-	for _, l := range links {
-		addrs, _ := netlink.AddrList(l, netlink.FAMILY_V6)
-		for _, a := range addrs {
-			if ip.Equal(a.IP) {
-				return l, nil
-			}
-		}
-	}
-
-	return nil, fmt.Errorf("No address found")
 }
 
 func routeAdd(dstNode, podCIDR, dev string) error {

--- a/pkg/node/node_address_darwin.go
+++ b/pkg/node/node_address_darwin.go
@@ -1,0 +1,43 @@
+// Copyright 2016-2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// +build darwin
+
+package node
+
+import (
+	"net"
+
+	"github.com/vishvananda/netlink"
+)
+
+func firstGlobalV4Addr(intf string) (net.IP, error) {
+	return net.IP{}, nil
+}
+
+func findIPv6NodeAddr() net.IP {
+	return net.IP{}
+}
+
+// getCiliumHostIPsFromNetDev returns the first IPv4 link local and returns
+// it
+func getCiliumHostIPsFromNetDev(devName string) (ipv4GW, ipv6Router net.IP) {
+	return net.IP{}, net.IP{}
+}
+
+// firstLinkWithv6 returns the first network interface that contains the given
+// IPv6 address.
+func firstLinkWithv6(ip net.IP) (netlink.Link, error) {
+	return nil, nil
+}

--- a/pkg/node/node_address_linux.go
+++ b/pkg/node/node_address_linux.go
@@ -1,0 +1,124 @@
+// Copyright 2016-2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// +build !darwin
+
+package node
+
+import (
+	"fmt"
+	"net"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/vishvananda/netlink"
+)
+
+func firstGlobalV4Addr(intf string) (net.IP, error) {
+	var link netlink.Link
+	var err error
+
+	if intf != "" && intf != "undefined" {
+		link, err = netlink.LinkByName(intf)
+		if err != nil {
+			return firstGlobalV4Addr("")
+		}
+	}
+
+	addr, err := netlink.AddrList(link, netlink.FAMILY_V4)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, a := range addr {
+		if a.Scope == unix.RT_SCOPE_UNIVERSE {
+			if len(a.IP) >= 4 {
+				return a.IP, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("No address found")
+}
+
+func findIPv6NodeAddr() net.IP {
+	addr, err := netlink.AddrList(nil, netlink.FAMILY_V6)
+	if err != nil {
+		return nil
+	}
+
+	// prefer global scope address
+	for _, a := range addr {
+		if a.Scope == unix.RT_SCOPE_UNIVERSE {
+			if len(a.IP) >= 16 {
+				return a.IP
+			}
+		}
+	}
+
+	// fall back to anything wider than link (site, custom, ...)
+	for _, a := range addr {
+		if a.Scope < unix.RT_SCOPE_LINK {
+			if len(a.IP) >= 16 {
+				return a.IP
+			}
+		}
+	}
+
+	return nil
+}
+
+// getCiliumHostIPsFromNetDev returns the first IPv4 link local and returns
+// it
+func getCiliumHostIPsFromNetDev(devName string) (ipv4GW, ipv6Router net.IP) {
+	hostDev, err := netlink.LinkByName(devName)
+	if err != nil {
+		return nil, nil
+	}
+	addrs, err := netlink.AddrList(hostDev, netlink.FAMILY_ALL)
+	if err != nil {
+		return nil, nil
+	}
+	for _, addr := range addrs {
+		if addr.IP.To4() != nil {
+			if addr.Scope == int(netlink.SCOPE_LINK) {
+				ipv4GW = addr.IP
+			}
+		} else {
+			if addr.Scope != int(netlink.SCOPE_LINK) {
+				ipv6Router = addr.IP
+			}
+		}
+	}
+	return ipv4GW, ipv6Router
+}
+
+// firstLinkWithv6 returns the first network interface that contains the given
+// IPv6 address.
+func firstLinkWithv6(ip net.IP) (netlink.Link, error) {
+	links, err := netlink.LinkList()
+	if err != nil {
+		return nil, err
+	}
+	for _, l := range links {
+		addrs, _ := netlink.AddrList(l, netlink.FAMILY_V6)
+		for _, a := range addrs {
+			if ip.Equal(a.IP) {
+				return l, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("No address found")
+}


### PR DESCRIPTION
Running unit tests on Mac OS environments for many packages in Cilium has not
been possible due to the fact that there are dependencies which depend on
variables that are defined only for Linux architectures, e.g. netlink.FAMILY_V6.

Refactor the node and route packages to have Linux-specific and Darwin-specific
files, by using build constraints. For Darwin builds, stubs are created, while
the implementation used by the cilium-agent is factored out into files built
for non-Darwin builds. This allows for running of unit tests on the Mac for
`pkg/policy`, for instance.

No functional change is intended by this.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6306)
<!-- Reviewable:end -->
