### PR TITLE
agent: Increase node init timeout to 15 minutes

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -117,4 +117,8 @@ const (
 
 	// MonitorQueueSize is the default value for the monitor queue size
 	MonitorQueueSize = 32768
+
+	// NodeInitTimeout is the time the agent is waiting until giving up to
+	// initialize the local node with the kvstore
+	NodeInitTimeout = 15 * time.Minute
 )

--- a/pkg/node/local_node.go
+++ b/pkg/node/local_node.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -76,7 +77,7 @@ func configureLocalNode() {
 	go func() {
 		select {
 		case <-nodeRegistered:
-		case <-time.NewTimer(3 * time.Minute).C:
+		case <-time.NewTimer(defaults.NodeInitTimeout).C:
 			log.Fatalf("Unable to initialize local node due timeout")
 		}
 	}()


### PR DESCRIPTION
On smaller clusters, the etcd operator can take a while to spin up the entire
cluster. Increase the node init timeout to 15 minutes to avoid running in this
timeout prematurely and requiring to restart the agent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6492)
<!-- Reviewable:end -->
