### PR TITLE
order files by the same order kubernetes output

### DIFF
--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -2,247 +2,270 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-            - "--container-runtime=crio"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        - --container-runtime=crio
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: crio-socket
-              mountPath: /var/run/crio.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/crio.sock
+          name: crio-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read labels from CRI-O containers running in the host
-        - name: crio-socket
-          hostPath:
-            path: /var/run/crio/crio.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/crio/crio.sock
+          type: Socket
+        name: crio-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -84,250 +84,273 @@ data:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-            - "--container-runtime=crio"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        - --container-runtime=crio
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: crio-socket
-              mountPath: /var/run/crio.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/crio.sock
+          name: crio-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read labels from CRI-O containers running in the host
-        - name: crio-socket
-          hostPath:
-            path: /var/run/crio/crio.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/crio/crio.sock
+          type: Socket
+        name: crio-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -547,100 +570,120 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
-      tolerations:
-        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
   name: cilium-operator
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: cilium-operator
         io.cilium/app: operator
+        name: cilium-operator
     spec:
-      serviceAccountName: cilium-operator
-      restartPolicy: Always
       containers:
-      - name: cilium-operator
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        command:
+        - cilium-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
-        command: ["cilium-operator"]
-        args:
-          - "--debug=$(CILIUM_DEBUG)"
-          - "--kvstore=etcd"
-          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-        env:
-          - name: "POD_NAMESPACE"
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: "K8S_NODE_NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: "CILIUM_DEBUG"
-            valueFrom:
-              configMapKeyRef:
-                name: cilium-config
-                key: debug
-                optional: true
-          - name: CILIUM_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-name
-                name: cilium-config
-                optional: true
-          - name: CILIUM_CLUSTER_ID
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-id
-                name: cilium-config
-                optional: true
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_ACCESS_KEY_ID
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_SECRET_ACCESS_KEY
-                optional: true
-          - name: AWS_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_DEFAULT_REGION
-                optional: true
+        name: cilium-operator
         volumeMounts:
-          - name: etcd-config-path
-            mountPath: /var/lib/etcd-config
-            readOnly: true
-          - name: etcd-secrets
-            mountPath: /var/lib/etcd-secrets
-            readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
       volumes:
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -661,13 +704,16 @@ rules:
   - deployments
   - componentstatuses
   verbs:
