### PR TITLE
policy: Force L3 enforcement when toFQDNs is present via a selector

### DIFF
--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -48,6 +48,11 @@ const (
 	// received any labels yet.
 	IDNameInit = "init"
 
+	// IDNameNone is the label used to identify no endpoint or other L3 entity.
+	// It will never be assigned and this "label" is here for consistency with
+	// other Entities.
+	IDNameNone = "none"
+
 	// IDNameUnmanaged is the label used to identify unmanaged endpoints
 	IDNameUnmanaged = "unmanaged"
 

--- a/pkg/policy/api/egress.go
+++ b/pkg/policy/api/egress.go
@@ -131,7 +131,7 @@ type EgressRule struct {
 	// endpoint when the data changes often or the system is under load.
 	//
 	// +optional
-	ToFQDNs []FQDNSelector `json:"toFQDNs,omitempty"`
+	ToFQDNs FQDNSelectorSlice `json:"toFQDNs,omitempty"`
 
 	// ToGroups is a directive that allows the integration with multiple outside
 	// providers. Currently, only AWS is supported, and the rule can select by
@@ -151,14 +151,15 @@ type EgressRule struct {
 func (e *EgressRule) GetDestinationEndpointSelectors() EndpointSelectorSlice {
 	res := append(e.ToEndpoints, e.ToEntities.GetAsEndpointSelectors()...)
 	res = append(res, e.ToCIDR.GetAsEndpointSelectors()...)
-	return append(res, e.ToCIDRSet.GetAsEndpointSelectors()...)
+	res = append(res, e.ToCIDRSet.GetAsEndpointSelectors()...)
+	return append(res, e.ToFQDNs.GetAsEndpointSelectors()...)
 }
 
 // IsLabelBased returns true whether the L3 destination endpoints are selected
 // based on labels, i.e. either by setting ToEndpoints or ToEntities, or not
 // setting any To field.
 func (e *EgressRule) IsLabelBased() bool {
-	return len(e.ToRequires)+len(e.ToCIDR)+len(e.ToCIDRSet)+len(e.ToServices) == 0
+	return len(e.ToRequires)+len(e.ToCIDR)+len(e.ToCIDRSet)+len(e.ToServices)+len(e.ToFQDNs) == 0
 }
 
 // RequiresDerivative returns true when the EgressRule contains sections that

--- a/pkg/policy/api/entity.go
+++ b/pkg/policy/api/entity.go
@@ -41,6 +41,9 @@ const (
 
 	// EntityInit is an entity that represents an initializing endpoint
 	EntityInit Entity = "init"
+
+	// EntityNone is an entity that can be selected but never exist
+	EntityNone Entity = "none"
 )
 
 var (
@@ -49,6 +52,8 @@ var (
 	endpointSelectorHost = NewESFromLabels(labels.NewLabel(labels.IDNameHost, "", labels.LabelSourceReserved))
 
 	endpointSelectorInit = NewESFromLabels(labels.NewLabel(labels.IDNameInit, "", labels.LabelSourceReserved))
+
+	endpointSelectorNone = NewESFromLabels(labels.NewLabel(labels.IDNameNone, "", labels.LabelSourceReserved))
 
 	endpointSelectorUnmanaged = NewESFromLabels(labels.NewLabel(labels.IDNameUnmanaged, "", labels.LabelSourceReserved))
 
@@ -59,6 +64,7 @@ var (
 		EntityWorld: {endpointSelectorWorld},
 		EntityHost:  {endpointSelectorHost},
 		EntityInit:  {endpointSelectorInit},
+		EntityNone:  {endpointSelectorNone},
 
 		// EntityCluster is populated with an empty entry to allow the
 		// cilium client importing this package to perform basic rule

--- a/pkg/policy/api/entity_test.go
+++ b/pkg/policy/api/entity_test.go
@@ -31,15 +31,18 @@ func (s *PolicyAPITestSuite) TestEntityMatches(c *C) {
 	c.Assert(EntityHost.Matches(labels.ParseLabelArray("reserved:host")), Equals, true)
 	c.Assert(EntityHost.Matches(labels.ParseLabelArray("reserved:host", "id:foo")), Equals, true)
 	c.Assert(EntityHost.Matches(labels.ParseLabelArray("reserved:world")), Equals, false)
+	c.Assert(EntityHost.Matches(labels.ParseLabelArray("reserved:none")), Equals, false)
 	c.Assert(EntityHost.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
 
 	c.Assert(EntityAll.Matches(labels.ParseLabelArray("reserved:host")), Equals, true)
 	c.Assert(EntityAll.Matches(labels.ParseLabelArray("reserved:world")), Equals, true)
+	c.Assert(EntityAll.Matches(labels.ParseLabelArray("reserved:none")), Equals, true) // in a white-list model, All trumps None
 	c.Assert(EntityAll.Matches(labels.ParseLabelArray("id=foo")), Equals, true)
 
 	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("reserved:host")), Equals, true)
 	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("reserved:init")), Equals, true)
 	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("reserved:world")), Equals, false)
+	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("reserved:none")), Equals, false)
 
 	clusterLabel := fmt.Sprintf("k8s:%s=%s", k8sapi.PolicyLabelCluster, "cluster1")
 	c.Assert(EntityCluster.Matches(labels.ParseLabelArray(clusterLabel, "id=foo")), Equals, true)
