### PR TITLE
endpoint: Restore pod/namespace from state

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -197,8 +197,11 @@ type Endpoint struct {
 	// compiled and installed.
 	bpfHeaderfileHash string
 
-	k8sPodName   string
-	k8sNamespace string
+	// K8sPodName is the Kubernetes pod name of the endpoint
+	K8sPodName string
+
+	// K8sNamespace is the Kubernetes namespace of the endpoint
+	K8sNamespace string
 
 	// policyRevision is the policy revision this endpoint is currently on
 	// to modify this field please use endpoint.setPolicyRevision instead
@@ -402,8 +405,8 @@ func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, 
 		DockerNetworkID:  base.DockerNetworkID,
 		DockerEndpointID: base.DockerEndpointID,
 		IfName:           base.InterfaceName,
-		k8sPodName:       base.K8sPodName,
-		k8sNamespace:     base.K8sNamespace,
+		K8sPodName:       base.K8sPodName,
+		K8sNamespace:     base.K8sNamespace,
 		IfIndex:          int(base.InterfaceIndex),
 		OpLabels:         pkgLabels.NewOpLabels(),
 		state:            "",
@@ -1457,7 +1460,7 @@ func (e *Endpoint) SetContainerName(name string) {
 // Kubernetes pod
 func (e *Endpoint) GetK8sNamespace() string {
 	e.UnconditionalRLock()
-	ns := e.k8sNamespace
+	ns := e.K8sNamespace
 	e.RUnlock()
 	return ns
 }
@@ -1465,7 +1468,7 @@ func (e *Endpoint) GetK8sNamespace() string {
 // SetK8sNamespace modifies the endpoint's pod name
 func (e *Endpoint) SetK8sNamespace(name string) {
 	e.UnconditionalLock()
-	e.k8sNamespace = name
+	e.K8sNamespace = name
 	e.UpdateLogger(map[string]interface{}{
 		logfields.K8sPodName: e.GetK8sNamespaceAndPodNameLocked(),
 	})
@@ -1476,7 +1479,7 @@ func (e *Endpoint) SetK8sNamespace(name string) {
 // Kubernetes pod
 func (e *Endpoint) GetK8sPodName() string {
 	e.UnconditionalRLock()
-	k8sPodName := e.k8sPodName
+	k8sPodName := e.K8sPodName
 	e.RUnlock()
 
 	return k8sPodName
@@ -1485,13 +1488,13 @@ func (e *Endpoint) GetK8sPodName() string {
 // GetK8sNamespaceAndPodNameLocked returns the namespace and pod name.  This
 // function requires e.Mutex to be held.
 func (e *Endpoint) GetK8sNamespaceAndPodNameLocked() string {
-	return e.k8sNamespace + "/" + e.k8sPodName
+	return e.K8sNamespace + "/" + e.K8sPodName
 }
 
 // SetK8sPodName modifies the endpoint's pod name
 func (e *Endpoint) SetK8sPodName(name string) {
 	e.UnconditionalLock()
-	e.k8sPodName = name
+	e.K8sPodName = name
 	e.UpdateLogger(map[string]interface{}{
 		logfields.K8sPodName: e.GetK8sNamespaceAndPodNameLocked(),
 	})

--- a/pkg/workloads/cri.go
+++ b/pkg/workloads/cri.go
@@ -270,11 +270,7 @@ func (c *criClient) handleCreateWorkload(id string, retry bool) {
 
 		ep.SetContainerID(id)
 
-		// In Kubernetes mode, attempt to retrieve pod name stored in
-		// pod runtime label
-		//
-		// FIXME: Abstract via interface so other workload types can
-		// implement this
+		// FIXME: Remove this in 2019-06: GH-6526
 		if k8s.IsEnabled() {
 			ep.SetK8sNamespace(k8sLbls.GetPodNamespace(pod.Labels))
 			ep.SetK8sPodName(k8sLbls.GetPodName(pod.Labels))

--- a/pkg/workloads/docker.go
+++ b/pkg/workloads/docker.go
@@ -478,11 +478,7 @@ func (d *dockerClient) handleCreateWorkload(id string, retry bool) {
 		// Docker appends '/' to container names.
 		ep.SetContainerName(strings.Trim(containerName, "/"))
 
-		// In Kubernetes mode, attempt to retrieve pod name stored in
-		// container runtime label
-		//
-		// FIXME: Abstract via interface so other workload types can
-		// implement this
+		// FIXME: Remove this in 2019-06: GH-6526
 		if k8s.IsEnabled() {
 			if dockerContainer.Config != nil {
 				ep.SetK8sNamespace(k8sDockerLbls.GetPodNamespace(dockerContainer.Config.Labels))


### PR DESCRIPTION
The pod and namespace name is set via the CNI plugin. There is no reason to
overwrite it via the workloads API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6514)
<!-- Reviewable:end -->
