### PR TITLE
Test: First bootstrap of Kubernetes FQDN test

### DIFF
--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -1,0 +1,187 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sTest
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
+
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("K8sFQDNTest", func() {
+	var (
+		kubectl          *helpers.Kubectl
+		microscopeErr    error
+		microscopeCancel                    = func() error { return nil }
+		backgroundCancel context.CancelFunc = func() { return }
+		backgroundError  error
+
+		bindManifest = helpers.ManifestGet("bind_deployment.yaml")
+		demoManifest = helpers.ManifestGet("demo.yaml")
+
+		apps    = []string{helpers.App2, helpers.App3}
+		appPods map[string]string
+
+		worldTarget          = "http://world1.cilium.test"
+		worldTargetIP        = "192.168.9.10"
+		worldInvalidTarget   = "http://world2.cilium.test"
+		worldInvalidTargetIP = "192.168.9.11"
+	)
+
+	BeforeAll(func() {
+		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+		ProvisionInfraPods(kubectl)
+
+		bindManifest = helpers.ManifestGet("bind_deployment.yaml")
+
+		res := kubectl.Apply(bindManifest)
+		res.ExpectSuccess("Bind config cannot be deployed")
+
+		res = kubectl.Apply(demoManifest)
+		res.ExpectSuccess("Demo config cannot be deployed")
+
+		err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", helpers.HelperTimeout)
+		Expect(err).Should(BeNil(), "Testapp is not ready after timeout")
+
+		appPods = helpers.GetAppPods(apps, helpers.DefaultNamespace, kubectl, "id")
+
+		err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=bind", helpers.HelperTimeout)
+		Expect(err).Should(BeNil(), "Bind app is not ready after timeout")
+
+	})
+
+	AfterFailed(func() {
+		kubectl.CiliumReport(helpers.KubeSystemNamespace,
+			"cilium service list",
+			"cilium endpoint list")
+	})
+
+	AfterAll(func() {
+		_ = kubectl.Delete(bindManifest)
+		_ = kubectl.Delete(demoManifest)
+		ExpectAllPodsTerminated(kubectl)
+	})
+
+	JustBeforeEach(func() {
+		microscopeErr, microscopeCancel = kubectl.MicroscopeStart()
+		Expect(microscopeErr).To(BeNil(), "Microscope cannot be started")
+		backgroundCancel, backgroundError = kubectl.BackgroundReport("uptime")
+		Expect(backgroundError).To(BeNil(), "Cannot start background report process")
+	})
+
+	JustAfterEach(func() {
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		Expect(microscopeCancel()).To(BeNil(), "cannot stop microscope")
+		backgroundCancel()
+	})
+
+	AfterEach(func() {
+		_ = kubectl.Exec(fmt.Sprintf("%s delete --all cnp", helpers.KubectlCmd))
+	})
+
+	It("Restart Cilium validate that FQDN is still working", func() {
+		// Test functionality:
+		// - When Cilium is running) Connectivity from App2 application can
+		// connect to DNS because dns-proxy filter the DNS request. If the
+		// connection is made correctly the IP is whitelisted by the FQDN rule
+		// until the DNS TTL expires.
+		// When Cilium is not running) The DNS-proxy is not working, so the IP
+		// connectivity to an existing IP that was queried before will work,
+		// meanwhile connections using new DNS request will fail.
+		// On restart) Cilium will restore the IPS that were white-listted in
+		// the FQDN and connection will work as normal.
+
+		connectivityTest := func() {
+
+			By("Testing that connection from %q to %q should work",
+				appPods[helpers.App2], worldTarget)
+			res := kubectl.ExecPodCmd(
+				helpers.DefaultNamespace, appPods[helpers.App2],
+				helpers.CurlFail(worldTarget))
+			ExpectWithOffset(1, res).To(helpers.CMDSuccess(), "%q cannot curl to %q",
+				appPods[helpers.App2], worldTarget)
+
+			By("Testing that connection from %q to %q shouldn't work",
+				appPods[helpers.App2], worldTarget)
+			res = kubectl.ExecPodCmd(
+				helpers.DefaultNamespace, appPods[helpers.App2],
+				helpers.CurlFail(worldInvalidTarget))
+			ExpectWithOffset(1, res).ShouldNot(helpers.CMDSuccess(),
+				"%q can curl to %q when it should fail", appPods[helpers.App2], worldInvalidTarget)
+
+			By("Testing that connection from %q to %q works",
+				appPods[helpers.App2], worldInvalidTarget)
+			res = kubectl.ExecPodCmd(
+				helpers.DefaultNamespace, appPods[helpers.App2],
+				helpers.CurlFail(worldTargetIP))
+			res.ExpectSuccess("%q cannot curl to %q during restart", helpers.App2, worldTargetIP)
+
+			By("Testing that connection from %q to %q should not work",
+				appPods[helpers.App2], worldInvalidTargetIP)
+			res = kubectl.ExecPodCmd(
+				helpers.DefaultNamespace, appPods[helpers.App2],
+				helpers.CurlFail(worldInvalidTargetIP))
+			res.ExpectFail("%q can  connect when it should not work", helpers.App2)
+		}
+
+		fqndProxyPolicy := helpers.ManifestGet("fqdn-proxy-policy.yaml")
+
+		_, err := kubectl.CiliumPolicyAction(
+			helpers.KubeSystemNamespace, fqndProxyPolicy,
+			helpers.KubectlApply, helpers.HelperTimeout)
+		Expect(err).To(BeNil(), "Cannot install fqdn proxy policy")
+
+		connectivityTest()
+		By("Deleting cilium pods")
+
+		res := kubectl.Exec(fmt.Sprintf("%s -n %s delete pods -l k8s-app=cilium",
+			helpers.KubectlCmd, helpers.KubeSystemNamespace))
+		res.ExpectSuccess()
+
+		By("Testing connectivity when cilium is restoring using IPS without DNS")
+		res = kubectl.ExecPodCmd(
+			helpers.DefaultNamespace, appPods[helpers.App2],
+			helpers.CurlFail(worldTargetIP))
+		res.ExpectSuccess("%q cannot curl to %q during restart", helpers.App2, worldTargetIP)
+
+		res = kubectl.ExecPodCmd(
+			helpers.DefaultNamespace, appPods[helpers.App2],
+			helpers.CurlFail(worldInvalidTargetIP))
+		res.ExpectFail("%q can  connect when it should not work", helpers.App2)
+
+		ExpectAllPodsTerminated(kubectl)
+		ExpectCiliumReady(kubectl)
+
+		By("Testing connectivity when cilium is *restored* using IPS without DNS")
+		res = kubectl.ExecPodCmd(
+			helpers.DefaultNamespace, appPods[helpers.App2],
+			helpers.CurlFail(worldTargetIP))
+		res.ExpectSuccess("%q cannot curl to %q during restart", helpers.App2, worldTargetIP)
+
+		res = kubectl.ExecPodCmd(
+			helpers.DefaultNamespace, appPods[helpers.App2],
+			helpers.CurlFail(worldInvalidTargetIP))
+		res.ExpectFail("%q can  connect when it should not work", helpers.App2)
+
+		err = kubectl.CiliumEndpointWaitReady()
+		Expect(err).To(BeNil(), "Endpoints are not ready after Cilium restarts")
+		By("Testing connectivity using DNS request when cilium is restored correctly")
+		connectivityTest()
+	})
+})

