### PR TITLE
Clean up policymap

### DIFF
--- a/cilium/cmd/bpf_policy_get.go
+++ b/cilium/cmd/bpf_policy_get.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -97,14 +97,12 @@ func listMap(args []string) {
 }
 
 func dumpMap(file string) {
-
-	fd, err := bpf.ObjGet(file)
+	m, err := policymap.Open(file)
 	if err != nil {
-		Fatalf("%s\n", err)
+		Fatalf("Failed to open map: %s\n", err)
 	}
-	defer bpf.ObjClose(fd)
+	defer m.Close()
 
-	m := policymap.PolicyMap{Fd: fd}
 	statsMap, err := m.DumpToSlice()
 	if err != nil {
 		Fatalf("Error while opening bpf Map: %s\n", err)

--- a/cilium/cmd/helpers.go
+++ b/cilium/cmd/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -309,7 +309,7 @@ func parsePolicyUpdateArgsHelper(args []string) (*PolicyUpdateArgs, error) {
 // deleted.
 func updatePolicyKey(pa *PolicyUpdateArgs, add bool) {
 	policyMapPath := bpf.MapPath(policymap.MapName + pa.endpointID)
-	policyMap, _, err := policymap.OpenMap(policyMapPath)
+	policyMap, _, err := policymap.OpenOrCreate(policyMapPath)
 	if err != nil {
 		Fatalf("Cannot open policymap '%s' : %s", policyMapPath, err)
 	}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -69,11 +69,6 @@ func (e *Endpoint) PolicyMapPathLocked() string {
 	return e.mapPath(policymap.MapName)
 }
 
-// PolicyGlobalMapPathLocked returns the path to the global policy map.
-func (e *Endpoint) PolicyGlobalMapPathLocked() string {
-	return bpf.MapPath(PolicyGlobalMapName)
-}
-
 // CallsMapPathLocked returns the path to cilium tail calls map of an endpoint.
 func (e *Endpoint) CallsMapPathLocked() string {
 	return bpf.MapPath(CallsMapName + strconv.Itoa(int(e.ID)))
@@ -930,7 +925,7 @@ func (e *Endpoint) DeleteMapsLocked() []error {
 	}
 
 	// Remove handle_policy() tail call entry for EP
-	if err := e.RemoveFromGlobalPolicyMap(); err != nil {
+	if err := policymap.RemoveGlobalMapping(uint32(e.ID)); err != nil {
 		errors = append(errors, fmt.Errorf("unable to remove endpoint from global policy map: %s", err))
 	}
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -565,7 +565,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, regenContext *regenerationContext)
 
 	// Hook the endpoint into the endpoint and endpoint to policy tables then expose it
 	stats.mapSync.Start()
-	epErr := eppolicymap.WriteEndpoint(datapathRegenCtxt.epInfoCache.keys, e.PolicyMap.GetFd())
+	epErr := eppolicymap.WriteEndpoint(datapathRegenCtxt.epInfoCache.keys, e.PolicyMap)
 	err = lxcmap.WriteEndpoint(datapathRegenCtxt.epInfoCache)
 	stats.mapSync.End(err == nil)
 	if epErr != nil {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -52,7 +52,6 @@ import (
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/trigger"
-	"github.com/cilium/cilium/pkg/u8proto"
 
 	"github.com/sirupsen/logrus"
 
@@ -95,8 +94,6 @@ const (
 
 	// CallsMapName specifies the base prefix for EP specific call map.
 	CallsMapName = "cilium_calls_"
-	// PolicyGlobalMapName specifies the global tail call map for EP handle_policy() lookup.
-	PolicyGlobalMapName = "cilium_policy"
 	// IpvlanMapName specifies the tail call map for EP on egress used with ipvlan.
 	IpvlanMapName = "cilium_lxc_ipve_"
 
@@ -1037,19 +1034,6 @@ func ParseEndpoint(strEp string) (*Endpoint, error) {
 	ep.SetStateLocked(StateRestoring, "Endpoint restoring")
 
 	return &ep, nil
-}
-
-func (e *Endpoint) RemoveFromGlobalPolicyMap() error {
-	gpm, err := policymap.OpenGlobalMap(e.PolicyGlobalMapPathLocked())
-	if err == nil {
-		// We need to remove ourselves from global map, so that
-		// resources (prog/map reference counts) can be released.
-		gpm.Delete(uint32(e.ID), policymap.AllPorts, u8proto.All, trafficdirection.Ingress)
-		gpm.Delete(uint32(e.ID), policymap.AllPorts, u8proto.All, trafficdirection.Egress)
-		gpm.Close()
-	}
-
-	return err
 }
 
 func (e *Endpoint) LogStatus(typ StatusType, code StatusCode, msg string) {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1268,7 +1268,7 @@ func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup
 
 	if e.PolicyMap != nil {
 		if err := e.PolicyMap.Close(); err != nil {
-			errors = append(errors, fmt.Errorf("unable to close policymap %s: %s", e.PolicyGlobalMapPathLocked(), err))
+			errors = append(errors, fmt.Errorf("unable to close policymap %s: %s", e.PolicyMap.String(), err))
 		}
 	}
 

--- a/pkg/maps/eppolicymap/eppolicymap.go
+++ b/pkg/maps/eppolicymap/eppolicymap.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -104,11 +104,7 @@ func newEndpointKey(ip net.IP) *endpointKey {
 	}
 }
 
-// WriteEndpoint writes the policy map file descriptor into the map so that
-// the datapath side can do a lookup from endpointKey->PolicyMap. Locking is
-// handled in the usual way via Map lock. If sockops is disabled this will be
-// a nop.
-func WriteEndpoint(keys []*lxcmap.EndpointKey, fd int) error {
+func writeEndpoint(keys []*lxcmap.EndpointKey, fd int) error {
 	if option.Config.SockopsEnable == false {
 		return nil
 	}
@@ -126,4 +122,12 @@ func WriteEndpoint(keys []*lxcmap.EndpointKey, fd int) error {
 		}
 	}
 	return nil
+}
+
+// WriteEndpoint writes the policy map file descriptor into the map so that
+// the datapath side can do a lookup from endpointKey->PolicyMap. Locking is
+// handled in the usual way via Map lock. If sockops is disabled this will be
+// a nop.
+func WriteEndpoint(keys []*lxcmap.EndpointKey, pm *policymap.PolicyMap) error {
+	return writeEndpoint(keys, pm.GetFd())
 }

--- a/pkg/maps/eppolicymap/eppolicymap_test.go
+++ b/pkg/maps/eppolicymap/eppolicymap_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -72,9 +72,9 @@ func (e *EPPolicyMapTestSuite) TestWriteEndpoint(c *C) {
 	}
 
 	CreateEPPolicyMap()
-	err = WriteEndpoint(keys, fd)
+	err = writeEndpoint(keys, fd)
 	c.Assert(err, Not(IsNil))
-	err = WriteEndpoint(many, fd)
+	err = writeEndpoint(many, fd)
 	c.Assert(err, Not(IsNil))
 }
 
@@ -93,7 +93,7 @@ func (e *EPPolicyMapTestSuite) TestWriteEndpointFails(c *C) {
 
 	keys[0] = lxcmap.NewEndpointKey(net.ParseIP("1.2.3.4"))
 	CreateEPPolicyMap()
-	err = WriteEndpoint(keys, -1)
+	err = writeEndpoint(keys, -1)
 	c.Assert(err, Not(IsNil))
 }
 
@@ -109,6 +109,6 @@ func (e *EPPolicyMapTestSuite) TestWriteEndpointDisabled(c *C) {
 
 	keys[0] = lxcmap.NewEndpointKey(net.ParseIP("1.2.3.4"))
 	CreateEPPolicyMap()
-	err = WriteEndpoint(keys, fd)
+	err = writeEndpoint(keys, fd)
 	c.Assert(err, IsNil)
 }

--- a/pkg/maps/policymap/callmap.go
+++ b/pkg/maps/policymap/callmap.go
@@ -1,0 +1,75 @@
+// Copyright 2018-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policymap
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/cilium/cilium/pkg/bpf"
+)
+
+// PolicyPlumbingMap maps endpoint IDs to the fd for the program which
+// implements its policy.
+type PolicyPlumbingMap struct {
+	*bpf.Map
+}
+
+type plumbingKey struct {
+	key uint32
+}
+
+type plumbingValue struct {
+	fd uint32
+}
+
+func (k *plumbingKey) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
+func (k *plumbingKey) NewValue() bpf.MapValue    { return &plumbingValue{} }
+
+func (k *plumbingKey) String() string {
+	return fmt.Sprintf("Endpoint: %d", k.key)
+}
+
+func (v *plumbingValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
+
+func (v *plumbingValue) String() string {
+	return fmt.Sprintf("fd: %d", v.fd)
+}
+
+// RemoveGlobalMapping removes the mapping from the specified endpoint ID to
+// the BPF policy program for that endpoint.
+func RemoveGlobalMapping(id uint32) error {
+	gpm, err := OpenCallMap()
+	if err == nil {
+		k := plumbingKey{
+			key: id,
+		}
+		err = gpm.Map.Delete(&k)
+		gpm.Close()
+	}
+
+	return err
+}
+
+// OpenCallMap opens the map that maps endpoint IDs to program file
+// descriptors, which allows tail calling into the policy datapath code from
+// other BPF programs.
+func OpenCallMap() (*PolicyPlumbingMap, error) {
+	m, err := bpf.OpenMap(CallMapName)
+	if err != nil {
+		return nil, err
+	}
+	return &PolicyPlumbingMap{Map: m}, nil
+}

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -332,13 +332,3 @@ func OpenMap(path string) (*PolicyMap, bool, error) {
 
 	return m, isNewMap, nil
 }
-
-func OpenGlobalMap(path string) (*PolicyMap, error) {
-	fd, err := bpf.ObjGet(path)
-	if err != nil {
-		return nil, err
-	}
-
-	m := &PolicyMap{path: path, Fd: fd}
-	return m, nil
-}


### PR DESCRIPTION
`pkg/maps/policymap` has been reimplementing the core `pkg/bpf/` map logic for some time now, and recently caused some issues when attempting to rework the common core code to adjust map handling.

This PR looks to rework the policymap so that it uses the latest version of the libraries provided in `pkg/bpf`, and also clarifies the global policy map types by factoring that out into its own file with its own map handling logic.

Fixes: #681 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6476)
<!-- Reviewable:end -->
