### PR TITLE
policy: cache whether all L3 is allowed in L4 filter

### DIFF
--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -205,11 +205,12 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndShadowedL7(c *C) {
 	// the current implementation.
 	expected := NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port:      80,
-		Protocol:  api.ProtoTCP,
-		U8Proto:   6,
-		Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser:  "http",
+		Port:          80,
+		Protocol:      api.ProtoTCP,
+		U8Proto:       6,
+		allowsAllAtL3: true,
+		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
+		L7Parser:      "http",
 		L7RulesPerEp: L7DataMap{
 			api.WildcardEndpointSelector: api.L7Rules{
 				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
@@ -310,11 +311,12 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7HTTP(c *C)
 
 	expected := NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port:      80,
-		Protocol:  api.ProtoTCP,
-		U8Proto:   6,
-		Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser:  ParserTypeHTTP,
+		Port:          80,
+		Protocol:      api.ProtoTCP,
+		U8Proto:       6,
+		allowsAllAtL3: true,
+		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
+		L7Parser:      ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			api.WildcardEndpointSelector: api.L7Rules{
 				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
@@ -388,11 +390,12 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7Kafka(c *C
 
 	expected := NewL4Policy()
 	expected.Ingress["9092/TCP"] = L4Filter{
-		Port:      9092,
-		Protocol:  api.ProtoTCP,
-		U8Proto:   6,
-		Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser:  ParserTypeKafka,
+		Port:          9092,
+		Protocol:      api.ProtoTCP,
+		U8Proto:       6,
+		allowsAllAtL3: true,
+		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
+		L7Parser:      ParserTypeKafka,
 		L7RulesPerEp: L7DataMap{
 			api.WildcardEndpointSelector: api.L7Rules{
 				Kafka: []api.PortRuleKafka{{Topic: "foo"}},
@@ -644,6 +647,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 		Port:             80,
 		Protocol:         api.ProtoTCP,
 		U8Proto:          6,
+		allowsAllAtL3:    true,
 		Endpoints:        api.EndpointSelectorSlice{api.WildcardEndpointSelector},
 		L7Parser:         ParserTypeNone,
 		L7RulesPerEp:     L7DataMap{},
@@ -700,6 +704,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 		Port:             80,
 		Protocol:         api.ProtoTCP,
 		U8Proto:          6,
+		allowsAllAtL3:    true,
 		Endpoints:        api.EndpointSelectorSlice{api.WildcardEndpointSelector},
 		L7Parser:         ParserTypeNone,
 		L7RulesPerEp:     L7DataMap{},
@@ -766,11 +771,12 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 
 	expected := NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port:      80,
-		Protocol:  api.ProtoTCP,
-		U8Proto:   6,
-		Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser:  ParserTypeHTTP,
+		Port:          80,
+		Protocol:      api.ProtoTCP,
+		U8Proto:       6,
+		allowsAllAtL3: true,
+		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
+		L7Parser:      ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			endpointSelectorA: api.L7Rules{
 				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
@@ -833,11 +839,12 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 
 	expected = NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port:      80,
-		Protocol:  api.ProtoTCP,
-		U8Proto:   6,
-		Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser:  ParserTypeHTTP,
+		Port:          80,
+		Protocol:      api.ProtoTCP,
+		U8Proto:       6,
+		allowsAllAtL3: true,
+		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
+		L7Parser:      ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			endpointSelectorA: api.L7Rules{
 				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
@@ -913,11 +920,12 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 
 	expected := NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port:      80,
-		Protocol:  api.ProtoTCP,
-		U8Proto:   6,
-		Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser:  ParserTypeHTTP,
+		Port:          80,
+		Protocol:      api.ProtoTCP,
+		U8Proto:       6,
+		allowsAllAtL3: true,
+		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
+		L7Parser:      ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			api.WildcardEndpointSelector: api.L7Rules{
 				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
@@ -989,11 +997,12 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 
 	expected = NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port:      80,
-		Protocol:  api.ProtoTCP,
-		U8Proto:   6,
-		Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser:  ParserTypeHTTP,
+		Port:          80,
+		Protocol:      api.ProtoTCP,
+		U8Proto:       6,
+		allowsAllAtL3: true,
+		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
+		L7Parser:      ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			api.WildcardEndpointSelector: api.L7Rules{
 				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
@@ -1316,11 +1325,12 @@ func (ds *PolicyTestSuite) TestAllowingLocalhostShadowsL7(c *C) {
 
 	expected := NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port:      80,
-		Protocol:  api.ProtoTCP,
-		U8Proto:   6,
-		Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser:  ParserTypeHTTP,
+		Port:          80,
+		Protocol:      api.ProtoTCP,
+		U8Proto:       6,
+		allowsAllAtL3: true,
+		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
+		L7Parser:      ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			api.WildcardEndpointSelector: api.L7Rules{
 				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -41,6 +41,7 @@ func mergeL4Port(ctx *SearchContext, endpoints []api.EndpointSelector, existingF
 	// can now simply select all endpoints.
 	if existingFilter.AllowsAllAtL3() || filterToMerge.AllowsAllAtL3() {
 		existingFilter.Endpoints = api.EndpointSelectorSlice{api.WildcardEndpointSelector}
+		existingFilter.allowsAllAtL3 = true
 	} else {
 		// Case 2: no wildcard endpoint selectors in existing filter or in filter
 		// to merge, so just append endpoints.

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -162,24 +162,30 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 
 	expected := NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser: "http", L7RulesPerEp: l7map, Ingress: true,
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
+		allowsAllAtL3: true,
+		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
+		L7Parser:      "http", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil},
 	}
 	expected.Ingress["8080/TCP"] = L4Filter{
-		Port: 8080, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser: "http", L7RulesPerEp: l7map, Ingress: true,
+		Port: 8080, Protocol: api.ProtoTCP, U8Proto: 6,
+		allowsAllAtL3: true,
+		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
+		L7Parser:      "http", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil},
 	}
 
 	expected.Egress["3000/TCP"] = L4Filter{
 		Port: 3000, Protocol: api.ProtoTCP, U8Proto: 6, Ingress: false,
+		allowsAllAtL3:    true,
 		Endpoints:        api.EndpointSelectorSlice{api.WildcardEndpointSelector},
 		L7RulesPerEp:     L7DataMap{},
 		DerivedFromRules: labels.LabelArrayList{nil},
 	}
 	expected.Egress["3000/UDP"] = L4Filter{
 		Port: 3000, Protocol: api.ProtoUDP, U8Proto: 17, Ingress: false,
+		allowsAllAtL3:    true,
 		Endpoints:        api.EndpointSelectorSlice{api.WildcardEndpointSelector},
 		L7RulesPerEp:     L7DataMap{},
 		DerivedFromRules: labels.LabelArrayList{nil},
@@ -260,11 +266,12 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 
 	expected = NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port:      80,
-		Protocol:  api.ProtoTCP,
-		U8Proto:   6,
-		Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser:  ParserTypeHTTP,
+		Port:          80,
+		Protocol:      api.ProtoTCP,
+		U8Proto:       6,
+		allowsAllAtL3: true,
+		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
+		L7Parser:      ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			api.WildcardEndpointSelector: api.L7Rules{
 				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
@@ -275,12 +282,14 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	}
 	expected.Egress["3000/TCP"] = L4Filter{
 		Port: 3000, Protocol: api.ProtoTCP, U8Proto: 6, Ingress: false,
+		allowsAllAtL3:    true,
 		Endpoints:        api.EndpointSelectorSlice{api.WildcardEndpointSelector},
 		L7RulesPerEp:     L7DataMap{},
 		DerivedFromRules: labels.LabelArrayList{nil},
 	}
 	expected.Egress["3000/UDP"] = L4Filter{
 		Port: 3000, Protocol: api.ProtoUDP, U8Proto: 17, Ingress: false,
+		allowsAllAtL3:    true,
 		Endpoints:        api.EndpointSelectorSlice{api.WildcardEndpointSelector},
 		L7RulesPerEp:     L7DataMap{},
 		DerivedFromRules: labels.LabelArrayList{nil},
@@ -476,11 +485,12 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 
 	expected := NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port:      80,
-		Protocol:  api.ProtoTCP,
-		U8Proto:   6,
-		Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser:  ParserTypeHTTP,
+		Port:          80,
+		Protocol:      api.ProtoTCP,
+		U8Proto:       6,
+		allowsAllAtL3: true,
+		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
+		L7Parser:      ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			api.WildcardEndpointSelector: api.L7Rules{
 				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
@@ -551,8 +561,10 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 
 	expected = NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser: "kafka", L7RulesPerEp: l7map, Ingress: true,
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
+		allowsAllAtL3: true,
+		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
+		L7Parser:      "kafka", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
 	}
 
@@ -633,8 +645,10 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	expected = NewL4Policy()
 
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser: "kafka", L7RulesPerEp: l7map, Ingress: true,
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
+		allowsAllAtL3: true,
+		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
+		L7Parser:      "kafka", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
 	}
 
@@ -697,8 +711,10 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 
 	expected := NewL4Policy()
 	expected.Egress["80/TCP"] = L4Filter{
-		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: []api.EndpointSelector{api.WildcardEndpointSelector},
-		L7Parser: ParserTypeHTTP,
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
+		allowsAllAtL3: true,
+		Endpoints:     []api.EndpointSelector{api.WildcardEndpointSelector},
+		L7Parser:      ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			api.WildcardEndpointSelector: api.L7Rules{
 				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
@@ -768,8 +784,10 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 
 	expected = NewL4Policy()
 	expected.Egress["80/TCP"] = L4Filter{
-		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser: ParserTypeKafka,
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
+		allowsAllAtL3: true,
+		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
+		L7Parser:      ParserTypeKafka,
 		L7RulesPerEp: L7DataMap{
 			api.WildcardEndpointSelector: api.L7Rules{
 				Kafka: []api.PortRuleKafka{{Topic: "foo"}},
@@ -851,8 +869,10 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	}
 	expected = NewL4Policy()
 	expected.Egress["80/TCP"] = L4Filter{
-		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, Endpoints: api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser: "kafka", L7RulesPerEp: l7map, Ingress: false,
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
+		allowsAllAtL3: true,
+		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
+		L7Parser:      "kafka", L7RulesPerEp: l7map, Ingress: false,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
 	}
 


### PR DESCRIPTION
When analyzing pprof output of policy calculation, I saw that there was a lot of time spent in the `SelectsAllEndpoints` function as the number of rules increased. This is because the `Endpoints` field within an `L4Filter` grows by the number of rules (`O(n)`). When a given `L4Filter` is being merged with another one, all `EndpointSelectors` in `Endpoints` are traversed upon each merge to see if all endpoints are selected.  But, if any `EndpointSelector` within `Endpoints` selects all endpoints (i.e., it wildcards), this information can be stored as a boolean flag within the `L4Filter`, negating the need to check the entire list of `EndpointSelectors` in `Endpoints`. This PR adds said field, with performance gains illustrated below:

Policy generation benchmark before this change with 1000 rules:
```
PASS: resolve_test.go:94: PolicyTestSuite.BenchmarkRegeneratePolicyRules	    1000	   2584681 ns/op
```

Policy generation benchmark after this change with 1000 rules:
```
PASS: resolve_test.go:94: PolicyTestSuite.BenchmarkRegeneratePolicyRules	    1000	   1964271 ns/op
```

Policy calculation takes 76 % of the time now in the case where there is L4Policy which does not select all endpoints:

(1964271/2584681)*100 = 76%  

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6432)
<!-- Reviewable:end -->
