### PR TITLE
DNS Proxy emits error monitor events & proxy metrics

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -83,7 +83,7 @@ func (s *DNSProxyTestSuite) SetUpSuite(c *C) {
 		func(ip net.IP) (endpointID string, err error) {
 			return "endpoint1", nil
 		},
-		func(lookupTime time.Time, srcAddr, dstAddr string, msg *dns.Msg, protocol string, allowed bool) error {
+		func(lookupTime time.Time, srcAddr, dstAddr string, msg *dns.Msg, protocol string, allowed bool, proxyErr error) error {
 			return nil
 		})
 	c.Assert(err, IsNil, Commentf("error starting DNS Proxy"))


### PR DESCRIPTION
Processing a DNS request requires a number of steps that may fail. We
now emit error events, and send a REFUSED response when this occurs.
This is more in-line with our other proxies.
Note: This doesn't emit an event when the packet parsing fails. That is
handled by miekg/dns and it always just drops the request and lets it
time out.

The DNS proxy now also emits metrics like other proxies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6498)
<!-- Reviewable:end -->
