### PR TITLE
Add ability for packages to register debug status reported via /debuginfo

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -276,8 +276,7 @@
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   pruneopts = "NUT"
-  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
-  version = "v1.1.1"
+  revision = "v1.1.1"
 
 [[projects]]
   digest = "1:3cabbabc9e0e4aa7e12b882bdc213f41cf8bd2b2ce2a7b5e0aceaf8a6a78049b"
@@ -1764,6 +1763,7 @@
     "github.com/coreos/etcd/clientv3/concurrency",
     "github.com/coreos/etcd/clientv3/yaml",
     "github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes",
+    "github.com/davecgh/go-spew/spew",
     "github.com/docker/engine-api/client",
     "github.com/docker/engine-api/types",
     "github.com/docker/engine-api/types/events",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -101,6 +101,13 @@ required = [
   # on-revision = ""
 
 [[constraint]]
+  name = "github.com/davecgh/go-spew"
+  revision = "v1.1.1"
+
+  # main-usage = "pkg/debug"
+  # on-revision = ""
+
+[[constraint]]
   name = "github.com/docker/engine-api"
   revision = "4eca04ae18f4f93f40196a17b9aa6e11262a7269"
 

--- a/api/v1/models/debug_info.go
+++ b/api/v1/models/debug_info.go
@@ -45,6 +45,9 @@ type DebugInfo struct {
 
 	// service list
 	ServiceList []*Service `json:"service-list"`
+
+	// subsystem
+	Subsystem map[string]string `json:"subsystem,omitempty"`
 }
 
 /* polymorph DebugInfo cilium-memory-map false */
@@ -64,6 +67,8 @@ type DebugInfo struct {
 /* polymorph DebugInfo policy false */
 
 /* polymorph DebugInfo service-list false */
+
+/* polymorph DebugInfo subsystem false */
 
 // Validate validates this debug info
 func (m *DebugInfo) Validate(formats strfmt.Registry) error {

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1104,6 +1104,10 @@ definitions:
         type: array
         items:
           type: string
+      subsystem:
+        type: object
+        additionalProperties:
+          type: string
   IPAMResponse:
     description: IPAM configuration of an endpoint
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1357,6 +1357,12 @@ func init() {
           "items": {
             "$ref": "#/definitions/Service"
           }
+        },
+        "subsystem": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       }
     },

--- a/cilium/cmd/debuginfo.go
+++ b/cilium/cmd/debuginfo.go
@@ -92,6 +92,7 @@ var sections = map[string]addSection{
 	"cilium-service-list":     addCiliumServiceList,
 	"cilium-policy":           addCiliumPolicy,
 	"cilium-memory-map":       addCiliumMemoryMap,
+	"cilium-subsystems":       addSubsystems,
 }
 
 func init() {
@@ -315,6 +316,12 @@ func addCiliumServiceList(w *tabwriter.Writer, p *models.DebugInfo) {
 
 func addCiliumPolicy(w *tabwriter.Writer, p *models.DebugInfo) {
 	printMD(w, "Policy get", fmt.Sprintf(":\n %s\nRevision: %d\n", p.Policy.Policy, p.Policy.Revision))
+}
+
+func addSubsystems(w *tabwriter.Writer, p *models.DebugInfo) {
+	for name, status := range p.Subsystem {
+		printMD(w, name, status)
+	}
 }
 
 func addCiliumMemoryMap(w *tabwriter.Writer, p *models.DebugInfo) {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -43,6 +43,7 @@ import (
 	bpfIPCache "github.com/cilium/cilium/pkg/datapath/ipcache"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
+	"github.com/cilium/cilium/pkg/debug"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -829,6 +830,8 @@ func NewDaemon() (*Daemon, *endpointRestoreState, error) {
 		buildEndpointSem: semaphore.NewWeighted(int64(numWorkerThreads())),
 		compilationMutex: new(lock.RWMutex),
 	}
+
+	debug.RegisterStatusObject("k8s-service-cache", &d.k8sSvcCache)
 
 	d.runK8sServiceHandler()
 	policyApi.InitEntities(option.Config.ClusterName)

--- a/daemon/debuginfo.go
+++ b/daemon/debuginfo.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	restapi "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/api/v1/server/restapi/endpoint"
+	"github.com/cilium/cilium/pkg/debug"
 	"github.com/cilium/cilium/pkg/version"
 
 	"github.com/go-openapi/runtime/middleware"
@@ -55,7 +56,7 @@ func (h *getDebugInfo) Handle(params restapi.GetDebuginfoParams) middleware.Resp
 
 	dr.EndpointList = getEndpointList(p)
 	dr.Policy = d.policy.GetRulesList()
-
+	dr.Subsystem = debug.CollectSubsystemStatus()
 	dr.CiliumMemoryMap = memoryMap(os.Getpid())
 
 	if d.nodeMonitor.State() != nil {

--- a/pkg/debug/subsystem.go
+++ b/pkg/debug/subsystem.go
@@ -1,0 +1,105 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debug
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// StatusFunc is a function returning the debug status of a subsytem. It is
+// passed into RegisterStatusFunc().
+type StatusFunc func() string
+
+// StatusMap is the collection of debug status of all subsystems. The key is
+// the subsystem name. The value is the subsystem debug status.
+type StatusMap map[string]string
+
+// StatusObject is the interface an object must impelement to be able to be
+// passed into RegisterStatusObject().
+type StatusObject interface {
+	// DebugStatus() is the equivalent of StatusFunc. It must return the
+	// debug status as a string.
+	DebugStatus() string
+}
+
+type functionMap map[string]StatusFunc
+
+type statusFunctions struct {
+	functions functionMap
+	mutex     lock.RWMutex
+}
+
+func newStatusFunctions() statusFunctions {
+	return statusFunctions{
+		functions: functionMap{},
+	}
+}
+
+func (s *statusFunctions) register(name string, fn StatusFunc) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if _, ok := s.functions[name]; ok {
+		return fmt.Errorf("subsystem already registered")
+	}
+
+	s.functions[name] = fn
+
+	return nil
+}
+
+func (s *statusFunctions) registerStatusObject(name string, obj StatusObject) error {
+	return s.register(name, func() string { return obj.DebugStatus() })
+}
+
+func (s *statusFunctions) collectStatus() StatusMap {
+	fnCopy := functionMap{}
+
+	// Make a copy to not hold the mutex while collecting the status
+	s.mutex.RLock()
+	for name, fn := range s.functions {
+		fnCopy[name] = fn
+	}
+	s.mutex.RUnlock()
+
+	status := StatusMap{}
+
+	for name, fn := range fnCopy {
+		status[name] = fn()
+	}
+
+	return status
+}
+
+var globalStatusFunctions = newStatusFunctions()
+
+// RegisterStatusFunc registers a subsystem and associates a status function to
+// call for debug status collection
+func RegisterStatusFunc(name string, fn StatusFunc) error {
+	return globalStatusFunctions.register(name, fn)
+}
+
+// RegisterStatusObject registers a subsystem and associated a status object on
+// which DebugStatus() is called to collect debug status
+func RegisterStatusObject(name string, obj StatusObject) error {
+	return globalStatusFunctions.registerStatusObject(name, obj)
+}
+
+// CollectSubsystemStatus collects the status of all subsystems and returns it
+func CollectSubsystemStatus() StatusMap {
+	return globalStatusFunctions.collectStatus()
+}

--- a/pkg/debug/subsystem_test.go
+++ b/pkg/debug/subsystem_test.go
@@ -1,0 +1,68 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package debug
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type DebugTestSuite struct{}
+
+var _ = Suite(&DebugTestSuite{})
+
+type debugObj struct{}
+
+func (d *debugObj) DebugStatus() string {
+	return "test3"
+}
+
+func (s *DebugTestSuite) TestSubsystem(c *C) {
+	sf := newStatusFunctions()
+	c.Assert(sf.collectStatus(), DeepEquals, StatusMap{})
+
+	sf = newStatusFunctions()
+	sf.register("foo", func() string { return "test1" })
+	c.Assert(sf.collectStatus(), DeepEquals, StatusMap{
+		"foo": "test1",
+	})
+
+	sf.register("bar", func() string { return "test2" })
+	c.Assert(sf.collectStatus(), DeepEquals, StatusMap{
+		"foo": "test1",
+		"bar": "test2",
+	})
+
+	sf.register("bar", func() string { return "test2" })
+	c.Assert(sf.collectStatus(), DeepEquals, StatusMap{
+		"foo": "test1",
+		"bar": "test2",
+	})
+
+	sf.registerStatusObject("baz", &debugObj{})
+	c.Assert(sf.collectStatus(), DeepEquals, StatusMap{
+		"foo": "test1",
+		"bar": "test2",
+		"baz": "test3",
+	})
+}

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/service"
 	"github.com/cilium/cilium/pkg/versioned"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
@@ -515,4 +516,13 @@ func (s *ServiceCache) MergeExternalServiceDelete(service *service.ClusterServic
 			s.Events <- event
 		}
 	}
+}
+
+// DebugStatus implements debug.StatusObject to provide debug status collection
+// ability
+func (s *ServiceCache) DebugStatus() string {
+	s.mutex.RLock()
+	str := spew.Sdump(s)
+	s.mutex.RUnlock()
+	return str
 }


### PR DESCRIPTION
This adds a simple framework which provides the ability to register a debug status collector which is collected on demand and served via the `GET /debuginfo` API.

The registration can happen in two forms:

1. Standalone status function:
```
debug.RegisterStatusFunc("mySubsys", func() string {
       return "debug ...."
})
```

2. Object implementing the `StatusObject` interface:

```
type debugObj struct{}
func (d *debugObj) DebugStatus() string {
        return "debug ...."
}
debug.RegisterStatusObject("mySubsys", &debugObj{})
```

### Example of implementation:

```
import "github.com/davecgh/go-spew/spew"

func (s *ServiceCache) DebugStatus() string {
        s.mutex.RLock()
        str := spew.Sdump(s)
        s.mutex.RUnlock()
        return str
}
```

Example output:
```
(*k8s.ServiceCache)(0xc000ee17b0)({
 mutex: (lock.RWMutex) {
  internalRWMutex: (lock.internalRWMutex) {
   RWMutex: (sync.RWMutex) {
    w: (sync.Mutex) {
     state: (int32) 0,
     sema: (uint32) 0
    },
    writerSem: (uint32) 0,
    readerSem: (uint32) 0,
    readerCount: (int32) 1,
    readerWait: (int32) 0
   }
  }
 },
 services: (map[k8s.ServiceID]*k8s.Service) (len=9) {
  (k8s.ServiceID) cilium/cilium-etcd: (*k8s.Service)(0xc00269dc40)(frontend:<nil>/ports=[client peer]/selector=map[etcd_cluster:cilium-etcd app:etcd]),
  (k8s.ServiceID) cilium/cilium-etcd-external: (*k8s.Service)(0xc00269dcc0)(frontend:10.39.250.93/ports=[]/selector=map[app:etcd etcd_cluster:cilium-etcd io.cilium/app:etcd-operator]),
  (k8s.ServiceID) default/echo: (*k8s.Service)(0xc00269dd40)(frontend:10.39.242.53/ports=[]/selector=map[name:echo]),
  (k8s.ServiceID) kube-system/heapster: (*k8s.Service)(0xc00269dd80)(frontend:10.39.249.220/ports=[]/selector=map[k8s-app:heapster]),
  (k8s.ServiceID) default/kubernetes: (*k8s.Service)(0xc00269ddc0)(frontend:10.39.240.1/ports=[https]/selector=map[]),
  (k8s.ServiceID) kube-system/kube-dns: (*k8s.Service)(0xc00269de00)(frontend:10.39.240.10/ports=[dns dns-tcp]/selector=map[k8s-app:kube-dns]),
  (k8s.ServiceID) kube-system/metrics-server: (*k8s.Service)(0xc00269de40)(frontend:10.39.253.59/ports=[]/selector=map[k8s-app:metrics-server]),
  (k8s.ServiceID) kube-system/default-http-backend: (*k8s.Service)(0xc00269dd00)(frontend:10.39.247.42/ports=[http]/selector=map[k8s-app:glbc]),
  (k8s.ServiceID) cilium/cilium-etcd-client: (*k8s.Service)(0xc00269de80)(frontend:10.39.249.127/ports=[client]/selector=map[app:etcd etcd_cluster:cilium-etcd])
 },
 endpoints: (map[k8s.ServiceID]*k8s.Endpoints) (len=13) {
  (k8s.ServiceID) default/echo: (*k8s.Endpoints)(0xc0010ee648)(10.36.1.170:80/TCP),
  (k8s.ServiceID) kube-system/gcp-controller-manager: (*k8s.Endpoints)(0xc0010ee658)(),
  (k8s.ServiceID) kube-system/kube-dns: (*k8s.Endpoints)(0xc0010ee668)(10.36.0.190:53/TCP,10.36.0.190:53/UDP,10.36.2.184:53/TCP,10.36.2.184:53/UDP),
  (k8s.ServiceID) kube-system/kube-scheduler: (*k8s.Endpoints)(0xc0010ee678)(),
  (k8s.ServiceID) cilium/cilium-etcd-client: (*k8s.Endpoints)(0xc0010ee688)(10.36.0.69:2379/TCP,10.36.1.90:2379/TCP,10.36.2.191:2379/TCP),
  (k8s.ServiceID) kube-system/metrics-server: (*k8s.Endpoints)(0xc0010ee608)(10.36.1.2:443/TCP),
  (k8s.ServiceID) kube-system/heapster: (*k8s.Endpoints)(0xc00161d870)(10.36.1.3:8082/TCP),
  (k8s.ServiceID) kube-system/kube-controller-manager: (*k8s.Endpoints)(0xc0010ee698)(),
  (k8s.ServiceID) cilium/cilium-etcd-external: (*k8s.Endpoints)(0xc003620978)(10.36.0.69:2379/TCP,10.36.1.90:2379/TCP,10.36.2.191:2379/TCP),
  (k8s.ServiceID) cilium/etcd-operator: (*k8s.Endpoints)(0xc0010ee6b8)(),
  (k8s.ServiceID) default/kubernetes: (*k8s.Endpoints)(0xc0010ee6c8)(35.228.70.208:443/TCP),
  (k8s.ServiceID) kube-system/default-http-backend: (*k8s.Endpoints)(0xc0010ee618)(),
  (k8s.ServiceID) cilium/cilium-etcd: (*k8s.Endpoints)(0xc0010ee638)(10.36.0.69:2379/TCP,10.36.0.69:2380/TCP,10.36.1.90:2379/TCP,10.36.1.90:2380/TCP,10.36.2.191:2379/TCP,10.36.2.191:2380/TCP)
 },
 ingresses: (map[k8s.ServiceID]*k8s.Service) {
 },
[...]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6383)
<!-- Reviewable:end -->
