### PR TITLE
Improve map open test coverage, fix erroneous error message

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -924,11 +924,13 @@ func (e *Endpoint) garbageCollectConntrack(filter *ctmap.GCFilter) {
 	}
 	for _, m := range maps {
 		if err := m.Open(); err != nil {
-			filepath, err2 := m.Path()
-			if err2 != nil {
-				log.WithError(err2).Warn("Unable to get CT map path")
+			// If the CT table doesn't exist, there's nothing to GC.
+			scopedLog := log.WithError(err).WithField(logfields.EndpointID, e.ID)
+			if os.IsNotExist(err) {
+				scopedLog.WithError(err).Debug("Skipping GC for endpoint")
+			} else {
+				scopedLog.WithError(err).Warn("Unable to open map")
 			}
-			log.WithError(err).WithField(logfields.Path, filepath).Warn("Unable to open map")
 			continue
 		}
 		defer m.Close()

--- a/pkg/maps/eppolicymap/eppolicymap.go
+++ b/pkg/maps/eppolicymap/eppolicymap.go
@@ -72,7 +72,7 @@ func CreateEPPolicyMap() {
 			uint32(unsafe.Sizeof(policymap.PolicyKey{})),
 			uint32(unsafe.Sizeof(policymap.PolicyEntry{})),
 			policymap.MaxEntries,
-			0, 0)
+			0, 0, "ep-policy-inner-map")
 
 		if err != nil {
 			log.WithError(err).Warning("unable to create EP to policy map")

--- a/pkg/maps/eppolicymap/eppolicymap_test.go
+++ b/pkg/maps/eppolicymap/eppolicymap_test.go
@@ -50,7 +50,8 @@ func (e *EPPolicyMapTestSuite) TestWriteEndpoint(c *C) {
 	many := make([]*lxcmap.EndpointKey, 256)
 	fd, err := bpf.CreateMap(bpf.BPF_MAP_TYPE_HASH,
 		uint32(unsafe.Sizeof(policymap.PolicyKey{})),
-		uint32(unsafe.Sizeof(policymap.PolicyEntry{})), 1024, 0, 0)
+		uint32(unsafe.Sizeof(policymap.PolicyEntry{})), 1024, 0, 0,
+		"ep-policy-inner-map")
 	c.Assert(err, IsNil)
 
 	keys[0] = lxcmap.NewEndpointKey(net.ParseIP("1.2.3.4"))
@@ -75,7 +76,8 @@ func (e *EPPolicyMapTestSuite) TestWriteEndpointFails(c *C) {
 	keys := make([]*lxcmap.EndpointKey, 1)
 	_, err := bpf.CreateMap(bpf.BPF_MAP_TYPE_HASH,
 		uint32(unsafe.Sizeof(policymap.PolicyKey{})),
-		uint32(unsafe.Sizeof(policymap.PolicyEntry{})), 1024, 0, 0)
+		uint32(unsafe.Sizeof(policymap.PolicyEntry{})), 1024, 0, 0,
+		"ep-policy-inner-map")
 	c.Assert(err, IsNil)
 
 	keys[0] = lxcmap.NewEndpointKey(net.ParseIP("1.2.3.4"))
@@ -90,7 +92,8 @@ func (e *EPPolicyMapTestSuite) TestWriteEndpointDisabled(c *C) {
 	keys := make([]*lxcmap.EndpointKey, 1)
 	fd, err := bpf.CreateMap(bpf.BPF_MAP_TYPE_HASH,
 		uint32(unsafe.Sizeof(policymap.PolicyKey{})),
-		uint32(unsafe.Sizeof(policymap.PolicyEntry{})), 1024, 0, 0)
+		uint32(unsafe.Sizeof(policymap.PolicyEntry{})), 1024, 0, 0,
+		"ep-policy-inner-map")
 	c.Assert(err, IsNil)
 
 	keys[0] = lxcmap.NewEndpointKey(net.ParseIP("1.2.3.4"))


### PR DESCRIPTION
This series improves the bpf.Map `Open()` implementation to allow users to call `os.IsNotExist()` upon the error type, and if the map cannot be opened based on its path because the map isn't pinned to the filesystem, perform logic based on this.

A new unit test is introduced to validate the new functionality, which improves test coverage of the `bpf` package.

Finally, `endpoint`/`endpointmanager` is improved to detect that the CT maps are not yet created because a TC load has not yet occurred (which is how CT maps are created), so we will avoid complaining at warning level in this case and instead present an Info-level log message to state that CT garbage collection was skipped this time.

Fixes: #5751

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6443)
<!-- Reviewable:end -->
