### PR TITLE
kubernetes: Change terminationGracePeriodSeconds to 1

### DIFF
--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -219,7 +219,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -219,7 +219,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -218,7 +218,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -218,7 +218,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -220,7 +220,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -220,7 +220,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -219,7 +219,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -219,7 +219,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -220,7 +220,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -220,7 +220,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -219,7 +219,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -219,7 +219,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -220,7 +220,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -220,7 +220,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.13/cilium-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-ds.yaml
@@ -219,7 +219,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -219,7 +219,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -219,7 +219,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -219,7 +219,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -218,7 +218,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -218,7 +218,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -219,7 +219,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -219,7 +219,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -218,7 +218,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -218,7 +218,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -219,7 +219,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -218,7 +218,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:


### PR DESCRIPTION
There is no graceful shutdown involved so we can limit the graceful shutdown
period to a second. Any Cilium pod in terminating state only causes downtime of
new pods being scheduled onto the node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6555)
<!-- Reviewable:end -->
