### PR TITLE
examples/kubernetes: make cilium-pre-flight to run in hostNetwork

### DIFF
--- a/examples/kubernetes/1.10/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.10/cilium-pre-flight.yaml
@@ -54,6 +54,7 @@ spec:
               - /tmp/ready
             initialDelaySeconds: 5
             periodSeconds: 5
+      hostNetwork: true
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.11/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.11/cilium-pre-flight.yaml
@@ -54,6 +54,7 @@ spec:
               - /tmp/ready
             initialDelaySeconds: 5
             periodSeconds: 5
+      hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:

--- a/examples/kubernetes/1.12/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.12/cilium-pre-flight.yaml
@@ -54,6 +54,7 @@ spec:
               - /tmp/ready
             initialDelaySeconds: 5
             periodSeconds: 5
+      hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:

--- a/examples/kubernetes/1.8/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.8/cilium-pre-flight.yaml
@@ -54,6 +54,7 @@ spec:
               - /tmp/ready
             initialDelaySeconds: 5
             periodSeconds: 5
+      hostNetwork: true
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.9/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.9/cilium-pre-flight.yaml
@@ -54,6 +54,7 @@ spec:
               - /tmp/ready
             initialDelaySeconds: 5
             periodSeconds: 5
+      hostNetwork: true
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/templates/v1/cilium-pre-flight.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-pre-flight.yaml.sed
@@ -54,6 +54,7 @@ spec:
               - /tmp/ready
             initialDelaySeconds: 5
             periodSeconds: 5
+      hostNetwork: true
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule


### PR DESCRIPTION
This will avoid the pod requirement of needing a CNI plugin to be setup.

Signed-off-by: André Martins <andre@cilium.io>

This will fix some flakes found in https://github.com/cilium/cilium/pull/6287

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6309)
<!-- Reviewable:end -->
