### PR TITLE
pkg/client: sort kubernetes API versions for CLI output

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -198,6 +198,7 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, allAddresses, 
 	if sr.Kubernetes != nil {
 		fmt.Fprintf(w, "Kubernetes:\t%s\t%s\n", sr.Kubernetes.State, sr.Kubernetes.Msg)
 		if sr.Kubernetes.State != models.K8sStatusStateDisabled {
+			sort.Strings(sr.Kubernetes.K8sAPIVersions)
 			fmt.Fprintf(w, "Kubernetes APIs:\t[\"%s\"]\n", strings.Join(sr.Kubernetes.K8sAPIVersions, "\", \""))
 		}
 	}


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

Related: https://github.com/cilium/cilium/issues/6574

```release-note
Sort kubernetes API versions on cilium status output
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6575)
<!-- Reviewable:end -->
