### PR TITLE
identity: Block createEndpoint() while identity is being resolved

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -228,7 +228,7 @@ func LaunchAsEndpoint(owner endpoint.Owner, hostAddressing *models.NodeAddressin
 	ep.SetDefaultOpts(option.Config.Opts)
 
 	// Give the endpoint a security identity
-	ep.UpdateLabels(owner, labels.LabelHealth, nil)
+	ep.UpdateLabels(owner, labels.LabelHealth, nil, true)
 
 	// Wait until the cilium-health endpoint is running before setting up routes
 	deadline := time.Now().Add(1 * time.Minute)

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -211,7 +211,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		}
 	}
 
-	ep.UpdateLabels(d, addLabels, infoLabels)
+	ep.UpdateLabels(d, addLabels, infoLabels, true)
 
 	if err := endpointmanager.AddEndpoint(d, ep, "Create endpoint from API PUT"); err != nil {
 		log.WithError(err).Warn("Aborting endpoint join")

--- a/pkg/workloads/cri.go
+++ b/pkg/workloads/cri.go
@@ -284,7 +284,7 @@ func (c *criClient) handleCreateWorkload(id string, retry bool) {
 		// attributes with new attributes set on endpoint
 		endpointmanager.UpdateReferences(ep)
 
-		ep.UpdateLabels(Owner(), identityLabels, informationLabels)
+		ep.UpdateLabels(Owner(), identityLabels, informationLabels, false)
 		return
 	}
 

--- a/pkg/workloads/docker.go
+++ b/pkg/workloads/docker.go
@@ -494,7 +494,7 @@ func (d *dockerClient) handleCreateWorkload(id string, retry bool) {
 		// attributes with new attributes set on endpoint
 		endpointmanager.UpdateReferences(ep)
 
-		ep.UpdateLabels(Owner(), identityLabels, informationLabels)
+		ep.UpdateLabels(Owner(), identityLabels, informationLabels, false)
 		return
 	}
 


### PR DESCRIPTION
Commit 65fe98 has changed the endpoint creation API to resolve and assign the
endpoint labels in a synchronous manner when running in Kubernetes mode.
However, the identity resolution has remained non-blocking. This leads to the
endpoint not being assigned an identity for some period of time. Previously,
the init identity was resolved immediately due to not depending on the kvstore.

Resolve the identity while creating the endpoint via the API. This guarantees
that an endpoint has a proper identity from the moment it starts up. The
consequence is that endpoint creation and thus CNI ADD will fail for pods when
the kvstore is not available and the pod is not using a well-known identity.

Fixes: #6342

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6346)
<!-- Reviewable:end -->
