### PR TITLE
daemon: Exit daemon when usage is printed

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -281,6 +281,15 @@ func checkMinRequirements() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
+
+	// Reset the help function to also exit, as we block elsewhere in interrupts
+	// and would not exit when called with -h.
+	oldHelpFunc := RootCmd.HelpFunc()
+	RootCmd.SetHelpFunc(func(c *cobra.Command, a []string) {
+		oldHelpFunc(c, a)
+		os.Exit(0)
+	})
+
 	flags := RootCmd.Flags()
 
 	// Validators


### PR DESCRIPTION
We recently changed how the daemon waits on interrupt signals, and this
caused it to block exiting when it only printed usage text. We now force
an exit when the usage printing is invoked.

fixes 70bfbef14bb01465e2e6b158fb390f75b49bdee6

I'm not sure if this is the best place to do this, and if it also needs to be in other daemon things we have (probably not, since this specific blocking is inside daemonMain).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6609)
<!-- Reviewable:end -->
