### PR TITLE
metricsmap: fix retrieval of possible CPU count

### DIFF
--- a/pkg/maps/metricsmap/metricsmap_test.go
+++ b/pkg/maps/metricsmap/metricsmap_test.go
@@ -1,0 +1,50 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package metricsmap
+
+import (
+	"strings"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+type MetricsMapTestSuite struct{}
+
+var _ = Suite(&MetricsMapTestSuite{})
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+func (m *MetricsMapTestSuite) TestGetNumPossibleCPUsFromReader(c *C) {
+	tests := []struct {
+		in       string
+		expected int
+	}{
+		{"0", 1},
+		{"0-7", 8},
+		{"0,2-3", 3},
+		{"", 0},
+		{"foobar", 0},
+	}
+
+	for _, t := range tests {
+		c.Assert(getNumPossibleCPUsFromReader(strings.NewReader(t.in)), Equals, t.expected)
+	}
+
+}


### PR DESCRIPTION
We use `/sys/devices/system/cpu/possible` to get a number of possible CPUs. The number is used to determine how many entries there are per value in a BPF map of the `BPF_MAP_TYPE_*_PERCPU_*` type.

Previously, the retrieval function contained two bugs:

- It didn't handle the case of sparse CPU allocations.
- It logged the error when only one CPU was possible.

The side-effect of the second bug was that upon issuing a cilium cli cmd, `level=error msg="unable to parse sysfs to get CPU count" error="input does not match format"` was printed as a part of the cmd output.

Fixes #4559.

I'm going to fix https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/tools/testing/selftests/bpf/bpf_util.h#n10 (from which the function was previously derived) once the PR has been approved.

Signed-off-by: Martynas Pumputis <martynas@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6427)
<!-- Reviewable:end -->
