### PR TITLE
vendor: downgrade hashicorp/go-version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -640,11 +640,19 @@
   revision = "v1.0.0"
 
 [[projects]]
-  digest = "1:0b06ffe0c0764e413a6738e3f045d6bb14117359aef80a09f8c60fbff2ecad6b"
+  branch = "master"
+  digest = "1:cdb5ce76cd7af19e3d2d5ba9b6458a2ee804f0d376711215dd3df5f51100d423"
+  name = "github.com/hashicorp/go-rootcerts"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "6bb64b370b90e7ef1fa532be9e591a81c3493e00"
+
+[[projects]]
+  digest = "1:b02943d3542f3fcb6faa4723b4e4f879d7fc166451e24f72c449de9a3be50e3c"
   name = "github.com/hashicorp/go-version"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "v1.0.0"
+  revision = "4fe82ae3040f80a03d04d2cccb5606a626b8e1ee"
 
 [[projects]]
   digest = "1:b42cde0e1f3c816dd57f57f7bbcf05ca40263ad96f168714c130c611fc0856a6"
@@ -815,6 +823,14 @@
   packages = ["."]
   pruneopts = "NUT"
   revision = "v1.0.10"
+
+[[projects]]
+  digest = "1:a4df73029d2c42fabcb6b41e327d2f87e685284ec03edf76921c267d9cfc9c23"
+  name = "github.com/mitchellh/go-homedir"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "ae18d6b8b3205b561c79e8e5f69bff09736185f4"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:5fe20cfe4ef484c237cec9f947b2a6fa90bad4b8610fd014f0e4211e13d82d5d"
@@ -1806,6 +1822,7 @@
     "gopkg.in/check.v1",
     "gopkg.in/fsnotify.v1",
     "gopkg.in/natefinch/lumberjack.v2",
+    "gopkg.in/yaml.v2",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
     "k8s.io/api/networking/v1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -229,10 +229,12 @@ required = [
 
 [[constraint]]
   name = "github.com/hashicorp/go-version"
-  revision = "v1.0.0"
+  revision = "4fe82ae3040f80a03d04d2cccb5606a626b8e1ee"
 
   # main-usage = "multiple packages"
-  # on-revision = ""
+  # on-revision = "this revision is the parent revision of the commit removes"
+  #               "comparision between constrains that are not pre-releases and
+  #               "versions that are pre-releases"
 
 [[constraint]]
   name = "github.com/jessevdk/go-flags"

--- a/vendor/github.com/hashicorp/consul/website/source/api/operator/license.html.md
+++ b/vendor/github.com/hashicorp/consul/website/source/api/operator/license.html.md
@@ -52,25 +52,25 @@ $ curl \
 {
     "Valid": true,
     "License": {
-	"license_id": "2afbf681-0d1a-0649-cb6c-333ec9f0989c",
-	"customer_id": "0259271d-8ffc-e85e-0830-c0822c1f5f2b",
-	"installation_id": "*",
-	"issue_time": "2018-05-21T20:03:35.911567355Z",
-	"start_time": "2018-05-21T04:00:00Z",
-	"expiration_time": "2019-05-22T03:59:59.999Z",
-	"product": "consul",
-	"flags": {
-	    "package": "premium"
-	},
-	"features": [
-	    "Automated Backups",
-	    "Automated Upgrades",
-	    "Enhanced Read Scalability",
-	    "Network Segments",
-	    "Redundancy Zone",
-	    "Advanced Network Federation"
-	],
-	"temporary": false
+        "license_id": "2afbf681-0d1a-0649-cb6c-333ec9f0989c",
+        "customer_id": "0259271d-8ffc-e85e-0830-c0822c1f5f2b",
+        "installation_id": "*",
+        "issue_time": "2018-05-21T20:03:35.911567355Z",
+        "start_time": "2018-05-21T04:00:00Z",
+        "expiration_time": "2019-05-22T03:59:59.999Z",
+        "product": "consul",
+        "flags": {
+            "package": "premium"
+        },
+        "features": [
+            "Automated Backups",
+            "Automated Upgrades",
+            "Enhanced Read Scalability",
+            "Network Segments",
+            "Redundancy Zone",
+            "Advanced Network Federation"
+        ],
+        "temporary": false
     },
     "Warnings": []
 }
