### PR TITLE
policy: skip matching if rulesSelect set in SearchContext

### DIFF
--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -237,9 +237,11 @@ func (state *traceState) unSelectRule(ctx *SearchContext, labels labels.LabelArr
 
 // resolveL4IngressPolicy determines whether (TODO ianvernon)
 func (r *rule) resolveL4IngressPolicy(ctx *SearchContext, state *traceState, result *L4Policy, requirements []v1.LabelSelectorRequirement) (*L4Policy, error) {
-	if !r.EndpointSelector.Matches(ctx.To) {
-		state.unSelectRule(ctx, ctx.To, r)
-		return nil, nil
+	if !ctx.rulesSelect {
+		if !r.EndpointSelector.Matches(ctx.To) {
+			state.unSelectRule(ctx, ctx.To, r)
+			return nil, nil
+		}
 	}
 
 	state.selectRule(ctx, r)
@@ -537,10 +539,11 @@ func mergeL4EgressPort(ctx *SearchContext, endpoints []api.EndpointSelector, r a
 }
 
 func (r *rule) resolveL4EgressPolicy(ctx *SearchContext, state *traceState, result *L4Policy, requirements []v1.LabelSelectorRequirement) (*L4Policy, error) {
-
-	if !r.EndpointSelector.Matches(ctx.From) {
-		state.unSelectRule(ctx, ctx.From, r)
-		return nil, nil
+	if !ctx.rulesSelect {
+		if !r.EndpointSelector.Matches(ctx.From) {
+			state.unSelectRule(ctx, ctx.From, r)
+			return nil, nil
+		}
 	}
 
 	state.selectRule(ctx, r)

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -57,8 +57,10 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 	// Duplicate L3-only rules into wildcard L7 rules.
 	for _, r := range rules {
 		if ingress {
-			if !r.EndpointSelector.Matches(ctx.To) {
-				continue
+			if !ctx.rulesSelect {
+				if !r.EndpointSelector.Matches(ctx.To) {
+					continue
+				}
 			}
 			for _, rule := range r.Ingress {
 				// Non-label-based rule. Ignore.
@@ -87,8 +89,10 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 				}
 			}
 		} else {
-			if !r.EndpointSelector.Matches(ctx.From) {
-				continue
+			if !ctx.rulesSelect {
+				if !r.EndpointSelector.Matches(ctx.From) {
+					continue
+				}
 			}
 			for _, rule := range r.Egress {
 				// Non-label-based rule. Ignore.


### PR DESCRIPTION
Do so in L4Policy ingress and egress checks, and for wildcarding checks.
This allows for rules which have already been determined to select the
given set of labels in the SearchContext to skip having the Match
operation performed against their EndpointSelectors, as this operation
is costly.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6400)
<!-- Reviewable:end -->
