### PR TITLE
clustermesh: Do not error out of agent when remote cluster is unreachable

### DIFF
--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -50,7 +50,7 @@ type backendModule interface {
 
 	// newClient must initializes the backend and create a new kvstore
 	// client which implements the BackendOperations interface
-	newClient() (BackendOperations, error)
+	newClient() (BackendOperations, chan error)
 
 	// createInstance creates a new instance of the module
 	createInstance() backendModule

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -104,7 +104,17 @@ func (c *consulModule) getConfig() map[string]string {
 	return getOpts(c.opts)
 }
 
-func (c *consulModule) newClient() (BackendOperations, error) {
+func (c *consulModule) newClient() (BackendOperations, chan error) {
+	errChan := make(chan error, 1)
+	backend, err := c.connectConsulClient()
+	if err != nil {
+		errChan <- err
+	}
+	close(errChan)
+	return backend, errChan
+}
+
+func (c *consulModule) connectConsulClient() (BackendOperations, error) {
 	if c.config == nil {
 		consulAddr, consulAddrSet := c.opts[optAddress]
 		configPathOpt, configPathOptSet := c.opts[consulOptionConfig]

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -45,11 +45,6 @@ type etcdModule struct {
 }
 
 var (
-	// etcdVersionMismatchFatal defines whether the agent should die
-	// immediately if an etcd not matching the minimal version is
-	// encountered.
-	etcdVersionMismatchFatal = true
-
 	// versionCheckTimeout is the time we wait trying to verify the version
 	// of an etcd endpoint. The timeout can be encountered on network
 	// connectivity problems.
@@ -109,20 +104,25 @@ func (e *etcdModule) getConfig() map[string]string {
 	return getOpts(e.opts)
 }
 
-func (e *etcdModule) newClient() (BackendOperations, error) {
+func (e *etcdModule) newClient() (BackendOperations, chan error) {
+	errChan := make(chan error, 10)
+
 	endpointsOpt, endpointsSet := e.opts[addrOption]
 	configPathOpt, configSet := e.opts[EtcdOptionConfig]
 	configPath := ""
 
 	if e.config == nil {
 		if !endpointsSet && !configSet {
-			return nil, fmt.Errorf("invalid etcd configuration, %s or %s must be specified",
-				EtcdOptionConfig, addrOption)
+			errChan <- fmt.Errorf("invalid etcd configuration, %s or %s must be specified", EtcdOptionConfig, addrOption)
+			close(errChan)
+			return nil, errChan
 		}
 
 		if endpointsOpt.value == "" && configPathOpt.value == "" {
-			return nil, fmt.Errorf("invalid etcd configuration, %s or %s must be specified",
+			errChan <- fmt.Errorf("invalid etcd configuration, %s or %s must be specified",
 				EtcdOptionConfig, addrOption)
+			close(errChan)
+			return nil, errChan
 		}
 
 		e.config = &client.Config{}
@@ -136,7 +136,15 @@ func (e *etcdModule) newClient() (BackendOperations, error) {
 		}
 	}
 
-	return newEtcdClient(e.config, configPath)
+	// connectEtcdClient will close errChan when the connection attempt has
+	// been successful
+	backend, err := connectEtcdClient(e.config, configPath, errChan)
+	if err != nil {
+		errChan <- err
+		close(errChan)
+	}
+
+	return backend, errChan
 }
 
 func init() {
@@ -227,7 +235,7 @@ func (e *etcdClient) renewSession() error {
 	return nil
 }
 
-func newEtcdClient(config *client.Config, cfgPath string) (BackendOperations, error) {
+func connectEtcdClient(config *client.Config, cfgPath string, errChan chan error) (BackendOperations, error) {
 	if cfgPath != "" {
 		cfg, err := clientyaml.NewConfig(cfgPath)
 		if err != nil {
@@ -248,7 +256,7 @@ func newEtcdClient(config *client.Config, cfgPath string) (BackendOperations, er
 	log.WithFields(logrus.Fields{
 		"endpoints": config.Endpoints,
 		"config":    cfgPath,
-	}).Info("Waiting for etcd client to be ready")
+	}).Info("Connecting to etcd server...")
 
 	var s concurrency.Session
 	firstSession := make(chan struct{})
@@ -277,6 +285,8 @@ func newEtcdClient(config *client.Config, cfgPath string) (BackendOperations, er
 
 	// wait for session to be created also in parallel
 	go func() {
+		defer close(errChan)
+
 		var session concurrency.Session
 		select {
 		case err = <-errorChan:
@@ -287,7 +297,7 @@ func newEtcdClient(config *client.Config, cfgPath string) (BackendOperations, er
 			err = fmt.Errorf("timed out while waiting for etcd session. Ensure that etcd is running on %s", config.Endpoints)
 		}
 		if err != nil {
-			log.Fatal(err)
+			errChan <- err
 			return
 		}
 
@@ -295,14 +305,13 @@ func newEtcdClient(config *client.Config, cfgPath string) (BackendOperations, er
 		s = session
 		if err != nil {
 			c.Close()
-			err = fmt.Errorf("unable to create default lease: %s", err)
-			log.Fatal(err)
+			errChan <- fmt.Errorf("unable to create default lease: %s", err)
 			return
 		}
 		close(ec.firstSession)
 
 		if err := ec.checkMinVersion(); err != nil {
-			log.Fatalf("Unable to validate etcd version: %s", err)
+			errChan <- fmt.Errorf("Unable to validate etcd version: %s", err)
 		}
 	}()
 

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -544,8 +544,6 @@ func (e *etcdClient) statusChecker() {
 		newStatus := []string{}
 		ok := 0
 
-		e.getLogger().Debugf("Performing status check to etcd")
-
 		endpoints := e.client.Endpoints()
 		for _, ep := range endpoints {
 			st, err := e.determineEndpointStatus(ep)

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -17,7 +17,6 @@ package kvstore
 import (
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/cilium/cilium/pkg/controller"
@@ -150,9 +149,8 @@ type etcdClient struct {
 	// is set up in the etcd Client.
 	firstSession chan struct{}
 
-	client               *client.Client
-	controllers          *controller.Manager
-	statusCheckerStarted sync.Once
+	client      *client.Client
+	controllers *controller.Manager
 
 	// config and configPath are initialized once and never written to again, they can be accessed without locking
 	config     *client.Config
@@ -298,10 +296,7 @@ func newEtcdClient(config *client.Config, cfgPath string) (BackendOperations, er
 		close(ec.firstSession)
 	}()
 
-	ec.statusCheckerStarted.Do(func() {
-		go ec.statusChecker()
-	})
-
+	go ec.statusChecker()
 	go ec.checkMinVersion()
 
 	ec.controllers.UpdateController("kvstore-etcd-session-renew",

--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -136,13 +136,10 @@ func (s *EtcdSuite) TestETCDVersionCheck(c *C) {
 		client: cli,
 	}
 
-	// disable fatal log message on version mismatch
-	etcdVersionMismatchFatal = false
-
 	// short timeout for tests
 	versionCheckTimeout = time.Second
 
-	c.Assert(client.checkMinVersion(), Equals, true)
+	c.Assert(client.checkMinVersion(), IsNil)
 
 	// One endpoint has a bad version and should fail
 	cfg.Endpoints = []string{"http://127.0.0.1:4003", "http://127.0.0.1:4004", "http://127.0.0.1:4005"}
@@ -153,5 +150,5 @@ func (s *EtcdSuite) TestETCDVersionCheck(c *C) {
 		client: cli,
 	}
 
-	c.Assert(client.checkMinVersion(), Equals, false)
+	c.Assert(client.checkMinVersion(), Not(IsNil))
 }


### PR DESCRIPTION
This PR fixes various ClusterMesh related bugs:

* The etcd client code contained a log.Fatalf() error message when the session could not be established after a certain timeout. This would error out of the agent immediately. This is desired behavior for the main etcd connection but not for connection to remote clusters. Return a channel containing the error when session establishment fails to give the caller a chance to decide how to react to connectivity problems.

* Stop leaking etcd status checker go routines

* On change of the connection information to a remote cluster, release the old connection information 

Fixes: #6376

Signed-off-by: Thomas Graf <thomas@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6401)
<!-- Reviewable:end -->
