### PR TITLE
make: Allow to disable envoy installation

### DIFF
--- a/envoy/Makefile
+++ b/envoy/Makefile
@@ -31,9 +31,11 @@ all:
 	echo "cilium-envoy has been moved to github.com/cilium/proxy"
 
 install:
+ifndef DISABLE_ENVOY_INSTALLATION
 	docker create -ti --name cilium-envoy quay.io/cilium/cilium-envoy:${CILIUM_ENVOY_SHA} bash
 	docker cp cilium-envoy:/usr/bin/cilium-envoy $(BINDIR)/cilium-envoy
 	docker rm -fv cilium-envoy
+endif
 
 clean:
 


### PR DESCRIPTION
The standard way of installing cilium-envoy binary is to unpack it from
Docker image, which works for specific glibc version included in Ubuntu.
The same binary will not work with other glibc versions and with other
Linux distributions.

This change introduces `DISABLE_ENVOY_INSTALLATION` variable which
disables cilium-envoy installation if it's defined.

For example, openSUSE is going to build separate RPM package with
cilium-envoy[0] straight from cilium/proxy git repository.

[0] https://build.opensuse.org/package/show/devel:kubic/cilium-proxy

Signed-off-by: Michal Rostecki <mrostecki@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6595)
<!-- Reviewable:end -->
