### PR TITLE
Backport 1.3 Service account manifest changes

### DIFF
--- a/examples/kubernetes/1.10/cilium-rbac.yaml
+++ b/examples/kubernetes/1.10/cilium-rbac.yaml
@@ -77,3 +77,9 @@ rules:
       - ciliumendpoints/status
     verbs:
       - "*"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium
+  namespace: kube-system

--- a/examples/kubernetes/1.10/cilium-sa.yaml
+++ b/examples/kubernetes/1.10/cilium-sa.yaml
@@ -1,6 +1,0 @@
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium
-  namespace: kube-system

--- a/examples/kubernetes/1.11/cilium-rbac.yaml
+++ b/examples/kubernetes/1.11/cilium-rbac.yaml
@@ -77,3 +77,9 @@ rules:
       - ciliumendpoints/status
     verbs:
       - "*"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium
+  namespace: kube-system

--- a/examples/kubernetes/1.11/cilium-sa.yaml
+++ b/examples/kubernetes/1.11/cilium-sa.yaml
@@ -1,6 +1,0 @@
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium
-  namespace: kube-system

--- a/examples/kubernetes/1.12/cilium-rbac.yaml
+++ b/examples/kubernetes/1.12/cilium-rbac.yaml
@@ -77,3 +77,9 @@ rules:
       - ciliumendpoints/status
     verbs:
       - "*"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium
+  namespace: kube-system

--- a/examples/kubernetes/1.12/cilium-sa.yaml
+++ b/examples/kubernetes/1.12/cilium-sa.yaml
@@ -1,6 +1,0 @@
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium
-  namespace: kube-system

--- a/examples/kubernetes/1.13/cilium-rbac.yaml
+++ b/examples/kubernetes/1.13/cilium-rbac.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium
+rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - nodes
+  - endpoints
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/status
+  - ciliumendpoints
+  - ciliumendpoints/status
+  verbs:
+  - '*'
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium
+  namespace: kube-system

--- a/examples/kubernetes/1.8/cilium-rbac.yaml
+++ b/examples/kubernetes/1.8/cilium-rbac.yaml
@@ -77,3 +77,9 @@ rules:
       - ciliumendpoints/status
     verbs:
       - "*"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium
+  namespace: kube-system

--- a/examples/kubernetes/1.8/cilium-sa.yaml
+++ b/examples/kubernetes/1.8/cilium-sa.yaml
@@ -1,6 +1,0 @@
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium
-  namespace: kube-system

--- a/examples/kubernetes/1.9/cilium-rbac.yaml
+++ b/examples/kubernetes/1.9/cilium-rbac.yaml
@@ -77,3 +77,9 @@ rules:
       - ciliumendpoints/status
     verbs:
       - "*"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium
+  namespace: kube-system

--- a/examples/kubernetes/1.9/cilium-sa.yaml
+++ b/examples/kubernetes/1.9/cilium-sa.yaml
@@ -1,6 +1,0 @@
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium
-  namespace: kube-system

--- a/examples/kubernetes/Makefile
+++ b/examples/kubernetes/Makefile
@@ -66,7 +66,6 @@ transform: cilium-rbac.yaml.sed \
     cilium-crio-ds.yaml.sed \
     cilium-ds.yaml.sed \
     cilium-pre-flight.yaml.sed \
-    cilium-rbac.yaml.sed \
-    cilium-sa.yaml
+    cilium-rbac.yaml.sed
 
 .PHONY: transform cilium.yaml

--- a/examples/kubernetes/Makefile
+++ b/examples/kubernetes/Makefile
@@ -65,7 +65,6 @@ transform: cilium-rbac.yaml.sed \
     cilium-cm.yaml \
     cilium-crio-ds.yaml.sed \
     cilium-ds.yaml.sed \
-    cilium-pre-flight.yaml.sed \
-    cilium-rbac.yaml.sed
+    cilium-pre-flight.yaml.sed
 
 .PHONY: transform cilium.yaml

--- a/examples/kubernetes/README.rst
+++ b/examples/kubernetes/README.rst
@@ -41,9 +41,8 @@ are 5 files:
   the Kubernetes cluster in combination with Istio, some advanced options can
   be changed here.
 
-- :code:`cilium-rbac.yaml` - The Cilium's RBAC for the Kubernetes cluster.
-
-- :code:`cilium-sa.yaml` - The Cilium's Kubernetes :code:`ServiceAccount`.
+- :code:`cilium-rbac.yaml` - The RBAC rules and ServiceAcccount to grant Cilium
+  the required access to the Kubernetes apiserver.
 
 - :code:`cilium.yaml` - All previous files concatenated into a single file,
   useful to deploy Cilium in a minikube environment with a "single line" command.

--- a/examples/kubernetes/templates/v1/cilium-rbac.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-rbac.yaml.sed
@@ -77,3 +77,9 @@ rules:
       - ciliumendpoints/status
     verbs:
       - "*"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium
+  namespace: kube-system

--- a/examples/kubernetes/templates/v1/cilium-sa.yaml
+++ b/examples/kubernetes/templates/v1/cilium-sa.yaml
@@ -1,6 +1,0 @@
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium
-  namespace: kube-system

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -821,10 +821,6 @@ func (kub *Kubectl) ciliumInstall(dsPatchName, cmPatchName string, getK8sDescrip
 	if rbacPathname == "" {
 		return fmt.Errorf("Cilium RBAC descriptor not found")
 	}
-	saPathname := getK8sDescriptor("cilium-sa.yaml")
-	if saPathname == "" {
-		return fmt.Errorf("Cilium ServiceAccount descriptor not found")
-	}
 
 	deployOriginal := func(original string) error {
 		// debugYaml only dumps the full created yaml file to the test output if
@@ -846,10 +842,6 @@ func (kub *Kubectl) ciliumInstall(dsPatchName, cmPatchName string, getK8sDescrip
 			return res.GetErr("Cannot apply Cilium manifest")
 		}
 		return nil
-	}
-
-	if err := deployOriginal(saPathname); err != nil {
-		return err
 	}
 
 	if err := deployOriginal(rbacPathname); err != nil {


### PR DESCRIPTION
Backporting https://github.com/cilium/cilium/pull/6494 because if in master the first test to run was the update one, cilium-sa.yaml was not installed in master because it is not in master, and cilium 1.3 daemon set cannot be started pods due no service account. 

Jenkins build reference: 
https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/5304/execution/node/103/log/?consoleFull

DS status: 

```
Events:
  Type     Reason        Age                 From        Message
  ----     ------        ----                ----        -------
Warning FailedCreate 11s (x14 over 52s) daemon-set Error creating: pods "cilium-" is forbidden: service account kube-system/cilium was not found, retry after the service account is created
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6507)
<!-- Reviewable:end -->
