### PR TITLE
docs: Update spelling list for toFQDNs rules

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -448,7 +448,7 @@ provided in DNS responses are allowed by Cilium in a similar manner to IPs in
 or are not know a priori, or when DNS is more convenient. To enforce policy on
 DNS requests themselves, see `Layer 7 Examples`_.
 
-IP information is captured from DNS responses per-Endpoint via `_DNS Proxy`_ or
+IP information is captured from DNS responses per-Endpoint via `DNS Proxy`_ or
 `DNS Polling`_ may be used. A generated L3 `CIDR based`_ rule is generated for
 every ``toFQDNs`` rule and applies to the same endpoints. The IP information is
 selected for insertion by ``matchName`` or ``matchPattern`` rules, and is

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -488,6 +488,8 @@ subclasses
 subcommand
 subcommands
 subdirectories
+subdomain
+subdomains
 subnet
 subnets
 subregister
@@ -585,6 +587,8 @@ whitelisted
 whitelisting
 whitelists
 whitespace
+wildcard
+wildcards
 wip
 Wireshark
 workflow


### PR DESCRIPTION
These were missed, and have broken the docs build.

Fixes: https://github.com/cilium/cilium/commit/92224cece0f5f5b1677756c9bc9c529e8666e0ed ("docs: L3/7 toFQDNs documentation w/ matchPattern")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6585)
<!-- Reviewable:end -->