-  - "*"
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   - endpoints
-  verbs: ["get","list","watch"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cilium.io
   resources:
@@ -676,7 +722,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -701,75 +747,76 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -2,252 +2,269 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_K8S_NAMESPACE"
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_TCP
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-tcp
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_ANY
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-other
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: docker-socket
-              mountPath: /var/run/docker.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/docker.sock
+          name: docker-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read docker events from the node
-        - name: docker-socket
-          hostPath:
-            path: /var/run/docker.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+        name: docker-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      tolerations:
-        - operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate

--- a/examples/kubernetes/1.10/cilium-etcd-operator.yaml
+++ b/examples/kubernetes/1.10/cilium-etcd-operator.yaml
@@ -53,7 +53,7 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
-      tolerations:
-        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists

--- a/examples/kubernetes/1.10/cilium-operator.yaml
+++ b/examples/kubernetes/1.10/cilium-operator.yaml
@@ -1,93 +1,113 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
   name: cilium-operator
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: cilium-operator
         io.cilium/app: operator
+        name: cilium-operator
     spec:
-      serviceAccountName: cilium-operator
-      restartPolicy: Always
       containers:
-      - name: cilium-operator
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        command:
+        - cilium-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
-        command: ["cilium-operator"]
-        args:
-          - "--debug=$(CILIUM_DEBUG)"
-          - "--kvstore=etcd"
-          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-        env:
-          - name: "POD_NAMESPACE"
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: "K8S_NODE_NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: "CILIUM_DEBUG"
-            valueFrom:
-              configMapKeyRef:
-                name: cilium-config
-                key: debug
-                optional: true
-          - name: CILIUM_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-name
-                name: cilium-config
-                optional: true
-          - name: CILIUM_CLUSTER_ID
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-id
-                name: cilium-config
-                optional: true
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_ACCESS_KEY_ID
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_SECRET_ACCESS_KEY
-                optional: true
-          - name: AWS_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_DEFAULT_REGION
-                optional: true
+        name: cilium-operator
         volumeMounts:
-          - name: etcd-config-path
-            mountPath: /var/lib/etcd-config
-            readOnly: true
-          - name: etcd-secrets
-            mountPath: /var/lib/etcd-secrets
-            readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
       volumes:
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -108,13 +128,16 @@ rules:
   - deployments
   - componentstatuses
   verbs:
-  - "*"
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   - endpoints
-  verbs: ["get","list","watch"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cilium.io
   resources:
@@ -123,7 +146,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/examples/kubernetes/1.10/cilium-rbac.yaml
+++ b/examples/kubernetes/1.10/cilium-rbac.yaml
@@ -8,72 +8,73 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -84,255 +84,272 @@ data:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_K8S_NAMESPACE"
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_TCP
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-tcp
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_ANY
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-other
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: docker-socket
-              mountPath: /var/run/docker.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/docker.sock
+          name: docker-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read docker events from the node
-        - name: docker-socket
-          hostPath:
-            path: /var/run/docker.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+        name: docker-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      tolerations:
-        - operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -552,100 +569,120 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
-      tolerations:
-        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
   name: cilium-operator
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: cilium-operator
         io.cilium/app: operator
+        name: cilium-operator
     spec:
-      serviceAccountName: cilium-operator
-      restartPolicy: Always
       containers:
-      - name: cilium-operator
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        command:
+        - cilium-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
-        command: ["cilium-operator"]
-        args:
-          - "--debug=$(CILIUM_DEBUG)"
-          - "--kvstore=etcd"
-          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-        env:
-          - name: "POD_NAMESPACE"
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: "K8S_NODE_NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: "CILIUM_DEBUG"
-            valueFrom:
-              configMapKeyRef:
-                name: cilium-config
-                key: debug
-                optional: true
-          - name: CILIUM_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-name
-                name: cilium-config
-                optional: true
-          - name: CILIUM_CLUSTER_ID
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-id
-                name: cilium-config
-                optional: true
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_ACCESS_KEY_ID
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_SECRET_ACCESS_KEY
-                optional: true
-          - name: AWS_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_DEFAULT_REGION
-                optional: true
+        name: cilium-operator
         volumeMounts:
-          - name: etcd-config-path
-            mountPath: /var/lib/etcd-config
-            readOnly: true
-          - name: etcd-secrets
-            mountPath: /var/lib/etcd-secrets
-            readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
       volumes:
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -666,13 +703,16 @@ rules:
   - deployments
   - componentstatuses
   verbs:
-  - "*"
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   - endpoints
-  verbs: ["get","list","watch"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cilium.io
   resources:
@@ -681,7 +721,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -706,75 +746,76 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -2,239 +2,266 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-            - "--container-runtime=crio"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        - --container-runtime=crio
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: crio-socket
-              mountPath: /var/run/crio.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/crio.sock
+          name: crio-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To read labels from CRI-O containers running in the host
-        - name: crio-socket
-          hostPath:
-            path: /var/run/crio/crio.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/crio/crio.sock
+          type: Socket
+        name: crio-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      priorityClassName: system-node-critical
-      tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -84,242 +84,269 @@ data:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-            - "--container-runtime=crio"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        - --container-runtime=crio
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: crio-socket
-              mountPath: /var/run/crio.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/crio.sock
+          name: crio-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To read labels from CRI-O containers running in the host
-        - name: crio-socket
-          hostPath:
-            path: /var/run/crio/crio.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/crio/crio.sock
+          type: Socket
+        name: crio-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      priorityClassName: system-node-critical
-      tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -538,103 +565,123 @@ spec:
         name: cilium-etcd-operator
       dnsPolicy: ClusterFirst
       hostNetwork: true
-      restartPolicy: Always
       priorityClassName: system-node-critical
-      tolerations:
-        - operator: "Exists"
+      restartPolicy: Always
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
   name: cilium-operator
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: cilium-operator
         io.cilium/app: operator
+        name: cilium-operator
     spec:
-      serviceAccountName: cilium-operator
-      restartPolicy: Always
-      priorityClassName: system-node-critical
       containers:
-      - name: cilium-operator
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        command:
+        - cilium-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
-        command: ["cilium-operator"]
-        args:
-          - "--debug=$(CILIUM_DEBUG)"
-          - "--kvstore=etcd"
-          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-        env:
-          - name: "POD_NAMESPACE"
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: "K8S_NODE_NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: "CILIUM_DEBUG"
-            valueFrom:
-              configMapKeyRef:
-                name: cilium-config
-                key: debug
-                optional: true
-          - name: CILIUM_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-name
-                name: cilium-config
-                optional: true
-          - name: CILIUM_CLUSTER_ID
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-id
-                name: cilium-config
-                optional: true
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_ACCESS_KEY_ID
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_SECRET_ACCESS_KEY
-                optional: true
-          - name: AWS_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_DEFAULT_REGION
-                optional: true
+        name: cilium-operator
         volumeMounts:
-          - name: etcd-config-path
-            mountPath: /var/lib/etcd-config
-            readOnly: true
-          - name: etcd-secrets
-            mountPath: /var/lib/etcd-secrets
-            readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
       volumes:
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -655,13 +702,16 @@ rules:
   - deployments
   - componentstatuses
   verbs:
-  - "*"
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   - endpoints
-  verbs: ["get","list","watch"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cilium.io
   resources:
@@ -670,7 +720,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -695,75 +745,76 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -2,253 +2,270 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_K8S_NAMESPACE"
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_TCP
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-tcp
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_ANY
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-other
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: docker-socket
-              mountPath: /var/run/docker.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/docker.sock
+          name: docker-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read docker events from the node
-        - name: docker-socket
-          hostPath:
-            path: /var/run/docker.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+        name: docker-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      priorityClassName: system-node-critical
-      tolerations:
-        - operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate

--- a/examples/kubernetes/1.11/cilium-etcd-operator.yaml
+++ b/examples/kubernetes/1.11/cilium-etcd-operator.yaml
@@ -52,9 +52,9 @@ spec:
         name: cilium-etcd-operator
       dnsPolicy: ClusterFirst
       hostNetwork: true
-      restartPolicy: Always
       priorityClassName: system-node-critical
-      tolerations:
-        - operator: "Exists"
+      restartPolicy: Always
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists

--- a/examples/kubernetes/1.11/cilium-operator.yaml
+++ b/examples/kubernetes/1.11/cilium-operator.yaml
@@ -1,94 +1,114 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
   name: cilium-operator
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: cilium-operator
         io.cilium/app: operator
+        name: cilium-operator
     spec:
-      serviceAccountName: cilium-operator
-      restartPolicy: Always
-      priorityClassName: system-node-critical
       containers:
-      - name: cilium-operator
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        command:
+        - cilium-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
-        command: ["cilium-operator"]
-        args:
-          - "--debug=$(CILIUM_DEBUG)"
-          - "--kvstore=etcd"
-          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-        env:
-          - name: "POD_NAMESPACE"
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: "K8S_NODE_NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: "CILIUM_DEBUG"
-            valueFrom:
-              configMapKeyRef:
-                name: cilium-config
-                key: debug
-                optional: true
-          - name: CILIUM_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-name
-                name: cilium-config
-                optional: true
-          - name: CILIUM_CLUSTER_ID
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-id
-                name: cilium-config
-                optional: true
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_ACCESS_KEY_ID
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_SECRET_ACCESS_KEY
-                optional: true
-          - name: AWS_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_DEFAULT_REGION
-                optional: true
+        name: cilium-operator
         volumeMounts:
-          - name: etcd-config-path
-            mountPath: /var/lib/etcd-config
-            readOnly: true
-          - name: etcd-secrets
-            mountPath: /var/lib/etcd-secrets
-            readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
       volumes:
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -109,13 +129,16 @@ rules:
   - deployments
   - componentstatuses
   verbs:
-  - "*"
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   - endpoints
-  verbs: ["get","list","watch"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cilium.io
   resources:
@@ -124,7 +147,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/examples/kubernetes/1.11/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.11/cilium-pre-flight.yaml
@@ -55,8 +55,8 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
       hostNetwork: true
-      restartPolicy: Always
       priorityClassName: system-node-critical
+      restartPolicy: Always
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.11/cilium-rbac.yaml
+++ b/examples/kubernetes/1.11/cilium-rbac.yaml
@@ -8,72 +8,73 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -84,256 +84,273 @@ data:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_K8S_NAMESPACE"
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_TCP
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-tcp
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_ANY
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-other
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: docker-socket
-              mountPath: /var/run/docker.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/docker.sock
+          name: docker-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read docker events from the node
-        - name: docker-socket
-          hostPath:
-            path: /var/run/docker.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+        name: docker-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      priorityClassName: system-node-critical
-      tolerations:
-        - operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -552,103 +569,123 @@ spec:
         name: cilium-etcd-operator
       dnsPolicy: ClusterFirst
       hostNetwork: true
-      restartPolicy: Always
       priorityClassName: system-node-critical
-      tolerations:
-        - operator: "Exists"
+      restartPolicy: Always
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
   name: cilium-operator
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: cilium-operator
         io.cilium/app: operator
+        name: cilium-operator
     spec:
-      serviceAccountName: cilium-operator
-      restartPolicy: Always
-      priorityClassName: system-node-critical
       containers:
-      - name: cilium-operator
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        command:
+        - cilium-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
-        command: ["cilium-operator"]
-        args:
-          - "--debug=$(CILIUM_DEBUG)"
-          - "--kvstore=etcd"
-          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-        env:
-          - name: "POD_NAMESPACE"
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: "K8S_NODE_NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: "CILIUM_DEBUG"
-            valueFrom:
-              configMapKeyRef:
-                name: cilium-config
-                key: debug
-                optional: true
-          - name: CILIUM_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-name
-                name: cilium-config
-                optional: true
-          - name: CILIUM_CLUSTER_ID
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-id
-                name: cilium-config
-                optional: true
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_ACCESS_KEY_ID
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_SECRET_ACCESS_KEY
-                optional: true
-          - name: AWS_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_DEFAULT_REGION
-                optional: true
+        name: cilium-operator
         volumeMounts:
-          - name: etcd-config-path
-            mountPath: /var/lib/etcd-config
-            readOnly: true
-          - name: etcd-secrets
-            mountPath: /var/lib/etcd-secrets
-            readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
       volumes:
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -669,13 +706,16 @@ rules:
   - deployments
   - componentstatuses
   verbs:
-  - "*"
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   - endpoints
-  verbs: ["get","list","watch"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cilium.io
   resources:
@@ -684,7 +724,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -709,75 +749,76 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/examples/kubernetes/1.11/transforms2sed.sed
+++ b/examples/kubernetes/1.11/transforms2sed.sed
@@ -1,4 +1,4 @@
 s+__DS_API_VERSION__+apps/v1+g
 s+__DEPLOYMENT_API_VERSION__+apps/v1+g
 s+__RBAC_API_VERSION__+rbac.authorization.k8s.io/v1+g
-s+restartPolicy: Always+restartPolicy: Always\n      priorityClassName: system-node-critical+g
+s+restartPolicy: Always+priorityClassName: system-node-critical\n      restartPolicy: Always+g

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -2,239 +2,266 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-            - "--container-runtime=crio"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        - --container-runtime=crio
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: crio-socket
-              mountPath: /var/run/crio.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/crio.sock
+          name: crio-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To read labels from CRI-O containers running in the host
-        - name: crio-socket
-          hostPath:
-            path: /var/run/crio/crio.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/crio/crio.sock
+          type: Socket
+        name: crio-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      priorityClassName: system-node-critical
-      tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -84,242 +84,269 @@ data:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-            - "--container-runtime=crio"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        - --container-runtime=crio
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: crio-socket
-              mountPath: /var/run/crio.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/crio.sock
+          name: crio-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To read labels from CRI-O containers running in the host
-        - name: crio-socket
-          hostPath:
-            path: /var/run/crio/crio.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/crio/crio.sock
+          type: Socket
+        name: crio-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      priorityClassName: system-node-critical
-      tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -538,103 +565,123 @@ spec:
         name: cilium-etcd-operator
       dnsPolicy: ClusterFirst
       hostNetwork: true
-      restartPolicy: Always
       priorityClassName: system-node-critical
-      tolerations:
-        - operator: "Exists"
+      restartPolicy: Always
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
   name: cilium-operator
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: cilium-operator
         io.cilium/app: operator
+        name: cilium-operator
     spec:
-      serviceAccountName: cilium-operator
-      restartPolicy: Always
-      priorityClassName: system-node-critical
       containers:
-      - name: cilium-operator
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        command:
+        - cilium-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
-        command: ["cilium-operator"]
-        args:
-          - "--debug=$(CILIUM_DEBUG)"
-          - "--kvstore=etcd"
-          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-        env:
-          - name: "POD_NAMESPACE"
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: "K8S_NODE_NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: "CILIUM_DEBUG"
-            valueFrom:
-              configMapKeyRef:
-                name: cilium-config
-                key: debug
-                optional: true
-          - name: CILIUM_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-name
-                name: cilium-config
-                optional: true
-          - name: CILIUM_CLUSTER_ID
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-id
-                name: cilium-config
-                optional: true
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_ACCESS_KEY_ID
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_SECRET_ACCESS_KEY
-                optional: true
-          - name: AWS_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_DEFAULT_REGION
-                optional: true
+        name: cilium-operator
         volumeMounts:
-          - name: etcd-config-path
-            mountPath: /var/lib/etcd-config
-            readOnly: true
-          - name: etcd-secrets
-            mountPath: /var/lib/etcd-secrets
-            readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
       volumes:
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -655,13 +702,16 @@ rules:
   - deployments
   - componentstatuses
   verbs:
-  - "*"
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   - endpoints
-  verbs: ["get","list","watch"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cilium.io
   resources:
@@ -670,7 +720,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -695,75 +745,76 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -2,253 +2,270 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_K8S_NAMESPACE"
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_TCP
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-tcp
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_ANY
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-other
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: docker-socket
-              mountPath: /var/run/docker.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/docker.sock
+          name: docker-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read docker events from the node
-        - name: docker-socket
-          hostPath:
-            path: /var/run/docker.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+        name: docker-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      priorityClassName: system-node-critical
-      tolerations:
-        - operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate

--- a/examples/kubernetes/1.12/cilium-etcd-operator.yaml
+++ b/examples/kubernetes/1.12/cilium-etcd-operator.yaml
@@ -52,9 +52,9 @@ spec:
         name: cilium-etcd-operator
       dnsPolicy: ClusterFirst
       hostNetwork: true
-      restartPolicy: Always
       priorityClassName: system-node-critical
-      tolerations:
-        - operator: "Exists"
+      restartPolicy: Always
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists

--- a/examples/kubernetes/1.12/cilium-operator.yaml
+++ b/examples/kubernetes/1.12/cilium-operator.yaml
@@ -1,94 +1,114 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
   name: cilium-operator
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: cilium-operator
         io.cilium/app: operator
+        name: cilium-operator
     spec:
-      serviceAccountName: cilium-operator
-      restartPolicy: Always
-      priorityClassName: system-node-critical
       containers:
-      - name: cilium-operator
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        command:
+        - cilium-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
-        command: ["cilium-operator"]
-        args:
-          - "--debug=$(CILIUM_DEBUG)"
-          - "--kvstore=etcd"
-          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-        env:
-          - name: "POD_NAMESPACE"
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: "K8S_NODE_NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: "CILIUM_DEBUG"
-            valueFrom:
-              configMapKeyRef:
-                name: cilium-config
-                key: debug
-                optional: true
-          - name: CILIUM_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-name
-                name: cilium-config
-                optional: true
-          - name: CILIUM_CLUSTER_ID
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-id
-                name: cilium-config
-                optional: true
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_ACCESS_KEY_ID
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_SECRET_ACCESS_KEY
-                optional: true
-          - name: AWS_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_DEFAULT_REGION
-                optional: true
+        name: cilium-operator
         volumeMounts:
-          - name: etcd-config-path
-            mountPath: /var/lib/etcd-config
-            readOnly: true
-          - name: etcd-secrets
-            mountPath: /var/lib/etcd-secrets
-            readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
       volumes:
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -109,13 +129,16 @@ rules:
   - deployments
   - componentstatuses
   verbs:
-  - "*"
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   - endpoints
-  verbs: ["get","list","watch"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cilium.io
   resources:
@@ -124,7 +147,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/examples/kubernetes/1.12/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.12/cilium-pre-flight.yaml
@@ -55,8 +55,8 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
       hostNetwork: true
-      restartPolicy: Always
       priorityClassName: system-node-critical
+      restartPolicy: Always
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.12/cilium-rbac.yaml
+++ b/examples/kubernetes/1.12/cilium-rbac.yaml
@@ -8,72 +8,73 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -84,256 +84,273 @@ data:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_K8S_NAMESPACE"
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_TCP
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-tcp
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_ANY
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-other
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: docker-socket
-              mountPath: /var/run/docker.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/docker.sock
+          name: docker-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read docker events from the node
-        - name: docker-socket
-          hostPath:
-            path: /var/run/docker.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+        name: docker-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      priorityClassName: system-node-critical
-      tolerations:
-        - operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -552,103 +569,123 @@ spec:
         name: cilium-etcd-operator
       dnsPolicy: ClusterFirst
       hostNetwork: true
-      restartPolicy: Always
       priorityClassName: system-node-critical
-      tolerations:
-        - operator: "Exists"
+      restartPolicy: Always
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
   name: cilium-operator
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: cilium-operator
         io.cilium/app: operator
+        name: cilium-operator
     spec:
-      serviceAccountName: cilium-operator
-      restartPolicy: Always
-      priorityClassName: system-node-critical
       containers:
-      - name: cilium-operator
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        command:
+        - cilium-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
-        command: ["cilium-operator"]
-        args:
-          - "--debug=$(CILIUM_DEBUG)"
-          - "--kvstore=etcd"
-          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-        env:
-          - name: "POD_NAMESPACE"
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: "K8S_NODE_NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: "CILIUM_DEBUG"
-            valueFrom:
-              configMapKeyRef:
-                name: cilium-config
-                key: debug
-                optional: true
-          - name: CILIUM_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-name
-                name: cilium-config
-                optional: true
-          - name: CILIUM_CLUSTER_ID
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-id
-                name: cilium-config
-                optional: true
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_ACCESS_KEY_ID
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_SECRET_ACCESS_KEY
-                optional: true
-          - name: AWS_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_DEFAULT_REGION
-                optional: true
+        name: cilium-operator
         volumeMounts:
-          - name: etcd-config-path
-            mountPath: /var/lib/etcd-config
-            readOnly: true
-          - name: etcd-secrets
-            mountPath: /var/lib/etcd-secrets
-            readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
       volumes:
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -669,13 +706,16 @@ rules:
   - deployments
   - componentstatuses
   verbs:
-  - "*"
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   - endpoints
-  verbs: ["get","list","watch"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cilium.io
   resources:
@@ -684,7 +724,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -709,75 +749,76 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/examples/kubernetes/1.12/transforms2sed.sed
+++ b/examples/kubernetes/1.12/transforms2sed.sed
@@ -1,4 +1,4 @@
 s+__DS_API_VERSION__+apps/v1+g
 s+__DEPLOYMENT_API_VERSION__+apps/v1+g
 s+__RBAC_API_VERSION__+rbac.authorization.k8s.io/v1+g
-s+restartPolicy: Always+restartPolicy: Always\n      priorityClassName: system-node-critical+g
+s+restartPolicy: Always+priorityClassName: system-node-critical\n      restartPolicy: Always+g

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -2,239 +2,266 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-            - "--container-runtime=crio"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        - --container-runtime=crio
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: crio-socket
-              mountPath: /var/run/crio.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/crio.sock
+          name: crio-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To read labels from CRI-O containers running in the host
-        - name: crio-socket
-          hostPath:
-            path: /var/run/crio/crio.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/crio/crio.sock
+          type: Socket
+        name: crio-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      priorityClassName: system-node-critical
-      tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -84,242 +84,269 @@ data:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-            - "--container-runtime=crio"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        - --container-runtime=crio
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: crio-socket
-              mountPath: /var/run/crio.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/crio.sock
+          name: crio-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To read labels from CRI-O containers running in the host
-        - name: crio-socket
-          hostPath:
-            path: /var/run/crio/crio.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/crio/crio.sock
+          type: Socket
+        name: crio-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      priorityClassName: system-node-critical
-      tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -538,103 +565,123 @@ spec:
         name: cilium-etcd-operator
       dnsPolicy: ClusterFirst
       hostNetwork: true
-      restartPolicy: Always
       priorityClassName: system-node-critical
-      tolerations:
-        - operator: "Exists"
+      restartPolicy: Always
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
   name: cilium-operator
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: cilium-operator
         io.cilium/app: operator
+        name: cilium-operator
     spec:
-      serviceAccountName: cilium-operator
-      restartPolicy: Always
-      priorityClassName: system-node-critical
       containers:
-      - name: cilium-operator
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        command:
+        - cilium-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
-        command: ["cilium-operator"]
-        args:
-          - "--debug=$(CILIUM_DEBUG)"
-          - "--kvstore=etcd"
-          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-        env:
-          - name: "POD_NAMESPACE"
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: "K8S_NODE_NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: "CILIUM_DEBUG"
-            valueFrom:
-              configMapKeyRef:
-                name: cilium-config
-                key: debug
-                optional: true
-          - name: CILIUM_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-name
-                name: cilium-config
-                optional: true
-          - name: CILIUM_CLUSTER_ID
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-id
-                name: cilium-config
-                optional: true
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_ACCESS_KEY_ID
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_SECRET_ACCESS_KEY
-                optional: true
-          - name: AWS_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_DEFAULT_REGION
-                optional: true
+        name: cilium-operator
         volumeMounts:
-          - name: etcd-config-path
-            mountPath: /var/lib/etcd-config
-            readOnly: true
-          - name: etcd-secrets
-            mountPath: /var/lib/etcd-secrets
-            readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
       volumes:
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -655,13 +702,16 @@ rules:
   - deployments
   - componentstatuses
   verbs:
-  - "*"
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   - endpoints
-  verbs: ["get","list","watch"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cilium.io
   resources:
@@ -670,7 +720,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -695,75 +745,76 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/examples/kubernetes/1.13/cilium-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-ds.yaml
@@ -2,253 +2,270 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_K8S_NAMESPACE"
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_TCP
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-tcp
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_ANY
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-other
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: docker-socket
-              mountPath: /var/run/docker.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/docker.sock
+          name: docker-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read docker events from the node
-        - name: docker-socket
-          hostPath:
-            path: /var/run/docker.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+        name: docker-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      priorityClassName: system-node-critical
-      tolerations:
-        - operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate

--- a/examples/kubernetes/1.13/cilium-etcd-operator.yaml
+++ b/examples/kubernetes/1.13/cilium-etcd-operator.yaml
@@ -52,9 +52,9 @@ spec:
         name: cilium-etcd-operator
       dnsPolicy: ClusterFirst
       hostNetwork: true
-      restartPolicy: Always
       priorityClassName: system-node-critical
-      tolerations:
-        - operator: "Exists"
+      restartPolicy: Always
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists

--- a/examples/kubernetes/1.13/cilium-operator.yaml
+++ b/examples/kubernetes/1.13/cilium-operator.yaml
@@ -1,94 +1,114 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
   name: cilium-operator
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: cilium-operator
         io.cilium/app: operator
+        name: cilium-operator
     spec:
-      serviceAccountName: cilium-operator
-      restartPolicy: Always
-      priorityClassName: system-node-critical
       containers:
-      - name: cilium-operator
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        command:
+        - cilium-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
-        command: ["cilium-operator"]
-        args:
-          - "--debug=$(CILIUM_DEBUG)"
-          - "--kvstore=etcd"
-          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-        env:
-          - name: "POD_NAMESPACE"
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: "K8S_NODE_NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: "CILIUM_DEBUG"
-            valueFrom:
-              configMapKeyRef:
-                name: cilium-config
-                key: debug
-                optional: true
-          - name: CILIUM_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-name
-                name: cilium-config
-                optional: true
-          - name: CILIUM_CLUSTER_ID
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-id
-                name: cilium-config
-                optional: true
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_ACCESS_KEY_ID
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_SECRET_ACCESS_KEY
-                optional: true
-          - name: AWS_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_DEFAULT_REGION
-                optional: true
+        name: cilium-operator
         volumeMounts:
-          - name: etcd-config-path
-            mountPath: /var/lib/etcd-config
-            readOnly: true
-          - name: etcd-secrets
-            mountPath: /var/lib/etcd-secrets
-            readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
       volumes:
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -109,13 +129,16 @@ rules:
   - deployments
   - componentstatuses
   verbs:
-  - "*"
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   - endpoints
-  verbs: ["get","list","watch"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cilium.io
   resources:
@@ -124,7 +147,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/examples/kubernetes/1.13/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.13/cilium-pre-flight.yaml
@@ -55,8 +55,8 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
       hostNetwork: true
-      restartPolicy: Always
       priorityClassName: system-node-critical
+      restartPolicy: Always
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.13/cilium-rbac.yaml
+++ b/examples/kubernetes/1.13/cilium-rbac.yaml
@@ -8,72 +8,73 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -84,256 +84,273 @@ data:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_K8S_NAMESPACE"
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_TCP
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-tcp
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_ANY
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-other
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: docker-socket
-              mountPath: /var/run/docker.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/docker.sock
+          name: docker-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read docker events from the node
-        - name: docker-socket
-          hostPath:
-            path: /var/run/docker.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+        name: docker-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      priorityClassName: system-node-critical
-      tolerations:
-        - operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -552,103 +569,123 @@ spec:
         name: cilium-etcd-operator
       dnsPolicy: ClusterFirst
       hostNetwork: true
-      restartPolicy: Always
       priorityClassName: system-node-critical
-      tolerations:
-        - operator: "Exists"
+      restartPolicy: Always
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
   name: cilium-operator
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: cilium-operator
         io.cilium/app: operator
+        name: cilium-operator
     spec:
-      serviceAccountName: cilium-operator
-      restartPolicy: Always
-      priorityClassName: system-node-critical
       containers:
-      - name: cilium-operator
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        command:
+        - cilium-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
-        command: ["cilium-operator"]
-        args:
-          - "--debug=$(CILIUM_DEBUG)"
-          - "--kvstore=etcd"
-          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-        env:
-          - name: "POD_NAMESPACE"
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: "K8S_NODE_NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: "CILIUM_DEBUG"
-            valueFrom:
-              configMapKeyRef:
-                name: cilium-config
-                key: debug
-                optional: true
-          - name: CILIUM_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-name
-                name: cilium-config
-                optional: true
-          - name: CILIUM_CLUSTER_ID
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-id
-                name: cilium-config
-                optional: true
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_ACCESS_KEY_ID
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_SECRET_ACCESS_KEY
-                optional: true
-          - name: AWS_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_DEFAULT_REGION
-                optional: true
+        name: cilium-operator
         volumeMounts:
-          - name: etcd-config-path
-            mountPath: /var/lib/etcd-config
-            readOnly: true
-          - name: etcd-secrets
-            mountPath: /var/lib/etcd-secrets
-            readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
       volumes:
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -669,13 +706,16 @@ rules:
   - deployments
   - componentstatuses
   verbs:
-  - "*"
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   - endpoints
-  verbs: ["get","list","watch"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cilium.io
   resources:
@@ -684,7 +724,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -709,75 +749,76 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/examples/kubernetes/1.13/transforms2sed.sed
+++ b/examples/kubernetes/1.13/transforms2sed.sed
@@ -1,4 +1,4 @@
 s+__DS_API_VERSION__+apps/v1+g
 s+__DEPLOYMENT_API_VERSION__+apps/v1+g
 s+__RBAC_API_VERSION__+rbac.authorization.k8s.io/v1+g
-s+restartPolicy: Always+restartPolicy: Always\n      priorityClassName: system-node-critical+g
+s+restartPolicy: Always+priorityClassName: system-node-critical\n      restartPolicy: Always+g

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -2,247 +2,270 @@
 apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-            - "--container-runtime=crio"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        - --container-runtime=crio
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: crio-socket
-              mountPath: /var/run/crio.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/crio.sock
+          name: crio-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read labels from CRI-O containers running in the host
-        - name: crio-socket
-          hostPath:
-            path: /var/run/crio/crio.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/crio/crio.sock
+          type: Socket
+        name: crio-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -84,250 +84,273 @@ data:
 apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-            - "--container-runtime=crio"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        - --container-runtime=crio
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: crio-socket
-              mountPath: /var/run/crio.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/crio.sock
+          name: crio-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read labels from CRI-O containers running in the host
-        - name: crio-socket
-          hostPath:
-            path: /var/run/crio/crio.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/crio/crio.sock
+          type: Socket
+        name: crio-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -547,100 +570,120 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
-      tolerations:
-        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
   name: cilium-operator
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: cilium-operator
         io.cilium/app: operator
+        name: cilium-operator
     spec:
-      serviceAccountName: cilium-operator
-      restartPolicy: Always
       containers:
-      - name: cilium-operator
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        command:
+        - cilium-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
-        command: ["cilium-operator"]
-        args:
-          - "--debug=$(CILIUM_DEBUG)"
-          - "--kvstore=etcd"
-          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-        env:
-          - name: "POD_NAMESPACE"
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: "K8S_NODE_NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: "CILIUM_DEBUG"
-            valueFrom:
-              configMapKeyRef:
-                name: cilium-config
-                key: debug
-                optional: true
-          - name: CILIUM_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-name
-                name: cilium-config
-                optional: true
-          - name: CILIUM_CLUSTER_ID
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-id
-                name: cilium-config
-                optional: true
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_ACCESS_KEY_ID
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_SECRET_ACCESS_KEY
-                optional: true
-          - name: AWS_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_DEFAULT_REGION
-                optional: true
+        name: cilium-operator
         volumeMounts:
-          - name: etcd-config-path
-            mountPath: /var/lib/etcd-config
-            readOnly: true
-          - name: etcd-secrets
-            mountPath: /var/lib/etcd-secrets
-            readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
       volumes:
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -661,13 +704,16 @@ rules:
   - deployments
   - componentstatuses
   verbs:
-  - "*"
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   - endpoints
-  verbs: ["get","list","watch"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cilium.io
   resources:
@@ -676,7 +722,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -701,75 +747,76 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -2,252 +2,269 @@
 apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_K8S_NAMESPACE"
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_TCP
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-tcp
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_ANY
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-other
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: docker-socket
-              mountPath: /var/run/docker.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/docker.sock
+          name: docker-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read docker events from the node
-        - name: docker-socket
-          hostPath:
-            path: /var/run/docker.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+        name: docker-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      tolerations:
-        - operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate

--- a/examples/kubernetes/1.8/cilium-etcd-operator.yaml
+++ b/examples/kubernetes/1.8/cilium-etcd-operator.yaml
@@ -53,7 +53,7 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
-      tolerations:
-        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists

--- a/examples/kubernetes/1.8/cilium-operator.yaml
+++ b/examples/kubernetes/1.8/cilium-operator.yaml
@@ -1,93 +1,113 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
   name: cilium-operator
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: cilium-operator
         io.cilium/app: operator
+        name: cilium-operator
     spec:
-      serviceAccountName: cilium-operator
-      restartPolicy: Always
       containers:
-      - name: cilium-operator
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        command:
+        - cilium-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
-        command: ["cilium-operator"]
-        args:
-          - "--debug=$(CILIUM_DEBUG)"
-          - "--kvstore=etcd"
-          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-        env:
-          - name: "POD_NAMESPACE"
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: "K8S_NODE_NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: "CILIUM_DEBUG"
-            valueFrom:
-              configMapKeyRef:
-                name: cilium-config
-                key: debug
-                optional: true
-          - name: CILIUM_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-name
-                name: cilium-config
-                optional: true
-          - name: CILIUM_CLUSTER_ID
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-id
-                name: cilium-config
-                optional: true
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_ACCESS_KEY_ID
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_SECRET_ACCESS_KEY
-                optional: true
-          - name: AWS_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_DEFAULT_REGION
-                optional: true
+        name: cilium-operator
         volumeMounts:
-          - name: etcd-config-path
-            mountPath: /var/lib/etcd-config
-            readOnly: true
-          - name: etcd-secrets
-            mountPath: /var/lib/etcd-secrets
-            readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
       volumes:
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -108,13 +128,16 @@ rules:
   - deployments
   - componentstatuses
   verbs:
-  - "*"
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   - endpoints
-  verbs: ["get","list","watch"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cilium.io
   resources:
@@ -123,7 +146,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/examples/kubernetes/1.8/cilium-rbac.yaml
+++ b/examples/kubernetes/1.8/cilium-rbac.yaml
@@ -8,72 +8,73 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -84,255 +84,272 @@ data:
 apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_K8S_NAMESPACE"
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_TCP
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-tcp
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_ANY
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-other
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: docker-socket
-              mountPath: /var/run/docker.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/docker.sock
+          name: docker-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read docker events from the node
-        - name: docker-socket
-          hostPath:
-            path: /var/run/docker.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+        name: docker-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      tolerations:
-        - operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -552,100 +569,120 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
-      tolerations:
-        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
   name: cilium-operator
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: cilium-operator
         io.cilium/app: operator
+        name: cilium-operator
     spec:
-      serviceAccountName: cilium-operator
-      restartPolicy: Always
       containers:
-      - name: cilium-operator
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        command:
+        - cilium-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
-        command: ["cilium-operator"]
-        args:
-          - "--debug=$(CILIUM_DEBUG)"
-          - "--kvstore=etcd"
-          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-        env:
-          - name: "POD_NAMESPACE"
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: "K8S_NODE_NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: "CILIUM_DEBUG"
-            valueFrom:
-              configMapKeyRef:
-                name: cilium-config
-                key: debug
-                optional: true
-          - name: CILIUM_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-name
-                name: cilium-config
-                optional: true
-          - name: CILIUM_CLUSTER_ID
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-id
-                name: cilium-config
-                optional: true
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_ACCESS_KEY_ID
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_SECRET_ACCESS_KEY
-                optional: true
-          - name: AWS_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_DEFAULT_REGION
-                optional: true
+        name: cilium-operator
         volumeMounts:
-          - name: etcd-config-path
-            mountPath: /var/lib/etcd-config
-            readOnly: true
-          - name: etcd-secrets
-            mountPath: /var/lib/etcd-secrets
-            readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
       volumes:
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -666,13 +703,16 @@ rules:
   - deployments
   - componentstatuses
   verbs:
-  - "*"
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   - endpoints
-  verbs: ["get","list","watch"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cilium.io
   resources:
@@ -681,7 +721,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -706,75 +746,76 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -2,247 +2,270 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-            - "--container-runtime=crio"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        - --container-runtime=crio
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: crio-socket
-              mountPath: /var/run/crio.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/crio.sock
+          name: crio-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read labels from CRI-O containers running in the host
-        - name: crio-socket
-          hostPath:
-            path: /var/run/crio/crio.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/crio/crio.sock
+          type: Socket
+        name: crio-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -84,250 +84,273 @@ data:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-            - "--container-runtime=crio"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        - --container-runtime=crio
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: crio-socket
-              mountPath: /var/run/crio.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/crio.sock
+          name: crio-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read labels from CRI-O containers running in the host
-        - name: crio-socket
-          hostPath:
-            path: /var/run/crio/crio.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/crio/crio.sock
+          type: Socket
+        name: crio-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -547,100 +570,120 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
-      tolerations:
-        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
   name: cilium-operator
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: cilium-operator
         io.cilium/app: operator
+        name: cilium-operator
     spec:
-      serviceAccountName: cilium-operator
-      restartPolicy: Always
       containers:
-      - name: cilium-operator
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        command:
+        - cilium-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
-        command: ["cilium-operator"]
-        args:
-          - "--debug=$(CILIUM_DEBUG)"
-          - "--kvstore=etcd"
-          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-        env:
-          - name: "POD_NAMESPACE"
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: "K8S_NODE_NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: "CILIUM_DEBUG"
-            valueFrom:
-              configMapKeyRef:
-                name: cilium-config
-                key: debug
-                optional: true
-          - name: CILIUM_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-name
-                name: cilium-config
-                optional: true
-          - name: CILIUM_CLUSTER_ID
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-id
-                name: cilium-config
-                optional: true
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_ACCESS_KEY_ID
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_SECRET_ACCESS_KEY
-                optional: true
-          - name: AWS_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_DEFAULT_REGION
-                optional: true
+        name: cilium-operator
         volumeMounts:
-          - name: etcd-config-path
-            mountPath: /var/lib/etcd-config
-            readOnly: true
-          - name: etcd-secrets
-            mountPath: /var/lib/etcd-secrets
-            readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
       volumes:
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -661,13 +704,16 @@ rules:
   - deployments
   - componentstatuses
   verbs:
-  - "*"
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   - endpoints
-  verbs: ["get","list","watch"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cilium.io
   resources:
@@ -676,7 +722,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -701,75 +747,76 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -2,252 +2,269 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_K8S_NAMESPACE"
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_TCP
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-tcp
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_ANY
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-other
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: docker-socket
-              mountPath: /var/run/docker.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/docker.sock
+          name: docker-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read docker events from the node
-        - name: docker-socket
-          hostPath:
-            path: /var/run/docker.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+        name: docker-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      tolerations:
-        - operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate

--- a/examples/kubernetes/1.9/cilium-etcd-operator.yaml
+++ b/examples/kubernetes/1.9/cilium-etcd-operator.yaml
@@ -53,7 +53,7 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
-      tolerations:
-        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists

--- a/examples/kubernetes/1.9/cilium-operator.yaml
+++ b/examples/kubernetes/1.9/cilium-operator.yaml
@@ -1,93 +1,113 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
   name: cilium-operator
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: cilium-operator
         io.cilium/app: operator
+        name: cilium-operator
     spec:
-      serviceAccountName: cilium-operator
-      restartPolicy: Always
       containers:
-      - name: cilium-operator
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        command:
+        - cilium-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
-        command: ["cilium-operator"]
-        args:
-          - "--debug=$(CILIUM_DEBUG)"
-          - "--kvstore=etcd"
-          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-        env:
-          - name: "POD_NAMESPACE"
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: "K8S_NODE_NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: "CILIUM_DEBUG"
-            valueFrom:
-              configMapKeyRef:
-                name: cilium-config
-                key: debug
-                optional: true
-          - name: CILIUM_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-name
-                name: cilium-config
-                optional: true
-          - name: CILIUM_CLUSTER_ID
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-id
-                name: cilium-config
-                optional: true
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_ACCESS_KEY_ID
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_SECRET_ACCESS_KEY
-                optional: true
-          - name: AWS_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_DEFAULT_REGION
-                optional: true
+        name: cilium-operator
         volumeMounts:
-          - name: etcd-config-path
-            mountPath: /var/lib/etcd-config
-            readOnly: true
-          - name: etcd-secrets
-            mountPath: /var/lib/etcd-secrets
-            readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
       volumes:
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -108,13 +128,16 @@ rules:
   - deployments
   - componentstatuses
   verbs:
-  - "*"
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   - endpoints
-  verbs: ["get","list","watch"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cilium.io
   resources:
@@ -123,7 +146,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/examples/kubernetes/1.9/cilium-rbac.yaml
+++ b/examples/kubernetes/1.9/cilium-rbac.yaml
@@ -8,72 +8,73 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -84,255 +84,272 @@ data:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:latest
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_K8S_NAMESPACE"
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_TCP
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-tcp
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_ANY
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-other
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: docker-socket
-              mountPath: /var/run/docker.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/docker.sock
+          name: docker-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:2018-10-16
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read docker events from the node
-        - name: docker-socket
-          hostPath:
-            path: /var/run/docker.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+        name: docker-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      tolerations:
-        - operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -552,100 +569,120 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
-      tolerations:
-        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
   name: cilium-operator
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: cilium-operator
         io.cilium/app: operator
+        name: cilium-operator
     spec:
-      serviceAccountName: cilium-operator
-      restartPolicy: Always
       containers:
-      - name: cilium-operator
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        command:
+        - cilium-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
-        command: ["cilium-operator"]
-        args:
-          - "--debug=$(CILIUM_DEBUG)"
-          - "--kvstore=etcd"
-          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-        env:
-          - name: "POD_NAMESPACE"
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: "K8S_NODE_NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: "CILIUM_DEBUG"
-            valueFrom:
-              configMapKeyRef:
-                name: cilium-config
-                key: debug
-                optional: true
-          - name: CILIUM_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-name
-                name: cilium-config
-                optional: true
-          - name: CILIUM_CLUSTER_ID
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-id
-                name: cilium-config
-                optional: true
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_ACCESS_KEY_ID
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_SECRET_ACCESS_KEY
-                optional: true
-          - name: AWS_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_DEFAULT_REGION
-                optional: true
+        name: cilium-operator
         volumeMounts:
-          - name: etcd-config-path
-            mountPath: /var/lib/etcd-config
-            readOnly: true
-          - name: etcd-secrets
-            mountPath: /var/lib/etcd-secrets
-            readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
       volumes:
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -666,13 +703,16 @@ rules:
   - deployments
   - componentstatuses
   verbs:
-  - "*"
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   - endpoints
-  verbs: ["get","list","watch"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cilium.io
   resources:
@@ -681,7 +721,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -706,75 +746,76 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -2,247 +2,270 @@
 apiVersion: __DS_API_VERSION__
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:__CILIUM_VERSION__
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-            - "--container-runtime=crio"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        - --container-runtime=crio
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:__CILIUM_VERSION__
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: crio-socket
-              mountPath: /var/run/crio.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/crio.sock
+          name: crio-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:__CILIUM_INIT_VERSION__
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read labels from CRI-O containers running in the host
-        - name: crio-socket
-          hostPath:
-            path: /var/run/crio/crio.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/crio/crio.sock
+          type: Socket
+        name: crio-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      tolerations:
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: "Exists"
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: "Exists"
-        # Mark cilium's pod as critical for rescheduling
-        - key: CriticalAddonsOnly
-          operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -2,252 +2,269 @@
 apiVersion: __DS_API_VERSION__
 kind: DaemonSet
 metadata:
+  labels:
+    k8s-app: cilium
+    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
-  updateStrategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      # Specifies the maximum number of Pods that can be unavailable during the update process.
-      maxUnavailable: 2
   selector:
     matchLabels:
       k8s-app: cilium
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      labels:
-        k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
       annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: >-
-          [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
+      labels:
+        k8s-app: cilium
+        kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: cilium
-      initContainers:
-        - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:__CILIUM_INIT_VERSION__
-          imagePullPolicy: IfNotPresent
-          command: ["/init-container.sh"]
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          env:
-            - name: "CLEAN_CILIUM_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-state
-            - name: "CLEAN_CILIUM_BPF_STATE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: clean-cilium-bpf-state
       containers:
-        - image: docker.io/cilium/cilium:__CILIUM_VERSION__
-          imagePullPolicy: Always
-          name: cilium-agent
-          command: ["cilium-agent"]
-          args:
-            - "--debug=$(CILIUM_DEBUG)"
-            - "--kvstore=etcd"
-            - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-            - "--disable-ipv4=$(DISABLE_IPV4)"
-          ports:
-            - name: prometheus
-              containerPort: 9090
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/cni-install.sh"
-            preStop:
-              exec:
-                command:
-                  - "/cni-uninstall.sh"
-          env:
-            - name: "K8S_NODE_NAME"
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: "CILIUM_K8S_NAMESPACE"
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: "CILIUM_DEBUG"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: debug
-            - name: "DISABLE_IPV4"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: disable-ipv4
-            # Note: this variable is a no-op if not defined, and is used in the
-            # prometheus examples.
-            - name: "CILIUM_PROMETHEUS_SERVE_ADDR"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-metrics-config
-                  optional: true
-                  key: prometheus-serve-addr
-            - name: "CILIUM_LEGACY_HOST_ALLOWS_WORLD"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  optional: true
-                  key: legacy-host-allows-world
-            - name: "CILIUM_SIDECAR_ISTIO_PROXY_IMAGE"
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: sidecar-istio-proxy-image
-                  optional: true
-            - name: "CILIUM_TUNNEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: tunnel
-                  name: cilium-config
-                  optional: true
-            - name: "CILIUM_MONITOR_AGGREGATION_LEVEL"
-              valueFrom:
-                configMapKeyRef:
-                  key: monitor-aggregation-level
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: "/var/lib/cilium/clustermesh/"
-            - name: CILIUM_CLUSTER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-name
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  key: cluster-id
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_TCP
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-tcp
-                  name: cilium-config
-                  optional: true
-            - name: CILIUM_GLOBAL_CT_MAX_ANY
-              valueFrom:
-                configMapKeyRef:
-                  key: ct-global-max-entries-other
-                  name: cilium-config
-                  optional: true
-          livenessProbe:
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        - --disable-ipv4=$(DISABLE_IPV4)
+        command:
+        - cilium-agent
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+        - name: DISABLE_IPV4
+          valueFrom:
+            configMapKeyRef:
+              key: disable-ipv4
+              name: cilium-config
+          # Note: this variable is a no-op if not defined, and is used in the
+          # prometheus examples.
+        - name: CILIUM_PROMETHEUS_SERVE_ADDR
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus-serve-addr
+              name: cilium-metrics-config
+              optional: true
+        - name: CILIUM_LEGACY_HOST_ALLOWS_WORLD
+          valueFrom:
+            configMapKeyRef:
+              key: legacy-host-allows-world
+              name: cilium-config
+              optional: true
+        - name: CILIUM_SIDECAR_ISTIO_PROXY_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              key: sidecar-istio-proxy-image
+              name: cilium-config
+              optional: true
+        - name: CILIUM_TUNNEL
+          valueFrom:
+            configMapKeyRef:
+              key: tunnel
+              name: cilium-config
+              optional: true
+        - name: CILIUM_MONITOR_AGGREGATION_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: monitor-aggregation-level
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_TCP
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-tcp
+              name: cilium-config
+              optional: true
+        - name: CILIUM_GLOBAL_CT_MAX_ANY
+          valueFrom:
+            configMapKeyRef:
+              key: ct-global-max-entries-other
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium:__CILIUM_VERSION__
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
             exec:
               command:
-                - cilium
-                - status
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 10
-          readinessProbe:
+              - /cni-install.sh
+          preStop:
             exec:
               command:
-                - cilium
-                - status
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: cni-path
-              mountPath: /host/opt/cni/bin
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: docker-socket
-              mountPath: /var/run/docker.sock
-              readOnly: true
-            - name: etcd-config-path
-              mountPath: /var/lib/etcd-config
-              readOnly: true
-            - name: etcd-secrets
-              mountPath: /var/lib/etcd-secrets
-              readOnly: true
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-          securityContext:
-            capabilities:
-              add:
-                - "NET_ADMIN"
-            privileged: true
+              - /cni-uninstall.sh
+        livenessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 10
+          # The initial delay for the liveness probe is intentionally large to
+          # avoid an endless kill & restart cycle if in the event that the initial
+          # bootstrapping takes longer than expected.
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: cilium-agent
+        ports:
+        - containerPort: 9090
+          hostPort: 9090
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cilium
+            - status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+        - mountPath: /host/etc/cni/net.d
+          name: etc-cni-netd
+        - mountPath: /var/run/docker.sock
+          name: docker-socket
+          readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+        - mountPath: /var/lib/cilium/clustermesh
+          name: clustermesh-secrets
+          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
+      initContainers:
+      - command:
+        - /init-container.sh
+        env:
+        - name: CLEAN_CILIUM_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-state
+              name: cilium-config
+              optional: true
+        - name: CLEAN_CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        image: docker.io/cilium/cilium-init:__CILIUM_INIT_VERSION__
+        imagePullPolicy: IfNotPresent
+        name: clean-cilium-state
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/run/cilium
+          name: cilium-run
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read docker events from the node
-        - name: docker-socket
-          hostPath:
-            path: /var/run/docker.sock
-            type: "Socket"
+      - hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+        name: docker-socket
         # To install cilium cni plugin in the host
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+        name: cni-path
         # To install cilium cni configuration in the host
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: "DirectoryOrCreate"
+      - hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+        name: etc-cni-netd
         # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
-        - name: clustermesh-secrets
-          secret:
-            defaultMode: 420
-            optional: true
-            secretName: cilium-clustermesh
-      restartPolicy: Always
-      tolerations:
-        - operator: "Exists"
+      - name: clustermesh-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-clustermesh
+  updateStrategy:
+    rollingUpdate:
+      # Specifies the maximum number of Pods that can be unavailable during the update process.
+      maxUnavailable: 2
+    type: RollingUpdate

--- a/examples/kubernetes/templates/v1/cilium-etcd-operator.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-etcd-operator.yaml.sed
@@ -53,7 +53,7 @@ spec:
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
-      tolerations:
-        - operator: "Exists"
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists

--- a/examples/kubernetes/templates/v1/cilium-operator.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-operator.yaml.sed
@@ -1,93 +1,113 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: __DEPLOYMENT_API_VERSION__
 kind: Deployment
 metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
   name: cilium-operator
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
-        name: cilium-operator
         io.cilium/app: operator
+        name: cilium-operator
     spec:
-      serviceAccountName: cilium-operator
-      restartPolicy: Always
       containers:
-      - name: cilium-operator
+      - args:
+        - --debug=$(CILIUM_DEBUG)
+        - --kvstore=etcd
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+        command:
+        - cilium-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_DEBUG
+          valueFrom:
+            configMapKeyRef:
+              key: debug
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-name
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              key: cluster-id
+              name: cilium-config
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: cilium-aws
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: cilium-aws
+              optional: true
+        - name: AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              key: AWS_DEFAULT_REGION
+              name: cilium-aws
+              optional: true
         image: docker.io/cilium/operator:__CILIUM_VERSION__
         imagePullPolicy: Always
-        command: ["cilium-operator"]
-        args:
-          - "--debug=$(CILIUM_DEBUG)"
-          - "--kvstore=etcd"
-          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
-        env:
-          - name: "POD_NAMESPACE"
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: "K8S_NODE_NAME"
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: "CILIUM_DEBUG"
-            valueFrom:
-              configMapKeyRef:
-                name: cilium-config
-                key: debug
-                optional: true
-          - name: CILIUM_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-name
-                name: cilium-config
-                optional: true
-          - name: CILIUM_CLUSTER_ID
-            valueFrom:
-              configMapKeyRef:
-                key: cluster-id
-                name: cilium-config
-                optional: true
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_ACCESS_KEY_ID
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_SECRET_ACCESS_KEY
-                optional: true
-          - name: AWS_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: cilium-aws
-                key: AWS_DEFAULT_REGION
-                optional: true
+        name: cilium-operator
         volumeMounts:
-          - name: etcd-config-path
-            mountPath: /var/lib/etcd-config
-            readOnly: true
-          - name: etcd-secrets
-            mountPath: /var/lib/etcd-secrets
-            readOnly: true
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+        - mountPath: /var/lib/etcd-secrets
+          name: etcd-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccount: cilium-operator
+      serviceAccountName: cilium-operator
       volumes:
-        # To read the etcd config stored in config maps
-        - name: etcd-config-path
-          configMap:
-            name: cilium-config
-            items:
-              - key: etcd-config
-                path: etcd.config
+      # To read the etcd config stored in config maps
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
         # To read the k8s etcd secrets in case the user might want to use TLS
-        - name: etcd-secrets
-          secret:
-            secretName: cilium-etcd-secrets
-            optional: true
+      - name: etcd-secrets
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: cilium-etcd-secrets
+
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -108,13 +128,16 @@ rules:
   - deployments
   - componentstatuses
   verbs:
-  - "*"
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   - endpoints
-  verbs: ["get","list","watch"]
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cilium.io
   resources:
@@ -123,7 +146,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/examples/kubernetes/templates/v1/cilium-rbac.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-rbac.yaml.sed
@@ -8,72 +8,73 @@ roleRef:
   kind: ClusterRole
   name: cilium
 subjects:
-  - kind: ServiceAccount
-    name: cilium
-    namespace: kube-system
-  - kind: Group
-    name: system:nodes
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 ---
 apiVersion: __RBAC_API_VERSION__
 kind: ClusterRole
 metadata:
   name: cilium
 rules:
-  - apiGroups:
-      - "networking.k8s.io"
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - services
-      - nodes
-      - endpoints
-      - componentstatuses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - cilium.io
-    resources:
-      - ciliumnetworkpolicies
-      - ciliumnetworkpolicies/status
-      - ciliumendpoints
-      - ciliumendpoints/status
-    verbs:
-      - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'


### PR DESCRIPTION
This allows to perform an easiest diff between deployed files and files
that we provide to the users.

Signed-off-by: André Martins <andre@cilium.io>

The changes seem to be a lot and to avoid any bugs I basically created a k8s 1.8 cluster and ran `kubectl create -f examples/kubernetes/1.8/cilium.yaml && kubectl get ds -n kube-system cilium -o yaml > examples/kubernetes/1.8/cilium-ds.yaml`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6405)
<!-- Reviewable:end -->
