### PR TITLE
ipcache: Restrict deletions from original source

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1515,7 +1515,7 @@ func (d *Daemon) deletePodHostIP(pod *v1.Pod) (bool, error) {
 		return true, fmt.Errorf("ipcache entry not owned by kubernetes source")
 	}
 
-	ipcache.IPIdentityCache.Delete(pod.Status.PodIP)
+	ipcache.IPIdentityCache.Delete(pod.Status.PodIP, ipcache.FromKubernetes)
 
 	return false, nil
 }
@@ -1848,7 +1848,7 @@ func (d *Daemon) deleteK8sNodeV1(k8sNode *v1.Node) error {
 		return nil
 	}
 
-	ipcache.IPIdentityCache.Delete(ip)
+	ipcache.IPIdentityCache.Delete(ip, ipcache.FromKubernetes)
 
 	ciliumIP := net.ParseIP(ip)
 	if ciliumIP == nil {

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -45,7 +45,7 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	c.Assert(len(IPIdentityCache.identityToIPCache), Equals, 0)
 
 	// Deletion of key that doesn't exist doesn't cause panic.
-	IPIdentityCache.Delete(endpointIP)
+	IPIdentityCache.Delete(endpointIP, FromKVStore)
 
 	IPIdentityCache.Upsert(endpointIP, nil, Identity{
 		ID:     identity,
@@ -77,7 +77,7 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 1)
 	c.Assert(len(IPIdentityCache.identityToIPCache), Equals, 1)
 
-	IPIdentityCache.Delete(endpointIP)
+	IPIdentityCache.Delete(endpointIP, FromKVStore)
 
 	// Assure deletion occurs across both mappings.
 	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 0)
@@ -109,7 +109,7 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 		c.Assert(cachedIP, Equals, endpointIP)
 	}
 
-	IPIdentityCache.Delete(endpointIP)
+	IPIdentityCache.Delete(endpointIP, FromKVStore)
 
 	// Assure deletion occurs across both mappings.
 	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 0)
@@ -136,7 +136,7 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	cachedEndpointIPs, _ := IPIdentityCache.LookupByIdentity(29)
 	c.Assert(reflect.DeepEqual(cachedEndpointIPs, expectedIPList), Equals, true)
 
-	IPIdentityCache.Delete("27.2.2.2")
+	IPIdentityCache.Delete("27.2.2.2", FromKVStore)
 
 	expectedIPList = map[string]struct{}{
 		"127.0.0.1": {},
@@ -154,7 +154,7 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	c.Assert(exists, Equals, true)
 	c.Assert(cachedIdentity.ID, Equals, identityPkg.NumericIdentity(29))
 
-	IPIdentityCache.Delete("127.0.0.1")
+	IPIdentityCache.Delete("127.0.0.1", FromKVStore)
 
 	_, exists = IPIdentityCache.LookupByIdentity(29)
 	c.Assert(exists, Equals, false)
@@ -164,7 +164,7 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 
 	// Clean up.
 	for index := range endpointIPs {
-		IPIdentityCache.Delete(endpointIPs[index])
+		IPIdentityCache.Delete(endpointIPs[index], FromKVStore)
 		_, exists = IPIdentityCache.LookupByIP(endpointIPs[index])
 		c.Assert(exists, Equals, false)
 

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -417,7 +417,7 @@ restart:
 					// The key no longer exists in the
 					// local cache, it is safe to remove
 					// from the datapath ipcache.
-					IPIdentityCache.Delete(ip)
+					IPIdentityCache.Delete(ip, FromKVStore)
 				}
 			}
 


### PR DESCRIPTION
ipcache entries can be populated from various sources. Multiple sources can
provide conflicting IP entries. Prevent deletion of ipcache entries if the
source does not own the ipcache entry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6475)
<!-- Reviewable:end -->
