### PR TITLE
dnsproxy: Add acccess-log and monitor events

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -72,7 +72,7 @@ func (s *DNSProxyTestSuite) SetUpSuite(c *C) {
 		func(ip net.IP) (endpointID string, err error) {
 			return "endpoint1", nil
 		},
-		func(lookupTime time.Time, name string, ips []net.IP, ttl int) error {
+		func(lookupTime time.Time, srcAddr, dstAddr string, msg *dns.Msg, protocol string, allowed bool) error {
 			return nil
 		})
 	c.Assert(err, IsNil, Commentf("error starting DNS Proxy"))

--- a/pkg/proxy/accesslog/record.go
+++ b/pkg/proxy/accesslog/record.go
@@ -15,6 +15,7 @@
 package accesslog
 
 import (
+	"net"
 	"net/http"
 	"net/url"
 )
@@ -195,6 +196,9 @@ type LogRecord struct {
 	// Kafka contains information for Kafka request/responses
 	Kafka *LogRecordKafka `json:"Kafka,omitempty"`
 
+	// DNS contains information for DNS request/responses
+	DNS *LogRecordDNS `json:"DNS,omitempty"`
+
 	// L7 contains information about generic L7 protocols
 	L7 *LogRecordL7 `json:"L7,omitempty"`
 }
@@ -242,6 +246,25 @@ type LogRecordKafka struct {
 	// Note that this string can be empty since not all messages use
 	// Topic. example: LeaveGroup, Heartbeat
 	Topic KafkaTopic
+}
+
+// LogRecordDNS contains the DNS specific portion of a log record
+type LogRecordDNS struct {
+	// Query is the name in the original query
+	Query string `json:"Query,omitempty"`
+
+	// IPs are any IPs seen in this response.
+	// This field is filled only for DNS responses with IPs.
+	IPs []net.IP `json:"IPs,omitempty"`
+
+	// TTL is the lowest applicable TTL for this data
+	// This field is filled only for DNS responses.
+	TTL uint32 `json:"TTL,omitempty"`
+
+	// CNAMEs are any CNAME records seen in the response leading from Query
+	// to the IPs.
+	// This field is filled only for DNS responses with CNAMEs to IP data.
+	CNAMEs []string `json:"CNAMEs,omitempty"`
 }
 
 // LogRecordL7 contains the generic L7 portion of a log record

--- a/pkg/proxy/logger/logger.go
+++ b/pkg/proxy/logger/logger.go
@@ -262,6 +262,13 @@ func (logTags) Kafka(k *accesslog.LogRecordKafka) LogTag {
 	}
 }
 
