### PR TITLE
DNSProxy: Provide a flag for rejected DNS queries.

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -90,6 +90,7 @@ cilium-agent [flags]
       --socket-path string                          Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
       --sockops-enable                              Enable sockops when kernel supported
       --state-dir string                            Directory path to store runtime state (default "/var/run/cilium")
+      --tofqdns-dns-reject-response-code string     DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
       --tofqdns-enable-poller                       Enable proactive polling of DNS names in toFQDNs.matchName rules.
       --tofqdns-min-ttl int                         The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600)
       --tofqdns-proxy-port int                      Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1551,5 +1551,6 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState) (err err
 
 			return nil
 		})
+	proxy.DefaultDNSProxy.SetRejectReply(option.Config.FQDNRejectResponse)
 	return err // filled by StartDNSProxy
 }

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -602,6 +602,9 @@ func init() {
 	flags.Bool(option.ToFQDNsEnablePoller, false, "Enable proactive polling of DNS names in toFQDNs.matchName rules.")
 	option.BindEnv(option.ToFQDNsEnablePoller)
 
+	flags.StringVar(&option.Config.FQDNRejectResponse, option.FQDNRejectResponseCode, option.FQDNProxyDenyWithRefused, fmt.Sprintf("DNS response code for rejecting DNS requests, available options are '%v'", option.FQDNRejectOptions))
+	viper.BindEnv(option.FQDNRejectResponseCode, option.FQDNRejectResponseCodeEnv)
+
 	viper.BindPFlags(flags)
 }
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -328,7 +328,29 @@ const (
 	EnableIPv6Name = "enable-ipv6"
 
 	// MonitorQueueSizeName is the name of the option MonitorQueueSize
-	MonitorQueueSizeName = "monitor-queue-size"
+	MonitorQueueSizeName    = "monitor-queue-size"
+	MonitorQueueSizeNameEnv = "CILIUM_MONITOR_QUEUE_SIZE"
+
+	//FQDNRejectResponseCode is the name for the option for dns-proxy reject response code
+	FQDNRejectResponseCode = "tofqdns-dns-reject-response-code"
+
+	//FQDNRejectResponseCodeEnv is the env name for FQDNRejectResponseCode option
+	FQDNRejectResponseCodeEnv = "CILIUM_TOFQDNS_DNS_REJECT_RESPONSE_CODE"
+
+	// FQDNProxyDenyWithNameError is useful when stub resolvers, like the one
+	// in Alpine Linux's libc (musl), treat a REFUSED as a resolution error.
+	// This happens when trying a DNS search list, as in kubernetes, and breaks
+	// even whitelisted DNS names.
+	FQDNProxyDenyWithNameError = "nameError"
+
+	// FQDNProxyDenyWithRefused is the response code for Domain refused. It is
+	// the default for denied DNS requests.
+	FQDNProxyDenyWithRefused = "refused"
+)
+
+// FQDNS variables
+var (
+	FQDNRejectOptions = []string{FQDNProxyDenyWithNameError, FQDNProxyDenyWithRefused}
 )
 
 // Available option for DaemonConfig.Tunnel
@@ -636,6 +658,9 @@ type DaemonConfig struct {
 	// DefaultDNSProxy below.
 	ToFQDNsProxyPort    int
 	ToFQDNsEnablePoller bool
+
+	// FQDNRejectResponse is the dns-proxy response for invalid dns-proxy request
+	FQDNRejectResponse string
 }
 
 var (


### PR DESCRIPTION
Due Alpine Linux uses musl libc library the dns support is not the same
as libc. One of the biggest different is that Alpine Linux containers
under Kubernetes will query using the search string from
resolv.conf, like `www.google.com.default.svc.cluster.local.`

The default response code is Refused(5) but in this case Alpine Linux
will not do the query again with the correct fqdn. So this flag allows
Cilium to reply NXDomain flag(3) so the dns flow will work as normal.

The new flag is `--tofqdns-dns-response-code=3`

The list of valid responses codes are:
https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6571)
<!-- Reviewable:end -->
