### PR TITLE
Fix bug where cilium would misread map flags from /proc

### DIFF
--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -336,7 +336,7 @@ func GetMapInfo(pid int, fd int) (*MapInfo, error) {
 			info.ValueSize = uint32(value)
 		} else if n, err := fmt.Sscanf(line, "max_entries:\t%d", &value); n == 1 && err == nil {
 			info.MaxEntries = uint32(value)
-		} else if n, err := fmt.Sscanf(line, "map_flags:\t%x", &value); n == 1 && err == nil {
+		} else if n, err := fmt.Sscanf(line, "map_flags:\t0x%x", &value); n == 1 && err == nil {
 			info.Flags = uint32(value)
 		} else if n, err := fmt.Sscanf(line, "owner_prog_type:\t%d", &value); n == 1 && err == nil {
 			info.OwnerProgType = ProgType(value)

--- a/pkg/bpf/map_test.go
+++ b/pkg/bpf/map_test.go
@@ -1,0 +1,77 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build privileged_tests
+
+package bpf
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/checker"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type BPFTestSuite struct{}
+
+var _ = Suite(&BPFTestSuite{})
+
+var (
+	maxEntries = 2
+
+	testMap = NewMap("cilium_test",
+		MapTypeHash,
+		4,
+		4,
+		maxEntries,
+		BPF_F_NO_PREALLOC,
+		0,
+		nil)
+)
+
+func runTests(m *testing.M) (int, error) {
+	CheckOrMountFS("")
+
+	_, err := testMap.OpenOrCreate()
+	if err != nil {
+		return 1, fmt.Errorf("Failed to create map")
+	}
+	defer func() {
+		path, _ := testMap.Path()
+		os.Remove(path)
+	}()
+	defer testMap.Close()
+
+	return m.Run(), nil
+}
+
+func TestMain(m *testing.M) {
+	exitCode, err := runTests(m)
+	if err != nil {
+		log.Fatal(err)
+	}
+	os.Exit(exitCode)
+}
+
+func (s *BPFTestSuite) TestGetMapInfo(c *C) {
+	mi, err := GetMapInfo(os.Getpid(), testMap.fd)
+	c.Assert(err, IsNil)
+	c.Assert(&testMap.MapInfo, checker.DeepEquals, mi)
+}


### PR DESCRIPTION
The bug fixed by the first commit in this PR would cause Cilium to re-create maps in userspace if the map has any flags set, because it would first read the attributes from the filesystem and think that the flags are 0, then go ahead and recreate the map with the expected flags value (nonzero). 

The second commit introduces a privileged unit test to validate that the fix works as intended.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6435)
<!-- Reviewable:end -->
