### PR TITLE
Test: FQDN add dnssec test.

### DIFF
--- a/test/helpers/docker.go
+++ b/test/helpers/docker.go
@@ -30,6 +30,19 @@ func (s *SSHMeta) ContainerExec(name string, cmd string, optionalArgs ...string)
 	return s.Exec(dockerCmd)
 }
 
+// ContainerRun is a wrapper to a one execution docker run container. It runs
+// an instance of the specific Docker image with the provided network, name and
+// options.
+func (s *SSHMeta) ContainerRun(name, image, net, options string, cmdParams ...string) *CmdRes {
+	cmdOnStart := ""
+	if len(cmdParams) > 0 {
+		cmdOnStart = strings.Join(cmdParams, " ")
+	}
+	cmd := fmt.Sprintf(
+		"docker run --name %s --net %s %s %s %s", name, net, options, image, cmdOnStart)
+	return s.ExecWithSudo(cmd)
+}
+
 // ContainerCreate is a wrapper for `docker run`. It runs an instance of the
 // specified Docker image with the provided network, name, options and container
 // startup commands.


### PR DESCRIPTION
This add the support of testing DNSSEC responses.

The non use of curl is because dnssec is not supported in
`getaddrInfo()` so a new small container made the call using a small
python client.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

This PR is still wip waiting for: 

- https://github.com/cilium/docker-bind/pull/1
- Transfer eloycoto/dnssec-client to cilium and create container. 
- Update packer-ci-build. 
- Update vagrant image to contain new images.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6503)
<!-- Reviewable:end -->
