### PR TITLE
Disable broken sphinx-version-warning

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -37,8 +37,8 @@ extensions = ['sphinx.ext.ifconfig',
     'sphinx.ext.extlinks',
     'sphinxcontrib.openapi',
     'sphinx_tabs.tabs',
-    'sphinxcontrib.spelling',
-    'versionwarning.extension' ]
+    'sphinxcontrib.spelling']
+#    'versionwarning.extension' ] <--- build is currently broken, see GH-6460
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
The doc build is currently broken because of this dependency:
```
Exception occurred:
  File "/home/vagrant/.local/lib/python2.7/site-packages/versionwarning/extension.py", line 5, in <module>
    from .signals import generate_versionwarning_data_json
  File "/home/vagrant/.local/lib/python2.7/site-packages/versionwarning/signals.py", line 41
    **{config.versionwarning_message_placeholder: '<a href="#"></a>'},
```

Related: #6460

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6461)
<!-- Reviewable:end -->
