### PR TITLE
Support Cilium deployment into non-standard namespace

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -38,4 +38,5 @@ func populateConfig() {
 	option.Config.EnvoyLogPath = viper.GetString("envoy-log")
 	option.Config.SockopsEnable = viper.GetBool(option.SockopsEnableName)
 	option.Config.PrependIptablesChains = viper.GetBool(option.PrependIptablesChainsName)
+	option.Config.K8sNamespace = viper.GetString(option.K8sNamespaceName)
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -847,6 +847,9 @@ func NewDaemon() (*Daemon, *endpointRestoreState, error) {
 			log.WithError(err).Fatal("Unable to initialize Kubernetes subsystem")
 		}
 
+		log.Info("Kubernetes information:")
+		log.Infof("  Namespace: %s", option.Config.K8sNamespace)
+
 		// Kubernetes demands that the localhost can always reach local
 		// pods. Therefore unless the AllowLocalhost policy is set to a
 		// specific mode, always allow localhost to reach local

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -423,6 +423,9 @@ func init() {
 	flags.StringVar(&k8sKubeConfigPath,
 		"k8s-kubeconfig-path", "", "Absolute path of the kubernetes kubeconfig file")
 	viper.BindEnv("k8s-legacy-host-allows-world", "CILIUM_LEGACY_HOST_ALLOWS_WORLD")
+	flags.String(option.K8sNamespaceName, "", "Name of the Kubernetes namespace in which Cilium is deployed in")
+	viper.BindEnv(option.K8sNamespaceName, option.K8sNamespaceNameEnv)
+	flags.MarkHidden(option.K8sNamespaceName)
 	flags.BoolVar(&option.Config.K8sRequireIPv4PodCIDR,
 		option.K8sRequireIPv4PodCIDRName, false, "Require IPv4 PodCIDR to be specified in node resource")
 	flags.BoolVar(&option.Config.K8sRequireIPv6PodCIDR,

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -86,6 +86,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: "CILIUM_K8S_NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: "CILIUM_DEBUG"
               valueFrom:
                 configMapKeyRef:

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -168,6 +168,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: "CILIUM_K8S_NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: "CILIUM_DEBUG"
               valueFrom:
                 configMapKeyRef:

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -86,6 +86,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: "CILIUM_K8S_NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: "CILIUM_DEBUG"
               valueFrom:
                 configMapKeyRef:

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -168,6 +168,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: "CILIUM_K8S_NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: "CILIUM_DEBUG"
               valueFrom:
                 configMapKeyRef:

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -86,6 +86,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: "CILIUM_K8S_NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: "CILIUM_DEBUG"
               valueFrom:
                 configMapKeyRef:

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -168,6 +168,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: "CILIUM_K8S_NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: "CILIUM_DEBUG"
               valueFrom:
                 configMapKeyRef:

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -86,6 +86,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: "CILIUM_K8S_NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: "CILIUM_DEBUG"
               valueFrom:
                 configMapKeyRef:

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -168,6 +168,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: "CILIUM_K8S_NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: "CILIUM_DEBUG"
               valueFrom:
                 configMapKeyRef:

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -86,6 +86,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: "CILIUM_K8S_NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: "CILIUM_DEBUG"
               valueFrom:
                 configMapKeyRef:

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -168,6 +168,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: "CILIUM_K8S_NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: "CILIUM_DEBUG"
               valueFrom:
                 configMapKeyRef:

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -86,6 +86,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: "CILIUM_K8S_NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: "CILIUM_DEBUG"
               valueFrom:
                 configMapKeyRef:

--- a/pkg/identity/cache/cache_test.go
+++ b/pkg/identity/cache/cache_test.go
@@ -46,6 +46,10 @@ type IdentityCacheTestSuite struct{}
 
 var _ = Suite(&IdentityCacheTestSuite{})
 
+func (s *IdentityCacheTestSuite) SetUpTest(c *C) {
+	option.Config.K8sNamespace = "kube-system"
+}
+
 func (s *IdentityCacheTestSuite) TestLookupReservedIdentity(c *C) {
 	bak := option.Config.ClusterName
 	option.Config.ClusterName = "default"
@@ -127,6 +131,7 @@ func (s *IdentityCacheTestSuite) TestLookupReservedIdentityByLabels(c *C) {
 			want: identity.NewIdentity(identity.ReservedCiliumKVStore, kvstoreLabels),
 		},
 	}
+
 	for _, tt := range tests {
 		got := LookupReservedIdentityByLabels(tt.args.lbls)
 		switch {

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -123,14 +123,17 @@ func (w wellKnownIdentities) lookupByNumericIdentity(identity NumericIdentity) *
 
 // InitWellKnownIdentities establishes all well-known identities
 func InitWellKnownIdentities() {
+	// Derive the namespace in which the Cilium components are running
+	namespace := option.Config.K8sNamespace
+
 	// etcd-operator labels
 	//   k8s:io.cilium.k8s.policy.serviceaccount=cilium-etcd-sa
-	//   k8s:io.kubernetes.pod.namespace=kube-system
+	//   k8s:io.kubernetes.pod.namespace=<NAMESPACE>
 	//   k8s:io.cilium/app=etcd-operator
 	//   k8s:io.cilium.k8s.policy.cluster=default
 	WellKnown.add(ReservedETCDOperator, []string{
 		"k8s:io.cilium/app=etcd-operator",
-		fmt.Sprintf("k8s:%s=kube-system", api.PodNamespaceLabel),
+		fmt.Sprintf("k8s:%s=%s", api.PodNamespaceLabel, namespace),
 		fmt.Sprintf("k8s:%s=cilium-etcd-sa", api.PolicyLabelServiceAccount),
 		fmt.Sprintf("k8s:%s=%s", api.PolicyLabelCluster, option.Config.ClusterName),
 	})
@@ -140,7 +143,7 @@ func InitWellKnownIdentities() {
 	//   k8s:io.cilium/app=etcd-operator
 	//   k8s:etcd_cluster=cilium-etcd
 	//   k8s:io.cilium.k8s.policy.serviceaccount=default
-	//   k8s:io.kubernetes.pod.namespace=kube-system
+	//   k8s:io.kubernetes.pod.namespace=<NAMESPACE>
 	//   k8s:io.cilium.k8s.policy.cluster=default
 	// these 2 labels are ignored by cilium-agent as they can change over time
 	//   container:annotation.etcd.version=3.3.9
@@ -149,7 +152,7 @@ func InitWellKnownIdentities() {
 		"k8s:app=etcd",
 		"k8s:etcd_cluster=cilium-etcd",
 		"k8s:io.cilium/app=etcd-operator",
-		fmt.Sprintf("k8s:%s=kube-system", api.PodNamespaceLabel),
+		fmt.Sprintf("k8s:%s=%s", api.PodNamespaceLabel, namespace),
 		fmt.Sprintf("k8s:%s=default", api.PolicyLabelServiceAccount),
 		fmt.Sprintf("k8s:%s=%s", api.PolicyLabelCluster, option.Config.ClusterName),
 	})
@@ -194,14 +197,14 @@ func InitWellKnownIdentities() {
 
 	// CiliumOperator labels
 	//   k8s:io.cilium.k8s.policy.serviceaccount=cilium-operator
-	//   k8s:io.kubernetes.pod.namespace=kube-system
+	//   k8s:io.kubernetes.pod.namespace=<NAMESPACE>
 	//   k8s:name=cilium-operator
 	//   k8s:io.cilium/app=operator
 	//   k8s:io.cilium.k8s.policy.cluster=default
 	WellKnown.add(ReservedCiliumOperator, []string{
 		"k8s:name=cilium-operator",
 		"k8s:io.cilium/app=operator",
-		fmt.Sprintf("k8s:%s=kube-system", api.PodNamespaceLabel),
+		fmt.Sprintf("k8s:%s=%s", api.PodNamespaceLabel, namespace),
 		fmt.Sprintf("k8s:%s=cilium-operator", api.PolicyLabelServiceAccount),
 		fmt.Sprintf("k8s:%s=%s", api.PolicyLabelCluster, option.Config.ClusterName),
 	})

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -146,6 +146,13 @@ const (
 
 	// SockopsEnableName is the name of the option to enable sockops
 	SockopsEnableName = "sockops-enable"
+
+	// K8sNamespaceName is the name of the K8sNamespace option
+	K8sNamespaceName = "k8s-namespace"
+
+	// K8sNamespaceNameEnv is the name of the K8sNamespace environment
+	// variable
+	K8sNamespaceNameEnv = "CILIUM_K8S_NAMESPACE"
 )
 
 // Available option for daemonConfig.Tunnel
@@ -346,6 +353,10 @@ type daemonConfig struct {
 	// PrependIptablesChains is the name of the option to enable prepending
 	// iptables chains instead of appending
 	PrependIptablesChains bool
+
+	// K8sNamespace is the name of the namespace in which Cilium is
+	// deployed in when running in Kubernetes mode
+	K8sNamespace string
 }
 
 var (


### PR DESCRIPTION
This is required for the GKE guide which does not allow deploying into kube-system

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6333)
<!-- Reviewable:end -->
