### PR TITLE
Vagrantfile: Silence chown -R permission warnings

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,7 +37,7 @@ sudo -E /usr/local/go/bin/go get -u github.com/google/gops
 sudo -E /usr/local/go/bin/go get -d github.com/lyft/protoc-gen-validate
 sudo -E /usr/local/go/bin/go get -u github.com/gordonklaus/ineffassign
 (cd ~/go/src/github.com/lyft/protoc-gen-validate ; sudo git checkout 930a67cf7ba41b9d9436ad7a1be70a5d5ff6e1fc ; make build)
-sudo chown -R vagrant:vagrant /home/vagrant
+sudo chown -R vagrant:vagrant /home/vagrant 2>/dev/null
 curl -SsL https://github.com/cilium/bpf-map/releases/download/v1.0/bpf-map -o bpf-map
 chmod +x bpf-map
 mv bpf-map /usr/bin


### PR DESCRIPTION
When using NFS mounted shared directories a dev VM start up emits thousands of lines like:

    runtime1: chown: changing ownership of '/home/vagrant/go/src/github.com/cilium/cilium/vendor/github.com/davecgh/go-spew/spew': Operation not permitted
    runtime1: chown: changing ownership of '/home/vagrant/go/src/github.com/cilium/cilium/vendor/github.com/davecgh/go-spew': Operation not permitted
    runtime1: chown: changing ownership of '/home/vagrant/go/src/github.com/cilium/cilium/vendor/github.com/davecgh': Operation not permitted

Suppress these by forwarding error output from chown to /dev/null.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6334)
<!-- Reviewable:end -->
