### PR TITLE
agent: Avoid panic when more than one endpoint fails to restore

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -174,7 +174,8 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) {
 	// account for the new identity during the grace period. For this
 	// purpose, all endpoints being restored must already be in the
 	// endpoint list.
-	for i, ep := range state.restored {
+	for i := len(state.restored) - 1; i >= 0; i-- {
+		ep := state.restored[i]
 		// If the endpoint has local conntrack option enabled, then
 		// check whether the CT map needs upgrading (and do so).
 		if ep.Options.IsEnabled(option.ConntrackLocal) {


### PR DESCRIPTION
Branches 1.3 and 1.2 are not affected by this.

Fixes panic seen in PR #6464

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6468)
<!-- Reviewable:end -->
