### PR TITLE
1.3.2 backports 2018-01-08

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -10,7 +10,7 @@ jsonschema==2.6.0
 MarkupSafe==1.0
 Pygments==2.2.0
 pytz==2018.7
-PyYAML==3.13
+PyYAML==4.2b1
 requests==2.20.0
 six==1.11.0
 snowballstemmer==1.2.1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -784,6 +784,13 @@
   version = "1.0.1"
 
 [[projects]]
+  digest = "1:048215a208d3f928e14cad3906c2aad4dc8412a81780f9a5260eaf7998c92df6"
+  name = "github.com/mohae/deepcopy"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "c48cc78d482608239f6c4c92a4abd87eb8761c90"
+
+[[projects]]
   digest = "1:3dc39744bbac155b21a79c6b8e250d6985bbab77b71c073a4477071e59fe5e61"
   name = "github.com/onsi/ginkgo"
   packages = [
@@ -1710,6 +1717,7 @@
     "github.com/mattn/go-shellwords",
     "github.com/miekg/dns",
     "github.com/mitchellh/hashstructure",
+    "github.com/mohae/deepcopy",
     "github.com/onsi/ginkgo",
     "github.com/onsi/ginkgo/config",
     "github.com/onsi/ginkgo/types",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -201,6 +201,13 @@ required = [
   revision = "9858af9cca4c73576f0b8c6609a396eb0878023c"
 
 [[constraint]]
+  name = "github.com/mohae/deepcopy"
+  revision = "c48cc78d482608239f6c4c92a4abd87eb8761c90"
+
+  # main-usage = "daemon"
+  # on-revision = "last available commit and there is not stable releases"
+
+[[constraint]]
   name = "github.com/onsi/ginkgo"
   revision = "ba8e856bb854d6771a72ddf6497a42dad3a0c971"
 

--- a/api/v1/models/status_response.go
+++ b/api/v1/models/status_response.go
@@ -43,6 +43,9 @@ type StatusResponse struct {
 
 	// Status of proxy
 	Proxy *ProxyStatus `json:"proxy,omitempty"`
+
+	// List of stale information in the status
+	Stale map[string]strfmt.DateTime `json:"stale,omitempty"`
 }
 
 /* polymorph StatusResponse cilium false */
@@ -62,6 +65,8 @@ type StatusResponse struct {
 /* polymorph StatusResponse nodeMonitor false */
 
 /* polymorph StatusResponse proxy false */
+
+/* polymorph StatusResponse stale false */
 
 // Validate validates this status response
 func (m *StatusResponse) Validate(formats strfmt.Registry) error {

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1252,6 +1252,13 @@ definitions:
       proxy:
         description: Status of proxy
         "$ref": "#/definitions/ProxyStatus"
+      stale:
+        description: List of stale information in the status
+        type: object
+        additionalProperties:
+          description: Timestamp when the probe was started
+          type: string
+          format: date-time
 
   Status:
     description: Status of an individual component

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2338,6 +2338,15 @@ func init() {
         "proxy": {
           "description": "Status of proxy",
           "$ref": "#/definitions/ProxyStatus"
+        },
+        "stale": {
+          "description": "List of stale information in the status",
+          "type": "object",
+          "additionalProperties": {
+            "description": "Timestamp when the probe was started",
+            "type": "string",
+            "format": "date-time"
+          }
         }
       }
     },

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1328,8 +1328,6 @@ func NewDaemon() (*Daemon, *endpointRestoreState, error) {
 	d.l7Proxy = proxy.StartProxySupport(10000, 20000, option.Config.RunDir,
 		option.Config.AccessLog, &d, option.Config.AgentLabels)
 
-	d.startStatusCollector()
-
 	if err := fqdn.ConfigFromResolvConf(); err != nil {
 		return nil, nil, err
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -74,6 +74,7 @@ import (
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/proxy/logger"
 	"github.com/cilium/cilium/pkg/revert"
+	"github.com/cilium/cilium/pkg/status"
 	"github.com/cilium/cilium/pkg/u8proto"
 	"github.com/cilium/cilium/pkg/workloads"
 
@@ -117,9 +118,9 @@ type Daemon struct {
 	// Only used for CRI-O since it does not support events.
 	workloadsEventsCh chan<- *workloads.EventMessage
 
-	statusCollectMutex      lock.RWMutex
-	statusResponse          models.StatusResponse
-	statusResponseTimestamp time.Time
+	statusCollectMutex lock.RWMutex
+	statusResponse     models.StatusResponse
+	statusCollector    *status.Collector
 
 	uniqueIDMU lock.Mutex
 	uniqueID   map[uint64]context.CancelFunc

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -147,7 +147,7 @@ func fetchK8sLabels(ep *endpoint.Endpoint) (labels.Labels, labels.Labels, error)
 // createEndpoint attempts to create the endpoint corresponding to the change
 // request that was specified. Returns an HTTP code response code and an
 // error msg (or nil on success).
-func (d *Daemon) createEndpoint(epTemplate *models.EndpointChangeRequest, id string, lbls []string) (int, error) {
+func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.EndpointChangeRequest, id string, lbls []string) (int, error) {
 	ep, err := endpoint.NewEndpointFromChangeModel(epTemplate)
 	if err != nil {
 		return PutEndpointIDInvalidCode, err
@@ -198,6 +198,14 @@ func (d *Daemon) createEndpoint(epTemplate *models.EndpointChangeRequest, id str
 
 	ep.UpdateLabels(d, addLabels, infoLabels, true)
 
+	// Do not add endpoint to the endpoint manager if client abort connection
+	select {
+	case <-ctx.Done():
+		log.WithError(ctx.Err()).Warn("Aborting endpoint join due client connection closed")
+		return PutEndpointIDFailedCode, fmt.Errorf("aborting endpoint %d join due client connection closed", ep.ID)
+	default:
+	}
+
 	if err := endpointmanager.AddEndpoint(d, ep, "Create endpoint from API PUT"); err != nil {
 		log.WithError(err).Warn("Aborting endpoint join")
 		return PutEndpointIDFailedCode, err
@@ -234,7 +242,7 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder 
 			"endpoint ID cannot be 0")
 	}
 
-	code, err := h.d.createEndpoint(epTemplate, params.ID, params.Endpoint.Labels)
+	code, err := h.d.createEndpoint(params.HTTPRequest.Context(), epTemplate, params.ID, params.Endpoint.Labels)
 	if err != nil {
 		logger.WithError(err).Error("Endpoint cannot be created")
 		return api.Error(code, err)

--- a/daemon/endpoint_test.go
+++ b/daemon/endpoint_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"strconv"
 	"time"
 
@@ -55,7 +56,7 @@ func getEPTemplate(c *C) *models.EndpointChangeRequest {
 func (ds *DaemonSuite) TestEndpointAddReservedLabel(c *C) {
 	epTemplate := getEPTemplate(c)
 	lbls := []string{"reserved:world"}
-	code, err := ds.d.createEndpoint(epTemplate, strconv.FormatInt(epTemplate.ID, 10), lbls)
+	code, err := ds.d.createEndpoint(context.TODO(), epTemplate, strconv.FormatInt(epTemplate.ID, 10), lbls)
 	c.Assert(err, Not(IsNil))
 	c.Assert(code, Equals, apiEndpoint.PutEndpointIDInvalidCode)
 }
@@ -63,7 +64,7 @@ func (ds *DaemonSuite) TestEndpointAddReservedLabel(c *C) {
 func (ds *DaemonSuite) TestEndpointAddInvalidLabel(c *C) {
 	epTemplate := getEPTemplate(c)
 	lbls := []string{"reserved:foo"}
-	code, err := ds.d.createEndpoint(epTemplate, strconv.FormatInt(epTemplate.ID, 10), lbls)
+	code, err := ds.d.createEndpoint(context.TODO(), epTemplate, strconv.FormatInt(epTemplate.ID, 10), lbls)
 	c.Assert(err, Not(IsNil))
 	c.Assert(code, Equals, apiEndpoint.PutEndpointIDInvalidCode)
 }
@@ -71,7 +72,7 @@ func (ds *DaemonSuite) TestEndpointAddInvalidLabel(c *C) {
 func (ds *DaemonSuite) TestEndpointAddNoLabels(c *C) {
 	// Create the endpoint without any labels.
 	epTemplate := getEPTemplate(c)
-	code, err := ds.d.createEndpoint(epTemplate, strconv.FormatInt(epTemplate.ID, 10), nil)
+	code, err := ds.d.createEndpoint(context.TODO(), epTemplate, strconv.FormatInt(epTemplate.ID, 10), nil)
 	c.Assert(err, IsNil)
 	c.Assert(code, Equals, apiEndpoint.PutEndpointIDCreatedCode)
 

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -781,22 +781,24 @@ func initEnv(cmd *cobra.Command) {
 
 	k8s.Configure(k8sAPIServer, k8sKubeConfigPath)
 
-	// workaround for to use the values of the deprecated dockerEndpoint
-	// variable if it is set with a different value than defaults.
-	defaultDockerEndpoint := workloads.GetRuntimeDefaultOpt(workloads.Docker, "endpoint")
-	if defaultDockerEndpoint != dockerEndpoint {
-		containerRuntimesOpts[string(workloads.Docker)] = dockerEndpoint
-		log.Warn(`"docker" flag is deprecated.` +
-			`Please use "--container-runtime-endpoint=docker=` + defaultDockerEndpoint + `" instead`)
-	}
+	if option.Config.WorkloadsEnabled() {
+		// workaround for to use the values of the deprecated dockerEndpoint
+		// variable if it is set with a different value than defaults.
+		defaultDockerEndpoint := workloads.GetRuntimeDefaultOpt(workloads.Docker, "endpoint")
+		if defaultDockerEndpoint != dockerEndpoint {
+			containerRuntimesOpts[string(workloads.Docker)] = dockerEndpoint
+			log.Warn(`"docker" flag is deprecated.` +
+				`Please use "--container-runtime-endpoint=docker=` + defaultDockerEndpoint + `" instead`)
+		}
 
-	err = workloads.ParseConfigEndpoint(option.Config.Workloads, containerRuntimesOpts)
-	if err != nil {
-		log.WithError(err).Fatal("Unable to initialize policy container runtimes")
-		return
-	}
+		err = workloads.ParseConfigEndpoint(option.Config.Workloads, containerRuntimesOpts)
+		if err != nil {
+			log.WithError(err).Fatal("Unable to initialize policy container runtimes")
+			return
+		}
 
-	log.Infof("Container runtime options set: %s", workloads.GetRuntimeOptions())
+		log.Infof("Container runtime options set: %s", workloads.GetRuntimeOptions())
+	}
 
 	if viper.GetBool("sidecar-http-proxy") {
 		log.Warn(`"sidecar-http-proxy" flag is deprecated and has no effect`)

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -844,11 +844,14 @@ func runCiliumHealthEndpoint(d *Daemon) error {
 
 func runDaemon() {
 	log.Info("Initializing daemon")
+
 	d, restoredEndpoints, err := NewDaemon()
 	if err != nil {
 		log.WithError(err).Fatal("Error while creating daemon")
 		return
 	}
+
+	d.startStatusCollector()
 
 	log.Info("Starting connection tracking garbage collector")
 	endpointmanager.EnableConntrackGC(!option.Config.IPv4Disabled, true,

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -97,7 +97,7 @@ func (d *Daemon) restoreOldEndpoints(dir string, clean bool) (*endpointRestoreSt
 			if _, err := netlink.LinkByName(ep.IfName); err != nil {
 				scopedLog.Infof("Interface %s could not be found for endpoint being restored, ignoring", ep.IfName)
 				skipRestore = true
-			} else if !workloads.IsRunning(ep) {
+			} else if option.Config.WorkloadsEnabled() && !workloads.IsRunning(ep) {
 				scopedLog.Info("No workload could be associated with endpoint being restored, ignoring")
 				skipRestore = true
 			}

--- a/daemon/status.go
+++ b/daemon/status.go
@@ -345,11 +345,7 @@ func (d *Daemon) startStatusCollector() {
 		},
 	}
 
-	d.statusCollector = status.NewCollector(probes, status.Config{
-		Interval:         5 * time.Second,
-		WarningThreshold: 15 * time.Second,
-		FailureThreshold: time.Minute,
-	})
+	d.statusCollector = status.NewCollector(probes, status.Config{})
 
 	return
 }

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -233,6 +233,7 @@ spec:
             optional: true
             secretName: cilium-clustermesh
       restartPolicy: Always
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -315,6 +315,7 @@ spec:
             optional: true
             secretName: cilium-clustermesh
       restartPolicy: Always
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -245,6 +245,7 @@ spec:
             optional: true
             secretName: cilium-clustermesh
       restartPolicy: Always
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.10/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.10/cilium-pre-flight.yaml
@@ -56,6 +56,7 @@ spec:
             periodSeconds: 5
       hostNetwork: true
       restartPolicy: Always
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -327,6 +327,7 @@ spec:
             optional: true
             secretName: cilium-clustermesh
       restartPolicy: Always
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -225,6 +225,7 @@ spec:
             secretName: cilium-clustermesh
       restartPolicy: Always
       priorityClassName: system-node-critical
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -307,6 +307,7 @@ spec:
             secretName: cilium-clustermesh
       restartPolicy: Always
       priorityClassName: system-node-critical
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -246,6 +246,7 @@ spec:
             secretName: cilium-clustermesh
       restartPolicy: Always
       priorityClassName: system-node-critical
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.11/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.11/cilium-pre-flight.yaml
@@ -57,6 +57,7 @@ spec:
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-node-critical
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -328,6 +328,7 @@ spec:
             secretName: cilium-clustermesh
       restartPolicy: Always
       priorityClassName: system-node-critical
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -225,6 +225,7 @@ spec:
             secretName: cilium-clustermesh
       restartPolicy: Always
       priorityClassName: system-node-critical
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -307,6 +307,7 @@ spec:
             secretName: cilium-clustermesh
       restartPolicy: Always
       priorityClassName: system-node-critical
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -246,6 +246,7 @@ spec:
             secretName: cilium-clustermesh
       restartPolicy: Always
       priorityClassName: system-node-critical
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.12/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.12/cilium-pre-flight.yaml
@@ -57,6 +57,7 @@ spec:
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-node-critical
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -328,6 +328,7 @@ spec:
             secretName: cilium-clustermesh
       restartPolicy: Always
       priorityClassName: system-node-critical
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -233,6 +233,7 @@ spec:
             optional: true
             secretName: cilium-clustermesh
       restartPolicy: Always
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -315,6 +315,7 @@ spec:
             optional: true
             secretName: cilium-clustermesh
       restartPolicy: Always
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -245,6 +245,7 @@ spec:
             optional: true
             secretName: cilium-clustermesh
       restartPolicy: Always
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.8/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.8/cilium-pre-flight.yaml
@@ -56,6 +56,7 @@ spec:
             periodSeconds: 5
       hostNetwork: true
       restartPolicy: Always
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -327,6 +327,7 @@ spec:
             optional: true
             secretName: cilium-clustermesh
       restartPolicy: Always
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -233,6 +233,7 @@ spec:
             optional: true
             secretName: cilium-clustermesh
       restartPolicy: Always
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -315,6 +315,7 @@ spec:
             optional: true
             secretName: cilium-clustermesh
       restartPolicy: Always
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -245,6 +245,7 @@ spec:
             optional: true
             secretName: cilium-clustermesh
       restartPolicy: Always
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.9/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.9/cilium-pre-flight.yaml
@@ -56,6 +56,7 @@ spec:
             periodSeconds: 5
       hostNetwork: true
       restartPolicy: Always
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -327,6 +327,7 @@ spec:
             optional: true
             secretName: cilium-clustermesh
       restartPolicy: Always
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -233,6 +233,7 @@ spec:
             optional: true
             secretName: cilium-clustermesh
       restartPolicy: Always
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -245,6 +245,7 @@ spec:
             optional: true
             secretName: cilium-clustermesh
       restartPolicy: Always
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/examples/kubernetes/templates/v1/cilium-pre-flight.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-pre-flight.yaml.sed
@@ -56,6 +56,7 @@ spec:
             periodSeconds: 5
       hostNetwork: true
       restartPolicy: Always
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -205,6 +205,21 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, allAddresses, 
 		fmt.Fprintf(w, "Cilium:\t%s\t%s\n", sr.Cilium.State, sr.Cilium.Msg)
 	}
 
+	if sr.Stale != nil {
+		sortedProbes := make([]string, 0, len(sr.Stale))
+		for probe := range sr.Stale {
+			sortedProbes = append(sortedProbes, probe)
+		}
+		sort.Strings(sortedProbes)
+
+		stalesStr := make([]string, 0, len(sr.Stale))
+		for _, probe := range sortedProbes {
+			stalesStr = append(stalesStr, fmt.Sprintf("%q since %s", probe, sr.Stale[probe]))
+		}
+
+		fmt.Fprintf(w, "Stale status:\t%s\n", strings.Join(stalesStr, ", "))
+	}
+
 	if nm := sr.NodeMonitor; nm != nil {
 		fmt.Fprintf(w, "NodeMonitor:\tListening for events on %d CPUs with %dx%d of shared memory\n",
 			nm.Cpus, nm.Npages, nm.Pagesize)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -94,4 +94,15 @@ const (
 	// already been allocated and other nodes in the cluster have a chance
 	// to whitelist the new upcoming identity of the endpoint.
 	IdentityChangeGracePeriod = 25 * time.Second
+
+	// StatusCollectorInterval is the interval between a probe invocations
+	StatusCollectorInterval = 5 * time.Second
+
+	// StatusCollectorWarningThreshold is the duration after which a probe
+	// is declared as stale
+	StatusCollectorWarningThreshold = 15 * time.Second
+
+	// StatusCollectorFailureThreshold is the duration after which a probe
+	// is considered failed
+	StatusCollectorFailureThreshold = 1 * time.Minute
 )

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -392,8 +392,11 @@ type Endpoint struct {
 	// compiled and installed.
 	bpfHeaderfileHash string
 
-	k8sPodName   string
-	k8sNamespace string
+	// K8sPodName is the Kubernetes pod name of the endpoint
+	K8sPodName string
+
+	// K8sNamespace is the Kubernetes namespace of the endpoint
+	K8sNamespace string
 
 	// policyRevision is the policy revision this endpoint is currently on
 	// to modify this field please use endpoint.setPolicyRevision instead
@@ -750,8 +753,8 @@ func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, 
 		DockerNetworkID:  base.DockerNetworkID,
 		DockerEndpointID: base.DockerEndpointID,
 		IfName:           base.InterfaceName,
-		k8sPodName:       base.K8sPodName,
-		k8sNamespace:     base.K8sNamespace,
+		K8sPodName:       base.K8sPodName,
+		K8sNamespace:     base.K8sNamespace,
 		IfIndex:          int(base.InterfaceIndex),
 		OpLabels: pkgLabels.OpLabels{
 			Custom:                pkgLabels.Labels{},
@@ -1901,7 +1904,7 @@ func (e *Endpoint) SetContainerName(name string) {
 // Kubernetes pod
 func (e *Endpoint) GetK8sNamespace() string {
 	e.UnconditionalRLock()
-	ns := e.k8sNamespace
+	ns := e.K8sNamespace
 	e.RUnlock()
 	return ns
 }
@@ -1909,7 +1912,7 @@ func (e *Endpoint) GetK8sNamespace() string {
 // SetK8sNamespace modifies the endpoint's pod name
 func (e *Endpoint) SetK8sNamespace(name string) {
 	e.UnconditionalLock()
-	e.k8sNamespace = name
+	e.K8sNamespace = name
 	e.UpdateLogger(map[string]interface{}{
 		logfields.K8sPodName: e.GetK8sNamespaceAndPodNameLocked(),
 	})
@@ -1920,7 +1923,7 @@ func (e *Endpoint) SetK8sNamespace(name string) {
 // Kubernetes pod
 func (e *Endpoint) GetK8sPodName() string {
 	e.UnconditionalRLock()
-	k8sPodName := e.k8sPodName
+	k8sPodName := e.K8sPodName
 	e.RUnlock()
 
 	return k8sPodName
@@ -1929,13 +1932,13 @@ func (e *Endpoint) GetK8sPodName() string {
 // GetK8sNamespaceAndPodNameLocked returns the namespace and pod name.  This
 // function requires e.Mutex to be held.
 func (e *Endpoint) GetK8sNamespaceAndPodNameLocked() string {
-	return e.k8sNamespace + "/" + e.k8sPodName
+	return e.K8sNamespace + "/" + e.K8sPodName
 }
 
 // SetK8sPodName modifies the endpoint's pod name
 func (e *Endpoint) SetK8sPodName(name string) {
 	e.UnconditionalLock()
-	e.k8sPodName = name
+	e.K8sPodName = name
 	e.UpdateLogger(map[string]interface{}{
 		logfields.K8sPodName: e.GetK8sNamespaceAndPodNameLocked(),
 	})

--- a/pkg/maps/lbmap/bpfservice.go
+++ b/pkg/maps/lbmap/bpfservice.go
@@ -136,8 +136,15 @@ func (b *bpfService) deleteBackend(backend ServiceValue) {
 func (b *bpfService) getBackends() []ServiceValue {
 	b.mutex.RLock()
 	backends := make([]ServiceValue, len(b.backendsByMapIndex))
+	dstIndex := 0
 	for i := 1; i <= len(b.backendsByMapIndex); i++ {
-		backends[i-1] = b.backendsByMapIndex[i].bpfValue
+		if b.backendsByMapIndex[i] == nil {
+			log.Errorf("BUG: hole found in backendsByMapIndex: %#v", b.backendsByMapIndex)
+			continue
+		}
+
+		backends[dstIndex] = b.backendsByMapIndex[i].bpfValue
+		dstIndex++
 	}
 	b.mutex.RUnlock()
 	return backends

--- a/pkg/maps/lbmap/bpfservice.go
+++ b/pkg/maps/lbmap/bpfservice.go
@@ -74,7 +74,7 @@ func (b *bpfService) addBackend(backend ServiceValue) {
 		b.backendsByMapIndex[index].isHole = false
 	} else {
 		// No holes, we need to allocate a new backend slot
-		nextSlot := len(b.uniqueBackends) + 1
+		nextSlot := len(b.backendsByMapIndex) + 1
 		b.backendsByMapIndex[nextSlot] = &bpfBackend{
 			bpfValue: backend,
 			id:       backend.String(),

--- a/pkg/maps/lbmap/bpfservice_test.go
+++ b/pkg/maps/lbmap/bpfservice_test.go
@@ -18,6 +18,8 @@ import (
 	"net"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/checker"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -49,69 +51,69 @@ func (b *LBMapTestSuite) TestScaleService(c *C) {
 	b1 := createBackend(c, "2.2.2.2", 80, 1)
 	svc.addBackend(b1)
 	c.Assert(len(svc.backendsByMapIndex), Equals, 1)
-	c.Assert(len(svc.holes), Equals, 0)
 	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b1)
 
 	b2 := createBackend(c, "3.3.3.3", 80, 1)
 	svc.addBackend(b2)
 	c.Assert(len(svc.backendsByMapIndex), Equals, 2)
-	c.Assert(len(svc.holes), Equals, 0)
 	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b1)
 	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
 
 	svc.deleteBackend(b1)
 	c.Assert(len(svc.backendsByMapIndex), Equals, 2)
-	c.Assert(len(svc.holes), Equals, 1)
 	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b2)
 	c.Assert(svc.backendsByMapIndex[1].isHole, Equals, true)
 	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
 
 	b3 := createBackend(c, "4.4.4.4", 80, 1)
 	svc.addBackend(b3)
-	c.Assert(len(svc.backendsByMapIndex), Equals, 2)
-	c.Assert(len(svc.holes), Equals, 0)
-	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b3)
-	c.Assert(svc.backendsByMapIndex[1].isHole, Equals, false)
-	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
-	c.Assert(svc.backendsByMapIndex[2].isHole, Equals, false)
-
-	b4 := createBackend(c, "5.5.5.5", 80, 1)
-	svc.addBackend(b4)
 	c.Assert(len(svc.backendsByMapIndex), Equals, 3)
-	c.Assert(len(svc.holes), Equals, 0)
-	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b3)
-	c.Assert(svc.backendsByMapIndex[1].isHole, Equals, false)
-	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
-	c.Assert(svc.backendsByMapIndex[2].isHole, Equals, false)
-	c.Assert(svc.backendsByMapIndex[3].bpfValue, Equals, b4)
-	c.Assert(svc.backendsByMapIndex[3].isHole, Equals, false)
-
-	svc.deleteBackend(b4)
-	c.Assert(len(svc.backendsByMapIndex), Equals, 3)
-	c.Assert(len(svc.holes), Equals, 1)
-	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b3)
-	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
-	// either b2 or b3 can be used to fill in
-	c.Assert(svc.backendsByMapIndex[3].isHole && (svc.backendsByMapIndex[3].bpfValue == b3 || svc.backendsByMapIndex[3].bpfValue == b2), Equals, true)
-
-	svc.deleteBackend(b3)
-	c.Assert(len(svc.backendsByMapIndex), Equals, 3)
-	c.Assert(len(svc.holes), Equals, 2)
 	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b2)
 	c.Assert(svc.backendsByMapIndex[1].isHole, Equals, true)
 	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
 	c.Assert(svc.backendsByMapIndex[2].isHole, Equals, false)
+	c.Assert(svc.backendsByMapIndex[3].bpfValue, Equals, b3)
+	c.Assert(svc.backendsByMapIndex[3].isHole, Equals, false)
+
+	b4 := createBackend(c, "5.5.5.5", 80, 1)
+	svc.addBackend(b4)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 4)
+	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b2)
+	c.Assert(svc.backendsByMapIndex[1].isHole, Equals, true)
+	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
+	c.Assert(svc.backendsByMapIndex[2].isHole, Equals, false)
+	c.Assert(svc.backendsByMapIndex[3].bpfValue, Equals, b3)
+	c.Assert(svc.backendsByMapIndex[3].isHole, Equals, false)
+	c.Assert(svc.backendsByMapIndex[4].bpfValue, Equals, b4)
+	c.Assert(svc.backendsByMapIndex[4].isHole, Equals, false)
+
+	svc.deleteBackend(b4)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 4)
+	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b2)
+	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
+	c.Assert(svc.backendsByMapIndex[3].bpfValue, Equals, b3)
+	// b3 has less duplicates and must be used
+	c.Assert(svc.backendsByMapIndex[4].isHole, Equals, true)
+	c.Assert(svc.backendsByMapIndex[4].bpfValue, Equals, b3)
+
+	svc.deleteBackend(b3)
+	c.Assert(len(svc.backendsByMapIndex), Equals, 4)
+	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b2)
+	c.Assert(svc.backendsByMapIndex[1].isHole, Equals, true)
+	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
+	c.Assert(svc.backendsByMapIndex[2].isHole, Equals, false)
+	c.Assert(svc.backendsByMapIndex[2].bpfValue, Equals, b2)
 	c.Assert(svc.backendsByMapIndex[3].bpfValue, Equals, b2)
 	c.Assert(svc.backendsByMapIndex[3].isHole, Equals, true)
+	c.Assert(svc.backendsByMapIndex[4].bpfValue, Equals, b2)
+	c.Assert(svc.backendsByMapIndex[4].isHole, Equals, true)
 
 	// last backend is removed, we can finally remove all backend slots
 	svc.deleteBackend(b2)
 	c.Assert(len(svc.backendsByMapIndex), Equals, 0)
-	c.Assert(len(svc.holes), Equals, 0)
 
 	svc.addBackend(b4)
 	c.Assert(len(svc.backendsByMapIndex), Equals, 1)
-	c.Assert(len(svc.holes), Equals, 0)
 	c.Assert(svc.backendsByMapIndex[1].bpfValue, Equals, b4)
 }
 
@@ -158,15 +160,17 @@ func (b *LBMapTestSuite) TestPrepareUpdate(c *C) {
 	c.Assert(backends[2], DeepEquals, b3)
 
 	bpfSvc = cache.prepareUpdate(frontend, []ServiceValue{b1, b2, b3})
-	c.Assert(bpfSvc.backendsByMapIndex[1].bpfValue, DeepEquals, b1)
-	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, DeepEquals, b2)
-	c.Assert(bpfSvc.backendsByMapIndex[3].bpfValue, DeepEquals, b3)
+	c.Assert(bpfSvc.backendsByMapIndex[1].bpfValue, Not(DeepEquals), b1)
+	c.Assert(bpfSvc.backendsByMapIndex[2].bpfValue, checker.DeepEquals, b2)
+	c.Assert(bpfSvc.backendsByMapIndex[3].bpfValue, checker.DeepEquals, b3)
+	c.Assert(bpfSvc.backendsByMapIndex[4].bpfValue, checker.DeepEquals, b1)
 
 	backends = bpfSvc.getBackends()
-	c.Assert(len(backends), Equals, 3)
-	c.Assert(backends[0], DeepEquals, b1)
-	c.Assert(backends[1], DeepEquals, b2)
-	c.Assert(backends[2], DeepEquals, b3)
+	c.Assert(len(backends), Equals, 4)
+	c.Assert(backends[0], Not(DeepEquals), b1)
+	c.Assert(backends[1], checker.DeepEquals, b2)
+	c.Assert(backends[2], checker.DeepEquals, b3)
+	c.Assert(backends[3], checker.DeepEquals, b1)
 
 	bpfSvc = cache.prepareUpdate(frontend, []ServiceValue{})
 	c.Assert(len(bpfSvc.backendsByMapIndex), Equals, 0)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -343,6 +343,17 @@ func (c *daemonConfig) GetGlobalsDir() string {
 	return filepath.Join(c.StateDir, "globals")
 }
 
+// WorkloadsEnabled returns true if any workload runtimes are enabled
+func (c *daemonConfig) WorkloadsEnabled() bool {
+	for _, w := range c.Workloads {
+		if w == "none" {
+			return false
+		}
+	}
+
+	return len(c.Workloads) > 0
+}
+
 // AlwaysAllowLocalhost returns true if the daemon has the option set that
 // localhost can always reach local endpoints
 func (c *daemonConfig) AlwaysAllowLocalhost() bool {

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -39,3 +39,26 @@ func (s *OptionSuite) TestValidateIPv6ClusterAllocCIDR(c *C) {
 	invalid4 := &daemonConfig{}
 	c.Assert(invalid4.validateIPv6ClusterAllocCIDR(), Not(IsNil))
 }
+
+func (s *OptionSuite) TestWorkloadsEnabled(c *C) {
+	type testDefinition struct {
+		config   *daemonConfig
+		expected bool
+	}
+
+	tests := []testDefinition{
+		{&daemonConfig{Workloads: []string{}}, false},
+		{&daemonConfig{Workloads: []string{"none"}}, false},
+		{&daemonConfig{Workloads: []string{"none"}}, false},
+		{&daemonConfig{Workloads: []string{"docker", "none"}}, false},
+		{&daemonConfig{Workloads: []string{"docker"}}, true},
+		{&daemonConfig{Workloads: []string{"docker", "crio"}}, true},
+		{&daemonConfig{Workloads: []string{"docker", "nonefalse"}}, true},
+	}
+
+	for _, test := range tests {
+		if test.config.WorkloadsEnabled() != test.expected {
+			c.Errorf("%#v != %#v", test.config.Workloads, test.expected)
+		}
+	}
+}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -19,16 +19,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 const (
-	defaultInterval         = 5 * time.Second
-	defaultFailureThreshold = time.Minute
-	defaultWarningThreshold = 20 * time.Second
-	subsystem               = "status"
+	subsystem = "status"
 )
 
 var (
@@ -87,15 +85,15 @@ func NewCollector(probes []Probe, config Config) *Collector {
 	}
 
 	if c.config.Interval == time.Duration(0) {
-		c.config.Interval = defaultInterval
+		c.config.Interval = defaults.StatusCollectorInterval
 	}
 
 	if c.config.FailureThreshold == time.Duration(0) {
-		c.config.FailureThreshold = defaultFailureThreshold
+		c.config.FailureThreshold = defaults.StatusCollectorFailureThreshold
 	}
 
 	if c.config.WarningThreshold == time.Duration(0) {
-		c.config.WarningThreshold = defaultWarningThreshold
+		c.config.WarningThreshold = defaults.StatusCollectorWarningThreshold
 	}
 
 	for i := range probes {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -1,0 +1,237 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+const (
+	defaultInterval         = 5 * time.Second
+	defaultFailureThreshold = time.Minute
+	defaultWarningThreshold = 20 * time.Second
+	subsystem               = "status"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, subsystem)
+)
+
+// Status is passed to a probe when its state changes
+type Status struct {
+	// Data is non-nil when the probe has completed successfully. Data is
+	// set to the value returned by Probe()
+	Data interface{}
+
+	// Err is non-nil if either the probe file or the Failure or Warning
+	// threshold has been reached
+	Err error
+
+	// StaleWarning is true once the WarningThreshold has been reached
+	StaleWarning bool
+}
+
+// Probe is run by the collector at a particular interval between invocations
+type Probe struct {
+	Name string
+
+	Probe func(ctx context.Context) (interface{}, error)
+
+	// OnStatusUpdate is called whenever the status of the probe changes
+	OnStatusUpdate func(status Status)
+}
+
+// Collector concurrently runs probes used to check status of various subsystems
+type Collector struct {
+	lock.RWMutex   // protects staleProbes and probeStartTime
+	config         Config
+	stop           chan struct{}
+	staleProbes    map[string]struct{}
+	probeStartTime map[string]time.Time
+}
+
+// Config is the collector configuration
+type Config struct {
+	WarningThreshold time.Duration
+	FailureThreshold time.Duration
+	Interval         time.Duration
+}
+
+// NewCollector creates a collector and starts the given probes.
+//
+// Each probe runs in a separate goroutine.
+func NewCollector(probes []Probe, config Config) *Collector {
+	c := &Collector{
+		config:         config,
+		stop:           make(chan struct{}, 0),
+		staleProbes:    make(map[string]struct{}),
+		probeStartTime: make(map[string]time.Time),
+	}
+
+	if c.config.Interval == time.Duration(0) {
+		c.config.Interval = defaultInterval
+	}
+
+	if c.config.FailureThreshold == time.Duration(0) {
+		c.config.FailureThreshold = defaultFailureThreshold
+	}
+
+	if c.config.WarningThreshold == time.Duration(0) {
+		c.config.WarningThreshold = defaultWarningThreshold
+	}
+
+	for i := range probes {
+		c.spawnProbe(&probes[i])
+	}
+
+	return c
+}
+
+// Close exits all probes and shuts down the collector
+// TODO(brb): call it when daemon exits (after GH#6248).
+func (c *Collector) Close() {
+	close(c.stop)
+}
+
+// GetStaleProbes returns a map of stale probes which key is a probe name and
+// value is a time when the last instance of the probe has been started.
+func (c *Collector) GetStaleProbes() map[string]time.Time {
+	c.RLock()
+	defer c.RUnlock()
+
+	probes := make(map[string]time.Time)
+
+	for p := range c.staleProbes {
+		probes[p] = c.probeStartTime[p]
+	}
+
+	return probes
+}
+
+// spawnProbe starts a goroutine which invokes the probe at the particular interval.
+func (c *Collector) spawnProbe(p *Probe) {
+	go func() {
+		for {
+			c.runProbe(p)
+
+			select {
+			case <-c.stop:
+				// collector is closed, stop looping
+				return
+			case <-time.After(c.config.Interval):
+				// keep looping
+			}
+		}
+	}()
+}
+
+// runProbe runs the given probe, and returns either after the probe has returned
+// or after the collector has been closed.
+func (c *Collector) runProbe(p *Probe) {
+	var (
+		statusData       interface{}
+		err              error
+		warningThreshold = time.After(c.config.WarningThreshold)
+		hardTimeout      = false
+		probeReturned    = make(chan struct{}, 1)
+		ctx, cancel      = context.WithTimeout(context.Background(), c.config.FailureThreshold)
+		ctxTimeout       = make(chan struct{}, 1)
+	)
+
+	c.Lock()
+	c.probeStartTime[p.Name] = time.Now()
+	c.Unlock()
+
+	go func() {
+		statusData, err = p.Probe(ctx)
+		close(probeReturned)
+	}()
+
+	go func() {
+		// Once ctx.Done() has been closed, we notify the polling loop by
+		// sending to the ctxTimeout channel. We cannot just close the channel,
+		// because otherwise the loop will always enter the "<-ctxTimeout" case.
+		<-ctx.Done()
+		ctxTimeout <- struct{}{}
+	}()
+
+	// This is a loop so that, when we hit a FailureThreshold, we still do
+	// not return until the probe returns. This is to ensure the same probe
+	// does not run again while it is blocked.
+	for {
+		select {
+		case <-c.stop:
+			// Collector was closed. The probe will complete in the background
+			// and won't be restarted again.
+			cancel()
+			return
+
+		case <-warningThreshold:
+			// Publish warning and continue waiting for probe
+			staleErr := fmt.Errorf("No response from %s probe within %v seconds",
+				p.Name, c.config.WarningThreshold.Seconds())
+			c.updateProbeStatus(p, nil, true, staleErr)
+
+		case <-probeReturned:
+			// The probe completed and we can return from runProbe
+			switch {
+			case hardTimeout:
+				// FailureThreshold was already reached. Keep the failure error
+				// message
+			case err != nil:
+				c.updateProbeStatus(p, nil, false, err)
+			default:
+				c.updateProbeStatus(p, statusData, false, nil)
+			}
+
+			cancel()
+			return
+
+		case <-ctxTimeout:
+			// We have timed out. Report a status and mark that we timed out so we
+			// do not emit status later.
+			staleErr := fmt.Errorf("No response from %s probe within %v seconds",
+				p.Name, c.config.FailureThreshold.Seconds())
+			c.updateProbeStatus(p, nil, true, staleErr)
+			hardTimeout = true
+		}
+	}
+}
+
+func (c *Collector) updateProbeStatus(p *Probe, data interface{}, staleWarning bool, err error) {
+	// Update stale status of the probe
+	c.Lock()
+	startTime := c.probeStartTime[p.Name]
+	if staleWarning {
+		c.staleProbes[p.Name] = struct{}{}
+	} else {
+		delete(c.staleProbes, p.Name)
+	}
+	c.Unlock()
+
+	if staleWarning {
+		log.WithField(logfields.StartTime, startTime).
+			Warn(fmt.Sprintf("Timeout while waiting for %q probe", p.Name))
+	}
+
+	// Notify the probe about status update
+	p.OnStatusUpdate(Status{Err: err, Data: data, StaleWarning: staleWarning})
+}

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -72,7 +72,7 @@ func (s *StatusTestSuite) TestCollectorStaleWarning(c *C) {
 	c.Assert(testutils.WaitUntil(func() bool {
 		return atomic.LoadUint64(&ok) >= 2
 	}, 1*time.Second), IsNil)
-	c.Assert(len(collector.GetStaleProbes()), Equals, 1)
+	c.Assert(collector.GetStaleProbes(), HasLen, 1)
 }
 
 func (s *StatusTestSuite) TestCollectorFailureTimeout(c *C) {
@@ -103,7 +103,7 @@ func (s *StatusTestSuite) TestCollectorFailureTimeout(c *C) {
 	c.Assert(testutils.WaitUntil(func() bool {
 		return atomic.LoadUint64(&ok) >= 1
 	}, 1*time.Second), IsNil)
-	c.Assert(len(collector.GetStaleProbes()), Equals, 1)
+	c.Assert(collector.GetStaleProbes(), HasLen, 1)
 }
 
 func (s *StatusTestSuite) TestCollectorSuccess(c *C) {
@@ -138,7 +138,7 @@ func (s *StatusTestSuite) TestCollectorSuccess(c *C) {
 	c.Assert(testutils.WaitUntil(func() bool {
 		return atomic.LoadUint64(&ok) >= 3 && atomic.LoadUint64(&errors) >= 3
 	}, 1*time.Second), IsNil)
-	c.Assert(len(collector.GetStaleProbes()), Equals, 0)
+	c.Assert(collector.GetStaleProbes(), HasLen, 0)
 }
 
 func (s *StatusTestSuite) TestCollectorSuccessAfterTimeout(c *C) {
@@ -170,5 +170,5 @@ func (s *StatusTestSuite) TestCollectorSuccessAfterTimeout(c *C) {
 	c.Assert(testutils.WaitUntil(func() bool {
 		return atomic.LoadUint64(&timeout) == 2 && atomic.LoadUint64(&ok) > 0
 	}, 1*time.Second), IsNil)
-	c.Assert(len(collector.GetStaleProbes()), Equals, 0)
+	c.Assert(collector.GetStaleProbes(), HasLen, 0)
 }

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -1,0 +1,174 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package status
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cilium/cilium/pkg/testutils"
+
+	. "gopkg.in/check.v1"
+)
+
+type StatusTestSuite struct {
+	config Config
+}
+
+var _ = Suite(&StatusTestSuite{})
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+func (s *StatusTestSuite) SetUpTest(c *C) {
+	s.config = Config{
+		Interval:         10 * time.Millisecond,
+		WarningThreshold: 20 * time.Millisecond,
+		FailureThreshold: 80 * time.Millisecond,
+	}
+}
+
+func (s *StatusTestSuite) TestCollectorStaleWarning(c *C) {
+	var ok uint64
+
+	p := []Probe{
+		{
+			Probe: func(ctx context.Context) (interface{}, error) {
+				time.Sleep(s.config.WarningThreshold * 2)
+				return nil, nil
+			},
+			OnStatusUpdate: func(status Status) {
+				if status.StaleWarning && status.Data == nil && status.Err != nil {
+					atomic.AddUint64(&ok, 1)
+
+				}
+			},
+		},
+	}
+
+	collector := NewCollector(p, s.config)
+	defer collector.Close()
+
+	// wait for the warning timeout to be reached twice
+	c.Assert(testutils.WaitUntil(func() bool {
+		return atomic.LoadUint64(&ok) >= 2
+	}, 1*time.Second), IsNil)
+	c.Assert(len(collector.GetStaleProbes()), Equals, 1)
+}
+
+func (s *StatusTestSuite) TestCollectorFailureTimeout(c *C) {
+	var ok uint64
+
+	p := []Probe{
+		{
+			Probe: func(ctx context.Context) (interface{}, error) {
+				time.Sleep(s.config.FailureThreshold * 2)
+				return nil, nil
+			},
+			OnStatusUpdate: func(status Status) {
+				if status.StaleWarning && status.Data == nil && status.Err != nil {
+					if strings.Contains(status.Err.Error(),
+						fmt.Sprintf("within %v seconds", s.config.FailureThreshold.Seconds())) {
+
+						atomic.AddUint64(&ok, 1)
+					}
+				}
+			},
+		},
+	}
+
+	collector := NewCollector(p, s.config)
+	defer collector.Close()
+
+	// wait for the failure timeout to kick in
+	c.Assert(testutils.WaitUntil(func() bool {
+		return atomic.LoadUint64(&ok) >= 1
+	}, 1*time.Second), IsNil)
+	c.Assert(len(collector.GetStaleProbes()), Equals, 1)
+}
+
+func (s *StatusTestSuite) TestCollectorSuccess(c *C) {
+	var ok, errors uint64
+	err := fmt.Errorf("error")
+
+	p := []Probe{
+		{
+			Probe: func(ctx context.Context) (interface{}, error) {
+				if atomic.LoadUint64(&ok) > 3 {
+					return nil, err
+				}
+				return "testData", nil
+			},
+			OnStatusUpdate: func(status Status) {
+				if status.Err == err {
+					atomic.AddUint64(&errors, 1)
+				}
+				if !status.StaleWarning && status.Data != nil && status.Err == nil {
+					if s, isString := status.Data.(string); isString && s == "testData" {
+						atomic.AddUint64(&ok, 1)
+					}
+				}
+			},
+		},
+	}
+
+	collector := NewCollector(p, s.config)
+	defer collector.Close()
+
+	// wait for the probe to succeed 3 times and to return the error 3 times
+	c.Assert(testutils.WaitUntil(func() bool {
+		return atomic.LoadUint64(&ok) >= 3 && atomic.LoadUint64(&errors) >= 3
+	}, 1*time.Second), IsNil)
+	c.Assert(len(collector.GetStaleProbes()), Equals, 0)
+}
+
+func (s *StatusTestSuite) TestCollectorSuccessAfterTimeout(c *C) {
+	var ok, timeout uint64
+
+	p := []Probe{
+		{
+			Probe: func(ctx context.Context) (interface{}, error) {
+				if atomic.LoadUint64(&timeout) == 0 {
+					time.Sleep(2 * s.config.FailureThreshold)
+				}
+				return nil, nil
+			},
+			OnStatusUpdate: func(status Status) {
+				if status.StaleWarning {
+					atomic.AddUint64(&timeout, 1)
+				} else {
+					atomic.AddUint64(&ok, 1)
+				}
+
+			},
+		},
+	}
+
+	collector := NewCollector(p, s.config)
+	defer collector.Close()
+
+	// wait for the probe to timeout (warning and failure) and then to succeed
+	c.Assert(testutils.WaitUntil(func() bool {
+		return atomic.LoadUint64(&timeout) == 2 && atomic.LoadUint64(&ok) > 0
+	}, 1*time.Second), IsNil)
+	c.Assert(len(collector.GetStaleProbes()), Equals, 0)
+}

--- a/pkg/workloads/cri.go
+++ b/pkg/workloads/cri.go
@@ -263,11 +263,7 @@ func (c *criClient) handleCreateWorkload(id string, retry bool) {
 
 		ep.SetContainerID(id)
 
-		// In Kubernetes mode, attempt to retrieve pod name stored in
-		// pod runtime label
-		//
-		// FIXME: Abstract via interface so other workload types can
-		// implement this
+		// FIXME: Remove this in 2019-06: GH-6526
 		if k8s.IsEnabled() {
 			ep.SetK8sNamespace(k8sLbls.GetPodNamespace(pod.Labels))
 			ep.SetK8sPodName(k8sLbls.GetPodName(pod.Labels))

--- a/pkg/workloads/docker.go
+++ b/pkg/workloads/docker.go
@@ -460,11 +460,7 @@ func (d *dockerClient) handleCreateWorkload(id string, retry bool) {
 		// Docker appends '/' to container names.
 		ep.SetContainerName(strings.Trim(containerName, "/"))
 
-		// In Kubernetes mode, attempt to retrieve pod name stored in
-		// container runtime label
-		//
-		// FIXME: Abstract via interface so other workload types can
-		// implement this
+		// FIXME: Remove this in 2019-06: GH-6526
 		if k8s.IsEnabled() {
 			if dockerContainer.Config != nil {
 				ep.SetK8sNamespace(k8sDockerLbls.GetPodNamespace(dockerContainer.Config.Labels))

--- a/vendor/github.com/mohae/deepcopy/LICENSE
+++ b/vendor/github.com/mohae/deepcopy/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Joel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/mohae/deepcopy/deepcopy.go
+++ b/vendor/github.com/mohae/deepcopy/deepcopy.go
@@ -1,0 +1,125 @@
+// deepcopy makes deep copies of things. A standard copy will copy the
+// pointers: deep copy copies the values pointed to.  Unexported field
+// values are not copied.
+//
+// Copyright (c)2014-2016, Joel Scoble (github.com/mohae), all rights reserved.
+// License: MIT, for more details check the included LICENSE file.
+package deepcopy
+
+import (
+	"reflect"
+	"time"
+)
+
+// Interface for delegating copy process to type
+type Interface interface {
+	DeepCopy() interface{}
+}
+
+// Iface is an alias to Copy; this exists for backwards compatibility reasons.
+func Iface(iface interface{}) interface{} {
+	return Copy(iface)
+}
+
+// Copy creates a deep copy of whatever is passed to it and returns the copy
+// in an interface{}.  The returned value will need to be asserted to the
+// correct type.
+func Copy(src interface{}) interface{} {
+	if src == nil {
+		return nil
+	}
+
+	// Make the interface a reflect.Value
+	original := reflect.ValueOf(src)
+
+	// Make a copy of the same type as the original.
+	cpy := reflect.New(original.Type()).Elem()
+
+	// Recursively copy the original.
+	copyRecursive(original, cpy)
+
+	// Return the copy as an interface.
+	return cpy.Interface()
+}
+
+// copyRecursive does the actual copying of the interface. It currently has
+// limited support for what it can handle. Add as needed.
+func copyRecursive(original, cpy reflect.Value) {
+	// check for implement deepcopy.Interface
+	if original.CanInterface() {
+		if copier, ok := original.Interface().(Interface); ok {
+			cpy.Set(reflect.ValueOf(copier.DeepCopy()))
+			return
+		}
+	}
+
+	// handle according to original's Kind
+	switch original.Kind() {
+	case reflect.Ptr:
+		// Get the actual value being pointed to.
+		originalValue := original.Elem()
+
+		// if  it isn't valid, return.
+		if !originalValue.IsValid() {
+			return
+		}
+		cpy.Set(reflect.New(originalValue.Type()))
+		copyRecursive(originalValue, cpy.Elem())
+
+	case reflect.Interface:
+		// If this is a nil, don't do anything
+		if original.IsNil() {
+			return
+		}
+		// Get the value for the interface, not the pointer.
+		originalValue := original.Elem()
+
+		// Get the value by calling Elem().
+		copyValue := reflect.New(originalValue.Type()).Elem()
+		copyRecursive(originalValue, copyValue)
+		cpy.Set(copyValue)
+
+	case reflect.Struct:
+		t, ok := original.Interface().(time.Time)
+		if ok {
+			cpy.Set(reflect.ValueOf(t))
+			return
+		}
+		// Go through each field of the struct and copy it.
+		for i := 0; i < original.NumField(); i++ {
+			// The Type's StructField for a given field is checked to see if StructField.PkgPath
+			// is set to determine if the field is exported or not because CanSet() returns false
+			// for settable fields.  I'm not sure why.  -mohae
+			if original.Type().Field(i).PkgPath != "" {
+				continue
+			}
+			copyRecursive(original.Field(i), cpy.Field(i))
+		}
+
+	case reflect.Slice:
+		if original.IsNil() {
+			return
+		}
+		// Make a new slice and copy each element.
+		cpy.Set(reflect.MakeSlice(original.Type(), original.Len(), original.Cap()))
+		for i := 0; i < original.Len(); i++ {
+			copyRecursive(original.Index(i), cpy.Index(i))
+		}
+
+	case reflect.Map:
+		if original.IsNil() {
+			return
+		}
+		cpy.Set(reflect.MakeMap(original.Type()))
+		for _, key := range original.MapKeys() {
+			originalValue := original.MapIndex(key)
+			copyValue := reflect.New(originalValue.Type()).Elem()
+			copyRecursive(originalValue, copyValue)
+			copyKey := Copy(key.Interface())
+			cpy.SetMapIndex(reflect.ValueOf(copyKey), copyValue)
+		}
+
+	default:
+		cpy.Set(original)
+	}
+}


### PR DESCRIPTION
 * PR: 6555 -- kubernetes: Change terminationGracePeriodSeconds to 1 (@tgraf) -- https://github.com/cilium/cilium/pull/6555
 * PR: 6549 -- doc: Fix non-critical CVE-2017-18342: (@tgraf) -- https://github.com/cilium/cilium/pull/6549
 * PR: 6518 -- Fix endpoint restore when container runtime is disabled (@tgraf) -- https://github.com/cilium/cilium/pull/6518
 * PR: 6514 -- endpoint: Restore pod/namespace from state (@tgraf) -- https://github.com/cilium/cilium/pull/6514
 * PR: 6271 -- Report stale status (@brb) -- https://github.com/cilium/cilium/pull/6271
 * PR: 6551 -- daemon: do not add endpoint if client connection closes during add operation (@aanm) -- https://github.com/cilium/cilium/pull/6551
 * PR: 6558 -- Fix crash in lbmap due to backendsByMapIndex containing holes (@tgraf) -- https://github.com/cilium/cilium/pull/6558
 * PR: 6567 -- daemon: start status collector after cilium-health initialization (@brb) -- https://github.com/cilium/cilium/pull/6567

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6562)
<!-- Reviewable:end -->
