### PR TITLE
Test: Fix kubectl.CiliumPolicyAction to work with CNP derivatives

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -128,38 +128,6 @@ func (kub *Kubectl) GetNumNodes() int {
 	return len(strings.Split(res.SingleOut(), " "))
 }
 
-// WaitForEnforcingCNP waits for the CNP with the specified to go into
-// enforcing mode on all nodes
-func (kub *Kubectl) WaitForEnforcingCNP(cnpName, namespace string) error {
-	numNodes := kub.GetNumNodes()
-
-	body := func() bool {
-		cnpCMD := fmt.Sprintf("%s get cnp -n %s %s -o jsonpath='{.status.nodes.*.enforcing}'", KubectlCmd, namespace, cnpName)
-		res := kub.Exec(cnpCMD)
-		if !res.WasSuccessful() {
-			return false
-		}
-
-		enforcingState := strings.Split(res.SingleOut(), " ")
-		if len(enforcingState) != numNodes {
-			return false
-		}
-
-		for _, state := range enforcingState {
-			if state != "true" {
-				return false
-			}
-		}
-
-		return true
-	}
-
-	// Wait for CNP to go into enforcing mode.
-	// - 30s timeout
-	// - 1s interval
-	return WithTimeout(body, "CNP not enforcing after timeout", &TimeoutConfig{Timeout: 30, Ticker: 1})
-}
-
 // WaitCEPReady waits until all Cilium endpoints are sync in Kubernetes resource.
 func (kub *Kubectl) WaitCEPReady() error {
 	pods, err := kub.GetCiliumPods(KubeSystemNamespace)


### PR DESCRIPTION
Make a refactor on CiliumPolicyAction to make sure that the policy is
enforced correctly and all other policies are in the rigth status.

In case of kubernetes network policies, it'll check that the policy is
loaded in the cilium agent due no status.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6513)
<!-- Reviewable:end -->
