### PR TITLE
examples/kubernetes: add dnsPolicy: ClusterFirstWithHostNet

### DIFF
--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -198,6 +198,7 @@ spec:
               add:
                 - "NET_ADMIN"
             privileged: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       volumes:
         # To keep state between restarts / upgrades

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -280,6 +280,7 @@ spec:
               add:
                 - "NET_ADMIN"
             privileged: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       volumes:
         # To keep state between restarts / upgrades

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -198,6 +198,7 @@ spec:
               add:
                 - "NET_ADMIN"
             privileged: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       volumes:
         # To keep state between restarts / upgrades

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -280,6 +280,7 @@ spec:
               add:
                 - "NET_ADMIN"
             privileged: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       volumes:
         # To keep state between restarts / upgrades

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -198,6 +198,7 @@ spec:
               add:
                 - "NET_ADMIN"
             privileged: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       volumes:
         # To keep state between restarts / upgrades

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -280,6 +280,7 @@ spec:
               add:
                 - "NET_ADMIN"
             privileged: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       volumes:
         # To keep state between restarts / upgrades

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -198,6 +198,7 @@ spec:
               add:
                 - "NET_ADMIN"
             privileged: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       volumes:
         # To keep state between restarts / upgrades

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -280,6 +280,7 @@ spec:
               add:
                 - "NET_ADMIN"
             privileged: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       volumes:
         # To keep state between restarts / upgrades

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -198,6 +198,7 @@ spec:
               add:
                 - "NET_ADMIN"
             privileged: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       volumes:
         # To keep state between restarts / upgrades

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -280,6 +280,7 @@ spec:
               add:
                 - "NET_ADMIN"
             privileged: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       volumes:
         # To keep state between restarts / upgrades

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -198,6 +198,7 @@ spec:
               add:
                 - "NET_ADMIN"
             privileged: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       volumes:
         # To keep state between restarts / upgrades


### PR DESCRIPTION
this allows cilium v1.3 to be deployed with cilium-etcd-operator

Signed-off-by: André Martins <andre@cilium.io>

Fixes: #6515

```release-note
set dnsPolicy for Cilium DaemonSet to ClusterFirstWithHostNet
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6544)
<!-- Reviewable:end -->
