### PR TITLE
loader: sockops: do not pass empty state dir

### DIFF
--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -144,6 +144,7 @@ func Compile(ctx context.Context, src string, out string) error {
 		Library: option.Config.BpfDir,
 		Runtime: option.Config.StateDir,
 		Output:  option.Config.StateDir,
+		State:   option.Config.StateDir,
 	}
 	return compile(ctx, &prog, &dirs, debug)
 }


### PR DESCRIPTION
sockops pass empty state dir which causes :
    
    level=debug msg="Launching compiler" args="[-emit-llvm -O2 -target bpf -D__NR_CPUS__=8 -Wno-address-of-packed-member -Wno-unknown-warning-option  -I/var/run/cilium/state/globals -I -I/var/lib/cilium/bpf/include -c /var/lib/cilium/bpf/sockops/bpf_sockops.c -o -]" subsys=datapath-loader target=clang
    level=error msg="Failed to compile bpf_sockops.o: exit status 1" compiler-pid=25324 linker-pid=25325 subsys=datapath-loader
    level=warning msg="/var/lib/cilium/bpf/sockops/bpf_sockops.c:22:10: fatal error: 'bpf/api.h' file not found" subsys=datapath-loader
    level=warning msg="#include <bpf/api.h>" subsys=datapath-loader
    level=warning msg="         ^~~~~~~~~~~" subsys=datapath-loader
    level=warning msg="1 error generated." subsys=datapath-loader
    level=error msg="failed compile sockops/bpf_sockops.c: Failed to compile bpf_sockops.o: exit status 1" subsys=sockops
    
    Signed-off-by: Nirmoy Das <ndas@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6410)
<!-- Reviewable:end -->
