### PR TITLE
agent: Ignore IPV4_GATEWAY=0x0 when restoring

### DIFF
--- a/pkg/node/node_address.go
+++ b/pkg/node/node_address.go
@@ -418,9 +418,11 @@ func getCiliumHostIPsFromFile(nodeConfig string) (ipv4GW, ipv6Router net.IP) {
 				if err != nil {
 					continue
 				}
-				bs := make([]byte, net.IPv4len)
-				byteorder.NetworkToHostPut(bs, uint32(ipv4GWint64))
-				ipv4GW = net.IPv4(bs[0], bs[1], bs[2], bs[3])
+				if ipv4GWint64 != int64(0) {
+					bs := make([]byte, net.IPv4len)
+					byteorder.NetworkToHostPut(bs, uint32(ipv4GWint64))
+					ipv4GW = net.IPv4(bs[0], bs[1], bs[2], bs[3])
+				}
 			case strings.Contains(txt, " ROUTER_IP "):
 				// #define ROUTER_IP 0xf0, 0xd, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xa, 0x0, 0x0, 0x0, 0x0, 0x0, 0x8a, 0xd6
 				defineLine := strings.Split(txt, " ROUTER_IP ")


### PR DESCRIPTION
I ended up with a node_config.h where IPV4_GATEWAY is set to 0x0. This causes
the internalIP to be restored to 0.0.0.0 which causes the agent to refuse
to start up and recover. It is better to continue and attempt to recover from
the IP assigned to the cilium_host device.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6360)
<!-- Reviewable:end -->