--- a/test/k8sT/manifests/bind_deployment.yaml
+++ b/test/k8sT/manifests/bind_deployment.yaml
@@ -1,0 +1,115 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: bind-config
+  namespace: default
+data:
+  db.cilium.test: |
+    $TTL 300
+    $ORIGIN cilium.test.
+    @       IN      SOA     cilium.test. admin.cilium.test. (
+                            200608081       ; serial, todays date + todays serial #
+                            8H              ; refresh, seconds
+                            2H              ; retry, seconds
+                            4W              ; expire, seconds
+                            1D )            ; minimum, seconds
+    ;
+    ;
+    @               IN NS server
+
+    server.cilium.test. IN A 127.0.0.1
+    world1.cilium.test. IN A 192.168.9.10
+    world2.cilium.test. IN A 192.168.9.11
+
+  named.conf: |
+    options {
+      directory "/var/cache/bind";
+      dnssec-validation auto;
+
+      auth-nxdomain no;    # conform to RFC1035
+      listen-on-v6 { any; };
+    };
+
+    logging {
+      category default { default_stderr; };
+      category queries { default_stderr; };
+    };
+
+    zone "cilium.test" {
+            type master;
+            file "/data/db.cilium.test";
+    };
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    zgroup: bind
+  name: bind
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        zgroup: bind
+    spec:
+      containers:
+      - image: docker.io/cilium/docker-bind:v0.1
+        command: [ "/usr/sbin/named"]
+        args:
+          - "-c"
+          - "/data/named.conf.local"
+          - "-u"
+          - "bind"
+          - "-f"
+          - "-d"
+          - "8"
+        imagePullPolicy: IfNotPresent
+        name: bind
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /data/
+          name: config-volume
+        securityContext:
+          privileged: true
+      dnsPolicy: Default
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - name: config-volume
+        configMap:
+          defaultMode: 0777
+          items:
+          - key: db.cilium.test
+            path: db.cilium.test
+          - key: named.conf
+            path: named.conf.local
+          name: bind-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bind
+  namespace: default
+  labels:
+    zgroup: bind
+spec:
+  selector:
+    zgroup: bind
+  clusterIP: 10.96.0.100
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP

