### PR TITLE
policy: cache denied identities at ingress and egress to improve policy computation performance

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -200,7 +200,7 @@ func (d *Daemon) RemoveProxyRedirect(e *endpoint.Endpoint, id string, proxyWaitG
 // UpdateNetworkPolicy adds or updates a network policy in the set
 // published to L7 proxies.
 func (d *Daemon) UpdateNetworkPolicy(e *endpoint.Endpoint, policy *policy.L4Policy,
-	labelsMap cache.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc) {
+	labelsMap, deniedIngressIdentities, deniedEgressIdentities cache.IdentityCache, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc) {
 	if d.l7Proxy == nil {
 		return fmt.Errorf("can't update network policy, proxy disabled"), nil
 	}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -61,7 +61,7 @@ type DaemonSuite struct {
 	OnGetPolicyRepository     func() *policy.Repository
 	OnUpdateProxyRedirect     func(e *e.Endpoint, l4 *policy.L4Filter, proxyWaitGroup *completion.WaitGroup) (uint16, error, revert.FinalizeFunc, revert.RevertFunc)
 	OnRemoveProxyRedirect     func(e *e.Endpoint, id string, proxyWaitGroup *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc)
-	OnUpdateNetworkPolicy     func(e *e.Endpoint, policy *policy.L4Policy, labelsMap cache.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc)
+	OnUpdateNetworkPolicy     func(e *e.Endpoint, policy *policy.L4Policy, labelsMap, deniedIngressIdentities, deniedEgressIdentities cache.IdentityCache, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc)
 	OnRemoveNetworkPolicy     func(e *e.Endpoint)
 	OnQueueEndpointBuild      func(epID uint64) func()
 	OnRemoveFromEndpointQueue func(epID uint64)
@@ -215,7 +215,7 @@ func (ds *DaemonSuite) RemoveProxyRedirect(e *e.Endpoint, id string, proxyWaitGr
 }
 
 func (ds *DaemonSuite) UpdateNetworkPolicy(e *e.Endpoint, policy *policy.L4Policy,
-	labelsMap cache.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc) {
+	labelsMap, deniedIngressIdentities, deniedEgressIdentities cache.IdentityCache, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc) {
 	if ds.OnUpdateNetworkPolicy != nil {
 		return ds.OnUpdateNetworkPolicy(e, policy, labelsMap, deniedIngressIdentities, deniedEgressIdentities, proxyWaitGroup)
 	}

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -135,7 +135,7 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 	}
 
 	ds.OnUpdateNetworkPolicy = func(e *e.Endpoint, policy *policy.L4Policy,
-		labelsMap cache.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc) {
+		labelsMap, deniedIngressIdentities, deniedEgressIdentities cache.IdentityCache, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc) {
 		return nil, nil
 	}
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -334,7 +334,9 @@ func (e *Endpoint) addNewRedirectsFromMap(owner Owner, m policy.L4PolicyMap, des
 			} else {
 				direction = trafficdirection.Egress
 			}
-			keysFromFilter := l4.ToKeys(direction, *e.prevIdentityCache)
+
+			keysFromFilter := l4.ToKeys(direction, *e.prevIdentityCache, e.desiredPolicy.DeniedIngressIdentities)
+
 			for _, keyFromFilter := range keysFromFilter {
 				if oldEntry, ok := e.desiredPolicy.PolicyMapState[keyFromFilter]; ok {
 					updatedDesiredMapState[keyFromFilter] = oldEntry

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -16,7 +16,6 @@ package endpoint
 
 import (
 	"github.com/cilium/cilium/pkg/completion"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/monitor"
@@ -39,7 +38,7 @@ type Owner interface {
 	// UpdateNetworkPolicy adds or updates a network policy in the set
 	// published to L7 proxies.
 	UpdateNetworkPolicy(e *Endpoint, policy *policy.L4Policy,
-		labelsMap cache.IdentityCache, deniedIngressIdentities, deniedEgressIdentities map[identity.NumericIdentity]bool, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc)
+		labelsMap, deniedIngressIdentities, deniedEgressIdentities cache.IdentityCache, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc)
 
 	// RemoveNetworkPolicy removes a network policy from the set published to
 	// L7 proxies.

--- a/pkg/envoy/server_test.go
+++ b/pkg/envoy/server_test.go
@@ -127,9 +127,9 @@ var IdentityCache = cache.IdentityCache{
 	},
 }
 
-var DeniedIdentitiesNone = make(map[identity.NumericIdentity]bool)
+var DeniedIdentitiesNone = make(cache.IdentityCache)
 
-var DeniedIdentities1001 = map[identity.NumericIdentity]bool{1001: true}
+var DeniedIdentities1001 = cache.IdentityCache{1001: labels.LabelArray{}}
 
 var ExpectedPortNetworkPolicyRule1 = &cilium.PortNetworkPolicyRule{
 	RemotePolicies: []uint64{1001, 1002},

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -118,22 +118,25 @@ func (l4 *L4Filter) AllowsAllAtL3() bool {
 }
 
 // ToKeys converts filter into a list of Keys.
-func (l4 *L4Filter) ToKeys(direction trafficdirection.TrafficDirection, identityCache cache.IdentityCache) []Key {
+func (l4 *L4Filter) ToKeys(direction trafficdirection.TrafficDirection, identityCache cache.IdentityCache, deniedIdentities cache.IdentityCache) []Key {
 	keysToAdd := []Key{}
 	port := uint16(l4.Port)
 	proto := uint8(l4.U8Proto)
 
 	for _, sel := range l4.Endpoints {
-		for _, id := range getSecurityIdentities(identityCache, &sel) {
-			srcID := id.Uint32()
-			keyToAdd := Key{
-				Identity: srcID,
-				// NOTE: Port is in host byte-order!
-				DestPort:         port,
-				Nexthdr:          proto,
-				TrafficDirection: direction.Uint8(),
+		identities := getSecurityIdentities(identityCache, &sel)
+		for _, id := range identities {
+			if _, identityIsDenied := deniedIdentities[id]; !identityIsDenied {
+				srcID := id.Uint32()
+				keyToAdd := Key{
+					Identity: srcID,
+					// NOTE: Port is in host byte-order!
+					DestPort:         port,
+					Nexthdr:          proto,
+					TrafficDirection: direction.Uint8(),
+				}
+				keysToAdd = append(keysToAdd, keyToAdd)
 			}
-			keysToAdd = append(keysToAdd, keyToAdd)
 		}
 	}
 	return keysToAdd

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -73,6 +73,12 @@ type SearchContext struct {
 	// This is used to avoid using EndpointSelector.Matches() if possible,
 	// since it is costly in terms of performance.
 	rulesSelect bool
+	// skipL4RequirementsAggregation allows for skipping of aggregation of
+	// requirements in L4 policy parsing, as it is expensive. This is used
+	// when the policy is being calculated for an endpoint (vs. a trace),
+	// and the set of denied identities can be consulted for when the PolicyMap
+	// state is computed for an endpoint.
+	skipL4RequirementsAggregation bool
 }
 
 func (s *SearchContext) String() string {

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -582,13 +582,15 @@ func (p *Repository) ResolvePolicy(id uint16, labels labels.LabelArray, policyOw
 	calculatedPolicy.EgressPolicyEnabled = egressEnabled
 
 	ingressCtx := SearchContext{
-		To:          labels,
-		rulesSelect: true,
+		To:                            labels,
+		rulesSelect:                   true,
+		skipL4RequirementsAggregation: true,
 	}
 
 	egressCtx := SearchContext{
-		From:        labels,
-		rulesSelect: true,
+		From:                          labels,
+		rulesSelect:                   true,
+		skipL4RequirementsAggregation: true,
 	}
 
 	if option.Config.TracingEnabled() {

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -54,6 +54,16 @@ type EndpointPolicy struct {
 
 	// PolicyOwner describes any type which consumes this EndpointPolicy object.
 	PolicyOwner PolicyOwner
+
+	// DeniedIngressIdentities is the set of identities which are not allowed
+	// by policy on ingress. This field is populated when an identity does not
+	// meet restraints set forth in FromRequires.
+	DeniedIngressIdentities cache.IdentityCache
+
+	// DeniedEgressIdentities is the set of identities which are not allowed
+	// by policy on egress. This field is populated when an identity does not
+	// meet restraints set forth in ToRequires.
+	DeniedEgressIdentities cache.IdentityCache
 }
 
 // PolicyOwner is anything which consumes a EndpointPolicy.
@@ -121,4 +131,6 @@ func (p *EndpointPolicy) Realizes(desired *EndpointPolicy) {
 	p.EgressPolicyEnabled = desired.EgressPolicyEnabled
 	p.L4Policy = desired.L4Policy
 	p.CIDRPolicy = desired.CIDRPolicy
+	p.DeniedEgressIdentities = desired.DeniedEgressIdentities
+	p.DeniedIngressIdentities = desired.DeniedIngressIdentities
 }

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -137,11 +137,13 @@ func (rules ruleSlice) resolveL4IngressPolicy(ctx *SearchContext, revision uint6
 	// will be appended to each EndpointSelector's MatchExpressions in
 	// each FromEndpoints for all ingress rules. This ensures that FromRequires
 	// is taken into account when evaluating policy at L4.
-	for _, r := range rules {
-		for _, ingressRule := range r.Ingress {
-			if r.EndpointSelector.Matches(ctx.To) {
-				for _, requirement := range ingressRule.FromRequires {
-					requirements = append(requirements, requirement.ConvertToLabelSelectorRequirementSlice()...)
+	if !ctx.skipL4RequirementsAggregation {
+		for _, r := range rules {
+			for _, ingressRule := range r.Ingress {
+				if r.EndpointSelector.Matches(ctx.To) {
+					for _, requirement := range ingressRule.FromRequires {
+						requirements = append(requirements, requirement.ConvertToLabelSelectorRequirementSlice()...)
+					}
 				}
 			}
 		}
@@ -177,11 +179,13 @@ func (rules ruleSlice) resolveL4EgressPolicy(ctx *SearchContext, revision uint64
 	// be appended to each EndpointSelector's MatchExpressions in each
 	// ToEndpoints for all ingress rules. This ensures that ToRequires is
 	// taken into account when evaluating policy at L4.
-	for _, r := range rules {
-		for _, egressRule := range r.Egress {
-			if r.EndpointSelector.Matches(ctx.From) {
-				for _, requirement := range egressRule.ToRequires {
-					requirements = append(requirements, requirement.ConvertToLabelSelectorRequirementSlice()...)
+	if !ctx.skipL4RequirementsAggregation {
+		for _, r := range rules {
+			for _, egressRule := range r.Egress {
+				if r.EndpointSelector.Matches(ctx.From) {
+					for _, requirement := range egressRule.ToRequires {
+						requirements = append(requirements, requirement.ConvertToLabelSelectorRequirementSlice()...)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Depends on #6375.

Before the generated policy within Cilium is translated into its corresponding `NetworkPolicy` form for consumption by Envoy, another iteration was performed over the rules to obtain the set of identities denied at ingress or egress for a given Endpoint. This means that more matching operations are performed than are necessary. Given that matching is costly, instead, while the `EndpointPolicy` object is being calculated, cache what identities are denied at L3 while L3 policy is being generated, and pass this set of denied identities to the `NetworkPolicy` generation code. This results in the removal of another iteration over the rules, improving performance in calculating policy for large numbers of rules within Cilium.

Furthermore, before, while calculating policy at L4, requirements were aggregated across all rules for a given L4Filter, which was extremely costly and non-performant. Add an option to the `SearchContext` structure which allows for skipping of this aggregation of requirements, and instead, while translating the `L4Filters` within an `L4Policy` into their corresponding PolicyMap entries, do not create any PolicyMap entries at L4 for any identity which is contained within the sets of denied identities for ingress and egress. The side effect of this is that the `Endpoints` field in the `L4Filter` may contain more EndpointSelectors than are allowed by the requirements set forth in the policy rules which select the Endpoint for which policy is being calculated. However, the translation to the datapath of these L4Filters (for `PolicyMap` keys and `NetworkPolicy` generation) takes into account these denied identities.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6404)
<!-- Reviewable:end -->
