### PR TITLE
vagrant: set locate to en_US.UTF-8

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -93,6 +93,10 @@ if ENV['K8S'] then
 else
     $vm_base_name = "runtime"
 end
+	
+# Set locate to en_US.UTF-8
+ENV["LC_ALL"] = "en_US.UTF-8"
+ENV["LC_CTYPE"] = "en_US.UTF-8"
 
 # We need this workaround since kube-proxy is not aware of multiple network
 # interfaces. If we send a packet to a service IP that packet is sent


### PR DESCRIPTION

Try to avoid python thow exception `Python locale error: unsupported locale setting` when install python-sphinxcontrib-* module via `pip install -r Documentation/requirements.txt` on vagrant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6565)
<!-- Reviewable:end -->
