### PR TITLE
examples/kubernetes: loosen up tolerations used

### DIFF
--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -547,6 +547,8 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
+      tolerations:
+        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
 ---

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -250,15 +250,4 @@ spec:
             secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+        - operator: "Exists"

--- a/examples/kubernetes/1.10/cilium-etcd-operator.yaml
+++ b/examples/kubernetes/1.10/cilium-etcd-operator.yaml
@@ -53,5 +53,7 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
+      tolerations:
+        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -332,18 +332,7 @@ spec:
             secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+        - operator: "Exists"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -563,6 +552,8 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
+      tolerations:
+        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
 ---

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -540,6 +540,8 @@ spec:
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-node-critical
+      tolerations:
+        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
 ---

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -251,15 +251,4 @@ spec:
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+        - operator: "Exists"

--- a/examples/kubernetes/1.11/cilium-etcd-operator.yaml
+++ b/examples/kubernetes/1.11/cilium-etcd-operator.yaml
@@ -54,5 +54,7 @@ spec:
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-node-critical
+      tolerations:
+        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -333,18 +333,7 @@ spec:
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+        - operator: "Exists"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -565,6 +554,8 @@ spec:
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-node-critical
+      tolerations:
+        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
 ---

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -540,6 +540,8 @@ spec:
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-node-critical
+      tolerations:
+        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
 ---

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -251,15 +251,4 @@ spec:
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+        - operator: "Exists"

--- a/examples/kubernetes/1.12/cilium-etcd-operator.yaml
+++ b/examples/kubernetes/1.12/cilium-etcd-operator.yaml
@@ -54,5 +54,7 @@ spec:
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-node-critical
+      tolerations:
+        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -333,18 +333,7 @@ spec:
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+        - operator: "Exists"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -565,6 +554,8 @@ spec:
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-node-critical
+      tolerations:
+        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
 ---

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -540,6 +540,8 @@ spec:
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-node-critical
+      tolerations:
+        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
 ---

--- a/examples/kubernetes/1.13/cilium-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-ds.yaml
@@ -251,15 +251,4 @@ spec:
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+        - operator: "Exists"

--- a/examples/kubernetes/1.13/cilium-etcd-operator.yaml
+++ b/examples/kubernetes/1.13/cilium-etcd-operator.yaml
@@ -54,5 +54,7 @@ spec:
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-node-critical
+      tolerations:
+        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -333,18 +333,7 @@ spec:
       restartPolicy: Always
       priorityClassName: system-node-critical
       tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+        - operator: "Exists"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -565,6 +554,8 @@ spec:
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-node-critical
+      tolerations:
+        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
 ---

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -547,6 +547,8 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
+      tolerations:
+        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
 ---

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -250,15 +250,4 @@ spec:
             secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+        - operator: "Exists"

--- a/examples/kubernetes/1.8/cilium-etcd-operator.yaml
+++ b/examples/kubernetes/1.8/cilium-etcd-operator.yaml
@@ -53,5 +53,7 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
+      tolerations:
+        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -332,18 +332,7 @@ spec:
             secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+        - operator: "Exists"
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -563,6 +552,8 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
+      tolerations:
+        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
 ---

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -547,6 +547,8 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
+      tolerations:
+        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
 ---

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -250,15 +250,4 @@ spec:
             secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+        - operator: "Exists"

--- a/examples/kubernetes/1.9/cilium-etcd-operator.yaml
+++ b/examples/kubernetes/1.9/cilium-etcd-operator.yaml
@@ -53,5 +53,7 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
+      tolerations:
+        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -332,18 +332,7 @@ spec:
             secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+        - operator: "Exists"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -563,6 +552,8 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
+      tolerations:
+        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
 ---

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -250,15 +250,4 @@ spec:
             secretName: cilium-clustermesh
       restartPolicy: Always
       tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+        - operator: "Exists"

--- a/examples/kubernetes/templates/v1/cilium-etcd-operator.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-etcd-operator.yaml.sed
@@ -53,5 +53,7 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
+      tolerations:
+        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator


### PR DESCRIPTION
As Cilium is a critical component in the network we can loose up the
tolerations used in the DaemonSet the pods can be scheduled in all
nodes by default.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6359)
<!-- Reviewable:end -->
