### PR TITLE
make: Ensure that checker.DeepEquals is used everywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,6 +246,8 @@ precheck: govet ineffassign logging-subsys-field
 	$(QUIET) contrib/scripts/check-log-newlines.sh
 	@$(ECHO_CHECK) contrib/scripts/check-missing-tags-in-tests.sh
 	$(QUIET) contrib/scripts/check-missing-tags-in-tests.sh
+	@$(ECHO_CHECK) contrib/scripts/check-assert-deep-equals.sh
+	$(QUIET) contrib/scripts/check-assert-deep-equals.sh
 
 pprof-help:
 	@echo "Available pprof targets:"

--- a/cilium/cmd/bpf_ipcache_get_test.go
+++ b/cilium/cmd/bpf_ipcache_get_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/cilium/cilium/pkg/checker"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -48,7 +50,7 @@ func (s *BPFIPCacheGetSuite) TestGetPrefix(c *C) {
 	for _, tt := range tests {
 		prefix := toBits(tt.prefix)
 		for maskSize := 0; maskSize <= tt.length; maskSize++ {
-			c.Assert(getPrefix(tt.ip, maskSize), DeepEquals, prefix[:maskSize], Commentf("invalid prefix for %v/%v", tt.ip, maskSize))
+			c.Assert(getPrefix(tt.ip, maskSize), checker.DeepEquals, prefix[:maskSize], Commentf("invalid prefix for %v/%v", tt.ip, maskSize))
 		}
 	}
 }
@@ -86,7 +88,7 @@ func (s *BPFIPCacheGetSuite) TestGetLPMValue(c *C) {
 
 		if exists {
 			identity := v.([]string)
-			c.Assert(identity, DeepEquals, tt.identity, Commentf("Wrong identity was retrieved for ip %s", tt.ip))
+			c.Assert(identity, checker.DeepEquals, tt.identity, Commentf("Wrong identity was retrieved for ip %s", tt.ip))
 		}
 	}
 }

--- a/cilium/cmd/helpers_test.go
+++ b/cilium/cmd/helpers_test.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
@@ -165,7 +166,7 @@ func (s *CMDHelpersSuite) TestParsePolicyUpdateArgsHelper(c *C) {
 
 			sortProtos(args.protocols)
 			sortProtos(tt.protos)
-			c.Assert(args.protocols, DeepEquals, tt.protos)
+			c.Assert(args.protocols, checker.DeepEquals, tt.protos)
 		}
 	}
 }

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -19,6 +19,8 @@ package common
 import (
 	"testing"
 
+	"github.com/cilium/cilium/pkg/checker"
+
 	"gopkg.in/check.v1"
 	"io/ioutil"
 	"os"
@@ -43,11 +45,11 @@ func (s *CommonSuite) TestGoArray2C(c *check.C) {
 }
 
 func (s *CommonSuite) TestC2GoArray(c *check.C) {
-	c.Assert(C2GoArray("0x0, 0x1, 0x2, 0x3"), check.DeepEquals, []byte{0, 0x01, 0x02, 0x03})
-	c.Assert(C2GoArray("0x0, 0xff, 0xff, 0xff"), check.DeepEquals, []byte{0, 0xFF, 0xFF, 0xFF})
-	c.Assert(C2GoArray("0xa, 0xbc, 0xde, 0xf1"), check.DeepEquals, []byte{0xa, 0xbc, 0xde, 0xf1})
-	c.Assert(C2GoArray("0x0"), check.DeepEquals, []byte{0})
-	c.Assert(C2GoArray(""), check.DeepEquals, []byte{})
+	c.Assert(C2GoArray("0x0, 0x1, 0x2, 0x3"), checker.DeepEquals, []byte{0, 0x01, 0x02, 0x03})
+	c.Assert(C2GoArray("0x0, 0xff, 0xff, 0xff"), checker.DeepEquals, []byte{0, 0xFF, 0xFF, 0xFF})
+	c.Assert(C2GoArray("0xa, 0xbc, 0xde, 0xf1"), checker.DeepEquals, []byte{0xa, 0xbc, 0xde, 0xf1})
+	c.Assert(C2GoArray("0x0"), checker.DeepEquals, []byte{0})
+	c.Assert(C2GoArray(""), checker.DeepEquals, []byte{})
 }
 
 func (s *CommonSuite) TestFmtDefineComma(c *check.C) {
@@ -89,7 +91,7 @@ func (s *CommonSuite) TestMoveNewFilesTo(c *check.C) {
 		for _, file := range files {
 			filesNames = append(filesNames, file.Name())
 		}
-		c.Assert(wantedFiles, check.DeepEquals, filesNames)
+		c.Assert(wantedFiles, checker.DeepEquals, filesNames)
 	}
 
 	type args struct {

--- a/contrib/scripts/check-assert-deep-equals.sh
+++ b/contrib/scripts/check-assert-deep-equals.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# check-assert-deep-equals.sh checks whether DeepEquals checker from
+# pkg/checker is used every time instead of the checker from gopkg.in/check.v1.
+# If not, it returns an error. Cilium implements its own DeepEquals checker
+# which gives a more detailed trace when the assertion fails.
+
+set -eu
+
+if grep -IPRns 'c.Assert\(.*, (check\.)?DeepEquals, .*\)' \
+        --exclude-dir=vendor \
+        --include=*.go; then
+    echo "Found tests which use DeepEquals checker imported from check.v1."
+    echo "Cilium implements its own DeepEquals checker which can be imported from:"
+    echo -e "\tgithub.com/cilium/cilium/pkg/checker"
+    echo "It gives a more detailed trace when the assertion fails."
+    exit 1
+fi

--- a/daemon/k8s_watcher_test.go
+++ b/daemon/k8s_watcher_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -156,7 +157,7 @@ func (ds *DaemonSuite) Test_missingK8sNetworkPolicyV1(c *C) {
 		want := tt.setupWanted()
 		ds.d.policy = args.repo
 		got := ds.d.missingK8sNetworkPolicyV1(args.m)
-		c.Assert(got, DeepEquals, want, Commentf("Test name: %q", tt.name))
+		c.Assert(got, checker.DeepEquals, want, Commentf("Test name: %q", tt.name))
 	}
 }
 
@@ -260,7 +261,7 @@ func (ds *DaemonSuite) Test_missingCNPv2(c *C) {
 		want := tt.setupWanted()
 		ds.d.policy = args.repo
 		got := ds.d.missingCNPv2(args.m)
-		c.Assert(got, DeepEquals, want, Commentf("Test name: %q", tt.name))
+		c.Assert(got, checker.DeepEquals, want, Commentf("Test name: %q", tt.name))
 	}
 }
 
@@ -520,7 +521,7 @@ func (ds *DaemonSuite) Test_missingK8sPodV1(c *C) {
 		want := tt.setupWanted()
 		ipcache.IPIdentityCache = args.cache
 		got := missingK8sPodV1(args.m)
-		c.Assert(got, DeepEquals, want, Commentf("Test name: %q", tt.name))
+		c.Assert(got, checker.DeepEquals, want, Commentf("Test name: %q", tt.name))
 	}
 }
 
