### PR TITLE
pkg/kvstore: set defaultClient before calling deleteLegacyPrefixes

### DIFF
--- a/pkg/kvstore/client.go
+++ b/pkg/kvstore/client.go
@@ -23,6 +23,9 @@ var (
 
 func initClient(module backendModule) error {
 	c, errChan := module.newClient()
+
+	defaultClient = c
+
 	go func() {
 		err, isErr := <-errChan
 		if isErr {
@@ -31,8 +34,6 @@ func initClient(module backendModule) error {
 
 		deleteLegacyPrefixes()
 	}()
-
-	defaultClient = c
 
 	return nil
 }


### PR DESCRIPTION
As deleteLegacyPrefixes depends on the defaultClient to not be nil, the
go routine should be scheduled after defaultClient has a client assign
to it.

Fixes: d37e16129d49 ("clustermesh: Do not error out of agent when remote cluster is unreachable")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6552)
<!-- Reviewable:end -->
