### PR TITLE
README: fix the link rendering to the SIG

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -262,7 +262,7 @@ Special Interest Groups (SIG)
 -----------------------------
 
 See `Special Interest groups
-<http://docs.cilium.io/en/stable/community.html#special-interest-groups` for a list of all SIGs and their meeting times.
+<https://docs.cilium.io/en/stable/community/#special-interest-groups>`_ for a list of all SIGs and their meeting times.
 
 Weekly Developer meeting
 ------------------------


### PR DESCRIPTION
The link changed and the syntax for link was missing characters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6425)
<!-- Reviewable:end -->