@@ -120,25 +120,25 @@ $ curl \
 {
     "Valid": true,
     "License": {
-	"license_id": "2afbf681-0d1a-0649-cb6c-333ec9f0989c",
-	"customer_id": "0259271d-8ffc-e85e-0830-c0822c1f5f2b",
-	"installation_id": "*",
-	"issue_time": "2018-05-21T20:03:35.911567355Z",
-	"start_time": "2018-05-21T04:00:00Z",
-	"expiration_time": "2019-05-22T03:59:59.999Z",
-	"product": "consul",
-	"flags": {
-	    "package": "premium"
-	},
-	"features": [
-	    "Automated Backups",
-	    "Automated Upgrades",
-	    "Enhanced Read Scalability",
-	    "Network Segments",
-	    "Redundancy Zone",
-	    "Advanced Network Federation"
-	],
-	"temporary": false
+        "license_id": "2afbf681-0d1a-0649-cb6c-333ec9f0989c",
+        "customer_id": "0259271d-8ffc-e85e-0830-c0822c1f5f2b",
+        "installation_id": "*",
+        "issue_time": "2018-05-21T20:03:35.911567355Z",
+        "start_time": "2018-05-21T04:00:00Z",
+        "expiration_time": "2019-05-22T03:59:59.999Z",
+        "product": "consul",
+        "flags": {
+            "package": "premium"
+        },
+        "features": [
+            "Automated Backups",
+            "Automated Upgrades",
+            "Enhanced Read Scalability",
+            "Network Segments",
+            "Redundancy Zone",
+            "Advanced Network Federation"
+        ],
+        "temporary": false
     },
     "Warnings": []
 }

--- a/vendor/github.com/hashicorp/consul/website/source/docs/commands/license.html.markdown.erb
+++ b/vendor/github.com/hashicorp/consul/website/source/docs/commands/license.html.markdown.erb
@@ -71,12 +71,12 @@ Expires At: 2019-05-22 03:59:59.999 +0000 UTC
 Datacenter: *
 Package: premium
 Licensed Features:
-	Automated Backups
-	Automated Upgrades
-	Enhanced Read Scalability
-	Network Segments
-	Redundancy Zone
-	Advanced Network Federation
+        Automated Backups
+        Automated Upgrades
+        Enhanced Read Scalability
+        Network Segments
+        Redundancy Zone
+        Advanced Network Federation
 ```
 
 ## get
@@ -100,10 +100,10 @@ Expires At: 2019-05-22 03:59:59.999 +0000 UTC
 Datacenter: *
 Package: premium
 Licensed Features:
-	Automated Backups
-	Automated Upgrades
-	Enhanced Read Scalability
-	Network Segments
-	Redundancy Zone
-	Advanced Network Federation
+        Automated Backups
+        Automated Upgrades
+        Enhanced Read Scalability
+        Network Segments
+        Redundancy Zone
+        Advanced Network Federation
 ```

--- a/vendor/github.com/hashicorp/go-rootcerts/LICENSE
+++ b/vendor/github.com/hashicorp/go-rootcerts/LICENSE
@@ -27,11 +27,11 @@ Mozilla Public License, version 2.0
      means
 
      a. that the initial Contributor has attached the notice described in
-	Exhibit B to the Covered Software; or
+        Exhibit B to the Covered Software; or
 
      b. that the Covered Software was made available under the terms of
