### PR TITLE
kubernetes: Disable IPv6 for real

### DIFF
--- a/examples/kubernetes/1.10/cilium-cm.yaml
+++ b/examples/kubernetes/1.10/cilium-cm.yaml
@@ -32,7 +32,7 @@ data:
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "true"
+  enable-ipv6: "false"
 
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -32,7 +32,7 @@ data:
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "true"
+  enable-ipv6: "false"
 
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -32,7 +32,7 @@ data:
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "true"
+  enable-ipv6: "false"
 
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent

--- a/examples/kubernetes/1.11/cilium-cm.yaml
+++ b/examples/kubernetes/1.11/cilium-cm.yaml
@@ -32,7 +32,7 @@ data:
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "true"
+  enable-ipv6: "false"
 
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -32,7 +32,7 @@ data:
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "true"
+  enable-ipv6: "false"
 
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -32,7 +32,7 @@ data:
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "true"
+  enable-ipv6: "false"
 
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent

--- a/examples/kubernetes/1.12/cilium-cm.yaml
+++ b/examples/kubernetes/1.12/cilium-cm.yaml
@@ -32,7 +32,7 @@ data:
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "true"
+  enable-ipv6: "false"
 
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -32,7 +32,7 @@ data:
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "true"
+  enable-ipv6: "false"
 
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -32,7 +32,7 @@ data:
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "true"
+  enable-ipv6: "false"
 
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent

--- a/examples/kubernetes/1.13/cilium-cm.yaml
+++ b/examples/kubernetes/1.13/cilium-cm.yaml
@@ -32,7 +32,7 @@ data:
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "true"
+  enable-ipv6: "false"
 
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -32,7 +32,7 @@ data:
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "true"
+  enable-ipv6: "false"
 
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -32,7 +32,7 @@ data:
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "true"
+  enable-ipv6: "false"
 
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent

--- a/examples/kubernetes/1.8/cilium-cm.yaml
+++ b/examples/kubernetes/1.8/cilium-cm.yaml
@@ -32,7 +32,7 @@ data:
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "true"
+  enable-ipv6: "false"
 
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -32,7 +32,7 @@ data:
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "true"
+  enable-ipv6: "false"
 
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -32,7 +32,7 @@ data:
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "true"
+  enable-ipv6: "false"
 
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent

--- a/examples/kubernetes/1.9/cilium-cm.yaml
+++ b/examples/kubernetes/1.9/cilium-cm.yaml
@@ -32,7 +32,7 @@ data:
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "true"
+  enable-ipv6: "false"
 
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -32,7 +32,7 @@ data:
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "true"
+  enable-ipv6: "false"
 
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -32,7 +32,7 @@ data:
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "true"
+  enable-ipv6: "false"
 
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent

--- a/examples/kubernetes/templates/v1/cilium-cm.yaml
+++ b/examples/kubernetes/templates/v1/cilium-cm.yaml
@@ -32,7 +32,7 @@ data:
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "true"
+  enable-ipv6: "false"
 
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent


### PR DESCRIPTION
Commit 5104ff68d429 intended to disable IPv6 for new deployments but kept the
default as-is.

Fixes: 5104ff68d429 ("kubernetes: Disable IPv6 by default for new deployments")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6488)
<!-- Reviewable:end -->
