### PR TITLE
[wip]node: error on local host IP addresses collision with podCIDR

### DIFF
--- a/pkg/node/node_address_test.go
+++ b/pkg/node/node_address_test.go
@@ -51,6 +51,27 @@ func (s *NodeSuite) TestMaskCheck(c *C) {
 	c.Assert(IsHostIPv6(GetIPv6()), Equals, true)
 }
 
+func (s *NodeSuite) TestHostIPCollision(c *C) {
+	InitDefaultPrefix("")
+	SetIPv4ClusterCidrMaskSize(8)
+
+	_, cidr, _ := net.ParseCIDR("127.0.0.1/8")
+	SetIPv4AllocRange(cidr)
+	SetInternalIPv4(cidr.IP)
+
+	// Must fail, as lo contains 127.0.0.1
+	c.Assert(ValidatePostInit(), Not(IsNil))
+
+	_, cidr, _ = net.ParseCIDR("1.1.1.1/8")
+
+	SetIPv4AllocRange(cidr)
+	SetInternalIPv4(cidr.IP)
+
+	// OK, 127.0.0.1 removed
+	c.Assert(ValidatePostInit(), IsNil)
+
+}
+
 func (s *NodeSuite) Test_getCiliumHostIPsFromFile(c *C) {
 	tmpDir := c.MkDir()
 	allIPsCorrect := filepath.Join(tmpDir, "node_config.h")


### PR DESCRIPTION
avoid running cilium if any of the local host IP addresses
conflict with any other node's podCIDR

Fixes:#6321

Signed-off-by: Nirmoy Das <ndas@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6415)
<!-- Reviewable:end -->
