### PR TITLE
fqdn/proxy: Send REFUSED response on policy deny

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -272,6 +272,9 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	// This isn't ideal but we are trusting the DNS responses anyway.
 	if !p.CheckAllowed(qname, endpointID) {
 		scopedLog.Debug("Rejecting DNS query from endpoint")
+		refused := new(dns.Msg)
+		refused.SetRcode(r, dns.RcodeRefused)
+		w.WriteMsg(refused)
 		return
 	}
 


### PR DESCRIPTION
Return a synthetic REFUSED DNS response when the proxy rejects a DNS
lookup. This avoids the requester from having to wait (and to retry).
REFUSED doesn't seem to be a cached negative response, and RFC 1035
explicitly references policy as a reason to refuse a request (in
https://tools.ietf.org/html/rfc1035#section-4.1.1).
In kubernetes a search domain list is provided, listing various
combinations of service, namespace, and cluster.local. Stub resolvers
follow this list and may have to wait for a very long time (2 timeouts
per possible name), rendering even allowed DNS lookups unusable. This is
because the rejected combinations may be attempted first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6366)
<!-- Reviewable:end -->
