### PR TITLE
FQDN: use the correct TTL on DNS-proxy

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1522,7 +1522,12 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState) (err err
 				}
 				ep.DNSHistory.Update(lookupTime, qname, responseIPs, effectiveTTL)
 				log.Debug("Updating DNS name in cache from response to to query")
-				if err := d.dnsRuleGen.UpdateGenerateDNS(lookupTime, map[string]*fqdn.DNSIPRecords{qname: {IPs: responseIPs, TTL: int(TTL)}}); err != nil {
+				err = d.dnsRuleGen.UpdateGenerateDNS(lookupTime, map[string]*fqdn.DNSIPRecords{
+					qname: {
+						IPs: responseIPs,
+						TTL: int(effectiveTTL),
+					}})
+				if err != nil {
 					log.WithError(err).Error("error updating internal DNS cache for rule generation")
 				}
 			}


### PR DESCRIPTION
When daemon call UpdateGenareDNS used the DNS reply TTL but it ignores
the `ToFQDNsMinTTL` value.

With this change is uses the correct TTL value.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6606)
<!-- Reviewable:end -->