-	version 1.1 or earlier of the License, but not also under the terms of
-	a Secondary License.
+        version 1.1 or earlier of the License, but not also under the terms of
+        a Secondary License.
 
 1.6. "Executable Form"
 
@@ -57,7 +57,7 @@ Mozilla Public License, version 2.0
      means any of the following:
 
      a. any file in Source Code Form that results from an addition to,
-	deletion from, or modification of the contents of Covered Software; or
+        deletion from, or modification of the contents of Covered Software; or
 
      b. any new file in Source Code Form that contains any Covered Software.
 
@@ -98,14 +98,14 @@ Mozilla Public License, version 2.0
      non-exclusive license:
 
      a. under intellectual property rights (other than patent or trademark)
-	Licensable by such Contributor to use, reproduce, make available,
-	modify, display, perform, distribute, and otherwise exploit its
-	Contributions, either on an unmodified basis, with Modifications, or
-	as part of a Larger Work; and
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and
 
      b. under Patent Claims of such Contributor to make, use, sell, offer for
-	sale, have made, import, and otherwise transfer either its
-	Contributions or its Contributor Version.
+        sale, have made, import, and otherwise transfer either its
+        Contributions or its Contributor Version.
 
 2.2. Effective Date
 
@@ -124,12 +124,12 @@ Mozilla Public License, version 2.0
      a. for any code that a Contributor has removed from Covered Software; or
 
      b. for infringements caused by: (i) Your and any other third party's
-	modifications of Covered Software, or (ii) the combination of its
-	Contributions with other software (except as part of its Contributor
-	Version); or
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
 
      c. under Patent Claims infringed by Covered Software in the absence of
-	its Contributions.
+        its Contributions.
 
      This License does not grant any rights in the trademarks, service marks,
      or logos of any Contributor (except as may be necessary to comply with
@@ -177,15 +177,15 @@ Mozilla Public License, version 2.0
      If You distribute Covered Software in Executable Form then:
 
      a. such Covered Software must also be made available in Source Code Form,
-	as described in Section 3.1, and You must inform recipients of the
-	Executable Form how they can obtain a copy of such Source Code Form by
-	reasonable means in a timely manner, at a charge no more than the cost
-	of distribution to the recipient; and
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
 
      b. You may distribute such Executable Form under the terms of this
-	License, or sublicense it under different terms, provided that the
-	license for the Executable Form does not attempt to limit or alter the
-	recipients' rights in the Source Code Form under this License.
+        License, or sublicense it under different terms, provided that the
+        license for the Executable Form does not attempt to limit or alter the
+        recipients' rights in the Source Code Form under this License.
 
 3.3. Distribution of a Larger Work
 
@@ -360,3 +360,4 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
       This Source Code Form is "Incompatible
       With Secondary Licenses", as defined by
       the Mozilla Public License, v. 2.0.
+

--- a/vendor/github.com/hashicorp/go-version/constraint.go
+++ b/vendor/github.com/hashicorp/go-version/constraint.go
@@ -2,7 +2,6 @@ package version
 
 import (
 	"fmt"
-	"reflect"
 	"regexp"
 	"strings"
 )
@@ -114,26 +113,6 @@ func parseSingle(v string) (*Constraint, error) {
 	}, nil
 }
 
-func prereleaseCheck(v, c *Version) bool {
-	switch vPre, cPre := v.Prerelease() != "", c.Prerelease() != ""; {
-	case cPre && vPre:
-		// A constraint with a pre-release can only match a pre-release version
-		// with the same base segments.
-		return reflect.DeepEqual(c.Segments64(), v.Segments64())
-
-	case !cPre && vPre:
-		// A constraint without a pre-release can only match a version without a
-		// pre-release.
-		return false
-
-	case cPre && !vPre:
-		// OK, except with the pessimistic operator
-	case !cPre && !vPre:
-		// OK
-	}
-	return true
-}
-
 //-------------------------------------------------------------------
 // Constraint functions
 //-------------------------------------------------------------------
