### PR TITLE
daemon: Do not omit any error of createNodeConfigHeaderfile

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -523,9 +523,6 @@ func (d *Daemon) compileBase() error {
 }
 
 func (d *Daemon) init() error {
-
-	var err error
-
 	globalsDir := option.Config.GetGlobalsDir()
 	if err := os.MkdirAll(globalsDir, defaults.RuntimePathRights); err != nil {
 		log.WithError(err).WithField(logfields.Path, globalsDir).Fatal("Could not create runtime directory")
@@ -535,8 +532,8 @@ func (d *Daemon) init() error {
 		log.WithError(err).WithField(logfields.Path, option.Config.StateDir).Fatal("Could not change to runtime directory")
 	}
 
-	if err = d.createNodeConfigHeaderfile(); err != nil {
-		return nil
+	if err := d.createNodeConfigHeaderfile(); err != nil {
+		return err
 	}
 
 	if !option.Config.DryMode {


### PR DESCRIPTION
Previously, any error returned by the function was omitted.

Fixes: cf52c0691 ("daemon: factor out node config headerfile into separate")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6611)
<!-- Reviewable:end -->
