### PR TITLE
examples: update docker-compose guide

### DIFF
--- a/examples/getting-started/README.rst
+++ b/examples/getting-started/README.rst
@@ -6,23 +6,31 @@ simply run ``vagrant up`` and then log into the VM with ``vagrant ssh``.
 
 For further instructions, please see the `Getting started guide`_.
 
-.. _Getting started guide: http://cilium.readthedocs.io/en/doc-1.0/gettingstarted/docker
+.. _Getting started guide: https://cilium.readthedocs.io/en/latest/gettingstarted/docker
 
 ::
 
     $ vagrant up
-    Bringing machine 'cilium-1' up with 'virtualbox' provider...
+    Bringing machine 'default' up with 'virtualbox' provider...
     [...]
-    ==> cilium-1: cilium-kvstore is up-to-date
-    ==> cilium-1: Recreating cilium
-    ==> cilium-1: Recreating cilium-docker-plugin
+    ==> default: cilium-kvstore is up-to-date
+    ==> default: Recreating cilium
+    ==> default: Recreating cilium-docker-plugin
 
     $ vagrant ssh
-    Welcome to Ubuntu 16.10 (GNU/Linux 4.8.0-41-generic x86_64)
+    Welcome to Ubuntu 18.04.1 LTS (GNU/Linux 4.15.0-29-generic x86_64)
     [...]
 
-    vagrant@cilium-1:~/cilium/examples/getting-started$ cilium status
-    KVStore:            Ok
-    ContainerRuntime:   Ok
-    Kubernetes:         Disabled
-    Cilium:             Ok
+    vagrant@vagrant:~/cilium/examples/getting-started$ cilium status
+    KVStore:                Ok         Consul: 172.18.0.2:8300
+    ContainerRuntime:       Ok         docker daemon: OK
+    Kubernetes:             Disabled
+    Cilium:                 Ok         OK
+    NodeMonitor:            Disabled
+    Cilium health daemon:   Ok
+    IPv4 address pool:      3/65535 allocated
+    IPv6 address pool:      2/65535 allocated
+    Controller Status:      13/13 healthy
+    Proxy Status:           OK, ip 10.15.0.1, port-range 10000-20000
+    Cluster health:   1/1 reachable   (2018-12-20T15:06:09Z)
+

--- a/examples/getting-started/Vagrantfile
+++ b/examples/getting-started/Vagrantfile
@@ -3,14 +3,14 @@
 
 Vagrant.require_version ">= 2.0.0"
 
-cilium_version = (ENV['CILIUM_VERSION'] || "v1.2.0")
-cilium_opts = (ENV['CILIUM_OPTS'] || "--kvstore consul --kvstore-opt consul.address 192.168.33.11:8500 -t vxlan")
-cilium_tag = (ENV['CILIUM_TAG'] || "v1.2.0")
+cilium_version = (ENV['CILIUM_VERSION'] || "v1.3.1")
+cilium_opts = (ENV['CILIUM_OPTS'] || "--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 -t vxlan")
+cilium_tag = (ENV['CILIUM_TAG'] || "v1.3.1")
 
 # This runs only once when vagrant box is provisioned for the first time
 $bootstrap = <<SCRIPT
 # install docker-compose
-curl -sS -L "https://github.com/docker/compose/releases/download/1.11.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+curl -sS -L "https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 chmod +x /usr/local/bin/docker-compose
 
 # install cilium client
@@ -35,7 +35,7 @@ sudo -E docker-compose up -d --remove-orphans
 SCRIPT
 
 Vagrant.configure(2) do |config|
-    config.vm.box = "bento/ubuntu-17.10"
+    config.vm.box = "bento/ubuntu-18.04"
 
     # http://foo-o-rama.com/vagrant--stdin-is-not-a-tty--fix.html
     config.vm.provision "fix-no-tty", type: "shell" do |s|
@@ -49,6 +49,7 @@ Vagrant.configure(2) do |config|
         # Do not inherit DNS server from host, use proxy
         vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
         vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+        vb.memory = 2048
     end
 
     # install docker runtime


### PR DESCRIPTION
Previously, [the docker-compose example](https://cilium.readthedocs.io/en/latest/gettingstarted/docker/) was failing when running `vagrant up`:

```
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

curl -sSL https://get.docker.com/ | sh

Stdout from the command:

# Executing docker install script, commit: 4957679


Stderr from the command:


Either your platform is not easily detectable or is not supported by this
installer script.
Please visit the following URL for more detailed installation instructions:

https://docs.docker.com/engine/installation/
```

This PR fixes the failure and adds more improvements.

- Update Ubuntu to 18.04 LTS.
- Update cilium to v1.3.1.
- Update docker-compose to v1.23.2.
- Increase VM memory to 2048mb to avoid ENOMEMs.
- Fix cilium-agent command line params.

Signed-off-by: Martynas Pumputis <martynas@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6489)
<!-- Reviewable:end -->
