### PR TITLE
health-ep: provide netmask to spawn_netns

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -27,12 +27,13 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/datapath/route"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/connector"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	healthPkg "github.com/cilium/cilium/pkg/health/client"
-	"github.com/cilium/cilium/pkg/health/defaults"
+	healthDefaults "github.com/cilium/cilium/pkg/health/defaults"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/launcher"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -192,6 +193,8 @@ func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressin
 
 	ip4 := node.GetIPv4HealthIP()
 	ip6 := node.GetIPv6HealthIP()
+	ip4WithMask := net.IPNet{IP: ip4, Mask: defaults.ContainerIPv4Mask}
+	ip6WithMask := net.IPNet{IP: ip6, Mask: defaults.ContainerIPv6Mask}
 	cmd := launcher.Launcher{}
 
 	// Prepare the endpoint change request
@@ -214,7 +217,7 @@ func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressin
 	pidfile := filepath.Join(option.Config.StateDir, PidfilePath)
 	healthArgs := fmt.Sprintf("-d --admin=unix --passive --pidfile %s", pidfile)
 	args := []string{info.ContainerName, info.InterfaceName, vethPeerName,
-		ip6.String(), ip4.String(), ciliumHealth, healthArgs}
+		ip6WithMask.String(), ip4WithMask.String(), ciliumHealth, healthArgs}
 	prog := filepath.Join(option.Config.BpfDir, "spawn_netns.sh")
 	cmd.SetTarget(prog)
 	cmd.SetArgs(args)
@@ -265,7 +268,7 @@ func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressin
 
 	// Initialize the health client to talk to this instance. This is why
 	// the caller must limit usage of this package to a single goroutine.
-	client, err = healthPkg.NewClient(fmt.Sprintf("tcp://%s:%d", ip4, defaults.HTTPPathPort))
+	client, err = healthPkg.NewClient(fmt.Sprintf("tcp://%s:%d", ip4, healthDefaults.HTTPPathPort))
 	if err != nil {
 		return fmt.Errorf("Cannot establish connection to health endpoint: %s", err)
 	}


### PR DESCRIPTION
spawn_netns expects IP address with mask.
IP removal without mask using iputils might cause below error:
RTNETLINK answers: Cannot assign requested address
Warning: Executing wildcard deletion to stay compatible with old scripts.
         Explicitly specify the prefix length (10.77.202.221/32) to avoid this warning.
         This special behaviour is likely to disappear in further releases,
         fix your scripts!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6313)
<!-- Reviewable:end -->
