### PR TITLE
[RFC] fqdn: Timeouts in forwarded DNS Proxy passed back

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -317,6 +317,14 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	request.Id = dns.Id() // force a random new ID for this request
 	response, _, err := client.Exchange(request, targetServerAddr)
 	if err != nil {
+		// Timeouts are a special case. They are "normal operation" from our
+		// perspective and we pass them on by not responding.
+		netErr, isNetErr := err.(net.Error)
+		if isNetErr && netErr.Timeout() {
+			scopedLog.WithError(err).Warn("Timeout waiting for response to forwarded proxied DNS lookup")
+			return
+		}
+
 		scopedLog.WithError(err).Error("Cannot forward proxied DNS lookup")
 		p.NotifyOnDNSMsg(time.Now(), endpointAddr, targetServerAddr, request, protocol, false,
 			fmt.Errorf("Cannot forward proxied DNS lookup: %s", err))


### PR DESCRIPTION
A timeout when forwarding a DNS lookup triggers an error in the proxy,
but we intend to emulate what the original requester would see. Thus,
we now do nothing and let them timeout.
This is motivated by how we handle errors with proxies. If we report
timeouts as errors, they increment l7_proxy_parse_errors and that is
misleading.

I'm not sure about the best log level for this error. I've set it to warn since it is useful to know if this happens often, but the real manifestation will be timeouts in the apps that made the original request. Debug may be the correct level here.
Relatedly, perhaps it is also good to add a proxy metric to count these occurrences. As-is, the warning is the only source of info.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6602)
<!-- Reviewable:end -->
