### PR TITLE
etcd: Increase initial connection timeout to 15 minutes

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -59,7 +59,7 @@ var (
 
 	// initialConnectionTimeout  is the timeout for the initial connection to
 	// the etcd server
-	initialConnectionTimeout = 3 * time.Minute
+	initialConnectionTimeout = 15 * time.Minute
 
 	minRequiredVersion, _ = version.NewConstraint(">= 3.1.0")
 


### PR DESCRIPTION
Failing the agent can make it complicated to get everything up and running as
exponential backoff can cause cilium to not be running for a while which can
delay cilium-etcd from bootstrapping. This makes troubleshooting more
difficult.

Thus increase the timeout to 15 minutes to create a much larger overlap while
Cilium is up and running and etcd-operator can bring up a cluster in time.

Fixes: #6457

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6472)
<!-- Reviewable:end -->
