### PR TITLE
Test: set terminationGracePeriodSeconds to 0.

### DIFF
--- a/test/k8sT/manifests/bookinfo-v1.yaml
+++ b/test/k8sT/manifests/bookinfo-v1.yaml
@@ -42,6 +42,7 @@ spec:
         track: stable
         zgroup: bookinfo
     spec:
+      terminationGracePeriodSeconds: 0
       containers:
       - name: details
         image: docker.io/istio/examples-bookinfo-details-v1:1.6.0
@@ -79,6 +80,7 @@ spec:
         track: stable
         zgroup: bookinfo
     spec:
+      terminationGracePeriodSeconds: 0
       containers:
       - name: reviews
         image: docker.io/istio/examples-bookinfo-reviews-v1:1.6.0
@@ -116,6 +118,7 @@ spec:
         track: stable
         zgroup: bookinfo
     spec:
+      terminationGracePeriodSeconds: 0
       containers:
       # Use v0.2.3 because it still contains 'wget', necessary for tests.
       - name: productpage

--- a/test/k8sT/manifests/bookinfo-v2.yaml
+++ b/test/k8sT/manifests/bookinfo-v2.yaml
@@ -41,6 +41,7 @@ spec:
         version: v1
         zgroup: bookinfo
     spec:
+      terminationGracePeriodSeconds: 0
       containers:
       - name: ratings
         image: docker.io/istio/examples-bookinfo-ratings-v1:1.6.0
@@ -64,6 +65,7 @@ spec:
         version: v2
         zgroup: bookinfo
     spec:
+      terminationGracePeriodSeconds: 0
       containers:
       - name: reviews
         image: docker.io/istio/examples-bookinfo-reviews-v2:1.6.0

--- a/test/k8sT/manifests/demo.yaml
+++ b/test/k8sT/manifests/demo.yaml
@@ -31,6 +31,7 @@ spec:
         zgroup: testapp
     spec:
       serviceAccountName: app1-account
+      terminationGracePeriodSeconds: 0
       containers:
       - name: web
         image: docker.io/cilium/demo-httpd:latest
@@ -54,6 +55,7 @@ spec:
         appSecond: "true"
     spec:
       serviceAccountName: app2-account
+      terminationGracePeriodSeconds: 0
       containers:
       - name: app-frontend
         image: docker.io/cilium/demo-client:latest
@@ -76,6 +78,7 @@ spec:
         id: app3
         zgroup: testapp
     spec:
+      terminationGracePeriodSeconds: 0
       containers:
       - name: app-frontend
         image: docker.io/cilium/demo-client:latest

--- a/test/k8sT/manifests/demo_ds.yaml
+++ b/test/k8sT/manifests/demo_ds.yaml
@@ -16,6 +16,7 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
+      terminationGracePeriodSeconds: 0
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
@@ -34,6 +35,7 @@ spec:
       labels:
         zgroup: testDSClient
     spec:
+      terminationGracePeriodSeconds: 0
       containers:
       - name: web
         image: docker.io/cilium/demo-client:latest

--- a/test/k8sT/manifests/guestbook_deployment.json
+++ b/test/k8sT/manifests/guestbook_deployment.json
@@ -23,6 +23,7 @@
                 }
             },
             "spec":{
+                "terminationGracePeriodSeconds": 0,
                 "containers":[{
                     "name":"redis-master",
                     "image":"docker.io/library/redis:4.0.11",
@@ -86,6 +87,7 @@
                 }
             },
             "spec":{
+                "terminationGracePeriodSeconds": 0,
                 "containers":[{
                     "name":"redis-slave",
                     "image":"gcr.io/google_samples/gb-redisslave:v1",
@@ -145,6 +147,7 @@
                 }
             },
             "spec":{
+                "terminationGracePeriodSeconds": 0,
                 "containers":[{
                     "name":"guestbook",
                     "image":"docker.io/kubernetes/guestbook:v2",

--- a/test/k8sT/manifests/kafka-sw-app.yaml
+++ b/test/k8sT/manifests/kafka-sw-app.yaml
@@ -10,6 +10,7 @@ spec:
         app: kafka
         zgroup: kafkaTestApp
     spec:
+      terminationGracePeriodSeconds: 0
       containers:
       - name: kafka
         # Normally we would specify an exact version of the image instead of
@@ -63,6 +64,7 @@ spec:
         app: empire-hq
         zgroup: kafkaTestApp
     spec:
+      terminationGracePeriodSeconds: 0
       containers:
       - name: empire-hq
         image: docker.io/cilium/kafkaclient:latest
@@ -83,6 +85,7 @@ spec:
         outpostid: "8888"
         zgroup: kafkaTestApp
     spec:
+      terminationGracePeriodSeconds: 0
       containers:
       - name: empire-outpost-8888
         image: docker.io/cilium/kafkaclient:latest
@@ -101,6 +104,7 @@ spec:
         outpostid: "9999"
         zgroup: kafkaTestApp
     spec:
+      terminationGracePeriodSeconds: 0
       containers:
       - name: empire-outpost-9999
         image: docker.io/cilium/kafkaclient:latest
@@ -118,6 +122,7 @@ spec:
         app: empire-backup
         zgroup: kafkaTestApp
     spec:
+      terminationGracePeriodSeconds: 0
       containers:
       - name: empire-backup
         image: docker.io/cilium/kafkaclient:latest

--- a/test/k8sT/manifests/microscope.yaml
+++ b/test/k8sT/manifests/microscope.yaml
@@ -65,6 +65,7 @@ metadata:
     k8s-app: microscope
 spec:
   serviceAccountName: microscope
+  terminationGracePeriodSeconds: 0
   containers:
   - args:
     - sleep

--- a/test/k8sT/manifests/netcat-ds.yaml
+++ b/test/k8sT/manifests/netcat-ds.yaml
@@ -10,6 +10,7 @@ spec:
       labels:
         zgroup: netcatds
     spec:
+      terminationGracePeriodSeconds: 0
       containers:
       - name: netcat
         image: docker.io/cilium/demo-client:latest

--- a/test/k8sT/manifests/netperf-deployment.yaml
+++ b/test/k8sT/manifests/netperf-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     id: netperf-server
     zgroup: testapp
 spec:
+  terminationGracePeriodSeconds: 0
   containers:
   - name: netperf
     image: tgraf/netperf
@@ -19,6 +20,7 @@ metadata:
     id: netperf-client
     zgroup: testapp
 spec:
+  terminationGracePeriodSeconds: 0
   containers:
   - name: netperf
     image: tgraf/netperf


### PR DESCRIPTION
Test application takes 30 seconds to be deleted on Kubernetes 1.13. With
this change the grace period has 0 seconds, so delete pods are much
faster.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6523)
<!-- Reviewable:end -->
