### PR TITLE
pkg/health: protect local variable against concurrent writes

### DIFF
--- a/pkg/health/server/server.go
+++ b/pkg/health/server/server.go
@@ -119,9 +119,11 @@ func (s *Server) getNodes() (nodeMap, error) {
 	}
 
 	if resp.Payload.Cluster.Self != "" {
+		s.RWMutex.Lock()
 		s.localStatus = &healthModels.SelfStatus{
 			Name: resp.Payload.Cluster.Self,
 		}
+		s.RWMutex.Unlock()
 	}
 
 	nodes := make(nodeMap)


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Write at 0x00c0004c8590 by goroutine 26:
  github.com/cilium/cilium/pkg/health/server.(*Server).getNodes()
      /go/src/github.com/cilium/cilium/pkg/health/server/server.go:122 +0xa18
  github.com/cilium/cilium/pkg/health/server.(*Server).FetchStatusResponse()
      /go/src/github.com/cilium/cilium/pkg/health/server/server.go:189 +0x3f
  github.com/cilium/cilium/pkg/health/server.(*putStatusProbe).Handle()
      /go/src/github.com/cilium/cilium/pkg/health/server/status.go:53 +0xab
  github.com/cilium/cilium/api/v1/health/server/restapi/connectivity.(*PutStatusProbe).ServeHTTP()
      /go/src/github.com/cilium/cilium/api/v1/health/server/restapi/connectivity/put_status_probe.go:59 +0x2b1
  github.com/cilium/cilium/vendor/github.com/go-openapi/runtime/middleware.NewOperationExecutor.func1()
      /go/src/github.com/cilium/cilium/vendor/github.com/go-openapi/runtime/middleware/operation.go:28 +0xb3
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:1964 +0x51
  github.com/cilium/cilium/vendor/github.com/go-openapi/runtime/middleware.NewRouter.func1()
      /go/src/github.com/cilium/cilium/vendor/github.com/go-openapi/runtime/middleware/router.go:73 +0x440
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:1964 +0x51
  github.com/cilium/cilium/vendor/github.com/go-openapi/runtime/middleware.Redoc.func1()
      /go/src/github.com/cilium/cilium/vendor/github.com/go-openapi/runtime/middleware/redoc.go:72 +0xff
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:1964 +0x51
  github.com/cilium/cilium/vendor/github.com/go-openapi/runtime/middleware.Spec.func1()
      /go/src/github.com/cilium/cilium/vendor/github.com/go-openapi/runtime/middleware/spec.go:45 +0xee
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:1964 +0x51
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2741 +0xc4
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1847 +0x80a

Previous write at 0x00c0004c8590 by goroutine 58:
  github.com/cilium/cilium/pkg/health/server.(*Server).getNodes()
      /go/src/github.com/cilium/cilium/pkg/health/server/server.go:122 +0xa18
  github.com/cilium/cilium/pkg/health/server.(*Server).runActiveServices.func1()
      /go/src/github.com/cilium/cilium/pkg/health/server/server.go:220 +0x6f
  github.com/cilium/cilium/vendor/github.com/servak/go-fastping.(*Pinger).run()
      /go/src/github.com/cilium/cilium/vendor/github.com/servak/go-fastping/fastping.go:454 +0xa33

Goroutine 26 (running) created at:
  net/http.(*Server).Serve()
      /usr/local/go/src/net/http/server.go:2851 +0x4c5
  github.com/cilium/cilium/vendor/github.com/tylerb/graceful.(*Server).Serve()
      /go/src/github.com/cilium/cilium/vendor/github.com/tylerb/graceful/graceful.go:307 +0x464
  github.com/cilium/cilium/api/v1/health/server.(*Server).Serve.func1()
      /go/src/github.com/cilium/cilium/api/v1/health/server/server.go:177 +0x80

Goroutine 58 (running) created at:
  github.com/cilium/cilium/vendor/github.com/servak/go-fastping.(*Pinger).RunLoop()
      /go/src/github.com/cilium/cilium/vendor/github.com/servak/go-fastping/fastping.go:362 +0x199
  github.com/cilium/cilium/pkg/health/server.(*prober).RunLoop()
      /go/src/github.com/cilium/cilium/pkg/health/server/prober.go:354 +0x4b
  github.com/cilium/cilium/pkg/health/server.(*Server).runActiveServices()
      /go/src/github.com/cilium/cilium/pkg/health/server/server.go:224 +0x1ab
  github.com/cilium/cilium/pkg/health/server.(*Server).Serve.func2()
      /go/src/github.com/cilium/cilium/pkg/health/server/server.go:251 +0x38
==================
```

Fixes: d95ad2edb5eb ("cilium-health: Report ping status to other nodes")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6570)
<!-- Reviewable:end -->
