### PR TITLE
docs: L3/7 toFQDNs documentation w/ matchPattern

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -418,6 +418,7 @@ qdisc
 qdiscs
 qede
 queueing
+queryable
 readelf
 rebase
 rebased
@@ -521,6 +522,7 @@ timestamps
 tlsconfig
 toCIDR
 toCIDRSet
+toFQDNs
 Toolchain
 toolchain
 tracepoint

--- a/examples/policies/l3/fqdn/fqdn.yaml
+++ b/examples/policies/l3/fqdn/fqdn.yaml
@@ -9,7 +9,6 @@ spec:
   egress:
     - toEndpoints:
       - matchLabels:
-          "k8s:io.cilium.k8s.policy.serviceaccount": kube-dns
           "k8s:io.kubernetes.pod.namespace": kube-system
           "k8s:k8s-app": kube-dns
     - toFQDNs:

--- a/examples/policies/l7/dns/dns-visibility.json
+++ b/examples/policies/l7/dns/dns-visibility.json
@@ -1,0 +1,42 @@
+[
+  {
+    "endpointSelector": {
+      "matchLabels": {
+        "app": "test-app"
+      }
+    },
+    "egress": [
+      {
+        "toEndpoints": [
+          {
+            "matchLabels": {
+              "app-type": "dns"
+            }
+          }
+        ],
+        "toPorts": [
+          {
+            "ports": [
+              {
+                "port": "53",
+                "protocol": "ANY"
+              }
+            ],
+            "rules": {
+              "dns": [
+                { "matchName": "*" }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "toFQDNs": [
+          { "matchName": "cilium.io" },
+          { "matchName": "sub.cilium.io" },
+          { "matchPattern": "*.sub.cilium.io" }
+        ]
+      }
+    ]
+  }
+]

--- a/examples/policies/l7/dns/dns-visibility.yaml
+++ b/examples/policies/l7/dns/dns-visibility.yaml
@@ -1,0 +1,25 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: "tofqdn-dns-visibility"
+spec:
+  endpointSelector:
+    matchLabels:
+      any:org: alliance
+  egress:
+  - toEndpoints:
+    - matchLabels:
+       "k8s:io.kubernetes.pod.namespace": kube-system
+       "k8s:k8s-app": kube-dns
+    toPorts:
+      - ports:
+         - port: "53"
+           protocol: ANY
+        rules:
+          dns:
+            - matchPattern: "*"
+
+  - toFQDNs:
+      - matchName: "cilium.io"
+      - matchName: "sub.cilium.io"
+      - matchPattern: "*.sub.cilium.io"

--- a/examples/policies/l7/dns/dns.json
+++ b/examples/policies/l7/dns/dns.json
@@ -1,0 +1,45 @@
+[
+  {
+    "endpointSelector": {
+      "matchLabels": {
+        "app": "test-app"
+      }
+    },
+    "egress": [
+      {
+        "toEndpoints": [
+          {
+            "matchLabels": {
+              "app-type": "dns"
+            }
+          }
+        ],
+        "toPorts": [
+          {
+            "ports": [
+              {
+                "port": "53",
+                "protocol": "ANY"
+              }
+            ],
+            "rules": {
+              "dns": [
+                { "matchName": "cilium.io" },
+                { "matchPattern": "*.cilium.io" }, 
+                { "matchPattern": "*.api.cilium.io" }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "toFQDNs": [
+          { "matchName": "cilium.io" },
+          { "matchName": "sub.cilium.io" },
+          { "matchName": "service1.api.cilium.io" },
+          { "matchPattern": "special*service.api.cilium.io" }
+       ]
+      }
+    ]
+  }
+]

--- a/examples/policies/l7/dns/dns.yaml
+++ b/examples/policies/l7/dns/dns.yaml
@@ -1,0 +1,33 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: "tofqdn-dns-visibility"
+spec:
+  endpointSelector:
+    matchLabels:
+      any:org: alliance
+  egress:
+  - toEndpoints:
+    - matchLabels:
+       "k8s:io.kubernetes.pod.namespace": kube-system
+       "k8s:k8s-app": kube-dns
+    toPorts:
+      - ports:
+         - port: "53"
+           protocol: ANY
+        rules:
+          dns:
+            - matchName: "cilium.io"
+            - matchPattern: "*.cilium.io"
+            - matchPattern: "*.api.cilium.io"
+
+  - toFQDNs:
+      - matchName: "cilium.io"
+      - matchName: "sub.cilium.io"
+      - matchName: "service1.api.cilium.io"
+      - matchPattern: "special*service.api.cilium.io"
+    toPorts:
+      - ports:
+         - port: "80"
+           protocol: TCP
+


### PR DESCRIPTION
We added toFQDNs.matchPattern, and L7 toPorts.rules.dns.match{Name,Pattern} to the policy language. These are now documented.

I'm not sure how clear this information is, or if the structure is helpful. Let me know what I should change, I expect this PR to take some iteration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6547)
<!-- Reviewable:end -->
