### PR TITLE
Print IPAM ranges in cilium status

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -270,21 +270,23 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, allAddresses, 
 
 	if sr.IPAM != nil {
 		var v4CIDR, v6CIDR string
+		v4AllocRange := localNode.PrimaryAddress.IPV4.AllocRange
+		v6AllocRange := localNode.PrimaryAddress.IPV6.AllocRange
 		if localNode != nil {
-			if nIPs := ip.CountIPsInCIDR(localNode.PrimaryAddress.IPV4.AllocRange); nIPs > 0 {
+			if nIPs := ip.CountIPsInCIDR(v4AllocRange); nIPs > 0 {
 				v4CIDR = fmt.Sprintf("/%d", nIPs)
 			}
-			if nIPs := ip.CountIPsInCIDR(localNode.PrimaryAddress.IPV6.AllocRange); nIPs > 0 {
+			if nIPs := ip.CountIPsInCIDR(v6AllocRange); nIPs > 0 {
 				v6CIDR = fmt.Sprintf("/%d", nIPs)
 			}
 		}
-		fmt.Fprintf(w, "IPv4 address pool:\t%d%s allocated\n", len(sr.IPAM.IPV4), v4CIDR)
+		fmt.Fprintf(w, "IPv4 address pool:\t%d%s allocated from %s\n", len(sr.IPAM.IPV4), v4CIDR, v4AllocRange)
 		if allAddresses {
 			for _, ipv4 := range sr.IPAM.IPV4 {
 				fmt.Fprintf(w, "  %s\n", ipv4)
 			}
 		}
-		fmt.Fprintf(w, "IPv6 address pool:\t%d%s allocated\n", len(sr.IPAM.IPV6), v6CIDR)
+		fmt.Fprintf(w, "IPv6 address pool:\t%d%s allocated from %s\n", len(sr.IPAM.IPV6), v6CIDR, v6AllocRange)
 		if allAddresses {
 			for _, ipv6 := range sr.IPAM.IPV6 {
 				fmt.Fprintf(w, "  %s\n", ipv6)


### PR DESCRIPTION
Example:
```
# cilium status
KVStore:                Ok   etcd: 1/1 connected: http://cilium-etcd-client.kube-system.svc:31079 - 3.3.2 (Leader)
ContainerRuntime:       Ok   docker daemon: OK
Kubernetes:             Ok   1.13 (v1.13.1) [linux/amd64]
Kubernetes APIs:        ["CustomResourceDefinition", "cilium/v2::CiliumNetworkPolicy", "core/v1::Endpoint", "core/v1::Namespace", "core/v1::Node", "core/v1::Pods", "core/v1::Service", "networking.k8s.io/v1::NetworkPolicy"]                                
Cilium:                 Ok   OK
NodeMonitor:            Listening for events on 4 CPUs with 64x4096 of shared memory
Cilium health daemon:   Ok
IPv4 address pool:      15/65535 allocated from 10.132.0.0/16
IPv6 address pool:      14/65535 allocated from f00d::a84:0:0:0/112
Controller Status:      80/80 healthy
Proxy Status:           OK, ip 10.132.0.1, port-range 10000-20000
Cluster health:            0/1 reachable    (2019-01-11T17:43:35Z)
  Name                     IP               Reachable   Endpoints reachable
  allosaurus (localhost)   192.168.55.132   true        false
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6613)
<!-- Reviewable:end -->
