### PR TITLE
cni: Wait for cilium-agent availability

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -76,6 +76,28 @@ func NewDefaultClient() (*Client, error) {
 	return NewClient("")
 }
 
+// NewDefaultClientWithTimeout creates a client with default parameters connecting to UNIX
+// domain socket and waits for cilium-agent availability.
+func NewDefaultClientWithTimeout(timeout time.Duration) (*Client, error) {
+	timeoutAfter := time.After(timeout)
+	var c *Client
+	var err error
+	for {
+		select {
+		case <-timeoutAfter:
+			return c, fmt.Errorf("Failed to create cilium agent client after %f seconds timeout: %s", timeout.Seconds(), err)
+		default:
+		}
+
+		c, err = NewDefaultClient()
+		if err == nil {
+			break
+		}
+	}
+
+	return c, nil
+}
+
 // NewClient creates a client for the given `host`.
 // If host is nil then use SockPath provided by CILIUM_SOCK
 // or the cilium default SockPath

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -121,4 +121,8 @@ const (
 	// NodeInitTimeout is the time the agent is waiting until giving up to
 	// initialize the local node with the kvstore
 	NodeInitTimeout = 15 * time.Minute
+
+	// ClientConnectTimeout is the time the cilium-agent client is
+	// (optionally) waiting before returning an error.
+	ClientConnectTimeout = 30 * time.Second
 )

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/client"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	"github.com/cilium/cilium/pkg/datapath/route"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint/connector"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/labels"
@@ -313,7 +314,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("unable to extract CNI arguments: %s", err)
 	}
 
-	c, err := client.NewDefaultClient()
+	c, err := client.NewDefaultClientWithTimeout(defaults.ClientConnectTimeout)
 	if err != nil {
 		return fmt.Errorf("unable to connect to Cilium daemon: %s", err)
 	}
@@ -471,7 +472,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 func cmdDel(args *skel.CmdArgs) error {
 	log.WithField("args", args).Debug("Processing CNI DEL request")
 
-	c, err := client.NewDefaultClient()
+	c, err := client.NewDefaultClientWithTimeout(defaults.ClientConnectTimeout)
 	if err != nil {
 		return fmt.Errorf("unable to connect to Cilium daemon: %s", err)
 	}


### PR DESCRIPTION
Sometimes Kubernetes schedules pods and executes CNI plugin before
cilium-agent is available. It causes unnecessary failures in pods' event
logs, especially when Cilium was just deployed on the cluster.

Fixes #6556

Signed-off-by: Michal Rostecki <mrostecki@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6583)
<!-- Reviewable:end -->