--- a/test/k8sT/manifests/fqdn-proxy-policy.yaml
+++ b/test/k8sT/manifests/fqdn-proxy-policy.yaml
@@ -1,0 +1,19 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+description: "fqdn-proxy-policy.yaml"
+metadata:
+  name: "fqdn-proxy-policy.yaml"
+spec:
+  endpointSelector:
+    matchLabels:
+      id: app2
+  egress:
+  - toPorts:
+    - ports:
+      - port: '53'
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: "*"
+  - toFQDNs:
+    - matchPattern: "world1.cilium.test"

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -265,4 +265,9 @@ else
     sudo iptables -t nat -A POSTROUTING -o enp0s8 ! -s 192.168.36.12 -j MASQUERADE
 fi
 
+# Create world network
+docker network create --subnet=192.168.9.0/24 outside
+docker run --net outside --ip 192.168.9.10 --restart=always -d docker.io/cilium/demo-httpd:latest
+docker run --net outside --ip 192.168.9.11 --restart=always -d docker.io/cilium/demo-httpd:latest
+
 sudo touch /etc/provision_finished

--- a/test/provision/manifest/1.12/coredns_deployment.yaml
+++ b/test/provision/manifest/1.12/coredns_deployment.yaml
@@ -65,6 +65,7 @@ data:
             upstream
             fallthrough in-addr.arpa ip6.arpa
         }
+        proxy cilium.test 10.96.0.100:53
         prometheus :9153
         proxy . /etc/resolv.conf
         cache 30

--- a/test/provision/manifest/1.13/coredns_deployment.yaml
+++ b/test/provision/manifest/1.13/coredns_deployment.yaml
@@ -72,6 +72,7 @@ data:
             fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
+        proxy cilium.test 10.96.0.100:53
         proxy . /etc/resolv.conf
         cache 30
         loop

--- a/test/provision/manifest/coredns_deployment.yaml
+++ b/test/provision/manifest/coredns_deployment.yaml
@@ -97,6 +97,7 @@ data:
            upstream
            fallthrough in-addr.arpa ip6.arpa
         }
+        proxy cilium.test 10.96.0.100:53
         prometheus :9153
         proxy . /etc/resolv.conf
         cache 3

--- a/test/provision/manifest/kubedns_deployment.yaml
+++ b/test/provision/manifest/kubedns_deployment.yaml
@@ -39,6 +39,9 @@ metadata:
   namespace: kube-system
   labels:
     addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  stubDomains: |
+    {"cilium.test": ["10.96.0.100"]}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment


### PR DESCRIPTION
This new Kubernetes end-to-end test creates a new Bind container with
the cilium.test domain.

Also all kubedns and coredns services will proxy a cilium.test to the
bind service.

For simulating world, two new containers in the 192.168.9.X Docker
network will be online where applications can ping, http request without
using internet connection and avoid flakes.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6521)
<!-- Reviewable:end -->