+// DNS attaches DNS information to the log record
+func (logTags) DNS(d *accesslog.LogRecordDNS) LogTag {
+	return func(lr *LogRecord) {
+		lr.DNS = d
+	}
+}
+
 // L7 attaches generic L7 information to the log record
 func (logTags) L7(h *accesslog.LogRecordL7) LogTag {
 	return func(lr *LogRecord) {


### PR DESCRIPTION
_The data in the LogRecordDNS is different as of 2018-12-06_

The DNS proxy now emits accesslog LogRecords, and the corresponding monitor events. These are labelled L7 and DNS.

```
-> Request dns from 54882 ([k8s:org=alliance k8s:class=xwing k8s:io.cilium.k8s.policy.cluster=default k8s:io.cilium.k8s.policy.serviceaccount=default k8s:io.kubernetes.pod.namespace=default]) to 56347 ([k8s:k8s-app=kube-dns k8s:io.kubernetes.pod.namespace=kube-system k8s:io.cilium.k8s.policy.serviceaccount=coredns k8s:io.cilium.k8s.policy.cluster=default]), identity 5229->104, verdict Forwarded DNS Query: google.com.
<- Response dns from 0 ([k8s:k8s-app=kube-dns k8s:io.kubernetes.pod.namespace=kube-system k8s:io.cilium.k8s.policy.serviceaccount=coredns k8s:io.cilium.k8s.policy.cluster=default]) to 56347 ([k8s:k8s-app=kube-dns k8s:io.kubernetes.pod.namespace=kube-system k8s:io.cilium.k8s.policy.serviceaccount=coredns k8s:io.cilium.k8s.policy.cluster=default]), identity 104->104, verdict Forwarded DNS Query: google.com. TTL: 4294967295 Answer: '216.58.215.238'
```

```
{
  "type": "logRecord",
  "observationPoint": "Egress",
  "flowType": "Request",
  "l7Proto": "dns",
  "srcEpID": 54882,
  "srcEpLabels": [
    "k8s:io.kubernetes.pod.namespace=default",
    "k8s:org=alliance",
    "k8s:class=xwing",
    "k8s:io.cilium.k8s.policy.cluster=default",
    "k8s:io.cilium.k8s.policy.serviceaccount=default"
  ],
  "srcIdentity": 5229,
  "dstEpID": 56347,
  "dstEpLabels": [
    "k8s:k8s-app=kube-dns",
    "k8s:io.kubernetes.pod.namespace=kube-system",
    "k8s:io.cilium.k8s.policy.serviceaccount=coredns",
    "k8s:io.cilium.k8s.policy.cluster=default"
  ],
  "dstIdentity": 104,
  "verdict": "Denied",
  "dns": {
    "Query": "google.com.default.svc.cluster.local.",
    "TTL": 4294967295
  }
}
{
  "type": "logRecord",
  "observationPoint": "Egress",
  "flowType": "Request",
  "l7Proto": "dns",
  "srcEpID": 54882,
  "srcEpLabels": [
    "k8s:class=xwing",
    "k8s:io.cilium.k8s.policy.cluster=default",
    "k8s:io.cilium.k8s.policy.serviceaccount=default",
    "k8s:io.kubernetes.pod.namespace=default",
    "k8s:org=alliance"
  ],
  "srcIdentity": 5229,
  "dstEpID": 56347,
  "dstEpLabels": [
    "k8s:io.cilium.k8s.policy.cluster=default",
    "k8s:k8s-app=kube-dns",
    "k8s:io.kubernetes.pod.namespace=kube-system",
    "k8s:io.cilium.k8s.policy.serviceaccount=coredns"
  ],
  "dstIdentity": 104,
  "verdict": "Denied",
  "dns": {
    "Query": "google.com.default.svc.cluster.local.",
    "TTL": 4294967295
  }
}
{
  "type": "logRecord",
  "observationPoint": "Egress",
  "flowType": "Request",
  "l7Proto": "dns",
  "srcEpID": 54882,
  "srcEpLabels": [
    "k8s:io.cilium.k8s.policy.cluster=default",
    "k8s:io.cilium.k8s.policy.serviceaccount=default",
    "k8s:io.kubernetes.pod.namespace=default",
    "k8s:org=alliance",
    "k8s:class=xwing"
  ],
  "srcIdentity": 5229,
  "dstEpID": 56347,
  "dstEpLabels": [
    "k8s:k8s-app=kube-dns",
    "k8s:io.kubernetes.pod.namespace=kube-system",
    "k8s:io.cilium.k8s.policy.serviceaccount=coredns",
    "k8s:io.cilium.k8s.policy.cluster=default"
  ],
  "dstIdentity": 104,
  "verdict": "Forwarded",
  "dns": {
    "Query": "google.com.",
    "TTL": 4294967295
  }
}
{
  "type": "logRecord",
  "observationPoint": "Ingress",
  "flowType": "Response",
  "l7Proto": "dns",
  "srcEpID": 0,
  "srcEpLabels": [
    "k8s:k8s-app=kube-dns",
    "k8s:io.kubernetes.pod.namespace=kube-system",
    "k8s:io.cilium.k8s.policy.serviceaccount=coredns",
    "k8s:io.cilium.k8s.policy.cluster=default"
  ],
  "srcIdentity": 104,
  "dstEpID": 56347,
  "dstEpLabels": [
    "k8s:k8s-app=kube-dns",
    "k8s:io.kubernetes.pod.namespace=kube-system",
    "k8s:io.cilium.k8s.policy.serviceaccount=coredns",
    "k8s:io.cilium.k8s.policy.cluster=default"
  ],
  "dstIdentity": 104,
  "verdict": "Forwarded",
  "dns": {
    "Query": "google.com.",
    "IPs": [
      "216.58.215.238"
    ],
    "TTL": 4294967295
  }
}
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6371)
<!-- Reviewable:end -->
