### PR TITLE
endpoint: make policy calculation log Debug level

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -263,7 +263,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner) error {
 	totalRegeneration, _ := safetime.TimeSinceSafe(regenerateStart, logger)
 
 	logger.WithField(logfields.PolicyRegenerationTime, totalRegeneration.String()).
-		Info("Completed endpoint policy recalculation")
+		Debug("Completed endpoint policy recalculation")
 
 	regenerateTimeSec := totalRegeneration.Seconds()
 	metrics.PolicyRegenerationCount.Inc()


### PR DESCRIPTION
Given that this log message occurs for each endpoint that is regenerated, it
does not make sense to have it at Info level, since the amount of log messages
will increase as the number of both regenerations and endpoints increases on a
given node.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6389)
<!-- Reviewable:end -->
