### PR TITLE
k8s: Treat service annotation changes as unequal objects

### DIFF
--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -419,6 +419,11 @@ func equalV1Services(o1, o2 interface{}) bool {
 		return false
 	}
 
+	// Service annotations are used to mark services as global, shared, etc.
+	if !comparator.MapStringEquals(svc1.GetAnnotations(), svc2.GetAnnotations()) {
+		return false
+	}
+
 	clusterIP := net.ParseIP(svc1.Spec.ClusterIP)
 	headless := false
 	if strings.ToLower(svc1.Spec.ClusterIP) == "none" {

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -883,3 +883,38 @@ func (s *K8sSuite) Test_equalV1beta1Ingress(c *C) {
 		c.Assert(got, Equals, tt.want, Commentf("Test Name: %s", tt.name))
 	}
 }
+
+func (s *K8sSuite) Test_equalV1Service(c *C) {
+	type args struct {
+		o1 interface{}
+		o2 interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Service with different annotations",
+			args: args{
+				o1: &core_v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+				o2: &core_v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"io.cilium/shared-service": "true",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		got := equalV1Services(tt.args.o1, tt.args.o2)
+		c.Assert(got, Equals, tt.want, Commentf("Test Name: %s", tt.name))
+	}
+}


### PR DESCRIPTION
Fixes: #6393

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6407)
<!-- Reviewable:end -->
