### PR TITLE
Misc ginkgo cleanups

### DIFF
--- a/examples/policies/l7/dns/dns.yaml
+++ b/examples/policies/l7/dns/dns.yaml
@@ -30,4 +30,3 @@ spec:
       - ports:
          - port: "80"
            protocol: TCP
-

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -518,7 +518,7 @@ func (s *SSHMeta) PolicyGetRevision() (int, error) {
 // PolicyImportAndWait validates and imports a new policy into Cilium and waits
 // until the policy revision number increments. Returns an error if the policy
 // is invalid or could not be imported.
-func (s *SSHMeta) PolicyImportAndWait(path string, timeout int64) (int, error) {
+func (s *SSHMeta) PolicyImportAndWait(path string, timeout time.Duration) (int, error) {
 	ginkgoext.By(fmt.Sprintf("Setting up policy: %s", path))
 
 	revision, err := s.PolicyGetRevision()
@@ -919,7 +919,7 @@ func (s *SSHMeta) SetUpCiliumWithOptions(template string) error {
 // WaitUntilReady waits until the output of `cilium status` returns with code
 // zero. Returns an error if the output of `cilium status` returns a nonzero
 // return code after the specified timeout duration has elapsed.
-func (s *SSHMeta) WaitUntilReady(timeout int64) error {
+func (s *SSHMeta) WaitUntilReady(timeout time.Duration) error {
 
 	body := func() bool {
 		res := s.ExecCilium("status")
@@ -939,7 +939,7 @@ func (s *SSHMeta) RestartCilium() error {
 	if !res.WasSuccessful() {
 		return fmt.Errorf("%s", res.CombineOutput())
 	}
-	if err := s.WaitUntilReady(100); err != nil {
+	if err := s.WaitUntilReady(CiliumStartTimeout); err != nil {
 		return err
 	}
 	if !s.WaitEndpointsReady() {

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,10 +26,11 @@ import (
 )
 
 var (
-	// HelperTimeout is a predefined timeout value for commands, in seconds.
-	HelperTimeout int64 = 300
-	// HelperTimeoutDuration is a predefined timeout value for commands.
-	HelperTimeoutDuration = time.Duration(HelperTimeout) * time.Second
+	// HelperTimeout is a predefined timeout value for commands.
+	HelperTimeout = 5 * time.Minute
+
+	// CiliumStartTimeout is a predefined timeout value for Cilium startup.
+	CiliumStartTimeout = 100 * time.Second
 
 	// BasePath is the path in the Vagrant VMs to which the test directory
 	// is mounted

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1064,12 +1064,13 @@ func (kub *Kubectl) CiliumEndpointWaitReady() error {
 	}
 
 	callback := func() string {
+		ctx, cancel := context.WithTimeout(context.Background(), HelperTimeoutDuration)
+		defer cancel()
+
 		var errorMessage string
 		for _, pod := range ciliumPods {
 			var endpoints []models.Endpoint
-			ctx, cancel := context.WithTimeout(context.Background(), HelperTimeoutDuration)
 			cmdRes := kub.CiliumEndpointsList(ctx, pod)
-			cancel()
 			if !cmdRes.WasSuccessful() {
 				return fmt.Sprintf("unable to get cilium endpoint list from pod %s: %s", pod, cmdRes.err)
 			}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1072,11 +1072,17 @@ func (kub *Kubectl) CiliumEndpointWaitReady() error {
 			var endpoints []models.Endpoint
 			cmdRes := kub.CiliumEndpointsList(ctx, pod)
 			if !cmdRes.WasSuccessful() {
-				return fmt.Sprintf("unable to get cilium endpoint list from pod %s: %s", pod, cmdRes.err)
+				errorMessage += fmt.Sprintf(
+					"\tCilium Pod: %s \terror: unable to get endpoint list: %s",
+					pod, cmdRes.err)
+				continue
 			}
 			err := cmdRes.Unmarshal(&endpoints)
 			if err != nil {
-				return fmt.Sprintf("error parsing endpoint list for pod %s: %s", pod, err)
+				errorMessage += fmt.Sprintf(
+					"\tCilium Pod: %s \terror: unable to parse endpoint list: %s",
+					pod, err)
+				continue
 			}
 			for _, ep := range endpoints {
 				errorMessage += fmt.Sprintf(

--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+var timeout = 10 * time.Minute
 
 // ConnTestSpec Connectivity Test Specification. This structs contains the
 // mapping of all protocols tested and the expected result based on the context
@@ -491,7 +493,7 @@ func (t *TestSpec) ApplyManifest() (string, error) {
 	err = t.Kub.WaitforPods(
 		helpers.DefaultNamespace,
 		fmt.Sprintf("-l zgroup=%s", t.Prefix),
-		600)
+		timeout)
 	if err != nil {
 		return "", err
 	}

--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -195,7 +195,7 @@ func (client *SSHClient) RunCommand(cmd *SSHCommand) error {
 // returned instead the context error.
 func (client *SSHClient) RunCommandInBackground(ctx context.Context, cmd *SSHCommand) error {
 	if ctx == nil {
-		panic("nil context provided to RunCommandContext()")
+		panic("nil context provided to RunCommandInBackground()")
 	}
 
 	session, err := client.newSession()

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -107,8 +107,8 @@ func RenderTemplateToFile(filename string, tmplt string, perm os.FileMode) error
 
 // TimeoutConfig represents the configuration for the timeout of a command.
 type TimeoutConfig struct {
-	Ticker  int64 // Check interval in duration, in seconds.
-	Timeout int64 // Timeout definition, in seconds.
+	Ticker  time.Duration // Check interval
+	Timeout time.Duration // Limit for how long to spend in the command
 }
 
 // WithTimeout executes body using the time interval specified in config until
@@ -119,8 +119,8 @@ func WithTimeout(body func() bool, msg string, config *TimeoutConfig) error {
 		config.Ticker = 5
 	}
 
-	done := time.After(time.Duration(config.Timeout) * time.Second)
-	ticker := time.NewTicker(time.Duration(config.Ticker) * time.Second)
+	done := time.After(config.Timeout)
+	ticker := time.NewTicker(config.Ticker)
 	defer ticker.Stop()
 	if body() {
 		return nil

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ var _ = Describe("K8sChaosTest", func() {
 			kubectl.Apply(demoDSPath).ExpectSuccess("DS deployment cannot be applied")
 
 			err := kubectl.WaitforPods(
-				helpers.DefaultNamespace, fmt.Sprintf("-l zgroup=testDS"), 300)
+				helpers.DefaultNamespace, fmt.Sprintf("-l zgroup=testDS"), helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 		})
 
@@ -116,7 +116,7 @@ var _ = Describe("K8sChaosTest", func() {
 			By("Waiting for deployed pods to be ready")
 			err := kubectl.WaitforPods(
 				helpers.DefaultNamespace,
-				fmt.Sprintf("-l zgroup=testDSClient"), 300)
+				fmt.Sprintf("-l zgroup=testDSClient"), helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 
 			err = kubectl.CiliumEndpointWaitReady()
@@ -181,7 +181,7 @@ var _ = Describe("K8sChaosTest", func() {
 
 			err := kubectl.WaitforPods(
 				helpers.DefaultNamespace,
-				fmt.Sprintf("-l zgroup=testapp"), 300)
+				fmt.Sprintf("-l zgroup=testapp"), helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 
 			podsIps, err = kubectl.GetPodsIPs(helpers.DefaultNamespace, "zgroup=testapp")
@@ -213,7 +213,7 @@ var _ = Describe("K8sChaosTest", func() {
 
 			By("Waiting for cilium pods to be ready")
 			err := kubectl.WaitforPods(
-				helpers.KubeSystemNamespace, fmt.Sprintf("-l %s", ciliumFilter), 300)
+				helpers.KubeSystemNamespace, fmt.Sprintf("-l %s", ciliumFilter), helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 
 			err = kubectl.CiliumEndpointWaitReady()
@@ -249,7 +249,7 @@ var _ = Describe("K8sChaosTest", func() {
 
 			By("Installing the L3-L4 Policy")
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, netperfPolicy, helpers.KubectlApply, 300)
+				helpers.KubeSystemNamespace, netperfPolicy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot install %q policy", netperfPolicy)
 
 			restartCilium()

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -147,7 +147,7 @@ var _ = Describe("K8sPolicyTest", func() {
 		BeforeAll(func() {
 			kubectl.Apply(demoPath)
 
-			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", 300)
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Test pods are not ready after timeout")
 
 			ciliumPod, err = kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
@@ -175,7 +175,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			err := kubectl.CiliumEndpointWaitReady()
 			Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 
-			err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", 300)
+			err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
 		})
@@ -192,7 +192,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			By("Testing L3/L4 rules")
 
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, l3Policy, helpers.KubectlApply, 300)
+				helpers.KubeSystemNamespace, l3Policy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
 			trace := kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
@@ -225,7 +225,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			By("Testing L7 Policy")
 
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, l7Policy, helpers.KubectlApply, 300)
+				helpers.KubeSystemNamespace, l7Policy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot install %q policy", l7Policy)
 
 			res = kubectl.ExecPodCmd(
@@ -257,7 +257,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			// Load policy allowing serviceAccount of app2 to talk
 			// to app1 on port 80 TCP
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, serviceAccountPolicy, helpers.KubectlApply, 300)
+				helpers.KubeSystemNamespace, serviceAccountPolicy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
 			trace := kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
@@ -286,7 +286,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 		It("CNP test MatchExpressions key", func() {
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, cnpMatchExpression, helpers.KubectlApply, 300)
+				helpers.KubeSystemNamespace, cnpMatchExpression, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "cannot install policy %s", cnpMatchExpression)
 
 			res := kubectl.ExecPodCmd(
@@ -316,7 +316,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			By("Installing knp ingress default-deny")
 
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, knpDenyIngress, helpers.KubectlApply, 300)
+				helpers.KubeSystemNamespace, knpDenyIngress, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"L3 deny-ingress Policy cannot be applied in %q namespace", helpers.DefaultNamespace)
 
@@ -348,7 +348,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			By("Installing knp egress default-deny")
 
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, knpDenyEgress, helpers.KubectlApply, 300)
+				helpers.KubeSystemNamespace, knpDenyEgress, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"L3 deny-egress Policy cannot be applied in %q namespace", helpers.DefaultNamespace)
 
@@ -387,7 +387,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			By("Installing knp ingress-egress default-deny")
 
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, knpDenyIngressEgress, helpers.KubectlApply, 300)
+				helpers.KubeSystemNamespace, knpDenyIngressEgress, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"L3 deny-ingress-egress policy cannot be applied in %q namespace", helpers.DefaultNamespace)
 
@@ -438,7 +438,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			By("Installing cnp ingress default-deny")
 
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, cnpDenyIngress, helpers.KubectlApply, 300)
+				helpers.KubeSystemNamespace, cnpDenyIngress, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"L3 deny-ingress Policy cannot be applied in %q namespace", helpers.DefaultNamespace)
 
@@ -460,7 +460,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 			By("Installing cnp egress default-deny")
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, cnpDenyEgress, helpers.KubectlApply, 300)
+				helpers.KubeSystemNamespace, cnpDenyEgress, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"L3 deny-egress Policy cannot be applied in %q namespace", helpers.DefaultNamespace)
 
@@ -634,35 +634,35 @@ var _ = Describe("K8sPolicyTest", func() {
 			It("Enforces connectivity correctly when the same L3/L4 CNP is updated", func() {
 				By("Applying default allow policy")
 				_, err := kubectl.CiliumPolicyAction(
-					helpers.KubeSystemNamespace, cnpUpdateAllow, helpers.KubectlApply, 300)
+					helpers.KubeSystemNamespace, cnpUpdateAllow, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateAllow)
 
 				validateL3L4(allowAll)
 
 				By("Applying l3-l4 policy")
 				_, err = kubectl.CiliumPolicyAction(
-					helpers.KubeSystemNamespace, cnpUpdateDeny, helpers.KubectlApply, 300)
+					helpers.KubeSystemNamespace, cnpUpdateDeny, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateDeny)
 
 				validateL3L4(denyFromApp3)
 
 				By("Applying no-specs policy")
 				_, err = kubectl.CiliumPolicyAction(
-					helpers.KubeSystemNamespace, cnpUpdateNoSpecs, helpers.KubectlApply, 300)
+					helpers.KubeSystemNamespace, cnpUpdateNoSpecs, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateAllow)
 
 				validateL3L4(allowAll)
 
 				By("Applying l3-l4 policy with user-specified labels")
 				_, err = kubectl.CiliumPolicyAction(
-					helpers.KubeSystemNamespace, cnpUpdateDenyLabelled, helpers.KubectlApply, 300)
+					helpers.KubeSystemNamespace, cnpUpdateDenyLabelled, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateDeny)
 
 				validateL3L4(denyFromApp3)
 
 				By("Applying default allow policy (should remove policy with user labels)")
 				_, err = kubectl.CiliumPolicyAction(
-					helpers.KubeSystemNamespace, cnpUpdateAllow, helpers.KubectlApply, 300)
+					helpers.KubeSystemNamespace, cnpUpdateAllow, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateAllow)
 
 				validateL3L4(allowAll)
@@ -675,7 +675,7 @@ var _ = Describe("K8sPolicyTest", func() {
 				// test "checks all kind of Kubernetes policies".
 				// Install it then move on.
 				_, err := kubectl.CiliumPolicyAction(
-					helpers.KubeSystemNamespace, l7Policy, helpers.KubectlApply, 300)
+					helpers.KubeSystemNamespace, l7Policy, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "Cannot install %q policy", l7Policy)
 
 				// Update existing policy on port 80 from http to kafka
@@ -683,7 +683,7 @@ var _ = Describe("K8sPolicyTest", func() {
 				// Traffic cannot flow but policy must be able to be
 				// imported and applied to the endpoints.
 				_, err = kubectl.CiliumPolicyAction(
-					helpers.KubeSystemNamespace, l7PolicyKafka, helpers.KubectlApply, 300)
+					helpers.KubeSystemNamespace, l7PolicyKafka, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "Cannot update L7 policy (%q) from parser http to kafka", l7PolicyKafka)
 
 				res := kubectl.ExecPodCmd(
@@ -758,7 +758,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 			err = kubectl.WaitforPods(
 				helpers.DefaultNamespace,
-				fmt.Sprintf("-l %s", groupLabel), 300)
+				fmt.Sprintf("-l %s", groupLabel), helpers.HelperTimeout)
 			ExpectWithOffset(1, err).Should(BeNil(), "Bookinfo pods are not ready after timeout")
 
 			err := kubectl.WaitForServiceEndpoints(
@@ -809,7 +809,7 @@ EOF`, k, v)
 			By("Apply policy to web")
 			_, err = kubectl.CiliumPolicyAction(
 				helpers.KubeSystemNamespace, helpers.ManifestGet(webPolicy),
-				helpers.KubectlApply, 300)
+				helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot apply web-policy")
 
 			policyCheck := fmt.Sprintf("%s=%s %s=%s",
@@ -820,7 +820,7 @@ EOF`, k, v)
 			By("Apply policy to Redis")
 			_, err = kubectl.CiliumPolicyAction(
 				helpers.KubeSystemNamespace, helpers.ManifestGet(redisPolicy),
-				helpers.KubectlApply, 300)
+				helpers.KubectlApply, helpers.HelperTimeout)
 
 			Expect(err).Should(BeNil(), "Cannot apply redis policy")
 
@@ -833,14 +833,14 @@ EOF`, k, v)
 
 			_, err = kubectl.CiliumPolicyAction(
 				helpers.KubeSystemNamespace, helpers.ManifestGet(redisPolicy),
-				helpers.KubectlDelete, 300)
+				helpers.KubectlDelete, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot apply redis policy")
 
 			By("Apply deprecated policy to Redis")
 
 			_, err = kubectl.CiliumPolicyAction(
 				helpers.KubeSystemNamespace, helpers.ManifestGet(redisPolicyDeprecated),
-				helpers.KubectlApply, 300)
+				helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot apply redis deprecated policy err: %q", err)
 
 			policyCheck = fmt.Sprintf("%s=%s %s=%s",
@@ -884,11 +884,11 @@ EOF`, k, v)
 			res = kubectl.Apply(demoPath)
 			res.ExpectSuccess("unable to apply manifest")
 
-			err := kubectl.WaitforPods(secondNS, "-l zgroup=testapp", 300)
+			err := kubectl.WaitforPods(secondNS, "-l zgroup=testapp", helpers.HelperTimeout)
 			Expect(err).To(BeNil(),
 				"testapp pods are not ready after timeout in namspace %q", secondNS)
 
-			err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", 300)
+			err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", helpers.HelperTimeout)
 			Expect(err).To(BeNil(),
 				"testapp pods are not ready after timeout in %q namespace", helpers.DefaultNamespace)
 
@@ -923,13 +923,13 @@ EOF`, k, v)
 			// namespace and all works as expected.
 			By("Applying Policy in %q namespace", secondNS)
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, l3l4PolicySecondNS, helpers.KubectlApply, 300)
+				helpers.KubeSystemNamespace, l3l4PolicySecondNS, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"%q Policy cannot be applied in %q namespace", l3l4PolicySecondNS, secondNS)
 
 			By("Applying Policy in default namespace")
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, l3L4Policy, helpers.KubectlApply, 300)
+				helpers.KubeSystemNamespace, l3L4Policy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"%q Policy cannot be applied in %q namespace", l3L4Policy, helpers.DefaultNamespace)
 
@@ -979,7 +979,7 @@ EOF`, k, v)
 
 			By("Applying Policy in %q namespace", secondNS)
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, netpolNsSelector, helpers.KubectlApply, 300)
+				helpers.KubeSystemNamespace, netpolNsSelector, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Policy cannot be applied")
 
 			for _, pod := range []string{helpers.App2, helpers.App3} {
@@ -1000,7 +1000,7 @@ EOF`, k, v)
 
 			By("Delete Kubernetes Network Policies in %q namespace", secondNS)
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, netpolNsSelector, helpers.KubectlDelete, 300)
+				helpers.KubeSystemNamespace, netpolNsSelector, helpers.KubectlDelete, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Policy %q cannot be deleted", netpolNsSelector)
 
 			for _, pod := range []string{helpers.App2, helpers.App3} {
@@ -1019,7 +1019,7 @@ EOF`, k, v)
 		It("Cilium Network policy using namespace label and L7", func() {
 
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, cnpSecondNS, helpers.KubectlApply, 300)
+				helpers.KubeSystemNamespace, cnpSecondNS, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpSecondNS)
 
 			By("Testing connectivity in %q namespace", secondNS)

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package k8sTest
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -27,7 +28,7 @@ import (
 var _ = Describe("NightlyPolicies", func() {
 
 	var kubectl *helpers.Kubectl
-	var timeout int64 = 600
+	var timeout = 10 * time.Minute
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -102,7 +102,7 @@ var _ = Describe("K8sServicesTest", func() {
 	waitPodsDs := func() {
 		groups := []string{testDS, testDSClient}
 		for _, pod := range groups {
-			err := kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", pod), 300)
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", pod), helpers.HelperTimeout)
 			ExpectWithOffset(1, err).Should(BeNil())
 		}
 	}
@@ -125,7 +125,7 @@ var _ = Describe("K8sServicesTest", func() {
 		})
 
 		It("Checks service on same node", func() {
-			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", 300)
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 			clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, serviceName)
 			Expect(err).Should(BeNil(), "Cannot get service %s", serviceName)
@@ -244,7 +244,7 @@ var _ = Describe("K8sServicesTest", func() {
 			kubectl.Apply(servicePath).ExpectSuccess("cannot install external service")
 			kubectl.Apply(podPath).ExpectSuccess("cannot install pod path")
 
-			err := kubectl.WaitforPods(helpers.DefaultNamespace, "", 300)
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "", helpers.HelperTimeout)
 			Expect(err).To(BeNil(), "Pods are not ready after timeout")
 		})
 

--- a/test/k8sT/Tunnels.go
+++ b/test/k8sT/Tunnels.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ var _ = Describe("K8sTunnelTest", func() {
 
 		It("Check VXLAN mode", func() {
 			ProvisionInfraPods(kubectl)
-			err := kubectl.WaitforPods(helpers.DefaultNamespace, "", 300)
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "", helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 
 			ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
@@ -126,7 +126,7 @@ var _ = Describe("K8sTunnelTest", func() {
 			ExpectCiliumReady(kubectl)
 			ExpectETCDOperatorReady(kubectl)
 
-			err = kubectl.WaitforPods(helpers.DefaultNamespace, "", 300)
+			err = kubectl.WaitforPods(helpers.DefaultNamespace, "", helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 
 			ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
@@ -151,14 +151,14 @@ var _ = Describe("K8sTunnelTest", func() {
 
 			// FIXME GH-4456
 			cleanService()
-		}, 600)
+		})
 
 	})
 
 })
 
 func isNodeNetworkingWorking(kubectl *helpers.Kubectl, filter string) bool {
-	err := kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", filter), 3000)
+	err := kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", filter), helpers.HelperTimeout)
 	Expect(err).Should(BeNil())
 	pods, err := kubectl.GetPodNames(helpers.DefaultNamespace, filter)
 	Expect(err).Should(BeNil())

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,11 +16,14 @@ package k8sTest
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 	. "github.com/onsi/gomega"
 )
+
+var longTimeout = 10 * time.Minute
 
 // ExpectKubeDNSReady is a wrapper around helpers/WaitKubeDNS. It asserts that
 // the error returned by that function is nil.
@@ -35,7 +38,7 @@ func ExpectKubeDNSReady(vm *helpers.Kubectl) {
 // ExpectCiliumReady is a wrapper around helpers/WaitForPods. It asserts that
 // the error returned by that function is nil.
 func ExpectCiliumReady(vm *helpers.Kubectl) {
-	err := vm.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", 600)
+	err := vm.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", longTimeout)
 	ExpectWithOffset(1, err).Should(BeNil(), "cilium was not able to get into ready state")
 
 	err = vm.CiliumPreFlightCheck()
@@ -66,7 +69,7 @@ func ExpectETCDOperatorReady(vm *helpers.Kubectl) {
 	// new one is not created yet.
 	By("Waiting for all etcd-operator pods are ready")
 
-	err := vm.WaitforNPods(helpers.KubeSystemNamespace, "-l io.cilium/app=etcd-operator", 5, 600)
+	err := vm.WaitforNPods(helpers.KubeSystemNamespace, "-l io.cilium/app=etcd-operator", 5, longTimeout)
 	warningMessage := ""
 	if err != nil {
 		res := vm.Exec(fmt.Sprintf(
@@ -82,7 +85,7 @@ func ExpectETCDOperatorReady(vm *helpers.Kubectl) {
 func ExpectCiliumPreFlightInstallReady(vm *helpers.Kubectl) {
 	By("Waiting for all cilium pre-flight pods to be ready")
 
-	err := vm.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium-pre-flight-check", 600)
+	err := vm.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium-pre-flight-check", longTimeout)
 	warningMessage := ""
 	if err != nil {
 		res := vm.Exec(fmt.Sprintf(

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -102,7 +102,7 @@ var _ = Describe("K8sDemosTest", func() {
 		res.ExpectSuccess("unable to apply %s: %s", xwingYAMLLink, res.CombineOutput())
 
 		By("Waiting for pods to be ready")
-		err := kubectl.WaitforPods(helpers.DefaultNamespace, "", 300)
+		err := kubectl.WaitforPods(helpers.DefaultNamespace, "", helpers.HelperTimeout)
 		Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 
 		By("Getting xwing pod names")
@@ -128,7 +128,7 @@ var _ = Describe("K8sDemosTest", func() {
 
 		By("Importing L7 Policy which restricts access to %q", exhaustPortPath)
 		_, err = kubectl.CiliumPolicyAction(
-			helpers.KubeSystemNamespace, l7PolicyYAMLLink, helpers.KubectlApply, 300)
+			helpers.KubeSystemNamespace, l7PolicyYAMLLink, helpers.KubectlApply, helpers.HelperTimeout)
 		Expect(err).Should(BeNil(), "Unable to apply %s", l7PolicyYAMLLink)
 
 		By("Waiting for endpoints to be ready after importing policy")

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package k8sTest
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -70,6 +71,8 @@ var _ = Describe("K8sIstioTest", func() {
 		kubectl          *helpers.Kubectl
 		microscopeCancel = func() error { return nil }
 		uptimeCancel     context.CancelFunc
+
+		teardownTimeout = 10 * time.Minute
 	)
 
 	BeforeAll(func() {
@@ -94,7 +97,7 @@ var _ = Describe("K8sIstioTest", func() {
 		// Ignore one-time jobs and Prometheus. All other pods in the
 		// namespaces have an "istio" label.
 		By("Waiting for Istio pods to be ready")
-		err := kubectl.WaitforPods(istioSystemNamespace, "-l istio", 300)
+		err := kubectl.WaitforPods(istioSystemNamespace, "-l istio", helpers.HelperTimeout)
 		Expect(err).To(BeNil(),
 			"Istio pods are not ready after timeout in namespace %q", istioSystemNamespace)
 
@@ -119,7 +122,7 @@ var _ = Describe("K8sIstioTest", func() {
 		By("Deleting the istio-system namespace")
 		_ = kubectl.NamespaceDelete(istioSystemNamespace)
 
-		kubectl.WaitCleanAllTerminatingPods(600)
+		kubectl.WaitCleanAllTerminatingPods(teardownTimeout)
 	})
 
 	JustBeforeEach(func() {
@@ -316,7 +319,7 @@ var _ = Describe("K8sIstioTest", func() {
 				allGood = shouldNotConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, ratingsPath)) && allGood
 
 				return allGood
-			}, "Istio sidecar proxies are not configured", &helpers.TimeoutConfig{Timeout: 300})
+			}, "Istio sidecar proxies are not configured", &helpers.TimeoutConfig{Timeout: helpers.HelperTimeout})
 			Expect(err).Should(BeNil(), "Cannot configure Istio sidecar proxies")
 		})
 	})

--- a/test/runtime/assertionHelpers.go
+++ b/test/runtime/assertionHelpers.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ func ExpectEndpointSummary(vm *helpers.SSHMeta, policyEnforcementType string, nu
 
 // ExpectCiliumReady asserts that cilium status is ready
 func ExpectCiliumReady(vm *helpers.SSHMeta) {
-	err := vm.WaitUntilReady(100)
+	err := vm.WaitUntilReady(helpers.CiliumStartTimeout)
 	ExpectWithOffset(1, err).To(BeNil(), "Cilium-agent cannot be started")
 
 	vm.NetworkCreate(helpers.CiliumDockerNetwork, "")

--- a/test/runtime/cassandra.go
+++ b/test/runtime/cassandra.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -125,7 +125,7 @@ var _ = Describe("RuntimeCassandra", func() {
 	})
 
 	It("Tests policy allowing all actions", func() {
-		_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-cassandra-allow-all.json"), 300)
+		_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-cassandra-allow-all.json"), helpers.HelperTimeout)
 		Expect(err).Should(BeNil(), "Failed to import policy")
 
 		endPoints, err := vm.PolicyEndpointsSummary()
@@ -147,7 +147,7 @@ var _ = Describe("RuntimeCassandra", func() {
 
 	It("Tests policy disallowing Insert action", func() {
 
-		_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-cassandra-no-insert-posts.json"), 300)
+		_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-cassandra-no-insert-posts.json"), helpers.HelperTimeout)
 		Expect(err).Should(BeNil(), "Failed to import policy")
 
 		endPoints, err := vm.PolicyEndpointsSummary()

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/fqdn"
@@ -318,12 +317,12 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		// increment it by 1 again. We can wait for two policy revisions to happen.
 		// Once we have an API to expose DNS->IP mappings we can also use that to
 		// ensure the lookup has completed more explicitly
-		timeout_s := int64(3 * fqdn.DNSPollerInterval / time.Second) // convert to seconds
+		timeout := 3 * fqdn.DNSPollerInterval
 		dnsWaitBody := func() bool {
 			return vm.PolicyWait(preImportPolicyRevision + 2).WasSuccessful()
 		}
 		err = helpers.WithTimeout(dnsWaitBody, "DNSPoller did not update IPs",
-			&helpers.TimeoutConfig{Ticker: 1, Timeout: timeout_s})
+			&helpers.TimeoutConfig{Ticker: 1, Timeout: timeout})
 		ExpectWithOffset(1, err).To(BeNil(), "Unable to update IPs")
 		ExpectWithOffset(1, vm.WaitEndpointsReady()).Should(BeTrue(),
 			"Endpoints are not ready after ToFQDNs DNS poll triggered a regenerate")

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 		vm.ExecInBackground(
 			ctx,
 			"sudo cilium-agent --kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug")
-		err := vm.WaitUntilReady(150)
+		err := vm.WaitUntilReady(helpers.CiliumStartTimeout)
 		Expect(err).Should(BeNil())
 
 		By("Restarting cilium-docker service")
@@ -89,7 +89,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 		vm.ExecInBackground(
 			ctx,
 			"sudo cilium-agent --kvstore etcd --kvstore-opt etcd.address=127.0.0.1:4001 2>&1 | logger -t cilium")
-		err := vm.WaitUntilReady(150)
+		err := vm.WaitUntilReady(helpers.CiliumStartTimeout)
 		Expect(err).Should(BeNil(), "Timed out waiting for VM to be ready after restarting Cilium")
 
 		By("Restarting cilium-docker service")

--- a/test/runtime/memcache.go
+++ b/test/runtime/memcache.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -138,7 +138,7 @@ var _ = Describe("RuntimeMemcache", func() {
 		})
 
 		It("Tests policy allowing all actions", func() {
-			_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-memcache-allow.json"), 300)
+			_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-memcache-allow.json"), helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Failed to import policy")
 
 			key := "test2"
@@ -161,7 +161,7 @@ var _ = Describe("RuntimeMemcache", func() {
 			r.ExpectSuccess("Unable to set key %q without policy loaded", keyBeforePolicy)
 
 			By("Importing policy disallowing set")
-			_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-memcache-disallow-set.json"), 300)
+			_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-memcache-disallow-set.json"), helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Failed to import policy")
 
 			By("Trying to set new key")
@@ -180,7 +180,7 @@ var _ = Describe("RuntimeMemcache", func() {
 
 		It("Tests policy allowing actions only for key", func() {
 			By("Importing key-specific policy")
-			_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-memcache-allow-key.json"), 300)
+			_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-memcache-allow-key.json"), helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Failed to import policy")
 
 			key := "allowed"
@@ -206,7 +206,7 @@ var _ = Describe("RuntimeMemcache", func() {
 			r.ExpectSuccess("Unable to set disallowed value")
 
 			By("Importing key-specific policy")
-			_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-memcache-allow-key-get.json"), 300)
+			_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-memcache-allow-key-get.json"), helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Failed to import policy")
 
 			By("Getting multiple keys")
@@ -249,7 +249,7 @@ var _ = Describe("RuntimeMemcache", func() {
 		})
 
 		It("Tests policy allowing all actions", func() {
-			_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-memcache-allow.json"), 300)
+			_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-memcache-allow.json"), helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Failed to import policy")
 
 			key := "test2"
@@ -275,7 +275,7 @@ var _ = Describe("RuntimeMemcache", func() {
 			r.ExpectContains("STORED", "value not stored")
 
 			By("Importing policy disallowing set")
-			_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-memcache-disallow-set.json"), 300)
+			_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-memcache-disallow-set.json"), helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Failed to import policy")
 
 			By("Trying to set new key")
@@ -295,7 +295,7 @@ var _ = Describe("RuntimeMemcache", func() {
 
 		It("Tests policy allowing actions only for allowed key", func() {
 			By("Importing key-specific policy")
-			_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-memcache-allow-key.json"), 300)
+			_, err := vm.PolicyImportAndWait(vm.GetFullPath("Policies-memcache-allow-key.json"), helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Failed to import policy")
 
 			key := "allowed"


### PR DESCRIPTION
Sprinkling of various ginkgo/ci-related cleanups:
* Fix panic error message to be more descriptive, useful
* Attempt to gather endpoint info for all cilium pods even if one cilium pod cannot be reached
* Consistently use `time` package for time durations throughout `test/`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6576)
<!-- Reviewable:end -->
