### PR TITLE
test/k8sT: specify image tag for Kafka proxy image

### DIFF
--- a/test/k8sT/manifests/kafka-sw-app.yaml
+++ b/test/k8sT/manifests/kafka-sw-app.yaml
@@ -12,7 +12,9 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: docker.io/spotify/kafkaproxy
+        # Normally we would specify an exact version of the image instead of
+        # 'latest', but this is the only tagged version on Dockerhub.
+        image: docker.io/spotify/kafkaproxy:latest
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9092


### PR DESCRIPTION
While the only tag available on DockerHub is 'latest' for
'docker.io/spotify/kafkaproxy', explicitly state that the tag is 'latest', and
add a comment indicating that the only tagged version on DockerHub is 'latest'.

No functional change is intended with this PR. 

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6352)
<!-- Reviewable:end -->
