### PR TITLE
Test: Test toFQDNs when DNS poller is disabled

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -893,7 +893,12 @@ func (s *SSHMeta) SetUpCilium() error {
 PATH=/usr/lib/llvm-3.8/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
 CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug --pprof=true --log-system-load --tofqdns-enable-poller=true
 INITSYSTEM=SYSTEMD`
+	return s.SetUpCiliumWithOptions(template)
+}
 
+// SetUpCiliumWithOptions sets up Cilium as a systemd service with a given set of options. It
+// returns an error if any of the operations needed to start Cilium fail.
+func (s *SSHMeta) SetUpCiliumWithOptions(template string) error {
 	err := RenderTemplateToFile("cilium", template, os.ModePerm)
 	if err != nil {
 		return err


### PR DESCRIPTION
_This is a redo of https://github.com/cilium/cilium/pull/6345 with fixes applied, and doesn't need to be re-reviewed_

Added a new test without poller to validate scenarios where is not
enabled.

Added a test for policy addition after DNS lookup.


Fixes https://github.com/cilium/cilium/pull/6345

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6429)
<!-- Reviewable:end -->
