### PR TITLE
clustermesh: Add debug messages to help future services troubleshooting

### DIFF
--- a/pkg/clustermesh/services.go
+++ b/pkg/clustermesh/services.go
@@ -17,7 +17,10 @@ package clustermesh
 import (
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/service"
+
+	"github.com/sirupsen/logrus"
 )
 
 // ServiceMerger is the interface to be implemented by the owner of local
@@ -52,12 +55,20 @@ func newGlobalServiceCache() *globalServiceCache {
 func (c *globalServiceCache) onUpdate(svc *service.ClusterService) {
 	c.mutex.Lock()
 
+	scopedLog := log.WithFields(logrus.Fields{
+		logfields.ServiceName: svc.String(),
+		logfields.ClusterName: svc.Cluster,
+	})
+
 	// Validate that the global service is known
 	globalSvc, ok := c.byName[svc.NamespaceServiceName()]
 	if !ok {
 		globalSvc = newGlobalService()
 		c.byName[svc.NamespaceServiceName()] = globalSvc
+		scopedLog.Debugf("Created global service %s", svc.NamespaceServiceName())
 	}
+
+	scopedLog.Debugf("Updated service definition of remote cluster %#v", svc)
 
 	globalSvc.clusterServices[svc.Cluster] = svc
 	c.mutex.Unlock()
@@ -65,28 +76,44 @@ func (c *globalServiceCache) onUpdate(svc *service.ClusterService) {
 
 // must be called with c.mutex held
 func (c *globalServiceCache) delete(globalService *globalService, clusterName, serviceName string) {
+	scopedLog := log.WithFields(logrus.Fields{
+		logfields.ServiceName: serviceName,
+		logfields.ClusterName: clusterName,
+	})
+
 	if _, ok := globalService.clusterServices[clusterName]; !ok {
+		scopedLog.Debug("Ignoring delete request for unknown cluster")
 		return
 	}
 
+	scopedLog.Debugf("Deleted service definition of remote cluster")
 	delete(globalService.clusterServices, clusterName)
 
 	// After the last cluster service is removed, remove the
 	// global service
 	if len(globalService.clusterServices) == 0 {
+		scopedLog.Debugf("Deleted global service %s", serviceName)
 		delete(c.byName, serviceName)
 	}
 }
 
 func (c *globalServiceCache) onDelete(svc *service.ClusterService) {
+	scopedLog := log.WithFields(logrus.Fields{logfields.ServiceName: svc.String()})
+	scopedLog.Debug("Delete event for service")
+
 	c.mutex.Lock()
 	if globalService, ok := c.byName[svc.NamespaceServiceName()]; ok {
 		c.delete(globalService, svc.NamespaceServiceName(), svc.Cluster)
+	} else {
+		scopedLog.Debugf("Ignoring delete request for unknown global service")
 	}
 	c.mutex.Unlock()
 }
 
 func (c *globalServiceCache) onClusterDelete(clusterName string) {
+	scopedLog := log.WithFields(logrus.Fields{logfields.ClusterName: clusterName})
+	scopedLog.Debugf("Cluster deletion event")
+
 	c.mutex.Lock()
 	for serviceName, globalService := range c.byName {
 		c.delete(globalService, serviceName, clusterName)
@@ -101,11 +128,16 @@ type remoteServiceObserver struct {
 // OnUpdate is called when a service in a remote cluster is updated
 func (r *remoteServiceObserver) OnUpdate(key store.Key) {
 	if svc, ok := key.(*service.ClusterService); ok {
+		scopedLog := log.WithFields(logrus.Fields{logfields.ServiceName: svc.String()})
+		scopedLog.Debugf("Update event of remote service %#v", svc)
+
 		mesh := r.remoteCluster.mesh
 		mesh.globalServices.onUpdate(svc)
 
 		if merger := mesh.conf.ServiceMerger; merger != nil {
 			merger.MergeExternalServiceUpdate(svc)
+		} else {
+			scopedLog.Debugf("Ignoring remote service update. Missing merger function")
 		}
 	} else {
 		log.Warningf("Received unexpected remote service update object %+v", key)
@@ -115,11 +147,16 @@ func (r *remoteServiceObserver) OnUpdate(key store.Key) {
 // OnDelete is called when a service in a remote cluster is deleted
 func (r *remoteServiceObserver) OnDelete(key store.Key) {
 	if svc, ok := key.(*service.ClusterService); ok {
+		scopedLog := log.WithFields(logrus.Fields{logfields.ServiceName: svc.String()})
+		scopedLog.Debugf("Update event of remote service %#v", svc)
+
 		mesh := r.remoteCluster.mesh
 		mesh.globalServices.onDelete(svc)
 
 		if merger := mesh.conf.ServiceMerger; merger != nil {
 			merger.MergeExternalServiceDelete(svc)
+		} else {
+			scopedLog.Debugf("Ignoring remote service update. Missing merger function")
 		}
 	} else {
 		log.Warningf("Received unexpected remote service delete object %+v", key)

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -159,6 +159,9 @@ const (
 	// ServiceName is the orchestration framework name for a service
 	ServiceName = "serviceName"
 
+	// ClusterName is the name of the cluster
+	ClusterName = "clusterName"
+
 	// ServiceID is the orchestration unique ID of a service
 	ServiceID = "serviceID"
 


### PR DESCRIPTION
The debug messages are sparse right now. Add debug messages to help
troubleshoot global service correlation issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6421)
<!-- Reviewable:end -->
