### PR TITLE
Workaround for unexpected json.Unmarshal() behavior

### DIFF
--- a/pkg/node/manager.go
+++ b/pkg/node/manager.go
@@ -69,23 +69,10 @@ var clusterConf = &clusterConfiguation{
 	auxPrefixes: []*net.IPNet{},
 }
 
-func (cc *clusterConfiguation) getNode(ni Identity) *Node {
-	cc.RLock()
-	n := cc.nodes[ni]
-	cc.RUnlock()
-	return n
-}
-
 func (cc *clusterConfiguation) addAuxPrefix(prefix *net.IPNet) {
 	cc.Lock()
 	cc.auxPrefixes = append(cc.auxPrefixes, prefix)
 	cc.Unlock()
-}
-
-// GetNode returns the node with the given identity, if exists, from the nodes
-// map.
-func GetNode(ni Identity) *Node {
-	return clusterConf.getNode(ni)
 }
 
 func deleteTunnelMapping(ip *net.IPNet) {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -309,5 +309,20 @@ func (n *Node) Marshal() ([]byte, error) {
 
 // Unmarshal parses the JSON byte slice and updates the node receiver
 func (n *Node) Unmarshal(data []byte) error {
-	return json.Unmarshal(data, n)
+	// Backup private fields
+	cluster := n.cluster
+	dev := n.dev
+
+	newNode := Node{}
+	if err := json.Unmarshal(data, &newNode); err != nil {
+		return err
+	}
+
+	*n = newNode
+
+	// Restore private fields
+	n.cluster = cluster
+	n.dev = dev
+
+	return nil
 }

--- a/pkg/service/store.go
+++ b/pkg/service/store.go
@@ -103,7 +103,15 @@ func (s *ClusterService) Marshal() ([]byte, error) {
 
 // Unmarshal parses the JSON byte slice and updates the global service receiver
 func (s *ClusterService) Unmarshal(data []byte) error {
-	return json.Unmarshal(data, s)
+	newService := NewClusterService("", "")
+
+	if err := json.Unmarshal(data, &newService); err != nil {
+		return err
+	}
+
+	*s = newService
+
+	return nil
 }
 
 // NewClusterService returns a new cluster service definition


### PR DESCRIPTION
Several SharedStore users are assuming that when calling `json.Unmarshal()` on a structure that does not mark any field with `omitEmpty`, then calling `json.Marshal()` and passing that into `json.Unmarshal()` is guaranteed to overwrite all fields as long as the structure definition at `Marshal()` and `Unmarshal()` time is the same. This is *not* the case as the following unit test illustrates. The unit test will fail if `Unmarshal()` does not re-initialize the object first.

```
type updateTest struct {
	Items map[string]string
}

func (u *updateTest) GetKeyName() string       { return "" }
func (s *updateTest) Marshal() ([]byte, error) { return json.Marshal(s) }
func (s *updateTest) Unmarshal(data []byte) error {
	*s = updateTest{}
	return json.Unmarshal(data, s)
}

func (s *StoreSuite) TestUpdateKey(c *C) {
	store := &SharedStore{
		conf: Configuration{
			KeyCreator: func() Key { return &updateTest{} },
		},
		localKeys:  map[string]LocalKey{},
		sharedKeys: map[string]Key{},
	}

	v1 := &updateTest{Items: map[string]string{"foo": "bar"}}
	json, err := v1.Marshal()
	c.Assert(err, IsNil)
	store.updateKey("foo", json)
	c.Assert(store.sharedKeys["foo"], DeepEquals, v1)

	v2 := &updateTest{Items: map[string]string{}}
	json, err = v2.Marshal()
	c.Assert(err, IsNil)
	store.updateKey("foo", json)
	c.Assert(store.sharedKeys["foo"], DeepEquals, v2)
}
```

While `updateTest{}` will cause `Unmarshal()` to overwrite the Items field with an empty map, `updateTest{Items: map[string]string{}}` does not and the previous values prevail.

The quick fix is to fix `Unmarshal()` implementations of the Key interface to re-initialize but a better long-term fix has to be found.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6423)
<!-- Reviewable:end -->
