### PR TITLE
policy: add ResolvePolicy benchmark based off of variable number of rules

### DIFF
--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -1,0 +1,99 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package policy
+
+import (
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy/api"
+	. "gopkg.in/check.v1"
+)
+
+var (
+	fooLabel = labels.NewLabel("k8s:foo", "", "")
+	lbls     = labels.Labels{
+		"foo": fooLabel,
+	}
+	lblsArray   = lbls.LabelArray()
+	repo        = &Repository{}
+	fooIdentity = &identity.Identity{
+		ID:         303,
+		Labels:     lbls,
+		LabelArray: lbls.LabelArray(),
+	}
+	identityCache = cache.IdentityCache{303: lblsArray}
+)
+
+func (ds *PolicyTestSuite) SetUpSuite(c *C) {
+	SetPolicyEnabled(option.DefaultEnforcement)
+	repo.AddList(GenerateNumRules(1000000))
+
+}
+
+func (ds *PolicyTestSuite) TearDownSuite(c *C) {
+	repo = &Repository{}
+}
+
+func GenerateNumRules(numRules int) api.Rules {
+	parseFooLabel := labels.ParseSelectLabel("k8s:foo")
+	fooSelector := api.NewESFromLabels(parseFooLabel)
+	barSelector := api.NewESFromLabels(labels.ParseSelectLabel("bar"))
+
+	// Change ingRule and rule in the for-loop below to change what type of rules
+	// are added into the policy repository.
+	ingRule := api.IngressRule{
+		FromEndpoints: []api.EndpointSelector{barSelector},
+		/*FromRequires:  []api.EndpointSelector{barSelector},
+		ToPorts: []api.PortRule{
+			{
+				Ports: []api.PortProtocol{
+					{
+						Port:     "8080",
+						Protocol: api.ProtoTCP,
+					},
+				},
+			},
+		},*/
+	}
+
+	var rules api.Rules
+	for i := 1; i <= numRules; i++ {
+
+		rule := api.Rule{
+			EndpointSelector: fooSelector,
+			Ingress:          []api.IngressRule{ingRule},
+		}
+
+		rules = append(rules, &rule)
+	}
+	return rules
+}
+
+type DummyOwner struct{}
+
+func (d DummyOwner) LookupRedirectPort(l4 *L4Filter) uint16 {
+	return 0
+}
+
+func (ds *PolicyTestSuite) BenchmarkRegeneratePolicyRules(c *C) {
+	c.ResetTimer()
+	for i := 0; i < c.N; i++ {
+		repo.ResolvePolicy(1, lblsArray, DummyOwner{}, identityCache)
+	}
+}


### PR DESCRIPTION
This test adds a basic benchmark test for `ResolvePolicy` within `pkg/policy`. It adds a hardcoded number of rules (currently 1000000 copies of one rule over and over again) into the policy repository, and then runs the benchmark. Thus, it tests how policy regeneration scales in relation to the number of rules added to the policy repository. 

You can run it by doing the following from the cilium repository root:

```
$ go test -ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyConfigFile=/tmp/cilium-consul-certs/cilium-consul.yaml" github.com/cilium/cilium/pkg/policy -test.v -check.b -timeout 360s -coverprofile=coverage.out -covermode=count -coverpkg ./... 
```

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6374)
<!-- Reviewable:end -->