@@ -147,27 +126,22 @@ func constraintNotEqual(v, c *Version) bool {
 }
 
 func constraintGreaterThan(v, c *Version) bool {
-	return prereleaseCheck(v, c) && v.Compare(c) == 1
+	return v.Compare(c) == 1
 }
 
 func constraintLessThan(v, c *Version) bool {
-	return prereleaseCheck(v, c) && v.Compare(c) == -1
+	return v.Compare(c) == -1
 }
 
 func constraintGreaterThanEqual(v, c *Version) bool {
-	return prereleaseCheck(v, c) && v.Compare(c) >= 0
+	return v.Compare(c) >= 0
 }
 
 func constraintLessThanEqual(v, c *Version) bool {
-	return prereleaseCheck(v, c) && v.Compare(c) <= 0
+	return v.Compare(c) <= 0
 }
 
 func constraintPessimistic(v, c *Version) bool {
-	// Using a pessimistic constraint with a pre-release, restricts versions to pre-releases
-	if !prereleaseCheck(v, c) || (c.Prerelease() != "" && v.Prerelease() == "") {
-		return false
-	}
-
 	// If the version being checked is naturally less than the constraint, then there
 	// is no way for the version to be valid against the constraint
 	if v.LessThan(c) {

--- a/vendor/github.com/hashicorp/go-version/version.go
+++ b/vendor/github.com/hashicorp/go-version/version.go
@@ -15,7 +15,7 @@ var versionRegexp *regexp.Regexp
 // The raw regular expression string used for testing the validity
 // of a version.
 const VersionRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
-	`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|(-?([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
+	`(-?([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
 	`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
 	`?`
 
@@ -25,7 +25,6 @@ type Version struct {
 	pre      string
 	segments []int64
 	si       int
-	original string
 }
 
 func init() {
@@ -60,17 +59,11 @@ func NewVersion(v string) (*Version, error) {
 		segments = append(segments, 0)
 	}
 
-	pre := matches[7]
-	if pre == "" {
-		pre = matches[4]
-	}
-
 	return &Version{
-		metadata: matches[10],
-		pre:      pre,
+		metadata: matches[7],
+		pre:      matches[4],
 		segments: segments,
 		si:       si,
-		original: v,
 	}, nil
 }
 
@@ -308,19 +301,11 @@ func (v *Version) Segments() []int {
 // for a version "1.2.3-beta", segments will return a slice of
 // 1, 2, 3.
 func (v *Version) Segments64() []int64 {
-	result := make([]int64, len(v.segments))
-	copy(result, v.segments)
-	return result
+	return v.segments
 }
 
 // String returns the full version string included pre-release
 // and metadata information.
-//
-// This value is rebuilt according to the parsed segments and other
-// information. Therefore, ambiguities in the version string such as
-// prefixed zeroes (1.04.0 => 1.4.0), `v` prefix (v1.0.0 => 1.0.0), and
-// missing parts (1.0 => 1.0.0) will be made into a canonicalized form
-// as shown in the parenthesized examples.
 func (v *Version) String() string {
 	var buf bytes.Buffer
 	fmtParts := make([]string, len(v.segments))
@@ -338,10 +323,4 @@ func (v *Version) String() string {
 	}
 
 	return buf.String()
-}
-
-// Original returns the original parsed version as-is, including any
-// potential whitespace, `v` prefix, etc.
-func (v *Version) Original() string {
-	return v.original
 }


### PR DESCRIPTION
As hashicorp/go-version introduced an unwanted behavior in the
go-version library we marked the revision number to be the previous
revision where the unwanted commit was introduced.

https://github.com/hashicorp/go-version/commit/fbe76cfa08cd0fa2695a1e8feea4687221ed2b32

Fixes: 24ed166d72a0 ("vendor: update hashicorp/go-version to latest stable"
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6335)
<!-- Reviewable:end -->
