### PR TITLE
Store/Restore DNS Cache state on restart

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1118,7 +1118,7 @@ func NewDaemon() (*Daemon, *endpointRestoreState, error) {
 		return nil, nil, err
 	}
 
-	err = d.bootstrapFQDN()
+	err = d.bootstrapFQDN(restoredEndpoints)
 	if err != nil {
 		return nil, restoredEndpoints, err
 	}
@@ -1378,9 +1378,10 @@ func (d *Daemon) GetNodeSuffix() string {
 // dnsRuleGen and DNSPoller will use the default resolver and, implicitly, the
 // default DNS cache. The proxy binds to all interfaces, and uses the
 // configured DNS proxy port (this may be 0 and so OS-assigned).
-func (d *Daemon) bootstrapFQDN() (err error) {
+func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState) (err error) {
 	cfg := fqdn.Config{
 		MinTTL:         toFQDNsMinTTL,
+		Cache:          fqdn.DefaultDNSCache,
 		LookupDNSNames: fqdn.DNSLookupDefaultResolver,
 		AddGeneratedRules: func(generatedRules []*policyApi.Rule) error {
 			// Insert the new rules into the policy repository. We need them to
@@ -1393,6 +1394,17 @@ func (d *Daemon) bootstrapFQDN() (err error) {
 	d.dnsPoller = fqdn.NewDNSPoller(cfg, d.dnsRuleGen)
 	if enableDNSPoller {
 		fqdn.StartDNSPoller(d.dnsPoller)
+	}
+
+	// Prefill the cache with DNS lookups from restored endpoints. This is needed
+	// to maintain continuity of which IPs are allowed.
+	// Note: This is TTL aware, and expired data will not be used (e.g. when
+	// restoring after a long delay).
+	for _, restoredEP := range restoredEndpoints.restored {
+		// Upgrades from old ciliums have this nil
+		if restoredEP.DNSHistory != nil {
+			fqdn.DefaultDNSCache.UpdateFromCache(restoredEP.DNSHistory)
+		}
 	}
 
 	// Once we stop returning errors from StartDNSProxy this should live in
@@ -1506,6 +1518,17 @@ func (d *Daemon) bootstrapFQDN() (err error) {
 			record.Log()
 
 			if msg.Response && msg.Rcode == dns.RcodeSuccess {
+				// This must happen before the ruleGen update below, to ensure that
+				// this data is included in the serialized Endpoint object.
+				// Note: We need to fixup minTTL to be consistent with how we insert it
+				// elsewhere i.e. we don't want to lose the lower bound for DNS data
+				// TTL if we reboot twice.
+				log.WithField(logfields.EndpointID, ep.ID).Debug("Recording DNS lookup in endpoint specific cache")
+				effectiveTTL := int(TTL)
+				if effectiveTTL < toFQDNsMinTTL {
+					effectiveTTL = toFQDNsMinTTL
+				}
+				ep.DNSHistory.Update(lookupTime, qname, responseIPs, effectiveTTL)
 				log.Debug("Updating DNS name in cache from response to to query")
 				if err := d.dnsRuleGen.UpdateGenerateDNS(lookupTime, map[string]*fqdn.DNSIPRecords{qname: {IPs: responseIPs, TTL: int(TTL)}}); err != nil {
 					log.WithError(err).Error("error updating internal DNS cache for rule generation")

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -161,18 +161,21 @@ func (ds *DNSCacheTestSuite) TestReverseUpdateLookup(c *C) {
 
 var (
 	now         = time.Now()
-	size        = 1000 // size of array to operate on
+	size        = uint32(1000) // size of array to operate on
 	entriesOrig = makeEntries(now, 1+size/3, 1+size/3, 1+size/3)
-	ipsOrig     = func() []net.IP {
-		ips := make([]net.IP, 0, size)
-		for i := 0; i < size; i++ {
-			ips = append(ips, net.IPv4(byte(i>>24), byte(i>>16), byte(i>>8), byte(i>>0)))
-		}
-		return ips
-	}()
+	ipsOrig     = makeIPs(size)
 )
 
-func makeEntries(now time.Time, live, redundant, expired int) (entries []*cacheEntry) {
+// makeIPs generates count sequential IPv4 IPs
+func makeIPs(count uint32) []net.IP {
+	ips := make([]net.IP, 0, count)
+	for i := uint32(0); i < count; i++ {
+		ips = append(ips, net.IPv4(byte(i>>24), byte(i>>16), byte(i>>8), byte(i>>0)))
+	}
+	return ips
+}
+
+func makeEntries(now time.Time, live, redundant, expired uint32) (entries []*cacheEntry) {
 	liveTTL := 120
 	redundantTTL := 60
 


### PR DESCRIPTION
When cilium restarts, the collection of DNS responses that were used to
generate toCIDR rules from toFQDNs need to restored. Previously, this
information was lost but is now part of each endpoint's state
information.

I ended up storing the information on each endpoint mainly because we already store/restore that information. This also allows for future per-EP handling. On the other hand, the data is only stored if the policy is regenerated. I'm not sure how to fix this, since we're trying to avoid regenerating needlessly :( The failure mode would be when a lookup repeats the same IPs, but the expiration time is further in the future. The endpoint's policy doesn't change, but the DNS data in the cache does. This might force me to try something else completely (like a globally shared BPF map that stores the DNS cache data).
*Update*: I've opted to store this data here, and I'll look into syncing the endpoint data more often in a separate PR.


The runtime test for this behaviour is in https://github.com/cilium/cilium/pull/6521 but I've tested that this makes that test pass.

#### Benchmarks
```
$ go test github.com/cilium/cilium/pkg/fqdn -check.b -check.f 'Benchmark.*JSON' -v
=== RUN   Test
PASS: cache_test.go:338: DNSCacheTestSuite.BenchmarkMarshalJSON10          50000             62956 ns/op
PASS: cache_test.go:339: DNSCacheTestSuite.BenchmarkMarshalJSON100          5000            572678 ns/op
PASS: cache_test.go:340: DNSCacheTestSuite.BenchmarkMarshalJSON1000          500           6302145 ns/op
PASS: cache_test.go:341: DNSCacheTestSuite.BenchmarkMarshalJSON10000          50          74597825 ns/op
PASS: cache_test.go:355: DNSCacheTestSuite.BenchmarkMarshalJSON1000Repeat2           500           6199934 ns/op
PASS: cache_test.go:350: DNSCacheTestSuite.BenchmarkMarshalJSON100Repeat2           5000            578313 ns/op
PASS: cache_test.go:343: DNSCacheTestSuite.BenchmarkUnmarshalJSON10        10000            172864 ns/op
PASS: cache_test.go:344: DNSCacheTestSuite.BenchmarkUnmarshalJSON100        1000           1468690 ns/op
PASS: cache_test.go:345: DNSCacheTestSuite.BenchmarkUnmarshalJSON1000        100          15734228 ns/op
PASS: cache_test.go:346: DNSCacheTestSuite.BenchmarkUnmarshalJSON10000        10         181890159 ns/op
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6563)
<!-- Reviewable:end -->
