### PR TITLE
Test: On fail retrieve all the logs

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1359,11 +1359,20 @@ func (kub *Kubectl) CiliumReport(namespace string, commands ...string) {
 		ginkgoext.GinkgoPrint("Skipped gathering logs (-cilium.skipLogs=true)\n")
 		return
 	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		kub.DumpCiliumCommandOutput(namespace)
+		kub.GatherLogs()
+	}()
+
 	kub.CiliumCheckReport()
+
 	pods, err := kub.GetCiliumPods(namespace)
 	if err != nil {
 		kub.logger.WithError(err).Error("cannot retrieve cilium pods on ReportDump")
-		return
 	}
 	res := kub.Exec(fmt.Sprintf("%s get pods -o wide --all-namespaces", KubectlCmd))
 	ginkgoext.GinkgoPrint(res.GetDebugMessage())
@@ -1375,8 +1384,7 @@ func (kub *Kubectl) CiliumReport(namespace string, commands ...string) {
 		}
 	}
 
-	kub.DumpCiliumCommandOutput(namespace)
-	kub.GatherLogs()
+	wg.Wait()
 }
 
 // CiliumCheckReport prints a few checks on the Junit output to provide more
@@ -1418,12 +1426,21 @@ func (kub *Kubectl) CiliumCheckReport() {
 	for _, pod := range pods {
 		var prefix = ""
 		status := kub.CiliumExec(pod, "cilium status --all-controllers -o json")
-		result, _ := status.Filter(controllersFilter)
+		result, err := status.Filter(controllersFilter)
+		if err != nil {
+			kub.logger.WithError(err).Error("Cannot filter controller status output")
+			continue
+		}
 		var total = 0
 		var failed = 0
 		for name, data := range result.KVOutput() {
 			total++
-			status := strings.Split(data, "::")
+			status := strings.SplitN(data, "::", 2)
+			if len(status) != 2 {
+				// Just make sure that the the len of the output is 2 to not
+				// fail on index error in the following lines.
+				continue
+			}
 			if status[0] != "" {
 				failed++
 				prefix = "⚠️  "


### PR DESCRIPTION
Due the latest fail on CI I observed that the reportFailed information
was not retrieved correctly due a early return due no Cilium Pods.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6557)
<!-- Reviewable:end -->
