### PR TITLE
daemon: do not add endpoint if client connection closes during add operation

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -213,6 +213,14 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 
 	ep.UpdateLabels(d, addLabels, infoLabels, true)
 
+	// Do not add endpoint to the endpoint manager if client abort connection
+	select {
+	case <-ctx.Done():
+		log.WithError(ctx.Err()).Warn("Aborting endpoint join due client connection closed")
+		return PutEndpointIDFailedCode, fmt.Errorf("aborting endpoint %d join due client connection closed", ep.ID)
+	default:
+	}
+
 	if err := endpointmanager.AddEndpoint(d, ep, "Create endpoint from API PUT"); err != nil {
 		log.WithError(err).Warn("Aborting endpoint join")
 		return PutEndpointIDFailedCode, err


### PR DESCRIPTION
If a client closes the connection during a endpoint creation with the
cilium-agent while the cilium-agent is resolving the identity for that
particular endpoint, the cilium-agent will continue to create the endpoint
although the endpoint should not be created as the connection with the client
was terminated.

This bug also explains the problem when an interface does not exist when
cilium-agent tries to regenerate the endpoint. Since the client, in this case
cilium-cni, times out while waiting for a response from the cilium-agent,
cilium-cni cleans up the interface as it assumes the cilium-agent will not be
able to perform the task requested. As cilium-agent was not aware the client
terminated the connection, once it tries to regenerate the endpoint, it will
fail to do so as the interface no longer exists since the interface was removed
by the client, cilium-cni.

Fixes: 65fe98c4f391 ("cni: Synchroneous pod label retrieval on CNI add")
Signed-off-by: André Martins <andre@cilium.io>

Fixes: https://github.com/cilium/cilium/issues/6059

Adding `area/k8s` to trigger more tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6551)
<!-- Reviewable:end -->
