### PR TITLE
re-enable version warning check and fix documentation build

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -24,11 +24,11 @@ PIP_REQUIREMENTS = $(shell cat requirements.txt | sed -e 's/==.*//g' -e 's/\n/ /
 check-requirements:
 	@set -e;								\
 	$(ECHO_CHECK) documentation dependencies...;				\
-	PYPKGS=$$(pip freeze);							\
+	PYPKGS=$$(pip3 freeze);							\
 	for pkg in ${PIP_REQUIREMENTS}; do					\
 		echo $${PYPKGS} | grep -q $${pkg}				\
 		|| (echo "Documentation dependency '$${pkg}' not found.";	\
-		    echo "Run 'pip install -r Documentation/requirements.txt'";	\
+		    echo "Run 'pip3 install --user -r Documentation/requirements.txt'";	\
 		    exit 2);							\
 	done
 

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -37,8 +37,8 @@ extensions = ['sphinx.ext.ifconfig',
     'sphinx.ext.extlinks',
     'sphinxcontrib.openapi',
     'sphinx_tabs.tabs',
-    'sphinxcontrib.spelling']
-#    'versionwarning.extension' ] <--- build is currently broken, see GH-6460
+    'sphinxcontrib.spelling',
+    'versionwarning.extension' ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Since there's a bug with NFS or the kernel, the flock syscall
hangs the documentation build in the developer VM. For this
reason the documentation build is skipped if NFS is running
in the developer VM.

Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/6460

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6536)
<!-- Reviewable:end -->
