### PR TITLE
iptables: Fix iptables removal logic on bootstrap

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -102,7 +102,11 @@ func removeCiliumRules(table string) {
 		rule := scanner.Text()
 		log.WithField(logfields.Object, logfields.Repr(rule)).Debug("Considering removing iptables rule")
 
-		if strings.Contains(strings.ToLower(rule), "cilium") {
+		// All rules installed by cilium either belong to a chain with
+		// the name CILIUM_ or call a chain with the name CILIUM_:
+		// -A CILIUM_FORWARD -o cilium_host -m comment --comment "cilium: any->cluster on cilium_host forward accept" -j ACCEPT
+		// -A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST" -j CILIUM_POST
+		if strings.Contains(rule, "CILIUM_") {
 			reversedRule, err := reverseRule(rule)
 			if err != nil {
 				log.WithError(err).WithField(logfields.Object, rule).Warn("Unable to parse iptables rule into slice. Leaving rule behind.")


### PR DESCRIPTION
The existing legacy rule removal logic on bootstrap removed all rules which
contain the word "cilium". While this removed Cilium relevant rules, it also
incorrectly removed rules installed by the portmap/hostport plugin if the
plugin was configured with a name that contained the string cilium.

Example CNI configuration:
```
    {
      "cniVersion": "0.3.1",
        "name": "cilium-portmap",
        "plugins": [
          {
            "type": "cilium-cni"
          },
          {
            "type": "portmap",
            "capabilities": { "portMappings": true }
          }
        ]
    }
```

Example of incorrectly removed rule:
-A CNI-HOSTPORT-DNAT -m comment --comment "dnat name: \"cilium-portmap\" id: \"95dc537b9152da5f91be3fc5692bf91592bf1871b6e61755aed2056a03e98c4f\"" -j CNI-DN-258a52f03b4b7aa8abdc5

The fix is to be more restrictive in selecting rules to remove and limit it to
rules which contain the string "CILIUM_".

Fixes: #6499

Signed-off-by: Thomas Graf <thomas@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6502)
<!-- Reviewable:end -->
