### PR TITLE
loader: check for nil StateDir

### DIFF
--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -190,15 +190,18 @@ func progCFlags(prog *progInfo, dir *directoryInfo) []string {
 	} else {
 		output = "-" // stdout
 	}
-
-	return []string{
+	flags := []string{
 		testIncludes,
 		fmt.Sprintf("-I%s", path.Join(dir.Runtime, "globals")),
-		fmt.Sprintf("-I%s", dir.State),
 		fmt.Sprintf("-I%s", path.Join(dir.Library, "include")),
 		"-c", path.Join(dir.Library, prog.Source),
 		"-o", output,
 	}
+	if dir.State != "" {
+		flags = append([]string{fmt.Sprintf("-I%s", dir.State)}, flags...)
+	}
+
+	return flags
 }
 
 // compile and link a program.


### PR DESCRIPTION


initially StateDir is empty as compilation happned before
createEpInfoCache() which fills StateDir.
This PR fixes:

level=debug msg="Launching compiler" args="[-emit-llvm -O2 -target bpf -D__NR_CPUS__=8 -Wno-address-of-packed-member -Wno-unknown-warning-option  -I/var/run/cilium/state/globals **-I** -I/var/lib/cilium/bpf/include -c /var/lib/cilium/bpf/sockops/bpf_sockops.c -o -]" subsys=datapath-loader target=clang
level=error msg="Failed to compile bpf_sockops.o: exit status 1" compiler-pid=25324 linker-pid=25325 subsys=datapath-loader
level=warning msg="/var/lib/cilium/bpf/sockops/bpf_sockops.c:22:10: fatal error: 'bpf/api.h' file not found" subsys=datapath-loader
level=warning msg="#include <bpf/api.h>" subsys=datapath-loader
level=warning msg="         ^~~~~~~~~~~" subsys=datapath-loader
level=warning msg="1 error generated." subsys=datapath-loader
level=error msg="failed compile sockops/bpf_sockops.c: Failed to compile bpf_sockops.o: exit status 1" subsys=sockops



Signed-off-by: Nirmoy Das <ndas@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6409)
<!-- Reviewable:end -->