@@ -715,7 +716,7 @@ func (ds *DaemonSuite) Test_missingK8sNodeV1(c *C) {
 		want := tt.setupWanted()
 		ipcache.IPIdentityCache = args.cache
 		got := ds.d.missingK8sNodeV1(args.m)
-		c.Assert(got, DeepEquals, want, Commentf("Test name: %q", tt.name))
+		c.Assert(got, checker.DeepEquals, want, Commentf("Test name: %q", tt.name))
 	}
 }
 
@@ -842,7 +843,7 @@ func (ds *DaemonSuite) Test_missingK8sNamespaceV1(c *C) {
 		args := tt.setupArgs()
 		want := tt.setupWanted()
 		got := ds.d.missingK8sNamespaceV1(args.m)
-		c.Assert(got, DeepEquals, want, Commentf("Test name: %q", tt.name))
+		c.Assert(got, checker.DeepEquals, want, Commentf("Test name: %q", tt.name))
 	}
 }
 
@@ -1107,7 +1108,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 		want := tt.setupWanted()
 		ds.d.policy = args.repo
 		err := ds.d.addCiliumNetworkPolicyV2(args.ciliumV2Store, args.cnp)
-		c.Assert(err, DeepEquals, want.err, Commentf("Test name: %q", tt.name))
-		c.Assert(ds.d.policy.GetRulesList().Policy, DeepEquals, want.repo.GetRulesList().Policy, Commentf("Test name: %q", tt.name))
+		c.Assert(err, checker.DeepEquals, want.err, Commentf("Test name: %q", tt.name))
+		c.Assert(ds.d.policy.GetRulesList().Policy, checker.DeepEquals, want.repo.GetRulesList().Policy, Commentf("Test name: %q", tt.name))
 	}
 }

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 
 	"github.com/cilium/cilium/common/addressing"
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/completion"
 	e "github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/identity"
@@ -209,7 +210,7 @@ func (ds *DaemonSuite) TestReadEPsFromDirNames(c *C) {
 		if ep.ID == 256 {
 			// Make sure the NodeMac equals to the one we set for the endpoint
 			// regeneration that should take priority. (The non-failed one)
-			c.Assert(ep.NodeMAC, DeepEquals, mac.MAC([]byte{0x02, 0xff, 0xf2, 0x12, 0xc1, 0xc1}))
+			c.Assert(ep.NodeMAC, checker.DeepEquals, mac.MAC([]byte{0x02, 0xff, 0xf2, 0x12, 0xc1, 0xc1}))
 		}
 	}
 }

--- a/pkg/datapath/route/route_test.go
+++ b/pkg/datapath/route/route_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/checker"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -64,12 +66,12 @@ func (p *RouteSuite) TestToIPCommand(c *C) {
 		expRes := fmt.Sprintf("ip %sroute add %s/%d via %s dev %s", v6,
 			r.Prefix.IP.String(), masklen, r.Nexthop.String(), dev)
 		result := strings.Join(r.ToIPCommand(dev), " ")
-		c.Assert(result, DeepEquals, expRes)
+		c.Assert(result, checker.DeepEquals, expRes)
 
 		r.Nexthop = nil
 		expRes = fmt.Sprintf("ip %sroute add %s/%d dev %s", v6,
 			r.Prefix.IP.String(), masklen, dev)
 		result = strings.Join(r.ToIPCommand(dev), " ")
-		c.Assert(result, DeepEquals, expRes)
+		c.Assert(result, checker.DeepEquals, expRes)
 	}
 }

