### PR TITLE
loader: Fix race condition in unit test

### DIFF
--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -35,7 +35,7 @@ type LoaderTestSuite struct{}
 
 var (
 	_              = Suite(&LoaderTestSuite{})
-	contextTimeout = 5 * time.Minute
+	contextTimeout = 10 * time.Second
 
 	dirInfo *directoryInfo
 	ep      = &testEP{}
@@ -175,7 +175,11 @@ func (s *LoaderTestSuite) TestCompileFailure(c *C) {
 		}
 	}()
 
-	err := compileAndLoad(ctx, ep, dirInfo)
+	timeout := time.Now().Add(contextTimeout)
+	var err error
+	for err == nil && time.Now().Before(timeout) {
+		err = compileAndLoad(ctx, ep, dirInfo)
+	}
 	c.Assert(err, NotNil)
 }
 


### PR DESCRIPTION
The compile failure unit test could fail if the scheduling of the
goroutine is delayed for longer than the time that it takes to compile
the datapath. Work around this by continually attempting to compile the
datapath until either the test timeout is reached or an error occurs
(indicating that the cancel operated correctly).

Also, reduce the maximum timeout. It doesn't need to wait 5 minutes to
validate this behaviour.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6483)
<!-- Reviewable:end -->