@@ -48,8 +51,16 @@ func (s *PolicyAPITestSuite) TestEntityMatches(c *C) {
 
 	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("reserved:host")), Equals, false)
 	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("reserved:world")), Equals, true)
+	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("reserved:none")), Equals, false)
 	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
 	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("id=foo", "id=bar")), Equals, false)
+
+	c.Assert(EntityNone.Matches(labels.ParseLabelArray("reserved:host")), Equals, false)
+	c.Assert(EntityNone.Matches(labels.ParseLabelArray("reserved:world")), Equals, false)
+	c.Assert(EntityNone.Matches(labels.ParseLabelArray("reserved:init")), Equals, false)
+	c.Assert(EntityNone.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
+	c.Assert(EntityNone.Matches(labels.ParseLabelArray(clusterLabel, "id=foo", "id=bar")), Equals, false)
+
 }
 
 func (s *PolicyAPITestSuite) TestEntitySliceMatches(c *C) {
@@ -58,11 +69,13 @@ func (s *PolicyAPITestSuite) TestEntitySliceMatches(c *C) {
 	slice := EntitySlice{EntityHost, EntityWorld}
 	c.Assert(slice.Matches(labels.ParseLabelArray("reserved:host")), Equals, true)
 	c.Assert(slice.Matches(labels.ParseLabelArray("reserved:world")), Equals, true)
+	c.Assert(slice.Matches(labels.ParseLabelArray("reserved:none")), Equals, false)
 	c.Assert(slice.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
 
 	// result must be identical if matched via endpoint selector
 	selector := slice.GetAsEndpointSelectors()
 	c.Assert(selector.Matches(labels.ParseLabelArray("reserved:host")), Equals, true)
 	c.Assert(selector.Matches(labels.ParseLabelArray("reserved:world")), Equals, true)
+	c.Assert(selector.Matches(labels.ParseLabelArray("reserved:none")), Equals, false)
 	c.Assert(selector.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
 }

--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -83,3 +83,25 @@ func (r *PortRuleDNS) Sanitize() error {
 	}
 	return matchpattern.Validate(r.MatchPattern)
 }
+
+// GetAsEndpointSelectors returns a FQDNSelector as a single EntityNone
+// EndpointSelector slice.
+// Note that toFQDNs behaves differently than most other rules. The presence of
+// any toFQDNs rules means the endpoint must enforce policy, but the IPs are later
+// added as toCIDRSet entries and processed as such.
+func (s *FQDNSelector) GetAsEndpointSelectors() EndpointSelectorSlice {
+	return []EndpointSelector{endpointSelectorNone}
+}
+
+// FQDNSelectorSlice is a wrapper type for []FQDNSelector to make is simpler to
+// bind methods.
+type FQDNSelectorSlice []FQDNSelector
+
+// GetAsEndpointSelectors will return a single EntityNone if any
+// toFQDNs rules exist, and a nil slice otherwise.
+func (s FQDNSelectorSlice) GetAsEndpointSelectors() EndpointSelectorSlice {
+	for _, rule := range s {
+		return rule.GetAsEndpointSelectors()
+	}
+	return nil
+}

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1139,6 +1139,122 @@ var _ = Describe("RuntimePolicies", func() {
 		vm.PolicyDelAll().ExpectSuccess("Unable to delete all policies")
 	})
 
+	It("Tests EntityNone as a deny-all", func() {
+		worldIP := "1.1.1.1"
+
+		httpd1Label := "id.httpd1"
+		http1IP, err := vm.ContainerInspectNet(helpers.Httpd1)
+		Expect(err).Should(BeNil(), "Cannot get httpd1 server address")
+
+		setupPolicy := func(policy string) {
+			_, err := vm.PolicyRenderAndImport(policy)
+			ExpectWithOffset(1, err).To(BeNil(), "Unable to import policy: %s\n%s", err, policy)
+
+			areEndpointsReady := vm.WaitEndpointsReady()
+			ExpectWithOffset(1, areEndpointsReady).Should(BeTrue(), "Endpoints are not ready after timeout")
+		}
+
+		// curlWithRetry retries the curl, to make sure that allowed curls don't
+		// flake on bad connectivity
+		curlWithRetry := func(name string, cmd string, optionalArgs ...interface{}) (res *helpers.CmdRes) {
+			for try := 0; try < 5; try++ {
+				res = vm.ContainerExec(name, helpers.CurlFail(cmd, optionalArgs...))
+				if res.WasSuccessful() {
+					return res
+				}
+			}
+			return res
+		}
+
+		By("setting policy enforcement to default so that EntityNone is the source of deny-all")
+		ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementDefault)
+		app1Label := fmt.Sprintf("id.%s", helpers.App1)
+		policy := fmt.Sprintf(`
+		[{
+			"endpointSelector": {"matchLabels":{"%s":""}},
+			"egress": [{
+				"toEntities": [
+					"%s"
+				]
+			}]
+		}]`, app1Label, api.EntityNone)
+		setupPolicy(policy)
+
+		app2Label := fmt.Sprintf("id.%s", helpers.App2)
+		policy = fmt.Sprintf(`
+		[{
+			"endpointSelector": {"matchLabels":{"%s":""}},
+			"egress": [{
+				"toEntities": [
+					"%s"
+				]
+			}]
+		}]`, app2Label, api.EntityNone)
+		setupPolicy(policy)
+
+		By("testing that EntityNone is denying all egress for app1 and app2")
+		vm.ContainerExec(helpers.App1, helpers.CurlFail("http://%s/public", http1IP[helpers.IPv4])).ExpectFail("%q can make http request to pod", helpers.App1)
+		vm.ContainerExec(helpers.App1, helpers.CurlFail("-4 http://%s", worldIP)).ExpectFail("%q can make http request to %s", helpers.App1, worldIP)
+		vm.ContainerExec(helpers.App2, helpers.CurlFail("http://%s/public", http1IP[helpers.IPv4])).ExpectFail("%q can make http request to pod", helpers.App1)
+		vm.ContainerExec(helpers.App2, helpers.CurlFail("-4 http://%s", worldIP)).ExpectFail("%q can make http request to %s", helpers.App1, worldIP)
+
+		By("testing basic egress between endpoints (app1->app2)")
+		policy = fmt.Sprintf(`
+		[{
+			"endpointSelector": {"matchLabels":{"%s":""}},
+			"egress": [{
+				"toEndpoints": [{"matchLabels": {"%s": ""}}]
+			}]
+		}]`, app1Label, httpd1Label)
+		setupPolicy(policy)
+		curlWithRetry(helpers.App1, "http://%s/public", http1IP[helpers.IPv4]).ExpectSuccess("%q cannot make http request to pod", helpers.App1)
+		vm.ContainerExec(helpers.App1, helpers.CurlFail("-4 http://%s", worldIP)).ExpectFail("%q can make http request to %s", helpers.App1, worldIP)
+
+		By("testing basic egress to 1.1.1.1/32")
+		policy = fmt.Sprintf(`
+		[{
+			"endpointSelector": {"matchLabels":{"%s":""}},
+			"egress": [{
+				"toCIDR": [
+					"1.1.1.1/32"
+				]
+			}]
+		}]`, app1Label)
+		setupPolicy(policy)
+		curlWithRetry(helpers.App1, "http://%s/public", http1IP[helpers.IPv4]).ExpectSuccess("%q cannot make http request to pod", helpers.App1)
+		curlWithRetry(helpers.App1, "-4 http://%s", worldIP).ExpectSuccess("%q cannot make http request to pod", helpers.App1)
+
+		By("testing egress toEntity: world in combination with previous rules (app1)")
+		policy = fmt.Sprintf(`
+		[{
+			"endpointSelector": {"matchLabels":{"%s":""}},
+			"egress": [{
+				"toEntities": [
+					"%s"
+				]
+			}]
+		}]`, app1Label, api.EntityAll)
+		setupPolicy(policy)
+		curlWithRetry(helpers.App1, "http://%s/public", http1IP[helpers.IPv4]).ExpectSuccess("%q cannot make http request to pod", helpers.App1)
+		curlWithRetry(helpers.App1, "-4 http://%s", worldIP).ExpectSuccess("%q cannot make http request to pod", helpers.App1)
+
+		By("testing egress toEntity: world alone with EntityNone")
+		policy = fmt.Sprintf(`
+		[{
+			"endpointSelector": {"matchLabels":{"%s":""}},
+			"egress": [{
+				"toEntities": [
+					"%s"
+				]
+			}]
+		}]`, app2Label, api.EntityAll)
+		setupPolicy(policy)
+		curlWithRetry(helpers.App2, "http://%s/public", http1IP[helpers.IPv4]).ExpectSuccess("%q cannot make http request to pod", helpers.App2)
+		curlWithRetry(helpers.App2, "-4 http://%s", worldIP).ExpectSuccess("%q cannot make http request to pod", helpers.App2)
+
+		vm.PolicyDelAll().ExpectSuccess("Unable to delete all policies")
+	})
+
 	Context("TestsEgressToHost", func() {
 		hostDockerContainer := "hostDockerContainer"
 		hostIP := "10.0.2.15"


### PR DESCRIPTION
When calculating L3/L4 policy, toFQDNs was ignored. In the cases where a
DNS lookup had not occured, and no toCIDRSet rules generated, the policy
was interpreted as L3 wildcard. We now treat toFQDNs as a label selector
style rule that always selects EntityNone. Nothing can create an
EntityNone so it should never be a valid target.

Fixes https://github.com/cilium/cilium/issues/6292

**update**
Here is a test I used:
```
$ cat tmp/empty-fqdn.yaml
apiVersion: cilium.io/v2
kind: CiliumNetworkPolicy
metadata:
  name: rebel-escape
  namespace: default
spec:
  endpointSelector:
    matchLabels:
      any:org: alliance
  egress:
  - toEndpoints:
    - matchLabels:
       "k8s:io.kubernetes.pod.namespace": kube-system
       "k8s:k8s-app": kube-dns
    toPorts:
      - ports:
          - port: "53"
            protocol: ANY
        rules:
          dns:
            - matchPattern: "*cloudhmar.com"

  - toFQDNs:
      - matchName: "blsadsfadsfafds.cloudhmar.com"
      - matchName: "cloudhmar.com"
    toPorts:
      - ports:
        - port: "80"
```
* `$ kubectl exec xwing -- curl -svvv -4 -I cloudhmar.com --resolve cloudhmar.com:80:104.28.6.79` # timeout because no DNS lookup happens because of --resolve
* `$ kubectl exec xwing -- curl -svvv -4 -I cloudhmar.com --resolve cloudhmar.com:83:104.28.6.79` # success because a DNS lookup happens because --resolve doesn't apply here (port 83 not 80)
* `$ kubectl exec xwing -- curl -svvv -4 -I cname.cloudhmar.com --resolve cloudhmar.com:83:104.28.6.79` # timeout because the policy only allows connections to cloudhmar.com at L3, not any subdomains (except blsadsfadsfafds.cloudhmar.com but that doesn't exist)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6326)
<!-- Reviewable:end -->
