### PR TITLE
Extend RedirectImplementation to callback on updates

### DIFF
--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/revert"
 )
 
@@ -62,6 +63,12 @@ func createEnvoyRedirect(r *Redirect, stateDir string, xdsServer *envoy.XDSServe
 	}
 
 	return nil, fmt.Errorf("%s: Envoy proxy process failed to start, cannot add redirect", r.id)
+}
+
+// UpdateRules is a no-op for envoy, as redirect data is synchronized via the
+// xDS cache.
+func (k *envoyRedirect) UpdateRules(wg *completion.WaitGroup, l4 *policy.L4Filter) (revert.RevertFunc, error) {
+	return func() error { return nil }, nil
 }
 
 // Close the redirect.

--- a/pkg/proxy/kafka.go
+++ b/pkg/proxy/kafka.go
@@ -441,6 +441,12 @@ func (k *kafkaRedirect) handleResponseConnection(pair *connectionPair, correlati
 		}, remoteAddr, remoteIdentity, origDstAddr)
 }
 
+// UpdateRules is a no-op for kafka redirects, as rules are read directly
+// during request processing.
+func (k *kafkaRedirect) UpdateRules(wg *completion.WaitGroup, l4 *policy.L4Filter) (revert.RevertFunc, error) {
+	return func() error { return nil }, nil
+}
+
 // Close the redirect.
 func (k *kafkaRedirect) Close(wg *completion.WaitGroup) (revert.FinalizeFunc, revert.RevertFunc) {
 	return k.socket.Close, nil

--- a/pkg/proxy/redirect.go
+++ b/pkg/proxy/redirect.go
@@ -30,6 +30,18 @@ import (
 // RedirectImplementation is the generic proxy redirect interface that each
 // proxy redirect type must implement
 type RedirectImplementation interface {
+	// UpdateRules notifies the proxy implementation that the new rules in
+	// parameter l4 are to be applied. The implementation should .Add to the
+	// WaitGroup if the update is asynchronous and the update should not return
+	// until it is complete.
+	// The returned RevertFunc must be non-nil.
+	// Note: UpdateRules is not called when a redirect is created.
+	UpdateRules(wg *completion.WaitGroup, l4 *policy.L4Filter) (revert.RevertFunc, error)
+
+	// Close closes and cleans up resources associated with the redirect
+	// implementation. The implementation should .Add to the WaitGroup if the
+	// update is asynchronous and the update should not return until it is
+	// complete.
 	Close(wg *completion.WaitGroup) (revert.FinalizeFunc, revert.RevertFunc)
 }
 


### PR DESCRIPTION
The DNS proxy doesn't have a way to see updates, but needs a trigger to read the new rules in each redirect. The proxy package already updated the generic `Redirect` instance and now will call into the `implementation` to notify it of a change.

I'm not too sure that this is the best way to do this. It feels too specific for the DNS proxy. The other solution would be to have a xDS cache like envoy. I assumed that was a lot more involved so I went with this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6325)
<!-- Reviewable:end -->
