### PR TITLE
endpoint: add desired and realized EndpointPolicy fields

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -124,8 +124,8 @@ func (d *Daemon) restoreOldEndpoints(dir string, clean bool) (*endpointRestoreSt
 		} else {
 			ep.SetDefaultOpts(option.Config.Opts)
 			alwaysEnforce := policy.GetPolicyEnabled() == option.AlwaysEnforce
-			ep.SetIngressPolicyEnabledLocked(alwaysEnforce)
-			ep.SetEgressPolicyEnabledLocked(alwaysEnforce)
+			ep.SetDesiredIngressPolicyEnabledLocked(alwaysEnforce)
+			ep.SetDesiredEgressPolicyEnabledLocked(alwaysEnforce)
 		}
 
 		ep.Unlock()

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -204,7 +204,7 @@ func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 	// Endpoint options
 	fw.WriteString(e.Options.GetFmtList())
 
-	if (e.desiredPolicy == nil) || (e.desiredPolicy != nil && e.desiredPolicy.CIDRPolicy == nil) {
+	if e.desiredPolicy == nil || e.desiredPolicy.CIDRPolicy == nil {
 		WriteIPCachePrefixes(fw, nil)
 	} else {
 		WriteIPCachePrefixes(fw, e.desiredPolicy.CIDRPolicy.ToBPFData)

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -673,6 +673,10 @@ func (e *Endpoint) runPreCompilationSteps(owner Owner, regenContext *regeneratio
 		close(datapathRegenCtxt.ctCleaned)
 	}
 
+	if e.realizedPolicy == nil {
+		e.realizedPolicy = &policy.EndpointPolicy{}
+	}
+
 	// If dry mode is enabled, no further changes to BPF maps are performed
 	if option.Config.DryMode {
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -334,7 +334,7 @@ func (e *Endpoint) addNewRedirectsFromMap(owner Owner, m policy.L4PolicyMap, des
 			} else {
 				direction = trafficdirection.Egress
 			}
-			keysFromFilter := l4.ToKeys(&l4, direction, *e.prevIdentityCache)
+			keysFromFilter := l4.ToKeys(direction, *e.prevIdentityCache)
 			for _, keyFromFilter := range keysFromFilter {
 				if oldEntry, ok := e.desiredPolicy.PolicyMapState[keyFromFilter]; ok {
 					updatedDesiredMapState[keyFromFilter] = oldEntry

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -204,10 +204,10 @@ func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 	// Endpoint options
 	fw.WriteString(e.Options.GetFmtList())
 
-	if e.L3Policy == nil {
+	if (e.desiredPolicy == nil) || (e.desiredPolicy != nil && e.desiredPolicy.CIDRPolicy == nil) {
 		WriteIPCachePrefixes(fw, nil)
 	} else {
-		WriteIPCachePrefixes(fw, e.L3Policy.ToBPFData)
+		WriteIPCachePrefixes(fw, e.desiredPolicy.CIDRPolicy.ToBPFData)
 	}
 
 	return fw.Flush()
@@ -334,15 +334,15 @@ func (e *Endpoint) addNewRedirectsFromMap(owner Owner, m policy.L4PolicyMap, des
 			} else {
 				direction = trafficdirection.Egress
 			}
-			keysFromFilter := e.convertL4FilterToPolicyMapKeys(&l4, direction)
+			keysFromFilter := l4.ToKeys(&l4, direction, *e.prevIdentityCache)
 			for _, keyFromFilter := range keysFromFilter {
-				if oldEntry, ok := e.desiredMapState[keyFromFilter]; ok {
+				if oldEntry, ok := e.desiredPolicy.PolicyMapState[keyFromFilter]; ok {
 					updatedDesiredMapState[keyFromFilter] = oldEntry
 				} else {
 					insertedDesiredMapState[keyFromFilter] = struct{}{}
 				}
 
-				e.desiredMapState[keyFromFilter] = policy.MapStateEntry{ProxyPort: redirectPort}
+				e.desiredPolicy.PolicyMapState[keyFromFilter] = policy.MapStateEntry{ProxyPort: redirectPort}
 			}
 
 		}
@@ -358,10 +358,10 @@ func (e *Endpoint) addNewRedirectsFromMap(owner Owner, m policy.L4PolicyMap, des
 
 		// Restore the desired policy map state.
 		for key := range insertedDesiredMapState {
-			delete(e.desiredMapState, key)
+			delete(e.desiredPolicy.PolicyMapState, key)
 		}
 		for key, entry := range updatedDesiredMapState {
-			e.desiredMapState[key] = entry
+			e.desiredPolicy.PolicyMapState[key] = entry
 		}
 		return nil
 	})
@@ -711,7 +711,7 @@ func (e *Endpoint) runPreCompilationSteps(owner Owner, regenContext *regeneratio
 
 		// Also reset the in-memory state of the realized state as the
 		// BPF map content is guaranteed to be empty right now.
-		e.realizedMapState = make(policy.MapState)
+		e.realizedPolicy.PolicyMapState = make(policy.MapState)
 	}
 
 	if e.bpfConfigMap == nil {
@@ -785,8 +785,8 @@ func (e *Endpoint) runPreCompilationSteps(owner Owner, regenContext *regeneratio
 	// Walk the L4Policy to add new redirects and update the desired policy map
 	// state to set the newly allocated proxy ports.
 	var desiredRedirects map[string]bool
-	if e.DesiredL4Policy != nil {
-		desiredRedirects, err, finalizeFunc, revertFunc = e.addNewRedirects(owner, e.DesiredL4Policy, datapathRegenCtxt.proxyWaitGroup)
+	if e.desiredPolicy != nil && e.desiredPolicy.L4Policy != nil {
+		desiredRedirects, err, finalizeFunc, revertFunc = e.addNewRedirects(owner, e.desiredPolicy.L4Policy, datapathRegenCtxt.proxyWaitGroup)
 		if err != nil {
 			stats.proxyConfiguration.End(false)
 			return err
@@ -1011,12 +1011,12 @@ func (e *Endpoint) GetBPFValue() (*lxcmap.EndpointInfo, error) {
 // Must be called with e.Mutex locked.
 func (e *Endpoint) syncPolicyMap() error {
 
-	if e.realizedMapState == nil {
-		e.realizedMapState = make(policy.MapState)
+	if e.realizedPolicy.PolicyMapState == nil {
+		e.realizedPolicy.PolicyMapState = make(policy.MapState)
 	}
 
-	if e.desiredMapState == nil {
-		e.desiredMapState = make(policy.MapState)
+	if e.desiredPolicy.PolicyMapState == nil {
+		e.desiredPolicy.PolicyMapState = make(policy.MapState)
 	}
 
 	if e.PolicyMap == nil {
@@ -1065,7 +1065,7 @@ func (e *Endpoint) syncPolicyMap() error {
 		}
 
 		// If key that is in policy map is not in desired state, just remove it.
-		if _, ok := e.desiredMapState[policyMapKeyToPolicyKey]; !ok {
+		if _, ok := e.desiredPolicy.PolicyMapState[policyMapKeyToPolicyKey]; !ok {
 			// Can pass key with host byte-order fields, as it will get
 			// converted to network byte-order.
 			err := e.PolicyMap.DeleteKey(keyHostOrder)
@@ -1074,13 +1074,13 @@ func (e *Endpoint) syncPolicyMap() error {
 				errors = append(errors, err)
 			} else {
 				// Operation was successful, remove from realized state.
-				delete(e.realizedMapState, policyMapKeyToPolicyKey)
+				delete(e.realizedPolicy.PolicyMapState, policyMapKeyToPolicyKey)
 			}
 		}
 	}
 
-	for keyToAdd, entry := range e.desiredMapState {
-		if oldEntry, ok := e.realizedMapState[keyToAdd]; !ok || oldEntry != entry {
+	for keyToAdd, entry := range e.desiredPolicy.PolicyMapState {
+		if oldEntry, ok := e.realizedPolicy.PolicyMapState[keyToAdd]; !ok || oldEntry != entry {
 
 			// Convert from policy.Key to policymap.Key
 			policyKeyToPolicyMapKey := policymap.PolicyKey{
@@ -1096,7 +1096,7 @@ func (e *Endpoint) syncPolicyMap() error {
 				errors = append(errors, err)
 			} else {
 				// Operation was successful, add to realized state.
-				e.realizedMapState[keyToAdd] = entry
+				e.realizedPolicy.PolicyMapState[keyToAdd] = entry
 			}
 		}
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -687,9 +687,6 @@ func (e *Endpoint) GetPolicyModel() *models.EndpointPolicyStatus {
 	if e.realizedPolicy != nil {
 		realizedL4Policy = e.realizedPolicy.L4Policy
 		realizedCIDRPolicy = e.realizedPolicy.CIDRPolicy
-	} else {
-		realizedL4Policy = &policy.L4Policy{}
-		realizedCIDRPolicy = &policy.CIDRPolicy{}
 	}
 
 	mdl := &models.EndpointPolicy{

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -331,22 +331,6 @@ func (e *Endpoint) SetDesiredIngressPolicyEnabled(ingress bool) {
 
 }
 
-// SetRealizedIngressPolicyEnabled sets Endpoint's ingress policy enforcement
-// configuration to the specified value. The endpoint's mutex must not be held.
-func (e *Endpoint) SetRealizedIngressPolicyEnabled(ingress bool) {
-	e.UnconditionalLock()
-	e.realizedPolicy.IngressPolicyEnabled = ingress
-	e.Unlock()
-}
-
-// SetRealizedEgressPolicyEnabled sets Endpoint's egress policy enforcement
-// configuration to the specified value. The endpoint's mutex must not be held.
-func (e *Endpoint) SetRealizedEgressPolicyEnabled(egress bool) {
-	e.UnconditionalLock()
-	e.realizedPolicy.EgressPolicyEnabled = egress
-	e.Unlock()
-}
-
 // SetDesiredEgressPolicyEnabled sets Endpoint's egress policy enforcement
 // configuration to the specified value. The endpoint's mutex must not be held.
 func (e *Endpoint) SetDesiredEgressPolicyEnabled(egress bool) {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -121,9 +121,7 @@ func (e *Endpoint) updateNetworkPolicy(owner Owner, proxyWaitGroup *completion.W
 
 	// Publish the updated policy to L7 proxies.
 	var desiredL4Policy *policy.L4Policy
-	if e.desiredPolicy == nil {
-		desiredL4Policy = &policy.L4Policy{}
-	} else {
+	if e.desiredPolicy != nil {
 		desiredL4Policy = e.desiredPolicy.L4Policy
 	}
 	return owner.UpdateNetworkPolicy(e, desiredL4Policy, *e.prevIdentityCache, deniedIngressIdentities, deniedEgressIdentities, proxyWaitGroup)

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -396,14 +396,8 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 
 	e.realizedBPFConfig = e.desiredBPFConfig
 
-	if e.realizedPolicy == nil {
-		e.realizedPolicy = &policy.EndpointPolicy{}
-	}
-
-	e.realizedPolicy.IngressPolicyEnabled = e.desiredPolicy.IngressPolicyEnabled
-	e.realizedPolicy.EgressPolicyEnabled = e.desiredPolicy.EgressPolicyEnabled
-	e.realizedPolicy.L4Policy = e.desiredPolicy.L4Policy
-	e.realizedPolicy.CIDRPolicy = e.desiredPolicy.CIDRPolicy
+	// Set realized state to desired state fields.
+	e.realizedPolicy.Realizes(e.desiredPolicy)
 
 	// Mark the endpoint to be running the policy revision it was
 	// compiled for

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/safetime"
 	"github.com/cilium/cilium/pkg/uuid"
@@ -51,45 +50,6 @@ import (
 // ProxyID returns a unique string to identify a proxy mapping.
 func (e *Endpoint) ProxyID(l4 *policy.L4Filter) string {
 	return policy.ProxyID(e.ID, l4.Ingress, string(l4.Protocol), uint16(l4.Port))
-}
-
-func getSecurityIdentities(labelsMap cache.IdentityCache, selector *api.EndpointSelector) []identityPkg.NumericIdentity {
-	identities := []identityPkg.NumericIdentity{}
-	for idx, labels := range labelsMap {
-		if selector.Matches(labels) {
-			log.WithFields(logrus.Fields{
-				logfields.IdentityLabels: labels,
-				logfields.L4PolicyID:     idx,
-			}).Debug("L4 Policy matches")
-			identities = append(identities, idx)
-		}
-	}
-
-	return identities
-}
-
-// convertL4FilterToPolicyMapKeys converts filter into a list of PolicyKeys
-// that apply to this endpoint.
-// Must be called with endpoint.Mutex locked.
-func (e *Endpoint) convertL4FilterToPolicyMapKeys(filter *policy.L4Filter, direction trafficdirection.TrafficDirection) []policy.Key {
-	keysToAdd := []policy.Key{}
-	port := uint16(filter.Port)
-	proto := uint8(filter.U8Proto)
-
-	for _, sel := range filter.Endpoints {
-		for _, id := range getSecurityIdentities(*e.prevIdentityCache, &sel) {
-			srcID := id.Uint32()
-			keyToAdd := policy.Key{
-				Identity: srcID,
-				// NOTE: Port is in host byte-order!
-				DestPort:         port,
-				Nexthdr:          proto,
-				TrafficDirection: direction.Uint8(),
-			}
-			keysToAdd = append(keysToAdd, keyToAdd)
-		}
-	}
-	return keysToAdd
 }
 
 // lookupRedirectPort returns the redirect L4 proxy port for the given L4
@@ -160,7 +120,13 @@ func (e *Endpoint) updateNetworkPolicy(owner Owner, proxyWaitGroup *completion.W
 	}
 
 	// Publish the updated policy to L7 proxies.
-	return owner.UpdateNetworkPolicy(e, e.DesiredL4Policy, *e.prevIdentityCache, deniedIngressIdentities, deniedEgressIdentities, proxyWaitGroup)
+	var desiredL4Policy *policy.L4Policy
+	if e.desiredPolicy == nil {
+		desiredL4Policy = &policy.L4Policy{}
+	} else {
+		desiredL4Policy = e.desiredPolicy.L4Policy
+	}
+	return owner.UpdateNetworkPolicy(e, desiredL4Policy, *e.prevIdentityCache, deniedIngressIdentities, deniedEgressIdentities, proxyWaitGroup)
 }
 
 // setNextPolicyRevision updates the desired policy revision field
@@ -240,11 +206,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner) error {
 		return err
 	}
 
-	e.DesiredL4Policy = calculatedPolicy.L4Policy
-	e.L3Policy = calculatedPolicy.CIDRPolicy
-	e.desiredMapState = calculatedPolicy.PolicyMapState
-	e.ingressPolicyEnabled = calculatedPolicy.IngressPolicyEnabled
-	e.egressPolicyEnabled = calculatedPolicy.EgressPolicyEnabled
+	e.desiredPolicy = calculatedPolicy
 
 	if e.forcePolicyCompute {
 		forceRegeneration = true     // Options were changed by the caller.
@@ -286,8 +248,8 @@ func (e *Endpoint) updateAndOverrideEndpointOptions(opts option.OptionMap) (opts
 	}
 	// Apply possible option changes before regenerating maps, as map regeneration
 	// depends on the conntrack options
-	if e.DesiredL4Policy != nil {
-		if e.DesiredL4Policy.RequiresConntrack() {
+	if e.desiredPolicy != nil && e.desiredPolicy.L4Policy != nil {
+		if e.desiredPolicy.L4Policy.RequiresConntrack() {
 			opts[option.Conntrack] = option.OptionEnabled
 		}
 	}
@@ -435,7 +397,16 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 	}
 
 	e.realizedBPFConfig = e.desiredBPFConfig
-	e.RealizedL4Policy = e.DesiredL4Policy
+
+	if e.realizedPolicy == nil {
+		e.realizedPolicy = &policy.EndpointPolicy{}
+	}
+
+	e.realizedPolicy.IngressPolicyEnabled = e.desiredPolicy.IngressPolicyEnabled
+	e.realizedPolicy.EgressPolicyEnabled = e.desiredPolicy.EgressPolicyEnabled
+	e.realizedPolicy.L4Policy = e.desiredPolicy.L4Policy
+	e.realizedPolicy.CIDRPolicy = e.desiredPolicy.CIDRPolicy
+
 	// Mark the endpoint to be running the policy revision it was
 	// compiled for
 	e.setPolicyRevision(revision)

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -371,8 +371,8 @@ func GetEndpoints() []*endpoint.Endpoint {
 // AddEndpoint takes the prepared endpoint object and starts managing it.
 func AddEndpoint(owner endpoint.Owner, ep *endpoint.Endpoint, reason string) (err error) {
 	alwaysEnforce := policy.GetPolicyEnabled() == option.AlwaysEnforce
-	ep.SetIngressPolicyEnabled(alwaysEnforce)
-	ep.SetEgressPolicyEnabled(alwaysEnforce)
+	ep.SetDesiredIngressPolicyEnabled(alwaysEnforce)
+	ep.SetDesiredEgressPolicyEnabled(alwaysEnforce)
 
 	if ep.ID != 0 {
 		return fmt.Errorf("Endpoint ID is already set to %d", ep.ID)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -118,12 +118,12 @@ func (l4 *L4Filter) AllowsAllAtL3() bool {
 }
 
 // ToKeys converts filter into a list of Keys.
-func (l4 *L4Filter) ToKeys(filter *L4Filter, direction trafficdirection.TrafficDirection, identityCache cache.IdentityCache) []Key {
+func (l4 *L4Filter) ToKeys(direction trafficdirection.TrafficDirection, identityCache cache.IdentityCache) []Key {
 	keysToAdd := []Key{}
-	port := uint16(filter.Port)
-	proto := uint8(filter.U8Proto)
+	port := uint16(l4.Port)
+	proto := uint8(l4.U8Proto)
 
-	for _, sel := range filter.Endpoints {
+	for _, sel := range l4.Endpoints {
 		for _, id := range getSecurityIdentities(identityCache, &sel) {
 			srcID := id.Uint32()
 			keyToAdd := Key{

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -47,6 +47,9 @@ type EndpointPolicy struct {
 	// datapath. In the future, this will be factored out of this object to
 	// decouple the policy as it relates to the datapath vs. its userspace
 	// representation.
+	// It maps each Key to the proxy port if proxy redirection is needed.
+	// Proxy port 0 indicates no proxy redirection.
+	// All fields within the Key and the proxy port must be in host byte-order.
 	PolicyMapState MapState
 
 	// PolicyOwner describes any type which consumes this EndpointPolicy object.

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -109,3 +109,16 @@ func (p *EndpointPolicy) computeDirectionL4PolicyMapEntries(identityCache cache.
 		}
 	}
 }
+
+// Realizes copies the fields from desired into p. It assumes that the fields in
+// desired are not modified after this function is called.
+func (p *EndpointPolicy) Realizes(desired *EndpointPolicy) {
+	if p == nil {
+		p = &EndpointPolicy{}
+	}
+
+	p.IngressPolicyEnabled = desired.IngressPolicyEnabled
+	p.EgressPolicyEnabled = desired.EgressPolicyEnabled
+	p.L4Policy = desired.L4Policy
+	p.CIDRPolicy = desired.CIDRPolicy
+}

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -90,7 +90,7 @@ func (p *EndpointPolicy) computeDesiredL4PolicyMapEntries(identityCache cache.Id
 
 func (p *EndpointPolicy) computeDirectionL4PolicyMapEntries(identityCache cache.IdentityCache, l4PolicyMap L4PolicyMap, direction trafficdirection.TrafficDirection) {
 	for _, filter := range l4PolicyMap {
-		keysFromFilter := filter.ToKeys(&filter, direction, identityCache)
+		keysFromFilter := filter.ToKeys(direction, identityCache)
 		for _, keyFromFilter := range keysFromFilter {
 			var proxyPort uint16
 			// Preserve the already-allocated proxy ports for redirects that


### PR DESCRIPTION
Remove the fields which are now contained within the `EndpointPolicy` type that were previously in Endpoint, and plumb them appropriately throughout the regeneration process for an Endpoint.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6375)
<!-- Reviewable:end -->
