### PR TITLE
endpoint: separate code in regenerate() into separate functions

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -757,22 +757,30 @@ func (e *Endpoint) regenerate(owner Owner, context *regenerationContext) (retErr
 		return err
 	}
 
+	return e.updateRealizedState(stats, origDir, revision, compilationExecuted)
+}
+
+// updateRealizedState sets any realized state fields within the endpoint to
+// be the desired state of the endpoint. This is only called after a successful
+// regeneration of the endpoint.
+func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir string, revision uint64, compilationExecuted bool) error {
 	// Update desired policy for endpoint because policy has now been realized
 	// in the datapath. PolicyMap state is not updated here, because that is
 	// performed in endpoint.syncPolicyMap().
 	stats.waitingForLock.Start()
-	err = e.LockAlive()
+	err := e.LockAlive()
 	stats.waitingForLock.End(err == nil)
 	if err != nil {
 		return err
 	}
+
+	defer e.Unlock()
 
 	// Depending upon result of BPF regeneration (compilation executed),
 	// shift endpoint directories to match said BPF regeneration
 	// results.
 	err = e.synchronizeDirectories(origDir, compilationExecuted)
 	if err != nil {
-		e.Unlock()
 		return fmt.Errorf("error synchronizing endpoint BPF program directories: %s", err)
 	}
 
@@ -786,7 +794,6 @@ func (e *Endpoint) regenerate(owner Owner, context *regenerationContext) (retErr
 	// Mark the endpoint to be running the policy revision it was
 	// compiled for
 	e.setPolicyRevision(revision)
-	e.Unlock()
 
 	return nil
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -636,38 +636,7 @@ func (e *Endpoint) regenerate(owner Owner, context *regenerationContext) (retErr
 	}).Info("Regenerating endpoint")
 
 	defer func() {
-		success := retErr == nil
-		stats.totalTime.End(success)
-		stats.success = success
-
-		e.mutex.RLock()
-		stats.endpointID = e.ID
-		stats.policyStatus = e.policyStatus()
-		e.RUnlock()
-		stats.SendMetrics()
-
-		scopedLog := e.getLogger().WithFields(logrus.Fields{
-			"waitingForLock":         stats.waitingForLock.Total(),
-			"waitingForCTClean":      stats.waitingForCTClean.Total(),
-			"policyCalculation":      stats.policyCalculation.Total(),
-			"proxyConfiguration":     stats.proxyConfiguration.Total(),
-			"proxyPolicyCalculation": stats.proxyPolicyCalculation.Total(),
-			"proxyWaitForAck":        stats.proxyWaitForAck.Total(),
-			"bpfCompilation":         stats.bpfCompilation.Total(),
-			"mapSync":                stats.mapSync.Total(),
-			"prepareBuild":           stats.prepareBuild.Total(),
-			logfields.BuildDuration:  stats.totalTime.Total(),
-			logfields.Reason:         context.Reason,
-		})
-
-		if retErr != nil {
-			scopedLog.WithError(retErr).Warn("Regeneration of endpoint failed")
-			e.LogStatus(BPF, Failure, "Error regenerating endpoint: "+retErr.Error())
-			return
-		}
-
-		scopedLog.Info("Completed endpoint regeneration")
-		e.LogStatusOK(BPF, "Successfully regenerated endpoint program (Reason: "+context.Reason+")")
+		e.updateRegenerationStatistics(context, retErr)
 	}()
 
 	e.BuildMutex.Lock()
@@ -796,6 +765,43 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 	e.setPolicyRevision(revision)
 
 	return nil
+}
+
+func (e *Endpoint) updateRegenerationStatistics(context *regenerationContext, err error) {
+	success := err == nil
+	stats := &context.Stats
+
+	stats.totalTime.End(success)
+	stats.success = success
+
+	e.mutex.RLock()
+	stats.endpointID = e.ID
+	stats.policyStatus = e.policyStatus()
+	e.RUnlock()
+	stats.SendMetrics()
+
+	scopedLog := e.getLogger().WithFields(logrus.Fields{
+		"waitingForLock":         stats.waitingForLock.Total(),
+		"waitingForCTClean":      stats.waitingForCTClean.Total(),
+		"policyCalculation":      stats.policyCalculation.Total(),
+		"proxyConfiguration":     stats.proxyConfiguration.Total(),
+		"proxyPolicyCalculation": stats.proxyPolicyCalculation.Total(),
+		"proxyWaitForAck":        stats.proxyWaitForAck.Total(),
+		"bpfCompilation":         stats.bpfCompilation.Total(),
+		"mapSync":                stats.mapSync.Total(),
+		"prepareBuild":           stats.prepareBuild.Total(),
+		logfields.BuildDuration:  stats.totalTime.Total(),
+		logfields.Reason:         context.Reason,
+	})
+
+	if err != nil {
+		scopedLog.WithError(err).Warn("Regeneration of endpoint failed")
+		e.LogStatus(BPF, Failure, "Error regenerating endpoint: "+err.Error())
+		return
+	}
+
+	scopedLog.Info("Completed endpoint regeneration")
+	e.LogStatusOK(BPF, "Successfully regenerated endpoint program (Reason: "+context.Reason+")")
 }
 
 // Regenerate forces the regeneration of endpoint programs & policy


### PR DESCRIPTION
This makes the code easier to read and more maintainable. 

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #6209 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6354)
<!-- Reviewable:end -->
