### PR TITLE
FQDN new tests

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -891,7 +891,7 @@ func (s *SSHMeta) ServiceDelAll() *CmdRes {
 func (s *SSHMeta) SetUpCilium() error {
 	template := `
 PATH=/usr/lib/llvm-3.8/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
-CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug --pprof=true --log-system-load --tofqdns-enable-poller=true
+CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug --pprof=true --log-system-load --tofqdns-enable-poller=true --tofqdns-min-ttl=1
 INITSYSTEM=SYSTEMD`
 	return s.SetUpCiliumWithOptions(template)
 }


### PR DESCRIPTION
Hi

Two commits, and both has some issues:

1) TTL test:

This test is always failing. In this case if the TTL expires nothing will be
cleaned from the policy until policy regenerates. This commit is to open a
discussion if a controller or a time.After should be in place to delete these
entries. (I think so)


2) On-going connections:

App1 starts a connection using DNS and the IP is whitelisted correctly. Once
the connection is ok and in  the Conntrack Table that connection is whitelisted
and nothing will be drop that communication.

This test works, but I'm not sure if:

- TTL expires, should we close that connection?
- Policy Changes from allow to deny, does the old connections should be drop
  also?


I'll raise these issues in the next sig-policy meeting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6610)
<!-- Reviewable:end -->