--- a/pkg/debug/subsystem_test.go
+++ b/pkg/debug/subsystem_test.go
@@ -19,6 +19,8 @@ package debug
 import (
 	"testing"
 
+	"github.com/cilium/cilium/pkg/checker"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -39,28 +41,28 @@ func (d *debugObj) DebugStatus() string {
 
 func (s *DebugTestSuite) TestSubsystem(c *C) {
 	sf := newStatusFunctions()
-	c.Assert(sf.collectStatus(), DeepEquals, StatusMap{})
+	c.Assert(sf.collectStatus(), checker.DeepEquals, StatusMap{})
 
 	sf = newStatusFunctions()
 	sf.register("foo", func() string { return "test1" })
-	c.Assert(sf.collectStatus(), DeepEquals, StatusMap{
+	c.Assert(sf.collectStatus(), checker.DeepEquals, StatusMap{
 		"foo": "test1",
 	})
 
 	sf.register("bar", func() string { return "test2" })
-	c.Assert(sf.collectStatus(), DeepEquals, StatusMap{
+	c.Assert(sf.collectStatus(), checker.DeepEquals, StatusMap{
 		"foo": "test1",
 		"bar": "test2",
 	})
 
 	sf.register("bar", func() string { return "test2" })
-	c.Assert(sf.collectStatus(), DeepEquals, StatusMap{
+	c.Assert(sf.collectStatus(), checker.DeepEquals, StatusMap{
 		"foo": "test1",
 		"bar": "test2",
 	})
 
 	sf.registerStatusObject("baz", &debugObj{})
-	c.Assert(sf.collectStatus(), DeepEquals, StatusMap{
+	c.Assert(sf.collectStatus(), checker.DeepEquals, StatusMap{
 		"foo": "test1",
 		"bar": "test2",
 		"baz": "test3",

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/common/addressing"
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/option"
@@ -277,7 +278,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 		want := tt.setupWant()
 		got, err := Lookup(args.id)
 		c.Assert(err, want.errCheck, want.err, Commentf("Test Name: %s", tt.name))
-		c.Assert(got, DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
+		c.Assert(got, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
 		tt.postTestRun()
 	}
 }
@@ -344,7 +345,7 @@ func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 		args := tt.setupArgs()
 		want := tt.setupWant()
 		got := LookupCiliumID(args.id)
-		c.Assert(got, DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
+		c.Assert(got, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
 		tt.postTestRun()
 	}
 }
@@ -411,7 +412,7 @@ func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
 		args := tt.setupArgs()
 		want := tt.setupWant()
 		got := LookupContainerID(args.id)
-		c.Assert(got, DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
+		c.Assert(got, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
 		tt.postTestRun()
 	}
 }
@@ -480,7 +481,7 @@ func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
 		args := tt.setupArgs()
 		want := tt.setupWant()
 		got := LookupIPv4(args.ip)
-		c.Assert(got, DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
+		c.Assert(got, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
 		tt.postTestRun()
 	}
 }
@@ -548,7 +549,7 @@ func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
 		args := tt.setupArgs()
 		want := tt.setupWant()
 		got := LookupPodName(args.podName)
-		c.Assert(got, DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
+		c.Assert(got, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
 		tt.postTestRun()
 	}
 }
@@ -614,21 +615,21 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 		UpdateReferences(args.ep)
 
 		ep = LookupContainerID(want.ep.GetContainerID())
-		c.Assert(ep, DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
+		c.Assert(ep, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
 
 		ep = lookupDockerEndpoint(want.ep.DockerEndpointID)
-		c.Assert(ep, DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
+		c.Assert(ep, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
 
 		ep = LookupIPv4(want.ep.IPv4.String())
-		c.Assert(ep, DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
+		c.Assert(ep, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
 
 		ep = lookupDockerContainerName(want.ep.ContainerName)
-		c.Assert(ep, DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
+		c.Assert(ep, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
 
 		want.ep.UnconditionalRLock()
 		ep = LookupPodName(want.ep.GetK8sNamespaceAndPodNameLocked())
 		want.ep.RUnlock()
-		c.Assert(ep, DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
+		c.Assert(ep, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
 		tt.postTestRun()
 	}
 }
@@ -731,7 +732,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 		tt.preTestRun()
 		want := tt.setupWant()
 		got := HasGlobalCT()
-		c.Assert(got, DeepEquals, want.result, Commentf("Test Name: %s", tt.name))
+		c.Assert(got, checker.DeepEquals, want.result, Commentf("Test Name: %s", tt.name))
 		tt.postTestRun()
 	}
 }

--- a/pkg/envoy/envoy_test.go
+++ b/pkg/envoy/envoy_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/envoy/xds"
 	"github.com/cilium/cilium/pkg/flowdebug"
@@ -170,7 +171,7 @@ func (s *EnvoySuite) TestEnvoyNACK(c *C) {
 
 	err = s.waitForProxyCompletion()
 	c.Assert(err, Not(IsNil))
-	c.Assert(err, DeepEquals, &xds.ProxyError{Err: xds.ErrNackReceived, Detail: "Error adding/updating listener listener:22: cannot bind '[::]:22': Address already in use"})
+	c.Assert(err, checker.DeepEquals, &xds.ProxyError{Err: xds.ErrNackReceived, Detail: "Error adding/updating listener listener:22: cannot bind '[::]:22': Address already in use"})
 
 	s.waitGroup = completion.NewWaitGroup(ctx)
 	// Remove listener1

--- a/pkg/envoy/sort_test.go
+++ b/pkg/envoy/sort_test.go
@@ -17,10 +17,11 @@
 package envoy
 
 import (
+	"github.com/cilium/cilium/pkg/checker"
+
 	"github.com/cilium/proxy/go/cilium/api"
 	envoy_api_v2_core "github.com/cilium/proxy/go/envoy/api/v2/core"
 	envoy_api_v2_route "github.com/cilium/proxy/go/envoy/api/v2/route"
-
 	. "gopkg.in/check.v1"
 )
 
@@ -64,7 +65,7 @@ func (s *SortSuite) TestSortHeaderMatchers(c *C) {
 		HeaderMatcher4,
 	}
 	SortHeaderMatchers(slice)
-	c.Assert(slice, DeepEquals, expected)
+	c.Assert(slice, checker.DeepEquals, expected)
 }
 
 var HTTPNetworkPolicyRule1 = &cilium.HttpNetworkPolicyRule{}
@@ -97,7 +98,7 @@ func (s *SortSuite) TestSortHttpNetworkPolicyRules(c *C) {
 		HTTPNetworkPolicyRule4,
 	}
 	SortHTTPNetworkPolicyRules(slice)
-	c.Assert(slice, DeepEquals, expected)
+	c.Assert(slice, checker.DeepEquals, expected)
 }
 
 var PortNetworkPolicyRule1 = &cilium.PortNetworkPolicyRule{
@@ -185,7 +186,7 @@ func (s *SortSuite) TestSortPortNetworkPolicyRules(c *C) {
 		PortNetworkPolicyRule7,
 	}
 	SortPortNetworkPolicyRules(slice)
-	c.Assert(slice, DeepEquals, expected)
+	c.Assert(slice, checker.DeepEquals, expected)
 }
 
 var PortNetworkPolicy1 = &cilium.PortNetworkPolicy{
@@ -252,5 +253,5 @@ func (s *SortSuite) TestSortPortNetworkPolicies(c *C) {
 		PortNetworkPolicy6,
 	}
 	SortPortNetworkPolicies(slice)
-	c.Assert(slice, DeepEquals, expected)
+	c.Assert(slice, checker.DeepEquals, expected)
 }

--- a/pkg/envoy/xds/ack_test.go
+++ b/pkg/envoy/xds/ack_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/completion"
 	envoy_api_v2_core "github.com/cilium/proxy/go/envoy/api/v2/core"
 
@@ -183,7 +184,7 @@ func (s *AckSuite) TestUpsertMoreRecentVersionNack(c *C) {
 	// IsCompleted is true only for completions without error
 	c.Assert(comp, Not(IsCompleted))
 	c.Assert(comp.Err(), Not(Equals), nil)
-	c.Assert(comp.Err(), DeepEquals, &ProxyError{Err: ErrNackReceived, Detail: "Detail"})
+	c.Assert(comp.Err(), checker.DeepEquals, &ProxyError{Err: ErrNackReceived, Detail: "Detail"})
 }
 
 func (s *AckSuite) TestDeleteSingleNode(c *C) {

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -909,7 +909,7 @@ func (s *ServerSuite) TestNAck(c *C) {
 
 	// Version 2 was NACKed by the last request, so comp1 must NOT be completed ever.
 	c.Assert(comp1, Not(IsCompleted))
-	c.Assert(comp1.Err(), DeepEquals, &ProxyError{Err: ErrNackReceived, Detail: "FAILFAIL"})
+	c.Assert(comp1.Err(), checker.DeepEquals, &ProxyError{Err: ErrNackReceived, Detail: "FAILFAIL"})
 
 	// Expecting a response with both resources.
 	// Note that the stream should not have a message that repeats the previous one!
@@ -1038,7 +1038,7 @@ func (s *ServerSuite) TestNAckFromTheStart(c *C) {
 	c.Assert(comp1, Not(IsCompleted))
 	// Version 2 did not have a callback, so the completion was completed with an error
 	c.Assert(comp1.Err(), Not(IsNil))
-	c.Assert(comp1.Err(), DeepEquals, &ProxyError{Err: ErrNackReceived})
+	c.Assert(comp1.Err(), checker.DeepEquals, &ProxyError{Err: ErrNackReceived})
 
 	// NACK canceled the WaitGroup, create new one
 	wg = completion.NewWaitGroup(ctx)

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"sync"
 
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
@@ -154,7 +155,7 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 
 	identity := LookupIdentityByID(id1b.ID)
 	c.Assert(identity, Not(IsNil))
-	c.Assert(lbls1, DeepEquals, identity.Labels)
+	c.Assert(lbls1, checker.DeepEquals, identity.Labels)
 
 	id2, isNew, err := AllocateIdentity(lbls2)
 	c.Assert(id2, Not(IsNil))

--- a/pkg/idpool/idpool_test.go
+++ b/pkg/idpool/idpool_test.go
@@ -20,6 +20,8 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/checker"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -93,7 +95,7 @@ func (s *IDPoolTestSuite) TestInsertRemoveIDs(c *C) {
 	c.Assert(id, Equals, NoID)
 
 	sort.Ints(actualIDs)
-	c.Assert(actualIDs, DeepEquals, evenIDs)
+	c.Assert(actualIDs, checker.DeepEquals, evenIDs)
 }
 
 func (s *IDPoolTestSuite) TestRefresh(c *C) {
@@ -138,7 +140,7 @@ func (s *IDPoolTestSuite) TestRefresh(c *C) {
 	c.Assert(id, Equals, NoID)
 
 	sort.Ints(actual)
-	c.Assert(actual, DeepEquals, expected)
+	c.Assert(actual, checker.DeepEquals, expected)
 }
 
 func (s *IDPoolTestSuite) TestReleaseID(c *C) {
@@ -322,5 +324,5 @@ func leaseAllIDs(p *IDPool, minID int, maxID int, c *C) {
 
 	// Unique ids must have been leased.
 	sort.Ints(actual)
-	c.Assert(actual, DeepEquals, expected)
+	c.Assert(actual, checker.DeepEquals, expected)
 }

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -22,6 +22,8 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/checker"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -462,48 +464,48 @@ func (s *IPTestSuite) TestNextIP(c *C) {
 	expectedNext := net.ParseIP("10.0.0.0")
 	ip := net.ParseIP("9.255.255.255")
 	nextIP := GetNextIP(ip)
-	c.Assert(nextIP, DeepEquals, expectedNext)
+	c.Assert(nextIP, checker.DeepEquals, expectedNext)
 
 	// Check that overflow does not occur.
 	ip = net.ParseIP("255.255.255.255")
 	nextIP = GetNextIP(ip)
 	expectedNext = ip
-	c.Assert(nextIP, DeepEquals, expectedNext)
+	c.Assert(nextIP, checker.DeepEquals, expectedNext)
 
 	ip = net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
 	nextIP = GetNextIP(ip)
 	expectedNext = ip
-	c.Assert(nextIP, DeepEquals, expectedNext)
+	c.Assert(nextIP, checker.DeepEquals, expectedNext)
 
 	ip = net.IP([]byte{0xa, 0, 0, 0})
 	nextIP = GetNextIP(ip)
 	expectedNext = net.IP([]byte{0xa, 0, 0, 1})
-	c.Assert(nextIP, DeepEquals, expectedNext)
+	c.Assert(nextIP, checker.DeepEquals, expectedNext)
 
 	ip = net.IP([]byte{0xff, 0xff, 0xff, 0xff})
 	nextIP = GetNextIP(ip)
 	expectedNext = net.IP([]byte{0xff, 0xff, 0xff, 0xff})
-	c.Assert(nextIP, DeepEquals, expectedNext)
+	c.Assert(nextIP, checker.DeepEquals, expectedNext)
 
 	ip = net.ParseIP("10.0.0.0")
 	nextIP = GetNextIP(ip)
 	expectedNext = net.ParseIP("10.0.0.1")
-	c.Assert(nextIP, DeepEquals, expectedNext)
+	c.Assert(nextIP, checker.DeepEquals, expectedNext)
 
 	ip = net.ParseIP("0:0:0:0:ffff:ffff:ffff:ffff")
 	nextIP = GetNextIP(ip)
 	expectedNext = net.ParseIP("0:0:0:1:0:0:0:0")
-	c.Assert(nextIP, DeepEquals, expectedNext)
+	c.Assert(nextIP, checker.DeepEquals, expectedNext)
 
 	ip = net.ParseIP("ffff:ffff:ffff:fffe:ffff:ffff:ffff:ffff")
 	nextIP = GetNextIP(ip)
 	expectedNext = net.ParseIP("ffff:ffff:ffff:ffff:0:0:0:0")
-	c.Assert(nextIP, DeepEquals, expectedNext)
+	c.Assert(nextIP, checker.DeepEquals, expectedNext)
 
 	ip = net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe")
 	nextIP = GetNextIP(ip)
 	expectedNext = net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
-	c.Assert(nextIP, DeepEquals, expectedNext)
+	c.Assert(nextIP, checker.DeepEquals, expectedNext)
 }
 
 func (s *IPTestSuite) TestCreateSpanningCIDR(c *C) {

--- a/pkg/k8s/apis/cilium.io/utils/utils_test.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils_test.go
@@ -353,6 +353,6 @@ func (s *CiliumUtilsSuite) TestParseToCiliumLabels(c *C) {
 	}
 	for _, tt := range tests {
 		got := ParseToCiliumLabels(tt.args.namespace, tt.args.name, tt.args.uid, tt.args.ruleLbs)
-		c.Assert(got, DeepEquals, tt.want, Commentf("Test Name: %s", tt.name))
+		c.Assert(got, checker.DeepEquals, tt.want, Commentf("Test Name: %s", tt.name))
 	}
 }

--- a/pkg/k8s/endpoints_test.go
+++ b/pkg/k8s/endpoints_test.go
@@ -19,6 +19,7 @@ package k8s
 import (
 	"testing"
 
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/service"
 
@@ -428,7 +429,7 @@ func (s *K8sSuite) Test_parseK8sEPv1(c *check.C) {
 		args := tt.setupArgs()
 		want := tt.setupWanted()
 		_, got := ParseEndpoints(args.eps)
-		c.Assert(got, check.DeepEquals, want, check.Commentf("Test name: %q", tt.name))
+		c.Assert(got, checker.DeepEquals, want, check.Commentf("Test name: %q", tt.name))
 	}
 }
 

--- a/pkg/k8s/ingress_test.go
+++ b/pkg/k8s/ingress_test.go
@@ -144,8 +144,8 @@ func (s *K8sSuite) Test_parsingV1beta1(c *check.C) {
 		args := tt.setupArgs()
 		wantK8sSvcInfo, wantError := tt.setupWanted()
 		_, gotK8sSvcInfo, gotError := ParseIngress(args.i, args.host)
-		c.Assert(gotError, check.DeepEquals, wantError, check.Commentf("Test name: %q", tt.name))
-		c.Assert(gotK8sSvcInfo, check.DeepEquals, wantK8sSvcInfo, check.Commentf("Test name: %q", tt.name))
+		c.Assert(gotError, checker.DeepEquals, wantError, check.Commentf("Test name: %q", tt.name))
+		c.Assert(gotK8sSvcInfo, checker.DeepEquals, wantK8sSvcInfo, check.Commentf("Test name: %q", tt.name))
 	}
 }
 
@@ -195,6 +195,6 @@ func (s *K8sSuite) Test_supportV1beta1(c *check.C) {
 		args := tt.setupArgs()
 		want := tt.want
 		got := supportV1beta1(args.i)
-		c.Assert(got, check.DeepEquals, want, check.Commentf("Test name: %q", tt.name))
+		c.Assert(got, checker.DeepEquals, want, check.Commentf("Test name: %q", tt.name))
 	}
 }

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -1674,7 +1674,7 @@ func (s *K8sSuite) TestIPBlockToCIDRRule(c *C) {
 		if block.Except == nil || len(block.Except) == 0 {
 			c.Assert(cidrRule.ExceptCIDRs, IsNil)
 		} else {
-			c.Assert(cidrRule.ExceptCIDRs, DeepEquals, exceptCIDRs)
+			c.Assert(cidrRule.ExceptCIDRs, checker.DeepEquals, exceptCIDRs)
 		}
 	}
 }

--- a/pkg/k8s/service_cache_test.go
+++ b/pkg/k8s/service_cache_test.go
@@ -364,7 +364,7 @@ func (s *K8sSuite) Test_missingK8sEndpointsV1(c *check.C) {
 		args := tt.setupArgs()
 		want := tt.setupWanted()
 		got := args.svcCache.ListMissingEndpoints(args.m)
-		c.Assert(got, check.DeepEquals, want, check.Commentf("Test name: %q", tt.name))
+		c.Assert(got, checker.DeepEquals, want, check.Commentf("Test name: %q", tt.name))
 	}
 }
 
@@ -471,7 +471,7 @@ func (s *K8sSuite) Test_missingK8sServicesV1(c *check.C) {
 		args := tt.setupArgs()
 		want := tt.setupWanted()
 		got := args.svcCache.ListMissingServices(args.m)
-		c.Assert(got, check.DeepEquals, want, check.Commentf("Test name: %q", tt.name))
+		c.Assert(got, checker.DeepEquals, want, check.Commentf("Test name: %q", tt.name))
 	}
 }
 
@@ -593,7 +593,7 @@ func (s *K8sSuite) Test_missingK8sIngressV1Beta1(c *check.C) {
 		args := tt.setupArgs()
 		want := tt.setupWanted()
 		got := args.svcCache.ListMissingIngresses(args.m, hostIP)
-		c.Assert(got, check.DeepEquals, want, check.Commentf("Test name: %q", tt.name))
+		c.Assert(got, checker.DeepEquals, want, check.Commentf("Test name: %q", tt.name))
 	}
 }
 

--- a/pkg/k8s/utils/factory_test.go
+++ b/pkg/k8s/utils/factory_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/serializer"
 	"github.com/cilium/cilium/pkg/versioned"
 
@@ -156,7 +157,7 @@ func (s *FactorySuite) Test_replaceFuncFactory(c *C) {
 							ResourceVersion: "12",
 						},
 					}
-					c.Assert(obj, DeepEquals, wanted, Commentf("NetworkPolicy added should be exactly the same from kube-apiserver"))
+					c.Assert(obj, checker.DeepEquals, wanted, Commentf("NetworkPolicy added should be exactly the same from kube-apiserver"))
 					addFuncCalls++
 					return func() error {
 						return nil
@@ -248,7 +249,7 @@ func (s *FactorySuite) Test_replaceFuncFactory(c *C) {
 							ResourceVersion: "12",
 						},
 					}
-					c.Assert(obj, DeepEquals, wanted, Commentf("NetworkPolicy deleted should be exactly that is missing from kube-apiserver"))
+					c.Assert(obj, checker.DeepEquals, wanted, Commentf("NetworkPolicy deleted should be exactly that is missing from kube-apiserver"))
 					delFuncCalls++
 					return func() error {
 						return nil
@@ -265,7 +266,7 @@ func (s *FactorySuite) Test_replaceFuncFactory(c *C) {
 				missingFunc := func(m versioned.Map) versioned.Map {
 					// missingFunc will be called with all objects that should
 					// exist locally.
-					c.Assert(m, DeepEquals, versioned.NewMap())
+					c.Assert(m, checker.DeepEquals, versioned.NewMap())
 					return m
 				}
 
@@ -367,7 +368,7 @@ func (s *FactorySuite) Test_replaceFuncFactory(c *C) {
 					})
 					// missingFunc will be called with all objects that should
 					// exist locally.
-					c.Assert(m, DeepEquals, newMap)
+					c.Assert(m, checker.DeepEquals, newMap)
 					return nil
 				}
 
@@ -491,7 +492,7 @@ func (s *FactorySuite) Test_replaceFuncFactory(c *C) {
 							},
 						},
 					}
-					c.Assert(objNew, DeepEquals, wantedNew, Commentf("The new NetworkPolicy added should be exactly the one that is missing from kube-apiserver"))
+					c.Assert(objNew, checker.DeepEquals, wantedNew, Commentf("The new NetworkPolicy added should be exactly the one that is missing from kube-apiserver"))
 
 					objOld, ok := old.(*v1.NetworkPolicy)
 					c.Assert(ok, Equals, true)
@@ -503,7 +504,7 @@ func (s *FactorySuite) Test_replaceFuncFactory(c *C) {
 							ResourceVersion: "12",
 						},
 					}
-					c.Assert(objOld, DeepEquals, wantedOld, Commentf("The old NetworkPolicy should be the previous know object"))
+					c.Assert(objOld, checker.DeepEquals, wantedOld, Commentf("The old NetworkPolicy should be the previous know object"))
 
 					updateFuncCalls++
 					return func() error {
@@ -537,7 +538,7 @@ func (s *FactorySuite) Test_replaceFuncFactory(c *C) {
 					})
 					// missingFunc will be called with all objects that should
 					// exist locally.
-					c.Assert(m, DeepEquals, newMap)
+					c.Assert(m, checker.DeepEquals, newMap)
 					return nil
 				}
 
@@ -668,7 +669,7 @@ func (s *FactorySuite) Test_replaceFuncFactory(c *C) {
 					})
 					// missingFunc will be called with all objects that should
 					// exist locally.
-					c.Assert(m, DeepEquals, wanted)
+					c.Assert(m, checker.DeepEquals, wanted)
 					return nil
 				}
 
@@ -727,7 +728,7 @@ func (s *FactorySuite) Test_replaceFuncFactory(c *C) {
 		replaceFunc := replaceFuncFactory(args.listerClient, args.resourceObj, args.addFunc, args.delFunc, args.updateFunc, args.missingFunc, args.fqueue)
 		newMap, err := replaceFunc(want.oldMap)
 		c.Assert(err, IsNil, Commentf("Test Name: %s", tt.name))
-		c.Assert(newMap.Map, DeepEquals, want.newMap.Map, Commentf("Test Name: %s", tt.name))
+		c.Assert(newMap.Map, checker.DeepEquals, want.newMap.Map, Commentf("Test Name: %s", tt.name))
 		c.Assert(*args.addFuncCalls, Equals, want.addFuncCalls, Commentf("Test Name: %s", tt.name))
 		c.Assert(*args.delFuncCalls, Equals, want.delFuncCalls, Commentf("Test Name: %s", tt.name))
 	}

--- a/pkg/kvstore/base_test.go
+++ b/pkg/kvstore/base_test.go
@@ -76,11 +76,11 @@ func (s *BaseTests) TestGetSet(c *C) {
 
 		val, err = Get(testKey(prefix, i))
 		c.Assert(err, IsNil)
-		c.Assert(val, DeepEquals, testValue(i))
+		c.Assert(val, checker.DeepEquals, testValue(i))
 
 		val, err = Get(testKey(prefix, i))
 		c.Assert(err, IsNil)
-		c.Assert(val, DeepEquals, testValue(i))
+		c.Assert(val, checker.DeepEquals, testValue(i))
 	}
 
 	for i := 0; i < maxID; i++ {
@@ -141,14 +141,14 @@ func (s *BaseTests) TestUpdate(c *C) {
 
 	val, err = Get(testKey(prefix, 0))
 	c.Assert(err, IsNil)
-	c.Assert(val, DeepEquals, testValue(0))
+	c.Assert(val, checker.DeepEquals, testValue(0))
 
 	// update
 	c.Assert(Update(testKey(prefix, 0), testValue(0), true), IsNil)
 
 	val, err = Get(testKey(prefix, 0))
 	c.Assert(err, IsNil)
-	c.Assert(val, DeepEquals, testValue(0))
+	c.Assert(val, checker.DeepEquals, testValue(0))
 }
 
 func (s *BaseTests) TestCreateOnly(c *C) {
@@ -165,13 +165,13 @@ func (s *BaseTests) TestCreateOnly(c *C) {
 
 	val, err = Get(testKey(prefix, 0))
 	c.Assert(err, IsNil)
-	c.Assert(val, DeepEquals, testValue(0))
+	c.Assert(val, checker.DeepEquals, testValue(0))
 
 	c.Assert(CreateOnly(testKey(prefix, 0), testValue(1), false), Not(IsNil))
 
 	val, err = Get(testKey(prefix, 0))
 	c.Assert(err, IsNil)
-	c.Assert(val, DeepEquals, testValue(0))
+	c.Assert(val, checker.DeepEquals, testValue(0))
 
 	// key 1 does not exist so CreateIfExists should fail
 	c.Assert(CreateIfExists(testKey(prefix, 1), testKey(prefix, 2), testValue(2), false), Not(IsNil))
@@ -185,7 +185,7 @@ func (s *BaseTests) TestCreateOnly(c *C) {
 
 	val, err = Get(testKey(prefix, 2))
 	c.Assert(err, IsNil)
-	c.Assert(val, DeepEquals, testValue(2))
+	c.Assert(val, checker.DeepEquals, testValue(2))
 }
 
 func drainEvents(w *Watcher) {

--- a/pkg/kvstore/store/store_test.go
+++ b/pkg/kvstore/store/store_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/testutils"
 
@@ -276,11 +277,11 @@ func (s *StoreSuite) TestUpdateKey(c *C) {
 	json, err := v1.Marshal()
 	c.Assert(err, IsNil)
 	store.updateKey("foo", json)
-	c.Assert(store.sharedKeys["foo"], DeepEquals, v1)
+	c.Assert(store.sharedKeys["foo"], checker.DeepEquals, v1)
 
 	v2 := &updateTest{Items: map[string]string{}}
 	json, err = v2.Marshal()
 	c.Assert(err, IsNil)
 	store.updateKey("foo", json)
-	c.Assert(store.sharedKeys["foo"], DeepEquals, v2)
+	c.Assert(store.sharedKeys["foo"], checker.DeepEquals, v2)
 }

--- a/pkg/maps/lbmap/bpfservice_test.go
+++ b/pkg/maps/lbmap/bpfservice_test.go
@@ -20,6 +20,8 @@ import (
 	"net"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/checker"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -129,46 +131,46 @@ func (b *LBMapTestSuite) TestPrepareUpdate(c *C) {
 	b3 := createBackend(c, "4.4.4.4", 80, 1)
 
 	bpfSvc := cache.prepareUpdate(frontend, []ServiceValue{b1, b2})
-	c.Assert(bpfSvc.backendsByMapIndex[1].bpfValue, DeepEquals, b1)
-	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, DeepEquals, b2)
+	c.Assert(bpfSvc.backendsByMapIndex[1].bpfValue, checker.DeepEquals, b1)
+	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, checker.DeepEquals, b2)
 
 	backends := bpfSvc.getBackends()
 	c.Assert(len(backends), Equals, 2)
-	c.Assert(backends[0], DeepEquals, b1)
-	c.Assert(backends[1], DeepEquals, b2)
+	c.Assert(backends[0], checker.DeepEquals, b1)
+	c.Assert(backends[1], checker.DeepEquals, b2)
 
 	bpfSvc = cache.prepareUpdate(frontend, []ServiceValue{b1, b2, b3})
-	c.Assert(bpfSvc.backendsByMapIndex[1].bpfValue, DeepEquals, b1)
-	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, DeepEquals, b2)
-	c.Assert(bpfSvc.backendsByMapIndex[3].bpfValue, DeepEquals, b3)
+	c.Assert(bpfSvc.backendsByMapIndex[1].bpfValue, checker.DeepEquals, b1)
+	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, checker.DeepEquals, b2)
+	c.Assert(bpfSvc.backendsByMapIndex[3].bpfValue, checker.DeepEquals, b3)
 
 	backends = bpfSvc.getBackends()
 	c.Assert(len(backends), Equals, 3)
-	c.Assert(backends[0], DeepEquals, b1)
-	c.Assert(backends[1], DeepEquals, b2)
-	c.Assert(backends[2], DeepEquals, b3)
+	c.Assert(backends[0], checker.DeepEquals, b1)
+	c.Assert(backends[1], checker.DeepEquals, b2)
+	c.Assert(backends[2], checker.DeepEquals, b3)
 
 	bpfSvc = cache.prepareUpdate(frontend, []ServiceValue{b2, b3})
 	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, Not(DeepEquals), b1)
-	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, DeepEquals, b2)
-	c.Assert(bpfSvc.backendsByMapIndex[3].bpfValue, DeepEquals, b3)
+	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, checker.DeepEquals, b2)
+	c.Assert(bpfSvc.backendsByMapIndex[3].bpfValue, checker.DeepEquals, b3)
 
 	backends = bpfSvc.getBackends()
 	c.Assert(len(backends), Equals, 3)
 	c.Assert(backends[0], Not(DeepEquals), b1)
-	c.Assert(backends[1], DeepEquals, b2)
-	c.Assert(backends[2], DeepEquals, b3)
+	c.Assert(backends[1], checker.DeepEquals, b2)
+	c.Assert(backends[2], checker.DeepEquals, b3)
 
 	bpfSvc = cache.prepareUpdate(frontend, []ServiceValue{b1, b2, b3})
-	c.Assert(bpfSvc.backendsByMapIndex[1].bpfValue, DeepEquals, b1)
-	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, DeepEquals, b2)
-	c.Assert(bpfSvc.backendsByMapIndex[3].bpfValue, DeepEquals, b3)
+	c.Assert(bpfSvc.backendsByMapIndex[1].bpfValue, checker.DeepEquals, b1)
+	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, checker.DeepEquals, b2)
+	c.Assert(bpfSvc.backendsByMapIndex[3].bpfValue, checker.DeepEquals, b3)
 
 	backends = bpfSvc.getBackends()
 	c.Assert(len(backends), Equals, 3)
-	c.Assert(backends[0], DeepEquals, b1)
-	c.Assert(backends[1], DeepEquals, b2)
-	c.Assert(backends[2], DeepEquals, b3)
+	c.Assert(backends[0], checker.DeepEquals, b1)
+	c.Assert(backends[1], checker.DeepEquals, b2)
+	c.Assert(backends[2], checker.DeepEquals, b3)
 
 	bpfSvc = cache.prepareUpdate(frontend, []ServiceValue{})
 	c.Assert(len(bpfSvc.backendsByMapIndex), Equals, 0)
@@ -192,7 +194,7 @@ func (b *LBMapTestSuite) TestGetBackends(c *C) {
 
 	backends := svc.getBackends()
 	c.Assert(len(backends), Equals, 1)
-	c.Assert(backends[0], DeepEquals, b1)
+	c.Assert(backends[0], checker.DeepEquals, b1)
 
 	svc = bpfService{
 		backendsByMapIndex: map[int]*bpfBackend{
@@ -203,6 +205,6 @@ func (b *LBMapTestSuite) TestGetBackends(c *C) {
 
 	backends = svc.getBackends()
 	c.Assert(len(backends), Equals, 2)
-	c.Assert(backends[0], DeepEquals, b1)
-	c.Assert(backends[1], DeepEquals, b2)
+	c.Assert(backends[0], checker.DeepEquals, b1)
+	c.Assert(backends[1], checker.DeepEquals, b2)
 }

--- a/pkg/node/node_address_test.go
+++ b/pkg/node/node_address_test.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"reflect"
 
+	"github.com/cilium/cilium/pkg/checker"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -122,10 +124,10 @@ func (s *NodeSuite) Test_getCiliumHostIPsFromFile(c *C) {
 	for _, tt := range tests {
 		gotIpv4GW, gotIpv6Router := getCiliumHostIPsFromFile(tt.args.nodeConfig)
 		if !reflect.DeepEqual(gotIpv4GW, tt.wantIpv4GW) {
-			c.Assert(gotIpv4GW, DeepEquals, tt.wantIpv4GW)
+			c.Assert(gotIpv4GW, checker.DeepEquals, tt.wantIpv4GW)
 		}
 		if !reflect.DeepEqual(gotIpv6Router, tt.wantIpv6Router) {
-			c.Assert(gotIpv6Router, DeepEquals, tt.wantIpv6Router)
+			c.Assert(gotIpv6Router, checker.DeepEquals, tt.wantIpv6Router)
 		}
 	}
 }

--- a/pkg/option/option_test.go
+++ b/pkg/option/option_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/checker"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -305,7 +307,7 @@ func (s *OptionSuite) TestGetImmutableModel(c *C) {
 
 	cfg := o.GetImmutableModel()
 	c.Assert(cfg, NotNil)
-	c.Assert(cfg, DeepEquals, &models.ConfigurationMap{})
+	c.Assert(cfg, checker.DeepEquals, &models.ConfigurationMap{})
 }
 
 func (s *OptionSuite) TestGetMutableModel(c *C) {
@@ -338,7 +340,7 @@ func (s *OptionSuite) TestGetMutableModel(c *C) {
 
 	cfg := o.GetMutableModel()
 	c.Assert(cfg, NotNil)
-	c.Assert(cfg, DeepEquals, &models.ConfigurationMap{
+	c.Assert(cfg, checker.DeepEquals, &models.ConfigurationMap{
 		k1: "Enabled",
 		k2: "Disabled",
 		k3: "ok",
@@ -347,7 +349,7 @@ func (s *OptionSuite) TestGetMutableModel(c *C) {
 	o2 := IntOptions{}
 	cfg2 := o2.GetMutableModel()
 	c.Assert(cfg2, NotNil)
-	c.Assert(cfg2, DeepEquals, &models.ConfigurationMap{})
+	c.Assert(cfg2, checker.DeepEquals, &models.ConfigurationMap{})
 }
 
 func (s *OptionSuite) TestValidate(c *C) {
@@ -451,7 +453,7 @@ func (s *OptionSuite) TestApplyValidated(c *C) {
 	om, err := o.Library.ValidateConfigurationMap(cfg)
 	c.Assert(err, IsNil)
 	c.Assert(o.ApplyValidated(om, changed, &cfg), Equals, len(expectedChanges))
-	c.Assert(actualChanges, DeepEquals, expectedChanges)
+	c.Assert(actualChanges, checker.DeepEquals, expectedChanges)
 
 	expectedOpts := OptionMap{
 		k1: OptionDisabled,

--- a/pkg/policy/api/egress_test.go
+++ b/pkg/policy/api/egress_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/cilium/cilium/pkg/checker"
+
 	. "gopkg.in/check.v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -49,7 +51,7 @@ func (s *PolicyAPITestSuite) TestCreateDerivativeRuleWithoutToGroups(c *C) {
 		},
 	}
 	newRule, err := eg.CreateDerivative()
-	c.Assert(eg, DeepEquals, newRule)
+	c.Assert(eg, checker.DeepEquals, newRule)
 	c.Assert(err, IsNil)
 }
 
@@ -104,5 +106,5 @@ func (s *PolicyAPITestSuite) TestCreateDerivativeWithoutErrorAndNoIPs(c *C) {
 
 	newRule, err := eg.CreateDerivative()
 	c.Assert(err, IsNil)
-	c.Assert(newRule, DeepEquals, &EgressRule{})
+	c.Assert(newRule, checker.DeepEquals, &EgressRule{})
 }

--- a/pkg/policy/api/groups_test.go
+++ b/pkg/policy/api/groups_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/cilium/cilium/pkg/checker"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -59,7 +61,7 @@ func (s *PolicyAPITestSuite) TestGetCIDRSetWithValidValue(c *C) {
 		{Cidr: "192.168.1.1/32", ExceptCIDRs: []CIDR{}, Generated: true}}
 	group := GetToGroupsRule()
 	cidr, err := group.GetCidrSet()
-	c.Assert(cidr, DeepEquals, expectedCidrRule)
+	c.Assert(cidr, checker.DeepEquals, expectedCidrRule)
 	c.Assert(err, IsNil)
 }
 
@@ -72,7 +74,7 @@ func (s *PolicyAPITestSuite) TestGetCIDRSetWithMultipleSorted(c *C) {
 		{Cidr: "192.168.10.10/32", ExceptCIDRs: []CIDR{}, Generated: true}}
 	group := GetToGroupsRule()
 	cidr, err := group.GetCidrSet()
-	c.Assert(cidr, DeepEquals, expectedCidrRule)
+	c.Assert(cidr, checker.DeepEquals, expectedCidrRule)
 	c.Assert(err, IsNil)
 }
 
@@ -86,7 +88,7 @@ func (s *PolicyAPITestSuite) TestGetCIDRSetWithUniqueCIDRRule(c *C) {
 
 	group := GetToGroupsRule()
 	cidr, err := group.GetCidrSet()
-	c.Assert(cidr, DeepEquals, cidrRule)
+	c.Assert(cidr, checker.DeepEquals, cidrRule)
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/policy/groups/helpers_test.go
+++ b/pkg/policy/groups/helpers_test.go
@@ -20,12 +20,13 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/cilium/cilium/pkg/checker"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"k8s.io/apimachinery/pkg/types"
 
 	. "gopkg.in/check.v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func getSamplePolicy(name, ns string) *cilium_v2.CiliumNetworkPolicy {
@@ -75,7 +76,7 @@ func (s *GroupsTestSuite) TestDerivativePoliciesAreDeletedIfNoToGroups(c *C) {
 
 	DerivativeCNP, err := createDerivativeCNP(cnp)
 	c.Assert(err, IsNil)
-	c.Assert(DerivativeCNP.Specs[0].Egress, DeepEquals, cnp.Spec.Egress)
+	c.Assert(DerivativeCNP.Specs[0].Egress, checker.DeepEquals, cnp.Spec.Egress)
 	c.Assert(len(DerivativeCNP.Specs), Equals, 1)
 }
 
@@ -115,6 +116,6 @@ func (s *GroupsTestSuite) TestDerivativePoliciesAreInheritCorrectly(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(DerivativeCNP.Spec, IsNil)
 	c.Assert(len(DerivativeCNP.Specs), Equals, 1)
-	c.Assert(DerivativeCNP.Specs[0].Egress[0].ToPorts, DeepEquals, cnp.Spec.Egress[0].ToPorts)
+	c.Assert(DerivativeCNP.Specs[0].Egress[0].ToPorts, checker.DeepEquals, cnp.Spec.Egress[0].ToPorts)
 	c.Assert(len(DerivativeCNP.Specs[0].Egress[0].ToGroups), Equals, 0)
 }

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -1397,7 +1397,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 	c.Assert(len(*policy), Equals, 2)
 	c.Assert(len((*policy)["80/TCP"].Endpoints), Equals, 2)
 	selWorld := (*policy)["80/TCP"].Endpoints[1]
-	c.Assert(api.EndpointSelectorSlice{selWorld}, DeepEquals, api.EntitySelectorMapping[api.EntityWorld])
+	c.Assert(api.EndpointSelectorSlice{selWorld}, checker.DeepEquals, api.EntitySelectorMapping[api.EntityWorld])
 
 	expectedPolicy := L4PolicyMap{
 		"9092/TCP": {
@@ -1519,7 +1519,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 	c.Assert(len(*policy), Equals, 2)
 	c.Assert(len((*policy)["80/TCP"].Endpoints), Equals, 2)
 	selWorld := (*policy)["80/TCP"].Endpoints[1]
-	c.Assert(api.EndpointSelectorSlice{selWorld}, DeepEquals, api.EntitySelectorMapping[api.EntityWorld])
+	c.Assert(api.EndpointSelectorSlice{selWorld}, checker.DeepEquals, api.EntitySelectorMapping[api.EntityWorld])
 
 	expectedPolicy := L4PolicyMap{
 		"9092/TCP": {

--- a/pkg/service/store_test.go
+++ b/pkg/service/store_test.go
@@ -17,6 +17,7 @@
 package service
 
 import (
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 
 	"gopkg.in/check.v1"
@@ -41,7 +42,7 @@ func (s *ServiceGenericSuite) TestClusterService(c *check.C) {
 	unmarshal := ClusterService{}
 	err = unmarshal.Unmarshal(b)
 	c.Assert(err, check.IsNil)
-	c.Assert(svc, check.DeepEquals, unmarshal)
+	c.Assert(svc, checker.DeepEquals, unmarshal)
 
 	c.Assert(svc.GetKeyName(), check.Equals, "default/bar/foo")
 }

--- a/pkg/versioned/map_test.go
+++ b/pkg/versioned/map_test.go
@@ -19,6 +19,7 @@ package versioned
 import (
 	"testing"
 
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/lock"
 
 	"gopkg.in/check.v1"
@@ -160,7 +161,7 @@ func (s *VersionedSuite) TestComparableMap_AddEqual(c *check.C) {
 			DeepEquals: tt.fields.deepEquals,
 		}
 		if got := m.AddEqual(tt.args.uuid, tt.args.obj); got != tt.want {
-			c.Assert(got, check.DeepEquals, tt.want, check.Commentf("Test name: %q", tt.name))
+			c.Assert(got, checker.DeepEquals, tt.want, check.Commentf("Test name: %q", tt.name))
 		}
 	}
 }
@@ -212,12 +213,12 @@ func (s *VersionedSuite) TestSyncComparableMap_DoLocked(c *check.C) {
 			cm:    tt.fields.cm,
 		}
 		if err := sm.Replace(tt.args.replace); (err != nil) != tt.wantErr {
-			c.Assert(err, check.DeepEquals, tt.wantErr, check.Commentf("Test name: %q", tt.name))
+			c.Assert(err, checker.DeepEquals, tt.wantErr, check.Commentf("Test name: %q", tt.name))
 		}
 		for _, v := range tt.functionsCalled {
 			switch v {
 			case "replace":
-				c.Assert(sm.cm, check.DeepEquals, m,
+				c.Assert(sm.cm, checker.DeepEquals, m,
 					check.Commentf("%s", "replace function was not called, otherwise the maps would be the same"))
 			}
 		}


### PR DESCRIPTION
Cilium defines its own DeepEquals checker in pkg/checker which gives a
more detailed trace than DeepEquals checker from gopkg.in/check.v1.

Signed-off-by: Michal Rostecki <mrostecki@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6452)
<!-- Reviewable:end -->
