### PR TITLE
doc: Fix non-critical CVE-2017-18342:

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -10,7 +10,7 @@ jsonschema==2.6.0
 MarkupSafe==1.0
 Pygments==2.2.0
 pytz==2018.7
-PyYAML==3.13
+PyYAML==4.2b1
 requests==2.20.0
 six==1.11.0
 snowballstemmer==1.2.1


### PR DESCRIPTION
In PyYAML before 4.1, the yaml.load() API could execute arbitrary code. In
other words, yaml.safe_load is not used.

PyYAML is only used in the documentation building chain. This is not security relevant for Cilium.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6549)
<!-- Reviewable:end -->
