### PR TITLE
pkg/fqdn: matchPattern supports "*" allow-all

### DIFF
--- a/pkg/fqdn/matchpattern/matchpattern_test.go
+++ b/pkg/fqdn/matchpattern/matchpattern_test.go
@@ -43,6 +43,7 @@ func (ts *MatchPatternTestSuite) TestMatchPatternREConversion(c *C) {
 		"cilium.io.":   "^cilium[.]io[.]$",
 		"*.cilium.io.": "^" + allowedDNSCharsREGroup + "*[.]cilium[.]io[.]$",
 		"*cilium.io.":  "^(" + allowedDNSCharsREGroup + "+[.])?cilium[.]io[.]$",
+		"*":            "^(" + allowedDNSCharsREGroup + "+[.])+$",
 	} {
 		reStr := ToRegexp(source)
 		_, err := regexp.Compile(reStr)
@@ -65,22 +66,27 @@ func (ts *MatchPatternTestSuite) TestMatchPatternMatching(c *C) {
 		{
 			pattern: "cilium.io.",
 			accept:  []string{"cilium.io."},
-			reject:  []string{"anysub.cilium.io.", "anysub.ci.io.", "anysub.ciliumandmore.io."},
+			reject:  []string{"", "anysub.cilium.io.", "anysub.ci.io.", "anysub.ciliumandmore.io."},
 		},
 		{
 			pattern: "*.cilium.io.",
 			accept:  []string{"anysub.cilium.io."},
-			reject:  []string{"cilium.io.", "anysub.ci.io.", "anysub.ciliumandmore.io."},
+			reject:  []string{"", "cilium.io.", "anysub.ci.io.", "anysub.ciliumandmore.io."},
 		},
 		{
 			pattern: "*cilium.io.",
 			accept:  []string{"anysub.cilium.io.", "cilium.io."},
-			reject:  []string{"anysub.ci.io.", "anysub.ciliumandmore.io."},
+			reject:  []string{"", "anysub.ci.io.", "anysub.ciliumandmore.io."},
 		},
 		{
 			pattern: "*.ci*.io.",
 			accept:  []string{"anysub.cilium.io.", "anysub.ci.io.", "anysub.ciliumandmore.io."},
-			reject:  []string{"cilium.io."},
+			reject:  []string{"", "cilium.io."},
+		},
+		{
+			pattern: "*",
+			accept:  []string{"io.", "cilium.io.", "svc.cluster.local.", "service.namesace.svc.cluster.local."},
+			reject:  []string{"", ".", ".io.", ".cilium.io.", ".svc.cluster.local.", "cilium.io"}, // note no final . on this last one
 		},
 	} {
 		reStr := ToRegexp(testCase.pattern)


### PR DESCRIPTION
toFQDNs rules need a source of DNS information, nominally the proxy.
While it is better to specify explicit patterns to allow, it may be
easier to allow all, but still capture the DNS data for more specific
toFQDNs.
Note that toFQDNs can also use "*" but that may be a little pointless.
It will select all known IPs in the DNS cache and generate rules with
them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6411)
<!-- Reviewable:end -->
