### PR TITLE
agent: Fix endpoint removal when createEndpoint() fails

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -238,10 +238,9 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 	ep.Unlock()
 
 	if build {
-		if err := ep.RegenerateWait(d, "Initial build on endpoint creation"); err != nil {
-			d.deleteEndpoint(ep)
-			return PutEndpointIDFailedCode, fmt.Errorf("failed to build the endpoint: %s", err)
-		}
+		ep.Regenerate(d, &endpoint.ExternalRegenerationMetadata{
+			Reason: "Initial build on endpoint creation",
+		})
 	}
 
 	// Only used for CRI-O since it does not support events.

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -287,9 +287,10 @@ func (driver *driver) createEndpoint(w http.ResponseWriter, r *http.Request) {
 	}
 
 	endpoint := &models.EndpointChangeRequest{
-		State:            models.EndpointStateWaitingForIdentity,
-		DockerEndpointID: create.EndpointID,
-		DockerNetworkID:  create.NetworkID,
+		SyncBuildEndpoint: true,
+		State:             models.EndpointStateWaitingForIdentity,
+		DockerEndpointID:  create.EndpointID,
+		DockerNetworkID:   create.NetworkID,
 		Addressing: &models.AddressPair{
 			IPV6: create.Interface.AddressIPv6,
 			IPV4: create.Interface.Address,


### PR DESCRIPTION
This fixes two scenarios where a failure in createEndpoint() can lead to the
controller created in endpoint.UpdateLabels() to be leaked due to lack of
invoking `d.deleteEndpoint()`. This had resulted in an endpoint to exist,
invisible in the endpoint list that would be continuously rebuilt via the
identity controller.

1. Endpoint build triggered via AddEndpoint() fails
2. Client context timeout causes exit after UpdateLabels()

Fixes: 186b5e93a84 ("daemon: do not add endpoint if client connection closes during add operation")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6586)
<!-- Reviewable:end -->
