### PR TITLE
Cilium-operator fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V SKIP_DOCS=true DESTDIR=/tmp/insta
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2018-10-29
+FROM quay.io/cilium/cilium-runtime:2018-11-29
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /tmp/install /
 COPY --from=cilium-envoy / /

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -7,7 +7,9 @@ apt-get upgrade -y && \
 #
 # Prepackaged Cilium runtime dependencies
 #
-apt-get install -y --no-install-recommends gpg gpg-agent libelf-dev libmnl-dev libc6-dev-i386 iptables libgcc-5-dev bash-completion binutils binutils-dev && \
+apt-get install -y --no-install-recommends \
+    gpg gpg-agent libelf-dev libmnl-dev libc6-dev-i386 iptables libgcc-5-dev \
+    bash-completion binutils binutils-dev ca-certificates && \
 apt-get purge --auto-remove && \
 apt-get clean
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -15,3 +15,6 @@ clean:
 	$(GO) clean
 
 install:
+	groupadd -f cilium
+	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)


### PR DESCRIPTION
- Operator: install on path
- Runtime: Install ca-certificates to be able to communicate with AWS on toGroups rule. 
- Bump version on the main dockerfile. (I'm not sure If it is the right workflow

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6322)
<!-- Reviewable:end -->
