### PR TITLE
Periodically sync endpoint state to lxc_config

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -142,6 +142,7 @@ func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 		e.logStatusLocked(BPF, Warning, fmt.Sprintf("Unable to create a base64: %s", err))
 	}
 
+	fmt.Fprintf(fw, " * File Timestamp: %s\n", time.Now())
 	if e.ContainerID == "" {
 		fmt.Fprintf(fw, " * Docker Network ID: %s\n", e.DockerNetworkID)
 		fmt.Fprintf(fw, " * Docker Endpoint ID: %s\n", e.DockerEndpointID)

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -397,6 +397,7 @@ func AddEndpoint(owner endpoint.Owner, ep *endpoint.Endpoint, reason string) (er
 	if err := Insert(ep); err != nil {
 		return err
 	}
+	endpoint.RunHeaderSync(ep, owner)
 
 	if build {
 		if err := ep.RegenerateWait(owner, reason); err != nil {


### PR DESCRIPTION
_This is still WIP but I put it up in case anyone strongly opposes it. I'd rather find a different way to solve the problem, since this feel very kludgy. I also wanted to run it in CI._

We normally include a dump of the endpoint state when generating BPF.
When changes occur but no BPF needs to be regenerated, this data is not
updated. This state is used to restore endpoints and can become somewhat
outdated.
A new controller periodically writes out the lxc_config.h file,
thus keeping the stored state more up-to-date. In most cases, the stale
state would be overwritten by source-of-truth upstreams (e.g. labels
from the container runtime) but fields like the DNSHistory may be
updated but not trigger a regeneration (common when DNS returns the
same, already allowed, IPs).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6588)
<!-- Reviewable:end -->
