### PR TITLE
restore: Improve endpoint restore ability with Kubernetes apiserver

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -96,9 +97,9 @@ func (d *Daemon) restoreOldEndpoints(dir string, clean bool) (*endpointRestoreSt
 		if ep.HasLabels(labels.LabelHealth) {
 			skipRestore = true
 		} else {
-			if ep.K8sPodName != "" && ep.K8sNamespace != "" {
+			if ep.K8sPodName != "" && ep.K8sNamespace != "" && k8s.IsEnabled() {
 				_, err := k8s.Client().CoreV1().Pods(ep.K8sNamespace).Get(ep.K8sPodName, meta_v1.GetOptions{})
-				if err != nil {
+				if err != nil && k8serrors.IsNotFound(err) {
 					skipRestore = true
 				}
 			}


### PR DESCRIPTION
Only perform check with apiserver if Kubernetes is enabled. This fixes a panic
when Kubernetes was enabled before and then gets disabled and endpoints are
being restored.

Instead of treating all errors as a trigger to skip restore, only skip restore
and remove the stale endpoint if the apiserver returns a NotFound error.

Fixes: d23f8cc8e2a ("restore: Check if Kubernetes pod still exists")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6546)
<!-- Reviewable:end -->
