### PR TITLE
bpf: Remove OpenAfterMount() to avoid unnecessary map creation

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -538,6 +538,51 @@ func (d *Daemon) init() error {
 	}
 
 	if !option.Config.DryMode {
+		if _, err := lxcmap.LXCMap.OpenOrCreate(); err != nil {
+			return err
+		}
+
+		if _, err := ipcachemap.IPCache.OpenOrCreate(); err != nil {
+			return err
+		}
+
+		if _, err := metricsmap.Metrics.OpenOrCreate(); err != nil {
+			return err
+		}
+
+		if _, err := tunnel.TunnelMap.OpenOrCreate(); err != nil {
+			return err
+		}
+
+		if option.Config.EnableIPv6 {
+			if _, err := lbmap.Service6Map.OpenOrCreate(); err != nil {
+				return err
+			}
+			if _, err := lbmap.RevNat6Map.OpenOrCreate(); err != nil {
+				return err
+			}
+			if _, err := lbmap.RRSeq6Map.OpenOrCreate(); err != nil {
+				return err
+			}
+			if _, err := proxymap.Proxy6Map.OpenOrCreate(); err != nil {
+				return err
+			}
+		}
+
+		if option.Config.EnableIPv4 {
+			if _, err := lbmap.Service4Map.OpenOrCreate(); err != nil {
+				return err
+			}
+			if _, err := lbmap.RevNat4Map.OpenOrCreate(); err != nil {
+				return err
+			}
+			if _, err := lbmap.RRSeq4Map.OpenOrCreate(); err != nil {
+				return err
+			}
+			if _, err := proxymap.Proxy4Map.OpenOrCreate(); err != nil {
+				return err
+			}
+		}
 
 		if err := d.compileBase(); err != nil {
 			return err
@@ -585,29 +630,6 @@ func (d *Daemon) init() error {
 				RunInterval: 5 * time.Second,
 			})
 
-		if option.Config.EnableIPv6 {
-			if _, err := lbmap.Service6Map.OpenOrCreate(); err != nil {
-				return err
-			}
-			if _, err := lbmap.RevNat6Map.OpenOrCreate(); err != nil {
-				return err
-			}
-			if _, err := lbmap.RRSeq6Map.OpenOrCreate(); err != nil {
-				return err
-			}
-		}
-
-		if option.Config.EnableIPv4 {
-			if _, err := lbmap.Service4Map.OpenOrCreate(); err != nil {
-				return err
-			}
-			if _, err := lbmap.RevNat4Map.OpenOrCreate(); err != nil {
-				return err
-			}
-			if _, err := lbmap.RRSeq4Map.OpenOrCreate(); err != nil {
-				return err
-			}
-		}
 		// Clean all lb entries
 		if !option.Config.RestoreState {
 			log.Debug("cleaning up all BPF LB maps")

--- a/pkg/maps/eppolicymap/eppolicymap.go
+++ b/pkg/maps/eppolicymap/eppolicymap.go
@@ -82,7 +82,9 @@ func CreateEPPolicyMap() {
 		EpPolicyMap.InnerID = uint32(fd)
 	})
 
-	bpf.OpenAfterMount(EpPolicyMap)
+	if _, err := EpPolicyMap.OpenOrCreate(); err != nil {
+		log.WithError(err).Warning("Unable to open or create endpoint policy map")
+	}
 }
 
 func (v epPolicyFd) String() string { return fmt.Sprintf("fd=%d", v.Fd) }

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -247,13 +247,6 @@ var (
 	IPCache = NewMap(Name)
 )
 
-func init() {
-	err := bpf.OpenAfterMount(&IPCache.Map)
-	if err != nil {
-		log.WithError(err).Error("unable to open map")
-	}
-}
-
 // Reopen attempts to close and re-open the IPCache map at the standard path
 // on the filesystem.
 func Reopen() error {

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -56,10 +56,6 @@ var (
 	).WithCache()
 )
 
-func init() {
-	bpf.OpenAfterMount(LXCMap)
-}
-
 // MAC is the __u64 representation of a MAC address.
 type MAC uint64
 

--- a/pkg/maps/metricsmap/metricsmap.go
+++ b/pkg/maps/metricsmap/metricsmap.go
@@ -263,9 +263,4 @@ func init() {
 			}
 			return &k, &v, nil
 		})
-
-	err := bpf.OpenAfterMount(Metrics)
-	if err != nil {
-		log.WithError(err).Error("unable to open metrics map")
-	}
 }

--- a/pkg/maps/proxymap/ipv4.go
+++ b/pkg/maps/proxymap/ipv4.go
@@ -83,10 +83,6 @@ var (
 		}).WithNonPersistent()
 )
 
-func init() {
-	bpf.OpenAfterMount(Proxy4Map)
-}
-
 func (k Proxy4Key) NewValue() bpf.MapValue {
 	return &Proxy4Value{}
 }

--- a/pkg/maps/proxymap/ipv6.go
+++ b/pkg/maps/proxymap/ipv6.go
@@ -78,10 +78,6 @@ var (
 		}).WithNonPersistent()
 )
 
-func init() {
-	bpf.OpenAfterMount(Proxy6Map)
-}
-
 func (k Proxy6Key) NewValue() bpf.MapValue {
 	return &Proxy6Value{}
 }

--- a/pkg/maps/tunnel/tunnel.go
+++ b/pkg/maps/tunnel/tunnel.go
@@ -65,7 +65,6 @@ type Map struct {
 
 func init() {
 	TunnelMap.NonPersistent = true
-	bpf.OpenAfterMount(TunnelMap.Map)
 
 	// Remove old map and ignore errors; this is the "normal" case.
 	// BPFFS map root in older versions of Cilium wasn't dynamic, so the


### PR DESCRIPTION
The OpenAfterMount() is creating many BPF maps even if a particular subsystem
is disabled. Notably IPv6. Call OpenOrCreate() from the daemon init functions
directly to guarantee that it happens after the BPF filesystem has been mounted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6527)
<!-- Reviewable:end -->
