### PR TITLE
daemon: start status collector after cilium-health initialization

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1111,8 +1111,6 @@ func NewDaemon() (*Daemon, *endpointRestoreState, error) {
 	d.l7Proxy = proxy.StartProxySupport(10000, 20000, option.Config.RunDir,
 		option.Config.AccessLog, &d, option.Config.AgentLabels)
 
-	d.startStatusCollector()
-
 	if err := fqdn.ConfigFromResolvConf(); err != nil {
 		return nil, nil, err
 	}

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -895,6 +895,8 @@ func runDaemon() {
 
 	d.initHealth()
 
+	d.startStatusCollector()
+
 	metricsErrs := initMetrics()
 
 	api := d.instantiateAPI()


### PR DESCRIPTION
Otherwise, the "cilium-health" status collector probe will race with `d.initHealth()` to access `d.ciliumHealth`.

Reported by @aanm with the help of the Go race detector:

```
WARNING: DATA RACE
Write at 0x00c0002a8878 by main goroutine:
  main.(*Daemon).initHealth()
      /home/vagrant/go/src/github.com/cilium/cilium/daemon/health.go:56 +0x3f9
<..>
Previous read at 0x00c0002a8878 by goroutine 37:
  main.(*Daemon).startStatusCollector.func16()
      /home/vagrant/go/src/github.com/cilium/cilium/daemon/status.go:294 +0x53
```

Fixes: 80b1636 ("daemon: get status of each subsystem concurrently")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6567)
<!-- Reviewable:end -->
